### PR TITLE
fix(cli): refine 'Action Required' indicator and focus hints

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -827,10 +827,13 @@ Logging in with Google... Restarting Gemini CLI to continue.
     lastOutputTimeRef.current = lastOutputTime;
   }, [lastOutputTime]);
 
-  const isShellAwaitingFocus = !!activePtyId && !embeddedShellFocused;
+  const isShellAwaitingFocus =
+    !!activePtyId &&
+    !embeddedShellFocused &&
+    config.isInteractiveShellEnabled();
   const showShellActionRequired = useInactivityTimer(
     isShellAwaitingFocus,
-    isShellAwaitingFocus,
+    lastOutputTime,
     SHELL_ACTION_REQUIRED_TITLE_DELAY_MS,
   );
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -120,6 +120,8 @@ export const useGeminiStream = (
   const [thought, setThought] = useState<ThoughtSummary | null>(null);
   const [pendingHistoryItem, pendingHistoryItemRef, setPendingHistoryItem] =
     useStateAndRef<HistoryItemWithoutId | null>(null);
+  const [lastGeminiActivityTime, setLastGeminiActivityTime] =
+    useState<number>(0);
   const processedMemoryToolsRef = useRef<Set<string>>(new Set());
   const { startNewPrompt, getPromptCount } = useSessionStats();
   const storage = config.storage;
@@ -839,9 +841,11 @@ export const useGeminiStream = (
       for await (const event of stream) {
         switch (event.type) {
           case ServerGeminiEventType.Thought:
+            setLastGeminiActivityTime(Date.now());
             setThought(event.value);
             break;
           case ServerGeminiEventType.Content:
+            setLastGeminiActivityTime(Date.now());
             geminiMessageBuffer = handleContentEvent(
               event.value,
               geminiMessageBuffer,
@@ -1371,7 +1375,11 @@ export const useGeminiStream = (
     storage,
   ]);
 
-  const lastOutputTime = Math.max(lastToolOutputTime, lastShellOutputTime);
+  const lastOutputTime = Math.max(
+    lastToolOutputTime,
+    lastShellOutputTime,
+    lastGeminiActivityTime,
+  );
 
   return {
     streamingState,

--- a/packages/cli/src/ui/hooks/usePhraseCycler.ts
+++ b/packages/cli/src/ui/hooks/usePhraseCycler.ts
@@ -38,7 +38,7 @@ export const usePhraseCycler = (
     loadingPhrases[0],
   );
   const showShellFocusHint = useInactivityTimer(
-    isInteractiveShellWaiting && lastOutputTime > 0,
+    isInteractiveShellWaiting,
     lastOutputTime,
     SHELL_FOCUS_HINT_DELAY_MS,
   );


### PR DESCRIPTION
## Summary

Refines the 'Action Required' indicator logic and interactive focus hints to prevent false positives and ensure they correctly trigger during long-running shell commands without output.

## Details

- **Indicator Refinement**: Added a check for `config.isInteractiveShellEnabled()` in `AppContainer.tsx` to ensure the 'Action Required' title only appears when the shell can actually receive input.
- **Activity Tracking**: Updated `useGeminiStream` to track `lastGeminiActivityTime` from Gemini thought and content events. This ensures that the inactivity timer resets whenever the model is active, preventing the indicator from appearing during long generation phases.
- **Focus Hint Improvement**: Removed the `lastOutputTime > 0` guard in `usePhraseCycler.ts`. This allows the focus hint to appear even if a command has not yet produced any output (e.g., during slow initialization), fixing a bug where hints would never show for the first command in a session.
- **Test Stability**: Increased Vitest `testTimeout` and `hookTimeout` to 60s in `packages/cli` and `packages/core` to accommodate complex inactivity tests that use fake timers to simulate long durations.

## Related Issues

Related to internal focus indicator improvements.

## How to Validate

1. Start Gemini CLI in a directory with interactive shell enabled.
2. Run a command that takes a long time to start producing output.
3. Observe that the loading phrase hint correctly appears after the inactivity delay.
4. Run a shell command and do not focus it; verify '✋ Action Required' appears in the terminal title after 30s.
5. Verify that any Gemini output (thought or text) resets the inactivity timer.
6. Run `npm run preflight` to ensure all automated tests pass with the new timeouts.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker