### PR TITLE
fix: add missing `type` field to MCPServerConfig

### DIFF
--- a/packages/cli/src/config/settings-validation.test.ts
+++ b/packages/cli/src/config/settings-validation.test.ts
@@ -219,7 +219,7 @@ describe('settings-validation', () => {
       }
     });
 
-    it('should validate mcpServers with type field for all transport types', () => {
+    it('should validate mcpServers with type field for SSE and HTTP transports', () => {
       const validSettings = {
         mcpServers: {
           'sse-server': {
@@ -230,10 +230,6 @@ describe('settings-validation', () => {
           'http-server': {
             url: 'https://example.com/mcp',
             type: 'http',
-          },
-          'stdio-server': {
-            command: '/usr/bin/mcp-server',
-            type: 'stdio',
           },
         },
       };
@@ -254,6 +250,23 @@ describe('settings-validation', () => {
 
       const result = validateSettings(invalidSettings);
       expect(result.success).toBe(false);
+    });
+
+    it('should validate mcpServers without type field', () => {
+      const validSettings = {
+        mcpServers: {
+          'stdio-server': {
+            command: '/usr/bin/mcp-server',
+            args: ['--port', '8080'],
+          },
+          'url-server': {
+            url: 'https://example.com/mcp',
+          },
+        },
+      };
+
+      const result = validateSettings(validSettings);
+      expect(result.success).toBe(true);
     });
 
     it('should validate complex nested customThemes configuration', () => {

--- a/packages/cli/src/config/settings-validation.test.ts
+++ b/packages/cli/src/config/settings-validation.test.ts
@@ -219,7 +219,7 @@ describe('settings-validation', () => {
       }
     });
 
-    it('should validate mcpServers with type field for SSE and HTTP transports', () => {
+    it('should validate mcpServers with type field for all transport types', () => {
       const validSettings = {
         mcpServers: {
           'sse-server': {
@@ -230,6 +230,10 @@ describe('settings-validation', () => {
           'http-server': {
             url: 'https://example.com/mcp',
             type: 'http',
+          },
+          'stdio-server': {
+            command: '/usr/bin/mcp-server',
+            type: 'stdio',
           },
         },
       };

--- a/packages/cli/src/config/settings-validation.test.ts
+++ b/packages/cli/src/config/settings-validation.test.ts
@@ -219,6 +219,43 @@ describe('settings-validation', () => {
       }
     });
 
+    it('should validate mcpServers with type field for all transport types', () => {
+      const validSettings = {
+        mcpServers: {
+          'sse-server': {
+            url: 'https://example.com/sse',
+            type: 'sse',
+            headers: { 'X-API-Key': 'key' },
+          },
+          'http-server': {
+            url: 'https://example.com/mcp',
+            type: 'http',
+          },
+          'stdio-server': {
+            command: '/usr/bin/mcp-server',
+            type: 'stdio',
+          },
+        },
+      };
+
+      const result = validateSettings(validSettings);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject invalid type values in mcpServers', () => {
+      const invalidSettings = {
+        mcpServers: {
+          'bad-server': {
+            url: 'https://example.com/mcp',
+            type: 'invalid-type',
+          },
+        },
+      };
+
+      const result = validateSettings(invalidSettings);
+      expect(result.success).toBe(false);
+    });
+
     it('should validate complex nested customThemes configuration', () => {
       const invalidSettings = {
         ui: {

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1723,8 +1723,8 @@ export const SETTINGS_SCHEMA_DEFINITIONS: Record<
       type: {
         type: 'string',
         description:
-          'Transport type. Use "stdio" for local command, "sse" for Server-Sent Events, or "http" for Streamable HTTP.',
-        enum: ['stdio', 'sse', 'http'],
+          'Transport type for URL-based transports. Use "sse" for Server-Sent Events or "http" for Streamable HTTP.',
+        enum: ['sse', 'http'],
       },
       timeout: {
         type: 'number',

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1723,8 +1723,8 @@ export const SETTINGS_SCHEMA_DEFINITIONS: Record<
       type: {
         type: 'string',
         description:
-          'Transport type for URL-based transports. Use "sse" for Server-Sent Events or "http" for Streamable HTTP.',
-        enum: ['sse', 'http'],
+          'Transport type. Use "stdio" for local command, "sse" for Server-Sent Events, or "http" for Streamable HTTP.',
+        enum: ['stdio', 'sse', 'http'],
       },
       timeout: {
         type: 'number',

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1662,7 +1662,8 @@ export const SETTINGS_SCHEMA_DEFINITIONS: Record<
       },
       url: {
         type: 'string',
-        description: 'SSE transport URL.',
+        description:
+          'URL for SSE or HTTP transport. Use with "type" field to specify transport type.',
       },
       httpUrl: {
         type: 'string',
@@ -1676,6 +1677,12 @@ export const SETTINGS_SCHEMA_DEFINITIONS: Record<
       tcp: {
         type: 'string',
         description: 'TCP address for websocket transport.',
+      },
+      type: {
+        type: 'string',
+        description:
+          'Transport type. Use "stdio" for local command, "sse" for Server-Sent Events, or "http" for Streamable HTTP.',
+        enum: ['stdio', 'sse', 'http'],
       },
       timeout: {
         type: 'number',

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1618,8 +1618,8 @@
         },
         "type": {
           "type": "string",
-          "description": "Transport type for URL-based transports. Use \"sse\" for Server-Sent Events or \"http\" for Streamable HTTP.",
-          "enum": ["sse", "http"]
+          "description": "Transport type. Use \"stdio\" for local command, \"sse\" for Server-Sent Events, or \"http\" for Streamable HTTP.",
+          "enum": ["stdio", "sse", "http"]
         },
         "timeout": {
           "type": "number",

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1618,8 +1618,8 @@
         },
         "type": {
           "type": "string",
-          "description": "Transport type. Use \"stdio\" for local command, \"sse\" for Server-Sent Events, or \"http\" for Streamable HTTP.",
-          "enum": ["stdio", "sse", "http"]
+          "description": "Transport type for URL-based transports. Use \"sse\" for Server-Sent Events or \"http\" for Streamable HTTP.",
+          "enum": ["sse", "http"]
         },
         "timeout": {
           "type": "number",

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1562,7 +1562,7 @@
         },
         "url": {
           "type": "string",
-          "description": "SSE transport URL."
+          "description": "URL for SSE or HTTP transport. Use with \"type\" field to specify transport type."
         },
         "httpUrl": {
           "type": "string",
@@ -1578,6 +1578,11 @@
         "tcp": {
           "type": "string",
           "description": "TCP address for websocket transport."
+        },
+        "type": {
+          "type": "string",
+          "description": "Transport type. Use \"stdio\" for local command, \"sse\" for Server-Sent Events, or \"http\" for Streamable HTTP.",
+          "enum": ["stdio", "sse", "http"]
         },
         "timeout": {
           "type": "number",


### PR DESCRIPTION
## Summary

Fix regression where `type` was added to `gemini mcp add` command but not `MCPServerConfig` causing startup to fail with servers added with `gemini mcp add` command.

- Adds missing `type` field to `MCPServerConfig` schema with enum values `['sse', 'http']`
- Updates `url` field description to clarify it works with SSE and HTTP transports
- Adds regression tests to validate MCP configs with the `type` field

## Details

The `gemini mcp add` command was updated to write a `type` field (e.g., `type: 'sse'` or `type: 'http'`) when adding remote MCP servers. 

However, the `MCPServerConfig` schema in `settingsSchema.ts` was not updated to include this field.

Since the schema uses `additionalProperties: false`, Zod validation rejects any unknown properties, causing startup failures:

```
Invalid configuration in /path/to/.gemini/settings.json:

Error in: mcpServers.sentry
    Unrecognized key(s) in object: 'type'
```

## Test plan

- [x] Added test that validates MCP configs with `type: 'sse'`, `type: 'http'`
- [x] Added test that rejects invalid type values

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

Fixes #15450
Fixes #15449

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
