### PR TITLE
fix(automation): correct status/need-issue label matching wildcard

### DIFF
--- a/.github/scripts/pr-triage.sh
+++ b/.github/scripts/pr-triage.sh
@@ -68,7 +68,7 @@ process_pr_optimized() {
             fi
         else
             echo "   ⚠️  No linked issue found for PR #${PR_NUMBER}"
-            if [[ ",${CURRENT_LABELS}," != ",status/need-issue,"* ]]; then
+            if [[ ",${CURRENT_LABELS}," != *",status/need-issue,"* ]]; then
                 echo "      ➕ Adding status/need-issue label"
                 LABELS_TO_ADD="status/need-issue"
             fi
@@ -82,7 +82,7 @@ process_pr_optimized() {
     else
         echo "   🔗 Found linked issue #${ISSUE_NUMBER}"
 
-        if [[ ",${CURRENT_LABELS}," == ",status/need-issue,"* ]]; then
+        if [[ ",${CURRENT_LABELS}," == *",status/need-issue,"* ]]; then
             echo "      ➖ Removing status/need-issue label"
             LABELS_TO_REMOVE="status/need-issue"
         fi


### PR DESCRIPTION
## Summary

Fixes a bug in the PR triage script where the `status/need-issue` label was not properly detected if it wasn't the first label in the list. This caused a race condition where the workflow would attempt to re-add the label or fail to remove it when an issue was linked.

## Details

The label matching logic used `== ",status/need-issue,"*`, which assumes the label string starts with the target label. Changed it to `== *",status/need-issue,"*` to match the label anywhere in the comma-separated string.

## Related Issues

N/A - fixing a bug discovered during conversation.

## How to Validate

1. Create a PR with multiple labels, including `status/need-issue` (e.g., `bug, status/need-issue`).
2. Verify that the triage script correctly identifies the label presence and doesn't try to add it again.
3. Link an issue to the PR.
4. Verify that the triage script correctly removes the `status/need-issue` label, even if other labels are present.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
