### PR TITLE
ci: guard links workflow from running on forks

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -12,7 +12,8 @@ on:
 
 jobs:
   linkChecker:
-    if: github.repository == 'google-gemini/gemini-cli'
+    if: |-
+      ${{ github.repository == 'google-gemini/gemini-cli' }}
     runs-on: 'ubuntu-latest'
     steps:
       - uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   linkChecker:
+    if: github.repository == 'google-gemini/gemini-cli'
     runs-on: 'ubuntu-latest'
     steps:
       - uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5


### PR DESCRIPTION
Restricts the links checker workflow to the main repository to prevent failures on forks.