### PR TITLE
ACP/ZedIntegration: add rawInput + rawOutput

### DIFF
--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -456,6 +456,7 @@ export class Session {
             title: invocation.getDescription(),
             content,
             locations: invocation.toolLocations(),
+            rawInput: invocation.params,
             kind: tool.kind,
           },
         };
@@ -495,6 +496,7 @@ export class Session {
           title: invocation.getDescription(),
           content: [],
           locations: invocation.toolLocations(),
+          rawInput: invocation.params,
           kind: tool.kind,
         });
       }
@@ -506,6 +508,7 @@ export class Session {
         sessionUpdate: 'tool_call_update',
         toolCallId: callId,
         status: 'completed',
+        rawOutput: toolResult.llmContent,
         content: content ? [content] : [],
       });
 
@@ -792,6 +795,7 @@ export class Session {
           content: [],
           locations: invocation.toolLocations(),
           kind: readManyFilesTool.kind,
+          rawInput: invocation.params,
         });
 
         const result = await invocation.execute(abortSignal);
@@ -807,6 +811,7 @@ export class Session {
           toolCallId: callId,
           status: 'completed',
           content: content ? [content] : [],
+          rawOutput: result.llmContent,
         });
         if (Array.isArray(result.llmContent)) {
           const fileContentRegex = /^--- (.*?) ---\n\n([\s\S]*?)\n\n$/;


### PR DESCRIPTION
Closes https://github.com/google-gemini/gemini-cli/issues/17450.

## Summary

The ACP specification supports providing the raw tool inputs and outputs (see https://agentclientprotocol.com/protocol/tool-calls#param-raw-input), which is very helpful for clients to customize the tool rendering.

Currently, MCP based tools include the tool parameters in the description, but as stated in https://github.com/google-gemini/gemini-cli/pull/6655 this might change in the future, so it's not reliable. Furthermore, other tools like the file read tool currently don't report their result anywhere over ACP.

Therefore, this PR adds the raw tool params in `rawInput` and the `llmContent` in `rawOutput` over ACP.

## How to Validate

You can add Gemini as custom agent in Zed and then use the "open acp logs" command to inspect the messages.

```json
{
  "agent_servers": {
    "custom-gemini": {
      "command": "npx",
      "args": ["/path/to/gemini-cli", "--experimental-acp"],
      "type": "custom"
    }
  }
}
```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
