### PR TITLE
Agent Skills: Status Bar Integration for Skill Counts

### DIFF
--- a/packages/cli/src/ui/components/Composer.test.tsx
+++ b/packages/cli/src/ui/components/Composer.test.tsx
@@ -144,10 +144,16 @@ const createMockConfig = (overrides = {}) => ({
   getDebugMode: vi.fn(() => false),
   getAccessibility: vi.fn(() => ({})),
   getMcpServers: vi.fn(() => ({})),
-  getMcpClientManager: vi.fn().mockImplementation(() => ({
-    getBlockedMcpServers: vi.fn(),
-    getMcpServers: vi.fn(),
-  })),
+  getToolRegistry: () => ({
+    getTool: vi.fn(),
+  }),
+  getSkillManager: () => ({
+    getSkills: () => [],
+  }),
+  getMcpClientManager: () => ({
+    getMcpServers: () => ({}),
+    getBlockedMcpServers: () => [],
+  }),
   ...overrides,
 });
 

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -120,6 +120,7 @@ export const Composer = () => {
                 blockedMcpServers={
                   config.getMcpClientManager()?.getBlockedMcpServers() ?? []
                 }
+                skillCount={config.getSkillManager().getSkills().length}
               />
             )
           )}

--- a/packages/cli/src/ui/components/ContextSummaryDisplay.test.tsx
+++ b/packages/cli/src/ui/components/ContextSummaryDisplay.test.tsx
@@ -34,14 +34,16 @@ describe('<ContextSummaryDisplay />', () => {
         openFiles: [{ path: '/a/b/c', timestamp: Date.now() }],
       },
     },
+    skillCount: 1,
   };
 
   it('should render on a single line on a wide screen', () => {
     const { lastFrame, unmount } = renderWithWidth(120, baseProps);
     const output = lastFrame()!;
     expect(output).toContain(
-      'Using: 1 open file (ctrl+g to view) | 1 GEMINI.md file | 1 MCP server',
+      '1 open file (ctrl+g to view) | 1 GEMINI.md file | 1 MCP server | 1 skill',
     );
+    expect(output).not.toContain('Using:');
     // Check for absence of newlines
     expect(output.includes('\n')).toBe(false);
     unmount();
@@ -51,10 +53,10 @@ describe('<ContextSummaryDisplay />', () => {
     const { lastFrame, unmount } = renderWithWidth(60, baseProps);
     const output = lastFrame()!;
     const expectedLines = [
-      ' Using:',
-      '   - 1 open file (ctrl+g to view)',
-      '   - 1 GEMINI.md file',
-      '   - 1 MCP server',
+      ' - 1 open file (ctrl+g to view)',
+      ' - 1 GEMINI.md file',
+      ' - 1 MCP server',
+      ' - 1 skill',
     ];
     const actualLines = output.split('\n');
     expect(actualLines).toEqual(expectedLines);
@@ -86,9 +88,10 @@ describe('<ContextSummaryDisplay />', () => {
       geminiMdFileCount: 0,
       contextFileNames: [],
       mcpServers: {},
+      skillCount: 0,
     };
     const { lastFrame, unmount } = renderWithWidth(60, props);
-    const expectedLines = [' Using:', '   - 1 open file (ctrl+g to view)'];
+    const expectedLines = [' - 1 open file (ctrl+g to view)'];
     const actualLines = lastFrame()!.split('\n');
     expect(actualLines).toEqual(expectedLines);
     unmount();

--- a/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
@@ -17,6 +17,7 @@ interface ContextSummaryDisplayProps {
   mcpServers?: Record<string, MCPServerConfig>;
   blockedMcpServers?: Array<{ name: string; extensionName: string }>;
   ideContext?: IdeContext;
+  skillCount: number;
 }
 
 export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
@@ -25,6 +26,7 @@ export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
   mcpServers,
   blockedMcpServers,
   ideContext,
+  skillCount,
 }) => {
   const { columns: terminalWidth } = useTerminalSize();
   const isNarrow = isNarrowWidth(terminalWidth);
@@ -36,7 +38,8 @@ export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
     geminiMdFileCount === 0 &&
     mcpServerCount === 0 &&
     blockedMcpServerCount === 0 &&
-    openFileCount === 0
+    openFileCount === 0 &&
+    skillCount === 0
   ) {
     return <Text> </Text>; // Render an empty space to reserve height
   }
@@ -83,15 +86,23 @@ export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
     return parts.join(', ');
   })();
 
-  const summaryParts = [openFilesText, geminiMdText, mcpText].filter(Boolean);
+  const skillText = (() => {
+    if (skillCount === 0) {
+      return '';
+    }
+    return `${skillCount} skill${skillCount > 1 ? 's' : ''}`;
+  })();
+
+  const summaryParts = [openFilesText, geminiMdText, mcpText, skillText].filter(
+    Boolean,
+  );
 
   if (isNarrow) {
     return (
       <Box flexDirection="column" paddingX={1}>
-        <Text color={theme.text.secondary}>Using:</Text>
         {summaryParts.map((part, index) => (
           <Text key={index} color={theme.text.secondary}>
-            {'  '}- {part}
+            - {part}
           </Text>
         ))}
       </Box>
@@ -100,9 +111,7 @@ export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
 
   return (
     <Box paddingX={1}>
-      <Text color={theme.text.secondary}>
-        Using: {summaryParts.join(' | ')}
-      </Text>
+      <Text color={theme.text.secondary}>{summaryParts.join(' | ')}</Text>
     </Box>
   );
 };


### PR DESCRIPTION
## Summary

This PR implements **Status Bar Integration** for Agent Skills, surfacing the count of discovered skills directly in the CLI's persistent footer. This provides users with a clear, unobtrusive visual indicator of available specialized expertise for their current session.

## Details

- **Context Summary Update:** Modified `ContextSummaryDisplay.tsx` to accept and render a `skillCount` prop alongside existing context info (files, MCP servers, etc.).
- **Composer Integration:** Updated the `Composer` component to retrieve real-time skill counts from the `SkillManager` and propagate them to the display layer.
- **Visual Consistency:** Integrated the skill count into the summary line using standard theme colors and separators (e.g., `2 open files | 1 context file | 3 skills`).
- **Responsive Layout:** Ensured the skill indicator correctly adapts to narrow terminal widths, appearing in the multi-line stack when space is constrained.
- **Testing:** Added comprehensive unit tests in `ContextSummaryDisplay.test.tsx` and `Composer.test.tsx` to verify correct rendering and layout behavior.

## Related Issues

Fixes #15692, Part of #15327

## How to Validate

1. **Verify Empty State:** Launch the CLI in a directory with no skills.
   - **Expectation:** The "skills" segment should be omitted from the status bar.
2. **Verify Discovery:** Add one or more skills to `.gemini/skills/` and restart.
   - **Expectation:** The status bar (above the input prompt) should now display `X skill(s)` (e.g., `1 skill`).
3. **Verify Layout:** Resize the terminal to a narrow width (< 80 columns).
   - **Expectation:** The status bar should switch to a vertical list format, including the skill count.
   
   
<img width="1818" height="1268" alt="image" src="https://github.com/user-attachments/assets/74c00843-c7fd-4af8-ace3-265d39a64729" />


## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run