### PR TITLE
fix: load extension context before workspace context

### DIFF
--- a/packages/core/src/utils/memoryDiscovery.test.ts
+++ b/packages/core/src/utils/memoryDiscovery.test.ts
@@ -528,6 +528,42 @@ Extension memory content
     });
   });
 
+  it('should load extension context files BEFORE user/workspace context files', async () => {
+    const extensionFilePath = await createTestFile(
+      path.join(testRootDir, 'extensions/ext1/GEMINI.md'),
+      'Extension memory content',
+    );
+    await createTestFile(
+      path.join(cwd, DEFAULT_CONTEXT_FILENAME),
+      'Workspace memory content',
+    );
+
+    const result = await loadServerHierarchicalMemory(
+      cwd,
+      [],
+      false,
+      new FileDiscoveryService(projectRoot),
+      new SimpleExtensionLoader([
+        {
+          contextFiles: [extensionFilePath],
+          isActive: true,
+        } as GeminiCLIExtension,
+      ]),
+      DEFAULT_FOLDER_TRUST,
+    );
+
+    const extensionIndex = result.memoryContent.indexOf(
+      'Extension memory content',
+    );
+    const workspaceIndex = result.memoryContent.indexOf(
+      'Workspace memory content',
+    );
+
+    expect(extensionIndex).toBeGreaterThan(-1);
+    expect(workspaceIndex).toBeGreaterThan(-1);
+    expect(extensionIndex).toBeLessThan(workspaceIndex);
+  });
+
   it('should load memory from included directories', async () => {
     const includedDir = await createEmptyDir(
       path.join(testRootDir, 'included'),

--- a/packages/core/src/utils/memoryDiscovery.ts
+++ b/packages/core/src/utils/memoryDiscovery.ts
@@ -499,7 +499,7 @@ export async function loadServerHierarchicalMemory(
   // For the server, homedir() refers to the server process's home.
   // This is consistent with how MemoryTool already finds the global path.
   const userHomePath = homedir();
-  const filePaths = await getGeminiMdFilePathsInternal(
+  const workspaceFilePaths = await getGeminiMdFilePathsInternal(
     currentWorkingDirectory,
     includeDirectoriesToReadGemini,
     userHomePath,
@@ -510,13 +510,13 @@ export async function loadServerHierarchicalMemory(
     maxDirs,
   );
 
-  // Add extension file paths separately since they may be conditionally enabled.
-  filePaths.push(
-    ...extensionLoader
-      .getExtensions()
-      .filter((ext) => ext.isActive)
-      .flatMap((ext) => ext.contextFiles),
-  );
+  const extensionFilePaths = extensionLoader
+    .getExtensions()
+    .filter((ext) => ext.isActive)
+    .flatMap((ext) => ext.contextFiles);
+
+  // Add extension file paths first so they appear before workspace context.
+  const filePaths = [...extensionFilePaths, ...workspaceFilePaths];
 
   if (filePaths.length === 0) {
     if (debugMode)


### PR DESCRIPTION
Disclaimer: This is fully vibe coded using gemini-cli with Gemini3 model. 
#pdxai

## Summary
Fixes the order of context loading so that extension context files are loaded and displayed before workspace context files. This ensures that user context can take precedence.

## Details
Previously, extension context files were appended to the end of the file list in loadServerHierarchicalMemory. This resulted in extension prompts appearing at the very bottom of the context sent to the model.

This PR modifies packages/core/src/utils/memoryDiscovery.ts to construct the file list by spreading extension paths first, followed by workspace paths: [...extensionFilePaths, ...workspaceFilePaths].

## How to Validate
Tests were added: npm test src/utils/memoryDiscovery.test.ts
Also manually verified the ordering via `/memory list` command

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- Only validated `npm run` on Linux