### PR TITLE
Feat/allow command

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -213,6 +213,20 @@ Slash commands provide meta-level control over the CLI itself.
   - **Description:** Show version info. Please share this information when
     filing issues.
 
+- **`/allow`**
+  - **Description:** Manage allowed tools (whitelist). This command allows you
+    to add, remove, and list tools that are permitted to run without manual
+    confirmation.
+  - **Sub-commands:**
+    - **`add`**
+      - **Description:** Adds a tool to the allowed list.
+      - **Usage:** `/allow add <tool> [--scope user|project]`
+    - **`remove`**
+      - **Description:** Removes a tool from the allowed list.
+      - **Usage:** `/allow remove <tool> [--scope user|project]`
+    - **`list`**
+      - **Description:** Lists all tools currently in the allowed list.
+
 - [**`/tools`**](../tools/index.md)
   - **Description:** Display a list of tools that are currently available within
     Gemini CLI.

--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -90,6 +90,7 @@ they appear in the UI.
 | Enable Interactive Shell         | `tools.shell.enableInteractiveShell` | Use node-pty for an interactive shell experience. Fallback to child_process still applies.                      | `true`  |
 | Show Color                       | `tools.shell.showColor`              | Show color in shell output.                                                                                     | `false` |
 | Auto Accept                      | `tools.autoAccept`                   | Automatically accept and execute tool calls that are considered safe (e.g., read-only operations).              | `false` |
+| Allowed Tools                    | `tools.allowed`                      | A list of tools that are allowed to run without manual confirmation.                                            | `[]`    |
 | Use Ripgrep                      | `tools.useRipgrep`                   | Use ripgrep for file content search instead of the fallback implementation. Provides faster search performance. | `true`  |
 | Enable Tool Output Truncation    | `tools.enableToolOutputTruncation`   | Enable truncation of large tool outputs.                                                                        | `true`  |
 | Tool Output Truncation Threshold | `tools.truncateToolOutputThreshold`  | Truncate tool output if it is larger than this many characters. Set to -1 to disable.                           | `10000` |

--- a/packages/a2a-server/src/commands/command-registry.test.ts
+++ b/packages/a2a-server/src/commands/command-registry.test.ts
@@ -31,26 +31,26 @@ describe('CommandRegistry', () => {
       ExtensionsCommand: mockExtensionsCommand,
       ListExtensionsCommand: mockListExtensionsCommand,
     }));
-  });
+  }, 10000);
 
   it('should register ExtensionsCommand on initialization', async () => {
     const { commandRegistry } = await import('./command-registry.js');
     expect(mockExtensionsCommand).toHaveBeenCalled();
     const command = commandRegistry.get('extensions');
     expect(command).toBe(mockExtensionsCommandInstance);
-  });
+  }, 10000);
 
   it('should register sub commands on initialization', async () => {
     const { commandRegistry } = await import('./command-registry.js');
     const command = commandRegistry.get('extensions list');
     expect(command).toBe(mockListExtensionsCommandInstance);
-  });
+  }, 10000);
 
   it('get() should return undefined for a non-existent command', async () => {
     const { commandRegistry } = await import('./command-registry.js');
     const command = commandRegistry.get('non-existent');
     expect(command).toBeUndefined();
-  });
+  }, 10000);
 
   it('register() should register a new command', async () => {
     const { commandRegistry } = await import('./command-registry.js');
@@ -62,7 +62,7 @@ describe('CommandRegistry', () => {
     commandRegistry.register(mockCommand);
     const command = commandRegistry.get('test-command');
     expect(command).toBe(mockCommand);
-  });
+  }, 10000);
 
   it('register() should register a nested command', async () => {
     const { commandRegistry } = await import('./command-registry.js');
@@ -92,7 +92,7 @@ describe('CommandRegistry', () => {
     expect(command).toBe(mockCommand);
     expect(subCommand).toBe(mockSubCommand);
     expect(subSubCommand).toBe(mockSubSubCommand);
-  });
+  }, 10000);
 
   it('register() should not enter an infinite loop with a cyclic command', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -114,5 +114,5 @@ describe('CommandRegistry', () => {
     );
     // If the test finishes, it means we didn't get into an infinite loop.
     warnSpy.mockRestore();
-  });
+  }, 10000);
 });

--- a/packages/a2a-server/src/commands/command-registry.test.ts
+++ b/packages/a2a-server/src/commands/command-registry.test.ts
@@ -31,26 +31,26 @@ describe('CommandRegistry', () => {
       ExtensionsCommand: mockExtensionsCommand,
       ListExtensionsCommand: mockListExtensionsCommand,
     }));
-  }, 10000);
+  });
 
   it('should register ExtensionsCommand on initialization', async () => {
     const { commandRegistry } = await import('./command-registry.js');
     expect(mockExtensionsCommand).toHaveBeenCalled();
     const command = commandRegistry.get('extensions');
     expect(command).toBe(mockExtensionsCommandInstance);
-  }, 10000);
+  });
 
   it('should register sub commands on initialization', async () => {
     const { commandRegistry } = await import('./command-registry.js');
     const command = commandRegistry.get('extensions list');
     expect(command).toBe(mockListExtensionsCommandInstance);
-  }, 10000);
+  });
 
   it('get() should return undefined for a non-existent command', async () => {
     const { commandRegistry } = await import('./command-registry.js');
     const command = commandRegistry.get('non-existent');
     expect(command).toBeUndefined();
-  }, 10000);
+  });
 
   it('register() should register a new command', async () => {
     const { commandRegistry } = await import('./command-registry.js');
@@ -62,7 +62,7 @@ describe('CommandRegistry', () => {
     commandRegistry.register(mockCommand);
     const command = commandRegistry.get('test-command');
     expect(command).toBe(mockCommand);
-  }, 10000);
+  });
 
   it('register() should register a nested command', async () => {
     const { commandRegistry } = await import('./command-registry.js');
@@ -92,7 +92,7 @@ describe('CommandRegistry', () => {
     expect(command).toBe(mockCommand);
     expect(subCommand).toBe(mockSubCommand);
     expect(subSubCommand).toBe(mockSubSubCommand);
-  }, 10000);
+  });
 
   it('register() should not enter an infinite loop with a cyclic command', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -114,5 +114,5 @@ describe('CommandRegistry', () => {
     );
     // If the test finishes, it means we didn't get into an infinite loop.
     warnSpy.mockRestore();
-  }, 10000);
+  });
 });

--- a/packages/cli/src/commands/allow.test.ts
+++ b/packages/cli/src/commands/allow.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { allowCommand } from './allow.js';
+import { type Argv } from 'yargs';
+import yargs from 'yargs';
+
+describe('allow command', () => {
+  it('should have correct command definition', () => {
+    expect(allowCommand.command).toBe('allow');
+    expect(allowCommand.describe).toBe('Manage allowed tools (whitelist)');
+    expect(typeof allowCommand.builder).toBe('function');
+    expect(typeof allowCommand.handler).toBe('function');
+  });
+
+  it('should show help when no subcommand is provided', async () => {
+    const yargsInstance = yargs();
+    (allowCommand.builder as (y: Argv) => Argv)(yargsInstance);
+
+    const parser = yargsInstance.command(allowCommand).help();
+
+    // Mock console.log and console.error to catch help output
+    const consoleLogMock = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => {});
+    const consoleErrorMock = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    try {
+      await parser.parse('allow');
+    } catch (_error) {
+      // yargs might throw an error when demandCommand is not met
+    }
+
+    // Check if help output is shown
+    const helpOutput =
+      consoleLogMock.mock.calls.join('\n') +
+      consoleErrorMock.mock.calls.join('\n');
+    expect(helpOutput).toContain('Manage allowed tools (whitelist)');
+    expect(helpOutput).toContain('Commands:');
+    expect(helpOutput).toContain('add');
+    expect(helpOutput).toContain('remove');
+    expect(helpOutput).toContain('list');
+
+    consoleLogMock.mockRestore();
+    consoleErrorMock.mockRestore();
+  });
+
+  it('should register add, remove, and list subcommands', () => {
+    const mockYargs = {
+      command: vi.fn().mockReturnThis(),
+      demandCommand: vi.fn().mockReturnThis(),
+      version: vi.fn().mockReturnThis(),
+      middleware: vi.fn().mockReturnThis(),
+    };
+
+    (allowCommand.builder as (y: Argv) => Argv)(mockYargs as unknown as Argv);
+
+    expect(mockYargs.command).toHaveBeenCalledTimes(3);
+
+    // Verify that the specific subcommands are registered
+    const commandCalls = mockYargs.command.mock.calls;
+    const commandNames = commandCalls.map((call) => call[0].command);
+
+    expect(commandNames).toContain('add <tool>');
+    expect(commandNames).toContain('remove <tool>');
+    expect(commandNames).toContain('list');
+
+    expect(mockYargs.demandCommand).toHaveBeenCalledWith(
+      1,
+      'You need at least one command before continuing.',
+    );
+  });
+});

--- a/packages/cli/src/commands/allow.ts
+++ b/packages/cli/src/commands/allow.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule, Argv } from 'yargs';
+import { addCommand } from './allow/add.js';
+import { removeCommand } from './allow/remove.js';
+import { listCommand } from './allow/list.js';
+import { initializeOutputListenersAndFlush } from '../gemini.js';
+
+export const allowCommand: CommandModule = {
+  command: 'allow',
+  describe: 'Manage allowed tools (whitelist)',
+  builder: (yargs: Argv) =>
+    yargs
+      .middleware(() => initializeOutputListenersAndFlush())
+      .command(addCommand)
+      .command(removeCommand)
+      .command(listCommand)
+      .demandCommand(1, 'You need at least one command before continuing.')
+      .version(false),
+  handler: () => {
+    // yargs will automatically show help if no subcommand is provided
+  },
+};

--- a/packages/cli/src/commands/allow/add.test.ts
+++ b/packages/cli/src/commands/allow/add.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  type Mock,
+  type MockInstance,
+} from 'vitest';
+import yargs, { type Argv } from 'yargs';
+import { addCommand } from './add.js';
+import { loadSettings, SettingScope } from '../../config/settings.js';
+import { debugLogger } from '@google/gemini-cli-core';
+
+vi.mock('../utils.js', () => ({
+  exitCli: vi.fn(),
+}));
+
+vi.mock('../../config/settings.js', async () => {
+  const actual = await vi.importActual('../../config/settings.js');
+  return {
+    ...actual,
+    loadSettings: vi.fn(),
+  };
+});
+
+const mockedLoadSettings = loadSettings as Mock;
+
+describe('allow add command', () => {
+  let parser: Argv;
+  let mockSetValue: Mock;
+  let debugLoggerLogSpy: MockInstance;
+  let debugLoggerErrorSpy: MockInstance;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    const yargsInstance = yargs([]).command(addCommand);
+    parser = yargsInstance;
+    mockSetValue = vi.fn();
+    debugLoggerLogSpy = vi
+      .spyOn(debugLogger, 'log')
+      .mockImplementation(() => {});
+    debugLoggerErrorSpy = vi
+      .spyOn(debugLogger, 'error')
+      .mockImplementation(() => {});
+
+    mockedLoadSettings.mockReturnValue({
+      forScope: () => ({ settings: { tools: { allowed: [] } } }),
+      setValue: mockSetValue,
+      workspace: { path: '/path/to/project' },
+      user: { path: '/home/user' },
+    });
+  });
+
+  it('should add a tool to project settings by default', async () => {
+    await parser.parseAsync('add my_tool');
+
+    expect(mockSetValue).toHaveBeenCalledWith(
+      SettingScope.Workspace,
+      'tools.allowed',
+      ['my_tool'],
+    );
+    expect(debugLoggerLogSpy).toHaveBeenCalledWith(
+      'Tool "my_tool" added to allowed list in project settings.',
+    );
+  });
+
+  it('should add a tool to user settings when --scope user is used', async () => {
+    await parser.parseAsync('add --scope user my_tool');
+
+    expect(mockSetValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      'tools.allowed',
+      ['my_tool'],
+    );
+    expect(debugLoggerLogSpy).toHaveBeenCalledWith(
+      'Tool "my_tool" added to allowed list in user settings.',
+    );
+  });
+
+  it('should not add a tool if it is already allowed', async () => {
+    mockedLoadSettings.mockReturnValue({
+      forScope: () => ({ settings: { tools: { allowed: ['my_tool'] } } }),
+      setValue: mockSetValue,
+      workspace: { path: '/path/to/project' },
+      user: { path: '/home/user' },
+    });
+
+    await parser.parseAsync('add my_tool');
+
+    expect(mockSetValue).not.toHaveBeenCalled();
+    expect(debugLoggerLogSpy).toHaveBeenCalledWith(
+      'Tool "my_tool" is already allowed in project settings.',
+    );
+  });
+
+  it('should error when adding to project scope while in home directory', async () => {
+    mockedLoadSettings.mockReturnValue({
+      forScope: () => ({ settings: { tools: { allowed: [] } } }),
+      setValue: mockSetValue,
+      workspace: { path: '/home/user' },
+      user: { path: '/home/user' },
+    });
+
+    const mockProcessExit = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => {
+        throw new Error('process.exit called');
+      }) as (code?: number | string | null) => never);
+
+    await expect(parser.parseAsync('add my_tool')).rejects.toThrow(
+      'process.exit called',
+    );
+
+    expect(debugLoggerErrorSpy).toHaveBeenCalledWith(
+      'Error: Please use --scope user to edit settings in the home directory.',
+    );
+    expect(mockProcessExit).toHaveBeenCalledWith(1);
+    expect(mockSetValue).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/allow/add.test.ts
+++ b/packages/cli/src/commands/allow/add.test.ts
@@ -108,20 +108,14 @@ describe('allow add command', () => {
       user: { path: '/home/user' },
     });
 
-    const mockProcessExit = vi
-      .spyOn(process, 'exit')
-      .mockImplementation((() => {
-        throw new Error('process.exit called');
-      }) as (code?: number | string | null) => never);
+    const { exitCli } = await import('../utils.js');
 
-    await expect(parser.parseAsync('add my_tool')).rejects.toThrow(
-      'process.exit called',
-    );
+    await parser.parseAsync('add my_tool');
 
     expect(debugLoggerErrorSpy).toHaveBeenCalledWith(
       'Error: Please use --scope user to edit settings in the home directory.',
     );
-    expect(mockProcessExit).toHaveBeenCalledWith(1);
+    expect(exitCli).toHaveBeenCalledWith(1);
     expect(mockSetValue).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/allow/add.ts
+++ b/packages/cli/src/commands/allow/add.ts
@@ -14,7 +14,7 @@ async function addAllowedTool(
   options: {
     scope: string;
   },
-) {
+): Promise<boolean> {
   const { scope } = options;
 
   const settings = loadSettings(process.cwd());
@@ -24,7 +24,7 @@ async function addAllowedTool(
     debugLogger.error(
       'Error: Please use --scope user to edit settings in the home directory.',
     );
-    process.exit(1);
+    return false;
   }
 
   const settingsScope =
@@ -36,7 +36,7 @@ async function addAllowedTool(
 
   if (allowed.includes(tool)) {
     debugLogger.log(`Tool "${tool}" is already allowed in ${scope} settings.`);
-    return;
+    return true;
   }
 
   const newAllowed = [...allowed, tool];
@@ -44,6 +44,7 @@ async function addAllowedTool(
   settings.setValue(settingsScope, 'tools.allowed', newAllowed);
 
   debugLogger.log(`Tool "${tool}" added to allowed list in ${scope} settings.`);
+  return true;
 }
 
 export const addCommand: CommandModule = {
@@ -65,9 +66,9 @@ export const addCommand: CommandModule = {
         choices: ['user', 'project'],
       }),
   handler: async (argv) => {
-    await addAllowedTool(argv['tool'] as string, {
+    const success = await addAllowedTool(argv['tool'] as string, {
       scope: argv['scope'] as string,
     });
-    await exitCli();
+    await exitCli(success ? 0 : 1);
   },
 };

--- a/packages/cli/src/commands/allow/add.ts
+++ b/packages/cli/src/commands/allow/add.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule } from 'yargs';
+import { loadSettings, SettingScope } from '../../config/settings.js';
+import { debugLogger } from '@google/gemini-cli-core';
+import { exitCli } from '../utils.js';
+
+async function addAllowedTool(
+  tool: string,
+  options: {
+    scope: string;
+  },
+) {
+  const { scope } = options;
+
+  const settings = loadSettings(process.cwd());
+  const inHome = settings.workspace.path === settings.user.path;
+
+  if (scope === 'project' && inHome) {
+    debugLogger.error(
+      'Error: Please use --scope user to edit settings in the home directory.',
+    );
+    process.exit(1);
+  }
+
+  const settingsScope =
+    scope === 'user' ? SettingScope.User : SettingScope.Workspace;
+
+  const existingSettings = settings.forScope(settingsScope).settings;
+  const tools = existingSettings.tools || {};
+  const allowed = tools.allowed || [];
+
+  if (allowed.includes(tool)) {
+    debugLogger.log(`Tool "${tool}" is already allowed in ${scope} settings.`);
+    return;
+  }
+
+  const newAllowed = [...allowed, tool];
+
+  settings.setValue(settingsScope, 'tools.allowed', newAllowed);
+
+  debugLogger.log(`Tool "${tool}" added to allowed list in ${scope} settings.`);
+}
+
+export const addCommand: CommandModule = {
+  command: 'add <tool>',
+  describe: 'Add a tool to the allowed list',
+  builder: (yargs) =>
+    yargs
+      .usage('Usage: gemini allow add [options] <tool>')
+      .positional('tool', {
+        describe: 'Tool pattern to allow (e.g. "run_shell_command(git)")',
+        type: 'string',
+        demandOption: true,
+      })
+      .option('scope', {
+        alias: 's',
+        describe: 'Configuration scope (user or project)',
+        type: 'string',
+        default: 'project',
+        choices: ['user', 'project'],
+      }),
+  handler: async (argv) => {
+    await addAllowedTool(argv['tool'] as string, {
+      scope: argv['scope'] as string,
+    });
+    await exitCli();
+  },
+};

--- a/packages/cli/src/commands/allow/list.test.ts
+++ b/packages/cli/src/commands/allow/list.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  type Mock,
+  type MockInstance,
+} from 'vitest';
+import yargs, { type Argv } from 'yargs';
+import { listCommand } from './list.js';
+import { loadSettings } from '../../config/settings.js';
+import { debugLogger } from '@google/gemini-cli-core';
+
+vi.mock('../utils.js', () => ({
+  exitCli: vi.fn(),
+}));
+
+vi.mock('../../config/settings.js', async () => {
+  const actual = await vi.importActual('../../config/settings.js');
+  return {
+    ...actual,
+    loadSettings: vi.fn(),
+  };
+});
+
+const mockedLoadSettings = loadSettings as Mock;
+
+describe('allow list command', () => {
+  let parser: Argv;
+  let debugLoggerLogSpy: MockInstance;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    const yargsInstance = yargs([]).command(listCommand);
+    parser = yargsInstance;
+    debugLoggerLogSpy = vi
+      .spyOn(debugLogger, 'log')
+      .mockImplementation(() => {});
+  });
+
+  it('should list allowed tools', async () => {
+    mockedLoadSettings.mockReturnValue({
+      merged: { tools: { allowed: ['tool1', 'tool2'] } },
+    });
+
+    await parser.parseAsync('list');
+
+    expect(debugLoggerLogSpy).toHaveBeenCalledWith('Allowed tools:');
+    expect(debugLoggerLogSpy).toHaveBeenCalledWith('- tool1');
+    expect(debugLoggerLogSpy).toHaveBeenCalledWith('- tool2');
+  });
+
+  it('should show message when no tools are allowed', async () => {
+    mockedLoadSettings.mockReturnValue({
+      merged: { tools: { allowed: [] } },
+    });
+
+    await parser.parseAsync('list');
+
+    expect(debugLoggerLogSpy).toHaveBeenCalledWith(
+      'No allowed tools configured.',
+    );
+  });
+});

--- a/packages/cli/src/commands/allow/list.ts
+++ b/packages/cli/src/commands/allow/list.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule } from 'yargs';
+import { loadSettings } from '../../config/settings.js';
+import { debugLogger } from '@google/gemini-cli-core';
+import { exitCli } from '../utils.js';
+
+async function listAllowedTools() {
+  const settings = loadSettings(process.cwd());
+  const allowed = settings.merged.tools?.allowed || [];
+
+  if (allowed.length === 0) {
+    debugLogger.log('No allowed tools configured.');
+    return;
+  }
+
+  debugLogger.log('Allowed tools:');
+  for (const tool of allowed) {
+    debugLogger.log(`- ${tool}`);
+  }
+}
+
+export const listCommand: CommandModule = {
+  command: 'list',
+  describe: 'List allowed tools',
+  handler: async () => {
+    await listAllowedTools();
+    await exitCli();
+  },
+};

--- a/packages/cli/src/commands/allow/remove.test.ts
+++ b/packages/cli/src/commands/allow/remove.test.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  type Mock,
+  type MockInstance,
+} from 'vitest';
+import yargs, { type Argv } from 'yargs';
+import { removeCommand } from './remove.js';
+import { loadSettings, SettingScope } from '../../config/settings.js';
+import { debugLogger } from '@google/gemini-cli-core';
+
+vi.mock('../utils.js', () => ({
+  exitCli: vi.fn(),
+}));
+
+vi.mock('../../config/settings.js', async () => {
+  const actual = await vi.importActual('../../config/settings.js');
+  return {
+    ...actual,
+    loadSettings: vi.fn(),
+  };
+});
+
+const mockedLoadSettings = loadSettings as Mock;
+
+describe('allow remove command', () => {
+  let parser: Argv;
+  let mockSetValue: Mock;
+  let debugLoggerLogSpy: MockInstance;
+  let debugLoggerWarnSpy: MockInstance;
+  let debugLoggerErrorSpy: MockInstance;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    const yargsInstance = yargs([]).command(removeCommand);
+    parser = yargsInstance;
+    mockSetValue = vi.fn();
+    debugLoggerLogSpy = vi
+      .spyOn(debugLogger, 'log')
+      .mockImplementation(() => {});
+    debugLoggerWarnSpy = vi
+      .spyOn(debugLogger, 'warn')
+      .mockImplementation(() => {});
+    debugLoggerErrorSpy = vi
+      .spyOn(debugLogger, 'error')
+      .mockImplementation(() => {});
+
+    mockedLoadSettings.mockReturnValue({
+      forScope: () => ({ settings: { tools: { allowed: ['my_tool'] } } }),
+      setValue: mockSetValue,
+      workspace: { path: '/path/to/project' },
+      user: { path: '/home/user' },
+    });
+  });
+
+  it('should remove a tool from project settings', async () => {
+    await parser.parseAsync('remove my_tool');
+
+    expect(mockSetValue).toHaveBeenCalledWith(
+      SettingScope.Workspace,
+      'tools.allowed',
+      [],
+    );
+    expect(debugLoggerLogSpy).toHaveBeenCalledWith(
+      'Tool "my_tool" removed from allowed list in project settings.',
+    );
+  });
+
+  it('should remove a tool from user settings', async () => {
+    await parser.parseAsync('remove --scope user my_tool');
+
+    expect(mockSetValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      'tools.allowed',
+      [],
+    );
+    expect(debugLoggerLogSpy).toHaveBeenCalledWith(
+      'Tool "my_tool" removed from allowed list in user settings.',
+    );
+  });
+
+  it('should warn if tool is not found', async () => {
+    mockedLoadSettings.mockReturnValue({
+      forScope: () => ({ settings: { tools: { allowed: [] } } }),
+      setValue: mockSetValue,
+      workspace: { path: '/path/to/project' },
+      user: { path: '/home/user' },
+    });
+
+    await parser.parseAsync('remove my_tool');
+
+    expect(mockSetValue).not.toHaveBeenCalled();
+    expect(debugLoggerWarnSpy).toHaveBeenCalledWith(
+      'Tool "my_tool" is not found in project allowed list.',
+    );
+  });
+
+  it('should error when removing from project scope while in home directory', async () => {
+    mockedLoadSettings.mockReturnValue({
+      forScope: () => ({ settings: { tools: { allowed: ['my_tool'] } } }),
+      setValue: mockSetValue,
+      workspace: { path: '/home/user' },
+      user: { path: '/home/user' },
+    });
+
+    const mockProcessExit = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => {
+        throw new Error('process.exit called');
+      }) as (code?: number | string | null) => never);
+
+    await expect(parser.parseAsync('remove my_tool')).rejects.toThrow(
+      'process.exit called',
+    );
+
+    expect(debugLoggerErrorSpy).toHaveBeenCalledWith(
+      'Error: Please use --scope user to edit settings in the home directory.',
+    );
+    expect(mockProcessExit).toHaveBeenCalledWith(1);
+    expect(mockSetValue).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/allow/remove.test.ts
+++ b/packages/cli/src/commands/allow/remove.test.ts
@@ -112,20 +112,14 @@ describe('allow remove command', () => {
       user: { path: '/home/user' },
     });
 
-    const mockProcessExit = vi
-      .spyOn(process, 'exit')
-      .mockImplementation((() => {
-        throw new Error('process.exit called');
-      }) as (code?: number | string | null) => never);
+    const { exitCli } = await import('../utils.js');
 
-    await expect(parser.parseAsync('remove my_tool')).rejects.toThrow(
-      'process.exit called',
-    );
+    await parser.parseAsync('remove my_tool');
 
     expect(debugLoggerErrorSpy).toHaveBeenCalledWith(
       'Error: Please use --scope user to edit settings in the home directory.',
     );
-    expect(mockProcessExit).toHaveBeenCalledWith(1);
+    expect(exitCli).toHaveBeenCalledWith(1);
     expect(mockSetValue).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/allow/remove.ts
+++ b/packages/cli/src/commands/allow/remove.ts
@@ -14,7 +14,7 @@ async function removeAllowedTool(
   options: {
     scope: string;
   },
-) {
+): Promise<boolean> {
   const { scope } = options;
 
   const settings = loadSettings(process.cwd());
@@ -24,7 +24,7 @@ async function removeAllowedTool(
     debugLogger.error(
       'Error: Please use --scope user to edit settings in the home directory.',
     );
-    process.exit(1);
+    return false;
   }
 
   const settingsScope =
@@ -36,7 +36,7 @@ async function removeAllowedTool(
 
   if (!allowed.includes(tool)) {
     debugLogger.warn(`Tool "${tool}" is not found in ${scope} allowed list.`);
-    return;
+    return true;
   }
 
   const newAllowed = allowed.filter((t) => t !== tool);
@@ -46,6 +46,7 @@ async function removeAllowedTool(
   debugLogger.log(
     `Tool "${tool}" removed from allowed list in ${scope} settings.`,
   );
+  return true;
 }
 
 export const removeCommand: CommandModule = {
@@ -67,9 +68,9 @@ export const removeCommand: CommandModule = {
         choices: ['user', 'project'],
       }),
   handler: async (argv) => {
-    await removeAllowedTool(argv['tool'] as string, {
+    const success = await removeAllowedTool(argv['tool'] as string, {
       scope: argv['scope'] as string,
     });
-    await exitCli();
+    await exitCli(success ? 0 : 1);
   },
 };

--- a/packages/cli/src/commands/allow/remove.ts
+++ b/packages/cli/src/commands/allow/remove.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule } from 'yargs';
+import { loadSettings, SettingScope } from '../../config/settings.js';
+import { debugLogger } from '@google/gemini-cli-core';
+import { exitCli } from '../utils.js';
+
+async function removeAllowedTool(
+  tool: string,
+  options: {
+    scope: string;
+  },
+) {
+  const { scope } = options;
+
+  const settings = loadSettings(process.cwd());
+  const inHome = settings.workspace.path === settings.user.path;
+
+  if (scope === 'project' && inHome) {
+    debugLogger.error(
+      'Error: Please use --scope user to edit settings in the home directory.',
+    );
+    process.exit(1);
+  }
+
+  const settingsScope =
+    scope === 'user' ? SettingScope.User : SettingScope.Workspace;
+
+  const existingSettings = settings.forScope(settingsScope).settings;
+  const tools = existingSettings.tools || {};
+  const allowed = tools.allowed || [];
+
+  if (!allowed.includes(tool)) {
+    debugLogger.warn(`Tool "${tool}" is not found in ${scope} allowed list.`);
+    return;
+  }
+
+  const newAllowed = allowed.filter((t) => t !== tool);
+
+  settings.setValue(settingsScope, 'tools.allowed', newAllowed);
+
+  debugLogger.log(
+    `Tool "${tool}" removed from allowed list in ${scope} settings.`,
+  );
+}
+
+export const removeCommand: CommandModule = {
+  command: 'remove <tool>',
+  describe: 'Remove a tool from the allowed list',
+  builder: (yargs) =>
+    yargs
+      .usage('Usage: gemini allow remove [options] <tool>')
+      .positional('tool', {
+        describe: 'Tool pattern to remove',
+        type: 'string',
+        demandOption: true,
+      })
+      .option('scope', {
+        alias: 's',
+        describe: 'Configuration scope (user or project)',
+        type: 'string',
+        default: 'project',
+        choices: ['user', 'project'],
+      }),
+  handler: async (argv) => {
+    await removeAllowedTool(argv['tool'] as string, {
+      scope: argv['scope'] as string,
+    });
+    await exitCli();
+  },
+};

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -10,6 +10,7 @@ import type { SlashCommand } from '../ui/commands/types.js';
 import type { Config } from '@google/gemini-cli-core';
 import { startupProfiler } from '@google/gemini-cli-core';
 import { aboutCommand } from '../ui/commands/aboutCommand.js';
+import { allowCommand } from '../ui/commands/allowCommand.js';
 import { authCommand } from '../ui/commands/authCommand.js';
 import { bugCommand } from '../ui/commands/bugCommand.js';
 import { chatCommand } from '../ui/commands/chatCommand.js';
@@ -61,6 +62,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
     const handle = startupProfiler.start('load_builtin_commands');
     const allDefinitions: Array<SlashCommand | null> = [
       aboutCommand,
+      allowCommand,
       authCommand,
       bugCommand,
       chatCommand,

--- a/packages/cli/src/ui/commands/allowCommand.tsx
+++ b/packages/cli/src/ui/commands/allowCommand.tsx
@@ -35,24 +35,37 @@ const addAction = async (
   args: string,
 ): Promise<SlashCommandActionReturn> => {
   // Parse arguments to find scope flag
-  // Split by whitespace and filter out empty strings to handle multiple spaces safely
   const argsList = args.trim().split(/\s+/).filter(Boolean);
+
+  // Normalize --scope=value to --scope value
+  for (let i = 0; i < argsList.length; i++) {
+    if (argsList[i].startsWith('--scope=')) {
+      const [flag, value] = argsList[i].split('=');
+      argsList.splice(i, 1, flag, value);
+    }
+  }
+
   let scope = SettingScope.Workspace;
   const toolArgs: string[] = [];
 
   for (let i = 0; i < argsList.length; i++) {
     const arg = argsList[i];
     if (arg === '-s' || arg === '--scope') {
-      const next = argsList[i + 1];
-      if (next === 'user') {
-        scope = SettingScope.User;
-        i++; // skip next
-      } else if (next === 'project' || next === 'workspace') {
-        scope = SettingScope.Workspace;
-        i++; // skip next
-      } else {
-        // likely an invalid scope name, consume it to avoid confusion if it's not a flag
-        if (next && !next.startsWith('-')) i++;
+      const value = argsList[i + 1]?.toLowerCase();
+      switch (value) {
+        case 'user':
+          scope = SettingScope.User;
+          i++;
+          break;
+        case 'project':
+        case 'workspace':
+          scope = SettingScope.Workspace;
+          i++;
+          break;
+        default:
+          // If the next token isn't a valid scope, we treat it as part of the tool name
+          // and keep the default scope.
+          break;
       }
     } else {
       toolArgs.push(arg);
@@ -112,21 +125,34 @@ const removeAction = async (
 ): Promise<SlashCommandActionReturn> => {
   // Parse arguments to find scope flag
   const argsList = args.trim().split(/\s+/).filter(Boolean);
+
+  // Normalize --scope=value to --scope value
+  for (let i = 0; i < argsList.length; i++) {
+    if (argsList[i].startsWith('--scope=')) {
+      const [flag, value] = argsList[i].split('=');
+      argsList.splice(i, 1, flag, value);
+    }
+  }
+
   let scope = SettingScope.Workspace;
   const toolArgs: string[] = [];
 
   for (let i = 0; i < argsList.length; i++) {
     const arg = argsList[i];
     if (arg === '-s' || arg === '--scope') {
-      const next = argsList[i + 1];
-      if (next === 'user') {
-        scope = SettingScope.User;
-        i++;
-      } else if (next === 'project' || next === 'workspace') {
-        scope = SettingScope.Workspace;
-        i++;
-      } else {
-        if (next && !next.startsWith('-')) i++;
+      const value = argsList[i + 1]?.toLowerCase();
+      switch (value) {
+        case 'user':
+          scope = SettingScope.User;
+          i++;
+          break;
+        case 'project':
+        case 'workspace':
+          scope = SettingScope.Workspace;
+          i++;
+          break;
+        default:
+          break;
       }
     } else {
       toolArgs.push(arg);

--- a/packages/cli/src/ui/commands/allowCommand.tsx
+++ b/packages/cli/src/ui/commands/allowCommand.tsx
@@ -1,0 +1,238 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  SlashCommand,
+  SlashCommandActionReturn,
+  CommandContext,
+} from './types.js';
+import { CommandKind } from './types.js';
+import { loadSettings, SettingScope } from '../../config/settings.js';
+import { AllowWizard } from '../components/AllowWizard.js';
+
+const listAction = async (context: CommandContext): Promise<void> => {
+  const settings = loadSettings(process.cwd());
+  const allowed = settings.merged.tools?.allowed || [];
+
+  if (allowed.length === 0) {
+    context.ui.addItem(
+      { type: 'info', text: 'No allowed tools configured.' },
+      Date.now(),
+    );
+    return;
+  }
+
+  const text =
+    'Allowed tools:\n' + allowed.map((tool) => `- ${tool}`).join('\n');
+  context.ui.addItem({ type: 'info', text }, Date.now());
+};
+
+const addAction = async (
+  context: CommandContext,
+  args: string,
+): Promise<SlashCommandActionReturn> => {
+  // Parse arguments to find scope flag
+  // Split by whitespace and filter out empty strings to handle multiple spaces safely
+  const argsList = args.trim().split(/\s+/).filter(Boolean);
+  let scope = SettingScope.Workspace;
+  const toolArgs: string[] = [];
+
+  for (let i = 0; i < argsList.length; i++) {
+    const arg = argsList[i];
+    if (arg === '-s' || arg === '--scope') {
+      const next = argsList[i + 1];
+      if (next === 'user') {
+        scope = SettingScope.User;
+        i++; // skip next
+      } else if (next === 'project' || next === 'workspace') {
+        scope = SettingScope.Workspace;
+        i++; // skip next
+      } else {
+        // likely an invalid scope name, consume it to avoid confusion if it's not a flag
+        if (next && !next.startsWith('-')) i++;
+      }
+    } else {
+      toolArgs.push(arg);
+    }
+  }
+
+  const tool = toolArgs.join(' ').trim();
+
+  // If no tool provided, show the interactive wizard
+  if (!tool) {
+    return {
+      type: 'custom_dialog',
+      component: (
+        <AllowWizard
+          context={context}
+          scope={scope}
+          onClose={() => context.ui.removeComponent()}
+        />
+      ),
+    };
+  }
+
+  const settings = loadSettings(process.cwd());
+  // Use the scope determined from flags, defaulting to Workspace
+  const existingSettings = settings.forScope(scope).settings;
+  const tools = existingSettings.tools || {};
+  const allowed = tools.allowed || [];
+
+  if (allowed.includes(tool)) {
+    return {
+      type: 'message',
+      messageType: 'info',
+      content: `Tool "${tool}" is already allowed.`,
+    };
+  }
+
+  const newAllowed = [...allowed, tool];
+  settings.setValue(scope, 'tools.allowed', newAllowed);
+
+  // Update in-memory config for immediate effect
+  if (context.services.config) {
+    const reloadedSettings = loadSettings(process.cwd());
+    const mergedAllowed = reloadedSettings.merged.tools?.allowed || [];
+    context.services.config.setAllowedTools(mergedAllowed);
+  }
+
+  return {
+    type: 'message',
+    messageType: 'info',
+    content: `Tool "${tool}" added to allowed list (${scope === SettingScope.User ? 'User' : 'Workspace'} scope).`,
+  };
+};
+
+const removeAction = async (
+  context: CommandContext,
+  args: string,
+): Promise<SlashCommandActionReturn> => {
+  // Parse arguments to find scope flag
+  const argsList = args.trim().split(/\s+/).filter(Boolean);
+  let scope = SettingScope.Workspace;
+  const toolArgs: string[] = [];
+
+  for (let i = 0; i < argsList.length; i++) {
+    const arg = argsList[i];
+    if (arg === '-s' || arg === '--scope') {
+      const next = argsList[i + 1];
+      if (next === 'user') {
+        scope = SettingScope.User;
+        i++;
+      } else if (next === 'project' || next === 'workspace') {
+        scope = SettingScope.Workspace;
+        i++;
+      } else {
+        if (next && !next.startsWith('-')) i++;
+      }
+    } else {
+      toolArgs.push(arg);
+    }
+  }
+
+  const tool = toolArgs.join(' ').trim();
+
+  if (!tool) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: 'Please specify a tool pattern to remove.',
+    };
+  }
+
+  const settings = loadSettings(process.cwd());
+  const existingSettings = settings.forScope(scope).settings;
+  const tools = existingSettings.tools || {};
+  const allowed = tools.allowed || [];
+
+  if (!allowed.includes(tool)) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: `Tool "${tool}" not found in allowed list (${scope === SettingScope.User ? 'User' : 'Workspace'} scope).`,
+    };
+  }
+
+  const newAllowed = allowed.filter((t) => t !== tool);
+  settings.setValue(scope, 'tools.allowed', newAllowed);
+
+  // Update in-memory config for immediate effect
+  if (context.services.config) {
+    const reloadedSettings = loadSettings(process.cwd());
+    const mergedAllowed = reloadedSettings.merged.tools?.allowed || [];
+    context.services.config.setAllowedTools(mergedAllowed);
+  }
+
+  return {
+    type: 'message',
+    messageType: 'info',
+    content: `Tool "${tool}" removed from allowed list.`,
+  };
+};
+
+const listCommand: SlashCommand = {
+  name: 'list',
+  description: 'List all allowed tools',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: async (context) => {
+    await listAction(context);
+  },
+};
+
+const addCommand: SlashCommand = {
+  name: 'add',
+  description: 'Add a tool to the allowed list',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: addAction,
+  completion: (context: CommandContext, partialArg: string) => {
+    const suggestions = [
+      'run_shell_command(',
+      'read_file',
+      'replace',
+      'grep',
+      'list_directory',
+      'glob',
+      '-s user',
+      '-s project',
+    ];
+
+    // If they already started typing run_shell_command, give some examples
+    if (partialArg.startsWith('run_shell_command')) {
+      suggestions.push(
+        'run_shell_command(git)',
+        'run_shell_command(ls)',
+        'run_shell_command(npm)',
+      );
+    }
+
+    return suggestions.filter((s) => s.startsWith(partialArg));
+  },
+};
+
+const removeCommand: SlashCommand = {
+  name: 'remove',
+  description: 'Remove a tool from the allowed list',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: removeAction,
+  completion: async (context: CommandContext, partialArg: string) => {
+    const allowed = context.services.config?.getAllowedTools() || [];
+    return allowed.filter((t) => t.startsWith(partialArg));
+  },
+};
+
+export const allowCommand: SlashCommand = {
+  name: 'allow',
+  description: 'Manage allowed tools (whitelist)',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: false,
+  subCommands: [listCommand, addCommand, removeCommand],
+  action: async (context) => {
+    await listAction(context);
+  },
+};

--- a/packages/cli/src/ui/components/AllowWizard.tsx
+++ b/packages/cli/src/ui/components/AllowWizard.tsx
@@ -1,0 +1,203 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, useCallback, useMemo } from 'react';
+import { Box, Text } from 'ink';
+import { DescriptiveRadioButtonSelect } from './shared/DescriptiveRadioButtonSelect.js';
+import { TextInput } from './shared/TextInput.js';
+import { useTextBuffer } from './shared/text-buffer.js';
+import { useTerminalSize } from '../hooks/useTerminalSize.js';
+import { theme } from '../semantic-colors.js';
+import { useKeypress } from '../hooks/useKeypress.js';
+import {
+  SettingScope,
+  loadSettings,
+  type LoadableSettingScope,
+} from '../../config/settings.js';
+import type { CommandContext } from '../commands/types.js';
+
+interface AllowWizardProps {
+  context: CommandContext;
+  scope: SettingScope;
+  onClose: () => void;
+}
+
+export function AllowWizard({ context, scope, onClose }: AllowWizardProps) {
+  const [step, setStep] = useState<'select' | 'input'>('select');
+  const [type, setType] = useState<'shell' | 'other' | null>(null);
+  const terminalSize = useTerminalSize();
+
+  const buffer = useTextBuffer({
+    initialText: '',
+    viewport: { width: Math.max(20, terminalSize.columns - 4), height: 1 }, // Adjust width for padding/borders, ensure min width
+    isValidPath: () => true, // Simple validation for now
+    singleLine: true,
+  });
+
+  useKeypress(
+    (key) => {
+      if (key.name === 'escape') {
+        onClose();
+      }
+    },
+    { isActive: true },
+  );
+
+  const options = useMemo(
+    () => [
+      {
+        value: 'shell',
+        title: 'Shell Command',
+        description: 'Allow specific shell commands (e.g. "git status")',
+        key: '1',
+      },
+      {
+        value: 'other',
+        title: 'Other Tool',
+        description: 'Allow other tools by name (e.g. "read_file")',
+        key: '2',
+      },
+    ],
+    [],
+  );
+
+  const handleSelect = useCallback((value: string) => {
+    setType(value as 'shell' | 'other');
+    setStep('input');
+  }, []);
+
+  const handleInputSubmit = useCallback(
+    (input: string) => {
+      const tools = input
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean);
+      if (tools.length === 0) return;
+
+      const settings = loadSettings(process.cwd());
+      // Safe cast because we know the scope passed from allowCommand is valid for loading/saving
+      // (User or Workspace)
+      const loadableScope = scope as LoadableSettingScope;
+      const existingSettings = settings.forScope(loadableScope).settings;
+      const currentAllowed = existingSettings.tools?.allowed || [];
+
+      const newAllowed = [...currentAllowed];
+      let addedCount = 0;
+
+      tools.forEach((tool) => {
+        // If shell, wrap in run_shell_command(). If it already has it, don't double wrap.
+        let finalTool = tool;
+        if (type === 'shell') {
+          if (
+            !tool.startsWith('run_shell_command(') &&
+            !tool.startsWith('ShellTool(')
+          ) {
+            finalTool = `run_shell_command(${tool})`;
+          }
+        }
+
+        if (!newAllowed.includes(finalTool)) {
+          newAllowed.push(finalTool);
+          addedCount++;
+        }
+      });
+
+      if (addedCount > 0) {
+        settings.setValue(loadableScope, 'tools.allowed', newAllowed);
+
+        // Update in-memory config
+        if (context.services.config) {
+          const reloadedSettings = loadSettings(process.cwd());
+          const mergedAllowed = reloadedSettings.merged.tools?.allowed || [];
+          context.services.config.setAllowedTools(mergedAllowed);
+        }
+
+        context.ui.addItem(
+          {
+            type: 'info',
+            text: `Added ${addedCount} tool(s) to ${scope === SettingScope.User ? 'User' : 'Workspace'} allowlist.`,
+          },
+          Date.now(),
+        );
+      } else {
+        context.ui.addItem(
+          {
+            type: 'info',
+            text: `No new tools added (duplicates or empty).`,
+          },
+          Date.now(),
+        );
+      }
+
+      onClose();
+    },
+    [type, scope, context, onClose],
+  );
+
+  if (step === 'select') {
+    return (
+      <Box
+        flexDirection="column"
+        borderStyle="round"
+        borderColor={theme.border.default}
+        padding={1}
+      >
+        <Text bold>Allow Tools</Text>
+        <Box marginTop={1}>
+          <Text color={theme.status.warning}>
+            {scope === SettingScope.Workspace
+              ? 'You are modifying the Workspace (project) scope.'
+              : 'You are modifying the User (global) scope.'}
+          </Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text color={theme.text.secondary}>
+            Select the type of tool you want to allow:
+          </Text>
+        </Box>
+        <Box marginTop={1}>
+          <DescriptiveRadioButtonSelect
+            items={options}
+            onSelect={handleSelect}
+            showNumbers
+          />
+        </Box>
+        <Box marginTop={1}>
+          <Text color={theme.text.secondary}>(Press Esc to cancel)</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={theme.border.default}
+      padding={1}
+    >
+      <Text bold>Allow {type === 'shell' ? 'Shell Commands' : 'Tools'}</Text>
+      <Box marginTop={1} marginBottom={1}>
+        <Text>
+          Enter {type === 'shell' ? 'commands' : 'tool names'} to allow,
+          separated by commas.
+          {type === 'shell' && (
+            <Text color={theme.text.secondary}>
+              {' '}
+              (e.g. &quot;ls -la, git status&quot;)
+            </Text>
+          )}
+        </Text>
+      </Box>
+      <TextInput
+        buffer={buffer}
+        placeholder="> "
+        onSubmit={handleInputSubmit}
+        onCancel={onClose}
+      />
+    </Box>
+  );
+}

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -285,6 +285,38 @@ describe('ToolRegistry', () => {
     });
   });
 
+  describe('allowed tools', () => {
+    const toolA = new MockTool({ name: 'tool-a', displayName: 'Tool A' });
+    const toolB = new MockTool({ name: 'tool-b', displayName: 'Tool B' });
+
+    it('should only return tools that are in the allowlist', () => {
+      toolRegistry.registerTool(toolA);
+      toolRegistry.registerTool(toolB);
+
+      // Set allowlist to only include toolA
+      toolRegistry.setAllowedTools(['tool-a']);
+
+      expect(toolRegistry.getAllToolNames()).toEqual(['tool-a']);
+      expect(toolRegistry.getTool('tool-a')).toBe(toolA);
+      expect(toolRegistry.getTool('tool-b')).toBeUndefined();
+    });
+
+    it('should initialize with allowed tools from config', () => {
+      const configWithAllowed = new Config({
+        ...baseConfigParams,
+        allowedTools: ['tool-a'],
+      });
+      const registryWithAllowed = new ToolRegistry(configWithAllowed);
+
+      registryWithAllowed.registerTool(toolA);
+      registryWithAllowed.registerTool(toolB);
+
+      expect(registryWithAllowed.getAllToolNames()).toEqual(['tool-a']);
+      expect(registryWithAllowed.getTool('tool-a')).toBe(toolA);
+      expect(registryWithAllowed.getTool('tool-b')).toBeUndefined();
+    });
+  });
+
   describe('getAllTools', () => {
     it('should return all registered tools sorted alphabetically by displayName', () => {
       // Register tools with displayNames in non-alphabetical order

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -191,11 +191,16 @@ export class ToolRegistry {
   // This includes tools which are currently not active, use `getActiveTools`
   // and `isActive` to get only the active tools.
   private allKnownTools: Map<string, AnyDeclarativeTool> = new Map();
+  private allowedTools: Set<string> | undefined;
   private config: Config;
   private messageBus?: MessageBus;
 
   constructor(config: Config) {
     this.config = config;
+  }
+
+  setAllowedTools(allowedTools: string[] | undefined): void {
+    this.allowedTools = allowedTools ? new Set(allowedTools) : undefined;
   }
 
   setMessageBus(messageBus: MessageBus): void {
@@ -457,6 +462,13 @@ export class ToolRegistry {
         possibleNames.push(`${tool.getFullyQualifiedPrefix()}${tool.name}`);
       }
     }
+
+    if (this.allowedTools) {
+      if (!possibleNames.some((name) => this.allowedTools!.has(name))) {
+        return false;
+      }
+    }
+
     return !possibleNames.some((name) => excludeTools.has(name));
   }
 

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -197,6 +197,7 @@ export class ToolRegistry {
 
   constructor(config: Config) {
     this.config = config;
+    this.setAllowedTools(config.getAllowedTools());
   }
 
   setAllowedTools(allowedTools: string[] | undefined): void {


### PR DESCRIPTION
## Summary
  This PR adds the /allow slash command to Gemini CLI, enabling users to manage their tools whitelist (allowed tools)
  directly from the active session. It also implements a critical core update that allows the model's tool declarations
  to be refreshed at runtime without requiring a restart.

## Details

   - Feature Implementation: Adds /allow with add, remove, and list subcommands.
   - Interactive Experience: Includes a React-based interactive wizard (AllowWizard) that triggers when /allow add is
     called without arguments, helping users safely whitelist shell commands or built-in tools.
   - Configuration Management: Updates are persisted to the user's settings.json in either user or workspace scope.
   - Dynamic Tool Refreshing:
       - Implemented Config.setAllowedTools() and ToolRegistry.setAllowedTools().
       - Updated GeminiClient to re-send tool declarations to the model immediately when the whitelist changes. This
         allows the model to "see" and use newly permitted tools instantly.
   - Critical Fix (Startup): Fixed an issue where the ToolRegistry ignored the whitelist on startup. It now correctly
     initializes from settings.json in the constructor.
   - Critical Fix (Graceful Shutdown): Refactored CLI commands to use exitCli instead of process.exit(1), ensuring
     proper cleanup and preventing resource leaks.
   - Robust Parsing: Improved argument parsing for the --scope flag to handle both space-separated and equals-sign
     syntax (--scope user and --scope=user) and added input validation.

## Related Issues

Closes #15629

## How to Validate

   1. List Tools: Run /allow list to view the current whitelist.
   2. Add a Tool via CLI: Run /allow add "run_shell_command(ls)" --scope project.
   3. Use the Wizard: Run /allow add and follow the prompts to add a tool (e.g., read_file).
   4. Verify Immediate Refresh: Ask the model to use a tool that is not yet allowed. It will fail or ask for permission.
      Then, use /allow add to whitelist it and ask the model again. It should now be able to use the tool without a
      restart.
   5. Remove a Tool: Run /allow remove "run_shell_command(ls)".
   6. Run Tests: npx vitest packages/cli/src/commands/allow

