### PR TITLE
fix: limit scheduled issue triage queries to prevent argument list too long error

### DIFF
--- a/.github/workflows/gemini-scheduled-issue-triage.yml
+++ b/.github/workflows/gemini-scheduled-issue-triage.yml
@@ -45,11 +45,11 @@ jobs:
 
           echo '🔍 Finding issues without labels...'
           NO_LABEL_ISSUES="$(gh issue list --repo "${GITHUB_REPOSITORY}" \
-            --search 'is:open is:issue no:label' --json number,title,body)"
+            --search 'is:open is:issue no:label' --limit 10 --json number,title,body)"
 
           echo '🏷️ Finding issues that need triage...'
           NEED_TRIAGE_ISSUES="$(gh issue list --repo "${GITHUB_REPOSITORY}" \
-            --search "is:open is:issue label:\"status/need-triage\""  --limit 1000 --json number,title,body)"
+            --search "is:open is:issue label:\"status/need-triage\"" --limit 10 --json number,title,body)"
 
           echo '🔄 Merging and deduplicating issues...'
           ISSUES="$(echo "${NO_LABEL_ISSUES}" "${NEED_TRIAGE_ISSUES}" | jq -c -s 'add | unique_by(.number)')"


### PR DESCRIPTION
Add --limit 10 to both gh issue list commands to cap the number of issues fetched per run. 

This prevents the `ISSUES_TO_TRIAGE` environment variable from exceeding the OS argument list limit (`ARG_MAX`) when there are many issues with long bodies.

Since the workflow runs hourly, remaining issues will be processed in subsequent runs.

Fixes https://github.com/google-gemini/gemini-cli/issues/16020