### PR TITLE
do not persist the fallback model

### DIFF
--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
@@ -69,6 +69,7 @@ describe('useQuotaAndFallback', () => {
 
     setFallbackHandlerSpy = vi.spyOn(mockConfig, 'setFallbackModelHandler');
     vi.spyOn(mockConfig, 'setQuotaErrorOccurred');
+    vi.spyOn(mockConfig, 'setModel');
   });
 
   afterEach(() => {
@@ -162,6 +163,9 @@ describe('useQuotaAndFallback', () => {
         // The original promise from the handler should now resolve
         const intent = await promise!;
         expect(intent).toBe('retry_always');
+
+        // Verify setModel was called with isFallbackModel=true
+        expect(mockConfig.setModel).toHaveBeenCalledWith('gemini-flash', true);
 
         // The pending request should be cleared from the state
         expect(result.current.proQuotaRequest).toBeNull();
@@ -274,6 +278,9 @@ describe('useQuotaAndFallback', () => {
           const intent = await promise!;
           expect(intent).toBe('retry_always');
 
+          // Verify setModel was called with isFallbackModel=true
+          expect(mockConfig.setModel).toHaveBeenCalledWith('model-B', true);
+
           // The pending request should be cleared from the state
           expect(result.current.proQuotaRequest).toBeNull();
           expect(mockConfig.setQuotaErrorOccurred).toHaveBeenCalledWith(true);
@@ -328,6 +335,13 @@ To disable gemini-3-pro-preview, disable "Preview features" in /settings.`,
 
         const intent = await promise!;
         expect(intent).toBe('retry_always');
+
+        // Verify setModel was called with isFallbackModel=true
+        expect(mockConfig.setModel).toHaveBeenCalledWith(
+          'gemini-2.5-pro',
+          true,
+        );
+
         expect(result.current.proQuotaRequest).toBeNull();
       });
     });
@@ -410,6 +424,9 @@ To disable gemini-3-pro-preview, disable "Preview features" in /settings.`,
       const intent = await promise!;
       expect(intent).toBe('retry_always');
       expect(result.current.proQuotaRequest).toBeNull();
+
+      // Verify setModel was called with isFallbackModel=true
+      expect(mockConfig.setModel).toHaveBeenCalledWith('gemini-flash', true);
 
       // Check for the "Switched to fallback model" message
       expect(mockHistoryManager.addItem).toHaveBeenCalledTimes(1);

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -130,9 +130,9 @@ export function useQuotaAndFallback({
       isDialogPending.current = false; // Reset the flag here
 
       if (choice === 'retry_always') {
-        // Explicitly set the model to the fallback model to persist the user's choice.
+        // Set the model to the fallback model for the current session.
         // This ensures the Footer updates and future turns use this model.
-        // Passing true value ensures we do not persist the fallback model.
+        // The change is not persisted, so the original model is restored on restart.
         config.setModel(proQuotaRequest.fallbackModel, true);
 
         historyManager.addItem(

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -132,7 +132,8 @@ export function useQuotaAndFallback({
       if (choice === 'retry_always') {
         // Explicitly set the model to the fallback model to persist the user's choice.
         // This ensures the Footer updates and future turns use this model.
-        config.setModel(proQuotaRequest.fallbackModel);
+        // Passing true value ensures we do not persist the fallback model.
+        config.setModel(proQuotaRequest.fallbackModel, true);
 
         historyManager.addItem(
           {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1641,6 +1641,18 @@ describe('Config getHooks', () => {
 
       expect(onModelChange).toHaveBeenCalledWith(DEFAULT_GEMINI_MODEL);
     });
+
+    it('should NOT call onModelChange when a new model is set as a fallback', () => {
+      const onModelChange = vi.fn();
+      const config = new Config({
+        ...baseParams,
+        onModelChange,
+      });
+
+      config.setModel(DEFAULT_GEMINI_MODEL, true);
+
+      expect(onModelChange).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -876,13 +876,13 @@ export class Config {
     return this.model;
   }
 
-  setModel(newModel: string): void {
+  setModel(newModel: string, isFallbackModel: boolean = false): void {
     if (this.model !== newModel || this._activeModel !== newModel) {
       this.model = newModel;
       // When the user explicitly sets a model, that becomes the active model.
       this._activeModel = newModel;
       coreEvents.emitModelChanged(newModel);
-      if (this.onModelChange) {
+      if (this.onModelChange && !isFallbackModel) {
         this.onModelChange(newModel);
       }
     }


### PR DESCRIPTION
## Summary
Do not persist the fallback model.
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details
When falling back from Auto mode to a Flash model, the change should not persist in the settings. This ensures that when a user restarts, they continue in Auto mode rather than remaining on the fallback model.
<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
