### PR TITLE
fix: handle cumulative stream chunks to prevent API 400 errors

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -15,6 +15,7 @@ import { runExitCleanup } from './src/utils/cleanup.js';
 // Suppress known race condition error in node-pty on Windows
 process.on('uncaughtException', (error) => {
   if (
+    process.platform === 'win32' &&
     error instanceof Error &&
     error.message === 'Cannot resize a pty that has already exited'
   ) {

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -20,19 +20,18 @@ process.on('uncaughtException', (error) => {
     error instanceof Error &&
     error.message === 'Cannot resize a pty that has already exited'
   ) {
-    // This error happens on Windows with node-pty when resizing a pty that has just exited.
-    // It is a race condition in node-pty that we cannot prevent, so we silence it.
     return;
   }
 
-  // For other errors, we rely on the default behavior, but since we attached a listener,
-  // we must manually replicate it.
-  if (error instanceof Error) {
-    writeToStderr(error.stack + '\n');
-  } else {
-    writeToStderr(String(error) + '\n');
-  }
-  process.exit(1);
+  // FIX: Run cleanup before exiting
+  runExitCleanup().finally(() => {
+    if (error instanceof Error) {
+      writeToStderr(error.stack + '\n');
+    } else {
+      writeToStderr(String(error) + '\n');
+    }
+    process.exit(1);
+  });
 });
 
 main().catch(async (error) => {

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -13,6 +13,7 @@ import { runExitCleanup } from './src/utils/cleanup.js';
 // --- Global Entry Point ---
 
 // Suppress known race condition error in node-pty on Windows
+// Tracking bug: https://github.com/microsoft/node-pty/issues/827
 process.on('uncaughtException', (error) => {
   if (
     process.platform === 'win32' &&

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -11,6 +11,28 @@ import { FatalError, writeToStderr } from '@google/gemini-cli-core';
 import { runExitCleanup } from './src/utils/cleanup.js';
 
 // --- Global Entry Point ---
+
+// Suppress known race condition error in node-pty on Windows
+process.on('uncaughtException', (error) => {
+  if (
+    error instanceof Error &&
+    error.message === 'Cannot resize a pty that has already exited'
+  ) {
+    // This error happens on Windows with node-pty when resizing a pty that has just exited.
+    // It is a race condition in node-pty that we cannot prevent, so we silence it.
+    return;
+  }
+
+  // For other errors, we rely on the default behavior, but since we attached a listener,
+  // we must manually replicate it.
+  if (error instanceof Error) {
+    writeToStderr(error.stack + '\n');
+  } else {
+    writeToStderr(String(error) + '\n');
+  }
+  process.exit(1);
+});
+
 main().catch(async (error) => {
   await runExitCleanup();
 

--- a/packages/core/src/utils/partUtils.ts
+++ b/packages/core/src/utils/partUtils.ts
@@ -84,7 +84,10 @@ export function isCumulative(prev: Part[], curr: Part[]): boolean {
 
   // If the first part is text, check if it's growing
   if (p0.text !== undefined && c0.text !== undefined) {
-    return c0.text.length > p0.text.length && c0.text.startsWith(p0.text);
+    // Only return true if strictly growing. If lengths are equal, fall through to deep equality check.
+    if (c0.text.length > p0.text.length && c0.text.startsWith(p0.text)) {
+      return true;
+    }
   }
 
   // For non-text parts (like functionCall), check if they are identical
@@ -107,7 +110,10 @@ export function isCumulativeFunctionCalls(
   if (curr.length < prev.length) return false;
 
   try {
-    return JSON.stringify(prev[0]) === JSON.stringify(curr[0]);
+    // To be truly cumulative, the current array of function calls must start with the previous one.
+    const prevStr = JSON.stringify(prev);
+    const currPrefixStr = JSON.stringify(curr.slice(0, prev.length));
+    return prevStr === currPrefixStr;
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
Fixes a critical bug where cumulative stream chunks caused duplicate function calls in the conversation history, resulting in INVALID_ARGUMENT (400) errors from the Gemini API.

## Details
The CLI previously assumed all stream chunks were deltas (new data only). However, in certain environments or with specific SDK behaviors, chunks can be cumulative (containing the full response so far). This caused the CLI to naively append duplicate functionCall parts to the history.

Error that occurs:
✕ [API Error: [{
    "error": {
      "code": 400,
      "message": "Please ensure that the number of function response parts is equal to the number of function call parts of the function call turn.",
      "errors": [
        {
          "message": "Please ensure that the number of function response parts is equal to the number of function call parts of the function call turn.",
          "domain": "global",
          "reason": "badRequest"
        }
      ],
      "status": "INVALID_ARGUMENT"
    }
  }
  ]]

Changes:
- Detection: Added isCumulative and isCumulativeFunctionCalls helpers in packages/core/src/utils/partUtils.ts.
- History Management: Updated geminiChat.ts to correctly replace accumulated history parts rather than appending when a cumulative chunk is detected.
- Execution: Modified turn.ts to yield only new tool calls from each chunk, preventing duplicate tool executions.

Note: This PR includes the Windows PTY crash fix (from PR #15757) in its history as it is required to run the test suite and validate on Windows machines.

## Related Issues

Related to #15757 (Windows PTY fix dependency)

## How to Validate
1. Launch the CLI in an environment where stream chunks may be cumulative (or on Windows).
2. Request a task that involves tool use (e.g., "Read config/settings.py").
3. Expected Result: The CLI should execute the tool and continue the conversation.
4. Previous Behavior: The CLI would crash with an API 400 error: "Please ensure that the number of function response parts is equal to the number of function call parts..."

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
