### PR TITLE
Update troubleshooting doc for UNABLE_TO_GET_ISSUER_CERT_LOCALLY

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,9 +43,15 @@ topics on:
   - **Cause:** You may be on a corporate network with a firewall that intercepts
     and inspects SSL/TLS traffic. This often requires a custom root CA
     certificate to be trusted by Node.js.
-  - **Solution:** Set the `NODE_EXTRA_CA_CERTS` environment variable to the
-    absolute path of your corporate root CA certificate file.
-    - Example: `export NODE_EXTRA_CA_CERTS=/path/to/your/corporate-ca.crt`
+  - **Solution:** First try setting `NODE_USE_SYSTEM_CA`; if that does not
+    resolve the issue, set `NODE_EXTRA_CA_CERTS`.
+    - Set the `NODE_USE_SYSTEM_CA=1` environment variable to tell Node.js to use
+      the operating system's native certificate store (where corporate
+      certificates are typically already installed).
+      - Example: `export NODE_USE_SYSTEM_CA=1`
+    - Set the `NODE_EXTRA_CA_CERTS` environment variable to the absolute path of
+      your corporate root CA certificate file.
+      - Example: `export NODE_EXTRA_CA_CERTS=/path/to/your/corporate-ca.crt`
 
 ## Common error messages and solutions
 


### PR DESCRIPTION
## Summary
Update troubleshooting doc for UNABLE_TO_GET_ISSUER_CERT_LOCALLY with additional preferred approach
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details
Setting NODE_USE_SYSTEM_CA=1 should be a preferred approach if system's keychain/certificate store is available and it tells node applications to look up this keychain/certificate store. The other existing option explicitly set the path as an alternative.
<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
