### PR TITLE
Add upgrade option for paid users

### DIFF
--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -62,7 +62,6 @@ export const DialogManager = ({
         isTerminalQuotaError={uiState.proQuotaRequest.isTerminalQuotaError}
         isModelNotFoundError={!!uiState.proQuotaRequest.isModelNotFoundError}
         onChoice={uiActions.handleProQuotaChoice}
-        userTier={uiState.userTier}
       />
     );
   }

--- a/packages/cli/src/ui/components/ProQuotaDialog.test.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.test.tsx
@@ -12,11 +12,10 @@ import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
 
 import {
   PREVIEW_GEMINI_MODEL,
-  UserTierId,
   DEFAULT_GEMINI_FLASH_MODEL,
 } from '@google/gemini-cli-core';
 
-// Mock the child component to make it easier to test the parent
+ƒ// Mock the child component to make it easier to test the parent
 vi.mock('./shared/RadioButtonSelect.js', () => ({
   RadioButtonSelect: vi.fn(),
 }));
@@ -37,7 +36,6 @@ describe('ProQuotaDialog', () => {
           message="flash error"
           isTerminalQuotaError={true} // should not matter
           onChoice={mockOnChoice}
-          userTier={UserTierId.FREE}
         />,
       );
 
@@ -73,7 +71,6 @@ describe('ProQuotaDialog', () => {
             isTerminalQuotaError={true}
             isModelNotFoundError={false}
             onChoice={mockOnChoice}
-            userTier={UserTierId.LEGACY}
           />,
         );
 
@@ -110,7 +107,6 @@ describe('ProQuotaDialog', () => {
             message="flash error"
             isTerminalQuotaError={true}
             onChoice={mockOnChoice}
-            userTier={UserTierId.FREE}
           />,
         );
 
@@ -143,7 +139,6 @@ describe('ProQuotaDialog', () => {
             isTerminalQuotaError={true}
             isModelNotFoundError={false}
             onChoice={mockOnChoice}
-            userTier={UserTierId.FREE}
           />,
         );
 
@@ -183,7 +178,6 @@ describe('ProQuotaDialog', () => {
             isTerminalQuotaError={false}
             isModelNotFoundError={false}
             onChoice={mockOnChoice}
-            userTier={UserTierId.FREE}
           />,
         );
 
@@ -214,7 +208,6 @@ describe('ProQuotaDialog', () => {
             isTerminalQuotaError={false}
             isModelNotFoundError={true}
             onChoice={mockOnChoice}
-            userTier={UserTierId.FREE}
           />,
         );
 
@@ -247,7 +240,6 @@ describe('ProQuotaDialog', () => {
             isTerminalQuotaError={false}
             isModelNotFoundError={true}
             onChoice={mockOnChoice}
-            userTier={UserTierId.LEGACY}
           />,
         );
 
@@ -282,7 +274,6 @@ describe('ProQuotaDialog', () => {
           message=""
           isTerminalQuotaError={false}
           onChoice={mockOnChoice}
-          userTier={UserTierId.FREE}
         />,
       );
 

--- a/packages/cli/src/ui/components/ProQuotaDialog.test.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.test.tsx
@@ -15,7 +15,7 @@ import {
   DEFAULT_GEMINI_FLASH_MODEL,
 } from '@google/gemini-cli-core';
 
-ƒ// Mock the child component to make it easier to test the parent
+// Mock the child component to make it easier to test the parent
 vi.mock('./shared/RadioButtonSelect.js', () => ({
   RadioButtonSelect: vi.fn(),
 }));
@@ -220,6 +220,11 @@ describe('ProQuotaDialog', () => {
                 key: 'retry_always',
               },
               {
+                label: 'Upgrade for higher limits',
+                value: 'upgrade',
+                key: 'upgrade',
+              },
+              {
                 label: 'Stop',
                 value: 'retry_later',
                 key: 'retry_later',
@@ -250,6 +255,11 @@ describe('ProQuotaDialog', () => {
                 label: 'Switch to gemini-2.5-pro',
                 value: 'retry_always',
                 key: 'retry_always',
+              },
+              {
+                label: 'Upgrade for higher limits',
+                value: 'upgrade',
+                key: 'upgrade',
               },
               {
                 label: 'Stop',

--- a/packages/cli/src/ui/components/ProQuotaDialog.test.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.test.tsx
@@ -86,6 +86,11 @@ describe('ProQuotaDialog', () => {
                 key: 'retry_always',
               },
               {
+                label: 'Upgrade for higher limits',
+                value: 'upgrade',
+                key: 'upgrade',
+              },
+              {
                 label: 'Stop',
                 value: 'retry_later',
                 key: 'retry_later',

--- a/packages/cli/src/ui/components/ProQuotaDialog.test.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.test.tsx
@@ -64,7 +64,7 @@ describe('ProQuotaDialog', () => {
 
   describe('for non-flash model failures', () => {
     describe('when it is a terminal quota error', () => {
-      it('should render switch and stop options for paid tiers', () => {
+      it('should render switch, upgrade, and stop options for paid tiers', () => {
         const { unmount } = render(
           <ProQuotaDialog
             failedModel="gemini-2.5-pro"

--- a/packages/cli/src/ui/components/ProQuotaDialog.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.tsx
@@ -32,9 +32,6 @@ export function ProQuotaDialog({
   onChoice,
   userTier,
 }: ProQuotaDialogProps): React.JSX.Element {
-  // Use actual user tier if available; otherwise, default to FREE tier behavior (safe default)
-  const isPaidTier =
-    userTier === UserTierId.LEGACY || userTier === UserTierId.STANDARD;
   let items;
   // Do not provide a fallback option if failed model and fallbackmodel are same.
   if (failedModel === fallbackModel) {

--- a/packages/cli/src/ui/components/ProQuotaDialog.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.tsx
@@ -9,8 +9,6 @@ import { Box, Text } from 'ink';
 import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
 import { theme } from '../semantic-colors.js';
 
-import { UserTierId } from '@google/gemini-cli-core';
-
 interface ProQuotaDialogProps {
   failedModel: string;
   fallbackModel: string;
@@ -20,7 +18,6 @@ interface ProQuotaDialogProps {
   onChoice: (
     choice: 'retry_later' | 'retry_once' | 'retry_always' | 'upgrade',
   ) => void;
-  userTier: UserTierId | undefined;
 }
 
 export function ProQuotaDialog({

--- a/packages/cli/src/ui/components/ProQuotaDialog.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.tsx
@@ -30,7 +30,6 @@ export function ProQuotaDialog({
   isTerminalQuotaError,
   isModelNotFoundError,
   onChoice,
-  userTier,
 }: ProQuotaDialogProps): React.JSX.Element {
   let items;
   // Do not provide a fallback option if failed model and fallbackmodel are same.

--- a/packages/cli/src/ui/components/ProQuotaDialog.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.tsx
@@ -50,22 +50,8 @@ export function ProQuotaDialog({
         key: 'retry_later',
       },
     ];
-  } else if (isModelNotFoundError || (isTerminalQuotaError && isPaidTier)) {
-    // out of quota
-    items = [
-      {
-        label: `Switch to ${fallbackModel}`,
-        value: 'retry_always' as const,
-        key: 'retry_always',
-      },
-      {
-        label: `Stop`,
-        value: 'retry_later' as const,
-        key: 'retry_later',
-      },
-    ];
-  } else if (isTerminalQuotaError && !isPaidTier) {
-    // free user gets an option to upgrade
+  } else if (isModelNotFoundError || isTerminalQuotaError) {
+    // free users and out of quota users on G1 pro and Cloud Console gets an option to upgrade
     items = [
       {
         label: `Switch to ${fallbackModel}`,


### PR DESCRIPTION
## Summary

Paid users on Google One AI Pro, Cloud Console and others can upgrade when they run out of quota. 

## Details

For those users who are already on the maximum paid tiers they will see a page showing that they are already on the highest tier eg. Google One AI Ultra. 

For Googlers: Feel free to reach out to me internally with any questions. 

## How to Validate

1. Run out of quota on Google One AI Pro
2. See option to upgrade
3. Upgrade option prompts you to upgrade to Google One AI Ultra 

I have tested the upgrade URL and observed this is the result in prod.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
