### PR TITLE
docs: shorten run command and use published version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Learn all about Gemini CLI in our [documentation](https://geminicli.com/docs/).
 
 ```bash
 # Using npx (no installation required)
-npx @google-gemini/gemini-cli
+npx @google/gemini-cli
 ```
 
 #### Install globally with npm

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Learn all about Gemini CLI in our [documentation](https://geminicli.com/docs/).
 
 ```bash
 # Using npx (no installation required)
-npx https://github.com/google-gemini/gemini-cli
+npx @google-gemini/gemini-cli
 ```
 
 #### Install globally with npm


### PR DESCRIPTION
## Summary

Shortens the run command and only uses the latest published version instead of the latest commit.

## Related Issues

None

## How to Validate

Ran `npx @google/gemini-cli`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] ~~Added/updated tests (if needed)~~
- [ ] ~~Noted breaking changes (if any)~~