### PR TITLE
fix(infra): update maintainer rollup label to 'workstream-rollup'

### DIFF
--- a/.github/scripts/sync-maintainer-labels.cjs
+++ b/.github/scripts/sync-maintainer-labels.cjs
@@ -23,7 +23,7 @@ const ROOT_ISSUES = [
   { owner: REPO_OWNER, repo: PUBLIC_REPO, number: 15324 },
 ];
 
-const TARGET_LABEL = '🔒 maintainer only';
+const TARGET_LABEL = 'workstream-rollup';
 const isDryRun =
   process.argv.includes('--dry-run') || process.env.DRY_RUN === 'true';
 

--- a/.github/workflows/label-backlog-child-issues.yml
+++ b/.github/workflows/label-backlog-child-issues.yml
@@ -6,12 +6,6 @@ on:
   schedule:
     - cron: '0 * * * *' # Run every hour
   workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Run in dry-run mode (no labels applied)'
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   issues: 'write'
@@ -60,5 +54,4 @@ jobs:
       - name: 'Run Multi-Repo Sync Script'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          DRY_RUN: '${{ inputs.dry_run }}'
         run: 'node .github/scripts/sync-maintainer-labels.cjs'

--- a/.github/workflows/label-backlog-child-issues.yml
+++ b/.github/workflows/label-backlog-child-issues.yml
@@ -6,6 +6,12 @@ on:
   schedule:
     - cron: '0 * * * *' # Run every hour
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode (no labels applied)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   issues: 'write'
@@ -54,4 +60,5 @@ jobs:
       - name: 'Run Multi-Repo Sync Script'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          DRY_RUN: '${{ inputs.dry_run }}'
         run: 'node .github/scripts/sync-maintainer-labels.cjs'


### PR DESCRIPTION
## Summary

Updates the `.github/scripts/sync-maintainer-labels.cjs` script to use the `workstream-rollup` label instead of `🔒 maintainer only`. This ensures that child issues are correctly labeled for project rollup tracking.

## Details

The sync script was previously configured to apply a maintainer-only label. This change aligns the script with the current workflow requirement to use `workstream-rollup` for grouping child issues under parent epics.

## Related Issues

Related to https://github.com/google-gemini/gemini-cli/issues/16802

## How to Validate

1. **Dry Run Validation**:
   - Run the updated script locally in dry-run mode:
     ```bash
     DRY_RUN=true node .github/scripts/sync-maintainer-labels.cjs
     ```
   - Verify in the output that it attempts to label issues with `workstream-rollup` (or notes missing labels).

2. **Workflow Verification**:
   - Manually trigger the "Label Child Issues for Project Rollup" workflow on this branch (once pushed).
   - Check the logs to confirm it targets the correct label.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
