### PR TITLE
fix(hooks): enable /hooks disable to reliably stop single hooks

### DIFF
--- a/packages/cli/src/ui/commands/hooksCommand.test.ts
+++ b/packages/cli/src/ui/commands/hooksCommand.test.ts
@@ -22,7 +22,7 @@ describe('hooksCommand', () => {
   let mockConfig: {
     getHookSystem: ReturnType<typeof vi.fn>;
     getEnableHooks: ReturnType<typeof vi.fn>;
-    updateHooks: ReturnType<typeof vi.fn>;
+    updateDisabledHooks: ReturnType<typeof vi.fn>;
   };
   let mockSettings: {
     merged: {
@@ -52,7 +52,7 @@ describe('hooksCommand', () => {
     mockConfig = {
       getHookSystem: vi.fn().mockReturnValue(mockHookSystem),
       getEnableHooks: vi.fn().mockReturnValue(true),
-      updateHooks: vi.fn(),
+      updateDisabledHooks: vi.fn(),
     };
 
     // Create mock settings
@@ -449,7 +449,7 @@ describe('hooksCommand', () => {
         'test-hook',
         false,
       );
-      expect(mockConfig.updateHooks).toHaveBeenCalled();
+      expect(mockConfig.updateDisabledHooks).toHaveBeenCalled();
       expect(result).toEqual({
         type: 'message',
         messageType: 'info',

--- a/packages/cli/src/ui/commands/hooksCommand.test.ts
+++ b/packages/cli/src/ui/commands/hooksCommand.test.ts
@@ -22,6 +22,7 @@ describe('hooksCommand', () => {
   let mockConfig: {
     getHookSystem: ReturnType<typeof vi.fn>;
     getEnableHooks: ReturnType<typeof vi.fn>;
+    updateHooks: ReturnType<typeof vi.fn>;
   };
   let mockSettings: {
     merged: {
@@ -51,6 +52,7 @@ describe('hooksCommand', () => {
     mockConfig = {
       getHookSystem: vi.fn().mockReturnValue(mockHookSystem),
       getEnableHooks: vi.fn().mockReturnValue(true),
+      updateHooks: vi.fn(),
     };
 
     // Create mock settings
@@ -429,7 +431,7 @@ describe('hooksCommand', () => {
       });
     });
 
-    it('should return info when hook is already disabled', async () => {
+    it('should synchronize with hook system even if hook is already in disabled list', async () => {
       // Update the context's settings with the hook already disabled
       mockContext.services.settings.merged.hooks.disabled = ['test-hook'];
 
@@ -443,11 +445,15 @@ describe('hooksCommand', () => {
       const result = await disableCmd.action(mockContext, 'test-hook');
 
       expect(mockContext.services.settings.setValue).not.toHaveBeenCalled();
-      expect(mockHookSystem.setHookEnabled).not.toHaveBeenCalled();
+      expect(mockHookSystem.setHookEnabled).toHaveBeenCalledWith(
+        'test-hook',
+        false,
+      );
+      expect(mockConfig.updateHooks).toHaveBeenCalled();
       expect(result).toEqual({
         type: 'message',
         messageType: 'info',
-        content: 'Hook "test-hook" is already disabled.',
+        content: 'Hook "test-hook" disabled successfully.',
       });
     });
 

--- a/packages/cli/src/ui/commands/hooksCommand.ts
+++ b/packages/cli/src/ui/commands/hooksCommand.ts
@@ -90,7 +90,7 @@ async function enableAction(
     settings.setValue(scope, 'hooks.disabled', newDisabledHooks);
 
     // Update core config so re-initialization (e.g. extension reload) respects the change
-    config.updateHooks(settings.merged.hooks);
+    config.updateDisabledHooks(settings.merged.hooks.disabled);
 
     // Enable in hook system
     hookSystem.setHookEnabled(hookName, true);
@@ -158,7 +158,7 @@ async function disableAction(
     }
 
     // Update core config so re-initialization (e.g. extension reload) respects the change
-    config.updateHooks(settings.merged.hooks);
+    config.updateDisabledHooks(settings.merged.hooks.disabled);
 
     // Always disable in hook system to ensure in-memory state matches settings
     hookSystem.setHookEnabled(hookName, false);
@@ -253,7 +253,7 @@ async function enableAllAction(
     settings.setValue(scope, 'hooks.disabled', []);
 
     // Update core config so re-initialization (e.g. extension reload) respects the change
-    config.updateHooks(settings.merged.hooks);
+    config.updateDisabledHooks(settings.merged.hooks.disabled);
 
     for (const hook of disabledHooks) {
       const hookName = getHookDisplayName(hook);
@@ -326,7 +326,7 @@ async function disableAllAction(
     settings.setValue(scope, 'hooks.disabled', allHookNames);
 
     // Update core config so re-initialization (e.g. extension reload) respects the change
-    config.updateHooks(settings.merged.hooks);
+    config.updateDisabledHooks(settings.merged.hooks.disabled);
 
     for (const hook of enabledHooks) {
       const hookName = getHookDisplayName(hook);

--- a/packages/cli/src/ui/commands/hooksCommand.ts
+++ b/packages/cli/src/ui/commands/hooksCommand.ts
@@ -89,6 +89,9 @@ async function enableAction(
       : SettingScope.User;
     settings.setValue(scope, 'hooks.disabled', newDisabledHooks);
 
+    // Update core config so re-initialization (e.g. extension reload) respects the change
+    config.updateHooks(settings.merged.hooks);
+
     // Enable in hook system
     hookSystem.setHookEnabled(hookName, true);
 
@@ -144,36 +147,32 @@ async function disableAction(
   const settings = context.services.settings;
   const disabledHooks = settings.merged.hooks.disabled;
   // Add to disabled list if not already present
-  if (!disabledHooks.includes(hookName)) {
-    const newDisabledHooks = [...disabledHooks, hookName];
+  try {
+    if (!disabledHooks.includes(hookName)) {
+      const newDisabledHooks = [...disabledHooks, hookName];
 
-    // Update settings (setValue automatically saves)
-    try {
       const scope = settings.workspace
         ? SettingScope.Workspace
         : SettingScope.User;
       settings.setValue(scope, 'hooks.disabled', newDisabledHooks);
-
-      // Disable in hook system
-      hookSystem.setHookEnabled(hookName, false);
-
-      return {
-        type: 'message',
-        messageType: 'info',
-        content: `Hook "${hookName}" disabled successfully.`,
-      };
-    } catch (error) {
-      return {
-        type: 'message',
-        messageType: 'error',
-        content: `Failed to disable hook: ${getErrorMessage(error)}`,
-      };
     }
-  } else {
+
+    // Update core config so re-initialization (e.g. extension reload) respects the change
+    config.updateHooks(settings.merged.hooks);
+
+    // Always disable in hook system to ensure in-memory state matches settings
+    hookSystem.setHookEnabled(hookName, false);
+
     return {
       type: 'message',
       messageType: 'info',
-      content: `Hook "${hookName}" is already disabled.`,
+      content: `Hook "${hookName}" disabled successfully.`,
+    };
+  } catch (error) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: `Failed to disable hook: ${getErrorMessage(error)}`,
     };
   }
 }
@@ -253,6 +252,9 @@ async function enableAllAction(
       : SettingScope.User;
     settings.setValue(scope, 'hooks.disabled', []);
 
+    // Update core config so re-initialization (e.g. extension reload) respects the change
+    config.updateHooks(settings.merged.hooks);
+
     for (const hook of disabledHooks) {
       const hookName = getHookDisplayName(hook);
       hookSystem.setHookEnabled(hookName, true);
@@ -322,6 +324,9 @@ async function disableAllAction(
       ? SettingScope.Workspace
       : SettingScope.User;
     settings.setValue(scope, 'hooks.disabled', allHookNames);
+
+    // Update core config so re-initialization (e.g. extension reload) respects the change
+    config.updateHooks(settings.merged.hooks);
 
     for (const hook of enabledHooks) {
       const hookName = getHookDisplayName(hook);

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1842,6 +1842,45 @@ describe('Availability Service Integration', () => {
   });
 });
 
+describe('Hooks configuration', () => {
+  const baseParams: ConfigParameters = {
+    sessionId: 'test',
+    targetDir: '.',
+    debugMode: false,
+    model: 'test-model',
+    cwd: '.',
+    hooks: { disabled: ['initial-hook'] },
+  };
+
+  it('updateHooks should update hooks and disabled list', () => {
+    const config = new Config(baseParams);
+    expect(config.getDisabledHooks()).toEqual(['initial-hook']);
+
+    const newHooks = {
+      disabled: ['new-hook-1', 'new-hook-2'],
+      BeforeAgent: [],
+    };
+
+    config.updateHooks(newHooks);
+
+    expect(config.getDisabledHooks()).toEqual(['new-hook-1', 'new-hook-2']);
+    expect(config.getHooks()).toEqual(newHooks);
+  });
+
+  it('updateHooks should handle missing disabled property gracefully', () => {
+    const config = new Config(baseParams);
+    const newHooks = {
+      BeforeAgent: [],
+    };
+
+    config.updateHooks(newHooks);
+
+    // Should keep previous disabled hooks if not provided in new object
+    expect(config.getDisabledHooks()).toEqual(['initial-hook']);
+    expect(config.getHooks()).toEqual(newHooks);
+  });
+});
+
 describe('Config Quota & Preview Model Access', () => {
   let config: Config;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1532,40 +1532,16 @@ describe('Config getHooks', () => {
   });
 
   it('should return the hooks configuration when provided', () => {
-    const mockHooks: { [K in HookEventName]?: HookDefinition[] } = {
-      [HookEventName.BeforeTool]: [
+    const mockHooks = {
+      BeforeTool: [
         {
-          matcher: 'write_file',
-          hooks: [
-            {
-              type: HookType.Command,
-              command: 'echo "test hook"',
-              timeout: 5000,
-            },
-          ],
-        },
-      ],
-      [HookEventName.AfterTool]: [
-        {
-          hooks: [
-            {
-              type: HookType.Command,
-              command: './hooks/after-tool.sh',
-              timeout: 10000,
-            },
-          ],
+          hooks: [{ type: HookType.Command, command: 'echo 1' }],
         },
       ],
     };
-
-    const config = new Config({
-      ...baseParams,
-      hooks: mockHooks,
-    });
-
+    const config = new Config({ ...baseParams, hooks: mockHooks });
     const retrievedHooks = config.getHooks();
     expect(retrievedHooks).toEqual(mockHooks);
-    expect(retrievedHooks).toBe(mockHooks); // Should return the same reference
   });
 
   it('should return hooks with all supported event types', () => {
@@ -1852,32 +1828,30 @@ describe('Hooks configuration', () => {
     hooks: { disabled: ['initial-hook'] },
   };
 
-  it('updateHooks should update hooks and disabled list', () => {
+  it('updateDisabledHooks should update the disabled list', () => {
     const config = new Config(baseParams);
     expect(config.getDisabledHooks()).toEqual(['initial-hook']);
 
-    const newHooks = {
-      disabled: ['new-hook-1', 'new-hook-2'],
-      BeforeAgent: [],
-    };
-
-    config.updateHooks(newHooks);
+    const newDisabled = ['new-hook-1', 'new-hook-2'];
+    config.updateDisabledHooks(newDisabled);
 
     expect(config.getDisabledHooks()).toEqual(['new-hook-1', 'new-hook-2']);
-    expect(config.getHooks()).toEqual(newHooks);
   });
 
-  it('updateHooks should handle missing disabled property gracefully', () => {
-    const config = new Config(baseParams);
-    const newHooks = {
-      BeforeAgent: [],
+  it('updateDisabledHooks should only update disabled list and not definitions', () => {
+    const initialHooks = {
+      BeforeAgent: [
+        {
+          hooks: [{ type: HookType.Command, command: 'initial' }],
+        },
+      ],
     };
+    const config = new Config({ ...baseParams, hooks: initialHooks });
 
-    config.updateHooks(newHooks);
+    config.updateDisabledHooks(['some-hook']);
 
-    // Should keep previous disabled hooks if not provided in new object
-    expect(config.getDisabledHooks()).toEqual(['initial-hook']);
-    expect(config.getHooks()).toEqual(newHooks);
+    expect(config.getDisabledHooks()).toEqual(['some-hook']);
+    expect(config.getHooks()).toEqual(initialHooks);
   });
 });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -511,13 +511,11 @@ export class Config {
   private pendingIncludeDirectories: string[];
   private readonly enableHooks: boolean;
   private readonly enableHooksUI: boolean;
-  private readonly hooks:
-    | { [K in HookEventName]?: HookDefinition[] }
-    | undefined;
-  private readonly projectHooks:
+  private hooks: { [K in HookEventName]?: HookDefinition[] } | undefined;
+  private projectHooks:
     | ({ [K in HookEventName]?: HookDefinition[] } & { disabled?: string[] })
     | undefined;
-  private readonly disabledHooks: string[];
+  private disabledHooks: string[];
   private experiments: Experiments | undefined;
   private experimentsPromise: Promise<void> | undefined;
   private hookSystem?: HookSystem;
@@ -1928,6 +1926,20 @@ export class Config {
     | ({ [K in HookEventName]?: HookDefinition[] } & { disabled?: string[] })
     | undefined {
     return this.projectHooks;
+  }
+
+  /**
+   * Update hooks configuration dynamically
+   */
+  updateHooks(
+    hooks: { [K in HookEventName]?: HookDefinition[] } & {
+      disabled?: string[];
+    },
+  ): void {
+    this.hooks = hooks;
+    if (Array.isArray(hooks.disabled)) {
+      this.disabledHooks = hooks.disabled;
+    }
   }
 
   /**

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -708,8 +708,15 @@ export class Config {
     };
     this.retryFetchErrors = params.retryFetchErrors ?? false;
     this.disableYoloMode = params.disableYoloMode ?? false;
-    this.hooks = params.hooks;
-    this.projectHooks = params.projectHooks;
+
+    if (params.hooks) {
+      const { disabled: _, ...restOfHooks } = params.hooks;
+      this.hooks = restOfHooks;
+    }
+    if (params.projectHooks) {
+      this.projectHooks = params.projectHooks;
+    }
+
     this.experiments = params.experiments;
     this.onModelChange = params.onModelChange;
     this.onReload = params.onReload;
@@ -1929,16 +1936,13 @@ export class Config {
   }
 
   /**
-   * Update hooks configuration dynamically
+   * Update the list of disabled hooks dynamically.
+   * This is used to keep the running system in sync with settings changes
+   * without risk of loading new hook definitions into memory.
    */
-  updateHooks(
-    hooks: { [K in HookEventName]?: HookDefinition[] } & {
-      disabled?: string[];
-    },
-  ): void {
-    this.hooks = hooks;
-    if (Array.isArray(hooks.disabled)) {
-      this.disabledHooks = hooks.disabled;
+  updateDisabledHooks(disabledHooks: string[]): void {
+    if (Array.isArray(disabledHooks)) {
+      this.disabledHooks = disabledHooks;
     }
   }
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1941,9 +1941,7 @@ export class Config {
    * without risk of loading new hook definitions into memory.
    */
   updateDisabledHooks(disabledHooks: string[]): void {
-    if (Array.isArray(disabledHooks)) {
-      this.disabledHooks = disabledHooks;
-    }
+    this.disabledHooks = disabledHooks;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes a bug where disabling a single hook using `/hooks disable <name>` failed to stop the hook from firing during the current session, and would be reverted after any hook system re-initialization (e.g., extension reload or memory refresh).

## Details

- **Immediate Fix**: Updated `/hooks disable` command logic to always notify the running hook system to stop the hook, even if it is already present in the `disabled` list in `settings.json`. This ensures memory state immediately matches disk state.
- **Persistence Fix**: Added an `updateHooks` method to the core `Config` class. This allows the CLI to push runtime hook configuration changes down to the core package.
- **Re-initialization Sync**: Integrated `config.updateHooks` into all `/hooks` management commands. This ensures that when the hook registry is re-initialized (which happens during extension loads/reloads), it uses the most up-to-date session configuration instead of stale startup parameters.
- **Type Safety**: Ensured `updateHooks` respects the existing `Config` and `HookEventName` types.

## Related Issues

Fixes bug where `/hooks disable` was ineffective for single hooks while `/hooks disable-all` worked correctly.

## How to Validate

1. Configure a hook in your project settings.
2. Start Gemini CLI and verify the hook fires.
3. Run `/hooks disable <hook-name>`.
4. Verify the "disabled successfully" message and confirm the hook no longer fires.
5. Run `/memory refresh` (which triggers hook re-initialization).
6. Verify the hook remains disabled.
7. Run the updated test suites:
   - `npm test -w @google/gemini-cli -- src/ui/commands/hooksCommand.test.ts`
   - `npm test -w @google/gemini-cli-core -- src/config/config.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
