### PR TITLE
feat(cli): add model usage percentage display in footer

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -458,6 +458,16 @@ const SETTINGS_SCHEMA = {
             description: 'Hides the context window remaining percentage.',
             showInDialog: true,
           },
+          showModelUsage: {
+            type: 'boolean',
+            label: 'Show Model Usage',
+            category: 'UI',
+            requiresRestart: false,
+            default: false,
+            description:
+              'Show model usage percentage in the footer (e.g. "95% model usage left").',
+            showInDialog: true,
+          },
         },
       },
       hideFooter: {

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -17,6 +17,7 @@ import process from 'node:process';
 import { ThemedGradient } from './ThemedGradient.js';
 import { MemoryUsageDisplay } from './MemoryUsageDisplay.js';
 import { ContextUsageDisplay } from './ContextUsageDisplay.js';
+import { ModelUsageDisplay } from './ModelUsageDisplay.js';
 import { DebugProfiler } from './DebugProfiler.js';
 import { isDevelopment } from '../../utils/installationInfo.js';
 import { useUIState } from '../contexts/UIStateContext.js';
@@ -66,6 +67,7 @@ export const Footer: React.FC = () => {
   const hideModelInfo = settings.merged.ui?.footer?.hideModelInfo || false;
   const hideContextPercentage =
     settings.merged.ui?.footer?.hideContextPercentage ?? true;
+  const showModelUsage = settings.merged.ui?.footer?.showModelUsage || false;
 
   const pathLength = Math.max(20, Math.floor(mainAreaWidth * 0.25));
   const displayPath = shortenPath(tildeifyPath(targetDir), pathLength);
@@ -159,6 +161,12 @@ export const Footer: React.FC = () => {
                     model={model}
                     terminalWidth={mainAreaWidth}
                   />
+                </>
+              )}
+              {showModelUsage && (
+                <>
+                  {' '}
+                  <ModelUsageDisplay model={model} />
                 </>
               )}
             </Text>

--- a/packages/cli/src/ui/components/ModelUsageDisplay.tsx
+++ b/packages/cli/src/ui/components/ModelUsageDisplay.tsx
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useState, useMemo } from 'react';
+import { Text } from 'ink';
+import { theme } from '../semantic-colors.js';
+import { useConfig } from '../contexts/ConfigContext.js';
+import { useSessionStats } from '../contexts/SessionContext.js';
+import { type RetrieveUserQuotaResponse } from '@google/gemini-cli-core';
+
+export const ModelUsageDisplay = ({ model }: { model: string }) => {
+  const config = useConfig();
+  const { stats } = useSessionStats();
+  const [quota, setQuota] = useState<RetrieveUserQuotaResponse | null>(null);
+
+  // Calculate total API requests to detect when a response completes
+  const totalApiRequests = useMemo(
+    () =>
+      Object.values(stats.metrics.models).reduce<number>(
+        (sum, m) =>
+          sum +
+          ((m as { api?: { totalRequests?: number } })?.api?.totalRequests ??
+            0),
+        0,
+      ),
+    [stats.metrics.models],
+  );
+
+  useEffect(() => {
+    let mounted = true;
+    const fetchQuota = async () => {
+      try {
+        const q = await config.refreshUserQuota();
+        if (mounted && q) {
+          setQuota(q);
+        }
+      } catch (_e) {
+        // Fail silently - quota display is optional
+      }
+    };
+    void fetchQuota();
+    return () => {
+      mounted = false;
+    };
+  }, [config, totalApiRequests, stats.lastPromptTokenCount]); // Re-fetch after each API response and token count change
+
+  const bucket = quota?.buckets?.find((b) => b.modelId === model);
+
+  if (!bucket || bucket.remainingFraction === undefined) {
+    return null;
+  }
+
+  const percentageLeft = (bucket.remainingFraction * 100).toFixed(1);
+
+  return (
+    <Text color={theme.text.secondary}>
+      ({percentageLeft}% model usage left)
+    </Text>
+  );
+};


### PR DESCRIPTION
- Add new 'showModelUsage' setting under ui.footer (default: false)
- Create ModelUsageDisplay component that fetches live quota from API
- Display remaining model usage percentage (e.g. '73.6% model usage left')
- Auto-refresh quota after each API response

## Summary

Adds an optional footer setting to display the current model's API usage quota percentage, similar to the existing context percentage display. This helps users monitor their daily usage limits without needing to run /stats.

## Details

- **New Setting:** ui.footer.showModelUsage (boolean, default: false)
- Located under the existing ui.footer settings group
- Toggleable in the settings dialog

- **New Component:** ModelUsageDisplay.tsx
- Fetches live quota data via config.refreshUserQuota()
- Displays remaining percentage (e.g., "73.6% model usage left")
- Auto-refreshes after each API response by listening to session metrics changes

- **Integration:** Renders in the Footer component next to the existing context percentage

The component uses useMemo to track API request count and lastPromptTokenCount as dependencies to trigger quota refresh after each model response, ensuring the displayed value stays current.

## Related Issues

## How to Validate

1. Enable the setting in your settings.json:
```
{
  "ui": {
    "footer": {
      "showModelUsage": true
    }
  }
}
```
2. Run `npm start` and send a prompt
3. Verify the footer shows "(XX.X% model usage left)" next to the model name
4. Send another prompt and verify the percentage updates
5. Run `/stats` and confirm the footer percentage matches the stats display

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
