### PR TITLE
ci: guard nightly release workflow from running on forks

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   release:
-    if: 'github.repository == ''google-gemini/gemini-cli'''
+    if: "github.repository == 'google-gemini/gemini-cli'"
     environment: "${{ github.event.inputs.environment || 'prod' }}"
     runs-on: 'ubuntu-latest'
     permissions:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -31,6 +31,7 @@ on:
 
 jobs:
   release:
+    if: 'github.repository == ''google-gemini/gemini-cli'''
     environment: "${{ github.event.inputs.environment || 'prod' }}"
     runs-on: 'ubuntu-latest'
     permissions:


### PR DESCRIPTION
Restricts the nightly release workflow to the main repository to prevent failures on forks.