### PR TITLE
fix: skip /dev/tty on Windows to avoid invalid clipboard operations

### DIFF
--- a/packages/cli/src/ui/utils/commandUtils.ts
+++ b/packages/cli/src/ui/utils/commandUtils.ts
@@ -67,11 +67,14 @@ type TtyTarget = { stream: Writable; closeAfter: boolean } | null;
 
 const pickTty = (): TtyTarget => {
   // Prefer the controlling TTY to avoid interleaving escape sequences with piped stdout.
-  try {
-    const devTty = fs.createWriteStream('/dev/tty');
-    return { stream: devTty, closeAfter: true };
-  } catch {
-    // fall through
+  // Skip /dev/tty on Windows as it's not a valid path, even in Unix-like shells like Git Bash.
+  if (process.platform !== 'win32') {
+    try {
+      const devTty = fs.createWriteStream('/dev/tty');
+      return { stream: devTty, closeAfter: true };
+    } catch {
+      // fall through
+    }
   }
   if (process.stderr?.isTTY)
     return { stream: process.stderr, closeAfter: false };


### PR DESCRIPTION
## Summary

Attempting to create a write stream to '/dev/tty' on Windows causes clipboard copying to fail in Windows Terminal and Unix-like shell environments (e.g., Git Bash, Cygwin).

## Details

The fix adds a platform check before attempting to open '/dev/tty', ensuring that Windows environments skip this step and correctly fall back to using the `clipboardy` library for clipboard access.

## Related Issues

Fixes #15787

## How to Validate

The `/copy` command now correctly copies the last result to the clipboard on Windows.

