### PR TITLE
Agent Skills: Add gemini skills CLI management command

### DIFF
--- a/packages/cli/src/commands/skills.test.tsx
+++ b/packages/cli/src/commands/skills.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { skillsCommand } from './skills.js';
+
+// Mock subcommands
+vi.mock('./skills/list.js', () => ({ listCommand: { command: 'list' } }));
+vi.mock('./skills/enable.js', () => ({
+  enableCommand: { command: 'enable <name>' },
+}));
+vi.mock('./skills/disable.js', () => ({
+  disableCommand: { command: 'disable <name>' },
+}));
+
+// Mock gemini.js
+vi.mock('../gemini.js', () => ({
+  initializeOutputListenersAndFlush: vi.fn(),
+}));
+
+describe('skillsCommand', () => {
+  it('should have correct command and aliases', () => {
+    expect(skillsCommand.command).toBe('skills <command>');
+    expect(skillsCommand.aliases).toEqual(['skill']);
+    expect(skillsCommand.describe).toBe('Manage Gemini CLI agent skills.');
+  });
+
+  it('should register all subcommands in builder', () => {
+    const mockYargs = {
+      middleware: vi.fn().mockReturnThis(),
+      command: vi.fn().mockReturnThis(),
+      demandCommand: vi.fn().mockReturnThis(),
+      version: vi.fn().mockReturnThis(),
+    };
+
+    // @ts-expect-error - Mocking yargs
+    skillsCommand.builder(mockYargs);
+
+    expect(mockYargs.middleware).toHaveBeenCalled();
+    expect(mockYargs.command).toHaveBeenCalledWith({ command: 'list' });
+    expect(mockYargs.command).toHaveBeenCalledWith({
+      command: 'enable <name>',
+    });
+    expect(mockYargs.command).toHaveBeenCalledWith({
+      command: 'disable <name>',
+    });
+    expect(mockYargs.demandCommand).toHaveBeenCalledWith(1, expect.any(String));
+    expect(mockYargs.version).toHaveBeenCalledWith(false);
+  });
+
+  it('should have a handler that does nothing', () => {
+    // @ts-expect-error - Handler doesn't take arguments in this case
+    expect(skillsCommand.handler()).toBeUndefined();
+  });
+});

--- a/packages/cli/src/commands/skills.test.tsx
+++ b/packages/cli/src/commands/skills.test.tsx
@@ -1,13 +1,12 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
 import { describe, it, expect, vi } from 'vitest';
 import { skillsCommand } from './skills.js';
 
-// Mock subcommands
 vi.mock('./skills/list.js', () => ({ listCommand: { command: 'list' } }));
 vi.mock('./skills/enable.js', () => ({
   enableCommand: { command: 'enable <name>' },
@@ -16,7 +15,6 @@ vi.mock('./skills/disable.js', () => ({
   disableCommand: { command: 'disable <name>' },
 }));
 
-// Mock gemini.js
 vi.mock('../gemini.js', () => ({
   initializeOutputListenersAndFlush: vi.fn(),
 }));
@@ -25,7 +23,7 @@ describe('skillsCommand', () => {
   it('should have correct command and aliases', () => {
     expect(skillsCommand.command).toBe('skills <command>');
     expect(skillsCommand.aliases).toEqual(['skill']);
-    expect(skillsCommand.describe).toBe('Manage Gemini CLI agent skills.');
+    expect(skillsCommand.describe).toBe('Manage agent skills.');
   });
 
   it('should register all subcommands in builder', () => {

--- a/packages/cli/src/commands/skills.tsx
+++ b/packages/cli/src/commands/skills.tsx
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule } from 'yargs';
+import { listCommand } from './skills/list.js';
+import { enableCommand } from './skills/enable.js';
+import { disableCommand } from './skills/disable.js';
+import { initializeOutputListenersAndFlush } from '../gemini.js';
+
+export const skillsCommand: CommandModule = {
+  command: 'skills <command>',
+  aliases: ['skill'],
+  describe: 'Manage Gemini CLI agent skills.',
+  builder: (yargs) =>
+    yargs
+      .middleware(() => initializeOutputListenersAndFlush())
+      .command(listCommand)
+      .command(enableCommand)
+      .command(disableCommand)
+      .demandCommand(1, 'You need at least one command before continuing.')
+      .version(false),
+  handler: () => {
+    // This handler is not called when a subcommand is provided.
+    // Yargs will show the help menu.
+  },
+};

--- a/packages/cli/src/commands/skills.tsx
+++ b/packages/cli/src/commands/skills.tsx
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,7 @@ import { initializeOutputListenersAndFlush } from '../gemini.js';
 export const skillsCommand: CommandModule = {
   command: 'skills <command>',
   aliases: ['skill'],
-  describe: 'Manage Gemini CLI agent skills.',
+  describe: 'Manage agent skills.',
   builder: (yargs) =>
     yargs
       .middleware(() => initializeOutputListenersAndFlush())

--- a/packages/cli/src/commands/skills/disable.test.ts
+++ b/packages/cli/src/commands/skills/disable.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { format } from 'node:util';
+import { handleDisable, disableCommand } from './disable.js';
+import {
+  loadSettings,
+  SettingScope,
+  type LoadedSettings,
+  type LoadableSettingScope,
+} from '../../config/settings.js';
+
+// Mock dependencies
+const emitConsoleLog = vi.hoisted(() => vi.fn());
+const debugLogger = vi.hoisted(() => ({
+  log: vi.fn((message, ...args) => {
+    emitConsoleLog('log', format(message, ...args));
+  }),
+}));
+
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    debugLogger,
+  };
+});
+
+vi.mock('../../config/settings.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../config/settings.js')>();
+  return {
+    ...actual,
+    loadSettings: vi.fn(),
+  };
+});
+
+vi.mock('../utils.js', () => ({
+  exitCli: vi.fn(),
+}));
+
+describe('skills disable command', () => {
+  const mockLoadSettings = vi.mocked(loadSettings);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('handleDisable', () => {
+    it('should disable an enabled skill in user scope', async () => {
+      const mockSettings = {
+        forScope: vi.fn().mockReturnValue({
+          settings: { skills: { disabled: [] } },
+        }),
+        setValue: vi.fn(),
+      };
+      mockLoadSettings.mockReturnValue(
+        mockSettings as unknown as LoadedSettings,
+      );
+
+      await handleDisable({
+        name: 'skill1',
+        scope: SettingScope.User as LoadableSettingScope,
+      });
+
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'skills.disabled',
+        ['skill1'],
+      );
+      expect(emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        'Skill "skill1" successfully disabled in scope "User".',
+      );
+    });
+
+    it('should log a message if the skill is already disabled', async () => {
+      const mockSettings = {
+        forScope: vi.fn().mockReturnValue({
+          settings: { skills: { disabled: ['skill1'] } },
+        }),
+        setValue: vi.fn(),
+      };
+      mockLoadSettings.mockReturnValue(
+        mockSettings as unknown as LoadedSettings,
+      );
+
+      await handleDisable({
+        name: 'skill1',
+        scope: SettingScope.User as LoadableSettingScope,
+      });
+
+      expect(mockSettings.setValue).not.toHaveBeenCalled();
+      expect(emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        'Skill "skill1" is already disabled in scope "User".',
+      );
+    });
+  });
+
+  describe('disableCommand', () => {
+    it('should have correct command and describe', () => {
+      expect(disableCommand.command).toBe('disable <name>');
+      expect(disableCommand.describe).toBe('Disables an agent skill.');
+    });
+  });
+});

--- a/packages/cli/src/commands/skills/disable.test.ts
+++ b/packages/cli/src/commands/skills/disable.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,7 +14,6 @@ import {
   type LoadableSettingScope,
 } from '../../config/settings.js';
 
-// Mock dependencies
 const emitConsoleLog = vi.hoisted(() => vi.fn());
 const debugLogger = vi.hoisted(() => ({
   log: vi.fn((message, ...args) => {

--- a/packages/cli/src/commands/skills/disable.ts
+++ b/packages/cli/src/commands/skills/disable.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/cli/src/commands/skills/disable.ts
+++ b/packages/cli/src/commands/skills/disable.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule } from 'yargs';
+import {
+  loadSettings,
+  SettingScope,
+  type LoadableSettingScope,
+} from '../../config/settings.js';
+import { debugLogger } from '@google/gemini-cli-core';
+import { exitCli } from '../utils.js';
+
+interface DisableArgs {
+  name: string;
+  scope: LoadableSettingScope;
+}
+
+export async function handleDisable(args: DisableArgs) {
+  const { name, scope } = args;
+  const workspaceDir = process.cwd();
+  const settings = loadSettings(workspaceDir);
+
+  const currentDisabled =
+    settings.forScope(scope).settings.skills?.disabled || [];
+
+  if (currentDisabled.includes(name)) {
+    debugLogger.log(`Skill "${name}" is already disabled in scope "${scope}".`);
+    return;
+  }
+
+  const newDisabled = [...currentDisabled, name];
+  settings.setValue(scope, 'skills.disabled', newDisabled);
+  debugLogger.log(`Skill "${name}" successfully disabled in scope "${scope}".`);
+}
+
+export const disableCommand: CommandModule = {
+  command: 'disable <name>',
+  describe: 'Disables an agent skill.',
+  builder: (yargs) =>
+    yargs
+      .positional('name', {
+        describe: 'The name of the skill to disable.',
+        type: 'string',
+        demandOption: true,
+      })
+      .option('scope', {
+        alias: 's',
+        describe: 'The scope to disable the skill in (user or project).',
+        type: 'string',
+        default: 'user',
+        choices: ['user', 'project'],
+      }),
+  handler: async (argv) => {
+    const scope: LoadableSettingScope =
+      argv['scope'] === 'project' ? SettingScope.Workspace : SettingScope.User;
+    await handleDisable({
+      name: argv['name'] as string,
+      scope,
+    });
+    await exitCli();
+  },
+};

--- a/packages/cli/src/commands/skills/enable.test.ts
+++ b/packages/cli/src/commands/skills/enable.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { format } from 'node:util';
+import { handleEnable, enableCommand } from './enable.js';
+import {
+  loadSettings,
+  SettingScope,
+  type LoadedSettings,
+  type LoadableSettingScope,
+} from '../../config/settings.js';
+
+// Mock dependencies
+const emitConsoleLog = vi.hoisted(() => vi.fn());
+const debugLogger = vi.hoisted(() => ({
+  log: vi.fn((message, ...args) => {
+    emitConsoleLog('log', format(message, ...args));
+  }),
+}));
+
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    debugLogger,
+  };
+});
+
+vi.mock('../../config/settings.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../config/settings.js')>();
+  return {
+    ...actual,
+    loadSettings: vi.fn(),
+  };
+});
+
+vi.mock('../utils.js', () => ({
+  exitCli: vi.fn(),
+}));
+
+describe('skills enable command', () => {
+  const mockLoadSettings = vi.mocked(loadSettings);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('handleEnable', () => {
+    it('should enable a disabled skill in user scope', async () => {
+      const mockSettings = {
+        forScope: vi.fn().mockReturnValue({
+          settings: { skills: { disabled: ['skill1'] } },
+        }),
+        setValue: vi.fn(),
+      };
+      mockLoadSettings.mockReturnValue(
+        mockSettings as unknown as LoadedSettings,
+      );
+
+      await handleEnable({
+        name: 'skill1',
+        scope: SettingScope.User as LoadableSettingScope,
+      });
+
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'skills.disabled',
+        [],
+      );
+      expect(emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        'Skill "skill1" successfully enabled in scope "User".',
+      );
+    });
+
+    it('should log a message if the skill is already enabled', async () => {
+      const mockSettings = {
+        forScope: vi.fn().mockReturnValue({
+          settings: { skills: { disabled: [] } },
+        }),
+        setValue: vi.fn(),
+      };
+      mockLoadSettings.mockReturnValue(
+        mockSettings as unknown as LoadedSettings,
+      );
+
+      await handleEnable({
+        name: 'skill1',
+        scope: SettingScope.User as LoadableSettingScope,
+      });
+
+      expect(mockSettings.setValue).not.toHaveBeenCalled();
+      expect(emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        'Skill "skill1" is already enabled in scope "User".',
+      );
+    });
+  });
+
+  describe('enableCommand', () => {
+    it('should have correct command and describe', () => {
+      expect(enableCommand.command).toBe('enable <name>');
+      expect(enableCommand.describe).toBe('Enables an agent skill.');
+    });
+  });
+});

--- a/packages/cli/src/commands/skills/enable.test.ts
+++ b/packages/cli/src/commands/skills/enable.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,7 +14,6 @@ import {
   type LoadableSettingScope,
 } from '../../config/settings.js';
 
-// Mock dependencies
 const emitConsoleLog = vi.hoisted(() => vi.fn());
 const debugLogger = vi.hoisted(() => ({
   log: vi.fn((message, ...args) => {

--- a/packages/cli/src/commands/skills/enable.ts
+++ b/packages/cli/src/commands/skills/enable.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/cli/src/commands/skills/enable.ts
+++ b/packages/cli/src/commands/skills/enable.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule } from 'yargs';
+import {
+  loadSettings,
+  SettingScope,
+  type LoadableSettingScope,
+} from '../../config/settings.js';
+import { debugLogger } from '@google/gemini-cli-core';
+import { exitCli } from '../utils.js';
+
+interface EnableArgs {
+  name: string;
+  scope: LoadableSettingScope;
+}
+
+export async function handleEnable(args: EnableArgs) {
+  const { name, scope } = args;
+  const workspaceDir = process.cwd();
+  const settings = loadSettings(workspaceDir);
+
+  const currentDisabled =
+    settings.forScope(scope).settings.skills?.disabled || [];
+  const newDisabled = currentDisabled.filter((d) => d !== name);
+
+  if (currentDisabled.length === newDisabled.length) {
+    debugLogger.log(`Skill "${name}" is already enabled in scope "${scope}".`);
+    return;
+  }
+
+  settings.setValue(scope, 'skills.disabled', newDisabled);
+  debugLogger.log(`Skill "${name}" successfully enabled in scope "${scope}".`);
+}
+
+export const enableCommand: CommandModule = {
+  command: 'enable <name>',
+  describe: 'Enables an agent skill.',
+  builder: (yargs) =>
+    yargs
+      .positional('name', {
+        describe: 'The name of the skill to enable.',
+        type: 'string',
+        demandOption: true,
+      })
+      .option('scope', {
+        alias: 's',
+        describe: 'The scope to enable the skill in (user or project).',
+        type: 'string',
+        default: 'user',
+        choices: ['user', 'project'],
+      }),
+  handler: async (argv) => {
+    const scope: LoadableSettingScope =
+      argv['scope'] === 'project' ? SettingScope.Workspace : SettingScope.User;
+    await handleEnable({
+      name: argv['name'] as string,
+      scope,
+    });
+    await exitCli();
+  },
+};

--- a/packages/cli/src/commands/skills/list.test.ts
+++ b/packages/cli/src/commands/skills/list.test.ts
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { format } from 'node:util';
+import { handleList, listCommand } from './list.js';
+import { loadSettings, type LoadedSettings } from '../../config/settings.js';
+import { loadCliConfig } from '../../config/config.js';
+import { getErrorMessage } from '../../utils/errors.js';
+import type { Config } from '@google/gemini-cli-core';
+import chalk from 'chalk';
+
+// Mock dependencies
+const emitConsoleLog = vi.hoisted(() => vi.fn());
+const debugLogger = vi.hoisted(() => ({
+  log: vi.fn((message, ...args) => {
+    emitConsoleLog('log', format(message, ...args));
+  }),
+  error: vi.fn((message, ...args) => {
+    emitConsoleLog('error', format(message, ...args));
+  }),
+}));
+
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    coreEvents: {
+      emitConsoleLog,
+    },
+    debugLogger,
+  };
+});
+
+vi.mock('../../config/settings.js');
+vi.mock('../../config/config.js');
+vi.mock('../../utils/errors.js');
+vi.mock('../utils.js', () => ({
+  exitCli: vi.fn(),
+}));
+
+describe('skills list command', () => {
+  const mockLoadSettings = vi.mocked(loadSettings);
+  const mockLoadCliConfig = vi.mocked(loadCliConfig);
+  const mockGetErrorMessage = vi.mocked(getErrorMessage);
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockLoadSettings.mockReturnValue({
+      merged: {},
+    } as unknown as LoadedSettings);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('handleList', () => {
+    it('should log a message if no skills are discovered', async () => {
+      const mockConfig = {
+        initialize: vi.fn().mockResolvedValue(undefined),
+        getSkillManager: vi.fn().mockReturnValue({
+          getAllSkills: vi.fn().mockReturnValue([]),
+        }),
+      };
+      mockLoadCliConfig.mockResolvedValue(mockConfig as unknown as Config);
+
+      await handleList();
+
+      expect(emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        'No skills discovered.',
+      );
+    });
+
+    it('should list all discovered skills', async () => {
+      const skills = [
+        {
+          name: 'skill1',
+          description: 'desc1',
+          disabled: false,
+          location: '/path/to/skill1',
+        },
+        {
+          name: 'skill2',
+          description: 'desc2',
+          disabled: true,
+          location: '/path/to/skill2',
+        },
+      ];
+      const mockConfig = {
+        initialize: vi.fn().mockResolvedValue(undefined),
+        getSkillManager: vi.fn().mockReturnValue({
+          getAllSkills: vi.fn().mockReturnValue(skills),
+        }),
+      };
+      mockLoadCliConfig.mockResolvedValue(mockConfig as unknown as Config);
+
+      await handleList();
+
+      expect(emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        chalk.bold('Discovered Agent Skills:'),
+      );
+      expect(emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        expect.stringContaining('skill1'),
+      );
+      expect(emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        expect.stringContaining(chalk.green('[Enabled]')),
+      );
+      expect(emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        expect.stringContaining('skill2'),
+      );
+      expect(emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        expect.stringContaining(chalk.red('[Disabled]')),
+      );
+    });
+
+    it('should log an error message and exit with code 1 when listing fails', async () => {
+      const mockProcessExit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {}) as (
+          code?: string | number | null | undefined,
+        ) => never);
+
+      mockLoadCliConfig.mockRejectedValue(new Error('List failed'));
+      mockGetErrorMessage.mockReturnValue('List failed message');
+
+      await handleList();
+
+      expect(emitConsoleLog).toHaveBeenCalledWith(
+        'error',
+        'List failed message',
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+      mockProcessExit.mockRestore();
+    });
+  });
+
+  describe('listCommand', () => {
+    const command = listCommand;
+
+    it('should have correct command and describe', () => {
+      expect(command.command).toBe('list');
+      expect(command.describe).toBe('Lists discovered agent skills.');
+    });
+  });
+});

--- a/packages/cli/src/commands/skills/list.test.ts
+++ b/packages/cli/src/commands/skills/list.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,11 +9,9 @@ import { format } from 'node:util';
 import { handleList, listCommand } from './list.js';
 import { loadSettings, type LoadedSettings } from '../../config/settings.js';
 import { loadCliConfig } from '../../config/config.js';
-import { getErrorMessage } from '../../utils/errors.js';
 import type { Config } from '@google/gemini-cli-core';
 import chalk from 'chalk';
 
-// Mock dependencies
 const emitConsoleLog = vi.hoisted(() => vi.fn());
 const debugLogger = vi.hoisted(() => ({
   log: vi.fn((message, ...args) => {
@@ -38,7 +36,6 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
 
 vi.mock('../../config/settings.js');
 vi.mock('../../config/config.js');
-vi.mock('../../utils/errors.js');
 vi.mock('../utils.js', () => ({
   exitCli: vi.fn(),
 }));
@@ -46,7 +43,6 @@ vi.mock('../utils.js', () => ({
 describe('skills list command', () => {
   const mockLoadSettings = vi.mocked(loadSettings);
   const mockLoadCliConfig = vi.mocked(loadCliConfig);
-  const mockGetErrorMessage = vi.mocked(getErrorMessage);
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -124,24 +120,10 @@ describe('skills list command', () => {
       );
     });
 
-    it('should log an error message and exit with code 1 when listing fails', async () => {
-      const mockProcessExit = vi
-        .spyOn(process, 'exit')
-        .mockImplementation((() => {}) as (
-          code?: string | number | null | undefined,
-        ) => never);
-
+    it('should throw an error when listing fails', async () => {
       mockLoadCliConfig.mockRejectedValue(new Error('List failed'));
-      mockGetErrorMessage.mockReturnValue('List failed message');
 
-      await handleList();
-
-      expect(emitConsoleLog).toHaveBeenCalledWith(
-        'error',
-        'List failed message',
-      );
-      expect(mockProcessExit).toHaveBeenCalledWith(1);
-      mockProcessExit.mockRestore();
+      await expect(handleList()).rejects.toThrow('List failed');
     });
   });
 

--- a/packages/cli/src/commands/skills/list.ts
+++ b/packages/cli/src/commands/skills/list.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule } from 'yargs';
+import { getErrorMessage } from '../../utils/errors.js';
+import { debugLogger } from '@google/gemini-cli-core';
+import { loadSettings } from '../../config/settings.js';
+import { loadCliConfig, type CliArgs } from '../../config/config.js';
+import { exitCli } from '../utils.js';
+import chalk from 'chalk';
+
+export async function handleList() {
+  try {
+    const workspaceDir = process.cwd();
+    const settings = loadSettings(workspaceDir);
+
+    const config = await loadCliConfig(
+      settings.merged,
+      'skills-list-session',
+      {
+        debug: false,
+      } as Partial<CliArgs> as CliArgs,
+      { cwd: workspaceDir },
+    );
+
+    // Initialize to trigger extension loading and skill discovery
+    await config.initialize();
+
+    const skillManager = config.getSkillManager();
+    const skills = skillManager.getAllSkills();
+
+    if (skills.length === 0) {
+      debugLogger.log('No skills discovered.');
+      return;
+    }
+
+    debugLogger.log(chalk.bold('Discovered Agent Skills:'));
+    debugLogger.log('');
+
+    for (const skill of skills) {
+      const status = skill.disabled
+        ? chalk.red('[Disabled]')
+        : chalk.green('[Enabled]');
+
+      debugLogger.log(`${chalk.bold(skill.name)} ${status}`);
+      debugLogger.log(`  Description: ${skill.description}`);
+      debugLogger.log(`  Location:    ${skill.location}`);
+      debugLogger.log('');
+    }
+  } catch (error) {
+    debugLogger.error(getErrorMessage(error));
+    process.exit(1);
+  }
+}
+
+export const listCommand: CommandModule = {
+  command: 'list',
+  describe: 'Lists discovered agent skills.',
+  builder: (yargs) => yargs,
+  handler: async () => {
+    await handleList();
+    await exitCli();
+  },
+};

--- a/packages/cli/src/commands/skills/list.ts
+++ b/packages/cli/src/commands/skills/list.ts
@@ -1,11 +1,10 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
 import type { CommandModule } from 'yargs';
-import { getErrorMessage } from '../../utils/errors.js';
 import { debugLogger } from '@google/gemini-cli-core';
 import { loadSettings } from '../../config/settings.js';
 import { loadCliConfig, type CliArgs } from '../../config/config.js';
@@ -13,46 +12,41 @@ import { exitCli } from '../utils.js';
 import chalk from 'chalk';
 
 export async function handleList() {
-  try {
-    const workspaceDir = process.cwd();
-    const settings = loadSettings(workspaceDir);
+  const workspaceDir = process.cwd();
+  const settings = loadSettings(workspaceDir);
 
-    const config = await loadCliConfig(
-      settings.merged,
-      'skills-list-session',
-      {
-        debug: false,
-      } as Partial<CliArgs> as CliArgs,
-      { cwd: workspaceDir },
-    );
+  const config = await loadCliConfig(
+    settings.merged,
+    'skills-list-session',
+    {
+      debug: false,
+    } as Partial<CliArgs> as CliArgs,
+    { cwd: workspaceDir },
+  );
 
-    // Initialize to trigger extension loading and skill discovery
-    await config.initialize();
+  // Initialize to trigger extension loading and skill discovery
+  await config.initialize();
 
-    const skillManager = config.getSkillManager();
-    const skills = skillManager.getAllSkills();
+  const skillManager = config.getSkillManager();
+  const skills = skillManager.getAllSkills();
 
-    if (skills.length === 0) {
-      debugLogger.log('No skills discovered.');
-      return;
-    }
+  if (skills.length === 0) {
+    debugLogger.log('No skills discovered.');
+    return;
+  }
 
-    debugLogger.log(chalk.bold('Discovered Agent Skills:'));
+  debugLogger.log(chalk.bold('Discovered Agent Skills:'));
+  debugLogger.log('');
+
+  for (const skill of skills) {
+    const status = skill.disabled
+      ? chalk.red('[Disabled]')
+      : chalk.green('[Enabled]');
+
+    debugLogger.log(`${chalk.bold(skill.name)} ${status}`);
+    debugLogger.log(`  Description: ${skill.description}`);
+    debugLogger.log(`  Location:    ${skill.location}`);
     debugLogger.log('');
-
-    for (const skill of skills) {
-      const status = skill.disabled
-        ? chalk.red('[Disabled]')
-        : chalk.green('[Enabled]');
-
-      debugLogger.log(`${chalk.bold(skill.name)} ${status}`);
-      debugLogger.log(`  Description: ${skill.description}`);
-      debugLogger.log(`  Location:    ${skill.location}`);
-      debugLogger.log('');
-    }
-  } catch (error) {
-    debugLogger.error(getErrorMessage(error));
-    process.exit(1);
   }
 }
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -9,6 +9,7 @@ import { hideBin } from 'yargs/helpers';
 import process from 'node:process';
 import { mcpCommand } from '../commands/mcp.js';
 import { extensionsCommand } from '../commands/extensions.js';
+import { skillsCommand } from '../commands/skills.js';
 import { hooksCommand } from '../commands/hooks.js';
 import {
   Config,
@@ -283,6 +284,10 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
 
   if (settings?.experimental?.extensionManagement ?? true) {
     yargsInstance.command(extensionsCommand);
+  }
+
+  if (settings?.experimental?.skills ?? false) {
+    yargsInstance.command(skillsCommand);
   }
 
   // Register hooks command if hooks are enabled

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -91,6 +91,7 @@ const MIGRATION_MAP: Record<string, string> = {
   excludeTools: 'tools.exclude',
   excludeMCPServers: 'mcp.excluded',
   excludedProjectEnvVars: 'advanced.excludedEnvVars',
+  experimentalSkills: 'experimental.skills',
   extensionManagement: 'experimental.extensionManagement',
   extensions: 'extensions',
   fileFiltering: 'context.fileFiltering',


### PR DESCRIPTION
## Summary

This PR implements the top-level `gemini skills` CLI command, providing a dedicated interface for managing Agent Skills outside of the interactive session.

## Details

- **New CLI Command**: Added `gemini skills` to the core CLI with the following subcommands:
    - `list`: Displays all discovered skills across Extensions, User Global, and Project directories, including their description, location, and current enabled/disabled status.
    - `enable <name>`: Re-enables a previously disabled skill.
    - `disable <name>`: Disables a skill to prevent it from being injected into the agent's system prompt.
- **Scope Support**: Both `enable` and `disable` support a `--scope` (or `-s`) flag to target either `user` (default) or `project` settings.
- **Experimental Gating**: The `gemini skills` command is correctly gated by the `experimental.skills` setting, defaulting to `false`.
- **Consistent Discovery**: Integrated with `loadCliConfig` and `Config.initialize()` to ensure the management command sees the exact same tiered skills as the interactive agent.
- **Visual Feedback**: Utilizes `chalk` for clear, terminal-friendly output, highlighting status (Enabled/Disabled) and bolding skill names.
- **Testing**: Added comprehensive unit tests for the command module and each subcommand (`list.test.ts`, `enable.test.ts`, `disable.test.ts`).

## Related Issues

Fixes #15694

## How to Validate

1. **Build the CLI**: `npm run build`
2. **Verify Gating (Default)**: Run `npm run start -- --help | grep skills`.
   - **Expectation**: The command should NOT be listed.
3. **Enable Skills**: Update your settings to include `experimental.skills: true`.
4. **List Skills**: Run `npm run start -- skills list`.
   - **Expectation**: All skills (including those from linked extensions) should be listed with their status.
5. **Disable a Skill**: Run `npm run start -- skills disable <name> --scope project`.
   - **Expectation**: CLI confirms the skill is disabled in the Workspace scope.
6. **Verify Status**: Run `npm run start -- skills list` again.
   - **Expectation**: The targeted skill should now show as `[Disabled]`.
7. **Re-enable**: Run `npm run start -- skills enable <name> --scope project` and verify it returns to `[Enabled]`.

<img width="1102" height="742" alt="image" src="https://github.com/user-attachments/assets/f2e34f8f-a90f-44dc-a859-36854c9782dc" />
<img width="3444" height="1364" alt="image" src="https://github.com/user-attachments/assets/14b446cc-a5dd-40f4-8d5e-5722bc908ce4" />


## Pre-Merge Checklist

- [x] Added/updated tests
- [x] Validated on MacOS