### PR TITLE
fix(cli): handle Shift+Space encoded as CSI u escape sequence

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -246,6 +246,16 @@ describe('KeypressContext', () => {
           sequence: ' ',
         },
       },
+      {
+        name: 'Alt+Space (Escape sequence)',
+        sequence: '\x1b ',
+        expected: {
+          name: 'space',
+          meta: true,
+          insertable: true,
+          sequence: ' ',
+        },
+      },
     ])(
       'should recognize $name as insertable space',
       async ({ sequence, expected }) => {

--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -224,6 +224,44 @@ describe('KeypressContext', () => {
     });
   });
 
+  describe('Space key handling', () => {
+    it.each([
+      {
+        name: 'Space (CSI u)',
+        sequence: '\x1b[32u',
+        expected: {
+          name: 'space',
+          shift: false,
+          insertable: true,
+          sequence: ' ',
+        },
+      },
+      {
+        name: 'Shift+Space (CSI u)',
+        sequence: '\x1b[32;2u',
+        expected: {
+          name: 'space',
+          shift: true,
+          insertable: true,
+          sequence: ' ',
+        },
+      },
+    ])(
+      'should recognize $name as insertable space',
+      async ({ sequence, expected }) => {
+        const { keyHandler } = setupKeypressTest();
+
+        act(() => {
+          stdin.write(sequence);
+        });
+
+        expect(keyHandler).toHaveBeenCalledWith(
+          expect.objectContaining(expected),
+        );
+      },
+    );
+  });
+
   describe('Tab and Backspace handling', () => {
     it.each([
       {

--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -247,6 +247,16 @@ describe('KeypressContext', () => {
         },
       },
       {
+        name: 'Ctrl+Space (CSI u)',
+        sequence: '\x1b[32;5u',
+        expected: {
+          name: 'space',
+          ctrl: true,
+          insertable: false,
+          sequence: ' ',
+        },
+      },
+      {
         name: 'Alt+Space (Escape sequence)',
         sequence: '\x1b ',
         expected: {

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -84,6 +84,7 @@ const KEY_INFO_MAP: Record<
   '[13u': { name: 'return' },
   '[27u': { name: 'escape' },
   '[127u': { name: 'backspace' },
+  '[32u': { name: 'space' },
   '[57414u': { name: 'return' }, // Numpad Enter
   '[a': { name: 'up', shift: true },
   '[b': { name: 'down', shift: true },
@@ -435,6 +436,10 @@ function* emitKeys(
         }
         if (keyInfo.ctrl) {
           ctrl = true;
+        }
+        if (name === 'space') {
+          insertable = true;
+          sequence = ' ';
         }
       } else {
         name = 'undefined';

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -437,7 +437,7 @@ function* emitKeys(
         if (keyInfo.ctrl) {
           ctrl = true;
         }
-        if (name === 'space' && code === '[32u') {
+        if (name === 'space') {
           insertable = true;
           sequence = ' ';
         }

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -437,10 +437,6 @@ function* emitKeys(
         if (keyInfo.ctrl) {
           ctrl = true;
         }
-        if (name === 'space') {
-          insertable = true;
-          sequence = ' ';
-        }
       } else {
         name = 'undefined';
         if ((ctrl || meta) && (code.endsWith('u') || code.endsWith('~'))) {
@@ -477,7 +473,6 @@ function* emitKeys(
     } else if (ch === ' ') {
       name = 'space';
       meta = escaped;
-      insertable = true;
     } else if (!escaped && ch <= '\x1a') {
       // ctrl+letter
       name = String.fromCharCode(ch.charCodeAt(0) + 'a'.charCodeAt(0) - 1);
@@ -513,6 +508,12 @@ function* emitKeys(
     } else {
       // Any other character is considered printable.
       insertable = true;
+    }
+
+    // Consolidate space handling: ensure consistent insertable state and sequence
+    if (name === 'space' && !ctrl) {
+      insertable = true;
+      sequence = ' ';
     }
 
     if (

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -437,7 +437,7 @@ function* emitKeys(
         if (keyInfo.ctrl) {
           ctrl = true;
         }
-        if (name === 'space') {
+        if (name === 'space' && code === '[32u') {
           insertable = true;
           sequence = ' ';
         }

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -510,9 +510,10 @@ function* emitKeys(
       insertable = true;
     }
 
-    // Consolidate space handling: ensure consistent insertable state and sequence
-    if (name === 'space' && !ctrl) {
-      insertable = true;
+    // Consolidate space handling: normalize sequence for all space encodings.
+    // Space is only insertable when Ctrl is not pressed.
+    if (name === 'space') {
+      insertable = !ctrl;
       sequence = ' ';
     }
 


### PR DESCRIPTION
Adds [32u (Space) to KEY_INFO_MAP and ensures it is treated as an insertable space character. This fixes an issue where Shift+Space would be ignored in terminals sending CSI u sequences (like when using node-pty-shim or certain modern terminal configurations).
