### PR TITLE
ci: guard stale issue closer from running on forks

### DIFF
--- a/.github/workflows/gemini-scheduled-stale-issue-closer.yml
+++ b/.github/workflows/gemini-scheduled-stale-issue-closer.yml
@@ -21,6 +21,7 @@ defaults:
 
 jobs:
   close-stale-issues:
+    if: 'github.repository == ''google-gemini/gemini-cli'''
     runs-on: 'ubuntu-latest'
     permissions:
       issues: 'write'


### PR DESCRIPTION
Restricts the stale issue closer workflow to the main repository to prevent failures on forks.