### PR TITLE
 fix(scripts): Add Windows (win32/x64) support to lint.js

### DIFF
--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -45,6 +45,12 @@ function getPlatformArch() {
       shellcheck: 'darwin.aarch64',
     };
   }
+  if (platform === 'win32' && arch === 'x64') {
+    return {
+      actionlint: 'windows_amd64',
+      shellcheck: 'windows_amd64',
+    };
+  }
   throw new Error(`Unsupported platform/architecture: ${platform}/${arch}`);
 }
 
@@ -58,10 +64,53 @@ const pythonVenvPythonPath = join(
   process.platform === 'win32' ? 'python.exe' : 'python',
 );
 
-const yamllintCheck =
-  process.platform === 'win32'
-    ? `if exist "${PYTHON_VENV_PATH}\\Scripts\\yamllint.exe" (exit 0) else (exit 1)`
-    : `test -x "${PYTHON_VENV_PATH}/bin/yamllint"`;
+const isWindows = process.platform === 'win32';
+
+const actionlintCheck = isWindows
+  ? `where actionlint 2>nul`
+  : 'command -v actionlint';
+
+const actionlintInstaller = isWindows
+  ? `powershell -Command "` +
+    `New-Item -ItemType Directory -Force -Path '${TEMP_DIR}/actionlint' | Out-Null; ` +
+    `Invoke-WebRequest -Uri 'https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_${platformArch.actionlint}.zip' -OutFile '${TEMP_DIR}/.actionlint.zip'; ` +
+    `Add-Type -AssemblyName System.IO.Compression.FileSystem; ` +
+    `[System.IO.Compression.ZipFile]::ExtractToDirectory('${TEMP_DIR}/.actionlint.zip', '${TEMP_DIR}/actionlint')"`
+  : `
+      mkdir -p "${TEMP_DIR}/actionlint"
+      curl -sSLo "${TEMP_DIR}/.actionlint.tgz" "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_${platformArch.actionlint}.tar.gz"
+      tar -xzf "${TEMP_DIR}/.actionlint.tgz" -C "${TEMP_DIR}/actionlint"
+    `;
+
+const shellcheckCheck = isWindows
+  ? `where shellcheck 2>nul`
+  : 'command -v shellcheck';
+
+const shellcheckInstaller = isWindows
+  ? `powershell -Command "` +
+    `New-Item -ItemType Directory -Force -Path '${TEMP_DIR}/shellcheck' | Out-Null; ` +
+    `Invoke-WebRequest -Uri 'https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.zip' -OutFile '${TEMP_DIR}/.shellcheck.zip'; ` +
+    `Add-Type -AssemblyName System.IO.Compression.FileSystem; ` +
+    `[System.IO.Compression.ZipFile]::ExtractToDirectory('${TEMP_DIR}/.shellcheck.zip', '${TEMP_DIR}/shellcheck')"`
+  : `
+      mkdir -p "${TEMP_DIR}/shellcheck"
+      curl -sSLo "${TEMP_DIR}/.shellcheck.txz" "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.${platformArch.shellcheck}.tar.xz"
+      tar -xf "${TEMP_DIR}/.shellcheck.txz" -C "${TEMP_DIR}/shellcheck" --strip-components=1
+    `;
+
+const yamllintCheck = isWindows
+  ? `if exist "${PYTHON_VENV_PATH}\\Scripts\\yamllint.exe" (exit 0) else (exit 1)`
+  : `test -x "${PYTHON_VENV_PATH}/bin/yamllint"`;
+
+const yamllintInstaller = isWindows
+  ? `python -m venv "${PYTHON_VENV_PATH}" && ` +
+    `"${pythonVenvPythonPath}" -m pip install --upgrade pip && ` +
+    `"${pythonVenvPythonPath}" -m pip install "yamllint==${YAMLLINT_VERSION}" --index-url https://pypi.org/simple`
+  : `
+    python3 -m venv "${PYTHON_VENV_PATH}" && \
+    "${pythonVenvPythonPath}" -m pip install --upgrade pip && \
+    "${pythonVenvPythonPath}" -m pip install "yamllint==${YAMLLINT_VERSION}" --index-url https://pypi.org/simple
+  `;
 
 /**
  * @typedef {{
@@ -76,12 +125,8 @@ const yamllintCheck =
  */
 const LINTERS = {
   actionlint: {
-    check: 'command -v actionlint',
-    installer: `
-      mkdir -p "${TEMP_DIR}/actionlint"
-      curl -sSLo "${TEMP_DIR}/.actionlint.tgz" "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_${platformArch.actionlint}.tar.gz"
-      tar -xzf "${TEMP_DIR}/.actionlint.tgz" -C "${TEMP_DIR}/actionlint"
-    `,
+    check: actionlintCheck,
+    installer: actionlintInstaller,
     run: `
       actionlint \
         -color \
@@ -92,12 +137,8 @@ const LINTERS = {
     `,
   },
   shellcheck: {
-    check: 'command -v shellcheck',
-    installer: `
-      mkdir -p "${TEMP_DIR}/shellcheck"
-      curl -sSLo "${TEMP_DIR}/.shellcheck.txz" "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.${platformArch.shellcheck}.tar.xz"
-      tar -xf "${TEMP_DIR}/.shellcheck.txz" -C "${TEMP_DIR}/shellcheck" --strip-components=1
-    `,
+    check: shellcheckCheck,
+    installer: shellcheckInstaller,
     run: `
       git ls-files | grep -E '^([^.]+|.*\\.(sh|zsh|bash))' | xargs file --mime-type \
         | grep "text/x-shellscript" | awk '{ print substr($1, 1, length($1)-1) }' \
@@ -112,11 +153,7 @@ const LINTERS = {
   },
   yamllint: {
     check: yamllintCheck,
-    installer: `
-    python3 -m venv "${PYTHON_VENV_PATH}" && \
-    "${pythonVenvPythonPath}" -m pip install --upgrade pip && \
-    "${pythonVenvPythonPath}" -m pip install "yamllint==${YAMLLINT_VERSION}" --index-url https://pypi.org/simple
-  `,
+    installer: yamllintInstaller,
     run: "git ls-files | grep -E '\\.(yaml|yml)' | xargs yamllint --format github",
   },
 };
@@ -125,8 +162,18 @@ function runCommand(command, stdio = 'inherit') {
   try {
     const env = { ...process.env };
     const nodeBin = join(process.cwd(), 'node_modules', '.bin');
-    env.PATH = `${nodeBin}:${TEMP_DIR}/actionlint:${TEMP_DIR}/shellcheck:${PYTHON_VENV_PATH}/bin:${env.PATH}`;
-    execSync(command, { stdio, env });
+    const sep = isWindows ? ';' : ':';
+    const pythonBin = isWindows
+      ? join(PYTHON_VENV_PATH, 'Scripts')
+      : join(PYTHON_VENV_PATH, 'bin');
+    env.PATH = [
+      nodeBin,
+      join(TEMP_DIR, 'actionlint'),
+      join(TEMP_DIR, 'shellcheck'),
+      pythonBin,
+      env.PATH,
+    ].join(sep);
+    execSync(command, { stdio, env, shell: true });
     return true;
   } catch (_e) {
     return false;

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -48,7 +48,7 @@ function getPlatformArch() {
   if (platform === 'win32' && arch === 'x64') {
     return {
       actionlint: 'windows_amd64',
-      shellcheck: 'windows_amd64',
+      shellcheck: 'win.x86_64',
     };
   }
   throw new Error(`Unsupported platform/architecture: ${platform}/${arch}`);
@@ -88,7 +88,6 @@ const shellcheckCheck = isWindows
 
 const shellcheckInstaller = isWindows
   ? `powershell -Command "` +
-    `New-Item -ItemType Directory -Force -Path '${TEMP_DIR}/shellcheck' | Out-Null; ` +
     `Invoke-WebRequest -Uri 'https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.zip' -OutFile '${TEMP_DIR}/.shellcheck.zip'; ` +
     `Add-Type -AssemblyName System.IO.Compression.FileSystem; ` +
     `[System.IO.Compression.ZipFile]::ExtractToDirectory('${TEMP_DIR}/.shellcheck.zip', '${TEMP_DIR}/shellcheck')"`

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -166,12 +166,14 @@ function runCommand(command, stdio = 'inherit') {
     const pythonBin = isWindows
       ? join(PYTHON_VENV_PATH, 'Scripts')
       : join(PYTHON_VENV_PATH, 'bin');
-    env.PATH = [
+    // Windows sometimes uses 'Path' instead of 'PATH'
+    const pathKey = 'Path' in env ? 'Path' : 'PATH';
+    env[pathKey] = [
       nodeBin,
       join(TEMP_DIR, 'actionlint'),
       join(TEMP_DIR, 'shellcheck'),
       pythonBin,
-      env.PATH,
+      env[pathKey],
     ].join(sep);
     execSync(command, { stdio, env, shell: true });
     return true;

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -48,7 +48,8 @@ function getPlatformArch() {
   if (platform === 'win32' && arch === 'x64') {
     return {
       actionlint: 'windows_amd64',
-      shellcheck: 'win.x86_64',
+      // shellcheck is not used for Windows since it uses the .zip release
+      // which has a consistent name across architectures
     };
   }
   throw new Error(`Unsupported platform/architecture: ${platform}/${arch}`);


### PR DESCRIPTION
## Summary
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Add Windows (win32/x64) support to scripts/lint.js to fix the "Unsupported platform/architecture" error when running npm run preflight on Windows.

## Details
<!-- Add any extra context and design decisions. Keep it brief but complete. -->
 - Added win32/x64 case to getPlatformArch() returning windows_amd64 for actionlint and shellcheck
  - Added platform-specific variables following existing codebase conventions:
    - isWindows flag for platform detection
    - actionlintCheck/Installer - uses where and PowerShell on Windows
    - shellcheckCheck/Installer - uses where and PowerShell on Windows
    - yamllintInstaller - uses python instead of python3 on Windows
  - Fixed runCommand() PATH handling: uses ; separator and Scripts/ directory on Windows
  - All Unix code paths remain unchanged via ternary operators

## Related Issues
<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes #15074

## How to Validate
<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

 1. On Windows x64, run:
  node scripts/lint.js --setup
  1. Expected: Linters install successfully without "Unsupported platform/architecture" error
  2. Run ESLint check:
  node scripts/lint.js --eslint
  2. Expected: ESLint runs successfully
  3. Verify Unix systems still work (no regression):
    - On macOS/Linux, run node scripts/lint.js --setup - should work as before
   
## Pre-Merge Checklist
<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
