### PR TITLE
fix: preserve draft on rapid history navigation

### DIFF
--- a/packages/cli/src/ui/hooks/useInputHistory.test.ts
+++ b/packages/cli/src/ui/hooks/useInputHistory.test.ts
@@ -158,6 +158,30 @@ describe('useInputHistory', () => {
       expect(mockOnChange).toHaveBeenCalledWith(currentQuery);
     });
 
+    it('should restore original query when navigateUp and navigateDown happen back-to-back', () => {
+      const currentQuery = 'draft prompt';
+      const { result } = renderHook(() =>
+        useInputHistory({
+          userMessages,
+          onSubmit: mockOnSubmit,
+          isActive: true,
+          currentQuery,
+          onChange: mockOnChange,
+        }),
+      );
+
+      mockOnChange.mockClear();
+      act(() => {
+        result.current.navigateUp();
+        result.current.navigateDown();
+      });
+
+      expect(mockOnChange.mock.calls).toEqual([
+        [userMessages[2]],
+        [currentQuery],
+      ]);
+    });
+
     it('should navigate through history messages on subsequent navigateUp calls', () => {
       const { result } = renderHook(() =>
         useInputHistory({

--- a/packages/cli/src/ui/hooks/useInputHistory.ts
+++ b/packages/cli/src/ui/hooks/useInputHistory.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 interface UseInputHistoryProps {
   userMessages: readonly string[];
@@ -27,8 +27,13 @@ export function useInputHistory({
   currentQuery,
   onChange,
 }: UseInputHistoryProps): UseInputHistoryReturn {
+  const currentQueryRef = useRef(currentQuery);
   const historyIndexRef = useRef<number>(-1);
   const originalQueryBeforeNavRef = useRef<string>('');
+
+  useEffect(() => {
+    currentQueryRef.current = currentQuery;
+  }, [currentQuery]);
 
   const resetHistoryNav = useCallback(() => {
     historyIndexRef.current = -1;
@@ -53,7 +58,7 @@ export function useInputHistory({
     let nextIndex = historyIndexRef.current;
     if (historyIndexRef.current === -1) {
       // Store the current query from the parent before navigating
-      originalQueryBeforeNavRef.current = currentQuery;
+      originalQueryBeforeNavRef.current = currentQueryRef.current;
       nextIndex = 0;
     } else if (historyIndexRef.current < userMessages.length - 1) {
       nextIndex = historyIndexRef.current + 1;
@@ -68,12 +73,7 @@ export function useInputHistory({
       return true;
     }
     return false;
-  }, [
-    onChange,
-    userMessages,
-    isActive,
-    currentQuery, // Use currentQuery from props
-  ]);
+  }, [onChange, userMessages, isActive]);
 
   const navigateDown = useCallback(() => {
     if (!isActive) return false;

--- a/packages/cli/src/ui/hooks/useInputHistory.ts
+++ b/packages/cli/src/ui/hooks/useInputHistory.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 
 interface UseInputHistoryProps {
   userMessages: readonly string[];
@@ -27,13 +27,12 @@ export function useInputHistory({
   currentQuery,
   onChange,
 }: UseInputHistoryProps): UseInputHistoryReturn {
-  const [historyIndex, setHistoryIndex] = useState<number>(-1);
-  const [originalQueryBeforeNav, setOriginalQueryBeforeNav] =
-    useState<string>('');
+  const historyIndexRef = useRef<number>(-1);
+  const originalQueryBeforeNavRef = useRef<string>('');
 
   const resetHistoryNav = useCallback(() => {
-    setHistoryIndex(-1);
-    setOriginalQueryBeforeNav('');
+    historyIndexRef.current = -1;
+    originalQueryBeforeNavRef.current = '';
   }, []);
 
   const handleSubmit = useCallback(
@@ -51,57 +50,47 @@ export function useInputHistory({
     if (!isActive) return false;
     if (userMessages.length === 0) return false;
 
-    let nextIndex = historyIndex;
-    if (historyIndex === -1) {
+    let nextIndex = historyIndexRef.current;
+    if (historyIndexRef.current === -1) {
       // Store the current query from the parent before navigating
-      setOriginalQueryBeforeNav(currentQuery);
+      originalQueryBeforeNavRef.current = currentQuery;
       nextIndex = 0;
-    } else if (historyIndex < userMessages.length - 1) {
-      nextIndex = historyIndex + 1;
+    } else if (historyIndexRef.current < userMessages.length - 1) {
+      nextIndex = historyIndexRef.current + 1;
     } else {
       return false; // Already at the oldest message
     }
 
-    if (nextIndex !== historyIndex) {
-      setHistoryIndex(nextIndex);
+    if (nextIndex !== historyIndexRef.current) {
+      historyIndexRef.current = nextIndex;
       const newValue = userMessages[userMessages.length - 1 - nextIndex];
       onChange(newValue);
       return true;
     }
     return false;
   }, [
-    historyIndex,
-    setHistoryIndex,
     onChange,
     userMessages,
     isActive,
     currentQuery, // Use currentQuery from props
-    setOriginalQueryBeforeNav,
   ]);
 
   const navigateDown = useCallback(() => {
     if (!isActive) return false;
-    if (historyIndex === -1) return false; // Not currently navigating history
+    if (historyIndexRef.current === -1) return false; // Not currently navigating history
 
-    const nextIndex = historyIndex - 1;
-    setHistoryIndex(nextIndex);
+    const nextIndex = historyIndexRef.current - 1;
+    historyIndexRef.current = nextIndex;
 
     if (nextIndex === -1) {
       // Reached the end of history navigation, restore original query
-      onChange(originalQueryBeforeNav);
+      onChange(originalQueryBeforeNavRef.current);
     } else {
       const newValue = userMessages[userMessages.length - 1 - nextIndex];
       onChange(newValue);
     }
     return true;
-  }, [
-    historyIndex,
-    setHistoryIndex,
-    originalQueryBeforeNav,
-    onChange,
-    userMessages,
-    isActive,
-  ]);
+  }, [onChange, userMessages, isActive]);
 
   return {
     handleSubmit,


### PR DESCRIPTION
## Issue
Fixes #16550

## Summary
- Preserve draft text when rapid history navigation occurs
- Avoid recreating history navigation callbacks on each keystroke
- Add coverage for immediate up/down restore behavior

## Motivation
Accidental history navigation while editing long prompts should not discard in-progress edits. Keeping navigation callbacks stable also avoids unnecessary re-renders.

## Validation
- npm test --workspace @google/gemini-cli -- src/ui/hooks/useInputHistory.test.ts