### PR TITLE
Polish: Move 'Failed to load skills' warning to debug logs

### DIFF
--- a/packages/cli/src/config/extension-manager-skills.test.ts
+++ b/packages/cli/src/config/extension-manager-skills.test.ts
@@ -12,7 +12,7 @@ import { ExtensionManager } from './extension-manager.js';
 import { loadSettings } from './settings.js';
 import { createExtension } from '../test-utils/createExtension.js';
 import { EXTENSIONS_DIRECTORY_NAME } from './extensions/variables.js';
-import { coreEvents } from '@google/gemini-cli-core';
+import { coreEvents, debugLogger } from '@google/gemini-cli-core';
 
 const mockHomedir = vi.hoisted(() => vi.fn());
 
@@ -58,6 +58,7 @@ describe('ExtensionManager skills validation', () => {
       settings: loadSettings(tempWorkspaceDir).merged,
     });
     vi.spyOn(coreEvents, 'emitFeedback');
+    vi.spyOn(debugLogger, 'debug').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -83,8 +84,7 @@ describe('ExtensionManager skills validation', () => {
     });
 
     expect(extension.name).toBe('skills-ext');
-    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
-      'warning',
+    expect(debugLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining('Failed to load skills from'),
     );
   });
@@ -102,12 +102,10 @@ describe('ExtensionManager skills validation', () => {
 
     await extensionManager.loadExtensions();
 
-    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
-      'warning',
+    expect(debugLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining('Failed to load skills from'),
     );
-    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
-      'warning',
+    expect(debugLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining(
         'The directory is not empty but no valid skills were discovered',
       ),
@@ -139,8 +137,7 @@ describe('ExtensionManager skills validation', () => {
     expect(extension.skills![0].name).toBe('test-skill');
     // It might be called for other reasons during startup, but shouldn't be called for our skills loading success
     // Actually, it shouldn't be called with our warning message
-    expect(coreEvents.emitFeedback).not.toHaveBeenCalledWith(
-      'warning',
+    expect(debugLogger.debug).not.toHaveBeenCalledWith(
       expect.stringContaining('Failed to load skills from'),
     );
   });

--- a/packages/core/src/skills/skillLoader.test.ts
+++ b/packages/core/src/skills/skillLoader.test.ts
@@ -10,6 +10,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { loadSkillsFromDir } from './skillLoader.js';
 import { coreEvents } from '../utils/events.js';
+import { debugLogger } from '../utils/debugLogger.js';
 
 describe('skillLoader', () => {
   let testRootDir: string;
@@ -19,6 +20,7 @@ describe('skillLoader', () => {
       path.join(os.tmpdir(), 'skill-loader-test-'),
     );
     vi.spyOn(coreEvents, 'emitFeedback');
+    vi.spyOn(debugLogger, 'debug').mockImplementation(() => {});
   });
 
   afterEach(async () => {
@@ -53,8 +55,7 @@ describe('skillLoader', () => {
     const skills = await loadSkillsFromDir(testRootDir);
 
     expect(skills).toHaveLength(0);
-    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
-      'warning',
+    expect(debugLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining('Failed to load skills from'),
     );
   });
@@ -89,8 +90,7 @@ describe('skillLoader', () => {
     const skills = await loadSkillsFromDir(testRootDir);
 
     expect(skills).toHaveLength(0);
-    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
-      'warning',
+    expect(debugLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining('Failed to load skills from'),
     );
   });

--- a/packages/core/src/skills/skillLoader.ts
+++ b/packages/core/src/skills/skillLoader.ts
@@ -60,8 +60,7 @@ export async function loadSkillsFromDir(
     if (discoveredSkills.length === 0) {
       const files = await fs.readdir(absoluteSearchPath);
       if (files.length > 0) {
-        coreEvents.emitFeedback(
-          'warning',
+        debugLogger.debug(
           `Failed to load skills from ${absoluteSearchPath}. The directory is not empty but no valid skills were discovered. Please ensure SKILL.md files are present in subdirectories and have valid frontmatter.`,
         );
       }


### PR DESCRIPTION
## Summary

This PR moves the "Failed to load skills from <path>" warning from a user-facing feedback event to the debug logs. This reduces noise for users when an extension's `skills` folder contains non-skill files, while keeping the information available for troubleshooting via the F12 debug panel.

### Before
<img width="3456" height="2160" alt="image" src="https://github.com/user-attachments/assets/59bb37cb-d568-41a6-b5fc-40b561f3ad48" />

### After
<img width="3456" height="2160" alt="image" src="https://github.com/user-attachments/assets/ee82350b-8132-4640-84fc-0a25c84112c5" />

## Details

- Changed `coreEvents.emitFeedback('warning', ...)` to `debugLogger.debug(...)` in `packages/core/src/skills/skillLoader.ts`.
- Updated tests in `packages/core/src/skills/skillLoader.test.ts` and `packages/cli/src/config/extension-manager-skills.test.ts` to verify the debug log call.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/16140
Parent of https://github.com/google-gemini/gemini-cli/issues/15327

## How to Validate

1. Create a local extension with a `skills` directory containing a file that is not `SKILL.md` (e.g., `not-a-skill.txt`).
2. Load/Install the extension.
3. Observe that no warning is emitted to the main CLI output.
4. Press F12 to open the debug panel and verify the "Failed to load skills" message is present in the debug logs.
5. Run tests: `npx vitest packages/core/src/skills/skillLoader.test.ts packages/cli/src/config/extension-manager-skills.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker