### PR TITLE
ci(github-actions): triage all new issues automatically

### DIFF
--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -39,7 +39,6 @@ jobs:
         github.event_name == 'workflow_dispatch' ||
         (
           (github.event_name == 'issues' || github.event_name == 'issue_comment') &&
-          contains(github.event.issue.labels.*.name, 'status/need-triage') &&
           (github.event_name != 'issue_comment' || (
             contains(github.event.comment.body, '@gemini-cli /triage') &&
             (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')
@@ -75,11 +74,6 @@ jobs:
           ISSUE_NUMBER_INPUT: '${{ github.event.inputs.issue_number }}'
           LABELS: '${{ steps.get_issue_data.outputs.labels }}'
         run: |
-          if ! echo "${LABELS}" | grep -q 'status/need-triage'; then
-            echo "Issue #${ISSUE_NUMBER_INPUT} does not have the 'status/need-triage' label. Stopping workflow."
-            exit 1
-          fi
-
           if echo "${LABELS}" | grep -q 'area/'; then
             echo "Issue #${ISSUE_NUMBER_INPUT} already has 'area/' label. Stopping workflow."
             exit 1


### PR DESCRIPTION
Removes the requirement for the 'status/need-triage' label for the triage workflow to run. This allows issues that are opened from a blank template to be triaged.

Fixes #16019

cc @srithreepo 

