### PR TITLE
feat:Add ~/.gemini/system.md fallback for GEMINI_SYSTEM_MD=1|true

### DIFF
--- a/docs/cli/system-prompt.md
+++ b/docs/cli/system-prompt.md
@@ -27,7 +27,7 @@ via a `.gemini/.env` file. See
 - Use the project default path (`.gemini/system.md`):
   - `GEMINI_SYSTEM_MD=true` or `GEMINI_SYSTEM_MD=1`
   - The CLI reads `./.gemini/system.md` (relative to your current project
-    directory).
+    directory). If it does not exist, it falls back to `~/.gemini/system.md`.
 
 - Use a custom file path:
   - `GEMINI_SYSTEM_MD=/absolute/path/to/my-system.md`
@@ -85,7 +85,8 @@ GEMINI.md focused on high‑level guidance and project specifics.
 
 - Error: `missing system prompt file '…'`
   - Ensure the referenced path exists and is readable.
-  - For `GEMINI_SYSTEM_MD=1|true`, create `./.gemini/system.md` in your project.
+  - For `GEMINI_SYSTEM_MD=1|true`, create `./.gemini/system.md` in your project
+    or `~/.gemini/system.md` in your home directory.
 - Override not taking effect
   - Confirm the variable is loaded (use `.gemini/.env` or export in your shell).
   - Paths are resolved from the current working directory; try an absolute path.

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -1222,7 +1222,8 @@ the `advanced.excludedEnvVars` setting in your `settings.json` file.
   - Accepts `true`, `false`, `docker`, `podman`, or a custom command string.
 - **`GEMINI_SYSTEM_MD`**:
   - Replaces the built‑in system prompt with content from a Markdown file.
-  - `true`/`1`: Use project default path `./.gemini/system.md`.
+  - `true`/`1`: Use project default path `./.gemini/system.md`; if missing, fall
+    back to `~/.gemini/system.md`.
   - Any other string: Treat as a path (relative/absolute supported, `~`
     expands).
   - `false`/`0` or unset: Use the built‑in prompt. See


### PR DESCRIPTION
## Summary

This PR allows setting GEMINI_SYSTEM_MD=1 or true so that when .gemini/system.md does not exist in the project root, the system will fall back to $HOME/.gemini/system.md.

## Details

Although GEMINI_SYSTEM_MD can be used to specify an explicit path, once a path is set, .gemini/system.md inside certain repositories will no longer take effect, which is inconvenient for our team.

What we want instead is:
	- Use .gemini/system.md if it exists in the project
	- Otherwise, fall back to $HOME/.gemini/system.md
	- 
This allows our team to keep a consistent global setup while still easily enabling repository-specific .gemini/system.md files when needed.
The behavior is intuitive and provides good flexibility.

## Related Issues

#15549 

## How to Validate

Run test at `packages/core/src/core/prompts.test.ts`

#### Use .gemini/system.md in the project directory.
```
(base) wangboxue@wangboxuedeMacBook-Air gemini-cli % echo 'YOU ANSWER "I am just a robot" NO MATTER WHAT USER ASK.' >> .gemini/system.md
(base) wangboxue@wangboxuedeMacBook-Air gemini-cli % GEMINI_SYSTEM_MD=1 npm start
```
<img width="2286" height="1110" alt="gemini_feature_p1" src="https://github.com/user-attachments/assets/9ae766cd-4c65-4641-9b9a-78266f312992" />

#### Use ~/.gemini/system.md
```
(base) wangboxue@wangboxuedeMacBook-Air gemini-cli % rm .gemini/system.md                                                               
(base) wangboxue@wangboxuedeMacBook-Air gemini-cli % echo 'YOU ANSWER "I am just a human" NO MATTER WHAT USER ASK.' >> ~/.gemini/system.md
(base) wangboxue@wangboxuedeMacBook-Air gemini-cli % GEMINI_SYSTEM_MD=1 npm start
```
<img width="2294" height="1254" alt="gemini_f_p2" src="https://github.com/user-attachments/assets/d9c90f6a-b4ef-41b8-becc-3db949095df9" />

#### Prefer .gemini/system.md in the project directory even when ~/.gemini/system.md exists.
```
(base) wangboxue@wangboxuedeMacBook-Air gemini-cli % echo 'YOU ANSWER "I am just a human" NO MATTER WHAT USER ASK.' >> ~/.gemini/system.md
(base) wangboxue@wangboxuedeMacBook-Air gemini-cli % echo 'YOU ANSWER "I am just a robot" NO MATTER WHAT USER ASK.' >> .gemini/system.md 
```
<img width="2222" height="992" alt="gemini_f_p3" src="https://github.com/user-attachments/assets/9431ac32-458b-4d4f-bfb4-c741366dd69b" />


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [  ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
