### PR TITLE
fix(core): truncate large telemetry log entries

### DIFF
--- a/packages/core/src/telemetry/semantic.truncation.test.ts
+++ b/packages/core/src/telemetry/semantic.truncation.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it, expect } from 'vitest';
+import { toInputMessages } from './semantic.js';
+import { type Content } from '@google/genai';
+
+// 160KB limit for the total size of string content in a log entry.
+const GLOBAL_TEXT_LIMIT = 160 * 1024;
+const SUFFIX = '...[TRUNCATED]';
+
+describe('Semantic Telemetry Truncation', () => {
+  it('should not truncate a single part if it is within global limit', () => {
+    // 150KB part -> Should fit in 160KB limit
+    const textLen = 150 * 1024;
+    const longText = 'a'.repeat(textLen);
+    const contents: Content[] = [
+      {
+        role: 'user',
+        parts: [{ text: longText }],
+      },
+    ];
+    const result = toInputMessages(contents);
+    // @ts-expect-error - testing internal state
+    expect(result[0].parts[0].content.length).toBe(textLen);
+    // @ts-expect-error - testing internal state
+    expect(result[0].parts[0].content.endsWith(SUFFIX)).toBe(false);
+  });
+
+  it('should truncate a single part if it exceeds global limit', () => {
+    // 170KB part -> Should get truncated to ~160KB
+    const textLen = 170 * 1024;
+    const longText = 'a'.repeat(textLen);
+    const contents: Content[] = [
+      {
+        role: 'user',
+        parts: [{ text: longText }],
+      },
+    ];
+    const result = toInputMessages(contents);
+    // @ts-expect-error - testing internal state
+    const content = result[0].parts[0].content;
+    expect(content.length).toBeLessThan(textLen);
+    // Because it's the only part, it gets the full budget of 160KB
+    expect(content.length).toBe(GLOBAL_TEXT_LIMIT + SUFFIX.length);
+    expect(content.endsWith(SUFFIX)).toBe(true);
+  });
+
+  it('should fairly distribute budget among multiple large parts', () => {
+    // Two 100KB parts (Total 200KB) -> Budget 160KB
+    // Each should get roughly 80KB
+    const partLen = 100 * 1024;
+    const part1 = 'a'.repeat(partLen);
+    const part2 = 'b'.repeat(partLen);
+    const contents: Content[] = [
+      { role: 'user', parts: [{ text: part1 }] },
+      { role: 'model', parts: [{ text: part2 }] },
+    ];
+
+    const result = toInputMessages(contents);
+
+    // @ts-expect-error - testing internal state
+    const c1 = result[0].parts[0].content;
+    // @ts-expect-error - testing internal state
+    const c2 = result[1].parts[0].content;
+
+    expect(c1.length).toBeLessThan(partLen);
+    expect(c2.length).toBeLessThan(partLen);
+
+    // Budget is split evenly
+    const expectedLen = Math.floor(GLOBAL_TEXT_LIMIT / 2) + SUFFIX.length;
+    expect(c1.length).toBe(expectedLen);
+    expect(c2.length).toBe(expectedLen);
+  });
+
+  it('should not truncate small parts while truncating large ones', () => {
+    // One 200KB part, one 1KB part.
+    // 1KB part is small (below average), so it keeps its size.
+    // 200KB part gets the remaining budget (128KB - 1KB = 127KB).
+    const bigLen = 200 * 1024;
+    const smallLen = 1 * 1024;
+    const bigText = 'a'.repeat(bigLen);
+    const smallText = 'b'.repeat(smallLen);
+
+    const contents: Content[] = [
+      { role: 'user', parts: [{ text: bigText }] },
+      { role: 'model', parts: [{ text: smallText }] },
+    ];
+
+    const result = toInputMessages(contents);
+    // @ts-expect-error - testing internal state
+    const cBig = result[0].parts[0].content;
+    // @ts-expect-error - testing internal state
+    const cSmall = result[1].parts[0].content;
+
+    expect(cSmall.length).toBe(smallLen); // Untouched
+    expect(cBig.length).toBeLessThan(bigLen);
+
+    const expectedBigLen = GLOBAL_TEXT_LIMIT - smallLen + SUFFIX.length;
+    expect(cBig.length).toBe(expectedBigLen);
+  });
+});

--- a/packages/core/src/utils/textUtils.test.ts
+++ b/packages/core/src/utils/textUtils.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { safeLiteralReplace } from './textUtils.js';
+import { safeLiteralReplace, truncateString } from './textUtils.js';
 
 describe('safeLiteralReplace', () => {
   it('returns original string when oldString empty or not found', () => {
@@ -75,5 +75,27 @@ describe('safeLiteralReplace', () => {
 
   it('handles newString with only dollar signs', () => {
     expect(safeLiteralReplace('abc', 'b', '$$')).toBe('a$$c');
+  });
+});
+
+describe('truncateString', () => {
+  it('should not truncate string shorter than maxLength', () => {
+    expect(truncateString('abc', 5)).toBe('abc');
+  });
+
+  it('should not truncate string equal to maxLength', () => {
+    expect(truncateString('abcde', 5)).toBe('abcde');
+  });
+
+  it('should truncate string longer than maxLength and append default suffix', () => {
+    expect(truncateString('abcdef', 5)).toBe('abcde...[TRUNCATED]');
+  });
+
+  it('should truncate string longer than maxLength and append custom suffix', () => {
+    expect(truncateString('abcdef', 5, '...')).toBe('abcde...');
+  });
+
+  it('should handle empty string', () => {
+    expect(truncateString('', 5)).toBe('');
   });
 });

--- a/packages/core/src/utils/textUtils.ts
+++ b/packages/core/src/utils/textUtils.ts
@@ -53,3 +53,21 @@ export function isBinary(
   // If no NULL bytes were found in the sample, we assume it's text.
   return false;
 }
+
+/**
+ * Truncates a string to a maximum length, appending a suffix if truncated.
+ * @param str The string to truncate.
+ * @param maxLength The maximum length of the string.
+ * @param suffix The suffix to append if truncated (default: '...[TRUNCATED]').
+ * @returns The truncated string.
+ */
+export function truncateString(
+  str: string,
+  maxLength: number,
+  suffix = '...[TRUNCATED]',
+): string {
+  if (str.length <= maxLength) {
+    return str;
+  }
+  return str.slice(0, maxLength) + suffix;
+}


### PR DESCRIPTION
## Summary

Truncate large telemetry log entries to prevent rejection by the logging endpoint (GCP) when they exceed the 256KB limit.

## Details

Introduced a `GLOBAL_TEXT_LIMIT` of 160KB for the aggregate size of all string content within a single log entry. A new `limitTotalLength` function dynamically calculates the total size and distributes the budget among "large" parts, ensuring that the total log entry size (including JSON overhead) remains safely under 256KB. This prevents data loss for large contexts while preserving as much information as possible.

## Related Issues

Fixes #11845

## How to Validate

Run the new truncation tests:
`npx vitest run packages/core/src/telemetry/semantic.truncation.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
