### PR TITLE
docs: add instructions for using PR templates in GEMINI.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -81,6 +81,14 @@ tests, aim to follow existing patterns. Key conventions include:
 
 The main branch for this project is called "main"
 
+### Creating Pull Requests
+
+When asked to create a pull request, always search for and read the repository's
+pull request template (typically found in `.github/pull_request_template.md`).
+Ensure the PR description follows the structure and requirements defined in the
+template. If the template includes a checklist, ensure it is accurately
+reflected in the PR body.
+
 ## JavaScript/TypeScript
 
 When contributing to this React, Node, and TypeScript codebase, please


### PR DESCRIPTION
## Summary

This PR adds instructions to `GEMINI.md` for future agents to look up and follow the repository's pull request template when creating PRs.

## Details

- Added a new '### Creating Pull Requests' section under '## Git Repo'.
- Instructs the agent to search for and read `.github/pull_request_template.md`.
- Emphasizes following the template structure and checklists.

## Related Issues

N/A

## How to Validate

1. Read the updated `GEMINI.md` file.
2. Verify the new section exists and provides clear instructions.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker