### PR TITLE
Always enable bracketed paste

### DIFF
--- a/packages/cli/src/ui/utils/terminalCapabilityManager.test.ts
+++ b/packages/cli/src/ui/utils/terminalCapabilityManager.test.ts
@@ -266,46 +266,4 @@ describe('TerminalCapabilityManager', () => {
       expect(manager.isModifyOtherKeysEnabled()).toBe(true);
     });
   });
-
-  describe('bracketed paste detection', () => {
-    it('should detect bracketed paste support (mode set)', async () => {
-      const manager = TerminalCapabilityManager.getInstance();
-      const promise = manager.detectCapabilities();
-
-      // Simulate bracketed paste response: \x1b[?2004;1$y
-      stdin.emit('data', Buffer.from('\x1b[?2004;1$y'));
-      // Complete detection with DA1
-      stdin.emit('data', Buffer.from('\x1b[?62c'));
-
-      await promise;
-      expect(manager.isBracketedPasteSupported()).toBe(true);
-      expect(manager.isBracketedPasteEnabled()).toBe(true);
-    });
-
-    it('should detect bracketed paste support (mode reset)', async () => {
-      const manager = TerminalCapabilityManager.getInstance();
-      const promise = manager.detectCapabilities();
-
-      // Simulate bracketed paste response: \x1b[?2004;2$y
-      stdin.emit('data', Buffer.from('\x1b[?2004;2$y'));
-      // Complete detection with DA1
-      stdin.emit('data', Buffer.from('\x1b[?62c'));
-
-      await promise;
-      expect(manager.isBracketedPasteSupported()).toBe(true);
-      expect(manager.isBracketedPasteEnabled()).toBe(true);
-    });
-
-    it('should not enable bracketed paste if not supported', async () => {
-      const manager = TerminalCapabilityManager.getInstance();
-      const promise = manager.detectCapabilities();
-
-      // Complete detection with DA1 only
-      stdin.emit('data', Buffer.from('\x1b[?62c'));
-
-      await promise;
-      expect(manager.isBracketedPasteSupported()).toBe(false);
-      expect(manager.isBracketedPasteEnabled()).toBe(false);
-    });
-  });
 });

--- a/packages/cli/src/ui/utils/terminalCapabilityManager.ts
+++ b/packages/cli/src/ui/utils/terminalCapabilityManager.ts
@@ -25,7 +25,6 @@ export class TerminalCapabilityManager {
   private static readonly TERMINAL_NAME_QUERY = '\x1b[>q';
   private static readonly DEVICE_ATTRIBUTES_QUERY = '\x1b[c';
   private static readonly MODIFY_OTHER_KEYS_QUERY = '\x1b[>4;?m';
-  private static readonly BRACKETED_PASTE_QUERY = '\x1b[?2004$p';
 
   // Kitty keyboard flags: CSI ? flags u
   // eslint-disable-next-line no-control-regex
@@ -43,10 +42,6 @@ export class TerminalCapabilityManager {
   // modifyOtherKeys response: CSI > 4 ; level m
   // eslint-disable-next-line no-control-regex
   private static readonly MODIFY_OTHER_KEYS_REGEX = /\x1b\[>4;(\d+)m/;
-  // DECRQM response for bracketed paste: CSI ? 2004 ; Ps $ y
-  // Ps = 1 (set), 2 (reset), 3 (permanently set), 4 (permanently reset)
-  // eslint-disable-next-line no-control-regex
-  private static readonly BRACKETED_PASTE_REGEX = /\x1b\[\?2004;([1-4])\$y/;
 
   private terminalBackgroundColor: TerminalBackgroundColor;
   private kittySupported = false;
@@ -55,7 +50,6 @@ export class TerminalCapabilityManager {
   private terminalName: string | undefined;
   private modifyOtherKeysSupported = false;
   private modifyOtherKeysEnabled = false;
-  private bracketedPasteSupported = false;
   private bracketedPasteEnabled = false;
 
   private constructor() {}
@@ -107,7 +101,6 @@ export class TerminalCapabilityManager {
       let deviceAttributesReceived = false;
       let bgReceived = false;
       let modifyOtherKeysReceived = false;
-      let bracketedPasteReceived = false;
       // eslint-disable-next-line prefer-const
       let timeoutId: NodeJS.Timeout;
 
@@ -172,17 +165,6 @@ export class TerminalCapabilityManager {
           }
         }
 
-        // check for bracketed paste support
-        if (!bracketedPasteReceived) {
-          const match = buffer.match(
-            TerminalCapabilityManager.BRACKETED_PASTE_REGEX,
-          );
-          if (match) {
-            bracketedPasteReceived = true;
-            this.bracketedPasteSupported = true;
-          }
-        }
-
         // Check for Terminal Name/Version response.
         if (!terminalNameReceived) {
           const match = buffer.match(
@@ -219,7 +201,6 @@ export class TerminalCapabilityManager {
             TerminalCapabilityManager.OSC_11_QUERY +
             TerminalCapabilityManager.TERMINAL_NAME_QUERY +
             TerminalCapabilityManager.MODIFY_OTHER_KEYS_QUERY +
-            TerminalCapabilityManager.BRACKETED_PASTE_QUERY +
             TerminalCapabilityManager.DEVICE_ATTRIBUTES_QUERY,
         );
       } catch (e) {
@@ -238,10 +219,9 @@ export class TerminalCapabilityManager {
         enableModifyOtherKeys();
         this.modifyOtherKeysEnabled = true;
       }
-      if (this.bracketedPasteSupported) {
-        enableBracketedPasteMode();
-        this.bracketedPasteEnabled = true;
-      }
+      // Always enable bracketed paste since it'll be ignored if unsupported.
+      enableBracketedPasteMode();
+      this.bracketedPasteEnabled = true;
     } catch (e) {
       debugLogger.warn('Failed to enable keyboard protocols:', e);
     }
@@ -257,10 +237,6 @@ export class TerminalCapabilityManager {
 
   isKittyProtocolEnabled(): boolean {
     return this.kittyEnabled;
-  }
-
-  isBracketedPasteSupported(): boolean {
-    return this.bracketedPasteSupported;
   }
 
   isBracketedPasteEnabled(): boolean {


### PR DESCRIPTION
## Summary

Always enable bracket paste since it'll either be supported, or ignored.

## Details

We were previously using DECRQM to detected bracketed paste support. Unfortunately it's not supported by important terminals like hterm (and thus secure shell, and ChromeOS) even though they do support bracketed paste. 

Also: Removes fast-return support since this is a better fix for that issue and it could have caused problems for users on slow connections.

## Related Issues

Fixes #16125

## How to Validate

Running through secure shell, copy/paste the contents of https://en.wikipedia.org/wiki/Copper into the input and verify that it's fast and speedy.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
