### PR TITLE
fix(core): correctly resolve 'auto' model alias to concrete model

### DIFF
--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -80,6 +80,16 @@ describe('supportsMultimodalFunctionResponse', () => {
 
 describe('resolveModel', () => {
   describe('delegation logic', () => {
+    it('should return the Preview Pro model when auto is requested and preview is enabled', () => {
+      const model = resolveModel(GEMINI_MODEL_ALIAS_AUTO, true);
+      expect(model).toBe(PREVIEW_GEMINI_MODEL);
+    });
+
+    it('should return the Default Pro model when auto is requested and preview is disabled', () => {
+      const model = resolveModel(GEMINI_MODEL_ALIAS_AUTO, false);
+      expect(model).toBe(DEFAULT_GEMINI_MODEL);
+    });
+
     it('should return the Preview Pro model when auto-gemini-3 is requested', () => {
       const model = resolveModel(PREVIEW_GEMINI_MODEL_AUTO, false);
       expect(model).toBe(PREVIEW_GEMINI_MODEL);
@@ -196,6 +206,9 @@ describe('isAutoModel', () => {
 describe('resolveClassifierModel', () => {
   it('should return flash model when alias is flash', () => {
     expect(
+      resolveClassifierModel(GEMINI_MODEL_ALIAS_AUTO, GEMINI_MODEL_ALIAS_FLASH),
+    ).toBe(DEFAULT_GEMINI_FLASH_MODEL);
+    expect(
       resolveClassifierModel(
         DEFAULT_GEMINI_MODEL_AUTO,
         GEMINI_MODEL_ALIAS_FLASH,
@@ -211,6 +224,9 @@ describe('resolveClassifierModel', () => {
 
   it('should return pro model when alias is pro', () => {
     expect(
+      resolveClassifierModel(GEMINI_MODEL_ALIAS_AUTO, GEMINI_MODEL_ALIAS_PRO),
+    ).toBe(DEFAULT_GEMINI_MODEL);
+    expect(
       resolveClassifierModel(DEFAULT_GEMINI_MODEL_AUTO, GEMINI_MODEL_ALIAS_PRO),
     ).toBe(DEFAULT_GEMINI_MODEL);
     expect(
@@ -219,6 +235,20 @@ describe('resolveClassifierModel', () => {
   });
 
   it('should handle preview features being enabled', () => {
+    expect(
+      resolveClassifierModel(
+        GEMINI_MODEL_ALIAS_AUTO,
+        GEMINI_MODEL_ALIAS_FLASH,
+        true,
+      ),
+    ).toBe(PREVIEW_GEMINI_FLASH_MODEL);
+    expect(
+      resolveClassifierModel(
+        GEMINI_MODEL_ALIAS_AUTO,
+        GEMINI_MODEL_ALIAS_PRO,
+        true,
+      ),
+    ).toBe(PREVIEW_GEMINI_MODEL);
     // If preview is enabled, resolving 'flash' without context (fallback) might switch to preview flash,
     // but here we test explicit auto models which should stick to their families if possible?
     // Actually our logic forces DEFAULT_GEMINI_FLASH_MODEL for DEFAULT_GEMINI_MODEL_AUTO even if preview is on,

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -45,6 +45,11 @@ export function resolveModel(
   previewFeaturesEnabled: boolean = false,
 ): string {
   switch (requestedModel) {
+    case GEMINI_MODEL_ALIAS_AUTO: {
+      return previewFeaturesEnabled
+        ? PREVIEW_GEMINI_MODEL
+        : DEFAULT_GEMINI_MODEL;
+    }
     case PREVIEW_GEMINI_MODEL_AUTO: {
       return PREVIEW_GEMINI_MODEL;
     }


### PR DESCRIPTION
## Summary

Fixed an issue where the 'auto' model alias was not being correctly resolved to a concrete model name (e.g., gemini-2.5-pro). This resulted in the string 'auto' being passed directly to the API, causing failures for complex requests.

## Details

The `resolveModel` function was missing a case for `GEMINI_MODEL_ALIAS_AUTO` ('auto'). When this alias was provided, it fell through to the `default` case, returning the requested string as-is. This fix ensures 'auto' resolves to the appropriate Pro model based on whether preview features are enabled.

## Related Issues

None.

## How to Validate

1. Run the updated tests: `npm test -w @google/gemini-cli-core -- src/config/models.test.ts`
2. Verify manually: `npm run start -- --debug -m auto "redesign this codebase to build a cutting edge new ml classifier"`
   Confirm that the resolved model is a concrete name like `gemini-2.5-pro` and not 'auto'.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
