### PR TITLE
feat(policy): allow 'modes' in user and admin policies

### DIFF
--- a/packages/core/src/policy/toml-loader.test.ts
+++ b/packages/core/src/policy/toml-loader.test.ts
@@ -172,7 +172,7 @@ allow_redirection = true
       expect(result.errors).toHaveLength(0);
     });
 
-    it('should return error if modes property is used for Tier 2 and Tier 3 policies', async () => {
+    it('should support modes property for Tier 2 and Tier 3 policies', async () => {
       await fs.writeFile(
         path.join(tempDir, 'tier2.toml'),
         `
@@ -187,13 +187,10 @@ modes = ["autoEdit"]
       const getPolicyTier = (_dir: string) => 2; // Tier 2
       const result = await loadPoliciesFromToml([tempDir], getPolicyTier);
 
-      // It still transforms the rule, but it should also report an error
       expect(result.rules).toHaveLength(1);
       expect(result.rules[0].toolName).toBe('tier2-tool');
-      expect(result.rules[0].modes).toBeUndefined(); // Should be restricted
-      expect(result.errors).toHaveLength(1);
-      expect(result.errors[0].errorType).toBe('rule_validation');
-      expect(result.errors[0].message).toContain('Restricted property "modes"');
+      expect(result.rules[0].modes).toEqual(['autoEdit']);
+      expect(result.errors).toHaveLength(0);
     });
 
     it('should handle TOML parse errors', async () => {

--- a/packages/core/src/policy/toml-loader.ts
+++ b/packages/core/src/policy/toml-loader.ts
@@ -293,7 +293,6 @@ export async function loadPoliciesFromToml(
 
         // Validate shell command convenience syntax
         const tomlRules = validationResult.data.rule ?? [];
-        const tomlCheckers = validationResult.data.safety_checker ?? [];
 
         for (let i = 0; i < tomlRules.length; i++) {
           const rule = tomlRules[i];
@@ -309,36 +308,6 @@ export async function loadPoliciesFromToml(
               details: validationError,
             });
             // Continue to next rule, don't skip the entire file
-          }
-
-          if (tier > 1 && rule.modes && rule.modes.length > 0) {
-            errors.push({
-              filePath,
-              fileName: file,
-              tier: tierName,
-              ruleIndex: i,
-              errorType: 'rule_validation',
-              message: 'Restricted property "modes"',
-              details: `Rule #${i + 1}: The "modes" property is currently reserved for Tier 1 (system) policies and cannot be used in ${tierName} policies.`,
-              suggestion: 'Remove the "modes" property from this rule.',
-            });
-          }
-        }
-
-        for (let i = 0; i < tomlCheckers.length; i++) {
-          const checker = tomlCheckers[i];
-          if (tier > 1 && checker.modes && checker.modes.length > 0) {
-            errors.push({
-              filePath,
-              fileName: file,
-              tier: tierName,
-              ruleIndex: i,
-              errorType: 'rule_validation',
-              message: 'Restricted property "modes" in safety checker',
-              details: `Safety Checker #${i + 1}: The "modes" property is currently reserved for Tier 1 (system) policies and cannot be used in ${tierName} policies.`,
-              suggestion:
-                'Remove the "modes" property from this safety checker.',
-            });
           }
         }
 
@@ -375,7 +344,7 @@ export async function loadPoliciesFromToml(
                   toolName: effectiveToolName,
                   decision: rule.decision,
                   priority: transformPriority(rule.priority, tier),
-                  modes: tier === 1 ? rule.modes : undefined,
+                  modes: rule.modes,
                   allowRedirection: rule.allow_redirection,
                 };
 
@@ -440,7 +409,7 @@ export async function loadPoliciesFromToml(
                   toolName: effectiveToolName,
                   priority: checker.priority,
                   checker: checker.checker as SafetyCheckerConfig,
-                  modes: tier === 1 ? checker.modes : undefined,
+                  modes: checker.modes,
                 };
 
                 if (argsPattern) {


### PR DESCRIPTION
## Summary

Lifts the restriction on using the `modes` property in non-system (Tier 2/3) policy files. This aligns the implementation with the documentation and allows users to define rules that only apply in specific CLI modes like `autoEdit` or `yolo`.

## Details

Previously, the `toml-loader.ts` explicitly threw a `rule_validation` error if `modes` was used in any policy directory other than the core system directory. This PR removes that restriction and ensures the `modes` property is preserved during rule transformation for all tiers.

- Removed `tier > 1` check for `modes` in `toml-loader.ts`.
- Updated `PolicyRule` and `SafetyCheckerRule` transformation logic to preserve `modes` for all tiers.
- Updated `toml-loader.test.ts` to verify support for `modes` in Tier 2.

## Related Issues

None.

## How to Validate

1. Run `npx vitest packages/core/src/policy/toml-loader.test.ts` to ensure tests pass.
2. Create a local policy file with a rule containing `modes = ["autoEdit"]`.
3. Verify that the rule is only active when the CLI is in `autoEdit` mode.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run