### PR TITLE
feat(agents): add support for remote agents and multi-agent TOML files

### DIFF
--- a/packages/core/src/agents/registry.test.ts
+++ b/packages/core/src/agents/registry.test.ts
@@ -257,6 +257,40 @@ describe('AgentRegistry', () => {
       });
     });
 
+    it('should register a remote agent definition', () => {
+      const remoteAgent: AgentDefinition = {
+        kind: 'remote',
+        name: 'RemoteAgent',
+        description: 'A remote agent',
+        agentCardUrl: 'https://example.com/card',
+        inputConfig: { inputs: {} },
+      };
+      registry.testRegisterAgent(remoteAgent);
+      expect(registry.getDefinition('RemoteAgent')).toEqual(remoteAgent);
+    });
+
+    it('should log remote agent registration in debug mode', () => {
+      const debugConfig = makeFakeConfig({ debugMode: true });
+      const debugRegistry = new TestableAgentRegistry(debugConfig);
+      const debugLogSpy = vi
+        .spyOn(debugLogger, 'log')
+        .mockImplementation(() => {});
+
+      const remoteAgent: AgentDefinition = {
+        kind: 'remote',
+        name: 'RemoteAgent',
+        description: 'A remote agent',
+        agentCardUrl: 'https://example.com/card',
+        inputConfig: { inputs: {} },
+      };
+
+      debugRegistry.testRegisterAgent(remoteAgent);
+
+      expect(debugLogSpy).toHaveBeenCalledWith(
+        `[AgentRegistry] Registered remote agent 'RemoteAgent' with card: https://example.com/card`,
+      );
+    });
+
     it('should handle special characters in agent names', () => {
       const specialAgent = {
         ...MOCK_AGENT_V1,

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -202,7 +202,7 @@ export class AgentRegistry {
       );
     }
 
-    // Register configured remote A2A agents.
+    // Log remote A2A agent registration for visibility.
     if (definition.kind === 'remote' && this.config.getDebugMode()) {
       debugLogger.log(
         `[AgentRegistry] Registered remote agent '${definition.name}' with card: ${definition.agentCardUrl}`,

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -203,7 +203,11 @@ export class AgentRegistry {
     }
 
     // Register configured remote A2A agents.
-    // TODO: Implement remote agent registration.
+    if (definition.kind === 'remote' && this.config.getDebugMode()) {
+      debugLogger.log(
+        `[AgentRegistry] Registered remote agent '${definition.name}' with card: ${definition.agentCardUrl}`,
+      );
+    }
   }
 
   /**

--- a/packages/core/src/agents/toml-loader.test.ts
+++ b/packages/core/src/agents/toml-loader.test.ts
@@ -74,15 +74,53 @@ describe('toml-loader', () => {
       });
     });
 
+    it('should infer remote agent kind from agent_card_url', async () => {
+      const filePath = await writeAgentToml(`
+        name = "inferred-remote"
+        description = "Inferred"
+        agent_card_url = "https://example.com/inferred"
+      `);
+
+      const result = await parseAgentToml(filePath);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        kind: 'remote',
+        name: 'inferred-remote',
+        description: 'Inferred',
+        agent_card_url: 'https://example.com/inferred',
+      });
+    });
+
+    it('should parse a remote agent without description', async () => {
+      const filePath = await writeAgentToml(`
+        kind = "remote"
+        name = "no-description-remote"
+        agent_card_url = "https://example.com/card"
+      `);
+
+      const result = await parseAgentToml(filePath);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        kind: 'remote',
+        name: 'no-description-remote',
+        agent_card_url: 'https://example.com/card',
+      });
+      expect(result[0].description).toBeUndefined();
+
+      // defined after conversion to AgentDefinition
+      const agentDef = tomlToAgentDefinition(result[0]);
+      expect(agentDef.description).toBe('(Loading description...)');
+    });
+
     it('should parse multiple agents in one file', async () => {
       const filePath = await writeAgentToml(`
-        [[agents]]
+        [[remote_agents]]
+        kind = "remote"
         name = "agent-1"
-        description = "Local 1"
-        [agents.prompts]
-        system_prompt = "Prompt 1"
+        description = "Remote 1"
+        agent_card_url = "https://example.com/1"
 
-        [[agents]]
+        [[remote_agents]]
         kind = "remote"
         name = "agent-2"
         description = "Remote 2"
@@ -92,8 +130,34 @@ describe('toml-loader', () => {
       const result = await parseAgentToml(filePath);
       expect(result).toHaveLength(2);
       expect(result[0].name).toBe('agent-1');
+      expect(result[0].kind).toBe('remote');
       expect(result[1].name).toBe('agent-2');
       expect(result[1].kind).toBe('remote');
+    });
+
+    it('should allow omitting kind in remote_agents block', async () => {
+      const filePath = await writeAgentToml(`
+        [[remote_agents]]
+        name = "implicit-remote-1"
+        agent_card_url = "https://example.com/1"
+
+        [[remote_agents]]
+        name = "implicit-remote-2"
+        agent_card_url = "https://example.com/2"
+      `);
+
+      const result = await parseAgentToml(filePath);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        kind: 'remote',
+        name: 'implicit-remote-1',
+        agent_card_url: 'https://example.com/1',
+      });
+      expect(result[1]).toMatchObject({
+        kind: 'remote',
+        name: 'implicit-remote-2',
+        agent_card_url: 'https://example.com/2',
+      });
     });
 
     it('should throw AgentLoadError if file reading fails', async () => {
@@ -153,27 +217,36 @@ describe('toml-loader', () => {
         system_prompt = "You are a test agent."
       `);
       await expect(parseAgentToml(filePath)).rejects.toThrow(
-        /Validation failed: tools.0: Invalid tool name/,
+        /Validation failed:[\s\S]*tools.0: Invalid tool name/,
       );
     });
 
     it('should throw AgentLoadError if file contains both single and multiple agents', async () => {
       const filePath = await writeAgentToml(`
-        name = "top-level-agent"
-        description = "I should not be here"
-        [prompts]
-        system_prompt = "..."
+            name = "top-level-agent"
+            description = "I should not be here"
+            [prompts]
+            system_prompt = "..."
 
-        [[agents]]
-        name = "array-agent"
-        description = "I am in an array"
-        [agents.prompts]
-        system_prompt = "..."
-      `);
+            [[remote_agents]]
+            kind = "remote"
+            name = "array-agent"
+            description = "I am in an array"
+            agent_card_url = "https://example.com/card"
+          `);
 
-      // Zod union errors can be verbose, but it should definitely fail validation
       await expect(parseAgentToml(filePath)).rejects.toThrow(
         /Validation failed/,
+      );
+    });
+
+    it('should show both options in error message when validation fails ambiguously', async () => {
+      const filePath = await writeAgentToml(`
+        name = "ambiguous-agent"
+        description = "I have neither prompts nor card"
+      `);
+      await expect(parseAgentToml(filePath)).rejects.toThrow(
+        /Validation failed: Agent Definition:\n\(Local Agent\) prompts: Required\n\(Remote Agent\) agent_card_url: Required/,
       );
     });
   });
@@ -181,6 +254,7 @@ describe('toml-loader', () => {
   describe('tomlToAgentDefinition', () => {
     it('should convert valid TOML to AgentDefinition with defaults', () => {
       const toml = {
+        kind: 'local' as const,
         name: 'test-agent',
         description: 'A test agent',
         prompts: {
@@ -215,6 +289,7 @@ describe('toml-loader', () => {
 
     it('should pass through model aliases', () => {
       const toml = {
+        kind: 'local' as const,
         name: 'test-agent',
         description: 'A test agent',
         model: {
@@ -231,6 +306,7 @@ describe('toml-loader', () => {
 
     it('should pass through unknown model names (e.g. auto)', () => {
       const toml = {
+        kind: 'local' as const,
         name: 'test-agent',
         description: 'A test agent',
         model: {

--- a/packages/core/src/agents/toml-loader.test.ts
+++ b/packages/core/src/agents/toml-loader.test.ts
@@ -46,13 +46,54 @@ describe('toml-loader', () => {
       `);
 
       const result = await parseAgentToml(filePath);
-      expect(result).toEqual({
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
         name: 'test-agent',
         description: 'A test agent',
         prompts: {
           system_prompt: 'You are a test agent.',
         },
       });
+    });
+
+    it('should parse a valid remote agent TOML file', async () => {
+      const filePath = await writeAgentToml(`
+        kind = "remote"
+        name = "remote-agent"
+        description = "A remote agent"
+        agent_card_url = "https://example.com/card"
+      `);
+
+      const result = await parseAgentToml(filePath);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        kind: 'remote',
+        name: 'remote-agent',
+        description: 'A remote agent',
+        agent_card_url: 'https://example.com/card',
+      });
+    });
+
+    it('should parse multiple agents in one file', async () => {
+      const filePath = await writeAgentToml(`
+        [[agents]]
+        name = "agent-1"
+        description = "Local 1"
+        [agents.prompts]
+        system_prompt = "Prompt 1"
+
+        [[agents]]
+        kind = "remote"
+        name = "agent-2"
+        description = "Remote 2"
+        agent_card_url = "https://example.com/2"
+      `);
+
+      const result = await parseAgentToml(filePath);
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe('agent-1');
+      expect(result[1].name).toBe('agent-2');
+      expect(result[1].kind).toBe('remote');
     });
 
     it('should throw AgentLoadError if file reading fails', async () => {

--- a/packages/core/src/agents/toml-loader.test.ts
+++ b/packages/core/src/agents/toml-loader.test.ts
@@ -156,6 +156,26 @@ describe('toml-loader', () => {
         /Validation failed: tools.0: Invalid tool name/,
       );
     });
+
+    it('should throw AgentLoadError if file contains both single and multiple agents', async () => {
+      const filePath = await writeAgentToml(`
+        name = "top-level-agent"
+        description = "I should not be here"
+        [prompts]
+        system_prompt = "..."
+
+        [[agents]]
+        name = "array-agent"
+        description = "I am in an array"
+        [agents.prompts]
+        system_prompt = "..."
+      `);
+
+      // Zod union errors can be verbose, but it should definitely fail validation
+      await expect(parseAgentToml(filePath)).rejects.toThrow(
+        /Validation failed/,
+      );
+    });
   });
 
   describe('tomlToAgentDefinition', () => {

--- a/packages/core/src/agents/toml-loader.ts
+++ b/packages/core/src/agents/toml-loader.ts
@@ -74,51 +74,57 @@ const nameSchema = z
   .string()
   .regex(/^[a-z0-9-_]+$/, 'Name must be a valid slug');
 
-const localAgentSchema = z.object({
-  kind: z.literal('local').optional().default('local'),
-  name: nameSchema,
-  description: z.string().min(1),
-  display_name: z.string().optional(),
-  tools: z
-    .array(
-      z.string().refine((val) => isValidToolName(val), {
-        message: 'Invalid tool name',
-      }),
-    )
-    .optional(),
-  prompts: z.object({
-    system_prompt: z.string().min(1),
-    query: z.string().optional(),
-  }),
-  model: z
-    .object({
-      model: z.string().optional(),
-      temperature: z.number().optional(),
-    })
-    .optional(),
-  run: z
-    .object({
-      max_turns: z.number().int().positive().optional(),
-      timeout_mins: z.number().int().positive().optional(),
-    })
-    .optional(),
-});
+const localAgentSchema = z
+  .object({
+    kind: z.literal('local').optional().default('local'),
+    name: nameSchema,
+    description: z.string().min(1),
+    display_name: z.string().optional(),
+    tools: z
+      .array(
+        z.string().refine((val) => isValidToolName(val), {
+          message: 'Invalid tool name',
+        }),
+      )
+      .optional(),
+    prompts: z.object({
+      system_prompt: z.string().min(1),
+      query: z.string().optional(),
+    }),
+    model: z
+      .object({
+        model: z.string().optional(),
+        temperature: z.number().optional(),
+      })
+      .optional(),
+    run: z
+      .object({
+        max_turns: z.number().int().positive().optional(),
+        timeout_mins: z.number().int().positive().optional(),
+      })
+      .optional(),
+  })
+  .strict();
 
-const remoteAgentSchema = z.object({
-  kind: z.literal('remote'),
-  name: nameSchema,
-  description: z.string().min(1),
-  display_name: z.string().optional(),
-  agent_card_url: z.string().url(),
-});
+const remoteAgentSchema = z
+  .object({
+    kind: z.literal('remote'),
+    name: nameSchema,
+    description: z.string().min(1),
+    display_name: z.string().optional(),
+    agent_card_url: z.string().url(),
+  })
+  .strict();
 
 const agentSchema = z.union([remoteAgentSchema, localAgentSchema]);
 
 const tomlSchema = z.union([
   agentSchema,
-  z.object({
-    agents: z.array(agentSchema),
-  }),
+  z
+    .object({
+      agents: z.array(agentSchema),
+    })
+    .strict(),
 ]);
 
 /**


### PR DESCRIPTION
## Summary

This PR enables the discovery and registration of remote agents (via A2A) defined in TOML files. It also introduces support for defining multiple remote agents within a single TOML file using the `[[remote_agents]]` array syntax.

## Details

* Remote Agent Support: Implemented schema validation for agents defined with an agent_card_url.
* Multi-Agent Config: Added support for [[remote_agents]] blocks to define multiple remote agents in
one file.
* Flexible Syntax:
  * description is optional for remote agents (defaults to a placeholder).
  * kind defaults to "remote" and can be omitted within [[remote_agents]] blocks.

## Related Issues

Fixes: https://github.com/google-gemini/gemini-cli/issues/15094

## How to Validate
- Enabled experimental agents with `"experimental": { "enableAgents": true }` in your settings.json
- Add 
```
kind = "remote"
name = "remote-tester"
description = "A remote testing agent (A2A)"
agent_card_url = "https://example.com/agent-card.json"
```
to .gemini/agents/remote-agent-example.toml
- run npm run start -- --debug and confirm `AgentRegistry] Registered remote agent 'remote-tester'...` appears in debug console

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
