### PR TITLE
fix(cli): add enableShellOutputEfficiency to settings schema

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -621,6 +621,11 @@ their corresponding top-level category object in your `settings.json` file.
     shell command. Defaults to 5 minutes.
   - **Default:** `300`
 
+- **`tools.shell.enableShellOutputEfficiency`** (boolean):
+  - **Description:** Enable shell output efficiency optimizations for better
+    performance.
+  - **Default:** `true`
+
 - **`tools.autoAccept`** (boolean):
   - **Description:** Automatically accept and execute tool calls that are
     considered safe (e.g., read-only operations).

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -683,7 +683,7 @@ export async function loadCliConfig(
       settings.tools?.shell?.enableInteractiveShell ?? true,
     shellToolInactivityTimeout: settings.tools?.shell?.inactivityTimeout,
     enableShellOutputEfficiency:
-      settings.tools?.shell?.enableShellOutputEfficiency,
+      settings.tools?.shell?.enableShellOutputEfficiency ?? true,
     skipNextSpeakerCheck: settings.model?.skipNextSpeakerCheck,
     enablePromptCompletion: settings.general?.enablePromptCompletion ?? false,
     truncateToolOutputThreshold: settings.tools?.truncateToolOutputThreshold,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -682,6 +682,8 @@ export async function loadCliConfig(
     enableInteractiveShell:
       settings.tools?.shell?.enableInteractiveShell ?? true,
     shellToolInactivityTimeout: settings.tools?.shell?.inactivityTimeout,
+    enableShellOutputEfficiency:
+      settings.tools?.shell?.enableShellOutputEfficiency,
     skipNextSpeakerCheck: settings.model?.skipNextSpeakerCheck,
     enablePromptCompletion: settings.general?.enablePromptCompletion ?? false,
     truncateToolOutputThreshold: settings.tools?.truncateToolOutputThreshold,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -953,6 +953,16 @@ const SETTINGS_SCHEMA = {
               'The maximum time in seconds allowed without output from the shell command. Defaults to 5 minutes.',
             showInDialog: false,
           },
+          enableShellOutputEfficiency: {
+            type: 'boolean',
+            label: 'Enable Shell Output Efficiency',
+            category: 'Tools',
+            requiresRestart: false,
+            default: true,
+            description:
+              'Enable shell output efficiency optimizations for better performance.',
+            showInDialog: false,
+          },
         },
       },
       autoAccept: {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1043,6 +1043,13 @@
               "markdownDescription": "The maximum time in seconds allowed without output from the shell command. Defaults to 5 minutes.\n\n- Category: `Tools`\n- Requires restart: `no`\n- Default: `300`",
               "default": 300,
               "type": "number"
+            },
+            "enableShellOutputEfficiency": {
+              "title": "Enable Shell Output Efficiency",
+              "description": "Enable shell output efficiency optimizations for better performance.",
+              "markdownDescription": "Enable shell output efficiency optimizations for better performance.\n\n- Category: `Tools`\n- Requires restart: `no`\n- Default: `true`",
+              "default": true,
+              "type": "boolean"
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
## What
Add `enableShellOutputEfficiency` setting to the settings schema so users can configure it via settings file.

## Why
Fixes #12546

The `enableShellOutputEfficiency` option was introduced in PR #10651 but was not added to the settings schema. This means users cannot configure this setting through their settings file - it can only be controlled programmatically.

## How
1. Added `enableShellOutputEfficiency` boolean setting to `tools.shell` section in `settingsSchema.ts`
2. Added mapping in `cli/src/config/config.ts` to pass the setting value to `ConfigParameters`

## Notes
- Default value is `true` to maintain existing behavior
- The setting is under `tools.shell.enableShellOutputEfficiency` to be consistent with other shell-related settings
- `npm run preflight` completed successfully (exit code 0)