### PR TITLE
feat(agents): improve UI feedback and parser reliability

### DIFF
--- a/packages/cli/src/ui/commands/agentsCommand.ts
+++ b/packages/cli/src/ui/commands/agentsCommand.ts
@@ -65,6 +65,14 @@ const agentsRefreshCommand: SlashCommand = {
       };
     }
 
+    context.ui.addItem(
+      {
+        type: MessageType.INFO,
+        text: 'Refreshing agent registry...',
+      },
+      Date.now(),
+    );
+
     await agentRegistry.reload();
 
     return {

--- a/packages/core/src/agents/agentLoader.test.ts
+++ b/packages/core/src/agents/agentLoader.test.ts
@@ -198,6 +198,32 @@ agent_card_url: https://example.com/card
         agent_card_url: 'https://example.com/2',
       });
     });
+
+    it('should parse frontmatter without a trailing newline', async () => {
+      const filePath = await writeAgentMarkdown(`---
+kind: remote
+name: no-trailing-newline
+agent_card_url: https://example.com/card
+---`);
+      const result = await parseAgentMarkdown(filePath);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        kind: 'remote',
+        name: 'no-trailing-newline',
+        agent_card_url: 'https://example.com/card',
+      });
+    });
+
+    it('should throw AgentLoadError if agent name is not a valid slug', async () => {
+      const filePath = await writeAgentMarkdown(`---
+name: Invalid Name With Spaces
+description: Test
+---
+Body`);
+      await expect(parseAgentMarkdown(filePath)).rejects.toThrow(
+        /Name must be a valid slug/,
+      );
+    });
   });
 
   describe('markdownToAgentDefinition', () => {

--- a/packages/core/src/agents/cli-help-agent.ts
+++ b/packages/core/src/agents/cli-help-agent.ts
@@ -80,7 +80,9 @@ export const CliHelpAgent = (
         ? '### Sub-Agents (Local & Remote)\n' +
           "User defined sub-agents are defined in `.gemini/agents/` or `~/.gemini/agents/` as .md files. These files contain YAML frontmatter for metadata, and the Markdown body becomes the agent's system prompt (`system_prompt`). Always reference the types and properties outlined here directly when answering questions about sub-agents.\n" +
           '- **Local Agent:** `kind = "local"`, `name`, `description`, `system_prompt`, and optional `tools`, `model`, `temperate`, `max_turns`, `timeout_mins`.\n' +
-          '- **Remote Agent (A2A):** `kind = "remote"`, `name`, `agent_card_url`. Remote Agents do not use `system_prompt`. Multiple remote agents can be defined by using a YAML array at the top level of the frontmatter. **Note:** When users ask about "remote agents", they are referring to this Agent2Agent functionality, which is completely distinct from MCP servers.\n\n'
+          '- **Remote Agent (A2A):** `kind = "remote"`, `name`, `agent_card_url`. Remote Agents do not use `system_prompt`. Multiple remote agents can be defined by using a YAML array at the top level of the frontmatter. **Note:** When users ask about "remote agents", they are referring to this Agent2Agent functionality, which is completely distinct from MCP servers.\n' +
+          '- **Agent Names:** Must be valid slugs (lowercase letters, numbers, hyphens, and underscores only).\n' +
+          '- **User Commands:** The user can manage agents using `/agents list` to see all available agents and `/agents refresh` to reload the registry after modifying definition files. You (the agent) cannot run these commands.\n\n'
         : '') +
       '### Instructions\n' +
       "1. **Explore Documentation**: Use the `get_internal_docs` tool to find answers. If you don't know where to start, call `get_internal_docs()` without arguments to see the full list of available documentation files.\n" +

--- a/packages/core/src/skills/skillLoader.ts
+++ b/packages/core/src/skills/skillLoader.ts
@@ -29,7 +29,8 @@ export interface SkillDefinition {
   isBuiltin?: boolean;
 }
 
-export const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)/;
+export const FRONTMATTER_REGEX =
+  /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n([\s\S]*))?/;
 
 /**
  * Discovers and loads all skills in the provided directory.


### PR DESCRIPTION
## Summary
This PR improves the reliability and UX of the new Agent features by fixing frontmatter parsing issues, enforcing naming conventions, and providing better feedback to the user.

## Details
- **Parser Reliability**: Updated `FRONTMATTER_REGEX` to handle Markdown files that only contain frontmatter (no body) or lack a trailing newline. This ensures agents and skills are loaded correctly regardless of file ending.
- **Agent UX**: Added an "INFO" message to the `/agents refresh` command so users know the registry is being reloaded.
- **Naming Conventions**: Enforced that agent names must be valid slugs (lowercase, numbers, hyphens, underscores). This prevents issues in command parsing and file system interactions.
- **Help Agent Grounding**: Hardcoded agent documentation into the `cli-help` agent's system prompt to provide better assistance without needing external docs. Clarified that `/agents` commands are user-driven.
- **Regression Tests**: Added tests for frontmatter edge cases and slug validation in `agentLoader.test.ts`.

## Related Issues
Part of the "Act 2" agent demo improvements.

## How to Validate
1. Run `npm run preflight` to verify all tests pass (including new regression tests).
2. Create an agent file without a trailing newline and verify it loads via `/agents list`.
3. Try to create an agent with spaces in the name and verify it fails with a clear error.
4. Run `/agents refresh` and observe the "Refreshing agent registry..." message.

## Pre-Merge Checklist
- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
  - [ ] Linux
    - [ ] npm run