### PR TITLE
Exponential back-off retries for retryable error without a specified …

### DIFF
--- a/packages/core/src/utils/googleQuotaErrors.test.ts
+++ b/packages/core/src/utils/googleQuotaErrors.test.ts
@@ -342,7 +342,7 @@ describe('classifyGoogleError', () => {
     const result = classifyGoogleError(originalError);
     expect(result).toBeInstanceOf(RetryableQuotaError);
     if (result instanceof RetryableQuotaError) {
-      expect(result.retryDelayMs).toBe(5000);
+      expect(result.retryDelayMs).toBeUndefined();
     }
   });
 
@@ -393,7 +393,7 @@ describe('classifyGoogleError', () => {
     }
   });
 
-  it('should return RetryableQuotaError with 5s fallback for generic 429 without specific message', () => {
+  it('should return RetryableQuotaError without delay time for generic 429 without specific message', () => {
     const generic429 = {
       status: 429,
       message: 'Resource exhausted. No specific retry info.',
@@ -403,11 +403,11 @@ describe('classifyGoogleError', () => {
 
     expect(result).toBeInstanceOf(RetryableQuotaError);
     if (result instanceof RetryableQuotaError) {
-      expect(result.retryDelayMs).toBe(5000);
+      expect(result.retryDelayMs).toBeUndefined();
     }
   });
 
-  it('should return RetryableQuotaError with 5s fallback for 429 with empty details and no regex match', () => {
+  it('should return RetryableQuotaError without delay time for 429 with empty details and no regex match', () => {
     const errorWithEmptyDetails = {
       error: {
         code: 429,
@@ -420,11 +420,11 @@ describe('classifyGoogleError', () => {
 
     expect(result).toBeInstanceOf(RetryableQuotaError);
     if (result instanceof RetryableQuotaError) {
-      expect(result.retryDelayMs).toBe(5000);
+      expect(result.retryDelayMs).toBeUndefined();
     }
   });
 
-  it('should return RetryableQuotaError with 5s fallback for 429 with some detail', () => {
+  it('should return RetryableQuotaError without delay time for 429 with some detail', () => {
     const errorWithEmptyDetails = {
       error: {
         code: 429,
@@ -446,7 +446,7 @@ describe('classifyGoogleError', () => {
 
     expect(result).toBeInstanceOf(RetryableQuotaError);
     if (result instanceof RetryableQuotaError) {
-      expect(result.retryDelayMs).toBe(5000);
+      expect(result.retryDelayMs).toBeUndefined();
     }
   });
 });

--- a/packages/core/src/utils/googleQuotaErrors.ts
+++ b/packages/core/src/utils/googleQuotaErrors.ts
@@ -13,8 +13,6 @@ import type {
 import { parseGoogleApiError } from './googleErrors.js';
 import { getErrorStatus, ModelNotFoundError } from './httpErrors.js';
 
-const DEFAULT_RETRYABLE_DELAY_SECOND = 5;
-
 /**
  * A non-retryable error indicating a hard quota limit has been reached (e.g., daily limit).
  */
@@ -24,11 +22,13 @@ export class TerminalQuotaError extends Error {
   constructor(
     message: string,
     override readonly cause: GoogleApiError,
-    retryDelayMs?: number,
+    retryDelaySeconds?: number,
   ) {
     super(message);
     this.name = 'TerminalQuotaError';
-    this.retryDelayMs = retryDelayMs ? retryDelayMs * 1000 : undefined;
+    this.retryDelayMs = retryDelaySeconds
+      ? retryDelaySeconds * 1000
+      : undefined;
   }
 }
 
@@ -36,16 +36,18 @@ export class TerminalQuotaError extends Error {
  * A retryable error indicating a temporary quota issue (e.g., per-minute limit).
  */
 export class RetryableQuotaError extends Error {
-  retryDelayMs: number;
+  retryDelayMs?: number;
 
   constructor(
     message: string,
     override readonly cause: GoogleApiError,
-    retryDelaySeconds: number,
+    retryDelaySeconds?: number,
   ) {
     super(message);
     this.name = 'RetryableQuotaError';
-    this.retryDelayMs = retryDelaySeconds * 1000;
+    this.retryDelayMs = retryDelaySeconds
+      ? retryDelaySeconds * 1000
+      : undefined;
   }
 }
 
@@ -124,7 +126,6 @@ export function classifyGoogleError(error: unknown): unknown {
           message: errorMessage,
           details: [],
         },
-        DEFAULT_RETRYABLE_DELAY_SECOND,
       );
     }
 
@@ -259,7 +260,6 @@ export function classifyGoogleError(error: unknown): unknown {
         message: errorMessage,
         details: [],
       },
-      DEFAULT_RETRYABLE_DELAY_SECOND,
     );
   }
   return error; // Fallback to original error if no specific classification fits.

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -240,7 +240,10 @@ export async function retryWithBackoff<T>(
             : error;
         }
 
-        if (classifiedError instanceof RetryableQuotaError) {
+        if (
+          classifiedError instanceof RetryableQuotaError &&
+          classifiedError.retryDelayMs
+        ) {
           console.warn(
             `Attempt ${attempt} failed: ${classifiedError.message}. Retrying after ${classifiedError.retryDelayMs}ms...`,
           );


### PR DESCRIPTION
…delay time

## Summary
Perform exponential back-off retries with jitter for retryable error that doesn't have a specified delay time.
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details
When a retryable error is returned without a specified delay, we currently default to a fixed retry interval. This implements exponential backoff to increase the likelihood of success and prevent overwhelming the server.
<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues
https://github.com/google-gemini/gemini-cli/issues/15481
<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
