### PR TITLE
fix: eliminate debug console warnings and improve Antigravity CLI detection

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -4,14 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isDevelopment } from '../utils/installationInfo.js';
-import type { ICommandLoader } from './types.js';
-import {
-  CommandKind,
-  type SlashCommand,
-  type CommandContext,
-} from '../ui/commands/types.js';
-import type { MessageActionReturn, Config } from '@google/gemini-cli-core';
+import type { Config, MessageActionReturn } from '@google/gemini-cli-core';
 import { startupProfiler } from '@google/gemini-cli-core';
 import { aboutCommand } from '../ui/commands/aboutCommand.js';
 import { agentsCommand } from '../ui/commands/agentsCommand.js';
@@ -22,8 +15,8 @@ import { clearCommand } from '../ui/commands/clearCommand.js';
 import { compressCommand } from '../ui/commands/compressCommand.js';
 import { copyCommand } from '../ui/commands/copyCommand.js';
 import { corgiCommand } from '../ui/commands/corgiCommand.js';
-import { docsCommand } from '../ui/commands/docsCommand.js';
 import { directoryCommand } from '../ui/commands/directoryCommand.js';
+import { docsCommand } from '../ui/commands/docsCommand.js';
 import { editorCommand } from '../ui/commands/editorCommand.js';
 import { extensionsCommand } from '../ui/commands/extensionsCommand.js';
 import { helpCommand } from '../ui/commands/helpCommand.js';
@@ -34,20 +27,27 @@ import { mcpCommand } from '../ui/commands/mcpCommand.js';
 import { memoryCommand } from '../ui/commands/memoryCommand.js';
 import { modelCommand } from '../ui/commands/modelCommand.js';
 import { permissionsCommand } from '../ui/commands/permissionsCommand.js';
-import { privacyCommand } from '../ui/commands/privacyCommand.js';
 import { policiesCommand } from '../ui/commands/policiesCommand.js';
+import { privacyCommand } from '../ui/commands/privacyCommand.js';
 import { profileCommand } from '../ui/commands/profileCommand.js';
 import { quitCommand } from '../ui/commands/quitCommand.js';
 import { restoreCommand } from '../ui/commands/restoreCommand.js';
 import { resumeCommand } from '../ui/commands/resumeCommand.js';
+import { settingsCommand } from '../ui/commands/settingsCommand.js';
+import { setupGithubCommand } from '../ui/commands/setupGithubCommand.js';
+import { skillsCommand } from '../ui/commands/skillsCommand.js';
 import { statsCommand } from '../ui/commands/statsCommand.js';
+import { terminalSetupCommand } from '../ui/commands/terminalSetupCommand.js';
 import { themeCommand } from '../ui/commands/themeCommand.js';
 import { toolsCommand } from '../ui/commands/toolsCommand.js';
-import { skillsCommand } from '../ui/commands/skillsCommand.js';
-import { settingsCommand } from '../ui/commands/settingsCommand.js';
+import {
+  CommandKind,
+  type CommandContext,
+  type SlashCommand,
+} from '../ui/commands/types.js';
 import { vimCommand } from '../ui/commands/vimCommand.js';
-import { setupGithubCommand } from '../ui/commands/setupGithubCommand.js';
-import { terminalSetupCommand } from '../ui/commands/terminalSetupCommand.js';
+import { isDevelopment } from '../utils/installationInfo.js';
+import type { ICommandLoader } from './types.js';
 
 /**
  * Loads the core, hard-coded slash commands that are an integral part
@@ -65,79 +65,82 @@ export class BuiltinCommandLoader implements ICommandLoader {
    */
   async loadCommands(_signal: AbortSignal): Promise<SlashCommand[]> {
     const handle = startupProfiler.start('load_builtin_commands');
-    const allDefinitions: Array<SlashCommand | null> = [
-      aboutCommand,
-      ...(this.config?.isAgentsEnabled() ? [agentsCommand] : []),
-      authCommand,
-      bugCommand,
-      chatCommand,
-      clearCommand,
-      compressCommand,
-      copyCommand,
-      corgiCommand,
-      docsCommand,
-      directoryCommand,
-      editorCommand,
-      ...(this.config?.getExtensionsEnabled() === false
-        ? [
-            {
-              name: 'extensions',
-              description: 'Manage extensions',
-              kind: CommandKind.BUILT_IN,
-              autoExecute: false,
-              subCommands: [],
-              action: async (
-                _context: CommandContext,
-              ): Promise<MessageActionReturn> => ({
-                type: 'message',
-                messageType: 'error',
-                content: 'Extensions are disabled by your admin.',
-              }),
-            },
-          ]
-        : [extensionsCommand(this.config?.getEnableExtensionReloading())]),
-      helpCommand,
-      ...(this.config?.getEnableHooksUI() ? [hooksCommand] : []),
-      await ideCommand(),
-      initCommand,
-      ...(this.config?.getMcpEnabled() === false
-        ? [
-            {
-              name: 'mcp',
-              description:
-                'Manage configured Model Context Protocol (MCP) servers',
-              kind: CommandKind.BUILT_IN,
-              autoExecute: false,
-              subCommands: [],
-              action: async (
-                _context: CommandContext,
-              ): Promise<MessageActionReturn> => ({
-                type: 'message',
-                messageType: 'error',
-                content: 'MCP is disabled by your admin.',
-              }),
-            },
-          ]
-        : [mcpCommand]),
-      memoryCommand,
-      modelCommand,
-      ...(this.config?.getFolderTrust() ? [permissionsCommand] : []),
-      privacyCommand,
-      policiesCommand,
-      ...(isDevelopment ? [profileCommand] : []),
-      quitCommand,
-      restoreCommand(this.config),
-      resumeCommand,
-      statsCommand,
-      themeCommand,
-      toolsCommand,
-      ...(this.config?.isSkillsSupportEnabled() ? [skillsCommand] : []),
-      settingsCommand,
-      vimCommand,
-      setupGithubCommand,
-      terminalSetupCommand,
-    ];
-    handle?.end();
-    return allDefinitions.filter((cmd): cmd is SlashCommand => cmd !== null);
+    try {
+      const allDefinitions: Array<SlashCommand | null> = [
+        aboutCommand,
+        ...(this.config?.isAgentsEnabled() ? [agentsCommand] : []),
+        authCommand,
+        bugCommand,
+        chatCommand,
+        clearCommand,
+        compressCommand,
+        copyCommand,
+        corgiCommand,
+        docsCommand,
+        directoryCommand,
+        editorCommand,
+        ...(this.config?.getExtensionsEnabled() === false
+          ? [
+              {
+                name: 'extensions',
+                description: 'Manage extensions',
+                kind: CommandKind.BUILT_IN,
+                autoExecute: false,
+                subCommands: [],
+                action: async (
+                  _context: CommandContext,
+                ): Promise<MessageActionReturn> => ({
+                  type: 'message',
+                  messageType: 'error',
+                  content: 'Extensions are disabled by your admin.',
+                }),
+              },
+            ]
+          : [extensionsCommand(this.config?.getEnableExtensionReloading())]),
+        helpCommand,
+        ...(this.config?.getEnableHooksUI() ? [hooksCommand] : []),
+        await ideCommand(),
+        initCommand,
+        ...(this.config?.getMcpEnabled() === false
+          ? [
+              {
+                name: 'mcp',
+                description:
+                  'Manage configured Model Context Protocol (MCP) servers',
+                kind: CommandKind.BUILT_IN,
+                autoExecute: false,
+                subCommands: [],
+                action: async (
+                  _context: CommandContext,
+                ): Promise<MessageActionReturn> => ({
+                  type: 'message',
+                  messageType: 'error',
+                  content: 'MCP is disabled by your admin.',
+                }),
+              },
+            ]
+          : [mcpCommand]),
+        memoryCommand,
+        modelCommand,
+        ...(this.config?.getFolderTrust() ? [permissionsCommand] : []),
+        privacyCommand,
+        policiesCommand,
+        ...(isDevelopment ? [profileCommand] : []),
+        quitCommand,
+        restoreCommand(this.config),
+        resumeCommand,
+        statsCommand,
+        themeCommand,
+        toolsCommand,
+        ...(this.config?.isSkillsSupportEnabled() ? [skillsCommand] : []),
+        settingsCommand,
+        vimCommand,
+        setupGithubCommand,
+        terminalSetupCommand,
+      ];
+      return allDefinitions.filter((cmd): cmd is SlashCommand => cmd !== null);
+    } finally {
+      handle?.end();
+    }
   }
 }

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -4,37 +4,37 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { Mock } from 'vitest';
-import type { ConfigParameters, SandboxConfig } from './config.js';
-import { Config, DEFAULT_FILE_FILTERING_OPTIONS } from './config.js';
-import { ExperimentFlags } from '../code_assist/experiments/flagNames.js';
-import { debugLogger } from '../utils/debugLogger.js';
-import { ApprovalMode } from '../policy/types.js';
-import type { HookDefinition } from '../hooks/types.js';
-import { HookType, HookEventName } from '../hooks/types.js';
 import * as path from 'node:path';
-import { setGeminiMdFilename as mockSetGeminiMdFilename } from '../tools/memoryTool.js';
-import {
-  DEFAULT_TELEMETRY_TARGET,
-  DEFAULT_OTLP_ENDPOINT,
-} from '../telemetry/index.js';
+import type { Mock } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ExperimentFlags } from '../code_assist/experiments/flagNames.js';
+import { GeminiClient } from '../core/client.js';
 import type { ContentGeneratorConfig } from '../core/contentGenerator.js';
 import {
   AuthType,
   createContentGeneratorConfig,
 } from '../core/contentGenerator.js';
-import { GeminiClient } from '../core/client.js';
+import type { HookDefinition } from '../hooks/types.js';
+import { HookEventName, HookType } from '../hooks/types.js';
+import { ApprovalMode } from '../policy/types.js';
 import { GitService } from '../services/gitService.js';
-import { ShellTool } from '../tools/shell.js';
-import { ReadFileTool } from '../tools/read-file.js';
-import { GrepTool } from '../tools/grep.js';
-import { RipGrepTool, canUseRipgrep } from '../tools/ripGrep.js';
+import type { SkillDefinition } from '../skills/skillLoader.js';
+import {
+  DEFAULT_OTLP_ENDPOINT,
+  DEFAULT_TELEMETRY_TARGET,
+} from '../telemetry/index.js';
 import { logRipgrepFallback } from '../telemetry/loggers.js';
 import { RipgrepFallbackEvent } from '../telemetry/types.js';
-import { ToolRegistry } from '../tools/tool-registry.js';
+import { GrepTool } from '../tools/grep.js';
+import { setGeminiMdFilename as mockSetGeminiMdFilename } from '../tools/memoryTool.js';
+import { ReadFileTool } from '../tools/read-file.js';
+import { RipGrepTool, canUseRipgrep } from '../tools/ripGrep.js';
+import { ShellTool } from '../tools/shell.js';
 import { ACTIVATE_SKILL_TOOL_NAME } from '../tools/tool-names.js';
-import type { SkillDefinition } from '../skills/skillLoader.js';
+import { ToolRegistry } from '../tools/tool-registry.js';
+import { debugLogger } from '../utils/debugLogger.js';
+import type { ConfigParameters, SandboxConfig } from './config.js';
+import { Config, DEFAULT_FILE_FILTERING_OPTIONS } from './config.js';
 import { DEFAULT_MODEL_CONFIGS } from './defaultModelConfigs.js';
 import {
   DEFAULT_GEMINI_MODEL,
@@ -181,13 +181,13 @@ vi.mock('../utils/fetch.js', () => ({
 
 vi.mock('../services/contextManager.js');
 
-import { BaseLlmClient } from '../core/baseLlmClient.js';
-import { tokenLimit } from '../core/tokenLimits.js';
-import { uiTelemetryService } from '../telemetry/index.js';
 import { getCodeAssistServer } from '../code_assist/codeAssist.js';
 import { getExperiments } from '../code_assist/experiments/experiments.js';
 import type { CodeAssistServer } from '../code_assist/server.js';
+import { BaseLlmClient } from '../core/baseLlmClient.js';
+import { tokenLimit } from '../core/tokenLimits.js';
 import { ContextManager } from '../services/contextManager.js';
+import { uiTelemetryService } from '../telemetry/index.js';
 
 vi.mock('../core/baseLlmClient.js');
 vi.mock('../core/tokenLimits.js', () => ({
@@ -2023,10 +2023,10 @@ describe('Config JIT Initialization', () => {
 
       expect(mockOnReload).toHaveBeenCalled();
       expect(skillManager.setDisabledSkills).toHaveBeenCalledWith(['skill2']);
-      expect(toolRegistry.registerTool).toHaveBeenCalled();
-      expect(toolRegistry.unregisterTool).not.toHaveBeenCalledWith(
+      expect(toolRegistry.unregisterTool).toHaveBeenCalledWith(
         ACTIVATE_SKILL_TOOL_NAME,
       );
+      expect(toolRegistry.registerTool).toHaveBeenCalled();
     });
 
     it('should unregister ActivateSkillTool when no skills exist after reload', async () => {

--- a/packages/core/src/ide/ide-installer.ts
+++ b/packages/core/src/ide/ide-installer.ts
@@ -28,20 +28,23 @@ async function findCommand(
   // 1. Check PATH first.
   try {
     if (platform === 'win32') {
-      const result = child_process
-        .execSync(`where.exe ${command}`)
-        .toString()
-        .trim();
-      // `where.exe` can return multiple paths. Return the first one.
-      const firstPath = result.split(/\r?\n/)[0];
-      if (firstPath) {
-        return firstPath;
+      const result = child_process.spawnSync('where.exe', [command], {
+        encoding: 'utf-8',
+      });
+      if (result.status === 0 && result.stdout) {
+        // `where.exe` can return multiple paths. Return the first one.
+        const firstPath = result.stdout.trim().split(/\r?\n/)[0];
+        if (firstPath) {
+          return firstPath;
+        }
       }
     } else {
-      child_process.execSync(`command -v ${command}`, {
+      const result = child_process.spawnSync('command', ['-v', command], {
         stdio: 'ignore',
       });
-      return command;
+      if (result.status === 0) {
+        return command;
+      }
     }
   } catch {
     // Not in PATH, continue to check common locations.


### PR DESCRIPTION
## Summary

This PR eliminates debug console warnings that appear during Gemini CLI startup
and improves Antigravity IDE detection reliability.

## Changes

### Debug Console Warnings Fixed

1. **Duplicate tool registration warning** - Fixed by calling `unregisterTool`
   before `registerTool` when re-registering `ActivateSkillTool` to update its
   schema after skill discovery.

2. **Startup phase profiler warning** - Fixed by wrapping command loading in
   `try/finally` to ensure `profiler.end()` is always called, even if an error
   occurs.

3. **Flicker frame false positive** - Fixed by adding a 50-frame grace period to
   `useFlickerDetector` to allow initial layout to settle before detecting
   genuine flickers.

### Antigravity IDE Improvements

- Added fallback logic for Antigravity CLI detection to try multiple commands
  (`agy`, `antigravity`, and `.cmd` variants on Windows) if the primary command
  from `ANTIGRAVITY_CLI_ALIAS` is not found.
- This helps users whose Antigravity installation doesn't include the expected
  `agy` command alias.

## Files Changed

- `packages/core/src/config/config.ts` - Add unregisterTool before re-register
- `packages/cli/src/services/BuiltinCommandLoader.ts` - Wrap in try/finally
- `packages/cli/src/ui/hooks/useFlickerDetector.ts` - Add grace period
- `packages/core/src/ide/ide-installer.ts` - Add fallback commands

## Testing

- All existing tests pass
- Updated tests to reflect new behavior
- Manually verified debug console is clean after startup
