### PR TITLE
feat: add native Sublime Text support to IDE detection

### DIFF
--- a/packages/core/src/ide/detect-ide.test.ts
+++ b/packages/core/src/ide/detect-ide.test.ts
@@ -114,6 +114,18 @@ describe('detectIde', () => {
     vi.stubEnv('ANTIGRAVITY_CLI_ALIAS', 'agy');
     expect(detectIde(ideProcessInfo)).toBe(IDE_DEFINITIONS.antigravity);
   });
+
+  it('should detect Sublime Text', () => {
+    vi.stubEnv('TERM_PROGRAM', 'sublime');
+    vi.stubEnv('ANTIGRAVITY_CLI_ALIAS', '');
+    expect(detectIde(ideProcessInfo)).toBe(IDE_DEFINITIONS.sublimetext);
+  });
+
+  it('should prioritize Antigravity over Sublime Text', () => {
+    vi.stubEnv('TERM_PROGRAM', 'sublime');
+    vi.stubEnv('ANTIGRAVITY_CLI_ALIAS', 'agy');
+    expect(detectIde(ideProcessInfo)).toBe(IDE_DEFINITIONS.antigravity);
+  });
 });
 
 describe('detectIde with ideInfoFromFile', () => {

--- a/packages/core/src/ide/detect-ide.ts
+++ b/packages/core/src/ide/detect-ide.ts
@@ -15,6 +15,7 @@ export const IDE_DEFINITIONS = {
   vscode: { name: 'vscode', displayName: 'VS Code' },
   vscodefork: { name: 'vscodefork', displayName: 'IDE' },
   antigravity: { name: 'antigravity', displayName: 'Antigravity' },
+  sublimetext: { name: 'sublimetext', displayName: 'Sublime Text' },
 } as const;
 
 export interface IdeInfo {
@@ -50,6 +51,9 @@ export function detectIdeFromEnv(): IdeInfo {
   }
   if (process.env['MONOSPACE_ENV']) {
     return IDE_DEFINITIONS.firebasestudio;
+  }
+  if (process.env['TERM_PROGRAM'] === 'sublime') {
+    return IDE_DEFINITIONS.sublimetext;
   }
   return IDE_DEFINITIONS.vscode;
 }
@@ -87,8 +91,11 @@ export function detectIde(
     };
   }
 
-  // Only VSCode-based integrations are currently supported.
-  if (process.env['TERM_PROGRAM'] !== 'vscode') {
+  // Only VS Code and Sublime Text integrations are currently supported.
+  if (
+    process.env['TERM_PROGRAM'] !== 'vscode' &&
+    process.env['TERM_PROGRAM'] !== 'sublime'
+  ) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary
Adds native recognition for Sublime Text as a supported IDE environment.

## Details
Currently, Gemini CLI restricts IDE integration features to environments where `TERM_PROGRAM` is `vscode` (or other hardcoded values). This forces 3rd-party integrations like [sublime-gemini](https://github.com/phreakocious/sublime-gemini) to mock VS Code by spoofing environment variables to enable core features. 

This PR adds `sublimetext` to the `IDE_DEFINITIONS` and updates the detection logic to recognize `TERM_PROGRAM=sublime` as a first-class supported environment.

## Related Issues
#16111 

## How to Validate
1. Run `TERM_PROGRAM=sublime node packages/cli/dist/index.js --debug`.
2. Verify that detection recognizes "Sublime Text".
3. Execute unit tests: `cd packages/core && npm run test` (verified `detect-ide.test.ts` passes).

## Pre-Merge Checklist
- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
