### PR TITLE
Add option to fallback for capacity errors in ProQuotaDi…

### DIFF
--- a/packages/cli/src/ui/components/ProQuotaDialog.test.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.test.tsx
@@ -169,7 +169,7 @@ describe('ProQuotaDialog', () => {
     });
 
     describe('when it is a capacity error', () => {
-      it('should render keep trying and stop options', () => {
+      it('should render keep trying, switch, and stop options', () => {
         const { unmount } = render(
           <ProQuotaDialog
             failedModel="gemini-2.5-pro"
@@ -189,6 +189,11 @@ describe('ProQuotaDialog', () => {
                 label: 'Keep trying',
                 value: 'retry_once',
                 key: 'retry_once',
+              },
+              {
+                label: 'Switch to gemini-2.5-flash',
+                value: 'retry_always',
+                key: 'retry_always',
               },
               { label: 'Stop', value: 'retry_later', key: 'retry_later' },
             ],

--- a/packages/cli/src/ui/components/ProQuotaDialog.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.tsx
@@ -92,6 +92,11 @@ export function ProQuotaDialog({
         key: 'retry_once',
       },
       {
+        label: `Switch to ${fallbackModel}`,
+        value: 'retry_always' as const,
+        key: 'retry_always',
+      },
+      {
         label: 'Stop',
         value: 'retry_later' as const,
         key: 'retry_later',


### PR DESCRIPTION
…alog

## Summary
Add an option to fallback when a capacity error occurs
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details
When a capacity error occurs, users get a dialog to either retry or stop. We used to have the option to switch to flash model as a fallback and that was removed, and this PR adds the option back.

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
