### PR TITLE
fix: resolve API 400 error for parallel tool calls

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1979,8 +1979,10 @@ describe('GeminiChat', () => {
       expect(newContents[3]?.parts?.[0]?.thoughtSignature).toBe(
         SYNTHETIC_THOUGHT_SIGNATURE,
       );
-      // Second function call does NOT
-      expect(newContents[3]?.parts?.[1]).not.toHaveProperty('thoughtSignature');
+      // Second function call also gets a signature
+      expect(newContents[3]?.parts?.[1]?.thoughtSignature).toBe(
+        SYNTHETIC_THOUGHT_SIGNATURE,
+      );
 
       // User functionResponse part - unchanged (this is not a model turn)
       expect(newContents[4]?.parts?.[0]).not.toHaveProperty('thoughtSignature');
@@ -1988,8 +1990,10 @@ describe('GeminiChat', () => {
       // Inside active loop, second model turn
       // First function call already has a signature, so nothing changes
       expect(newContents[5]?.parts?.[0]?.thoughtSignature).toBe('existing-sig');
-      // Second function call does NOT get a signature
-      expect(newContents[5]?.parts?.[1]).not.toHaveProperty('thoughtSignature');
+      // Second function call now gets a signature
+      expect(newContents[5]?.parts?.[1]?.thoughtSignature).toBe(
+        SYNTHETIC_THOUGHT_SIGNATURE,
+      );
     });
 
     it('should not modify contents if there is no user text message', () => {


### PR DESCRIPTION
## Summary

Fixes an issue where parallel tool calls would fail with an API 400 error ("number of function response parts must equal function call parts"). This ensures all tool calls in a single turn are correctly signed.

## Details

In ensureActiveLoopHasThoughtSignatures method, there was a break statement, that break every loop after first tool call. This caused issue like in #16415. I removed the break statement completetly, added new "partChanged' variable to check if object changed, if yes we save just then. Modified slicing, so It works only when we change message. Also changed test before it was expecting that second function call would return no ThoughtSignature, now it expects one.

## Related Issues

Fixes #16415

## How to Validate

 Run the updated test :
   npx vitest packages/core/src/core/geminiChat.test.ts

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ x] MacOS
    - [ x] npm run
    - [ x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
