### PR TITLE
fix(automation): prevent label-enforcer loop by ignoring all bots

### DIFF
--- a/.github/scripts/pr-triage.sh
+++ b/.github/scripts/pr-triage.sh
@@ -68,7 +68,7 @@ process_pr_optimized() {
             fi
         else
             echo "   ⚠️  No linked issue found for PR #${PR_NUMBER}"
-            if [[ ",${CURRENT_LABELS}," != ",status/need-issue,"* ]]; then
+            if [[ ",${CURRENT_LABELS}," != *",status/need-issue,"* ]]; then
                 echo "      ➕ Adding status/need-issue label"
                 LABELS_TO_ADD="status/need-issue"
             fi
@@ -82,7 +82,7 @@ process_pr_optimized() {
     else
         echo "   🔗 Found linked issue #${ISSUE_NUMBER}"
 
-        if [[ ",${CURRENT_LABELS}," == ",status/need-issue,"* ]]; then
+        if [[ ",${CURRENT_LABELS}," == *",status/need-issue,"* ]]; then
             echo "      ➖ Removing status/need-issue label"
             LABELS_TO_REMOVE="status/need-issue"
         fi

--- a/.github/workflows/label-enforcer.yml
+++ b/.github/workflows/label-enforcer.yml
@@ -39,7 +39,7 @@ jobs:
             const labelName = context.payload.label.name;
 
             // Skip if the change was made by a bot to avoid infinite loops
-            if (username === 'github-actions[bot]') {
+            if (username === 'github-actions[bot]' || username === 'gemini-cli[bot]' || username.endsWith('[bot]')) {
               core.info('Change made by a bot. Skipping.');
               return;
             }


### PR DESCRIPTION
## Summary

Fixes a critical infinite loop in the  workflow where the workflow would fight with other bots (including itself) over label application.

## Details

The workflow previously only ignored changes made by . However, when the workflow runs using the  App ID, the actions appear as . Since this bot user is not a member of the maintainers team, the workflow would revert its own changes (or changes by other bots), triggering the workflow again, leading to an infinite add/remove loop.

This change broadens the check to ignore any user ending in `[bot]`.

## Related Issues

Fixes #16205

## How to Validate

1. Trigger the workflow using a bot account (or by simulating a bot user in a test script).
2. Verify that the workflow logs "Change made by a bot. Skipping." and exits without taking action.
3. Verify that human maintainers can still add/remove labels without interference.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
  - [ ] Windows
  - [ ] Linux
