### PR TITLE
fix(cli): fix 'gemini skills install' unknown argument error

### DIFF
--- a/packages/cli/src/commands/skills/disable.test.ts
+++ b/packages/cli/src/commands/skills/disable.test.ts
@@ -108,7 +108,7 @@ describe('skills disable command', () => {
 
   describe('disableCommand', () => {
     it('should have correct command and describe', () => {
-      expect(disableCommand.command).toBe('disable <name>');
+      expect(disableCommand.command).toBe('disable <name> [--scope]');
       expect(disableCommand.describe).toBe('Disables an agent skill.');
     });
   });

--- a/packages/cli/src/commands/skills/disable.ts
+++ b/packages/cli/src/commands/skills/disable.ts
@@ -31,7 +31,7 @@ export async function handleDisable(args: DisableArgs) {
 }
 
 export const disableCommand: CommandModule = {
-  command: 'disable <name>',
+  command: 'disable <name> [--scope]',
   describe: 'Disables an agent skill.',
   builder: (yargs) =>
     yargs

--- a/packages/cli/src/commands/skills/install.test.ts
+++ b/packages/cli/src/commands/skills/install.test.ts
@@ -17,12 +17,23 @@ vi.mock('@google/gemini-cli-core', () => ({
 }));
 
 import { debugLogger } from '@google/gemini-cli-core';
-import { handleInstall } from './install.js';
+import { handleInstall, installCommand } from './install.js';
 
 describe('skill install command', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  });
+
+  describe('installCommand', () => {
+    it('should have correct command and describe', () => {
+      expect(installCommand.command).toBe(
+        'install <source> [--scope] [--path]',
+      );
+      expect(installCommand.describe).toBe(
+        'Installs an agent skill from a git repository URL or a local path.',
+      );
+    });
   });
 
   it('should call installSkill with correct arguments for user scope', async () => {

--- a/packages/cli/src/commands/skills/install.ts
+++ b/packages/cli/src/commands/skills/install.ts
@@ -46,7 +46,7 @@ export async function handleInstall(args: InstallArgs) {
 }
 
 export const installCommand: CommandModule = {
-  command: 'install <source>',
+  command: 'install <source> [--scope] [--path]',
   describe:
     'Installs an agent skill from a git repository URL or a local path.',
   builder: (yargs) =>

--- a/packages/cli/src/commands/skills/list.test.ts
+++ b/packages/cli/src/commands/skills/list.test.ts
@@ -184,7 +184,7 @@ describe('skills list command', () => {
     const command = listCommand;
 
     it('should have correct command and describe', () => {
-      expect(command.command).toBe('list');
+      expect(command.command).toBe('list [--all]');
       expect(command.describe).toBe('Lists discovered agent skills.');
     });
   });

--- a/packages/cli/src/commands/skills/list.ts
+++ b/packages/cli/src/commands/skills/list.ts
@@ -63,7 +63,7 @@ export async function handleList(args: { all?: boolean }) {
 }
 
 export const listCommand: CommandModule = {
-  command: 'list',
+  command: 'list [--all]',
   describe: 'Lists discovered agent skills.',
   builder: (yargs) =>
     yargs.option('all', {

--- a/packages/cli/src/commands/skills/uninstall.test.ts
+++ b/packages/cli/src/commands/skills/uninstall.test.ts
@@ -17,12 +17,21 @@ vi.mock('@google/gemini-cli-core', () => ({
 }));
 
 import { debugLogger } from '@google/gemini-cli-core';
-import { handleUninstall } from './uninstall.js';
+import { handleUninstall, uninstallCommand } from './uninstall.js';
 
 describe('skill uninstall command', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  });
+
+  describe('uninstallCommand', () => {
+    it('should have correct command and describe', () => {
+      expect(uninstallCommand.command).toBe('uninstall <name> [--scope]');
+      expect(uninstallCommand.describe).toBe(
+        'Uninstalls an agent skill by name.',
+      );
+    });
   });
 
   it('should call uninstallSkill with correct arguments for user scope', async () => {

--- a/packages/cli/src/commands/skills/uninstall.ts
+++ b/packages/cli/src/commands/skills/uninstall.ts
@@ -41,7 +41,7 @@ export async function handleUninstall(args: UninstallArgs) {
 }
 
 export const uninstallCommand: CommandModule = {
-  command: 'uninstall <name>',
+  command: 'uninstall <name> [--scope]',
   describe: 'Uninstalls an agent skill by name.',
   builder: (yargs) =>
     yargs


### PR DESCRIPTION
## Summary

This PR fixes an issue where the `gemini skills install` command (and other skills subcommands) would fail with an "Unknown arguments" error when optional flags like `--path` or `--scope` were provided.

## Details

The fix involves explicitly adding the optional flags (`[--scope]`, `[--path]`, `[--all]`) to the command strings of the skills subcommands. This ensures better compatibility with `yargs` when `strict()` mode is enabled, as `yargs` can sometimes be sensitive to flags not being present in the command string, especially in nested command structures. This pattern matches the one already successfully used for extension management commands.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/16482

## How to Validate

1. Run `gemini skills install https://github.com/team-attention/plugins-for-claude-natives.git --path plugins/clarify/skills/clarify`
2. Verify it no longer fails with "Unknown arguments: path".
3. Run `npm test packages/cli/src/commands/skills` to verify all skills unit tests pass.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
