### PR TITLE
fix(cli): allow @ file selector on slash command lines

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -26,7 +26,10 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import type { UseShellHistoryReturn } from '../hooks/useShellHistory.js';
 import { useShellHistory } from '../hooks/useShellHistory.js';
 import type { UseCommandCompletionReturn } from '../hooks/useCommandCompletion.js';
-import { useCommandCompletion } from '../hooks/useCommandCompletion.js';
+import {
+  useCommandCompletion,
+  CompletionMode,
+} from '../hooks/useCommandCompletion.js';
 import type { UseInputHistoryReturn } from '../hooks/useInputHistory.js';
 import { useInputHistory } from '../hooks/useInputHistory.js';
 import type { UseReverseSearchCompletionReturn } from '../hooks/useReverseSearchCompletion.js';
@@ -209,6 +212,7 @@ describe('InputPrompt', () => {
         leafCommand: null,
       },
       getCompletedText: vi.fn().mockReturnValue(null),
+      completionMode: CompletionMode.IDLE,
     };
     mockedUseCommandCompletion.mockReturnValue(mockCommandCompletion);
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -18,7 +18,10 @@ import chalk from 'chalk';
 import stringWidth from 'string-width';
 import { useShellHistory } from '../hooks/useShellHistory.js';
 import { useReverseSearchCompletion } from '../hooks/useReverseSearchCompletion.js';
-import { useCommandCompletion } from '../hooks/useCommandCompletion.js';
+import {
+  useCommandCompletion,
+  CompletionMode,
+} from '../hooks/useCommandCompletion.js';
 import type { Key } from '../hooks/useKeypress.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { keyMatchers, Command } from '../keyMatchers.js';
@@ -1035,11 +1038,13 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         scrollOffset={activeCompletion.visibleStartIndex}
         userInput={buffer.text}
         mode={
-          buffer.text.startsWith('/') &&
-          !reverseSearchActive &&
-          !commandSearchActive
-            ? 'slash'
-            : 'reverse'
+          completion.completionMode === CompletionMode.AT
+            ? 'reverse'
+            : buffer.text.startsWith('/') &&
+                !reverseSearchActive &&
+                !commandSearchActive
+              ? 'slash'
+              : 'reverse'
         }
         expandedIndex={expandedSuggestionIndex}
       />

--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
@@ -16,7 +16,10 @@ import {
 import { act, useEffect } from 'react';
 import { renderWithProviders } from '../../test-utils/render.js';
 import { waitFor } from '../../test-utils/async.js';
-import { useCommandCompletion } from './useCommandCompletion.js';
+import {
+  useCommandCompletion,
+  CompletionMode,
+} from './useCommandCompletion.js';
 import type { CommandContext } from '../commands/types.js';
 import type { Config } from '@google/gemini-cli-core';
 import { useTextBuffer } from '../components/shared/text-buffer.js';
@@ -160,6 +163,7 @@ describe('useCommandCompletion', () => {
         expect(result.current.visibleStartIndex).toBe(0);
         expect(result.current.showSuggestions).toBe(false);
         expect(result.current.isLoadingSuggestions).toBe(false);
+        expect(result.current.completionMode).toBe(CompletionMode.IDLE);
       });
 
       it('should reset state when completion mode becomes IDLE', async () => {
@@ -207,7 +211,7 @@ describe('useCommandCompletion', () => {
 
       it('should call useAtCompletion with the correct query for an escaped space', async () => {
         const text = '@src/a\\ file.txt';
-        renderCommandCompletionHook(text);
+        const { result } = renderCommandCompletionHook(text);
 
         await waitFor(() => {
           expect(useAtCompletion).toHaveBeenLastCalledWith(
@@ -216,6 +220,7 @@ describe('useCommandCompletion', () => {
               pattern: 'src/a\\ file.txt',
             }),
           );
+          expect(result.current.completionMode).toBe(CompletionMode.AT);
         });
       });
 
@@ -272,6 +277,9 @@ describe('useCommandCompletion', () => {
             expect(result.current.showSuggestions).toBe(
               expectedShowSuggestions,
             );
+            if (!shellModeActive) {
+              expect(result.current.completionMode).toBe(CompletionMode.SLASH);
+            }
           });
         },
       );

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -55,6 +55,7 @@ export interface UseCommandCompletionReturn {
     leafCommand: SlashCommand | null;
   };
   getCompletedText: (suggestion: Suggestion) => string | null;
+  completionMode: CompletionMode;
 }
 
 export function useCommandCompletion(
@@ -341,5 +342,6 @@ export function useCommandCompletion(
     getCommandFromSuggestion: slashCompletionRange.getCommandFromSuggestion,
     slashCompletionRange,
     getCompletedText,
+    completionMode,
   };
 }


### PR DESCRIPTION
## Summary

Fixes a bug where the `@` file selector fails to render correctly (or at all) when used on the same line as a slash command (e.g., `/pickle @`). This was caused by the UI incorrectly forcing a two-column "slash command" layout whenever the input started with `/`, which truncated or hid file path suggestions.

## Details

The fix involves two main changes:
1.  **Exposed Completion State**: Modified the `useCommandCompletion` hook to expose the `completionMode` enum (`IDLE`, `SLASH`, `AT`). This provides the UI with an authoritative source of truth for what type of suggestions are actually being generated.
2.  **UI Priority**: Updated `InputPrompt.tsx` to check for `CompletionMode.AT`. If the hook is in "At mode," we now force the `'reverse'` (full-width) display mode for `SuggestionsDisplay`. This ensures file paths have the necessary horizontal space, even if the line prefix is a slash command.

## Related Issues

Fixes a bug reported where file selection was difficult when using slash commands.

## How to Validate

1. Start Gemini CLI.
2. Type a slash command followed by a space and the `@` symbol, e.g., `/pickle @src`.
3. **Verify**: The file picker overlay should appear and display full file paths without truncation.
4. Select a file and ensure it is correctly inserted into the command line.
5. Type `@` on a fresh line (no slash) to ensure no regression in standard file picking.
6. Type a slash command without `@`, e.g., `/help`, to ensure the standard two-column command layout is still used for command suggestions.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [x] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
