### PR TITLE
docs(skills): clarify skill directory structure and file location

### DIFF
--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -98,7 +98,20 @@ gemini skills disable my-expertise --scope project
 A skill is a directory containing a `SKILL.md` file at its root. This file uses
 YAML frontmatter for metadata and Markdown for instructions.
 
-### Basic Structure
+### Folder Structure
+
+Skills are self-contained directories. At a minimum, a skill requires a
+`SKILL.md` file, but can include other resources:
+
+```text
+my-skill/
+├── SKILL.md       (Required) Instructions and metadata
+├── scripts/       (Optional) Executable scripts/tools
+├── references/    (Optional) Static documentation and examples
+└── assets/        (Optional) Templates and binary resources
+```
+
+### Basic Structure (SKILL.md)
 
 ```markdown
 ---
@@ -116,6 +129,8 @@ description: <what the skill does and when Gemini should use it>
   guidance for the model.
 
 ### Example: Team Code Reviewer
+
+Create `~/.gemini/skills/code-reviewer/SKILL.md`:
 
 ```markdown
 ---


### PR DESCRIPTION
## Summary

Clarify skill directory structure and file location in documentation based on user feedback.

## Details

- Added a directory tree diagram to the 'Creating a Skill' section to emphasize that each skill is a self-contained folder.
- Added a 'Create `~/.gemini/skills/code-reviewer/SKILL.md`:' line to the example to provide a concrete file path.

## Related Issues

N/A

## How to Validate

- Review `docs/cli/skills.md` for clarity.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS