### PR TITLE
feat(core): restore MessageBus optionality for soft migration (Phase 1)

### DIFF
--- a/packages/a2a-server/src/http/app.test.ts
+++ b/packages/a2a-server/src/http/app.test.ts
@@ -35,7 +35,8 @@ import {
   createStreamMessageRequest,
   createMockConfig,
 } from '../utils/testing_utils.js';
-import { MockTool } from '@google/gemini-cli-core';
+// Import MockTool from specific path to avoid vitest dependency in main core bundle
+import { MockTool } from '@google/gemini-cli-core/src/test-utils/mock-tool.js';
 import type { Command, CommandContext } from '../commands/types.js';
 
 const mockToolConfirmationFn = async () =>

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -31,10 +31,10 @@ import {
   DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
   ToolConfirmationOutcome,
   ApprovalMode,
-  MockTool,
   HookSystem,
   PREVIEW_GEMINI_MODEL,
 } from '@google/gemini-cli-core';
+import { MockTool } from '@google/gemini-cli-core/src/test-utils/mock-tool.js';
 import { createMockMessageBus } from '@google/gemini-cli-core/src/test-utils/mock-message-bus.js';
 import { ToolCallStatus } from '../types.js';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -157,9 +157,6 @@ export { Storage } from './config/storage.js';
 // Export hooks system
 export * from './hooks/index.js';
 
-// Export test utils
-export * from './test-utils/index.js';
-
 // Export hook types
 export * from './hooks/types.js';
 

--- a/packages/core/src/test-utils/mock-message-bus.ts
+++ b/packages/core/src/test-utils/mock-message-bus.ts
@@ -24,7 +24,7 @@ export class MockMessageBus {
   publishedMessages: Message[] = [];
   hookRequests: HookExecutionRequest[] = [];
   hookResponses: HookExecutionResponse[] = [];
-  defaultToolDecision: 'allow' | 'deny' | 'ask_user' = 'allow';
+  defaultToolDecision: 'allow' | 'deny' | 'ask_user' = 'ask_user';
 
   /**
    * Mock publish method that captures messages and simulates responses

--- a/packages/core/src/test-utils/mock-message-bus.ts
+++ b/packages/core/src/test-utils/mock-message-bus.ts
@@ -24,7 +24,7 @@ export class MockMessageBus {
   publishedMessages: Message[] = [];
   hookRequests: HookExecutionRequest[] = [];
   hookResponses: HookExecutionResponse[] = [];
-  defaultToolDecision: 'allow' | 'deny' | 'ask_user' = 'ask_user';
+  defaultToolDecision: 'allow' | 'deny' | 'ask_user' = 'allow';
 
   /**
    * Mock publish method that captures messages and simulates responses

--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -59,6 +59,10 @@ import { ApprovalMode } from '../policy/types.js';
 import type { Content, Part, SchemaUnion } from '@google/genai';
 import { StandardFileSystemService } from '../services/fileSystemService.js';
 import { WorkspaceContext } from '../utils/workspaceContext.js';
+import {
+  createMockMessageBus,
+  getMockMessageBusInstance,
+} from '../test-utils/mock-message-bus.js';
 
 describe('EditTool', () => {
   let tool: EditTool;
@@ -177,7 +181,9 @@ describe('EditTool', () => {
       },
     );
 
-    tool = new EditTool(mockConfig);
+    const bus = createMockMessageBus();
+    getMockMessageBusInstance(bus).defaultToolDecision = 'ask_user';
+    tool = new EditTool(mockConfig, bus);
   });
 
   afterEach(() => {
@@ -1029,7 +1035,10 @@ describe('EditTool', () => {
     it('should use windows-style path examples on windows', () => {
       vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
 
-      const tool = new EditTool({} as unknown as Config);
+      const tool = new EditTool(
+        {} as unknown as Config,
+        createMockMessageBus(),
+      );
       const schema = tool.schema;
       expect(
         (schema.parametersJsonSchema as EditFileParameterSchema).properties
@@ -1040,7 +1049,10 @@ describe('EditTool', () => {
     it('should use unix-style path examples on non-windows platforms', () => {
       vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
 
-      const tool = new EditTool({} as unknown as Config);
+      const tool = new EditTool(
+        {} as unknown as Config,
+        createMockMessageBus(),
+      );
       const schema = tool.schema;
       expect(
         (schema.parametersJsonSchema as EditFileParameterSchema).properties

--- a/packages/core/src/tools/glob.test.ts
+++ b/packages/core/src/tools/glob.test.ts
@@ -16,6 +16,7 @@ import type { Config } from '../config/config.js';
 import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.js';
 import { ToolErrorType } from './tool-error.js';
 import * as glob from 'glob';
+import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 
 vi.mock('glob', { spy: true });
 
@@ -43,7 +44,7 @@ describe('GlobTool', () => {
     // Create a unique root directory for each test run
     tempRootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'glob-tool-root-'));
     await fs.writeFile(path.join(tempRootDir, '.git'), ''); // Fake git repo
-    globTool = new GlobTool(mockConfig);
+    globTool = new GlobTool(mockConfig, createMockMessageBus());
 
     // Create some test files and directories within this root
     // Top-level files

--- a/packages/core/src/tools/grep.test.ts
+++ b/packages/core/src/tools/grep.test.ts
@@ -14,6 +14,7 @@ import type { Config } from '../config/config.js';
 import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.js';
 import { ToolErrorType } from './tool-error.js';
 import * as glob from 'glob';
+import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 
 vi.mock('glob', { spy: true });
 
@@ -47,7 +48,7 @@ describe('GrepTool', () => {
 
   beforeEach(async () => {
     tempRootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'grep-tool-root-'));
-    grepTool = new GrepTool(mockConfig);
+    grepTool = new GrepTool(mockConfig, createMockMessageBus());
 
     // Create some test files and directories
     await fs.writeFile(
@@ -270,7 +271,10 @@ describe('GrepTool', () => {
         }),
       } as unknown as Config;
 
-      const multiDirGrepTool = new GrepTool(multiDirConfig);
+      const multiDirGrepTool = new GrepTool(
+        multiDirConfig,
+        createMockMessageBus(),
+      );
       const params: GrepToolParams = { pattern: 'world' };
       const invocation = multiDirGrepTool.build(params);
       const result = await invocation.execute(abortSignal);
@@ -323,7 +327,10 @@ describe('GrepTool', () => {
         }),
       } as unknown as Config;
 
-      const multiDirGrepTool = new GrepTool(multiDirConfig);
+      const multiDirGrepTool = new GrepTool(
+        multiDirConfig,
+        createMockMessageBus(),
+      );
 
       // Search only in the 'sub' directory of the first workspace
       const params: GrepToolParams = { pattern: 'world', dir_path: 'sub' };
@@ -385,7 +392,10 @@ describe('GrepTool', () => {
         }),
       } as unknown as Config;
 
-      const multiDirGrepTool = new GrepTool(multiDirConfig);
+      const multiDirGrepTool = new GrepTool(
+        multiDirConfig,
+        createMockMessageBus(),
+      );
       const params: GrepToolParams = { pattern: 'testPattern' };
       const invocation = multiDirGrepTool.build(params);
       expect(invocation.getDescription()).toBe(

--- a/packages/core/src/tools/ls.test.ts
+++ b/packages/core/src/tools/ls.test.ts
@@ -13,6 +13,7 @@ import type { Config } from '../config/config.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { ToolErrorType } from './tool-error.js';
 import { WorkspaceContext } from '../utils/workspaceContext.js';
+import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 
 describe('LSTool', () => {
   let lsTool: LSTool;
@@ -39,7 +40,7 @@ describe('LSTool', () => {
       }),
     } as unknown as Config;
 
-    lsTool = new LSTool(mockConfig);
+    lsTool = new LSTool(mockConfig, createMockMessageBus());
   });
 
   afterEach(async () => {

--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -17,6 +17,7 @@ import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { StandardFileSystemService } from '../services/fileSystemService.js';
 import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.js';
 import { WorkspaceContext } from '../utils/workspaceContext.js';
+import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 
 vi.mock('../telemetry/loggers.js', () => ({
   logFileOperation: vi.fn(),
@@ -46,7 +47,7 @@ describe('ReadFileTool', () => {
       },
       isInteractive: () => false,
     } as unknown as Config;
-    tool = new ReadFileTool(mockConfigInstance);
+    tool = new ReadFileTool(mockConfigInstance, createMockMessageBus());
   });
 
   afterEach(async () => {
@@ -438,7 +439,7 @@ describe('ReadFileTool', () => {
             getProjectTempDir: () => path.join(tempRootDir, '.temp'),
           },
         } as unknown as Config;
-        tool = new ReadFileTool(mockConfigInstance);
+        tool = new ReadFileTool(mockConfigInstance, createMockMessageBus());
       });
 
       it('should throw error if path is ignored by a .geminiignore pattern', async () => {

--- a/packages/core/src/tools/read-many-files.test.ts
+++ b/packages/core/src/tools/read-many-files.test.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_FILE_EXCLUDES,
 } from '../utils/ignorePatterns.js';
 import * as glob from 'glob';
+import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 
 vi.mock('glob', { spy: true });
 
@@ -90,7 +91,7 @@ describe('ReadManyFilesTool', () => {
       }),
       isInteractive: () => false,
     } as Partial<Config> as Config;
-    tool = new ReadManyFilesTool(mockConfig);
+    tool = new ReadManyFilesTool(mockConfig, createMockMessageBus());
 
     mockReadFileFn = mockControl.mockReadFile;
     mockReadFileFn.mockReset();
@@ -505,7 +506,7 @@ describe('ReadManyFilesTool', () => {
         }),
         isInteractive: () => false,
       } as Partial<Config> as Config;
-      tool = new ReadManyFilesTool(mockConfig);
+      tool = new ReadManyFilesTool(mockConfig, createMockMessageBus());
 
       fs.writeFileSync(path.join(tempDir1, 'file1.txt'), 'Content1');
       fs.writeFileSync(path.join(tempDir2, 'file2.txt'), 'Content2');

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -172,7 +172,7 @@ Signal: Signal number or \`(none)\` if no signal was received.
 
   protected createInvocation(
     params: ToolParams,
-    _messageBus?: MessageBus,
+    messageBus?: MessageBus,
     _toolName?: string,
     _displayName?: string,
   ): ToolInvocation<ToolParams, ToolResult> {
@@ -181,7 +181,7 @@ Signal: Signal number or \`(none)\` if no signal was received.
       this.originalName,
       this.name,
       params,
-      _messageBus,
+      messageBus,
     );
   }
 }
@@ -194,16 +194,22 @@ export class ToolRegistry {
   private config: Config;
   private messageBus?: MessageBus;
 
-  constructor(config: Config) {
+  constructor(config: Config, messageBus?: MessageBus) {
     this.config = config;
-  }
-
-  setMessageBus(messageBus: MessageBus): void {
     this.messageBus = messageBus;
   }
 
   getMessageBus(): MessageBus | undefined {
     return this.messageBus;
+  }
+
+  /**
+   * @deprecated migration only - will be removed in PR 3 (Enforcement)
+   * TODO: DELETE ME in PR 3. This is a temporary shim to allow for soft migration
+   * of tools while the core infrastructure is updated to require a MessageBus at birth.
+   */
+  setMessageBus(messageBus: MessageBus): void {
+    this.messageBus = messageBus;
   }
 
   /**

--- a/packages/core/src/tools/write-file.test.ts
+++ b/packages/core/src/tools/write-file.test.ts
@@ -41,6 +41,7 @@ import { StandardFileSystemService } from '../services/fileSystemService.js';
 import type { DiffUpdateResult } from '../ide/ide-client.js';
 import { IdeClient } from '../ide/ide-client.js';
 import { WorkspaceContext } from '../utils/workspaceContext.js';
+import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 
 const rootDir = path.resolve(os.tmpdir(), 'gemini-cli-test-root');
 
@@ -150,7 +151,7 @@ describe('WriteFileTool', () => {
       mockBaseLlmClientInstance,
     );
 
-    tool = new WriteFileTool(mockConfig);
+    tool = new WriteFileTool(mockConfig, createMockMessageBus());
 
     // Reset mocks before each test
     mockConfigInternal.getApprovalMode.mockReturnValue(ApprovalMode.DEFAULT);

--- a/packages/core/src/tools/write-file.test.ts
+++ b/packages/core/src/tools/write-file.test.ts
@@ -41,7 +41,10 @@ import { StandardFileSystemService } from '../services/fileSystemService.js';
 import type { DiffUpdateResult } from '../ide/ide-client.js';
 import { IdeClient } from '../ide/ide-client.js';
 import { WorkspaceContext } from '../utils/workspaceContext.js';
-import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
+import {
+  createMockMessageBus,
+  getMockMessageBusInstance,
+} from '../test-utils/mock-message-bus.js';
 
 const rootDir = path.resolve(os.tmpdir(), 'gemini-cli-test-root');
 
@@ -151,7 +154,9 @@ describe('WriteFileTool', () => {
       mockBaseLlmClientInstance,
     );
 
-    tool = new WriteFileTool(mockConfig, createMockMessageBus());
+    const bus = createMockMessageBus();
+    getMockMessageBusInstance(bus).defaultToolDecision = 'ask_user';
+    tool = new WriteFileTool(mockConfig, bus);
 
     // Reset mocks before each test
     mockConfigInternal.getApprovalMode.mockReturnValue(ApprovalMode.DEFAULT);

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -475,11 +475,12 @@ export class WriteFileTool
 
   protected createInvocation(
     params: WriteFileToolParams,
+    messageBus?: MessageBus,
   ): ToolInvocation<WriteFileToolParams, ToolResult> {
     return new WriteFileToolInvocation(
       this.config,
       params,
-      this.messageBus,
+      messageBus ?? this.messageBus,
       this.name,
       this.displayName,
     );

--- a/packages/core/src/utils/editCorrector.test.ts
+++ b/packages/core/src/utils/editCorrector.test.ts
@@ -164,7 +164,10 @@ describe('editCorrector', () => {
     const abortSignal = new AbortController().signal;
 
     beforeEach(() => {
-      mockToolRegistry = new ToolRegistry({} as Config) as Mocked<ToolRegistry>;
+      mockToolRegistry = new ToolRegistry(
+        {} as Config,
+        {} as any,
+      ) as Mocked<ToolRegistry>;
       const configParams = {
         apiKey: 'test-api-key',
         model: 'test-model',

--- a/packages/core/src/utils/tool-utils.test.ts
+++ b/packages/core/src/utils/tool-utils.test.ts
@@ -8,6 +8,7 @@ import { expect, describe, it } from 'vitest';
 import { doesToolInvocationMatch, getToolSuggestion } from './tool-utils.js';
 import type { AnyToolInvocation, Config } from '../index.js';
 import { ReadFileTool } from '../tools/read-file.js';
+import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 
 describe('getToolSuggestion', () => {
   it('should suggest the top N closest tool names for a typo', () => {
@@ -83,7 +84,7 @@ describe('doesToolInvocationMatch', () => {
   });
 
   describe('for non-shell tools', () => {
-    const readFileTool = new ReadFileTool({} as Config);
+    const readFileTool = new ReadFileTool({} as Config, createMockMessageBus());
     const invocation = {
       params: { file: 'test.txt' },
     } as AnyToolInvocation;


### PR DESCRIPTION
## Summary

Restores optionality to the MessageBus in tool constructors to facilitate a soft migration strategy.

## Details

This is Phase 1 of the migration plan. It allows tools to function with or without the message bus, enabling a stepped migration where we first update the infrastructure and then enforce the requirement in later phases.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword (Related to #123). -->

## How to Validate

Run `npm test` to ensure no regressions in existing tools.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker