### PR TITLE
Migrate beforeModelHook and afterModelHook to hookSystem

### DIFF
--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -842,7 +842,7 @@ export class GeminiChat {
         }
 
         const afterModelOutput = hookResult as AfterModelHookOutput | undefined;
-        const modifiedResponse = afterModelOutput?.getModifiedResponse?.();
+        const modifiedResponse = afterModelOutput?.getModifiedResponse();
         yield modifiedResponse || chunk;
       } else {
         yield chunk; // Yield every chunk to the UI immediately.

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -20,6 +20,10 @@ import type {
   PreCompressTrigger,
 } from './types.js';
 import type { AggregatedHookResult } from './hookAggregator.js';
+import type {
+  GenerateContentParameters,
+  GenerateContentResponse,
+} from '@google/genai';
 /**
  * Main hook system that coordinates all hook-related functionality
  */
@@ -140,5 +144,24 @@ export class HookSystem {
       response,
       stopHookActive,
     );
+  }
+
+  async fireBeforeModelEvent(
+    llmRequest: GenerateContentParameters,
+  ): Promise<AggregatedHookResult | undefined> {
+    if (!this.config.getEnableHooks()) {
+      return undefined;
+    }
+    return this.hookEventHandler.fireBeforeModelEvent(llmRequest);
+  }
+
+  async fireAfterModelEvent(
+    llmRequest: GenerateContentParameters,
+    llmResponse: GenerateContentResponse,
+  ): Promise<AggregatedHookResult | undefined> {
+    if (!this.config.getEnableHooks()) {
+      return undefined;
+    }
+    return this.hookEventHandler.fireAfterModelEvent(llmRequest, llmResponse);
   }
 }


### PR DESCRIPTION
## Summary

Migrates [fireBeforeModelHook](cci:1://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/core/src/core/geminiChatHookTriggers.ts:71:0-142:1) and [fireAfterModelHook](cci:1://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/core/src/core/geminiChatHookTriggers.ts:198:0-268:1) from deprecated MessageBus-based triggers to use the [HookSystem](cci:2://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/core/src/hooks/hookSystem.ts:29:0-166:1). 
## Details

- Added [fireBeforeModelEvent](cci:1://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/core/src/hooks/hookSystem.ts:148:2-155:3) and [fireAfterModelEvent](cci:1://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/core/src/hooks/hookSystem.ts:157:2-165:3) wrapper methods to [HookSystem](cci:2://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/core/src/hooks/hookSystem.ts:29:0-166:1) class
- Updated [geminiChat.ts](cci:7://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/core/src/core/geminiChat.ts:0:0-0:0) to call `config.getHookSystem()?.fireBeforeModelEvent()` and `config.getHookSystem()?.fireAfterModelEvent()` instead of direct MessageBus-based functions
- Updated [geminiChat.test.ts](cci:7://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/core/src/core/geminiChat.test.ts:0:0-0:0) to mock `mockHookSystem.fireBeforeModelEvent` and `mockHookSystem.fireAfterModelEvent` with `AggregatedHookResult` structure

This follows the same pattern established for [fireBeforeAgentHook](cci:1://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/core/src/core/client.ts:110:2-166:3) and [fireAfterAgentHook](cci:1://file:///Users/vedantmahajan/Desktop/gemini-cli/packages/core/src/core/client.ts:168:2-195:3) migrations.

## Related Issues

Related to #14317

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

@scidomino please have a look