### PR TITLE
fix(ide): use localhost in devcontainers to fix IDE connection

### DIFF
--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -847,6 +847,15 @@ export class IdeClient {
 }
 
 function getIdeServerHost() {
+  // In a VS Code Dev Container or other remote environment, the IDE companion
+  // is typically running inside the same container.
+  if (
+    process.env['VSCODE_IPC_HOOK_CLI'] ||
+    process.env['VSCODE_TERMINAL_TOKEN']
+  ) {
+    return '127.0.0.1';
+  }
+
   const isInContainer =
     fs.existsSync('/.dockerenv') || fs.existsSync('/run/.containerenv');
   return isInContainer ? 'host.docker.internal' : '127.0.0.1';


### PR DESCRIPTION
## Summary

Fixes [google-gemini/gemini-cli#15607](https://github.com/google-gemini/gemini-cli/issues/15607)

When running inside a Dev Container, the IDE Extension host is reachable at `127.0.0.1` inside the container. Currentl the CLI incorrectly attempts to use `host.docker.internal` when it detects a container environment, leading to connection failures and direct-to-disk write fallbacks.

## Details

This PR adds a check for VS Code remote environment variables (`VSCODE_IPC_HOOK_CLI` or `VSCODE_TERMINAL_TOKEN`) to identify when the CLI is running in a VS Code remote environment (like a Dev Container). In these cases, it correctly targets `127.0.0.1`.

## Related Issues

Fixes [google-gemini/gemini-cli#15607](https://github.com/google-gemini/gemini-cli/issues/15607)

 ## How to Validate
1. Open this repository in a VS Code Dev Container.
1. Build the project:
     `npm install`
     `npm run bundle`
1. Create a dummy file: `echo "original text" > test_diff.txt`
1. Run the CLI to propose a change: `node bundle/gemini.js "change the text in test_diff.txt to 'new text'"`
1. **Expected Result:** A "Review Changes" / Diff View tab should open in VS Code.
1. **Prior to Fix:** The file `test_diff.txt` would be modified directly on disk with no IDE interaction.
 
## Pre-Merge Checklist

 - [ ] Updated relevant documentation and README (if needed)
 - [ ] Added/updated tests (if needed)
 - [ ] Noted breaking changes (if any)
 - [ ] Validated on required platforms/methods:
   - [ ] MacOS
     - [ ] npm run
     - [ ] npx
     - [ ] Docker
     - [ ] Podman
     - [ ] Seatbelt
   - [ ] Windows
     - [ ] npm run
     - [ ] npx
     - [ ] Docker
   - [x] Linux (Dev Container)
     - [ ] npm run
     - [ ] npx
     - [x] Docker