### PR TITLE
prefactor: add rootCommands as array so it can be used for policy parsing

### DIFF
--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -208,6 +208,7 @@ describe('<HistoryItemDisplay />', () => {
             title: 'Run Shell Command',
             command: 'echo "\u001b[31mhello\u001b[0m"',
             rootCommand: 'echo',
+            rootCommands: ['echo'],
             onConfirm: async () => {},
           },
         },

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.test.tsx
@@ -83,6 +83,7 @@ describe('ToolConfirmationMessage', () => {
       title: 'Confirm Execution',
       command: 'echo "hello"',
       rootCommand: 'echo',
+      rootCommands: ['echo'],
       onConfirm: vi.fn(),
     };
 

--- a/packages/cli/src/ui/utils/textUtils.test.ts
+++ b/packages/cli/src/ui/utils/textUtils.test.ts
@@ -63,6 +63,7 @@ describe('textUtils', () => {
             type: 'exec',
             command: '\u001b[31mmls -l\u001b[0m',
             rootCommand: '\u001b[32msudo apt-get update\u001b[0m',
+            rootCommands: ['sudo'],
             onConfirm: async () => {},
           };
 

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -1245,6 +1245,7 @@ describe('CoreToolScheduler request queueing', () => {
           title: 'Confirm Shell Command',
           command: String(params['command'] ?? ''),
           rootCommand: 'git',
+          rootCommands: ['git'],
           onConfirm: async () => {},
         }),
       execute: () => executeFn({}),

--- a/packages/core/src/test-utils/mock-tool.ts
+++ b/packages/core/src/test-utils/mock-tool.ts
@@ -136,6 +136,7 @@ export const MOCK_TOOL_SHOULD_CONFIRM_EXECUTE = () =>
     title: 'Confirm mockTool',
     command: 'mockTool',
     rootCommand: 'mockTool',
+    rootCommands: ['mockTool'],
     onConfirm: async () => {},
   });
 

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -120,6 +120,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
       title: 'Confirm Shell Command',
       command: this.params.command,
       rootCommand: rootCommands.join(', '),
+      rootCommands,
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         await this.publishPolicyUpdate(outcome);
       },

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -693,6 +693,7 @@ export interface ToolExecuteConfirmationDetails {
   onConfirm: (outcome: ToolConfirmationOutcome) => Promise<void>;
   command: string;
   rootCommand: string;
+  rootCommands: string[];
 }
 
 export interface ToolMcpConfirmationDetails {


### PR DESCRIPTION
## Summary

Currently we pass back a string of concat'd subcommands. We should keep this as an array and allow clients to parse as needed from array form. 

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

Works towards 14306

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
