### PR TITLE
Unify shell security policy and remove legacy logic

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -536,20 +536,22 @@ export async function loadCliConfig(
     throw err;
   }
 
-  const policyEngineConfig = await createPolicyEngineConfig(
-    settings,
-    approvalMode,
-  );
-
-  const allowedTools = argv.allowedTools || settings.tools?.allowed || [];
-  const allowedToolsSet = new Set(allowedTools);
-
   // Interactive mode: explicit -i flag or (TTY + no args + no -p flag)
   const hasQuery = !!argv.query;
   const interactive =
     !!argv.promptInteractive ||
     !!argv.experimentalAcp ||
     (process.stdin.isTTY && !hasQuery && !argv.prompt);
+
+  const policyEngineConfig = await createPolicyEngineConfig(
+    settings,
+    approvalMode,
+  );
+  policyEngineConfig.nonInteractive = !interactive;
+
+  const allowedTools = argv.allowedTools || settings.tools?.allowed || [];
+  const allowedToolsSet = new Set(allowedTools);
+
   // In non-interactive mode, exclude tools that require a prompt.
   const extraExcludes: string[] = [];
   if (!interactive) {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -543,12 +543,6 @@ export async function loadCliConfig(
     !!argv.experimentalAcp ||
     (process.stdin.isTTY && !hasQuery && !argv.prompt);
 
-  const policyEngineConfig = await createPolicyEngineConfig(
-    settings,
-    approvalMode,
-  );
-  policyEngineConfig.nonInteractive = !interactive;
-
   const allowedTools = argv.allowedTools || settings.tools?.allowed || [];
   const allowedToolsSet = new Set(allowedTools);
 
@@ -590,6 +584,26 @@ export async function loadCliConfig(
     settings,
     extraExcludes.length > 0 ? extraExcludes : undefined,
   );
+
+  // Create a settings object that includes CLI overrides for policy generation
+  const effectiveSettings: Settings = {
+    ...settings,
+    tools: {
+      ...settings.tools,
+      allowed: allowedTools,
+      exclude: excludeTools,
+    },
+    mcp: {
+      ...settings.mcp,
+      allowed: argv.allowedMcpServerNames ?? settings.mcp?.allowed,
+    },
+  };
+
+  const policyEngineConfig = await createPolicyEngineConfig(
+    effectiveSettings,
+    approvalMode,
+  );
+  policyEngineConfig.nonInteractive = !interactive;
 
   const defaultModel = settings.general?.previewFeatures
     ? PREVIEW_GEMINI_MODEL_AUTO

--- a/packages/core/src/policy/persistence.test.ts
+++ b/packages/core/src/policy/persistence.test.ts
@@ -127,7 +127,7 @@ describe('createPolicyUpdater', () => {
     expect(addedRule).toBeDefined();
     expect(addedRule?.priority).toBe(2.95);
     expect(addedRule?.argsPattern).toEqual(
-      new RegExp(`"command":"git status(?:[\\s"]|$)`),
+      new RegExp(`"command":"git\\ status(?:[\\s"]|$)`),
     );
 
     // Verify file written

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -195,13 +195,15 @@ export class PolicyEngine {
           serverName,
         );
 
+        const subDecision = this.applyNonInteractiveMode(subResult.decision);
+
         // If any part is DENIED, the whole command is DENIED
-        if (subResult.decision === PolicyDecision.DENY) {
+        if (subDecision === PolicyDecision.DENY) {
           return PolicyDecision.DENY;
         }
 
         // If any part requires ASK_USER, the whole command requires ASK_USER (unless already DENY)
-        if (subResult.decision === PolicyDecision.ASK_USER) {
+        if (subDecision === PolicyDecision.ASK_USER) {
           if (aggregateDecision === PolicyDecision.ALLOW) {
             aggregateDecision = PolicyDecision.ASK_USER;
           }
@@ -209,7 +211,7 @@ export class PolicyEngine {
 
         // Check for redirection in allowed sub-commands
         if (
-          subResult.decision === PolicyDecision.ALLOW &&
+          subDecision === PolicyDecision.ALLOW &&
           !allowRedirection &&
           hasRedirection(subCmd)
         ) {

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -172,8 +172,13 @@ export class PolicyEngine {
         `[PolicyEngine.check] Validating shell command: ${subCommands.length} parts`,
       );
 
-      // Start with the decision for the full command string
-      let aggregateDecision = ruleDecision;
+      if (ruleDecision === PolicyDecision.DENY) {
+        return PolicyDecision.DENY;
+      }
+
+      // Start optimistically. If all parts are ALLOW, the whole is ALLOW.
+      // We will downgrade if any part is ASK_USER or DENY.
+      let aggregateDecision = PolicyDecision.ALLOW;
 
       for (const subCmd of subCommands) {
         // Prevent infinite recursion for the root command
@@ -186,6 +191,17 @@ export class PolicyEngine {
             if (aggregateDecision === PolicyDecision.ALLOW) {
               aggregateDecision = PolicyDecision.ASK_USER;
             }
+          } else {
+            // If the command is atomic (cannot be split further) and didn't
+            // trigger infinite recursion checks, we must respect the decision
+            // of the rule that triggered this check. If the rule was ASK_USER
+            // (e.g. wildcard), we must downgrade.
+            if (
+              ruleDecision === PolicyDecision.ASK_USER &&
+              aggregateDecision === PolicyDecision.ALLOW
+            ) {
+              aggregateDecision = PolicyDecision.ASK_USER;
+            }
           }
           continue;
         }
@@ -195,14 +211,15 @@ export class PolicyEngine {
           serverName,
         );
 
-        const subDecision = this.applyNonInteractiveMode(subResult.decision);
+        // subResult.decision is already filtered through applyNonInteractiveMode by this.check()
+        const subDecision = subResult.decision;
 
         // If any part is DENIED, the whole command is DENIED
         if (subDecision === PolicyDecision.DENY) {
           return PolicyDecision.DENY;
         }
 
-        // If any part requires ASK_USER, the whole command requires ASK_USER (unless already DENY)
+        // If any part requires ASK_USER, the whole command requires ASK_USER
         if (subDecision === PolicyDecision.ASK_USER) {
           if (aggregateDecision === PolicyDecision.ALLOW) {
             aggregateDecision = PolicyDecision.ASK_USER;

--- a/packages/core/src/policy/toml-loader.test.ts
+++ b/packages/core/src/policy/toml-loader.test.ts
@@ -157,6 +157,21 @@ modes = ["yolo"]
       expect(result.errors).toHaveLength(0);
     });
 
+    it('should parse and transform allow_redirection property', async () => {
+      const result = await runLoadPoliciesFromToml(`
+[[rule]]
+toolName = "run_shell_command"
+commandPrefix = "echo"
+decision = "allow"
+priority = 100
+allow_redirection = true
+`);
+
+      expect(result.rules).toHaveLength(1);
+      expect(result.rules[0].allowRedirection).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
     it('should return error if modes property is used for Tier 2 and Tier 3 policies', async () => {
       await fs.writeFile(
         path.join(tempDir, 'tier2.toml'),

--- a/packages/core/src/policy/toml-loader.ts
+++ b/packages/core/src/policy/toml-loader.ts
@@ -12,6 +12,7 @@ import {
   type SafetyCheckerRule,
   InProcessCheckerType,
 } from './types.js';
+import { buildArgsPatterns } from './utils.js';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import toml from '@iarna/toml';
@@ -44,6 +45,7 @@ const PolicyRuleSchema = z.object({
         'priority must be <= 999 to prevent tier overflow. Priorities >= 1000 would jump to the next tier.',
     }),
   modes: z.array(z.nativeEnum(ApprovalMode)).optional(),
+  allow_redirection: z.boolean().optional(),
 });
 
 /**
@@ -117,17 +119,6 @@ export interface PolicyLoadResult {
   rules: PolicyRule[];
   checkers: SafetyCheckerRule[];
   errors: PolicyFileError[];
-}
-
-/**
- * Escapes special regex characters in a string for use in a regex pattern.
- * This is used for commandPrefix to ensure literal string matching.
- *
- * @param str The string to escape
- * @returns The escaped string safe for use in a regex
- */
-export function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**
@@ -354,26 +345,11 @@ export async function loadPoliciesFromToml(
         // Transform rules
         const parsedRules: PolicyRule[] = (validationResult.data.rule ?? [])
           .flatMap((rule) => {
-            // Transform commandPrefix/commandRegex to argsPattern
-            let effectiveArgsPattern = rule.argsPattern;
-            const commandPrefixes: string[] = [];
-
-            if (rule.commandPrefix) {
-              const prefixes = Array.isArray(rule.commandPrefix)
-                ? rule.commandPrefix
-                : [rule.commandPrefix];
-              commandPrefixes.push(...prefixes);
-            } else if (rule.commandRegex) {
-              effectiveArgsPattern = `"command":"${rule.commandRegex}`;
-            }
-
-            // Expand command prefixes to multiple patterns
-            const argsPatterns: Array<string | undefined> =
-              commandPrefixes.length > 0
-                ? commandPrefixes.map(
-                    (prefix) => `"command":"${escapeRegex(prefix)}(?:[\\s"]|$)`,
-                  )
-                : [effectiveArgsPattern];
+            const argsPatterns = buildArgsPatterns(
+              rule.argsPattern,
+              rule.commandPrefix,
+              rule.commandRegex,
+            );
 
             // For each argsPattern, expand toolName arrays
             return argsPatterns.flatMap((argsPattern) => {
@@ -400,6 +376,7 @@ export async function loadPoliciesFromToml(
                   decision: rule.decision,
                   priority: transformPriority(rule.priority, tier),
                   modes: tier === 1 ? rule.modes : undefined,
+                  allowRedirection: rule.allow_redirection,
                 };
 
                 // Compile regex pattern
@@ -436,24 +413,11 @@ export async function loadPoliciesFromToml(
           validationResult.data.safety_checker ?? []
         )
           .flatMap((checker) => {
-            let effectiveArgsPattern = checker.argsPattern;
-            const commandPrefixes: string[] = [];
-
-            if (checker.commandPrefix) {
-              const prefixes = Array.isArray(checker.commandPrefix)
-                ? checker.commandPrefix
-                : [checker.commandPrefix];
-              commandPrefixes.push(...prefixes);
-            } else if (checker.commandRegex) {
-              effectiveArgsPattern = `"command":"${checker.commandRegex}`;
-            }
-
-            const argsPatterns: Array<string | undefined> =
-              commandPrefixes.length > 0
-                ? commandPrefixes.map(
-                    (prefix) => `"command":"${escapeRegex(prefix)}(?:[\\s"]|$)`,
-                  )
-                : [effectiveArgsPattern];
+            const argsPatterns = buildArgsPatterns(
+              checker.argsPattern,
+              checker.commandPrefix,
+              checker.commandRegex,
+            );
 
             return argsPatterns.flatMap((argsPattern) => {
               const toolNames: Array<string | undefined> = checker.toolName

--- a/packages/core/src/policy/utils.test.ts
+++ b/packages/core/src/policy/utils.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { escapeRegex, buildArgsPatterns } from './utils.js';
+
+describe('policy/utils', () => {
+  describe('escapeRegex', () => {
+    it('should escape special regex characters', () => {
+      const input = '.-*+?^${}()|[]\\ ';
+      const escaped = escapeRegex(input);
+      expect(escaped).toBe('\\.\\-\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\\\ ');
+    });
+
+    it('should return the same string if no special characters are present', () => {
+      const input = 'abcABC123';
+      expect(escapeRegex(input)).toBe(input);
+    });
+  });
+
+  describe('buildArgsPatterns', () => {
+    it('should return argsPattern if provided and no commandPrefix/regex', () => {
+      const result = buildArgsPatterns('my-pattern', undefined, undefined);
+      expect(result).toEqual(['my-pattern']);
+    });
+
+    it('should build pattern from a single commandPrefix', () => {
+      const result = buildArgsPatterns(undefined, 'ls', undefined);
+      expect(result).toEqual(['"command":"ls(?:[\\s"]|$)']);
+    });
+
+    it('should build patterns from an array of commandPrefixes', () => {
+      const result = buildArgsPatterns(undefined, ['ls', 'cd'], undefined);
+      expect(result).toEqual([
+        '"command":"ls(?:[\\s"]|$)',
+        '"command":"cd(?:[\\s"]|$)',
+      ]);
+    });
+
+    it('should build pattern from commandRegex', () => {
+      const result = buildArgsPatterns(undefined, undefined, 'rm -rf .*');
+      expect(result).toEqual(['"command":"rm -rf .*']);
+    });
+
+    it('should prioritize commandPrefix over commandRegex and argsPattern', () => {
+      const result = buildArgsPatterns('raw', 'prefix', 'regex');
+      expect(result).toEqual(['"command":"prefix(?:[\\s"]|$)']);
+    });
+
+    it('should prioritize commandRegex over argsPattern if no commandPrefix', () => {
+      const result = buildArgsPatterns('raw', undefined, 'regex');
+      expect(result).toEqual(['"command":"regex']);
+    });
+
+    it('should escape characters in commandPrefix', () => {
+      const result = buildArgsPatterns(undefined, 'git checkout -b', undefined);
+      expect(result).toEqual(['"command":"git\\ checkout\\ \\-b(?:[\\s"]|$)']);
+    });
+
+    it('should handle undefined correctly when no inputs are provided', () => {
+      const result = buildArgsPatterns(undefined, undefined, undefined);
+      expect(result).toEqual([undefined]);
+    });
+  });
+});

--- a/packages/core/src/policy/utils.test.ts
+++ b/packages/core/src/policy/utils.test.ts
@@ -10,9 +10,11 @@ import { escapeRegex, buildArgsPatterns } from './utils.js';
 describe('policy/utils', () => {
   describe('escapeRegex', () => {
     it('should escape special regex characters', () => {
-      const input = '.-*+?^${}()|[]\\ ';
+      const input = '.-*+?^${}()|[]\\ "';
       const escaped = escapeRegex(input);
-      expect(escaped).toBe('\\.\\-\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\\\ ');
+      expect(escaped).toBe(
+        '\\.\\-\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\\\ \\"',
+      );
     });
 
     it('should return the same string if no special characters are present', () => {
@@ -58,6 +60,13 @@ describe('policy/utils', () => {
     it('should escape characters in commandPrefix', () => {
       const result = buildArgsPatterns(undefined, 'git checkout -b', undefined);
       expect(result).toEqual(['"command":"git\\ checkout\\ \\-b(?:[\\s"]|$)']);
+    });
+
+    it('should correctly escape quotes in commandPrefix', () => {
+      const result = buildArgsPatterns(undefined, 'git "fix"', undefined);
+      expect(result).toEqual([
+        '"command":"git\\ \\\\\\"fix\\\\\\"(?:[\\s"]|$)',
+      ]);
     });
 
     it('should handle undefined correctly when no inputs are provided', () => {

--- a/packages/core/src/policy/utils.ts
+++ b/packages/core/src/policy/utils.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Escapes a string for use in a regular expression.
+ */
+export function escapeRegex(text: string): string {
+  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+}
+
+/**
+ * Builds a list of args patterns for policy matching.
+ *
+ * This function handles the transformation of command prefixes and regexes into
+ * the internal argsPattern representation used by the PolicyEngine.
+ *
+ * @param argsPattern An optional raw regex string for arguments.
+ * @param commandPrefix An optional command prefix (or list of prefixes) to allow.
+ * @param commandRegex An optional command regex string to allow.
+ * @returns An array of string patterns (or undefined) for the PolicyEngine.
+ */
+export function buildArgsPatterns(
+  argsPattern?: string,
+  commandPrefix?: string | string[],
+  commandRegex?: string,
+): Array<string | undefined> {
+  let effectiveArgsPattern = argsPattern;
+  const commandPrefixes: string[] = [];
+
+  if (commandPrefix) {
+    const prefixes = Array.isArray(commandPrefix)
+      ? commandPrefix
+      : [commandPrefix];
+    commandPrefixes.push(...prefixes);
+  } else if (commandRegex) {
+    effectiveArgsPattern = `"command":"${commandRegex}`;
+  }
+
+  // Expand command prefixes to multiple patterns.
+  // We append [\\s"] to ensure we match whole words only (e.g., "git" but not "github").
+  // Since we match against JSON stringified args, the value is always followed by a space or a closing quote.
+  return commandPrefixes.length > 0
+    ? commandPrefixes.map(
+        (prefix) => `"command":"${escapeRegex(prefix)}(?:[\\s"]|$)`,
+      )
+    : [effectiveArgsPattern];
+}

--- a/packages/core/src/test-utils/mock-message-bus.ts
+++ b/packages/core/src/test-utils/mock-message-bus.ts
@@ -24,6 +24,7 @@ export class MockMessageBus {
   publishedMessages: Message[] = [];
   hookRequests: HookExecutionRequest[] = [];
   hookResponses: HookExecutionResponse[] = [];
+  defaultToolDecision: 'allow' | 'deny' | 'ask_user' = 'allow';
 
   /**
    * Mock publish method that captures messages and simulates responses
@@ -50,6 +51,34 @@ export class MockMessageBus {
       // Emit response to subscribers
       this.emit(MessageBusType.HOOK_EXECUTION_RESPONSE, response);
     }
+
+    // Handle tool confirmation requests
+    if (message.type === MessageBusType.TOOL_CONFIRMATION_REQUEST) {
+      if (this.defaultToolDecision === 'allow') {
+        this.emit(MessageBusType.TOOL_CONFIRMATION_RESPONSE, {
+          type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+          correlationId: message.correlationId,
+          confirmed: true,
+        });
+      } else if (this.defaultToolDecision === 'deny') {
+        this.emit(MessageBusType.TOOL_CONFIRMATION_RESPONSE, {
+          type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+          correlationId: message.correlationId,
+          confirmed: false,
+        });
+      } else {
+        // ask_user
+        this.emit(MessageBusType.TOOL_CONFIRMATION_RESPONSE, {
+          type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+          correlationId: message.correlationId,
+          confirmed: false,
+          requiresUserConfirmation: true,
+        });
+      }
+    }
+
+    // Emit the message to subscribers (mimicking real MessageBus behavior)
+    this.emit(message.type, message);
   });
 
   /**

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -103,7 +103,8 @@ export class ShellToolInvocation extends BaseToolInvocation<
     const command = stripShellWrapper(this.params.command);
     let rootCommands = [...new Set(getCommandRoots(command))];
 
-    // Fallback for UI display if parser fails
+    // Fallback for UI display if parser fails or returns no commands (e.g.
+    // variable assignments only)
     if (rootCommands.length === 0 && command.trim()) {
       const fallback = command.trim().split(/\s+/)[0];
       if (fallback) {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -9,7 +9,7 @@ import path from 'node:path';
 import os, { EOL } from 'node:os';
 import crypto from 'node:crypto';
 import type { Config } from '../config/config.js';
-import { debugLogger, type AnyToolInvocation } from '../index.js';
+import { debugLogger } from '../index.js';
 import { ToolErrorType } from './tool-error.js';
 import type {
   ToolInvocation,
@@ -24,7 +24,6 @@ import {
   Kind,
   type PolicyUpdateOptions,
 } from './tools.js';
-import { ApprovalMode } from '../policy/types.js';
 
 import { getErrorMessage } from '../utils/errors.js';
 import { summarizeToolOutput } from '../utils/summarizer.js';
@@ -40,10 +39,6 @@ import {
   initializeShellParsers,
   stripShellWrapper,
 } from '../utils/shell-utils.js';
-import {
-  isCommandAllowed,
-  isShellInvocationAllowlisted,
-} from '../utils/shell-permissions.js';
 import { SHELL_TOOL_NAME } from './tool-names.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 
@@ -106,24 +101,14 @@ export class ShellToolInvocation extends BaseToolInvocation<
     _abortSignal: AbortSignal,
   ): Promise<ToolCallConfirmationDetails | false> {
     const command = stripShellWrapper(this.params.command);
-    const rootCommands = [...new Set(getCommandRoots(command))];
+    let rootCommands = [...new Set(getCommandRoots(command))];
 
-    // In non-interactive mode, we need to prevent the tool from hanging while
-    // waiting for user input. If a tool is not fully allowed (e.g. via
-    // --allowed-tools="ShellTool(wc)"), we should throw an error instead of
-    // prompting for confirmation. This check is skipped in YOLO mode.
-    if (
-      !this.config.isInteractive() &&
-      this.config.getApprovalMode() !== ApprovalMode.YOLO
-    ) {
-      if (this.isInvocationAllowlisted(command)) {
-        // If it's an allowed shell command, we don't need to confirm execution.
-        return false;
+    // Fallback for UI display if parser fails
+    if (rootCommands.length === 0 && command.trim()) {
+      const fallback = command.trim().split(/\s+/)[0];
+      if (fallback) {
+        rootCommands = [fallback];
       }
-
-      throw new Error(
-        `Command "${command}" is not in the list of allowed tools for non-interactive mode.`,
-      );
     }
 
     // Rely entirely on PolicyEngine for interactive confirmation.
@@ -394,16 +379,6 @@ export class ShellToolInvocation extends BaseToolInvocation<
       }
     }
   }
-
-  private isInvocationAllowlisted(command: string): boolean {
-    const allowedTools = this.config.getAllowedTools() || [];
-    if (allowedTools.length === 0) {
-      return false;
-    }
-
-    const invocation = { params: { command } } as unknown as AnyToolInvocation;
-    return isShellInvocationAllowlisted(invocation, allowedTools);
-  }
 }
 
 function getShellToolDescription(): string {
@@ -487,19 +462,6 @@ export class ShellTool extends BaseDeclarativeTool<
       return 'Command cannot be empty.';
     }
 
-    const commandCheck = isCommandAllowed(params.command, this.config);
-    if (!commandCheck.allowed) {
-      if (!commandCheck.reason) {
-        debugLogger.error(
-          'Unexpected: isCommandAllowed returned false without a reason',
-        );
-        return `Command is not allowed: ${params.command}`;
-      }
-      return commandCheck.reason;
-    }
-    if (getCommandRoots(params.command).length === 0) {
-      return 'Could not identify command root to obtain permission from user.';
-    }
     if (params.dir_path) {
       const resolvedPath = path.resolve(
         this.config.getTargetDir(),


### PR DESCRIPTION
## Summary

Integrates, unifies, and hardens the shell security architecture by centralizing all permission logic in `PolicyEngine`, removing redundant legacy checks from `ShellTool`, and closing a critical non-interactive redirection leak.

## Details

- **Architectural Unification:** `ShellTool` is now a "dumb" executor. All redirection detection, non-interactive mode logic, and recursive decomposition of compound commands are handled by the `PolicyEngine`.
- **Security Hardening:** Fixed a bug where redirected shell commands (detected as `ASK_USER`) were leaking through in non-interactive sessions. They are now correctly converted to `DENY`.
- **Power User Features:** Implemented `allow_redirection` property in TOML policy rules, allowing explicit authorization of specific redirection patterns.
- **Context Preservation:** Fixed a gap where `dir_path` was lost during recursive decomposition of commands like `git status && ls`.
- **Build Stability:** Isolated Vitest-dependent mocks to prevent build-time environment errors in `packages/core`.

## Related Issues

Related to PR #15683 and PR #15597.

## How to Validate

1. Run `npm run preflight` to verify all tests pass.
2. Verify non-interactive redirection block:
   `npm start -- "echo hello > test.txt"` (Should be blocked in one-shot mode).
3. Verify TOML override:
   Add a rule with `allow_redirection = true` for `echo` and re-run the command.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [x] Seatbelt
  - [ ] Windows
  - [ ] Linux