### PR TITLE
Agent Skills: Add skill directory to WorkspaceContext upon activation

### DIFF
--- a/packages/core/src/tools/activate-skill.test.ts
+++ b/packages/core/src/tools/activate-skill.test.ts
@@ -29,6 +29,9 @@ describe('ActivateSkillTool', () => {
       },
     ];
     mockConfig = {
+      getWorkspaceContext: vi.fn().mockReturnValue({
+        addDirectory: vi.fn(),
+      }),
       getSkillManager: vi.fn().mockReturnValue({
         getSkills: vi.fn().mockReturnValue(skills),
         getAllSkills: vi.fn().mockReturnValue(skills),
@@ -80,6 +83,9 @@ describe('ActivateSkillTool', () => {
 
     expect(mockConfig.getSkillManager().activateSkill).toHaveBeenCalledWith(
       'test-skill',
+    );
+    expect(mockConfig.getWorkspaceContext().addDirectory).toHaveBeenCalledWith(
+      '/path/to/test-skill',
     );
     expect(result.llmContent).toContain('<ACTIVATED_SKILL name="test-skill">');
     expect(result.llmContent).toContain('<INSTRUCTIONS>');

--- a/packages/core/src/tools/activate-skill.ts
+++ b/packages/core/src/tools/activate-skill.ts
@@ -115,6 +115,12 @@ ${folderStructure}`,
 
     skillManager.activateSkill(skillName);
 
+    // Add the skill's directory to the workspace context so the agent has permission
+    // to read its bundled resources.
+    this.config
+      .getWorkspaceContext()
+      .addDirectory(path.dirname(skill.location));
+
     const folderStructure = await this.getOrFetchFolderStructure(
       skill.location,
     );


### PR DESCRIPTION
When an agent skill is activated via the 'activate_skill' tool, its directory is now added to the WorkspaceContext. This ensures that the 'AllowedPathChecker' permits the agent to access bundled resources (like scripts or reference files) within that directory.

Fixes https://github.com/google-gemini/gemini-cli/issues/15868