### PR TITLE
feat(scheduler): add functional awaitConfirmation utility

### DIFF
--- a/packages/core/src/scheduler/confirmation.test.ts
+++ b/packages/core/src/scheduler/confirmation.test.ts
@@ -1,0 +1,215 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { awaitConfirmation } from './confirmation.js';
+import {
+  MessageBusType,
+  type ToolConfirmationResponse,
+  type Message,
+} from '../confirmation-bus/types.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+import { ToolConfirmationOutcome } from '../tools/tools.js';
+
+describe('awaitConfirmation', () => {
+  let mockMessageBus: MessageBus;
+  let listeners: Record<string, (message: Message) => void> = {};
+
+  beforeEach(() => {
+    listeners = {};
+    mockMessageBus = {
+      publish: vi.fn().mockResolvedValue(undefined),
+      subscribe: vi.fn((type, listener) => {
+        listeners[type] = listener as (message: Message) => void;
+      }),
+      unsubscribe: vi.fn(),
+    } as unknown as MessageBus;
+  });
+
+  const emitResponse = (response: ToolConfirmationResponse) => {
+    const listener = listeners[MessageBusType.TOOL_CONFIRMATION_RESPONSE];
+    if (listener) {
+      listener(response);
+    }
+  };
+
+  it('should resolve when confirmed response matches correlationId', async () => {
+    const correlationId = 'test-correlation-id';
+    const abortController = new AbortController();
+
+    const promise = awaitConfirmation(
+      mockMessageBus,
+      correlationId,
+      abortController.signal,
+    );
+
+    expect(mockMessageBus.subscribe).toHaveBeenCalledWith(
+      MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+      expect.any(Function),
+    );
+
+    // Simulate response
+    emitResponse({
+      type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+      correlationId,
+      confirmed: true,
+    });
+
+    const result = await promise;
+    expect(result).toEqual({
+      outcome: ToolConfirmationOutcome.ProceedOnce,
+      payload: undefined,
+    });
+    expect(mockMessageBus.unsubscribe).toHaveBeenCalled();
+  });
+
+  it('should resolve with mapped outcome when confirmed is false', async () => {
+    const correlationId = 'id-123';
+    const abortController = new AbortController();
+
+    const promise = awaitConfirmation(
+      mockMessageBus,
+      correlationId,
+      abortController.signal,
+    );
+
+    emitResponse({
+      type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+      correlationId,
+      confirmed: false,
+    });
+
+    const result = await promise;
+    expect(result.outcome).toBe(ToolConfirmationOutcome.Cancel);
+  });
+
+  it('should resolve with explicit outcome if provided', async () => {
+    const correlationId = 'id-456';
+    const abortController = new AbortController();
+
+    const promise = awaitConfirmation(
+      mockMessageBus,
+      correlationId,
+      abortController.signal,
+    );
+
+    emitResponse({
+      type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+      correlationId,
+      confirmed: true,
+      outcome: ToolConfirmationOutcome.ProceedAlways,
+    });
+
+    const result = await promise;
+    expect(result.outcome).toBe(ToolConfirmationOutcome.ProceedAlways);
+  });
+
+  it('should resolve with payload', async () => {
+    const correlationId = 'id-payload';
+    const abortController = new AbortController();
+    const payload = { newContent: 'updated' };
+
+    const promise = awaitConfirmation(
+      mockMessageBus,
+      correlationId,
+      abortController.signal,
+    );
+
+    emitResponse({
+      type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+      correlationId,
+      confirmed: true,
+      outcome: ToolConfirmationOutcome.ModifyWithEditor,
+      payload,
+    });
+
+    const result = await promise;
+    expect(result.payload).toEqual(payload);
+  });
+
+  it('should ignore responses with different correlation IDs', async () => {
+    const correlationId = 'my-id';
+    const abortController = new AbortController();
+
+    let resolved = false;
+    const promise = awaitConfirmation(
+      mockMessageBus,
+      correlationId,
+      abortController.signal,
+    ).then((r) => {
+      resolved = true;
+      return r;
+    });
+
+    // Emit wrong ID
+    emitResponse({
+      type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+      correlationId: 'wrong-id',
+      confirmed: true,
+    });
+
+    // Allow microtasks to process
+    await new Promise((r) => setTimeout(r, 0));
+    expect(resolved).toBe(false);
+
+    // Emit correct ID
+    emitResponse({
+      type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+      correlationId,
+      confirmed: true,
+    });
+
+    await expect(promise).resolves.toBeDefined();
+  });
+
+  it('should reject when abort signal is triggered', async () => {
+    const correlationId = 'abort-id';
+    const abortController = new AbortController();
+
+    const promise = awaitConfirmation(
+      mockMessageBus,
+      correlationId,
+      abortController.signal,
+    );
+
+    abortController.abort();
+
+    await expect(promise).rejects.toThrow('Operation cancelled');
+    expect(mockMessageBus.unsubscribe).toHaveBeenCalled();
+  });
+
+  it('should reject immediately if signal is already aborted', async () => {
+    const correlationId = 'pre-abort-id';
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const promise = awaitConfirmation(
+      mockMessageBus,
+      correlationId,
+      abortController.signal,
+    );
+
+    await expect(promise).rejects.toThrow('Operation cancelled');
+    expect(mockMessageBus.subscribe).not.toHaveBeenCalled();
+  });
+
+  it('should cleanup and reject if subscribe throws', async () => {
+    const error = new Error('Subscribe failed');
+    vi.mocked(mockMessageBus.subscribe).mockImplementationOnce(() => {
+      throw error;
+    });
+
+    const abortController = new AbortController();
+    const promise = awaitConfirmation(
+      mockMessageBus,
+      'fail-id',
+      abortController.signal,
+    );
+
+    await expect(promise).rejects.toThrow(error);
+    expect(mockMessageBus.unsubscribe).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/scheduler/confirmation.ts
+++ b/packages/core/src/scheduler/confirmation.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  MessageBusType,
+  type ToolConfirmationResponse,
+} from '../confirmation-bus/types.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+import {
+  ToolConfirmationOutcome,
+  type ToolConfirmationPayload,
+} from '../tools/tools.js';
+
+export interface ConfirmationResult {
+  outcome: ToolConfirmationOutcome;
+  payload?: ToolConfirmationPayload;
+}
+
+/**
+ * Waits for a confirmation response with the matching correlationId.
+ */
+export async function awaitConfirmation(
+  messageBus: MessageBus,
+  correlationId: string,
+  signal: AbortSignal,
+): Promise<ConfirmationResult> {
+  if (signal.aborted) {
+    throw new Error('Operation cancelled');
+  }
+
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      messageBus.unsubscribe(
+        MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+        onResponse,
+      );
+      signal.removeEventListener('abort', onAbort);
+    };
+
+    const onAbort = () => {
+      cleanup();
+      reject(new Error('Operation cancelled'));
+    };
+
+    const onResponse = (msg: ToolConfirmationResponse) => {
+      if (msg.correlationId === correlationId) {
+        cleanup();
+        resolve({
+          outcome:
+            msg.outcome ??
+            // TODO: Remove legacy confirmed boolean fallback once migration complete
+            (msg.confirmed
+              ? ToolConfirmationOutcome.ProceedOnce
+              : ToolConfirmationOutcome.Cancel),
+          payload: msg.payload,
+        });
+      }
+    };
+
+    try {
+      messageBus.subscribe(
+        MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+        onResponse,
+      );
+      signal.addEventListener('abort', onAbort);
+    } catch (error) {
+      cleanup();
+      reject(error);
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Introduces a functional `awaitConfirmation` utility to handle event-driven tool
confirmation responses. This is a core component of the new event-driven
architecture for the tool scheduler.

## Related Issues

Makes progress on #14306

## How to Validate

Run the dedicated unit tests:

```bash
npx vitest packages/core/src/scheduler/confirmation.test.ts
```

Also verified via the full preflight check:

```bash
npm run preflight
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
