### PR TITLE
remove unnecessary `\x7f` key bindings

### DIFF
--- a/docs/cli/keyboard-shortcuts.md
+++ b/docs/cli/keyboard-shortcuts.md
@@ -26,17 +26,17 @@ available combinations.
 
 #### Editing
 
-| Action                                           | Keys                                                                                         |
-| ------------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| Delete from the cursor to the end of the line.   | `Ctrl + K`                                                                                   |
-| Delete from the cursor to the start of the line. | `Ctrl + U`                                                                                   |
-| Clear all text in the input field.               | `Ctrl + C`                                                                                   |
-| Delete the previous word.                        | `Ctrl + Backspace`<br />`Cmd + Backspace`<br />`Ctrl + ""`<br />`Cmd + ""`<br />`Ctrl + W` |
-| Delete the next word.                            | `Ctrl + Delete`<br />`Cmd + Delete`                                                          |
-| Delete the character to the left.                | `Backspace`<br />`""`<br />`Ctrl + H`                                                       |
-| Delete the character to the right.               | `Delete`<br />`Ctrl + D`                                                                     |
-| Undo the most recent text edit.                  | `Ctrl + Z (no Shift)`                                                                        |
-| Redo the most recent undone text edit.           | `Ctrl + Shift + Z`                                                                           |
+| Action                                           | Keys                                                      |
+| ------------------------------------------------ | --------------------------------------------------------- |
+| Delete from the cursor to the end of the line.   | `Ctrl + K`                                                |
+| Delete from the cursor to the start of the line. | `Ctrl + U`                                                |
+| Clear all text in the input field.               | `Ctrl + C`                                                |
+| Delete the previous word.                        | `Ctrl + Backspace`<br />`Cmd + Backspace`<br />`Ctrl + W` |
+| Delete the next word.                            | `Ctrl + Delete`<br />`Cmd + Delete`                       |
+| Delete the character to the left.                | `Backspace`<br />`Ctrl + H`                               |
+| Delete the character to the right.               | `Delete`<br />`Ctrl + D`                                  |
+| Undo the most recent text edit.                  | `Ctrl + Z (no Shift)`                                     |
+| Redo the most recent undone text edit.           | `Ctrl + Shift + Z`                                        |
 
 #### Screen Control
 

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -136,8 +136,6 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.DELETE_WORD_BACKWARD]: [
     { key: 'backspace', ctrl: true },
     { key: 'backspace', command: true },
-    { sequence: '\x7f', ctrl: true },
-    { sequence: '\x7f', command: true },
     { key: 'w', ctrl: true },
   ],
   [Command.MOVE_LEFT]: [
@@ -158,11 +156,7 @@ export const defaultKeyBindings: KeyBindingConfig = {
     { key: 'right', command: true },
     { key: 'f', command: true },
   ],
-  [Command.DELETE_CHAR_LEFT]: [
-    { key: 'backspace' },
-    { sequence: '\x7f' },
-    { key: 'h', ctrl: true },
-  ],
+  [Command.DELETE_CHAR_LEFT]: [{ key: 'backspace' }, { key: 'h', ctrl: true }],
   [Command.DELETE_CHAR_RIGHT]: [{ key: 'delete' }, { key: 'd', ctrl: true }],
   [Command.DELETE_WORD_FORWARD]: [
     { key: 'delete', ctrl: true },

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -102,11 +102,7 @@ describe('keyMatchers', () => {
     },
     {
       command: Command.DELETE_CHAR_LEFT,
-      positive: [
-        createKey('backspace'),
-        { ...createKey('\x7f'), sequence: '\x7f' },
-        createKey('h', { ctrl: true }),
-      ],
+      positive: [createKey('backspace'), createKey('h', { ctrl: true })],
       negative: [createKey('h'), createKey('x', { ctrl: true })],
     },
     {
@@ -119,8 +115,6 @@ describe('keyMatchers', () => {
       positive: [
         createKey('backspace', { ctrl: true }),
         createKey('backspace', { meta: true }),
-        { ...createKey('\x7f', { ctrl: true }), sequence: '\x7f' },
-        { ...createKey('\x7f', { meta: true }), sequence: '\x7f' },
         createKey('w', { ctrl: true }),
       ],
       negative: [createKey('backspace'), createKey('delete', { ctrl: true })],


### PR DESCRIPTION
## Summary

Remove `\x7f` bindings because KeypressContext always gives these keystrokes `name = 'backspace'`.

## Related Issues

For #14425

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
