### PR TITLE
remove manual string when displaying manual model in the footer

### DIFF
--- a/packages/cli/src/ui/components/__snapshots__/Footer.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/Footer.test.tsx.snap
@@ -1,8 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`<Footer /> > footer configuration filtering (golden snapshots) > renders complete footer in narrow terminal (baseline narrow) > complete-footer-narrow 1`] = `" ...s/to/make/it/long      no sandbox       Manual (gemini-pro) /model (100%)"`;
+exports[`<Footer /> > footer configuration filtering (golden snapshots) > renders complete footer in narrow terminal (baseline narrow) > complete-footer-narrow 1`] = `" ...s/to/make/it/long           no sandbox           gemini-pro /model (100%)"`;
 
-exports[`<Footer /> > footer configuration filtering (golden snapshots) > renders complete footer with all sections visible (baseline) > complete-footer-wide 1`] = `" ...irectories/to/make/it/long          no sandbox (see /docs)          Manual (gemini-pro) /model (100% context left)"`;
+exports[`<Footer /> > footer configuration filtering (golden snapshots) > renders complete footer with all sections visible (baseline) > complete-footer-wide 1`] = `" ...irectories/to/make/it/long              no sandbox (see /docs)               gemini-pro /model (100% context left)"`;
 
 exports[`<Footer /> > footer configuration filtering (golden snapshots) > renders footer with CWD and model info hidden to test alignment (only sandbox visible) > footer-only-sandbox 1`] = `"                                                no sandbox (see /docs)"`;
 

--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -9,6 +9,7 @@ import {
   resolveModel,
   resolveClassifierModel,
   isGemini2Model,
+  getDisplayString,
   DEFAULT_GEMINI_MODEL,
   PREVIEW_GEMINI_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
@@ -21,6 +22,43 @@ import {
   PREVIEW_GEMINI_MODEL_AUTO,
   DEFAULT_GEMINI_MODEL_AUTO,
 } from './models.js';
+
+describe('getDisplayString', () => {
+  it('should return Auto (Gemini 3) for preview auto model', () => {
+    expect(getDisplayString(PREVIEW_GEMINI_MODEL_AUTO)).toBe('Auto (Gemini 3)');
+  });
+
+  it('should return Auto (Gemini 2.5) for default auto model', () => {
+    expect(getDisplayString(DEFAULT_GEMINI_MODEL_AUTO)).toBe(
+      'Auto (Gemini 2.5)',
+    );
+  });
+
+  it('should return concrete model name for pro alias', () => {
+    expect(getDisplayString(GEMINI_MODEL_ALIAS_PRO, false)).toBe(
+      DEFAULT_GEMINI_MODEL,
+    );
+    expect(getDisplayString(GEMINI_MODEL_ALIAS_PRO, true)).toBe(
+      PREVIEW_GEMINI_MODEL,
+    );
+  });
+
+  it('should return concrete model name for flash alias', () => {
+    expect(getDisplayString(GEMINI_MODEL_ALIAS_FLASH, false)).toBe(
+      DEFAULT_GEMINI_FLASH_MODEL,
+    );
+    expect(getDisplayString(GEMINI_MODEL_ALIAS_FLASH, true)).toBe(
+      PREVIEW_GEMINI_FLASH_MODEL,
+    );
+  });
+
+  it('should return the model name as is for other models', () => {
+    expect(getDisplayString('custom-model')).toBe('custom-model');
+    expect(getDisplayString(DEFAULT_GEMINI_FLASH_LITE_MODEL)).toBe(
+      DEFAULT_GEMINI_FLASH_LITE_MODEL,
+    );
+  });
+});
 
 describe('supportsMultimodalFunctionResponse', () => {
   it('should return true for gemini-3 model', () => {

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -110,17 +110,15 @@ export function getDisplayString(
     case DEFAULT_GEMINI_MODEL_AUTO:
       return 'Auto (Gemini 2.5)';
     case GEMINI_MODEL_ALIAS_PRO:
-      return `Manual (${
-        previewFeaturesEnabled ? PREVIEW_GEMINI_MODEL : DEFAULT_GEMINI_MODEL
-      })`;
+      return previewFeaturesEnabled
+        ? PREVIEW_GEMINI_MODEL
+        : DEFAULT_GEMINI_MODEL;
     case GEMINI_MODEL_ALIAS_FLASH:
-      return `Manual (${
-        previewFeaturesEnabled
-          ? PREVIEW_GEMINI_FLASH_MODEL
-          : DEFAULT_GEMINI_FLASH_MODEL
-      })`;
+      return previewFeaturesEnabled
+        ? PREVIEW_GEMINI_FLASH_MODEL
+        : DEFAULT_GEMINI_FLASH_MODEL;
     default:
-      return `Manual (${model})`;
+      return model;
   }
 }
 


### PR DESCRIPTION
## Summary
Remove "manual" when displaying manual model in the footer.
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details
Simply display the manual model name. Having Manual in front of the model name is redundant.
<!-- Add any extra context and design decisions. Keep it brief but complete. -->
Before:
<img width="289" height="72" alt="image" src="https://github.com/user-attachments/assets/4db9f642-d720-4463-8e77-c5cf5fd2d355" />
After:
<img width="223" height="70" alt="image" src="https://github.com/user-attachments/assets/a7c8c185-73dc-43b9-aa52-1a08745ca997" />

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
