### PR TITLE
fix(core): handle checkIsRepo failure in GitService.initialize

### DIFF
--- a/packages/core/src/services/gitService.test.ts
+++ b/packages/core/src/services/gitService.test.ts
@@ -248,6 +248,17 @@ describe('GitService', () => {
       await service.setupShadowGitRepository();
       expect(hoistedMockCommit).not.toHaveBeenCalled();
     });
+
+    it('should handle checkIsRepo failure gracefully and initialize repo', async () => {
+      // Simulate checkIsRepo failing (e.g., on certain Git versions like macOS 2.39.5)
+      hoistedMockCheckIsRepo.mockRejectedValue(
+        new Error('git rev-parse --is-inside-work-tree failed'),
+      );
+      const service = new GitService(projectRoot, storage);
+      await service.setupShadowGitRepository();
+      // Should proceed to initialize the repo since checkIsRepo failed
+      expect(hoistedMockInit).toHaveBeenCalled();
+    });
   });
 
   describe('createFileSnapshot', () => {

--- a/packages/core/src/services/gitService.test.ts
+++ b/packages/core/src/services/gitService.test.ts
@@ -60,6 +60,15 @@ vi.mock('os', async (importOriginal) => {
   };
 });
 
+const hoistedMockDebugLogger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+vi.mock('../utils/debugLogger.js', () => ({
+  debugLogger: hoistedMockDebugLogger,
+}));
+
 describe('GitService', () => {
   let testRootDir: string;
   let projectRoot: string;
@@ -258,6 +267,10 @@ describe('GitService', () => {
       await service.setupShadowGitRepository();
       // Should proceed to initialize the repo since checkIsRepo failed
       expect(hoistedMockInit).toHaveBeenCalled();
+      // Should log the error using debugLogger
+      expect(hoistedMockDebugLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('checkIsRepo failed'),
+      );
     });
   });
 

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -67,7 +67,14 @@ export class GitService {
     await fs.writeFile(gitConfigPath, gitConfigContent);
 
     const repo = simpleGit(repoDir);
-    const isRepoDefined = await repo.checkIsRepo(CheckRepoActions.IS_REPO_ROOT);
+    let isRepoDefined = false;
+    try {
+      isRepoDefined = await repo.checkIsRepo(CheckRepoActions.IS_REPO_ROOT);
+    } catch (_error) {
+      // If checkIsRepo fails (e.g., on certain Git versions like macOS 2.39.5),
+      // assume repo is not defined and proceed with initialization
+      isRepoDefined = false;
+    }
 
     if (!isRepoDefined) {
       await repo.init(false, {

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -11,6 +11,7 @@ import { spawnAsync } from '../utils/shell-utils.js';
 import type { SimpleGit } from 'simple-git';
 import { simpleGit, CheckRepoActions } from 'simple-git';
 import type { Storage } from '../config/storage.js';
+import { debugLogger } from '../utils/debugLogger.js';
 
 export class GitService {
   private projectRoot: string;
@@ -70,10 +71,12 @@ export class GitService {
     let isRepoDefined = false;
     try {
       isRepoDefined = await repo.checkIsRepo(CheckRepoActions.IS_REPO_ROOT);
-    } catch (_error) {
+    } catch (error) {
       // If checkIsRepo fails (e.g., on certain Git versions like macOS 2.39.5),
-      // assume repo is not defined and proceed with initialization
-      isRepoDefined = false;
+      // log the error and assume repo is not defined, then proceed with initialization
+      debugLogger.debug(
+        `checkIsRepo failed, will initialize repository: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
 
     if (!isRepoDefined) {


### PR DESCRIPTION
## Description

Fixes #15308

Wrap the `simple-git` `checkIsRepo()` call in a try-catch block to handle failures on certain Git versions (e.g., macOS Apple Git 2.39.5).

When `checkIsRepo()` fails, we assume the repository is not defined and proceed with initialization, rather than crashing the CLI.

## Changes

- Added try-catch around `checkIsRepo()` in `setupShadowGitRepository()`
- - If `checkIsRepo()` throws, treat it as if the repo doesn't exist (proceed with init)
- - Added test case for this error handling scenario
## Testing

- All 18 GitService unit tests pass
- - New test case specifically tests the graceful handling of `checkIsRepo()` failure
- 