### PR TITLE
feat(scheduler): add types needed for event driven scheduler

### DIFF
--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -378,7 +378,7 @@ export class Task {
       if (tc.status === 'awaiting_approval' && tc.confirmationDetails) {
         this.pendingToolConfirmationDetails.set(
           tc.request.callId,
-          tc.confirmationDetails,
+          tc.confirmationDetails as ToolCallConfirmationDetails,
         );
       }
 
@@ -412,7 +412,9 @@ export class Task {
       toolCalls.forEach((tc: ToolCall) => {
         if (tc.status === 'awaiting_approval' && tc.confirmationDetails) {
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          tc.confirmationDetails.onConfirm(ToolConfirmationOutcome.ProceedOnce);
+          (tc.confirmationDetails as ToolCallConfirmationDetails).onConfirm(
+            ToolConfirmationOutcome.ProceedOnce,
+          );
           this.pendingToolConfirmationDetails.delete(tc.request.callId);
         }
       });

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -43,6 +43,7 @@ import type {
   ToolCallRequestInfo,
   GeminiErrorEventValue,
   RetryAttemptPayload,
+  ToolCallConfirmationDetails,
 } from '@google/gemini-cli-core';
 import { type Part, type PartListUnion, FinishReason } from '@google/genai';
 import type {
@@ -1132,11 +1133,13 @@ export const useGeminiStream = (
 
         // Process pending tool calls sequentially to reduce UI chaos
         for (const call of awaitingApprovalCalls) {
-          if (call.confirmationDetails?.onConfirm) {
+          if (
+            (call.confirmationDetails as ToolCallConfirmationDetails)?.onConfirm
+          ) {
             try {
-              await call.confirmationDetails.onConfirm(
-                ToolConfirmationOutcome.ProceedOnce,
-              );
+              await (
+                call.confirmationDetails as ToolCallConfirmationDetails
+              ).onConfirm(ToolConfirmationOutcome.ProceedOnce);
             } catch (error) {
               debugLogger.warn(
                 `Failed to auto-approve tool call ${call.request.callId}:`,

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -17,6 +17,7 @@ import type {
   AllToolCallsCompleteHandler,
   ToolCallsUpdateHandler,
   ToolCall,
+  ToolCallConfirmationDetails,
   Status as CoreStatus,
   EditorType,
 } from '@google/gemini-cli-core';
@@ -306,7 +307,8 @@ export function mapToDisplay(
             ...baseDisplayProperties,
             status: mapCoreStatusToDisplayStatus(trackedCall.status),
             resultDisplay: undefined,
-            confirmationDetails: trackedCall.confirmationDetails,
+            confirmationDetails:
+              trackedCall.confirmationDetails as ToolCallConfirmationDetails,
           };
         case 'executing':
           return {

--- a/packages/core/src/confirmation-bus/types.ts
+++ b/packages/core/src/confirmation-bus/types.ts
@@ -5,6 +5,11 @@
  */
 
 import { type FunctionCall } from '@google/genai';
+import type {
+  ToolConfirmationOutcome,
+  ToolConfirmationPayload,
+} from '../tools/tools.js';
+import type { ToolCall } from '../scheduler/types.js';
 
 export enum MessageBusType {
   TOOL_CONFIRMATION_REQUEST = 'tool-confirmation-request',
@@ -16,6 +21,12 @@ export enum MessageBusType {
   HOOK_EXECUTION_REQUEST = 'hook-execution-request',
   HOOK_EXECUTION_RESPONSE = 'hook-execution-response',
   HOOK_POLICY_DECISION = 'hook-policy-decision',
+  TOOL_CALLS_UPDATE = 'tool-calls-update',
+}
+
+export interface ToolCallsUpdateMessage {
+  type: MessageBusType.TOOL_CALLS_UPDATE;
+  toolCalls: ToolCall[];
 }
 
 export interface ToolConfirmationRequest {
@@ -23,6 +34,10 @@ export interface ToolConfirmationRequest {
   toolCall: FunctionCall;
   correlationId: string;
   serverName?: string;
+  /**
+   * Optional rich details for the confirmation UI (diffs, counts, etc.)
+   */
+  details?: SerializableConfirmationDetails;
 }
 
 export interface ToolConfirmationResponse {
@@ -30,11 +45,50 @@ export interface ToolConfirmationResponse {
   correlationId: string;
   confirmed: boolean;
   /**
+   * The specific outcome selected by the user.
+   *
+   * TODO: Make required after migration.
+   */
+  outcome?: ToolConfirmationOutcome;
+  /**
+   * Optional payload (e.g., modified content for 'modify_with_editor').
+   */
+  payload?: ToolConfirmationPayload;
+  /**
    * When true, indicates that policy decision was ASK_USER and the tool should
    * show its legacy confirmation UI instead of auto-proceeding.
    */
   requiresUserConfirmation?: boolean;
 }
+
+/**
+ * Data-only versions of ToolCallConfirmationDetails for bus transmission.
+ */
+export type SerializableConfirmationDetails =
+  | { type: 'info'; title: string; prompt: string; urls?: string[] }
+  | {
+      type: 'edit';
+      title: string;
+      fileName: string;
+      filePath: string;
+      fileDiff: string;
+      originalContent: string | null;
+      newContent: string;
+    }
+  | {
+      type: 'exec';
+      title: string;
+      command: string;
+      rootCommand: string;
+      rootCommands: string[];
+    }
+  | {
+      type: 'mcp';
+      title: string;
+      serverName: string;
+      toolName: string;
+      toolDisplayName: string;
+    };
 
 export interface UpdatePolicy {
   type: MessageBusType.UPDATE_POLICY;
@@ -94,4 +148,5 @@ export type Message =
   | UpdatePolicy
   | HookExecutionRequest
   | HookExecutionResponse
-  | HookPolicyDecision;
+  | HookPolicyDecision
+  | ToolCallsUpdateMessage;

--- a/packages/core/src/scheduler/types.ts
+++ b/packages/core/src/scheduler/types.ts
@@ -14,6 +14,7 @@ import type {
 } from '../tools/tools.js';
 import type { AnsiOutput } from '../utils/terminalSerializer.js';
 import type { ToolErrorType } from '../tools/tool-error.js';
+import type { SerializableConfirmationDetails } from '../confirmation-bus/types.js';
 
 export interface ToolCallRequestInfo {
   callId: string;
@@ -98,7 +99,18 @@ export type WaitingToolCall = {
   request: ToolCallRequestInfo;
   tool: AnyDeclarativeTool;
   invocation: AnyToolInvocation;
-  confirmationDetails: ToolCallConfirmationDetails;
+  /**
+   * Supports both legacy (with callbacks) and new (serializable) details.
+   * New code should treat this as SerializableConfirmationDetails.
+   *
+   * TODO: Remove ToolCallConfirmationDetails and collapse to just
+   * SerializableConfirmationDetails after migration.
+   */
+  confirmationDetails:
+    | ToolCallConfirmationDetails
+    | SerializableConfirmationDetails;
+  // TODO: Make required after migration.
+  correlationId?: string;
   startTime?: number;
   outcome?: ToolConfirmationOutcome;
 };


### PR DESCRIPTION
## Summary

Introduce foundational types and message structures required for the new pure event-driven tool scheduler. This is a non-breaking change that sets up the protocol for cross-process tool confirmation and reactive UI updates.

## Details

This PR establishes the "State as Data" model for the upcoming scheduler migration:
- **`correlationId`**: Added to `WaitingToolCall` and `ToolConfirmationResponse` to enable asynchronous matching of tool approvals across the MessageBus without relying on local memory references.
- **`SerializableConfirmationDetails`**: A data-only (POJO) version of tool confirmation info. This allows the full context of a pending tool (diffs, commands, etc.) to be serialized and sent to external listeners like the VS Code extension.
- **`TOOL_CALLS_UPDATE`**: A new broadcast message type that allows the scheduler to publish its entire state snapshot, enabling reactive UI rendering.
- **Migration Bridge**: Added temporary type assertions in `useReactToolScheduler.ts` and `useGeminiStream.ts` to maintain compatibility with the legacy callback-based system while the new scheduler is being integrated.

## Related Issues

Progresses #14306

## How to Validate

Run the type checker to ensure the new union types and assertions are correctly integrated:
```bash
npm run typecheck
```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (Types are self-documenting)
- [ ] Added/updated tests (Types-only change; logic follows in subsequent PRs)
- [ ] Noted breaking changes (None)
- [x] Validated on required platforms/methods:
  - [x] MacOS (Verified via preflight)
