### PR TITLE
fix(workflows): fix and limit labels for pr-triage.sh script

### DIFF
--- a/.github/scripts/pr-triage.sh
+++ b/.github/scripts/pr-triage.sh
@@ -48,9 +48,14 @@ process_pr() {
         # Get issue labels
         echo "📥 Fetching area and priority labels from issue #${ISSUE_NUMBER}"
         local ISSUE_LABELS=""
-        if ! ISSUE_LABELS=$(gh issue view "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json labels -q '.labels[].name' 2>/dev/null | grep -E "^(area|priority)/" | tr '\n' ',' | sed 's/,$//' || echo ""); then
+        local gh_output
+        if ! gh_output=$(gh issue view "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json labels -q '.labels[].name' 2>/dev/null); then
             echo "   ⚠️ Could not fetch issue #${ISSUE_NUMBER} (may not exist or be in different repo)"
             ISSUE_LABELS=""
+        else
+            # If grep finds no matches, it exits with 1, which pipefail would treat as an error.
+            # `|| echo ""` ensures the command succeeds with an empty string in that case.
+            ISSUE_LABELS=$(echo "${gh_output}" | grep -E "^(area|priority)/" | tr '\n' ',' | sed 's/,$//' || echo "")
         fi
 
         # Get PR labels

--- a/.github/scripts/pr-triage.sh
+++ b/.github/scripts/pr-triage.sh
@@ -19,24 +19,40 @@ process_pr() {
     local PR_NUMBER=$1
     echo "🔄 Processing PR #${PR_NUMBER}"
 
-    # Get closing issue number with error handling
-    local ISSUE_NUMBER
-    if ! ISSUE_NUMBER=$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json closingIssuesReferences -q '.closingIssuesReferences[0].number' 2>/dev/null); then
-        echo "   ⚠️ Could not fetch closing issue for PR #${PR_NUMBER}"
+    # Get PR details: closing issue and draft status
+    local PR_DATA
+    if ! PR_DATA=$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json closingIssuesReferences,isDraft 2>/dev/null); then
+        echo "   ⚠️ Could not fetch data for PR #${PR_NUMBER}"
+        return 0
     fi
 
+    local ISSUE_NUMBER
+    ISSUE_NUMBER=$(echo "${PR_DATA}" | jq -r '.closingIssuesReferences[0].number // empty')
+
+    local IS_DRAFT
+    IS_DRAFT=$(echo "${PR_DATA}" | jq -r '.isDraft')
+
     if [[ -z "${ISSUE_NUMBER}" ]]; then
-        echo "⚠️  No linked issue found for PR #${PR_NUMBER}, adding status/need-issue label"
-        if ! gh pr edit "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-label "status/need-issue" 2>/dev/null; then
-            echo "   ⚠️ Failed to add label (may already exist or have permission issues)"
-        fi
-        # Add PR number to the list
-        if [[ -z "${PRS_NEEDING_COMMENT}" ]]; then
-            PRS_NEEDING_COMMENT="${PR_NUMBER}"
+        if [[ "${IS_DRAFT}" == "true" ]]; then
+            echo "📝 PR #${PR_NUMBER} is a draft and has no linked issue, skipping status/need-issue label"
+            # Remove status/need-issue label if it was previously added
+            if ! gh pr edit "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --remove-label "status/need-issue" 2>/dev/null; then
+                echo "   status/need-issue label not present or could not be removed"
+            fi
+            echo "needs_comment=false" >> "${GITHUB_OUTPUT}"
         else
-            PRS_NEEDING_COMMENT="${PRS_NEEDING_COMMENT},${PR_NUMBER}"
+            echo "⚠️  No linked issue found for PR #${PR_NUMBER}, adding status/need-issue label"
+            if ! gh pr edit "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-label "status/need-issue" 2>/dev/null; then
+                echo "   ⚠️ Failed to add label (may already exist or have permission issues)"
+            fi
+            # Add PR number to the list
+            if [[ -z "${PRS_NEEDING_COMMENT}" ]]; then
+                PRS_NEEDING_COMMENT="${PR_NUMBER}"
+            else
+                PRS_NEEDING_COMMENT="${PRS_NEEDING_COMMENT},${PR_NUMBER}"
+            fi
+            echo "needs_comment=true" >> "${GITHUB_OUTPUT}"
         fi
-        echo "needs_comment=true" >> "${GITHUB_OUTPUT}"
     else
         echo "🔗 Found linked issue #${ISSUE_NUMBER}"
 


### PR DESCRIPTION


## Summary
Fix pr-triage.sh and limit labels added by the  pr-triage.sh script to priority and area labels.

The pr-triage.sh script is associated with a workflow 
https://github.com/google-gemini/gemini-cli/actions/workflows/gemini-scheduled-pr-triage.yml
that was disabled in October.

## Details

Breaking changes to the `gh` tool broke this script and it was disabled rather than fixed.
The script also previously transferred all labels rather than just important ones such as area and priority.

Also fix so the workflow is not run on draft PRs.

## How to Validate

Run pr-triage.sh locally to verify that it adds area labels, priority and need-issue labels correctly.

Example run with 20 PRs
<img width="1709" height="1108" alt="image" src="https://github.com/user-attachments/assets/dc2aea89-067c-4e2a-a7a9-f7496b4976b6" />


Example showing testing with draft and non draft PRs
<img width="828" height="263" alt="image" src="https://github.com/user-attachments/assets/c3391aa4-1324-41a7-bfb3-315a495959a0" />
