### PR TITLE
[hooks] Reduce MessageBus debug log verbosity for hook execution messages

### DIFF
--- a/packages/core/src/confirmation-bus/message-bus.ts
+++ b/packages/core/src/confirmation-bus/message-bus.ts
@@ -16,6 +16,35 @@ import {
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 import { debugLogger } from '../utils/debugLogger.js';
 
+function formatMessageForDebugLog(message: Message): string {
+  if (message.type === MessageBusType.HOOK_EXECUTION_REQUEST) {
+    const inputKeys = Object.keys(message.input ?? {});
+    return (
+      `[MESSAGE_BUS] publish: hook-execution-request ` +
+      `(eventName=${message.eventName}, correlationId=${message.correlationId}, ` +
+      `inputKeys=[${inputKeys.join(', ')}])`
+    );
+  }
+
+  if (message.type === MessageBusType.HOOK_EXECUTION_RESPONSE) {
+    const outputKeys = message.output ? Object.keys(message.output) : [];
+    const errorMessage = message.error
+      ? message.error instanceof Error
+        ? message.error.message
+        : String(message.error)
+      : undefined;
+
+    return (
+      `[MESSAGE_BUS] publish: hook-execution-response ` +
+      `(correlationId=${message.correlationId}, success=${message.success}` +
+      `${outputKeys.length ? `, outputKeys=[${outputKeys.join(', ')}]` : ''}` +
+      `${errorMessage ? `, error=${errorMessage}` : ''})`
+    );
+  }
+
+  return `[MESSAGE_BUS] publish: ${safeJsonStringify(message)}`;
+}
+
 export class MessageBus extends EventEmitter {
   constructor(
     private readonly policyEngine: PolicyEngine,
@@ -46,7 +75,7 @@ export class MessageBus extends EventEmitter {
 
   async publish(message: Message): Promise<void> {
     if (this.debug) {
-      debugLogger.debug(`[MESSAGE_BUS] publish: ${safeJsonStringify(message)}`);
+      debugLogger.debug(formatMessageForDebugLog(message));
     }
     try {
       if (!this.isValidMessage(message)) {

--- a/packages/core/src/confirmation-bus/message-bus.ts
+++ b/packages/core/src/confirmation-bus/message-bus.ts
@@ -19,27 +19,29 @@ import { debugLogger } from '../utils/debugLogger.js';
 function formatMessageForDebugLog(message: Message): string {
   if (message.type === MessageBusType.HOOK_EXECUTION_REQUEST) {
     const inputKeys = Object.keys(message.input ?? {});
-    return (
-      `[MESSAGE_BUS] publish: hook-execution-request ` +
-      `(eventName=${message.eventName}, correlationId=${message.correlationId}, ` +
-      `inputKeys=[${inputKeys.join(', ')}])`
-    );
+    return `[MESSAGE_BUS] publish: hook-execution-request (eventName=${message.eventName}, correlationId=${message.correlationId}, inputKeys=[${inputKeys.join(', ')}])`;
   }
 
   if (message.type === MessageBusType.HOOK_EXECUTION_RESPONSE) {
-    const outputKeys = message.output ? Object.keys(message.output) : [];
-    const errorMessage = message.error
-      ? message.error instanceof Error
-        ? message.error.message
-        : String(message.error)
-      : undefined;
+    const parts: string[] = [
+      `correlationId=${message.correlationId}`,
+      `success=${message.success}`,
+    ];
 
-    return (
-      `[MESSAGE_BUS] publish: hook-execution-response ` +
-      `(correlationId=${message.correlationId}, success=${message.success}` +
-      `${outputKeys.length ? `, outputKeys=[${outputKeys.join(', ')}]` : ''}` +
-      `${errorMessage ? `, error=${errorMessage}` : ''})`
-    );
+    const outputKeys = message.output ? Object.keys(message.output) : [];
+    if (outputKeys.length > 0) {
+      parts.push(`outputKeys=[${outputKeys.join(', ')}]`);
+    }
+
+    if (message.error) {
+      const errorMessage =
+        message.error instanceof Error
+          ? message.error.message
+          : String(message.error);
+      parts.push(`error=${errorMessage}`);
+    }
+
+    return `[MESSAGE_BUS] publish: hook-execution-response (${parts.join(', ')})`;
   }
 
   return `[MESSAGE_BUS] publish: ${safeJsonStringify(message)}`;

--- a/packages/vscode-ide-companion/NOTICES.txt
+++ b/packages/vscode-ide-companion/NOTICES.txt
@@ -487,7 +487,7 @@ SOFTWARE.
 
 
 ============================================================
-express@5.1.0
+express@4.21.2
 (No repository found)
 
 (The MIT License)
@@ -631,6 +631,33 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+============================================================
+array-flatten@1.1.1
+(git://github.com/blakeembrey/array-flatten.git)
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 
 ============================================================
@@ -1039,7 +1066,7 @@ THE SOFTWARE.
 
 
 ============================================================
-qs@6.14.0
+qs@6.13.0
 (https://github.com/ljharb/qs.git)
 
 BSD 3-Clause License
@@ -1615,7 +1642,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ============================================================
-type-is@2.0.1
+type-is@1.6.18
 (No repository found)
 
 (The MIT License)
@@ -1672,7 +1699,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ============================================================
-content-disposition@1.0.0
+content-disposition@0.5.4
 (No repository found)
 
 (The MIT License)
@@ -1849,7 +1876,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ============================================================
-finalhandler@2.1.0
+finalhandler@1.3.1
 (No repository found)
 
 (The MIT License)
@@ -1965,45 +1992,60 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ============================================================
-once@1.4.0
-(git://github.com/isaacs/once)
+methods@1.1.2
+(No repository found)
 
-The ISC License
+(The MIT License)
 
-Copyright (c) Isaac Z. Schlueter and Contributors
+Copyright (c) 2013-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2015-2016 Douglas Christopher Wilson <doug@somethingdoug.com>
 
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 
 
 ============================================================
-wrappy@1.0.2
-(https://github.com/npm/wrappy)
+path-to-regexp@0.1.12
+(https://github.com/pillarjs/path-to-regexp.git)
 
-The ISC License
+The MIT License (MIT)
 
-Copyright (c) Isaac Z. Schlueter and Contributors
+Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)
 
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 
 ============================================================
@@ -2117,87 +2159,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ============================================================
-router@2.2.0
-(No repository found)
-
-(The MIT License)
-
-Copyright (c) 2013 Roman Shtylman
-Copyright (c) 2014-2022 Douglas Christopher Wilson
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-'Software'), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-============================================================
-is-promise@4.0.0
-(https://github.com/then/is-promise.git)
-
-Copyright (c) 2014 Forbes Lindesay
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-============================================================
-path-to-regexp@0.1.12
-(https://github.com/pillarjs/path-to-regexp.git)
-
-The MIT License (MIT)
-
-Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-
-============================================================
-send@1.2.0
+send@0.19.0
 (No repository found)
 
 (The MIT License)
@@ -2223,6 +2185,33 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+============================================================
+mime@3.0.0
+(https://github.com/broofa/mime)
+
+The MIT License (MIT)
+
+Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 
 ============================================================
@@ -2254,6 +2243,32 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+============================================================
+utils-merge@1.0.1
+(git://github.com/jaredhanson/utils-merge.git)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2017 Jared Hanson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ============================================================


### PR DESCRIPTION
### Summary

Reduce the verbosity of MessageBus debug logs for hook execution messages. With `--debug` enabled, full hook payloads—including large `llm_request` and `llm_response` objects—were making logs extremely noisy and difficult to navigate. This PR summarizes hook messages while keeping essential debugging information.

## Details

- Hook execution messages now log only:
  - **Requests:** `eventName`, `correlationId`, `inputKeys`
  - **Responses:** `correlationId`, `success`, optional `outputKeys`, optional error message
- All other non-hook messages continue to use `safeJsonStringify`.
- Improves log readability and reduces noise, making it easier to debug large payloads.
- No breaking changes; existing functionality remains unchanged.

## Related Issues

- Fixes #16629

## How to Validate

1. Enable debug logs: `--debug`  
2. Trigger hook executions in the application  
3. Observe MessageBus logs:  
   - Hook requests should only show `eventName`, `correlationId`, `inputKeys`  
   - Hook responses should only show `correlationId`, `success`, and optional fields  
4. Verify non-hook messages are still fully logged using `safeJsonStringify`.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
