### PR TITLE
feat(cli): cleanup activity logs alongside session files

### DIFF
--- a/packages/cli/src/utils/sessionCleanup.ts
+++ b/packages/cli/src/utils/sessionCleanup.ts
@@ -86,6 +86,18 @@ export async function cleanupExpiredSessions(
         const sessionPath = path.join(chatsDir, sessionToDelete.fileName);
         await fs.unlink(sessionPath);
 
+        // ALSO cleanup Activity logs in the project logs directory
+        const sessionId = sessionToDelete.sessionInfo?.id;
+        if (sessionId) {
+          const logsDir = path.join(config.storage.getProjectTempDir(), 'logs');
+          const logPath = path.join(logsDir, `session-${sessionId}.jsonl`);
+          try {
+            await fs.unlink(logPath);
+          } catch {
+            /* ignore if log doesn't exist */
+          }
+        }
+
         if (config.getDebugMode()) {
           if (sessionToDelete.sessionInfo === null) {
             debugLogger.debug(


### PR DESCRIPTION
## TLDR

This pull request updates the session cleanup utility to also remove the corresponding activity log files (`session-<id>.jsonl`) from the project logs directory when an old session file is purged.

## Dive Deeper

Currently, the CLI has an automatic session cleanup mechanism that removes old or corrupted session files (`chats/session-*.json`) based on the retention policy. With the introduction of the activity logger (Gemini DevTools), we now also generate activity log files (`logs/session-*.jsonl`). 

If these log files are not cleaned up synchronously with the session files, they will accumulate indefinitely and bloat the user's disk storage. This change ensures that when a session file is deleted, its matching activity log file is also removed. It gracefully handles the case where the log file might not exist (e.g., if logging was disabled for that session).

## Reviewer Test Plan

1. Create a session that generates an activity log: `gemini -m "Hello"`
2. Verify that both `chats/session-<id>.json` and `logs/session-<id>.jsonl` exist in the project's temp directory (`.gemini/tmp/`).
3. Force a cleanup of the session by modifying your retention settings in `.gemini/settings.json` to have a `maxCount: 0` or waiting for the expiration.
4. Run the CLI again.
5. Verify that *both* the chat json and the log jsonl files for the old session have been deleted.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A