### PR TITLE
fix(cli): copy uses OSC52 only in SSH/WSL

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -73,6 +73,9 @@ Slash commands provide meta-level control over the CLI itself.
 - **`/copy`**
   - **Description:** Copies the last output produced by Gemini CLI to your
     clipboard, for easy sharing or reuse.
+  - **Behavior:**
+    - Local sessions use system clipboard tools (pbcopy/xclip/clip).
+    - Remote sessions (SSH/WSL) use OSC 52 and require terminal support.
   - **Note:** This command requires platform-specific clipboard tools to be
     installed.
     - On Linux, it requires `xclip` or `xsel`. You can typically install them

--- a/packages/cli/src/ui/utils/commandUtils.ts
+++ b/packages/cli/src/ui/utils/commandUtils.ts
@@ -113,9 +113,7 @@ const isWSL = (): boolean =>
 const isDumbTerm = (): boolean => (process.env['TERM'] ?? '') === 'dumb';
 
 const shouldUseOsc52 = (tty: TtyTarget): boolean =>
-  Boolean(tty) &&
-  !isDumbTerm() &&
-  (isSSH() || inTmux() || inScreen() || isWSL());
+  Boolean(tty) && !isDumbTerm() && (isSSH() || isWSL());
 
 const safeUtf8Truncate = (buf: Buffer, maxBytes: number): Buffer => {
   if (buf.length <= maxBytes) return buf;


### PR DESCRIPTION
• ## Summary

  Fix /copy false-success in local tmux by using OSC52 only for SSH/WSL; local terminals now use native clipboard so “copied” matches actual clipboard contents.

  ## Details

  - OSC52 is gated to SSH/WSL and non‑dumb TTYs; tmux/screen only wrap when OSC52 is selected.
  - Tests updated to reflect SSH‑only OSC52 and local tmux clipboard behavior.
  - /copy docs clarified (local uses pbcopy/xclip/clip; remote uses OSC52 when supported).

  ## How to Validate

  1. Local macOS + tmux: run gemini-cli from repo, /copy, paste in a macOS app → clipboard updates via pbcopy.
  2. SSH + tmux: SSH into host, run gemini-cli, /copy, paste locally → OSC52 works if terminal supports it.
  3. Tests: npm test -- packages/cli (or packages/cli/src/ui/utils/commandUtils.test.ts).

  ## Pre-Merge Checklist

  - [x] Updated relevant documentation and README (if needed)
  - [x] Added/updated tests (if needed)
  - [ ] Noted breaking changes (if any)
  - [ ] Validated on required platforms/methods:
      - [x] MacOS
          - [x] npm run
          - [ ] npx
          - [ ] Docker
          - [ ] Podman
          - [ ] Seatbelt
      - [ ] Windows
          - [ ] npm run
          - [ ] npx
          - [ ] Docker
      - [ ] Linux
          - [ ] npm run
          - [ ] npx
          - [ ] Docker
