### PR TITLE
chore: limit MCP resources display to 10 by default

### DIFF
--- a/packages/cli/src/ui/components/views/McpStatus.test.tsx
+++ b/packages/cli/src/ui/components/views/McpStatus.test.tsx
@@ -185,33 +185,17 @@ describe('McpStatus', () => {
     unmount();
   });
 
-  it('renders correctly with many resources (truncated)', () => {
+  it('truncates resources when exceeding limit', () => {
     const manyResources = Array.from({ length: 25 }, (_, i) => ({
       serverName: 'server-1',
       name: `resource-${i + 1}`,
       uri: `file:///tmp/resource-${i + 1}.txt`,
-      description: `Resource ${i + 1} description`,
     }));
 
     const { lastFrame, unmount } = render(
       <McpStatus {...baseProps} resources={manyResources} />,
     );
-    expect(lastFrame()).toMatchSnapshot();
     expect(lastFrame()).toContain('15 resources hidden');
-    unmount();
-  });
-
-  it('renders correctly with single hidden resource', () => {
-    const resources = Array.from({ length: 11 }, (_, i) => ({
-      serverName: 'server-1',
-      name: `resource-${i + 1}`,
-      uri: `file:///tmp/resource-${i + 1}.txt`,
-    }));
-
-    const { lastFrame, unmount } = render(
-      <McpStatus {...baseProps} resources={resources} />,
-    );
-    expect(lastFrame()).toContain('1 resource hidden');
     unmount();
   });
 });

--- a/packages/cli/src/ui/components/views/McpStatus.test.tsx
+++ b/packages/cli/src/ui/components/views/McpStatus.test.tsx
@@ -184,4 +184,34 @@ describe('McpStatus', () => {
     expect(lastFrame()).toMatchSnapshot();
     unmount();
   });
+
+  it('renders correctly with many resources (truncated)', () => {
+    const manyResources = Array.from({ length: 25 }, (_, i) => ({
+      serverName: 'server-1',
+      name: `resource-${i + 1}`,
+      uri: `file:///tmp/resource-${i + 1}.txt`,
+      description: `Resource ${i + 1} description`,
+    }));
+
+    const { lastFrame, unmount } = render(
+      <McpStatus {...baseProps} resources={manyResources} />,
+    );
+    expect(lastFrame()).toMatchSnapshot();
+    expect(lastFrame()).toContain('15 resources hidden');
+    unmount();
+  });
+
+  it('renders correctly with single hidden resource', () => {
+    const resources = Array.from({ length: 11 }, (_, i) => ({
+      serverName: 'server-1',
+      name: `resource-${i + 1}`,
+      uri: `file:///tmp/resource-${i + 1}.txt`,
+    }));
+
+    const { lastFrame, unmount } = render(
+      <McpStatus {...baseProps} resources={resources} />,
+    );
+    expect(lastFrame()).toContain('1 resource hidden');
+    unmount();
+  });
 });

--- a/packages/cli/src/ui/components/views/McpStatus.tsx
+++ b/packages/cli/src/ui/components/views/McpStatus.tsx
@@ -8,6 +8,7 @@ import type { MCPServerConfig } from '@google/gemini-cli-core';
 import { MCPServerStatus } from '@google/gemini-cli-core';
 import { Box, Text } from 'ink';
 import type React from 'react';
+import { MAX_MCP_RESOURCES_TO_SHOW } from '../../constants.js';
 import { theme } from '../../semantic-colors.js';
 import type {
   HistoryItemMcpStatus,
@@ -251,28 +252,40 @@ export const McpStatus: React.FC<McpStatusProps> = ({
             {serverResources.length > 0 && (
               <Box flexDirection="column" marginLeft={2}>
                 <Text color={theme.text.primary}>Resources:</Text>
-                {serverResources.map((resource, index) => {
-                  const label = resource.name || resource.uri || 'resource';
-                  return (
-                    <Box
-                      key={`${resource.serverName}-resource-${index}`}
-                      flexDirection="column"
-                    >
-                      <Text>
-                        - <Text color={theme.text.primary}>{label}</Text>
-                        {resource.uri ? ` (${resource.uri})` : ''}
-                        {resource.mimeType ? ` [${resource.mimeType}]` : ''}
-                      </Text>
-                      {showDescriptions && resource.description && (
-                        <Box marginLeft={2}>
-                          <Text color={theme.text.secondary}>
-                            {resource.description.trim()}
-                          </Text>
-                        </Box>
-                      )}
-                    </Box>
-                  );
-                })}
+                {serverResources
+                  .slice(0, MAX_MCP_RESOURCES_TO_SHOW)
+                  .map((resource, index) => {
+                    const label = resource.name || resource.uri || 'resource';
+                    return (
+                      <Box
+                        key={`${resource.serverName}-resource-${index}`}
+                        flexDirection="column"
+                      >
+                        <Text>
+                          - <Text color={theme.text.primary}>{label}</Text>
+                          {resource.uri ? ` (${resource.uri})` : ''}
+                          {resource.mimeType ? ` [${resource.mimeType}]` : ''}
+                        </Text>
+                        {showDescriptions && resource.description && (
+                          <Box marginLeft={2}>
+                            <Text color={theme.text.secondary}>
+                              {resource.description.trim()}
+                            </Text>
+                          </Box>
+                        )}
+                      </Box>
+                    );
+                  })}
+                {serverResources.length > MAX_MCP_RESOURCES_TO_SHOW && (
+                  <Text color={theme.text.secondary}>
+                    {'  '}...{' '}
+                    {serverResources.length - MAX_MCP_RESOURCES_TO_SHOW}{' '}
+                    {serverResources.length - MAX_MCP_RESOURCES_TO_SHOW === 1
+                      ? 'resource'
+                      : 'resources'}{' '}
+                    hidden
+                  </Text>
+                )}
               </Box>
             )}
           </Box>

--- a/packages/cli/src/ui/components/views/__snapshots__/McpStatus.test.tsx.snap
+++ b/packages/cli/src/ui/components/views/__snapshots__/McpStatus.test.tsx.snap
@@ -82,6 +82,39 @@ A test server
 "
 `;
 
+exports[`McpStatus > renders correctly with many resources (truncated) 1`] = `
+"Configured MCP servers:
+
+🟢 server-1 - Ready (1 tool, 25 resources)
+A test server
+  Tools:
+  - tool-1
+    A test tool
+  Resources:
+  - resource-1 (file:///tmp/resource-1.txt)
+    Resource 1 description
+  - resource-2 (file:///tmp/resource-2.txt)
+    Resource 2 description
+  - resource-3 (file:///tmp/resource-3.txt)
+    Resource 3 description
+  - resource-4 (file:///tmp/resource-4.txt)
+    Resource 4 description
+  - resource-5 (file:///tmp/resource-5.txt)
+    Resource 5 description
+  - resource-6 (file:///tmp/resource-6.txt)
+    Resource 6 description
+  - resource-7 (file:///tmp/resource-7.txt)
+    Resource 7 description
+  - resource-8 (file:///tmp/resource-8.txt)
+    Resource 8 description
+  - resource-9 (file:///tmp/resource-9.txt)
+    Resource 9 description
+  - resource-10 (file:///tmp/resource-10.txt)
+    Resource 10 description
+    ... 15 resources hidden
+"
+`;
+
 exports[`McpStatus > renders correctly with parametersJsonSchema 1`] = `
 "Configured MCP servers:
 

--- a/packages/cli/src/ui/components/views/__snapshots__/McpStatus.test.tsx.snap
+++ b/packages/cli/src/ui/components/views/__snapshots__/McpStatus.test.tsx.snap
@@ -82,39 +82,6 @@ A test server
 "
 `;
 
-exports[`McpStatus > renders correctly with many resources (truncated) 1`] = `
-"Configured MCP servers:
-
-🟢 server-1 - Ready (1 tool, 25 resources)
-A test server
-  Tools:
-  - tool-1
-    A test tool
-  Resources:
-  - resource-1 (file:///tmp/resource-1.txt)
-    Resource 1 description
-  - resource-2 (file:///tmp/resource-2.txt)
-    Resource 2 description
-  - resource-3 (file:///tmp/resource-3.txt)
-    Resource 3 description
-  - resource-4 (file:///tmp/resource-4.txt)
-    Resource 4 description
-  - resource-5 (file:///tmp/resource-5.txt)
-    Resource 5 description
-  - resource-6 (file:///tmp/resource-6.txt)
-    Resource 6 description
-  - resource-7 (file:///tmp/resource-7.txt)
-    Resource 7 description
-  - resource-8 (file:///tmp/resource-8.txt)
-    Resource 8 description
-  - resource-9 (file:///tmp/resource-9.txt)
-    Resource 9 description
-  - resource-10 (file:///tmp/resource-10.txt)
-    Resource 10 description
-    ... 15 resources hidden
-"
-`;
-
 exports[`McpStatus > renders correctly with parametersJsonSchema 1`] = `
 "Configured MCP servers:
 

--- a/packages/cli/src/ui/constants.ts
+++ b/packages/cli/src/ui/constants.ts
@@ -25,3 +25,6 @@ export const TOOL_STATUS = {
   CANCELED: '-',
   ERROR: 'x',
 } as const;
+
+// Maximum number of MCP resources to display per server before truncating
+export const MAX_MCP_RESOURCES_TO_SHOW = 10;


### PR DESCRIPTION
## Summary

Servers that have MCP resources can easily have hundreds of resources. (Wix MCP has 2000+)

- Limits MCP resources displayed per server to 10 in `/mcp list` output
- Shows "... X resources hidden" message when more resources exist
- Prevents overwhelming output when MCP servers have thousands of resources

<img width="1050" height="1200" alt="image" src="https://github.com/user-attachments/assets/581776d4-1e5a-4d2b-bf48-3a0f73d71001" />


## Details

Some MCP servers (e.g., file system servers) expose thousands of resources. When
running `/mcp list`, the command would display all resources, making the output
overwhelming and unusable.

This change adds a sensible default limit while still informing users about the
total number of resources available via the hidden count message.

## Test plan

- [x] Added test for many resources (25) - verifies only 10 shown and "15
      resources hidden" message appears
- [x] Verified existing McpStatus tests still pass


## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
