### PR TITLE
fix(core): mock powershell output in shell-utils test

### DIFF
--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -69,6 +69,24 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+const mockPowerShellResult = (
+  commands: Array<{ name: string; text: string }>,
+  hasRedirection: boolean,
+) => {
+  mockSpawnSync.mockReturnValue({
+    stdout: Buffer.from(
+      JSON.stringify({
+        success: true,
+        commands,
+        hasRedirection,
+      }),
+    ),
+    stderr: Buffer.from(''),
+    status: 0,
+    error: undefined,
+  });
+};
+
 describe('getCommandRoots', () => {
   it('should return a single command', () => {
     expect(getCommandRoots('ls -l')).toEqual(['ls']);
@@ -197,21 +215,13 @@ describeWindowsOnly('PowerShell integration', () => {
   });
 
   it('should return command roots using PowerShell AST output', () => {
-    mockSpawnSync.mockReturnValue({
-      stdout: Buffer.from(
-        JSON.stringify({
-          success: true,
-          commands: [
-            { name: 'Get-ChildItem', text: 'Get-ChildItem' },
-            { name: 'Select-Object', text: 'Select-Object Name' },
-          ],
-          hasRedirection: false,
-        }),
-      ),
-      stderr: Buffer.from(''),
-      status: 0,
-      error: undefined,
-    });
+    mockPowerShellResult(
+      [
+        { name: 'Get-ChildItem', text: 'Get-ChildItem' },
+        { name: 'Select-Object', text: 'Select-Object Name' },
+      ],
+      false,
+    );
 
     const roots = getCommandRoots('Get-ChildItem | Select-Object Name');
     expect(roots.length).toBeGreaterThan(0);
@@ -393,24 +403,6 @@ describe('hasRedirection (PowerShell via mock)', () => {
     mockPlatform.mockReturnValue('win32');
     process.env['ComSpec'] = 'powershell.exe';
   });
-
-  const mockPowerShellResult = (
-    commands: Array<{ name: string; text: string }>,
-    hasRedirection: boolean,
-  ) => {
-    mockSpawnSync.mockReturnValue({
-      stdout: Buffer.from(
-        JSON.stringify({
-          success: true,
-          commands,
-          hasRedirection,
-        }),
-      ),
-      stderr: Buffer.from(''),
-      status: 0,
-      error: undefined,
-    });
-  };
 
   it('should return true when PowerShell parser detects redirection', () => {
     mockPowerShellResult([{ name: 'echo', text: 'echo hello' }], true);

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -197,6 +197,22 @@ describeWindowsOnly('PowerShell integration', () => {
   });
 
   it('should return command roots using PowerShell AST output', () => {
+    mockSpawnSync.mockReturnValue({
+      stdout: Buffer.from(
+        JSON.stringify({
+          success: true,
+          commands: [
+            { name: 'Get-ChildItem', text: 'Get-ChildItem' },
+            { name: 'Select-Object', text: 'Select-Object Name' },
+          ],
+          hasRedirection: false,
+        }),
+      ),
+      stderr: Buffer.from(''),
+      status: 0,
+      error: undefined,
+    });
+
     const roots = getCommandRoots('Get-ChildItem | Select-Object Name');
     expect(roots.length).toBeGreaterThan(0);
     expect(roots).toContain('Get-ChildItem');


### PR DESCRIPTION
## Summary

Fixes a failing unit test in `shell-utils` by properly mocking PowerShell output for command root extraction.

## Details

The test case `'should return command roots using PowerShell AST output'` in `packages/core/src/utils/shell-utils.test.ts` verifies that the `getCommandRoots` function correctly parses PowerShell commands. This function relies on `spawnSync` to execute a PowerShell script.

Previously, the test did not mock the `spawnSync` return value for this specific call, which would lead to failures or reliance on the actual system's PowerShell (if available), breaking isolation. This PR adds the missing `mockSpawnSync` configuration to return a deterministic JSON response representing the expected PowerShell AST output, ensuring the test passes reliably.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

Run the specific test file using Vitest. Note that this test is wrapped in `describeWindowsOnly`, so it may only execute on Windows environments.

```bash
npm run test packages/core/src/utils/shell-utils.test.ts
```

Expected result:
- The test `'should return command roots using PowerShell AST output'` should pass.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (Fixes existing test)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
