### PR TITLE
Implements real-time hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ patch_output.log
 
 .genkit
 .gemini-clipboard/
+
+# CodeRhapsody internal files
+cr/

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -825,6 +825,12 @@ their corresponding top-level category object in your `settings.json` file.
   - **Default:** `false`
   - **Requires restart:** Yes
 
+- **`experimental.enableRealTimeHints`** (boolean):
+  - **Description:** Allows providing guidance to the model mid-execution
+    without interrupting the tool chain.
+  - **Default:** `false`
+  - **Requires restart:** Yes
+
 - **`experimental.codebaseInvestigatorSettings.enabled`** (boolean):
   - **Description:** Enable the Codebase Investigator agent.
   - **Default:** `true`

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -670,6 +670,7 @@ export async function loadCliConfig(
     extensionLoader: extensionManager,
     enableExtensionReloading: settings.experimental?.extensionReloading,
     enableAgents: settings.experimental?.enableAgents,
+    enableRealTimeHints: settings.experimental?.enableRealTimeHints,
     experimentalJitContext: settings.experimental?.jitContext,
     noBrowser: !!process.env['NO_BROWSER'],
     summarizeToolOutput: settings.model?.summarizeToolOutput,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1385,6 +1385,16 @@ const SETTINGS_SCHEMA = {
         description: 'Enable Just-In-Time (JIT) context loading.',
         showInDialog: false,
       },
+      enableRealTimeHints: {
+        type: 'boolean',
+        label: 'Enable Real-Time Hints',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: false,
+        description:
+          'Allows providing guidance to the model mid-execution without interrupting the tool chain.',
+        showInDialog: true,
+      },
       codebaseInvestigatorSettings: {
         type: 'object',
         label: 'Codebase Investigator Settings',

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -209,7 +209,7 @@ describe('useGeminiStream', () => {
       getGeminiClient: mockGetGeminiClient,
       getApprovalMode: () => ApprovalMode.DEFAULT,
       getUsageStatisticsEnabled: () => true,
-      getDebugMode: () => false,
+      getDebugMode: false,
       addHistory: vi.fn(),
       getSessionId() {
         return 'test-session-id';
@@ -220,8 +220,8 @@ describe('useGeminiStream', () => {
       getContentGeneratorConfig: vi
         .fn()
         .mockReturnValue(contentGeneratorConfig),
-      getUseSmartEdit: () => false,
-      isInteractive: () => false,
+      getUseSmartEdit: false,
+      isInteractive: false,
       getExperiments: () => {},
       isRealTimeHintsEnabled: vi.fn(() => true),
     } as unknown as Config;
@@ -2760,7 +2760,7 @@ describe('useGeminiStream', () => {
           () => {},
           80,
           24,
-          () => false,
+          false,
           mockPopAllMessages,
         ),
       );
@@ -2841,7 +2841,7 @@ describe('useGeminiStream', () => {
           () => {},
           80,
           24,
-          () => false,
+          false,
           mockPopAllMessages,
         ),
       );
@@ -2913,7 +2913,7 @@ describe('useGeminiStream', () => {
           () => {},
           80,
           24,
-          () => false,
+          false,
           mockPopAllMessages,
         ),
       );
@@ -2990,7 +2990,7 @@ describe('useGeminiStream', () => {
           () => {},
           80,
           24,
-          () => false,
+          false,
           mockPopAllMessages,
         ),
       );

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1208,7 +1208,7 @@ export const useGeminiStream = (
 
       // HINTS: Drain any queued messages as hints before sending tool responses
       // Messages typed while the system is busy become hints that influence the current turn
-      if (popAllMessages) {
+      if (config.isRealTimeHintsEnabled() && popAllMessages) {
         const queuedMessages = popAllMessages();
         if (queuedMessages) {
           // SANITIZATION: Only inject hints that are not commands
@@ -1265,6 +1265,7 @@ export const useGeminiStream = (
       addItem,
       popAllMessages,
       onDebugMessage,
+      config,
     ],
   );
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -335,6 +335,7 @@ export interface ConfigParameters {
   enableAgents?: boolean;
   experimentalJitContext?: boolean;
   onModelChange?: (model: string) => void;
+  enableRealTimeHints?: boolean;
 }
 
 export class Config {
@@ -461,6 +462,7 @@ export class Config {
   private readonly onModelChange: ((model: string) => void) | undefined;
 
   private readonly enableAgents: boolean;
+  private readonly enableRealTimeHints: boolean;
 
   private readonly experimentalJitContext: boolean;
   private contextManager?: ContextManager;
@@ -528,6 +530,7 @@ export class Config {
     this.model = params.model;
     this._activeModel = params.model;
     this.enableAgents = params.enableAgents ?? false;
+    this.enableRealTimeHints = params.enableRealTimeHints ?? false;
     this.experimentalJitContext = params.experimentalJitContext ?? false;
     this.modelAvailabilityService = new ModelAvailabilityService();
     this.previewFeatures = params.previewFeatures ?? undefined;
@@ -1347,6 +1350,10 @@ export class Config {
 
   isAgentsEnabled(): boolean {
     return this.enableAgents;
+  }
+
+  isRealTimeHintsEnabled(): boolean {
+    return this.enableRealTimeHints;
   }
 
   getNoBrowser(): boolean {

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -72,6 +72,7 @@ describe('Core System Prompt (prompts.ts)', () => {
       getAgentRegistry: vi.fn().mockReturnValue({
         getDirectoryContext: vi.fn().mockReturnValue('Mock Agent Directory'),
       }),
+      isRealTimeHintsEnabled: vi.fn().mockReturnValue(false),
     } as unknown as Config;
   });
 
@@ -153,6 +154,22 @@ describe('Core System Prompt (prompts.ts)', () => {
     expect(prompt).toMatchSnapshot(); // Use snapshot for base prompt structure
   });
 
+  it('should include real-time hints instructions when enabled', () => {
+    vi.mocked(mockConfig.isRealTimeHintsEnabled).mockReturnValue(true);
+    const prompt = getCoreSystemPrompt(mockConfig);
+    expect(prompt).toContain(
+      'You may receive real-time hints from the user while executing tools',
+    );
+  });
+
+  it('should not include real-time hints instructions when disabled', () => {
+    vi.mocked(mockConfig.isRealTimeHintsEnabled).mockReturnValue(false);
+    const prompt = getCoreSystemPrompt(mockConfig);
+    expect(prompt).not.toContain(
+      'You may receive real-time hints from the user while executing tools',
+    );
+  });
+
   it.each([
     [[CodebaseInvestigatorAgent.name], true],
     [[], false],
@@ -175,6 +192,7 @@ describe('Core System Prompt (prompts.ts)', () => {
         getAgentRegistry: vi.fn().mockReturnValue({
           getDirectoryContext: vi.fn().mockReturnValue('Mock Agent Directory'),
         }),
+        isRealTimeHintsEnabled: vi.fn().mockReturnValue(false),
       } as unknown as Config;
 
       const prompt = getCoreSystemPrompt(testConfig);

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -148,6 +148,11 @@ export function getCoreSystemPrompt(
 - ${interactiveMode ? `**Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If asked *how* to do something, explain first, don't just do it.` : `**Handle Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request.`}
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.${mandatesVariant}${
+        config.isRealTimeHintsEnabled()
+          ? `
+- **Real-Time Hints:** You may receive real-time hints from the user while executing tools; these are normal, helpful interventions to guide your work—incorporate them immediately.`
+          : ''
+      }${
         !interactiveMode
           ? `
   - **Continue the work** You are not to interact with the user. Do your best to complete the task at hand, using your best judgement and avoid asking user for any additional information.`

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1373,6 +1373,13 @@
           "default": false,
           "type": "boolean"
         },
+        "enableRealTimeHints": {
+          "title": "Enable Real-Time Hints",
+          "description": "Allows providing guidance to the model mid-execution without interrupting the tool chain.",
+          "markdownDescription": "Allows providing guidance to the model mid-execution without interrupting the tool chain.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
+          "default": false,
+          "type": "boolean"
+        },
         "codebaseInvestigatorSettings": {
           "title": "Codebase Investigator Settings",
           "description": "Configuration for Codebase Investigator.",


### PR DESCRIPTION
[Issue #14390](https://github.com/google-gemini/gemini-cli/issues/14390)

Implements real-time hints, a feature that allows users to provide guidance to the AI model mid-execution without interrupting the tool chain. When users type messages while tools are running or the model is thinking, those messages are captured and automatically injected into the conversation history as user messages before the model generates its next response.

This enables dynamic steering: users can provide clarifications, corrections, or new context in real-time, and the model incorporates this feedback into its ongoing work. The tool chain continues uninterrupted, but the model's behavior adapts based on the user's hints.

How it works:
1. User types message while model is busy (tool execution, thinking, etc.)
2. Message is queued instead of starting a new turn
3. When tools complete, queued messages are drained and injected as hints
4. Hints appear as user messages in the conversation history before the model's next response
5. Model sees hints and adjusts its behavior accordingly
6. Tool chain continues seamlessly with updated guidance

Key changes:
- geminiChat.ts: Add hint queue and automatic draining before tool responses
- client.ts: Expose addHint() API for hint submission
- AppContainer.tsx: Automatically convert user messages to hints when busy