### PR TITLE
test: add regression test for --include-directories in non-interactive mode

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1434,10 +1434,9 @@ describe('loadCliConfig with includeDirectories', () => {
     const argv = await parseArguments({} as Settings);
     const settings: Settings = {};
     const config = await loadCliConfig(settings, 'test-session', argv);
-    expect(config.getPendingIncludeDirectories()).toContain(
+    expect(config.getPendingIncludeDirectories()).toEqual([
       path.resolve(path.sep, 'cli', 'path1'),
-    );
-    expect(config.getPendingIncludeDirectories()).toHaveLength(1);
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a regression test for `--include-directories` in non-interactive mode. This test would have caught the bug introduced by PR #12652, where directories weren't processed when running with `-p` flag due to React hook dependency.

## Details

- Added test `should include directories as pending in non-interactive mode` in [config.test.ts](cci:7://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/cli/src/config/config.test.ts:0:0-0:0)
- Test sets `process.stdin.isTTY = false` to force non-interactive mode
- Verifies directories passed via `--include-directories` are stored correctly when using `-p` flag
- The underlying bug has already been fixed in subsequent commits, this test prevents regression

## Related Issues

Related to #13453 

## How to Validate

1. Run the following command from the root:
```bash
node packages/cli/dist/index.js --include-directories ./packages/core/src "list files"
```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
