### PR TITLE
refactor(mcp): remove connection logic from gemini mcp list

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -996,8 +996,8 @@ gemini mcp add --transport sse --header "Authorization: Bearer abc123" secure-ss
 ### Listing servers (`gemini mcp list`)
 
 To view all MCP servers currently configured, use the `list` command. It
-displays each server's name, configuration details, and connection status. This
-command has no flags.
+displays each server's name and configuration details. This command has no
+flags.
 
 **Command:**
 
@@ -1008,9 +1008,9 @@ gemini mcp list
 **Example output:**
 
 ```sh
-✓ stdio-server: command: python3 server.py (stdio) - Connected
-✓ http-server: https://api.example.com/mcp (http) - Connected
-✗ sse-server: https://api.example.com/sse (sse) - Disconnected
+stdio-server: command: python3 server.py (stdio)
+http-server: https://api.example.com/mcp (http)
+sse-server: https://api.example.com/sse (sse)
 ```
 
 ### Removing a server (`gemini mcp remove`)

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -8,21 +8,11 @@
 import type { CommandModule } from 'yargs';
 import { loadSettings } from '../../config/settings.js';
 import type { MCPServerConfig } from '@google/gemini-cli-core';
-import {
-  MCPServerStatus,
-  createTransport,
-  debugLogger,
-} from '@google/gemini-cli-core';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { debugLogger } from '@google/gemini-cli-core';
 import { ExtensionManager } from '../../config/extension-manager.js';
 import { requestConsentNonInteractive } from '../../config/extensions/consent.js';
 import { promptForSetting } from '../../config/extensions/extensionSettings.js';
 import { exitCli } from '../utils.js';
-
-const COLOR_GREEN = '\u001b[32m';
-const COLOR_YELLOW = '\u001b[33m';
-const COLOR_RED = '\u001b[31m';
-const RESET_COLOR = '\u001b[0m';
 
 async function getMcpServersFromConfig(): Promise<
   Record<string, MCPServerConfig>
@@ -50,60 +40,6 @@ async function getMcpServersFromConfig(): Promise<
   return mcpServers;
 }
 
-async function testMCPConnection(
-  serverName: string,
-  config: MCPServerConfig,
-): Promise<MCPServerStatus> {
-  const client = new Client({
-    name: 'mcp-test-client',
-    version: '0.0.1',
-  });
-
-  const settings = loadSettings();
-  const sanitizationConfig = {
-    enableEnvironmentVariableRedaction: true,
-    allowedEnvironmentVariables: [],
-    blockedEnvironmentVariables:
-      settings.merged.advanced?.excludedEnvVars || [],
-  };
-
-  let transport;
-  try {
-    // Use the same transport creation logic as core
-    transport = await createTransport(
-      serverName,
-      config,
-      false,
-      sanitizationConfig,
-    );
-  } catch (_error) {
-    await client.close();
-    return MCPServerStatus.DISCONNECTED;
-  }
-
-  try {
-    // Attempt actual MCP connection with short timeout
-    await client.connect(transport, { timeout: 5000 }); // 5s timeout
-
-    // Test basic MCP protocol by pinging the server
-    await client.ping();
-
-    await client.close();
-    return MCPServerStatus.CONNECTED;
-  } catch (_error) {
-    await transport.close();
-    return MCPServerStatus.DISCONNECTED;
-  }
-}
-
-async function getServerStatus(
-  serverName: string,
-  server: MCPServerConfig,
-): Promise<MCPServerStatus> {
-  // Test all server types by attempting actual connection
-  return testMCPConnection(serverName, server);
-}
-
 export async function listMcpServers(): Promise<void> {
   const mcpServers = await getMcpServersFromConfig();
   const serverNames = Object.keys(mcpServers);
@@ -118,26 +54,6 @@ export async function listMcpServers(): Promise<void> {
   for (const serverName of serverNames) {
     const server = mcpServers[serverName];
 
-    const status = await getServerStatus(serverName, server);
-
-    let statusIndicator = '';
-    let statusText = '';
-    switch (status) {
-      case MCPServerStatus.CONNECTED:
-        statusIndicator = COLOR_GREEN + '✓' + RESET_COLOR;
-        statusText = 'Connected';
-        break;
-      case MCPServerStatus.CONNECTING:
-        statusIndicator = COLOR_YELLOW + '…' + RESET_COLOR;
-        statusText = 'Connecting';
-        break;
-      case MCPServerStatus.DISCONNECTED:
-      default:
-        statusIndicator = COLOR_RED + '✗' + RESET_COLOR;
-        statusText = 'Disconnected';
-        break;
-    }
-
     let serverInfo =
       serverName +
       (server.extension?.name ? ` (from ${server.extension.name})` : '') +
@@ -150,7 +66,7 @@ export async function listMcpServers(): Promise<void> {
       serverInfo += `${server.command} ${server.args?.join(' ') || ''} (stdio)`;
     }
 
-    debugLogger.log(`${statusIndicator} ${serverInfo} - ${statusText}`);
+    debugLogger.log(`${serverInfo}`);
   }
 }
 


### PR DESCRIPTION
This PR decouples connection logic from the gemini mcp list command. Previously, the command attempted to initialize a connection with every configured MCP server to report its live status.

By moving to a purely configuration-based display, we ensure list remains a read-only command with no side effects. This change mitigates potential security risks where connecting to an untrusted or malicious MCP server during a simple listing operation could trigger unintended code execution or other side effects.