### PR TITLE
feat(core): add built-in customization-creator skill

### DIFF
--- a/packages/core/src/skills/builtin/customization-creator/SKILL.md
+++ b/packages/core/src/skills/builtin/customization-creator/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: customization-creator
+description: Use this skill to help users build Gemini CLI extensions, custom commands (slash commands), hooks, and agent skills.
+---
+
+# Instructions
+
+You are an expert at extending Gemini CLI. You help users create customizations to tailor the CLI to their workflows.
+
+## Customization Components
+
+Gemini CLI has four primary customization components. When a user asks to customize the CLI, identify which component best suits their needs:
+
+1.  **Custom Commands (Slash Commands)**: For triggering deterministic actions (e.g., `/my-command`). Best for utility scripts, complex git operations, or integrating with external tools that the user wants to run explicitly.
+2.  **Hooks**: For intercepting the AI's standard flow (before/after tools, models, or agents). Best for injecting context, modifying prompts, filtering sensitive data, or auto-logging outputs without user intervention.
+3.  **Agent Skills**: For extending the agent's autonomous capabilities. Best for packaging complex multi-step workflows, providing specialized expertise, or giving the agent access to domain-specific documentation/tools.
+4.  **Extensions**: npm packages that bundle together any combination of custom commands, hooks, and skills. Best for distributing a comprehensive set of features to a team or the community.
+
+## Workflow
+
+1.  **Clarify Goal**: Ask the user what they want to achieve to determine the right component(s).
+2.  **Scaffold**: Use the templates in `./assets/` to create the initial structure.
+3.  **Implement**: Write the code/markdown based on the user's requirements.
+4.  **Test**: Instruct the user on how to load and test their new customization.
+
+## Available Resources & Docs
+
+Consult the bundled documentation for implementation details (paths are relative to this skill):
+- **Custom Commands**: `../../../docs/cli/custom-commands.md`
+- **Hooks Reference**: `../../../docs/hooks/index.md` and `../../../docs/hooks/writing-hooks.md`
+- **Skills Reference**: `../../../docs/cli/skills.md`
+- **Extensions Guide**: `../../../docs/extensions/index.md`
+
+## Templates
+
+- Custom Command: `./assets/command-template.ts`
+- Hook: `./assets/hook-template.ts`
+- Skill: `./assets/skill-template.md`
+- Extension Entry Point: `./assets/extension-template.ts`

--- a/packages/core/src/skills/builtin/customization-creator/assets/command-template.ts
+++ b/packages/core/src/skills/builtin/customization-creator/assets/command-template.ts
@@ -1,0 +1,18 @@
+/* eslint-disable no-restricted-imports */
+import { defineCommand } from '@google/gemini-cli-core';
+
+export default defineCommand({
+  name: 'my-command',
+  description: 'Description of what this command does.',
+  usage: '/my-command [args]',
+  async run(context, args) {
+    // Access UI, file system, or execute shell commands via context
+    context.ui.print('Running my custom command...');
+    
+    // Example: Read arguments
+    const arg = args[0] || 'default';
+    
+    // Example: Return a response to the chat
+    return `Command executed with argument: ${arg}`;
+  },
+});

--- a/packages/core/src/skills/builtin/customization-creator/assets/extension-template.ts
+++ b/packages/core/src/skills/builtin/customization-creator/assets/extension-template.ts
@@ -1,0 +1,18 @@
+// Entry point for a Gemini CLI Extension (npm package)
+// This file exports the commands and hooks provided by the extension.
+// It is referenced by the "main" field in package.json.
+
+import myCommand from './commands/my-command.js';
+import myHook from './hooks/my-hook.js';
+
+export const commands = [myCommand];
+export const hooks = [myHook];
+
+export function activate() {
+  // Optional: Run setup logic when the extension is loaded
+  // console.log('My Extension Activated');
+}
+
+export function deactivate() {
+  // Optional: Run cleanup logic when the extension is unloaded
+}

--- a/packages/core/src/skills/builtin/customization-creator/assets/hook-template.ts
+++ b/packages/core/src/skills/builtin/customization-creator/assets/hook-template.ts
@@ -1,0 +1,21 @@
+/* eslint-disable no-restricted-imports */
+import { defineHook } from '@google/gemini-cli-core';
+
+export default defineHook({
+  name: 'my-hook',
+  // See docs/hooks/reference.md for all available events
+  events: ['before-agent', 'after-model'], 
+  async handler(event, context) {
+    if (event.type === 'before-agent') {
+      context.ui.print('Hook intercepting before agent runs...');
+      
+      // Example: Inject additional context into the prompt
+      event.context.prompt += '\nNote: Consider local time constraints.';
+    }
+
+    if (event.type === 'after-model') {
+      // Example: Log model output
+      // console.log(event.context.response.text);
+    }
+  },
+});

--- a/packages/core/src/skills/builtin/customization-creator/assets/skill-template.md
+++ b/packages/core/src/skills/builtin/customization-creator/assets/skill-template.md
@@ -1,0 +1,21 @@
+---
+name: my-skill
+description: |
+  A concise description of what the skill does and when the agent should use it. 
+  E.g., "Use this skill to audit code for security vulnerabilities."
+---
+
+# Instructions
+
+You are an expert at [Domain]. When the user asks for [Trigger], follow this workflow:
+
+1. **Step 1**: Run `some command` to gather data.
+2. **Step 2**: Analyze the output for X, Y, and Z.
+3. **Step 3**: Provide a summary of the findings.
+
+## Constraints
+- Never do X.
+- Always format output as JSON/Markdown/etc.
+
+## Available Resources
+- [Link to internal docs or bundled files in the skill's assets/ folder]


### PR DESCRIPTION
## Summary

This PR introduces the `customization-creator` skill as a built-in skill. This skill guides users through the process of extending the Gemini CLI by helping them choose between commands, hooks, skills, and extensions, and providing necessary boilerplate templates.

## Details

- Provides expert guidance and instructions for choosing the right customization mechanism (commands, hooks, skills, or extensions).
- Links to relevant bundled documentation for each customization type.
- Includes boilerplate templates for rapid scaffolding of commands, extensions, hooks, and skills.

## Related Issues

Fixes #16290

## How to Validate

1. Run `npm run build` and start the CLI.
2. Trigger the skill by asking how to create a command, hook, skill, or extension.
3. Verify that the skill activates, provides the appropriate guidance, and successfully generates the boilerplate templates.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker