### PR TITLE
feat(agent): enable agent skills by default

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -285,16 +285,15 @@ export async function parseArguments(
       return true;
     });
 
-  if (settings.experimental.extensionManagement) {
+  if (settings.experimental?.extensionManagement) {
     yargsInstance.command(extensionsCommand);
   }
 
-  if (settings.experimental.skills) {
+  if (settings.skills?.enabled ?? settings.experimental?.skills ?? true) {
     yargsInstance.command(skillsCommand);
   }
-
   // Register hooks command if hooks are enabled
-  if (settings.tools.enableHooks) {
+  if (settings.tools?.enableHooks) {
     yargsInstance.command(hooksCommand);
   }
 
@@ -531,7 +530,7 @@ export async function loadCliConfig(
   // Force approval mode to default if the folder is not trusted.
   if (!trustedFolder && approvalMode !== ApprovalMode.DEFAULT) {
     debugLogger.warn(
-      `Approval mode overridden to "default" because the current folder is not trusted.`,
+      `Approval mode overridden to "default" because the current folder is not trusted.`, 
     );
     approvalMode = ApprovalMode.DEFAULT;
   }
@@ -709,7 +708,7 @@ export async function loadCliConfig(
     enableExtensionReloading: settings.experimental?.extensionReloading,
     enableAgents: settings.experimental?.enableAgents,
     plan: settings.experimental?.plan,
-    skillsSupport: settings.experimental?.skills,
+    skillsSupport: settings.skills?.enabled ?? settings.experimental?.skills ?? true,
     disabledSkills: settings.skills?.disabled,
     experimentalJitContext: settings.experimental?.jitContext,
     noBrowser: !!process.env['NO_BROWSER'],

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -289,7 +289,7 @@ export async function parseArguments(
     yargsInstance.command(extensionsCommand);
   }
 
-  if (settings.skills?.enabled ?? settings.experimental?.skills ?? true) {
+  if (settings.experimental?.skills || (settings.skills?.enabled ?? true)) {
     yargsInstance.command(skillsCommand);
   }
   // Register hooks command if hooks are enabled
@@ -530,7 +530,7 @@ export async function loadCliConfig(
   // Force approval mode to default if the folder is not trusted.
   if (!trustedFolder && approvalMode !== ApprovalMode.DEFAULT) {
     debugLogger.warn(
-      `Approval mode overridden to "default" because the current folder is not trusted.`, 
+      `Approval mode overridden to "default" because the current folder is not trusted.`,
     );
     approvalMode = ApprovalMode.DEFAULT;
   }
@@ -709,7 +709,7 @@ export async function loadCliConfig(
     enableAgents: settings.experimental?.enableAgents,
     plan: settings.experimental?.plan,
     skillsSupport:
-      settings.skills?.enabled ?? settings.experimental?.skills ?? true,
+      settings.experimental?.skills || (settings.skills?.enabled ?? true),
     disabledSkills: settings.skills?.disabled,
     experimentalJitContext: settings.experimental?.jitContext,
     noBrowser: !!process.env['NO_BROWSER'],

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -708,7 +708,8 @@ export async function loadCliConfig(
     enableExtensionReloading: settings.experimental?.extensionReloading,
     enableAgents: settings.experimental?.enableAgents,
     plan: settings.experimental?.plan,
-    skillsSupport: settings.skills?.enabled ?? settings.experimental?.skills ?? true,
+    skillsSupport:
+      settings.skills?.enabled ?? settings.experimental?.skills ?? true,
     disabledSkills: settings.skills?.disabled,
     experimentalJitContext: settings.experimental?.jitContext,
     noBrowser: !!process.env['NO_BROWSER'],

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -357,6 +357,17 @@ describe('SettingsSchema', () => {
       );
     });
 
+    it('should have skills setting enabled by default', () => {
+      const setting = getSettingsSchema().skills.properties.enabled;
+      expect(setting).toBeDefined();
+      expect(setting.type).toBe('boolean');
+      expect(setting.category).toBe('Advanced');
+      expect(setting.default).toBe(true);
+      expect(setting.requiresRestart).toBe(true);
+      expect(setting.showInDialog).toBe(true);
+      expect(setting.description).toBe('Enable Agent Skills.');
+    });
+
     it('should have plan setting in schema', () => {
       const setting = getSettingsSchema().experimental.properties.plan;
       expect(setting).toBeDefined();

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -109,6 +109,7 @@ export interface SettingDefinition {
   key?: string;
   properties?: SettingsSchema;
   showInDialog?: boolean;
+  ignoreInDocs?: boolean;
   mergeStrategy?: MergeStrategy;
   /** Enum type options  */
   options?: readonly SettingEnumOption[];
@@ -1597,6 +1598,16 @@ const SETTINGS_SCHEMA = {
     description: 'Settings for agent skills.',
     showInDialog: false,
     properties: {
+      enabled: {
+        type: 'boolean',
+        label: 'Enable Agent Skills',
+        category: 'Advanced',
+        requiresRestart: true,
+        default: true,
+        description: 'Enable Agent Skills.',
+        showInDialog: true,
+        ignoreInDocs: true,
+      },
       disabled: {
         type: 'array',
         label: 'Disabled Skills',

--- a/packages/cli/src/config/skills-backward-compatibility.test.ts
+++ b/packages/cli/src/config/skills-backward-compatibility.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { loadCliConfig, parseArguments } from './config.js';
+import * as trustedFolders from './trustedFolders.js';
+import { loadServerHierarchicalMemory } from '@google/gemini-cli-core';
+
+vi.mock('./trustedFolders.js');
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    loadServerHierarchicalMemory: vi.fn(),
+    getPty: vi.fn().mockResolvedValue({ name: 'test-pty' }),
+    getVersion: vi.fn().mockResolvedValue('0.0.0-test'),
+  };
+});
+
+describe('Agent Skills Backward Compatibility', () => {
+  const originalArgv = process.argv;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(trustedFolders.isWorkspaceTrusted).mockResolvedValue({
+      isTrusted: true,
+      reason: 'test',
+    });
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+  });
+
+  describe('loadCliConfig', () => {
+    it('should default skillsSupport to true when no settings are present', async () => {
+      vi.mocked(loadServerHierarchicalMemory).mockResolvedValue({
+        settings: {},
+        configFiles: [],
+      });
+
+      process.argv = ['node', 'gemini'];
+      const config = await loadCliConfig(
+        {},
+        'test-session',
+        await parseArguments({}),
+      );
+      expect(config.skillsSupport).toBe(true);
+    });
+
+    it('should prioritize skills.enabled=false from settings', async () => {
+      vi.mocked(loadServerHierarchicalMemory).mockResolvedValue({
+        settings: {},
+        configFiles: [],
+      });
+
+      const settings = {
+        skills: { enabled: false },
+      };
+
+      process.argv = ['node', 'gemini'];
+      const config = await loadCliConfig(
+        settings,
+        'test-session',
+        await parseArguments(settings),
+      );
+      expect(config.skillsSupport).toBe(false);
+    });
+
+    it('should support legacy experimental.skills=true from settings', async () => {
+      vi.mocked(loadServerHierarchicalMemory).mockResolvedValue({
+        settings: {},
+        configFiles: [],
+      });
+
+      const settings = {
+        experimental: { skills: true },
+      };
+
+      process.argv = ['node', 'gemini'];
+      const config = await loadCliConfig(
+        settings,
+        'test-session',
+        await parseArguments(settings),
+      );
+      expect(config.skillsSupport).toBe(true);
+    });
+
+    it('should support legacy experimental.skills=false from settings', async () => {
+      vi.mocked(loadServerHierarchicalMemory).mockResolvedValue({
+        settings: {},
+        configFiles: [],
+      });
+
+      const settings = {
+        experimental: { skills: false },
+      };
+
+      process.argv = ['node', 'gemini'];
+      const config = await loadCliConfig(
+        settings,
+        'test-session',
+        await parseArguments(settings),
+      );
+      expect(config.skillsSupport).toBe(false);
+    });
+
+    it('should prioritize new skills.enabled over legacy experimental.skills in settings', async () => {
+      vi.mocked(loadServerHierarchicalMemory).mockResolvedValue({
+        settings: {},
+        configFiles: [],
+      });
+
+      const settings = {
+        skills: { enabled: true },
+        experimental: { skills: false },
+      };
+
+      process.argv = ['node', 'gemini'];
+      const config = await loadCliConfig(
+        settings,
+        'test-session',
+        await parseArguments(settings),
+      );
+      expect(config.skillsSupport).toBe(true);
+    });
+  });
+});

--- a/packages/cli/src/config/skills-backward-compatibility.test.ts
+++ b/packages/cli/src/config/skills-backward-compatibility.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { loadCliConfig, parseArguments } from './config.js';
 import * as trustedFolders from './trustedFolders.js';
 import { loadServerHierarchicalMemory } from '@google/gemini-cli-core';
-import { createTestMergedSettings } from './settings.js';
+import { type Settings, createTestMergedSettings } from './settings.js';
 
 vi.mock('./trustedFolders.js');
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {

--- a/packages/cli/src/ui/commands/skillsCommand.test.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.test.ts
@@ -181,7 +181,7 @@ describe('skillsCommand', () => {
 
   describe('disable/enable', () => {
     beforeEach(() => {
-      context.services.settings.merged.skills = { disabled: [] };
+      context.services.settings.merged.skills = { enabled: true, disabled: [] };
       (
         context.services.settings as unknown as { workspace: { path: string } }
       ).workspace = {
@@ -234,7 +234,7 @@ describe('skillsCommand', () => {
       const enableCmd = skillsCommand.subCommands!.find(
         (s) => s.name === 'enable',
       )!;
-      context.services.settings.merged.skills = { disabled: ['skill1'] };
+      context.services.settings.merged.skills = { enabled: true, disabled: ['skill1'] };
       (
         context.services.settings as unknown as {
           workspace: { settings: { skills: { disabled: string[] } } };

--- a/packages/cli/src/ui/commands/skillsCommand.test.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.test.ts
@@ -10,7 +10,11 @@ import { MessageType, type HistoryItemSkillsList } from '../types.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import type { CommandContext } from './types.js';
 import type { Config, SkillDefinition } from '@google/gemini-cli-core';
-import { SettingScope, type LoadedSettings } from '../../config/settings.js';
+import {
+  SettingScope,
+  type LoadedSettings,
+  createTestMergedSettings,
+} from '../../config/settings.js';
 
 vi.mock('../../config/settings.js', async (importOriginal) => {
   const actual =
@@ -55,7 +59,7 @@ describe('skillsCommand', () => {
           }),
         } as unknown as Config,
         settings: {
-          merged: { skills: { disabled: [] } },
+          merged: createTestMergedSettings({ skills: { disabled: [] } }),
           workspace: { path: '/workspace' },
           setValue: vi.fn(),
         } as unknown as LoadedSettings,
@@ -181,7 +185,9 @@ describe('skillsCommand', () => {
 
   describe('disable/enable', () => {
     beforeEach(() => {
-      context.services.settings.merged.skills = { enabled: true, disabled: [] };
+      context.services.settings.merged = createTestMergedSettings({
+        skills: { enabled: true, disabled: [] },
+      });
       (
         context.services.settings as unknown as { workspace: { path: string } }
       ).workspace = {
@@ -234,7 +240,12 @@ describe('skillsCommand', () => {
       const enableCmd = skillsCommand.subCommands!.find(
         (s) => s.name === 'enable',
       )!;
-      context.services.settings.merged.skills = { enabled: true, disabled: ['skill1'] };
+      context.services.settings.merged = createTestMergedSettings({
+        skills: {
+          enabled: true,
+          disabled: ['skill1'],
+        },
+      });
       (
         context.services.settings as unknown as {
           workspace: { settings: { skills: { disabled: string[] } } };

--- a/packages/cli/src/ui/commands/skillsCommand.test.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.test.ts
@@ -14,6 +14,7 @@ import {
   SettingScope,
   type LoadedSettings,
   createTestMergedSettings,
+  type MergedSettings,
 } from '../../config/settings.js';
 
 vi.mock('../../config/settings.js', async (importOriginal) => {
@@ -185,7 +186,9 @@ describe('skillsCommand', () => {
 
   describe('disable/enable', () => {
     beforeEach(() => {
-      context.services.settings.merged = createTestMergedSettings({
+      (
+        context.services.settings as unknown as { merged: MergedSettings }
+      ).merged = createTestMergedSettings({
         skills: { enabled: true, disabled: [] },
       });
       (
@@ -240,7 +243,9 @@ describe('skillsCommand', () => {
       const enableCmd = skillsCommand.subCommands!.find(
         (s) => s.name === 'enable',
       )!;
-      context.services.settings.merged = createTestMergedSettings({
+      (
+        context.services.settings as unknown as { merged: MergedSettings }
+      ).merged = createTestMergedSettings({
         skills: {
           enabled: true,
           disabled: ['skill1'],

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1537,6 +1537,13 @@
       "default": {},
       "type": "object",
       "properties": {
+        "enabled": {
+          "title": "Enable Agent Skills",
+          "description": "Enable Agent Skills.",
+          "markdownDescription": "Enable Agent Skills.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `true`",
+          "default": true,
+          "type": "boolean"
+        },
         "disabled": {
           "title": "Disabled Skills",
           "description": "List of disabled skills.",

--- a/scripts/generate-settings-doc.ts
+++ b/scripts/generate-settings-doc.ts
@@ -133,6 +133,10 @@ function collectEntries(
         definition.properties &&
         Object.keys(definition.properties).length > 0;
 
+      if (definition.ignoreInDocs) {
+        continue;
+      }
+
       if (!hasChildren && (options.includeAll || definition.showInDialog)) {
         if (!sections.has(sectionKey)) {
           sections.set(sectionKey, []);


### PR DESCRIPTION
## Summary

This PR enables the Agent Skills feature by default. It refactors the internal settings structure to promote skills from an experimental toggle to a top-level feature while maintaining backward compatibility for documentation and user discovery.

## Details

- **Settings Refactoring**: Promotes the `skills` setting from `experimental.skills` to `skills.enabled`.
- **Default State**: Sets `skills.enabled` to `true` by default.
- **Backward Compatibility**:
    - Retains existing documentation references to `experimental.skills` to support users on older client versions until this change reaches the stable channel.
    - Keeps the Agent Skills toggle visible in the `/settings` dialog for now. This ensures users searching for the feature can confirm it is enabled.
- **Future Work**: A subsequent PR will remove the setting from the UI and fully update the documentation once this change is stable (tracked in #16734).
- **Code & Tests**: Updated internal logic in `config.ts` and added regression tests in `settingsSchema.test.ts`.

## Related Issues

Fixes #16701

## How to Validate

1. Run `npm run preflight` to ensure all tests pass.
2. Launch the CLI and verify that skills are enabled by default (e.g., check `/skills list` or see the toggle in `/settings`).
3. Verify that the system instruction includes the `activate_skill` tool when skills are discovered.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
