### PR TITLE
fix: handle editor launch failures

### DIFF
--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -417,6 +417,17 @@ describe('editor utils', () => {
       });
     }
 
+    it('should return a friendly error when terminal editor is missing', async () => {
+      const spawnError = Object.assign(new Error('spawnSync vim ENOENT'), {
+        code: 'ENOENT',
+      });
+      (spawnSync as Mock).mockReturnValueOnce({ error: spawnError, status: 1 });
+
+      await expect(openDiff('old.txt', 'new.txt', 'vim')).rejects.toThrow(
+        'Failed to launch vim. Ensure it is installed and available on PATH.',
+      );
+    });
+
     it('should log an error if diff command is not available', async () => {
       const consoleErrorSpy = vi
         .spyOn(debugLogger, 'error')


### PR DESCRIPTION
## Issue
- https://github.com/google-gemini/gemini-cli/issues/16492

## Summary
- catch Modify With Editor failures and surface them as tool errors instead of unhandled rejections
- add a friendly ENOENT message when the editor binary is missing
- cover the error paths with scheduler and editor tests

## Motivation
- prevents the CLI from crashing when an editor is missing or fails to launch

## Validation
- `npm test --workspace @google/gemini-cli-core -- src/utils/editor.test.ts src/core/coreToolScheduler.test.ts` (fails: missing `systeminformation` module in `packages/core`)