### PR TITLE
feat(cli): add /restart command for graceful session restart

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -47,6 +47,7 @@ import { policiesCommand } from '../ui/commands/policiesCommand.js';
 import { privacyCommand } from '../ui/commands/privacyCommand.js';
 import { profileCommand } from '../ui/commands/profileCommand.js';
 import { quitCommand } from '../ui/commands/quitCommand.js';
+import { restartCommand } from '../ui/commands/restartCommand.js';
 import { restoreCommand } from '../ui/commands/restoreCommand.js';
 import { resumeCommand } from '../ui/commands/resumeCommand.js';
 import { statsCommand } from '../ui/commands/statsCommand.js';
@@ -152,6 +153,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       privacyCommand,
       ...(isDevelopment ? [profileCommand] : []),
       quitCommand,
+      restartCommand,
       restoreCommand(this.config),
       resumeCommand,
       statsCommand,

--- a/packages/cli/src/ui/commands/restartCommand.test.ts
+++ b/packages/cli/src/ui/commands/restartCommand.test.ts
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Mock } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { restartCommand } from './restartCommand.js';
+import { type CommandContext } from './types.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { SessionEndReason, flushTelemetry } from '@google/gemini-cli-core';
+
+// Mock process.exit to prevent tests from terminating
+vi.stubGlobal('process', {
+  ...process,
+  exit: vi.fn(),
+});
+
+// Mock the relaunch module
+vi.mock('../../utils/relaunch.js', () => ({
+  relaunchAppInChildProcess: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock the telemetry service
+vi.mock('@google/gemini-cli-core', async () => {
+  const actual = await vi.importActual('@google/gemini-cli-core');
+  return {
+    ...actual,
+    flushTelemetry: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+import { relaunchAppInChildProcess } from '../../utils/relaunch.js';
+
+describe('restartCommand', () => {
+  let mockContext: CommandContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockContext = createMockCommandContext({
+      services: {
+        config: {
+          getSessionId: vi.fn().mockReturnValue('test-session-id-123'),
+          getHookSystem: vi.fn().mockReturnValue({
+            fireSessionEndEvent: vi.fn().mockResolvedValue(undefined),
+            fireSessionStartEvent: vi.fn().mockResolvedValue(undefined),
+          }),
+        },
+      },
+    });
+  });
+
+  it('should restart with the current session ID preserved', async () => {
+    if (!restartCommand.action) {
+      throw new Error('restartCommand must have an action.');
+    }
+
+    await restartCommand.action(mockContext, '');
+
+    // Verify session ID is retrieved
+    const config = mockContext.services.config as unknown as Record<
+      string,
+      Mock
+    >;
+    expect(config['getSessionId']).toHaveBeenCalledTimes(1);
+
+    // Verify SessionEnd hook is fired
+    const hookSystem = config['getHookSystem']();
+    expect(hookSystem['fireSessionEndEvent']).toHaveBeenCalledWith(
+      SessionEndReason.Restart,
+    );
+
+    // Verify telemetry is flushed
+    expect(flushTelemetry).toHaveBeenCalledWith(config);
+
+    // Verify relaunch is called with the correct session ID
+    expect(relaunchAppInChildProcess).toHaveBeenCalledWith(
+      [],
+      ['--resume', 'test-session-id-123'],
+    );
+
+    // Verify process.exit(0) is called to exit the parent process
+    expect(process.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('should set debug message during restart', async () => {
+    if (!restartCommand.action) {
+      throw new Error('restartCommand must have an action.');
+    }
+
+    await restartCommand.action(mockContext, '');
+
+    expect(mockContext.ui.setDebugMessage).toHaveBeenCalledWith(
+      'Restarting CLI with current session...',
+    );
+  });
+
+  it('should return error message when config is not available', async () => {
+    if (!restartCommand.action) {
+      throw new Error('restartCommand must have an action.');
+    }
+
+    const nullConfigContext = createMockCommandContext({
+      services: {
+        config: null,
+      },
+    });
+
+    const result = await restartCommand.action(nullConfigContext, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Unable to restart: config not available',
+    });
+
+    // Relaunch should not be called when config is unavailable
+    expect(relaunchAppInChildProcess).not.toHaveBeenCalled();
+  });
+
+  it('should flush telemetry after firing session end event', async () => {
+    if (!restartCommand.action) {
+      throw new Error('restartCommand must have an action.');
+    }
+
+    const callOrder: string[] = [];
+
+    const config = mockContext.services.config as unknown as Record<
+      string,
+      Record<string, Mock> | Mock
+    >;
+    ((config['getHookSystem'] as Mock)() as Record<string, Mock>)[
+      'fireSessionEndEvent'
+    ].mockImplementation(async () => {
+      callOrder.push('fireSessionEndEvent');
+    });
+
+    (flushTelemetry as Mock).mockImplementation(async () => {
+      callOrder.push('flushTelemetry');
+    });
+
+    await restartCommand.action(mockContext, '');
+
+    // Verify order: fireSessionEndEvent -> flushTelemetry
+    const fireIndex = callOrder.indexOf('fireSessionEndEvent');
+    const flushIndex = callOrder.indexOf('flushTelemetry');
+
+    expect(fireIndex).toBeLessThan(flushIndex);
+  });
+});

--- a/packages/cli/src/ui/commands/restartCommand.ts
+++ b/packages/cli/src/ui/commands/restartCommand.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SessionEndReason, flushTelemetry } from '@google/gemini-cli-core';
+import type { SlashCommand } from './types.js';
+import { CommandKind } from './types.js';
+import { relaunchAppInChildProcess } from '../../utils/relaunch.js';
+
+export const restartCommand: SlashCommand = {
+  name: 'restart',
+  description: 'Restart the CLI and resume the current session',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: async (context) => {
+    const config = context.services.config;
+
+    if (!config) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'Unable to restart: config not available',
+      };
+    }
+
+    const sessionId = config.getSessionId();
+    context.ui.setDebugMessage('Restarting CLI with current session...');
+
+    // Fire SessionEnd hook before restarting
+    await config.getHookSystem()?.fireSessionEndEvent(SessionEndReason.Restart);
+
+    // Give the event loop a chance to process any pending telemetry operations.
+    // This ensures logger.emit() calls have fully propagated to the BatchLogRecordProcessor.
+    // This is critical for tests and environments with I/O latency.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    // Flush telemetry to ensure hooks are written to disk immediately
+    await flushTelemetry(config);
+
+    // Restart the process with the current session ID preserved
+    await relaunchAppInChildProcess([], ['--resume', sessionId]);
+
+    // Ensure the parent process exits. relaunchAppInChildProcess spawns a child
+    // but the parent must exit to prevent both instances from running simultaneously
+    // and fighting for stdin/stdout, which causes terminal corruption
+    process.exit(0);
+  },
+};

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -619,6 +619,7 @@ export enum SessionEndReason {
   Clear = 'clear',
   Logout = 'logout',
   PromptInputExit = 'prompt_input_exit',
+  Restart = 'restart',
   Other = 'other',
 }
 


### PR DESCRIPTION
Implements a /restart command that gracefully shuts down the CLI and automatically resumes the current session. This is particularly useful when the tool updates itself - users can now type /restart instead of manually reopening with the resume flag.

The restart process:
- Fires SessionEnd hook with new Restart reason
- Flushes telemetry to preserve any pending data
- Restarts the process with --resume flag preserving session context
- User can continue the conversation exactly where they left off

Addresses: https://github.com/google-gemini/gemini-cli/issues/16124

Changes:
- Add restartCommand with proper session and telemetry handling
- Extend SessionEndReason enum with Restart value
- Register restart command in BuiltinCommandLoader
- Add comprehensive unit tests

Fixes #16124 

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
