### PR TITLE
feat(cli): add Ghostty support to /terminal-setup

### DIFF
--- a/packages/cli/src/ui/commands/terminalSetupCommand.ts
+++ b/packages/cli/src/ui/commands/terminalSetupCommand.ts
@@ -10,15 +10,16 @@ import { terminalSetup } from '../utils/terminalSetup.js';
 import { type MessageActionReturn } from '@google/gemini-cli-core';
 
 /**
- * Command to configure terminal keybindings for multiline input support.
+ * Command to configure terminal settings for an optimal experience.
  *
- * This command automatically detects and configures VS Code, Cursor, and Windsurf
- * to support Shift+Enter and Ctrl+Enter for multiline input.
+ * This command automatically detects and configures supported terminals
+ * (VS Code, Cursor, Windsurf, Ghostty) to support features like multiline
+ * input (newlines) and improved keyboard input mechanics.
  */
 export const terminalSetupCommand: SlashCommand = {
   name: 'terminal-setup',
   description:
-    'Configure terminal keybindings for multiline input (VS Code, Cursor, Windsurf)',
+    'Configure terminal settings for newlines and improved input mechanics (VS Code, Cursor, Windsurf, Ghostty)',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
   action: async (): Promise<MessageActionReturn> => {


### PR DESCRIPTION
This PR adds Ghostty to the list of terminals supported by the `/terminal-setup` command. 

### Key Changes:
- **Ghostty Detection**: Automatically detects if the CLI is running inside Ghostty via environment variables or parent process name.
- **Auto-Configuration**: Adds `macos-option-as-alt = true` to the Ghostty configuration file if not already present. This ensures that Meta-key combinations like `Alt+Backspace` (word deletion) work correctly.
- **Updated UI**: Refined the description of `/terminal-setup` to reflect that it optimizes for both multiline input and improved keyboard mechanics across all supported terminals (VS Code, Cursor, Windsurf, and Ghostty).
- **Informed Feedback**: Updated the success message for Ghostty to explain exactly why the change was made.

### Verification:
- Manual testing in Ghostty on macOS.
- New unit tests for detection and configuration logic in `terminalSetup.test.ts`.

<img width="1748" height="524" alt="image" src="https://github.com/user-attachments/assets/0105668c-41a0-4633-8716-e99a0c2b8c59" />
