### PR TITLE
fix(core): use debugLogger.debug for startup profiler logs

### DIFF
--- a/packages/core/src/telemetry/startupProfiler.test.ts
+++ b/packages/core/src/telemetry/startupProfiler.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { StartupProfiler } from './startupProfiler.js';
 import type { Config } from '../config/config.js';
+import { debugLogger } from '../utils/debugLogger.js';
 
 // Mock the metrics module
 vi.mock('./metrics.js', () => ({
@@ -254,6 +255,19 @@ describe('StartupProfiler', () => {
           }),
         }),
       );
+    });
+
+    it('should use debug logging instead of standard logging', () => {
+      const logSpy = vi.spyOn(debugLogger, 'log');
+      const debugSpy = vi.spyOn(debugLogger, 'debug');
+
+      const handle = profiler.start('test_phase');
+      handle?.end();
+
+      profiler.flush(mockConfig);
+
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(debugSpy).toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/telemetry/startupProfiler.ts
+++ b/packages/core/src/telemetry/startupProfiler.ts
@@ -145,7 +145,7 @@ export class StartupProfiler {
    * Flushes buffered metrics to the telemetry system.
    */
   flush(config: Config): void {
-    debugLogger.log(
+    debugLogger.debug(
       '[STARTUP] StartupProfiler.flush() called with',
       this.phases.size,
       'phases',
@@ -181,7 +181,7 @@ export class StartupProfiler {
           ...phase.details,
         };
 
-        debugLogger.log(
+        debugLogger.debug(
           '[STARTUP] Recording metric for phase:',
           phase.name,
           'duration:',
@@ -192,7 +192,7 @@ export class StartupProfiler {
           details,
         });
       } else {
-        debugLogger.log(
+        debugLogger.debug(
           '[STARTUP] Skipping phase without measure:',
           phase.name,
         );


### PR DESCRIPTION
Replaces debugLogger.log with debugLogger.debug in StartupProfiler to prevent startup metrics from cluttering stdout in non-debug modes. Includes a regression test.