### PR TITLE
feat(cli): export chat history in /bug and prefill GitHub issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ patch_output.log
 
 .genkit
 .gemini-clipboard/
+.eslintcache

--- a/packages/cli/src/ui/commands/bugCommand.test.ts
+++ b/packages/cli/src/ui/commands/bugCommand.test.ts
@@ -15,6 +15,16 @@ import { formatMemoryUsage } from '../utils/formatters.js';
 // Mock dependencies
 vi.mock('open');
 vi.mock('../utils/formatters.js');
+vi.mock('../utils/historyExportUtils.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../utils/historyExportUtils.js')>();
+  return {
+    ...actual,
+    exportHistoryToFile: vi.fn(),
+  };
+});
+import { exportHistoryToFile } from '../utils/historyExportUtils.js';
+
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('@google/gemini-cli-core')>();
@@ -27,6 +37,13 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     },
     sessionId: 'test-session-id',
     getVersion: vi.fn(),
+    INITIAL_HISTORY_LENGTH: 1,
+    debugLogger: {
+      error: vi.fn(),
+      log: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+    },
   };
 });
 vi.mock('node:process', () => ({
@@ -52,11 +69,14 @@ describe('bugCommand', () => {
     vi.mocked(getVersion).mockResolvedValue('0.1.0');
     vi.mocked(formatMemoryUsage).mockReturnValue('100 MB');
     vi.stubEnv('SANDBOX', 'gemini-test');
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   it('should generate the default GitHub issue URL', async () => {
@@ -66,6 +86,11 @@ describe('bugCommand', () => {
           getModel: () => 'gemini-pro',
           getBugCommand: () => undefined,
           getIdeMode: () => true,
+          getGeminiClient: () => ({
+            getChat: () => ({
+              getHistory: () => [],
+            }),
+          }),
         },
       },
     });
@@ -86,11 +111,54 @@ describe('bugCommand', () => {
 * **Kitty Keyboard Protocol:** Supported
 * **IDE Client:** VSCode
 `;
-    const expectedUrl =
-      'https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.yml&title=A%20test%20bug&info=' +
-      encodeURIComponent(expectedInfo);
+    const expectedUrl = `https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.yml&title=A%20test%20bug&info=${encodeURIComponent(expectedInfo)}&problem=A%20test%20bug`;
 
     expect(open).toHaveBeenCalledWith(expectedUrl);
+  });
+
+  it('should export chat history if available', async () => {
+    const history = [
+      { role: 'user', parts: [{ text: 'hello' }] },
+      { role: 'model', parts: [{ text: 'hi' }] },
+    ];
+    const mockContext = createMockCommandContext({
+      services: {
+        config: {
+          getModel: () => 'gemini-pro',
+          getBugCommand: () => undefined,
+          getIdeMode: () => true,
+          getGeminiClient: () => ({
+            getChat: () => ({
+              getHistory: () => history,
+            }),
+          }),
+          storage: {
+            getProjectTempDir: () => '/tmp/gemini',
+          },
+        },
+      },
+    });
+
+    if (!bugCommand.action) throw new Error('Action is not defined');
+    await bugCommand.action(mockContext, 'Bug with history');
+
+    expect(exportHistoryToFile).toHaveBeenCalledWith({
+      history,
+      filePath: '/tmp/gemini/bug-report-history-1704067200000.json',
+    });
+
+    const addItemCall = vi.mocked(mockContext.ui.addItem).mock.calls[0];
+    const messageText = addItemCall[0].text;
+    expect(messageText).toContain(
+      '/tmp/gemini/bug-report-history-1704067200000.json',
+    );
+    expect(messageText).toContain('📄 **Chat History Exported**');
+    expect(messageText).toContain('Privacy Disclaimer:');
+    expect(messageText).not.toContain('additional-context=');
+    expect(messageText).toContain('problem=');
+    const reminder =
+      '\n\n[ACTION REQUIRED] 📎 PLEASE ATTACH THE EXPORTED CHAT HISTORY JSON FILE TO THIS ISSUE IF YOU FEEL COMFORTABLE SHARING IT.';
+    expect(messageText).toContain(encodeURIComponent(reminder));
   });
 
   it('should use a custom URL template from config if provided', async () => {
@@ -102,6 +170,11 @@ describe('bugCommand', () => {
           getModel: () => 'gemini-pro',
           getBugCommand: () => ({ urlTemplate: customTemplate }),
           getIdeMode: () => true,
+          getGeminiClient: () => ({
+            getChat: () => ({
+              getHistory: () => [],
+            }),
+          }),
         },
       },
     });

--- a/packages/cli/src/ui/commands/bugCommand.test.ts
+++ b/packages/cli/src/ui/commands/bugCommand.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import open from 'open';
+import path from 'node:path';
 import { bugCommand } from './bugCommand.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import { getVersion } from '@google/gemini-cli-core';
@@ -142,16 +143,18 @@ describe('bugCommand', () => {
     if (!bugCommand.action) throw new Error('Action is not defined');
     await bugCommand.action(mockContext, 'Bug with history');
 
+    const expectedPath = path.join(
+      '/tmp/gemini',
+      'bug-report-history-1704067200000.json',
+    );
     expect(exportHistoryToFile).toHaveBeenCalledWith({
       history,
-      filePath: '/tmp/gemini/bug-report-history-1704067200000.json',
+      filePath: expectedPath,
     });
 
     const addItemCall = vi.mocked(mockContext.ui.addItem).mock.calls[0];
     const messageText = addItemCall[0].text;
-    expect(messageText).toContain(
-      '/tmp/gemini/bug-report-history-1704067200000.json',
-    );
+    expect(messageText).toContain(expectedPath);
     expect(messageText).toContain('📄 **Chat History Exported**');
     expect(messageText).toContain('Privacy Disclaimer:');
     expect(messageText).not.toContain('additional-context=');

--- a/packages/cli/src/ui/commands/chatCommand.test.ts
+++ b/packages/cli/src/ui/commands/chatCommand.test.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Mocked } from 'vitest';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import type { SlashCommand, CommandContext } from './types.js';
@@ -14,7 +13,10 @@ import { AuthType, type GeminiClient } from '@google/gemini-cli-core';
 
 import * as fsPromises from 'node:fs/promises';
 import { chatCommand } from './chatCommand.js';
-import { serializeHistoryToMarkdown , exportHistoryToFile } from '../utils/historyExportUtils.js';
+import {
+  serializeHistoryToMarkdown,
+  exportHistoryToFile,
+} from '../utils/historyExportUtils.js';
 import type { Stats } from 'node:fs';
 import type { HistoryItemWithoutId } from '../types.js';
 import path from 'node:path';
@@ -34,10 +36,9 @@ vi.mock('../utils/historyExportUtils.js', async (importOriginal) => {
   };
 });
 
-
 describe('chatCommand', () => {
-  const mockFs = fsPromises as Mocked<typeof fsPromises>;
-  const mockExport = exportHistoryToFile as Mocked<typeof exportHistoryToFile>;
+  const mockFs = vi.mocked(fsPromises);
+  const mockExport = vi.mocked(exportHistoryToFile);
 
   let mockContext: CommandContext;
   let mockGetChat: ReturnType<typeof vi.fn>;

--- a/packages/cli/src/ui/commands/chatCommand.test.ts
+++ b/packages/cli/src/ui/commands/chatCommand.test.ts
@@ -13,7 +13,8 @@ import type { Content } from '@google/genai';
 import { AuthType, type GeminiClient } from '@google/gemini-cli-core';
 
 import * as fsPromises from 'node:fs/promises';
-import { chatCommand, serializeHistoryToMarkdown } from './chatCommand.js';
+import { chatCommand } from './chatCommand.js';
+import { serializeHistoryToMarkdown , exportHistoryToFile } from '../utils/historyExportUtils.js';
 import type { Stats } from 'node:fs';
 import type { HistoryItemWithoutId } from '../types.js';
 import path from 'node:path';
@@ -24,8 +25,19 @@ vi.mock('fs/promises', () => ({
   writeFile: vi.fn(),
 }));
 
+vi.mock('../utils/historyExportUtils.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../utils/historyExportUtils.js')>();
+  return {
+    ...actual,
+    exportHistoryToFile: vi.fn(),
+  };
+});
+
+
 describe('chatCommand', () => {
   const mockFs = fsPromises as Mocked<typeof fsPromises>;
+  const mockExport = exportHistoryToFile as Mocked<typeof exportHistoryToFile>;
 
   let mockContext: CommandContext;
   let mockGetChat: ReturnType<typeof vi.fn>;
@@ -448,9 +460,10 @@ describe('chatCommand', () => {
         process.cwd(),
         'gemini-conversation-1234567890.json',
       );
-      const [actualPath, actualContent] = mockFs.writeFile.mock.calls[0];
-      expect(actualPath).toEqual(expectedPath);
-      expect(actualContent).toEqual(JSON.stringify(mockHistory, null, 2));
+      expect(mockExport).toHaveBeenCalledWith({
+        history: mockHistory,
+        filePath: expectedPath,
+      });
       expect(result).toEqual({
         type: 'message',
         messageType: 'info',
@@ -462,9 +475,10 @@ describe('chatCommand', () => {
       const filePath = 'my-chat.json';
       const result = await shareCommand?.action?.(mockContext, filePath);
       const expectedPath = path.join(process.cwd(), 'my-chat.json');
-      const [actualPath, actualContent] = mockFs.writeFile.mock.calls[0];
-      expect(actualPath).toEqual(expectedPath);
-      expect(actualContent).toEqual(JSON.stringify(mockHistory, null, 2));
+      expect(mockExport).toHaveBeenCalledWith({
+        history: mockHistory,
+        filePath: expectedPath,
+      });
       expect(result).toEqual({
         type: 'message',
         messageType: 'info',
@@ -476,30 +490,10 @@ describe('chatCommand', () => {
       const filePath = 'my-chat.md';
       const result = await shareCommand?.action?.(mockContext, filePath);
       const expectedPath = path.join(process.cwd(), 'my-chat.md');
-      const [actualPath, actualContent] = mockFs.writeFile.mock.calls[0];
-      expect(actualPath).toEqual(expectedPath);
-      const expectedContent = `## USER 🧑‍💻
-
-context
-
----
-
-## MODEL ✨
-
-context response
-
----
-
-## USER 🧑‍💻
-
-Hello
-
----
-
-## MODEL ✨
-
-Hi there!`;
-      expect(actualContent).toEqual(expectedContent);
+      expect(mockExport).toHaveBeenCalledWith({
+        history: mockHistory,
+        filePath: expectedPath,
+      });
       expect(result).toEqual({
         type: 'message',
         messageType: 'info',
@@ -510,7 +504,7 @@ Hi there!`;
     it('should return an error for unsupported file extensions', async () => {
       const filePath = 'my-chat.txt';
       const result = await shareCommand?.action?.(mockContext, filePath);
-      expect(mockFs.writeFile).not.toHaveBeenCalled();
+      expect(mockExport).not.toHaveBeenCalled();
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
@@ -523,7 +517,7 @@ Hi there!`;
         { role: 'user', parts: [{ text: 'context' }] },
       ]);
       const result = await shareCommand?.action?.(mockContext, 'my-chat.json');
-      expect(mockFs.writeFile).not.toHaveBeenCalled();
+      expect(mockExport).not.toHaveBeenCalled();
       expect(result).toEqual({
         type: 'message',
         messageType: 'info',
@@ -533,7 +527,7 @@ Hi there!`;
 
     it('should handle errors during file writing', async () => {
       const error = new Error('Permission denied');
-      mockFs.writeFile.mockRejectedValue(error);
+      mockExport.mockRejectedValue(error);
       const result = await shareCommand?.action?.(mockContext, 'my-chat.json');
       expect(result).toEqual({
         type: 'message',
@@ -546,14 +540,9 @@ Hi there!`;
       const filePath = 'my-chat.json';
       await shareCommand?.action?.(mockContext, filePath);
       const expectedPath = path.join(process.cwd(), 'my-chat.json');
-      const [actualPath, actualContent] = mockFs.writeFile.mock.calls[0];
-      expect(actualPath).toEqual(expectedPath);
-      const parsedContent = JSON.parse(actualContent as string);
-      expect(Array.isArray(parsedContent)).toBe(true);
-      parsedContent.forEach((item: Content) => {
-        expect(item).toHaveProperty('role');
-        expect(item).toHaveProperty('parts');
-        expect(Array.isArray(item.parts)).toBe(true);
+      expect(mockExport).toHaveBeenCalledWith({
+        history: mockHistory,
+        filePath: expectedPath,
       });
     });
 
@@ -561,15 +550,9 @@ Hi there!`;
       const filePath = 'my-chat.md';
       await shareCommand?.action?.(mockContext, filePath);
       const expectedPath = path.join(process.cwd(), 'my-chat.md');
-      const [actualPath, actualContent] = mockFs.writeFile.mock.calls[0];
-      expect(actualPath).toEqual(expectedPath);
-      const entries = (actualContent as string).split('\n\n---\n\n');
-      expect(entries.length).toBe(mockHistory.length);
-      entries.forEach((entry: string, index: number) => {
-        const { role, parts } = mockHistory[index];
-        const text = parts.map((p) => p.text).join('');
-        const roleIcon = role === 'user' ? '🧑‍💻' : '✨';
-        expect(entry).toBe(`## ${role.toUpperCase()} ${roleIcon}\n\n${text}`);
+      expect(mockExport).toHaveBeenCalledWith({
+        history: mockHistory,
+        filePath: expectedPath,
       });
     });
   });

--- a/packages/cli/src/ui/utils/historyExportUtils.ts
+++ b/packages/cli/src/ui/utils/historyExportUtils.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fsPromises from 'node:fs/promises';
+import path from 'node:path';
+import type { Content } from '@google/genai';
+
+/**
+ * Serializes chat history to a Markdown string.
+ */
+export function serializeHistoryToMarkdown(history: Content[]): string {
+  return history
+    .map((item) => {
+      const text =
+        item.parts
+          ?.map((part) => {
+            if (part.text) {
+              return part.text;
+            }
+            if (part.functionCall) {
+              return (
+                `**Tool Command**:\n` +
+                '```json\n' +
+                JSON.stringify(part.functionCall, null, 2) +
+                '\n```'
+              );
+            }
+            if (part.functionResponse) {
+              return (
+                `**Tool Response**:\n` +
+                '```json\n' +
+                JSON.stringify(part.functionResponse, null, 2) +
+                '\n```'
+              );
+            }
+            return '';
+          })
+          .join('') || '';
+      const roleIcon = item.role === 'user' ? '🧑‍💻' : '✨';
+      return `## ${(item.role || 'model').toUpperCase()} ${roleIcon}\n\n${text}`;
+    })
+    .join('\n\n---\n\n');
+}
+
+/**
+ * Options for exporting chat history.
+ */
+export interface ExportHistoryOptions {
+  history: Content[];
+  filePath: string;
+}
+
+/**
+ * Exports chat history to a file (JSON or Markdown).
+ */
+export async function exportHistoryToFile(
+  options: ExportHistoryOptions,
+): Promise<void> {
+  const { history, filePath } = options;
+  const extension = path.extname(filePath).toLowerCase();
+
+  let content: string;
+  if (extension === '.json') {
+    content = JSON.stringify(history, null, 2);
+  } else if (extension === '.md') {
+    content = serializeHistoryToMarkdown(history);
+  } else {
+    throw new Error(
+      `Unsupported file extension: ${extension}. Use .json or .md.`,
+    );
+  }
+
+  const dir = path.dirname(filePath);
+  await fsPromises.mkdir(dir, { recursive: true });
+  await fsPromises.writeFile(filePath, content, 'utf-8');
+}


### PR DESCRIPTION
This PR enhances the `/bug` command to automatically export the current chat history to a JSON file and prefill the GitHub issue with a reminder to attach it.

### Changes:
- Automatically export chat history to a JSON file in the project's temporary directory when running `/bug`.
- Prefill the GitHub issue 'problem' field with the bug description and a prominent `[ACTION REQUIRED] 📎` reminder to attach the history file.
- Refactor chat history serialization and file export into a shared utility (`packages/cli/src/ui/utils/historyExportUtils.ts`) used by both `/bug` and `/chat share`.
- Add a visual separator, emoji, and privacy disclaimer to the `/bug` command output in the CLI.
- Update tests to reflect the new shared utility and URL structure.
- Add `.eslintcache` to `.gitignore`.

Fixes https://github.com/google-gemini/gemini-cli/issues/16105