### PR TITLE
Add initiation method telemetry property

### DIFF
--- a/packages/core/src/code_assist/telemetry.test.ts
+++ b/packages/core/src/code_assist/telemetry.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   ActionStatus,
   ConversationInteractionInteraction,
+  InitiationMethod,
   type StreamingLatency,
 } from './types.js';
 import {
@@ -100,6 +101,7 @@ describe('telemetry', () => {
         traceId,
         streamingLatency,
         isAgentic: true,
+        initiationMethod: InitiationMethod.COMMAND,
       });
     });
 

--- a/packages/core/src/code_assist/telemetry.ts
+++ b/packages/core/src/code_assist/telemetry.ts
@@ -9,6 +9,7 @@ import { getCitations } from '../utils/generateContentResponseUtilities.js';
 import {
   ActionStatus,
   ConversationInteractionInteraction,
+  InitiationMethod,
   type ConversationInteraction,
   type ConversationOffered,
   type StreamingLatency,
@@ -96,6 +97,7 @@ export function createConversationOffered(
     traceId,
     streamingLatency,
     isAgentic: true,
+    initiationMethod: InitiationMethod.COMMAND,
   };
 }
 

--- a/packages/core/src/code_assist/types.ts
+++ b/packages/core/src/code_assist/types.ts
@@ -255,6 +255,13 @@ export enum ActionStatus {
   ACTION_STATUS_EMPTY = 4,
 }
 
+export enum InitiationMethod {
+  INITIATION_METHOD_UNSPECIFIED = 0,
+  TAB = 1,
+  COMMAND = 2,
+  AGENT = 3,
+}
+
 export interface ConversationOffered {
   citationCount?: string;
   includedCode?: boolean;
@@ -262,6 +269,7 @@ export interface ConversationOffered {
   traceId?: string;
   streamingLatency?: StreamingLatency;
   isAgentic?: boolean;
+  initiationMethod?: InitiationMethod;
 }
 
 export interface StreamingLatency {


### PR DESCRIPTION
## Summary

Adds an initiation method property for telemetry. This property will help to distinguish our telemetry, which is primarily from tool calls, from other code assist telemetry.

## How to Validate

- npm install
- npm run build
- Start debugging in a VS Code OSS editor, like antigravity.
- Ask Gemini CLI to write a file and approve the tool call that comes through. You should see breakpoints in core/src/code_assist/telemetry.ts get hit.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
