### PR TITLE
 align README header, badges, and image to center

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<div align="center">
+
 # Gemini CLI
 
 [![Gemini CLI CI](https://github.com/google-gemini/gemini-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/google-gemini/gemini-cli/actions/workflows/ci.yml)
@@ -6,7 +8,11 @@
 [![License](https://img.shields.io/github/license/google-gemini/gemini-cli)](https://github.com/google-gemini/gemini-cli/blob/main/LICENSE)
 [![View Code Wiki](https://www.gstatic.com/_/boq-sdlc-agents-ui/_/r/YUi5dj2UWvE.svg)](https://codewiki.google/github.com/google-gemini/gemini-cli)
 
+<br/>
+
 ![Gemini CLI Screenshot](./docs/assets/gemini-screenshot.png)
+
+</div>
 
 Gemini CLI is an open-source AI agent that brings the power of Gemini directly
 into your terminal. It provides lightweight access to Gemini, giving you the


### PR DESCRIPTION

## Summary

Center the README header content, including the title, badges, and screenshot, to improve visual consistency and first-impression readability on GitHub.

## Details

Wrapped the top section of the README in a centered HTML container to reliably align the title, status badges, and screenshot across GitHub’s Markdown renderer. No functional or behavioral changes were made.

## Related Issues

N/A

## How to Validate

1. Open the repository README on GitHub.
2. Confirm the title, badges, and screenshot are centered.
3. Verify no Markdown rendering issues on desktop or mobile views.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README
- [ ] Added/updated tests (not applicable)
- [ ] Noted breaking changes (none)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run (not applicable)
    - [x] npx (not applicable)
    - [x] Docker (not applicable)
    - [x] Podman (not applicable)
    - [x] Seatbelt (not applicable)
  - [x] Windows
    - [x] npm run (not applicable)
