### PR TITLE
refactor(core): extract SchedulerStateManager and modularize state transitions

### DIFF
--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -750,6 +750,17 @@ describe('CoreToolScheduler with payload', () => {
       );
     }
 
+    // After internal update, the tool should be awaiting approval again with the NEW content.
+    const updatedAwaitingCall = (await waitForStatus(
+      onToolCallsUpdate,
+      'awaiting_approval',
+    )) as WaitingToolCall;
+
+    // Now confirm for real to execute.
+    await updatedAwaitingCall.confirmationDetails.onConfirm(
+      ToolConfirmationOutcome.ProceedOnce,
+    );
+
     // Wait for the tool execution to complete
     await vi.waitFor(() => {
       expect(onAllToolCallsComplete).toHaveBeenCalled();

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -990,7 +990,11 @@ describe('CoreToolScheduler YOLO mode', () => {
       .map((call) => (call[0][0] as ToolCall)?.status)
       .filter(Boolean);
     expect(statusUpdates).not.toContain('awaiting_approval');
-    expect(statusUpdates).toEqual([
+    // Expect the sequence of states, ignoring duplicates
+    const uniqueStatusUpdates = statusUpdates.filter(
+      (status, index, self) => index === 0 || status !== self[index - 1],
+    );
+    expect(uniqueStatusUpdates).toEqual([
       'validating',
       'scheduled',
       'executing',
@@ -1207,7 +1211,11 @@ describe('CoreToolScheduler request queueing', () => {
       .map((call) => (call[0][0] as ToolCall)?.status)
       .filter(Boolean);
     expect(statusUpdates).not.toContain('awaiting_approval');
-    expect(statusUpdates).toEqual([
+    // Expect the sequence of states, ignoring duplicates
+    const uniqueStatusUpdates = statusUpdates.filter(
+      (status, index, self) => index === 0 || status !== self[index - 1],
+    );
+    expect(uniqueStatusUpdates).toEqual([
       'validating',
       'scheduled',
       'executing',
@@ -1810,8 +1818,9 @@ describe('CoreToolScheduler Sequential Execution', () => {
       abortController.signal,
     );
 
-    const toolCall = (scheduler as unknown as { toolCalls: ToolCall[] })
-      .toolCalls[0] as WaitingToolCall;
+    const toolCall = (
+      scheduler as unknown as { state: { getSnapshot: () => ToolCall[] } }
+    ).state.getSnapshot()[0] as WaitingToolCall;
     expect(toolCall.status).toBe('awaiting_approval');
 
     const confirmationSignal = new AbortController().signal;

--- a/packages/core/src/scheduler/state-manager.test.ts
+++ b/packages/core/src/scheduler/state-manager.test.ts
@@ -1,0 +1,403 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SchedulerStateManager } from './state-manager.js';
+import {
+  type ValidatingToolCall,
+  type WaitingToolCall,
+  type SuccessfulToolCall,
+  type ErroredToolCall,
+  type CancelledToolCall,
+  type ExecutingToolCall,
+  type ToolCallRequestInfo,
+  type ToolCallResponseInfo,
+  type ToolCallsUpdateHandler,
+} from './types.js';
+import {
+  ToolConfirmationOutcome,
+  type AnyDeclarativeTool,
+  type AnyToolInvocation,
+} from '../tools/tools.js';
+
+describe('SchedulerStateManager', () => {
+  const mockRequest: ToolCallRequestInfo = {
+    callId: 'call-1',
+    name: 'test-tool',
+    args: { foo: 'bar' },
+    isClientInitiated: false,
+    prompt_id: 'prompt-1',
+  };
+
+  const mockTool = {
+    name: 'test-tool',
+    displayName: 'Test Tool',
+  } as AnyDeclarativeTool;
+
+  const mockInvocation = {
+    shouldConfirmExecute: vi.fn(),
+  } as unknown as AnyToolInvocation;
+
+  const createValidatingCall = (id = 'call-1'): ValidatingToolCall => ({
+    status: 'validating',
+    request: { ...mockRequest, callId: id },
+    tool: mockTool,
+    invocation: mockInvocation,
+    startTime: Date.now(),
+  });
+
+  let stateManager: SchedulerStateManager;
+  let onUpdate: ToolCallsUpdateHandler;
+
+  beforeEach(() => {
+    onUpdate = vi.fn() as unknown as ToolCallsUpdateHandler;
+    stateManager = new SchedulerStateManager(onUpdate);
+  });
+
+  describe('Initialization', () => {
+    it('should start with empty state', () => {
+      expect(stateManager.hasActiveCalls()).toBe(false);
+      expect(stateManager.getActiveCallCount()).toBe(0);
+      expect(stateManager.getQueueLength()).toBe(0);
+      expect(stateManager.getSnapshot()).toEqual([]);
+    });
+  });
+
+  describe('Queue Management', () => {
+    it('should enqueue calls and notify', () => {
+      const call = createValidatingCall();
+      stateManager.enqueue([call]);
+
+      expect(stateManager.getQueueLength()).toBe(1);
+      expect(onUpdate).toHaveBeenCalledWith([call]);
+    });
+
+    it('should dequeue calls and notify', () => {
+      const call = createValidatingCall();
+      stateManager.enqueue([call]);
+
+      const dequeued = stateManager.dequeue();
+
+      expect(dequeued).toEqual(call);
+      expect(stateManager.getQueueLength()).toBe(0);
+      expect(stateManager.getActiveCallCount()).toBe(1);
+      expect(onUpdate).toHaveBeenCalled();
+    });
+
+    it('should return undefined when dequeueing from empty queue', () => {
+      const dequeued = stateManager.dequeue();
+      expect(dequeued).toBeUndefined();
+    });
+  });
+
+  describe('Status Transitions', () => {
+    it('should transition validating to scheduled', () => {
+      const call = createValidatingCall();
+      stateManager.enqueue([call]);
+      stateManager.dequeue();
+
+      stateManager.updateStatus(call.request.callId, 'scheduled');
+
+      const snapshot = stateManager.getSnapshot();
+      expect(snapshot[0].status).toBe('scheduled');
+      expect(snapshot[0].request.callId).toBe(call.request.callId);
+    });
+
+    it('should transition scheduled to executing', () => {
+      const call = createValidatingCall();
+      stateManager.enqueue([call]);
+      stateManager.dequeue();
+      stateManager.updateStatus(call.request.callId, 'scheduled');
+
+      stateManager.updateStatus(call.request.callId, 'executing');
+
+      expect(stateManager.getFirstActiveCall()?.status).toBe('executing');
+    });
+
+    it('should transition to success and move to completed batch', () => {
+      const call = createValidatingCall();
+      stateManager.enqueue([call]);
+      stateManager.dequeue();
+
+      const response: ToolCallResponseInfo = {
+        callId: call.request.callId,
+        responseParts: [],
+        resultDisplay: 'Success',
+        error: undefined,
+        errorType: undefined,
+      };
+
+      stateManager.updateStatus(call.request.callId, 'success', response);
+      stateManager.finalizeCall(call.request.callId);
+
+      expect(stateManager.hasActiveCalls()).toBe(false);
+      expect(stateManager.getCompletedBatch()).toHaveLength(1);
+      const completed =
+        stateManager.getCompletedBatch()[0] as SuccessfulToolCall;
+      expect(completed.status).toBe('success');
+      expect(completed.response).toEqual(response);
+      expect(completed.durationMs).toBeDefined();
+    });
+
+    it('should transition to error and move to completed batch', () => {
+      const call = createValidatingCall();
+      stateManager.enqueue([call]);
+      stateManager.dequeue();
+
+      const response: ToolCallResponseInfo = {
+        callId: call.request.callId,
+        responseParts: [],
+        resultDisplay: 'Error',
+        error: new Error('Failed'),
+        errorType: undefined,
+      };
+
+      stateManager.updateStatus(call.request.callId, 'error', response);
+      stateManager.finalizeCall(call.request.callId);
+
+      expect(stateManager.hasActiveCalls()).toBe(false);
+      expect(stateManager.getCompletedBatch()).toHaveLength(1);
+      const completed = stateManager.getCompletedBatch()[0] as ErroredToolCall;
+      expect(completed.status).toBe('error');
+      expect(completed.response).toEqual(response);
+    });
+
+    it('should transition to awaiting_approval with details', () => {
+      const call = createValidatingCall();
+      stateManager.enqueue([call]);
+      stateManager.dequeue();
+
+      const details = { type: 'info', title: 'Confirm', prompt: 'Proceed?' };
+
+      stateManager.updateStatus(
+        call.request.callId,
+        'awaiting_approval',
+        details,
+      );
+
+      const active = stateManager.getFirstActiveCall() as WaitingToolCall;
+      expect(active.status).toBe('awaiting_approval');
+      expect(active.confirmationDetails).toEqual(details);
+    });
+
+    it('should preserve diff when cancelling an edit tool call', () => {
+      const call = createValidatingCall();
+      stateManager.enqueue([call]);
+      stateManager.dequeue();
+
+      const details = {
+        type: 'edit',
+        title: 'Edit',
+        fileName: 'test.txt',
+        fileDiff: 'diff',
+        originalContent: 'old',
+        newContent: 'new',
+      };
+
+      stateManager.updateStatus(
+        call.request.callId,
+        'awaiting_approval',
+        details,
+      );
+      stateManager.updateStatus(
+        call.request.callId,
+        'cancelled',
+        'User said no',
+      );
+      stateManager.finalizeCall(call.request.callId);
+
+      const completed =
+        stateManager.getCompletedBatch()[0] as CancelledToolCall;
+      expect(completed.status).toBe('cancelled');
+      expect(completed.response.resultDisplay).toEqual({
+        fileDiff: 'diff',
+        fileName: 'test.txt',
+        originalContent: 'old',
+        newContent: 'new',
+      });
+    });
+
+    it('should ignore status updates for non-existent callIds', () => {
+      stateManager.updateStatus('unknown', 'scheduled');
+      expect(onUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should ignore status updates for terminal calls', () => {
+      const call = createValidatingCall();
+      stateManager.enqueue([call]);
+      stateManager.dequeue();
+      stateManager.updateStatus(call.request.callId, 'success', {});
+      stateManager.finalizeCall(call.request.callId);
+
+      vi.mocked(onUpdate).mockClear();
+      stateManager.updateStatus(call.request.callId, 'scheduled');
+      expect(onUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should only finalize terminal calls', () => {
+      const call = createValidatingCall();
+      stateManager.enqueue([call]);
+      stateManager.dequeue();
+
+      stateManager.updateStatus(call.request.callId, 'executing');
+      stateManager.finalizeCall(call.request.callId);
+
+      expect(stateManager.hasActiveCalls()).toBe(true);
+      expect(stateManager.getCompletedBatch()).toHaveLength(0);
+
+      stateManager.updateStatus(call.request.callId, 'success', {});
+      stateManager.finalizeCall(call.request.callId);
+
+      expect(stateManager.hasActiveCalls()).toBe(false);
+      expect(stateManager.getCompletedBatch()).toHaveLength(1);
+    });
+
+    it('should merge liveOutput and pid during executing updates', () => {
+      const call = createValidatingCall();
+      stateManager.enqueue([call]);
+      stateManager.dequeue();
+
+      // Start executing
+      stateManager.updateStatus(call.request.callId, 'executing');
+      let active = stateManager.getFirstActiveCall() as ExecutingToolCall;
+      expect(active.status).toBe('executing');
+      expect(active.liveOutput).toBeUndefined();
+
+      // Update with live output
+      stateManager.updateStatus(call.request.callId, 'executing', {
+        liveOutput: 'chunk 1',
+      });
+      active = stateManager.getFirstActiveCall() as ExecutingToolCall;
+      expect(active.liveOutput).toBe('chunk 1');
+
+      // Update with pid (should preserve liveOutput)
+      stateManager.updateStatus(call.request.callId, 'executing', {
+        pid: 1234,
+      });
+      active = stateManager.getFirstActiveCall() as ExecutingToolCall;
+      expect(active.liveOutput).toBe('chunk 1');
+      expect(active.pid).toBe(1234);
+
+      // Update live output again (should preserve pid)
+      stateManager.updateStatus(call.request.callId, 'executing', {
+        liveOutput: 'chunk 2',
+      });
+      active = stateManager.getFirstActiveCall() as ExecutingToolCall;
+      expect(active.liveOutput).toBe('chunk 2');
+      expect(active.pid).toBe(1234);
+    });
+  });
+
+  describe('Argument Updates', () => {
+    it('should update args and invocation', () => {
+      const call = createValidatingCall();
+      stateManager.enqueue([call]);
+      stateManager.dequeue();
+
+      const newArgs = { foo: 'updated' };
+      const newInvocation = { ...mockInvocation } as AnyToolInvocation;
+
+      stateManager.updateArgs(call.request.callId, newArgs, newInvocation);
+
+      const active = stateManager.getFirstActiveCall();
+      if (active && 'invocation' in active) {
+        expect(active.invocation).toEqual(newInvocation);
+      } else {
+        throw new Error('Active call should have invocation');
+      }
+    });
+
+    it('should ignore arg updates for errored calls', () => {
+      const call = createValidatingCall();
+      stateManager.enqueue([call]);
+      stateManager.dequeue();
+      stateManager.updateStatus(call.request.callId, 'error', {});
+      stateManager.finalizeCall(call.request.callId);
+
+      stateManager.updateArgs(
+        call.request.callId,
+        { foo: 'new' },
+        mockInvocation,
+      );
+
+      const completed = stateManager.getCompletedBatch()[0];
+      expect(completed.request.args).toEqual(mockRequest.args);
+    });
+  });
+
+  describe('Outcome Tracking', () => {
+    it('should set outcome and notify', () => {
+      const call = createValidatingCall();
+      stateManager.enqueue([call]);
+      stateManager.dequeue();
+
+      stateManager.setOutcome(
+        call.request.callId,
+        ToolConfirmationOutcome.ProceedAlways,
+      );
+
+      const active = stateManager.getFirstActiveCall();
+      expect(active?.outcome).toBe(ToolConfirmationOutcome.ProceedAlways);
+      expect(onUpdate).toHaveBeenCalled();
+    });
+  });
+
+  describe('Batch Operations', () => {
+    it('should cancel all queued calls', () => {
+      stateManager.enqueue([
+        createValidatingCall('1'),
+        createValidatingCall('2'),
+      ]);
+
+      stateManager.cancelAllQueued('Batch cancel');
+
+      expect(stateManager.getQueueLength()).toBe(0);
+      expect(stateManager.getCompletedBatch()).toHaveLength(2);
+      expect(
+        stateManager.getCompletedBatch().every((c) => c.status === 'cancelled'),
+      ).toBe(true);
+    });
+
+    it('should clear batch and notify', () => {
+      const call = createValidatingCall();
+      stateManager.enqueue([call]);
+      stateManager.dequeue();
+      stateManager.updateStatus(call.request.callId, 'success', {});
+      stateManager.finalizeCall(call.request.callId);
+
+      stateManager.clearBatch();
+
+      expect(stateManager.getCompletedBatch()).toHaveLength(0);
+      expect(onUpdate).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('Snapshot and Ordering', () => {
+    it('should return snapshot in order: completed, active, queue', () => {
+      // 1. Completed
+      const call1 = createValidatingCall('1');
+      stateManager.enqueue([call1]);
+      stateManager.dequeue();
+      stateManager.updateStatus('1', 'success', {});
+      stateManager.finalizeCall('1');
+
+      // 2. Active
+      const call2 = createValidatingCall('2');
+      stateManager.enqueue([call2]);
+      stateManager.dequeue();
+
+      // 3. Queue
+      const call3 = createValidatingCall('3');
+      stateManager.enqueue([call3]);
+
+      const snapshot = stateManager.getSnapshot();
+      expect(snapshot).toHaveLength(3);
+      expect(snapshot[0].request.callId).toBe('1');
+      expect(snapshot[1].request.callId).toBe('2');
+      expect(snapshot[2].request.callId).toBe('3');
+    });
+  });
+});

--- a/packages/core/src/scheduler/state-manager.ts
+++ b/packages/core/src/scheduler/state-manager.ts
@@ -1,0 +1,365 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  type ToolCall,
+  type Status,
+  type WaitingToolCall,
+  type ToolCallsUpdateHandler,
+  type CompletedToolCall,
+  type SuccessfulToolCall,
+  type ErroredToolCall,
+  type CancelledToolCall,
+  type ScheduledToolCall,
+  type ValidatingToolCall,
+  type ExecutingToolCall,
+  type ToolCallResponseInfo,
+} from './types.js';
+import {
+  type ToolCallConfirmationDetails,
+  ToolConfirmationOutcome,
+  type ToolResultDisplay,
+  type AnyToolInvocation,
+} from '../tools/tools.js';
+
+/**
+ * Manages the state of tool calls for the CoreToolScheduler.
+ * This class encapsulates the data structures and state transitions.
+ */
+export class SchedulerStateManager {
+  private activeCalls = new Map<string, ToolCall>();
+  private queue: ToolCall[] = [];
+  private completedBatch: CompletedToolCall[] = [];
+
+  constructor(private onUpdate?: ToolCallsUpdateHandler) {}
+
+  enqueue(calls: ToolCall[]): void {
+    this.queue.push(...calls);
+    this.emitUpdate();
+  }
+
+  dequeue(): ToolCall | undefined {
+    const next = this.queue.shift();
+    if (next) {
+      this.activeCalls.set(next.request.callId, next);
+    }
+    return next;
+  }
+
+  hasActiveCalls(): boolean {
+    return this.activeCalls.size > 0;
+  }
+
+  getActiveCallCount(): number {
+    return this.activeCalls.size;
+  }
+
+  getQueueLength(): number {
+    return this.queue.length;
+  }
+
+  /**
+   * Returns the first active call, if any.
+   * Useful for the current single-active-tool implementation.
+   */
+  getFirstActiveCall(): ToolCall | undefined {
+    return this.activeCalls.values().next().value;
+  }
+
+  updateStatus(callId: string, status: Status, auxiliaryData?: unknown): void {
+    const call = this.activeCalls.get(callId);
+    if (!call) return;
+
+    const updatedCall = this.transitionCall(call, status, auxiliaryData);
+
+    this.activeCalls.set(callId, updatedCall);
+
+    this.emitUpdate();
+  }
+
+  /**
+   * Moves an active tool call to the completed batch.
+   * This should be called by the scheduler after it has finished processing
+   * the terminal state (e.g., logging, etc).
+   */
+  finalizeCall(callId: string): void {
+    const call = this.activeCalls.get(callId);
+    if (!call) {
+      return;
+    }
+
+    if (this.isTerminal(call.status)) {
+      this.completedBatch.push(call as CompletedToolCall);
+      this.activeCalls.delete(callId);
+    }
+  }
+
+  updateArgs(
+    callId: string,
+    newArgs: Record<string, unknown>,
+    newInvocation: AnyToolInvocation,
+  ): void {
+    const call = this.activeCalls.get(callId);
+    if (!call || call.status === 'error') return;
+
+    this.activeCalls.set(callId, {
+      ...call,
+      request: { ...call.request, args: newArgs },
+      invocation: newInvocation,
+    } as ToolCall);
+    this.emitUpdate();
+  }
+
+  setOutcome(callId: string, outcome: ToolConfirmationOutcome): void {
+    const call = this.activeCalls.get(callId);
+    if (!call) return;
+
+    this.activeCalls.set(callId, {
+      ...call,
+      outcome,
+    } as ToolCall);
+    this.emitUpdate();
+  }
+
+  cancelAllQueued(reason: string): void {
+    while (this.queue.length > 0) {
+      const queuedCall = this.queue.shift()!;
+
+      // Don't cancel tools that already errored during validation.
+      if (queuedCall.status === 'error') {
+        this.completedBatch.push(queuedCall);
+        continue;
+      }
+
+      const durationMs =
+        'startTime' in queuedCall && queuedCall.startTime
+          ? Date.now() - queuedCall.startTime
+          : undefined;
+
+      const errorMessage = `[Operation Cancelled] ${reason}`;
+
+      this.completedBatch.push({
+        request: queuedCall.request,
+        tool: queuedCall.tool,
+        invocation: queuedCall.invocation,
+        status: 'cancelled',
+        response: {
+          callId: queuedCall.request.callId,
+          responseParts: [
+            {
+              functionResponse: {
+                id: queuedCall.request.callId,
+                name: queuedCall.request.name,
+                response: {
+                  error: errorMessage,
+                },
+              },
+            },
+          ],
+          resultDisplay: undefined,
+          error: undefined,
+          errorType: undefined,
+          contentLength: errorMessage.length,
+        },
+        durationMs,
+        outcome: ToolConfirmationOutcome.Cancel,
+      } as CancelledToolCall);
+    }
+    this.emitUpdate();
+  }
+
+  getSnapshot(): ToolCall[] {
+    return [
+      ...this.completedBatch,
+      ...Array.from(this.activeCalls.values()),
+      ...this.queue,
+    ];
+  }
+
+  clearBatch(): void {
+    if (this.completedBatch.length === 0) return;
+    this.completedBatch = [];
+    this.emitUpdate();
+  }
+
+  getCompletedBatch(): CompletedToolCall[] {
+    return this.completedBatch;
+  }
+
+  private emitUpdate() {
+    if (this.onUpdate) {
+      this.onUpdate(this.getSnapshot());
+    }
+  }
+
+  private isTerminal(status: Status): boolean {
+    return status === 'success' || status === 'error' || status === 'cancelled';
+  }
+
+  private transitionCall(
+    call: ToolCall,
+    newStatus: Status,
+    auxiliaryData?: unknown,
+  ): ToolCall {
+    switch (newStatus) {
+      case 'success':
+        return this.toSuccess(call, auxiliaryData as ToolCallResponseInfo);
+      case 'error':
+        return this.toError(call, auxiliaryData as ToolCallResponseInfo);
+      case 'awaiting_approval':
+        return this.toAwaitingApproval(
+          call,
+          auxiliaryData as ToolCallConfirmationDetails,
+        );
+      case 'scheduled':
+        return this.toScheduled(call);
+      case 'cancelled':
+        return this.toCancelled(call, auxiliaryData as string);
+      case 'validating':
+        return this.toValidating(call);
+      case 'executing':
+        return this.toExecuting(call, auxiliaryData);
+      default: {
+        const exhaustiveCheck: never = newStatus;
+        return exhaustiveCheck;
+      }
+    }
+  }
+
+  private toSuccess(
+    call: ToolCall,
+    response: ToolCallResponseInfo,
+  ): SuccessfulToolCall {
+    const startTime = 'startTime' in call ? call.startTime : undefined;
+    return {
+      request: call.request,
+      tool: 'tool' in call ? call.tool : undefined,
+      invocation: 'invocation' in call ? call.invocation : undefined,
+      status: 'success',
+      response,
+      durationMs: startTime ? Date.now() - startTime : undefined,
+      outcome: call.outcome,
+    } as SuccessfulToolCall;
+  }
+
+  private toError(
+    call: ToolCall,
+    response: ToolCallResponseInfo,
+  ): ErroredToolCall {
+    const startTime = 'startTime' in call ? call.startTime : undefined;
+    return {
+      request: call.request,
+      status: 'error',
+      tool: 'tool' in call ? call.tool : undefined,
+      response,
+      durationMs: startTime ? Date.now() - startTime : undefined,
+      outcome: call.outcome,
+    } as ErroredToolCall;
+  }
+
+  private toAwaitingApproval(
+    call: ToolCall,
+    confirmationDetails: ToolCallConfirmationDetails,
+  ): WaitingToolCall {
+    return {
+      request: call.request,
+      tool: 'tool' in call ? call.tool : undefined,
+      status: 'awaiting_approval',
+      confirmationDetails,
+      startTime: 'startTime' in call ? call.startTime : undefined,
+      outcome: call.outcome,
+      invocation: 'invocation' in call ? call.invocation : undefined,
+    } as WaitingToolCall;
+  }
+
+  private toScheduled(call: ToolCall): ScheduledToolCall {
+    return {
+      request: call.request,
+      tool: 'tool' in call ? call.tool : undefined,
+      status: 'scheduled',
+      startTime: 'startTime' in call ? call.startTime : undefined,
+      outcome: call.outcome,
+      invocation: 'invocation' in call ? call.invocation : undefined,
+    } as ScheduledToolCall;
+  }
+
+  private toCancelled(call: ToolCall, reason: string): CancelledToolCall {
+    const startTime = 'startTime' in call ? call.startTime : undefined;
+
+    // Preserve diff for cancelled edit operations
+    let resultDisplay: ToolResultDisplay | undefined = undefined;
+    if (call.status === 'awaiting_approval') {
+      const waitingCall = call;
+      if (waitingCall.confirmationDetails.type === 'edit') {
+        resultDisplay = {
+          fileDiff: waitingCall.confirmationDetails.fileDiff,
+          fileName: waitingCall.confirmationDetails.fileName,
+          filePath: waitingCall.confirmationDetails.filePath,
+          originalContent: waitingCall.confirmationDetails.originalContent,
+          newContent: waitingCall.confirmationDetails.newContent,
+        };
+      }
+    }
+
+    const errorMessage = `[Operation Cancelled] Reason: ${reason}`;
+    return {
+      request: call.request,
+      tool: 'tool' in call ? call.tool : undefined,
+      invocation: 'invocation' in call ? call.invocation : undefined,
+      status: 'cancelled',
+      response: {
+        callId: call.request.callId,
+        responseParts: [
+          {
+            functionResponse: {
+              id: call.request.callId,
+              name: call.request.name,
+              response: {
+                error: errorMessage,
+              },
+            },
+          },
+        ],
+        resultDisplay,
+        error: undefined,
+        errorType: undefined,
+        contentLength: errorMessage.length,
+      },
+      durationMs: startTime ? Date.now() - startTime : undefined,
+      outcome: call.outcome,
+    } as CancelledToolCall;
+  }
+
+  private toValidating(call: ToolCall): ValidatingToolCall {
+    return {
+      request: call.request,
+      tool: 'tool' in call ? call.tool : undefined,
+      status: 'validating',
+      startTime: 'startTime' in call ? call.startTime : undefined,
+      outcome: call.outcome,
+      invocation: 'invocation' in call ? call.invocation : undefined,
+    } as ValidatingToolCall;
+  }
+
+  private toExecuting(call: ToolCall, data?: unknown): ExecutingToolCall {
+    const execData = data as Partial<ExecutingToolCall> | undefined;
+    const liveOutput =
+      execData?.liveOutput ??
+      ('liveOutput' in call ? call.liveOutput : undefined);
+    const pid = execData?.pid ?? ('pid' in call ? call.pid : undefined);
+
+    return {
+      request: call.request,
+      tool: 'tool' in call ? call.tool : undefined,
+      status: 'executing',
+      startTime: 'startTime' in call ? call.startTime : undefined,
+      outcome: call.outcome,
+      invocation: 'invocation' in call ? call.invocation : undefined,
+      liveOutput,
+      pid,
+    } as ExecutingToolCall;
+  }
+}

--- a/packages/core/src/scheduler/tool-modifier.test.ts
+++ b/packages/core/src/scheduler/tool-modifier.test.ts
@@ -1,0 +1,252 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ToolModificationHandler } from './tool-modifier.js';
+import type { WaitingToolCall, ToolCallRequestInfo } from './types.js';
+import * as modifiableToolModule from '../tools/modifiable-tool.js';
+import * as Diff from 'diff';
+import { MockModifiableTool, MockTool } from '../test-utils/mock-tool.js';
+import type {
+  ToolResult,
+  ToolInvocation,
+  ToolConfirmationPayload,
+} from '../tools/tools.js';
+import type { ModifyContext } from '../tools/modifiable-tool.js';
+import type { Mock } from 'vitest';
+
+// Mock the modules that export functions we need to control
+vi.mock('diff', () => ({
+  createPatch: vi.fn(),
+  diffLines: vi.fn(),
+}));
+
+vi.mock('../tools/modifiable-tool.js', () => ({
+  isModifiableDeclarativeTool: vi.fn(),
+  modifyWithEditor: vi.fn(),
+}));
+
+type MockModifyContext = {
+  [K in keyof ModifyContext<Record<string, unknown>>]: Mock;
+};
+
+function createMockWaitingToolCall(
+  overrides: Partial<WaitingToolCall> = {},
+): WaitingToolCall {
+  return {
+    status: 'awaiting_approval',
+    request: {
+      callId: 'test-call-id',
+      name: 'test-tool',
+      args: {},
+      isClientInitiated: false,
+      prompt_id: 'test-prompt-id',
+    } as ToolCallRequestInfo,
+    tool: new MockTool({ name: 'test-tool' }),
+    invocation: {} as ToolInvocation<Record<string, unknown>, ToolResult>, // We generally don't check invocation details in these tests
+    confirmationDetails: {
+      type: 'edit',
+      title: 'Test Confirmation',
+      fileName: 'test.txt',
+      filePath: '/path/to/test.txt',
+      fileDiff: 'diff',
+      originalContent: 'original',
+      newContent: 'new',
+      onConfirm: async () => {},
+    },
+    ...overrides,
+  };
+}
+
+describe('ToolModificationHandler', () => {
+  let handler: ToolModificationHandler;
+  let mockModifiableTool: MockModifiableTool;
+  let mockPlainTool: MockTool;
+  let mockModifyContext: MockModifyContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new ToolModificationHandler();
+    mockModifiableTool = new MockModifiableTool();
+    mockPlainTool = new MockTool({ name: 'plainTool' });
+
+    mockModifyContext = {
+      getCurrentContent: vi.fn(),
+      getFilePath: vi.fn(),
+      createUpdatedParams: vi.fn(),
+      getProposedContent: vi.fn(),
+    };
+
+    vi.spyOn(mockModifiableTool, 'getModifyContext').mockReturnValue(
+      mockModifyContext as unknown as ModifyContext<Record<string, unknown>>,
+    );
+  });
+
+  describe('handleModifyWithEditor', () => {
+    it('should return undefined if tool is not modifiable', async () => {
+      vi.mocked(
+        modifiableToolModule.isModifiableDeclarativeTool,
+      ).mockReturnValue(false);
+
+      const mockWaitingToolCall = createMockWaitingToolCall({
+        tool: mockPlainTool,
+        request: {
+          callId: 'call-1',
+          name: 'plainTool',
+          args: { path: 'foo.txt' },
+          isClientInitiated: false,
+          prompt_id: 'p1',
+        },
+      });
+
+      const result = await handler.handleModifyWithEditor(
+        mockWaitingToolCall,
+        'vscode',
+        new AbortController().signal,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should call modifyWithEditor and return updated params', async () => {
+      vi.mocked(
+        modifiableToolModule.isModifiableDeclarativeTool,
+      ).mockReturnValue(true);
+
+      vi.mocked(modifiableToolModule.modifyWithEditor).mockResolvedValue({
+        updatedParams: { path: 'foo.txt', content: 'new' },
+        updatedDiff: 'diff',
+      });
+
+      const mockWaitingToolCall = createMockWaitingToolCall({
+        tool: mockModifiableTool,
+        request: {
+          callId: 'call-1',
+          name: 'mockModifiableTool',
+          args: { path: 'foo.txt' },
+          isClientInitiated: false,
+          prompt_id: 'p1',
+        },
+        confirmationDetails: {
+          type: 'edit',
+          title: 'Confirm',
+          fileName: 'foo.txt',
+          filePath: 'foo.txt',
+          fileDiff: 'diff',
+          originalContent: 'old',
+          newContent: 'new',
+          onConfirm: async () => {},
+        },
+      });
+
+      const result = await handler.handleModifyWithEditor(
+        mockWaitingToolCall,
+        'vscode',
+        new AbortController().signal,
+      );
+
+      expect(modifiableToolModule.modifyWithEditor).toHaveBeenCalledWith(
+        mockWaitingToolCall.request.args,
+        mockModifyContext,
+        'vscode',
+        expect.any(AbortSignal),
+        { currentContent: 'old', proposedContent: 'new' },
+      );
+
+      expect(result).toEqual({
+        updatedParams: { path: 'foo.txt', content: 'new' },
+        updatedDiff: 'diff',
+      });
+    });
+  });
+
+  describe('applyInlineModify', () => {
+    it('should return undefined if tool is not modifiable', async () => {
+      vi.mocked(
+        modifiableToolModule.isModifiableDeclarativeTool,
+      ).mockReturnValue(false);
+
+      const mockWaitingToolCall = createMockWaitingToolCall({
+        tool: mockPlainTool,
+      });
+
+      const result = await handler.applyInlineModify(
+        mockWaitingToolCall,
+        { newContent: 'foo' },
+        new AbortController().signal,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined if payload has no new content', async () => {
+      vi.mocked(
+        modifiableToolModule.isModifiableDeclarativeTool,
+      ).mockReturnValue(true);
+
+      const mockWaitingToolCall = createMockWaitingToolCall({
+        tool: mockModifiableTool,
+      });
+
+      const result = await handler.applyInlineModify(
+        mockWaitingToolCall,
+        { newContent: undefined } as unknown as ToolConfirmationPayload,
+        new AbortController().signal,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should calculate diff and return updated params', async () => {
+      vi.mocked(
+        modifiableToolModule.isModifiableDeclarativeTool,
+      ).mockReturnValue(true);
+      (Diff.createPatch as unknown as Mock).mockReturnValue('mock-diff');
+
+      mockModifyContext.getCurrentContent.mockResolvedValue('old content');
+      mockModifyContext.getFilePath.mockReturnValue('test.txt');
+      mockModifyContext.createUpdatedParams.mockReturnValue({
+        content: 'new content',
+      });
+
+      const mockWaitingToolCall = createMockWaitingToolCall({
+        tool: mockModifiableTool,
+        request: {
+          callId: 'call-1',
+          name: 'mockModifiableTool',
+          args: { content: 'original' },
+          isClientInitiated: false,
+          prompt_id: 'p1',
+        },
+      });
+
+      const result = await handler.applyInlineModify(
+        mockWaitingToolCall,
+        { newContent: 'new content' },
+        new AbortController().signal,
+      );
+
+      expect(mockModifyContext.getCurrentContent).toHaveBeenCalled();
+      expect(mockModifyContext.createUpdatedParams).toHaveBeenCalledWith(
+        'old content',
+        'new content',
+        { content: 'original' },
+      );
+      expect(Diff.createPatch).toHaveBeenCalledWith(
+        'test.txt',
+        'old content',
+        'new content',
+        'Current',
+        'Proposed',
+      );
+
+      expect(result).toEqual({
+        updatedParams: { content: 'new content' },
+        updatedDiff: 'mock-diff',
+      });
+    });
+  });
+});

--- a/packages/core/src/scheduler/tool-modifier.ts
+++ b/packages/core/src/scheduler/tool-modifier.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Diff from 'diff';
+import type { EditorType } from '../utils/editor.js';
+import {
+  isModifiableDeclarativeTool,
+  modifyWithEditor,
+  type ModifyContext,
+} from '../tools/modifiable-tool.js';
+import type { ToolConfirmationPayload } from '../tools/tools.js';
+import type { WaitingToolCall } from './types.js';
+
+export interface ModificationResult {
+  updatedParams: Record<string, unknown>;
+  updatedDiff?: string;
+}
+
+export class ToolModificationHandler {
+  /**
+   * Handles the "Modify with Editor" flow where an external editor is launched
+   * to modify the tool's parameters.
+   */
+  async handleModifyWithEditor(
+    toolCall: WaitingToolCall,
+    editorType: EditorType,
+    signal: AbortSignal,
+  ): Promise<ModificationResult | undefined> {
+    if (!isModifiableDeclarativeTool(toolCall.tool)) {
+      return undefined;
+    }
+
+    const confirmationDetails = toolCall.confirmationDetails;
+    const modifyContext = toolCall.tool.getModifyContext(signal);
+
+    const contentOverrides =
+      confirmationDetails.type === 'edit'
+        ? {
+            currentContent: confirmationDetails.originalContent,
+            proposedContent: confirmationDetails.newContent,
+          }
+        : undefined;
+
+    const { updatedParams, updatedDiff } = await modifyWithEditor<
+      typeof toolCall.request.args
+    >(
+      toolCall.request.args,
+      modifyContext as ModifyContext<typeof toolCall.request.args>,
+      editorType,
+      signal,
+      contentOverrides,
+    );
+
+    return {
+      updatedParams,
+      updatedDiff,
+    };
+  }
+
+  /**
+   * Applies user-provided inline content updates (e.g. from the chat UI).
+   */
+  async applyInlineModify(
+    toolCall: WaitingToolCall,
+    payload: ToolConfirmationPayload,
+    signal: AbortSignal,
+  ): Promise<ModificationResult | undefined> {
+    if (
+      toolCall.confirmationDetails.type !== 'edit' ||
+      !payload.newContent ||
+      !isModifiableDeclarativeTool(toolCall.tool)
+    ) {
+      return undefined;
+    }
+
+    const modifyContext = toolCall.tool.getModifyContext(
+      signal,
+    ) as ModifyContext<typeof toolCall.request.args>;
+    const currentContent = await modifyContext.getCurrentContent(
+      toolCall.request.args,
+    );
+
+    const updatedParams = modifyContext.createUpdatedParams(
+      currentContent,
+      payload.newContent,
+      toolCall.request.args,
+    );
+
+    const updatedDiff = Diff.createPatch(
+      modifyContext.getFilePath(toolCall.request.args),
+      currentContent,
+      payload.newContent,
+      'Current',
+      'Proposed',
+    );
+
+    return {
+      updatedParams,
+      updatedDiff,
+    };
+  }
+}

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -311,11 +311,18 @@ describe('editor utils', () => {
       });
     }
 
-    it('should return the correct command for emacs', () => {
-      const command = getDiffCommand('old.txt', 'new.txt', 'emacs');
+    it('should return the correct command for emacs with escaped paths', () => {
+      const command = getDiffCommand(
+        'old file "quote".txt',
+        'new file \\back\\slash.txt',
+        'emacs',
+      );
       expect(command).toEqual({
         command: 'emacs',
-        args: ['--eval', '(ediff "old.txt" "new.txt")'],
+        args: [
+          '--eval',
+          '(ediff "old file \\"quote\\".txt" "new file \\\\back\\\\slash.txt")',
+        ],
       });
     });
 

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -60,6 +60,14 @@ function isValidEditorType(editor: string): editor is EditorType {
   return EDITORS_SET.has(editor);
 }
 
+/**
+ * Escapes a string for use in an Emacs Lisp string literal.
+ * Wraps in double quotes and escapes backslashes and double quotes.
+ */
+function escapeELispString(str: string): string {
+  return `"${str.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
 interface DiffCommand {
   command: string;
   args: string[];
@@ -182,7 +190,10 @@ export function getDiffCommand(
     case 'emacs':
       return {
         command: 'emacs',
-        args: ['--eval', `(ediff "${oldPath}" "${newPath}")`],
+        args: [
+          '--eval',
+          `(ediff ${escapeELispString(oldPath)} ${escapeELispString(newPath)})`,
+        ],
       };
     case 'hx':
       return {


### PR DESCRIPTION
## Summary

Extracts the scheduler state (active calls, queue, completed batch) from `CoreToolScheduler` into a dedicated `SchedulerStateManager`. This modularizes state management and simplifies the scheduler's logic, serving as a foundation for the Phase 2 asynchronous orchestrator.

## Details

- **State Extraction**: Created `SchedulerStateManager` to encapsulate all tool call data structures and status transitions, removing the complex `setStatusInternal` and `setArgsInternal` methods from the scheduler.
- **Fix for Live Output**: Implemented robust property merging in the `executing` state to prevent data loss for live output streaming and PID updates (discovered during internal review).
- **Standardized Finalization**: Introduced an explicit `finalizeCall` step to archive terminal calls into the completed batch after post-processing (like logging).
- **Improved Testability**: Added comprehensive unit tests for `SchedulerStateManager` and updated existing scheduler tests to be resilient to more granular state updates.

## Related Issues

Works towards resolving issue #14306.

## How to Validate

1. **Build**: Run `npm run build` to ensure type safety.
2. **Unit Tests**: Run `npx vitest packages/core/src/scheduler/state-manager.test.ts`.
3. **Integration Tests**: Run `npx vitest packages/core/src/core/coreToolScheduler.test.ts`.
4. **UI Hook Tests**: Run `npx vitest packages/cli/src/ui/hooks/useToolScheduler.test.ts`.
5. **E2E Tests**: Run `npx vitest packages/a2a-server/src/http/app.test.ts`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
