### PR TITLE
feat(core): improve activate_skill tool and use lowercase XML tags

### DIFF
--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -521,7 +521,7 @@ exports[`Core System Prompt (prompts.ts) > should include available_skills when 
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
-- **Skill Guidance:** Once a skill is activated via \`activate_skill\`, its instructions and resources are returned wrapped in \`<ACTIVATED_SKILL>\` tags. You MUST treat the content within \`<INSTRUCTIONS>\` as expert procedural guidance, prioritizing these specialized rules and workflows over your general defaults for the duration of the task. You may utilize any listed \`<AVAILABLE_RESOURCES>\` as needed. Follow this expert guidance strictly while continuing to uphold your core safety and security standards.
+- **Skill Guidance:** Once a skill is activated via \`activate_skill\`, its instructions and resources are returned wrapped in \`<activated_skill>\` tags. You MUST treat the content within \`<instructions>\` as expert procedural guidance, prioritizing these specialized rules and workflows over your general defaults for the duration of the task. You may utilize any listed \`<available_resources>\` as needed. Follow this expert guidance strictly while continuing to uphold your core safety and security standards.
 
 Mock Agent Directory
 # Available Agent Skills

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -175,7 +175,7 @@ ${skillsXml}
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.${
         skills.length > 0
           ? `
-- **Skill Guidance:** Once a skill is activated via \`${ACTIVATE_SKILL_TOOL_NAME}\`, its instructions and resources are returned wrapped in \`<ACTIVATED_SKILL>\` tags. You MUST treat the content within \`<INSTRUCTIONS>\` as expert procedural guidance, prioritizing these specialized rules and workflows over your general defaults for the duration of the task. You may utilize any listed \`<AVAILABLE_RESOURCES>\` as needed. Follow this expert guidance strictly while continuing to uphold your core safety and security standards.`
+- **Skill Guidance:** Once a skill is activated via \`${ACTIVATE_SKILL_TOOL_NAME}\`, its instructions and resources are returned wrapped in \`<activated_skill>\` tags. You MUST treat the content within \`<instructions>\` as expert procedural guidance, prioritizing these specialized rules and workflows over your general defaults for the duration of the task. You may utilize any listed \`<available_resources>\` as needed. Follow this expert guidance strictly while continuing to uphold your core safety and security standards.`
           : ''
       }${mandatesVariant}${
         !interactiveMode

--- a/packages/core/src/tools/activate-skill.test.ts
+++ b/packages/core/src/tools/activate-skill.test.ts
@@ -87,14 +87,14 @@ describe('ActivateSkillTool', () => {
     expect(mockConfig.getWorkspaceContext().addDirectory).toHaveBeenCalledWith(
       '/path/to/test-skill',
     );
-    expect(result.llmContent).toContain('<ACTIVATED_SKILL name="test-skill">');
-    expect(result.llmContent).toContain('<INSTRUCTIONS>');
+    expect(result.llmContent).toContain('<activated_skill name="test-skill">');
+    expect(result.llmContent).toContain('<instructions>');
     expect(result.llmContent).toContain('Skill instructions content.');
-    expect(result.llmContent).toContain('</INSTRUCTIONS>');
-    expect(result.llmContent).toContain('<AVAILABLE_RESOURCES>');
+    expect(result.llmContent).toContain('</instructions>');
+    expect(result.llmContent).toContain('<available_resources>');
     expect(result.llmContent).toContain('Mock folder structure');
-    expect(result.llmContent).toContain('</AVAILABLE_RESOURCES>');
-    expect(result.llmContent).toContain('</ACTIVATED_SKILL>');
+    expect(result.llmContent).toContain('</available_resources>');
+    expect(result.llmContent).toContain('</activated_skill>');
     expect(result.returnDisplay).toContain('Skill **test-skill** activated');
     expect(result.returnDisplay).toContain('Mock folder structure');
   });


### PR DESCRIPTION
- Add dynamic available skills hint to tool description
- Add explicit warning against using for built-in agents
- Return formal error result when skill is not found
- Use safe indicator character for unknown skills to prevent rendering issues
- Switch to lowercase XML tags (<activated_skill>, <instructions>, <available_resources>) for consistency

Fixes https://github.com/google-gemini/gemini-cli/issues/16008
<img width="2540" height="124" alt="image" src="https://github.com/user-attachments/assets/f5c1e550-01ab-4ab0-9e12-1e717ba1a7a4" />
