### PR TITLE
fix: yolo should auto allow redirection

### DIFF
--- a/packages/core/src/policy/policies/yolo.toml
+++ b/packages/core/src/policy/policies/yolo.toml
@@ -29,3 +29,4 @@
 decision = "allow"
 priority = 999
 modes = ["yolo"]
+allow_redirection = true


### PR DESCRIPTION
## Summary

YOLO should not ask for confirmation on any shell command including redirection.

## Details

This was accidentally added as a regression when this field was added.

## How to Validate

Test a redirection shell command while in yolo mode: `echo 'hello' > hello.txt`

## Pre-Merge Checklist


- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
