### PR TITLE
feat(core): add GEMINI_API_BASE_URL env var for custom API endpoints

### DIFF
--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -173,7 +173,12 @@ export async function createContentGenerator(
           'x-gemini-api-privileged-user-id': `${installationId}`,
         };
       }
-      const httpOptions = { headers };
+      // Support custom base URL for local LLM proxies (Ollama, LiteLLM, etc.)
+      const baseUrl = process.env['GEMINI_API_BASE_URL'] || undefined;
+      const httpOptions = {
+        headers,
+        ...(baseUrl && { baseUrl }),
+      };
 
       const googleGenAI = new GoogleGenAI({
         apiKey: config.apiKey === '' ? undefined : config.apiKey,

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -102,7 +102,23 @@ export class LoggingContentGenerator implements ContentGenerator {
       }
     }
 
-    // Case 3: Default to the public Gemini API endpoint.
+    // Case 3: Check for custom base URL override.
+    const customBaseUrl = process.env['GEMINI_API_BASE_URL'];
+    if (customBaseUrl) {
+      try {
+        const url = new URL(customBaseUrl);
+        const port = url.port
+          ? parseInt(url.port, 10)
+          : url.protocol === 'https:'
+            ? 443
+            : 80;
+        return { address: url.hostname, port };
+      } catch {
+        // Invalid URL, fall through to default
+      }
+    }
+
+    // Case 4: Default to the public Gemini API endpoint.
     // This is used when an API key is provided but not for Vertex AI.
     return { address: `generativelanguage.googleapis.com`, port: 443 };
   }


### PR DESCRIPTION
## Summary

This PR adds support for a `GEMINI_API_BASE_URL` environment variable that allows users to override the default Gemini API endpoint. This enables using the CLI as a frontend for local-first workflows with OpenAI-compatible proxies like Ollama and LiteLLM.

## Details

- **New Environment Variable:** Added `GEMINI_API_BASE_URL` support in `contentGenerator.ts`
- **Pass to SDK:** The base URL is passed to the `@google/genai` SDK via `httpOptions.baseUrl`
- **Backward Compatible:** When the env var is not set, behavior is unchanged

## Related Issues

Fixes #15430

## How to Validate

1. **Test with custom endpoint:**
   ```bash
   export GEMINI_API_BASE_URL="http://localhost:4000"
   export GEMINI_API_KEY="test-key"
   gemini -p "test"
   ```
   Verify requests go to `localhost:4000` instead of `generativelanguage.googleapis.com`

2. **Test without env var:**
   ```bash
   unset GEMINI_API_BASE_URL
   gemini -p "test"
   ```
   Verify normal operation with default endpoint

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
  - [ ] Linux
    - [ ] npm run
    - [ ] npx