### PR TITLE
skip simple-mcp-server.test.ts

### DIFF
--- a/integration-tests/simple-mcp-server.test.ts
+++ b/integration-tests/simple-mcp-server.test.ts
@@ -164,7 +164,7 @@ rpc.send({
 });
 `;
 
-describe('simple-mcp-server', () => {
+describe.skip('simple-mcp-server', () => {
   let rig: TestRig;
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Skip simple-mcp-server.test.ts.

## Details

The simple-mcp-server.test.ts seems very flakey all of a sudden. It blocked merging on [my PR](https://github.com/google-gemini/gemini-cli/pull/16798) 3 times and [PR](https://github.com/google-gemini/gemini-cli/pull/16759) once.

## Related Issues

For #16843
