### PR TITLE
feat(core): support shipping built-in skills with the CLI

### DIFF
--- a/packages/core/src/skills/skillManager.test.ts
+++ b/packages/core/src/skills/skillManager.test.ts
@@ -71,6 +71,8 @@ description: project-desc
     vi.spyOn(storage, 'getProjectSkillsDir').mockReturnValue(projectDir);
 
     const service = new SkillManager();
+    // @ts-expect-error accessing private method for testing
+    vi.spyOn(service, 'discoverBuiltinSkills').mockResolvedValue(undefined);
     await service.discoverSkills(storage, [mockExtension]);
 
     const skills = service.getSkills();
@@ -126,6 +128,8 @@ description: project-desc
     vi.spyOn(storage, 'getProjectSkillsDir').mockReturnValue(projectDir);
 
     const service = new SkillManager();
+    // @ts-expect-error accessing private method for testing
+    vi.spyOn(service, 'discoverBuiltinSkills').mockResolvedValue(undefined);
     await service.discoverSkills(storage, [mockExtension]);
 
     const skills = service.getSkills();
@@ -156,6 +160,8 @@ description: desc1
     vi.spyOn(Storage, 'getUserSkillsDir').mockReturnValue('/non-existent');
 
     const service = new SkillManager();
+    // @ts-expect-error accessing private method for testing
+    vi.spyOn(service, 'discoverBuiltinSkills').mockResolvedValue(undefined);
     await service.discoverSkills(storage);
     service.setDisabledSkills(['skill1']);
 

--- a/packages/core/src/skills/skillManager.ts
+++ b/packages/core/src/skills/skillManager.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Storage } from '../config/storage.js';
 import { type SkillDefinition, loadSkillsFromDir } from './skillLoader.js';
 import type { GeminiCLIExtension } from '../config/config.js';
@@ -56,9 +58,16 @@ export class SkillManager {
    * Discovers built-in skills.
    */
   private async discoverBuiltinSkills(): Promise<void> {
-    // Built-in skills can be added here.
-    // For now, this is a placeholder for where built-in skills will be loaded from.
-    // They could be loaded from a specific directory within the package.
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const builtinDir = path.join(__dirname, 'builtin');
+
+    const builtinSkills = await loadSkillsFromDir(builtinDir);
+
+    for (const skill of builtinSkills) {
+      skill.isBuiltin = true;
+    }
+
+    this.addSkillsWithPrecedence(builtinSkills);
   }
 
   private addSkillsWithPrecedence(newSkills: SkillDefinition[]): void {

--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -62,4 +62,15 @@ if (existsSync(docsSrc)) {
   console.log('Copied docs to bundle/docs/');
 }
 
+// 4. Copy Built-in Skills (packages/core/src/skills/builtin)
+const builtinSkillsSrc = join(root, 'packages/core/src/skills/builtin');
+const builtinSkillsDest = join(bundleDir, 'builtin');
+if (existsSync(builtinSkillsSrc)) {
+  cpSync(builtinSkillsSrc, builtinSkillsDest, {
+    recursive: true,
+    dereference: true,
+  });
+  console.log('Copied built-in skills to bundle/builtin/');
+}
+
 console.log('Assets copied to bundle/');

--- a/scripts/copy_files.js
+++ b/scripts/copy_files.js
@@ -74,4 +74,13 @@ if (packageName === 'cli') {
   }
 }
 
+// Copy built-in skills for the core package.
+if (packageName === 'core') {
+  const builtinSkillsSource = path.join(sourceDir, 'skills', 'builtin');
+  const builtinSkillsTarget = path.join(targetDir, 'skills', 'builtin');
+  if (fs.existsSync(builtinSkillsSource)) {
+    fs.cpSync(builtinSkillsSource, builtinSkillsTarget, { recursive: true });
+  }
+}
+
 console.log('Successfully copied files.');


### PR DESCRIPTION
## Summary

This PR enables the Gemini CLI to ship with built-in skills. It updates `SkillManager` to load skills from the `packages/core/src/skills/builtin` directory and includes this directory in the core package build.

## Details

- Implements `discoverBuiltinSkills` in `SkillManager` to load skills from the package bundle.
- Updates `copy_files.js` to ensure the `skills/builtin` directory is included in the core package build.
- Marks built-in skills with an `isBuiltin` flag, allowing them to be filtered in UI.

## Related Issues

Fixes #16289

## How to Validate

1. Run `npm run build` from the root.
2. Verify that any built-in skills added to `packages/core/src/skills/builtin` are copied to `packages/core/dist/skills/builtin`.
3. Start the CLI and verify built-in skills are loaded by `SkillManager`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker