### PR TITLE
fix: remove user email from /about

### DIFF
--- a/packages/cli/src/ui/commands/aboutCommand.test.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.test.ts
@@ -21,9 +21,6 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
         getDetectedIdeDisplayName: vi.fn().mockReturnValue('test-ide'),
       }),
     },
-    UserAccountManager: vi.fn().mockImplementation(() => ({
-      getCachedGoogleAccount: vi.fn().mockReturnValue('test-email@example.com'),
-    })),
     getVersion: vi.fn(),
   };
 });
@@ -97,7 +94,6 @@ describe('aboutCommand', () => {
         selectedAuthType: 'test-auth',
         gcpProject: 'test-gcp-project',
         ideClient: 'test-ide',
-        userEmail: 'test-email@example.com',
       },
       expect.any(Number),
     );

--- a/packages/cli/src/ui/commands/aboutCommand.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.ts
@@ -8,12 +8,7 @@ import type { CommandContext, SlashCommand } from './types.js';
 import { CommandKind } from './types.js';
 import process from 'node:process';
 import { MessageType, type HistoryItemAbout } from '../types.js';
-import {
-  IdeClient,
-  UserAccountManager,
-  debugLogger,
-  getVersion,
-} from '@google/gemini-cli-core';
+import { IdeClient, getVersion } from '@google/gemini-cli-core';
 
 export const aboutCommand: SlashCommand = {
   name: 'about',
@@ -37,13 +32,6 @@ export const aboutCommand: SlashCommand = {
     const gcpProject = process.env['GOOGLE_CLOUD_PROJECT'] || '';
     const ideClient = await getIdeClientName(context);
 
-    const userAccountManager = new UserAccountManager();
-    const cachedAccount = userAccountManager.getCachedGoogleAccount();
-    debugLogger.log('AboutCommand: Retrieved cached Google account', {
-      cachedAccount,
-    });
-    const userEmail = cachedAccount ?? undefined;
-
     const aboutItem: Omit<HistoryItemAbout, 'id'> = {
       type: MessageType.ABOUT,
       cliVersion,
@@ -53,7 +41,6 @@ export const aboutCommand: SlashCommand = {
       selectedAuthType,
       gcpProject,
       ideClient,
-      userEmail,
     };
 
     context.ui.addItem(aboutItem, Date.now());

--- a/packages/cli/src/ui/components/AboutBox.test.tsx
+++ b/packages/cli/src/ui/components/AboutBox.test.tsx
@@ -37,7 +37,6 @@ describe('AboutBox', () => {
   });
 
   it.each([
-    ['userEmail', 'test@example.com', 'User Email'],
     ['gcpProject', 'my-project', 'GCP Project'],
     ['ideClient', 'vscode', 'IDE Client'],
   ])('renders optional prop %s', (prop, value, label) => {

--- a/packages/cli/src/ui/components/AboutBox.tsx
+++ b/packages/cli/src/ui/components/AboutBox.tsx
@@ -17,7 +17,6 @@ interface AboutBoxProps {
   selectedAuthType: string;
   gcpProject: string;
   ideClient: string;
-  userEmail?: string;
 }
 
 export const AboutBox: React.FC<AboutBoxProps> = ({
@@ -28,7 +27,6 @@ export const AboutBox: React.FC<AboutBoxProps> = ({
   selectedAuthType,
   gcpProject,
   ideClient,
-  userEmail,
 }) => (
   <Box
     borderStyle="round"
@@ -107,18 +105,6 @@ export const AboutBox: React.FC<AboutBoxProps> = ({
         </Text>
       </Box>
     </Box>
-    {userEmail && (
-      <Box flexDirection="row">
-        <Box width="35%">
-          <Text bold color={theme.text.link}>
-            User Email
-          </Text>
-        </Box>
-        <Box>
-          <Text color={theme.text.primary}>{userEmail}</Text>
-        </Box>
-      </Box>
-    )}
     {gcpProject && (
       <Box flexDirection="row">
         <Box width="35%">

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -111,7 +111,6 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
           selectedAuthType={itemForDisplay.selectedAuthType}
           gcpProject={itemForDisplay.gcpProject}
           ideClient={itemForDisplay.ideClient}
-          userEmail={itemForDisplay.userEmail}
         />
       )}
       {itemForDisplay.type === 'help' && commands && (

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -134,7 +134,6 @@ export type HistoryItemAbout = HistoryItemBase & {
   selectedAuthType: string;
   gcpProject: string;
   ideClient: string;
-  userEmail?: string;
 };
 
 export type HistoryItemHelp = HistoryItemBase & {
@@ -350,7 +349,6 @@ export type Message =
       selectedAuthType: string;
       gcpProject: string;
       ideClient: string;
-      userEmail?: string;
       content?: string; // Optional content, not really used for ABOUT
     }
   | {


### PR DESCRIPTION
Issue: https://github.com/google-gemini/gemini-cli/issues/16374
Fixes https://github.com/google-gemini/gemini-cli/issues/16374
Summary:
- Stop including user email in /about output.
- Remove userEmail from AboutBox and related UI types/tests.

Motivation:
- Avoid exposing PII in bug reports that request /about output.

Validation:
- npm test --workspace @google/gemini-cli -- src/ui/commands/aboutCommand.test.ts src/ui/components/AboutBox.test.tsx