### PR TITLE
Remove sequence binding

### DIFF
--- a/packages/cli/src/config/keyBindings.test.ts
+++ b/packages/cli/src/config/keyBindings.test.ts
@@ -28,12 +28,9 @@ describe('keyBindings config', () => {
     it('should have valid key binding structures', () => {
       for (const [_, bindings] of Object.entries(defaultKeyBindings)) {
         for (const binding of bindings) {
-          // Each binding should have either key or sequence, but not both
-          const hasKey = binding.key !== undefined;
-          const hasSequence = binding.sequence !== undefined;
-
-          expect(hasKey || hasSequence).toBe(true);
-          expect(hasKey && hasSequence).toBe(false);
+          // Each binding must have a key name
+          expect(typeof binding.key).toBe('string');
+          expect(binding.key.length).toBeGreaterThan(0);
 
           // Modifier properties should be boolean or undefined
           if (binding.ctrl !== undefined) {

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -94,9 +94,7 @@ export enum Command {
  */
 export interface KeyBinding {
   /** The key name (e.g., 'a', 'return', 'tab', 'escape') */
-  key?: string;
-  /** The key sequence (e.g., '\x18' for Ctrl+X) - alternative to key name */
-  sequence?: string;
+  key: string;
   /** Control key requirement: true=must be pressed, false=must not be pressed, undefined=ignore */
   ctrl?: boolean;
   /** Shift key requirement: true=must be pressed, false=must not be pressed, undefined=ignore */
@@ -221,10 +219,7 @@ export const defaultKeyBindings: KeyBindingConfig = {
   ],
 
   // External tools
-  [Command.OPEN_EXTERNAL_EDITOR]: [
-    { key: 'x', ctrl: true },
-    { sequence: '\x18', ctrl: true },
-  ],
+  [Command.OPEN_EXTERNAL_EDITOR]: [{ key: 'x', ctrl: true }],
   [Command.PASTE_CLIPBOARD]: [
     { key: 'v', ctrl: true },
     { key: 'v', command: true },

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -256,10 +256,7 @@ describe('keyMatchers', () => {
     // External tools
     {
       command: Command.OPEN_EXTERNAL_EDITOR,
-      positive: [
-        createKey('x', { ctrl: true }),
-        { ...createKey('\x18'), sequence: '\x18', ctrl: true },
-      ],
+      positive: [createKey('x', { ctrl: true })],
       negative: [createKey('x'), createKey('c', { ctrl: true })],
     },
     {

--- a/packages/cli/src/ui/keyMatchers.ts
+++ b/packages/cli/src/ui/keyMatchers.ts
@@ -13,19 +13,7 @@ import { Command, defaultKeyBindings } from '../config/keyBindings.js';
  * Pure data-driven matching logic
  */
 function matchKeyBinding(keyBinding: KeyBinding, key: Key): boolean {
-  // Either key name or sequence must match (but not both should be defined)
-  let keyMatches = false;
-
-  if (keyBinding.key !== undefined) {
-    keyMatches = keyBinding.key === key.name;
-  } else if (keyBinding.sequence !== undefined) {
-    keyMatches = keyBinding.sequence === key.sequence;
-  } else {
-    // Neither key nor sequence defined - invalid binding
-    return false;
-  }
-
-  if (!keyMatches) {
+  if (keyBinding.key !== key.name) {
     return false;
   }
 

--- a/scripts/generate-keybindings-doc.ts
+++ b/scripts/generate-keybindings-doc.ts
@@ -157,14 +157,8 @@ function formatBinding(binding: KeyBinding): string {
   if (binding.ctrl) modifiers.push('Ctrl');
   if (binding.command) modifiers.push('Cmd');
   if (binding.shift) modifiers.push('Shift');
-  if (binding.paste) modifiers.push('Paste');
 
-  const keyName = binding.key
-    ? formatKeyName(binding.key)
-    : binding.sequence
-      ? formatSequence(binding.sequence)
-      : '';
-
+  const keyName = formatKeyName(binding.key);
   if (!keyName) {
     return '';
   }
@@ -176,7 +170,6 @@ function formatBinding(binding: KeyBinding): string {
   if (binding.ctrl === false) restrictions.push('no Ctrl');
   if (binding.shift === false) restrictions.push('no Shift');
   if (binding.command === false) restrictions.push('no Cmd');
-  if (binding.paste === false) restrictions.push('not Paste');
 
   if (restrictions.length > 0) {
     combo = `${combo} (${restrictions.join(', ')})`;
@@ -190,26 +183,7 @@ function formatKeyName(key: string): string {
   if (KEY_NAME_OVERRIDES[normalized]) {
     return KEY_NAME_OVERRIDES[normalized];
   }
-  if (key.length === 1) {
-    return key.toUpperCase();
-  }
-  return key;
-}
-
-function formatSequence(sequence: string): string {
-  if (sequence.length === 1) {
-    const code = sequence.charCodeAt(0);
-    if (code >= 1 && code <= 26) {
-      return String.fromCharCode(code + 64);
-    }
-    if (code === 10 || code === 13) {
-      return 'Enter';
-    }
-    if (code === 9) {
-      return 'Tab';
-    }
-  }
-  return JSON.stringify(sequence);
+  return key.length === 1 ? key.toUpperCase() : key;
 }
 
 if (process.argv[1]) {


### PR DESCRIPTION
## Summary

Key.sequence was only used in one redundant binding ('\x18') which is removed in this PR.

## Details

Also changes `KeyBinding.key` to be mandatory.

## Related Issues

For #14425

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
