### PR TITLE
fix(core): relax tool name validation to support unprefixed MCP tools

### DIFF
--- a/packages/core/src/agents/toml-loader.test.ts
+++ b/packages/core/src/agents/toml-loader.test.ts
@@ -107,7 +107,7 @@ describe('toml-loader', () => {
       const filePath = await writeAgentToml(`
         name = "test-agent"
         description = "A test agent"
-        tools = ["not-a-tool"]
+        tools = ["tool!"]
         [prompts]
         system_prompt = "You are a test agent."
       `);

--- a/packages/core/src/tools/tool-names.test.ts
+++ b/packages/core/src/tools/tool-names.test.ts
@@ -30,9 +30,14 @@ describe('tool-names', () => {
       expect(isValidToolName('my-server__my-tool')).toBe(true);
     });
 
+    it('should validate generic slug names (unprefixed tools)', () => {
+      expect(isValidToolName('search_for_files_codesearch')).toBe(true);
+      expect(isValidToolName('simple-tool-name')).toBe(true);
+      expect(isValidToolName('tool_with_underscores')).toBe(true);
+    });
+
     it('should reject invalid tool names', () => {
       expect(isValidToolName('')).toBe(false);
-      expect(isValidToolName('invalid-name')).toBe(false);
       expect(isValidToolName('server__')).toBe(false);
       expect(isValidToolName('__tool')).toBe(false);
       expect(isValidToolName('server__tool__extra')).toBe(false);

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -88,5 +88,7 @@ export function isValidToolName(
     return slugRegex.test(server) && slugRegex.test(tool);
   }
 
-  return false;
+  // Allow any valid slug to support unprefixed MCP tools or other dynamic tools
+  const slugRegex = /^[a-z0-9-_]+$/i;
+  return slugRegex.test(name);
 }


### PR DESCRIPTION
## Summary

Relaxes the tool name validation logic in [isValidToolName](cci:1://file:///usr/local/google/home/kevinramdass/github/gemini-cli/packages/core/src/tools/tool-names.ts:48:0-93:1) to accept any valid slug (alphanumeric with dashes/underscores). This fixes an issue where valid, unprefixed MCP tools were being rejected by the agent configuration validator.

## Details

Previously, [isValidToolName](cci:1://file:///usr/local/google/home/kevinramdass/github/gemini-cli/packages/core/src/tools/tool-names.ts:48:0-93:1) enforced a strict `namespace__tool` format for all non-built-in tools. However, the MCP runtime typically registers tools without a prefix by default (unless there is a name collision). This mismatch caused the static validator to reject valid tool names that the runtime was capable of executing, effectively blocking agents from using them.

This change aligns [isValidToolName](cci:1://file:///usr/local/google/home/kevinramdass/github/gemini-cli/packages/core/src/tools/tool-names.ts:48:0-93:1) with the runtime's behavior by allowing any tool name that matches the standard slug pattern `^[a-z0-9-_]+$/i`.

## Related Issues

<!-- N/A -->

## How to Validate

1.  Ensure you have an MCP extension installed that provides a tool.
2.  Create or modify an agent TOML file (e.g., `~/.gemini/agents/test.toml`) to include this tool using its simple, unprefixed name:
    ```toml
    tools = ["simple_tool_name"]
    ```
3.  Run the agent (restart of CLI may be required).
4.  **Expected:** The agent loads successfully. Previously, this would fail with a `Validation failed: tools.0: Invalid tool name` error.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker