### PR TITLE
fix(shell): ensure session persistence works with Policy Engine

### DIFF
--- a/packages/a2a-server/src/http/app.test.ts
+++ b/packages/a2a-server/src/http/app.test.ts
@@ -35,7 +35,7 @@ import {
   createStreamMessageRequest,
   createMockConfig,
 } from '../utils/testing_utils.js';
-import { MockTool } from '@google/gemini-cli-core';
+import { MockTool } from '@google/gemini-cli-core/src/test-utils/mock-tool.js';
 import type { Command, CommandContext } from '../commands/types.js';
 
 const mockToolConfirmationFn = async () =>

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -31,10 +31,10 @@ import {
   DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
   ToolConfirmationOutcome,
   ApprovalMode,
-  MockTool,
   HookSystem,
   PREVIEW_GEMINI_MODEL,
 } from '@google/gemini-cli-core';
+import { MockTool } from '@google/gemini-cli-core/src/test-utils/mock-tool.js';
 import { createMockMessageBus } from '@google/gemini-cli-core/src/test-utils/mock-message-bus.js';
 import { ToolCallStatus } from '../types.js';
 

--- a/packages/core/src/confirmation-bus/types.ts
+++ b/packages/core/src/confirmation-bus/types.ts
@@ -41,7 +41,7 @@ export interface UpdatePolicy {
   toolName: string;
   persist?: boolean;
   argsPattern?: string;
-  commandPrefix?: string;
+  commandPrefix?: string | string[];
   mcpName?: string;
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -155,9 +155,6 @@ export { Storage } from './config/storage.js';
 // Export hooks system
 export * from './hooks/index.js';
 
-// Export test utils
-export * from './test-utils/index.js';
-
 // Export hook types
 export * from './hooks/types.js';
 

--- a/packages/core/src/policy/config.ts
+++ b/packages/core/src/policy/config.ts
@@ -16,11 +16,8 @@ import {
   type PolicySettings,
 } from './types.js';
 import type { PolicyEngine } from './policy-engine.js';
-import {
-  loadPoliciesFromToml,
-  type PolicyFileError,
-  escapeRegex,
-} from './toml-loader.js';
+import { loadPoliciesFromToml, type PolicyFileError } from './toml-loader.js';
+import { buildArgsPatterns } from './utils.js';
 import toml from '@iarna/toml';
 import {
   MessageBusType,
@@ -266,8 +263,10 @@ export function createPolicyUpdater(
       if (message.commandPrefix) {
         // Convert commandPrefix to argsPattern for in-memory rule
         // This mimics what toml-loader does
-        const escapedPrefix = escapeRegex(message.commandPrefix);
-        argsPattern = new RegExp(`"command":"${escapedPrefix}`);
+        const patterns = buildArgsPatterns(undefined, message.commandPrefix);
+        if (patterns[0]) {
+          argsPattern = new RegExp(patterns[0]);
+        }
       }
 
       policyEngine.addRule({

--- a/packages/core/src/policy/persistence.test.ts
+++ b/packages/core/src/policy/persistence.test.ts
@@ -126,7 +126,9 @@ describe('createPolicyUpdater', () => {
     const addedRule = rules.find((r) => r.toolName === toolName);
     expect(addedRule).toBeDefined();
     expect(addedRule?.priority).toBe(2.95);
-    expect(addedRule?.argsPattern).toEqual(new RegExp(`"command":"git status`));
+    expect(addedRule?.argsPattern).toEqual(
+      new RegExp(`"command":"git\\ status(?:[\\s"]|$)`),
+    );
 
     // Verify file written
     expect(fs.writeFile).toHaveBeenCalledWith(

--- a/packages/core/src/policy/policy-updater.test.ts
+++ b/packages/core/src/policy/policy-updater.test.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import { createPolicyUpdater } from './config.js';
+import { PolicyEngine } from './policy-engine.js';
+import { MessageBus } from '../confirmation-bus/message-bus.js';
+import { MessageBusType } from '../confirmation-bus/types.js';
+import { Storage } from '../config/storage.js';
+import toml from '@iarna/toml';
+import { ShellToolInvocation } from '../tools/shell.js';
+import { type Config } from '../config/config.js';
+import {
+  ToolConfirmationOutcome,
+  type PolicyUpdateOptions,
+} from '../tools/tools.js';
+import * as shellUtils from '../utils/shell-utils.js';
+
+vi.mock('node:fs/promises');
+vi.mock('../config/storage.js');
+vi.mock('../utils/shell-utils.js', () => ({
+  getCommandRoots: vi.fn(),
+  stripShellWrapper: vi.fn(),
+}));
+interface ParsedPolicy {
+  rule?: Array<{
+    commandPrefix?: string | string[];
+  }>;
+}
+
+interface TestableShellToolInvocation {
+  getPolicyUpdateOptions(
+    outcome: ToolConfirmationOutcome,
+  ): PolicyUpdateOptions | undefined;
+}
+
+describe('createPolicyUpdater', () => {
+  let policyEngine: PolicyEngine;
+  let messageBus: MessageBus;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    policyEngine = new PolicyEngine({});
+    vi.spyOn(policyEngine, 'addRule');
+
+    messageBus = new MessageBus(policyEngine);
+    vi.spyOn(Storage, 'getUserPoliciesDir').mockReturnValue(
+      '/mock/user/policies',
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should add multiple rules when commandPrefix is an array', async () => {
+    createPolicyUpdater(policyEngine, messageBus);
+
+    await messageBus.publish({
+      type: MessageBusType.UPDATE_POLICY,
+      toolName: 'run_shell_command',
+      commandPrefix: ['echo', 'ls'],
+      persist: false,
+    });
+
+    expect(policyEngine.addRule).toHaveBeenCalledTimes(2);
+    expect(policyEngine.addRule).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        toolName: 'run_shell_command',
+        argsPattern: new RegExp('"command":"echo(?:[\\s"]|$)'),
+      }),
+    );
+    expect(policyEngine.addRule).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        toolName: 'run_shell_command',
+        argsPattern: new RegExp('"command":"ls(?:[\\s"]|$)'),
+      }),
+    );
+  });
+
+  it('should add a single rule when commandPrefix is a string', async () => {
+    createPolicyUpdater(policyEngine, messageBus);
+
+    await messageBus.publish({
+      type: MessageBusType.UPDATE_POLICY,
+      toolName: 'run_shell_command',
+      commandPrefix: 'git',
+      persist: false,
+    });
+
+    expect(policyEngine.addRule).toHaveBeenCalledTimes(1);
+    expect(policyEngine.addRule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: 'run_shell_command',
+        argsPattern: new RegExp('"command":"git(?:[\\s"]|$)'),
+      }),
+    );
+  });
+
+  it('should persist multiple rules correctly to TOML', async () => {
+    createPolicyUpdater(policyEngine, messageBus);
+    vi.mocked(fs.readFile).mockRejectedValue({ code: 'ENOENT' });
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+    vi.mocked(fs.rename).mockResolvedValue(undefined);
+
+    await messageBus.publish({
+      type: MessageBusType.UPDATE_POLICY,
+      toolName: 'run_shell_command',
+      commandPrefix: ['echo', 'ls'],
+      persist: true,
+    });
+
+    // Wait for the async listener to complete
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fs.writeFile).toHaveBeenCalled();
+    const [_path, content] = vi.mocked(fs.writeFile).mock.calls[0] as [
+      string,
+      string,
+    ];
+    const parsed = toml.parse(content) as unknown as ParsedPolicy;
+
+    expect(parsed.rule).toHaveLength(1);
+    expect(parsed.rule![0].commandPrefix).toEqual(['echo', 'ls']);
+  });
+});
+
+describe('ShellToolInvocation Policy Update', () => {
+  let mockConfig: Config;
+  let mockMessageBus: MessageBus;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockConfig = {} as Config;
+    mockMessageBus = {} as MessageBus;
+
+    vi.mocked(shellUtils.stripShellWrapper).mockImplementation(
+      (c: string) => c,
+    );
+  });
+
+  it('should extract multiple root commands for chained commands', () => {
+    vi.mocked(shellUtils.getCommandRoots).mockReturnValue(['git', 'npm']);
+
+    const invocation = new ShellToolInvocation(
+      mockConfig,
+      { command: 'git status && npm test' },
+      mockMessageBus,
+      'run_shell_command',
+      'Shell',
+    );
+
+    // Accessing protected method for testing
+    const options = (
+      invocation as unknown as TestableShellToolInvocation
+    ).getPolicyUpdateOptions(ToolConfirmationOutcome.ProceedAlways);
+    expect(options!.commandPrefix).toEqual(['git', 'npm']);
+    expect(shellUtils.getCommandRoots).toHaveBeenCalledWith(
+      'git status && npm test',
+    );
+  });
+
+  it('should extract a single root command', () => {
+    vi.mocked(shellUtils.getCommandRoots).mockReturnValue(['ls']);
+
+    const invocation = new ShellToolInvocation(
+      mockConfig,
+      { command: 'ls -la /tmp' },
+      mockMessageBus,
+      'run_shell_command',
+      'Shell',
+    );
+
+    // Accessing protected method for testing
+    const options = (
+      invocation as unknown as TestableShellToolInvocation
+    ).getPolicyUpdateOptions(ToolConfirmationOutcome.ProceedAlways);
+    expect(options!.commandPrefix).toEqual(['ls']);
+    expect(shellUtils.getCommandRoots).toHaveBeenCalledWith('ls -la /tmp');
+  });
+});

--- a/packages/core/src/policy/utils.test.ts
+++ b/packages/core/src/policy/utils.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { escapeRegex, buildArgsPatterns } from './utils.js';
+
+describe('policy/utils', () => {
+  describe('escapeRegex', () => {
+    it('should escape special regex characters', () => {
+      const input = '.-*+?^${}()|[]\\ ';
+      const escaped = escapeRegex(input);
+      expect(escaped).toBe('\\.\\-\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\\\ ');
+    });
+
+    it('should return the same string if no special characters are present', () => {
+      const input = 'abcABC123';
+      expect(escapeRegex(input)).toBe(input);
+    });
+  });
+
+  describe('buildArgsPatterns', () => {
+    it('should return argsPattern if provided and no commandPrefix/regex', () => {
+      const result = buildArgsPatterns('my-pattern', undefined, undefined);
+      expect(result).toEqual(['my-pattern']);
+    });
+
+    it('should build pattern from a single commandPrefix', () => {
+      const result = buildArgsPatterns(undefined, 'ls', undefined);
+      expect(result).toEqual(['"command":"ls(?:[\\s"]|$)']);
+    });
+
+    it('should build patterns from an array of commandPrefixes', () => {
+      const result = buildArgsPatterns(undefined, ['ls', 'cd'], undefined);
+      expect(result).toEqual([
+        '"command":"ls(?:[\\s"]|$)',
+        '"command":"cd(?:[\\s"]|$)',
+      ]);
+    });
+
+    it('should build pattern from commandRegex', () => {
+      const result = buildArgsPatterns(undefined, undefined, 'rm -rf .*');
+      expect(result).toEqual(['"command":"rm -rf .*']);
+    });
+
+    it('should prioritize commandPrefix over commandRegex and argsPattern', () => {
+      const result = buildArgsPatterns('raw', 'prefix', 'regex');
+      expect(result).toEqual(['"command":"prefix(?:[\\s"]|$)']);
+    });
+
+    it('should prioritize commandRegex over argsPattern if no commandPrefix', () => {
+      const result = buildArgsPatterns('raw', undefined, 'regex');
+      expect(result).toEqual(['"command":"regex']);
+    });
+
+    it('should escape characters in commandPrefix', () => {
+      const result = buildArgsPatterns(undefined, 'git checkout -b', undefined);
+      expect(result).toEqual(['"command":"git\\ checkout\\ \\-b(?:[\\s"]|$)']);
+    });
+
+    it('should handle undefined correctly when no inputs are provided', () => {
+      const result = buildArgsPatterns(undefined, undefined, undefined);
+      expect(result).toEqual([undefined]);
+    });
+  });
+});

--- a/packages/core/src/policy/utils.ts
+++ b/packages/core/src/policy/utils.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Escapes a string for use in a regular expression.
+ */
+export function escapeRegex(text: string): string {
+  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+}
+
+/**
+ * Builds a list of args patterns for policy matching.
+ *
+ * This function handles the transformation of command prefixes and regexes into
+ * the internal argsPattern representation used by the PolicyEngine.
+ *
+ * @param argsPattern An optional raw regex string for arguments.
+ * @param commandPrefix An optional command prefix (or list of prefixes) to allow.
+ * @param commandRegex An optional command regex string to allow.
+ * @returns An array of string patterns (or undefined) for the PolicyEngine.
+ */
+export function buildArgsPatterns(
+  argsPattern?: string,
+  commandPrefix?: string | string[],
+  commandRegex?: string,
+): Array<string | undefined> {
+  let effectiveArgsPattern = argsPattern;
+  const commandPrefixes: string[] = [];
+
+  if (commandPrefix) {
+    const prefixes = Array.isArray(commandPrefix)
+      ? commandPrefix
+      : [commandPrefix];
+    commandPrefixes.push(...prefixes);
+  } else if (commandRegex) {
+    effectiveArgsPattern = `"command":"${commandRegex}`;
+  }
+
+  // Expand command prefixes to multiple patterns.
+  // We append [\\s"] to ensure we match whole words only (e.g., "git" but not "github").
+  // Since we match against JSON stringified args, the value is always followed by a space or a closing quote.
+  return commandPrefixes.length > 0
+    ? commandPrefixes.map(
+        (prefix) => `"command":"${escapeRegex(prefix)}(?:[\\s"]|$)`,
+      )
+    : [effectiveArgsPattern];
+}

--- a/packages/core/src/test-utils/index.ts
+++ b/packages/core/src/test-utils/index.ts
@@ -5,3 +5,4 @@
  */
 
 export * from './mock-tool.js';
+export * from './mock-message-bus.js';

--- a/packages/core/src/test-utils/mock-message-bus.ts
+++ b/packages/core/src/test-utils/mock-message-bus.ts
@@ -24,6 +24,7 @@ export class MockMessageBus {
   publishedMessages: Message[] = [];
   hookRequests: HookExecutionRequest[] = [];
   hookResponses: HookExecutionResponse[] = [];
+  defaultToolDecision: 'allow' | 'deny' | 'ask_user' = 'allow';
 
   /**
    * Mock publish method that captures messages and simulates responses
@@ -50,6 +51,34 @@ export class MockMessageBus {
       // Emit response to subscribers
       this.emit(MessageBusType.HOOK_EXECUTION_RESPONSE, response);
     }
+
+    // Handle tool confirmation requests
+    if (message.type === MessageBusType.TOOL_CONFIRMATION_REQUEST) {
+      if (this.defaultToolDecision === 'allow') {
+        this.emit(MessageBusType.TOOL_CONFIRMATION_RESPONSE, {
+          type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+          correlationId: message.correlationId,
+          confirmed: true,
+        });
+      } else if (this.defaultToolDecision === 'deny') {
+        this.emit(MessageBusType.TOOL_CONFIRMATION_RESPONSE, {
+          type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+          correlationId: message.correlationId,
+          confirmed: false,
+        });
+      } else {
+        // ask_user
+        this.emit(MessageBusType.TOOL_CONFIRMATION_RESPONSE, {
+          type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+          correlationId: message.correlationId,
+          confirmed: false,
+          requiresUserConfirmation: true,
+        });
+      }
+    }
+
+    // Emit the message to subscribers (mimicking real MessageBus behavior)
+    this.emit(message.type, message);
   });
 
   /**

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -118,10 +118,13 @@ describe('ShellTool', () => {
     // Simulate policy update
     bus.subscribe(MessageBusType.UPDATE_POLICY, (msg: UpdatePolicy) => {
       if (msg.commandPrefix) {
+        const prefixes = Array.isArray(msg.commandPrefix)
+          ? msg.commandPrefix
+          : [msg.commandPrefix];
         const current = mockConfig.getAllowedTools() || [];
         (mockConfig.getAllowedTools as Mock).mockReturnValue([
           ...current,
-          msg.commandPrefix,
+          ...prefixes,
         ]);
         // Simulate Policy Engine allowing the tool after update
         mockBus.defaultToolDecision = 'allow';

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -37,7 +37,6 @@ vi.mock('crypto');
 vi.mock('../utils/summarizer.js');
 
 import { initializeShellParsers } from '../utils/shell-utils.js';
-import { isCommandAllowed } from '../utils/shell-permissions.js';
 import { ShellTool } from './shell.js';
 import { type Config } from '../config/config.js';
 import {
@@ -51,10 +50,27 @@ import * as path from 'node:path';
 import * as crypto from 'node:crypto';
 import * as summarizer from '../utils/summarizer.js';
 import { ToolErrorType } from './tool-error.js';
-import { ToolConfirmationOutcome } from './tools.js';
+import {
+  type ToolCallConfirmationDetails,
+  type ToolExecuteConfirmationDetails,
+  ToolConfirmationOutcome,
+} from './tools.js';
 import { OUTPUT_UPDATE_INTERVAL_MS } from './shell.js';
 import { SHELL_TOOL_NAME } from './tool-names.js';
 import { WorkspaceContext } from '../utils/workspaceContext.js';
+import {
+  createMockMessageBus,
+  getMockMessageBusInstance,
+} from '../test-utils/mock-message-bus.js';
+import {
+  MessageBusType,
+  type UpdatePolicy,
+} from '../confirmation-bus/types.js';
+import { type MessageBus } from '../confirmation-bus/message-bus.js';
+
+interface TestableMockMessageBus extends MessageBus {
+  defaultToolDecision: 'allow' | 'deny' | 'ask_user';
+}
 
 const originalComSpec = process.env['ComSpec'];
 const itWindowsOnly = process.platform === 'win32' ? it : it.skip;
@@ -93,7 +109,26 @@ describe('ShellTool', () => {
       getShellToolInactivityTimeout: vi.fn().mockReturnValue(300000),
     } as unknown as Config;
 
-    shellTool = new ShellTool(mockConfig);
+    const bus = createMockMessageBus();
+    const mockBus = getMockMessageBusInstance(
+      bus,
+    ) as unknown as TestableMockMessageBus;
+    mockBus.defaultToolDecision = 'ask_user';
+
+    // Simulate policy update
+    bus.subscribe(MessageBusType.UPDATE_POLICY, (msg: UpdatePolicy) => {
+      if (msg.commandPrefix) {
+        const current = mockConfig.getAllowedTools() || [];
+        (mockConfig.getAllowedTools as Mock).mockReturnValue([
+          ...current,
+          msg.commandPrefix,
+        ]);
+        // Simulate Policy Engine allowing the tool after update
+        mockBus.defaultToolDecision = 'allow';
+      }
+    });
+
+    shellTool = new ShellTool(mockConfig, bus);
 
     mockPlatform.mockReturnValue('linux');
     (vi.mocked(crypto.randomBytes) as Mock).mockReturnValue(
@@ -123,25 +158,6 @@ describe('ShellTool', () => {
     } else {
       process.env['ComSpec'] = originalComSpec;
     }
-  });
-
-  describe('isCommandAllowed', () => {
-    it('should allow a command if no restrictions are provided', () => {
-      (mockConfig.getCoreTools as Mock).mockReturnValue(undefined);
-      (mockConfig.getExcludeTools as Mock).mockReturnValue(undefined);
-      expect(isCommandAllowed('goodCommand --safe', mockConfig).allowed).toBe(
-        true,
-      );
-    });
-
-    it('should allow a command with command substitution using $()', () => {
-      const evaluation = isCommandAllowed(
-        'echo $(goodCommand --safe)',
-        mockConfig,
-      );
-      expect(evaluation.allowed).toBe(true);
-      expect(evaluation.reason).toBeUndefined();
-    });
   });
 
   describe('build', () => {
@@ -475,19 +491,30 @@ describe('ShellTool', () => {
     it('should request confirmation for a new command and allowlist it on "Always"', async () => {
       const params = { command: 'npm install' };
       const invocation = shellTool.build(params);
-      const confirmation = await invocation.shouldConfirmExecute(
-        new AbortController().signal,
-      );
+
+      // Accessing protected messageBus for testing purposes
+      const bus = (shellTool as unknown as { messageBus: MessageBus })
+        .messageBus;
+      const mockBus = getMockMessageBusInstance(
+        bus,
+      ) as unknown as TestableMockMessageBus;
+
+      // Initially needs confirmation
+      mockBus.defaultToolDecision = 'ask_user';
+      const confirmation: ToolCallConfirmationDetails | false =
+        await invocation.shouldConfirmExecute(new AbortController().signal);
 
       expect(confirmation).not.toBe(false);
-      expect(confirmation && confirmation.type).toBe('exec');
+      if (confirmation && confirmation.type === 'exec') {
+        expect(confirmation.type).toBe('exec');
+        const execConfirmation: ToolExecuteConfirmationDetails = confirmation;
+        await execConfirmation.onConfirm(ToolConfirmationOutcome.ProceedAlways);
+      } else {
+        throw new Error('Expected exec confirmation');
+      }
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await (confirmation as any).onConfirm(
-        ToolConfirmationOutcome.ProceedAlways,
-      );
-
-      // Should now be allowlisted
+      // After "Always", it should be allowlisted in the mock engine
+      mockBus.defaultToolDecision = 'allow';
       const secondInvocation = shellTool.build({ command: 'npm test' });
       const secondConfirmation = await secondInvocation.shouldConfirmExecute(
         new AbortController().signal,
@@ -499,61 +526,36 @@ describe('ShellTool', () => {
       expect(() => shellTool.build({ command: '' })).toThrow();
     });
 
-    describe('in non-interactive mode', () => {
-      beforeEach(() => {
-        (mockConfig.isInteractive as Mock).mockReturnValue(false);
+    describe('interaction with Policy Engine', () => {
+      it('should throw an error when policy DENIES execution', async () => {
+        const invocation = shellTool.build({ command: 'rm -rf /' });
+        const bus = (shellTool as unknown as { messageBus: MessageBus })
+          .messageBus;
+        const mockBus = getMockMessageBusInstance(
+          bus,
+        ) as unknown as TestableMockMessageBus;
+
+        mockBus.defaultToolDecision = 'deny';
+
+        await expect(
+          invocation.shouldConfirmExecute(new AbortController().signal),
+        ).rejects.toThrow('denied by policy');
       });
 
-      it('should not throw an error or block for an allowed command', async () => {
-        (mockConfig.getAllowedTools as Mock).mockReturnValue(['ShellTool(wc)']);
-        const invocation = shellTool.build({ command: 'wc -l foo.txt' });
+      it('should return false when policy ALLOWS execution', async () => {
+        const invocation = shellTool.build({ command: 'ls' });
+        const bus = (shellTool as unknown as { messageBus: MessageBus })
+          .messageBus;
+        const mockBus = getMockMessageBusInstance(
+          bus,
+        ) as unknown as TestableMockMessageBus;
+
+        mockBus.defaultToolDecision = 'allow';
+
         const confirmation = await invocation.shouldConfirmExecute(
           new AbortController().signal,
         );
         expect(confirmation).toBe(false);
-      });
-
-      it('should not throw an error or block for an allowed command with arguments', async () => {
-        (mockConfig.getAllowedTools as Mock).mockReturnValue([
-          'ShellTool(wc -l)',
-        ]);
-        const invocation = shellTool.build({ command: 'wc -l foo.txt' });
-        const confirmation = await invocation.shouldConfirmExecute(
-          new AbortController().signal,
-        );
-        expect(confirmation).toBe(false);
-      });
-
-      it('should throw an error for command that is not allowed', async () => {
-        (mockConfig.getAllowedTools as Mock).mockReturnValue([
-          'ShellTool(wc -l)',
-        ]);
-        const invocation = shellTool.build({ command: 'madeupcommand' });
-        await expect(
-          invocation.shouldConfirmExecute(new AbortController().signal),
-        ).rejects.toThrow('madeupcommand');
-      });
-
-      it('should throw an error for a command that is a prefix of an allowed command', async () => {
-        (mockConfig.getAllowedTools as Mock).mockReturnValue([
-          'ShellTool(wc -l)',
-        ]);
-        const invocation = shellTool.build({ command: 'wc' });
-        await expect(
-          invocation.shouldConfirmExecute(new AbortController().signal),
-        ).rejects.toThrow('wc');
-      });
-
-      it('should require all segments of a chained command to be allowlisted', async () => {
-        (mockConfig.getAllowedTools as Mock).mockReturnValue([
-          'ShellTool(echo)',
-        ]);
-        const invocation = shellTool.build({ command: 'echo "foo" && ls -l' });
-        await expect(
-          invocation.shouldConfirmExecute(new AbortController().signal),
-        ).rejects.toThrow(
-          'Command "echo "foo" && ls -l" is not in the list of allowed tools for non-interactive mode.',
-        );
       });
     });
   });
@@ -561,13 +563,13 @@ describe('ShellTool', () => {
   describe('getDescription', () => {
     it('should return the windows description when on windows', () => {
       mockPlatform.mockReturnValue('win32');
-      const shellTool = new ShellTool(mockConfig);
+      const shellTool = new ShellTool(mockConfig, createMockMessageBus());
       expect(shellTool.description).toMatchSnapshot();
     });
 
     it('should return the non-windows description when not on windows', () => {
       mockPlatform.mockReturnValue('linux');
-      const shellTool = new ShellTool(mockConfig);
+      const shellTool = new ShellTool(mockConfig, createMockMessageBus());
       expect(shellTool.description).toMatchSnapshot();
     });
   });

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -9,7 +9,7 @@ import path from 'node:path';
 import os, { EOL } from 'node:os';
 import crypto from 'node:crypto';
 import type { Config } from '../config/config.js';
-import { debugLogger, type AnyToolInvocation } from '../index.js';
+import { debugLogger } from '../index.js';
 import { ToolErrorType } from './tool-error.js';
 import type {
   ToolInvocation,
@@ -24,7 +24,6 @@ import {
   Kind,
   type PolicyUpdateOptions,
 } from './tools.js';
-import { ApprovalMode } from '../policy/types.js';
 
 import { getErrorMessage } from '../utils/errors.js';
 import { summarizeToolOutput } from '../utils/summarizer.js';
@@ -40,10 +39,6 @@ import {
   initializeShellParsers,
   stripShellWrapper,
 } from '../utils/shell-utils.js';
-import {
-  isCommandAllowed,
-  isShellInvocationAllowlisted,
-} from '../utils/shell-permissions.js';
 import { SHELL_TOOL_NAME } from './tool-names.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 
@@ -62,8 +57,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
   constructor(
     private readonly config: Config,
     params: ShellToolParams,
-    private readonly allowlist: Set<string>,
-    messageBus?: MessageBus,
+    messageBus: MessageBus,
     _toolName?: string,
     _toolDisplayName?: string,
   ) {
@@ -89,7 +83,10 @@ export class ShellToolInvocation extends BaseToolInvocation<
   protected override getPolicyUpdateOptions(
     outcome: ToolConfirmationOutcome,
   ): PolicyUpdateOptions | undefined {
-    if (outcome === ToolConfirmationOutcome.ProceedAlwaysAndSave) {
+    if (
+      outcome === ToolConfirmationOutcome.ProceedAlwaysAndSave ||
+      outcome === ToolConfirmationOutcome.ProceedAlways
+    ) {
       return { commandPrefix: this.params.command };
     }
     return undefined;
@@ -101,41 +98,12 @@ export class ShellToolInvocation extends BaseToolInvocation<
     const command = stripShellWrapper(this.params.command);
     const rootCommands = [...new Set(getCommandRoots(command))];
 
-    // In non-interactive mode, we need to prevent the tool from hanging while
-    // waiting for user input. If a tool is not fully allowed (e.g. via
-    // --allowed-tools="ShellTool(wc)"), we should throw an error instead of
-    // prompting for confirmation. This check is skipped in YOLO mode.
-    if (
-      !this.config.isInteractive() &&
-      this.config.getApprovalMode() !== ApprovalMode.YOLO
-    ) {
-      if (this.isInvocationAllowlisted(command)) {
-        // If it's an allowed shell command, we don't need to confirm execution.
-        return false;
-      }
-
-      throw new Error(
-        `Command "${command}" is not in the list of allowed tools for non-interactive mode.`,
-      );
-    }
-
-    const commandsToConfirm = rootCommands.filter(
-      (command) => !this.allowlist.has(command),
-    );
-
-    if (commandsToConfirm.length === 0) {
-      return false; // already approved and allowlisted
-    }
-
     const confirmationDetails: ToolExecuteConfirmationDetails = {
       type: 'exec',
       title: 'Confirm Shell Command',
       command: this.params.command,
-      rootCommand: commandsToConfirm.join(', '),
+      rootCommand: rootCommands.join(', '),
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
-        if (outcome === ToolConfirmationOutcome.ProceedAlways) {
-          commandsToConfirm.forEach((command) => this.allowlist.add(command));
-        }
         await this.publishPolicyUpdate(outcome);
       },
     };
@@ -395,16 +363,6 @@ export class ShellToolInvocation extends BaseToolInvocation<
       }
     }
   }
-
-  private isInvocationAllowlisted(command: string): boolean {
-    const allowedTools = this.config.getAllowedTools() || [];
-    if (allowedTools.length === 0) {
-      return false;
-    }
-
-    const invocation = { params: { command } } as unknown as AnyToolInvocation;
-    return isShellInvocationAllowlisted(invocation, allowedTools);
-  }
 }
 
 function getShellToolDescription(): string {
@@ -443,11 +401,9 @@ export class ShellTool extends BaseDeclarativeTool<
 > {
   static readonly Name = SHELL_TOOL_NAME;
 
-  private allowlist: Set<string> = new Set();
-
   constructor(
     private readonly config: Config,
-    messageBus?: MessageBus,
+    messageBus: MessageBus,
   ) {
     void initializeShellParsers().catch(() => {
       // Errors are surfaced when parsing commands.
@@ -490,16 +446,6 @@ export class ShellTool extends BaseDeclarativeTool<
       return 'Command cannot be empty.';
     }
 
-    const commandCheck = isCommandAllowed(params.command, this.config);
-    if (!commandCheck.allowed) {
-      if (!commandCheck.reason) {
-        debugLogger.error(
-          'Unexpected: isCommandAllowed returned false without a reason',
-        );
-        return `Command is not allowed: ${params.command}`;
-      }
-      return commandCheck.reason;
-    }
     if (getCommandRoots(params.command).length === 0) {
       return 'Could not identify command root to obtain permission from user.';
     }
@@ -518,14 +464,13 @@ export class ShellTool extends BaseDeclarativeTool<
 
   protected createInvocation(
     params: ShellToolParams,
-    messageBus?: MessageBus,
+    messageBus: MessageBus,
     _toolName?: string,
     _toolDisplayName?: string,
   ): ToolInvocation<ShellToolParams, ToolResult> {
     return new ShellToolInvocation(
       this.config,
       params,
-      this.allowlist,
       messageBus,
       _toolName,
       _toolDisplayName,

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -87,6 +87,11 @@ export class ShellToolInvocation extends BaseToolInvocation<
       outcome === ToolConfirmationOutcome.ProceedAlwaysAndSave ||
       outcome === ToolConfirmationOutcome.ProceedAlways
     ) {
+      const command = stripShellWrapper(this.params.command);
+      const rootCommands = [...new Set(getCommandRoots(command))];
+      if (rootCommands.length > 0) {
+        return { commandPrefix: rootCommands };
+      }
       return { commandPrefix: this.params.command };
     }
     return undefined;

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -69,7 +69,7 @@ export interface ToolInvocation<
  * Options for policy updates that can be customized by tool invocations.
  */
 export interface PolicyUpdateOptions {
-  commandPrefix?: string;
+  commandPrefix?: string | string[];
   mcpName?: string;
 }
 


### PR DESCRIPTION
## Summary

Refactors ShellTool to utilize the Policy Engine and Message Bus for command confirmation, ensuring that "Proceed Always" decisions are correctly persisted across sessions through the policy engine rather than a local in-memory allowlist.

## Details

- Detaches ShellTool from legacy permission checks and manual allowlist management.
- Implements `publishPolicyUpdate` in `ShellToolInvocation` to correctly inform the Policy Engine of user confirmation outcomes.
- Centralizes regex escaping and argument pattern building for policies in `packages/core/src/policy/utils.ts`.
- Updates `ShellTool` tests to properly mock Message Bus interactions and verify policy-driven behavior.
- Updates documentation and settings schema to reflect the transition to policy-based confirmation.

## Related Issues

Related to Policy Engine integration and session persistence.

## How to Validate

1. Run `npm run test` in `packages/core` to verify `ShellTool` and policy utility tests pass.
2. Run `npm run build` to ensure the workspace builds correctly.
3. Run Gemini CLI, execute a shell command (e.g., `ls`), select "Proceed Always", and verify subsequent calls to the same command are automatically allowed.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
