### PR TITLE
fix: handle Shift+Space in Kitty keyboard protocol terminals

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -224,40 +224,60 @@ describe('KeypressContext', () => {
     });
   });
 
-  describe('Tab and Backspace handling', () => {
+  describe('Tab, Backspace, and Space handling', () => {
     it.each([
       {
         name: 'Tab key',
-        sequence: '\x1b[9u',
+        inputSequence: '\x1b[9u',
         expected: { name: 'tab', shift: false },
       },
       {
         name: 'Shift+Tab',
-        sequence: '\x1b[9;2u',
+        inputSequence: '\x1b[9;2u',
         expected: { name: 'tab', shift: true },
       },
       {
         name: 'Backspace',
-        sequence: '\x1b[127u',
+        inputSequence: '\x1b[127u',
         expected: { name: 'backspace', meta: false },
       },
       {
         name: 'Option+Backspace',
-        sequence: '\x1b[127;3u',
+        inputSequence: '\x1b[127;3u',
         expected: { name: 'backspace', meta: true },
       },
       {
         name: 'Ctrl+Backspace',
-        sequence: '\x1b[127;5u',
+        inputSequence: '\x1b[127;5u',
         expected: { name: 'backspace', ctrl: true },
+      },
+      {
+        name: 'Shift+Space',
+        inputSequence: '\x1b[32;2u',
+        expected: {
+          name: 'space',
+          shift: true,
+          insertable: true,
+          sequence: ' ',
+        },
+      },
+      {
+        name: 'Ctrl+Space',
+        inputSequence: '\x1b[32;5u',
+        expected: {
+          name: 'space',
+          ctrl: true,
+          insertable: false,
+          sequence: '\x1b[32;5u',
+        },
       },
     ])(
       'should recognize $name in kitty protocol',
-      async ({ sequence, expected }) => {
+      async ({ inputSequence, expected }) => {
         const { keyHandler } = setupKeypressTest();
 
         act(() => {
-          stdin.write(sequence);
+          stdin.write(inputSequence);
         });
 
         expect(keyHandler).toHaveBeenCalledWith(

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -85,6 +85,7 @@ const KEY_INFO_MAP: Record<
   '[9u': { name: 'tab' },
   '[13u': { name: 'return' },
   '[27u': { name: 'escape' },
+  '[32u': { name: 'space' },
   '[127u': { name: 'backspace' },
   '[57414u': { name: 'return' }, // Numpad Enter
   '[a': { name: 'up', shift: true },
@@ -503,6 +504,10 @@ function* emitKeys(
         }
         if (keyInfo.ctrl) {
           ctrl = true;
+        }
+        if (name === 'space' && !ctrl && !meta) {
+          sequence = ' ';
+          insertable = true;
         }
       } else {
         name = 'undefined';


### PR DESCRIPTION
## Summary

- Fixed Shift+Space not inserting a space character in terminals using Kitty keyboard protocol (e.g., foot, kitty)
- Kitty terminals can send Shift+Space as CSI-u (e.g. `\x1b[32;2u`); we now recognize the normalized key code and treat it as an insertable space

## Root Cause

In Kitty protocol terminals, space with modifiers is often sent as a CSI-u sequence. The key parser normalizes CSI-u keys into a modifier-free code (e.g. `[32u`) and derives modifiers from the numeric parameter. Since `[32u` wasn't mapped, we fell through to `name='undefined'` and the raw escape sequence was never normalized into an insertable `' '`.

## Changes

- Added `[32u` to `KEY_INFO_MAP` as the `space` key
- When the resolved key is `space` without `ctrl/meta`, normalize the raw CSI-u sequence to `' '` and mark it `insertable` so downstream text insertion uses the correct input
- Added test cases for Shift+Space and Ctrl+Space in Kitty protocol

## Test Plan

- [x] `npx vitest run src/ui/contexts/KeypressContext.test.tsx`
- [x] Manual testing in foot terminal (requires user verification)

Fixes #15703

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
