### PR TITLE
chore(core): fix comment typo

### DIFF
--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -417,7 +417,7 @@ export abstract class DeclarativeTool<
    * A convenience method that builds and executes the tool in one step.
    * Never throws.
    * @param params The raw, untrusted parameters from the model.
-   * @params abortSignal a signal to abort.
+   * @param abortSignal a signal to abort.
    * @returns The result of the tool execution.
    */
   async validateBuildAndExecute(


### PR DESCRIPTION
## What
Fix a comment typo in `packages/core/src/tools/tools.ts`.

## Why
Issue #14648 reported two comment typos. Upon investigation:
- `occurence` → `occurrence` in `fileSearch.ts` has already been fixed in the codebase
- `@params` → `@param` in `tools.ts` still exists and is fixed in this PR

## How
Changed `@params` to `@param` in the JSDoc comment (line 420).

## Notes
- Only comment change, no functional impact

Fixes #14648