### PR TITLE
Use `httpURL` for http based mcp servers

### DIFF
--- a/packages/cli/src/commands/mcp/add.test.ts
+++ b/packages/cli/src/commands/mcp/add.test.ts
@@ -131,8 +131,7 @@ describe('mcp add command', () => {
       'mcpServers',
       {
         'http-server': {
-          url: 'https://example.com/mcp',
-          type: 'http',
+          httpUrl: 'https://example.com/mcp',
           headers: { Authorization: 'Bearer your-token' },
         },
       },
@@ -163,8 +162,7 @@ describe('mcp add command', () => {
       'mcpServers',
       {
         'http-server': {
-          url: 'https://example.com/mcp',
-          type: 'http',
+          httpUrl: 'https://example.com/mcp',
           headers: { Authorization: 'Bearer your-token' },
         },
       },

--- a/packages/cli/src/commands/mcp/add.ts
+++ b/packages/cli/src/commands/mcp/add.ts
@@ -80,8 +80,7 @@ async function addMcpServer(
       break;
     case 'http':
       newServer = {
-        url: commandOrUrl,
-        type: 'http',
+        httpUrl: commandOrUrl,
         headers,
         timeout,
         trust,


### PR DESCRIPTION
## Summary

Fixes an issue where configuring an MCP with an HTTP transport would save an invalid `settings.json` file, causing errors on startup. This change corrects the field name from `url` to `httpUrl` and removes a redundant `type` key that also caused issues.

## Details

When an MCP endpoint with an `http` transport was configured, the settings were incorrectly written with a `url` key. The application expects this key to be `httpUrl`, and the mismatch resulted in a validation error, preventing Gemini CLI from running.

This PR aligns the settings file generation with the expected schema by renaming the field. Additionally, a superfluous `type` key was being added to the configuration, which has been removed to prevent further validation conflicts.

## Related Issues

Fixes #15450

## How to Validate

1.  Ensure there are no existing MCPs configured with an HTTP transport, or back up and remove your `~/.gemini/settings.json` file.
2.  Configure a new MCP endpoint that uses the `http` transport. For example:

```bash
gemini mcp add --transport http todoist-ai https://ai.todoist.net/mcp
```

3.  Inspect the `~/.gemini/settings.json` file.
4.  Verify that the configuration for `"todoist-ai"` contains an `httpUrl` key with the correct URL.
5.  Confirm that there is no `url` key or `type` key within that model's configuration block.
6.  Run a simple `gemini` command (e.g., `gemini -h`) and confirm it executes without any errors related to an invalid settings file.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
- [ ] Noted breaking changes (if any)
