### PR TITLE
fix(automation): robust label enforcement with permission checks

### DIFF
--- a/.github/workflows/label-enforcer.yml
+++ b/.github/workflows/label-enforcer.yml
@@ -45,22 +45,28 @@ jobs:
             }
 
             try {
-              // This will succeed with a 204 status if the user is a member,
-              // and fail with a 404 error if they are not.
-              await github.rest.teams.getMembershipForUserInOrg ({
-                org,
-                team_slug,
+              // Check repository permission level directly.
+              // This is more robust than team membership as it doesn't require Org-level read permissions
+              // and correctly handles Repo Admins/Writers who might not be in the specific team.
+              const { data: { permission } } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: org,
+                repo: context.repo.repo,
                 username,
               });
-              core.info(`${username} is a member of the ${team_slug} team. No action needed.`);
-            } catch (error) {
-              // If the error is not 404, rethrow it to fail the action
-              if (error.status !== 404) {
-                throw error;
+
+              if (permission === 'admin' || permission === 'write') {
+                core.info(`${username} has '${permission}' permission. Allowed.`);
+                return;
               }
+              
+              core.info(`${username} has '${permission}' permission (needs 'write' or 'admin'). Reverting '${action}' action for '${labelName}' label.`);
+            } catch (error) {
+              core.error(`Failed to check permissions for ${username}: ${error.message}`);
+              // Fall through to revert logic if we can't verify permissions (fail safe)
+            }
 
-              core.info(`${username} is not a member. Reverting '${action}' action for '${labelName}' label.`);
-
+            // If we are here, the user is NOT authorized.
+            if (true) { // wrapping block to preserve variable scope if needed
               if (action === 'labeled') {
                 // 1. Remove the label if added by a non-maintainer
                 await github.rest.issues.removeLabel ({

--- a/.github/workflows/label-enforcer.yml
+++ b/.github/workflows/label-enforcer.yml
@@ -58,7 +58,7 @@ jobs:
                 core.info(`${username} has '${permission}' permission. Allowed.`);
                 return;
               }
-              
+
               core.info(`${username} has '${permission}' permission (needs 'write' or 'admin'). Reverting '${action}' action for '${labelName}' label.`);
             } catch (error) {
               core.error(`Failed to check permissions for ${username}: ${error.message}`);


### PR DESCRIPTION
## Summary

Fixes the `label-enforcer` workflow to properly handle maintainer permissions and avoid bot loops, while adding protection for the `🔒 maintainer only` label.

## Details

1.  **Permission Check Fix:** Switches from checking team membership to checking repository permission levels directly (`admin` or `write`). This is more robust as it doesn't require the GitHub App to have Organization-level read permissions and correctly handles anyone with write access to the repository.
2.  **Bot Loop Prevention:** Broadens the bot check to ignore all users ending in `[bot]`. This prevents the workflow from entering an infinite loop when interacting with other automated tools (like `gemini-cli[bot]`), which was causing hundreds of redundant comments.
3.  **Label Protection:** Adds `🔒 maintainer only` to the list of protected labels.

## Related Issues

Fixes #16205
Fixes #14139
Fixes #16741

## How to Validate

1.  **Permissions:** Verify that a user with 'Write' access (like @bdmorgan) can modify protected labels without the workflow reverting them.
2.  **Bot Loop:** Verify that actions by `gemini-cli[bot]` or other bots are ignored.
3.  **Label Enforcement:** Verify that a non-maintainer cannot remove `🔒 maintainer only`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
  - [ ] Windows
  - [ ] Linux
