### PR TITLE
refactor: migrate chatCompressionService to use HookSystem

### DIFF
--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -159,6 +159,7 @@ describe('ChatCompressionService', () => {
       }),
       getEnableHooks: vi.fn().mockReturnValue(false),
       getMessageBus: vi.fn().mockReturnValue(undefined),
+      getHookSystem: () => undefined,
     } as unknown as Config;
 
     vi.mocked(tokenLimit).mockReturnValue(1000);

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -22,7 +22,6 @@ import {
   PREVIEW_GEMINI_MODEL,
   PREVIEW_GEMINI_FLASH_MODEL,
 } from '../config/models.js';
-import { firePreCompressHook } from '../core/sessionHookTriggers.js';
 import { PreCompressTrigger } from '../hooks/types.js';
 
 /**
@@ -128,16 +127,10 @@ export class ChatCompressionService {
       };
     }
 
-    // Fire PreCompress hook before compression (only if hooks are enabled)
+    // Fire PreCompress hook before compression
     // This fires for both manual and auto compression attempts
-    const hooksEnabled = config.getEnableHooks();
-    const messageBus = config.getMessageBus();
-    if (hooksEnabled && messageBus) {
-      const trigger = force
-        ? PreCompressTrigger.Manual
-        : PreCompressTrigger.Auto;
-      await firePreCompressHook(messageBus, trigger);
-    }
+    const trigger = force ? PreCompressTrigger.Manual : PreCompressTrigger.Auto;
+    await config.getHookSystem()?.firePreCompressEvent(trigger);
 
     const originalTokenCount = chat.getLastPromptTokenCount();
 


### PR DESCRIPTION
collaborated with @ishaanxgupta 

## Summary

Refactors [chatCompressionService.ts](cci:7://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/core/src/services/chatCompressionService.ts:0:0-0:0) to use [HookSystem](cci:2://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/core/src/hooks/hookSystem.ts:25:0-119:1) wrapper methods instead of directly calling `firePreCompressHook` with boilerplate checks. Updates test mocks to include [getHookSystem](cci:1://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/cli/src/gemini_cleanup.test.tsx:191:6-191:36) method.

## Related Issues

Part of #14317

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

@scidomino please have a look