### PR TITLE
fix(ui): handle Ctrl+X external editor and env editor resolution

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -29,7 +29,6 @@ import {
 } from './types.js';
 import { MessageType, StreamingState } from './types.js';
 import {
-  type EditorType,
   type Config,
   type IdeInfo,
   type IdeContext,
@@ -392,8 +391,8 @@ export const AppContainer = (props: AppContainerProps) => {
   }, []);
 
   const getPreferredEditor = useCallback(
-    () => settings.merged.general.preferredEditor as EditorType,
-    [settings.merged.general.preferredEditor],
+    (): string | undefined => settings.merged.general?.preferredEditor,
+    [settings.merged.general?.preferredEditor],
   );
 
   const buffer = useTextBuffer({

--- a/packages/cli/src/ui/components/shared/text-buffer.external-editor.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.external-editor.test.ts
@@ -61,6 +61,7 @@ describe('useTextBuffer - openInExternalEditor', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it.each([
@@ -105,10 +106,6 @@ describe('useTextBuffer - openInExternalEditor', () => {
         expectedArgs,
         expect.objectContaining({ stdio: 'inherit' }),
       );
-
-      if (env) {
-        vi.unstubAllEnvs();
-      }
     },
   );
 });

--- a/packages/cli/src/ui/components/shared/text-buffer.external-editor.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.external-editor.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '../../../test-utils/render.js';
+import { useTextBuffer } from './text-buffer.js';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+// Mock dependencies
+vi.mock('node:fs');
+vi.mock('node:child_process');
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return {
+    ...actual,
+    tmpdir: vi.fn(() => '/tmp'),
+    homedir: vi.fn(() => '/mock-home'),
+  };
+});
+
+describe('useTextBuffer - openInExternalEditor', () => {
+  const mockSpawnSync = vi.mocked(spawnSync);
+  const mockMkdtempSync = vi.mocked(fs.mkdtempSync);
+  const mockReadFileSync = vi.mocked(fs.readFileSync);
+
+  function renderTextBuffer(getPreferredEditor?: () => string | undefined) {
+    return renderHook(() =>
+      useTextBuffer({
+        initialText: 'initial',
+        viewport: { width: 80, height: 24 },
+        isValidPath: () => false,
+        getPreferredEditor,
+      }),
+    );
+  }
+
+  const expectedTmpDir = path.join(os.tmpdir(), 'gemini-edit-123');
+  const expectedFilePath = path.join(expectedTmpDir, 'buffer.txt');
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Setup default mock behaviors
+    mockMkdtempSync.mockReturnValue(expectedTmpDir);
+    mockReadFileSync.mockReturnValue('edited content');
+    mockSpawnSync.mockReturnValue({
+      pid: 123,
+      output: [],
+      stdout: Buffer.from(''),
+      stderr: Buffer.from(''),
+      status: 0,
+      signal: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    {
+      name: 'command without arguments',
+      editor: 'vim',
+      expectedCmd: 'vim',
+      expectedArgs: [expectedFilePath],
+    },
+    {
+      name: 'VISUAL environment variable',
+      env: { VISUAL: 'nano' },
+      expectedCmd: 'nano',
+      expectedArgs: [expectedFilePath],
+    },
+    {
+      name: 'EDITOR environment variable',
+      env: { EDITOR: 'emacs' },
+      expectedCmd: 'emacs',
+      expectedArgs: [expectedFilePath],
+    },
+    {
+      name: 'VISUAL takes precedence over EDITOR',
+      env: { VISUAL: 'code', EDITOR: 'vim' },
+      expectedCmd: 'code',
+      expectedArgs: [expectedFilePath],
+    },
+  ])(
+    'should launch editor for $name with file path',
+    async ({ editor, env, expectedCmd, expectedArgs }) => {
+      if (env) {
+        Object.entries(env).forEach(([key, value]) => {
+          vi.stubEnv(key, value);
+        });
+      }
+      const { result } = renderTextBuffer(() => editor);
+
+      await result.current.openInExternalEditor();
+
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        expectedCmd,
+        expectedArgs,
+        expect.objectContaining({ stdio: 'inherit' }),
+      );
+
+      if (env) {
+        vi.unstubAllEnvs();
+      }
+    },
+  );
+});

--- a/packages/cli/src/ui/components/shared/text-buffer.external-editor.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.external-editor.test.ts
@@ -87,7 +87,7 @@ describe('useTextBuffer - openInExternalEditor', () => {
       name: 'VISUAL takes precedence over EDITOR',
       env: { VISUAL: 'code', EDITOR: 'vim' },
       expectedCmd: 'code',
-      expectedArgs: [expectedFilePath],
+      expectedArgs: ['--wait', expectedFilePath],
     },
   ])(
     'should launch editor for $name with file path',

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -34,7 +34,6 @@ import {
 } from '@google/gemini-cli-core';
 import type {
   Config,
-  EditorType,
   GeminiClient,
   ServerGeminiChatCompressedEvent,
   ServerGeminiContentEvent as ContentEvent,
@@ -106,7 +105,7 @@ export const useGeminiStream = (
     cmd: PartListUnion,
   ) => Promise<SlashCommandProcessorResult | false>,
   shellModeActive: boolean,
-  getPreferredEditor: () => EditorType | undefined,
+  getPreferredEditor: () => string | undefined,
   onAuthError: (error: string) => void,
   performMemoryRefresh: () => Promise<void>,
   modelSwitchedFromQuotaError: boolean,

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -19,7 +19,6 @@ import type {
   ToolCall,
   ToolCallConfirmationDetails,
   Status as CoreStatus,
-  EditorType,
 } from '@google/gemini-cli-core';
 import { CoreToolScheduler, debugLogger } from '@google/gemini-cli-core';
 import { useCallback, useState, useMemo, useEffect, useRef } from 'react';
@@ -68,7 +67,7 @@ export type CancelAllFn = (signal: AbortSignal) => void;
 export function useReactToolScheduler(
   onComplete: (tools: CompletedToolCall[]) => Promise<void>,
   config: Config,
-  getPreferredEditor: () => EditorType | undefined,
+  getPreferredEditor: () => string | undefined,
 ): [
   TrackedToolCall[],
   ScheduleFn,

--- a/packages/cli/src/ui/hooks/vim.test.tsx
+++ b/packages/cli/src/ui/hooks/vim.test.tsx
@@ -1343,6 +1343,18 @@ describe('useVim hook', () => {
         expect.objectContaining(key),
       );
     });
+
+    it.each([
+      { mode: 'NORMAL' as VimMode, key: { name: 'x', ctrl: true } },
+      { mode: 'INSERT' as VimMode, key: { name: 'x', ctrl: true } },
+    ])('should pass through ctrl+x in $mode mode', ({ mode, key }) => {
+      mockVimContext.vimMode = mode;
+      const { result } = renderVimHook();
+
+      const handled = result.current.handleInput(createKey(key));
+
+      expect(handled).toBe(false);
+    });
   });
 
   // Line operations (dd, cc) are tested in text-buffer.test.ts

--- a/packages/cli/src/ui/hooks/vim.test.tsx
+++ b/packages/cli/src/ui/hooks/vim.test.tsx
@@ -236,10 +236,24 @@ describe('useVim hook', () => {
       // Should be handled by vim hook (returned true) but NOT submitted
       expect(handled).toBe(true);
       expect(mockHandleFinalSubmit).not.toHaveBeenCalled();
-      // Should pass through to buffer.handleInput
-      expect(testBuffer.handleInput).toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'return', shift: true }),
+      // Should trigger newline
+      expect(testBuffer.newline).toHaveBeenCalled();
+    });
+
+    it('should treat "enter" key (Shift+Enter variant) as newline', () => {
+      // Some terminals (like iTerm2 or those with Kitty protocol) report
+      // Shift+Enter as name: 'enter' and sequence: '\n' instead of 'return' with shift modifier.
+      mockVimContext.vimMode = 'INSERT';
+      const testBuffer = createMockBuffer('some text');
+      const { result } = renderVimHook(testBuffer);
+
+      const handled = result.current.handleInput(
+        createKey({ name: 'enter', sequence: '\n' }),
       );
+
+      expect(handled).toBe(true);
+      expect(mockHandleFinalSubmit).not.toHaveBeenCalled();
+      expect(testBuffer.newline).toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/src/ui/hooks/vim.ts
+++ b/packages/cli/src/ui/hooks/vim.ts
@@ -9,6 +9,7 @@ import type { Key } from './useKeypress.js';
 import type { TextBuffer } from '../components/shared/text-buffer.js';
 import { useVimMode } from '../contexts/VimModeContext.js';
 import { debugLogger } from '@google/gemini-cli-core';
+import { keyMatchers, Command } from '../keyMatchers.js';
 
 export type VimMode = 'NORMAL' | 'INSERT';
 
@@ -396,6 +397,11 @@ export function useVim(buffer: TextBuffer, onSubmit?: (value: string) => void) {
       } catch (error) {
         // Handle malformed key inputs gracefully
         debugLogger.warn('Malformed key input in vim mode:', key, error);
+        return false;
+      }
+
+      // Let InputPrompt handle Ctrl+X for external editor
+      if (keyMatchers[Command.OPEN_EXTERNAL_EDITOR](normalizedKey)) {
         return false;
       }
 

--- a/packages/cli/src/ui/hooks/vim.ts
+++ b/packages/cli/src/ui/hooks/vim.ts
@@ -257,9 +257,14 @@ export function useVim(buffer: TextBuffer, onSubmit?: (value: string) => void) {
         return true;
       }
 
-      // Handle Shift+Enter explicitly to ensure it inserts a newline
-      if (keyMatchers[Command.NEWLINE](normalizedKey)) {
-        buffer.handleInput(normalizedKey);
+      // Handle Shift+Enter explicitly to ensure it inserts a newline.
+      // Note: Some terminals report Shift+Enter as 'enter' (not 'return'),
+      // while others report it as 'return' with shift=true.
+      if (
+        keyMatchers[Command.NEWLINE](normalizedKey) ||
+        normalizedKey.name === 'enter'
+      ) {
+        buffer.newline();
         return true;
       }
 

--- a/packages/cli/src/ui/hooks/vim.ts
+++ b/packages/cli/src/ui/hooks/vim.ts
@@ -257,6 +257,12 @@ export function useVim(buffer: TextBuffer, onSubmit?: (value: string) => void) {
         return true;
       }
 
+      // Handle Shift+Enter explicitly to ensure it inserts a newline
+      if (keyMatchers[Command.NEWLINE](normalizedKey)) {
+        buffer.handleInput(normalizedKey);
+        return true;
+      }
+
       // In INSERT mode, let InputPrompt handle completion keys and special commands
       if (
         normalizedKey.name === 'tab' ||
@@ -282,7 +288,8 @@ export function useVim(buffer: TextBuffer, onSubmit?: (value: string) => void) {
       if (
         normalizedKey.name === 'return' &&
         !normalizedKey.ctrl &&
-        !normalizedKey.meta
+        !normalizedKey.meta &&
+        !normalizedKey.shift
       ) {
         if (buffer.text.trim() && onSubmit) {
           // Handle command submission directly

--- a/packages/cli/src/ui/utils/terminalSetup.test.ts
+++ b/packages/cli/src/ui/utils/terminalSetup.test.ts
@@ -58,7 +58,7 @@ vi.mock('./terminalCapabilityManager.js', () => ({
 }));
 
 describe('terminalSetup', () => {
-  const originalEnv = process.env;
+  const originalEnv = { ...process.env };
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -78,7 +78,7 @@ describe('terminalSetup', () => {
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    process.env = { ...originalEnv };
   });
 
   describe('detectTerminal', () => {

--- a/packages/cli/src/ui/utils/terminalSetup.test.ts
+++ b/packages/cli/src/ui/utils/terminalSetup.test.ts
@@ -63,12 +63,17 @@ describe('terminalSetup', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     process.env = { ...originalEnv };
+    delete process.env['CURSOR_TRACE_ID'];
+    delete process.env['VSCODE_GIT_ASKPASS_MAIN'];
+    delete process.env['VSCODE_GIT_IPC_HANDLE'];
+    delete process.env['TERM_PROGRAM'];
 
     // Default mocks
     mocks.homedir.mockReturnValue('/home/user');
     mocks.platform.mockReturnValue('darwin');
     mocks.mkdir.mockResolvedValue(undefined);
     mocks.copyFile.mockResolvedValue(undefined);
+    mocks.readFile.mockRejectedValue(new Error('ENOENT'));
     mocks.exec.mockImplementation((cmd, cb) => cb(null, { stdout: '' }));
   });
 

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -15,6 +15,7 @@ import {
 } from 'vitest';
 import {
   checkHasEditorType,
+  getEditorCommand,
   getDiffCommand,
   openDiff,
   allowEditorTypeInSandbox,
@@ -147,7 +148,7 @@ describe('editor utils', () => {
           });
         }
 
-        it(`should return false if none of the commands exist on windows`, () => {
+        it('should return false if none of the commands exist on windows', () => {
           Object.defineProperty(process, 'platform', { value: 'win32' });
           (execSync as Mock).mockImplementation(() => {
             throw new Error(); // all commands not found
@@ -157,6 +158,11 @@ describe('editor utils', () => {
         });
       });
     }
+
+    it('getEditorCommand should return the editor string if it is an unknown editor type', () => {
+      // @ts-expect-error Testing unknown editor type
+      expect(getEditorCommand('unknown-editor')).toBe('unknown-editor');
+    });
   });
 
   describe('getDiffCommand', () => {

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -56,7 +56,7 @@ export function getEditorDisplayName(editor: EditorType): string {
   return EDITOR_DISPLAY_NAMES[editor] || editor;
 }
 
-function isValidEditorType(editor: string): editor is EditorType {
+export function isValidEditorType(editor: string): editor is EditorType {
   return EDITORS_SET.has(editor);
 }
 
@@ -114,6 +114,9 @@ export function checkHasEditorType(editor: EditorType): boolean {
 
 export function getEditorCommand(editor: EditorType): string {
   const commandConfig = editorCommands[editor];
+  if (!commandConfig) {
+    return editor;
+  }
   const commands =
     process.platform === 'win32' ? commandConfig.win32 : commandConfig.default;
   return (


### PR DESCRIPTION
## Summary

This PR restores the `Ctrl+X` functionality in Vim mode to trigger the external editor and refines the external editor resolution logic to fix crashes and type regressions.

## Details

- **Vim Mode Ctrl+X**: Fixes a regression where `Ctrl+X` would not trigger the external editor when Vim mode was active.
- **Editor Resolution Order**: Standardizes the resolution priority: `Settings (Preferred Editor)` > `VISUAL` > `EDITOR` > `Platform Default (notepad/vi)`.
- **Type Safety**: Fixes `EditorType` mismatches in `AppContainer.tsx` and `text-buffer.ts` introduced by upstream changes to the `useGeminiStream` hook.
- **Robustness**: 
    - Prevents CLI crashes when a user specifies an unknown editor string in settings.
    - Uses `keyMatchers` for more reliable Vim mode key detection.
- **Testing**: 
    - Added tests for `VISUAL` and `EDITOR` environment variable precedence.
    - Updated external editor tests to align with the new `getPreferredEditor` prop API.

## Related Issues

- Fixes #7258
- Related to #11532

## How to Validate

1. **Vim Mode Test**:
   - Enable Vim mode: `/mode vim`.
   - Press `Ctrl+X` while typing.
   - Verify the external editor opens with the current buffer.
2. **Environment Variable Test**:
   - `export VISUAL=nano`
   - Unset `preferredEditor` in settings.
   - Verify `nano` is used when triggering external editor.
3. **Regression Tests**:
   - Run `npm run build` to verify `EditorType` fixes.
   - Run `npx vitest packages/cli/src/ui/components/shared/text-buffer.external-editor.test.ts`
   - Run `npx vitest packages/cli/src/ui/hooks/vim.test.tsx`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
