### PR TITLE
feat(cli): improve link parsing

### DIFF
--- a/packages/cli/src/ui/utils/InlineMarkdownRenderer.tsx
+++ b/packages/cli/src/ui/utils/InlineMarkdownRenderer.tsx
@@ -138,10 +138,23 @@ const RenderInlineInternal: React.FC<RenderInlineProps> = ({
           </Text>
         );
       } else if (fullMatch.match(/^https?:\/\//)) {
+        // Strip trailing punctuation that shouldn't be part of URLs
+        // Includes ASCII punctuation and CJK punctuation (Chinese, Japanese, etc.)
+        const trailingPunctuationRegex =
+          /[.,;:!?\)\]\}>"'。，；：！？）】》'"、）〉》〕〗〙〛]+$/;
+        const trailingMatch = fullMatch.match(trailingPunctuationRegex);
+        const cleanUrl = trailingMatch
+          ? fullMatch.slice(0, -trailingMatch[0].length)
+          : fullMatch;
+        const trailingPunctuation = trailingMatch ? trailingMatch[0] : '';
+
         renderedNode = (
-          <Text key={key} color={theme.text.link}>
-            {fullMatch}
-          </Text>
+          <React.Fragment key={key}>
+            <Text color={theme.text.link}>{cleanUrl}</Text>
+            {trailingPunctuation && (
+              <Text color={baseColor}>{trailingPunctuation}</Text>
+            )}
+          </React.Fragment>
         );
       }
     } catch (e) {

--- a/packages/cli/src/ui/utils/InlineMarkdownRenderer.tsx
+++ b/packages/cli/src/ui/utils/InlineMarkdownRenderer.tsx
@@ -140,8 +140,9 @@ const RenderInlineInternal: React.FC<RenderInlineProps> = ({
       } else if (fullMatch.match(/^https?:\/\//)) {
         // Strip trailing punctuation that shouldn't be part of URLs
         // Includes ASCII punctuation and CJK punctuation (Chinese, Japanese, etc.)
-        const trailingPunctuationRegex =
-          /[.,;:!?\)\]\}>"'。，；：！？）】》'"、）〉》〕〗〙〛]+$/;
+        // Note: Excludes brackets/parens as they can be valid URL characters
+        // (e.g., https://en.wikipedia.org/wiki/Link_(The_Legend_of_Zelda))
+        const trailingPunctuationRegex = /[.,;:!?"'。，；：！？》'"、]+$/;
         const trailingMatch = fullMatch.match(trailingPunctuationRegex);
         const cleanUrl = trailingMatch
           ? fullMatch.slice(0, -trailingMatch[0].length)


### PR DESCRIPTION
Fix: Exclude trailing punctuation from auto-linked URLs in Markdown rendering
Problem
When a URL in inline Markdown is rendered, the clickable link incorrectly includes trailing punctuation marks (both ASCII and CJK) that are adjacent to the URL. This causes navigation to fail or lead to incorrect pages when clicking the link.

Added post-processing to strip trailing punctuation from matched URLs before rendering them as links. The punctuation is rendered separately as plain text outside the clickable area.