### PR TITLE
 refactor: clean up A2A task output for users and LLMs

### DIFF
--- a/packages/core/src/agents/a2aUtils.test.ts
+++ b/packages/core/src/agents/a2aUtils.test.ts
@@ -124,7 +124,7 @@ describe('a2aUtils', () => {
   });
 
   describe('extractTaskText', () => {
-    it('should extract basic task info', () => {
+    it('should extract basic task info (clean)', () => {
       const task: Task = {
         id: 'task-1',
         contextId: 'ctx-1',
@@ -141,12 +141,12 @@ describe('a2aUtils', () => {
       };
 
       const result = extractTaskText(task);
-      expect(result).toContain('ID: task-1');
-      expect(result).toContain('State: working');
-      expect(result).toContain('Status Message: Processing...');
+      expect(result).not.toContain('ID: task-1');
+      expect(result).not.toContain('State: working');
+      expect(result).toBe('Processing...');
     });
 
-    it('should extract artifacts', () => {
+    it('should extract artifacts with headers', () => {
       const task: Task = {
         id: 'task-1',
         contextId: 'ctx-1',
@@ -162,10 +162,10 @@ describe('a2aUtils', () => {
       };
 
       const result = extractTaskText(task);
-      expect(result).toContain('Artifacts:');
-      expect(result).toContain('  - Name: Report');
-      expect(result).toContain('    Content:');
-      expect(result).toContain('    This is the report.');
+      expect(result).toContain('Artifact (Report):');
+      expect(result).toContain('This is the report.');
+      expect(result).not.toContain('Artifacts:');
+      expect(result).not.toContain('  - Name: Report');
     });
   });
 });

--- a/packages/core/src/agents/remote-invocation.ts
+++ b/packages/core/src/agents/remote-invocation.ts
@@ -166,16 +166,16 @@ export class RemoteAgentInvocation extends BaseToolInvocation<
       });
 
       // Extract the output text
-      const resultData = response;
-      let outputText = '';
+      const outputText =
+        response.kind === 'task'
+          ? extractTaskText(response)
+          : response.kind === 'message'
+            ? extractMessageText(response)
+            : JSON.stringify(response);
 
-      if (resultData.kind === 'message') {
-        outputText = extractMessageText(resultData);
-      } else if (resultData.kind === 'task') {
-        outputText = extractTaskText(resultData);
-      } else {
-        outputText = JSON.stringify(resultData);
-      }
+      debugLogger.debug(
+        `[RemoteAgent] Response from ${this.definition.name}:\n${JSON.stringify(response, null, 2)}`,
+      );
 
       return {
         llmContent: [{ text: outputText }],


### PR DESCRIPTION
## Summary
This PR streamlines the text representation of A2A Tasks by removing protocol-level metadata (IDs, State) from the standard output. This results in a cleaner presentation for users and improved token efficiency for LLM consumption, while preserving full observability via debug logs.

## Details
Previously:

<img width="668" height="175" alt="Screenshot 2026-01-13 at 3 49 19 PM" src="https://github.com/user-attachments/assets/81af0367-46c5-45ff-8347-ce5b3b461ccc" />

Now:
<img width="1202" height="132" alt="Screenshot 2026-01-13 at 4 04 14 PM" src="https://github.com/user-attachments/assets/98c12236-603e-4e0b-b10e-c4a3e81af6fd" />


Progress towards: https://github.com/google-gemini/gemini-cli/issues/16544

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
