### PR TITLE
Fix race condition by awaiting scheduleToolCalls

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -460,7 +460,7 @@ export const useGeminiStream = (
                   isClientInitiated: true,
                   prompt_id,
                 };
-                await scheduleToolCalls([toolCallRequest], abortSignal);
+                scheduleToolCalls([toolCallRequest], abortSignal);
                 return { queryToSend: null, shouldProceed: false };
               }
               case 'submit_prompt': {
@@ -923,7 +923,7 @@ export const useGeminiStream = (
         }
       }
       if (toolCallRequests.length > 0) {
-        await scheduleToolCalls(toolCallRequests, signal);
+        scheduleToolCalls(toolCallRequests, signal);
       }
       return StreamProcessingStatus.Completed;
     },

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -460,7 +460,7 @@ export const useGeminiStream = (
                   isClientInitiated: true,
                   prompt_id,
                 };
-                scheduleToolCalls([toolCallRequest], abortSignal);
+                await scheduleToolCalls([toolCallRequest], abortSignal);
                 return { queryToSend: null, shouldProceed: false };
               }
               case 'submit_prompt': {
@@ -923,7 +923,7 @@ export const useGeminiStream = (
         }
       }
       if (toolCallRequests.length > 0) {
-        scheduleToolCalls(toolCallRequests, signal);
+        await scheduleToolCalls(toolCallRequests, signal);
       }
       return StreamProcessingStatus.Completed;
     },

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -32,7 +32,7 @@ import { ToolCallStatus } from '../types.js';
 export type ScheduleFn = (
   request: ToolCallRequestInfo | ToolCallRequestInfo[],
   signal: AbortSignal,
-) => void;
+) => Promise<void>;
 export type MarkToolsAsSubmittedFn = (callIds: string[]) => void;
 
 export type TrackedScheduledToolCall = ScheduledToolCall & {
@@ -181,7 +181,7 @@ export function useReactToolScheduler(
       signal: AbortSignal,
     ) => {
       setToolCallsForDisplay([]);
-      void scheduler.schedule(request, signal);
+      return scheduler.schedule(request, signal);
     },
     [scheduler, setToolCallsForDisplay],
   );

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -32,7 +32,7 @@ import { ToolCallStatus } from '../types.js';
 export type ScheduleFn = (
   request: ToolCallRequestInfo | ToolCallRequestInfo[],
   signal: AbortSignal,
-) => Promise<void>;
+) => void;
 export type MarkToolsAsSubmittedFn = (callIds: string[]) => void;
 
 export type TrackedScheduledToolCall = ScheduledToolCall & {
@@ -181,7 +181,7 @@ export function useReactToolScheduler(
       signal: AbortSignal,
     ) => {
       setToolCallsForDisplay([]);
-      return scheduler.schedule(request, signal);
+      void scheduler.schedule(request, signal);
     },
     [scheduler, setToolCallsForDisplay],
   );

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -172,8 +172,8 @@ describe('useReactToolScheduler in YOLO Mode', () => {
       args: { data: 'any data' },
     } as any;
 
-    act(() => {
-      schedule(request, new AbortController().signal);
+    await act(async () => {
+      await schedule(request, new AbortController().signal);
     });
 
     await act(async () => {
@@ -229,11 +229,11 @@ describe('useReactToolScheduler', () => {
     schedule: (
       req: ToolCallRequestInfo | ToolCallRequestInfo[],
       signal: AbortSignal,
-    ) => void,
+    ) => Promise<void>,
     request: ToolCallRequestInfo | ToolCallRequestInfo[],
   ) => {
-    act(() => {
-      schedule(request, new AbortController().signal);
+    await act(async () => {
+      await schedule(request, new AbortController().signal);
     });
 
     await advanceAndSettle();
@@ -346,8 +346,8 @@ describe('useReactToolScheduler', () => {
       name: 'mockTool',
       args: {},
     } as any;
-    act(() => {
-      schedule(newRequest, new AbortController().signal);
+    await act(async () => {
+      await schedule(newRequest, new AbortController().signal);
     });
 
     // After scheduling, the old call should be gone,
@@ -388,8 +388,8 @@ describe('useReactToolScheduler', () => {
       args: {},
     } as any;
 
-    act(() => {
-      schedule(request, new AbortController().signal);
+    await act(async () => {
+      await schedule(request, new AbortController().signal);
     });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
@@ -520,8 +520,8 @@ describe('useReactToolScheduler', () => {
       args: { data: 'sensitive' },
     } as any;
 
-    act(() => {
-      schedule(request, new AbortController().signal);
+    await act(async () => {
+      await schedule(request, new AbortController().signal);
     });
     await advanceAndSettle();
 
@@ -567,8 +567,8 @@ describe('useReactToolScheduler', () => {
       args: {},
     } as any;
 
-    act(() => {
-      schedule(request, new AbortController().signal);
+    await act(async () => {
+      await schedule(request, new AbortController().signal);
     });
     await advanceAndSettle();
 
@@ -628,8 +628,8 @@ describe('useReactToolScheduler', () => {
       args: {},
     } as any;
 
-    act(() => {
-      result.current[1](request, new AbortController().signal);
+    await act(async () => {
+      await result.current[1](request, new AbortController().signal);
     });
     await advanceAndSettle();
 
@@ -699,8 +699,8 @@ describe('useReactToolScheduler', () => {
       { callId: 'multi2', name: 'tool2', args: { p: 2 } } as any,
     ];
 
-    act(() => {
-      schedule(requests, new AbortController().signal);
+    await act(async () => {
+      await schedule(requests, new AbortController().signal);
     });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
@@ -791,15 +791,15 @@ describe('useReactToolScheduler', () => {
       args: {},
     } as any;
 
-    act(() => {
-      schedule(request1, new AbortController().signal);
+    await act(async () => {
+      await schedule(request1, new AbortController().signal);
     });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
 
-    act(() => {
-      schedule(request2, new AbortController().signal);
+    await act(async () => {
+      await schedule(request2, new AbortController().signal);
     });
 
     await act(async () => {

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -172,8 +172,8 @@ describe('useReactToolScheduler in YOLO Mode', () => {
       args: { data: 'any data' },
     } as any;
 
-    await act(async () => {
-      await schedule(request, new AbortController().signal);
+    act(() => {
+      schedule(request, new AbortController().signal);
     });
 
     await act(async () => {
@@ -229,11 +229,11 @@ describe('useReactToolScheduler', () => {
     schedule: (
       req: ToolCallRequestInfo | ToolCallRequestInfo[],
       signal: AbortSignal,
-    ) => Promise<void>,
+    ) => void,
     request: ToolCallRequestInfo | ToolCallRequestInfo[],
   ) => {
-    await act(async () => {
-      await schedule(request, new AbortController().signal);
+    act(() => {
+      schedule(request, new AbortController().signal);
     });
 
     await advanceAndSettle();
@@ -346,8 +346,8 @@ describe('useReactToolScheduler', () => {
       name: 'mockTool',
       args: {},
     } as any;
-    await act(async () => {
-      await schedule(newRequest, new AbortController().signal);
+    act(() => {
+      schedule(newRequest, new AbortController().signal);
     });
 
     // After scheduling, the old call should be gone,
@@ -388,8 +388,8 @@ describe('useReactToolScheduler', () => {
       args: {},
     } as any;
 
-    await act(async () => {
-      await schedule(request, new AbortController().signal);
+    act(() => {
+      schedule(request, new AbortController().signal);
     });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
@@ -520,8 +520,8 @@ describe('useReactToolScheduler', () => {
       args: { data: 'sensitive' },
     } as any;
 
-    await act(async () => {
-      await schedule(request, new AbortController().signal);
+    act(() => {
+      schedule(request, new AbortController().signal);
     });
     await advanceAndSettle();
 
@@ -567,8 +567,8 @@ describe('useReactToolScheduler', () => {
       args: {},
     } as any;
 
-    await act(async () => {
-      await schedule(request, new AbortController().signal);
+    act(() => {
+      schedule(request, new AbortController().signal);
     });
     await advanceAndSettle();
 
@@ -628,8 +628,8 @@ describe('useReactToolScheduler', () => {
       args: {},
     } as any;
 
-    await act(async () => {
-      await result.current[1](request, new AbortController().signal);
+    act(() => {
+      result.current[1](request, new AbortController().signal);
     });
     await advanceAndSettle();
 
@@ -699,8 +699,8 @@ describe('useReactToolScheduler', () => {
       { callId: 'multi2', name: 'tool2', args: { p: 2 } } as any,
     ];
 
-    await act(async () => {
-      await schedule(requests, new AbortController().signal);
+    act(() => {
+      schedule(requests, new AbortController().signal);
     });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
@@ -791,15 +791,15 @@ describe('useReactToolScheduler', () => {
       args: {},
     } as any;
 
-    await act(async () => {
-      await schedule(request1, new AbortController().signal);
+    act(() => {
+      schedule(request1, new AbortController().signal);
     });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
 
-    await act(async () => {
-      await schedule(request2, new AbortController().signal);
+    act(() => {
+      schedule(request2, new AbortController().signal);
     });
 
     await act(async () => {


### PR DESCRIPTION
## Summary

We've been seeing a lot of errors like this: #16415 

This was caused by sending requests that looked something like this:

```
Role: Model
Function Call: write_file (file_1.py)
Function Call: replace (file_2.py)
Function Call: replace (file_3.py)
Function Call: run_shell_command (rm file_4.py)
Function Call: write_file (README.md)

Role: User
Function Response: write_file (Success: file_1.py)

Role: User
Function Response: write_file (Success: file_1.py)
Function Response: replace (Success: file_2.py)
Function Response: replace (Success: file_3.py)
Function Response: run_shell_command (Success: rm file_4.py)
Function Response: write_file (Success: README.md)
```

Note that we are providing the function response to the first `write_file` call twice.

My theory is that this is happening a) only in yolo mode and b) when a user queues a message via the input prompt while the tool calls are still running. 

This meant the main chat loop thought it was "done" (Idle) for a split second while the tool was still getting ready to run. Because the system briefly reported "Idle", the queued message was immediately grabbed and sent. This started a new conversation turn while the old tool turn was still happening, causing the model to get confused and the history to be fragmented.

I changed the code to await the tool scheduling. Now, the system explicitly says "I am busy (Responding)" until the tool has been fully scheduled.


## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

In order to validate, prompt the CLI with this prompt:

```
There's a race condition with you (gemini cli) where sometimes we send tool call responses prematurely or in the wrong order.

Role: Model
Function Call: write_file (file_1.py)
Function Call: replace (file_2.py)
Function Call: replace (file_3.py)
Function Call: run_shell_command (rm file_4.py)
Function Call: write_file (README.md)

Role: User
Function Response: write_file (Success: file_1.py)

Role: User
Function Response: write_file (Success: file_1.py)
Function Response: replace (Success: file_2.py)
Function Response: replace (Success: file_3.py)
Function Response: run_shell_command (Success: rm file_4.py)
Function Response: write_file (Success: README.md)


The above is an example of an invalid request we sent to the API on the backend (it does not map to any formatting you are aware of, but has been made human-readable). Can you try to reproduce this by making tool calls and editing / writing/replacing files etc? Try a bunch of different things until we get an error.
```

Then, while it's running tool calls, enqueue a message.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
