### PR TITLE
Added modifyOtherKeys protocol support for tmux

### DIFF
--- a/packages/cli/src/ui/utils/terminalCapabilityManager.test.ts
+++ b/packages/cli/src/ui/utils/terminalCapabilityManager.test.ts
@@ -21,6 +21,8 @@ vi.mock('@google/gemini-cli-core', () => ({
   },
   enableKittyKeyboardProtocol: vi.fn(),
   disableKittyKeyboardProtocol: vi.fn(),
+  enableModifyOtherKeys: vi.fn(),
+  disableModifyOtherKeys: vi.fn(),
 }));
 
 describe('TerminalCapabilityManager', () => {
@@ -173,5 +175,93 @@ describe('TerminalCapabilityManager', () => {
 
     await promise;
     expect(manager.isKittyProtocolEnabled()).toBe(true);
+  });
+
+  describe('modifyOtherKeys detection', () => {
+    it('should detect modifyOtherKeys support (level 2)', async () => {
+      const manager = TerminalCapabilityManager.getInstance();
+      const promise = manager.detectCapabilities();
+
+      // Simulate modifyOtherKeys level 2 response: \x1b[>4;2m
+      stdin.emit('data', Buffer.from('\x1b[>4;2m'));
+      // Complete detection with DA1
+      stdin.emit('data', Buffer.from('\x1b[?62c'));
+
+      await promise;
+      expect(manager.isModifyOtherKeysEnabled()).toBe(true);
+    });
+
+    it('should not enable modifyOtherKeys for level 0', async () => {
+      const manager = TerminalCapabilityManager.getInstance();
+      const promise = manager.detectCapabilities();
+
+      // Simulate modifyOtherKeys level 0 response: \x1b[>4;0m
+      stdin.emit('data', Buffer.from('\x1b[>4;0m'));
+      // Complete detection with DA1
+      stdin.emit('data', Buffer.from('\x1b[?62c'));
+
+      await promise;
+      expect(manager.isModifyOtherKeysEnabled()).toBe(false);
+    });
+
+    it('should prefer Kitty over modifyOtherKeys', async () => {
+      const manager = TerminalCapabilityManager.getInstance();
+      const promise = manager.detectCapabilities();
+
+      // Simulate both Kitty and modifyOtherKeys responses
+      stdin.emit('data', Buffer.from('\x1b[?1u'));
+      stdin.emit('data', Buffer.from('\x1b[>4;2m'));
+      // Complete detection with DA1
+      stdin.emit('data', Buffer.from('\x1b[?62c'));
+
+      await promise;
+      expect(manager.isKittyProtocolEnabled()).toBe(true);
+      expect(manager.isModifyOtherKeysEnabled()).toBe(false);
+    });
+
+    it('should enable modifyOtherKeys when Kitty not supported', async () => {
+      const manager = TerminalCapabilityManager.getInstance();
+      const promise = manager.detectCapabilities();
+
+      // Simulate only modifyOtherKeys response (no Kitty)
+      stdin.emit('data', Buffer.from('\x1b[>4;2m'));
+      // Complete detection with DA1
+      stdin.emit('data', Buffer.from('\x1b[?62c'));
+
+      await promise;
+      expect(manager.isModifyOtherKeysEnabled()).toBe(true);
+      expect(manager.isKittyProtocolEnabled()).toBe(false);
+    });
+
+    it('should handle split modifyOtherKeys response chunks', async () => {
+      const manager = TerminalCapabilityManager.getInstance();
+      const promise = manager.detectCapabilities();
+
+      // Split response: \x1b[>4;2m
+      stdin.emit('data', Buffer.from('\x1b[>4;'));
+      stdin.emit('data', Buffer.from('2m'));
+      // Complete detection with DA1
+      stdin.emit('data', Buffer.from('\x1b[?62c'));
+
+      await promise;
+      expect(manager.isModifyOtherKeysEnabled()).toBe(true);
+    });
+
+    it('should detect modifyOtherKeys with other capabilities', async () => {
+      const manager = TerminalCapabilityManager.getInstance();
+      const promise = manager.detectCapabilities();
+
+      stdin.emit('data', Buffer.from('\x1b]11;rgb:1a1a/1a1a/1a1a\x1b\\')); // background color
+      stdin.emit('data', Buffer.from('\x1bP>|tmux\x1b\\')); // Terminal name
+      stdin.emit('data', Buffer.from('\x1b[>4;2m')); // modifyOtherKeys
+      // Complete detection with DA1
+      stdin.emit('data', Buffer.from('\x1b[?62c'));
+
+      await promise;
+
+      expect(manager.getTerminalBackgroundColor()).toBe('#1a1a1a');
+      expect(manager.getTerminalName()).toBe('tmux');
+      expect(manager.isModifyOtherKeysEnabled()).toBe(true);
+    });
   });
 });

--- a/packages/cli/src/ui/utils/terminalCapabilityManager.ts
+++ b/packages/cli/src/ui/utils/terminalCapabilityManager.ts
@@ -76,15 +76,6 @@ export class TerminalCapabilityManager {
     }
 
     return new Promise((resolve) => {
-      // tmux doesn't respond to modifyOtherKeys query, but supports it via extended-keys
-      // Check if we're in tmux and assume support immediately
-      if (process.env['TMUX']) {
-        this.modifyOtherKeysSupported = true;
-        debugLogger.log(
-          'Detected tmux environment, assuming modifyOtherKeys support',
-        );
-      }
-
       const originalRawMode = process.stdin.isRaw;
       if (!originalRawMode) {
         process.stdin.setRawMode(true);

--- a/packages/cli/src/ui/utils/terminalCapabilityManager.ts
+++ b/packages/cli/src/ui/utils/terminalCapabilityManager.ts
@@ -175,6 +175,7 @@ export class TerminalCapabilityManager {
           }
         }
 
+        // check for modifyOtherKeys support
         if (!modifyOtherKeysReceived) {
           const match = buffer.match(
             TerminalCapabilityManager.MODIFY_OTHER_KEYS_REGEX,

--- a/packages/core/src/utils/terminal.ts
+++ b/packages/core/src/utils/terminal.ts
@@ -26,6 +26,14 @@ export function disableKittyKeyboardProtocol() {
   writeToStdout('\x1b[<u');
 }
 
+export function enableModifyOtherKeys() {
+  writeToStdout('\x1b[>4;2m');
+}
+
+export function disableModifyOtherKeys() {
+  writeToStdout('\x1b[>4;0m');
+}
+
 export function enableLineWrapping() {
   writeToStdout('\x1b[?7h');
 }


### PR DESCRIPTION
@scidomino  Please have a look for the issue #15165 , if there are any changes required please let me know
## Summary

Add modifyOtherKeys protocol support to enable better keyboard handling in tmux sessions.

## Details

- Added [enableModifyOtherKeys()](cci:1://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/core/src/utils/terminal.ts:28:0-30:1) and [disableModifyOtherKeys()](cci:1://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/core/src/utils/terminal.ts:32:0-34:1) functions
- Terminal capability detection queries for modifyOtherKeys support (CSI > 4 ; ? m)
- Priority logic: Kitty protocol > modifyOtherKeys > standard input
- Added tests for modifyOtherKeys

**Note:** macOS Terminal.app doesn't send distinct sequences for Shift+Enter. Users can use Ctrl+J or Ctrl+Enter for multi-line input. For full Shift+Enter support, use iTerm2 with proper configuration.

## Related Issues

Fixes #15165

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

Collaborated with @ishaanxgupta