### PR TITLE
feat(config): add 'auto' alias for default model selection

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1313,6 +1313,20 @@ describe('loadCliConfig model selection', () => {
 
     expect(config.getModel()).toBe('gemini-2.5-flash-preview');
   });
+
+  it('selects the default auto model if provided via auto alias', async () => {
+    process.argv = ['node', 'script.js', '--model', 'auto'];
+    const argv = await parseArguments({} as Settings);
+    const config = await loadCliConfig(
+      {
+        // No model provided via settings.
+      },
+      'test-session',
+      argv,
+    );
+
+    expect(config.getModel()).toBe('auto-gemini-2.5');
+  });
 });
 
 describe('loadCliConfig folderTrust', () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -622,14 +622,15 @@ export async function loadCliConfig(
   const defaultModel = settings.general?.previewFeatures
     ? PREVIEW_GEMINI_MODEL_AUTO
     : DEFAULT_GEMINI_MODEL_AUTO;
-  const model: string =
+  const specifiedModel =
     argv.model ||
     process.env['GEMINI_MODEL'] ||
-    settings.model?.name ||
-    defaultModel;
+    settings.model?.name;
 
   const resolvedModel =
-    model === GEMINI_MODEL_ALIAS_AUTO ? defaultModel : model;
+    specifiedModel === GEMINI_MODEL_ALIAS_AUTO
+      ? defaultModel
+      : specifiedModel || defaultModel;
   const sandboxConfig = await loadSandboxConfig(settings, argv);
   const screenReader =
     argv.screenReader !== undefined

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -36,6 +36,7 @@ import {
   type HookDefinition,
   type HookEventName,
   type OutputFormat,
+  GEMINI_MODEL_ALIAS_AUTO,
 } from '@google/gemini-cli-core';
 import type { Settings } from './settings.js';
 import { saveModelChange, loadSettings } from './settings.js';
@@ -621,12 +622,14 @@ export async function loadCliConfig(
   const defaultModel = settings.general?.previewFeatures
     ? PREVIEW_GEMINI_MODEL_AUTO
     : DEFAULT_GEMINI_MODEL_AUTO;
-  const resolvedModel: string =
+  const model: string =
     argv.model ||
     process.env['GEMINI_MODEL'] ||
     settings.model?.name ||
     defaultModel;
 
+  const resolvedModel =
+    model === GEMINI_MODEL_ALIAS_AUTO ? defaultModel : model;
   const sandboxConfig = await loadSandboxConfig(settings, argv);
   const screenReader =
     argv.screenReader !== undefined

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -623,9 +623,7 @@ export async function loadCliConfig(
     ? PREVIEW_GEMINI_MODEL_AUTO
     : DEFAULT_GEMINI_MODEL_AUTO;
   const specifiedModel =
-    argv.model ||
-    process.env['GEMINI_MODEL'] ||
-    settings.model?.name;
+    argv.model || process.env['GEMINI_MODEL'] || settings.model?.name;
 
   const resolvedModel =
     specifiedModel === GEMINI_MODEL_ALIAS_AUTO


### PR DESCRIPTION
## Summary

This PR adds support for the `auto` alias when specifying the Gemini model. This allows users to use `--model auto` which maps to the default auto model.

## Details

- Modified `packages/cli/src/config/config.ts` to handle the `auto` string in the model configuration.
- Added a unit test in `packages/cli/src/config/config.test.ts` to verify that passing `auto` correctly resolves to the default model.
- This improves usability by providing a simple alias for the default model selection behavior.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

1. Run the unit tests: `npm run test:scripts` (or `npx vitest run packages/cli/src/config/config.test.ts`) to verify they pass.
2. Manual verification can be done by running the CLI with `--model auto`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
