### PR TITLE
fix(test-utils): resolve circular dependency

### DIFF
--- a/packages/test-utils/src/test-rig.ts
+++ b/packages/test-utils/src/test-rig.ts
@@ -11,7 +11,6 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { env } from 'node:process';
 import { setTimeout as sleep } from 'node:timers/promises';
-import { DEFAULT_GEMINI_MODEL, GEMINI_DIR } from '@google/gemini-cli-core';
 import fs from 'node:fs';
 import * as pty from '@lydell/node-pty';
 import stripAnsi from 'strip-ansi';
@@ -19,7 +18,8 @@ import * as os from 'node:os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BUNDLE_PATH = join(__dirname, '..', '..', '..', 'bundle/gemini.js');
-
+const GEMINI_DIR = '.gemini';
+const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro';
 // Get timeout based on environment
 export function getDefaultTimeout() {
   if (env['CI']) return 60000; // 1 minute in CI


### PR DESCRIPTION
## Summary

Resolves a circular dependency between `test-utils` and `core` by hardcoding `GEMINI_DIR` and `DEFAULT_GEMINI_MODEL` in `test-utils` instead of importing them from `@google/gemini-cli-core`.

## Details

Previously, `packages/test-utils/src/test-rig.ts` imported constants from `@google/gemini-cli-core`. This created a circular dependency chain. This PR breaks that chain by defining the necessary constants locally within the test utility.

## Related Issues
Fixes https://github.com/google-gemini/gemini-cli/issues/16732
<!-- None referenced -->

## How to Validate

Run the tests to ensure that the test rig still functions correctly:
```bash
npm run test:scripts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
