### PR TITLE
fix(core): ensure single part response for Gemini 2.x in parallel turns

### DIFF
--- a/packages/core/src/utils/generateContentResponseUtilities.test.ts
+++ b/packages/core/src/utils/generateContentResponseUtilities.test.ts
@@ -158,7 +158,7 @@ describe('generateContentResponseUtilities', () => {
       ]);
     });
 
-    it('should handle llmContent with fileData for Gemini 3 model (should be siblings)', () => {
+    it('should handle llmContent with fileData for Gemini 3 model (should be nested)', () => {
       const llmContent: Part = {
         fileData: { mimeType: 'application/pdf', fileUri: 'gs://...' },
       };
@@ -174,9 +174,9 @@ describe('generateContentResponseUtilities', () => {
             name: toolName,
             id: callId,
             response: { output: 'Binary content provided (1 item(s)).' },
+            parts: [llmContent],
           },
         },
-        llmContent,
       ]);
     });
 

--- a/packages/core/src/utils/generateContentResponseUtilities.test.ts
+++ b/packages/core/src/utils/generateContentResponseUtilities.test.ts
@@ -202,7 +202,7 @@ describe('generateContentResponseUtilities', () => {
       ]);
     });
 
-    it('should handle llmContent with fileData for non-Gemini 3 models', () => {
+    it('should handle llmContent with fileData for non-Gemini 3 models (should omit siblings)', () => {
       const llmContent: Part = {
         fileData: { mimeType: 'application/pdf', fileUri: 'gs://...' },
       };
@@ -220,7 +220,6 @@ describe('generateContentResponseUtilities', () => {
             response: { output: 'Binary content provided (1 item(s)).' },
           },
         },
-        llmContent,
       ]);
     });
 

--- a/packages/core/src/utils/generateContentResponseUtilities.ts
+++ b/packages/core/src/utils/generateContentResponseUtilities.ts
@@ -122,7 +122,12 @@ export function convertToFunctionResponse(
   }
 
   if (siblingParts.length > 0) {
-    return [part, ...siblingParts];
+    if (isMultimodalFRSupported) {
+      return [part, ...siblingParts];
+    }
+    debugLogger.warn(
+      `Model ${model} does not support multimodal function responses. Sibling parts will be omitted to prevent API errors in parallel function calling.`,
+    );
   }
 
   return [part];


### PR DESCRIPTION
Fixes #16135

### Problem
Gemini 2.x models (like `gemini-2.5-pro`) do not support multimodal function responses. When a tool returns binary content (like `inlineData`), `convertToFunctionResponse` currently appends it as a **sibling part** to the `functionResponse` part.

In a parallel function calling turn, the Gemini API requires a 1:1 mapping between calls and response parts. Sending extra sibling parts causes a `400 INVALID_ARGUMENT` error.

### Solution

Unknown. Closing this PR as it was unable to resolve the problem, despite initial success. This is clearly an intermittent problem. 

