### PR TITLE
fix(cli): improve custom sandbox profile handling, security, and error reporting

### DIFF
--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -87,6 +87,16 @@ Built-in profiles (set via `SEATBELT_PROFILE` env var):
 - `restrictive-open`: Strict restrictions, network allowed
 - `restrictive-closed`: Maximum restrictions
 
+### Custom macOS Seatbelt profiles
+
+You can create custom profiles by adding a `.sb` file to your project's
+`.gemini` directory or your home directory's `.gemini` folder (`~/.gemini/`).
+The file should be named `sandbox-macos-<profile>.sb`.
+
+For example, to create a profile named `custom`, create a file at
+`.gemini/sandbox-macos-custom.sb` or `~/.gemini/sandbox-macos-custom.sb` and set
+`SEATBELT_PROFILE=custom`.
+
 ### Custom sandbox flags
 
 For container-based sandboxing, you can inject custom flags into the `docker` or

--- a/packages/cli/src/utils/relaunch.ts
+++ b/packages/cli/src/utils/relaunch.ts
@@ -20,10 +20,14 @@ export async function relaunchOnExitCode(runner: () => Promise<number>) {
       process.stdin.resume();
       const errorMessage =
         error instanceof Error ? (error.stack ?? error.message) : String(error);
-      writeToStderr(
+      const flushed = writeToStderr(
         `Fatal error: Failed to relaunch the CLI process.\n${errorMessage}\n`,
       );
-      process.exit(1);
+      if (!flushed) {
+        process.stderr.once('drain', () => process.exit(1));
+      } else {
+        process.exit(1);
+      }
     }
   }
 }

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -57,12 +57,43 @@ export async function start_sandbox(
       }
 
       const profile = (process.env['SEATBELT_PROFILE'] ??= 'permissive-open');
+      // Prevent path traversal attacks (e.g. "../") by strictly validating the profile name.
+      // This ensures the user cannot break out of the intended directory structure.
+      if (!/^[a-zA-Z0-9-_]+$/.test(profile)) {
+        throw new FatalSandboxError(
+          `Invalid seatbelt profile name '${profile}'. Profile names can only contain alphanumeric characters, dashes, and underscores.`,
+        );
+      }
       let profileFile = fileURLToPath(
         new URL(`sandbox-macos-${profile}.sb`, import.meta.url),
       );
-      // if profile name is not recognized, then look for file under project settings directory
+      // if profile name is not recognized, then look for file under project settings directory or home directory
       if (!BUILTIN_SEATBELT_PROFILES.includes(profile)) {
-        profileFile = path.join(GEMINI_DIR, `sandbox-macos-${profile}.sb`);
+        const candidates = [
+          path.join(GEMINI_DIR, `sandbox-macos-${profile}.sb`),
+          path.join(homedir(), GEMINI_DIR, `sandbox-macos-${profile}.sb`),
+        ];
+
+        const matches = candidates.filter((candidate) =>
+          fs.existsSync(candidate),
+        );
+
+        if (matches.length > 1) {
+          throw new FatalSandboxError(
+            `Ambiguous macos seatbelt profile: found multiple candidates for profile '${profile}':\n${matches.map((m) => `- ${m}`).join('\n')}\nPlease remove duplicates so only one profile file exists.`,
+          );
+        }
+
+        if (matches.length === 1) {
+          profileFile = matches[0];
+        } else {
+          // If no matches found, set profileFile to the first candidate for context,
+          // but we will throw a detailed error below.
+          profileFile = candidates[0];
+          throw new FatalSandboxError(
+            `Missing macos seatbelt profile '${profile}'. Checked the following paths:\n${candidates.map((c) => `- ${c}`).join('\n')}`,
+          );
+        }
       }
       if (!fs.existsSync(profileFile)) {
         throw new FatalSandboxError(


### PR DESCRIPTION
This change addresses multiple issues regarding custom macOS Seatbelt profiles and CLI error handling:

1.  **Multi-path Discovery**: The CLI previously only looked for custom profiles in the project's `.gemini/` directory. It now also checks the user's home directory (`~/.gemini/`), allowing for global custom profiles.
2.  **Ambiguity Detection**: Strict checking ensures that if a profile exists in multiple valid locations, the CLI fails with a helpful error rather than silently choosing one.
3.  **Security Sanitization**: The `SEATBELT_PROFILE` environment variable is now validated against a strict regex (`/^[a-zA-Z0-9-_]+$/`) to prevent path traversal attacks ([Example Report](https://github.com/google-gemini/gemini-cli/pull/16360#discussion_r2679936948)).
4.  **Silent Failures**: Fixed race conditions in `relaunch.ts` and `gemini.tsx` where the process would exit before `stderr` could flush, causing silent failures (e.g. during profile missing errors or auth failures) ([Example Report](https://github.com/google-gemini/gemini-cli/pull/16360#discussion_r2679936952)).

Tests and documentation have been updated to reflect these changes.

Fixes #16363