### PR TITLE
prefactor: add auto-accept tools to single list

### DIFF
--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -23,6 +23,13 @@ export const MEMORY_TOOL_NAME = 'save_memory';
 export const GET_INTERNAL_DOCS_TOOL_NAME = 'get_internal_docs';
 export const ACTIVATE_SKILL_TOOL_NAME = 'activate_skill';
 export const EDIT_TOOL_NAMES = new Set([EDIT_TOOL_NAME, WRITE_FILE_TOOL_NAME]);
+
+/**
+ * Tools that automatically trigger AUTO_EDIT approval mode when "ProceedAlways"
+ * is selected.
+ */
+export const AUTO_EDIT_TOOLS = [EDIT_TOOL_NAME, WRITE_FILE_TOOL_NAME] as const;
+
 export const DELEGATE_TO_AGENT_TOOL_NAME = 'delegate_to_agent';
 
 /** Prefix used for tools discovered via the toolDiscoveryCommand. */


### PR DESCRIPTION
## Summary

This is a small extraction of tool names for auto-edit. This doesn't change anything. Just to keep things cleaner later on.

## Related Issues

Works on  #14306

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
