### PR TITLE
fix(core): prevent ModelInfo event emission on aborted signal

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -679,6 +679,34 @@ describe('Gemini Client (client.ts)', () => {
       });
     });
 
+    it('does not emit ModelInfo event if signal is aborted', async () => {
+      // Arrange
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: 'content', value: 'Hello' };
+        })(),
+      );
+
+      const controller = new AbortController();
+      controller.abort();
+
+      // Act
+      const stream = client.sendMessageStream(
+        [{ text: 'Hi' }],
+        controller.signal,
+        'prompt-id-1',
+      );
+
+      const events = await fromAsync(stream);
+
+      // Assert
+      expect(events).not.toContainEqual(
+        expect.objectContaining({
+          type: GeminiEventType.ModelInfo,
+        }),
+      );
+    });
+
     it.each([
       {
         compressionStatus:

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -627,8 +627,9 @@ export class GeminiClient {
     modelToUse = finalModel;
 
     this.currentSequenceModel = modelToUse;
-    yield { type: GeminiEventType.ModelInfo, value: modelToUse };
-
+    if (!signal.aborted) {
+      yield { type: GeminiEventType.ModelInfo, value: modelToUse };
+    }
     const resultStream = turn.run(modelConfigKey, request, linkedSignal);
     let isError = false;
     let isInvalidStream = false;


### PR DESCRIPTION
## Summary

This PR prevents the `ModelInfo` event from being emitted in `GeminiClient` if the signal has been aborted. This ensures that no model information is yielded when a request is cancelled early.

## Details
When a user cancels before the auto router finishes determining the model, it returns the default model, and this outputs "Responding with xxx model" with the default model which is not actually the case.
In `GeminiClient.sendMessageStream`, we check if the signal is aborted before yielding `GeminiEventType.ModelInfo`. This change adds a check for `!signal.aborted` immediately before yielding the event.

## Related Issues
Fixes https://github.com/google-gemini/gemini-cli/issues/16586
<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

1. Run the new regression test in `packages/core/src/core/client.test.ts`:
   ```bash
   npx vitest run packages/core/src/core/client.test.ts
   ```
2. Verify that the test "does not emit ModelInfo event if signal is aborted" passes.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
