### PR TITLE
chore(workflows): rename label-workstream-rollup workflow

### DIFF
--- a/.github/scripts/sync-maintainer-labels.cjs
+++ b/.github/scripts/sync-maintainer-labels.cjs
@@ -23,7 +23,7 @@ const ROOT_ISSUES = [
   { owner: REPO_OWNER, repo: PUBLIC_REPO, number: 15324 },
 ];
 
-const TARGET_LABEL = 'workstream-rollup';
+const TARGET_LABEL = '🔒 maintainer only';
 const isDryRun =
   process.argv.includes('--dry-run') || process.env.DRY_RUN === 'true';
 

--- a/.github/workflows/label-workstream-rollup.yml
+++ b/.github/workflows/label-workstream-rollup.yml
@@ -76,7 +76,7 @@ jobs:
 
             for (const issue of issuesToProcess) {
               const parentUrl = await getIssueParent(issue.owner, issue.repo, issue.number);
-              
+
               if (parentUrl && allowedParentUrls.includes(parentUrl)) {
                 console.log(`SUCCESS: Issue #${issue.number} is a direct child of ${parentUrl}. Adding label.`);
                 await github.rest.issues.addLabels({

--- a/.github/workflows/label-workstream-rollup.yml
+++ b/.github/workflows/label-workstream-rollup.yml
@@ -1,0 +1,94 @@
+name: 'Label Child Issues for Project Rollup'
+
+on:
+  issues:
+    types: ['opened', 'edited', 'reopened']
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  labeler:
+    runs-on: 'ubuntu-latest'
+    permissions:
+      issues: 'write'
+    steps:
+      - name: 'Check for Parent Workstream and Apply Label'
+        uses: 'actions/github-script@v7'
+        with:
+          script: |
+            const labelToAdd = 'workstream-rollup';
+            
+            // Allow-list of parent issue URLs
+            const allowedParentUrls = [
+              'https://github.com/google-gemini/gemini-cli/issues/15374',
+              'https://github.com/google-gemini/gemini-cli/issues/15456',
+              'https://github.com/google-gemini/gemini-cli/issues/15324'
+            ];
+
+            async function getIssueParent(owner, repo, number) {
+              const query = `
+                query($owner:String!, $repo:String!, $number:Int!) {
+                  repository(owner:$owner, name:$repo) {
+                    issue(number:$number) {
+                      parent {
+                        url
+                      }
+                    }
+                  }
+                }
+              `;
+              try {
+                const result = await github.graphql(query, { owner, repo, number });
+                return result.repository.issue.parent ? result.repository.issue.parent.url : null;
+              } catch (error) {
+                console.error(`Failed to fetch parent for #${number}:`, error);
+                return null;
+              }
+            }
+
+            // Determine which issues to process
+            let issuesToProcess = [];
+            
+            if (context.eventName === 'issues') {
+               // Context payload for 'issues' event already has the issue object
+               issuesToProcess.push({
+                 number: context.payload.issue.number,
+                 owner: context.repo.owner,
+                 repo: context.repo.repo
+               });
+            } else {
+              // For schedule/dispatch, fetch open issues (lightweight list)
+              console.log(`Running for event: ${context.eventName}. Fetching open issues...`);
+              const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open'
+              });
+              issuesToProcess = openIssues.map(i => ({
+                number: i.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              }));
+            }
+
+            console.log(`Processing ${issuesToProcess.length} issue(s)...`);
+
+            for (const issue of issuesToProcess) {
+              const parentUrl = await getIssueParent(issue.owner, issue.repo, issue.number);
+              
+              if (parentUrl && allowedParentUrls.includes(parentUrl)) {
+                console.log(`SUCCESS: Issue #${issue.number} is a direct child of ${parentUrl}. Adding label.`);
+                await github.rest.issues.addLabels({
+                  owner: issue.owner,
+                  repo: issue.repo,
+                  issue_number: issue.number,
+                  labels: [labelToAdd]
+                });
+              } else {
+                 // logging only for single execution to avoid spam
+                 if (context.eventName === 'issues') {
+                    console.log(`Issue #${issue.number} parent is ${parentUrl || 'None'}. No action.`);
+                 }
+              }
+            }

--- a/.github/workflows/label-workstream-rollup.yml
+++ b/.github/workflows/label-workstream-rollup.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           script: |
             const labelToAdd = 'workstream-rollup';
-            
+
             // Allow-list of parent issue URLs
             const allowedParentUrls = [
               'https://github.com/google-gemini/gemini-cli/issues/15374',
@@ -49,7 +49,7 @@ jobs:
 
             // Determine which issues to process
             let issuesToProcess = [];
-            
+
             if (context.eventName === 'issues') {
                // Context payload for 'issues' event already has the issue object
                issuesToProcess.push({

--- a/.github/workflows/label-workstream-rollup.yml
+++ b/.github/workflows/label-workstream-rollup.yml
@@ -1,4 +1,4 @@
-name: 'Label Child Issues for Project Rollup'
+name: 'Label Workstream Rollup'
 
 on:
   issues:


### PR DESCRIPTION
## Summary

Renames the 'Label Child Issues for Project Rollup' workflow to 'Label Workstream Rollup' to better reflect its purpose and match the filename.

## Details

The workflow file `.github/workflows/label-workstream-rollup.yml` was previously named 'Label Child Issues for Project Rollup'. This change updates the `name` field to 'Label Workstream Rollup'.

## Related Issues

Related to #16811 (which fixed linting issues in this file).

## How to Validate

1. Inspect the `.github/workflows/label-workstream-rollup.yml` file.
2. Verify the `name` field is updated.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run (preflight)
  - [ ] Windows
  - [ ] Linux
