### PR TITLE
fix(skills): remove "Restart required" message from non-interactive commands

### DIFF
--- a/packages/cli/src/commands/skills/disable.test.ts
+++ b/packages/cli/src/commands/skills/disable.test.ts
@@ -80,7 +80,7 @@ describe('skills disable command', () => {
       );
       expect(emitConsoleLog).toHaveBeenCalledWith(
         'log',
-        'Skill "skill1" disabled by adding it to the disabled list in user (/user/settings.json) settings. Restart required to take effect.',
+        'Skill "skill1" disabled by adding it to the disabled list in user (/user/settings.json) settings.',
       );
     });
 

--- a/packages/cli/src/commands/skills/disable.ts
+++ b/packages/cli/src/commands/skills/disable.ts
@@ -23,13 +23,10 @@ export async function handleDisable(args: DisableArgs) {
   const settings = loadSettings(workspaceDir);
 
   const result = disableSkill(settings, name, scope);
-  let feedback = renderSkillActionFeedback(
+  const feedback = renderSkillActionFeedback(
     result,
     (label, path) => `${chalk.bold(label)} (${chalk.dim(path)})`,
   );
-  if (result.status === 'success') {
-    feedback += ' Restart required to take effect.';
-  }
   debugLogger.log(feedback);
 }
 

--- a/packages/cli/src/commands/skills/enable.test.ts
+++ b/packages/cli/src/commands/skills/enable.test.ts
@@ -81,7 +81,7 @@ describe('skills enable command', () => {
       );
       expect(emitConsoleLog).toHaveBeenCalledWith(
         'log',
-        'Skill "skill1" enabled by removing it from the disabled list in user (/user/settings.json) and project (/project/settings.json) settings. Restart required to take effect.',
+        'Skill "skill1" enabled by removing it from the disabled list in user (/user/settings.json) and project (/project/settings.json) settings.',
       );
     });
 
@@ -122,7 +122,7 @@ describe('skills enable command', () => {
       );
       expect(emitConsoleLog).toHaveBeenCalledWith(
         'log',
-        'Skill "skill1" enabled by removing it from the disabled list in project (/workspace/settings.json) and user (/user/settings.json) settings. Restart required to take effect.',
+        'Skill "skill1" enabled by removing it from the disabled list in project (/workspace/settings.json) and user (/user/settings.json) settings.',
       );
     });
 

--- a/packages/cli/src/commands/skills/enable.ts
+++ b/packages/cli/src/commands/skills/enable.ts
@@ -22,13 +22,10 @@ export async function handleEnable(args: EnableArgs) {
   const settings = loadSettings(workspaceDir);
 
   const result = enableSkill(settings, name);
-  let feedback = renderSkillActionFeedback(
+  const feedback = renderSkillActionFeedback(
     result,
     (label, path) => `${chalk.bold(label)} (${chalk.dim(path)})`,
   );
-  if (result.status === 'success') {
-    feedback += ' Restart required to take effect.';
-  }
   debugLogger.log(feedback);
 }
 


### PR DESCRIPTION
## Summary

Removes the "Restart required to take effect" message from the `gemini skills enable` and `gemini skills disable` CLI commands.

## Details

This message is confusing when run non-interactively as a one-off command because the process finishes immediately. Interactive sessions (REPL) use a different message ("Use /skills reload") which is more appropriate for that context.

## Related Issues

Fixes #16306

## How to Validate

1. Run `gemini skills disable joke-skill`
2. Observe that "Restart required to take effect" is no longer present in the output.
3. Run `npm run test packages/cli/src/commands/skills/enable.test.ts packages/cli/src/commands/skills/disable.test.ts`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt