### PR TITLE
fix(mcp): ensure MCP servers are gracefully shut down on CLI exit

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -477,6 +477,9 @@ export async function main() {
     // This ensures telemetry (including SessionEnd hooks) is properly flushed on exit
     registerTelemetryConfig(config);
 
+    // Ensure MCP servers are stopped on exit
+    registerCleanup(() => config.dispose());
+
     const policyEngine = config.getPolicyEngine();
     const messageBus = config.getMessageBus();
     createPolicyUpdater(policyEngine, messageBus);

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -824,6 +824,15 @@ export class Config {
     await this.geminiClient.initialize();
   }
 
+  /**
+   * Disposes of resources held by the config.
+   */
+  async dispose(): Promise<void> {
+    if (this.mcpClientManager) {
+      await this.mcpClientManager.stop();
+    }
+  }
+
   getContentGenerator(): ContentGenerator {
     return this.contentGenerator;
   }


### PR DESCRIPTION
## Summary

Fixes an issue where downstream MCP servers were not receiving the `SIGTERM` signal when the Gemini CLI exited. While the processes were terminating, they were doing so abruptly, preventing graceful cleanup tasks from executing.

## Details

The `McpClientManager` had a `stop()` method intended to gracefully disconnect clients, but this method was never invoked during the application's shutdown lifecycle.

This PR addresses this by:
1.  Adding a `dispose()` method to the `Config` class in `packages/core` that calls `mcpClientManager.stop()`.
2.  Registering `config.dispose()` as a cleanup callback in the main CLI entry point (`packages/cli/src/gemini.tsx`) via `registerCleanup`.

This ensures that when the CLI exits, the `StdioClientTransport` is closed explicitly, triggering the appropriate termination signals (SIGTERM) to the child processes, allowing them to clean up resources before exiting.

## Related Issues

Fixes #13391

## How to Validate

1.  **Create a Test MCP Server**: Save the following Node.js script to `packages/cli/src/commands/extensions/examples/mcp-server/test-server.js`. This script uses the MCP SDK, traps `SIGTERM`, and logs to a file.
    ```javascript
    // packages/cli/src/commands/extensions/examples/mcp-server/test-server.js
    import { Server } from "@modelcontextprotocol/sdk/server/index.js";
    import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
    import fs from 'node:fs';

    const server = new Server(
      {
        name: "test-server",
        version: "1.0.0",
      },
      {
        capabilities: {},
      }
    );

    function log(msg) {
        fs.appendFileSync('shutdown.log', msg + '\n');
    }

    process.on('SIGINT', () => {
        log('Received SIGINT');
        process.exit(0);
    });

    process.on('SIGTERM', () => {
        log('Received SIGTERM');
        process.exit(0);
    });

    const transport = new StdioServerTransport();
    await server.connect(transport);
    log('Server started');
    ```
2.  **Configure Gemini**: Add this server to your configuration.
    ```json
    {
      "mcpServers": {
        "test-signal": {
          "command": "node",
          "args": ["{path-to-repo}/packages/cli/src/commands/extensions/examples/mcp-server/test-server.js"]
        }
      }
    }
    ```
3.  **Start Gemini CLI**: Run `npm start` or the bundled executable.
4.  **Exit CLI**: Exit the Gemini CLI by pressing "Ctrl + C" twice.
5.  **Verify Graceful Shutdown**: Check for the existence of `shutdown.log` (in the root directory or wherever the server ran) containing "Received SIGTERM". Before this fix, the file contents would not have "Received SIGTERM" in the logs

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker