### PR TITLE
fix(workflows): update PR triage schedule to run hourly

### DIFF
--- a/.github/workflows/gemini-scheduled-pr-triage.yml
+++ b/.github/workflows/gemini-scheduled-pr-triage.yml
@@ -2,7 +2,7 @@ name: 'Gemini Scheduled PR Triage 🚀'
 
 on:
   schedule:
-    - cron: '*/15 * * * *' # Runs every 15 minutes
+    - cron: '0 * * * *' # Runs every hour
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Updates the scheduled trigger for the PR triage workflow to run once an hour instead of every 15 minutes.