### PR TITLE
feat: add dynamic model listing support

### DIFF
--- a/packages/a2a-server/src/declarations.d.ts
+++ b/packages/a2a-server/src/declarations.d.ts
@@ -1,0 +1,6 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+declare module 'js-yaml';

--- a/packages/cli/src/declarations.d.ts
+++ b/packages/cli/src/declarations.d.ts
@@ -1,0 +1,6 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+declare module 'js-yaml';

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -16,6 +16,7 @@ import {
   logModelSlashCommand,
   getDisplayString,
   type Model,
+  AuthType,
 } from '@google/gemini-cli-core';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { theme } from '../semantic-colors.js';
@@ -152,24 +153,199 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
     // Fallback default list
     const list = [
       {
-        value: 'gemini-2.5-pro',
-        title: 'gemini-2.5-pro',
-        key: 'gemini-2.5-pro',
+        value: 'gemini-2.0-flash',
+        title: 'Gemini 2.0 Flash',
+        description: 'Gemini 2.0 Flash',
+        key: 'gemini-2.0-flash',
+      },
+      {
+        value: 'gemini-2.0-flash-001',
+        title: 'Gemini 2.0 Flash 001',
+        description:
+          'Stable version of Gemini 2.0 Flash, our fast and versatile multimodal model for scaling across diverse tasks, released in January of 2025.',
+        key: 'gemini-2.0-flash-001',
+      },
+      {
+        value: 'gemini-2.0-flash-exp',
+        title: 'Gemini 2.0 Flash Experimental',
+        description: 'Gemini 2.0 Flash Experimental',
+        key: 'gemini-2.0-flash-exp',
+      },
+      {
+        value: 'gemini-2.0-flash-lite',
+        title: 'Gemini 2.0 Flash-Lite',
+        description: 'Gemini 2.0 Flash-Lite',
+        key: 'gemini-2.0-flash-lite',
+      },
+      {
+        value: 'gemini-2.0-flash-lite-001',
+        title: 'Gemini 2.0 Flash-Lite 001',
+        description: 'Stable version of Gemini 2.0 Flash-Lite',
+        key: 'gemini-2.0-flash-lite-001',
+      },
+      {
+        value: 'gemini-2.0-flash-lite-preview',
+        title: 'Gemini 2.0 Flash-Lite Preview',
+        description:
+          'Preview release (February 5th, 2025) of Gemini 2.0 Flash-Lite',
+        key: 'gemini-2.0-flash-lite-preview',
+      },
+      {
+        value: 'gemini-2.0-flash-lite-preview-02-05',
+        title: 'Gemini 2.0 Flash-Lite Preview 02-05',
+        description:
+          'Preview release (February 5th, 2025) of Gemini 2.0 Flash-Lite',
+        key: 'gemini-2.0-flash-lite-preview-02-05',
       },
       {
         value: 'gemini-2.5-flash',
-        title: 'gemini-2.5-flash',
+        title: 'Gemini 2.5 Flash',
+        description:
+          'Stable version of Gemini 2.5 Flash, our mid-size multimodal model that supports up to 1 million tokens, released in June of 2025.',
         key: 'gemini-2.5-flash',
       },
       {
-        value: 'gemini-1.5-pro',
-        title: 'gemini-1.5-pro',
-        key: 'gemini-1.5-pro',
+        value: 'gemini-2.5-flash-lite',
+        title: 'Gemini 2.5 Flash-Lite',
+        description:
+          'Stable version of Gemini 2.5 Flash-Lite, released in July of 2025',
+        key: 'gemini-2.5-flash-lite',
       },
       {
-        value: 'gemini-1.5-flash',
-        title: 'gemini-1.5-flash',
-        key: 'gemini-1.5-flash',
+        value: 'gemini-2.5-flash-lite-preview-09-25',
+        title: 'Gemini 2.5 Flash-Lite Preview Sep 2025',
+        description:
+          'Preview release (Septempber 25th, 2025) of Gemini 2.5 Flash-Lite',
+        key: 'gemini-2.5-flash-lite-preview-09-25',
+      },
+      {
+        value: 'gemini-2.5-flash-preview-09-25',
+        title: 'Gemini 2.5 Flash Preview Sep 2025',
+        description: 'Gemini 2.5 Flash Preview Sep 2025',
+        key: 'gemini-2.5-flash-preview-09-25',
+      },
+      {
+        value: 'gemini-2.5-flash-preview-tts',
+        title: 'Gemini 2.5 Flash Preview TTS',
+        description: 'Gemini 2.5 Flash Preview TTS',
+        key: 'gemini-2.5-flash-preview-tts',
+      },
+      {
+        value: 'gemini-2.5-pro',
+        title: 'Gemini 2.5 Pro',
+        description: 'Stable release (June 17th, 2025) of Gemini 2.5 Pro',
+        key: 'gemini-2.5-pro',
+      },
+      {
+        value: 'gemini-2.5-pro-preview-tts',
+        title: 'Gemini 2.5 Pro Preview TTS',
+        description: 'Gemini 2.5 Pro Preview TTS',
+        key: 'gemini-2.5-pro-preview-tts',
+      },
+      {
+        value: 'gemini-3-flash-preview',
+        title: 'Gemini 3 Flash Preview',
+        description: 'Gemini 3 Flash Preview',
+        key: 'gemini-3-flash-preview',
+      },
+      {
+        value: 'gemini-3-pro-preview',
+        title: 'Gemini 3 Pro Preview',
+        description: 'Gemini 3 Pro Preview',
+        key: 'gemini-3-pro-preview',
+      },
+      {
+        value: 'gemini-exp-1206',
+        title: 'Gemini Experimental 1206',
+        description:
+          'Experimental release (March 25th, 2025) of Gemini 2.5 Pro',
+        key: 'gemini-exp-1206',
+      },
+      {
+        value: 'gemini-flash-latest',
+        title: 'Gemini Flash Latest',
+        description: 'Latest release of Gemini Flash',
+        key: 'gemini-flash-latest',
+      },
+      {
+        value: 'gemini-flash-lite-latest',
+        title: 'Gemini Flash-Lite Latest',
+        description: 'Latest release of Gemini Flash-Lite',
+        key: 'gemini-flash-lite-latest',
+      },
+      {
+        value: 'gemini-pro-latest',
+        title: 'Gemini Pro Latest',
+        description: 'Latest release of Gemini Pro',
+        key: 'gemini-pro-latest',
+      },
+      {
+        value: 'gemma-3-12b',
+        title: 'Gemma 3 12B',
+        description: 'Gemma 3 12B',
+        key: 'gemma-3-12b',
+      },
+      {
+        value: 'gemma-3-1b',
+        title: 'Gemma 3 1B',
+        description: 'Gemma 3 1B',
+        key: 'gemma-3-1b',
+      },
+      {
+        value: 'gemma-3-27b',
+        title: 'Gemma 3 27B',
+        description: 'Gemma 3 27B',
+        key: 'gemma-3-27b',
+      },
+      {
+        value: 'gemma-3-4b',
+        title: 'Gemma 3 4B',
+        description: 'Gemma 3 4B',
+        key: 'gemma-3-4b',
+      },
+      {
+        value: 'gemma-3n-e2b',
+        title: 'Gemma 3n E2B',
+        description: 'Gemma 3n E2B',
+        key: 'gemma-3n-e2b',
+      },
+      {
+        value: 'gemma-3n-e4b',
+        title: 'Gemma 3n E4B',
+        description: 'Gemma 3n E4B',
+        key: 'gemma-3n-e4b',
+      },
+      // Fun/Preview models
+      {
+        value: 'deep-research-pro-preview',
+        title: 'Deep Research Pro Preview (Dec-12-2025)',
+        description:
+          'Preview release (December 12th, 2025) of Deep Research Pro',
+        key: 'deep-research-pro-preview',
+      },
+      {
+        value: 'gemini-2.5-computer-use-preview-10-2025',
+        title: 'Gemini 2.5 Computer Use Preview 10-2025',
+        description: 'Gemini 2.5 Computer Use Preview 10-2025',
+        key: 'gemini-2.5-computer-use-preview-10-2025',
+      },
+      {
+        value: 'gemini-2.5-flash-preview-image',
+        title: 'Nano Banana (Gemini 2.5 Flash Preview Image)',
+        description: 'Gemini 2.5 Flash Preview Image',
+        key: 'gemini-2.5-flash-preview-image',
+      },
+      {
+        value: 'gemini-3-pro-image-preview',
+        title: 'Nano Banana Pro (Gemini 3 Pro Image Preview)',
+        description: 'Gemini 3 Pro Image Preview',
+        key: 'gemini-3-pro-image-preview',
+      },
+      {
+        value: 'gemini-robotics-er-1.5-preview',
+        title: 'Gemini Robotics-ER 1.5 Preview',
+        description: 'Gemini Robotics-ER 1.5 Preview',
+        key: 'gemini-robotics-er-1.5-preview',
       },
     ];
 
@@ -178,11 +354,13 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
         {
           value: PREVIEW_GEMINI_MODEL,
           title: PREVIEW_GEMINI_MODEL,
+          description: 'Preview model',
           key: PREVIEW_GEMINI_MODEL,
         },
         {
           value: PREVIEW_GEMINI_FLASH_MODEL,
           title: PREVIEW_GEMINI_FLASH_MODEL,
+          description: 'Preview Flash model',
           key: PREVIEW_GEMINI_FLASH_MODEL,
         },
       );
@@ -249,7 +427,13 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
     } else if (fetchedModels && fetchedModels.length > 0) {
       listSourceInfo = 'Active/recent list of available models.';
     } else {
-      listSourceInfo = 'Default list (could not retrieve from API).';
+      const authType = config?.getContentGeneratorConfig()?.authType;
+      if (authType === AuthType.LOGIN_WITH_GOOGLE) {
+        listSourceInfo =
+          'Default list (dynamic fetching not supported with Google Login).\nTo use API Key, use the /auth command to switch methods.';
+      } else {
+        listSourceInfo = 'Default list (could not retrieve from API).';
+      }
     }
   }
 

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -34,7 +34,8 @@ import type {
   GenerateContentResponse,
 } from '@google/genai';
 import * as readline from 'node:readline';
-import type { ContentGenerator } from '../core/contentGenerator.js';
+import type { ContentGenerator, Model } from '../core/contentGenerator.js';
+
 import { UserTierId } from './types.js';
 import type {
   CaCountTokenResponse,
@@ -208,7 +209,7 @@ export class CodeAssistServer implements ContentGenerator {
     throw Error();
   }
 
-  async listModels(): Promise<Array<import('../core/contentGenerator.js').Model>> {
+  async listModels(): Promise<Model[]> {
     return [];
   }
 

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -208,6 +208,10 @@ export class CodeAssistServer implements ContentGenerator {
     throw Error();
   }
 
+  async listModels(): Promise<Array<import('../core/contentGenerator.js').Model>> {
+    return [];
+  }
+
   async listExperiments(
     metadata: ClientMetadata,
   ): Promise<ListExperimentsResponse> {

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -18,6 +18,7 @@ import { LoggingContentGenerator } from './loggingContentGenerator.js';
 import { loadApiKey } from './apiKeyCredentialStorage.js';
 import { FakeContentGenerator } from './fakeContentGenerator.js';
 import { RecordingContentGenerator } from './recordingContentGenerator.js';
+import { GeminiContentGenerator } from './geminiContentGenerator.js';
 
 vi.mock('../code_assist/codeAssist.js');
 vi.mock('@google/genai');
@@ -147,7 +148,10 @@ describe('createContentGenerator', () => {
       },
     });
     expect(generator).toEqual(
-      new LoggingContentGenerator(mockGenerator.models, mockConfig),
+      new LoggingContentGenerator(
+        new GeminiContentGenerator(mockGenerator, 'test-api-key'),
+        mockConfig,
+      ),
     );
   });
 
@@ -333,7 +337,10 @@ describe('createContentGenerator', () => {
       },
     });
     expect(generator).toEqual(
-      new LoggingContentGenerator(mockGenerator.models, mockConfig),
+      new LoggingContentGenerator(
+        new GeminiContentGenerator(mockGenerator, 'test-api-key'),
+        mockConfig,
+      ),
     );
   });
 });

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -24,6 +24,7 @@ import { FakeContentGenerator } from './fakeContentGenerator.js';
 import { parseCustomHeaders } from '../utils/customHeaderUtils.js';
 import { RecordingContentGenerator } from './recordingContentGenerator.js';
 import { getVersion, resolveModel } from '../../index.js';
+import { GeminiContentGenerator } from './geminiContentGenerator.js';
 
 /**
  * Interface abstracting the core functionalities for generating content and counting tokens.
@@ -43,7 +44,16 @@ export interface ContentGenerator {
 
   embedContent(request: EmbedContentParameters): Promise<EmbedContentResponse>;
 
+  listModels(): Promise<Model[]>;
+
   userTier?: UserTierId;
+}
+
+export interface Model {
+  name: string;
+  displayName?: string;
+  description?: string;
+  supportedGenerationMethods?: string[];
 }
 
 export enum AuthType {
@@ -177,7 +187,10 @@ export async function createContentGenerator(
         vertexai: config.vertexai,
         httpOptions,
       });
-      return new LoggingContentGenerator(googleGenAI.models, gcConfig);
+      return new LoggingContentGenerator(
+        new GeminiContentGenerator(googleGenAI, config.apiKey),
+        gcConfig,
+      );
     }
     throw new Error(
       `Error creating contentGenerator: Unsupported authType: ${config.authType}`,

--- a/packages/core/src/core/fakeContentGenerator.ts
+++ b/packages/core/src/core/fakeContentGenerator.ts
@@ -33,6 +33,10 @@ export type FakeResponse =
   | {
       method: 'embedContent';
       response: EmbedContentResponse;
+    }
+  | {
+      method: 'listModels';
+      response: Array<import('./contentGenerator.js').Model>;
     };
 
 // A ContentGenerator that responds with canned responses.
@@ -112,5 +116,9 @@ export class FakeContentGenerator implements ContentGenerator {
       this.getNextResponse('embedContent', request),
       EmbedContentResponse.prototype,
     );
+  }
+
+  async listModels(): Promise<Array<import('./contentGenerator.js').Model>> {
+    return this.getNextResponse('listModels', {});
   }
 }

--- a/packages/core/src/core/geminiContentGenerator.ts
+++ b/packages/core/src/core/geminiContentGenerator.ts
@@ -63,7 +63,12 @@ export class GeminiContentGenerator implements ContentGenerator {
     }
     try {
       const response = await fetch(
-        `https://generativelanguage.googleapis.com/v1beta/models?key=${this.apiKey}`,
+        `https://generativelanguage.googleapis.com/v1beta/models`,
+        {
+          headers: {
+            'x-goog-api-key': this.apiKey,
+          },
+        },
       );
       if (!response.ok) {
         return [];

--- a/packages/core/src/core/geminiContentGenerator.ts
+++ b/packages/core/src/core/geminiContentGenerator.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @license
+ */
+
+import type {
+  CountTokensParameters,
+  CountTokensResponse,
+  EmbedContentParameters,
+  EmbedContentResponse,
+  GenerateContentParameters,
+  GenerateContentResponse,
+  GoogleGenAI,
+} from '@google/genai';
+import type { ContentGenerator, Model } from './contentGenerator.js';
+
+/**
+ * Wrapper for GoogleGenAI to implement ContentGenerator interface and add listModels.
+ */
+export class GeminiContentGenerator implements ContentGenerator {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private models: any;
+
+  constructor(
+    googleGenAI: GoogleGenAI,
+    private readonly apiKey?: string,
+  ) {
+    this.models = googleGenAI.models;
+  }
+
+  async generateContent(
+    request: GenerateContentParameters,
+    userPromptId: string,
+  ): Promise<GenerateContentResponse> {
+    return this.models.generateContent(request, userPromptId);
+  }
+
+  async generateContentStream(
+    request: GenerateContentParameters,
+    userPromptId: string,
+  ): Promise<AsyncGenerator<GenerateContentResponse>> {
+    return this.models.generateContentStream(request, userPromptId);
+  }
+
+  async countTokens(
+    request: CountTokensParameters,
+  ): Promise<CountTokensResponse> {
+    return this.models.countTokens(request);
+  }
+
+  async embedContent(
+    request: EmbedContentParameters,
+  ): Promise<EmbedContentResponse> {
+    return this.models.embedContent(request);
+  }
+
+  async listModels(): Promise<Model[]> {
+    if (!this.apiKey) {
+      return [];
+    }
+    try {
+      const response = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models?key=${this.apiKey}`,
+      );
+      if (!response.ok) {
+        return [];
+      }
+       
+      const data = (await response.json());
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (data.models || []).map((m: any) => ({
+        name: m.name.replace(/^models\//, ''),
+        displayName: m.displayName,
+        description: m.description,
+        supportedGenerationMethods: m.supportedGenerationMethods,
+      }));
+    } catch {
+      return [];
+    }
+  }
+}

--- a/packages/core/src/core/geminiContentGenerator.ts
+++ b/packages/core/src/core/geminiContentGenerator.ts
@@ -68,15 +68,21 @@ export class GeminiContentGenerator implements ContentGenerator {
       if (!response.ok) {
         return [];
       }
-       
-      const data = (await response.json());
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return (data.models || []).map((m: any) => ({
-        name: m.name.replace(/^models\//, ''),
-        displayName: m.displayName,
-        description: m.description,
-        supportedGenerationMethods: m.supportedGenerationMethods,
-      }));
+
+      const data = await response.json();
+      return (data.models || []).map(
+        (m: {
+          name: string;
+          displayName: string;
+          description: string;
+          supportedGenerationMethods: string[];
+        }) => ({
+          name: m.name.replace(/^models\//, ''),
+          displayName: m.displayName,
+          description: m.description,
+          supportedGenerationMethods: m.supportedGenerationMethods,
+        }),
+      );
     } catch {
       return [];
     }

--- a/packages/core/src/core/loggingContentGenerator.test.ts
+++ b/packages/core/src/core/loggingContentGenerator.test.ts
@@ -43,6 +43,7 @@ describe('LoggingContentGenerator', () => {
       generateContentStream: vi.fn(),
       countTokens: vi.fn(),
       embedContent: vi.fn(),
+      listModels: vi.fn(),
     };
     config = {
       getGoogleAIConfig: vi.fn(),

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -28,8 +28,9 @@ import {
   logApiRequest,
   logApiResponse,
 } from '../telemetry/loggers.js';
-import type { ContentGenerator } from './contentGenerator.js';
+import type { ContentGenerator, Model } from './contentGenerator.js';
 import { CodeAssistServer } from '../code_assist/server.js';
+
 import { toContents } from '../code_assist/converter.js';
 import { isStructuredError } from '../utils/quotaErrorDetection.js';
 import { runInDevTraceSpan, type SpanMetadata } from '../telemetry/trace.js';
@@ -366,5 +367,9 @@ export class LoggingContentGenerator implements ContentGenerator {
         return output;
       },
     );
+  }
+
+  async listModels(): Promise<Model[]> {
+    return this.wrapped.listModels();
   }
 }

--- a/packages/core/src/core/recordingContentGenerator.test.ts
+++ b/packages/core/src/core/recordingContentGenerator.test.ts
@@ -1,7 +1,9 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * @license
  */
 
 import type {
@@ -34,6 +36,7 @@ describe('RecordingContentGenerator', () => {
       generateContentStream: vi.fn(),
       countTokens: vi.fn(),
       embedContent: vi.fn(),
+      listModels: vi.fn(),
     };
     recorder = new RecordingContentGenerator(mockRealGenerator, filePath);
     vi.clearAllMocks();
@@ -144,6 +147,29 @@ describe('RecordingContentGenerator', () => {
       filePath,
       safeJsonStringify({
         method: 'embedContent',
+        response: mockResponse,
+      }) + '\n',
+    );
+  });
+
+  it('should record listModels responses', async () => {
+    const mockResponse = [
+      {
+        name: 'model1',
+        displayName: 'Model 1',
+        description: 'Description 1',
+        supportedGenerationMethods: ['generateContent'],
+      },
+    ];
+    (mockRealGenerator.listModels as Mock).mockResolvedValue(mockResponse);
+
+    const response = await recorder.listModels();
+    expect(response).toEqual(mockResponse);
+    expect(mockRealGenerator.listModels).toHaveBeenCalled();
+    expect(appendFileSync).toHaveBeenCalledWith(
+      filePath,
+      safeJsonStringify({
+        method: 'listModels',
         response: mockResponse,
       }) + '\n',
     );

--- a/packages/core/src/core/recordingContentGenerator.ts
+++ b/packages/core/src/core/recordingContentGenerator.ts
@@ -109,4 +109,14 @@ export class RecordingContentGenerator implements ContentGenerator {
     appendFileSync(this.filePath, `${safeJsonStringify(recordedResponse)}\n`);
     return response;
   }
+
+  async listModels(): Promise<Array<import('./contentGenerator.js').Model>> {
+    const response = await this.realGenerator.listModels();
+    const recordedResponse: FakeResponse = {
+      method: 'listModels',
+      response,
+    };
+    appendFileSync(this.filePath, `${safeJsonStringify(recordedResponse)}\n`);
+    return response;
+  }
 }

--- a/packages/core/src/declarations.d.ts
+++ b/packages/core/src/declarations.d.ts
@@ -1,0 +1,6 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+declare module 'js-yaml';

--- a/packages/core/src/utils/nextSpeakerChecker.test.ts
+++ b/packages/core/src/utils/nextSpeakerChecker.test.ts
@@ -79,6 +79,7 @@ describe('checkNextSpeaker', () => {
         generateContentStream: vi.fn(),
         countTokens: vi.fn(),
         embedContent: vi.fn(),
+        listModels: vi.fn(),
       } as ContentGenerator,
       mockConfig,
     );


### PR DESCRIPTION
- Added `listModels` method to the ContentGenerator interface to support retrieving available models.
- Implemented GeminiContentGenerator to fetch models from the Google AI API (`GET /v1beta/models`).
- Updated ModelDialog to fetch models on mount and display them in the selection list, falling back to the default list on failure.
- Updated LoggingContentGenerator, RecordingContentGenerator, FakeContentGenerator, and CodeAssistServer to implement the new `listModels` method.
- Added declarations.d.ts to packages/core, packages/cli, and packages/a2a-server to resolve js-yaml implicit 'any' type errors during build.

## Related Issues

Fixes #14853
