### PR TITLE
[Skills] UX Polishing: Transparent feedback and CLI refinements

### DIFF
--- a/packages/cli/src/commands/skills/disable.test.ts
+++ b/packages/cli/src/commands/skills/disable.test.ts
@@ -60,6 +60,7 @@ describe('skills disable command', () => {
       const mockSettings = {
         forScope: vi.fn().mockReturnValue({
           settings: { skills: { disabled: [] } },
+          path: '/user/settings.json',
         }),
         setValue: vi.fn(),
       };
@@ -79,7 +80,7 @@ describe('skills disable command', () => {
       );
       expect(emitConsoleLog).toHaveBeenCalledWith(
         'log',
-        'Skill "skill1" disabled by adding it to the disabled list in user settings.',
+        'Skill "skill1" disabled by adding it to the disabled list in user (/user/settings.json) settings. Restart required to take effect.',
       );
     });
 

--- a/packages/cli/src/commands/skills/enable.test.ts
+++ b/packages/cli/src/commands/skills/enable.test.ts
@@ -81,7 +81,7 @@ describe('skills enable command', () => {
       );
       expect(emitConsoleLog).toHaveBeenCalledWith(
         'log',
-        'Skill "skill1" enabled by removing it from the disabled list in user and project settings.',
+        'Skill "skill1" enabled by removing it from the disabled list in user (/user/settings.json) and project (/project/settings.json) settings. Restart required to take effect.',
       );
     });
 
@@ -122,7 +122,7 @@ describe('skills enable command', () => {
       );
       expect(emitConsoleLog).toHaveBeenCalledWith(
         'log',
-        'Skill "skill1" enabled by removing it from the disabled list in project and user settings.',
+        'Skill "skill1" enabled by removing it from the disabled list in project (/workspace/settings.json) and user (/user/settings.json) settings. Restart required to take effect.',
       );
     });
 

--- a/packages/cli/src/commands/skills/enable.ts
+++ b/packages/cli/src/commands/skills/enable.ts
@@ -10,6 +10,7 @@ import { debugLogger } from '@google/gemini-cli-core';
 import { exitCli } from '../utils.js';
 import { enableSkill } from '../../utils/skillSettings.js';
 import { renderSkillActionFeedback } from '../../utils/skillUtils.js';
+import chalk from 'chalk';
 
 interface EnableArgs {
   name: string;
@@ -21,7 +22,14 @@ export async function handleEnable(args: EnableArgs) {
   const settings = loadSettings(workspaceDir);
 
   const result = enableSkill(settings, name);
-  debugLogger.log(renderSkillActionFeedback(result, (label, _path) => label));
+  let feedback = renderSkillActionFeedback(
+    result,
+    (label, path) => `${chalk.bold(label)} (${chalk.dim(path)})`,
+  );
+  if (result.status === 'success') {
+    feedback += ' Restart required to take effect.';
+  }
+  debugLogger.log(feedback);
 }
 
 export const enableCommand: CommandModule = {

--- a/packages/cli/src/ui/commands/skillsCommand.test.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.test.ts
@@ -182,7 +182,7 @@ describe('skillsCommand', () => {
       expect(context.ui.addItem).toHaveBeenCalledWith(
         expect.objectContaining({
           type: MessageType.INFO,
-          text: 'Skill "skill1" disabled by adding it to the disabled list in project settings. Use "/skills reload" for it to take effect.',
+          text: 'Skill "skill1" disabled by adding it to the disabled list in project (/workspace) settings. Use "/skills reload" for it to take effect.',
         }),
         expect.any(Number),
       );
@@ -211,7 +211,7 @@ describe('skillsCommand', () => {
       expect(context.ui.addItem).toHaveBeenCalledWith(
         expect.objectContaining({
           type: MessageType.INFO,
-          text: 'Skill "skill1" enabled by removing it from the disabled list in project and user settings. Use "/skills reload" for it to take effect.',
+          text: 'Skill "skill1" enabled by removing it from the disabled list in project (/workspace) and user (/user/settings.json) settings. Use "/skills reload" for it to take effect.',
         }),
         expect.any(Number),
       );
@@ -251,7 +251,7 @@ describe('skillsCommand', () => {
       expect(context.ui.addItem).toHaveBeenCalledWith(
         expect.objectContaining({
           type: MessageType.INFO,
-          text: 'Skill "skill1" enabled by removing it from the disabled list in project and user settings. Use "/skills reload" for it to take effect.',
+          text: 'Skill "skill1" enabled by removing it from the disabled list in project (/workspace) and user (/user/settings.json) settings. Use "/skills reload" for it to take effect.',
         }),
         expect.any(Number),
       );

--- a/packages/cli/src/ui/commands/skillsCommand.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.ts
@@ -96,7 +96,7 @@ async function disableAction(
 
   let feedback = renderSkillActionFeedback(
     result,
-    (label, _path) => `${label}`,
+    (label, path) => `${label} (${path})`,
   );
   if (result.status === 'success') {
     feedback += ' Use "/skills reload" for it to take effect.';
@@ -131,7 +131,7 @@ async function enableAction(
 
   let feedback = renderSkillActionFeedback(
     result,
-    (label, _path) => `${label}`,
+    (label, path) => `${label} (${path})`,
   );
   if (result.status === 'success') {
     feedback += ' Use "/skills reload" for it to take effect.';


### PR DESCRIPTION
## Summary

Polishes the skill management user experience by providing transparent feedback and refining the CLI command defaults.

## Details

- Changed the default scope for the `gemini skills disable` CLI command from `user` to `project` (Workspace) to align with common project-specific needs.
- Updated all feedback messages to explicitly include the file paths of the modified `settings.json` files.
- Implemented caller-managed guidance messages to decouple business logic from the UI:
    - Interactive UI (`/skills`): Recommends using `/skills reload`.
    - Non-interactive CLI (`gemini skills`): Recommends a restart.
- Updated unit tests to verify the new descriptive feedback format and file path reporting.

## Related Issues

Part of https://github.com/google-gemini/gemini-cli/issues/15327

## How to Validate

- Run the unit tests: `npx vitest packages/cli/src/ui/commands/skillsCommand.test.ts packages/cli/src/commands/skills/enable.test.ts packages/cli/src/commands/skills/disable.test.ts`
- Manual validation:
    - Run `gemini skills disable <name>` and verify it defaults to the project scope and shows the file path.
    - Run `/skills enable <name>` in the interactive UI and verify it mentions all affected scopes with paths and recommends a reload.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) - Changed default disable scope.
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run