### PR TITLE
Update the page's title to be consistent and show in site.

### DIFF
--- a/docs/cli/model-routing.md
+++ b/docs/cli/model-routing.md
@@ -1,4 +1,4 @@
-## Model routing
+# Model routing
 
 Gemini CLI includes a model routing feature that automatically switches to a
 fallback model in case of a model failure. This feature is enabled by default


### PR DESCRIPTION
Updated header level for model routing documentation.

## Summary

The model routing page isn't being loaded in the site properly and shows as untitled.  Upon inspection this is due to the fact that the page title has the wrong header level in the markdown.