### PR TITLE
test: fix failures when GEMINI_DEBUG_LOG_FILE is set

### DIFF
--- a/packages/a2a-server/src/commands/init.test.ts
+++ b/packages/a2a-server/src/commands/init.test.ts
@@ -26,10 +26,14 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   };
 });
 
-vi.mock('node:fs', () => ({
-  existsSync: vi.fn(),
-  writeFileSync: vi.fn(),
-}));
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    writeFileSync: vi.fn(),
+  };
+});
 
 vi.mock('../agent/executor.js', () => ({
   CoderAgentExecutor: vi.fn().mockImplementation(() => ({

--- a/packages/a2a-server/src/commands/init.test.ts
+++ b/packages/a2a-server/src/commands/init.test.ts
@@ -28,10 +28,17 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
-  return {
-    ...actual,
+  const mocks = {
     existsSync: vi.fn(),
     writeFileSync: vi.fn(),
+  };
+  return {
+    ...actual,
+    ...mocks,
+    default: {
+      ...actual.default,
+      ...mocks,
+    },
   };
 });
 

--- a/packages/cli/src/ui/commands/initCommand.test.ts
+++ b/packages/cli/src/ui/commands/initCommand.test.ts
@@ -15,10 +15,17 @@ import type { SubmitPromptActionReturn } from '@google/gemini-cli-core';
 // Mock the 'fs' module
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
-  return {
-    ...actual,
+  const mocks = {
     existsSync: vi.fn(),
     writeFileSync: vi.fn(),
+  };
+  return {
+    ...actual,
+    ...mocks,
+    default: {
+      ...actual.default,
+      ...mocks,
+    },
   };
 });
 

--- a/packages/cli/src/ui/commands/initCommand.test.ts
+++ b/packages/cli/src/ui/commands/initCommand.test.ts
@@ -13,10 +13,14 @@ import type { CommandContext } from './types.js';
 import type { SubmitPromptActionReturn } from '@google/gemini-cli-core';
 
 // Mock the 'fs' module
-vi.mock('fs', () => ({
-  existsSync: vi.fn(),
-  writeFileSync: vi.fn(),
-}));
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    writeFileSync: vi.fn(),
+  };
+});
 
 describe('initCommand', () => {
   let mockContext: CommandContext;

--- a/packages/cli/src/ui/utils/commandUtils.test.ts
+++ b/packages/cli/src/ui/utils/commandUtils.test.ts
@@ -40,7 +40,7 @@ vi.mock('node:fs', async (importOriginal) => {
     ...actual,
     ...mockFs,
     default: {
-      ...actual,
+      ...actual.default,
       ...mockFs,
     },
   };

--- a/packages/cli/src/ui/utils/commandUtils.test.ts
+++ b/packages/cli/src/ui/utils/commandUtils.test.ts
@@ -34,9 +34,17 @@ vi.mock('child_process');
 const mockFs = vi.hoisted(() => ({
   createWriteStream: vi.fn(),
 }));
-vi.mock('node:fs', () => ({
-  default: mockFs,
-}));
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    ...mockFs,
+    default: {
+      ...actual,
+      ...mockFs,
+    },
+  };
+});
 
 // Mock process.platform for platform-specific tests
 const mockProcess = vi.hoisted(() => ({

--- a/packages/cli/src/ui/utils/directoryUtils.test.ts
+++ b/packages/cli/src/ui/utils/directoryUtils.test.ts
@@ -36,14 +36,22 @@ vi.mock('node:os', async (importOriginal) => {
   };
 });
 
-vi.mock('node:fs', () => ({
-  existsSync: vi.fn(),
-  statSync: vi.fn(),
-}));
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    statSync: vi.fn(),
+  };
+});
 
-vi.mock('node:fs/promises', () => ({
-  opendir: vi.fn(),
-}));
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    opendir: vi.fn(),
+  };
+});
 
 interface MockDirent {
   name: string;

--- a/packages/cli/src/ui/utils/directoryUtils.test.ts
+++ b/packages/cli/src/ui/utils/directoryUtils.test.ts
@@ -38,10 +38,17 @@ vi.mock('node:os', async (importOriginal) => {
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
-  return {
-    ...actual,
+  const mocks = {
     existsSync: vi.fn(),
     statSync: vi.fn(),
+  };
+  return {
+    ...actual,
+    ...mocks,
+    default: {
+      ...actual.default,
+      ...mocks,
+    },
   };
 });
 

--- a/packages/core/src/code_assist/experiments/experiments_local.test.ts
+++ b/packages/core/src/code_assist/experiments/experiments_local.test.ts
@@ -12,12 +12,17 @@ import type { ListExperimentsResponse } from './types.js';
 import type { ClientMetadata } from '../types.js';
 
 // Mock dependencies
-vi.mock('node:fs', () => ({
-  promises: {
-    readFile: vi.fn(),
-  },
-  readFileSync: vi.fn(),
-}));
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      readFile: vi.fn(),
+    },
+    readFileSync: vi.fn(),
+  };
+});
 vi.mock('node:os');
 vi.mock('../server.js');
 vi.mock('./client_metadata.js', () => ({

--- a/packages/core/src/code_assist/experiments/experiments_local.test.ts
+++ b/packages/core/src/code_assist/experiments/experiments_local.test.ts
@@ -14,13 +14,20 @@ import type { ClientMetadata } from '../types.js';
 // Mock dependencies
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
-  return {
-    ...actual,
+  const mocks = {
     promises: {
       ...actual.promises,
       readFile: vi.fn(),
     },
     readFileSync: vi.fn(),
+  };
+  return {
+    ...actual,
+    ...mocks,
+    default: {
+      ...actual.default,
+      ...mocks,
+    },
   };
 });
 vi.mock('node:os');

--- a/packages/core/src/core/geminiChat_network_retry.test.ts
+++ b/packages/core/src/core/geminiChat_network_retry.test.ts
@@ -18,19 +18,7 @@ import { createAvailabilityServiceMock } from '../availability/testUtils.js';
 // Mock fs module
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
-  return {
-    ...actual,
-    default: {
-      ...actual,
-      mkdirSync: vi.fn(),
-      writeFileSync: vi.fn(),
-      readFileSync: vi.fn(() => {
-        const error = new Error('ENOENT');
-        (error as NodeJS.ErrnoException).code = 'ENOENT';
-        throw error;
-      }),
-      existsSync: vi.fn(() => false),
-    },
+  const mocks = {
     mkdirSync: vi.fn(),
     writeFileSync: vi.fn(),
     readFileSync: vi.fn(() => {
@@ -39,6 +27,14 @@ vi.mock('node:fs', async (importOriginal) => {
       throw error;
     }),
     existsSync: vi.fn(() => false),
+  };
+  return {
+    ...actual,
+    ...mocks,
+    default: {
+      ...actual.default,
+      ...mocks,
+    },
   };
 });
 

--- a/packages/core/src/core/geminiChat_network_retry.test.ts
+++ b/packages/core/src/core/geminiChat_network_retry.test.ts
@@ -16,8 +16,21 @@ import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 import { createAvailabilityServiceMock } from '../availability/testUtils.js';
 
 // Mock fs module
-vi.mock('node:fs', () => ({
-  default: {
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      readFileSync: vi.fn(() => {
+        const error = new Error('ENOENT');
+        (error as NodeJS.ErrnoException).code = 'ENOENT';
+        throw error;
+      }),
+      existsSync: vi.fn(() => false),
+    },
     mkdirSync: vi.fn(),
     writeFileSync: vi.fn(),
     readFileSync: vi.fn(() => {
@@ -26,8 +39,8 @@ vi.mock('node:fs', () => ({
       throw error;
     }),
     existsSync: vi.fn(() => false),
-  },
-}));
+  };
+});
 
 const { mockRetryWithBackoff } = vi.hoisted(() => ({
   mockRetryWithBackoff: vi.fn(),


### PR DESCRIPTION
## Summary

This PR fixes test failures that occur when the `GEMINI_DEBUG_LOG_FILE` environment variable is set. Several tests were using full mocks of `node:fs` which lacked the `createWriteStream` method required by the `DebugLogger` (which is initialized as a side effect in many modules).

## Details

- Updated `vi.mock('node:fs', ...)` to use `importOriginal` to ensure all original methods are available while overriding only the necessary ones.
- Affected packages: `a2a-server`, `cli`, `core`.
- Fixed mocking in:
    - `packages/cli/src/ui/commands/initCommand.test.ts`
    - `packages/cli/src/ui/utils/commandUtils.test.ts`
    - `packages/cli/src/ui/utils/directoryUtils.test.ts`
    - `packages/core/src/code_assist/experiments/experiments_local.test.ts`
    - `packages/core/src/core/geminiChat_network_retry.test.ts`
    - `packages/a2a-server/src/commands/init.test.ts`

## Related Issues

N/A

## How to Validate

1. Set the debug log environment variable: `export GEMINI_DEBUG_LOG_FILE="./gemini-debug.log"`
2. Run the affected tests:
    - `npm test -w @google/gemini-cli -- src/ui/commands/initCommand.test.ts`
    - `npm test -w @google/gemini-cli -- src/ui/utils/commandUtils.test.ts src/ui/utils/directoryUtils.test.ts`
    - `npm test -w @google/gemini-cli-core -- src/code_assist/experiments/experiments_local.test.ts src/core/geminiChat_network_retry.test.ts`
    - `npm test -w @google/gemini-cli-a2a-server -- src/commands/init.test.ts`
3. Or run the full suite: `npm run preflight`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
