### PR TITLE
docs: correct typo in bufferFastReturn JSDoc ("accomodate" → "accommodate")

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -193,7 +193,7 @@ function bufferBackslashEnter(
  * Converts return keys pressed quickly after other keys into plain
  * insertable return characters.
  *
- * This is to accomodate older terminals that paste text without bracketing.
+ * This is to accommodate older terminals that paste text without bracketing.
  */
 function bufferFastReturn(keypressHandler: KeypressHandler): KeypressHandler {
   let lastKeyTime = 0;


### PR DESCRIPTION
## Summary

Fix a minor typo in the `bufferFastReturn` JSDoc: “accomodate” → “accommodate”.
This improves documentation clarity and searchability. No runtime or API behavior is affected.

## Details

- Corrects the spelling in the JSDoc comment for `bufferFastReturn`.
- Documentation-only change: code, types, and public APIs remain unchanged.
- Rationale: consistent spelling helps discoverability (e.g., grepping for “accommodate”) and maintains professional polish.

## Related Issues

N/A