### PR TITLE
Docs: Marking for experimental features

### DIFF
--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -1,4 +1,4 @@
-# Gemini CLI hooks
+# Gemini CLI hooks (experimental)
 
 Hooks are scripts or programs that Gemini CLI executes at specific points in the
 agentic loop, allowing you to intercept and customize behavior without modifying

--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -4,7 +4,8 @@ Hooks are scripts or programs that Gemini CLI executes at specific points in the
 agentic loop, allowing you to intercept and customize behavior without modifying
 the CLI's source code.
 
-> **Note: Hooks are currently an experimental feature.**
+> [!NOTE]
+> **Hooks are currently an experimental feature.**
 >
 > To use hooks, you must explicitly enable them in your `settings.json`:
 >

--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -4,8 +4,7 @@ Hooks are scripts or programs that Gemini CLI executes at specific points in the
 agentic loop, allowing you to intercept and customize behavior without modifying
 the CLI's source code.
 
-> [!NOTE]
-> **Hooks are currently an experimental feature.**
+> [!NOTE] **Hooks are currently an experimental feature.**
 >
 > To use hooks, you must explicitly enable them in your `settings.json`:
 >

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -206,7 +206,7 @@
     ]
   },
   {
-    "label": "Hooks",
+    "label": "Hooks (experimental)",
     "items": [
       {
         "label": "Introduction",


### PR DESCRIPTION
## Summary

More clearly marks hooks as an experimental feature.

## Details

Adds the "experimental" tag to the title of the "Hooks" documentation to properly denote it as an experimental feature. 