### PR TITLE
feat(cli): add Gruvbox dark and light themes

### DIFF
--- a/docs/cli/themes.md
+++ b/docs/cli/themes.md
@@ -16,12 +16,14 @@ using the `/theme` command within Gemini CLI:
   - `Default`
   - `Dracula`
   - `GitHub`
+  - `Gruvbox`
 - **Light themes:**
   - `ANSI Light`
   - `Ayu Light`
   - `Default Light`
   - `GitHub Light`
   - `Google Code`
+  - `Gruvbox Light`
   - `Xcode`
 
 ### Changing themes
@@ -210,6 +212,10 @@ untrusted sources.
 
 <img src="/assets/theme-github.png" alt="GitHub theme" width="600">
 
+### Gruvbox
+
+<img src="/assets/theme-gruvbox.png" alt="Gruvbox theme" width="600">
+
 ## Light themes
 
 ### ANSI Light
@@ -231,6 +237,10 @@ untrusted sources.
 ### Google Code
 
 <img src="/assets/theme-google-light.png" alt="Google Code theme" width="600">
+
+### Gruvbox Light
+
+<img src="/assets/theme-gruvbox-light.png" alt="Gruvbox Light theme" width="600">
 
 ### Xcode
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2501,7 +2501,6 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -2682,7 +2681,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2716,7 +2714,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
       "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -3085,7 +3082,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz",
       "integrity": "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -3119,7 +3115,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.1.tgz",
       "integrity": "sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/resources": "2.0.1"
@@ -3172,7 +3167,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
       "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/resources": "2.0.1",
@@ -4410,7 +4404,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4688,7 +4681,6 @@
       "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.0",
         "@typescript-eslint/types": "8.35.0",
@@ -5700,7 +5692,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6145,7 +6136,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/array-includes": {
       "version": "3.1.9",
@@ -7433,6 +7425,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -8755,7 +8748,6 @@
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9360,6 +9352,7 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -9369,6 +9362,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -9378,6 +9372,7 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -9631,6 +9626,7 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
       "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~2.0.0",
@@ -9649,6 +9645,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -9657,13 +9654,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/finalhandler/node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -10947,7 +10946,6 @@
       "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.4.6.tgz",
       "integrity": "sha512-QHl6l1cl3zPCaRMzt9TUbTX6Q5SzvkGEZDDad0DmSf5SPmT1/90k6pGPejEvDCJprkitwObXpPaTWGHItqsy4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.1",
         "ansi-escapes": "^7.0.0",
@@ -14136,7 +14134,8 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/path-type": {
       "version": "3.0.0",
@@ -14716,7 +14715,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14727,7 +14725,6 @@
       "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -16972,7 +16969,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17199,8 +17195,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.20.3",
@@ -17208,7 +17203,6 @@
       "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -17392,7 +17386,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17555,6 +17548,7 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -17610,7 +17604,6 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -17727,7 +17720,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17741,7 +17733,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -18448,7 +18439,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -19013,7 +19003,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/packages/cli/src/ui/themes/gruvbox-light.ts
+++ b/packages/cli/src/ui/themes/gruvbox-light.ts
@@ -1,0 +1,146 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type ColorsTheme, Theme } from './theme.js';
+import { interpolateColor } from './color-utils.js';
+
+// Gruvbox Light color palette
+// https://github.com/morhetz/gruvbox
+const gruvboxLightColors: ColorsTheme = {
+	type: 'light',
+	Background: '#fbf1c7',
+	Foreground: '#3c3836',
+	LightBlue: '#076678',
+	AccentBlue: '#076678',
+	AccentPurple: '#8f3f71',
+	AccentCyan: '#427b58',
+	AccentGreen: '#79740e',
+	AccentYellow: '#b57614',
+	AccentRed: '#9d0006',
+	DiffAdded: '#ebdbb2',
+	DiffRemoved: '#ebdbb2',
+	Comment: '#bdae93',
+	Gray: '#928374',
+	DarkGray: interpolateColor('#bdae93', '#fbf1c7', 0.5),
+	GradientColors: ['#af3a03', '#b57614'],
+};
+
+// Additional Gruvbox colors for syntax highlighting
+const orange = '#af3a03';
+const neutral_orange = '#d65d0e';
+
+export const GruvboxLight: Theme = new Theme(
+	'Gruvbox Light',
+	'light',
+	{
+		hljs: {
+			display: 'block',
+			overflowX: 'auto',
+			padding: '0.5em',
+			background: gruvboxLightColors.Background,
+			color: gruvboxLightColors.Foreground,
+		},
+		'hljs-keyword': {
+			color: gruvboxLightColors.AccentPurple,
+			fontWeight: 'bold',
+		},
+		'hljs-selector-tag': {
+			color: gruvboxLightColors.AccentRed,
+			fontWeight: 'bold',
+		},
+		'hljs-literal': {
+			color: orange,
+			fontWeight: 'bold',
+		},
+		'hljs-section': {
+			color: gruvboxLightColors.AccentBlue,
+			fontWeight: 'bold',
+		},
+		'hljs-link': {
+			color: orange,
+		},
+		'hljs-function .hljs-keyword': {
+			color: gruvboxLightColors.AccentPurple,
+		},
+		'hljs-subst': {
+			color: gruvboxLightColors.Foreground,
+		},
+		'hljs-string': {
+			color: gruvboxLightColors.AccentGreen,
+		},
+		'hljs-title': {
+			color: gruvboxLightColors.AccentYellow,
+			fontWeight: 'bold',
+		},
+		'hljs-title.function_': {
+			color: gruvboxLightColors.AccentBlue,
+			fontWeight: 'bold',
+		},
+		'hljs-name': {
+			color: gruvboxLightColors.AccentRed,
+			fontWeight: 'bold',
+		},
+		'hljs-type': {
+			color: gruvboxLightColors.AccentPurple,
+			fontWeight: 'bold',
+		},
+		'hljs-attribute': {
+			color: gruvboxLightColors.AccentBlue,
+		},
+		'hljs-attr': {
+			color: orange,
+		},
+		'hljs-symbol': {
+			color: orange,
+		},
+		'hljs-bullet': {
+			color: gruvboxLightColors.AccentRed,
+		},
+		'hljs-addition': {
+			color: gruvboxLightColors.AccentGreen,
+		},
+		'hljs-variable': {
+			color: gruvboxLightColors.AccentRed,
+		},
+		'hljs-template-tag': {
+			color: gruvboxLightColors.AccentCyan,
+		},
+		'hljs-template-variable': {
+			color: gruvboxLightColors.AccentRed,
+		},
+		'hljs-comment': {
+			color: gruvboxLightColors.Comment,
+		},
+		'hljs-quote': {
+			color: gruvboxLightColors.AccentCyan,
+		},
+		'hljs-deletion': {
+			color: gruvboxLightColors.AccentRed,
+		},
+		'hljs-meta': {
+			color: neutral_orange,
+		},
+		'hljs-built_in': {
+			color: gruvboxLightColors.AccentCyan,
+		},
+		'hljs-regexp': {
+			color: gruvboxLightColors.AccentCyan,
+		},
+		'hljs-number': {
+			color: orange,
+		},
+		'hljs-doctag': {
+			fontWeight: 'bold',
+		},
+		'hljs-strong': {
+			fontWeight: 'bold',
+		},
+		'hljs-emphasis': {
+			fontStyle: 'italic',
+		},
+	},
+	gruvboxLightColors,
+);

--- a/packages/cli/src/ui/themes/gruvbox-light.ts
+++ b/packages/cli/src/ui/themes/gruvbox-light.ts
@@ -10,22 +10,22 @@ import { interpolateColor } from './color-utils.js';
 // Gruvbox Light color palette
 // https://github.com/morhetz/gruvbox
 const gruvboxLightColors: ColorsTheme = {
-	type: 'light',
-	Background: '#fbf1c7',
-	Foreground: '#3c3836',
-	LightBlue: '#076678',
-	AccentBlue: '#076678',
-	AccentPurple: '#8f3f71',
-	AccentCyan: '#427b58',
-	AccentGreen: '#79740e',
-	AccentYellow: '#b57614',
-	AccentRed: '#9d0006',
-	DiffAdded: '#ebdbb2',
-	DiffRemoved: '#ebdbb2',
-	Comment: '#bdae93',
-	Gray: '#928374',
-	DarkGray: interpolateColor('#bdae93', '#fbf1c7', 0.5),
-	GradientColors: ['#af3a03', '#b57614'],
+  type: 'light',
+  Background: '#fbf1c7',
+  Foreground: '#3c3836',
+  LightBlue: '#076678',
+  AccentBlue: '#076678',
+  AccentPurple: '#8f3f71',
+  AccentCyan: '#427b58',
+  AccentGreen: '#79740e',
+  AccentYellow: '#b57614',
+  AccentRed: '#9d0006',
+  DiffAdded: interpolateColor('#79740e', '#fbf1c7', 0.85),
+  DiffRemoved: interpolateColor('#9d0006', '#fbf1c7', 0.85),
+  Comment: '#bdae93',
+  Gray: '#928374',
+  DarkGray: interpolateColor('#bdae93', '#fbf1c7', 0.5),
+  GradientColors: ['#af3a03', '#b57614'],
 };
 
 // Additional Gruvbox colors for syntax highlighting
@@ -33,114 +33,114 @@ const orange = '#af3a03';
 const neutral_orange = '#d65d0e';
 
 export const GruvboxLight: Theme = new Theme(
-	'Gruvbox Light',
-	'light',
-	{
-		hljs: {
-			display: 'block',
-			overflowX: 'auto',
-			padding: '0.5em',
-			background: gruvboxLightColors.Background,
-			color: gruvboxLightColors.Foreground,
-		},
-		'hljs-keyword': {
-			color: gruvboxLightColors.AccentPurple,
-			fontWeight: 'bold',
-		},
-		'hljs-selector-tag': {
-			color: gruvboxLightColors.AccentRed,
-			fontWeight: 'bold',
-		},
-		'hljs-literal': {
-			color: orange,
-			fontWeight: 'bold',
-		},
-		'hljs-section': {
-			color: gruvboxLightColors.AccentBlue,
-			fontWeight: 'bold',
-		},
-		'hljs-link': {
-			color: orange,
-		},
-		'hljs-function .hljs-keyword': {
-			color: gruvboxLightColors.AccentPurple,
-		},
-		'hljs-subst': {
-			color: gruvboxLightColors.Foreground,
-		},
-		'hljs-string': {
-			color: gruvboxLightColors.AccentGreen,
-		},
-		'hljs-title': {
-			color: gruvboxLightColors.AccentYellow,
-			fontWeight: 'bold',
-		},
-		'hljs-title.function_': {
-			color: gruvboxLightColors.AccentBlue,
-			fontWeight: 'bold',
-		},
-		'hljs-name': {
-			color: gruvboxLightColors.AccentRed,
-			fontWeight: 'bold',
-		},
-		'hljs-type': {
-			color: gruvboxLightColors.AccentPurple,
-			fontWeight: 'bold',
-		},
-		'hljs-attribute': {
-			color: gruvboxLightColors.AccentBlue,
-		},
-		'hljs-attr': {
-			color: orange,
-		},
-		'hljs-symbol': {
-			color: orange,
-		},
-		'hljs-bullet': {
-			color: gruvboxLightColors.AccentRed,
-		},
-		'hljs-addition': {
-			color: gruvboxLightColors.AccentGreen,
-		},
-		'hljs-variable': {
-			color: gruvboxLightColors.AccentRed,
-		},
-		'hljs-template-tag': {
-			color: gruvboxLightColors.AccentCyan,
-		},
-		'hljs-template-variable': {
-			color: gruvboxLightColors.AccentRed,
-		},
-		'hljs-comment': {
-			color: gruvboxLightColors.Comment,
-		},
-		'hljs-quote': {
-			color: gruvboxLightColors.AccentCyan,
-		},
-		'hljs-deletion': {
-			color: gruvboxLightColors.AccentRed,
-		},
-		'hljs-meta': {
-			color: neutral_orange,
-		},
-		'hljs-built_in': {
-			color: gruvboxLightColors.AccentCyan,
-		},
-		'hljs-regexp': {
-			color: gruvboxLightColors.AccentCyan,
-		},
-		'hljs-number': {
-			color: orange,
-		},
-		'hljs-doctag': {
-			fontWeight: 'bold',
-		},
-		'hljs-strong': {
-			fontWeight: 'bold',
-		},
-		'hljs-emphasis': {
-			fontStyle: 'italic',
-		},
-	},
-	gruvboxLightColors,
+  'Gruvbox Light',
+  'light',
+  {
+    hljs: {
+      display: 'block',
+      overflowX: 'auto',
+      padding: '0.5em',
+      background: gruvboxLightColors.Background,
+      color: gruvboxLightColors.Foreground,
+    },
+    'hljs-keyword': {
+      color: gruvboxLightColors.AccentPurple,
+      fontWeight: 'bold',
+    },
+    'hljs-selector-tag': {
+      color: gruvboxLightColors.AccentRed,
+      fontWeight: 'bold',
+    },
+    'hljs-literal': {
+      color: orange,
+      fontWeight: 'bold',
+    },
+    'hljs-section': {
+      color: gruvboxLightColors.AccentBlue,
+      fontWeight: 'bold',
+    },
+    'hljs-link': {
+      color: orange,
+    },
+    'hljs-function .hljs-keyword': {
+      color: gruvboxLightColors.AccentPurple,
+    },
+    'hljs-subst': {
+      color: gruvboxLightColors.Foreground,
+    },
+    'hljs-string': {
+      color: gruvboxLightColors.AccentGreen,
+    },
+    'hljs-title': {
+      color: gruvboxLightColors.AccentYellow,
+      fontWeight: 'bold',
+    },
+    'hljs-title.function_': {
+      color: gruvboxLightColors.AccentBlue,
+      fontWeight: 'bold',
+    },
+    'hljs-name': {
+      color: gruvboxLightColors.AccentRed,
+      fontWeight: 'bold',
+    },
+    'hljs-type': {
+      color: gruvboxLightColors.AccentPurple,
+      fontWeight: 'bold',
+    },
+    'hljs-attribute': {
+      color: gruvboxLightColors.AccentBlue,
+    },
+    'hljs-attr': {
+      color: orange,
+    },
+    'hljs-symbol': {
+      color: orange,
+    },
+    'hljs-bullet': {
+      color: gruvboxLightColors.AccentRed,
+    },
+    'hljs-addition': {
+      color: gruvboxLightColors.AccentGreen,
+    },
+    'hljs-variable': {
+      color: gruvboxLightColors.AccentRed,
+    },
+    'hljs-template-tag': {
+      color: gruvboxLightColors.AccentCyan,
+    },
+    'hljs-template-variable': {
+      color: gruvboxLightColors.AccentRed,
+    },
+    'hljs-comment': {
+      color: gruvboxLightColors.Comment,
+    },
+    'hljs-quote': {
+      color: gruvboxLightColors.AccentCyan,
+    },
+    'hljs-deletion': {
+      color: gruvboxLightColors.AccentRed,
+    },
+    'hljs-meta': {
+      color: neutral_orange,
+    },
+    'hljs-built_in': {
+      color: gruvboxLightColors.AccentCyan,
+    },
+    'hljs-regexp': {
+      color: gruvboxLightColors.AccentCyan,
+    },
+    'hljs-number': {
+      color: orange,
+    },
+    'hljs-doctag': {
+      fontWeight: 'bold',
+    },
+    'hljs-strong': {
+      fontWeight: 'bold',
+    },
+    'hljs-emphasis': {
+      fontStyle: 'italic',
+    },
+  },
+  gruvboxLightColors,
 );

--- a/packages/cli/src/ui/themes/gruvbox.ts
+++ b/packages/cli/src/ui/themes/gruvbox.ts
@@ -1,0 +1,146 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type ColorsTheme, Theme } from './theme.js';
+import { interpolateColor } from './color-utils.js';
+
+// Gruvbox Dark color palette
+// https://github.com/morhetz/gruvbox
+const gruvboxColors: ColorsTheme = {
+	type: 'dark',
+	Background: '#282828',
+	Foreground: '#ebdbb2',
+	LightBlue: '#83a598',
+	AccentBlue: '#83a598',
+	AccentPurple: '#d3869b',
+	AccentCyan: '#8ec07c',
+	AccentGreen: '#b8bb26',
+	AccentYellow: '#fabd2f',
+	AccentRed: '#fb4934',
+	DiffAdded: '#3c3836',
+	DiffRemoved: '#3c3836',
+	Comment: '#665c54',
+	Gray: '#928374',
+	DarkGray: interpolateColor('#665c54', '#282828', 0.5),
+	GradientColors: ['#fe8019', '#fabd2f'],
+};
+
+// Additional Gruvbox colors for syntax highlighting
+const orange = '#fe8019';
+const neutral_orange = '#d65d0e';
+
+export const Gruvbox: Theme = new Theme(
+	'Gruvbox',
+	'dark',
+	{
+		hljs: {
+			display: 'block',
+			overflowX: 'auto',
+			padding: '0.5em',
+			background: gruvboxColors.Background,
+			color: gruvboxColors.Foreground,
+		},
+		'hljs-keyword': {
+			color: gruvboxColors.AccentPurple,
+			fontWeight: 'bold',
+		},
+		'hljs-selector-tag': {
+			color: gruvboxColors.AccentRed,
+			fontWeight: 'bold',
+		},
+		'hljs-literal': {
+			color: orange,
+			fontWeight: 'bold',
+		},
+		'hljs-section': {
+			color: gruvboxColors.AccentBlue,
+			fontWeight: 'bold',
+		},
+		'hljs-link': {
+			color: orange,
+		},
+		'hljs-function .hljs-keyword': {
+			color: gruvboxColors.AccentPurple,
+		},
+		'hljs-subst': {
+			color: gruvboxColors.Foreground,
+		},
+		'hljs-string': {
+			color: gruvboxColors.AccentGreen,
+		},
+		'hljs-title': {
+			color: gruvboxColors.AccentYellow,
+			fontWeight: 'bold',
+		},
+		'hljs-title.function_': {
+			color: gruvboxColors.AccentBlue,
+			fontWeight: 'bold',
+		},
+		'hljs-name': {
+			color: gruvboxColors.AccentRed,
+			fontWeight: 'bold',
+		},
+		'hljs-type': {
+			color: gruvboxColors.AccentPurple,
+			fontWeight: 'bold',
+		},
+		'hljs-attribute': {
+			color: gruvboxColors.AccentBlue,
+		},
+		'hljs-attr': {
+			color: orange,
+		},
+		'hljs-symbol': {
+			color: orange,
+		},
+		'hljs-bullet': {
+			color: gruvboxColors.AccentRed,
+		},
+		'hljs-addition': {
+			color: gruvboxColors.AccentGreen,
+		},
+		'hljs-variable': {
+			color: gruvboxColors.AccentRed,
+		},
+		'hljs-template-tag': {
+			color: gruvboxColors.AccentCyan,
+		},
+		'hljs-template-variable': {
+			color: gruvboxColors.AccentRed,
+		},
+		'hljs-comment': {
+			color: gruvboxColors.Comment,
+		},
+		'hljs-quote': {
+			color: gruvboxColors.AccentCyan,
+		},
+		'hljs-deletion': {
+			color: gruvboxColors.AccentRed,
+		},
+		'hljs-meta': {
+			color: neutral_orange,
+		},
+		'hljs-built_in': {
+			color: gruvboxColors.AccentCyan,
+		},
+		'hljs-regexp': {
+			color: gruvboxColors.AccentCyan,
+		},
+		'hljs-number': {
+			color: orange,
+		},
+		'hljs-doctag': {
+			fontWeight: 'bold',
+		},
+		'hljs-strong': {
+			fontWeight: 'bold',
+		},
+		'hljs-emphasis': {
+			fontStyle: 'italic',
+		},
+	},
+	gruvboxColors,
+);

--- a/packages/cli/src/ui/themes/gruvbox.ts
+++ b/packages/cli/src/ui/themes/gruvbox.ts
@@ -10,22 +10,22 @@ import { interpolateColor } from './color-utils.js';
 // Gruvbox Dark color palette
 // https://github.com/morhetz/gruvbox
 const gruvboxColors: ColorsTheme = {
-	type: 'dark',
-	Background: '#282828',
-	Foreground: '#ebdbb2',
-	LightBlue: '#83a598',
-	AccentBlue: '#83a598',
-	AccentPurple: '#d3869b',
-	AccentCyan: '#8ec07c',
-	AccentGreen: '#b8bb26',
-	AccentYellow: '#fabd2f',
-	AccentRed: '#fb4934',
-	DiffAdded: '#3c3836',
-	DiffRemoved: '#3c3836',
-	Comment: '#665c54',
-	Gray: '#928374',
-	DarkGray: interpolateColor('#665c54', '#282828', 0.5),
-	GradientColors: ['#fe8019', '#fabd2f'],
+  type: 'dark',
+  Background: '#282828',
+  Foreground: '#ebdbb2',
+  LightBlue: '#83a598',
+  AccentBlue: '#83a598',
+  AccentPurple: '#d3869b',
+  AccentCyan: '#8ec07c',
+  AccentGreen: '#b8bb26',
+  AccentYellow: '#fabd2f',
+  AccentRed: '#fb4934',
+  DiffAdded: interpolateColor('#b8bb26', '#282828', 0.85),
+  DiffRemoved: interpolateColor('#fb4934', '#282828', 0.85),
+  Comment: '#665c54',
+  Gray: '#928374',
+  DarkGray: interpolateColor('#665c54', '#282828', 0.5),
+  GradientColors: ['#fe8019', '#fabd2f'],
 };
 
 // Additional Gruvbox colors for syntax highlighting
@@ -33,114 +33,114 @@ const orange = '#fe8019';
 const neutral_orange = '#d65d0e';
 
 export const Gruvbox: Theme = new Theme(
-	'Gruvbox',
-	'dark',
-	{
-		hljs: {
-			display: 'block',
-			overflowX: 'auto',
-			padding: '0.5em',
-			background: gruvboxColors.Background,
-			color: gruvboxColors.Foreground,
-		},
-		'hljs-keyword': {
-			color: gruvboxColors.AccentPurple,
-			fontWeight: 'bold',
-		},
-		'hljs-selector-tag': {
-			color: gruvboxColors.AccentRed,
-			fontWeight: 'bold',
-		},
-		'hljs-literal': {
-			color: orange,
-			fontWeight: 'bold',
-		},
-		'hljs-section': {
-			color: gruvboxColors.AccentBlue,
-			fontWeight: 'bold',
-		},
-		'hljs-link': {
-			color: orange,
-		},
-		'hljs-function .hljs-keyword': {
-			color: gruvboxColors.AccentPurple,
-		},
-		'hljs-subst': {
-			color: gruvboxColors.Foreground,
-		},
-		'hljs-string': {
-			color: gruvboxColors.AccentGreen,
-		},
-		'hljs-title': {
-			color: gruvboxColors.AccentYellow,
-			fontWeight: 'bold',
-		},
-		'hljs-title.function_': {
-			color: gruvboxColors.AccentBlue,
-			fontWeight: 'bold',
-		},
-		'hljs-name': {
-			color: gruvboxColors.AccentRed,
-			fontWeight: 'bold',
-		},
-		'hljs-type': {
-			color: gruvboxColors.AccentPurple,
-			fontWeight: 'bold',
-		},
-		'hljs-attribute': {
-			color: gruvboxColors.AccentBlue,
-		},
-		'hljs-attr': {
-			color: orange,
-		},
-		'hljs-symbol': {
-			color: orange,
-		},
-		'hljs-bullet': {
-			color: gruvboxColors.AccentRed,
-		},
-		'hljs-addition': {
-			color: gruvboxColors.AccentGreen,
-		},
-		'hljs-variable': {
-			color: gruvboxColors.AccentRed,
-		},
-		'hljs-template-tag': {
-			color: gruvboxColors.AccentCyan,
-		},
-		'hljs-template-variable': {
-			color: gruvboxColors.AccentRed,
-		},
-		'hljs-comment': {
-			color: gruvboxColors.Comment,
-		},
-		'hljs-quote': {
-			color: gruvboxColors.AccentCyan,
-		},
-		'hljs-deletion': {
-			color: gruvboxColors.AccentRed,
-		},
-		'hljs-meta': {
-			color: neutral_orange,
-		},
-		'hljs-built_in': {
-			color: gruvboxColors.AccentCyan,
-		},
-		'hljs-regexp': {
-			color: gruvboxColors.AccentCyan,
-		},
-		'hljs-number': {
-			color: orange,
-		},
-		'hljs-doctag': {
-			fontWeight: 'bold',
-		},
-		'hljs-strong': {
-			fontWeight: 'bold',
-		},
-		'hljs-emphasis': {
-			fontStyle: 'italic',
-		},
-	},
-	gruvboxColors,
+  'Gruvbox',
+  'dark',
+  {
+    hljs: {
+      display: 'block',
+      overflowX: 'auto',
+      padding: '0.5em',
+      background: gruvboxColors.Background,
+      color: gruvboxColors.Foreground,
+    },
+    'hljs-keyword': {
+      color: gruvboxColors.AccentPurple,
+      fontWeight: 'bold',
+    },
+    'hljs-selector-tag': {
+      color: gruvboxColors.AccentRed,
+      fontWeight: 'bold',
+    },
+    'hljs-literal': {
+      color: orange,
+      fontWeight: 'bold',
+    },
+    'hljs-section': {
+      color: gruvboxColors.AccentBlue,
+      fontWeight: 'bold',
+    },
+    'hljs-link': {
+      color: orange,
+    },
+    'hljs-function .hljs-keyword': {
+      color: gruvboxColors.AccentPurple,
+    },
+    'hljs-subst': {
+      color: gruvboxColors.Foreground,
+    },
+    'hljs-string': {
+      color: gruvboxColors.AccentGreen,
+    },
+    'hljs-title': {
+      color: gruvboxColors.AccentYellow,
+      fontWeight: 'bold',
+    },
+    'hljs-title.function_': {
+      color: gruvboxColors.AccentBlue,
+      fontWeight: 'bold',
+    },
+    'hljs-name': {
+      color: gruvboxColors.AccentRed,
+      fontWeight: 'bold',
+    },
+    'hljs-type': {
+      color: gruvboxColors.AccentPurple,
+      fontWeight: 'bold',
+    },
+    'hljs-attribute': {
+      color: gruvboxColors.AccentBlue,
+    },
+    'hljs-attr': {
+      color: orange,
+    },
+    'hljs-symbol': {
+      color: orange,
+    },
+    'hljs-bullet': {
+      color: gruvboxColors.AccentRed,
+    },
+    'hljs-addition': {
+      color: gruvboxColors.AccentGreen,
+    },
+    'hljs-variable': {
+      color: gruvboxColors.AccentRed,
+    },
+    'hljs-template-tag': {
+      color: gruvboxColors.AccentCyan,
+    },
+    'hljs-template-variable': {
+      color: gruvboxColors.AccentRed,
+    },
+    'hljs-comment': {
+      color: gruvboxColors.Comment,
+    },
+    'hljs-quote': {
+      color: gruvboxColors.AccentCyan,
+    },
+    'hljs-deletion': {
+      color: gruvboxColors.AccentRed,
+    },
+    'hljs-meta': {
+      color: neutral_orange,
+    },
+    'hljs-built_in': {
+      color: gruvboxColors.AccentCyan,
+    },
+    'hljs-regexp': {
+      color: gruvboxColors.AccentCyan,
+    },
+    'hljs-number': {
+      color: orange,
+    },
+    'hljs-doctag': {
+      fontWeight: 'bold',
+    },
+    'hljs-strong': {
+      fontWeight: 'bold',
+    },
+    'hljs-emphasis': {
+      fontStyle: 'italic',
+    },
+  },
+  gruvboxColors,
 );

--- a/packages/cli/src/ui/themes/theme-manager.ts
+++ b/packages/cli/src/ui/themes/theme-manager.ts
@@ -11,6 +11,8 @@ import { Dracula } from './dracula.js';
 import { GitHubDark } from './github-dark.js';
 import { GitHubLight } from './github-light.js';
 import { GoogleCode } from './googlecode.js';
+import { Gruvbox } from './gruvbox.js';
+import { GruvboxLight } from './gruvbox-light.js';
 import { Holiday } from './holiday.js';
 import { DefaultLight } from './default-light.js';
 import { DefaultDark } from './default.js';
@@ -51,6 +53,8 @@ class ThemeManager {
       GitHubDark,
       GitHubLight,
       GoogleCode,
+      Gruvbox,
+      GruvboxLight,
       Holiday,
       ShadesOfPurple,
       XCode,


### PR DESCRIPTION
## Summary

  Add Gruvbox dark and light themes to Gemini CLI. Gruvbox is a popular retro groove color scheme with warm, earthy tones that is easy on the eyes.

  ## Details

  Color mappings follow the official highlight.js Gruvbox theme:
  - Keywords: purple (#d3869b)
  - Strings: green (#b8bb26)
  - Numbers/literals: orange (#fe8019)
  - Variables: red (#fb4934)
  - Functions: blue (#83a598)
  - Comments: gray (#665c54)

  Light theme uses faded color variants for better contrast on light backgrounds.

  ## Related Issues

  N/A

  ## How to Validate

  1. Run `npm install && npm run build`
  2. Start CLI with `npm start`
  3. Enter `/theme` command
  4. Select "Gruvbox" or "Gruvbox Light"
  5. Verify syntax highlighting colors match Gruvbox scheme

  ## Pre-Merge Checklist

  - [x] Updated relevant documentation and README (if needed)
  - [ ] Added/updated tests (if needed)
  - [ ] Noted breaking changes (if any)
  - [ ] Validated on required platforms/methods:
    - [ ] MacOS
      - [ ] npm run
      - [ ] npx
      - [ ] Docker
      - [ ] Podman
      - [ ] Seatbelt
    - [ ] Windows
      - [ ] npm run
      - [ ] npx
      - [ ] Docker
    - [ ] Linux
      - [ ] npm run
      - [ ] npx
      - [ ] Docker