### PR TITLE
fix(cli): disableYoloMode shouldn't enforce default approval mode against args

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -520,7 +520,6 @@ export async function loadCliConfig(
         'Cannot start in YOLO mode since it is disabled by your admin',
       );
     }
-    approvalMode = ApprovalMode.DEFAULT;
   } else if (approvalMode === ApprovalMode.YOLO) {
     debugLogger.warn(
       'YOLO mode is enabled. All tool calls will be automatically approved.',


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

the line that sets approval mode to default is redundant because the fallback to legacy else block  logic also handles that case and sets the mode to default




## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
in other words

If an arg is passed for it, use that approval mode
if no arg is passed, use default

then if disable yolo mode is true, throw error only in yolo mode 

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

Fixes #13792

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

make a test directory 
make a text file test/question.txt
put this inside of it
```
Who is the mayor of San Francisco?
Answer Here:
```
set the workspace settings.json to disableYoloMode = true like this
```
{ "security": { "disableYoloMode": true } }
```
run
`gemini --approval-mode=auto_edit "answer the question in question.txt by editing the file and filling out the answer field" -m gemini-2.5-flash`

the write tool will be blocked on `main` but it will work with this pr

yolo mode still throws

## Future Work

Maybe there should be a config setting for approval modes like #12194 asks

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
