### PR TITLE
chore: rename smart-edit to edit

### DIFF
--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -297,7 +297,7 @@ Captures startup configuration and user prompt submissions.
 
 #### Tools
 
-Captures tool executions, output truncation, and Smart Edit behavior.
+Captures tool executions, output truncation, and Edit behavior.
 
 - `gemini_cli.tool_call`: Emitted for each tool (function) call.
   - **Attributes**:
@@ -325,11 +325,11 @@ Captures tool executions, output truncation, and Smart Edit behavior.
     - `lines` (int)
     - `prompt_id` (string)
 
-- `gemini_cli.smart_edit_strategy`: Smart Edit strategy chosen.
+- `gemini_cli.edit_strategy`: Edit strategy chosen.
   - **Attributes**:
     - `strategy` (string)
 
-- `gemini_cli.smart_edit_correction`: Smart Edit correction result.
+- `gemini_cli.edit_correction`: Edit correction result.
   - **Attributes**:
     - `correction` ("success" | "failure")
 

--- a/packages/cli/src/ui/constants/tips.ts
+++ b/packages/cli/src/ui/constants/tips.ts
@@ -75,7 +75,6 @@ export const INFORMATIVE_TIPS = [
   'Set the character threshold for truncating tool outputs (/settings)...',
   'Set the number of lines to keep when truncating outputs (/settings)...',
   'Enable policy-based tool confirmation via message bus (/settings)...',
-  'Enable smart-edit tool for more precise editing (/settings)...',
   'Enable write_todos_list tool to generate task lists (/settings)...',
   'Enable model routing based on complexity (/settings)...',
   'Enable experimental subagents for task delegation (/settings)...',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -25,7 +25,7 @@ import { GrepTool } from '../tools/grep.js';
 import { canUseRipgrep, RipGrepTool } from '../tools/ripGrep.js';
 import { GlobTool } from '../tools/glob.js';
 import { ActivateSkillTool } from '../tools/activate-skill.js';
-import { SmartEditTool } from '../tools/smart-edit.js';
+import { EditTool } from '../tools/edit.js';
 import { ShellTool } from '../tools/shell.js';
 import { WriteFileTool } from '../tools/write-file.js';
 import { WebFetchTool } from '../tools/web-fetch.js';
@@ -1690,7 +1690,7 @@ export class Config {
 
     registerCoreTool(GlobTool, this);
     registerCoreTool(ActivateSkillTool, this);
-    registerCoreTool(SmartEditTool, this);
+    registerCoreTool(EditTool, this);
     registerCoreTool(WriteFileTool, this);
     registerCoreTool(WebFetchTool, this);
     registerCoreTool(ShellTool, this);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -124,7 +124,7 @@ export * from './tools/ls.js';
 export * from './tools/grep.js';
 export * from './tools/ripGrep.js';
 export * from './tools/glob.js';
-export * from './tools/smart-edit.js';
+export * from './tools/edit.js';
 export * from './tools/write-file.js';
 export * from './tools/web-fetch.js';
 export * from './tools/memoryTool.js';

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -31,8 +31,8 @@ import type {
   ExtensionEnableEvent,
   ModelSlashCommandEvent,
   ExtensionDisableEvent,
-  SmartEditStrategyEvent,
-  SmartEditCorrectionEvent,
+  EditStrategyEvent,
+  EditCorrectionEvent,
   AgentStartEvent,
   AgentFinishEvent,
   RecoveryAttemptEvent,
@@ -89,8 +89,8 @@ export enum EventNames {
   TOOL_OUTPUT_TRUNCATED = 'tool_output_truncated',
   MODEL_ROUTING = 'model_routing',
   MODEL_SLASH_COMMAND = 'model_slash_command',
-  SMART_EDIT_STRATEGY = 'smart_edit_strategy',
-  SMART_EDIT_CORRECTION = 'smart_edit_correction',
+  EDIT_STRATEGY = 'edit_strategy',
+  EDIT_CORRECTION = 'edit_correction',
   AGENT_START = 'agent_start',
   AGENT_FINISH = 'agent_finish',
   RECOVERY_ATTEMPT = 'recovery_attempt',
@@ -1235,31 +1235,27 @@ export class ClearcutLogger {
     });
   }
 
-  logSmartEditStrategyEvent(event: SmartEditStrategyEvent): void {
+  logEditStrategyEvent(event: EditStrategyEvent): void {
     const data: EventValue[] = [
       {
-        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SMART_EDIT_STRATEGY,
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_EDIT_STRATEGY,
         value: event.strategy,
       },
     ];
 
-    this.enqueueLogEvent(
-      this.createLogEvent(EventNames.SMART_EDIT_STRATEGY, data),
-    );
+    this.enqueueLogEvent(this.createLogEvent(EventNames.EDIT_STRATEGY, data));
     this.flushIfNeeded();
   }
 
-  logSmartEditCorrectionEvent(event: SmartEditCorrectionEvent): void {
+  logEditCorrectionEvent(event: EditCorrectionEvent): void {
     const data: EventValue[] = [
       {
-        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SMART_EDIT_CORRECTION,
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_EDIT_CORRECTION,
         value: event.correction,
       },
     ];
 
-    this.enqueueLogEvent(
-      this.createLogEvent(EventNames.SMART_EDIT_CORRECTION, data),
-    );
+    this.enqueueLogEvent(this.createLogEvent(EventNames.EDIT_CORRECTION, data));
     this.flushIfNeeded();
   }
 

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -93,11 +93,11 @@ export enum EventMetadataKey {
   // Replace Tool Call Event Keys
   // ===========================================================================
 
-  // Logs a smart edit tool strategy choice.
-  GEMINI_CLI_SMART_EDIT_STRATEGY = 109,
+  // Logs a edit tool strategy choice.
+  GEMINI_CLI_EDIT_STRATEGY = 109,
 
-  // Logs a smart edit correction event.
-  GEMINI_CLI_SMART_EDIT_CORRECTION = 110,
+  // Logs a edit correction event.
+  GEMINI_CLI_EDIT_CORRECTION = 110,
 
   // Logs the reason for web fetch fallback.
   GEMINI_CLI_WEB_FETCH_FALLBACK_REASON = 116,

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -12,7 +12,7 @@ import type {
 } from '../index.js';
 import {
   AuthType,
-  SmartEditTool,
+  EditTool,
   GeminiClient,
   ToolConfirmationOutcome,
   ToolErrorType,
@@ -1034,7 +1034,7 @@ describe('loggers', () => {
     });
 
     it('should log a tool call with all fields', () => {
-      const tool = new SmartEditTool(mockConfig, createMockMessageBus());
+      const tool = new EditTool(mockConfig, createMockMessageBus());
       const call: CompletedToolCall = {
         status: 'success',
         request: {
@@ -1250,7 +1250,7 @@ describe('loggers', () => {
           contentLength: 13,
         },
         outcome: ToolConfirmationOutcome.ModifyWithEditor,
-        tool: new SmartEditTool(mockConfig, createMockMessageBus()),
+        tool: new EditTool(mockConfig, createMockMessageBus()),
         invocation: {} as AnyToolInvocation,
         durationMs: 100,
       };
@@ -1329,7 +1329,7 @@ describe('loggers', () => {
           errorType: undefined,
           contentLength: 13,
         },
-        tool: new SmartEditTool(mockConfig, createMockMessageBus()),
+        tool: new EditTool(mockConfig, createMockMessageBus()),
         invocation: {} as AnyToolInvocation,
         durationMs: 100,
       };

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -41,8 +41,8 @@ import type {
   ExtensionUninstallEvent,
   ExtensionInstallEvent,
   ModelSlashCommandEvent,
-  SmartEditStrategyEvent,
-  SmartEditCorrectionEvent,
+  EditStrategyEvent,
+  EditCorrectionEvent,
   AgentStartEvent,
   AgentFinishEvent,
   RecoveryAttemptEvent,
@@ -568,11 +568,11 @@ export async function logExtensionDisable(
   });
 }
 
-export function logSmartEditStrategy(
+export function logEditStrategy(
   config: Config,
-  event: SmartEditStrategyEvent,
+  event: EditStrategyEvent,
 ): void {
-  ClearcutLogger.getInstance(config)?.logSmartEditStrategyEvent(event);
+  ClearcutLogger.getInstance(config)?.logEditStrategyEvent(event);
   bufferTelemetryEvent(() => {
     const logger = logs.getLogger(SERVICE_NAME);
     const logRecord: LogRecord = {
@@ -583,11 +583,11 @@ export function logSmartEditStrategy(
   });
 }
 
-export function logSmartEditCorrectionEvent(
+export function logEditCorrectionEvent(
   config: Config,
-  event: SmartEditCorrectionEvent,
+  event: EditCorrectionEvent,
 ): void {
-  ClearcutLogger.getInstance(config)?.logSmartEditCorrectionEvent(event);
+  ClearcutLogger.getInstance(config)?.logEditCorrectionEvent(event);
   bufferTelemetryEvent(() => {
     const logger = logs.getLogger(SERVICE_NAME);
     const logRecord: LogRecord = {

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -1548,7 +1548,9 @@ export type TelemetryEvent =
   | RecoveryAttemptEvent
   | LlmLoopCheckEvent
   | StartupStatsEvent
-  | WebFetchFallbackAttemptEvent;
+  | WebFetchFallbackAttemptEvent
+  | EditStrategyEvent
+  | EditCorrectionEvent;
 
 export const EVENT_EXTENSION_DISABLE = 'gemini_cli.extension_disable';
 export class ExtensionDisableEvent implements BaseTelemetryEvent {
@@ -1588,14 +1590,14 @@ export class ExtensionDisableEvent implements BaseTelemetryEvent {
   }
 }
 
-export const EVENT_SMART_EDIT_STRATEGY = 'gemini_cli.smart_edit_strategy';
-export class SmartEditStrategyEvent implements BaseTelemetryEvent {
-  'event.name': 'smart_edit_strategy';
+export const EVENT_EDIT_STRATEGY = 'gemini_cli.edit_strategy';
+export class EditStrategyEvent implements BaseTelemetryEvent {
+  'event.name': 'edit_strategy';
   'event.timestamp': string;
   strategy: string;
 
   constructor(strategy: string) {
-    this['event.name'] = 'smart_edit_strategy';
+    this['event.name'] = 'edit_strategy';
     this['event.timestamp'] = new Date().toISOString();
     this.strategy = strategy;
   }
@@ -1603,25 +1605,25 @@ export class SmartEditStrategyEvent implements BaseTelemetryEvent {
   toOpenTelemetryAttributes(config: Config): LogAttributes {
     return {
       ...getCommonAttributes(config),
-      'event.name': EVENT_SMART_EDIT_STRATEGY,
+      'event.name': EVENT_EDIT_STRATEGY,
       'event.timestamp': this['event.timestamp'],
       strategy: this.strategy,
     };
   }
 
   toLogBody(): string {
-    return `Smart Edit Tool Strategy: ${this.strategy}`;
+    return `Edit Tool Strategy: ${this.strategy}`;
   }
 }
 
-export const EVENT_SMART_EDIT_CORRECTION = 'gemini_cli.smart_edit_correction';
-export class SmartEditCorrectionEvent implements BaseTelemetryEvent {
-  'event.name': 'smart_edit_correction';
+export const EVENT_EDIT_CORRECTION = 'gemini_cli.edit_correction';
+export class EditCorrectionEvent implements BaseTelemetryEvent {
+  'event.name': 'edit_correction';
   'event.timestamp': string;
   correction: 'success' | 'failure';
 
   constructor(correction: 'success' | 'failure') {
-    this['event.name'] = 'smart_edit_correction';
+    this['event.name'] = 'edit_correction';
     this['event.timestamp'] = new Date().toISOString();
     this.correction = correction;
   }
@@ -1629,14 +1631,14 @@ export class SmartEditCorrectionEvent implements BaseTelemetryEvent {
   toOpenTelemetryAttributes(config: Config): LogAttributes {
     return {
       ...getCommonAttributes(config),
-      'event.name': EVENT_SMART_EDIT_CORRECTION,
+      'event.name': EVENT_EDIT_CORRECTION,
       'event.timestamp': this['event.timestamp'],
       correction: this.correction,
     };
   }
 
   toLogBody(): string {
-    return `Smart Edit Tool Correction: ${this.correction}`;
+    return `Edit Tool Correction: ${this.correction}`;
   }
 }
 

--- a/packages/core/src/tools/confirmation-policy.test.ts
+++ b/packages/core/src/tools/confirmation-policy.test.ts
@@ -7,7 +7,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { SmartEditTool } from './smart-edit.js';
+import { EditTool } from './edit.js';
 import { WriteFileTool } from './write-file.js';
 import { WebFetchTool } from './web-fetch.js';
 import { ToolConfirmationOutcome } from './tools.js';
@@ -21,8 +21,8 @@ import os from 'node:os';
 
 // Mock telemetry loggers to avoid failures
 vi.mock('../telemetry/loggers.js', () => ({
-  logSmartEditStrategy: vi.fn(),
-  logSmartEditCorrectionEvent: vi.fn(),
+  logEditStrategy: vi.fn(),
+  logEditCorrectionEvent: vi.fn(),
   logFileOperation: vi.fn(),
 }));
 
@@ -81,9 +81,8 @@ describe('Tool Confirmation Policy Updates', () => {
 
   const tools = [
     {
-      name: 'SmartEditTool',
-      create: (config: Config, bus: MessageBus) =>
-        new SmartEditTool(config, bus),
+      name: 'EditTool',
+      create: (config: Config, bus: MessageBus) => new EditTool(config, bus),
       params: {
         file_path: 'test.txt',
         instruction: 'change content',

--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -43,11 +43,11 @@ import {
   type Mock,
 } from 'vitest';
 import {
-  SmartEditTool,
+  EditTool,
   type EditToolParams,
   applyReplacement,
   calculateReplacement,
-} from './smart-edit.js';
+} from './edit.js';
 import { type FileDiff, ToolConfirmationOutcome } from './tools.js';
 import { ToolErrorType } from './tool-error.js';
 import {
@@ -64,8 +64,8 @@ import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.j
 import { StandardFileSystemService } from '../services/fileSystemService.js';
 import type { BaseLlmClient } from '../core/baseLlmClient.js';
 
-describe('SmartEditTool', () => {
-  let tool: SmartEditTool;
+describe('EditTool', () => {
+  let tool: EditTool;
   let tempDir: string;
   let rootDir: string;
   let mockConfig: Config;
@@ -75,7 +75,7 @@ describe('SmartEditTool', () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smart-edit-tool-test-'));
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'edit-tool-test-'));
     rootDir = path.join(tempDir, 'root');
     fs.mkdirSync(rootDir);
 
@@ -172,7 +172,7 @@ describe('SmartEditTool', () => {
 
     const bus = createMockMessageBus();
     getMockMessageBusInstance(bus).defaultToolDecision = 'ask_user';
-    tool = new SmartEditTool(mockConfig, bus);
+    tool = new EditTool(mockConfig, bus);
   });
 
   afterEach(() => {
@@ -393,9 +393,7 @@ describe('SmartEditTool', () => {
 
       const invocation = tool.build(params);
       const abortController = new AbortController();
-      const abortError = new Error(
-        'Abort requested during smart edit execution',
-      );
+      const abortError = new Error('Abort requested during edit execution');
 
       const calculateSpy = vi
         .spyOn(invocation as any, 'calculateEdit')
@@ -755,9 +753,7 @@ describe('SmartEditTool', () => {
 
       const invocation = tool.build(params);
       const abortController = new AbortController();
-      const abortError = new Error(
-        'Abort requested during smart edit confirmation',
-      );
+      const abortError = new Error('Abort requested during edit confirmation');
 
       const calculateSpy = vi
         .spyOn(invocation as any, 'calculateEdit')

--- a/packages/core/src/tools/write-file.test.ts
+++ b/packages/core/src/tools/write-file.test.ts
@@ -23,7 +23,7 @@ import type {
   ToolResult,
 } from './tools.js';
 import { ToolConfirmationOutcome } from './tools.js';
-import { type EditToolParams } from './smart-edit.js';
+import { type EditToolParams } from './edit.js';
 import type { Config } from '../config/config.js';
 import { ApprovalMode } from '../policy/types.js';
 import type { ToolRegistry } from './tool-registry.js';

--- a/packages/core/src/utils/editCorrector.ts
+++ b/packages/core/src/utils/editCorrector.ts
@@ -7,7 +7,7 @@
 import type { Content } from '@google/genai';
 import type { GeminiClient } from '../core/client.js';
 import type { BaseLlmClient } from '../core/baseLlmClient.js';
-import type { EditToolParams } from '../tools/smart-edit.js';
+import type { EditToolParams } from '../tools/edit.js';
 import {
   EDIT_TOOL_NAME,
   GREP_TOOL_NAME,


### PR DESCRIPTION
## Summary

Renames `smart-edit` to `edit` throughout the repo. This includes: file names, symbols, and references.

## Details

This PR also renames telemetry names and events. We should ensure this is valid and okay before merging this PR.

## Related Issues

N/A

## How to Validate

Run preflight and use the CLI w/ a few edits being made.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
