### PR TITLE
Support for Built-in Agent Skills

### DIFF
--- a/packages/cli/src/commands/skills/list.test.ts
+++ b/packages/cli/src/commands/skills/list.test.ts
@@ -65,7 +65,7 @@ describe('skills list command', () => {
       };
       mockLoadCliConfig.mockResolvedValue(mockConfig as unknown as Config);
 
-      await handleList();
+      await handleList({});
 
       expect(emitConsoleLog).toHaveBeenCalledWith(
         'log',
@@ -96,7 +96,7 @@ describe('skills list command', () => {
       };
       mockLoadCliConfig.mockResolvedValue(mockConfig as unknown as Config);
 
-      await handleList();
+      await handleList({});
 
       expect(emitConsoleLog).toHaveBeenCalledWith(
         'log',
@@ -120,10 +120,63 @@ describe('skills list command', () => {
       );
     });
 
+    it('should filter built-in skills by default and show them with { all: true }', async () => {
+      const skills = [
+        {
+          name: 'regular',
+          description: 'desc1',
+          disabled: false,
+          location: '/loc1',
+        },
+        {
+          name: 'builtin',
+          description: 'desc2',
+          disabled: false,
+          location: '/loc2',
+          isBuiltin: true,
+        },
+      ];
+      const mockConfig = {
+        initialize: vi.fn().mockResolvedValue(undefined),
+        getSkillManager: vi.fn().mockReturnValue({
+          getAllSkills: vi.fn().mockReturnValue(skills),
+        }),
+      };
+      mockLoadCliConfig.mockResolvedValue(mockConfig as unknown as Config);
+
+      // Default
+      await handleList({ all: false });
+      expect(emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        expect.stringContaining('regular'),
+      );
+      expect(emitConsoleLog).not.toHaveBeenCalledWith(
+        'log',
+        expect.stringContaining('builtin'),
+      );
+
+      vi.clearAllMocks();
+
+      // With all: true
+      await handleList({ all: true });
+      expect(emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        expect.stringContaining('regular'),
+      );
+      expect(emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        expect.stringContaining('builtin'),
+      );
+      expect(emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        expect.stringContaining(chalk.gray(' [Built-in]')),
+      );
+    });
+
     it('should throw an error when listing fails', async () => {
       mockLoadCliConfig.mockRejectedValue(new Error('List failed'));
 
-      await expect(handleList()).rejects.toThrow('List failed');
+      await expect(handleList({})).rejects.toThrow('List failed');
     });
   });
 

--- a/packages/cli/src/config/extension-manager-skills.test.ts
+++ b/packages/cli/src/config/extension-manager-skills.test.ts
@@ -4,99 +4,119 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { ExtensionManager } from './extension-manager.js';
-import { loadSettings } from './settings.js';
+import { debugLogger, coreEvents } from '@google/gemini-cli-core';
+import { type Settings } from './settings.js';
 import { createExtension } from '../test-utils/createExtension.js';
 import { EXTENSIONS_DIRECTORY_NAME } from './extensions/variables.js';
-import { coreEvents, debugLogger } from '@google/gemini-cli-core';
 
-const mockHomedir = vi.hoisted(() => vi.fn());
+const mockHomedir = vi.hoisted(() => vi.fn(() => '/tmp/mock-home'));
 
-vi.mock('os', async (importOriginal) => {
-  const mockedOs = await importOriginal<typeof import('node:os')>();
-  return {
-    ...mockedOs,
-    homedir: mockHomedir,
-  };
-});
-
-vi.mock('@google/gemini-cli-core', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('@google/gemini-cli-core')>();
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
   return {
     ...actual,
     homedir: mockHomedir,
   };
 });
 
+// Mock @google/gemini-cli-core
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    homedir: mockHomedir,
+    debugLogger: {
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+    },
+  };
+});
+
 describe('ExtensionManager skills validation', () => {
-  let tempHomeDir: string;
-  let tempWorkspaceDir: string;
-  let userExtensionsDir: string;
   let extensionManager: ExtensionManager;
+  let tempDir: string;
+  let extensionsDir: string;
 
   beforeEach(() => {
-    tempHomeDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'gemini-cli-skills-test-home-'),
-    );
-    tempWorkspaceDir = fs.mkdtempSync(
-      path.join(tempHomeDir, 'gemini-cli-skills-test-workspace-'),
-    );
-    userExtensionsDir = path.join(tempHomeDir, EXTENSIONS_DIRECTORY_NAME);
-    fs.mkdirSync(userExtensionsDir, { recursive: true });
+    vi.clearAllMocks();
+    vi.spyOn(coreEvents, 'emitFeedback');
 
-    mockHomedir.mockReturnValue(tempHomeDir);
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gemini-test-'));
+    mockHomedir.mockReturnValue(tempDir);
+
+    // Create the extensions directory that ExtensionManager expects
+    extensionsDir = path.join(tempDir, '.gemini', EXTENSIONS_DIRECTORY_NAME);
+    fs.mkdirSync(extensionsDir, { recursive: true });
 
     extensionManager = new ExtensionManager({
-      workspaceDir: tempWorkspaceDir,
+      settings: {
+        telemetry: { enabled: false },
+        trustedFolders: [tempDir],
+      } as unknown as Settings,
       requestConsent: vi.fn().mockResolvedValue(true),
-      requestSetting: vi.fn().mockResolvedValue(''),
-      settings: loadSettings(tempWorkspaceDir).merged,
+      requestSetting: vi.fn(),
+      workspaceDir: tempDir,
     });
-    vi.spyOn(coreEvents, 'emitFeedback');
-    vi.spyOn(debugLogger, 'debug').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    fs.rmSync(tempHomeDir, { recursive: true, force: true });
-    vi.restoreAllMocks();
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
   });
 
   it('should emit a warning during install if skills directory is not empty but no skills are loaded', async () => {
-    const sourceExtDir = createExtension({
-      extensionsDir: tempHomeDir,
+    // Create a source extension
+    const sourceDir = path.join(tempDir, 'source-ext');
+    createExtension({
+      extensionsDir: sourceDir, // createExtension appends name
       name: 'skills-ext',
       version: '1.0.0',
+      installMetadata: {
+        type: 'local',
+        source: path.join(sourceDir, 'skills-ext'),
+      },
     });
+    const extensionPath = path.join(sourceDir, 'skills-ext');
 
-    const skillsDir = path.join(sourceExtDir, 'skills');
+    // Add invalid skills content
+    const skillsDir = path.join(extensionPath, 'skills');
     fs.mkdirSync(skillsDir);
     fs.writeFileSync(path.join(skillsDir, 'not-a-skill.txt'), 'hello');
 
     await extensionManager.loadExtensions();
-    const extension = await extensionManager.installOrUpdateExtension({
-      source: sourceExtDir,
+
+    await extensionManager.installOrUpdateExtension({
       type: 'local',
+      source: extensionPath,
     });
 
-    expect(extension.name).toBe('skills-ext');
     expect(debugLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining('Failed to load skills from'),
     );
   });
 
   it('should emit a warning during load if skills directory is not empty but no skills are loaded', async () => {
-    const extDir = createExtension({
-      extensionsDir: userExtensionsDir,
-      name: 'load-skills-ext',
+    // Manually create an installed extension
+    createExtension({
+      extensionsDir,
+      name: 'skills-ext-load',
       version: '1.0.0',
     });
+    const extensionPath = path.join(extensionsDir, 'skills-ext-load');
 
-    const skillsDir = path.join(extDir, 'skills');
+    const skillsDir = path.join(extensionPath, 'skills');
     fs.mkdirSync(skillsDir);
     fs.writeFileSync(path.join(skillsDir, 'not-a-skill.txt'), 'hello');
 
@@ -105,21 +125,22 @@ describe('ExtensionManager skills validation', () => {
     expect(debugLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining('Failed to load skills from'),
     );
-    expect(debugLogger.debug).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'The directory is not empty but no valid skills were discovered',
-      ),
-    );
   });
 
   it('should succeed if skills are correctly loaded', async () => {
-    const sourceExtDir = createExtension({
-      extensionsDir: tempHomeDir,
+    const sourceDir = path.join(tempDir, 'source-ext-good');
+    createExtension({
+      extensionsDir: sourceDir,
       name: 'good-skills-ext',
       version: '1.0.0',
+      installMetadata: {
+        type: 'local',
+        source: path.join(sourceDir, 'good-skills-ext'),
+      },
     });
+    const extensionPath = path.join(sourceDir, 'good-skills-ext');
 
-    const skillsDir = path.join(sourceExtDir, 'skills');
+    const skillsDir = path.join(extensionPath, 'skills');
     const skillSubdir = path.join(skillsDir, 'test-skill');
     fs.mkdirSync(skillSubdir, { recursive: true });
     fs.writeFileSync(
@@ -128,15 +149,13 @@ describe('ExtensionManager skills validation', () => {
     );
 
     await extensionManager.loadExtensions();
+
     const extension = await extensionManager.installOrUpdateExtension({
-      source: sourceExtDir,
       type: 'local',
+      source: extensionPath,
     });
 
-    expect(extension.skills).toHaveLength(1);
-    expect(extension.skills![0].name).toBe('test-skill');
-    // It might be called for other reasons during startup, but shouldn't be called for our skills loading success
-    // Actually, it shouldn't be called with our warning message
+    expect(extension.name).toBe('good-skills-ext');
     expect(debugLogger.debug).not.toHaveBeenCalledWith(
       expect.stringContaining('Failed to load skills from'),
     );

--- a/packages/cli/src/ui/commands/skillsCommand.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.ts
@@ -23,12 +23,18 @@ async function listAction(
   context: CommandContext,
   args: string,
 ): Promise<void | SlashCommandActionReturn> {
-  const subCommand = args.trim();
+  const subArgs = args.trim().split(/\s+/);
 
   // Default to SHOWING descriptions. The user can hide them with 'nodesc'.
   let useShowDescriptions = true;
-  if (subCommand === 'nodesc') {
-    useShowDescriptions = false;
+  let showAll = false;
+
+  for (const arg of subArgs) {
+    if (arg === 'nodesc') {
+      useShowDescriptions = false;
+    } else if (arg === 'all' || arg === '--all') {
+      showAll = true;
+    }
   }
 
   const skillManager = context.services.config?.getSkillManager();
@@ -43,7 +49,9 @@ async function listAction(
     return;
   }
 
-  const skills = skillManager.getAllSkills();
+  const skills = showAll
+    ? skillManager.getAllSkills()
+    : skillManager.getAllSkills().filter((s) => !s.isBuiltin);
 
   const skillsListItem: HistoryItemSkillsList = {
     type: MessageType.SKILLS_LIST,
@@ -53,6 +61,7 @@ async function listAction(
       disabled: skill.disabled,
       location: skill.location,
       body: skill.body,
+      isBuiltin: skill.isBuiltin,
     })),
     showDescriptions: useShowDescriptions,
   };
@@ -278,7 +287,8 @@ export const skillsCommand: SlashCommand = {
   subCommands: [
     {
       name: 'list',
-      description: 'List available agent skills. Usage: /skills list [nodesc]',
+      description:
+        'List available agent skills. Usage: /skills list [nodesc] [all]',
       kind: CommandKind.BUILT_IN,
       action: listAction,
     },

--- a/packages/cli/src/ui/commands/skillsCommand.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.ts
@@ -30,7 +30,7 @@ async function listAction(
   let showAll = false;
 
   for (const arg of subArgs) {
-    if (arg === 'nodesc') {
+    if (arg === 'nodesc' || arg === '--nodesc') {
       useShowDescriptions = false;
     } else if (arg === 'all' || arg === '--all') {
       showAll = true;

--- a/packages/cli/src/ui/components/Composer.test.tsx
+++ b/packages/cli/src/ui/components/Composer.test.tsx
@@ -154,6 +154,7 @@ const createMockConfig = (overrides = {}) => ({
   }),
   getSkillManager: () => ({
     getSkills: () => [],
+    getDisplayableSkills: () => [],
   }),
   getMcpClientManager: () => ({
     getMcpServers: () => ({}),

--- a/packages/cli/src/ui/components/StatusDisplay.test.tsx
+++ b/packages/cli/src/ui/components/StatusDisplay.test.tsx
@@ -45,6 +45,7 @@ const createMockConfig = (overrides = {}) => ({
   })),
   getSkillManager: vi.fn().mockImplementation(() => ({
     getSkills: vi.fn(() => ['skill1', 'skill2']),
+    getDisplayableSkills: vi.fn(() => ['skill1', 'skill2']),
   })),
   ...overrides,
 });

--- a/packages/cli/src/ui/components/StatusDisplay.tsx
+++ b/packages/cli/src/ui/components/StatusDisplay.tsx
@@ -69,7 +69,7 @@ export const StatusDisplay: React.FC<StatusDisplayProps> = ({
         blockedMcpServers={
           config.getMcpClientManager()?.getBlockedMcpServers() ?? []
         }
-        skillCount={config.getSkillManager().getSkills().length}
+        skillCount={config.getSkillManager().getDisplayableSkills().length}
       />
     );
   }

--- a/packages/cli/src/ui/components/StatusDisplay.tsx
+++ b/packages/cli/src/ui/components/StatusDisplay.tsx
@@ -25,7 +25,7 @@ export const StatusDisplay: React.FC<StatusDisplayProps> = ({
   const config = useConfig();
 
   if (process.env['GEMINI_SYSTEM_MD']) {
-    return <Text color={theme.status.error}>|⌐■_■| </Text>;
+    return <Text color={theme.status.error}>|⌐■_■|</Text>;
   }
 
   if (uiState.ctrlCPressedOnce) {

--- a/packages/cli/src/ui/components/__snapshots__/StatusDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/StatusDisplay.test.tsx.snap
@@ -2,20 +2,20 @@
 
 exports[`StatusDisplay > does NOT render HookStatusDisplay if notifications are disabled in settings 1`] = `"Mock Context Summary Display (Skills: 2)"`;
 
-exports[`StatusDisplay > prioritizes Ctrl+C prompt over everything else (except system md) 1`] = `"Press Ctrl+C again to exit."`;
+exports[`StatusDisplay > prioritizes Ctrl+C prompt over everything else (except system md) 1`] = `"[38;2;249;226;175mPress Ctrl+C again to exit.[39m"`;
 
-exports[`StatusDisplay > prioritizes warning over Ctrl+D 1`] = `"Warning"`;
+exports[`StatusDisplay > prioritizes warning over Ctrl+D 1`] = `"[38;2;249;226;175mWarning[39m"`;
 
 exports[`StatusDisplay > renders ContextSummaryDisplay by default 1`] = `"Mock Context Summary Display (Skills: 2)"`;
 
-exports[`StatusDisplay > renders Ctrl+D prompt 1`] = `"Press Ctrl+D again to exit."`;
+exports[`StatusDisplay > renders Ctrl+D prompt 1`] = `"[38;2;249;226;175mPress Ctrl+D again to exit.[39m"`;
 
-exports[`StatusDisplay > renders Escape prompt 1`] = `"Press Esc again to clear."`;
+exports[`StatusDisplay > renders Escape prompt 1`] = `"[38;2;108;112;134mPress Esc again to clear.[39m"`;
 
 exports[`StatusDisplay > renders HookStatusDisplay when hooks are active 1`] = `"Mock Hook Status Display"`;
 
-exports[`StatusDisplay > renders Queue Error Message 1`] = `"Queue Error"`;
+exports[`StatusDisplay > renders Queue Error Message 1`] = `"[38;2;243;139;168mQueue Error[39m"`;
 
-exports[`StatusDisplay > renders system md indicator if env var is set 1`] = `"|⌐■_■|"`;
+exports[`StatusDisplay > renders system md indicator if env var is set 1`] = `"[38;2;243;139;168m|⌐■_■| [39m"`;
 
-exports[`StatusDisplay > renders warning message 1`] = `"This is a warning"`;
+exports[`StatusDisplay > renders warning message 1`] = `"[38;2;249;226;175mThis is a warning[39m"`;

--- a/packages/cli/src/ui/components/__snapshots__/StatusDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/StatusDisplay.test.tsx.snap
@@ -2,20 +2,20 @@
 
 exports[`StatusDisplay > does NOT render HookStatusDisplay if notifications are disabled in settings 1`] = `"Mock Context Summary Display (Skills: 2)"`;
 
-exports[`StatusDisplay > prioritizes Ctrl+C prompt over everything else (except system md) 1`] = `"[38;2;249;226;175mPress Ctrl+C again to exit.[39m"`;
+exports[`StatusDisplay > prioritizes Ctrl+C prompt over everything else (except system md) 1`] = `"Press Ctrl+C again to exit."`;
 
-exports[`StatusDisplay > prioritizes warning over Ctrl+D 1`] = `"[38;2;249;226;175mWarning[39m"`;
+exports[`StatusDisplay > prioritizes warning over Ctrl+D 1`] = `"Warning"`;
 
 exports[`StatusDisplay > renders ContextSummaryDisplay by default 1`] = `"Mock Context Summary Display (Skills: 2)"`;
 
-exports[`StatusDisplay > renders Ctrl+D prompt 1`] = `"[38;2;249;226;175mPress Ctrl+D again to exit.[39m"`;
+exports[`StatusDisplay > renders Ctrl+D prompt 1`] = `"Press Ctrl+D again to exit."`;
 
-exports[`StatusDisplay > renders Escape prompt 1`] = `"[38;2;108;112;134mPress Esc again to clear.[39m"`;
+exports[`StatusDisplay > renders Escape prompt 1`] = `"Press Esc again to clear."`;
 
 exports[`StatusDisplay > renders HookStatusDisplay when hooks are active 1`] = `"Mock Hook Status Display"`;
 
-exports[`StatusDisplay > renders Queue Error Message 1`] = `"[38;2;243;139;168mQueue Error[39m"`;
+exports[`StatusDisplay > renders Queue Error Message 1`] = `"Queue Error"`;
 
-exports[`StatusDisplay > renders system md indicator if env var is set 1`] = `"[38;2;243;139;168m|⌐■_■| [39m"`;
+exports[`StatusDisplay > renders system md indicator if env var is set 1`] = `"|⌐■_■|"`;
 
-exports[`StatusDisplay > renders warning message 1`] = `"[38;2;249;226;175mThis is a warning[39m"`;
+exports[`StatusDisplay > renders warning message 1`] = `"This is a warning"`;

--- a/packages/cli/src/ui/components/views/SkillsList.test.tsx
+++ b/packages/cli/src/ui/components/views/SkillsList.test.tsx
@@ -105,4 +105,25 @@ describe('SkillsList Component', () => {
 
     unmount();
   });
+
+  it('should render [Built-in] tag for built-in skills', () => {
+    const builtinSkill: SkillDefinition = {
+      name: 'builtin-skill',
+      description: 'A built-in skill',
+      disabled: false,
+      location: 'loc',
+      body: 'body',
+      isBuiltin: true,
+    };
+
+    const { lastFrame, unmount } = render(
+      <SkillsList skills={[builtinSkill]} showDescriptions={true} />,
+    );
+    const output = lastFrame();
+
+    expect(output).toContain('builtin-skill');
+    expect(output).toContain('Built-in');
+
+    unmount();
+  });
 });

--- a/packages/cli/src/ui/components/views/SkillsList.tsx
+++ b/packages/cli/src/ui/components/views/SkillsList.tsx
@@ -18,24 +18,32 @@ export const SkillsList: React.FC<SkillsListProps> = ({
   skills,
   showDescriptions,
 }) => {
-  const enabledSkills = skills
-    .filter((s) => !s.disabled)
-    .sort((a, b) => a.name.localeCompare(b.name));
+  const sortSkills = (a: SkillDefinition, b: SkillDefinition) => {
+    if (a.isBuiltin === b.isBuiltin) {
+      return a.name.localeCompare(b.name);
+    }
+    return a.isBuiltin ? 1 : -1;
+  };
 
-  const disabledSkills = skills
-    .filter((s) => s.disabled)
-    .sort((a, b) => a.name.localeCompare(b.name));
+  const enabledSkills = skills.filter((s) => !s.disabled).sort(sortSkills);
+
+  const disabledSkills = skills.filter((s) => s.disabled).sort(sortSkills);
 
   const renderSkill = (skill: SkillDefinition) => (
     <Box key={skill.name} flexDirection="row">
       <Text color={theme.text.primary}>{'  '}- </Text>
       <Box flexDirection="column">
-        <Text
-          bold
-          color={skill.disabled ? theme.text.secondary : theme.text.link}
-        >
-          {skill.name}
-        </Text>
+        <Box flexDirection="row">
+          <Text
+            bold
+            color={skill.disabled ? theme.text.secondary : theme.text.link}
+          >
+            {skill.name}
+          </Text>
+          {skill.isBuiltin && (
+            <Text color={theme.text.secondary}>{' [Built-in]'}</Text>
+          )}
+        </Box>
         {showDescriptions && skill.description && (
           <Box marginLeft={2}>
             <Text

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
@@ -71,6 +71,7 @@ describe('useQuotaAndFallback', () => {
     vi.spyOn(mockConfig, 'setQuotaErrorOccurred');
     vi.spyOn(mockConfig, 'setModel');
     vi.spyOn(mockConfig, 'setActiveModel');
+    vi.spyOn(mockConfig, 'activateFallbackMode');
   });
 
   afterEach(() => {
@@ -165,8 +166,10 @@ describe('useQuotaAndFallback', () => {
         const intent = await promise!;
         expect(intent).toBe('retry_always');
 
-        // Verify setActiveModel was called
-        expect(mockConfig.setActiveModel).toHaveBeenCalledWith('gemini-flash');
+        // Verify activateFallbackMode was called
+        expect(mockConfig.activateFallbackMode).toHaveBeenCalledWith(
+          'gemini-flash',
+        );
 
         // The pending request should be cleared from the state
         expect(result.current.proQuotaRequest).toBeNull();
@@ -279,8 +282,10 @@ describe('useQuotaAndFallback', () => {
           const intent = await promise!;
           expect(intent).toBe('retry_always');
 
-          // Verify setActiveModel was called
-          expect(mockConfig.setActiveModel).toHaveBeenCalledWith('model-B');
+          // Verify activateFallbackMode was called
+          expect(mockConfig.activateFallbackMode).toHaveBeenCalledWith(
+            'model-B',
+          );
 
           // The pending request should be cleared from the state
           expect(result.current.proQuotaRequest).toBeNull();
@@ -337,8 +342,8 @@ To disable gemini-3-pro-preview, disable "Preview features" in /settings.`,
         const intent = await promise!;
         expect(intent).toBe('retry_always');
 
-        // Verify setActiveModel was called
-        expect(mockConfig.setActiveModel).toHaveBeenCalledWith(
+        // Verify activateFallbackMode was called
+        expect(mockConfig.activateFallbackMode).toHaveBeenCalledWith(
           'gemini-2.5-pro',
         );
 
@@ -425,8 +430,10 @@ To disable gemini-3-pro-preview, disable "Preview features" in /settings.`,
       expect(intent).toBe('retry_always');
       expect(result.current.proQuotaRequest).toBeNull();
 
-      // Verify setActiveModel was called
-      expect(mockConfig.setActiveModel).toHaveBeenCalledWith('gemini-flash');
+      // Verify activateFallbackMode was called
+      expect(mockConfig.activateFallbackMode).toHaveBeenCalledWith(
+        'gemini-flash',
+      );
 
       // Verify quota error flags are reset
       expect(mockSetModelSwitchedFromQuotaError).toHaveBeenCalledWith(false);

--- a/packages/core/src/skills/skillLoader.ts
+++ b/packages/core/src/skills/skillLoader.ts
@@ -25,6 +25,8 @@ export interface SkillDefinition {
   body: string;
   /** Whether the skill is currently disabled. */
   disabled?: boolean;
+  /** Whether the skill is a built-in skill. */
+  isBuiltin?: boolean;
 }
 
 const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)/;

--- a/packages/core/src/skills/skillManager.test.ts
+++ b/packages/core/src/skills/skillManager.test.ts
@@ -163,4 +163,45 @@ description: desc1
     expect(service.getAllSkills()).toHaveLength(1);
     expect(service.getAllSkills()[0].disabled).toBe(true);
   });
+
+  it('should filter built-in skills in getDisplayableSkills', async () => {
+    const service = new SkillManager();
+
+    // @ts-expect-error accessing private property for testing
+    service.skills = [
+      {
+        name: 'regular-skill',
+        description: 'regular',
+        location: 'loc1',
+        body: 'body',
+        isBuiltin: false,
+      },
+      {
+        name: 'builtin-skill',
+        description: 'builtin',
+        location: 'loc2',
+        body: 'body',
+        isBuiltin: true,
+      },
+      {
+        name: 'disabled-builtin',
+        description: 'disabled builtin',
+        location: 'loc3',
+        body: 'body',
+        isBuiltin: true,
+        disabled: true,
+      },
+    ];
+
+    const displayable = service.getDisplayableSkills();
+    expect(displayable).toHaveLength(1);
+    expect(displayable[0].name).toBe('regular-skill');
+
+    const all = service.getAllSkills();
+    expect(all).toHaveLength(3);
+
+    const enabled = service.getSkills();
+    expect(enabled).toHaveLength(2);
+    expect(enabled.map((s) => s.name)).toContain('builtin-skill');
+  });
 });

--- a/packages/core/src/skills/skillManager.ts
+++ b/packages/core/src/skills/skillManager.ts
@@ -31,22 +31,34 @@ export class SkillManager {
   ): Promise<void> {
     this.clearSkills();
 
-    // 1. Extension skills (lowest precedence)
+    // 1. Built-in skills (lowest precedence)
+    await this.discoverBuiltinSkills();
+
+    // 2. Extension skills
     for (const extension of extensions) {
       if (extension.isActive && extension.skills) {
         this.addSkillsWithPrecedence(extension.skills);
       }
     }
 
-    // 2. User skills
+    // 3. User skills
     const userSkills = await loadSkillsFromDir(Storage.getUserSkillsDir());
     this.addSkillsWithPrecedence(userSkills);
 
-    // 3. Project skills (highest precedence)
+    // 4. Project skills (highest precedence)
     const projectSkills = await loadSkillsFromDir(
       storage.getProjectSkillsDir(),
     );
     this.addSkillsWithPrecedence(projectSkills);
+  }
+
+  /**
+   * Discovers built-in skills.
+   */
+  private async discoverBuiltinSkills(): Promise<void> {
+    // Built-in skills can be added here.
+    // For now, this is a placeholder for where built-in skills will be loaded from.
+    // They could be loaded from a specific directory within the package.
   }
 
   private addSkillsWithPrecedence(newSkills: SkillDefinition[]): void {
@@ -62,6 +74,14 @@ export class SkillManager {
    */
   getSkills(): SkillDefinition[] {
     return this.skills.filter((s) => !s.disabled);
+  }
+
+  /**
+   * Returns the list of enabled discovered skills that should be displayed in the UI.
+   * This excludes built-in skills.
+   */
+  getDisplayableSkills(): SkillDefinition[] {
+    return this.skills.filter((s) => !s.disabled && !s.isBuiltin);
   }
 
   /**

--- a/packages/core/src/skills/skillManager.ts
+++ b/packages/core/src/skills/skillManager.ts
@@ -102,8 +102,11 @@ export class SkillManager {
    * Sets the list of disabled skill names.
    */
   setDisabledSkills(disabledNames: string[]): void {
+    const lowercaseDisabledNames = disabledNames.map((n) => n.toLowerCase());
     for (const skill of this.skills) {
-      skill.disabled = disabledNames.includes(skill.name);
+      skill.disabled = lowercaseDisabledNames.includes(
+        skill.name.toLowerCase(),
+      );
     }
   }
 
@@ -111,7 +114,10 @@ export class SkillManager {
    * Reads the full content (metadata + body) of a skill by name.
    */
   getSkill(name: string): SkillDefinition | null {
-    return this.skills.find((s) => s.name === name) ?? null;
+    const lowercaseName = name.toLowerCase();
+    return (
+      this.skills.find((s) => s.name.toLowerCase() === lowercaseName) ?? null
+    );
   }
 
   /**

--- a/packages/core/src/tools/activate-skill.test.ts
+++ b/packages/core/src/tools/activate-skill.test.ts
@@ -76,6 +76,34 @@ describe('ActivateSkillTool', () => {
     expect(details.prompt).toContain('Mock folder structure');
   });
 
+  it('should skip confirmation for built-in skills', async () => {
+    const builtinSkill = {
+      name: 'builtin-skill',
+      description: 'A built-in skill',
+      location: '/path/to/builtin/SKILL.md',
+      isBuiltin: true,
+      body: 'Built-in instructions',
+    };
+    vi.mocked(mockConfig.getSkillManager().getSkill).mockReturnValue(
+      builtinSkill,
+    );
+    vi.mocked(mockConfig.getSkillManager().getSkills).mockReturnValue([
+      builtinSkill,
+    ]);
+
+    const params = { name: 'builtin-skill' };
+    const toolWithBuiltin = new ActivateSkillTool(mockConfig, mockMessageBus);
+    const invocation = toolWithBuiltin.build(params);
+
+    const details = await (
+      invocation as unknown as {
+        getConfirmationDetails: (signal: AbortSignal) => Promise<unknown>;
+      }
+    ).getConfirmationDetails(new AbortController().signal);
+
+    expect(details).toBe(false);
+  });
+
   it('should activate a valid skill and return its content in XML tags', async () => {
     const params = { name: 'test-skill' };
     const invocation = tool.build(params);

--- a/packages/core/src/tools/activate-skill.ts
+++ b/packages/core/src/tools/activate-skill.ts
@@ -80,6 +80,10 @@ class ActivateSkillToolInvocation extends BaseToolInvocation<
       return false;
     }
 
+    if (skill.isBuiltin) {
+      return false;
+    }
+
     const folderStructure = await this.getOrFetchFolderStructure(
       skill.location,
     );


### PR DESCRIPTION
## Summary

This PR adds support for **Built-in Agent Skills**. These are pre-packaged capabilities that provide a more seamless experience by reducing user friction and UI clutter.

## Details

Built-in skills differ from standard skills in the following ways:
- **Zero-Confirmation Invocation**: They skip the `activate_skill` confirmation dialog, as they are considered trusted parts of the CLI.
- **Hidden from Toolbar**: They are excluded from the skill count in the status toolbar to focus on user-added expertise.
- **Filtered Listings**: They are hidden by default in `/skills list` and `gemini skills list`.
- **Explicit Visibility**: A new `all` argument (slash command) and `--all` flag (CLI) allows users to see them when needed.
- **UI Labeling**: When visible, they are explicitly tagged with a `[Built-in]` label.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/16042
Child of https://github.com/google-gemini/gemini-cli/issues/15327

## How to Validate

### Automated Tests
- Run `npx vitest packages/core/src/skills/skillManager.test.ts`
- Run `npx vitest packages/core/src/tools/activate-skill.test.ts`
- Run `npx vitest packages/cli/src/ui/commands/skillsCommand.test.ts`
- Run `npx vitest packages/cli/src/commands/skills/list.test.ts`

### Manual Verification
To manually verify the behavior without a real built-in skill source:
1. Create a skill in `.gemini/skills/test-skill/SKILL.md`.
2. Open `packages/core/src/skills/skillManager.ts`.
3. In the `addSkillsWithPrecedence` method, add a line to force the skill to be built-in:
   ```typescript
   private addSkillsWithPrecedence(newSkills: SkillDefinition[]): void {
     const skillMap = new Map<string, SkillDefinition>();
     for (const skill of [...this.skills, ...newSkills]) {
       if (skill.name === 'test-skill') skill.isBuiltin = true; // Temporary edit
       skillMap.set(skill.name, skill);
     }
     this.skills = Array.from(skillMap.values());
   }
   ```
4. Start the CLI with `npm run start`.
5. Verify that `test-skill` does **not** increase the skill count in the toolbar.
6. Run `/skills list` and verify `test-skill` is missing.
7. Run `/skills list all` and verify `test-skill` appears with a `[Built-in]` label.
8. Ask the model to "activate test-skill" and verify it activates **without** a confirmation dialog.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on MacOS
  - [x] npm run