### PR TITLE
fix cli settings: resolve layout jitter in settings bar

### DIFF
--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -948,12 +948,10 @@ export function SettingsDialog({
                   const afterCursor = cpSlice(editBuffer, editCursorPos + 1);
                   displayValue =
                     beforeCursor + chalk.inverse(atCursor) + afterCursor;
-                } else if (
-                  cursorVisible &&
-                  editCursorPos >= cpLen(editBuffer)
-                ) {
+                } else if (editCursorPos >= cpLen(editBuffer)) {
                   // Cursor is at the end - show inverted space
-                  displayValue = editBuffer + chalk.inverse(' ');
+                  displayValue =
+                    editBuffer + (cursorVisible ? chalk.inverse(' ') : ' ');
                 } else {
                   // Cursor not visible
                   displayValue = editBuffer;


### PR DESCRIPTION
## Summary

This PR fixes the backward and forward jitter effect in the /settings (Issue #16214).

## Details

When editing a value, the cursor logic only appended a space when cursorVisible was true. This caused the string length to toggle between $N$ and $N+1$ characters every 500ms, forcing ink to re-calculate the layout and shifting the text. I removed cursorVisible from line 951 

## Related Issues

Fixes #16214

## How to Validate

Run npm run build then npm run start
Enter /settings.
edit settings with text

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
