### PR TITLE
fix(cli): preserve input text when declining tool approval (#15624)

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -146,14 +146,11 @@ function isToolExecuting(pendingHistoryItems: HistoryItemWithoutId[]) {
 function isToolAwaitingConfirmation(
   pendingHistoryItems: HistoryItemWithoutId[],
 ) {
-  return pendingHistoryItems.some((item) => {
-    if (item && item.type === 'tool_group') {
-      return item.tools.some(
-        (tool) => ToolCallStatus.Confirming === tool.status,
-      );
-    }
-    return false;
-  });
+  return pendingHistoryItems
+    .filter((item): item is HistoryItemToolGroup => item.type === 'tool_group')
+    .some((item) =>
+      item.tools.some((tool) => ToolCallStatus.Confirming === tool.status),
+    );
 }
 
 interface AppContainerProps {
@@ -931,11 +928,9 @@ Logging in with Google... Restarting Gemini CLI to continue.
         ...pendingSlashCommandHistoryItems,
         ...pendingGeminiHistoryItems,
       ];
-      // If declining tool approval, preserve buffer (issue #15624)
       if (isToolAwaitingConfirmation(pendingHistoryItems)) {
         return; // Don't clear - user may be composing a follow-up message
       }
-      // If tool is executing and user pressed Ctrl+C, clear the buffer
       if (isToolExecuting(pendingHistoryItems)) {
         buffer.setText(''); // Clear for Ctrl+C cancellation
         return;


### PR DESCRIPTION
## Summary

When a user declines tool approval via "No, suggest changes" or by pressing ESC, the input text they had typed in the message field was being cleared. This fix preserves the user's typed text so they can continue composing their message.

## Details

Root Cause: In packages/cli/src/ui/AppContainer.tsx, the cancel handler unconditionally cleared the buffer when tools were executing by calling buffer.setText('').
This code path is triggered both when:
1. User presses Ctrl+C to cancel everything
2. User declines tool approval (ESC or "No, suggest changes")
The buffer clearing was intended for scenario 1 but was also affecting scenario 2, where the user may be composing a follow-up message.
Fix: Removed the buffer.setText('') call to preserve user's typed text when declining tool approval.

## Related Issues

Fixes #15624

## How to Validate

1. Start Gemini CLI and initiate a conversation
2. While the agent requests tool approval, type some text in the message input field
3. Press ESC or select "No, suggest changes" to decline the tool
4. Expected: The text you typed should still be in the input field
5. Previous behavior: The text was cleared

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
