### PR TITLE
fix(cli): correct migration map typo for loadMemoryFromIncludeDirectories

### DIFF
--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -371,6 +371,31 @@ describe('Settings Loading and Merging', () => {
       expect((settings.merged as TestSettings)['allowedTools']).toBeUndefined();
     });
 
+    it('should migrate loadMemoryFromIncludeDirectories to context.loadMemoryFromIncludeDirectories', () => {
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+      );
+      const legacySettingsContent = {
+        loadMemoryFromIncludeDirectories: true,
+      };
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(legacySettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged.context?.loadMemoryFromIncludeDirectories).toBe(
+        true,
+      );
+      expect(
+        (settings.merged as TestSettings)['loadMemoryFromIncludeDirectories'],
+      ).toBeUndefined();
+    });
+
     it('should allow V2 settings to override V1 settings when both are present (zombie setting fix)', () => {
       (mockFsExistsSync as Mock).mockImplementation(
         (p: fs.PathLike) => p === USER_SETTINGS_PATH,

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -112,7 +112,7 @@ const MIGRATION_MAP: Record<string, string> = {
   showCitations: 'ui.showCitations',
   ideMode: 'ide.enabled',
   includeDirectories: 'context.includeDirectories',
-  loadMemoryFromIncludeDirectories: 'context.loadFromIncludeDirectories',
+  loadMemoryFromIncludeDirectories: 'context.loadMemoryFromIncludeDirectories',
   maxSessionTurns: 'model.maxSessionTurns',
   mcpServers: 'mcpServers',
   mcpServerCommand: 'mcp.serverCommand',


### PR DESCRIPTION
## Summary
Fixes a typo in the `MIGRATION_MAP` that caused the V1 setting `loadMemoryFromIncludeDirectories` to be migrated to a non-existent V2 path.

## Problem
The migration mapped:
- `loadMemoryFromIncludeDirectories` → `context.loadFromIncludeDirectories` ❌

But the correct V2 schema key is:
- `context.loadMemoryFromIncludeDirectories` ✅

This caused the setting to be silently ignored, breaking GEMINI.md file discovery for users who had this enabled.

## Solution
- Fixed the typo in `MIGRATION_MAP` (line 115 of [settings.ts](cci:7://file:///home/ashwin/Projects/gemini-cli/packages/cli/src/config/settings.ts:0:0-0:0))
- Added a test case to prevent regression

Fixes #15069