### PR TITLE
feat(ui): reduce home directory warning noise and add opt-out setting

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -184,6 +184,12 @@ their corresponding top-level category object in your `settings.json` file.
     title
   - **Default:** `false`
 
+- **`ui.showHomeDirectoryWarning`** (boolean):
+  - **Description:** Show a warning when running Gemini CLI in the home
+    directory.
+  - **Default:** `true`
+  - **Requires restart:** Yes
+
 - **`ui.hideTips`** (boolean):
   - **Description:** Hide helpful tips in the UI
   - **Default:** `false`

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -384,6 +384,16 @@ const SETTINGS_SCHEMA = {
           'Show Gemini CLI status and thoughts in the terminal window title',
         showInDialog: true,
       },
+      showHomeDirectoryWarning: {
+        type: 'boolean',
+        label: 'Show Home Directory Warning',
+        category: 'UI',
+        requiresRestart: true,
+        default: true,
+        description:
+          'Show a warning when running Gemini CLI in the home directory.',
+        showInDialog: true,
+      },
       hideTips: {
         type: 'boolean',
         label: 'Hide Tips',

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -588,7 +588,7 @@ export async function main() {
     let input = config.getQuestion();
     const startupWarnings = [
       ...(await getStartupWarnings()),
-      ...(await getUserStartupWarnings()),
+      ...(await getUserStartupWarnings(settings.merged)),
     ];
 
     // Handle --resume flag

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -194,6 +194,13 @@
           "default": false,
           "type": "boolean"
         },
+        "showHomeDirectoryWarning": {
+          "title": "Show Home Directory Warning",
+          "description": "Show a warning when running Gemini CLI in the home directory.",
+          "markdownDescription": "Show a warning when running Gemini CLI in the home directory.\n\n- Category: `UI`\n- Requires restart: `yes`\n- Default: `true`",
+          "default": true,
+          "type": "boolean"
+        },
         "hideTips": {
           "title": "Hide Tips",
           "description": "Hide helpful tips in the UI",


### PR DESCRIPTION
## Summary

This PR reduces the noise of the home directory warning by adding a new setting to disable it and automatically suppressing it if the folder is already trusted.

## Details

- Introduced a new user setting: `ui.showHomeDirectoryWarning` (default: `true`).
- **Note:** This setting requires a restart to take effect.
- Updated the warning banner text to be more terse and inform users they can disable it in `/settings`.
- Added logic to automatically suppress the warning if the **Folder Trust** feature is enabled AND the home directory has been explicitly trusted.
- Updated unit tests to cover the new setting and trust logic.
- Regenerated settings documentation.

### Before
<img width="3680" height="2328" alt="image" src="https://github.com/user-attachments/assets/c9d07e7a-f1d8-4179-a319-2da69763ff12" />

### After
<img width="3680" height="2328" alt="image" src="https://github.com/user-attachments/assets/1ba35dfa-c64e-4e49-9552-6a7970f51671" />
<img width="3680" height="2328" alt="image" src="https://github.com/user-attachments/assets/99cba066-68a4-4e3b-89de-149b10a010d4" />


## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/15992

## How to Validate

1.  **Verify Setting:**
    - Run Gemini CLI in your home directory.
    - Confirm the warning appears.
    - Go to `/settings` and disable "Show Home Directory Warning".
    - **Restart Gemini CLI.**
    - Confirm the warning is gone.

2.  **Verify Folder Trust:**
    - Enable Folder Trust in `/settings`.
    - Ensure your home directory is trusted.
    - Restart and confirm the warning is suppressed (even if the specific warning setting is on).

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker