### PR TITLE
feat: add gemini update command

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -58,6 +58,7 @@ import { shellsCommand } from '../ui/commands/shellsCommand.js';
 import { vimCommand } from '../ui/commands/vimCommand.js';
 import { setupGithubCommand } from '../ui/commands/setupGithubCommand.js';
 import { terminalSetupCommand } from '../ui/commands/terminalSetupCommand.js';
+import { updateCommand } from '../ui/commands/updateCommand.js';
 
 /**
  * Loads the core, hard-coded slash commands that are an integral part
@@ -185,6 +186,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       vimCommand,
       setupGithubCommand,
       terminalSetupCommand,
+      updateCommand,
     ];
     handle?.end();
     return allDefinitions.filter((cmd): cmd is SlashCommand => cmd !== null);

--- a/packages/cli/src/ui/commands/updateCommand.test.ts
+++ b/packages/cli/src/ui/commands/updateCommand.test.ts
@@ -1,0 +1,242 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { updateCommand } from './updateCommand.js';
+import type { CommandContext } from './types.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import {
+  PackageManager,
+  getInstallationInfo,
+} from '../../utils/installationInfo.js';
+
+// Mock the update utilities
+vi.mock('../utils/updateCheck.js', () => ({
+  checkForUpdates: vi.fn(),
+}));
+
+vi.mock('../../utils/installationInfo.js', async () => {
+  const actual = await vi.importActual('../../utils/installationInfo.js');
+  return {
+    ...actual,
+    getInstallationInfo: vi.fn(),
+  };
+});
+
+vi.mock('../../utils/spawnWrapper.js', () => ({
+  spawnWrapper: vi.fn(() => ({
+    unref: vi.fn(),
+  })),
+}));
+
+import { checkForUpdates } from '../utils/updateCheck.js';
+import { spawnWrapper } from '../../utils/spawnWrapper.js';
+
+describe('updateCommand', () => {
+  let mockContext: CommandContext;
+
+  beforeEach(() => {
+    mockContext = createMockCommandContext();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should show message when already on latest version', async () => {
+    if (!updateCommand.action) {
+      throw new Error('updateCommand must have an action.');
+    }
+
+    vi.mocked(checkForUpdates).mockResolvedValue(null);
+
+    const result = await updateCommand.action(mockContext, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'You are already running the latest version of Gemini CLI.',
+    });
+  });
+
+  it('should show confirmation when update is available', async () => {
+    if (!updateCommand.action) {
+      throw new Error('updateCommand must have an action.');
+    }
+
+    const updateInfo = {
+      message: 'A new version is available! 1.0.0 → 1.1.0',
+      update: {
+        name: '@google/gemini-cli',
+        latest: '1.1.0',
+        current: '1.0.0',
+        type: 'minor' as const,
+      },
+    };
+
+    vi.mocked(checkForUpdates).mockResolvedValue(updateInfo);
+    vi.mocked(getInstallationInfo).mockReturnValue({
+      packageManager: PackageManager.NPM,
+      isGlobal: true,
+      updateCommand: 'npm install -g @google/gemini-cli@latest',
+    });
+
+    const result = await updateCommand.action(mockContext, '');
+
+    expect(result).toEqual({
+      type: 'confirm_action',
+      prompt:
+        'A new version is available! 1.0.0 → 1.1.0\n\nDo you want to update now?',
+      originalInvocation: {
+        raw: '/update',
+      },
+    });
+  });
+
+  it('should show message when running in sandbox', async () => {
+    if (!updateCommand.action) {
+      throw new Error('updateCommand must have an action.');
+    }
+
+    const updateInfo = {
+      message: 'A new version is available! 1.0.0 → 1.1.0',
+      update: {
+        name: '@google/gemini-cli',
+        latest: '1.1.0',
+        current: '1.0.0',
+        type: 'minor' as const,
+      },
+    };
+
+    vi.mocked(checkForUpdates).mockResolvedValue(updateInfo);
+    mockContext.services.settings.merged.tools = { sandbox: true };
+
+    const result = await updateCommand.action(mockContext, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: `${updateInfo.message}\nAutomatic update is not available in sandbox mode.`,
+    });
+  });
+
+  it('should handle confirmation and trigger update', async () => {
+    if (!updateCommand.action) {
+      throw new Error('updateCommand must have an action.');
+    }
+
+    const updateInfo = {
+      message: 'A new version is available! 1.0.0 → 1.1.0',
+      update: {
+        name: '@google/gemini-cli',
+        latest: '1.1.0',
+        current: '1.0.0',
+        type: 'minor' as const,
+      },
+    };
+
+    vi.mocked(checkForUpdates).mockResolvedValue(updateInfo);
+    vi.mocked(getInstallationInfo).mockReturnValue({
+      packageManager: PackageManager.NPM,
+      isGlobal: true,
+      updateCommand: 'npm install -g @google/gemini-cli@latest',
+    });
+
+    // Simulate a confirmed invocation
+    mockContext.overwriteConfirmed = true;
+
+    const result = await updateCommand.action(mockContext, '');
+
+    // Verify spawnWrapper is called to execute the update command directly
+    expect(spawnWrapper).toHaveBeenCalledWith(
+      'npm install -g @google/gemini-cli@1.1.0',
+      {
+        stdio: 'ignore',
+        shell: true,
+        detached: true,
+      },
+    );
+
+    // Verify user gets feedback message
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content:
+        'Update initiated. The new version will be used on your next run.',
+    });
+  });
+
+  it('should handle confirmation even when auto-update is disabled', async () => {
+    if (!updateCommand.action) {
+      throw new Error('updateCommand must have an action.');
+    }
+
+    const updateInfo = {
+      message: 'A new version is available! 1.0.0 → 1.1.0',
+      update: {
+        name: '@google/gemini-cli',
+        latest: '1.1.0',
+        current: '1.0.0',
+        type: 'minor' as const,
+      },
+    };
+
+    vi.mocked(checkForUpdates).mockResolvedValue(updateInfo);
+    vi.mocked(getInstallationInfo).mockReturnValue({
+      packageManager: PackageManager.NPM,
+      isGlobal: true,
+      updateCommand: 'npm install -g @google/gemini-cli@latest',
+    });
+
+    // Disable auto-update
+    mockContext.services.settings.merged.general = {
+      ...mockContext.services.settings.merged.general,
+      enableAutoUpdate: false,
+    };
+
+    // Simulate a confirmed invocation
+    mockContext.overwriteConfirmed = true;
+
+    const result = await updateCommand.action(mockContext, '');
+
+    // Verify spawnWrapper is called even though auto-update is disabled
+    // This is the key fix - manual updates should work regardless of auto-update setting
+    expect(spawnWrapper).toHaveBeenCalledWith(
+      'npm install -g @google/gemini-cli@1.1.0',
+      {
+        stdio: 'ignore',
+        shell: true,
+        detached: true,
+      },
+    );
+
+    // Verify user gets feedback message
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content:
+        'Update initiated. The new version will be used on your next run.',
+    });
+  });
+
+  it('should handle errors gracefully', async () => {
+    if (!updateCommand.action) {
+      throw new Error('updateCommand must have an action.');
+    }
+
+    const error = new Error('Network error');
+    vi.mocked(checkForUpdates).mockRejectedValue(error);
+
+    const result = await updateCommand.action(mockContext, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Failed to check for updates: Network error',
+    });
+  });
+});

--- a/packages/cli/src/ui/commands/updateCommand.ts
+++ b/packages/cli/src/ui/commands/updateCommand.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  CommandContext,
+  SlashCommand,
+  SlashCommandActionReturn,
+} from './types.js';
+import { CommandKind } from './types.js';
+import { checkForUpdates } from '../utils/updateCheck.js';
+import { getInstallationInfo } from '../../utils/installationInfo.js';
+import { spawnWrapper } from '../../utils/spawnWrapper.js';
+
+export const updateCommand: SlashCommand = {
+  name: 'update',
+  description: 'Check for and install Gemini CLI updates',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: async (
+    context: CommandContext,
+  ): Promise<SlashCommandActionReturn> => {
+    try {
+      // Check for available updates (force: true to bypass notification settings)
+      const updateInfo = await checkForUpdates(context.services.settings, true);
+
+      if (!updateInfo) {
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: 'You are already running the latest version of Gemini CLI.',
+        };
+      }
+
+      // Get installation info to determine if update is possible
+      const installationInfo = getInstallationInfo(
+        process.cwd(),
+        !(context.services.settings.merged.general?.enableAutoUpdate ?? true),
+      );
+
+      // Check if running in sandbox or via npx/bunx
+      if (
+        context.services.settings.merged.tools?.sandbox ||
+        process.env['GEMINI_SANDBOX']
+      ) {
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: `${updateInfo.message}\nAutomatic update is not available in sandbox mode.`,
+        };
+      }
+
+      if (installationInfo.updateMessage && !installationInfo.updateCommand) {
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: `${updateInfo.message}\n${installationInfo.updateMessage}`,
+        };
+      }
+
+      // If user has confirmed the update, proceed with installation
+      if (context.overwriteConfirmed) {
+        // For manual user-initiated updates, directly execute the update command
+        // bypassing the background auto-update checks
+        if (!installationInfo.updateCommand) {
+          return {
+            type: 'message',
+            messageType: 'error',
+            content:
+              'Update command not available for your installation method.',
+          };
+        }
+
+        const isNightly = updateInfo.update.latest.includes('nightly');
+        const updateCmd = installationInfo.updateCommand.replace(
+          '@latest',
+          isNightly ? '@nightly' : `@${updateInfo.update.latest}`,
+        );
+
+        const updateProcess = spawnWrapper(updateCmd, {
+          stdio: 'ignore',
+          shell: true,
+          detached: true,
+        });
+        updateProcess.unref();
+
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: `Update initiated. The new version will be used on your next run.`,
+        };
+      }
+
+      // Prompt user for confirmation
+      return {
+        type: 'confirm_action',
+        prompt: `${updateInfo.message}\n\nDo you want to update now?`,
+        originalInvocation: {
+          raw: '/update',
+        },
+      };
+    } catch (error) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: `Failed to check for updates: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      };
+    }
+  },
+};

--- a/packages/cli/src/ui/utils/updateCheck.ts
+++ b/packages/cli/src/ui/utils/updateCheck.ts
@@ -49,9 +49,10 @@ function getBestAvailableUpdate(
 
 export async function checkForUpdates(
   settings: LoadedSettings,
+  force: boolean = false,
 ): Promise<UpdateObject | null> {
   try {
-    if (!settings.merged.general.enableAutoUpdateNotification) {
+    if (!force && !settings.merged.general.enableAutoUpdateNotification) {
       return null;
     }
     // Skip update check when running from source (development mode)


### PR DESCRIPTION
Implement a new `/update` command that checks for available updates and allows users to install them interactively. The command respects the current installation method (npm, bun, pnpm, yarn, homebrew) and release channel (stable, preview, nightly), providing appropriate feedback for unsupported installation methods like npx or sandbox environments.

Features:
- Check for updates using existing updateCheck utility
- Show confirmation dialog before installing
- Execute updates for supported package managers
- Handle special cases (sandbox, npx, git clone, etc.)
- Release channel aware (respects current nightly/preview/stable)

Fixes #16122

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
