### PR TITLE
Docs: Update stale model references

### DIFF
--- a/docs/get-started/configuration-v1.md
+++ b/docs/get-started/configuration-v1.md
@@ -646,7 +646,7 @@ for that specific session.
 
 - **`--model <model_name>`** (**`-m <model_name>`**):
   - Specifies the Gemini model to use for this session.
-  - Example: `npm start -- --model gemini-1.5-pro-latest`
+  - Example: `npm start -- --model gemini-2.5-pro-latest`
 - **`--prompt <your_prompt>`** (**`-p <your_prompt>`**):
   - Used to pass a prompt directly to the command. This invokes Gemini CLI in a
     non-interactive mode.

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -1101,7 +1101,7 @@ of v0.3.0:
     "usageStatisticsEnabled": true
   },
   "model": {
-    "name": "gemini-1.5-pro-latest",
+    "name": "gemini-2.5-pro-latest",
     "maxSessionTurns": 10,
     "summarizeToolOutput": {
       "run_shell_command": {
@@ -1310,7 +1310,7 @@ for that specific session.
 
 - **`--model <model_name>`** (**`-m <model_name>`**):
   - Specifies the Gemini model to use for this session.
-  - Example: `npm start -- --model gemini-1.5-pro-latest`
+  - Example: `npm start -- --model gemini-2.5-pro-latest`
 - **`--prompt <your_prompt>`** (**`-p <your_prompt>`**):
   - Used to pass a prompt directly to the command. This invokes Gemini CLI in a
     non-interactive mode.


### PR DESCRIPTION
## Summary

Update stale model references in docs (1.5 -> 2.5)

## Details

Our docs still reference the 1.5 model in our configuration files. This small PR simply updates 1.5 to 2.5 in our configuration docs, to avoid the model becoming confused when it ingests its own documentation, and to ensure that users of our configuration files are up-to-date on the current model.

## Related Issues

Fixes #11663

Note: This had been fixed before, but it looks like that commit was deleted by the contributor after failed checks. This PR replaces the deleted PR.