### PR TITLE
fix(core): set non-interactive environment variables for shell execution

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1458,6 +1458,8 @@ describe('ShellExecutionService environment variables', () => {
     const ptyEnv = mockPtySpawn.mock.calls[0][2].env;
     expect(ptyEnv).toHaveProperty('MY_TEST_VAR', 'test-value');
     expect(ptyEnv).toHaveProperty('GEMINI_CLI', '1');
+    expect(ptyEnv).toHaveProperty('CI', 'true');
+    expect(ptyEnv).toHaveProperty('DEBIAN_FRONTEND', 'noninteractive');
 
     // Ensure pty process exits
     mockPtyProcess.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
@@ -1477,6 +1479,8 @@ describe('ShellExecutionService environment variables', () => {
     const cpEnv = mockCpSpawn.mock.calls[0][2].env;
     expect(cpEnv).toHaveProperty('MY_TEST_VAR', 'test-value');
     expect(cpEnv).toHaveProperty('GEMINI_CLI', '1');
+    expect(cpEnv).toHaveProperty('CI', 'true');
+    expect(cpEnv).toHaveProperty('DEBIAN_FRONTEND', 'noninteractive');
 
     // Ensure child_process exits
     mockChildProcess.emit('exit', 0, null);

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -258,6 +258,8 @@ export class ShellExecutionService {
         env: {
           ...sanitizeEnvironment(process.env, sanitizationConfig),
           GEMINI_CLI: '1',
+          CI: 'true',
+          DEBIAN_FRONTEND: 'noninteractive',
           TERM: 'xterm-256color',
           PAGER: 'cat',
           GIT_PAGER: 'cat',
@@ -475,6 +477,8 @@ export class ShellExecutionService {
             shellExecutionConfig.sanitizationConfig,
           ),
           GEMINI_CLI: '1',
+          CI: 'true',
+          DEBIAN_FRONTEND: 'noninteractive',
           TERM: 'xterm-256color',
           PAGER: shellExecutionConfig.pager ?? 'cat',
           GIT_PAGER: shellExecutionConfig.pager ?? 'cat',


### PR DESCRIPTION
## Summary

Sets `CI=true` and `DEBIAN_FRONTEND=noninteractive` for all shell executions managed by the CLI. This prevents executed commands from hanging on interactive prompts and ensures consistent non-interactive behavior, which is critical for automated tasks and headless environments.

## Details

Modified `ShellExecutionService` in `packages/core` to inject these variables into the environment for both PTY-based and standard `child_process` executions. This standardizes the environment for subprocesses, making them "aware" they are running in a non-interactive or CI-like context managed by Gemini.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

1. **Unit Tests**: Run the updated tests to confirm the environment variables are being set.
   ```bash
   npm run test packages/core/src/services/shellExecutionService.test.ts
   ```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
