### PR TITLE
feat(cli): support Ctrl-Z suspension (#5018)

### DIFF
--- a/docs/cli/keyboard-shortcuts.md
+++ b/docs/cli/keyboard-shortcuts.md
@@ -103,10 +103,11 @@ available combinations.
 
 #### Session Control
 
-| Action                                       | Keys       |
-| -------------------------------------------- | ---------- |
-| Cancel the current request or quit the CLI.  | `Ctrl + C` |
-| Exit the CLI when the input buffer is empty. | `Ctrl + D` |
+| Action                                         | Keys       |
+| ---------------------------------------------- | ---------- |
+| Cancel the current request or quit the CLI.    | `Ctrl + C` |
+| Exit the CLI when the input buffer is empty.   | `Ctrl + D` |
+| Suspend the CLI and move it to the background. | `Ctrl + Z` |
 
 <!-- KEYBINDINGS-AUTOGEN:END -->
 

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -64,6 +64,7 @@ export enum Command {
   TOGGLE_COPY_MODE = 'toggleCopyMode',
   QUIT = 'quit',
   EXIT = 'exit',
+  SUSPEND = 'suspend',
   SHOW_MORE_LINES = 'showMoreLines',
 
   // Shell commands
@@ -205,6 +206,7 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.TOGGLE_COPY_MODE]: [{ key: 's', ctrl: true }],
   [Command.QUIT]: [{ key: 'c', ctrl: true }],
   [Command.EXIT]: [{ key: 'd', ctrl: true }],
+  [Command.SUSPEND]: [{ key: 'z', ctrl: true }],
   [Command.SHOW_MORE_LINES]: [{ key: 's', ctrl: true }],
 
   // Shell commands
@@ -311,7 +313,7 @@ export const commandCategories: readonly CommandCategory[] = [
   },
   {
     title: 'Session Control',
-    commands: [Command.QUIT, Command.EXIT],
+    commands: [Command.QUIT, Command.EXIT, Command.SUSPEND],
   },
 ];
 
@@ -356,6 +358,7 @@ export const commandDescriptions: Readonly<Record<Command, string>> = {
     'Toggle copy mode when the terminal is using the alternate buffer.',
   [Command.QUIT]: 'Cancel the current request or quit the CLI.',
   [Command.EXIT]: 'Exit the CLI when the input buffer is empty.',
+  [Command.SUSPEND]: 'Suspend the CLI and move it to the background.',
   [Command.SHOW_MORE_LINES]:
     'Expand a height-constrained response to show additional lines.',
   [Command.REVERSE_SEARCH]: 'Start reverse search through history.',

--- a/packages/cli/src/ui/AppContainer.suspend.test.tsx
+++ b/packages/cli/src/ui/AppContainer.suspend.test.tsx
@@ -1,0 +1,257 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
+import { render as inkRender } from '../test-utils/render.js';
+import { act } from 'react';
+import { AppContainer } from './AppContainer.js';
+import { SettingsContext } from './contexts/SettingsContext.js';
+import {
+  type Config,
+  makeFakeConfig,
+  enableMouseEvents,
+  disableMouseEvents,
+  writeToStdout,
+} from '@google/gemini-cli-core';
+import { useKeypress, type Key } from './hooks/useKeypress.js';
+import type { ExtensionManager } from '../config/extension-manager.js';
+import type { LoadedSettings } from '../config/settings.js';
+import type { InitializationResult } from '../core/initializer.js';
+
+// Mocks
+const mocks = vi.hoisted(() => ({
+  mockStdout: { write: vi.fn(), emit: vi.fn() },
+  mockStdin: {
+    isTTY: true,
+    setRawMode: vi.fn(),
+    resume: vi.fn(),
+    ref: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    removeListener: vi.fn(),
+  },
+  mockApp: { rerender: vi.fn() },
+}));
+
+// Mock process
+const mockProcessStdoutWrite = vi
+  .spyOn(process.stdout, 'write')
+  .mockImplementation(() => true);
+vi.spyOn(process.stdout, 'emit').mockImplementation(() => true);
+const mockProcessOn = vi.spyOn(process, 'on').mockImplementation(() => process);
+vi.spyOn(process, 'kill').mockImplementation(() => true);
+vi.spyOn(process, 'off').mockImplementation(() => process);
+
+vi.mock('ink', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('ink')>();
+  return {
+    ...actual,
+    useStdout: () => ({ stdout: mocks.mockStdout }),
+    useStdin: () => ({
+      stdin: mocks.mockStdin,
+      setRawMode: mocks.mockStdin.setRawMode,
+    }),
+    useApp: () => mocks.mockApp,
+    measureElement: vi.fn(),
+  };
+});
+
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    enableMouseEvents: vi.fn(),
+    disableMouseEvents: vi.fn(),
+    writeToStdout: vi.fn(),
+    startupProfiler: { start: vi.fn(), end: vi.fn(), flush: vi.fn() },
+  };
+});
+
+// Mock all the hooks used in AppContainer to avoid complex setup
+vi.mock('./hooks/useQuotaAndFallback.js', () => ({
+  useQuotaAndFallback: () => ({ proQuotaRequest: null }),
+}));
+vi.mock('./hooks/useHistoryManager.js', () => ({
+  useHistory: () => ({ history: [], addItem: vi.fn() }),
+}));
+vi.mock('./hooks/useThemeCommand.js', () => ({ useThemeCommand: () => ({}) }));
+vi.mock('./auth/useAuth.js', () => ({
+  useAuthCommand: () => ({ authState: 'authenticated' }),
+}));
+vi.mock('./hooks/useEditorSettings.js', () => ({
+  useEditorSettings: () => ({}),
+}));
+vi.mock('./hooks/useSettingsCommand.js', () => ({
+  useSettingsCommand: () => ({}),
+}));
+vi.mock('./hooks/useModelCommand.js', () => ({ useModelCommand: () => ({}) }));
+vi.mock('./hooks/slashCommandProcessor.js', () => ({
+  useSlashCommandProcessor: () => ({ handleSlashCommand: vi.fn() }),
+}));
+vi.mock('./hooks/useConsoleMessages.js', () => ({
+  useConsoleMessages: () => ({ consoleMessages: [] }),
+}));
+vi.mock('./hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: 80, rows: 24 }),
+}));
+vi.mock('./hooks/useGeminiStream.js', () => ({
+  useGeminiStream: () => ({ streamingState: 'idle' }),
+}));
+vi.mock('./hooks/vim.js', () => ({ useVim: () => ({}) }));
+vi.mock('./hooks/useFocus.js', () => ({
+  useFocus: () => ({ isFocused: true }),
+}));
+vi.mock('./hooks/useBracketedPaste.js', () => ({
+  useBracketedPaste: () => ({}),
+}));
+vi.mock('./hooks/useLoadingIndicator.js', () => ({
+  useLoadingIndicator: () => ({}),
+}));
+vi.mock('./hooks/useFolderTrust.js', () => ({ useFolderTrust: () => ({}) }));
+vi.mock('./hooks/useIdeTrustListener.js', () => ({
+  useIdeTrustListener: () => ({}),
+}));
+vi.mock('./hooks/useMessageQueue.js', () => ({
+  useMessageQueue: () => ({ messageQueue: [] }),
+}));
+vi.mock('./hooks/useAutoAcceptIndicator.js', () => ({
+  useAutoAcceptIndicator: () => false,
+}));
+vi.mock('./hooks/useGitBranchName.js', () => ({ useGitBranchName: () => '' }));
+vi.mock('./contexts/VimModeContext.js', () => ({ useVimMode: () => ({}) }));
+vi.mock('./contexts/SessionContext.js', () => ({
+  useSessionStats: () => ({ stats: {} }),
+}));
+vi.mock('./components/shared/text-buffer.js', () => ({
+  useTextBuffer: () => ({ text: '' }),
+}));
+vi.mock('./hooks/useLogger.js', () => ({ useLogger: () => ({}) }));
+vi.mock('./hooks/useInputHistoryStore.js', () => ({
+  useInputHistoryStore: () => ({}),
+}));
+vi.mock('./utils/ConsolePatcher.js');
+vi.mock('../utils/cleanup.js');
+vi.mock('../utils/windowTitle.js', () => ({ computeWindowTitle: () => '' }));
+
+// Mock useKeypress to capture the handler
+vi.mock('./hooks/useKeypress.js', () => ({
+  useKeypress: vi.fn(),
+}));
+
+describe('AppContainer Suspend (Ctrl+Z)', () => {
+  let mockConfig: Config;
+  let handleGlobalKeypress: (key: Key) => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfig = makeFakeConfig();
+    vi.spyOn(mockConfig, 'getTargetDir').mockReturnValue('/test');
+    vi.spyOn(mockConfig, 'initialize').mockResolvedValue(undefined);
+    vi.spyOn(mockConfig, 'getExtensionLoader').mockReturnValue({
+      setRequestConsent: vi.fn(),
+      setRequestSetting: vi.fn(),
+      getExtensions: vi.fn().mockReturnValue([]),
+    } as unknown as ExtensionManager);
+
+    (useKeypress as Mock).mockImplementation((handler) => {
+      handleGlobalKeypress = handler;
+    });
+
+    // Mock process properties
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    Object.defineProperty(process, 'stdin', { value: mocks.mockStdin });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should suspend process on Ctrl+Z and restore on resume', async () => {
+    // Render AppContainer
+    const { unmount } = inkRender(
+      <SettingsContext.Provider
+        value={{ merged: {} } as unknown as LoadedSettings}
+      >
+        <AppContainer
+          config={mockConfig}
+          version="1.0.0"
+          initializationResult={{} as unknown as InitializationResult}
+        />
+      </SettingsContext.Provider>,
+    );
+
+    expect(handleGlobalKeypress).toBeDefined();
+
+    // Trigger Ctrl+Z
+    await act(async () => {
+      handleGlobalKeypress({
+        name: 'z',
+        ctrl: true,
+        meta: false,
+        shift: false,
+        paste: false,
+        insertable: false,
+        sequence: '\x1a',
+      });
+    });
+
+    // Verify suspend actions
+    // 1. Show cursor
+    expect(writeToStdout).toHaveBeenCalledWith('\x1b[?25h');
+    // 2. Disable mouse
+    expect(disableMouseEvents).toHaveBeenCalled();
+    // 3. Disable raw mode
+    expect(mocks.mockStdin.setRawMode).toHaveBeenCalledWith(false);
+    // 4. Register SIGCONT handler
+    expect(process.on).toHaveBeenCalledWith('SIGCONT', expect.any(Function));
+    // 5. Send SIGTSTP
+    expect(process.kill).toHaveBeenCalledWith(0, 'SIGTSTP');
+
+    // Get the onResume handler
+    const onResume = mockProcessOn.mock.calls.find(
+      (call) => call[0] === 'SIGCONT',
+    )?.[1] as () => void;
+    expect(onResume).toBeDefined();
+
+    // Reset mocks to verify resume actions
+    (disableMouseEvents as Mock).mockClear();
+    (enableMouseEvents as Mock).mockClear();
+    mocks.mockStdin.setRawMode.mockClear();
+    mockProcessStdoutWrite.mockClear();
+
+    // Simulate SIGCONT (Resume)
+    await act(async () => {
+      onResume();
+    });
+
+    // Verify resume actions
+    // 1. Restore raw mode
+    expect(mocks.mockStdin.setRawMode).toHaveBeenCalledWith(true);
+    expect(mocks.mockStdin.resume).toHaveBeenCalled();
+    // 2. Hide cursor
+    expect(writeToStdout).toHaveBeenCalledWith('\x1b[?25l');
+    // 3. Enable mouse
+    expect(enableMouseEvents).toHaveBeenCalled();
+    // 4. Emit resize to repaint
+    expect(process.stdout.emit).toHaveBeenCalledWith('resize');
+    // 5. Cleanup listener
+    expect(process.off).toHaveBeenCalledWith('SIGCONT', onResume);
+
+    // 6. Verify rerender key update (indirectly via App rerender? or just assume side effects)
+    // We can't easily check state internal to component without hacking, but checking side effects is good enough.
+
+    unmount();
+  });
+});

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2250,8 +2250,6 @@ export function useTextBuffer({
       )
         backspace();
       else if (key.name === 'delete' || (key.ctrl && key.name === 'd')) del();
-      else if (key.ctrl && !key.shift && key.name === 'z') undo();
-      else if (key.ctrl && key.shift && key.name === 'z') redo();
       else if (key.insertable) {
         insert(input, { paste: key.paste });
       }
@@ -2264,8 +2262,6 @@ export function useTextBuffer({
       backspace,
       del,
       insert,
-      undo,
-      redo,
       singleLine,
     ],
   );

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -69,6 +69,7 @@ describe('keyMatchers', () => {
     [Command.TOGGLE_COPY_MODE]: (key: Key) => key.ctrl && key.name === 's',
     [Command.QUIT]: (key: Key) => key.ctrl && key.name === 'c',
     [Command.EXIT]: (key: Key) => key.ctrl && key.name === 'd',
+    [Command.SUSPEND]: (key: Key) => key.ctrl && key.name === 'z',
     [Command.SHOW_MORE_LINES]: (key: Key) => key.ctrl && key.name === 's',
     [Command.REVERSE_SEARCH]: (key: Key) => key.ctrl && key.name === 'r',
     [Command.SUBMIT_REVERSE_SEARCH]: (key: Key) =>
@@ -308,6 +309,11 @@ describe('keyMatchers', () => {
       command: Command.EXIT,
       positive: [createKey('d', { ctrl: true })],
       negative: [createKey('d'), createKey('c', { ctrl: true })],
+    },
+    {
+      command: Command.SUSPEND,
+      positive: [createKey('z', { ctrl: true })],
+      negative: [createKey('z'), createKey('y', { ctrl: true })],
     },
     {
       command: Command.SHOW_MORE_LINES,


### PR DESCRIPTION
Refines the Ctrl+Z suspend handler to ensure a clean terminal state:
- Directly writes to stdout to show the cursor before suspending, bypassing Ink's internal buffer.
- Disables the Kitty keyboard protocol and mouse events to prevent raw escape codes from leaking.
- Removes alternate screen switching during suspend to avoid visual artifacts.
- Updates tests to verify correct sequence of terminal restoration commands.

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
