### PR TITLE
feat(plan): add experimental 'plan' approval mode

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -1346,6 +1346,10 @@ for that specific session.
     - `auto_edit`: Automatically approve edit tools (replace, write_file) while
       prompting for others
     - `yolo`: Automatically approve all tool calls (equivalent to `--yolo`)
+    - `plan`: Read-only mode for tool calls (requires experimental planning to
+      be enabled).
+      > **Note:** This mode is currently under development and not yet fully
+      > functional.
   - Cannot be used together with `--yolo`. Use `--approval-mode=yolo` instead of
     `--yolo` for the new unified approach.
   - Example: `gemini --approval-mode auto_edit`

--- a/packages/core/src/policy/types.ts
+++ b/packages/core/src/policy/types.ts
@@ -46,6 +46,7 @@ export enum ApprovalMode {
   DEFAULT = 'default',
   AUTO_EDIT = 'autoEdit',
   YOLO = 'yolo',
+  PLAN = 'plan',
 }
 
 /**


### PR DESCRIPTION
Introduces a new 'plan' approval mode, designed to support a future read-only agent state where write operations are automatically blocked or restricted. This foundation allows the system to distinguish between normal interactive modes and this restricted planning state.

The new mode is currently gated behind the `experimental.plan` setting to prevent premature usage while the underlying policy rules are being developed. When enabled, it allows users to start the CLI in this specific mode via the `--approval-mode=plan` flag.

Closes #16618
Closes #16619
