### PR TITLE
Optimize json-output tests with mock responses

### DIFF
--- a/integration-tests/json-output.france.responses
+++ b/integration-tests/json-output.france.responses
@@ -1,0 +1,1 @@
+{"method":"generateContentStream","response":[{"candidates":[{"content":{"parts":[{"text":"The capital of France is Paris."}],"role":"model"},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":7,"candidatesTokenCount":7,"totalTokenCount":14,"promptTokensDetails":[{"modality":"TEXT","tokenCount":7}]}}]}

--- a/integration-tests/json-output.session-id.responses
+++ b/integration-tests/json-output.session-id.responses
@@ -1,0 +1,1 @@
+{"method":"generateContentStream","response":[{"candidates":[{"content":{"parts":[{"text":"Hello! How can I help you today?"}],"role":"model"},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":9,"totalTokenCount":14,"promptTokensDetails":[{"modality":"TEXT","tokenCount":5}]}}]}

--- a/integration-tests/json-output.test.ts
+++ b/integration-tests/json-output.test.ts
@@ -9,13 +9,11 @@ import { TestRig } from './test-helper.js';
 import { join } from 'node:path';
 import { ExitCodes } from '@google/gemini-cli-core/src/index.js';
 
-// TODO: Enable these tests once we figure out why they are flaky in CI.
-describe.skip('JSON output', () => {
+describe('JSON output', () => {
   let rig: TestRig;
 
-  beforeEach(async (context) => {
+  beforeEach(async () => {
     rig = new TestRig();
-    await rig.setup(context.task.name);
   });
 
   afterEach(async () => {
@@ -115,7 +113,7 @@ describe.skip('JSON output', () => {
   });
 
   it('should not exit on tool errors and allow model to self-correct in JSON mode', async () => {
-    rig.setup('json-output-error', {
+    await rig.setup('json-output-error', {
       fakeResponsesPath: join(
         import.meta.dirname,
         'json-output.error.responses',

--- a/integration-tests/json-output.test.ts
+++ b/integration-tests/json-output.test.ts
@@ -13,8 +13,9 @@ import { ExitCodes } from '@google/gemini-cli-core/src/index.js';
 describe.skip('JSON output', () => {
   let rig: TestRig;
 
-  beforeEach(async () => {
+  beforeEach(async (context) => {
     rig = new TestRig();
+    await rig.setup(context.task.name);
   });
 
   afterEach(async () => {
@@ -22,7 +23,12 @@ describe.skip('JSON output', () => {
   });
 
   it('should return a valid JSON with response and stats', async () => {
-    await rig.setup('json-output-response-stats');
+    await rig.setup('json-output-france', {
+      fakeResponsesPath: join(
+        import.meta.dirname,
+        'json-output.france.responses',
+      ),
+    });
     const result = await rig.run({
       args: ['What is the capital of France?', '--output-format', 'json'],
     });
@@ -37,7 +43,12 @@ describe.skip('JSON output', () => {
   });
 
   it('should return a valid JSON with a session ID', async () => {
-    await rig.setup('json-output-session-id');
+    await rig.setup('json-output-session-id', {
+      fakeResponsesPath: join(
+        import.meta.dirname,
+        'json-output.session-id.responses',
+      ),
+    });
     const result = await rig.run({
       args: ['Hello', '--output-format', 'json'],
     });


### PR DESCRIPTION
- Switch slow integration tests to use mock responses instead of live API calls
- Drastically reduces test duration and eliminates external network flakiness
- Uses unique directory names for each test case to ensure proper isolation