### PR TITLE
feat(cli): add security consent prompts for skill installation

### DIFF
--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -1297,8 +1297,8 @@ describe('extension tests', () => {
       expect(mockRequestConsent).toHaveBeenCalledWith(
         `Installing extension "my-local-extension".
 This extension will run the following MCP servers:
-  - test-server (local): node dobadthing \\u001b[12D\\u001b[K server.js
-  - test-server-2 (remote): https://google.com
+  * test-server (local): node dobadthing \\u001b[12D\\u001b[K server.js
+  * test-server-2 (remote): https://google.com
 
 ${INSTALL_WARNING_MESSAGE}`,
       );

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -1296,10 +1296,11 @@ describe('extension tests', () => {
 
       expect(mockRequestConsent).toHaveBeenCalledWith(
         `Installing extension "my-local-extension".
-${INSTALL_WARNING_MESSAGE}
 This extension will run the following MCP servers:
-  * test-server (local): node dobadthing \\u001b[12D\\u001b[K server.js
-  * test-server-2 (remote): https://google.com`,
+  - test-server (local): node dobadthing \\u001b[12D\\u001b[K server.js
+  - test-server-2 (remote): https://google.com
+
+${INSTALL_WARNING_MESSAGE}`,
       );
     });
 

--- a/packages/cli/src/config/extensions/consent.test.ts
+++ b/packages/cli/src/config/extensions/consent.test.ts
@@ -192,8 +192,8 @@ describe('consent', () => {
         const expectedConsentString = [
           'Installing extension "test-ext".',
           'This extension will run the following MCP servers:',
-          '  - server1 (local): npm start',
-          '  - server2 (remote): https://remote.com',
+          '  * server1 (local): npm start',
+          '  * server2 (remote): https://remote.com',
           'This extension will append info to your gemini.md context using my-context.md',
           'This extension will exclude the following core tools: tool1,tool2',
           '',
@@ -326,17 +326,17 @@ describe('consent', () => {
         const expectedConsentString = [
           'Installing extension "test-ext".',
           'This extension will run the following MCP servers:',
-          '  - server1 (local): npm start',
-          '  - server2 (remote): https://remote.com',
+          '  * server1 (local): npm start',
+          '  * server2 (remote): https://remote.com',
           'This extension will append info to your gemini.md context using my-context.md',
           'This extension will exclude the following core tools: tool1,tool2',
           '',
           chalk.bold('Agent Skills:'),
           '\nThis extension will install the following agent skills:\n',
-          `  - ${chalk.bold('skill1')}: desc1`,
+          `  * ${chalk.bold('skill1')}: desc1`,
           chalk.dim(`    (Source: ${skill1.location}) (2 items in directory)`),
           '',
-          `  - ${chalk.bold('skill2')}: desc2`,
+          `  * ${chalk.bold('skill2')}: desc2`,
           chalk.dim(`    (Source: ${skill2.location}) (1 items in directory)`),
           '',
           '',
@@ -411,7 +411,7 @@ describe('consent', () => {
       );
       expect(consentString).toContain('Install Destination: /mock/target/dir');
       expect(consentString).toContain('\n' + SKILLS_WARNING_MESSAGE);
-      expect(consentString).toContain(`  - ${chalk.bold('skill1')}: desc1`);
+      expect(consentString).toContain(`  * ${chalk.bold('skill1')}: desc1`);
       expect(consentString).toContain(
         chalk.dim(`(Source: ${skill1.location}) (1 items in directory)`),
       );

--- a/packages/cli/src/config/extensions/consent.test.ts
+++ b/packages/cli/src/config/extensions/consent.test.ts
@@ -191,12 +191,13 @@ describe('consent', () => {
 
         const expectedConsentString = [
           'Installing extension "test-ext".',
-          INSTALL_WARNING_MESSAGE,
           'This extension will run the following MCP servers:',
-          '  * server1 (local): npm start',
-          '  * server2 (remote): https://remote.com',
+          '  - server1 (local): npm start',
+          '  - server2 (remote): https://remote.com',
           'This extension will append info to your gemini.md context using my-context.md',
           'This extension will exclude the following core tools: tool1,tool2',
+          '',
+          INSTALL_WARNING_MESSAGE,
         ].join('\n');
 
         expect(requestConsent).toHaveBeenCalledWith(expectedConsentString);
@@ -324,21 +325,24 @@ describe('consent', () => {
 
         const expectedConsentString = [
           'Installing extension "test-ext".',
-          INSTALL_WARNING_MESSAGE,
           'This extension will run the following MCP servers:',
-          '  * server1 (local): npm start',
-          '  * server2 (remote): https://remote.com',
+          '  - server1 (local): npm start',
+          '  - server2 (remote): https://remote.com',
           'This extension will append info to your gemini.md context using my-context.md',
           'This extension will exclude the following core tools: tool1,tool2',
           '',
           chalk.bold('Agent Skills:'),
-          SKILLS_WARNING_MESSAGE,
-          'This extension will install the following agent skills:',
-          `  * ${chalk.bold('skill1')}: desc1`,
-          `    (Location: ${skill1.location}) (2 items in directory)`,
-          `  * ${chalk.bold('skill2')}: desc2`,
-          `    (Location: ${skill2.location}) (1 items in directory)`,
+          '\nThis extension will install the following agent skills:\n',
+          `  - ${chalk.bold('skill1')}: desc1`,
+          chalk.dim(`    (Source: ${skill1.location}) (2 items in directory)`),
           '',
+          `  - ${chalk.bold('skill2')}: desc2`,
+          chalk.dim(`    (Source: ${skill2.location}) (1 items in directory)`),
+          '',
+          '',
+          INSTALL_WARNING_MESSAGE,
+          '',
+          SKILLS_WARNING_MESSAGE,
         ].join('\n');
 
         expect(requestConsent).toHaveBeenCalledWith(expectedConsentString);
@@ -375,10 +379,42 @@ describe('consent', () => {
 
         expect(requestConsent).toHaveBeenCalledWith(
           expect.stringContaining(
-            `    (Location: ${skill.location}) ${chalk.red('⚠️ (Could not count items in directory)')}`,
+            `    (Source: ${skill.location}) ${chalk.red('⚠️ (Could not count items in directory)')}`,
           ),
         );
       });
+    });
+  });
+
+  describe('skillsConsentString', () => {
+    it('should generate a consent string for skills', async () => {
+      const skill1Dir = path.join(tempDir, 'skill1');
+      await fs.mkdir(skill1Dir, { recursive: true });
+      await fs.writeFile(path.join(skill1Dir, 'SKILL.md'), 'body1');
+
+      const skill1: SkillDefinition = {
+        name: 'skill1',
+        description: 'desc1',
+        location: path.join(skill1Dir, 'SKILL.md'),
+        body: 'body1',
+      };
+
+      const { skillsConsentString } = await import('./consent.js');
+      const consentString = await skillsConsentString(
+        [skill1],
+        'https://example.com/repo.git',
+        '/mock/target/dir',
+      );
+
+      expect(consentString).toContain(
+        'Installing agent skill(s) from "https://example.com/repo.git".',
+      );
+      expect(consentString).toContain('Install Destination: /mock/target/dir');
+      expect(consentString).toContain('\n' + SKILLS_WARNING_MESSAGE);
+      expect(consentString).toContain(`  - ${chalk.bold('skill1')}: desc1`);
+      expect(consentString).toContain(
+        chalk.dim(`(Source: ${skill1.location}) (1 items in directory)`),
+      );
     });
   });
 });

--- a/packages/cli/src/config/extensions/consent.ts
+++ b/packages/cli/src/config/extensions/consent.ts
@@ -32,19 +32,7 @@ export async function skillsConsentString(
   const output: string[] = [];
   output.push(`Installing agent skill(s) from "${source}".`);
   output.push('\nThe following agent skill(s) will be installed:\n');
-  for (const skill of skills) {
-    output.push(`  - ${chalk.bold(skill.name)}: ${skill.description}`);
-    const skillDir = path.dirname(skill.location);
-    let fileCountStr = '';
-    try {
-      const skillDirItems = await fs.readdir(skillDir);
-      fileCountStr = ` (${skillDirItems.length} items in directory)`;
-    } catch {
-      fileCountStr = ` ${chalk.red('⚠️ (Could not count items in directory)')}`;
-    }
-    output.push(chalk.dim(`    (Source: ${skill.location})${fileCountStr}`));
-    output.push('');
-  }
+  output.push(...(await renderSkillsList(skills)));
 
   if (targetDir) {
     output.push(`Install Destination: ${targetDir}`);
@@ -182,19 +170,7 @@ async function extensionConsentString(
   if (skills.length > 0) {
     output.push(`\n${chalk.bold('Agent Skills:')}`);
     output.push('\nThis extension will install the following agent skills:\n');
-    for (const skill of skills) {
-      output.push(`  - ${chalk.bold(skill.name)}: ${skill.description}`);
-      const skillDir = path.dirname(skill.location);
-      let fileCountStr = '';
-      try {
-        const skillDirItems = await fs.readdir(skillDir);
-        fileCountStr = ` (${skillDirItems.length} items in directory)`;
-      } catch {
-        fileCountStr = ` ${chalk.red('⚠️ (Could not count items in directory)')}`;
-      }
-      output.push(chalk.dim(`    (Source: ${skill.location})${fileCountStr}`));
-      output.push('');
-    }
+    output.push(...(await renderSkillsList(skills)));
   }
 
   output.push('\n' + INSTALL_WARNING_MESSAGE);
@@ -203,6 +179,27 @@ async function extensionConsentString(
   }
 
   return output.join('\n');
+}
+
+/**
+ * Shared logic for formatting a list of agent skills for a consent prompt.
+ */
+async function renderSkillsList(skills: SkillDefinition[]): Promise<string[]> {
+  const output: string[] = [];
+  for (const skill of skills) {
+    output.push(`  - ${chalk.bold(skill.name)}: ${skill.description}`);
+    const skillDir = path.dirname(skill.location);
+    let fileCountStr = '';
+    try {
+      const skillDirItems = await fs.readdir(skillDir);
+      fileCountStr = ` (${skillDirItems.length} items in directory)`;
+    } catch {
+      fileCountStr = ` ${chalk.red('⚠️ (Could not count items in directory)')}`;
+    }
+    output.push(chalk.dim(`    (Source: ${skill.location})${fileCountStr}`));
+    output.push('');
+  }
+  return output;
 }
 
 /**

--- a/packages/cli/src/config/extensions/consent.ts
+++ b/packages/cli/src/config/extensions/consent.ts
@@ -149,7 +149,7 @@ async function extensionConsentString(
       const source =
         mcpServer.httpUrl ??
         `${mcpServer.command || ''}${mcpServer.args ? ' ' + mcpServer.args.join(' ') : ''}`;
-      output.push(`  - ${key} (${isLocal ? 'local' : 'remote'}): ${source}`);
+      output.push(`  * ${key} (${isLocal ? 'local' : 'remote'}): ${source}`);
     }
   }
   if (sanitizedConfig.contextFileName) {
@@ -187,7 +187,7 @@ async function extensionConsentString(
 async function renderSkillsList(skills: SkillDefinition[]): Promise<string[]> {
   const output: string[] = [];
   for (const skill of skills) {
-    output.push(`  - ${chalk.bold(skill.name)}: ${skill.description}`);
+    output.push(`  * ${chalk.bold(skill.name)}: ${skill.description}`);
     const skillDir = path.dirname(skill.location);
     let fileCountStr = '';
     try {


### PR DESCRIPTION
## Summary

This PR implements security disclaimers and interactive consent prompts for the `gemini skills install` command. It ensures users are aware of the risks of installing third-party agent skills and provides a clear overview of what is being installed and where.

## Details

- Refactored `installSkill` utility to support a consent callback.
- Added `--consent` flag to `skills install` for non-interactive environments.
- Updated `skillsConsentString` and `extensionConsentString` with refined visual formatting:
  - Bullet points changed from `*` to `-`.
  - Added 'Install Destination' to clearly show where files will be copied.
  - Critical security warnings and installation destination moved to the bottom of the prompt.
  - Dimmed metadata (Source locations) to improve readability.
- Consistent visual improvements applied to extension installation prompts.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/16376

## How to Validate

1. Run `gemini skills install <path-to-skill-or-git-url>`.
2. Verify the consent message shows the skills, their source, the install destination, and the security warning at the bottom.
3. Test with `--consent` flag to ensure it bypasses the prompt but still logs the consent details to the debug log.
4. Run tests: `npm test packages/cli/src/config/extensions/consent.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker