### PR TITLE
feat(cli): Add Interactive Hooks Configuration Wizard

### DIFF
--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -497,6 +497,49 @@ This command displays:
 - Hook type (command or plugin)
 - Execution status and recent output
 
+### Add a new hook
+
+You can add a new hook using an interactive wizard that guides you through the
+configuration process:
+
+**In interactive mode:**
+
+```bash
+/hooks add
+```
+
+**As a CLI command:**
+
+```bash
+gemini hooks add
+```
+
+The wizard will guide you through four steps:
+
+1. **Select Hook Event**: Choose when the hook should execute (e.g.,
+   `BeforeTool`, `AfterTool`, `BeforeAgent`). All available events are listed
+   with descriptions.
+
+2. **Configure Matcher** (optional): Specify a pattern to match specific tools
+   or contexts:
+   - **Exact match**: `read_file` matches only the `read_file` tool
+   - **Regex pattern**: `/read_.*/` matches tools starting with `read_`
+   - **Wildcard**: `*` or leave empty to match all tools
+
+3. **Enter Hook Details**:
+   - **Command** (required): Path to your script or executable command
+   - **Name** (optional): Unique identifier for enable/disable commands
+   - **Description** (optional): Human-readable description
+   - **Timeout** (optional): Maximum execution time in milliseconds (default:
+     60000ms, max: 300000ms)
+
+4. **Review and Save**: Review your configuration and save it to
+   `.gemini/settings.json`, or go back to edit any step.
+
+The wizard includes validation for all inputs and provides clear error messages
+if any field is invalid. You can navigate between steps using keyboard shortcuts
+(Tab, Enter, Esc) and cancel at any time.
+
 ### Enable and disable hooks
 
 You can temporarily enable or disable individual hooks using commands:

--- a/docs/hooks/writing-hooks.md
+++ b/docs/hooks/writing-hooks.md
@@ -43,7 +43,29 @@ chmod +x .gemini/hooks/log-tools.sh
 
 ### Step 2: Configure the hook
 
-Add the hook configuration to `.gemini/settings.json`:
+You can add the hook configuration in two ways:
+
+**Option 1: Use the interactive wizard (recommended)**
+
+Run the interactive wizard to add your hook:
+
+```bash
+/hooks add
+```
+
+Or as a CLI command:
+
+```bash
+gemini hooks add
+```
+
+The wizard will guide you through selecting the event, configuring the matcher,
+and entering hook details. See
+[Managing hooks](../hooks/index.md#managing-hooks) for more details.
+
+**Option 2: Manually edit settings**
+
+Alternatively, add the hook configuration directly to `.gemini/settings.json`:
 
 ```json
 {

--- a/packages/cli/src/commands/hooks.tsx
+++ b/packages/cli/src/commands/hooks.tsx
@@ -6,6 +6,7 @@
 
 import type { CommandModule } from 'yargs';
 import { migrateCommand } from './hooks/migrate.js';
+import { addCommand } from './hooks/add.js';
 import { initializeOutputListenersAndFlush } from '../gemini.js';
 
 export const hooksCommand: CommandModule = {
@@ -15,6 +16,7 @@ export const hooksCommand: CommandModule = {
   builder: (yargs) =>
     yargs
       .middleware(() => initializeOutputListenersAndFlush())
+      .command(addCommand)
       .command(migrateCommand)
       .demandCommand(1, 'You need at least one command before continuing.')
       .version(false),

--- a/packages/cli/src/commands/hooks/add.tsx
+++ b/packages/cli/src/commands/hooks/add.tsx
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule } from 'yargs';
+import { render } from 'ink';
+import { debugLogger } from '@google/gemini-cli-core';
+import { loadSettings } from '../../config/settings.js';
+import { exitCli } from '../utils.js';
+import { HookConfigurationWizard } from '../../ui/components/hooks/HookConfigurationWizard.js';
+import { KeypressProvider } from '../../ui/contexts/KeypressContext.js';
+
+async function handleAddHook(): Promise<void> {
+  const workingDir = process.cwd();
+  const settings = loadSettings(workingDir);
+
+  const { unmount, waitUntilExit } = render(
+    <KeypressProvider>
+      <HookConfigurationWizard
+        settings={settings}
+        onComplete={(success, message) => {
+          if (message) {
+            if (success) {
+              debugLogger.log(message);
+              debugLogger.log(
+                '\nNote: Set tools.enableHooks to true in your settings to enable the hook system.',
+              );
+            } else {
+              debugLogger.log(message);
+            }
+          }
+          unmount();
+        }}
+      />
+    </KeypressProvider>,
+  );
+
+  await waitUntilExit();
+}
+
+export const addCommand: CommandModule = {
+  command: 'add',
+  describe: 'Add a new hook via interactive wizard',
+  builder: (yargs) => yargs,
+  handler: async () => {
+    await handleAddHook();
+    await exitCli();
+  },
+};

--- a/packages/cli/src/ui/components/hooks/EventSelector.test.tsx
+++ b/packages/cli/src/ui/components/hooks/EventSelector.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithProviders } from '../../../test-utils/render.js';
+import { act } from 'react';
+import { waitFor } from '../../../test-utils/async.js';
+import { HookEventName } from '@google/gemini-cli-core';
+import { EventSelector } from './EventSelector.js';
+import { DescriptiveRadioButtonSelect } from '../shared/DescriptiveRadioButtonSelect.js';
+
+vi.mock('../shared/DescriptiveRadioButtonSelect.js', () => ({
+  DescriptiveRadioButtonSelect: vi.fn(() => null),
+}));
+
+const MockedDescriptiveRadioButtonSelect = vi.mocked(
+  DescriptiveRadioButtonSelect,
+);
+
+describe('EventSelector', () => {
+  const onSelect = vi.fn();
+  const onCancel = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render the step title', () => {
+    const { lastFrame } = renderWithProviders(
+      <EventSelector onSelect={onSelect} onCancel={onCancel} />,
+    );
+
+    expect(lastFrame()).toContain('Step 1: Select Hook Event');
+    expect(lastFrame()).toContain('Choose when your hook should execute');
+  });
+
+  it('should render DescriptiveRadioButtonSelect with all hook events', () => {
+    renderWithProviders(
+      <EventSelector onSelect={onSelect} onCancel={onCancel} />,
+    );
+
+    expect(MockedDescriptiveRadioButtonSelect).toHaveBeenCalled();
+    const props = MockedDescriptiveRadioButtonSelect.mock.calls[0][0];
+    expect(props.items).toHaveLength(11); // All HookEventName values
+    expect(props.items[0].value).toBe(HookEventName.BeforeTool);
+  });
+
+  it('should call onSelect when an event is selected', () => {
+    renderWithProviders(
+      <EventSelector onSelect={onSelect} onCancel={onCancel} />,
+    );
+
+    const props = MockedDescriptiveRadioButtonSelect.mock.calls[0][0];
+    act(() => {
+      props.onSelect(HookEventName.AfterTool);
+    });
+
+    expect(onSelect).toHaveBeenCalledWith(HookEventName.AfterTool);
+  });
+
+  it('should call onCancel when escape is pressed', async () => {
+    const { stdin } = renderWithProviders(
+      <EventSelector onSelect={onSelect} onCancel={onCancel} />,
+    );
+
+    await act(async () => {
+      stdin.write('\u001B'); // Escape key
+    });
+
+    await waitFor(() => {
+      expect(onCancel).toHaveBeenCalled();
+    });
+  });
+
+  it('should set initial index when selectedEvent is provided', () => {
+    renderWithProviders(
+      <EventSelector
+        selectedEvent={HookEventName.AfterTool}
+        onSelect={onSelect}
+        onCancel={onCancel}
+      />,
+    );
+
+    const props = MockedDescriptiveRadioButtonSelect.mock.calls[0][0];
+    expect(props.initialIndex).toBe(1); // AfterTool is at index 1
+  });
+
+  it('should render help text', () => {
+    const { lastFrame } = renderWithProviders(
+      <EventSelector onSelect={onSelect} onCancel={onCancel} />,
+    );
+
+    expect(lastFrame()).toContain('Enter to select');
+    expect(lastFrame()).toContain('Esc to cancel');
+  });
+});

--- a/packages/cli/src/ui/components/hooks/EventSelector.tsx
+++ b/packages/cli/src/ui/components/hooks/EventSelector.tsx
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box, Text } from 'ink';
+import type { HookEventName } from '@google/gemini-cli-core';
+import { theme } from '../../semantic-colors.js';
+import { DescriptiveRadioButtonSelect } from '../shared/DescriptiveRadioButtonSelect.js';
+import { useKeypress } from '../../hooks/useKeypress.js';
+import { HOOK_EVENTS } from './types.js';
+
+interface EventSelectorProps {
+  selectedEvent?: HookEventName;
+  onSelect: (event: HookEventName) => void;
+  onCancel: () => void;
+  isFocused?: boolean;
+}
+
+export function EventSelector({
+  selectedEvent,
+  onSelect,
+  onCancel,
+  isFocused = true,
+}: EventSelectorProps): React.JSX.Element {
+  useKeypress(
+    (key) => {
+      if (key.name === 'escape') {
+        onCancel();
+      }
+    },
+    { isActive: isFocused },
+  );
+
+  const items = HOOK_EVENTS.map((item) => ({
+    key: item.event,
+    value: item.event,
+    title: item.title,
+    description: item.description,
+  }));
+
+  const initialIndex = selectedEvent
+    ? HOOK_EVENTS.findIndex((item) => item.event === selectedEvent)
+    : 0;
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text bold color={theme.text.primary}>
+          Step 1: Select Hook Event
+        </Text>
+      </Box>
+      <Box marginBottom={1}>
+        <Text color={theme.text.secondary}>
+          Choose when your hook should execute:
+        </Text>
+      </Box>
+      <DescriptiveRadioButtonSelect<HookEventName>
+        items={items}
+        initialIndex={initialIndex >= 0 ? initialIndex : 0}
+        onSelect={onSelect}
+        isFocused={isFocused}
+        showNumbers={true}
+        showScrollArrows={true}
+        maxItemsToShow={8}
+      />
+      <Box marginTop={1}>
+        <Text color={theme.text.secondary}>
+          (Enter to select, Esc to cancel)
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/ui/components/hooks/HookConfigurationWizard.test.tsx
+++ b/packages/cli/src/ui/components/hooks/HookConfigurationWizard.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithProviders } from '../../../test-utils/render.js';
+import { act } from 'react';
+import { HookEventName } from '@google/gemini-cli-core';
+import { HookConfigurationWizard } from './HookConfigurationWizard.js';
+import type { LoadedSettings } from '../../../config/settings.js';
+import { SettingScope } from '../../../config/settings.js';
+
+const getGlobalCallbacks = (key: string): Record<string, unknown> =>
+  (global as unknown as Record<string, Record<string, unknown>>)[key];
+
+vi.mock('./EventSelector.js', () => ({
+  EventSelector: vi.fn(({ onSelect, onCancel }) => {
+    (global as unknown as Record<string, unknown>)['__eventSelectorCallbacks'] =
+      {
+        onSelect,
+        onCancel,
+      };
+    return null;
+  }),
+}));
+
+vi.mock('./MatcherInput.js', () => ({
+  MatcherInput: vi.fn(({ onSubmit, onBack, onCancel }) => {
+    (global as unknown as Record<string, unknown>)['__matcherInputCallbacks'] =
+      {
+        onSubmit,
+        onBack,
+        onCancel,
+      };
+    return null;
+  }),
+}));
+
+vi.mock('./HookDetailsForm.js', () => ({
+  HookDetailsForm: vi.fn(({ onSubmit, onBack, onCancel }) => {
+    (global as unknown as Record<string, unknown>)[
+      '__hookDetailsFormCallbacks'
+    ] = {
+      onSubmit,
+      onBack,
+      onCancel,
+    };
+    return null;
+  }),
+}));
+
+vi.mock('./HookReview.js', () => ({
+  HookReview: vi.fn(({ onConfirm, onEdit, onCancel }) => {
+    (global as unknown as Record<string, unknown>)['__hookReviewCallbacks'] = {
+      onConfirm,
+      onEdit,
+      onCancel,
+    };
+    return null;
+  }),
+}));
+
+describe('HookConfigurationWizard', () => {
+  const mockSettings: LoadedSettings = {
+    merged: {
+      hooks: {},
+    },
+    setValue: vi.fn(),
+    save: vi.fn(),
+  } as unknown as LoadedSettings;
+
+  const onComplete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render the wizard header with progress indicators', () => {
+    const { lastFrame } = renderWithProviders(
+      <HookConfigurationWizard
+        settings={mockSettings}
+        onComplete={onComplete}
+      />,
+    );
+
+    expect(lastFrame()).toContain('Add New Hook');
+    expect(lastFrame()).toContain('1');
+    expect(lastFrame()).toContain('→');
+  });
+
+  it('should start on the event step', () => {
+    renderWithProviders(
+      <HookConfigurationWizard
+        settings={mockSettings}
+        onComplete={onComplete}
+      />,
+    );
+
+    const callbacks = getGlobalCallbacks('__eventSelectorCallbacks') as {
+      onSelect: (event: HookEventName) => void;
+      onCancel: () => void;
+    };
+
+    expect(callbacks).toBeDefined();
+    expect(typeof callbacks.onSelect).toBe('function');
+  });
+
+  it('should progress through steps correctly', () => {
+    renderWithProviders(
+      <HookConfigurationWizard
+        settings={mockSettings}
+        onComplete={onComplete}
+      />,
+    );
+
+    // Step 1: Select event
+    const eventCallbacks = getGlobalCallbacks('__eventSelectorCallbacks') as {
+      onSelect: (event: HookEventName) => void;
+    };
+    act(() => {
+      eventCallbacks.onSelect(HookEventName.BeforeTool);
+    });
+
+    // Step 2: Enter matcher
+    const matcherCallbacks = getGlobalCallbacks('__matcherInputCallbacks') as {
+      onSubmit: (matcher: string) => void;
+    };
+    act(() => {
+      matcherCallbacks.onSubmit('read_file');
+    });
+
+    // Step 3: Enter details
+    const detailsCallbacks = getGlobalCallbacks(
+      '__hookDetailsFormCallbacks',
+    ) as {
+      onSubmit: (details: {
+        command: string;
+        name?: string;
+        description?: string;
+        timeout?: number;
+      }) => void;
+    };
+    act(() => {
+      detailsCallbacks.onSubmit({
+        command: '/path/to/script.sh',
+        name: 'my-hook',
+      });
+    });
+
+    const reviewCallbacks = getGlobalCallbacks('__hookReviewCallbacks') as {
+      onConfirm: () => void;
+    };
+    expect(reviewCallbacks).toBeDefined();
+  });
+
+  it('should call onComplete with cancel message when cancelled from event step', () => {
+    renderWithProviders(
+      <HookConfigurationWizard
+        settings={mockSettings}
+        onComplete={onComplete}
+      />,
+    );
+
+    const callbacks = getGlobalCallbacks('__eventSelectorCallbacks') as {
+      onCancel: () => void;
+    };
+
+    act(() => {
+      callbacks.onCancel();
+    });
+
+    expect(onComplete).toHaveBeenCalledWith(
+      false,
+      'Hook configuration cancelled.',
+    );
+  });
+
+  it('should save hook configuration when confirmed', async () => {
+    renderWithProviders(
+      <HookConfigurationWizard
+        settings={mockSettings}
+        onComplete={onComplete}
+      />,
+    );
+
+    act(() => {
+      const eventCallbacks = getGlobalCallbacks('__eventSelectorCallbacks') as {
+        onSelect: (event: HookEventName) => void;
+      };
+      eventCallbacks.onSelect(HookEventName.BeforeTool);
+    });
+
+    act(() => {
+      const matcherCallbacks = getGlobalCallbacks(
+        '__matcherInputCallbacks',
+      ) as { onSubmit: (matcher: string) => void };
+      matcherCallbacks.onSubmit('*');
+    });
+
+    act(() => {
+      const detailsCallbacks = getGlobalCallbacks(
+        '__hookDetailsFormCallbacks',
+      ) as {
+        onSubmit: (details: { command: string }) => void;
+      };
+      detailsCallbacks.onSubmit({ command: '/path/to/script.sh' });
+    });
+
+    await act(async () => {
+      const reviewCallbacks = getGlobalCallbacks('__hookReviewCallbacks') as {
+        onConfirm: () => void;
+      };
+      reviewCallbacks.onConfirm();
+    });
+
+    expect(mockSettings.setValue).toHaveBeenCalledWith(
+      SettingScope.Workspace,
+      'hooks.BeforeTool',
+      expect.arrayContaining([
+        expect.objectContaining({
+          hooks: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'command',
+              command: '/path/to/script.sh',
+            }),
+          ]),
+        }),
+      ]),
+    );
+    expect(onComplete).toHaveBeenCalledWith(
+      true,
+      expect.stringContaining('added successfully'),
+    );
+  });
+
+  it('should allow editing a previous step from review', () => {
+    renderWithProviders(
+      <HookConfigurationWizard
+        settings={mockSettings}
+        onComplete={onComplete}
+      />,
+    );
+
+    act(() => {
+      const eventCallbacks = getGlobalCallbacks('__eventSelectorCallbacks') as {
+        onSelect: (event: HookEventName) => void;
+      };
+      eventCallbacks.onSelect(HookEventName.BeforeTool);
+    });
+
+    act(() => {
+      const matcherCallbacks = getGlobalCallbacks(
+        '__matcherInputCallbacks',
+      ) as { onSubmit: (matcher: string) => void };
+      matcherCallbacks.onSubmit('*');
+    });
+
+    act(() => {
+      const detailsCallbacks = getGlobalCallbacks(
+        '__hookDetailsFormCallbacks',
+      ) as {
+        onSubmit: (details: { command: string }) => void;
+      };
+      detailsCallbacks.onSubmit({ command: '/path/to/script.sh' });
+    });
+
+    act(() => {
+      const reviewCallbacks = getGlobalCallbacks('__hookReviewCallbacks') as {
+        onEdit: (step: string) => void;
+      };
+      reviewCallbacks.onEdit('event');
+    });
+
+    const eventCallbacks = getGlobalCallbacks('__eventSelectorCallbacks') as {
+      onSelect: (event: HookEventName) => void;
+    };
+    expect(eventCallbacks).toBeDefined();
+  });
+});

--- a/packages/cli/src/ui/components/hooks/HookConfigurationWizard.tsx
+++ b/packages/cli/src/ui/components/hooks/HookConfigurationWizard.tsx
@@ -1,0 +1,231 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { useState, useCallback } from 'react';
+import { Box, Text } from 'ink';
+import {
+  HookType,
+  type HookEventName,
+  type HookDefinition,
+} from '@google/gemini-cli-core';
+import { theme } from '../../semantic-colors.js';
+import type { LoadedSettings } from '../../../config/settings.js';
+import { SettingScope } from '../../../config/settings.js';
+import { EventSelector } from './EventSelector.js';
+import { MatcherInput } from './MatcherInput.js';
+import { HookDetailsForm, type HookDetails } from './HookDetailsForm.js';
+import { HookReview } from './HookReview.js';
+import type { HookWizardStep, HookWizardState } from './types.js';
+
+export interface HookConfigurationWizardProps {
+  settings: LoadedSettings;
+  onComplete: (success: boolean, message?: string) => void;
+  isFocused?: boolean;
+}
+
+export function HookConfigurationWizard({
+  settings,
+  onComplete,
+  isFocused = true,
+}: HookConfigurationWizardProps): React.JSX.Element {
+  const [state, setState] = useState<HookWizardState>({
+    step: 'event',
+  });
+  const [saving, setSaving] = useState(false);
+
+  const handleCancel = useCallback(() => {
+    onComplete(false, 'Hook configuration cancelled.');
+  }, [onComplete]);
+
+  const handleEventSelect = useCallback((event: HookEventName) => {
+    setState((prev) => ({ ...prev, event, step: 'matcher' }));
+  }, []);
+
+  const handleMatcherSubmit = useCallback((matcher: string) => {
+    setState((prev) => ({ ...prev, matcher, step: 'details' }));
+  }, []);
+
+  const handleDetailsSubmit = useCallback((details: HookDetails) => {
+    setState((prev) => ({
+      ...prev,
+      command: details.command,
+      name: details.name,
+      description: details.description,
+      timeout: details.timeout,
+      step: 'review',
+    }));
+  }, []);
+
+  const handleEdit = useCallback((step: HookWizardStep) => {
+    setState((prev) => ({ ...prev, step }));
+  }, []);
+
+  const handleGoBack = useCallback(() => {
+    setState((prev) => {
+      switch (prev.step) {
+        case 'matcher':
+          return { ...prev, step: 'event' };
+        case 'details':
+          return { ...prev, step: 'matcher' };
+        case 'review':
+          return { ...prev, step: 'details' };
+        default:
+          return prev;
+      }
+    });
+  }, []);
+
+  const handleConfirm = useCallback(async () => {
+    if (!state.event || !state.command) {
+      onComplete(false, 'Missing required configuration.');
+      return;
+    }
+
+    setSaving(true);
+
+    try {
+      const newHookDef: HookDefinition = {
+        matcher: state.matcher || undefined,
+        hooks: [
+          {
+            type: HookType.Command,
+            command: state.command,
+            name: state.name || undefined,
+            description: state.description || undefined,
+            timeout: state.timeout || undefined,
+          },
+        ],
+      };
+
+      const hooksConfig =
+        (settings.merged.hooks as Record<string, unknown>) || {};
+      const existingHooks =
+        (hooksConfig[state.event] as HookDefinition[]) || [];
+
+      const updatedHooks = [...existingHooks, newHookDef];
+
+      settings.setValue(
+        SettingScope.Workspace,
+        `hooks.${state.event}`,
+        updatedHooks,
+      );
+
+      const hookName = state.name || state.command;
+      onComplete(
+        true,
+        `✓ Hook "${hookName}" added successfully to ${state.event} event.`,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      onComplete(false, `Failed to save hook: ${message}`);
+    } finally {
+      setSaving(false);
+    }
+  }, [state, settings, onComplete]);
+
+  if (saving) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text color={theme.status.warning}>Saving hook configuration...</Text>
+      </Box>
+    );
+  }
+
+  const steps: HookWizardStep[] = ['event', 'matcher', 'details', 'review'];
+  const currentStepIndex = steps.indexOf(state.step);
+
+  return (
+    <Box flexDirection="column">
+      <Box
+        borderStyle="round"
+        borderColor={theme.border.default}
+        paddingX={2}
+        paddingY={1}
+        marginBottom={1}
+      >
+        <Box flexDirection="column">
+          <Text bold color={theme.text.primary}>
+            Add New Hook
+          </Text>
+          <Box marginTop={1}>
+            {steps.map((step, index) => (
+              <Box key={step} marginRight={1}>
+                <Text
+                  color={
+                    index < currentStepIndex
+                      ? theme.status.success
+                      : index === currentStepIndex
+                        ? theme.text.accent
+                        : theme.text.secondary
+                  }
+                >
+                  {index < currentStepIndex ? '✓' : index + 1}
+                  {index < steps.length - 1 ? ' →' : ''}
+                </Text>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      </Box>
+
+      <Box
+        flexDirection="column"
+        borderStyle="round"
+        borderColor={theme.border.focused}
+        paddingX={2}
+        paddingY={1}
+      >
+        {state.step === 'event' && (
+          <EventSelector
+            selectedEvent={state.event}
+            onSelect={handleEventSelect}
+            onCancel={handleCancel}
+            isFocused={isFocused}
+          />
+        )}
+
+        {state.step === 'matcher' && (
+          <MatcherInput
+            initialValue={state.matcher}
+            onSubmit={handleMatcherSubmit}
+            onBack={handleGoBack}
+            onCancel={handleCancel}
+            isFocused={isFocused}
+          />
+        )}
+
+        {state.step === 'details' && (
+          <HookDetailsForm
+            initialCommand={state.command}
+            initialName={state.name}
+            initialDescription={state.description}
+            initialTimeout={state.timeout}
+            onSubmit={handleDetailsSubmit}
+            onBack={handleGoBack}
+            onCancel={handleCancel}
+            isFocused={isFocused}
+          />
+        )}
+
+        {state.step === 'review' && state.event && state.command && (
+          <HookReview
+            event={state.event}
+            matcher={state.matcher}
+            command={state.command}
+            name={state.name}
+            description={state.description}
+            timeout={state.timeout}
+            onConfirm={handleConfirm}
+            onEdit={handleEdit}
+            onCancel={handleCancel}
+            isFocused={isFocused}
+          />
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/ui/components/hooks/HookDetailsForm.tsx
+++ b/packages/cli/src/ui/components/hooks/HookDetailsForm.tsx
@@ -1,0 +1,302 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { useState, useCallback, useEffect } from 'react';
+import { Box, Text } from 'ink';
+import { theme } from '../../semantic-colors.js';
+import { TextInput } from '../shared/TextInput.js';
+import { useTextBuffer } from '../shared/text-buffer.js';
+import { useKeypress } from '../../hooks/useKeypress.js';
+import {
+  validateCommand,
+  validateName,
+  validateTimeout,
+  DEFAULT_HOOK_TIMEOUT,
+} from './types.js';
+
+interface HookDetailsFormProps {
+  initialCommand?: string;
+  initialName?: string;
+  initialDescription?: string;
+  initialTimeout?: number;
+  onSubmit: (details: HookDetails) => void;
+  onBack: () => void;
+  onCancel: () => void;
+  isFocused?: boolean;
+}
+
+export interface HookDetails {
+  command: string;
+  name?: string;
+  description?: string;
+  timeout?: number;
+}
+
+type Field = 'command' | 'name' | 'description' | 'timeout';
+
+const FIELDS: Field[] = ['command', 'name', 'description', 'timeout'];
+
+export function HookDetailsForm({
+  initialCommand = '',
+  initialName = '',
+  initialDescription = '',
+  initialTimeout,
+  onSubmit,
+  onBack,
+  onCancel: _onCancel,
+  isFocused = true,
+}: HookDetailsFormProps): React.JSX.Element {
+  const [activeField, setActiveField] = useState<Field>('command');
+  const [errors, setErrors] = useState<Partial<Record<Field, string>>>({});
+
+  const commandBuffer = useTextBuffer({
+    initialText: initialCommand,
+    viewport: { width: 60, height: 1 },
+    isValidPath: () => false,
+    singleLine: true,
+  });
+
+  const nameBuffer = useTextBuffer({
+    initialText: initialName,
+    viewport: { width: 60, height: 1 },
+    isValidPath: () => false,
+    singleLine: true,
+  });
+
+  const descriptionBuffer = useTextBuffer({
+    initialText: initialDescription,
+    viewport: { width: 60, height: 1 },
+    isValidPath: () => false,
+    singleLine: true,
+  });
+
+  const timeoutBuffer = useTextBuffer({
+    initialText: initialTimeout?.toString() || '',
+    viewport: { width: 20, height: 1 },
+    isValidPath: () => false,
+    singleLine: true,
+  });
+
+  useEffect(() => {
+    setErrors((prev) => ({ ...prev, command: undefined }));
+  }, [commandBuffer.text]);
+
+  useEffect(() => {
+    setErrors((prev) => ({ ...prev, name: undefined }));
+  }, [nameBuffer.text]);
+
+  useEffect(() => {
+    setErrors((prev) => ({ ...prev, timeout: undefined }));
+  }, [timeoutBuffer.text]);
+
+  const validateAll = useCallback((): boolean => {
+    const newErrors: Partial<Record<Field, string>> = {};
+
+    const cmdValidation = validateCommand(commandBuffer.text);
+    if (!cmdValidation.valid) {
+      newErrors.command = cmdValidation.error;
+    }
+
+    const nameValidation = validateName(nameBuffer.text);
+    if (!nameValidation.valid) {
+      newErrors.name = nameValidation.error;
+    }
+
+    const timeoutValue = timeoutBuffer.text.trim()
+      ? parseInt(timeoutBuffer.text.trim(), 10)
+      : undefined;
+    const timeoutValidation = validateTimeout(timeoutValue);
+    if (!timeoutValidation.valid) {
+      newErrors.timeout = timeoutValidation.error;
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }, [commandBuffer.text, nameBuffer.text, timeoutBuffer.text]);
+
+  const handleSubmit = useCallback(() => {
+    if (!validateAll()) {
+      const firstErrorField = FIELDS.find((f) => errors[f]);
+      if (firstErrorField) {
+        setActiveField(firstErrorField);
+      }
+      return;
+    }
+
+    const timeoutValue = timeoutBuffer.text.trim()
+      ? parseInt(timeoutBuffer.text.trim(), 10)
+      : undefined;
+
+    onSubmit({
+      command: commandBuffer.text.trim(),
+      name: nameBuffer.text.trim() || undefined,
+      description: descriptionBuffer.text.trim() || undefined,
+      timeout: timeoutValue,
+    });
+  }, [
+    validateAll,
+    errors,
+    onSubmit,
+    commandBuffer.text,
+    nameBuffer.text,
+    descriptionBuffer.text,
+    timeoutBuffer.text,
+  ]);
+
+  const navigateField = useCallback(
+    (direction: 'up' | 'down') => {
+      const currentIndex = FIELDS.indexOf(activeField);
+      if (direction === 'up') {
+        setActiveField(FIELDS[Math.max(0, currentIndex - 1)]);
+      } else {
+        setActiveField(FIELDS[Math.min(FIELDS.length - 1, currentIndex + 1)]);
+      }
+    },
+    [activeField],
+  );
+
+  useKeypress(
+    (key) => {
+      if (key.name === 'escape') {
+        onBack();
+        return;
+      }
+      if (key.name === 'tab' || (key.ctrl && key.name === 'n')) {
+        navigateField('down');
+        return;
+      }
+      if (key.shift && key.name === 'tab') {
+        navigateField('up');
+        return;
+      }
+      if (key.ctrl && key.name === 'return') {
+        handleSubmit();
+        return;
+      }
+    },
+    { isActive: isFocused },
+  );
+
+  const renderField = (
+    field: Field,
+    label: string,
+    buffer: ReturnType<typeof useTextBuffer>,
+    placeholder: string,
+    required: boolean = false,
+    helpText?: string,
+  ) => {
+    const isActive = activeField === field;
+    const hasError = !!errors[field];
+
+    return (
+      <Box flexDirection="column" marginBottom={1} key={field}>
+        <Box>
+          <Text color={isActive ? theme.text.primary : theme.text.secondary}>
+            {isActive ? '▸ ' : '  '}
+            {label}
+            {required && <Text color={theme.status.error}>*</Text>}:
+          </Text>
+        </Box>
+        <Box
+          borderStyle="round"
+          borderColor={
+            hasError
+              ? theme.status.error
+              : isActive
+                ? theme.border.focused
+                : theme.border.default
+          }
+          paddingX={1}
+          marginLeft={2}
+        >
+          <TextInput
+            buffer={buffer}
+            placeholder={placeholder}
+            onSubmit={() => {
+              if (field === 'timeout') {
+                handleSubmit();
+              } else {
+                navigateField('down');
+              }
+            }}
+            onCancel={onBack}
+            focus={isActive && isFocused}
+          />
+        </Box>
+        {hasError && (
+          <Box marginLeft={2}>
+            <Text color={theme.status.error}>✗ {errors[field]}</Text>
+          </Box>
+        )}
+        {helpText && !hasError && (
+          <Box marginLeft={2}>
+            <Text color={theme.text.secondary} dimColor>
+              {helpText}
+            </Text>
+          </Box>
+        )}
+      </Box>
+    );
+  };
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text bold color={theme.text.primary}>
+          Step 3: Hook Details
+        </Text>
+      </Box>
+      <Box marginBottom={1}>
+        <Text color={theme.text.secondary}>
+          Configure the hook command and optional metadata.
+        </Text>
+      </Box>
+
+      {renderField(
+        'command',
+        'Command',
+        commandBuffer,
+        '/path/to/script.sh or executable',
+        true,
+        'Shell command or script path. Supports $GEMINI_PROJECT_DIR.',
+      )}
+
+      {renderField(
+        'name',
+        'Name',
+        nameBuffer,
+        'my-hook (for enable/disable)',
+        false,
+        'Unique identifier for /hooks enable|disable commands.',
+      )}
+
+      {renderField(
+        'description',
+        'Description',
+        descriptionBuffer,
+        'What this hook does',
+        false,
+      )}
+
+      {renderField(
+        'timeout',
+        'Timeout (ms)',
+        timeoutBuffer,
+        `${DEFAULT_HOOK_TIMEOUT} (default)`,
+        false,
+        'Maximum execution time in milliseconds.',
+      )}
+
+      <Box marginTop={1}>
+        <Text color={theme.text.secondary}>
+          (Tab to navigate, Enter to continue, Ctrl+Enter to submit, Esc to go
+          back)
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/ui/components/hooks/HookReview.test.tsx
+++ b/packages/cli/src/ui/components/hooks/HookReview.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithProviders } from '../../../test-utils/render.js';
+import { act } from 'react';
+import { waitFor } from '../../../test-utils/async.js';
+import { HookEventName } from '@google/gemini-cli-core';
+import { HookReview, type HookReviewProps } from './HookReview.js';
+import { RadioButtonSelect } from '../shared/RadioButtonSelect.js';
+
+vi.mock('../shared/RadioButtonSelect.js', () => ({
+  RadioButtonSelect: vi.fn(() => null),
+}));
+
+const MockedRadioButtonSelect = vi.mocked(RadioButtonSelect);
+
+describe('HookReview', () => {
+  const defaultProps: Omit<
+    HookReviewProps,
+    'onConfirm' | 'onEdit' | 'onCancel'
+  > & {
+    onConfirm: ReturnType<typeof vi.fn>;
+    onEdit: ReturnType<typeof vi.fn>;
+    onCancel: ReturnType<typeof vi.fn>;
+  } = {
+    event: HookEventName.BeforeTool,
+    command: '/path/to/script.sh',
+    onConfirm: vi.fn(),
+    onEdit: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render the step title', () => {
+    const { lastFrame } = renderWithProviders(<HookReview {...defaultProps} />);
+
+    expect(lastFrame()).toContain('Step 5: Review Configuration');
+    expect(lastFrame()).toContain('Hook Configuration Summary');
+  });
+
+  it('should display all configuration values', () => {
+    const { lastFrame } = renderWithProviders(
+      <HookReview
+        {...defaultProps}
+        matcher="read_file"
+        name="my-hook"
+        description="A test hook"
+        timeout={30000}
+      />,
+    );
+
+    expect(lastFrame()).toContain('BeforeTool');
+    expect(lastFrame()).toContain('read_file');
+    expect(lastFrame()).toContain('/path/to/script.sh');
+    expect(lastFrame()).toContain('my-hook');
+    expect(lastFrame()).toContain('A test hook');
+    expect(lastFrame()).toContain('30000ms');
+    expect(lastFrame()).toContain('.gemini/settings.json');
+  });
+
+  it('should display default values when optional fields are not set', () => {
+    const { lastFrame } = renderWithProviders(<HookReview {...defaultProps} />);
+
+    expect(lastFrame()).toContain('*'); // Matcher default
+    expect(lastFrame()).toContain('(not set)'); // Name and description
+    expect(lastFrame()).toContain('60000ms'); // Default timeout
+  });
+
+  it('should render RadioButtonSelect with action options', () => {
+    renderWithProviders(<HookReview {...defaultProps} />);
+
+    expect(MockedRadioButtonSelect).toHaveBeenCalled();
+    const props = MockedRadioButtonSelect.mock.calls[0][0];
+    expect(props.items).toHaveLength(5);
+  });
+
+  it('should call onConfirm when save is selected', () => {
+    renderWithProviders(<HookReview {...defaultProps} />);
+
+    const props = MockedRadioButtonSelect.mock.calls[0][0];
+    act(() => {
+      props.onSelect('save');
+    });
+
+    expect(defaultProps.onConfirm).toHaveBeenCalled();
+  });
+
+  it('should call onEdit with correct step when edit options are selected', () => {
+    renderWithProviders(<HookReview {...defaultProps} />);
+
+    const props = MockedRadioButtonSelect.mock.calls[0][0];
+
+    act(() => {
+      props.onSelect('edit-event');
+    });
+    expect(defaultProps.onEdit).toHaveBeenCalledWith('event');
+
+    act(() => {
+      props.onSelect('edit-matcher');
+    });
+    expect(defaultProps.onEdit).toHaveBeenCalledWith('matcher');
+
+    act(() => {
+      props.onSelect('edit-details');
+    });
+    expect(defaultProps.onEdit).toHaveBeenCalledWith('details');
+  });
+
+  it('should call onCancel when cancel is selected', () => {
+    renderWithProviders(<HookReview {...defaultProps} />);
+
+    const props = MockedRadioButtonSelect.mock.calls[0][0];
+    act(() => {
+      props.onSelect('cancel');
+    });
+
+    expect(defaultProps.onCancel).toHaveBeenCalled();
+  });
+
+  it('should call onCancel when escape is pressed', async () => {
+    const { stdin } = renderWithProviders(<HookReview {...defaultProps} />);
+
+    await act(async () => {
+      stdin.write('\u001B');
+    });
+
+    await waitFor(() => {
+      expect(defaultProps.onCancel).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/cli/src/ui/components/hooks/HookReview.tsx
+++ b/packages/cli/src/ui/components/hooks/HookReview.tsx
@@ -98,7 +98,7 @@ export function HookReview({
     <Box flexDirection="column">
       <Box marginBottom={1}>
         <Text bold color={theme.text.primary}>
-          Step 5: Review Configuration
+          Step 4: Review Configuration
         </Text>
       </Box>
 

--- a/packages/cli/src/ui/components/hooks/HookReview.tsx
+++ b/packages/cli/src/ui/components/hooks/HookReview.tsx
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box, Text } from 'ink';
+import type { HookEventName } from '@google/gemini-cli-core';
+import { theme } from '../../semantic-colors.js';
+import { RadioButtonSelect } from '../shared/RadioButtonSelect.js';
+import { useKeypress } from '../../hooks/useKeypress.js';
+import { DEFAULT_HOOK_TIMEOUT, HOOK_EVENTS } from './types.js';
+
+export interface HookReviewProps {
+  event: HookEventName;
+  matcher?: string;
+  command: string;
+  name?: string;
+  description?: string;
+  timeout?: number;
+  onConfirm: () => void;
+  onEdit: (step: 'event' | 'matcher' | 'details') => void;
+  onCancel: () => void;
+  isFocused?: boolean;
+}
+
+type ReviewAction =
+  | 'save'
+  | 'edit-event'
+  | 'edit-matcher'
+  | 'edit-details'
+  | 'cancel';
+
+export function HookReview({
+  event,
+  matcher,
+  command,
+  name,
+  description,
+  timeout,
+  onConfirm,
+  onEdit,
+  onCancel,
+  isFocused = true,
+}: HookReviewProps): React.JSX.Element {
+  useKeypress(
+    (key) => {
+      if (key.name === 'escape') {
+        onCancel();
+      }
+    },
+    { isActive: isFocused },
+  );
+
+  const eventInfo = HOOK_EVENTS.find((e) => e.event === event);
+
+  const options: Array<{ label: string; value: ReviewAction; key: string }> = [
+    { label: '✓ Save & Exit', value: 'save', key: 'save' },
+    { label: '✎ Edit Event', value: 'edit-event', key: 'edit-event' },
+    { label: '✎ Edit Matcher', value: 'edit-matcher', key: 'edit-matcher' },
+    { label: '✎ Edit Details', value: 'edit-details', key: 'edit-details' },
+    { label: '✗ Cancel', value: 'cancel', key: 'cancel' },
+  ];
+
+  const handleSelect = (action: ReviewAction) => {
+    switch (action) {
+      case 'save':
+        onConfirm();
+        break;
+      case 'edit-event':
+        onEdit('event');
+        break;
+      case 'edit-matcher':
+        onEdit('matcher');
+        break;
+      case 'edit-details':
+        onEdit('details');
+        break;
+      case 'cancel':
+        onCancel();
+        break;
+      default:
+        break;
+    }
+  };
+
+  const renderConfigItem = (label: string, value: string | undefined) => (
+    <Box>
+      <Box width={14}>
+        <Text color={theme.text.secondary}>{label}:</Text>
+      </Box>
+      <Text color={theme.text.primary}>{value || '(not set)'}</Text>
+    </Box>
+  );
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text bold color={theme.text.primary}>
+          Step 5: Review Configuration
+        </Text>
+      </Box>
+
+      <Box
+        flexDirection="column"
+        borderStyle="round"
+        borderColor={theme.border.default}
+        paddingX={2}
+        paddingY={1}
+        marginBottom={1}
+      >
+        <Box marginBottom={1}>
+          <Text bold color={theme.text.accent}>
+            Hook Configuration Summary
+          </Text>
+        </Box>
+
+        {renderConfigItem('Event', eventInfo?.title)}
+        {eventInfo?.description && (
+          <Box marginLeft={14} marginBottom={1}>
+            <Text color={theme.text.secondary} dimColor>
+              {eventInfo.description}
+            </Text>
+          </Box>
+        )}
+
+        {renderConfigItem('Matcher', matcher || '*')}
+        {renderConfigItem('Command', command)}
+        {renderConfigItem('Name', name)}
+        {renderConfigItem('Description', description)}
+        {renderConfigItem('Timeout', `${timeout || DEFAULT_HOOK_TIMEOUT}ms`)}
+
+        <Box marginTop={1} />
+        <Box>
+          <Box width={14}>
+            <Text color={theme.text.secondary}>Saves to:</Text>
+          </Box>
+          <Text color={theme.text.primary}>.gemini/settings.json</Text>
+        </Box>
+      </Box>
+
+      <Box flexDirection="column" marginBottom={1}>
+        <RadioButtonSelect<ReviewAction>
+          items={options}
+          onSelect={handleSelect}
+          isFocused={isFocused}
+          showNumbers={true}
+        />
+      </Box>
+
+      <Box>
+        <Text color={theme.text.secondary}>
+          (Enter to select, Esc to cancel)
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/ui/components/hooks/MatcherInput.tsx
+++ b/packages/cli/src/ui/components/hooks/MatcherInput.tsx
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { useState, useCallback } from 'react';
+import { Box, Text } from 'ink';
+import { theme } from '../../semantic-colors.js';
+import { TextInput } from '../shared/TextInput.js';
+import { useTextBuffer } from '../shared/text-buffer.js';
+import { useKeypress } from '../../hooks/useKeypress.js';
+import { validateMatcher } from './types.js';
+
+interface MatcherInputProps {
+  initialValue?: string;
+  onSubmit: (matcher: string) => void;
+  onBack: () => void;
+  onCancel: () => void;
+  isFocused?: boolean;
+}
+
+export function MatcherInput({
+  initialValue = '',
+  onSubmit,
+  onBack,
+  onCancel,
+  isFocused = true,
+}: MatcherInputProps): React.JSX.Element {
+  const [error, setError] = useState<string | undefined>();
+
+  const buffer = useTextBuffer({
+    initialText: initialValue,
+    viewport: { width: 60, height: 1 },
+    isValidPath: () => false,
+    singleLine: true,
+  });
+
+  const handleSubmit = useCallback(
+    (value: string) => {
+      const trimmed = value.trim();
+      const validation = validateMatcher(trimmed);
+      if (!validation.valid) {
+        setError(validation.error);
+        return;
+      }
+      setError(undefined);
+      onSubmit(trimmed);
+    },
+    [onSubmit],
+  );
+
+  useKeypress(
+    (key) => {
+      if (key.name === 'escape') {
+        onBack();
+      }
+    },
+    { isActive: isFocused },
+  );
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text bold color={theme.text.primary}>
+          Step 2: Configure Matcher (Optional)
+        </Text>
+      </Box>
+      <Box marginBottom={1}>
+        <Text color={theme.text.secondary}>
+          Enter a pattern to match specific tool names or contexts.
+        </Text>
+      </Box>
+      <Box marginBottom={1}>
+        <Text color={theme.text.secondary}>Leave empty to match all.</Text>
+      </Box>
+
+      <Box
+        borderStyle="round"
+        borderColor={error ? theme.status.error : theme.border.default}
+        paddingX={1}
+        marginBottom={1}
+      >
+        <TextInput
+          buffer={buffer}
+          placeholder="e.g., read_file, /read_.*/, or * for all"
+          onSubmit={handleSubmit}
+          onCancel={onCancel}
+          focus={isFocused}
+        />
+      </Box>
+
+      {error && (
+        <Box marginBottom={1}>
+          <Text color={theme.status.error}>✗ {error}</Text>
+        </Box>
+      )}
+
+      <Box flexDirection="column" marginBottom={1}>
+        <Text color={theme.text.secondary} bold>
+          Examples:
+        </Text>
+        <Text color={theme.text.secondary}>
+          • <Text color={theme.text.accent}>read_file</Text> - exact tool name
+          match
+        </Text>
+        <Text color={theme.text.secondary}>
+          • <Text color={theme.text.accent}>/read_.*/</Text> - regex pattern
+        </Text>
+        <Text color={theme.text.secondary}>
+          • <Text color={theme.text.accent}>*</Text> or empty - match all
+        </Text>
+      </Box>
+
+      <Box>
+        <Text color={theme.text.secondary}>
+          (Enter to continue, Esc to go back)
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/ui/components/hooks/types.test.ts
+++ b/packages/cli/src/ui/components/hooks/types.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  validateCommand,
+  validateMatcher,
+  validateTimeout,
+  validateName,
+  HOOK_EVENTS,
+  DEFAULT_HOOK_TIMEOUT,
+} from './types.js';
+import { HookEventName } from '@google/gemini-cli-core';
+
+describe('Hook Configuration Types', () => {
+  describe('HOOK_EVENTS', () => {
+    it('should contain all HookEventName values', () => {
+      const eventNames = HOOK_EVENTS.map((e) => e.event);
+      expect(eventNames).toContain(HookEventName.BeforeTool);
+      expect(eventNames).toContain(HookEventName.AfterTool);
+      expect(eventNames).toContain(HookEventName.BeforeAgent);
+      expect(eventNames).toContain(HookEventName.AfterAgent);
+      expect(eventNames).toContain(HookEventName.Notification);
+      expect(eventNames).toContain(HookEventName.SessionStart);
+      expect(eventNames).toContain(HookEventName.SessionEnd);
+      expect(eventNames).toContain(HookEventName.PreCompress);
+      expect(eventNames).toContain(HookEventName.BeforeModel);
+      expect(eventNames).toContain(HookEventName.AfterModel);
+      expect(eventNames).toContain(HookEventName.BeforeToolSelection);
+    });
+
+    it('should have titles and descriptions for all events', () => {
+      HOOK_EVENTS.forEach((event) => {
+        expect(event.title).toBeDefined();
+        expect(event.title.length).toBeGreaterThan(0);
+        expect(event.description).toBeDefined();
+        expect(event.description.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('DEFAULT_HOOK_TIMEOUT', () => {
+    it('should be 60000ms', () => {
+      expect(DEFAULT_HOOK_TIMEOUT).toBe(60000);
+    });
+  });
+
+  describe('validateCommand', () => {
+    it('should reject empty command', () => {
+      expect(validateCommand('').valid).toBe(false);
+      expect(validateCommand('   ').valid).toBe(false);
+    });
+
+    it('should accept valid command', () => {
+      expect(validateCommand('/path/to/script.sh').valid).toBe(true);
+      expect(validateCommand('echo hello').valid).toBe(true);
+      expect(validateCommand('./relative/path').valid).toBe(true);
+    });
+  });
+
+  describe('validateMatcher', () => {
+    it('should accept empty matcher', () => {
+      expect(validateMatcher('').valid).toBe(true);
+    });
+
+    it('should accept wildcard', () => {
+      expect(validateMatcher('*').valid).toBe(true);
+    });
+
+    it('should accept exact string', () => {
+      expect(validateMatcher('read_file').valid).toBe(true);
+    });
+
+    it('should accept valid regex', () => {
+      expect(validateMatcher('/read_.*/').valid).toBe(true);
+      expect(validateMatcher('/^test$/').valid).toBe(true);
+    });
+
+    it('should reject invalid regex', () => {
+      const result = validateMatcher('/[invalid/');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('Invalid regex');
+    });
+  });
+
+  describe('validateTimeout', () => {
+    it('should accept undefined', () => {
+      expect(validateTimeout(undefined).valid).toBe(true);
+    });
+
+    it('should accept valid positive number', () => {
+      expect(validateTimeout(1000).valid).toBe(true);
+      expect(validateTimeout(60000).valid).toBe(true);
+      expect(validateTimeout(300000).valid).toBe(true);
+    });
+
+    it('should reject zero or negative', () => {
+      expect(validateTimeout(0).valid).toBe(false);
+      expect(validateTimeout(-1).valid).toBe(false);
+    });
+
+    it('should reject values exceeding 5 minutes', () => {
+      const result = validateTimeout(300001);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('5 minutes');
+    });
+
+    it('should reject NaN', () => {
+      expect(validateTimeout(NaN).valid).toBe(false);
+    });
+  });
+
+  describe('validateName', () => {
+    it('should accept undefined or empty', () => {
+      expect(validateName(undefined).valid).toBe(true);
+      expect(validateName('').valid).toBe(true);
+    });
+
+    it('should accept valid names', () => {
+      expect(validateName('my-hook').valid).toBe(true);
+      expect(validateName('my_hook').valid).toBe(true);
+      expect(validateName('myHook123').valid).toBe(true);
+    });
+
+    it('should reject names with invalid characters', () => {
+      expect(validateName('my hook').valid).toBe(false);
+      expect(validateName('my.hook').valid).toBe(false);
+      expect(validateName('my@hook').valid).toBe(false);
+    });
+  });
+});

--- a/packages/cli/src/ui/components/hooks/types.ts
+++ b/packages/cli/src/ui/components/hooks/types.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { HookEventName } from '@google/gemini-cli-core';
+
+export type HookWizardStep = 'event' | 'matcher' | 'details' | 'review';
+
+export interface HookWizardState {
+  step: HookWizardStep;
+  event?: HookEventName;
+  matcher?: string;
+  command?: string;
+  name?: string;
+  description?: string;
+  timeout?: number;
+  sequential?: boolean;
+}
+
+export interface WizardStepProps {
+  onNext: () => void;
+  onBack: () => void;
+  onCancel: () => void;
+}
+
+export interface HookEventItem {
+  event: HookEventName;
+  title: string;
+  description: string;
+}
+
+export const HOOK_EVENTS: HookEventItem[] = [
+  {
+    event: HookEventName.BeforeTool,
+    title: 'BeforeTool',
+    description: 'Execute before tool execution. Can intercept or validate.',
+  },
+  {
+    event: HookEventName.AfterTool,
+    title: 'AfterTool',
+    description: 'Execute after tool execution. Can process results or log.',
+  },
+  {
+    event: HookEventName.BeforeAgent,
+    title: 'BeforeAgent',
+    description: 'Execute before agent loop starts. Setup context.',
+  },
+  {
+    event: HookEventName.AfterAgent,
+    title: 'AfterAgent',
+    description: 'Execute after agent loop completes. Cleanup or summarize.',
+  },
+  {
+    event: HookEventName.Notification,
+    title: 'Notification',
+    description: 'Execute on notification events (errors, warnings, info).',
+  },
+  {
+    event: HookEventName.SessionStart,
+    title: 'SessionStart',
+    description: 'Execute when a session starts. Initialize resources.',
+  },
+  {
+    event: HookEventName.SessionEnd,
+    title: 'SessionEnd',
+    description: 'Execute when a session ends. Persist data or cleanup.',
+  },
+  {
+    event: HookEventName.PreCompress,
+    title: 'PreCompress',
+    description: 'Execute before chat history compression.',
+  },
+  {
+    event: HookEventName.BeforeModel,
+    title: 'BeforeModel',
+    description: 'Execute before LLM requests. Modify prompts or context.',
+  },
+  {
+    event: HookEventName.AfterModel,
+    title: 'AfterModel',
+    description: 'Execute after LLM responses. Process outputs.',
+  },
+  {
+    event: HookEventName.BeforeToolSelection,
+    title: 'BeforeToolSelection',
+    description: 'Execute before tool selection. Filter or prioritize tools.',
+  },
+];
+
+export const DEFAULT_HOOK_TIMEOUT = 60000;
+
+export interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+export function validateCommand(command: string): ValidationResult {
+  if (!command || command.trim().length === 0) {
+    return { valid: false, error: 'Command is required' };
+  }
+  const trimmed = command.trim();
+  if (trimmed.length === 0) {
+    return { valid: false, error: 'Command cannot be empty' };
+  }
+  return { valid: true };
+}
+
+export function validateMatcher(matcher: string): ValidationResult {
+  if (!matcher || matcher === '*' || matcher === '') {
+    return { valid: true };
+  }
+
+  if (matcher.startsWith('/') && matcher.endsWith('/')) {
+    try {
+      const pattern = matcher.slice(1, -1);
+      new RegExp(pattern);
+      return { valid: true };
+    } catch {
+      return { valid: false, error: 'Invalid regex pattern' };
+    }
+  }
+
+  return { valid: true };
+}
+
+export function validateTimeout(timeout: number | undefined): ValidationResult {
+  if (timeout === undefined) {
+    return { valid: true };
+  }
+  if (typeof timeout !== 'number' || isNaN(timeout)) {
+    return { valid: false, error: 'Timeout must be a number' };
+  }
+  if (timeout <= 0) {
+    return { valid: false, error: 'Timeout must be positive' };
+  }
+  if (timeout > 300000) {
+    return {
+      valid: false,
+      error: 'Timeout cannot exceed 5 minutes (300000ms)',
+    };
+  }
+  return { valid: true };
+}
+
+export function validateName(name: string | undefined): ValidationResult {
+  if (!name || name.trim().length === 0) {
+    return { valid: true };
+  }
+  if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+    return {
+      valid: false,
+      error:
+        'Name should only contain letters, numbers, hyphens, and underscores',
+    };
+  }
+  return { valid: true };
+}


### PR DESCRIPTION
## Summary

This PR implements an interactive GUI wizard for configuring hooks, replacing the need for manual JSON editing. Users can now add hooks through a guided multi-step interface accessible via `/hooks add`.

## Changes

- **HookConfigurationWizard**: Main wizard component orchestrating a 4-step flow (event selection → matcher → details → review)
- **EventSelector**: Interactive picker for selecting hook events with descriptions
- **MatcherInput**: Input component with validation for tool name patterns (exact match, regex, or wildcard)
- **HookDetailsForm**: Form for entering command, name, description, and timeout with real-time validation
- **HookReview**: Review screen allowing users to edit any step before saving
- **Validation utilities**: Functions to validate commands, matchers (regex), timeouts, and hook names
- **Integration**: Added `add` subcommand to `/hooks` command that launches the wizard

## Implementation Details

The wizard uses Ink components and follows the existing CLI UI patterns. State management is handled via React hooks, with validation performed at each step. The wizard saves hooks directly to `.gemini/settings.json` using the existing settings API.

## Related Issues
Fixes [15268](https://github.com/google-gemini/gemini-cli/issues/15268)

## How to Validate
`/hooks add` => Then just follow the steps shown on the UI

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
