### PR TITLE
fix(core): avoid 'activate_skill' re-registration warning

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -2024,7 +2024,7 @@ describe('Config JIT Initialization', () => {
       expect(mockOnReload).toHaveBeenCalled();
       expect(skillManager.setDisabledSkills).toHaveBeenCalledWith(['skill2']);
       expect(toolRegistry.registerTool).toHaveBeenCalled();
-      expect(toolRegistry.unregisterTool).not.toHaveBeenCalledWith(
+      expect(toolRegistry.unregisterTool).toHaveBeenCalledWith(
         ACTIVATE_SKILL_TOOL_NAME,
       );
     });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -759,6 +759,7 @@ export class Config {
 
       // Re-register ActivateSkillTool to update its schema with the discovered enabled skill enums
       if (this.getSkillManager().getSkills().length > 0) {
+        this.getToolRegistry().unregisterTool(ActivateSkillTool.Name);
         this.getToolRegistry().registerTool(
           new ActivateSkillTool(this, this.messageBus),
         );
@@ -1567,6 +1568,7 @@ export class Config {
 
     // Re-register ActivateSkillTool to update its schema with the newly discovered skills
     if (this.getSkillManager().getSkills().length > 0) {
+      this.getToolRegistry().unregisterTool(ActivateSkillTool.Name);
       this.getToolRegistry().registerTool(
         new ActivateSkillTool(this, this.messageBus),
       );


### PR DESCRIPTION
## Summary

Avoid the 'activate_skill' tool re-registration warning that occurs on startup and during skills reload.

## Details

The 'ActivateSkillTool' is re-registered after skills are discovered to update its JSON schema with the newly found skill names. The 'ToolRegistry' emits a warning whenever a tool name is overwritten. This PR explicitly unregisters the tool before re-registering it to avoid this warning.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/16397
Part of https://github.com/google-gemini/gemini-cli/issues/15327

## How to Validate

1. Run Gemini CLI.
2. Observe that the debug warning `Tool with name "activate_skill" is already registered. Overwriting.` is no longer emitted.
3. Run tests: `npm run test -w packages/core`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker