### PR TITLE
Infer modifyOtherKeys support

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -34,7 +34,6 @@ import { useReverseSearchCompletion } from '../hooks/useReverseSearchCompletion.
 import clipboardy from 'clipboardy';
 import * as clipboardUtils from '../utils/clipboardUtils.js';
 import { useKittyKeyboardProtocol } from '../hooks/useKittyKeyboardProtocol.js';
-import { terminalCapabilityManager } from '../utils/terminalCapabilityManager.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import stripAnsi from 'strip-ansi';
 import chalk from 'chalk';
@@ -125,10 +124,6 @@ describe('InputPrompt', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.spyOn(
-      terminalCapabilityManager,
-      'isBracketedPasteEnabled',
-    ).mockReturnValue(true);
 
     mockCommandContext = createMockCommandContext();
 

--- a/packages/cli/src/ui/components/SettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.test.tsx
@@ -35,7 +35,6 @@ import {
   type SettingDefinition,
   type SettingsSchemaType,
 } from '../../config/settingsSchema.js';
-import { terminalCapabilityManager } from '../../ui/utils/terminalCapabilityManager.js';
 
 // Mock the VimModeContext
 const mockToggleVimEnabled = vi.fn();
@@ -254,10 +253,6 @@ const renderDialog = (
 
 describe('SettingsDialog', () => {
   beforeEach(() => {
-    vi.spyOn(
-      terminalCapabilityManager,
-      'isBracketedPasteEnabled',
-    ).mockReturnValue(true);
     mockToggleVimEnabled.mockResolvedValue(true);
   });
 


### PR DESCRIPTION
## Summary

Always try enabling modifyOtherKeys support if we know it won't lead to garbage output.

## Details

Some terminals support modifyOtherKeys but DON't support the DECRQM we are using to detect it. But if the terminal returns device attributes it's safe to try enabling anyways, since it will be ignored if unsupported.

## Related Issues

Related: #15282 (though this won't fix the bug because hterm just doesn't support modifyOtherkeys)

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
