### PR TITLE
feat(hooks): support 'decision: ask' to force user confirmation

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -245,12 +245,18 @@ export const ToolConfirmationMessage: React.FC<
       const HEIGHT_QUESTION = 1; // The question text is one line.
       const MARGIN_QUESTION_BOTTOM = 1; // Margin on the question container.
       const HEIGHT_OPTIONS = options.length; // Each option in the radio select takes one line.
+      const HEIGHT_SYSTEM_MESSAGE = confirmationDetails.systemMessage ? 1 : 0;
+      const MARGIN_SYSTEM_MESSAGE_BOTTOM = confirmationDetails.systemMessage
+        ? 1
+        : 0;
 
       const surroundingElementsHeight =
         PADDING_OUTER_Y +
         MARGIN_BODY_BOTTOM +
         HEIGHT_QUESTION +
         MARGIN_QUESTION_BOTTOM +
+        HEIGHT_SYSTEM_MESSAGE +
+        MARGIN_SYSTEM_MESSAGE_BOTTOM +
         HEIGHT_OPTIONS;
       return Math.max(availableTerminalHeight - surroundingElementsHeight, 1);
     }
@@ -370,6 +376,16 @@ export const ToolConfirmationMessage: React.FC<
       <Box flexGrow={1} flexShrink={1} overflow="hidden" marginBottom={1}>
         {bodyContent}
       </Box>
+
+      {/* Hook/System context */}
+      {confirmationDetails.systemMessage && (
+        <Box marginBottom={1} flexShrink={0}>
+          <RenderInline
+            text={confirmationDetails.systemMessage}
+            defaultColor={theme.text.secondary}
+          />
+        </Box>
+      )}
 
       {/* Confirmation Question */}
       <Box marginBottom={1} flexShrink={0}>

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -1826,7 +1826,7 @@ describe('CoreToolScheduler BeforeTool hooks', () => {
           success: true,
           output: {
             decision: 'ask',
-            reason: 'Require user confirmation for this tool',
+            systemMessage: 'Forced confirmation by hook',
           },
         };
       }
@@ -1868,6 +1868,10 @@ describe('CoreToolScheduler BeforeTool hooks', () => {
     await vi.waitFor(() => {
       const calls = onToolCallsUpdate.mock.calls.at(-1)?.[0] as ToolCall[];
       expect(calls?.[0]?.status).toBe('awaiting_approval');
+      const awaitingApproval = calls?.[0] as WaitingToolCall | undefined;
+      expect(awaitingApproval?.confirmationDetails?.systemMessage).toBe(
+        'Forced confirmation by hook',
+      );
     });
 
     // Verify the tool was NOT executed yet (waiting for approval)

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -170,6 +170,13 @@ export class DefaultHookOutput implements HookOutput {
   }
 
   /**
+   * Check if this output requests user confirmation
+   */
+  isAskDecision(): boolean {
+    return this.decision === 'ask';
+  }
+
+  /**
    * Check if this output requests to stop execution
    */
   shouldStopExecution(): boolean {

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -667,6 +667,11 @@ export interface DiffStat {
 export interface ToolEditConfirmationDetails {
   type: 'edit';
   title: string;
+  /**
+   * Optional extra context to display to the user in the confirmation prompt.
+   * Used for cases like hooks forcing confirmation (decision: 'ask').
+   */
+  systemMessage?: string;
   onConfirm: (
     outcome: ToolConfirmationOutcome,
     payload?: ToolConfirmationPayload,
@@ -689,6 +694,11 @@ export interface ToolConfirmationPayload {
 export interface ToolExecuteConfirmationDetails {
   type: 'exec';
   title: string;
+  /**
+   * Optional extra context to display to the user in the confirmation prompt.
+   * Used for cases like hooks forcing confirmation (decision: 'ask').
+   */
+  systemMessage?: string;
   onConfirm: (outcome: ToolConfirmationOutcome) => Promise<void>;
   command: string;
   rootCommand: string;
@@ -697,6 +707,11 @@ export interface ToolExecuteConfirmationDetails {
 export interface ToolMcpConfirmationDetails {
   type: 'mcp';
   title: string;
+  /**
+   * Optional extra context to display to the user in the confirmation prompt.
+   * Used for cases like hooks forcing confirmation (decision: 'ask').
+   */
+  systemMessage?: string;
   serverName: string;
   toolName: string;
   toolDisplayName: string;
@@ -706,6 +721,11 @@ export interface ToolMcpConfirmationDetails {
 export interface ToolInfoConfirmationDetails {
   type: 'info';
   title: string;
+  /**
+   * Optional extra context to display to the user in the confirmation prompt.
+   * Used for cases like hooks forcing confirmation (decision: 'ask').
+   */
+  systemMessage?: string;
   onConfirm: (outcome: ToolConfirmationOutcome) => Promise<void>;
   prompt: string;
   urls?: string[];


### PR DESCRIPTION
## Summary
- Move BeforeTool hook trigger from `executeToolWithHooks` into `CoreToolScheduler._processNextInQueue`, firing before the `isAutoApproved` check
- Add `isAskDecision()` method to `DefaultHookOutput` class
- Handle `decision: 'ask'` to force user confirmation even when tools would normally be auto-approved (YOLO mode or allowlist)
- Update tests to reflect the new hook trigger location

## Test plan
- [x] Existing tests pass (19 coreToolScheduler tests, 4 coreToolHookTriggers tests)
- [x] Added 3 new tests for BeforeTool hook decisions (ask, block, continue: false)
- [x] Type checking passes

Closes #15732

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.