### PR TITLE
Default enable environment variable redaction

### DIFF
--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -98,13 +98,14 @@ they appear in the UI.
 
 ### Security
 
-| UI Label                      | Setting                                         | Description                                               | Default |
-| ----------------------------- | ----------------------------------------------- | --------------------------------------------------------- | ------- |
-| Disable YOLO Mode             | `security.disableYoloMode`                      | Disable YOLO mode, even if enabled by a flag.             | `false` |
-| Blocks extensions from Git    | `security.blockGitExtensions`                   | Blocks installing and loading extensions from Git.        | `false` |
-| Folder Trust                  | `security.folderTrust.enabled`                  | Setting to track whether Folder trust is enabled.         | `false` |
-| Allowed Environment Variables | `security.environmentVariableRedaction.allowed` | Environment variables to always allow (bypass redaction). | `[]`    |
-| Blocked Environment Variables | `security.environmentVariableRedaction.blocked` | Environment variables to always redact.                   | `[]`    |
+| UI Label                              | Setting                                         | Description                                                         | Default |
+| ------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------- | ------- |
+| Disable YOLO Mode                     | `security.disableYoloMode`                      | Disable YOLO mode, even if enabled by a flag.                       | `false` |
+| Blocks extensions from Git            | `security.blockGitExtensions`                   | Blocks installing and loading extensions from Git.                  | `false` |
+| Folder Trust                          | `security.folderTrust.enabled`                  | Setting to track whether Folder trust is enabled.                   | `false` |
+| Allowed Environment Variables         | `security.environmentVariableRedaction.allowed` | Environment variables to always allow (bypass redaction).           | `[]`    |
+| Blocked Environment Variables         | `security.environmentVariableRedaction.blocked` | Environment variables to always redact.                             | `[]`    |
+| Enable Environment Variable Redaction | `security.environmentVariableRedaction.enabled` | Enable redaction of environment variables that may contain secrets. | `true`  |
 
 ### Experimental
 

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -764,7 +764,7 @@ their corresponding top-level category object in your `settings.json` file.
 - **`security.environmentVariableRedaction.enabled`** (boolean):
   - **Description:** Enable redaction of environment variables that may contain
     secrets.
-  - **Default:** `false`
+  - **Default:** `true`
   - **Requires restart:** Yes
 
 - **`security.auth.selectedType`** (string):

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1248,7 +1248,7 @@ const SETTINGS_SCHEMA = {
             label: 'Enable Environment Variable Redaction',
             category: 'Security',
             requiresRestart: true,
-            default: false,
+            default: true,
             description:
               'Enable redaction of environment variables that may contain secrets.',
             showInDialog: true,

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -596,6 +596,15 @@ describe('Server Config (config.ts)', () => {
     expect(config.getTelemetryEnabled()).toBe(TELEMETRY_SETTINGS.enabled);
   });
 
+  it('Config constructor should default enableEnvironmentVariableRedaction to true if not provided', () => {
+    const paramsWithoutRedaction: ConfigParameters = { ...baseParams };
+    delete paramsWithoutRedaction.enableEnvironmentVariableRedaction;
+    const config = new Config(paramsWithoutRedaction);
+    expect(config.sanitizationConfig.enableEnvironmentVariableRedaction).toBe(
+      true,
+    );
+  });
+
   it('Config constructor should set telemetry useCollector to true when provided', () => {
     const paramsWithTelemetry: ConfigParameters = {
       ...baseParams,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -491,7 +491,7 @@ export class Config {
     this.allowedEnvironmentVariables = params.allowedEnvironmentVariables ?? [];
     this.blockedEnvironmentVariables = params.blockedEnvironmentVariables ?? [];
     this.enableEnvironmentVariableRedaction =
-      params.enableEnvironmentVariableRedaction ?? false;
+      params.enableEnvironmentVariableRedaction ?? true;
     this.userMemory = params.userMemory ?? '';
     this.geminiMdFileCount = params.geminiMdFileCount ?? 0;
     this.geminiMdFilePaths = params.geminiMdFilePaths ?? [];

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1268,8 +1268,8 @@
             "enabled": {
               "title": "Enable Environment Variable Redaction",
               "description": "Enable redaction of environment variables that may contain secrets.",
-              "markdownDescription": "Enable redaction of environment variables that may contain secrets.\n\n- Category: `Security`\n- Requires restart: `yes`\n- Default: `false`",
-              "default": false,
+              "markdownDescription": "Enable redaction of environment variables that may contain secrets.\n\n- Category: `Security`\n- Requires restart: `yes`\n- Default: `true`",
+              "default": true,
               "type": "boolean"
             }
           },


### PR DESCRIPTION
## Summary

Defaults environment variable secrets redaction to enabled. This is a breaking change which improves the security posture of Gemini CLI by preventing secrets from being inadvertently passed to hooks, MCP servers, and other extensibility provided child processes.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
