### PR TITLE
Add other hook wrapper methods to hooksystem

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -46,9 +46,8 @@ import type {
   ResolvedModelConfig,
 } from '../services/modelConfigService.js';
 import { ClearcutLogger } from '../telemetry/clearcut-logger/clearcut-logger.js';
-import { HookSystem } from '../hooks/hookSystem.js';
-import type { DefaultHookOutput } from '../hooks/types.js';
 import * as policyCatalog from '../availability/policyCatalog.js';
+import { partToString } from '../utils/partUtils.js';
 
 vi.mock('../services/chatCompressionService.js');
 
@@ -137,15 +136,22 @@ vi.mock('../telemetry/uiTelemetry.js', () => ({
   },
 }));
 vi.mock('../hooks/hookSystem.js');
-vi.mock('./clientHookTriggers.js', () => ({
-  fireBeforeAgentHook: vi.fn(),
-  fireAfterAgentHook: vi.fn().mockResolvedValue({
-    decision: 'allow',
-    continue: false,
-    suppressOutput: false,
-    systemMessage: undefined,
+const mockHookSystem = {
+  fireBeforeAgentEvent: vi.fn().mockResolvedValue({
+    success: true,
+    finalOutput: undefined,
+    allOutputs: [],
+    errors: [],
+    totalDuration: 0,
   }),
-}));
+  fireAfterAgentEvent: vi.fn().mockResolvedValue({
+    success: true,
+    finalOutput: undefined,
+    allOutputs: [],
+    errors: [],
+    totalDuration: 0,
+  }),
+};
 
 /**
  * Array.fromAsync ponyfill, which will be available in es 2024.
@@ -286,9 +292,7 @@ describe('Gemini Client (client.ts)', () => {
         .fn()
         .mockReturnValue(createAvailabilityServiceMock()),
     } as unknown as Config;
-    mockConfig.getHookSystem = vi
-      .fn()
-      .mockReturnValue(new HookSystem(mockConfig));
+    mockConfig.getHookSystem = vi.fn().mockReturnValue(mockHookSystem);
 
     client = new GeminiClient(mockConfig);
     await client.initialize();
@@ -2688,9 +2692,6 @@ ${JSON.stringify(
         const promptId = 'test-prompt-hook-1';
         const request = { text: 'Hello Hooks' };
         const signal = new AbortController().signal;
-        const { fireBeforeAgentHook, fireAfterAgentHook } = await import(
-          './clientHookTriggers.js'
-        );
 
         mockTurnRunFn.mockImplementation(async function* (
           this: MockTurnContext,
@@ -2702,11 +2703,10 @@ ${JSON.stringify(
         const stream = client.sendMessageStream(request, signal, promptId);
         while (!(await stream.next()).done);
 
-        expect(fireBeforeAgentHook).toHaveBeenCalledTimes(1);
-        expect(fireAfterAgentHook).toHaveBeenCalledTimes(1);
-        expect(fireAfterAgentHook).toHaveBeenCalledWith(
-          expect.anything(),
-          request,
+        expect(mockHookSystem.fireBeforeAgentEvent).toHaveBeenCalledTimes(1);
+        expect(mockHookSystem.fireAfterAgentEvent).toHaveBeenCalledTimes(1);
+        expect(mockHookSystem.fireAfterAgentEvent).toHaveBeenCalledWith(
+          partToString(request),
           'Hook Response',
         );
 
@@ -2725,9 +2725,6 @@ ${JSON.stringify(
         const promptId = 'test-prompt-hook-recursive';
         const request = { text: 'Recursion Test' };
         const signal = new AbortController().signal;
-        const { fireBeforeAgentHook, fireAfterAgentHook } = await import(
-          './clientHookTriggers.js'
-        );
 
         let callCount = 0;
         mockTurnRunFn.mockImplementation(async function* (
@@ -2743,15 +2740,14 @@ ${JSON.stringify(
         while (!(await stream.next()).done);
 
         // BeforeAgent should fire ONLY once despite multiple internal turns
-        expect(fireBeforeAgentHook).toHaveBeenCalledTimes(1);
+        expect(mockHookSystem.fireBeforeAgentEvent).toHaveBeenCalledTimes(1);
 
         // AfterAgent should fire ONLY when the stack unwinds
-        expect(fireAfterAgentHook).toHaveBeenCalledTimes(1);
+        expect(mockHookSystem.fireAfterAgentEvent).toHaveBeenCalledTimes(1);
 
         // Check cumulative response (separated by newline)
-        expect(fireAfterAgentHook).toHaveBeenCalledWith(
-          expect.anything(),
-          request,
+        expect(mockHookSystem.fireAfterAgentEvent).toHaveBeenCalledWith(
+          partToString(request),
           'Response 1\nResponse 2',
         );
 
@@ -2769,7 +2765,6 @@ ${JSON.stringify(
         const promptId = 'test-prompt-hook-original-req';
         const request = { text: 'Do something' };
         const signal = new AbortController().signal;
-        const { fireAfterAgentHook } = await import('./clientHookTriggers.js');
 
         mockTurnRunFn.mockImplementation(async function* (
           this: MockTurnContext,
@@ -2781,9 +2776,8 @@ ${JSON.stringify(
         const stream = client.sendMessageStream(request, signal, promptId);
         while (!(await stream.next()).done);
 
-        expect(fireAfterAgentHook).toHaveBeenCalledWith(
-          expect.anything(),
-          request, // Should be 'Do something'
+        expect(mockHookSystem.fireAfterAgentEvent).toHaveBeenCalledWith(
+          partToString(request), // Should be 'Do something'
           expect.stringContaining('Ok'),
         );
       });
@@ -2817,11 +2811,17 @@ ${JSON.stringify(
       });
 
       it('should stop execution in BeforeAgent when hook returns continue: false', async () => {
-        const { fireBeforeAgentHook } = await import('./clientHookTriggers.js');
-        vi.mocked(fireBeforeAgentHook).mockResolvedValue({
-          shouldStopExecution: () => true,
-          getEffectiveReason: () => 'Stopped by hook',
-        } as DefaultHookOutput);
+        mockHookSystem.fireBeforeAgentEvent.mockResolvedValue({
+          success: true,
+          finalOutput: {
+            shouldStopExecution: () => true,
+            getEffectiveReason: () => 'Stopped by hook',
+            systemMessage: undefined,
+          },
+          allOutputs: [],
+          errors: [],
+          totalDuration: 0,
+        });
 
         const mockChat: Partial<GeminiChat> = {
           addHistory: vi.fn(),
@@ -2850,12 +2850,18 @@ ${JSON.stringify(
       });
 
       it('should block execution in BeforeAgent when hook returns decision: block', async () => {
-        const { fireBeforeAgentHook } = await import('./clientHookTriggers.js');
-        vi.mocked(fireBeforeAgentHook).mockResolvedValue({
-          shouldStopExecution: () => false,
-          isBlockingDecision: () => true,
-          getEffectiveReason: () => 'Blocked by hook',
-        } as DefaultHookOutput);
+        mockHookSystem.fireBeforeAgentEvent.mockResolvedValue({
+          success: true,
+          finalOutput: {
+            shouldStopExecution: () => false,
+            isBlockingDecision: () => true,
+            getEffectiveReason: () => 'Blocked by hook',
+            systemMessage: undefined,
+          },
+          allOutputs: [],
+          errors: [],
+          totalDuration: 0,
+        });
 
         const mockChat: Partial<GeminiChat> = {
           addHistory: vi.fn(),
@@ -2883,11 +2889,17 @@ ${JSON.stringify(
       });
 
       it('should stop execution in AfterAgent when hook returns continue: false', async () => {
-        const { fireAfterAgentHook } = await import('./clientHookTriggers.js');
-        vi.mocked(fireAfterAgentHook).mockResolvedValue({
-          shouldStopExecution: () => true,
-          getEffectiveReason: () => 'Stopped after agent',
-        } as DefaultHookOutput);
+        mockHookSystem.fireAfterAgentEvent.mockResolvedValue({
+          success: true,
+          finalOutput: {
+            shouldStopExecution: () => true,
+            getEffectiveReason: () => 'Stopped after agent',
+            systemMessage: undefined,
+          },
+          allOutputs: [],
+          errors: [],
+          totalDuration: 0,
+        });
 
         mockTurnRunFn.mockImplementation(async function* () {
           yield { type: GeminiEventType.Content, value: 'Hello' };
@@ -2909,17 +2921,30 @@ ${JSON.stringify(
       });
 
       it('should yield AgentExecutionBlocked and recurse in AfterAgent when hook returns decision: block', async () => {
-        const { fireAfterAgentHook } = await import('./clientHookTriggers.js');
-        vi.mocked(fireAfterAgentHook)
+        mockHookSystem.fireAfterAgentEvent
           .mockResolvedValueOnce({
-            shouldStopExecution: () => false,
-            isBlockingDecision: () => true,
-            getEffectiveReason: () => 'Please explain',
-          } as DefaultHookOutput)
+            success: true,
+            finalOutput: {
+              shouldStopExecution: () => false,
+              isBlockingDecision: () => true,
+              getEffectiveReason: () => 'Please explain',
+              systemMessage: undefined,
+            },
+            allOutputs: [],
+            errors: [],
+            totalDuration: 0,
+          })
           .mockResolvedValueOnce({
-            shouldStopExecution: () => false,
-            isBlockingDecision: () => false,
-          } as DefaultHookOutput);
+            success: true,
+            finalOutput: {
+              shouldStopExecution: () => false,
+              isBlockingDecision: () => false,
+              systemMessage: undefined,
+            },
+            allOutputs: [],
+            errors: [],
+            totalDuration: 0,
+          });
 
         mockTurnRunFn.mockImplementation(async function* () {
           yield { type: GeminiEventType.Content, value: 'Response' };

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -18,8 +18,14 @@ import type {
   SessionStartSource,
   SessionEndReason,
   PreCompressTrigger,
+  McpToolContext,
+  NotificationType,
 } from './types.js';
 import type { AggregatedHookResult } from './hookAggregator.js';
+import type {
+  GenerateContentParameters,
+  GenerateContentResponse,
+} from '@google/genai';
 /**
  * Main hook system that coordinates all hook-related functionality
  */
@@ -116,5 +122,100 @@ export class HookSystem {
       return undefined;
     }
     return this.hookEventHandler.firePreCompressEvent(trigger);
+  }
+
+  async fireBeforeModelEvent(
+    llmRequest: GenerateContentParameters,
+  ): Promise<AggregatedHookResult | undefined> {
+    if (!this.config.getEnableHooks()) {
+      return undefined;
+    }
+    return this.hookEventHandler.fireBeforeModelEvent(llmRequest);
+  }
+
+  async fireAfterModelEvent(
+    llmRequest: GenerateContentParameters,
+    llmResponse: GenerateContentResponse,
+  ): Promise<AggregatedHookResult | undefined> {
+    if (!this.config.getEnableHooks()) {
+      return undefined;
+    }
+    return this.hookEventHandler.fireAfterModelEvent(llmRequest, llmResponse);
+  }
+
+  async fireBeforeToolSelectionEvent(
+    llmRequest: GenerateContentParameters,
+  ): Promise<AggregatedHookResult | undefined> {
+    if (!this.config.getEnableHooks()) {
+      return undefined;
+    }
+    return this.hookEventHandler.fireBeforeToolSelectionEvent(llmRequest);
+  }
+
+  async fireBeforeToolEvent(
+    toolName: string,
+    toolInput: Record<string, unknown>,
+    mcpContext?: McpToolContext,
+  ): Promise<AggregatedHookResult | undefined> {
+    if (!this.config.getEnableHooks()) {
+      return undefined;
+    }
+    return this.hookEventHandler.fireBeforeToolEvent(
+      toolName,
+      toolInput,
+      mcpContext,
+    );
+  }
+
+  async fireAfterToolEvent(
+    toolName: string,
+    toolInput: Record<string, unknown>,
+    toolOutput: Record<string, unknown>,
+    mcpContext?: McpToolContext,
+  ): Promise<AggregatedHookResult | undefined> {
+    if (!this.config.getEnableHooks()) {
+      return undefined;
+    }
+    return this.hookEventHandler.fireAfterToolEvent(
+      toolName,
+      toolInput,
+      toolOutput,
+      mcpContext,
+    );
+  }
+
+  async fireBeforeAgentEvent(
+    prompt: string,
+  ): Promise<AggregatedHookResult | undefined> {
+    if (!this.config.getEnableHooks()) {
+      return undefined;
+    }
+    return this.hookEventHandler.fireBeforeAgentEvent(prompt);
+  }
+
+  async fireAfterAgentEvent(
+    prompt: string,
+    response: string,
+    stopHookActive: boolean = false,
+  ): Promise<AggregatedHookResult | undefined> {
+    if (!this.config.getEnableHooks()) {
+      return undefined;
+    }
+    return this.hookEventHandler.fireAfterAgentEvent(
+      prompt,
+      response,
+      stopHookActive,
+    );
+  }
+
+  async fireNotificationEvent(
+    type: NotificationType,
+    message: string,
+    details: Record<string, unknown>,
+  ): Promise<AggregatedHookResult | undefined> {
+    if (!this.config.getEnableHooks()) {
+      return undefined;
+    }
+    return this.hookEventHandler.fireNotificationEvent(type, message, details);
   }
 }

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -18,13 +18,8 @@ import type {
   SessionStartSource,
   SessionEndReason,
   PreCompressTrigger,
-  McpToolContext,
 } from './types.js';
 import type { AggregatedHookResult } from './hookAggregator.js';
-import type {
-  GenerateContentParameters,
-  GenerateContentResponse,
-} from '@google/genai';
 /**
  * Main hook system that coordinates all hook-related functionality
  */
@@ -121,66 +116,6 @@ export class HookSystem {
       return undefined;
     }
     return this.hookEventHandler.firePreCompressEvent(trigger);
-  }
-
-  async fireBeforeModelEvent(
-    llmRequest: GenerateContentParameters,
-  ): Promise<AggregatedHookResult | undefined> {
-    if (!this.config.getEnableHooks()) {
-      return undefined;
-    }
-    return this.hookEventHandler.fireBeforeModelEvent(llmRequest);
-  }
-
-  async fireAfterModelEvent(
-    llmRequest: GenerateContentParameters,
-    llmResponse: GenerateContentResponse,
-  ): Promise<AggregatedHookResult | undefined> {
-    if (!this.config.getEnableHooks()) {
-      return undefined;
-    }
-    return this.hookEventHandler.fireAfterModelEvent(llmRequest, llmResponse);
-  }
-
-  async fireBeforeToolSelectionEvent(
-    llmRequest: GenerateContentParameters,
-  ): Promise<AggregatedHookResult | undefined> {
-    if (!this.config.getEnableHooks()) {
-      return undefined;
-    }
-    return this.hookEventHandler.fireBeforeToolSelectionEvent(llmRequest);
-  }
-
-  async fireBeforeToolEvent(
-    toolName: string,
-    toolInput: Record<string, unknown>,
-    mcpContext?: McpToolContext,
-  ): Promise<AggregatedHookResult | undefined> {
-    if (!this.config.getEnableHooks()) {
-      return undefined;
-    }
-    return this.hookEventHandler.fireBeforeToolEvent(
-      toolName,
-      toolInput,
-      mcpContext,
-    );
-  }
-
-  async fireAfterToolEvent(
-    toolName: string,
-    toolInput: Record<string, unknown>,
-    toolOutput: Record<string, unknown>,
-    mcpContext?: McpToolContext,
-  ): Promise<AggregatedHookResult | undefined> {
-    if (!this.config.getEnableHooks()) {
-      return undefined;
-    }
-    return this.hookEventHandler.fireAfterToolEvent(
-      toolName,
-      toolInput,
-      toolOutput,
-      mcpContext,
-    );
   }
 
   async fireBeforeAgentEvent(

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -19,7 +19,6 @@ import type {
   SessionEndReason,
   PreCompressTrigger,
   McpToolContext,
-  NotificationType,
 } from './types.js';
 import type { AggregatedHookResult } from './hookAggregator.js';
 import type {
@@ -206,16 +205,5 @@ export class HookSystem {
       response,
       stopHookActive,
     );
-  }
-
-  async fireNotificationEvent(
-    type: NotificationType,
-    message: string,
-    details: Record<string, unknown>,
-  ): Promise<AggregatedHookResult | undefined> {
-    if (!this.config.getEnableHooks()) {
-      return undefined;
-    }
-    return this.hookEventHandler.fireNotificationEvent(type, message, details);
   }
 }


### PR DESCRIPTION
## Summary

Adds wrapper methods to [HookSystem](cci:2://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/core/src/hooks/hookSystem.ts:31:0-220:1) for other hook events. This enables call sites to use `config.getHookSystem()?.fire*Event()` instead of directly calling hook trigger functions with MessageBus.

## Details

**Methods added to HookSystem:**
- [fireBeforeAgentEvent()](cci:1://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/core/src/hooks/hookSystem.ts:186:2-193:3)
- [fireAfterAgentEvent()](cci:1://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/core/src/hooks/hookEventHandler.ts:405:2-422:3)

## Related Issues

Part of #14317

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    
@scidomino please have a look
