### PR TITLE
refresh subagents after extension load

### DIFF
--- a/packages/core/src/utils/extensionLoader.ts
+++ b/packages/core/src/utils/extensionLoader.ts
@@ -112,6 +112,11 @@ export abstract class ExtensionLoader {
       // cache, we want to only do it once.
       await refreshServerHierarchicalMemory(this.config);
       await this.config.getHookSystem()?.initialize();
+      
+      // Refresh agent registry to pick up any new agents from extensions
+      if (this.config.isAgentsEnabled()) {
+        await this.config.getAgentRegistry().reload();
+      }
     }
   }
 


### PR DESCRIPTION
### Summary

- subagents are dynamically refreshed after extensions are loaded, making them immediately available without restart.

## Details

- AgentRegistry loads agents from extension `agents/` directories
- Registry refreshes after extensions finish loading

## Related Issues

Fixes #16526

## How to Validate

1. Install extension with agents in `agents/` directory
2. Verify agents appear in `delegate_to_agent` tool without restart