### PR TITLE
docs: add instructions for installing extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ npm install -g @google/gemini-cli
 brew install gemini-cli
 ```
 
+### Installing Extensions
+
+You can install extensions from a Git repository. For example, to install an extension from `https://github.com/example/gemini-extension.git`:
+
+```bash
+gemini extensions install https://github.com/example/gemini-extension.git
+```
+
+For more details on creating and using extensions, see the [Getting Started with Extensions](./docs/extensions/getting-started-extensions.md) guide.
+
 ## Release Cadence and Tags
 
 See [Releases](./docs/releases.md) for more details.

--- a/docs/extensions/getting-started-extensions.md
+++ b/docs/extensions/getting-started-extensions.md
@@ -231,6 +231,16 @@ Releases. Using a public Git repository is the simplest method.
 For detailed instructions on both methods, please refer to the
 [Extension Releasing Guide](./extension-releasing.md).
 
+## Installing Extensions
+
+You can install extensions from a Git repository. For example, to install an extension from `https://github.com/example/gemini-extension.git`:
+
+```bash
+gemini extensions install https://github.com/example/gemini-extension.git
+```
+
+Once installed, the extension's tools and commands will be available in your Gemini CLI session.
+
 ## Conclusion
 
 You've successfully created a Gemini CLI extension! You learned how to:


### PR DESCRIPTION
This PR adds instructions for installing and using extensions to the README.md and the getting-started-extensions.md files. This resolves issue #12209.