### PR TITLE
feat: add /whoami command

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -46,6 +46,7 @@ import { toolsCommand } from '../ui/commands/toolsCommand.js';
 import { skillsCommand } from '../ui/commands/skillsCommand.js';
 import { settingsCommand } from '../ui/commands/settingsCommand.js';
 import { vimCommand } from '../ui/commands/vimCommand.js';
+import { whoamiCommand } from '../ui/commands/whoamiCommand.js';
 import { setupGithubCommand } from '../ui/commands/setupGithubCommand.js';
 import { terminalSetupCommand } from '../ui/commands/terminalSetupCommand.js';
 
@@ -134,6 +135,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       ...(this.config?.isSkillsSupportEnabled() ? [skillsCommand] : []),
       settingsCommand,
       vimCommand,
+      whoamiCommand,
       setupGithubCommand,
       terminalSetupCommand,
     ];

--- a/packages/cli/src/ui/commands/whoamiCommand.test.ts
+++ b/packages/cli/src/ui/commands/whoamiCommand.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { whoamiCommand } from './whoamiCommand.js';
+import { type CommandContext } from './types.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { MessageType } from '../types.js';
+
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    UserAccountManager: vi.fn().mockImplementation(() => ({
+      getCachedGoogleAccount: vi.fn().mockReturnValue('test-email@example.com'),
+    })),
+  };
+});
+
+describe('whoamiCommand', () => {
+  let mockContext: CommandContext;
+
+  beforeEach(() => {
+    mockContext = createMockCommandContext({
+      services: {
+        settings: {
+          merged: {
+            security: {
+              auth: {
+                selectedType: 'test-auth',
+              },
+            },
+          },
+        },
+      },
+      ui: {
+        addItem: vi.fn(),
+      },
+    } as unknown as CommandContext);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should have the correct name and description', () => {
+    expect(whoamiCommand.name).toBe('whoami');
+    expect(whoamiCommand.description).toBe('Show current identity');
+  });
+
+  it('should call addItem with correct info', async () => {
+    if (!whoamiCommand.action) {
+      throw new Error('The whoami command must have an action.');
+    }
+
+    await whoamiCommand.action(mockContext, '');
+
+    expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+      {
+        type: MessageType.WHOAMI,
+        selectedAuthType: 'test-auth',
+        userEmail: 'test-email@example.com',
+      },
+      expect.any(Number),
+    );
+  });
+});

--- a/packages/cli/src/ui/commands/whoamiCommand.ts
+++ b/packages/cli/src/ui/commands/whoamiCommand.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { SlashCommand } from './types.js';
+import { CommandKind } from './types.js';
+import { MessageType, type HistoryItemWhoami } from '../types.js';
+import { UserAccountManager, debugLogger } from '@google/gemini-cli-core';
+
+export const whoamiCommand: SlashCommand = {
+  name: 'whoami',
+  description: 'Show current identity',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: async (context) => {
+    const userAccountManager = new UserAccountManager();
+    const cachedAccount = userAccountManager.getCachedGoogleAccount();
+    debugLogger.log('WhoamiCommand: Retrieved cached Google account', {
+      cachedAccount,
+    });
+    const userEmail = cachedAccount ?? undefined;
+    const selectedAuthType =
+      context.services.settings.merged.security?.auth?.selectedType || '';
+
+    const whoamiItem: Omit<HistoryItemWhoami, 'id'> = {
+      type: MessageType.WHOAMI,
+      selectedAuthType,
+      userEmail,
+    };
+
+    context.ui.addItem(whoamiItem, Date.now());
+  },
+};

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -19,6 +19,7 @@ import { CompressionMessage } from './messages/CompressionMessage.js';
 import { WarningMessage } from './messages/WarningMessage.js';
 import { Box } from 'ink';
 import { AboutBox } from './AboutBox.js';
+import { WhoamiBox } from './WhoamiBox.js';
 import { StatsDisplay } from './StatsDisplay.js';
 import { ModelStatsDisplay } from './ModelStatsDisplay.js';
 import { ToolStatsDisplay } from './ToolStatsDisplay.js';
@@ -111,6 +112,12 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
           selectedAuthType={itemForDisplay.selectedAuthType}
           gcpProject={itemForDisplay.gcpProject}
           ideClient={itemForDisplay.ideClient}
+          userEmail={itemForDisplay.userEmail}
+        />
+      )}
+      {itemForDisplay.type === 'whoami' && (
+        <WhoamiBox
+          selectedAuthType={itemForDisplay.selectedAuthType}
           userEmail={itemForDisplay.userEmail}
         />
       )}

--- a/packages/cli/src/ui/components/WhoamiBox.test.tsx
+++ b/packages/cli/src/ui/components/WhoamiBox.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render } from '../../test-utils/render.js';
+import { WhoamiBox } from './WhoamiBox.js';
+import { describe, it, expect } from 'vitest';
+
+describe('WhoamiBox', () => {
+  const defaultProps = {
+    selectedAuthType: 'oauth',
+  };
+
+  it('renders with required props', () => {
+    const { lastFrame } = render(<WhoamiBox {...defaultProps} />);
+    const output = lastFrame();
+    expect(output).toContain('Current Identity');
+    expect(output).toContain('OAuth');
+  });
+
+  it('renders userEmail when provided', () => {
+    const props = { ...defaultProps, userEmail: 'test@example.com' };
+    const { lastFrame } = render(<WhoamiBox {...props} />);
+    const output = lastFrame();
+    expect(output).toContain('User Email');
+    expect(output).toContain('test@example.com');
+  });
+
+  it('renders Auth Method correctly when not oauth', () => {
+    const props = { selectedAuthType: 'api-key' };
+    const { lastFrame } = render(<WhoamiBox {...props} />);
+    const output = lastFrame();
+    expect(output).toContain('api-key');
+  });
+});

--- a/packages/cli/src/ui/components/WhoamiBox.tsx
+++ b/packages/cli/src/ui/components/WhoamiBox.tsx
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box, Text } from 'ink';
+import { theme } from '../semantic-colors.js';
+
+interface WhoamiBoxProps {
+  selectedAuthType: string;
+  userEmail?: string;
+}
+
+export const WhoamiBox: React.FC<WhoamiBoxProps> = ({
+  selectedAuthType,
+  userEmail,
+}) => (
+  <Box
+    borderStyle="round"
+    borderColor={theme.border.default}
+    flexDirection="column"
+    padding={1}
+    marginY={1}
+    width="100%"
+  >
+    <Box marginBottom={1}>
+      <Text bold color={theme.text.accent}>
+        Current Identity
+      </Text>
+    </Box>
+    <Box flexDirection="row">
+      <Box width="35%">
+        <Text bold color={theme.text.link}>
+          Auth Method
+        </Text>
+      </Box>
+      <Box>
+        <Text color={theme.text.primary}>
+          {selectedAuthType.startsWith('oauth') ? 'OAuth' : selectedAuthType}
+        </Text>
+      </Box>
+    </Box>
+    {userEmail && (
+      <Box flexDirection="row">
+        <Box width="35%">
+          <Text bold color={theme.text.link}>
+            User Email
+          </Text>
+        </Box>
+        <Box>
+          <Text color={theme.text.primary}>{userEmail}</Text>
+        </Box>
+      </Box>
+    )}
+  </Box>
+);

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -137,6 +137,12 @@ export type HistoryItemAbout = HistoryItemBase & {
   userEmail?: string;
 };
 
+export type HistoryItemWhoami = HistoryItemBase & {
+  type: 'whoami';
+  selectedAuthType: string;
+  userEmail?: string;
+};
+
 export type HistoryItemHelp = HistoryItemBase & {
   type: 'help';
   timestamp: Date;
@@ -292,6 +298,7 @@ export type HistoryItemWithoutId =
   | HistoryItemError
   | HistoryItemWarning
   | HistoryItemAbout
+  | HistoryItemWhoami
   | HistoryItemHelp
   | HistoryItemToolGroup
   | HistoryItemStats
@@ -317,6 +324,7 @@ export enum MessageType {
   WARNING = 'warning',
   USER = 'user',
   ABOUT = 'about',
+  WHOAMI = 'whoami',
   HELP = 'help',
   STATS = 'stats',
   MODEL_STATS = 'model_stats',


### PR DESCRIPTION
This PR adds a new `/whoami` command to the Gemini CLI.

This command allows users to see their currently logged-in identity (Auth Type and Email if available).
It uses a similar UI presentation to the `/about` command.

Fixes #16197
