### PR TITLE
fix(cli): validate custom theme colors to prevent stray artifacts (#1…

### DIFF
--- a/packages/cli/src/ui/themes/theme-validation.test.ts
+++ b/packages/cli/src/ui/themes/theme-validation.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateCustomTheme, type CustomTheme } from './theme.js';
+
+describe('validateCustomTheme', () => {
+  it('should validate a correct theme', () => {
+    const validTheme: CustomTheme = {
+      name: 'Valid Theme',
+      type: 'custom',
+      background: {
+        primary: '#ffffff',
+      },
+      text: {
+        primary: 'black', // Ink color name
+      },
+      ui: {
+        gradient: ['#ff0000', '#0000ff'],
+      },
+      // unknown properties should be ignored by recursion if they are not colors
+      // but strictly speaking our types don't allow unknown props.
+      // However, extra props might exist in JSON.
+    };
+
+    const result = validateCustomTheme(validTheme);
+    expect(result.isValid).toBe(true);
+  });
+
+  it('should fail on invalid color name', () => {
+    const invalidTheme: CustomTheme = {
+      name: 'Invalid Theme',
+      type: 'custom',
+      text: {
+        primary: 'notacolor',
+      },
+    };
+
+    const result = validateCustomTheme(invalidTheme);
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain('Invalid color "notacolor"');
+  });
+
+  it('should fail on invalid hex code', () => {
+    const invalidTheme: CustomTheme = {
+      name: 'Invalid Hex',
+      type: 'custom',
+      background: {
+        primary: '#12', // Too short
+      },
+    };
+
+    const result = validateCustomTheme(invalidTheme);
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain('Invalid color "#12"');
+  });
+
+  it('should fail on invalid gradient color', () => {
+    const invalidTheme: CustomTheme = {
+      name: 'Invalid Gradient',
+      type: 'custom',
+      ui: {
+        gradient: ['red', 'blue', 'potato'],
+      },
+    };
+
+    const result = validateCustomTheme(invalidTheme);
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain('Invalid color "potato"');
+  });
+
+  it('should validate deeply nested colors', () => {
+    const invalidTheme: CustomTheme = {
+      name: 'Deep Invalid',
+      type: 'custom',
+      background: {
+        diff: {
+          added: 'invalid-green',
+        },
+      },
+    };
+
+    const result = validateCustomTheme(invalidTheme);
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain('Invalid color "invalid-green"');
+  });
+
+  it('should return error for invalid theme name', () => {
+    const invalidTheme: CustomTheme = {
+      name: '',
+      type: 'custom',
+    };
+    const result = validateCustomTheme(invalidTheme);
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain('Invalid theme name');
+  });
+});

--- a/packages/cli/src/ui/themes/theme-validation.test.ts
+++ b/packages/cli/src/ui/themes/theme-validation.test.ts
@@ -97,4 +97,35 @@ describe('validateCustomTheme', () => {
     expect(result.isValid).toBe(false);
     expect(result.error).toContain('Invalid theme name');
   });
+
+  it('should escape ANSI characters in error messages', () => {
+    const invalidTheme: CustomTheme = {
+      name: 'ANSI Injection',
+      type: 'custom',
+      text: {
+        primary: '\x1b[31;1mINJECTED\x1b[0m',
+      },
+    };
+
+    const result = validateCustomTheme(invalidTheme);
+    expect(result.isValid).toBe(false);
+    // The error message should contain the escaped string, not the raw ANSI codes
+    expect(result.error).toContain('"\\u001b[31;1mINJECTED\\u001b[0m"');
+  });
+
+  it('should fail on non-string value in gradient array', () => {
+    const invalidTheme = {
+      name: 'Invalid Gradient Array',
+      type: 'custom',
+      ui: {
+        gradient: ['red', 123],
+      },
+    } as unknown as CustomTheme;
+
+    const result = validateCustomTheme(invalidTheme);
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain(
+      'Invalid non-string value found in color array',
+    );
+  });
 });


### PR DESCRIPTION
fix(cli): validate custom theme colors to prevent stray artifacts (#16668)

## Description

### Summary
This PR fixes issue #16668 where a stray 'm' character would appear in the console output when using a custom theme.
The root cause was identified as the lack of validation for color values in custom themes. Invalid colors (e.g., malformed hex codes or unknown names) were being passed to `ink-gradient`, resulting in broken ANSI escape sequences (like `\x1b[m`), which rendered as artifacts in the terminal.
I have strictly enforced color validation in [ThemeManager](cci:2://file:///c:/Users/madha/code/opensource/gemini-cli/packages/cli/src/ui/themes/theme-manager.ts:37:0-333:1) to reject any custom themes containing invalid color values.

### Details
- **Modified [packages/cli/src/ui/themes/theme.ts](cci:7://file:///c:/Users/madha/code/opensource/gemini-cli/packages/cli/src/ui/themes/theme.ts:0:0-0:0)**:
  - Implemented a recursive [validateColors](cci:1://file:///c:/Users/madha/code/opensource/gemini-cli/packages/cli/src/ui/themes/theme.ts:484:2-525:4) helper that checks all string properties in a [CustomTheme](cci:2://file:///c:/Users/madha/code/opensource/gemini-cli/packages/cli/src/ui/themes/theme.ts:36:0-85:1) object against [isValidColor](cci:1://file:///c:/Users/madha/code/opensource/gemini-cli/packages/cli/src/ui/themes/color-utils.ts:174:0-201:1).
  - Added specific validation for gradient arrays to ensure all stops are valid colors.
  - Updated [validateCustomTheme](cci:1://file:///c:/Users/madha/code/opensource/gemini-cli/packages/cli/src/ui/themes/theme.ts:474:0-547:1) to return detailed error messages if any invalid color is found.
- **Added [packages/cli/src/ui/themes/theme-validation.test.ts](cci:7://file:///c:/Users/madha/code/opensource/gemini-cli/packages/cli/src/ui/themes/theme-validation.test.ts:0:0-0:0)**:
  - Created a new test suite to verify the validation logic.
  - Includes tests for:
    - Valid themes (should pass).
    - Invalid color names (should fail).
    - Invalid hex codes (should fail).
    - Invalid gradient colors (should fail).
    - Deeply nested invalid colors (should fail).
    - Edge cases like empty theme names.

### How to Validate
1.  Checkout this branch: `fix/issue-16668-stray-m-custom-theme`.
2.  Run the validation tests:
    ```bash
    npm test packages/cli/src/ui/themes/theme-validation.test.ts
    ```
    All 6 tests should pass.

### Pre-Merge Checklist
- [x] Added/updated tests.
- [x] Validated on local machine (Windows).