### PR TITLE
feat(core): optional local OCR for image/PDF reads

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -716,6 +716,7 @@ export async function loadCliConfig(
     interactive,
     trustedFolder,
     useRipgrep: settings.tools?.useRipgrep,
+    enableMediaTextExtraction: settings.tools?.mediaTextExtraction ?? false,
     enableInteractiveShell: settings.tools?.shell?.enableInteractiveShell,
     shellToolInactivityTimeout: settings.tools?.shell?.inactivityTimeout,
     enableShellOutputEfficiency:

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1045,6 +1045,18 @@ const SETTINGS_SCHEMA = {
           'Use ripgrep for file content search instead of the fallback implementation. Provides faster search performance.',
         showInDialog: true,
       },
+      mediaTextExtraction: {
+        type: 'boolean',
+        label: 'Enable Media Text Extraction',
+        category: 'Tools',
+        requiresRestart: false,
+        default: false,
+        description: oneLine`
+          Attempt local text extraction for PDFs and images using pdftotext or tesseract.
+          When extraction succeeds, read_file returns text instead of inlineData.
+        `,
+        showInDialog: false,
+      },
       enableToolOutputTruncation: {
         type: 'boolean',
         label: 'Enable Tool Output Truncation',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -319,6 +319,7 @@ export interface ConfigParameters {
   interactive?: boolean;
   trustedFolder?: boolean;
   useRipgrep?: boolean;
+  enableMediaTextExtraction?: boolean;
   enableInteractiveShell?: boolean;
   skipNextSpeakerCheck?: boolean;
   shellExecutionConfig?: ShellExecutionConfig;
@@ -446,6 +447,7 @@ export class Config {
   private readonly ptyInfo: string;
   private readonly trustedFolder: boolean | undefined;
   private readonly useRipgrep: boolean;
+  private readonly enableMediaTextExtraction: boolean;
   private readonly enableInteractiveShell: boolean;
   private readonly skipNextSpeakerCheck: boolean;
   private shellExecutionConfig: ShellExecutionConfig;
@@ -589,6 +591,7 @@ export class Config {
     this.ptyInfo = params.ptyInfo ?? 'child_process';
     this.trustedFolder = params.trustedFolder;
     this.useRipgrep = params.useRipgrep ?? true;
+    this.enableMediaTextExtraction = params.enableMediaTextExtraction ?? false;
     this.enableInteractiveShell = params.enableInteractiveShell ?? false;
     this.skipNextSpeakerCheck = params.skipNextSpeakerCheck ?? true;
     this.shellExecutionConfig = {
@@ -1579,6 +1582,10 @@ export class Config {
 
   getUseRipgrep(): boolean {
     return this.useRipgrep;
+  }
+
+  getEnableMediaTextExtraction(): boolean {
+    return this.enableMediaTextExtraction;
   }
 
   getEnableInteractiveShell(): boolean {

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -80,6 +80,9 @@ class ReadFileToolInvocation extends BaseToolInvocation<
       this.config.getFileSystemService(),
       this.params.offset,
       this.params.limit,
+      {
+        enableMediaTextExtraction: this.config.getEnableMediaTextExtraction(),
+      },
     );
 
     if (result.error) {

--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -283,6 +283,12 @@ ${finalExclusionPatternsForDescription
             filePath,
             this.config.getTargetDir(),
             this.config.getFileSystemService(),
+            undefined,
+            undefined,
+            {
+              enableMediaTextExtraction:
+                this.config.getEnableMediaTextExtraction(),
+            },
           );
 
           if (fileReadResult.error) {

--- a/packages/core/src/utils/mediaTextExtraction.ts
+++ b/packages/core/src/utils/mediaTextExtraction.ts
@@ -1,0 +1,229 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { debugLogger } from './debugLogger.js';
+
+const MAX_OUTPUT_BUFFER = 20 * 1024 * 1024;
+const OCR_MAX_PAGES = 20;
+const OCR_DPI = 150;
+const commandCache = new Map<string, boolean>();
+
+export interface MediaTextExtractionResult {
+  text: string;
+  method: 'pdftotext' | 'tesseract';
+}
+
+async function commandExists(command: string): Promise<boolean> {
+  const cached = commandCache.get(command);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const pathEnv = process.env['PATH'] ?? '';
+  if (!pathEnv) {
+    commandCache.set(command, false);
+    return false;
+  }
+
+  const pathEntries = pathEnv.split(path.delimiter).filter(Boolean);
+  const extensions =
+    process.platform === 'win32'
+      ? (process.env['PATHEXT'] ?? '.EXE;.CMD;.BAT;.COM').split(';')
+      : [''];
+  const accessMode =
+    process.platform === 'win32' ? fs.constants.F_OK : fs.constants.X_OK;
+
+  for (const entry of pathEntries) {
+    for (const ext of extensions) {
+      const candidate = path.join(entry, `${command}${ext}`);
+      try {
+        await fsPromises.access(candidate, accessMode);
+        commandCache.set(command, true);
+        return true;
+      } catch {
+        // Continue searching
+      }
+    }
+  }
+
+  commandCache.set(command, false);
+  return false;
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(
+      command,
+      args,
+      { encoding: 'utf8', maxBuffer: MAX_OUTPUT_BUFFER },
+      (error, stdout) => {
+        if (error) {
+          debugLogger.warn(
+            `Failed to run ${command} ${args.join(' ')}`,
+            error instanceof Error ? error.message : String(error),
+          );
+          resolve(null);
+          return;
+        }
+        if (typeof stdout === 'string') {
+          resolve(stdout);
+          return;
+        }
+        resolve(stdout.toString('utf8'));
+      },
+    );
+  });
+}
+
+async function extractPdfTextWithPdftotext(
+  filePath: string,
+): Promise<string | null> {
+  if (!(await commandExists('pdftotext'))) {
+    return null;
+  }
+
+  const output = await runCommand('pdftotext', [
+    '-q',
+    '-layout',
+    filePath,
+    '-',
+  ]);
+  if (output === null) {
+    return null;
+  }
+  const cleaned = output.trim();
+  return cleaned.length > 0 ? cleaned : null;
+}
+
+async function extractImageTextWithTesseract(
+  filePath: string,
+): Promise<string | null> {
+  if (!(await commandExists('tesseract'))) {
+    return null;
+  }
+
+  const output = await runCommand('tesseract', [
+    filePath,
+    'stdout',
+    '-l',
+    'eng',
+    '--psm',
+    '6',
+  ]);
+  if (output === null) {
+    return null;
+  }
+  const cleaned = output.trim();
+  return cleaned.length > 0 ? cleaned : null;
+}
+
+function sortPageImages(entries: string[]): string[] {
+  return entries.sort((a, b) => {
+    const aMatch = a.match(/-(\d+)\.png$/);
+    const bMatch = b.match(/-(\d+)\.png$/);
+    const aNum = aMatch ? Number(aMatch[1]) : Number.POSITIVE_INFINITY;
+    const bNum = bMatch ? Number(bMatch[1]) : Number.POSITIVE_INFINITY;
+    return aNum - bNum;
+  });
+}
+
+async function extractPdfTextWithTesseract(
+  filePath: string,
+): Promise<string | null> {
+  const hasPdftoppm = await commandExists('pdftoppm');
+  const hasTesseract = await commandExists('tesseract');
+  if (!hasPdftoppm || !hasTesseract) {
+    return null;
+  }
+
+  const tempDir = await fsPromises.mkdtemp(
+    path.join(os.tmpdir(), 'gemini-cli-ocr-'),
+  );
+  const prefix = path.join(tempDir, 'page');
+  try {
+    const renderResult = await runCommand('pdftoppm', [
+      '-r',
+      String(OCR_DPI),
+      '-png',
+      '-f',
+      '1',
+      '-l',
+      String(OCR_MAX_PAGES),
+      filePath,
+      prefix,
+    ]);
+    if (renderResult === null) {
+      return null;
+    }
+
+    const entries = await fsPromises.readdir(tempDir);
+    const images = sortPageImages(
+      entries.filter(
+        (entry) => entry.startsWith('page-') && entry.endsWith('.png'),
+      ),
+    );
+    if (images.length === 0) {
+      return null;
+    }
+
+    const chunks: string[] = [];
+    for (const image of images) {
+      const imagePath = path.join(tempDir, image);
+      const text = await extractImageTextWithTesseract(imagePath);
+      if (text) {
+        chunks.push(text);
+      }
+    }
+
+    const joined = chunks.join('\n\n=== PAGE BREAK ===\n\n').trim();
+    return joined.length > 0 ? joined : null;
+  } finally {
+    try {
+      await fsPromises.rm(tempDir, { recursive: true, force: true });
+    } catch (error) {
+      debugLogger.warn(
+        `Failed to remove OCR temp directory: ${tempDir}`,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+}
+
+export async function extractMediaText(
+  filePath: string,
+  mimeType: string,
+): Promise<MediaTextExtractionResult | null> {
+  if (mimeType === 'application/pdf') {
+    const text = await extractPdfTextWithPdftotext(filePath);
+    if (text) {
+      return { text, method: 'pdftotext' };
+    }
+
+    const ocrText = await extractPdfTextWithTesseract(filePath);
+    if (ocrText) {
+      return { text: ocrText, method: 'tesseract' };
+    }
+    return null;
+  }
+
+  if (mimeType.startsWith('image/')) {
+    const ocrText = await extractImageTextWithTesseract(filePath);
+    if (ocrText) {
+      return { text: ocrText, method: 'tesseract' };
+    }
+  }
+
+  return null;
+}

--- a/packages/core/src/utils/pathReader.ts
+++ b/packages/core/src/utils/pathReader.ts
@@ -87,6 +87,9 @@ export async function readPathFromWorkspace(
         filePath,
         config.getTargetDir(),
         config.getFileSystemService(),
+        undefined,
+        undefined,
+        { enableMediaTextExtraction: config.getEnableMediaTextExtraction() },
       );
       allParts.push(result.llmContent);
       allParts.push({ text: '\n' }); // Add a newline for separation
@@ -112,6 +115,9 @@ export async function readPathFromWorkspace(
       absolutePath,
       config.getTargetDir(),
       config.getFileSystemService(),
+      undefined,
+      undefined,
+      { enableMediaTextExtraction: config.getEnableMediaTextExtraction() },
     );
     return [result.llmContent];
   }


### PR DESCRIPTION
## Summary
- Add optional local media text extraction for PDFs/images (pdftotext first, tesseract OCR fallback).
- When enabled via `tools.mediaTextExtraction`, `read_file`/`read_many_files` return extracted text instead of inlineData.
- Share extraction flow in fileUtils and cover with a PDF extraction test.

## Details
- New `utils/mediaTextExtraction` uses `pdftotext` or `pdftoppm` + `tesseract` and cleans up temp files.
- OCR is capped to the first 20 pages at 150 DPI to avoid runaway work.
- Falls back to inlineData if tools are missing or extraction is empty.

## Related Issues
Refs #16310
Refs #11084
Related #15672

## Testing
- `npm run test --workspace @google/gemini-cli-core -- --run src/utils/fileUtils.test.ts`
- Manual OCR smoke test with local tools (`pdftotext`, `pdftoppm`, `tesseract`): PDF `/tmp/ocr-sample.pdf` (19,594 bytes; base64 length 26,128) -> `pdftotext` extracted 403 chars (~100 tokens via `estimateTokenCountSync`).
- Manual OCR smoke test with local tools (`pdftotext`, `pdftoppm`, `tesseract`): Image `docs/assets/gemini-screenshot.png` (61,239 bytes; base64 length 81,652) -> `tesseract` extracted 558 chars (~139 tokens via `estimateTokenCountSync`).
