### PR TITLE
feat(core,cli): relocate clipboard images to project-specific temp dir 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,4 @@ gha-creds-*.json
 patch_output.log
 
 .genkit
-.gemini-clipboard/
+

--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,3 @@ gha-creds-*.json
 patch_output.log
 
 .genkit
-

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -24,7 +24,7 @@ import { useKeypress } from '../hooks/useKeypress.js';
 import { keyMatchers, Command } from '../keyMatchers.js';
 import type { CommandContext, SlashCommand } from '../commands/types.js';
 import type { Config } from '@google/gemini-cli-core';
-import { ApprovalMode } from '@google/gemini-cli-core';
+import { ApprovalMode, escapePath } from '@google/gemini-cli-core';
 import {
   parseInputForHighlighting,
   parseSegmentsFromTokens,
@@ -323,7 +323,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           });
 
           // Insert @path reference at cursor position
-          const insertText = `@${imagePath}`;
+          const insertText = `@${escapePath(imagePath)}`;
           const currentText = buffer.text;
           const offset = buffer.getOffset();
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -39,7 +39,6 @@ import {
   isAutoExecutableCommand,
   isSlashCommand,
 } from '../utils/commandUtils.js';
-import * as path from 'node:path';
 import { SCREEN_READER_USER_PREFIX } from '../textConstants.js';
 import { useShellFocusState } from '../contexts/ShellFocusContext.js';
 import { useUIState } from '../contexts/UIStateContext.js';
@@ -316,18 +315,15 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   const handleClipboardPaste = useCallback(async () => {
     try {
       if (await clipboardHasImage()) {
-        const imagePath = await saveClipboardImage(config.getTargetDir());
+        const imagePath = await saveClipboardImage(config.storage);
         if (imagePath) {
           // Clean up old images
-          cleanupOldClipboardImages(config.getTargetDir()).catch(() => {
+          cleanupOldClipboardImages(config.storage).catch(() => {
             // Ignore cleanup errors
           });
 
-          // Get relative path from current directory
-          const relativePath = path.relative(config.getTargetDir(), imagePath);
-
           // Insert @path reference at cursor position
-          const insertText = `@${relativePath}`;
+          const insertText = `@${imagePath}`;
           const currentText = buffer.text;
           const offset = buffer.getOffset();
 

--- a/packages/cli/src/ui/utils/clipboardUtils.test.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.test.ts
@@ -58,9 +58,8 @@ describe('clipboardUtils', () => {
       const result = await saveClipboardImage(mockStorage);
 
       if (process.platform === 'darwin' || process.platform === 'win32') {
-        // On macOS/Windows, we can't easily force failure here without more complex mocking,
-        // but we verify the call structure matches.
-        expect(true).toBe(true);
+        // On macOS/Windows, might return null due to various errors
+        expect(result === null || typeof result === 'string').toBe(true);
       } else {
         // On other platforms, should always return null
         expect(result).toBe(null);

--- a/packages/cli/src/ui/utils/clipboardUtils.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.ts
@@ -6,11 +6,13 @@
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import type {
+  Storage} from '@google/gemini-cli-core';
 import {
   debugLogger,
   spawnAsync,
   unescapePath,
-  escapePath,
+  escapePath
 } from '@google/gemini-cli-core';
 
 /**
@@ -70,17 +72,16 @@ export async function clipboardHasImage(): Promise<boolean> {
  * @returns The path to the saved image file, or null if no image or error
  */
 export async function saveClipboardImage(
-  targetDir?: string,
+  storage: Storage,
 ): Promise<string | null> {
   if (process.platform !== 'darwin' && process.platform !== 'win32') {
     return null;
   }
 
   try {
-    // Create a temporary directory for clipboard images within the target directory
-    // This avoids security restrictions on paths outside the target directory
-    const baseDir = targetDir || process.cwd();
-    const tempDir = path.join(baseDir, '.gemini-clipboard');
+    // Use the project-specific temporary directory for clipboard images.
+    // This ensures physical relocation and full compatibility with the WorkspaceContext.
+    const tempDir = storage.getProjectClipboardDir();
     await fs.mkdir(tempDir, { recursive: true });
 
     // Generate a unique filename with timestamp
@@ -187,11 +188,10 @@ export async function saveClipboardImage(
  * @param targetDir The target directory where temp files are stored
  */
 export async function cleanupOldClipboardImages(
-  targetDir?: string,
+  storage: Storage,
 ): Promise<void> {
   try {
-    const baseDir = targetDir || process.cwd();
-    const tempDir = path.join(baseDir, '.gemini-clipboard');
+    const tempDir = storage.getProjectClipboardDir();
     const files = await fs.readdir(tempDir);
     const oneHourAgo = Date.now() - 60 * 60 * 1000;
 

--- a/packages/cli/src/ui/utils/clipboardUtils.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.ts
@@ -6,13 +6,12 @@
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import type {
-  Storage} from '@google/gemini-cli-core';
+import type { Storage } from '@google/gemini-cli-core';
 import {
   debugLogger,
   spawnAsync,
   unescapePath,
-  escapePath
+  escapePath,
 } from '@google/gemini-cli-core';
 
 /**

--- a/packages/cli/src/ui/utils/clipboardUtils.windows.test.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.windows.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { Storage } from '@google/gemini-cli-core';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs/promises';
 import { saveClipboardImage } from './clipboardUtils.js';
@@ -48,7 +49,10 @@ describe('saveClipboardImage Windows Path Escaping', () => {
     } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
     const targetDir = "C:\\User's Files";
-    await saveClipboardImage(targetDir);
+    const mockStorage = {
+      getProjectClipboardDir: vi.fn().mockReturnValue(targetDir),
+    } as unknown as Storage;
+    await saveClipboardImage(mockStorage);
 
     expect(spawnAsync).toHaveBeenCalled();
     const args = vi.mocked(spawnAsync).mock.calls[0][1];

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -563,9 +563,10 @@ describe('Server Config (config.ts)', () => {
     const workspaceContext = config.getWorkspaceContext();
     const directories = workspaceContext.getDirectories();
 
-    // Should include only the target directory initially
-    expect(directories).toHaveLength(1);
+    // Should include both the target directory and the clipboard directory initially
+    expect(directories).toHaveLength(2);
     expect(directories).toContain(path.resolve(baseParams.targetDir));
+    expect(directories).toContain(config.storage.getProjectClipboardDir());
 
     // The other directories should be in the pending list
     expect(config.getPendingIncludeDirectories()).toEqual(includeDirectories);

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -474,7 +474,10 @@ export class Config {
     this.sandbox = params.sandbox;
     this.targetDir = path.resolve(params.targetDir);
     this.folderTrust = params.folderTrust ?? false;
-    this.workspaceContext = new WorkspaceContext(this.targetDir, []);
+    this.storage = new Storage(this.targetDir);
+    this.workspaceContext = new WorkspaceContext(this.targetDir, [
+      this.storage.getProjectClipboardDir(),
+    ]);
     this.pendingIncludeDirectories = params.includeDirectories ?? [];
     this.debugMode = params.debugMode;
     this.question = params.question;
@@ -606,7 +609,6 @@ export class Config {
       (params.shellToolInactivityTimeout ?? 300) * 1000; // 5 minutes
     this.extensionManagement = params.extensionManagement ?? true;
     this.enableExtensionReloading = params.enableExtensionReloading ?? false;
-    this.storage = new Storage(this.targetDir);
     this.fakeResponses = params.fakeResponses;
     this.recordResponses = params.recordResponses;
     this.enablePromptCompletion = params.enablePromptCompletion ?? false;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { inspect } from 'node:util';
 import process from 'node:process';
@@ -475,6 +476,10 @@ export class Config {
     this.targetDir = path.resolve(params.targetDir);
     this.folderTrust = params.folderTrust ?? false;
     this.storage = new Storage(this.targetDir);
+    // Guarantee the clipboard directory exists so WorkspaceContext includes it.
+    // This is necessary because WorkspaceContext skips directories that don't exist,
+    // which would cause the directory to not be mounted in macOS sandbox on first run.
+    fs.mkdirSync(this.storage.getProjectClipboardDir(), { recursive: true });
     this.workspaceContext = new WorkspaceContext(this.targetDir, [
       this.storage.getProjectClipboardDir(),
     ]);

--- a/packages/core/src/config/storage.test.ts
+++ b/packages/core/src/config/storage.test.ts
@@ -68,4 +68,12 @@ describe('Storage – additional helpers', () => {
     const expected = path.join(os.homedir(), GEMINI_DIR, 'tmp', 'bin');
     expect(Storage.getGlobalBinDir()).toBe(expected);
   });
+
+  it('getProjectClipboardDir returns project-specific temp clipboard path', () => {
+    const tempDir = path.join(os.homedir(), GEMINI_DIR, 'tmp');
+    // The hash is derived from projectRoot
+    const hash = storage['getFilePathHash'](projectRoot);
+    const expected = path.join(tempDir, hash, 'clipboard');
+    expect(storage.getProjectClipboardDir()).toBe(expected);
+  });
 });

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -135,6 +135,10 @@ export class Storage {
     return path.join(this.getProjectTempDir(), 'checkpoints');
   }
 
+  getProjectClipboardDir(): string {
+    return path.join(this.getProjectTempDir(), 'clipboard');
+  }
+
   getExtensionsDir(): string {
     return path.join(this.getGeminiDir(), 'extensions');
   }


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

Currently pasting images creates a temporary directory inside the project which requires users to add that path to .gitignore
This PR has the temporary directory live inside `~/.gemini/tmp/${project_hash}/`

It treats that path as valid in the workspace 
## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

By deliberately adding this path as part of the "workspace" it should work as intended including for all sandbox modes

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

Fixes #15453

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
