### PR TITLE
fix(core): resolve circular dependency via tsconfig paths

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "composite": true,
     "types": ["node", "vitest/globals"],
+    "baseUrl": ".",
     "paths": {
       "@google/gemini-cli-core": ["./index.ts"]
     }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,7 +4,10 @@
     "outDir": "dist",
     "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "composite": true,
-    "types": ["node", "vitest/globals"]
+    "types": ["node", "vitest/globals"],
+    "paths": {
+      "@google/gemini-cli-core": ["./index.ts"]
+    }
   },
   "include": ["index.ts", "src/**/*.ts", "src/**/*.json"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

Resolves a circular dependency between test-utils and core

## Details

The `packages/core` package has a circular dependency with `packages/test-utils` (which depends on `core`). When running tests in `core`, the build process could fail or run against stale artifacts because imports were resolving to `package.json` "main" (`dist/index.js`) instead of source files.

This change adds a path mapping in `packages/core/tsconfig.json` to alias `@google/gemini-cli-core` to `./index.ts`. This forces TypeScript to resolve imports to the source files during development and testing, breaking the cycle and ensuring tests run against current code.

## Related Issues
Fixes https://github.com/google-gemini/gemini-cli/issues/16732
Related to https://github.com/google-gemini/gemini-cli/pull/16047

## How to Validate

1. Checkout this branch.
2. Navigate to `packages/core`.
3. Run `npm run test` (or `vitest`).
4. Verify that tests run correctly and resolve imports without circular dependency errors.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
  - [ ] Windows
  - [ ] Linux
