### PR TITLE
enable cli_help agent by default

### DIFF
--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -111,4 +111,5 @@ they appear in the UI.
 | ----------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------ | ------- |
 | Enable Codebase Investigator        | `experimental.codebaseInvestigatorSettings.enabled`     | Enable the Codebase Investigator agent.                      | `true`  |
 | Codebase Investigator Max Num Turns | `experimental.codebaseInvestigatorSettings.maxNumTurns` | Maximum number of turns for the Codebase Investigator agent. | `10`    |
+| Enable CLI Help Agent               | `experimental.cliHelpAgentSettings.enabled`             | Enable the CLI Help Agent.                                   | `true`  |
 | Agent Skills                        | `experimental.skills`                                   | Enable Agent Skills (experimental).                          | `false` |

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -853,7 +853,7 @@ their corresponding top-level category object in your `settings.json` file.
 
 - **`experimental.cliHelpAgentSettings.enabled`** (boolean):
   - **Description:** Enable the CLI Help Agent.
-  - **Default:** `false`
+  - **Default:** `true`
   - **Requires restart:** Yes
 
 #### `skills`

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1467,7 +1467,7 @@ const SETTINGS_SCHEMA = {
             label: 'Enable CLI Help Agent',
             category: 'Experimental',
             requiresRestart: true,
-            default: false,
+            default: true,
             description: 'Enable the CLI Help Agent.',
             showInDialog: true,
           },

--- a/packages/core/src/agents/registry.test.ts
+++ b/packages/core/src/agents/registry.test.ts
@@ -209,6 +209,7 @@ describe('AgentRegistry', () => {
       const disabledConfig = makeFakeConfig({
         enableAgents: false,
         codebaseInvestigatorSettings: { enabled: false },
+        cliHelpAgentSettings: { enabled: false },
       });
       const disabledRegistry = new TestableAgentRegistry(disabledConfig);
 
@@ -220,10 +221,8 @@ describe('AgentRegistry', () => {
       ).not.toHaveBeenCalled();
     });
 
-    it('should register CLI help agent if enabled', async () => {
-      const config = makeFakeConfig({
-        cliHelpAgentSettings: { enabled: true },
-      });
+    it('should register CLI help agent by default', async () => {
+      const config = makeFakeConfig();
       const registry = new TestableAgentRegistry(config);
 
       await registry.initialize();

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -941,6 +941,7 @@ describe('Server Config (config.ts)', () => {
       const params: ConfigParameters = {
         ...baseParams,
         codebaseInvestigatorSettings: { enabled: false },
+        cliHelpAgentSettings: { enabled: false },
       };
       const config = new Config(params);
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -622,7 +622,7 @@ export class Config {
       model: params.codebaseInvestigatorSettings?.model,
     };
     this.cliHelpAgentSettings = {
-      enabled: params.cliHelpAgentSettings?.enabled ?? false,
+      enabled: params.cliHelpAgentSettings?.enabled ?? true,
     };
     this.continueOnFailedApiCall = params.continueOnFailedApiCall ?? true;
     this.enableShellOutputEfficiency =
@@ -1754,7 +1754,8 @@ export class Config {
     // Register DelegateToAgentTool if agents are enabled
     if (
       this.isAgentsEnabled() ||
-      this.getCodebaseInvestigatorSettings().enabled
+      this.getCodebaseInvestigatorSettings().enabled ||
+      this.getCliHelpAgentSettings().enabled
     ) {
       // Check if the delegate tool itself is allowed (if allowedTools is set)
       const allowedTools = this.getAllowedTools();

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1435,8 +1435,8 @@
             "enabled": {
               "title": "Enable CLI Help Agent",
               "description": "Enable the CLI Help Agent.",
-              "markdownDescription": "Enable the CLI Help Agent.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
-              "default": false,
+              "markdownDescription": "Enable the CLI Help Agent.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `true`",
+              "default": true,
               "type": "boolean"
             }
           },


### PR DESCRIPTION
## Summary

Enable the CLI Help Agent by default.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/15087

## How to Validate

run `/tools desc` and verify that `cli_help` is listed in the `delegate_to_agent` tool.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
