### PR TITLE
feat(automation): enforce '🔒 maintainer only' and fix bot loop

### DIFF
--- a/.github/workflows/label-enforcer.yml
+++ b/.github/workflows/label-enforcer.yml
@@ -10,7 +10,7 @@ jobs:
   enforce-label:
     # Run this job only when restricted labels are changed
     if: |-
-      ${{ (github.event.label.name == 'help wanted' || github.event.label.name == 'status/need-triage') &&
+      ${{ (github.event.label.name == 'help wanted' || github.event.label.name == 'status/need-triage' || github.event.label.name == '🔒 maintainer only') &&
           (github.repository == 'google-gemini/gemini-cli' || github.repository == 'google-gemini/maintainers-gemini-cli') }}
     runs-on: 'ubuntu-latest'
     permissions:


### PR DESCRIPTION
## Summary

This PR enhances the `label-enforcer` workflow to protect the `🔒 maintainer only` label and fixes a critical infinite loop bug involving bot accounts.

## Details

1.  **Enforce Restricted Labels**: Added `🔒 maintainer only` to the list of labels that can only be added or removed by members of the `gemini-cli-maintainers` team.
2.  **Bot Loop Prevention**: Updated the bot check to ignore any user ending in `[bot]`. This prevents the workflow from entering an infinite loop when interacting with other automated tools (like `gemini-cli[bot]`), which was previously causing hundreds of redundant comments on issues.

## Related Issues

Fixes #16205
Fixes #16741

## How to Validate

1.  **Bot Loop**: Verify that actions performed by `gemini-cli[bot]` or other bots no longer trigger a revert-loop in the logs.
2.  **Label Protection**: Attempt to remove the `🔒 maintainer only` label as a non-maintainer and verify that it is automatically re-added with a polite explanation.
3.  **Maintainer Access**: Verify that members of the maintainers team can still add/remove all protected labels without interference.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
  - [ ] Windows
  - [ ] Linux
