### PR TITLE
policy: enforce strict matching for MCP tools in allowed-tools

### DIFF
--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -231,6 +231,57 @@ describe('PolicyEngine', () => {
         PolicyDecision.ASK_USER,
       );
     });
+
+    it('should NOT match a simple tool name against a composite tool call name (strict matching)', async () => {
+      const rules: PolicyRule[] = [
+        {
+          toolName: 'notify_user',
+          decision: PolicyDecision.ALLOW,
+          priority: 2.3,
+        },
+      ];
+
+      engine = new PolicyEngine({ rules, nonInteractive: true });
+
+      // Composite name should NOT match the simple name (must be exact)
+      expect(
+        (await engine.check({ name: 'craftMCP__notify_user' }, 'craftMCP'))
+          .decision,
+      ).toBe(PolicyDecision.DENY);
+    });
+
+    it('should match regular tools exactly with --allowed-tools', async () => {
+      const rules: PolicyRule[] = [
+        {
+          toolName: 'run_shell_command',
+          decision: PolicyDecision.ALLOW,
+          priority: 2.3,
+        },
+      ];
+
+      engine = new PolicyEngine({ rules, nonInteractive: true });
+
+      expect(
+        (await engine.check({ name: 'run_shell_command' }, undefined)).decision,
+      ).toBe(PolicyDecision.ALLOW);
+    });
+
+    it('should match MCP tools only with fully qualified name', async () => {
+      const rules: PolicyRule[] = [
+        {
+          toolName: 'craftMCP__notify_user',
+          decision: PolicyDecision.ALLOW,
+          priority: 2.3,
+        },
+      ];
+
+      engine = new PolicyEngine({ rules, nonInteractive: true });
+
+      expect(
+        (await engine.check({ name: 'craftMCP__notify_user' }, 'craftMCP'))
+          .decision,
+      ).toBe(PolicyDecision.ALLOW);
+    });
   });
 
   describe('addRule', () => {

--- a/packages/core/src/utils/tool-utils.ts
+++ b/packages/core/src/utils/tool-utils.ts
@@ -5,7 +5,7 @@
  */
 
 import type { AnyDeclarativeTool, AnyToolInvocation } from '../index.js';
-import { isTool } from '../index.js';
+import { isTool, DiscoveredMCPTool } from '../index.js';
 import { SHELL_TOOL_NAMES } from './shell-utils.js';
 import levenshtein from 'fast-levenshtein';
 
@@ -65,7 +65,14 @@ export function doesToolInvocationMatch(
 ): boolean {
   let toolNames: string[];
   if (isTool(toolOrToolName)) {
-    toolNames = [toolOrToolName.name, toolOrToolName.constructor.name];
+    if (toolOrToolName instanceof DiscoveredMCPTool) {
+      // MCP tools MUST match via their fully qualified name for security.
+      toolNames = [
+        `${toolOrToolName.getFullyQualifiedPrefix()}${toolOrToolName.serverToolName}`,
+      ];
+    } else {
+      toolNames = [toolOrToolName.name, toolOrToolName.constructor.name];
+    }
   } else {
     toolNames = [toolOrToolName];
   }


### PR DESCRIPTION
## Summary

Enforce strict matching for MCP tools in the policy engine and scheduler. This
aligns interactive and non-interactive modes and fixes an issue where simple
tool names could be auto-approved for any MCP server.

## Details

MCP tools use a composite naming convention (`server__tool`) to prevent
collisions. Previously, the scheduler's `isAutoApproved` logic (used in
interactive mode) was too lenient, checking only the tool's simple name. This
created a discrepancy where `--allowed-tools=notify_user` would auto-approve
`craftMCP__notify_user` in interactive mode but fail in non-interactive mode
(where the `PolicyEngine` enforces strict matching).

We have aligned both modes to require the fully qualified `server__tool` name
for MCP tools.

Changes:

- Updated `doesToolInvocationMatch` in the scheduler to require fully qualified
  names for `DiscoveredMCPTool` instances.
- Added unit tests to `policy-engine.test.ts` and `tool-utils.test.ts` to
  enforce this strict behavior.

## Related Issues

Resolves the discrepancy between interactive and non-interactive modes for
`--allowed-tools`.

## How to Validate

1. Run an MCP tool in non-interactive mode using only its simple name in
   `--allowed-tools`: `gemini --allowed-tools=notify_user -p "Notify me"`
   **Expect failure:** "Tool execution ... denied by policy."

2. Run it with the fully qualified name:
   `gemini --allowed-tools=serverA__notify_user -p "Notify me"` **Expect
   success.**

3. Run unit tests: `npx vitest packages/core/src/policy/policy-engine.test.ts`
   `npx vitest packages/core/src/utils/tool-utils.test.ts`

## Pre-Merge Checklist

- [x] Added/updated tests (if needed)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
