### PR TITLE
feat(admin): enable session retention by default

### DIFF
--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -29,7 +29,7 @@ they appear in the UI.
 | Disable Auto Update             | `general.disableAutoUpdate`        | Disable automatic updates                                     | `false` |
 | Enable Prompt Completion        | `general.enablePromptCompletion`   | Enable AI-powered prompt completion suggestions while typing. | `false` |
 | Debug Keystroke Logging         | `general.debugKeystrokeLogging`    | Enable debug logging of keystrokes to the console.            | `false` |
-| Enable Session Cleanup          | `general.sessionRetention.enabled` | Enable automatic session cleanup                              | `false` |
+| Enable Session Cleanup          | `general.sessionRetention.enabled` | Enable automatic session cleanup                              | `true`  |
 
 ### Output
 

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -140,12 +140,12 @@ their corresponding top-level category object in your `settings.json` file.
 
 - **`general.sessionRetention.enabled`** (boolean):
   - **Description:** Enable automatic session cleanup
-  - **Default:** `false`
+  - **Default:** `true`
 
 - **`general.sessionRetention.maxAge`** (string):
   - **Description:** Maximum age of sessions to keep (e.g., "30d", "7d", "24h",
     "1w")
-  - **Default:** `undefined`
+  - **Default:** `"30d"`
 
 - **`general.sessionRetention.maxCount`** (number):
   - **Description:** Alternative: Maximum number of sessions to keep (most

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -271,7 +271,7 @@ const SETTINGS_SCHEMA = {
             label: 'Enable Session Cleanup',
             category: 'General',
             requiresRestart: false,
-            default: false,
+            default: true,
             description: 'Enable automatic session cleanup',
             showInDialog: true,
           },
@@ -280,7 +280,7 @@ const SETTINGS_SCHEMA = {
             label: 'Max Session Age',
             category: 'General',
             requiresRestart: false,
-            default: undefined as string | undefined,
+            default: '30d',
             description:
               'Maximum age of sessions to keep (e.g., "30d", "7d", "24h", "1w")',
             showInDialog: false,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -280,7 +280,7 @@ const SETTINGS_SCHEMA = {
             label: 'Max Session Age',
             category: 'General',
             requiresRestart: false,
-            default: '30d',
+            default: '30d' as string,
             description:
               'Maximum age of sessions to keep (e.g., "30d", "7d", "24h", "1w")',
             showInDialog: false,

--- a/packages/cli/src/ui/components/SettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.test.tsx
@@ -1266,6 +1266,9 @@ describe('SettingsDialog', () => {
             disableAutoUpdate: true,
             debugKeystrokeLogging: true,
             enablePromptCompletion: true,
+            sessionRetention: {
+              enabled: true,
+            },
           },
           ui: {
             hideWindowTitle: true,
@@ -1412,6 +1415,9 @@ describe('SettingsDialog', () => {
             disableAutoUpdate: false,
             debugKeystrokeLogging: false,
             enablePromptCompletion: false,
+            sessionRetention: {
+              enabled: false,
+            },
           },
           ui: {
             hideWindowTitle: false,

--- a/packages/cli/src/ui/components/__snapshots__/SettingsDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/SettingsDialog.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`SettingsDialog > Initial Rendering > should render settings list with v
 │    Debug Keystroke Logging                                                                false  │
 │    Enable debug logging of keystrokes to the console.                                            │
 │                                                                                                  │
-│    Enable Session Cleanup                                                                 false  │
+│    Enable Session Cleanup                                                                  true  │
 │    Enable automatic session cleanup                                                              │
 │                                                                                                  │
 │    Output Format                                                                           Text  │
@@ -71,7 +71,7 @@ exports[`SettingsDialog > Snapshot Tests > should render 'accessibility settings
 │    Debug Keystroke Logging                                                                false  │
 │    Enable debug logging of keystrokes to the console.                                            │
 │                                                                                                  │
-│    Enable Session Cleanup                                                                 false  │
+│    Enable Session Cleanup                                                                  true  │
 │    Enable automatic session cleanup                                                              │
 │                                                                                                  │
 │    Output Format                                                                           Text  │
@@ -117,7 +117,7 @@ exports[`SettingsDialog > Snapshot Tests > should render 'all boolean settings d
 │    Debug Keystroke Logging                                                               false*  │
 │    Enable debug logging of keystrokes to the console.                                            │
 │                                                                                                  │
-│    Enable Session Cleanup                                                                 false  │
+│    Enable Session Cleanup                                                                false*  │
 │    Enable automatic session cleanup                                                              │
 │                                                                                                  │
 │    Output Format                                                                           Text  │
@@ -163,7 +163,7 @@ exports[`SettingsDialog > Snapshot Tests > should render 'default state' correct
 │    Debug Keystroke Logging                                                                false  │
 │    Enable debug logging of keystrokes to the console.                                            │
 │                                                                                                  │
-│    Enable Session Cleanup                                                                 false  │
+│    Enable Session Cleanup                                                                  true  │
 │    Enable automatic session cleanup                                                              │
 │                                                                                                  │
 │    Output Format                                                                           Text  │
@@ -209,7 +209,7 @@ exports[`SettingsDialog > Snapshot Tests > should render 'file filtering setting
 │    Debug Keystroke Logging                                                                false  │
 │    Enable debug logging of keystrokes to the console.                                            │
 │                                                                                                  │
-│    Enable Session Cleanup                                                                 false  │
+│    Enable Session Cleanup                                                                  true  │
 │    Enable automatic session cleanup                                                              │
 │                                                                                                  │
 │    Output Format                                                                           Text  │
@@ -255,7 +255,7 @@ exports[`SettingsDialog > Snapshot Tests > should render 'focused on scope selec
 │    Debug Keystroke Logging                                                                false  │
 │    Enable debug logging of keystrokes to the console.                                            │
 │                                                                                                  │
-│    Enable Session Cleanup                                                                 false  │
+│    Enable Session Cleanup                                                                  true  │
 │    Enable automatic session cleanup                                                              │
 │                                                                                                  │
 │    Output Format                                                                           Text  │
@@ -301,7 +301,7 @@ exports[`SettingsDialog > Snapshot Tests > should render 'mixed boolean and numb
 │    Debug Keystroke Logging                                                                false  │
 │    Enable debug logging of keystrokes to the console.                                            │
 │                                                                                                  │
-│    Enable Session Cleanup                                                                 false  │
+│    Enable Session Cleanup                                                                  true  │
 │    Enable automatic session cleanup                                                              │
 │                                                                                                  │
 │    Output Format                                                                           Text  │
@@ -347,7 +347,7 @@ exports[`SettingsDialog > Snapshot Tests > should render 'tools and security set
 │    Debug Keystroke Logging                                                                false  │
 │    Enable debug logging of keystrokes to the console.                                            │
 │                                                                                                  │
-│    Enable Session Cleanup                                                                 false  │
+│    Enable Session Cleanup                                                                  true  │
 │    Enable automatic session cleanup                                                              │
 │                                                                                                  │
 │    Output Format                                                                           Text  │
@@ -393,7 +393,7 @@ exports[`SettingsDialog > Snapshot Tests > should render 'various boolean settin
 │    Debug Keystroke Logging                                                                true*  │
 │    Enable debug logging of keystrokes to the console.                                            │
 │                                                                                                  │
-│    Enable Session Cleanup                                                                 false  │
+│    Enable Session Cleanup                                                                 true*  │
 │    Enable automatic session cleanup                                                              │
 │                                                                                                  │
 │    Output Format                                                                           Text  │

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -110,14 +110,15 @@
             "enabled": {
               "title": "Enable Session Cleanup",
               "description": "Enable automatic session cleanup",
-              "markdownDescription": "Enable automatic session cleanup\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `false`",
-              "default": false,
+              "markdownDescription": "Enable automatic session cleanup\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `true`",
+              "default": true,
               "type": "boolean"
             },
             "maxAge": {
               "title": "Max Session Age",
               "description": "Maximum age of sessions to keep (e.g., \"30d\", \"7d\", \"24h\", \"1w\")",
-              "markdownDescription": "Maximum age of sessions to keep (e.g., \"30d\", \"7d\", \"24h\", \"1w\")\n\n- Category: `General`\n- Requires restart: `no`",
+              "markdownDescription": "Maximum age of sessions to keep (e.g., \"30d\", \"7d\", \"24h\", \"1w\")\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `30d`",
+              "default": "30d",
               "type": "string"
             },
             "maxCount": {


### PR DESCRIPTION
## TLDR

This pull request enables session retention and cleanup by default, setting the maximum session age to 30 days. This change aligns with a "secure by default" philosophy by automatically managing and cleaning up old session files, enhancing user privacy and preventing the indefinite accumulation of on-disk history.

## Linked Issues
Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/1194
