### PR TITLE
refactor: migrate clearCommand hook calls to HookSystem

### DIFF
--- a/packages/cli/src/ui/commands/clearCommand.test.ts
+++ b/packages/cli/src/ui/commands/clearCommand.test.ts
@@ -46,6 +46,10 @@ describe('clearCommand', () => {
           setSessionId: vi.fn(),
           getEnableHooks: vi.fn().mockReturnValue(false),
           getMessageBus: vi.fn().mockReturnValue(undefined),
+          getHookSystem: vi.fn().mockReturnValue({
+            fireSessionEndEvent: vi.fn().mockResolvedValue(undefined),
+            fireSessionStartEvent: vi.fn().mockResolvedValue(undefined),
+          }),
         },
       },
     });


### PR DESCRIPTION
## Summary

Refactors the `/clear` command to use [HookSystem](cci:2://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/core/src/hooks/hookSystem.ts:25:0-119:1) wrapper methods instead of directly calling `fireSessionStartHook` and `fireSessionEndHook` with boilerplate checks. 

## Related Issues

Part of #14317

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

@scidomino please have a look