### PR TITLE
fix(core): surface warnings for invalid hook event names in configuration (#16788)

### DIFF
--- a/packages/core/src/hooks/hookRegistry.ts
+++ b/packages/core/src/hooks/hookRegistry.ts
@@ -6,7 +6,7 @@
 
 import type { Config } from '../config/config.js';
 import type { HookDefinition, HookConfig } from './types.js';
-import { HookEventName, ConfigSource } from './types.js';
+import { HookEventName, ConfigSource, HOOKS_CONFIG_FIELDS } from './types.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { TrustedHooksManager } from './trustedHooks.js';
 import { coreEvents } from '../utils/events.js';
@@ -169,8 +169,15 @@ please review the project settings (.gemini/settings.json) and remove them.`;
     source: ConfigSource,
   ): void {
     for (const [eventName, definitions] of Object.entries(hooksConfig)) {
+      if (HOOKS_CONFIG_FIELDS.includes(eventName)) {
+        continue;
+      }
+
       if (!this.isValidEventName(eventName)) {
-        debugLogger.warn(`Invalid hook event name: ${eventName}`);
+        coreEvents.emitFeedback(
+          'warning',
+          `Invalid hook event name: "${eventName}" from ${source} config. Skipping.`,
+        );
         continue;
       }
 

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -45,6 +45,11 @@ export enum HookEventName {
 }
 
 /**
+ * Fields in the hooks configuration that are not hook event names
+ */
+export const HOOKS_CONFIG_FIELDS = ['enabled', 'disabled', 'notifications'];
+
+/**
  * Hook configuration entry
  */
 export interface CommandHookConfig {


### PR DESCRIPTION
## Summary

Surface warnings for invalid hook event names in configuration to improve discoverability of misconfigurations.

## Details

- Skips internal config fields (`enabled`, `disabled`, `notifications`) when scanning for hook events to avoid false positive warnings.
- Emits a user-facing warning via `coreEvents.emitFeedback` when an invalid hook event name is encountered.

## Related Issues

Fixes #16788

## How to Validate

1. Add an invalid field like `InvalidEvent: []` to the `hooks` section of `.gemini/settings.json`.
2. Run `npm test -w @google/gemini-cli-core -- src/hooks/hookRegistry.test.ts` to verify the new test case passes.
3. Manually verify that a warning is shown when running the CLI with such configuration.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
