### PR TITLE
fix: skip GEMINI.md directories in memory discovery

### DIFF
--- a/packages/core/src/utils/memoryDiscovery.test.ts
+++ b/packages/core/src/utils/memoryDiscovery.test.ts
@@ -165,6 +165,29 @@ describe('memoryDiscovery', () => {
     });
   });
 
+  it('should skip GEMINI.md directories without warnings', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('VITEST', '');
+    const warnSpy = vi.spyOn(debugLogger, 'warn').mockImplementation(() => {});
+
+    await createEmptyDir(path.join(projectRoot, DEFAULT_CONTEXT_FILENAME));
+
+    const result = await loadServerHierarchicalMemory(
+      cwd,
+      [],
+      false,
+      new FileDiscoveryService(projectRoot),
+      new SimpleExtensionLoader([]),
+      DEFAULT_FOLDER_TRUST,
+    );
+
+    expect(result.memoryContent).toBe('');
+    expect(result.filePaths).toContain(
+      path.join(projectRoot, DEFAULT_CONTEXT_FILENAME),
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
   it('should load only the global context file if present and others are not (default filename)', async () => {
     const defaultContextFile = await createTestFile(
       path.join(homedir, GEMINI_DIR, DEFAULT_CONTEXT_FILENAME),

--- a/packages/core/src/utils/memoryDiscovery.ts
+++ b/packages/core/src/utils/memoryDiscovery.ts
@@ -270,6 +270,16 @@ async function readGeminiMdFiles(
 
           return { filePath, content: processedResult.content };
         } catch (error: unknown) {
+          const errorCode =
+            typeof error === 'object' && error !== null && 'code' in error
+              ? (error as NodeJS.ErrnoException).code
+              : undefined;
+          if (errorCode === 'EISDIR') {
+            if (debugMode) {
+              logger.debug(`Skipping directory at ${filePath}`);
+            }
+            return { filePath, content: null };
+          }
           const isTestEnv =
             process.env['NODE_ENV'] === 'test' || process.env['VITEST'];
           if (!isTestEnv) {


### PR DESCRIPTION
## Issue
- https://github.com/google-gemini/gemini-cli/issues/16282
Fixes https://github.com/google-gemini/gemini-cli/issues/16673
## Summary
- skip EISDIR failures when a GEMINI.md path is a directory and avoid warning spam
- add a regression test to ensure directory-named GEMINI.md does not warn

## Motivation
- prevents noisy warnings when a folder is named GEMINI.md and keeps memory discovery resilient

## Validation
- `npm test --workspace @google/gemini-cli-core -- src/utils/memoryDiscovery.test.ts` (fails: missing `systeminformation` module in `packages/core`)