### PR TITLE
feat: truncate user messages that are over 15 lines

### DIFF
--- a/packages/cli/src/ui/components/messages/UserMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/UserMessage.test.tsx
@@ -37,4 +37,14 @@ describe('UserMessage', () => {
 
     expect(output).toMatchSnapshot();
   });
+
+  it('truncates long user message over 15 lines', () => {
+    const message = Array.from({ length: 20 }, (_, i) => `Line ${i + 1}`).join(
+      '\n',
+    );
+    const { lastFrame } = render(<UserMessage text={message} width={80} />);
+    const output = lastFrame();
+
+    expect(output).toMatchSnapshot();
+  });
 });

--- a/packages/cli/src/ui/components/messages/UserMessage.tsx
+++ b/packages/cli/src/ui/components/messages/UserMessage.tsx
@@ -10,6 +10,8 @@ import { theme } from '../../semantic-colors.js';
 import { SCREEN_READER_USER_PREFIX } from '../../textConstants.js';
 import { isSlashCommand as checkIsSlashCommand } from '../../utils/commandUtils.js';
 
+const MAX_DISPLAY_LINES = 15;
+
 interface UserMessageProps {
   text: string;
   width: number;
@@ -21,7 +23,6 @@ export const UserMessage: React.FC<UserMessageProps> = ({ text, width }) => {
   const isSlashCommand = checkIsSlashCommand(text);
 
   const lines = text.split('\n');
-  const MAX_DISPLAY_LINES = 15;
   const isTruncated = lines.length > MAX_DISPLAY_LINES;
   const displayText = isTruncated
     ? lines.slice(0, MAX_DISPLAY_LINES).join('\n')

--- a/packages/cli/src/ui/components/messages/UserMessage.tsx
+++ b/packages/cli/src/ui/components/messages/UserMessage.tsx
@@ -20,6 +20,13 @@ export const UserMessage: React.FC<UserMessageProps> = ({ text, width }) => {
   const prefixWidth = prefix.length;
   const isSlashCommand = checkIsSlashCommand(text);
 
+  const lines = text.split('\n');
+  const MAX_DISPLAY_LINES = 15;
+  const isTruncated = lines.length > MAX_DISPLAY_LINES;
+  const displayText = isTruncated
+    ? lines.slice(0, MAX_DISPLAY_LINES).join('\n')
+    : text;
+
   const textColor = isSlashCommand ? theme.text.accent : theme.text.secondary;
 
   return (
@@ -35,10 +42,15 @@ export const UserMessage: React.FC<UserMessageProps> = ({ text, width }) => {
           {prefix}
         </Text>
       </Box>
-      <Box flexGrow={1}>
+      <Box flexGrow={1} flexDirection="column">
         <Text wrap="wrap" color={textColor}>
-          {text}
+          {displayText}
         </Text>
+        {isTruncated && (
+          <Text color={theme.text.secondary} dimColor>
+            {`... (${lines.length - MAX_DISPLAY_LINES} more lines)`}
+          </Text>
+        )}
       </Box>
     </Box>
   );

--- a/packages/cli/src/ui/components/messages/__snapshots__/UserMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/UserMessage.test.tsx.snap
@@ -18,3 +18,24 @@ exports[`UserMessage > renders slash command message 1`] = `
 > /help
 "
 `;
+
+exports[`UserMessage > truncates long user message over 15 lines 1`] = `
+"
+> Line 1
+  Line 2
+  Line 3
+  Line 4
+  Line 5
+  Line 6
+  Line 7
+  Line 8
+  Line 9
+  Line 10
+  Line 11
+  Line 12
+  Line 13
+  Line 14
+  Line 15
+  ... (5 more lines)
+"
+`;


### PR DESCRIPTION
## Summary

Truncates user messages over 15 lines in the terminal history to improve readability and prevent flooding.

## Details

- Limits visual output to 15 lines in UserMessage.tsx.
- Displays a ... (N more lines) indicator for truncated text.
- Full message is still sent to Gemini.

## Related Issues

Fixes #15844

## How to Validate

Run unit tests in packages/cli:
npm run test -- src/ui/components/messages/UserMessage.test.tsx

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
