### PR TITLE
Agent Skills: Implement Autonomous Activation Tool & Context Injection

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -24,6 +24,7 @@ import { ReadFileTool } from '../tools/read-file.js';
 import { GrepTool } from '../tools/grep.js';
 import { canUseRipgrep, RipGrepTool } from '../tools/ripGrep.js';
 import { GlobTool } from '../tools/glob.js';
+import { ActivateSkillTool } from '../tools/activate-skill.js';
 import { EditTool } from '../tools/edit.js';
 import { SmartEditTool } from '../tools/smart-edit.js';
 import { ShellTool } from '../tools/shell.js';
@@ -734,6 +735,13 @@ export class Config {
     if (this.skillsSupport) {
       await this.getSkillManager().discoverSkills(this.storage);
       this.getSkillManager().setDisabledSkills(this.disabledSkills);
+
+      // Re-register ActivateSkillTool to update its schema with the discovered enabled skill enums
+      if (this.getSkillManager().getSkills().length > 0) {
+        this.getToolRegistry().registerTool(
+          new ActivateSkillTool(this, this.messageBus),
+        );
+      }
     }
 
     // Initialize hook system if enabled
@@ -1679,6 +1687,7 @@ export class Config {
     }
 
     registerCoreTool(GlobTool, this);
+    registerCoreTool(ActivateSkillTool, this);
     if (this.getUseSmartEdit()) {
       registerCoreTool(SmartEditTool, this);
     } else {

--- a/packages/core/src/policy/policies/write.toml
+++ b/packages/core/src/policy/policies/write.toml
@@ -57,6 +57,11 @@ decision = "ask_user"
 priority = 10
 
 [[rule]]
+toolName = "activate_skill"
+decision = "ask_user"
+priority = 10
+
+[[rule]]
 toolName = "write_file"
 decision = "allow"
 priority = 15

--- a/packages/core/src/tools/activate-skill.test.ts
+++ b/packages/core/src/tools/activate-skill.test.ts
@@ -75,7 +75,7 @@ describe('ActivateSkillTool', () => {
     expect(details.prompt).toContain('Mock folder structure');
   });
 
-  it('should activate a valid skill and return its content', async () => {
+  it('should activate a valid skill and return its content in XML tags', async () => {
     const params = { name: 'test-skill' };
     const invocation = tool.build(params);
     const result = await invocation.execute(new AbortController().signal);
@@ -83,13 +83,14 @@ describe('ActivateSkillTool', () => {
     expect(mockConfig.getSkillManager().activateSkill).toHaveBeenCalledWith(
       'test-skill',
     );
-    expect(result.llmContent).toContain(
-      'Skill "test-skill" activated successfully',
-    );
-    expect(result.llmContent).toContain('Specialized Skill Guidance');
-    expect(result.llmContent).toContain('Available Resources');
-    expect(result.llmContent).toContain('Mock folder structure');
+    expect(result.llmContent).toContain('<ACTIVATED_SKILL name="test-skill">');
+    expect(result.llmContent).toContain('<INSTRUCTIONS>');
     expect(result.llmContent).toContain('Skill instructions content.');
+    expect(result.llmContent).toContain('</INSTRUCTIONS>');
+    expect(result.llmContent).toContain('<AVAILABLE_RESOURCES>');
+    expect(result.llmContent).toContain('Mock folder structure');
+    expect(result.llmContent).toContain('</AVAILABLE_RESOURCES>');
+    expect(result.llmContent).toContain('</ACTIVATED_SKILL>');
     expect(result.returnDisplay).toContain('Skill **test-skill** activated');
     expect(result.returnDisplay).toContain('Mock folder structure');
   });

--- a/packages/core/src/tools/activate-skill.test.ts
+++ b/packages/core/src/tools/activate-skill.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ActivateSkillTool } from './activate-skill.js';
+import type { Config } from '../config/config.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+
+vi.mock('../utils/getFolderStructure.js', () => ({
+  getFolderStructure: vi.fn().mockResolvedValue('Mock folder structure'),
+}));
+
+describe('ActivateSkillTool', () => {
+  let mockConfig: Config;
+  let tool: ActivateSkillTool;
+  const mockMessageBus = {
+    publish: vi.fn(),
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+  } as unknown as MessageBus;
+
+  beforeEach(() => {
+    const skills = [
+      {
+        name: 'test-skill',
+        description: 'A test skill',
+        location: '/path/to/test-skill/SKILL.md',
+      },
+    ];
+    mockConfig = {
+      getSkillManager: vi.fn().mockReturnValue({
+        getSkills: vi.fn().mockReturnValue(skills),
+        getAllSkills: vi.fn().mockReturnValue(skills),
+        getSkill: vi.fn().mockImplementation((name: string) => {
+          if (name === 'test-skill') {
+            return {
+              name: 'test-skill',
+              description: 'A test skill',
+              location: '/path/to/test-skill/SKILL.md',
+              body: 'Skill instructions content.',
+            };
+          }
+          return null;
+        }),
+        activateSkill: vi.fn(),
+      }),
+    } as unknown as Config;
+    tool = new ActivateSkillTool(mockConfig, mockMessageBus);
+  });
+
+  it('should return enhanced description', () => {
+    const params = { name: 'test-skill' };
+    const invocation = tool.build(params);
+    expect(invocation.getDescription()).toBe('"test-skill": A test skill');
+  });
+
+  it('should return enhanced confirmation details', async () => {
+    const params = { name: 'test-skill' };
+    const invocation = tool.build(params);
+    const details = await (
+      invocation as unknown as {
+        getConfirmationDetails: (signal: AbortSignal) => Promise<{
+          prompt: string;
+          title: string;
+        }>;
+      }
+    ).getConfirmationDetails(new AbortController().signal);
+
+    expect(details.title).toBe('Activate Skill: test-skill');
+    expect(details.prompt).toContain('enable the specialized agent skill');
+    expect(details.prompt).toContain('A test skill');
+    expect(details.prompt).toContain('Mock folder structure');
+  });
+
+  it('should activate a valid skill and return its content', async () => {
+    const params = { name: 'test-skill' };
+    const invocation = tool.build(params);
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(mockConfig.getSkillManager().activateSkill).toHaveBeenCalledWith(
+      'test-skill',
+    );
+    expect(result.llmContent).toContain(
+      'Skill "test-skill" activated successfully',
+    );
+    expect(result.llmContent).toContain('Specialized Skill Guidance');
+    expect(result.llmContent).toContain('Available Resources');
+    expect(result.llmContent).toContain('Mock folder structure');
+    expect(result.llmContent).toContain('Skill instructions content.');
+    expect(result.returnDisplay).toContain('Skill **test-skill** activated');
+    expect(result.returnDisplay).toContain('Mock folder structure');
+  });
+
+  it('should throw error if skill is not in enum', async () => {
+    const params = { name: 'non-existent' };
+    expect(() => tool.build(params as { name: string })).toThrow();
+  });
+
+  it('should return an error if skill content cannot be read', async () => {
+    vi.mocked(mockConfig.getSkillManager().getSkill).mockReturnValue(null);
+    const params = { name: 'test-skill' };
+    const invocation = tool.build(params);
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.llmContent).toContain('Error: Skill "test-skill" not found.');
+    expect(mockConfig.getSkillManager().activateSkill).not.toHaveBeenCalled();
+  });
+
+  it('should validate that name is provided', () => {
+    expect(() =>
+      tool.build({ name: '' } as unknown as { name: string }),
+    ).toThrow();
+  });
+});

--- a/packages/core/src/tools/activate-skill.ts
+++ b/packages/core/src/tools/activate-skill.ts
@@ -1,0 +1,182 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import * as path from 'node:path';
+import { getFolderStructure } from '../utils/getFolderStructure.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+import type {
+  ToolResult,
+  ToolCallConfirmationDetails,
+  ToolInvocation,
+  ToolConfirmationOutcome,
+} from './tools.js';
+import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
+import type { Config } from '../config/config.js';
+import { ACTIVATE_SKILL_TOOL_NAME } from './tool-names.js';
+
+/**
+ * Parameters for the ActivateSkill tool
+ */
+export interface ActivateSkillToolParams {
+  /**
+   * The name of the skill to activate
+   */
+  name: string;
+}
+
+class ActivateSkillToolInvocation extends BaseToolInvocation<
+  ActivateSkillToolParams,
+  ToolResult
+> {
+  constructor(
+    private config: Config,
+    params: ActivateSkillToolParams,
+    messageBus: MessageBus | undefined,
+    _toolName?: string,
+    _toolDisplayName?: string,
+  ) {
+    super(params, messageBus, _toolName, _toolDisplayName);
+  }
+
+  getDescription(): string {
+    const skillName = this.params.name;
+    const skill = this.config.getSkillManager().getSkill(skillName);
+    if (skill) {
+      return `"${skillName}": ${skill.description}`;
+    }
+    return `"${skillName}" (⚠️ unknown skill)`;
+  }
+
+  protected override async getConfirmationDetails(
+    _abortSignal: AbortSignal,
+  ): Promise<ToolCallConfirmationDetails | false> {
+    if (!this.messageBus) {
+      return false;
+    }
+
+    const skillName = this.params.name;
+    const skill = this.config.getSkillManager().getSkill(skillName);
+
+    if (!skill) {
+      return false;
+    }
+
+    const folderStructure = await getFolderStructure(
+      path.dirname(skill.location),
+    );
+
+    const confirmationDetails: ToolCallConfirmationDetails = {
+      type: 'info',
+      title: `Activate Skill: ${skillName}`,
+      prompt: `You are about to enable the specialized agent skill **${skillName}**.
+
+**Description:**
+${skill.description}
+
+**Resources to be shared with the model:**
+${folderStructure}`,
+      onConfirm: async (outcome: ToolConfirmationOutcome) => {
+        await this.publishPolicyUpdate(outcome);
+      },
+    };
+    return confirmationDetails;
+  }
+
+  async execute(_signal: AbortSignal): Promise<ToolResult> {
+    const skillName = this.params.name;
+    const skillManager = this.config.getSkillManager();
+    const skill = skillManager.getSkill(skillName);
+
+    if (!skill) {
+      const skills = skillManager.getSkills();
+      return {
+        llmContent: `Error: Skill "${skillName}" not found. Available skills are: ${skills.map((s) => s.name).join(', ')}`,
+        returnDisplay: `Skill "${skillName}" not found.`,
+      };
+    }
+
+    skillManager.activateSkill(skillName);
+
+    const folderStructure = await getFolderStructure(
+      path.dirname(skill.location),
+    );
+
+    return {
+      llmContent: `Skill "${skillName}" activated successfully. 
+
+### Specialized Skill Guidance
+The following instructions for "${skillName}" provide the primary procedural framework for your current task. You should prioritize these specialized rules and steps over your general internal defaults. Follow them strictly and sequentially while continuing to uphold your core safety and security standards.
+
+### Available Resources
+Below is the file structure of the "${skillName}" skill directory. You can use these resources (scripts, references, assets) as needed to complete your task.
+
+${folderStructure}
+
+# Skill: ${skill.name}
+${skill.body}`,
+      returnDisplay: `Skill **${skillName}** activated. Resources loaded from \`${path.dirname(skill.location)}\`:\n\n${folderStructure}`,
+    };
+  }
+}
+
+/**
+ * Implementation of the ActivateSkill tool logic
+ */
+export class ActivateSkillTool extends BaseDeclarativeTool<
+  ActivateSkillToolParams,
+  ToolResult
+> {
+  static readonly Name = ACTIVATE_SKILL_TOOL_NAME;
+
+  constructor(
+    private config: Config,
+    messageBus?: MessageBus,
+  ) {
+    const skills = config.getSkillManager().getSkills();
+    const skillNames = skills.map((s) => s.name);
+
+    let schema: z.ZodTypeAny;
+    if (skillNames.length === 0) {
+      schema = z.object({
+        name: z.string().describe('No skills are currently available.'),
+      });
+    } else {
+      schema = z.object({
+        name: z
+          .enum(skillNames as [string, ...string[]])
+          .describe('The name of the skill to activate.'),
+      });
+    }
+
+    super(
+      ActivateSkillTool.Name,
+      'Activate Skill',
+      "Activates a specialized agent skill by name. Once activated, the skill's full instructions and rules are returned as a tool result and injected into the conversation. You MUST strictly follow these instructions for all subsequent turns. Use this when you identify a task that matches a skill's description.",
+      Kind.Other,
+      zodToJsonSchema(schema),
+      true,
+      false,
+      messageBus,
+    );
+  }
+
+  protected createInvocation(
+    params: ActivateSkillToolParams,
+    messageBus?: MessageBus,
+    _toolName?: string,
+    _toolDisplayName?: string,
+  ): ToolInvocation<ActivateSkillToolParams, ToolResult> {
+    return new ActivateSkillToolInvocation(
+      this.config,
+      params,
+      messageBus,
+      _toolName,
+      _toolDisplayName ?? 'Activate Skill',
+    );
+  }
+}

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -21,6 +21,7 @@ export const READ_FILE_TOOL_NAME = 'read_file';
 export const LS_TOOL_NAME = 'list_directory';
 export const MEMORY_TOOL_NAME = 'save_memory';
 export const GET_INTERNAL_DOCS_TOOL_NAME = 'get_internal_docs';
+export const ACTIVATE_SKILL_TOOL_NAME = 'activate_skill';
 export const EDIT_TOOL_NAMES = new Set([EDIT_TOOL_NAME, WRITE_FILE_TOOL_NAME]);
 export const DELEGATE_TO_AGENT_TOOL_NAME = 'delegate_to_agent';
 
@@ -43,6 +44,7 @@ export const ALL_BUILTIN_TOOL_NAMES = [
   READ_FILE_TOOL_NAME,
   LS_TOOL_NAME,
   MEMORY_TOOL_NAME,
+  ACTIVATE_SKILL_TOOL_NAME,
   DELEGATE_TO_AGENT_TOOL_NAME,
 ] as const;
 

--- a/packages/core/src/utils/getFolderStructure.ts
+++ b/packages/core/src/utils/getFolderStructure.ts
@@ -18,7 +18,12 @@ import { debugLogger } from './debugLogger.js';
 
 const MAX_ITEMS = 200;
 const TRUNCATION_INDICATOR = '...';
-const DEFAULT_IGNORED_FOLDERS = new Set(['node_modules', '.git', 'dist']);
+const DEFAULT_IGNORED_FOLDERS = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  '__pycache__',
+]);
 
 // --- Interfaces ---
 


### PR DESCRIPTION
## Summary

This PR implements the `activate_skill` tool, which serves as the primary mechanism for the model to transition from "knowing a skill exists" to "employing its expertise." It also refactors the `SkillManager` for better developer ergonomics and establishes standard security policies for skill activation.

## Details

- **`activate_skill` Tool:** A new tool in `packages/core/src/tools/activate-skill.ts` that:
  - Loads the full Markdown body of a skill from disk.
  - Injects the instructions into the conversation history as a "Specialized Skill Guidance" block.
  - Provides the model with a folder structure hint of the skill's directory for on-demand resource discovery.
- **SkillManager Refinement:** Added a `getSkill(name)` helper to reduce repetitive `.find()` logic and standardized internal parsing.
- **Security Policy:** Added a new rule to `packages/core/src/policy/policies/write.toml` requiring explicit user confirmation (`ASK_USER`) for activation.
- **Standardized Ignores:** Updated `DEFAULT_IGNORED_FOLDERS` to include `__pycache__` and ensured the `activate_skill` tool utilizes these shared patterns rather than hardcoding lists.
- **UX Improvements:**
  - Enhanced tool descriptions with a fallback for unknown skills: `"<name>" (⚠️ unknown skill)`.
  - Cleaned up `returnDisplay` string formatting using native template literals.
- **Quality:** Added unit tests in `activate-skill.test.ts` covering content loading, directory hinting, and error handling. Verified build and preflight passes on rebased branch.

## Related Issues

Part of #15327, Fixes #15688

## How to Validate

1. **Setup Test Skill:**
   Ensure you have a test skill in `.gemini/skills/`, for example:
   ```bash
   mkdir -p .gemini/skills/demo-skill
   cat <<EOF > .gemini/skills/demo-skill/SKILL.md
   ---
   name: demo-skill
   description: A demo skill to test the activation mechanism.
   ---
   # Demo Instructions
   If this text is visible to the model, activation was successful.
   EOF
   ```
2. **Launch CLI:**
   `npm run start` (ensure `experimental.skills: true` is in your `settings.json`)
3. **Verify Tool Call (via LLM):**
   Ask the model: `Activate the demo-skill.`
   **Expectation:** You should see a blue-themed confirmation prompt (using the standard tool UI for now, branding comes in a later PR) asking if you want to enable the specialized agent skill "demo-skill" and showing the resources being shared.
4. **Approve Activation:**
   Accept the tool call.
   **Expectation:** The model should confirm activation and follow any instructions provided in the skill's Markdown body.
5. **Verify Security:**
   The tool should never execute without your consent, as per the `write.toml` policy update.
<img width="2096" height="2010" alt="image" src="https://github.com/user-attachments/assets/97d57f0f-18f6-4f62-b2e0-ff98feae13f5" />

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
