### PR TITLE
fix: typo in MCP servers settings description

### DIFF
--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -165,7 +165,7 @@ The file has the following structure:
 - `version`: The version of the extension.
 - `mcpServers`: A map of MCP servers to settings. The key is the name of the
   server, and the value is the server configuration. These servers will be
-  loaded on startup just like MCP servers settingsd in a
+  loaded on startup just like MCP servers settings in a
   [`settings.json` file](../get-started/configuration.md). If both an extension
   and a `settings.json` file settings an MCP server with the same name, the
   server defined in the `settings.json` file takes precedence.


### PR DESCRIPTION
## Summary

This is a minor typo fix in the gemini extensions documentation. Urgency is low.

## Details

N/A minor typo fix.

## Related Issues:

None.

## How to Validate

N/A - doc change only.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

I don't think any of the below items apply.

- [ ] Updated relevant documentation and README (if needed) 
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
