### PR TITLE
feat(skills): add pr-creator skill and enable skills

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,5 @@
+{
+  "experimental": {
+    "skills": true
+  }
+}

--- a/.gemini/skills/pr-creator/SKILL.md
+++ b/.gemini/skills/pr-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-creator
-description: Use this skill when asked to create a pull request (PR) or when ready to submit changes. It ensures all PRs follow the repository's established templates and standards.
+description: Use this skill when asked to create a pull request (PR). It ensures all PRs follow the repository's established templates and standards.
 ---
 
 # Pull Request Creator

--- a/.gemini/skills/pr-creator/SKILL.md
+++ b/.gemini/skills/pr-creator/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: pr-creator
+description: Use this skill when asked to create a pull request (PR) or when ready to submit changes. It ensures all PRs follow the repository's established templates and standards.
+---
+
+# Pull Request Creator
+
+This skill guides the creation of high-quality Pull Requests that adhere to the repository's standards.
+
+## Workflow
+
+Follow these steps to create a Pull Request:
+
+1.  **Locate Template**: Search for a pull request template in the repository.
+    *   Check `.github/pull_request_template.md`
+    *   Check `.github/PULL_REQUEST_TEMPLATE.md`
+    *   If multiple templates exist (e.g., in `.github/PULL_REQUEST_TEMPLATE/`), ask the user which one to use or select the most appropriate one based on the context (e.g., `bug_fix.md` vs `feature.md`).
+
+2.  **Read Template**: Read the content of the identified template file.
+
+3.  **Draft Description**: Create a PR description that strictly follows the template's structure.
+    *   **Headings**: Keep all headings from the template.
+    *   **Checklists**: Review each item. Mark with `[x]` if completed. If an item is not applicable, leave it unchecked or mark as `[ ]` (depending on the template's instructions) or remove it if the template allows flexibility (but prefer keeping it unchecked for transparency).
+    *   **Content**: Fill in the sections with clear, concise summaries of your changes.
+    *   **Related Issues**: Link any issues fixed or related to this PR (e.g., "Fixes #123").
+
+4.  **Create PR**: Use the `gh` CLI to create the PR.
+    ```bash
+    gh pr create --title "type(scope): succinct description" --body "..."
+    ```
+    *   **Title**: Ensure the title follows the [Conventional Commits](https://www.conventionalcommits.org/) format if the repository uses it (e.g., `feat(ui): add new button`, `fix(core): resolve crash`).
+
+## Principles
+
+*   **Compliance**: Never ignore the PR template. It exists for a reason.
+*   **Completeness**: Fill out all relevant sections.
+*   **Accuracy**: Don't check boxes for tasks you haven't done.

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 .gemini/*
 !.gemini/config.yaml
 !.gemini/commands/
+!.gemini/skills/
+!.gemini/settings.json
 
 # Note: .gemini-clipboard/ is NOT in gitignore so Gemini can access pasted images
 


### PR DESCRIPTION
## Summary

This PR introduces a new skill, `pr-creator`, to standardize pull request creation and enables the skills feature for the project configuration.

## Details

- **New Skill**: Added `.gemini/skills/pr-creator/SKILL.md`, which instructs agents to locate and follow the repository's PR template.
- **Git Configuration**: Updated `.gitignore` to allow tracking of `.gemini/skills/` and `.gemini/settings.json`.
- **Project Settings**: Created `.gemini/settings.json` with `"experimental": { "skills": true }` to enable skills for anyone working in this repo.

## Related Issues

N/A

## How to Validate

1.  **Check Files**: Verify `.gemini/skills/pr-creator/SKILL.md` exists and contains the correct instructions.
2.  **Check Gitignore**: Verify `.gitignore` includes the new exceptions.
3.  **Check Settings**: Verify `.gemini/settings.json` enables skills.
4.  **Test Skill**: (Optional) Use an agent with this branch checked out to create a dummy PR and confirm it finds the template.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) - *Skill documentation added.*
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker