### PR TITLE
feat(policy): add source tracking to policy rules

### DIFF
--- a/packages/cli/src/ui/commands/policiesCommand.test.ts
+++ b/packages/cli/src/ui/commands/policiesCommand.test.ts
@@ -72,6 +72,7 @@ describe('policiesCommand', () => {
         {
           decision: PolicyDecision.ALLOW,
           argsPattern: /safe/,
+          source: 'test.toml',
         },
         {
           decision: PolicyDecision.ASK_USER,
@@ -101,7 +102,9 @@ describe('policiesCommand', () => {
       expect(content).toContain(
         '1. **DENY** tool: `dangerousTool` [Priority: 10]',
       );
-      expect(content).toContain('2. **ALLOW** all tools (args match: `safe`)');
+      expect(content).toContain(
+        '2. **ALLOW** all tools (args match: `safe`) [Source: test.toml]',
+      );
       expect(content).toContain('3. **ASK_USER** all tools');
     });
   });

--- a/packages/cli/src/ui/commands/policiesCommand.test.ts
+++ b/packages/cli/src/ui/commands/policiesCommand.test.ts
@@ -103,7 +103,7 @@ describe('policiesCommand', () => {
         '1. **DENY** tool: `dangerousTool` [Priority: 10]',
       );
       expect(content).toContain(
-        '2. **ALLOW** all tools (args match: `safe`) [Source: test.toml]',
+        '2. **ALLOW** all tools (args match: `safe`) [Source: `test.toml`]',
       );
       expect(content).toContain('3. **ASK_USER** all tools');
     });

--- a/packages/cli/src/ui/commands/policiesCommand.ts
+++ b/packages/cli/src/ui/commands/policiesCommand.ts
@@ -53,6 +53,9 @@ const listPoliciesCommand: SlashCommand = {
       if (rule.priority !== undefined) {
         content += ` [Priority: ${rule.priority}]`;
       }
+      if (rule.source) {
+        content += ` [Source: ${rule.source}]`;
+      }
       content += '\n';
     });
 

--- a/packages/cli/src/ui/commands/policiesCommand.ts
+++ b/packages/cli/src/ui/commands/policiesCommand.ts
@@ -54,7 +54,7 @@ const listPoliciesCommand: SlashCommand = {
         content += ` [Priority: ${rule.priority}]`;
       }
       if (rule.source) {
-        content += ` [Source: ${rule.source}]`;
+        content += ` [Source: \`${rule.source}\`]`;
       }
       content += '\n';
     });

--- a/packages/core/src/policy/config.ts
+++ b/packages/core/src/policy/config.ts
@@ -174,6 +174,7 @@ export async function createPolicyEngineConfig(
         toolName: `${serverName}__*`,
         decision: PolicyDecision.DENY,
         priority: 2.9,
+        source: 'Settings (MCP Excluded)',
       });
     }
   }
@@ -186,6 +187,7 @@ export async function createPolicyEngineConfig(
         toolName: tool,
         decision: PolicyDecision.DENY,
         priority: 2.4,
+        source: 'Settings (Tools Excluded)',
       });
     }
   }
@@ -213,6 +215,7 @@ export async function createPolicyEngineConfig(
                 decision: PolicyDecision.ALLOW,
                 priority: 2.3,
                 argsPattern: new RegExp(pattern),
+                source: 'Settings (Tools Allowed)',
               });
             }
           }
@@ -223,6 +226,7 @@ export async function createPolicyEngineConfig(
             toolName,
             decision: PolicyDecision.ALLOW,
             priority: 2.3,
+            source: 'Settings (Tools Allowed)',
           });
         }
       } else {
@@ -234,6 +238,7 @@ export async function createPolicyEngineConfig(
           toolName,
           decision: PolicyDecision.ALLOW,
           priority: 2.3,
+          source: 'Settings (Tools Allowed)',
         });
       }
     }
@@ -252,6 +257,7 @@ export async function createPolicyEngineConfig(
           toolName: `${serverName}__*`,
           decision: PolicyDecision.ALLOW,
           priority: 2.2,
+          source: 'Settings (MCP Trusted)',
         });
       }
     }
@@ -265,6 +271,7 @@ export async function createPolicyEngineConfig(
         toolName: `${serverName}__*`,
         decision: PolicyDecision.ALLOW,
         priority: 2.1,
+        source: 'Settings (MCP Allowed)',
       });
     }
   }
@@ -310,6 +317,7 @@ export function createPolicyUpdater(
               // but still lose to admin policies (3.xxx) and settings excludes (200)
               priority: 2.95,
               argsPattern: new RegExp(pattern),
+              source: 'Dynamic (Confirmed)',
             });
           }
         }
@@ -326,6 +334,7 @@ export function createPolicyUpdater(
           // but still lose to admin policies (3.xxx) and settings excludes (200)
           priority: 2.95,
           argsPattern,
+          source: 'Dynamic (Confirmed)',
         });
       }
 

--- a/packages/core/src/policy/toml-loader.test.ts
+++ b/packages/core/src/policy/toml-loader.test.ts
@@ -53,6 +53,7 @@ priority = 100
         toolName: 'glob',
         decision: PolicyDecision.ALLOW,
         priority: 1.1, // tier 1 + 100/1000
+        source: 'Default: test.toml',
       });
       expect(result.checkers).toHaveLength(0);
       expect(result.errors).toHaveLength(0);
@@ -190,6 +191,7 @@ modes = ["autoEdit"]
       expect(result.rules).toHaveLength(1);
       expect(result.rules[0].toolName).toBe('tier2-tool');
       expect(result.rules[0].modes).toEqual(['autoEdit']);
+      expect(result.rules[0].source).toBe('User: tier2.toml');
       expect(result.errors).toHaveLength(0);
     });
 

--- a/packages/core/src/policy/toml-loader.ts
+++ b/packages/core/src/policy/toml-loader.ts
@@ -346,6 +346,7 @@ export async function loadPoliciesFromToml(
                   priority: transformPriority(rule.priority, tier),
                   modes: rule.modes,
                   allowRedirection: rule.allow_redirection,
+                  source: `${tierName.charAt(0).toUpperCase() + tierName.slice(1)}: ${file}`,
                 };
 
                 // Compile regex pattern

--- a/packages/core/src/policy/types.ts
+++ b/packages/core/src/policy/types.ts
@@ -135,6 +135,12 @@ export interface PolicyRule {
    * Only applies when decision is ALLOW.
    */
   allowRedirection?: boolean;
+
+  /**
+   * Effect of the rule's source.
+   * e.g. "my-policies.toml", "Settings (MCP Trusted)", etc.
+   */
+  source?: string;
 }
 
 export interface SafetyCheckerRule {


### PR DESCRIPTION
## Summary

Adds source tracking to policy rules to identify where each rule originated (e.g., specific TOML file, settings, dynamic confirmation). This improves visibility into why certain policies are enforced.

## Details

- **`PolicyRule` Interface**: Added `source` field.
- **`toml-loader`**: Populates `source` with the filename when loading rules.
- **`config`**: Populates `source` for rules derived from user settings.
- **`/policies` Command**: Updated to display the `[Source: ...]` for each rule.

## Related Issues

<!-- None -->

## How to Validate

1.  Run the CLI with some policies configured (via `.gemini/config.toml` or settings).
2.  Execute the `/policies` command.
3.  Verify that the output includes `[Source: ...]` for the rules.

Example output:
```
  63. ALLOW all tools [Priority: 1.999] [Source: Default: yolo.toml]
  64. ASK_USER tool: delegate_to_agent [Priority: 1.05] [Source: Default: agent.toml]
  65. ALLOW tool: glob [Priority: 1.05] [Source: Default: read-only.toml]
  66. ALLOW tool: search_file_content [Priority: 1.05] [Source: Default: read-only.toml]
  67. ALLOW tool: list_directory [Priority: 1.05] [Source: Default: read-only.toml]
  68. ALLOW tool: read_file [Priority: 1.05] [Source: Default: read-only.toml]
  69. ALLOW tool: read_many_files [Priority: 1.05] [Source: Default: read-only.toml]
  70. ALLOW tool: google_web_search [Priority: 1.05] [Source: Default: read-only.toml]
  71. ALLOW tool: SubagentInvocation [Priority: 1.05] [Source: Default: read-only.toml]
  72. ALLOW tool: replace [Priority: 1.015] [Source: Default: write.toml]
  73. ALLOW tool: write_file [Priority: 1.015] [Source: Default: write.toml]
  74. ASK_USER tool: discovered_tool_* [Priority: 1.01] [Source: Default: discovered.toml]
  75. ASK_USER tool: replace [Priority: 1.01] [Source: Default: write.toml]
  76. ASK_USER tool: save_memory [Priority: 1.01] [Source: Default: write.toml]
  77. ASK_USER tool: run_shell_command [Priority: 1.01] [Source: Default: write.toml]
  78. ASK_USER tool: write_file [Priority: 1.01] [Source: Default: write.toml]
  79. ASK_USER tool: activate_skill [Priority: 1.01] [Source: Default: write.toml]
  80. ASK_USER tool: web_fetch [Priority: 1.01] [Source: Default: write.toml]
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
