### PR TITLE
Agent Skills: Implement Interactive Management Interface (/skills command)

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.test.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.test.ts
@@ -98,6 +98,9 @@ describe('BuiltinCommandLoader', () => {
       getFolderTrust: vi.fn().mockReturnValue(true),
       getEnableExtensionReloading: () => false,
       getEnableHooks: () => false,
+      getSkillManager: vi.fn().mockReturnValue({
+        getAllSkills: vi.fn().mockReturnValue([]),
+      }),
     } as unknown as Config;
 
     restoreCommandMock.mockReturnValue({
@@ -190,6 +193,9 @@ describe('BuiltinCommandLoader profile', () => {
       getCheckpointingEnabled: () => false,
       getEnableExtensionReloading: () => false,
       getEnableHooks: () => false,
+      getSkillManager: vi.fn().mockReturnValue({
+        getAllSkills: vi.fn().mockReturnValue([]),
+      }),
     } as unknown as Config;
   });
 

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -38,6 +38,7 @@ import { resumeCommand } from '../ui/commands/resumeCommand.js';
 import { statsCommand } from '../ui/commands/statsCommand.js';
 import { themeCommand } from '../ui/commands/themeCommand.js';
 import { toolsCommand } from '../ui/commands/toolsCommand.js';
+import { skillsCommand } from '../ui/commands/skillsCommand.js';
 import { settingsCommand } from '../ui/commands/settingsCommand.js';
 import { vimCommand } from '../ui/commands/vimCommand.js';
 import { setupGithubCommand } from '../ui/commands/setupGithubCommand.js';
@@ -89,6 +90,9 @@ export class BuiltinCommandLoader implements ICommandLoader {
       statsCommand,
       themeCommand,
       toolsCommand,
+      ...(this.config?.getSkillManager().getAllSkills().length
+        ? [skillsCommand]
+        : []),
       settingsCommand,
       vimCommand,
       setupGithubCommand,

--- a/packages/cli/src/ui/commands/skillsCommand.test.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.test.ts
@@ -24,7 +24,6 @@ describe('skillsCommand', () => {
       services: {
         config: {
           getSkillManager: vi.fn().mockReturnValue({
-            getSkills: vi.fn().mockReturnValue(skills),
             getAllSkills: vi.fn().mockReturnValue(skills),
           }),
         } as unknown as Config,

--- a/packages/cli/src/ui/commands/skillsCommand.test.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.test.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { skillsCommand } from './skillsCommand.js';
+import { MessageType } from '../types.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import type { CommandContext } from './types.js';
+import type { Config } from '@google/gemini-cli-core';
+import { SettingScope, type LoadedSettings } from '../../config/settings.js';
+
+describe('skillsCommand', () => {
+  let context: CommandContext;
+
+  beforeEach(() => {
+    const skills = [
+      { name: 'skill1', description: 'desc1' },
+      { name: 'skill2', description: 'desc2' },
+    ];
+    context = createMockCommandContext({
+      services: {
+        config: {
+          getSkillManager: vi.fn().mockReturnValue({
+            getSkills: vi.fn().mockReturnValue(skills),
+            getAllSkills: vi.fn().mockReturnValue(skills),
+          }),
+        } as unknown as Config,
+        settings: {
+          merged: { skills: { disabled: [] } },
+          workspace: { path: '/workspace' },
+          setValue: vi.fn(),
+        } as unknown as LoadedSettings,
+      },
+    });
+  });
+
+  it('should add a SKILLS_LIST item to UI with descriptions by default', async () => {
+    await skillsCommand.action!(context, '');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.SKILLS_LIST,
+        skills: [
+          { name: 'skill1', description: 'desc1' },
+          { name: 'skill2', description: 'desc2' },
+        ],
+        showDescriptions: true,
+      }),
+      expect.any(Number),
+    );
+  });
+
+  it('should list skills when "list" subcommand is used', async () => {
+    await skillsCommand.action!(context, 'list');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.SKILLS_LIST,
+        skills: [
+          { name: 'skill1', description: 'desc1' },
+          { name: 'skill2', description: 'desc2' },
+        ],
+        showDescriptions: true,
+      }),
+      expect.any(Number),
+    );
+  });
+
+  it('should disable descriptions if "nodesc" arg is provided to list', async () => {
+    await skillsCommand.action!(context, 'list nodesc');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        showDescriptions: false,
+      }),
+      expect.any(Number),
+    );
+  });
+
+  describe('disable/enable', () => {
+    beforeEach(() => {
+      context.services.settings.merged.skills = { disabled: [] };
+      (
+        context.services.settings as unknown as { workspace: { path: string } }
+      ).workspace = {
+        path: '/workspace',
+      };
+    });
+
+    it('should disable a skill', async () => {
+      await skillsCommand.action!(context, 'disable skill1');
+
+      expect(context.services.settings.setValue).toHaveBeenCalledWith(
+        SettingScope.Workspace,
+        'skills.disabled',
+        ['skill1'],
+      );
+      expect(context.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: expect.stringContaining('Skill "skill1" disabled'),
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('should enable a skill', async () => {
+      context.services.settings.merged.skills = { disabled: ['skill1'] };
+      await skillsCommand.action!(context, 'enable skill1');
+
+      expect(context.services.settings.setValue).toHaveBeenCalledWith(
+        SettingScope.Workspace,
+        'skills.disabled',
+        [],
+      );
+      expect(context.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: expect.stringContaining('Skill "skill1" enabled'),
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('should show error if skill not found during disable', async () => {
+      await skillsCommand.action!(context, 'disable non-existent');
+
+      expect(context.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.ERROR,
+          text: 'Skill "non-existent" not found.',
+        }),
+        expect.any(Number),
+      );
+    });
+  });
+});

--- a/packages/cli/src/ui/commands/skillsCommand.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.ts
@@ -1,0 +1,225 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  type CommandContext,
+  type SlashCommand,
+  type SlashCommandActionReturn,
+  CommandKind,
+} from './types.js';
+import { MessageType, type HistoryItemSkillsList } from '../types.js';
+import { SettingScope } from '../../config/settings.js';
+
+export const skillsCommand: SlashCommand = {
+  name: 'skills',
+  description:
+    'List, enable, or disable Gemini CLI agent skills. Usage: /skills [list | disable <name> | enable <name>]',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: false,
+  subCommands: [
+    {
+      name: 'list',
+      description: 'List available agent skills. Usage: /skills list [nodesc]',
+      kind: CommandKind.BUILT_IN,
+      action: async (
+        context: CommandContext,
+        args: string,
+      ): Promise<void | SlashCommandActionReturn> => {
+        const subCommand = args.trim();
+
+        // Default to SHOWING descriptions. The user can hide them with 'nodesc'.
+        let useShowDescriptions = true;
+        if (subCommand === 'nodesc') {
+          useShowDescriptions = false;
+        }
+
+        const skillManager = context.services.config?.getSkillManager();
+        if (!skillManager) {
+          context.ui.addItem(
+            {
+              type: MessageType.ERROR,
+              text: 'Could not retrieve skill manager.',
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        const skills = skillManager.getAllSkills();
+
+        const skillsListItem: HistoryItemSkillsList = {
+          type: MessageType.SKILLS_LIST,
+          skills: skills.map((skill) => ({
+            name: skill.name,
+            description: skill.description,
+            disabled: skill.disabled,
+          })),
+          showDescriptions: useShowDescriptions,
+        };
+
+        context.ui.addItem(skillsListItem, Date.now());
+      },
+    },
+    {
+      name: 'disable',
+      description: 'Disable a skill by name. Usage: /skills disable <name>',
+      kind: CommandKind.BUILT_IN,
+      action: async (
+        context: CommandContext,
+        args: string,
+      ): Promise<void | SlashCommandActionReturn> => {
+        const skillName = args.trim();
+        if (!skillName) {
+          context.ui.addItem(
+            {
+              type: MessageType.ERROR,
+              text: 'Please provide a skill name to disable.',
+            },
+            Date.now(),
+          );
+          return;
+        }
+        const skillManager = context.services.config?.getSkillManager();
+        const skill = skillManager
+          ?.getAllSkills()
+          .find((s) => s.name === skillName);
+        if (!skill) {
+          context.ui.addItem(
+            {
+              type: MessageType.ERROR,
+              text: `Skill "${skillName}" not found.`,
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        const currentDisabled =
+          context.services.settings.merged.skills?.disabled ?? [];
+        if (currentDisabled.includes(skillName)) {
+          context.ui.addItem(
+            {
+              type: MessageType.INFO,
+              text: `Skill "${skillName}" is already disabled.`,
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        const newDisabled = [...currentDisabled, skillName];
+        const scope = context.services.settings.workspace.path
+          ? SettingScope.Workspace
+          : SettingScope.User;
+
+        context.services.settings.setValue(
+          scope,
+          'skills.disabled',
+          newDisabled,
+        );
+        context.ui.addItem(
+          {
+            type: MessageType.INFO,
+            text: `Skill "${skillName}" disabled in ${scope} settings. Restart required to take effect.`,
+          },
+          Date.now(),
+        );
+      },
+    },
+    {
+      name: 'enable',
+      description:
+        'Enable a disabled skill by name. Usage: /skills enable <name>',
+      kind: CommandKind.BUILT_IN,
+      action: async (
+        context: CommandContext,
+        args: string,
+      ): Promise<void | SlashCommandActionReturn> => {
+        const skillName = args.trim();
+        if (!skillName) {
+          context.ui.addItem(
+            {
+              type: MessageType.ERROR,
+              text: 'Please provide a skill name to enable.',
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        const currentDisabled =
+          context.services.settings.merged.skills?.disabled ?? [];
+        if (!currentDisabled.includes(skillName)) {
+          context.ui.addItem(
+            {
+              type: MessageType.INFO,
+              text: `Skill "${skillName}" is not disabled.`,
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        const newDisabled = currentDisabled.filter(
+          (name) => name !== skillName,
+        );
+        const scope = context.services.settings.workspace.path
+          ? SettingScope.Workspace
+          : SettingScope.User;
+
+        context.services.settings.setValue(
+          scope,
+          'skills.disabled',
+          newDisabled,
+        );
+        context.ui.addItem(
+          {
+            type: MessageType.INFO,
+            text: `Skill "${skillName}" enabled in ${scope} settings. Restart required to take effect.`,
+          },
+          Date.now(),
+        );
+      },
+    },
+  ],
+  action: async (
+    context: CommandContext,
+    args: string,
+  ): Promise<void | SlashCommandActionReturn> => {
+    const subCommand = args.trim();
+
+    if (subCommand.startsWith('list ')) {
+      return skillsCommand.subCommands![0].action!(
+        context,
+        subCommand.slice('list '.length),
+      );
+    }
+    if (subCommand === 'list') {
+      return skillsCommand.subCommands![0].action!(context, '');
+    }
+    if (subCommand.startsWith('disable ')) {
+      return skillsCommand.subCommands![1].action!(
+        context,
+        subCommand.slice('disable '.length),
+      );
+    }
+    if (subCommand === 'disable') {
+      return skillsCommand.subCommands![1].action!(context, '');
+    }
+    if (subCommand.startsWith('enable ')) {
+      return skillsCommand.subCommands![2].action!(
+        context,
+        subCommand.slice('enable '.length),
+      );
+    }
+    if (subCommand === 'enable') {
+      return skillsCommand.subCommands![2].action!(context, '');
+    }
+
+    // Default to 'list' if no other subcommand matches
+    return skillsCommand.subCommands![0].action!(context, subCommand);
+  },
+};

--- a/packages/cli/src/ui/commands/skillsCommand.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.ts
@@ -191,35 +191,34 @@ export const skillsCommand: SlashCommand = {
   ): Promise<void | SlashCommandActionReturn> => {
     const subCommand = args.trim();
 
+    const subCommandsByName = new Map(
+      skillsCommand.subCommands!.map((cmd) => [cmd.name, cmd]),
+    );
+
+    const listAction = subCommandsByName.get('list')!.action!;
+    const disableAction = subCommandsByName.get('disable')!.action!;
+    const enableAction = subCommandsByName.get('enable')!.action!;
+
     if (subCommand.startsWith('list ')) {
-      return skillsCommand.subCommands![0].action!(
-        context,
-        subCommand.slice('list '.length),
-      );
+      return listAction(context, subCommand.slice('list '.length));
     }
     if (subCommand === 'list') {
-      return skillsCommand.subCommands![0].action!(context, '');
+      return listAction(context, '');
     }
     if (subCommand.startsWith('disable ')) {
-      return skillsCommand.subCommands![1].action!(
-        context,
-        subCommand.slice('disable '.length),
-      );
+      return disableAction(context, subCommand.slice('disable '.length));
     }
     if (subCommand === 'disable') {
-      return skillsCommand.subCommands![1].action!(context, '');
+      return disableAction(context, '');
     }
     if (subCommand.startsWith('enable ')) {
-      return skillsCommand.subCommands![2].action!(
-        context,
-        subCommand.slice('enable '.length),
-      );
+      return enableAction(context, subCommand.slice('enable '.length));
     }
     if (subCommand === 'enable') {
-      return skillsCommand.subCommands![2].action!(context, '');
+      return enableAction(context, '');
     }
 
     // Default to 'list' if no other subcommand matches
-    return skillsCommand.subCommands![0].action!(context, subCommand);
+    return listAction(context, subCommand);
   },
 };

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -28,6 +28,7 @@ import type { SlashCommand } from '../commands/types.js';
 import { ExtensionsList } from './views/ExtensionsList.js';
 import { getMCPServerStatus } from '@google/gemini-cli-core';
 import { ToolsList } from './views/ToolsList.js';
+import { SkillsList } from './views/SkillsList.js';
 import { McpStatus } from './views/McpStatus.js';
 import { ChatList } from './views/ChatList.js';
 import { HooksList } from './views/HooksList.js';
@@ -150,6 +151,12 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
         <ToolsList
           terminalWidth={terminalWidth}
           tools={itemForDisplay.tools}
+          showDescriptions={itemForDisplay.showDescriptions}
+        />
+      )}
+      {itemForDisplay.type === 'skills_list' && (
+        <SkillsList
+          skills={itemForDisplay.skills}
           showDescriptions={itemForDisplay.showDescriptions}
         />
       )}

--- a/packages/cli/src/ui/components/views/SkillsList.tsx
+++ b/packages/cli/src/ui/components/views/SkillsList.tsx
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box, Text } from 'ink';
+import { theme } from '../../semantic-colors.js';
+import { type SkillDefinition } from '../../types.js';
+
+interface SkillsListProps {
+  skills: readonly SkillDefinition[];
+  showDescriptions: boolean;
+}
+
+export const SkillsList: React.FC<SkillsListProps> = ({
+  skills,
+  showDescriptions,
+}) => {
+  const enabledSkills = skills
+    .filter((s) => !s.disabled)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const disabledSkills = skills
+    .filter((s) => s.disabled)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const renderSkill = (skill: SkillDefinition) => (
+    <Box key={skill.name} flexDirection="row">
+      <Text color={theme.text.primary}>{'  '}- </Text>
+      <Box flexDirection="column">
+        <Text
+          bold
+          color={skill.disabled ? theme.text.secondary : theme.text.link}
+        >
+          {skill.name}
+        </Text>
+        {showDescriptions && skill.description && (
+          <Box marginLeft={2}>
+            <Text
+              color={skill.disabled ? theme.text.secondary : theme.text.primary}
+            >
+              {skill.description}
+            </Text>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      {enabledSkills.length > 0 && (
+        <Box flexDirection="column">
+          <Text bold color={theme.text.primary}>
+            Available Agent Skills:
+          </Text>
+          <Box height={1} />
+          {enabledSkills.map(renderSkill)}
+        </Box>
+      )}
+
+      {enabledSkills.length > 0 && disabledSkills.length > 0 && (
+        <Box marginY={1}>
+          <Text color={theme.text.secondary}>{'-'.repeat(20)}</Text>
+        </Box>
+      )}
+
+      {disabledSkills.length > 0 && (
+        <Box flexDirection="column">
+          <Text bold color={theme.text.secondary}>
+            Disabled Skills:
+          </Text>
+          <Box height={1} />
+          {disabledSkills.map(renderSkill)}
+        </Box>
+      )}
+
+      {skills.length === 0 && (
+        <Text color={theme.text.primary}> No skills available</Text>
+      )}
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -206,6 +206,18 @@ export type HistoryItemToolsList = HistoryItemBase & {
   showDescriptions: boolean;
 };
 
+export interface SkillDefinition {
+  name: string;
+  description: string;
+  disabled?: boolean;
+}
+
+export type HistoryItemSkillsList = HistoryItemBase & {
+  type: 'skills_list';
+  skills: SkillDefinition[];
+  showDescriptions: boolean;
+};
+
 // JSON-friendly types for using as a simple data model showing info about an
 // MCP Server.
 export interface JsonMcpTool {
@@ -284,6 +296,7 @@ export type HistoryItemWithoutId =
   | HistoryItemCompression
   | HistoryItemExtensionsList
   | HistoryItemToolsList
+  | HistoryItemSkillsList
   | HistoryItemMcpStatus
   | HistoryItemChatList
   | HistoryItemHooksList;
@@ -306,6 +319,7 @@ export enum MessageType {
   COMPRESSION = 'compression',
   EXTENSIONS_LIST = 'extensions_list',
   TOOLS_LIST = 'tools_list',
+  SKILLS_LIST = 'skills_list',
   MCP_STATUS = 'mcp_status',
   CHAT_LIST = 'chat_list',
   HOOKS_LIST = 'hooks_list',


### PR DESCRIPTION
## Summary

This PR implements the interactive management interface for **Agent Skills** via the `/skills` slash command. This allows users to view, enable, and disable discovered expertise directly within an interactive session.

## Details

- **`/skills` Slash Command:** A new interactive command with support for:
  - `list` (default): Displays all discovered skills, their descriptions, and status.
  - `enable <name>`: Re-activates a previously disabled skill.
  - `disable <name>`: Prevents a skill from being used in the current and future sessions.
- **SkillsList View:** A new Ink-based React component (`SkillsList.tsx`) that provides a clean, categorized visual representation of skills (Available vs. Disabled).
- **Settings Integration:** Skill enablement status is persisted across sessions using the `skills.disabled` setting, with support for both User and Project (Workspace) scopes.
- **User Feedback:** Interactive confirmation messages for enablement/disablement actions, including clear restart notifications.
- **Quality & Stability:** Includes comprehensive unit tests for command parsing and settings updates. Verified build and preflight passes.

## Related Issues

Part of #15327, Fixes #15687

## How to Validate

1. **Setup Test Skill:**
   Run the following to create a dummy skill for the UI to discover:
   ```bash
   mkdir -p .gemini/skills/ui-tester
   cat <<EOF > .gemini/skills/ui-tester/SKILL.md
   ---
   name: ui-tester
   description: A test skill for validating the management UI.
   ---
   # Instructions
   Test.
   EOF
   ```
2. **Enable Feature:**
   Ensure `"experimental": { "skills": true }` is in your `settings.json`.
3. **Launch CLI:**
   `npm run start`
4. **List Skills:**
   Type `/skills`.
   **Expectation:** `ui-tester` should be listed under "Available Agent Skills".
5. **Disable a Skill:**
   Type `/skills disable ui-tester`.
   **Expectation:** Confirmation message stating the skill was disabled and a restart is required.
6. **Verify Effect:**
   Restart the CLI and type `/skills`.
   **Expectation:** `ui-tester` should now appear under the "Disabled Skills" section.
7. **Enable a Skill:**
   Type `/skills enable ui-tester`, then restart the CLI.
   **Expectation:** The skill should return to the "Available" list.

<img width="2096" height="1760" alt="image" src="https://github.com/user-attachments/assets/75f16b36-4ba5-441a-b92e-28ebb5e7a462" />
<img width="2096" height="1760" alt="image" src="https://github.com/user-attachments/assets/4e7b55d1-ccb7-4ae5-a00d-ae5c00227fc0" />


## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
