### PR TITLE
feat(cli): Pop up dialog when turns exceed threshold

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -295,6 +295,11 @@ their corresponding top-level category object in your `settings.json` file.
     session. -1 means unlimited.
   - **Default:** `-1`
 
+- **`model.renewSessionTurnsThreshold`** (number):
+  - **Description:** Number of conversation turns after which to prompt the user
+    to start a new session or compress. Set to -1 to disable.
+  - **Default:** `-1`
+
 - **`model.summarizeToolOutput`** (object):
   - **Description:** Enables or disables summarization of tool output. Configure
     per-tool token budgets (for example {"run_shell_command": {"tokenBudget":

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -706,6 +706,8 @@ export async function loadCliConfig(
     // TODO: loading of hooks based on workspace trust
     enableHooks: settings.tools?.enableHooks ?? false,
     hooks: settings.hooks || {},
+    renewSessionTurnsThreshold:
+      settings.model?.renewSessionTurnsThreshold ?? -1,
     projectHooks: projectHooks || {},
     onModelChange: (model: string) => saveModelChange(loadedSettings, model),
   });

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -670,6 +670,16 @@ const SETTINGS_SCHEMA = {
           'Maximum number of user/model/tool turns to keep in a session. -1 means unlimited.',
         showInDialog: true,
       },
+      renewSessionTurnsThreshold: {
+        type: 'number',
+        label: 'Renew Session Turn Threshold',
+        category: 'Model',
+        requiresRestart: false,
+        default: -1,
+        description:
+          'Number of conversation turns after which to prompt the user to start a new session or compress. Set to -1 to disable.',
+        showInDialog: true,
+      },
       summarizeToolOutput: {
         type: 'object',
         label: 'Summarize Tool Output',

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -766,7 +766,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     handleApprovalModeChange,
     activePtyId,
     loopDetectionConfirmationRequest,
-    RenewSessionConfirmationRequest,
+    renewSessionConfirmationRequest,
     lastOutputTime,
   } = useGeminiStream(
     config.getGeminiClient(),
@@ -1383,7 +1383,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     !!customDialog ||
     confirmUpdateExtensionRequests.length > 0 ||
     !!loopDetectionConfirmationRequest ||
-    !!RenewSessionConfirmationRequest ||
+    !!renewSessionConfirmationRequest ||
     isThemeDialogOpen ||
     isSettingsDialogOpen ||
     isModelDialogOpen ||
@@ -1478,7 +1478,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       confirmationRequest,
       confirmUpdateExtensionRequests,
       loopDetectionConfirmationRequest,
-      RenewSessionConfirmationRequest,
+      renewSessionConfirmationRequest,
       geminiMdFileCount,
       streamingState,
       initError,
@@ -1634,7 +1634,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       bannerData,
       bannerVisible,
       config,
-      RenewSessionConfirmationRequest,
+      renewSessionConfirmationRequest,
     ],
   );
 

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -756,6 +756,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     handleApprovalModeChange,
     activePtyId,
     loopDetectionConfirmationRequest,
+    RenewSessionConfirmationRequest,
     lastOutputTime,
   } = useGeminiStream(
     config.getGeminiClient(),
@@ -1371,6 +1372,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     !!customDialog ||
     confirmUpdateExtensionRequests.length > 0 ||
     !!loopDetectionConfirmationRequest ||
+    !!RenewSessionConfirmationRequest ||
     isThemeDialogOpen ||
     isSettingsDialogOpen ||
     isModelDialogOpen ||
@@ -1465,6 +1467,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       confirmationRequest,
       confirmUpdateExtensionRequests,
       loopDetectionConfirmationRequest,
+      RenewSessionConfirmationRequest,
       geminiMdFileCount,
       streamingState,
       initError,
@@ -1620,6 +1623,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       bannerData,
       bannerVisible,
       config,
+      RenewSessionConfirmationRequest,
     ],
   );
 

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -98,6 +98,7 @@ import { useLoadingIndicator } from './hooks/useLoadingIndicator.js';
 import { useFolderTrust } from './hooks/useFolderTrust.js';
 import { useIdeTrustListener } from './hooks/useIdeTrustListener.js';
 import { type IdeIntegrationNudgeResult } from './IdeIntegrationNudge.js';
+import { clearCommand } from './commands/clearCommand.js';
 import { appEvents, AppEvent } from '../utils/events.js';
 import { type UpdateObject } from './utils/updateCheck.js';
 import { setUpdateHandler } from '../utils/handleAutoUpdate.js';
@@ -746,6 +747,15 @@ Logging in with Google... Restarting Gemini CLI to continue.
     }
   }, [pendingRestorePrompt, inputHistory, historyManager.history]);
 
+  // Function to execute the clear command directly, bypassing the slash command processor.
+  // This is used by the RenewSessionDialog to avoid potential infinite loops caused
+  // by state updates within the processor.
+  const executeClearCommand = useCallback(async () => {
+    if (clearCommand.action) {
+      await clearCommand.action(commandContext, '');
+    }
+  }, [commandContext]);
+
   const {
     streamingState,
     submitQuery,
@@ -777,6 +787,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     terminalWidth,
     terminalHeight,
     embeddedShellFocused,
+    executeClearCommand,
   );
 
   // Auto-accept indicator

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -7,6 +7,7 @@
 import { Box, Text } from 'ink';
 import { IdeIntegrationNudge } from '../IdeIntegrationNudge.js';
 import { LoopDetectionConfirmation } from './LoopDetectionConfirmation.js';
+import { RenewSessionDialog } from './RenewSessionDialog.js';
 import { FolderTrustDialog } from './FolderTrustDialog.js';
 import { ShellConfirmationDialog } from './ShellConfirmationDialog.js';
 import { ConsentPrompt } from './ConsentPrompt.js';
@@ -85,6 +86,16 @@ export const DialogManager = ({
   if (uiState.shellConfirmationRequest) {
     return (
       <ShellConfirmationDialog request={uiState.shellConfirmationRequest} />
+    );
+  }
+  if (uiState.RenewSessionConfirmationRequest) {
+    return (
+      <RenewSessionDialog
+        maxSessionTurns={
+          settings.merged.model?.renewSessionTurnsThreshold ?? -1
+        }
+        onComplete={uiState.RenewSessionConfirmationRequest.onComplete}
+      />
     );
   }
   if (uiState.loopDetectionConfirmationRequest) {

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -88,13 +88,14 @@ export const DialogManager = ({
       <ShellConfirmationDialog request={uiState.shellConfirmationRequest} />
     );
   }
-  if (uiState.RenewSessionConfirmationRequest) {
+  if (uiState.renewSessionConfirmationRequest) {
     return (
       <RenewSessionDialog
         maxSessionTurns={
           settings.merged.model?.renewSessionTurnsThreshold ?? -1
         }
-        onComplete={uiState.RenewSessionConfirmationRequest.onComplete}
+        reason={uiState.renewSessionConfirmationRequest.reason}
+        onComplete={uiState.renewSessionConfirmationRequest.onComplete}
       />
     );
   }

--- a/packages/cli/src/ui/components/RenewSessionDialog.tsx
+++ b/packages/cli/src/ui/components/RenewSessionDialog.tsx
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Box, Text } from 'ink';
+import type { RadioSelectItem } from './shared/RadioButtonSelect.js';
+import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
+import { useKeypress } from '../hooks/useKeypress.js';
+import { theme } from '../semantic-colors.js';
+import type { RenewSessionConfirmationResult } from '../types.js';
+
+interface RenewSessionDialogProps {
+  onComplete: (result: RenewSessionConfirmationResult) => void;
+  maxSessionTurns: number;
+}
+
+export function RenewSessionDialog({
+  onComplete,
+  maxSessionTurns,
+}: RenewSessionDialogProps) {
+  useKeypress(
+    (key) => {
+      if (key.name === 'escape') {
+        onComplete({
+          userSelection: 'compress_session',
+        });
+      }
+    },
+    { isActive: true },
+  );
+
+  const OPTIONS: Array<RadioSelectItem<RenewSessionConfirmationResult>> = [
+    {
+      label: 'Compress session',
+      value: {
+        userSelection: 'compress_session',
+      } as RenewSessionConfirmationResult,
+      key: 'compress_session',
+    },
+    {
+      label: 'Start a new session',
+      value: {
+        userSelection: 'new_session',
+      } as RenewSessionConfirmationResult,
+      key: 'new_session',
+    },
+  ];
+
+  return (
+    <Box width="100%" flexDirection="row">
+      <Box
+        flexDirection="column"
+        borderStyle="round"
+        borderColor={theme.status.warning}
+        flexGrow={1}
+        marginLeft={1}
+      >
+        <Box paddingX={1} paddingY={0} flexDirection="column">
+          <Box minHeight={1}>
+            <Box minWidth={3}>
+              <Text
+                color={theme.status.warning}
+                aria-label="Max turns reached:"
+              >
+                !
+              </Text>
+            </Box>
+            <Box>
+              <Text wrap="truncate-end">
+                <Text color={theme.text.primary} bold>
+                  Turn limit reached
+                </Text>{' '}
+                <Text color={theme.text.secondary}>
+                  (current threshold: {maxSessionTurns} turns)
+                </Text>
+              </Text>
+            </Box>
+          </Box>
+          <Box marginTop={1}>
+            <Box flexDirection="column">
+              <Text color={theme.text.secondary}>
+                You&apos;ve reached the configured maximum number of turns for
+                this session. Choose whether to compress the conversation or
+                start a new session.
+              </Text>
+              <Box marginTop={1}>
+                <RadioButtonSelect items={OPTIONS} onSelect={onComplete} />
+              </Box>
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/ui/components/RenewSessionDialog.tsx
+++ b/packages/cli/src/ui/components/RenewSessionDialog.tsx
@@ -14,11 +14,13 @@ import type { RenewSessionConfirmationResult } from '../types.js';
 interface RenewSessionDialogProps {
   onComplete: (result: RenewSessionConfirmationResult) => void;
   maxSessionTurns: number;
+  reason?: 'turn_limit' | 'topic_change';
 }
 
 export function RenewSessionDialog({
   onComplete,
   maxSessionTurns,
+  reason = 'turn_limit',
 }: RenewSessionDialogProps) {
   useKeypress(
     (key) => {
@@ -31,9 +33,13 @@ export function RenewSessionDialog({
     { isActive: true },
   );
 
+  const isTopicChange = reason === 'topic_change';
+
   const OPTIONS: Array<RadioSelectItem<RenewSessionConfirmationResult>> = [
     {
-      label: 'Compress session',
+      label: isTopicChange
+        ? 'Continue with current context'
+        : 'Compress session',
       value: {
         userSelection: 'compress_session',
       } as RenewSessionConfirmationResult,
@@ -70,20 +76,24 @@ export function RenewSessionDialog({
             <Box>
               <Text wrap="truncate-end">
                 <Text color={theme.text.primary} bold>
-                  Turn limit reached
+                  {isTopicChange
+                    ? 'Topic change detected'
+                    : 'Turn limit reached'}
                 </Text>{' '}
-                <Text color={theme.text.secondary}>
-                  (current threshold: {maxSessionTurns} turns)
-                </Text>
+                {reason === 'turn_limit' && (
+                  <Text color={theme.text.secondary}>
+                    (current threshold: {maxSessionTurns} turns)
+                  </Text>
+                )}
               </Text>
             </Box>
           </Box>
           <Box marginTop={1}>
             <Box flexDirection="column">
               <Text color={theme.text.secondary}>
-                You&apos;ve reached the configured maximum number of turns for
-                this session. Choose whether to compress the conversation or
-                start a new session.
+                {isTopicChange
+                  ? 'Your query appears to be about a new topic. Would you like to start a new session?'
+                  : "You've reached the configured maximum number of turns for this session. Choose whether to compress the conversation or start a new session."}
               </Text>
               <Box marginTop={1}>
                 <RadioButtonSelect items={OPTIONS} onSelect={onComplete} />

--- a/packages/cli/src/ui/components/RenewSessionDialog.tsx
+++ b/packages/cli/src/ui/components/RenewSessionDialog.tsx
@@ -22,29 +22,48 @@ export function RenewSessionDialog({
   maxSessionTurns,
   reason = 'turn_limit',
 }: RenewSessionDialogProps) {
+  const isTopicChange = reason === 'topic_change';
+
   useKeypress(
     (key) => {
       if (key.name === 'escape') {
         onComplete({
-          userSelection: 'compress_session',
+          userSelection: isTopicChange
+            ? 'continue_session'
+            : 'compress_session',
         });
       }
     },
     { isActive: true },
   );
 
-  const isTopicChange = reason === 'topic_change';
-
   const OPTIONS: Array<RadioSelectItem<RenewSessionConfirmationResult>> = [
-    {
-      label: isTopicChange
-        ? 'Continue with current context'
-        : 'Compress session',
-      value: {
-        userSelection: 'compress_session',
-      } as RenewSessionConfirmationResult,
-      key: 'compress_session',
-    },
+    ...(isTopicChange
+      ? [
+          {
+            label: 'Continue with current context',
+            value: {
+              userSelection: 'continue_session',
+            } as RenewSessionConfirmationResult,
+            key: 'continue_session',
+          },
+          {
+            label: 'Compress conversation',
+            value: {
+              userSelection: 'compress_session',
+            } as RenewSessionConfirmationResult,
+            key: 'compress_session',
+          },
+        ]
+      : [
+          {
+            label: 'Compress session',
+            value: {
+              userSelection: 'compress_session',
+            } as RenewSessionConfirmationResult,
+            key: 'compress_session',
+          },
+        ]),
     {
       label: 'Start a new session',
       value: {

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -12,6 +12,7 @@ import type {
   ShellConfirmationRequest,
   ConfirmationRequest,
   LoopDetectionConfirmationRequest,
+  RenewSessionConfirmationRequest,
   HistoryItemWithoutId,
   StreamingState,
 } from '../types.js';
@@ -71,6 +72,7 @@ export interface UIState {
   confirmationRequest: ConfirmationRequest | null;
   confirmUpdateExtensionRequests: ConfirmationRequest[];
   loopDetectionConfirmationRequest: LoopDetectionConfirmationRequest | null;
+  RenewSessionConfirmationRequest: RenewSessionConfirmationRequest | null;
   geminiMdFileCount: number;
   streamingState: StreamingState;
   initError: string | null;

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -72,7 +72,7 @@ export interface UIState {
   confirmationRequest: ConfirmationRequest | null;
   confirmUpdateExtensionRequests: ConfirmationRequest[];
   loopDetectionConfirmationRequest: LoopDetectionConfirmationRequest | null;
-  RenewSessionConfirmationRequest: RenewSessionConfirmationRequest | null;
+  renewSessionConfirmationRequest: RenewSessionConfirmationRequest | null;
   geminiMdFileCount: number;
   streamingState: StreamingState;
   initError: string | null;

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -207,6 +207,7 @@ describe('useGeminiStream', () => {
       getProjectRoot: vi.fn(() => '/test/dir'),
       getCheckpointingEnabled: vi.fn(() => false),
       getGeminiClient: mockGetGeminiClient,
+      getMaxSessionTurns: vi.fn(() => 10),
       getApprovalMode: () => ApprovalMode.DEFAULT,
       getUsageStatisticsEnabled: () => true,
       getDebugMode: () => false,
@@ -2703,6 +2704,47 @@ describe('useGeminiStream', () => {
       // Then verify loop detection confirmation request was set
       await waitFor(() => {
         expect(result.current.loopDetectionConfirmationRequest).not.toBeNull();
+      });
+    });
+
+    describe('Session Renewal halting', () => {
+      it('should stop processing stream after RenewSession event', async () => {
+        mockSendMessageStream.mockReturnValue(
+          (async function* () {
+            yield {
+              type: ServerGeminiEventType.Content,
+              value: 'Initial content',
+            };
+            yield {
+              type: ServerGeminiEventType.RenewSession,
+            };
+            yield {
+              type: ServerGeminiEventType.Content,
+              value: 'Should be ignored',
+            };
+          })(),
+        );
+
+        const { result } = renderHookWithDefaults();
+
+        await act(async () => {
+          await result.current.submitQuery('Test renew halt');
+        });
+
+        await waitFor(() => {
+          expect(mockAddItem).toHaveBeenCalledWith(
+            expect.objectContaining({ text: 'Initial content' }),
+            expect.any(Number),
+          );
+        });
+
+        // The second content event should NOT have triggered addItem
+        expect(mockAddItem).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            text: expect.stringContaining('Should be ignored'),
+          }),
+          expect.any(Number),
+        );
       });
     });
   });

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -98,6 +98,9 @@ export const useGeminiStream = (
   onDebugMessage: (message: string) => void,
   handleSlashCommand: (
     cmd: PartListUnion,
+    oneTimeShellAllowlist?: Set<string>,
+    overwriteConfirmed?: boolean,
+    addToHistory?: boolean,
   ) => Promise<SlashCommandProcessorResult | false>,
   shellModeActive: boolean,
   getPreferredEditor: () => EditorType | undefined,
@@ -110,6 +113,7 @@ export const useGeminiStream = (
   terminalWidth: number,
   terminalHeight: number,
   isShellFocused?: boolean,
+  executeClearCommand?: () => Promise<void>,
 ) => {
   const [initError, setInitError] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -218,6 +222,19 @@ export const useGeminiStream = (
         userSelection: 'compress_session' | 'new_session';
       }) => void;
     } | null>(null);
+
+  const renewSessionConfirmationRequestRef = useRef(
+    RenewSessionConfirmationRequest,
+  );
+
+  useEffect(() => {
+    renewSessionConfirmationRequestRef.current =
+      RenewSessionConfirmationRequest;
+  }, [RenewSessionConfirmationRequest]);
+
+  // Flag to prevent showing the dialog multiple times if
+  // the RenewSession event is triggered repeatedly
+  const hasShownRenewDialogRef = useRef(false);
 
   const handleSlashCommandRef = useRef(handleSlashCommand);
   useEffect(() => {
@@ -751,7 +768,11 @@ export const useGeminiStream = (
   );
 
   const handleRenewSessionEvent = useCallback((): void => {
-    if (RenewSessionConfirmationRequest) {
+    // Prevent showing the dialog multiple times
+    if (
+      renewSessionConfirmationRequestRef.current ||
+      hasShownRenewDialogRef.current
+    ) {
       return;
     }
 
@@ -761,23 +782,51 @@ export const useGeminiStream = (
     }
     geminiClient.resetSessionTurnCount();
 
+    // Mark that we've shown the dialog
+    hasShownRenewDialogRef.current = true;
+
     setRenewSessionConfirmationRequest({
       onComplete: (result: {
         userSelection: 'compress_session' | 'new_session';
       }) => {
-        setRenewSessionConfirmationRequest(null);
+        queueMicrotask(async () => {
+          cancelOngoingRequest();
 
-        if (result.userSelection === 'compress_session') {
-          void handleSlashCommandRef.current('/compress');
-        } else if (result.userSelection === 'new_session') {
-          void handleSlashCommandRef.current('/clear');
-        }
+          if (result.userSelection === 'compress_session') {
+            // For compress, close dialog first as it's a long running operation
+            // and not destructive to the DOM structure immediately.
+            setRenewSessionConfirmationRequest(null);
+            hasShownRenewDialogRef.current = false;
+
+            await handleSlashCommandRef.current(
+              '/compress',
+              undefined,
+              undefined,
+              false,
+            );
+          } else if (result.userSelection === 'new_session') {
+            // For clear, execute the command FIRST while the dialog is still open.
+            // This ensures the heavy DOM destruction (clearing history) happens
+            // in a separate render cycle from the Dialog unmounting.
+            if (executeClearCommand) {
+              await executeClearCommand();
+            }
+
+            // Close the dialog AFTER the clear is done and processed.
+            // A short delay ensures React processes the history clearing first.
+            setTimeout(() => {
+              setRenewSessionConfirmationRequest(null);
+              hasShownRenewDialogRef.current = false;
+            }, 50);
+          }
+        });
       },
     });
   }, [
     addItem,
+    cancelOngoingRequest,
+    executeClearCommand,
     geminiClient,
-    RenewSessionConfirmationRequest,
     pendingHistoryItemRef,
     setPendingHistoryItem,
   ]);

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -47,6 +47,7 @@ import type {
   HistoryItemToolGroup,
   SlashCommandProcessorResult,
   HistoryItemModel,
+  RenewSessionConfirmationResult,
 } from '../types.js';
 import { StreamingState, MessageType, ToolCallStatus } from '../types.js';
 import { isAtCommand, isSlashCommand } from '../utils/commandUtils.js';
@@ -119,6 +120,7 @@ export const useGeminiStream = (
   const abortControllerRef = useRef<AbortController | null>(null);
   const turnCancelledRef = useRef(false);
   const activeQueryIdRef = useRef<string | null>(null);
+  const lastUserQueryTextRef = useRef<string | null>(null);
   const [isResponding, setIsResponding] = useState<boolean>(false);
   const [thought, setThought] = useState<ThoughtSummary | null>(null);
   const [pendingHistoryItem, pendingHistoryItemRef, setPendingHistoryItem] =
@@ -216,21 +218,22 @@ export const useGeminiStream = (
     onComplete: (result: { userSelection: 'disable' | 'keep' }) => void;
   } | null>(null);
 
-  const [RenewSessionConfirmationRequest, setRenewSessionConfirmationRequest] =
+  const [renewSessionConfirmationRequest, setRenewSessionConfirmationRequest] =
     useState<{
       onComplete: (result: {
         userSelection: 'compress_session' | 'new_session';
       }) => void;
+      reason?: 'turn_limit' | 'topic_change';
     } | null>(null);
 
   const renewSessionConfirmationRequestRef = useRef(
-    RenewSessionConfirmationRequest,
+    renewSessionConfirmationRequest,
   );
 
   useEffect(() => {
     renewSessionConfirmationRequestRef.current =
-      RenewSessionConfirmationRequest;
-  }, [RenewSessionConfirmationRequest]);
+      renewSessionConfirmationRequest;
+  }, [renewSessionConfirmationRequest]);
 
   // Flag to prevent showing the dialog multiple times if
   // the RenewSession event is triggered repeatedly
@@ -808,6 +811,7 @@ export const useGeminiStream = (
             // For clear, execute the command FIRST while the dialog is still open.
             // This ensures the heavy DOM destruction (clearing history) happens
             // in a separate render cycle from the Dialog unmounting.
+            lastUserQueryTextRef.current = null;
             if (executeClearCommand) {
               await executeClearCommand();
             }
@@ -1031,7 +1035,73 @@ export const useGeminiStream = (
             }
 
             if (!options?.isContinuation) {
-              if (typeof queryToSend === 'string') {
+              if (
+                typeof queryToSend === 'string' &&
+                config.getApprovalMode() !== ApprovalMode.YOLO
+              ) {
+                // Topic Detection
+                debugLogger.log(
+                  `useGeminiStream: Topic Detection Check starting. lastUserQueryTextRef: "${lastUserQueryTextRef.current}", queryToSend: "${queryToSend}"`,
+                );
+                if (lastUserQueryTextRef.current) {
+                  debugLogger.log(
+                    'useGeminiStream: Calling TopicDetectionService...',
+                  );
+                  const { topic_changed, reasoning } = await geminiClient
+                    .getTopicDetectionService()
+                    .isTopicChanged(
+                      lastUserQueryTextRef.current,
+                      queryToSend,
+                      prompt_id!,
+                      abortSignal,
+                    );
+
+                  debugLogger.log(
+                    `useGeminiStream: Topic detection result: ${topic_changed} (${reasoning})`,
+                  );
+
+                  if (topic_changed) {
+                    debugLogger.log(
+                      'useGeminiStream: Topic change detected! Setting request state...',
+                    );
+                    const selection = await new Promise<
+                      RenewSessionConfirmationResult['userSelection']
+                    >((resolve) => {
+                      setRenewSessionConfirmationRequest({
+                        reason: 'topic_change',
+                        onComplete: (result) => {
+                          setRenewSessionConfirmationRequest(null);
+                          resolve(result.userSelection);
+                        },
+                      });
+                    });
+
+                    if (selection === 'new_session') {
+                      queueMicrotask(async () => {
+                        if (executeClearCommand) {
+                          await executeClearCommand();
+                        } else {
+                          await geminiClient.resetChat();
+                        }
+                        lastUserQueryTextRef.current = null;
+
+                        addItem(
+                          {
+                            type: MessageType.INFO,
+                            text: 'Topic change detected. Starting a new session.',
+                          },
+                          Date.now(),
+                        );
+
+                        // A short delay ensures React processes the history clearing first.
+                        setTimeout(() => {
+                          setRenewSessionConfirmationRequest(null);
+                        }, 50);
+                      });
+                    }
+                  }
+                }
+
                 // logging the text prompts only for now
                 const promptText = queryToSend;
                 logUserPrompt(
@@ -1046,6 +1116,9 @@ export const useGeminiStream = (
               }
               startNewPrompt();
               setThought(null); // Reset thought when starting a new prompt
+
+              lastUserQueryTextRef.current =
+                typeof queryToSend === 'string' ? queryToSend : null;
             }
 
             setIsResponding(true);
@@ -1158,6 +1231,7 @@ export const useGeminiStream = (
       config,
       startNewPrompt,
       getPromptCount,
+      executeClearCommand,
     ],
   );
 
@@ -1414,7 +1488,7 @@ export const useGeminiStream = (
     handleApprovalModeChange,
     activePtyId,
     loopDetectionConfirmationRequest,
-    RenewSessionConfirmationRequest,
+    renewSessionConfirmationRequest,
     lastOutputTime,
   };
 };

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -409,3 +409,11 @@ export interface ConfirmationRequest {
 export interface LoopDetectionConfirmationRequest {
   onComplete: (result: { userSelection: 'disable' | 'keep' }) => void;
 }
+
+export interface RenewSessionConfirmationResult {
+  userSelection: 'compress_session' | 'new_session';
+}
+
+export interface RenewSessionConfirmationRequest {
+  onComplete: (result: RenewSessionConfirmationResult) => void;
+}

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -41,6 +41,7 @@ export enum StreamingState {
 export enum GeminiEventType {
   Content = 'content',
   ToolCallRequest = 'tool_call_request',
+  RenewSession = 'renew_session',
   // Add other event types if the UI hook needs to handle them
 }
 
@@ -416,4 +417,5 @@ export interface RenewSessionConfirmationResult {
 
 export interface RenewSessionConfirmationRequest {
   onComplete: (result: RenewSessionConfirmationResult) => void;
+  reason?: 'turn_limit' | 'topic_change';
 }

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -412,7 +412,7 @@ export interface LoopDetectionConfirmationRequest {
 }
 
 export interface RenewSessionConfirmationResult {
-  userSelection: 'compress_session' | 'new_session';
+  userSelection: 'compress_session' | 'new_session' | 'continue_session';
 }
 
 export interface RenewSessionConfirmationRequest {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -276,6 +276,7 @@ export interface ConfigParameters {
   bugCommand?: BugCommandSettings;
   model: string;
   maxSessionTurns?: number;
+  renewSessionTurnsThreshold?: number;
   experimentalZedIntegration?: boolean;
   listSessions?: boolean;
   deleteSession?: string;
@@ -399,6 +400,7 @@ export class Config {
 
   private _activeModel: string;
   private readonly maxSessionTurns: number;
+  private readonly renewSessionTurnsThreshold: number;
   private readonly listSessions: boolean;
   private readonly deleteSession: string | undefined;
   private readonly listExtensions: boolean;
@@ -532,6 +534,7 @@ export class Config {
     this.modelAvailabilityService = new ModelAvailabilityService();
     this.previewFeatures = params.previewFeatures ?? undefined;
     this.maxSessionTurns = params.maxSessionTurns ?? -1;
+    this.renewSessionTurnsThreshold = params.renewSessionTurnsThreshold ?? -1;
     this.experimentalZedIntegration =
       params.experimentalZedIntegration ?? false;
     this.listSessions = params.listSessions ?? false;
@@ -914,6 +917,10 @@ export class Config {
 
   getMaxSessionTurns(): number {
     return this.maxSessionTurns;
+  }
+
+  getRenewSessionTurnsThreshold(): number {
+    return this.renewSessionTurnsThreshold;
   }
 
   setQuotaErrorOccurred(value: boolean): void {

--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -189,6 +189,10 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
       extends: 'gemini-2.5-flash-base',
       modelConfig: {},
     },
+    'topic-detection': {
+      extends: 'gemini-2.5-flash-base',
+      modelConfig: {},
+    },
     'chat-compression-3-pro': {
       modelConfig: {
         model: 'gemini-3-pro-preview',

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -217,6 +217,7 @@ describe('Gemini Client (client.ts)', () => {
       getWorkingDir: vi.fn().mockReturnValue('/test/dir'),
       getFileService: vi.fn().mockReturnValue(fileService),
       getMaxSessionTurns: vi.fn().mockReturnValue(0),
+      getRenewSessionTurnsThreshold: vi.fn().mockReturnValue(-1),
       getQuotaErrorOccurred: vi.fn().mockReturnValue(false),
       setQuotaErrorOccurred: vi.fn(),
       getNoBrowser: vi.fn().mockReturnValue(false),

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -32,6 +32,7 @@ import type {
 } from '../services/chatRecordingService.js';
 import type { ContentGenerator } from './contentGenerator.js';
 import { LoopDetectionService } from '../services/loopDetectionService.js';
+import { TopicDetectionService } from '../services/topicDetectionService.js';
 import { ChatCompressionService } from '../services/chatCompressionService.js';
 import { ideContextStore } from '../ide/ideContext.js';
 import {
@@ -67,6 +68,7 @@ export class GeminiClient {
   private sessionTurnCount = 0;
 
   private readonly loopDetector: LoopDetectionService;
+  private readonly topicDetector: TopicDetectionService;
   private readonly compressionService: ChatCompressionService;
   private lastPromptId: string;
   private currentSequenceModel: string | null = null;
@@ -81,6 +83,7 @@ export class GeminiClient {
 
   constructor(private readonly config: Config) {
     this.loopDetector = new LoopDetectionService(config);
+    this.topicDetector = new TopicDetectionService(config);
     this.compressionService = new ChatCompressionService();
     this.lastPromptId = this.config.getSessionId();
   }
@@ -158,6 +161,10 @@ export class GeminiClient {
 
   getLoopDetectionService(): LoopDetectionService {
     return this.loopDetector;
+  }
+
+  getTopicDetectionService(): TopicDetectionService {
+    return this.topicDetector;
   }
 
   getCurrentSequenceModel(): string | null {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -475,6 +475,7 @@ export class GeminiClient {
       this.config.getApprovalMode() !== ApprovalMode.YOLO
     ) {
       yield { type: GeminiEventType.RenewSession };
+      return new Turn(this.getChat(), prompt_id);
     }
 
     // Ensure turns never exceeds MAX_TURNS to prevent infinite loops

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -65,6 +65,7 @@ export enum GeminiEventType {
   ContextWindowWillOverflow = 'context_window_will_overflow',
   InvalidStream = 'invalid_stream',
   ModelInfo = 'model_info',
+  RenewSession = 'renew_session',
 }
 
 export type ServerGeminiRetryEvent = {
@@ -206,6 +207,10 @@ export type ServerGeminiCitationEvent = {
   value: string;
 };
 
+export type ServerGeminiRenewSessionEvent = {
+  type: GeminiEventType.RenewSession;
+};
+
 // The original union type, now composed of the individual types
 export type ServerGeminiStreamEvent =
   | ServerGeminiChatCompressedEvent
@@ -223,7 +228,8 @@ export type ServerGeminiStreamEvent =
   | ServerGeminiRetryEvent
   | ServerGeminiContextWindowWillOverflowEvent
   | ServerGeminiInvalidStreamEvent
-  | ServerGeminiModelInfoEvent;
+  | ServerGeminiModelInfoEvent
+  | ServerGeminiRenewSessionEvent;
 
 // A turn manages the agentic loop turn within the server context.
 export class Turn {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -92,6 +92,7 @@ export * from './services/chatRecordingService.js';
 export * from './services/fileSystemService.js';
 export * from './services/sessionSummaryUtils.js';
 export * from './services/contextManager.js';
+export * from './services/topicDetectionService.js';
 
 // Export IDE specific logic
 export * from './ide/ide-client.js';

--- a/packages/core/src/services/topicDetectionService.ts
+++ b/packages/core/src/services/topicDetectionService.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '../config/config.js';
+import { debugLogger } from '../utils/debugLogger.js';
+
+const TOPIC_DETECTION_SYSTEM_PROMPT = `You are an expert at analyzing conversation topics.
+Your task is to determine if the "Current Query" represents a significant shift in topic from the "Last Query".
+
+Rules:
+1. If the "Current Query" is a follow-up, clarification, or related to the same subject as the "Last Query", it is NOT a topic change.
+2. If the "Current Query" introduces a completely different subject, task, or domain that has no relation to the "Last Query", it IS a topic change.
+3. If you are unsure, but the topics seem unrelated, favor flagging it as not a topic change.
+
+Output format:
+You must respond with a JSON object:
+{
+  "topic_changed": boolean,
+  "reasoning": "brief explanation"
+}
+`;
+
+const TOPIC_DETECTION_SCHEMA = {
+  type: 'object',
+  properties: {
+    topic_changed: {
+      type: 'boolean',
+      description: 'Whether the topic has shifted significantly.',
+    },
+    reasoning: {
+      type: 'string',
+      description: 'Brief explanation for the decision.',
+    },
+  },
+  required: ['topic_changed', 'reasoning'],
+};
+
+export class TopicDetectionService {
+  constructor(private readonly config: Config) {}
+
+  async isTopicChanged(
+    lastQuery: string,
+    currentQuery: string,
+    promptId: string,
+    abortSignal?: AbortSignal,
+  ): Promise<{ topic_changed: boolean; reasoning: string }> {
+    if (!lastQuery || !currentQuery) {
+      return { topic_changed: false, reasoning: 'Empty query' };
+    }
+
+    try {
+      const prompt = `Last Query: "${lastQuery}"\n\nCurrent Query: "${currentQuery}"`;
+
+      debugLogger.log(
+        `TopicDetectionService: Checking topic change. lastQuery: "${lastQuery}", currentQuery: "${currentQuery}"`,
+      );
+
+      const result = await this.config.getBaseLlmClient().generateJson({
+        modelConfigKey: { model: 'topic-detection' },
+        contents: [{ role: 'user', parts: [{ text: prompt }] }],
+        schema: TOPIC_DETECTION_SCHEMA,
+        systemInstruction: TOPIC_DETECTION_SYSTEM_PROMPT,
+        abortSignal: abortSignal!,
+        promptId,
+        maxAttempts: 2,
+      });
+
+      if (result && typeof result['topic_changed'] === 'boolean') {
+        const topic_changed = result['topic_changed'];
+        const reasoning = (result['reasoning'] as string) || '';
+        debugLogger.log(
+          `Topic detection result: ${topic_changed} (${reasoning})`,
+        );
+        return { topic_changed, reasoning };
+      }
+    } catch (error) {
+      debugLogger.warn(`Error in TopicDetectionService: ${error}`);
+      return { topic_changed: false, reasoning: `Error: ${error}` };
+    }
+
+    return { topic_changed: false, reasoning: 'Unexpected result format' };
+  }
+}

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -413,6 +413,13 @@
           "default": -1,
           "type": "number"
         },
+        "renewSessionTurnsThreshold": {
+          "title": "Renew Session Turn Threshold",
+          "description": "Number of conversation turns after which to prompt the user to start a new session or compress. Set to -1 to disable.",
+          "markdownDescription": "Number of conversation turns after which to prompt the user to start a new session or compress. Set to -1 to disable.\n\n- Category: `Model`\n- Requires restart: `no`\n- Default: `-1`",
+          "default": -1,
+          "type": "number"
+        },
         "summarizeToolOutput": {
           "title": "Summarize Tool Output",
           "description": "Enables or disables summarization of tool output. Configure per-tool token budgets (for example {\"run_shell_command\": {\"tokenBudget\": 2000}}). Currently only the run_shell_command tool supports summarization.",


### PR DESCRIPTION
## Summary
If the session turns exceed threshold or detect a new topic, ask user to compress or start new session.
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details
Add new config variable renewSessionTurnsThreshold. 
If session turns exceed the threshold, pop up a dialog, let user choose to compress conversation  
or start a new session.

TODO: Add detection for user query, if the new query is in different topic to previous ones, then pop up a dialog  
to let user choose to compress conversation or start a new session.
<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
