### PR TITLE
[Skills] Multi-scope skill enablement and shadowing fix

### DIFF
--- a/packages/cli/src/commands/skills/enable.ts
+++ b/packages/cli/src/commands/skills/enable.ts
@@ -5,11 +5,7 @@
  */
 
 import type { CommandModule } from 'yargs';
-import {
-  loadSettings,
-  SettingScope,
-  type LoadableSettingScope,
-} from '../../config/settings.js';
+import { loadSettings } from '../../config/settings.js';
 import { debugLogger } from '@google/gemini-cli-core';
 import { exitCli } from '../utils.js';
 import { enableSkill } from '../../utils/skillSettings.js';
@@ -17,15 +13,14 @@ import { renderSkillActionFeedback } from '../../utils/skillUtils.js';
 
 interface EnableArgs {
   name: string;
-  scope: LoadableSettingScope;
 }
 
 export async function handleEnable(args: EnableArgs) {
-  const { name, scope } = args;
+  const { name } = args;
   const workspaceDir = process.cwd();
   const settings = loadSettings(workspaceDir);
 
-  const result = enableSkill(settings, name, scope);
+  const result = enableSkill(settings, name);
   debugLogger.log(renderSkillActionFeedback(result, (label, _path) => label));
 }
 
@@ -33,25 +28,14 @@ export const enableCommand: CommandModule = {
   command: 'enable <name>',
   describe: 'Enables an agent skill.',
   builder: (yargs) =>
-    yargs
-      .positional('name', {
-        describe: 'The name of the skill to enable.',
-        type: 'string',
-        demandOption: true,
-      })
-      .option('scope', {
-        alias: 's',
-        describe: 'The scope to enable the skill in (user or project).',
-        type: 'string',
-        default: 'user',
-        choices: ['user', 'project'],
-      }),
+    yargs.positional('name', {
+      describe: 'The name of the skill to enable.',
+      type: 'string',
+      demandOption: true,
+    }),
   handler: async (argv) => {
-    const scope: LoadableSettingScope =
-      argv['scope'] === 'project' ? SettingScope.Workspace : SettingScope.User;
     await handleEnable({
       name: argv['name'] as string,
-      scope,
     });
     await exitCli();
   },

--- a/packages/cli/src/ui/commands/skillsCommand.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.ts
@@ -127,11 +127,7 @@ async function enableAction(
     return;
   }
 
-  const scope = context.services.settings.workspace.path
-    ? SettingScope.Workspace
-    : SettingScope.User;
-
-  const result = enableSkill(context.services.settings, skillName, scope);
+  const result = enableSkill(context.services.settings, skillName);
 
   let feedback = renderSkillActionFeedback(
     result,


### PR DESCRIPTION
## Summary

Fixes a bug where re-enabling a skill via `/skills enable` failed if it was disabled at a higher settings scope (e.g., User level).

## Details

- Updated `enableSkill` business logic to iterate through and clear the skill name from all writable disabled lists (both User and Workspace scopes).
- Removed the now-redundant `scope` option from the `gemini skills enable` CLI command.
- Updated the interactive `enableAction` (`/skills enable\b`) to utilize the new multi-scope enablement logic.
- Refactored `enable.test.ts` and `disable.test.ts` to use `debugLogger.log` consistently for easier debugging.
- Added comprehensive unit tests to verify that skills are correctly enabled across multiple scopes, resolving the shadowing issue.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/15910

## How to Validate

- Run the new multi-scope unit tests: `npx vitest packages/cli/src/ui/commands/skillsCommand.test.ts packages/cli/src/commands/skills/enable.test.ts`
- Manual validation:
    1. Disable a skill at the user level: `gemini skills disable <name> --scope user`
    2. Disable the same skill at the project level: `gemini skills disable <name> --scope project`
    3. Enable the skill: `gemini skills enable <name>`
    4. Verify the skill is no longer present in the `skills.disabled` list of both your User and Project `settings.json` files.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run