### PR TITLE
Fix MCP tool registration race condition and test stability

### DIFF
--- a/integration-tests/vitest.config.ts
+++ b/integration-tests/vitest.config.ts
@@ -8,7 +8,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    testTimeout: 300000, // 5 minutes
+    testTimeout: 600000, // 10 minutes
     globalSetup: './globalSetup.ts',
     reporters: ['default'],
     include: ['**/*.test.ts'],
@@ -16,8 +16,8 @@ export default defineConfig({
     fileParallelism: true,
     poolOptions: {
       threads: {
-        minThreads: 8,
-        maxThreads: 16,
+        minThreads: 2,
+        maxThreads: 4,
       },
     },
   },


### PR DESCRIPTION
- Await `discoveryPromise` in `Config.initialize()` to ensure MCP servers and extensions are fully started before initializing `GeminiClient`.
- Update `simple-mcp-server.test.ts` to disable experimental agents to prevent prompt bias.
- Refactor `TestRig` to use `spawn` instead of `execSync`.
- Increase integration test timeouts and reduce parallelism.

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
