### PR TITLE
Attempt to resolve OOM w/ useMemo on history items

### DIFF
--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -36,17 +36,26 @@ export const MainContent = () => {
     availableTerminalHeight,
   } = uiState;
 
-  const historyItems = uiState.history.map((h) => (
-    <HistoryItemDisplay
-      terminalWidth={mainAreaWidth}
-      availableTerminalHeight={staticAreaMaxItemHeight}
-      availableTerminalHeightGemini={MAX_GEMINI_MESSAGE_LINES}
-      key={h.id}
-      item={h}
-      isPending={false}
-      commands={uiState.slashCommands}
-    />
-  ));
+  const historyItems = useMemo(
+    () =>
+      uiState.history.map((h) => (
+        <MemoizedHistoryItemDisplay
+          terminalWidth={mainAreaWidth}
+          availableTerminalHeight={staticAreaMaxItemHeight}
+          availableTerminalHeightGemini={MAX_GEMINI_MESSAGE_LINES}
+          key={h.id}
+          item={h}
+          isPending={false}
+          commands={uiState.slashCommands}
+        />
+      )),
+    [
+      uiState.history,
+      mainAreaWidth,
+      staticAreaMaxItemHeight,
+      uiState.slashCommands,
+    ],
+  );
 
   const pendingItems = useMemo(
     () => (


### PR DESCRIPTION
## Summary

I believe this should fix #16396

My theory is that this is caused bc we are recreating the entire history list on almost every frame/render. I wrapped the list creation in useMemo so it's only recalculated when necessary.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
