### PR TITLE
fix: Handle colons in skill description frontmatter

### DIFF
--- a/packages/core/src/skills/skillLoader.test.ts
+++ b/packages/core/src/skills/skillLoader.test.ts
@@ -100,4 +100,98 @@ describe('skillLoader', () => {
     expect(skills).toEqual([]);
     expect(coreEvents.emitFeedback).not.toHaveBeenCalled();
   });
+
+  it('should parse skill with colon in description (issue #16323)', async () => {
+    const skillDir = path.join(testRootDir, 'colon-skill');
+    await fs.mkdir(skillDir, { recursive: true });
+    const skillFile = path.join(skillDir, 'SKILL.md');
+    await fs.writeFile(
+      skillFile,
+      `---
+name: foo
+description: Simple story generation assistant for fiction writing. Use for creating characters, scenes, storylines, and prose. Trigger words: character, scene, storyline, story, prose, fiction, writing.
+---
+# Instructions
+Do something.
+`,
+    );
+
+    const skills = await loadSkillsFromDir(testRootDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('foo');
+    expect(skills[0].description).toContain('Trigger words:');
+  });
+
+  it('should parse skill with multiple colons in description', async () => {
+    const skillDir = path.join(testRootDir, 'multi-colon-skill');
+    await fs.mkdir(skillDir, { recursive: true });
+    const skillFile = path.join(skillDir, 'SKILL.md');
+    await fs.writeFile(
+      skillFile,
+      `---
+name: multi-colon
+description: Use this for tasks like: coding, reviewing, testing. Keywords: async, await, promise.
+---
+# Instructions
+Do something.
+`,
+    );
+
+    const skills = await loadSkillsFromDir(testRootDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('multi-colon');
+    expect(skills[0].description).toContain('tasks like:');
+    expect(skills[0].description).toContain('Keywords:');
+  });
+
+  it('should parse skill with quoted YAML description (backward compatibility)', async () => {
+    const skillDir = path.join(testRootDir, 'quoted-skill');
+    await fs.mkdir(skillDir, { recursive: true });
+    const skillFile = path.join(skillDir, 'SKILL.md');
+    await fs.writeFile(
+      skillFile,
+      `---
+name: quoted-skill
+description: "A skill with colons: like this one: and another."
+---
+# Instructions
+Do something.
+`,
+    );
+
+    const skills = await loadSkillsFromDir(testRootDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('quoted-skill');
+    expect(skills[0].description).toBe(
+      'A skill with colons: like this one: and another.',
+    );
+  });
+
+  it('should parse skill with multi-line YAML description', async () => {
+    const skillDir = path.join(testRootDir, 'multiline-skill');
+    await fs.mkdir(skillDir, { recursive: true });
+    const skillFile = path.join(skillDir, 'SKILL.md');
+    await fs.writeFile(
+      skillFile,
+      `---
+name: multiline-skill
+description:
+  Expertise in reviewing code for style, security, and performance. Use when the
+  user asks for "feedback," a "review," or to "check" their changes.
+---
+# Instructions
+Do something.
+`,
+    );
+
+    const skills = await loadSkillsFromDir(testRootDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('multiline-skill');
+    expect(skills[0].description).toContain('Expertise in reviewing code');
+    expect(skills[0].description).toContain('check');
+  });
 });


### PR DESCRIPTION
## Summary
Fixes #16323

This PR resolves an issue where the skills parser would fail when a skill's description field contained colons (e.g., `Trigger words: foo, bar`). The YAML parser was interpreting these colons as key-value separators, causing parse errors.

## Problem
Users reported that skill files like this would fail to load:
```yaml
---
name: foo
description: Simple story generation assistant for fiction writing. Trigger words: character, scene, storyline, story, prose, fiction, writing.
---
```

Error:
```
YAMLException: bad indentation of a mapping entry (2:142)
```

## Solution
Implemented a two-tier parsing strategy:
1. **First tier**: Attempt standard YAML parsing (for properly formatted YAML with quotes)
2. **Second tier**: If YAML parsing fails, fall back to a simple key-value parser that treats everything after the first colon as the value

This approach:
- ✅ Maintains backward compatibility with existing properly formatted YAML skills
- ✅ Handles colons in description values without requiring quotes
- ✅ Supports multi-line descriptions with indented continuation lines
- ✅ Gracefully handles parse failures without breaking other skills

## Changes
- Added `parseFrontmatter()` function with YAML-first + fallback strategy
- Added `parseSimpleFrontmatter()` for handling colons in values
- Added 4 comprehensive test cases covering:
  - Single colon in description
  - Multiple colons in description
  - Quoted YAML descriptions (backward compatibility)
  - Multi-line YAML descriptions

## Testing
All existing tests pass (14 total skill loader tests), and new tests verify:
- `should parse skill with colon in description (issue #16323)`
- `should parse skill with multiple colons in description`
- `should parse skill with quoted YAML description (backward compatibility)`
- `should parse skill with multi-line YAML description`

## Comparison with Claude Code
This implementation follows a similar approach to Claude Code's skill parser, which uses a simple key-value parser that splits on the first colon only. Our implementation adds an additional layer by attempting YAML parsing first, ensuring maximum compatibility.