### PR TITLE
docs(skills): use body-file in pr-creator skill for better reliability

### DIFF
--- a/.gemini/skills/pr-creator/SKILL.md
+++ b/.gemini/skills/pr-creator/SKILL.md
@@ -35,9 +35,15 @@ Follow these steps to create a Pull Request:
     - **Related Issues**: Link any issues fixed or related to this PR (e.g.,
       "Fixes #123").
 
-4.  **Create PR**: Use the `gh` CLI to create the PR.
+4.  **Create PR**: Use the `gh` CLI to create the PR. To avoid shell escaping
+    issues with multi-line Markdown, write the description to a temporary file
+    first.
     ```bash
-    gh pr create --title "type(scope): succinct description" --body "..."
+    # 1. Write the drafted description to a temporary file
+    # 2. Create the PR using the --body-file flag
+    gh pr create --title "type(scope): succinct description" --body-file <temp_file_path>
+    # 3. Remove the temporary file
+    rm <temp_file_path>
     ```
     - **Title**: Ensure the title follows the
       [Conventional Commits](https://www.conventionalcommits.org/) format if the


### PR DESCRIPTION
## Summary
Update the `pr-creator` skill instructions to use the `--body-file` flag instead of passing the body as a string.

## Details
Passing multi-line Markdown descriptions directly via the `--body` flag in the shell is prone to escaping issues (especially with backticks and special characters). This change instructs the agent to write the description to a temporary file first, ensuring the PR content is preserved exactly as drafted.

## Related Issues
Internal improvement to agent reliability.

## How to Validate
N/A (Skill instruction update)

## Pre-Merge Checklist
- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
