### PR TITLE
fix(core): Implement two-stage hook validation and improve error handling

### DIFF
--- a/packages/core/src/core/coreToolHookTriggers.test.ts
+++ b/packages/core/src/core/coreToolHookTriggers.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { executeToolWithHooks } from './coreToolHookTriggers.js';
+import { ToolErrorType } from '../tools/tool-error.js';
+import type { AnyToolInvocation } from '../tools/tools.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+import type { HookExecutionResponse } from '../confirmation-bus/types.js';
+
+describe('coreToolHookTriggers - Two-Stage Validation', () => {
+  const mockInvocation = {
+    params: {},
+    execute: vi.fn().mockResolvedValue({
+      llmContent: 'success',
+      returnDisplay: 'success',
+    }),
+  } as unknown as AnyToolInvocation;
+  const toolName = 'test-tool';
+  const signal = new AbortController().signal;
+  const messageBus = {
+    request: vi.fn(),
+  } as unknown as MessageBus;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('BeforeTool Stage 1: should return PERMISSION_DENIED when isBlockingDecision is true', async () => {
+    vi.mocked(messageBus.request).mockResolvedValue({
+      output: {
+        decision: 'block',
+        reason: 'Security violation',
+      },
+    } as unknown as HookExecutionResponse);
+
+    const result = await executeToolWithHooks(
+      mockInvocation,
+      toolName,
+      signal,
+      messageBus,
+      true,
+    );
+
+    expect(result.error?.type).toBe(ToolErrorType.PERMISSION_DENIED);
+    expect(result.llmContent).toContain('Policy Block: Security violation');
+  });
+
+  it('BeforeTool Stage 2: should return EXECUTION_FAILED when shouldStopExecution is true', async () => {
+    vi.mocked(messageBus.request).mockResolvedValue({
+      output: {
+        continue: false,
+        stopReason: 'Manual stop',
+      },
+    } as unknown as HookExecutionResponse);
+
+    const result = await executeToolWithHooks(
+      mockInvocation,
+      toolName,
+      signal,
+      messageBus,
+      true,
+    );
+
+    expect(result.error?.type).toBe(ToolErrorType.EXECUTION_FAILED);
+    expect(result.llmContent).toContain('Execution stopped: Manual stop');
+  });
+
+  it('AfterTool: should return EXECUTION_FAILED when shouldStopExecution is true', async () => {
+    // BeforeTool (allow)
+    vi.mocked(messageBus.request).mockResolvedValueOnce({
+      output: {},
+    } as unknown as HookExecutionResponse);
+    // AfterTool (stop)
+    vi.mocked(messageBus.request).mockResolvedValueOnce({
+      output: {
+        continue: false,
+        stopReason: 'Halt after execution',
+      },
+    } as unknown as HookExecutionResponse);
+
+    const result = await executeToolWithHooks(
+      mockInvocation,
+      toolName,
+      signal,
+      messageBus,
+      true,
+    );
+
+    expect(result.error?.type).toBe(ToolErrorType.EXECUTION_FAILED);
+    expect(result.llmContent).toContain(
+      'Execution stopped: Halt after execution',
+    );
+  });
+});

--- a/packages/core/src/core/coreToolHookTriggers.ts
+++ b/packages/core/src/core/coreToolHookTriggers.ts
@@ -268,28 +268,28 @@ export async function executeToolWithHooks(
       toolInput,
     );
 
-    // Check if hook blocked the tool execution
+    // Stage 1: Security/Policy Decision
     const blockingError = beforeOutput?.getBlockingError();
     if (blockingError?.blocked) {
       return {
-        llmContent: `Tool execution blocked: ${blockingError.reason}`,
-        returnDisplay: `Tool execution blocked: ${blockingError.reason}`,
+        llmContent: `Policy Block: ${blockingError.reason}`,
+        returnDisplay: `Policy Block: ${blockingError.reason}`,
         error: {
-          type: ToolErrorType.EXECUTION_FAILED,
+          type: ToolErrorType.PERMISSION_DENIED,
           message: blockingError.reason,
         },
       };
     }
 
-    // Check if hook requested to stop entire agent execution
+    // Stage 2: Workflow Lifecycle Control
     if (beforeOutput?.shouldStopExecution()) {
       const reason = beforeOutput.getEffectiveReason();
       return {
-        llmContent: `Agent execution stopped by hook: ${reason}`,
-        returnDisplay: `Agent execution stopped by hook: ${reason}`,
+        llmContent: `Execution stopped: ${reason}`,
+        returnDisplay: `Execution stopped: ${reason}`,
         error: {
           type: ToolErrorType.EXECUTION_FAILED,
-          message: `Agent execution stopped: ${reason}`,
+          message: `Execution stopped: ${reason}`,
         },
       };
     }
@@ -329,11 +329,11 @@ export async function executeToolWithHooks(
     if (afterOutput?.shouldStopExecution()) {
       const reason = afterOutput.getEffectiveReason();
       return {
-        llmContent: `Agent execution stopped by hook: ${reason}`,
-        returnDisplay: `Agent execution stopped by hook: ${reason}`,
+        llmContent: `Execution stopped: ${reason}`,
+        returnDisplay: `Execution stopped: ${reason}`,
         error: {
           type: ToolErrorType.EXECUTION_FAILED,
-          message: `Agent execution stopped: ${reason}`,
+          message: `Execution stopped: ${reason}`,
         },
       };
     }


### PR DESCRIPTION
## TLDR

Implemented a strict 'Two-Stage Validation Pattern' for hook responses (`BeforeAgent`, `AfterAgent`, `BeforeTool`, `AfterTool`, `BeforeModel`). This distinguishes between **Stage 1: Policy/Security Decisions** (`decision: 'block'`) and **Stage 2: Workflow Lifecycle Decisions** (`continue: false`).

## Dive Deeper

Previously, the distinction between blocking an action for security reasons and stopping a workflow for logic reasons was ambiguous. This PR unifies the behavior:
*   **Stage 1 (Decision)**: Checks `decision: 'block'`. If blocked, it returns a `PERMISSION_DENIED` error (for tools) or a `Policy Block` error (for agents). This signals to the LLM that the action was forbidden.
*   **Stage 2 (Continue)**: Checks `continue: false`. If false, it gracefully terminates the execution with an `EXECUTION_FAILED` (or 'Execution stopped') status, often with a 'stop reason'. This is for natural workflow endpoints.
*   **BeforeModel**: Updated to support 'synthetic responses' for blocked calls, allowing the hook to provide a canned refusal message instead of a network call.
*   **Tests**: Added comprehensive tests for all stages in `client.test.ts`, `geminiChat.test.ts`, and `coreToolHookTriggers.test.ts`.

## Reviewer Test Plan

1.  Configure a `BeforeTool` hook that returns `decision: 'block', reason: 'Unsafe'`. Verify that the tool call fails with `PERMISSION_DENIED` and the model receives 'Policy Block: Unsafe'.
2.  Configure a `BeforeTool` hook that returns `continue: false, stopReason: 'Done'`. Verify that the tool call fails with `EXECUTION_FAILED` and the model receives 'Execution stopped: Done'.
3.  Run `npm test packages/core/src/core/client.test.ts`
4.  Run `npm test packages/core/src/core/geminiChat.test.ts`
5.  Run `npm test packages/core/src/core/coreToolHookTriggers.test.ts`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

[#14718](https://github.com/google-gemini/gemini-cli/issues/14718)