### PR TITLE
fix(ui): support ctrl+x for external editor in vim mode

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.external-editor.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.external-editor.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '../../../test-utils/render.js';
+import { useTextBuffer } from './text-buffer.js';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+// Mock dependencies
+vi.mock('node:fs');
+vi.mock('node:child_process');
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return {
+    ...actual,
+    tmpdir: vi.fn(() => '/tmp'),
+    homedir: vi.fn(() => '/mock-home'),
+  };
+});
+
+describe('useTextBuffer - openInExternalEditor', () => {
+  const mockSpawnSync = vi.mocked(spawnSync);
+  const mockMkdtempSync = vi.mocked(fs.mkdtempSync);
+  const mockReadFileSync = vi.mocked(fs.readFileSync);
+
+  function renderTextBuffer() {
+    return renderHook(() =>
+      useTextBuffer({
+        initialText: 'initial',
+        viewport: { width: 80, height: 24 },
+        isValidPath: () => false,
+      }),
+    );
+  }
+
+  const expectedTmpDir = path.join(os.tmpdir(), 'gemini-edit-123');
+  const expectedFilePath = path.join(expectedTmpDir, 'buffer.txt');
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Setup default mock behaviors
+    mockMkdtempSync.mockReturnValue(expectedTmpDir);
+    mockReadFileSync.mockReturnValue('edited content');
+    mockSpawnSync.mockReturnValue({
+      pid: 123,
+      output: [],
+      stdout: Buffer.from(''),
+      stderr: Buffer.from(''),
+      status: 0,
+      signal: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    {
+      name: 'command with arguments',
+      editor: 'code -n --wait',
+      expectedCmd: 'code',
+      expectedArgs: ['-n', '--wait', expectedFilePath],
+    },
+    {
+      name: 'command without arguments',
+      editor: 'vim',
+      expectedCmd: 'vim',
+      expectedArgs: [expectedFilePath],
+    },
+    {
+      name: 'quoted arguments',
+      editor: '/path/to/editor --arg "quoted value"',
+      expectedCmd: '/path/to/editor',
+      expectedArgs: ['--arg', 'quoted value', expectedFilePath],
+    },
+  ])(
+    'should parse editor $name correctly',
+    async ({ editor, expectedCmd, expectedArgs }) => {
+      const { result } = renderTextBuffer();
+
+      await result.current.openInExternalEditor({ editor });
+
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        expectedCmd,
+        expectedArgs,
+        expect.objectContaining({ stdio: 'inherit' }),
+      );
+    },
+  );
+
+  it.each([
+    { name: 'shell operators (&&)', editor: 'code -n && touch /tmp/malicious' },
+    { name: 'pipe operators', editor: 'cat | vim -' },
+  ])('should reject editor command with $name', async ({ editor }) => {
+    const { result } = renderTextBuffer();
+
+    await result.current.openInExternalEditor({ editor });
+
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/ui/hooks/vim.test.tsx
+++ b/packages/cli/src/ui/hooks/vim.test.tsx
@@ -1345,24 +1345,16 @@ describe('useVim hook', () => {
       );
     });
 
-    it('should pass through ctrl+x in NORMAL mode', () => {
-      mockVimContext.vimMode = 'NORMAL';
+    it.each([
+      { mode: 'NORMAL' as VimMode, key: { name: 'x', ctrl: true } },
+      { mode: 'INSERT' as VimMode, key: { name: 'x', ctrl: true } },
+      { mode: 'NORMAL' as VimMode, key: { sequence: '\x18', ctrl: true } },
+      { mode: 'INSERT' as VimMode, key: { sequence: '\x18', ctrl: true } },
+    ])('should pass through ctrl+x in $mode mode', ({ mode, key }) => {
+      mockVimContext.vimMode = mode;
       const { result } = renderVimHook();
 
-      const handled = result.current.handleInput(
-        createKey({ name: 'x', ctrl: true }),
-      );
-
-      expect(handled).toBe(false);
-    });
-
-    it('should pass through ctrl+x in INSERT mode', () => {
-      mockVimContext.vimMode = 'INSERT';
-      const { result } = renderVimHook();
-
-      const handled = result.current.handleInput(
-        createKey({ name: 'x', ctrl: true }),
-      );
+      const handled = result.current.handleInput(createKey(key));
 
       expect(handled).toBe(false);
     });

--- a/packages/cli/src/ui/hooks/vim.test.tsx
+++ b/packages/cli/src/ui/hooks/vim.test.tsx
@@ -1344,6 +1344,50 @@ describe('useVim hook', () => {
         expect.objectContaining(key),
       );
     });
+
+    it('should pass through ctrl+x in NORMAL mode', () => {
+      mockVimContext.vimMode = 'NORMAL';
+      const { result } = renderVimHook();
+
+      const handled = result.current.handleInput(
+        createKey({ name: 'x', ctrl: true }),
+      );
+
+      expect(handled).toBe(false);
+    });
+
+    it('should pass through ctrl+x in INSERT mode', () => {
+      mockVimContext.vimMode = 'INSERT';
+      const { result } = renderVimHook();
+
+      const handled = result.current.handleInput(
+        createKey({ name: 'x', ctrl: true }),
+      );
+
+      expect(handled).toBe(false);
+    });
+
+    it('should pass through ctrl+x (sequence \\x18) in NORMAL mode', () => {
+      mockVimContext.vimMode = 'NORMAL';
+      const { result } = renderVimHook();
+
+      const handled = result.current.handleInput(
+        createKey({ sequence: '\x18', ctrl: true }),
+      );
+
+      expect(handled).toBe(false);
+    });
+
+    it('should pass through ctrl+x (sequence \\x18) in INSERT mode', () => {
+      mockVimContext.vimMode = 'INSERT';
+      const { result } = renderVimHook();
+
+      const handled = result.current.handleInput(
+        createKey({ sequence: '\x18', ctrl: true }),
+      );
+
+      expect(handled).toBe(false);
+    });
   });
 
   // Line operations (dd, cc) are tested in text-buffer.test.ts

--- a/packages/cli/src/ui/hooks/vim.ts
+++ b/packages/cli/src/ui/hooks/vim.ts
@@ -400,6 +400,14 @@ export function useVim(buffer: TextBuffer, onSubmit?: (value: string) => void) {
         return false;
       }
 
+      // Let InputPrompt handle Ctrl+X for external editor
+      if (
+        normalizedKey.ctrl &&
+        (normalizedKey.name === 'x' || normalizedKey.sequence === '\x18')
+      ) {
+        return false;
+      }
+
       // Handle INSERT mode
       if (state.mode === 'INSERT') {
         return handleInsertModeInput(normalizedKey);

--- a/packages/cli/src/ui/hooks/vim.ts
+++ b/packages/cli/src/ui/hooks/vim.ts
@@ -9,6 +9,7 @@ import type { Key } from './useKeypress.js';
 import type { TextBuffer } from '../components/shared/text-buffer.js';
 import { useVimMode } from '../contexts/VimModeContext.js';
 import { debugLogger } from '@google/gemini-cli-core';
+import { keyMatchers, Command } from '../keyMatchers.js';
 
 export type VimMode = 'NORMAL' | 'INSERT';
 
@@ -401,10 +402,7 @@ export function useVim(buffer: TextBuffer, onSubmit?: (value: string) => void) {
       }
 
       // Let InputPrompt handle Ctrl+X for external editor
-      if (
-        normalizedKey.ctrl &&
-        (normalizedKey.name === 'x' || normalizedKey.sequence === '\x18')
-      ) {
+      if (keyMatchers[Command.OPEN_EXTERNAL_EDITOR](normalizedKey)) {
         return false;
       }
 


### PR DESCRIPTION
## Summary

Fixes the issue where Ctrl+X key combination was not triggering the external editor when user is in Vim mode (NORMAL or INSERT). This ensures consistent behavior across all terminal emulators by supporting both standard key representation and escape sequences.

## Details

The vim mode handler was consuming all key inputs, including Ctrl+X, which prevented it from reaching the InputPrompt handler responsible for external editor functionality. This PR adds early pass-through logic using `keyMatchers[Command.OPEN_EXTERNAL_EDITOR]`, which handles all key representations defined in `keyBindings.ts`.

This approach is consistent with key handling patterns used throughout the codebase (e.g., `InputPrompt.tsx`, `useSelectionList.ts`, `AppContainer.tsx`). The implementation is placed before mode-specific handling to ensure it works in both NORMAL and INSERT modes.

## Related Issues

Fixes #7258 - Ctrl+X not working to open external editor when vim mode is enabled.

Related to #16278 - This PR fixes the vim mode Ctrl+X pass-through issue. However, the full fix for `preferredEditor` setting being ignored requires additional work (passing the setting to `openInExternalEditor` function).

## How to Validate

1. Enable Vim mode in settings (set `vimMode: true`)
2. Start the CLI and enter some text
3. Press Ctrl+X
4. Verify that external editor opens (or prompts to select one if not configured)
5. Test on different terminals that send different key representations (e.g., iTerm2, Terminal.app, xterm)

Expected result: External editor should open consistently across all terminals when vim mode is enabled.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed) - No user-facing docs needed
- [x] Added/updated tests (if needed) - Added 4 test cases covering both modes and both key representations
- [ ] Noted breaking changes (if any) - No breaking changes
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker