### PR TITLE
fix: image token estimation

### DIFF
--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -60,6 +60,7 @@ import {
   applyModelSelection,
   createAvailabilityContextProvider,
 } from '../availability/policyHelpers.js';
+import { resolveModel } from '../config/models.js';
 import type { RetryAvailabilityContext } from '../utils/retry.js';
 
 const MAX_TURNS = 100;
@@ -508,7 +509,9 @@ export class GeminiClient {
 
     // Availability logic: The configured model is the source of truth,
     // including any permanent fallbacks (config.setModel) or manual overrides.
-    return this.config.getActiveModel();
+    // Resolve auto model names (e.g., "auto-gemini-3") to concrete model names
+    // (e.g., "gemini-3-pro-preview") so that API calls like countTokens work correctly.
+    return resolveModel(this.config.getActiveModel());
   }
 
   private async *processTurn(

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -509,8 +509,6 @@ export class GeminiClient {
 
     // Availability logic: The configured model is the source of truth,
     // including any permanent fallbacks (config.setModel) or manual overrides.
-    // Resolve auto model names (e.g., "auto-gemini-3") to concrete model names
-    // (e.g., "gemini-3-pro-preview") so that API calls like countTokens work correctly.
     return resolveModel(this.config.getActiveModel());
   }
 

--- a/packages/core/src/utils/tokenCalculation.test.ts
+++ b/packages/core/src/utils/tokenCalculation.test.ts
@@ -123,8 +123,26 @@ describe('calculateRequestTokenCount', () => {
 
     // Should fallback to estimation:
     // 'Hello': 5 chars * 0.25 = 1.25
-    // inlineData: JSON.stringify length / 4
-    expect(count).toBeGreaterThan(0);
+    // inlineData: 3000
+    // Total: 3001.25 -> 3001
+    expect(count).toBe(3001);
     expect(mockContentGenerator.countTokens).toHaveBeenCalled();
+  });
+
+  it('should use fixed estimate for images in fallback', async () => {
+    vi.mocked(mockContentGenerator.countTokens).mockRejectedValue(
+      new Error('API error'),
+    );
+    const request = [
+      { inlineData: { mimeType: 'image/png', data: 'large_data' } },
+    ];
+
+    const count = await calculateRequestTokenCount(
+      request,
+      mockContentGenerator,
+      model,
+    );
+
+    expect(count).toBe(3000);
   });
 });

--- a/packages/core/src/utils/tokenCalculation.ts
+++ b/packages/core/src/utils/tokenCalculation.ts
@@ -6,6 +6,7 @@
 
 import type { PartListUnion, Part } from '@google/genai';
 import type { ContentGenerator } from '../core/contentGenerator.js';
+import { debugLogger } from './debugLogger.js';
 
 // Token estimation constants
 // ASCII characters (0-127) are roughly 4 chars per token
@@ -13,6 +14,8 @@ const ASCII_TOKENS_PER_CHAR = 0.25;
 // Non-ASCII characters (including CJK) are often 1-2 tokens per char.
 // We use 1.3 as a conservative estimate to avoid underestimation.
 const NON_ASCII_TOKENS_PER_CHAR = 1.3;
+// Fixed token estimate for images
+const IMAGE_TOKEN_ESTIMATE = 3000;
 
 /**
  * Estimates token count for parts synchronously using a heuristic.
@@ -39,7 +42,7 @@ export function estimateTokenCountSync(parts: Part[]): number {
       const mimeType = inlineData?.mimeType || fileData?.mimeType;
 
       if (mimeType?.startsWith('image/')) {
-        totalTokens += 3000;
+        totalTokens += IMAGE_TOKEN_ESTIMATE;
       } else {
         // For other non-text parts (functionCall, functionResponse, etc.),
         // we fallback to the JSON string length heuristic.
@@ -80,8 +83,9 @@ export async function calculateRequestTokenCount(
         contents: [{ role: 'user', parts }],
       });
       return response.totalTokens ?? 0;
-    } catch {
+    } catch (error) {
       // Fallback to local estimation if the API call fails
+      debugLogger.debug('countTokens API failed:', error);
       return estimateTokenCountSync(parts);
     }
   }

--- a/packages/core/src/utils/tokenCalculation.ts
+++ b/packages/core/src/utils/tokenCalculation.ts
@@ -31,15 +31,14 @@ export function estimateTokenCountSync(parts: Part[]): number {
         }
       }
     } else {
-      // For images we use a safe fallback
+      // For images, we use a fixed safe estimate (3,000 tokens) covering
+      // up to 4K resolution on Gemini 3.
+      // See: https://ai.google.dev/gemini-api/docs/vision#token_counting
       const inlineData = 'inlineData' in part ? part.inlineData : undefined;
       const fileData = 'fileData' in part ? part.fileData : undefined;
       const mimeType = inlineData?.mimeType || fileData?.mimeType;
 
       if (mimeType?.startsWith('image/')) {
-        // For images, we use a fixed safe estimate (3,000 tokens) covering
-        // up to 4K resolution on Gemini 3.
-        // See: https://ai.google.dev/gemini-api/docs/vision#token_counting
         totalTokens += 3000;
       } else {
         // For other non-text parts (functionCall, functionResponse, etc.),


### PR DESCRIPTION
## Summary

Fallback token estimation vastly overestimates tokens for images (e.g., 2.7M
tokens for a 2.6MB image), causing false-positive "Context window will overflow"
errors.

<img width="950" height="2060" alt="image" src="https://github.com/user-attachments/assets/dc9fcc62-0a80-4b01-b0d9-3109598a5466" />

For two main reasons:

1) We are not resolving our model string properly so token count API is getting bad model string
2) Fallback logic is flawed

Updated the token estimation fallback heuristic to use a safe, fixed value of
3,000 tokens for images. 

Based on: https://ai.google.dev/gemini-api/docs/vision#token_counting

This value safely covers the maximum actual cost of an Ultra High Resolution
(4K) image in Gemini 3 (2,240 tokens) plus a buffer, while remaining well
below the context window limit.

## Details

When the CLI cannot reach the `countTokens` API (e.g., during rapid estimation
or API failure), it falls back to a heuristic. Previously, this heuristic
used `JSON.stringify(part).length / 4` for all non-text parts. 

**The Problem:**
For base64-encoded image data, this heuristic results in an estimate roughly
equal to the raw file size in bytes. A 2.6MB image was estimated at ~2.7 million
tokens, which exceeds the ~1 million token limit of most Gemini models,
triggering a blocking "Context window will overflow" warning.

**The Fix:**
- Updated `estimateTokenCountSync` in `packages/core/src/utils/tokenCalculation.ts`
to identify image parts via their MIME type.
- Images now use a fixed fallback estimate of **3,000 tokens**.

**Rationale:** This value safely covers the maximum actual cost of an Ultra High
Resolution (4K) image in Gemini 3 (2,240 tokens) plus a buffer, while remaining
well below the context window limit.
- Reference: [Gemini Vision Token Counting](https://ai.google.dev/gemini-api/docs/vision#token_counting)

## Test plan

- [x] Added unit test `should use fixed estimate for images in fallback` in `packages/core/src/utils/tokenCalculation.test.ts`.
- [x] Updated existing mixed-content fallback test to use deterministic token expectations (3,001 tokens).

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
