### PR TITLE
fix(policy): ensure MCP policies match unqualified names in non-interactive mode

### DIFF
--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -44,6 +44,7 @@ import {
   type ToolCallResponseInfo,
 } from '../scheduler/types.js';
 import { ToolExecutor } from '../scheduler/tool-executor.js';
+import { DiscoveredMCPTool } from '../tools/mcp-tool.js';
 
 export type {
   ToolCall,
@@ -591,9 +592,15 @@ export class CoreToolScheduler {
           name: toolCall.request.name,
           args: toolCall.request.args,
         };
+
+        const serverName =
+          toolCall.tool instanceof DiscoveredMCPTool
+            ? toolCall.tool.serverName
+            : undefined;
+
         const { decision } = await this.config
           .getPolicyEngine()
-          .check(toolCallForPolicy, undefined); // Server name undefined for local tools
+          .check(toolCallForPolicy, serverName);
 
         if (decision === PolicyDecision.DENY) {
           const errorMessage = `Tool execution denied by policy.`;

--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -109,6 +109,37 @@ describe('PolicyEngine', () => {
       );
     });
 
+    it('should match unqualified tool names with qualified rules when serverName is provided', async () => {
+      const rules: PolicyRule[] = [
+        {
+          toolName: 'my-server__tool',
+          decision: PolicyDecision.ALLOW,
+        },
+      ];
+
+      engine = new PolicyEngine({ rules });
+
+      // Match with qualified name (standard)
+      expect(
+        (await engine.check({ name: 'my-server__tool' }, 'my-server')).decision,
+      ).toBe(PolicyDecision.ALLOW);
+
+      // Match with unqualified name + serverName (the fix)
+      expect((await engine.check({ name: 'tool' }, 'my-server')).decision).toBe(
+        PolicyDecision.ALLOW,
+      );
+
+      // Should NOT match with unqualified name but NO serverName
+      expect((await engine.check({ name: 'tool' }, undefined)).decision).toBe(
+        PolicyDecision.ASK_USER,
+      );
+
+      // Should NOT match with unqualified name but WRONG serverName
+      expect(
+        (await engine.check({ name: 'tool' }, 'wrong-server')).decision,
+      ).toBe(PolicyDecision.ASK_USER);
+    });
+
     it('should match by args pattern', async () => {
       const rules: PolicyRule[] = [
         {


### PR DESCRIPTION
## Summary

Fixes an issue where MCP policies (like google-workspace) were failing in non-interactive mode because the scheduler wasn't passing the server name and the policy engine wasn't matching unqualified tool names against qualified rules.

## Details

- Updated `CoreToolScheduler` to detect if a tool is a `DiscoveredMCPTool` and pass its `serverName` to the `PolicyEngine`.
- Updated `PolicyEngine.check` to attempt matching both the original tool name and a qualified version (`server__tool`) when a `serverName` is provided. This ensures policies match regardless of whether the tool is registered with its simple or prefixed name.
- Added unit tests for both `CoreToolScheduler` and `PolicyEngine` to cover these scenarios.

## Related Issues

None.

## How to Validate

Run `npm run start -- -e google-workspace list my emails by title` in non-interactive mode with a policy that allows `google-workspace` tools.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker