### PR TITLE
Feat: Add a support to build Dockerfile without NodeJS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,58 @@
+# API keys and secrets
+.env
+.env~
+
+# gemini-cli settings
+# We want to keep the .gemini in the root of the repo and ignore any .gemini
+# in subdirectories. In our root .gemini we want to allow for version control
+# for subcommands.
+**/.gemini/
+!/.gemini/
+.gemini/*
+!.gemini/config.yaml
+!.gemini/commands/
+
+# Note: .gemini-clipboard/ is NOT in gitignore so Gemini can access pasted images
+
+# Dependency directory
+node_modules
+bower_components
+
+# Editors
+.idea
+*.iml
+
+# OS metadata
+.DS_Store
+Thumbs.db
+
+# TypeScript build info files
+*.tsbuildinfo
+
+# Ignore built ts files
+dist
+
+# Docker folder to help skip auth refreshes
+.docker
+
+bundle
+
+# Test report files
+junit.xml
+packages/*/coverage/
+
+# Generated files
+packages/cli/src/generated/
+packages/core/src/generated/
+.integration-tests/
+packages/vscode-ide-companion/*.vsix
+packages/cli/download-ripgrep*/
+
+# GHA credentials
+gha-creds-*.json
+
+# Log files
+patch_output.log
+
+.genkit
+.gemini-clipboard/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,35 @@
-FROM docker.io/library/node:20-slim
+# STAGE 1: Builder
+FROM node:20 AS builder
+
+WORKDIR /app
+
+# Copy source
+COPY . .
+
+# 1. Install dependencies
+RUN npm install
+
+# 2. Build the project
+# FIXED: Changed from 'npm run compile' to 'npm run build'
+RUN npm run build
+
+# 3. Create the Tarballs (.tgz)
+WORKDIR /app/packages/core
+RUN npm pack
+
+WORKDIR /app/packages/cli
+RUN npm pack
+
+# STAGE 2: Runtime
+FROM node:20-slim
 
 ARG SANDBOX_NAME="gemini-cli-sandbox"
 ARG CLI_VERSION_ARG
+
 ENV SANDBOX="$SANDBOX_NAME"
 ENV CLI_VERSION=$CLI_VERSION_ARG
 
-# install minimal set of packages, then clean up
+# Install dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
   python3 \
   make \
@@ -29,22 +53,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-# set up npm global package folder under /usr/local/share
-# give it to non-root user node, already set up in base image
+# Setup NPM Global
 RUN mkdir -p /usr/local/share/npm-global \
   && chown -R node:node /usr/local/share/npm-global
 ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
 ENV PATH=$PATH:/usr/local/share/npm-global/bin
 
-# switch to non-root user node
 USER node
 
-# install gemini-cli and clean up
-COPY packages/cli/dist/google-gemini-cli-*.tgz /tmp/gemini-cli.tgz
-COPY packages/core/dist/google-gemini-cli-core-*.tgz /tmp/gemini-core.tgz
+# Copy artifacts from Builder stage
+COPY --from=builder /app/packages/cli/google-gemini-cli-*.tgz /tmp/gemini-cli.tgz
+COPY --from=builder /app/packages/core/google-gemini-cli-core-*.tgz /tmp/gemini-core.tgz
+
+# Install global packages
 RUN npm install -g /tmp/gemini-cli.tgz /tmp/gemini-core.tgz \
   && npm cache clean --force \
   && rm -f /tmp/gemini-{cli,core}.tgz
 
-# default entrypoint when none specified
 CMD ["gemini"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
 # STAGE 1: Builder
-FROM docker.io/library/node:20-slim
+FROM docker.io/library/node:20-slim AS builder
 
 WORKDIR /app
 
 # Copy source
 COPY . .
+
+# install git for npm scripts/generate-git-commit-info.js
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # 1. Install dependencies
 RUN npm install
@@ -28,7 +33,7 @@ ARG CLI_VERSION_ARG
 ENV SANDBOX="$SANDBOX_NAME"
 ENV CLI_VERSION=$CLI_VERSION_ARG
 
-# install minimal set of packages, then clean up
+# install minimal set of packages for using by agent, then clean up
 RUN apt-get update && apt-get install -y --no-install-recommends \
   python3 \
   make \


### PR DESCRIPTION
## Summary

Looks like the current Dockerfile in the root of the repository assumes that the user has already installed Node.js dependencies and compiled the project artifacts (.tgz files) on their host machine before running docker/podman build.

If a user tries to build the container directly from a fresh clone (without having Node/NPM installed on their host), the build fails at the COPY step because the dist folders do not exist yet.

This PR fixes that

## Related Issues

Closes #15859

## How to Validate

```
podman build --no-cache  \
                                            --build-arg CLI_VERSION_ARG=1.0.0 \
                                            -t geminicli .
```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [X] Updated relevant documentation and README (if needed)

- [X] Added/updated tests (if needed)

- [X] Noted breaking changes (if any)
- [X] Validated on required platforms/methods:
  - [] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [X] Linux
    - [ ] npm run
    - [ ] npx
    - [X] Docker
