### PR TITLE
fix(core): ensure MCP session approvals update PolicyEngine

### DIFF
--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -895,7 +895,7 @@ describe('DiscoveredMCPTool', () => {
             // Should NOT have called update-policy
             const calls = publishSpy.mock.calls;
             const updatePolicyCalls = calls.filter(
-              (call) => call[0].type === 'update-policy',
+              (call) => (call[0] as any).type === 'update-policy',
             );
             expect(updatePolicyCalls.length).toBe(0);
           }

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -120,8 +120,13 @@ export class DiscoveredMCPToolInvocation extends BaseToolInvocation<
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         if (outcome === ToolConfirmationOutcome.ProceedAlwaysServer) {
           DiscoveredMCPToolInvocation.allowlist.add(serverAllowListKey);
-        } else if (outcome === ToolConfirmationOutcome.ProceedAlwaysTool) {
+          await this.publishPolicyUpdate(outcome);
+        } else if (
+          outcome === ToolConfirmationOutcome.ProceedAlwaysTool ||
+          outcome === ToolConfirmationOutcome.ProceedAlways
+        ) {
           DiscoveredMCPToolInvocation.allowlist.add(toolAllowListKey);
+          await this.publishPolicyUpdate(outcome);
         } else if (outcome === ToolConfirmationOutcome.ProceedAlwaysAndSave) {
           DiscoveredMCPToolInvocation.allowlist.add(toolAllowListKey);
           await this.publishPolicyUpdate(outcome);

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -120,17 +120,15 @@ export class DiscoveredMCPToolInvocation extends BaseToolInvocation<
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         if (outcome === ToolConfirmationOutcome.ProceedAlwaysServer) {
           DiscoveredMCPToolInvocation.allowlist.add(serverAllowListKey);
-          await this.publishPolicyUpdate(outcome);
         } else if (
           outcome === ToolConfirmationOutcome.ProceedAlwaysTool ||
-          outcome === ToolConfirmationOutcome.ProceedAlways
+          outcome === ToolConfirmationOutcome.ProceedAlways ||
+          outcome === ToolConfirmationOutcome.ProceedAlwaysAndSave
         ) {
           DiscoveredMCPToolInvocation.allowlist.add(toolAllowListKey);
-          await this.publishPolicyUpdate(outcome);
-        } else if (outcome === ToolConfirmationOutcome.ProceedAlwaysAndSave) {
-          DiscoveredMCPToolInvocation.allowlist.add(toolAllowListKey);
-          await this.publishPolicyUpdate(outcome);
         }
+
+        await this.publishPolicyUpdate(outcome);
       },
     };
     return confirmationDetails;

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -139,7 +139,9 @@ export abstract class BaseToolInvocation<
   ): Promise<void> {
     if (
       outcome === ToolConfirmationOutcome.ProceedAlways ||
-      outcome === ToolConfirmationOutcome.ProceedAlwaysAndSave
+      outcome === ToolConfirmationOutcome.ProceedAlwaysAndSave ||
+      outcome === ToolConfirmationOutcome.ProceedAlwaysTool ||
+      outcome === ToolConfirmationOutcome.ProceedAlwaysServer
     ) {
       if (this._toolName) {
         const options = this.getPolicyUpdateOptions(outcome);


### PR DESCRIPTION
## Summary

This PR fixes a bug where "Allow for this session" (and related MCP-specific approvals) failed to prevent subsequent tool confirmation prompts.

The issue was caused by `publishPolicyUpdate` only handling generic `ProceedAlways` and `ProceedAlwaysAndSave` outcomes. MCP tools use specific outcomes like `ProceedAlwaysTool` and `ProceedAlwaysServer`, which were correctly adding to the tool's local allowlist but **failing to update the global PolicyEngine**. As a result, the `PolicyEngine` would continue to return `ASK_USER` for subsequent calls, triggering redundant prompts.

## Details

- Updated `publishPolicyUpdate` in `BaseToolInvocation` (`packages/core/src/tools/tools.ts`) to include `ProceedAlwaysTool` and `ProceedAlwaysServer`.
- Modified `McpToolInvocation.onConfirm` to call `publishPolicyUpdate` for all "Always" outcomes.
- Ensured `ProceedAlways` is correctly handled in `McpToolInvocation`'s internal session allowlist for consistency.

## Related Issues

None.

## How to Validate

1. Start Gemini CLI in a session with at least one MCP server configured.
2. Trigger a tool call from that MCP server (e.g., "Use my-mcp-server to list files").
3. Select "Allow tool for this session" (or "Allow all server tools for this session").
4. Trigger the same tool call again.
5. **Expected:** The second call should execute immediately without prompting for confirmation.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
