### PR TITLE
feat(cli): integrate slash commands with PolicyEngine and unify auth

### DIFF
--- a/packages/cli/src/services/prompt-processors/shellProcessor.test.ts
+++ b/packages/cli/src/services/prompt-processors/shellProcessor.test.ts
@@ -92,9 +92,6 @@ describe('ShellProcessor', () => {
       services: {
         config: mockConfig as Config,
       },
-      session: {
-        sessionShellAllowlist: new Set(),
-      },
     });
 
     mockShellExecute.mockReturnValue({
@@ -354,7 +351,7 @@ describe('ShellProcessor', () => {
     );
 
     // Add commands to the session allowlist (conceptually, in this test we just mock the engine allowing them)
-    context.session.sessionShellAllowlist = new Set(['cmd1', 'cmd2']);
+    context.allowedShellCommands = new Set(['cmd1', 'cmd2']);
 
     // checkCommandPermissions should now pass for these
     mockPolicyEngineCheck.mockResolvedValue({
@@ -397,7 +394,10 @@ describe('ShellProcessor', () => {
     }
 
     // 3. User Approves: Add to session allowlist (simulating UI action)
-    context.session.sessionShellAllowlist.add('echo "once"');
+    if (!context.allowedShellCommands) {
+      context.allowedShellCommands = new Set();
+    }
+    context.allowedShellCommands.add('echo "once"');
 
     // 4. Retry: calling process() again with the same context
     // Reset mocks to ensure we track new calls cleanly

--- a/packages/cli/src/services/prompt-processors/shellProcessor.ts
+++ b/packages/cli/src/services/prompt-processors/shellProcessor.ts
@@ -119,7 +119,7 @@ export class ShellProcessor implements IPromptProcessor {
 
       if (!command) continue;
 
-      if (context.session.sessionShellAllowlist?.has(command)) {
+      if (context.allowedShellCommands?.has(command)) {
         continue;
       }
 

--- a/packages/cli/src/test-utils/mockCommandContext.ts
+++ b/packages/cli/src/test-utils/mockCommandContext.ts
@@ -66,7 +66,6 @@ export const createMockCommandContext = (
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any,
     session: {
-      sessionShellAllowlist: new Set<string>(),
       stats: {
         sessionStartTime: new Date(),
         lastPromptTokenCount: 0,

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -81,9 +81,9 @@ export interface CommandContext {
   // Session-specific data
   session: {
     stats: SessionStatsState;
-    /** A transient list of shell commands the user has approved for this session. */
-    sessionShellAllowlist: Set<string>;
   };
+  /** A list of shell commands explicitly allowed for this execution. */
+  allowedShellCommands?: Set<string>;
   // Flag to indicate if an overwrite has been confirmed
   overwriteConfirmed?: boolean;
 }

--- a/packages/cli/src/ui/components/ShellConfirmationDialog.tsx
+++ b/packages/cli/src/ui/components/ShellConfirmationDialog.tsx
@@ -12,14 +12,7 @@ import { RenderInline } from '../utils/InlineMarkdownRenderer.js';
 import type { RadioSelectItem } from './shared/RadioButtonSelect.js';
 import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
 import { useKeypress } from '../hooks/useKeypress.js';
-
-export interface ShellConfirmationRequest {
-  commands: string[];
-  onConfirm: (
-    outcome: ToolConfirmationOutcome,
-    approvedCommands?: string[],
-  ) => void;
-}
+import type { ShellConfirmationRequest } from '../types.js';
 
 export interface ShellConfirmationDialogProps {
   request: ShellConfirmationRequest;
@@ -28,7 +21,8 @@ export interface ShellConfirmationDialogProps {
 export const ShellConfirmationDialog: React.FC<
   ShellConfirmationDialogProps
 > = ({ request }) => {
-  const { commands, onConfirm } = request;
+  const { commands, onConfirm, isTrustedFolder, allowPermanentApproval } =
+    request;
 
   useKeypress(
     (key) => {
@@ -43,8 +37,8 @@ export const ShellConfirmationDialog: React.FC<
     if (item === ToolConfirmationOutcome.Cancel) {
       onConfirm(item);
     } else {
-      // For both ProceedOnce and ProceedAlways, we approve all the
-      // commands that were requested.
+      // For ProceedOnce, ProceedAlways and ProceedAlwaysAndSave, we approve all
+      // the commands that were requested.
       onConfirm(item, commands);
     }
   };
@@ -60,12 +54,21 @@ export const ShellConfirmationDialog: React.FC<
       value: ToolConfirmationOutcome.ProceedAlways,
       key: 'Allow for this session',
     },
-    {
-      label: 'No (esc)',
-      value: ToolConfirmationOutcome.Cancel,
-      key: 'No (esc)',
-    },
   ];
+
+  if (isTrustedFolder && allowPermanentApproval) {
+    options.push({
+      label: 'Allow for all future sessions',
+      value: ToolConfirmationOutcome.ProceedAlwaysAndSave,
+      key: 'Allow for all future sessions',
+    });
+  }
+
+  options.push({
+    label: 'No (esc)',
+    value: ToolConfirmationOutcome.Cancel,
+    key: 'No (esc)',
+  });
 
   return (
     <Box flexDirection="row" width="100%">

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -423,6 +423,8 @@ export interface ShellConfirmationRequest {
     outcome: ToolConfirmationOutcome,
     approvedCommands?: string[],
   ) => void;
+  isTrustedFolder?: boolean;
+  allowPermanentApproval?: boolean;
 }
 
 export interface ConfirmationRequest {


### PR DESCRIPTION
## Summary

Integrates slash commands (specifically shell execution confirmations) directly with the global `PolicyEngine`, removing redundant local authorization logic. Adds support for persistent shell permissions ("Allow for all future sessions") for trusted folders.

## Details

-   **Refactored `ShellProcessor`**: Removed the redundant `sessionShellAllowlist` check. It now relies entirely on the `PolicyEngine` for authorization, preventing policy bypasses and unifying logic.
-   **Updated `CommandContext`**: Introduced `allowedShellCommands` to support transient, one-time approvals ("Proceed Once") without polluting the global or session-wide policy.
-   **Updated `useSlashCommandProcessor`**:
    -   Handles `ConfirmationRequiredError` from `ShellProcessor` (both via return types and exceptions).
    -   Updates the `PolicyEngine` (via `MessageBus`) when users select "Proceed Always" or "Proceed Always and Save".
-   **Updated `ShellConfirmationDialog`**: Added the "Allow for all future sessions" checkbox, available only when the user is in a trusted folder.
-   **Non-Interactive Mode**: Handled `ConfirmationRequiredError` in `nonInteractiveCliCommands.ts` to ensure graceful exit instead of crash.
-   **Fixed Build/Types**: Resolved build errors related to missing settings properties, `ApprovalMode` enum mismatches, and `ConfirmationRequiredError` return type compatibility.
-   **Cleaned up**: Removed unused `sessionShellAllowlist` state and types.
-   **Tests**: Updated and added tests to verify the integration between `slashCommandProcessor`, `ShellProcessor`, and `PolicyEngine`, covering both transient and persistent approval flows.

## Related Issues

N/A

## How to Validate

1.  **Proceed Once**:
    -   Run a shell command like `/policy-test hello`.
    -   Verify the confirmation dialog appears.
    -   Select "Allow once".
    -   Verify the command runs.
    -   Run `/policy-test hello` again.
    -   Verify the confirmation dialog appears *again* (proving it was one-time).

2.  **Allow for this session**:
    -   Run `/policy-test session`.
    -   Select "Allow for this session".
    -   Verify it runs.
    -   Run `/policy-test session` again.
    -   Verify it runs *without* confirmation.
    -   Restart the CLI.
    -   Run `/policy-test session`.
    -   Verify the confirmation dialog appears (proving it was session-only).

3.  **Allow for all future sessions**:
    -   Ensure you are in a trusted folder (e.g., project root).
    -   Run `/policy-test persistent`.
    -   Select "Allow for all future sessions".
    -   Verify it runs.
    -   Restart the CLI.
    -   Run `/policy-test persistent`.
    -   Verify it runs *without* confirmation.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
