### PR TITLE
feat(core): add script-based PTY backend

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -972,6 +972,24 @@ const SETTINGS_SCHEMA = {
             `,
             showInDialog: true,
           },
+          ptyBackend: {
+            type: 'enum',
+            label: 'PTY Backend',
+            category: 'Tools',
+            requiresRestart: true,
+            default: 'auto',
+            description: oneLine`
+              Select the PTY backend implementation.
+              'auto' tries node-pty then script.
+            `,
+            showInDialog: true,
+            options: [
+              { value: 'auto', label: 'Auto' },
+              { value: 'node-pty', label: 'node-pty' },
+              { value: 'script', label: 'script' },
+              { value: 'none', label: 'None' },
+            ],
+          },
           pager: {
             type: 'string',
             label: 'Pager',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -377,6 +377,7 @@ export interface ConfigParameters {
   fakeResponses?: string;
   recordResponses?: string;
   ptyInfo?: string;
+  ptyBackend?: string;
   disableYoloMode?: boolean;
   rawOutput?: boolean;
   acceptRawOutputRisk?: boolean;
@@ -673,6 +674,7 @@ export class Config {
       showColor: params.shellExecutionConfig?.showColor ?? false,
       pager: params.shellExecutionConfig?.pager ?? 'cat',
       sanitizationConfig: this.sanitizationConfig,
+      ptyBackend: params.ptyBackend ?? 'auto',
     };
     this.truncateToolOutputThreshold =
       params.truncateToolOutputThreshold ??
@@ -1826,6 +1828,7 @@ export class Config {
       sanitizationConfig:
         config.sanitizationConfig ??
         this.shellExecutionConfig.sanitizationConfig,
+      ptyBackend: config.ptyBackend ?? this.shellExecutionConfig.ptyBackend,
     };
   }
   getScreenReader(): boolean {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -10,7 +10,7 @@ import { getPty } from '../utils/getPty.js';
 import { spawn as cpSpawn } from 'node:child_process';
 import { TextDecoder } from 'node:util';
 import os from 'node:os';
-import type { IPty } from '@lydell/node-pty';
+import type { IPty } from '../utils/pty/types.js';
 import { getCachedEncodingForBuffer } from '../utils/systemEncoding.js';
 import {
   getShellConfiguration,
@@ -70,7 +70,12 @@ export interface ShellExecutionResult {
   /** The process ID of the spawned shell. */
   pid: number | undefined;
   /** The method used to execute the shell command. */
-  executionMethod: 'lydell-node-pty' | 'node-pty' | 'child_process' | 'none';
+  executionMethod:
+    | 'lydell-node-pty'
+    | 'node-pty'
+    | 'script-pty'
+    | 'child_process'
+    | 'none';
 }
 
 /** A handle for an ongoing shell execution. */
@@ -92,6 +97,7 @@ export interface ShellExecutionConfig {
   // Used for testing
   disableDynamicLineTrimming?: boolean;
   scrollback?: number;
+  ptyBackend?: string;
 }
 
 /**
@@ -184,7 +190,7 @@ export class ShellExecutionService {
     shellExecutionConfig: ShellExecutionConfig,
   ): Promise<ShellExecutionHandle> {
     if (shouldUseNodePty) {
-      const ptyInfo = await getPty();
+      const ptyInfo = await getPty(shellExecutionConfig.ptyBackend);
       if (ptyInfo) {
         try {
           return await this.executeWithPty(
@@ -491,6 +497,7 @@ export class ShellExecutionService {
           PAGER: shellExecutionConfig.pager ?? 'cat',
           GIT_PAGER: shellExecutionConfig.pager ?? 'cat',
         },
+        encoding: null,
         handleFlowControl: true,
       });
 
@@ -662,9 +669,8 @@ export class ShellExecutionService {
           );
         };
 
-        ptyProcess.onData((data: string) => {
-          const bufferData = Buffer.from(data, 'utf-8');
-          handleOutput(bufferData);
+        ptyProcess.onData((data: Buffer) => {
+          handleOutput(data);
         });
 
         ptyProcess.onExit(

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -726,24 +726,11 @@ export class ShellExecutionService {
 
         const abortHandler = async () => {
           if (ptyProcess.pid && !exited) {
-            if (os.platform() === 'win32') {
-              ptyProcess.kill();
-            } else {
-              try {
-                // Kill the entire process group
-                process.kill(-ptyProcess.pid, 'SIGTERM');
-                await new Promise((res) => setTimeout(res, SIGKILL_TIMEOUT_MS));
-                if (!exited) {
-                  process.kill(-ptyProcess.pid, 'SIGKILL');
-                }
-              } catch (_e) {
-                // Fallback to killing just the process if the group kill fails
-                ptyProcess.kill('SIGTERM');
-                await new Promise((res) => setTimeout(res, SIGKILL_TIMEOUT_MS));
-                if (!exited) {
-                  ptyProcess.kill('SIGKILL');
-                }
-              }
+            // PTY implementations handle process group kill internally
+            ptyProcess.kill('SIGTERM');
+            await new Promise((res) => setTimeout(res, SIGKILL_TIMEOUT_MS));
+            if (!exited) {
+              ptyProcess.kill('SIGKILL');
             }
           }
         };

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -251,6 +251,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
           combinedController.signal,
           this.config.getEnableInteractiveShell(),
           {
+            ...this.config.getShellExecutionConfig(),
             ...shellExecutionConfig,
             pager: 'cat',
             sanitizationConfig:

--- a/packages/core/src/utils/getPty.ts
+++ b/packages/core/src/utils/getPty.ts
@@ -4,31 +4,62 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ScriptPtyModule } from './pty/ScriptPty.js';
+import type { PtyModule } from './pty/types.js';
+import { spawn } from 'node:child_process';
+
 export type PtyImplementation = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  module: any;
-  name: 'lydell-node-pty' | 'node-pty';
+  module: PtyModule;
+  name: 'lydell-node-pty' | 'node-pty' | 'script-pty';
 } | null;
 
-export interface PtyProcess {
-  readonly pid: number;
-  onData(callback: (data: string) => void): void;
-  onExit(callback: (e: { exitCode: number; signal?: number }) => void): void;
-  kill(signal?: string): void;
-}
+const checkScriptCommand = async (): Promise<boolean> =>
+  new Promise((resolve) => {
+    // Use POSIX 'command -v' to check if script exists
+    const check = spawn('sh', ['-c', 'command -v script'], { stdio: 'ignore' });
+    check.on('error', () => resolve(false));
+    check.on('exit', (code) => resolve(code === 0));
+  });
 
-export const getPty = async (): Promise<PtyImplementation> => {
+const getNodePty = async (): Promise<PtyImplementation> => {
   try {
     const lydell = '@lydell/node-pty';
     const module = await import(lydell);
-    return { module, name: 'lydell-node-pty' };
+    return { module: module.default || module, name: 'lydell-node-pty' };
   } catch (_e) {
     try {
       const nodePty = 'node-pty';
       const module = await import(nodePty);
-      return { module, name: 'node-pty' };
+      return { module: module.default || module, name: 'node-pty' };
     } catch (_e2) {
       return null;
     }
   }
+};
+
+export const getPty = async (
+  backend: string = 'auto',
+): Promise<PtyImplementation> => {
+  if (backend === 'none') {
+    return null;
+  }
+
+  if (backend === 'auto' || backend === 'node-pty') {
+    const nodePty = await getNodePty();
+    if (nodePty) {
+      return nodePty;
+    }
+    if (backend === 'node-pty') {
+      return null;
+    }
+  }
+
+  if (backend === 'auto' || backend === 'script') {
+    const hasScript = await checkScriptCommand();
+    if (hasScript) {
+      return { module: ScriptPtyModule, name: 'script-pty' };
+    }
+  }
+
+  return null;
 };

--- a/packages/core/src/utils/getPty.ts
+++ b/packages/core/src/utils/getPty.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { createNodePtyModule } from './pty/NodePty.js';
 import { ScriptPtyModule } from './pty/ScriptPty.js';
 import type { PtyModule } from './pty/types.js';
 import { spawn } from 'node:child_process';
@@ -25,12 +26,17 @@ const getNodePty = async (): Promise<PtyImplementation> => {
   try {
     const lydell = '@lydell/node-pty';
     const module = await import(lydell);
-    return { module: module.default || module, name: 'lydell-node-pty' };
+    const rawModule = module.default || module;
+    return {
+      module: createNodePtyModule(rawModule),
+      name: 'lydell-node-pty',
+    };
   } catch (_e) {
     try {
       const nodePty = 'node-pty';
       const module = await import(nodePty);
-      return { module: module.default || module, name: 'node-pty' };
+      const rawModule = module.default || module;
+      return { module: createNodePtyModule(rawModule), name: 'node-pty' };
     } catch (_e2) {
       return null;
     }

--- a/packages/core/src/utils/pty/NodePty.ts
+++ b/packages/core/src/utils/pty/NodePty.ts
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import os from 'node:os';
+import { debugLogger } from '../debugLogger.js';
+import type { IPty, PtyModule, PtySpawnOptions } from './types.js';
+
+const SIGKILL_TIMEOUT_MS = 200;
+
+/**
+ * Wrapper around node-pty that implements proper process group kill semantics.
+ * This encapsulates platform-specific kill logic that was previously in shellExecutionService.
+ */
+export class NodePtyWrapper implements IPty {
+  private _pty: IPty;
+  private _exited = false;
+
+  constructor(pty: IPty) {
+    this._pty = pty;
+  }
+
+  get pid(): number {
+    return this._pty.pid;
+  }
+
+  get cols(): number {
+    return this._pty.cols;
+  }
+
+  get rows(): number {
+    return this._pty.rows;
+  }
+
+  get process(): string {
+    return this._pty.process;
+  }
+
+  get handleFlowControl(): boolean {
+    return this._pty.handleFlowControl;
+  }
+
+  onData(listener: (data: Buffer) => void): { dispose: () => void } {
+    return this._pty.onData(listener);
+  }
+
+  onExit(listener: (e: { exitCode: number; signal?: number }) => void): {
+    dispose: () => void;
+  } {
+    const wrappedListener = (e: { exitCode: number; signal?: number }) => {
+      this._exited = true;
+      listener(e);
+    };
+    return this._pty.onExit(wrappedListener);
+  }
+
+  resize(cols: number, rows: number): void {
+    this._pty.resize(cols, rows);
+  }
+
+  write(data: string): void {
+    this._pty.write(data);
+  }
+
+  kill(signal?: string): void {
+    if (this._exited) {
+      return;
+    }
+
+    // On Windows, delegate to node-pty's kill which handles it appropriately
+    if (os.platform() === 'win32') {
+      this._pty.kill(signal);
+      return;
+    }
+
+    // On Unix, kill the entire process group for clean child process termination
+    const sig = (signal ?? 'SIGTERM') as NodeJS.Signals;
+    try {
+      process.kill(-this._pty.pid, sig);
+    } catch (e) {
+      // ESRCH means process group doesn't exist anymore
+      if ((e as NodeJS.ErrnoException).code === 'ESRCH') {
+        return;
+      }
+
+      debugLogger.debug(`Failed to kill process group ${-this._pty.pid}:`, e);
+
+      // Fallback to killing just the pty process
+      try {
+        this._pty.kill(signal);
+      } catch (fallbackError) {
+        if ((fallbackError as NodeJS.ErrnoException).code !== 'ESRCH') {
+          debugLogger.debug(
+            `Fallback kill failed for process ${this._pty.pid}:`,
+            fallbackError,
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Gracefully terminates the process with SIGTERM, then escalates to SIGKILL.
+   * This should be used for abort scenarios where we want to ensure termination.
+   */
+  async killGracefully(): Promise<void> {
+    if (this._exited) {
+      return;
+    }
+
+    this.kill('SIGTERM');
+    await new Promise((res) => setTimeout(res, SIGKILL_TIMEOUT_MS));
+
+    if (!this._exited) {
+      this.kill('SIGKILL');
+    }
+  }
+}
+
+/**
+ * Creates a PtyModule wrapper around a raw node-pty module that returns
+ * NodePtyWrapper instances with proper process group kill semantics.
+ */
+export const createNodePtyModule = (rawModule: PtyModule): PtyModule => ({
+  spawn: (
+    file: string,
+    args: string[] | string,
+    options: PtySpawnOptions,
+  ): IPty => new NodePtyWrapper(rawModule.spawn(file, args, options)),
+});

--- a/packages/core/src/utils/pty/ScriptPty.ts
+++ b/packages/core/src/utils/pty/ScriptPty.ts
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import os from 'node:os';
+import { quote } from 'shell-quote';
+import { debugLogger } from '../debugLogger.js';
+import type { IPty, PtyModule, PtySpawnOptions } from './types.js';
+
+const isMacOS = os.platform() === 'darwin';
+
+export class ScriptPty implements IPty {
+  private _process: ChildProcess;
+  private _pid: number;
+  private _emitter = new EventEmitter();
+
+  cols: number;
+  rows: number;
+  process: string;
+  handleFlowControl: boolean;
+
+  constructor(file: string, args: string[] | string, options: PtySpawnOptions) {
+    this.cols = options.cols || 80;
+    this.rows = options.rows || 24;
+    this.process = file;
+    this.handleFlowControl = options.handleFlowControl || false;
+
+    // Prepare arguments for 'script'
+    // Linux: script -qec "command args..." /dev/null
+    // macOS/BSD: script -q /dev/null sh -c "command args..."
+    const cmdArgs = Array.isArray(args) ? args : [args];
+    const fullCommand = quote([file, ...cmdArgs]);
+
+    // Platform-specific script arguments
+    const scriptArgs = isMacOS
+      ? ['-q', '/dev/null', 'sh', '-c', fullCommand]
+      : ['-qec', fullCommand, '/dev/null'];
+
+    this._process = spawn('script', scriptArgs, {
+      cwd: options.cwd,
+      env: options.env as NodeJS.ProcessEnv,
+      stdio: ['pipe', 'pipe', 'pipe'], // We pipe stdin/stdout/stderr
+      detached: true, // Create new process group for kill(-pid) to work reliably
+    });
+
+    if (!this._process.pid) {
+      throw new Error('Failed to spawn "script" process: PID is undefined');
+    }
+    this._pid = this._process.pid;
+
+    this._process.stdout?.on('data', (data: Buffer) => {
+      this._emitter.emit('data', data);
+    });
+
+    this._process.stderr?.on('data', (data: Buffer) => {
+      // script's stderr might contain its own errors or the inner process's
+      // usually strictly 'data' from the pty comes via stdout in script
+      // but we forward stderr as data too for the terminal to see it
+      this._emitter.emit('data', data);
+    });
+
+    this._process.on('exit', (code, signal) => {
+      const signalNumber = signal ? os.constants.signals[signal] : undefined;
+      this._emitter.emit('exit', {
+        exitCode: code ?? (signalNumber ? 128 + signalNumber : 1),
+        signal: signalNumber,
+      });
+    });
+
+    this._process.on('error', (_err) => {
+      // If script fails to start
+      this._emitter.emit('exit', { exitCode: 1, signal: undefined });
+    });
+  }
+
+  get pid(): number {
+    return this._pid;
+  }
+
+  onData(listener: (data: Buffer) => void): { dispose: () => void } {
+    this._emitter.on('data', listener);
+    return {
+      dispose: () => this._emitter.off('data', listener),
+    };
+  }
+
+  onExit(listener: (e: { exitCode: number; signal?: number }) => void): {
+    dispose: () => void;
+  } {
+    this._emitter.on('exit', listener);
+    return {
+      dispose: () => this._emitter.off('exit', listener),
+    };
+  }
+
+  resize(cols: number, rows: number): void {
+    this.cols = cols;
+    this.rows = rows;
+    // Resizing is not easily supported by 'script' command non-interactively
+    // without using stty on the allocated slave PTY, which we don't have easy access to.
+    // We ignore this for now.
+  }
+
+  write(data: string): void {
+    if (this._process.stdin && !this._process.stdin.destroyed) {
+      this._process.stdin.write(data);
+    }
+  }
+
+  kill(signal?: string): void {
+    // Kill entire process group to avoid orphaned child processes.
+    // No win32 special case needed since 'script' command is Unix-only.
+    if (this._process.pid) {
+      try {
+        process.kill(-this._process.pid, signal as NodeJS.Signals);
+      } catch (e) {
+        // ESRCH means process group doesn't exist anymore - nothing more to do.
+        if ((e as NodeJS.ErrnoException).code === 'ESRCH') {
+          return;
+        }
+
+        // Log other errors and attempt fallback kill on the main process.
+        debugLogger.debug(`Failed to kill process group ${-this._process.pid}:`, e);
+        if (!this._process.killed) {
+          try {
+            this._process.kill(signal as NodeJS.Signals);
+          } catch (fallbackError) {
+            // ESRCH is expected if process died in the meantime.
+            if ((fallbackError as NodeJS.ErrnoException).code !== 'ESRCH') {
+              debugLogger.debug(`Fallback kill failed for process ${this._process.pid}:`, fallbackError);
+            }
+          }
+        }
+      }
+    } else {
+      try {
+        this._process.kill(signal as NodeJS.Signals);
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== 'ESRCH') {
+          debugLogger.debug('Failed to kill process without PID:', e);
+        }
+      }
+    }
+  }
+}
+
+export const ScriptPtyModule: PtyModule = {
+  spawn: (file: string, args: string[] | string, options: PtySpawnOptions) =>
+    new ScriptPty(file, args, options),
+};

--- a/packages/core/src/utils/pty/types.ts
+++ b/packages/core/src/utils/pty/types.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface IPty {
+  readonly pid: number;
+  readonly cols: number;
+  readonly rows: number;
+  readonly process: string;
+  readonly handleFlowControl: boolean;
+
+  onData(listener: (data: Buffer) => void): { dispose: () => void };
+  onExit(listener: (e: { exitCode: number; signal?: number }) => void): {
+    dispose: () => void;
+  };
+  resize(cols: number, rows: number): void;
+  write(data: string): void;
+  kill(signal?: string): void;
+}
+
+export interface PtySpawnOptions {
+  name?: string;
+  cols?: number;
+  rows?: number;
+  cwd?: string;
+  env?: { [key: string]: string };
+  encoding?: string | null;
+  handleFlowControl?: boolean;
+}
+
+export interface PtyModule {
+  spawn(file: string, args: string[] | string, options: PtySpawnOptions): IPty;
+}

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1057,6 +1057,14 @@
               "default": true,
               "type": "boolean"
             },
+            "ptyBackend": {
+              "title": "PTY Backend",
+              "description": "Select the PTY backend implementation.",
+              "markdownDescription": "Select the PTY backend implementation.\n\n- `auto`: Tries `node-pty`, falls back to `script`, then `none`.\n- `node-pty`: Native backend (best experience).\n- `script`: Uses the `script` command (Linux/macOS, good fallback).\n- `none`: Disables PTY, uses standard pipes.\n\n- Category: `Tools`\n- Requires restart: `yes`\n- Default: `auto`",
+              "default": "auto",
+              "type": "string",
+              "enum": ["auto", "node-pty", "script", "none"]
+            },
             "pager": {
               "title": "Pager",
               "description": "The pager command to use for shell output. Defaults to `cat`.",


### PR DESCRIPTION
Adds a new PTY backend using the 'script' command to support environments where node-pty cannot be built or loaded (e.g. static/musl Node).

Fixes #12878