### PR TITLE
feat(core, cli): Add support for agents in settings.json.

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -557,6 +557,13 @@ their corresponding top-level category object in your `settings.json` file.
     used.
   - **Default:** `[]`
 
+#### `agents`
+
+- **`agents.overrides`** (object):
+  - **Description:** Override settings for specific agents.
+  - **Default:** `{}`
+  - **Requires restart:** Yes
+
 #### `context`
 
 - **`context.fileName`** (string | string[]):

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -560,7 +560,8 @@ their corresponding top-level category object in your `settings.json` file.
 #### `agents`
 
 - **`agents.overrides`** (object):
-  - **Description:** Override settings for specific agents.
+  - **Description:** Override settings for specific agents, e.g. to disable the
+    agent, set a custom model config, or run config.
   - **Default:** `{}`
   - **Requires restart:** Yes
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -660,6 +660,7 @@ export async function loadCliConfig(
     mcpServers: mcpEnabled ? settings.mcpServers : {},
     mcpEnabled,
     extensionsEnabled,
+    agents: settings.agents,
     allowedMcpServers: mcpEnabled
       ? (argv.allowedMcpServerNames ?? settings.mcp?.allowed)
       : undefined,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -785,6 +785,31 @@ const SETTINGS_SCHEMA = {
     },
   },
 
+  agents: {
+    type: 'object',
+    label: 'Agents',
+    category: 'Advanced',
+    requiresRestart: true,
+    default: {},
+    description: 'Settings for subagents.',
+    showInDialog: false,
+    properties: {
+      overrides: {
+        type: 'object',
+        label: 'Agent Overrides',
+        category: 'Advanced',
+        requiresRestart: true,
+        default: {},
+        description: 'Override settings for specific agents.',
+        showInDialog: false,
+        additionalProperties: {
+          type: 'object',
+          ref: 'AgentOverride',
+        },
+      },
+    },
+  },
+
   context: {
     type: 'object',
     label: 'Context',
@@ -1999,6 +2024,36 @@ export const SETTINGS_SCHEMA_DEFINITIONS: Record<
         type: 'number',
         description:
           'Maximum number of tokens used when summarizing tool output.',
+      },
+    },
+  },
+  AgentOverride: {
+    type: 'object',
+    description: 'Override settings for a specific agent.',
+    additionalProperties: false,
+    properties: {
+      modelConfig: {
+        type: 'object',
+        additionalProperties: true,
+      },
+      runConfig: {
+        type: 'object',
+        description: 'Run configuration for an agent.',
+        additionalProperties: false,
+        properties: {
+          maxTimeMinutes: {
+            type: 'number',
+            description: 'The maximum execution time for the agent in minutes.',
+          },
+          maxTurns: {
+            type: 'number',
+            description: 'The maximum number of conversational turns.',
+          },
+        },
+      },
+      disabled: {
+        type: 'boolean',
+        description: 'Whether to disable the agent.',
       },
     },
   },

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -800,7 +800,8 @@ const SETTINGS_SCHEMA = {
         category: 'Advanced',
         requiresRestart: true,
         default: {},
-        description: 'Override settings for specific agents.',
+        description:
+          'Override settings for specific agents, e.g. to disable the agent, set a custom model config, or run config.',
         showInDialog: false,
         additionalProperties: {
           type: 'object',

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -23,6 +23,10 @@ import {
   isPreviewModel,
   isAutoModel,
 } from '../config/models.js';
+import {
+  type ModelConfig,
+  ModelConfigService,
+} from '../services/modelConfigService.js';
 
 /**
  * Returns the model config alias for a given agent definition.
@@ -226,49 +230,80 @@ export class AgentRegistry {
       return;
     }
 
+    const overrides =
+      this.config.getAgentsSettings().overrides?.[definition.name];
+    if (overrides?.disabled) {
+      if (this.config.getDebugMode()) {
+        debugLogger.log(
+          `[AgentRegistry] Skipping disabled agent '${definition.name}'`,
+        );
+      }
+      return;
+    }
+
     if (this.agents.has(definition.name) && this.config.getDebugMode()) {
       debugLogger.log(`[AgentRegistry] Overriding agent '${definition.name}'`);
     }
 
-    this.agents.set(definition.name, definition);
+    const mergedDefinition = {
+      ...definition,
+      runConfig: {
+        ...definition.runConfig,
+        max_time_minutes:
+          overrides?.runConfig?.maxTimeMinutes ??
+          definition.runConfig.max_time_minutes,
+        max_turns:
+          overrides?.runConfig?.maxTurns ?? definition.runConfig.max_turns,
+      },
+    };
+
+    this.agents.set(mergedDefinition.name, mergedDefinition);
 
     // Register model config. We always create a runtime alias. However,
     // if the user is using `auto` as a model string then we also create
     // runtime overrides to ensure the subagent generation settings are
     // respected regardless of the final model string from routing.
     // TODO(12916): Migrate sub-agents where possible to static configs.
-    const modelConfig = definition.modelConfig;
+    const modelConfig = mergedDefinition.modelConfig;
     let model = modelConfig.model;
     if (model === 'inherit') {
       model = this.config.getModel();
     }
 
-    const generateContentConfig: GenerateContentConfig = {
-      temperature: modelConfig.temp,
-      topP: modelConfig.top_p,
-      thinkingConfig: {
-        includeThoughts: true,
-        thinkingBudget: modelConfig.thinkingBudget ?? -1,
+    let agentModelConfig: ModelConfig = {
+      model,
+      generateContentConfig: GenerateContentConfig: {
+        temperature: modelConfig.temp,
+        topP: modelConfig.top_p,
+        thinkingConfig: {
+          includeThoughts: true,
+          thinkingBudget: modelConfig.thinkingBudget ?? -1,
+        },
       },
     };
 
+    // Apply standardized modelConfig overrides if present.
+    if (overrides?.modelConfig) {
+      agentModelConfig = ModelConfigService.merge(
+        agentModelConfig,
+        overrides.modelConfig,
+      );
+    }
+
     this.config.modelConfigService.registerRuntimeModelConfig(
-      getModelConfigAlias(definition),
+      getModelConfigAlias(mergedDefinition),
       {
-        modelConfig: {
-          model,
-          generateContentConfig,
-        },
+        modelConfig: agentModelConfig,
       },
     );
 
-    if (isAutoModel(model)) {
+    if (agentModelConfig.model && isAutoModel(agentModelConfig.model)) {
       this.config.modelConfigService.registerRuntimeModelOverride({
         match: {
-          overrideScope: definition.name,
+          overrideScope: mergedDefinition.name,
         },
         modelConfig: {
-          generateContentConfig,
+          generateContentConfig: agentModelConfig.generateContentConfig,
         },
       });
     }
@@ -289,6 +324,17 @@ export class AgentRegistry {
       debugLogger.warn(
         `[AgentRegistry] Skipping invalid agent definition. Missing name or description.`,
       );
+      return;
+    }
+
+    const overrides =
+      this.config.getAgentsSettings().overrides?.[definition.name];
+    if (overrides?.disabled) {
+      if (this.config.getDebugMode()) {
+        debugLogger.log(
+          `[AgentRegistry] Skipping disabled remote agent '${definition.name}'`,
+        );
+      }
       return;
     }
 

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -14,7 +14,6 @@ import { CliHelpAgent } from './cli-help-agent.js';
 import { A2AClientManager } from './a2a-client-manager.js';
 import { ADCHandler } from './remote-invocation.js';
 import { type z } from 'zod';
-import type { GenerateContentConfig } from '@google/genai';
 import { debugLogger } from '../utils/debugLogger.js';
 import {
   DEFAULT_GEMINI_MODEL,
@@ -245,6 +244,9 @@ export class AgentRegistry {
       debugLogger.log(`[AgentRegistry] Overriding agent '${definition.name}'`);
     }
 
+    // TODO(16443): Refactor definition merging logic into a helper.
+    // To do this, we need to align the definition of the internal `Definition`
+    // type with the one exported in settings.json.
     const mergedDefinition = {
       ...definition,
       runConfig: {
@@ -272,7 +274,7 @@ export class AgentRegistry {
 
     let agentModelConfig: ModelConfig = {
       model,
-      generateContentConfig: GenerateContentConfig: {
+      generateContentConfig: {
         temperature: modelConfig.temp,
         topP: modelConfig.top_p,
         thinkingConfig: {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -515,9 +515,9 @@ export class Config {
     | undefined;
 
   private readonly enableAgents: boolean;
+  private readonly agents: AgentSettings;
   private readonly skillsSupport: boolean;
   private disabledSkills: string[];
-  private readonly agents: AgentSettings;
 
   private readonly experimentalJitContext: boolean;
   private readonly disableLLMCorrection: boolean;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -69,7 +69,10 @@ import type { FallbackModelHandler } from '../fallback/types.js';
 import { ModelAvailabilityService } from '../availability/modelAvailabilityService.js';
 import { ModelRouterService } from '../routing/modelRouterService.js';
 import { OutputFormat } from '../output/types.js';
-import type { ModelConfigServiceConfig } from '../services/modelConfigService.js';
+import type {
+  ModelConfig,
+  ModelConfigServiceConfig,
+} from '../services/modelConfigService.js';
 import { ModelConfigService } from '../services/modelConfigService.js';
 import { DEFAULT_MODEL_CONFIGS } from './defaultModelConfigs.js';
 import { ContextManager } from '../services/contextManager.js';
@@ -157,6 +160,21 @@ export interface ResolvedExtensionSetting {
 
 export interface CliHelpAgentSettings {
   enabled?: boolean;
+}
+
+export interface AgentRunConfig {
+  maxTimeMinutes?: number;
+  maxTurns?: number;
+}
+
+export interface AgentOverride {
+  modelConfig?: ModelConfig;
+  runConfig?: AgentRunConfig;
+  disabled?: boolean;
+}
+
+export interface AgentSettings {
+  overrides?: Record<string, AgentOverride>;
 }
 
 /**
@@ -364,6 +382,7 @@ export interface ConfigParameters {
   onModelChange?: (model: string) => void;
   mcpEnabled?: boolean;
   extensionsEnabled?: boolean;
+  agents?: AgentSettings;
   onReload?: () => Promise<{ disabledSkills?: string[] }>;
 }
 
@@ -498,6 +517,7 @@ export class Config {
   private readonly enableAgents: boolean;
   private readonly skillsSupport: boolean;
   private disabledSkills: string[];
+  private readonly agents: AgentSettings;
 
   private readonly experimentalJitContext: boolean;
   private readonly disableLLMCorrection: boolean;
@@ -570,6 +590,7 @@ export class Config {
     this.model = params.model;
     this._activeModel = params.model;
     this.enableAgents = params.enableAgents ?? false;
+    this.agents = params.agents ?? {};
     this.disableLLMCorrection = params.disableLLMCorrection ?? false;
     this.skillsSupport = params.skillsSupport ?? false;
     this.disabledSkills = params.disabledSkills ?? [];
@@ -1441,6 +1462,10 @@ export class Config {
 
   getNoBrowser(): boolean {
     return this.noBrowser;
+  }
+
+  getAgentsSettings(): AgentSettings {
+    return this.agents;
   }
 
   isBrowserLaunchSuppressed(): boolean {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -935,8 +935,8 @@
       "properties": {
         "overrides": {
           "title": "Agent Overrides",
-          "description": "Override settings for specific agents.",
-          "markdownDescription": "Override settings for specific agents.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `{}`",
+          "description": "Override settings for specific agents, e.g. to disable the agent, set a custom model config, or run config.",
+          "markdownDescription": "Override settings for specific agents, e.g. to disable the agent, set a custom model config, or run config.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `{}`",
           "default": {},
           "type": "object",
           "additionalProperties": {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -926,6 +926,26 @@
       },
       "additionalProperties": false
     },
+    "agents": {
+      "title": "Agents",
+      "description": "Settings for subagents.",
+      "markdownDescription": "Settings for subagents.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `{}`",
+      "default": {},
+      "type": "object",
+      "properties": {
+        "overrides": {
+          "title": "Agent Overrides",
+          "description": "Override settings for specific agents.",
+          "markdownDescription": "Override settings for specific agents.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `{}`",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/AgentOverride"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "context": {
       "title": "Context",
       "description": "Settings for managing context provided to the model.",
@@ -1851,6 +1871,36 @@
         "tokenBudget": {
           "type": "number",
           "description": "Maximum number of tokens used when summarizing tool output."
+        }
+      }
+    },
+    "AgentOverride": {
+      "type": "object",
+      "description": "Override settings for a specific agent.",
+      "additionalProperties": false,
+      "properties": {
+        "modelConfig": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "runConfig": {
+          "type": "object",
+          "description": "Run configuration for an agent.",
+          "additionalProperties": false,
+          "properties": {
+            "maxTimeMinutes": {
+              "type": "number",
+              "description": "The maximum execution time for the agent in minutes."
+            },
+            "maxTurns": {
+              "type": "number",
+              "description": "The maximum number of conversational turns."
+            }
+          }
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Whether to disable the agent."
         }
       }
     },


### PR DESCRIPTION
Fixes https://github.com/google-gemini/gemini-cli/issues/14873

As a concrete example, to configure the codebaseInvestigator, we might do:
```
"agents": {
  "codebaseInvestigator": {
    "modelConfig": {
      "temperature": 1
    },
    "runConfig": {
      "maxTurns": 100
    }
  }
}
```