### PR TITLE
feat(plan): remove `read_many_files` from approval mode policies

### DIFF
--- a/packages/core/src/policy/policies/plan.toml
+++ b/packages/core/src/policy/policies/plan.toml
@@ -59,12 +59,6 @@ priority = 50
 modes = ["plan"]
 
 [[rule]]
-toolName = "read_many_files"
-decision = "allow"
-priority = 50
-modes = ["plan"]
-
-[[rule]]
 toolName = "google_web_search"
 decision = "allow"
 priority = 50

--- a/packages/core/src/policy/policies/read-only.toml
+++ b/packages/core/src/policy/policies/read-only.toml
@@ -46,11 +46,6 @@ decision = "allow"
 priority = 50
 
 [[rule]]
-toolName = "read_many_files"
-decision = "allow"
-priority = 50
-
-[[rule]]
 toolName = "google_web_search"
 decision = "allow"
 priority = 50


### PR DESCRIPTION
## Summary

Removes the deprecated `read_many_files` tool from the allowed tool lists in `read-only.toml` (default) and `plan.toml` policy configurations.

## Details

The `read_many_files` tool was recently removed from the tool registry in PR #12796. However, references to it persisted in the default policy configuration files (`plan.toml` and `read-only.toml`), which caused errors during tool selection when these approval modes were active. This PR cleans up those stale references to prevent runtime errors.

## Related Issues

Fixes #16875
