### PR TITLE
fix(core): attempt compression before context overflow check

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -490,6 +490,7 @@ export class Config {
   private readonly enablePromptCompletion: boolean = false;
   private readonly truncateToolOutputThreshold: number;
   private readonly truncateToolOutputLines: number;
+  private compressionTruncationCounter = 0;
   private readonly enableToolOutputTruncation: boolean;
   private initialized: boolean = false;
   readonly storage: Storage;
@@ -1585,6 +1586,8 @@ export class Config {
       return this.compressionThreshold;
     }
 
+    await this.ensureExperimentsLoaded();
+
     const remoteThreshold =
       this.experiments?.flags[ExperimentFlags.CONTEXT_COMPRESSION_THRESHOLD]
         ?.floatValue;
@@ -1764,6 +1767,10 @@ export class Config {
 
   getTruncateToolOutputLines(): number {
     return this.truncateToolOutputLines;
+  }
+
+  getNextCompressionTruncationId(): number {
+    return ++this.compressionTruncationCounter;
   }
 
   getUseWriteTodos(): boolean {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -21,7 +21,7 @@ import {
   type ContentGenerator,
   type ContentGeneratorConfig,
 } from './contentGenerator.js';
-import { type GeminiChat } from './geminiChat.js';
+import { GeminiChat } from './geminiChat.js';
 import type { Config } from '../config/config.js';
 import {
   CompressionStatus,
@@ -48,8 +48,6 @@ import type {
 import { ClearcutLogger } from '../telemetry/clearcut-logger/clearcut-logger.js';
 import * as policyCatalog from '../availability/policyCatalog.js';
 import { partToString } from '../utils/partUtils.js';
-
-vi.mock('../services/chatCompressionService.js');
 
 // Mock fs module to prevent actual file system operations during tests
 const mockFileSystem = new Map<string, string>();
@@ -139,6 +137,7 @@ vi.mock('../hooks/hookSystem.js');
 const mockHookSystem = {
   fireBeforeAgentEvent: vi.fn().mockResolvedValue(undefined),
   fireAfterAgentEvent: vi.fn().mockResolvedValue(undefined),
+  firePreCompressEvent: vi.fn().mockResolvedValue(undefined),
 };
 
 /**
@@ -164,15 +163,6 @@ describe('Gemini Client (client.ts)', () => {
     vi.resetAllMocks();
     ClearcutLogger.clearInstance();
     vi.mocked(uiTelemetryService.setLastPromptTokenCount).mockClear();
-
-    vi.mocked(ChatCompressionService.prototype.compress).mockResolvedValue({
-      newHistory: null,
-      info: {
-        originalTokenCount: 0,
-        newTokenCount: 0,
-        compressionStatus: CompressionStatus.NOOP,
-      },
-    });
 
     mockGenerateContentFn = vi.fn().mockResolvedValue({
       candidates: [{ content: { parts: [{ text: '{"key": "value"}' }] } }],
@@ -246,6 +236,7 @@ describe('Gemini Client (client.ts)', () => {
       getMessageBus: vi.fn().mockReturnValue(undefined),
       getEnableHooks: vi.fn().mockReturnValue(false),
       getChatCompression: vi.fn().mockReturnValue(undefined),
+      getCompressionThreshold: vi.fn().mockReturnValue(undefined),
       getSkipNextSpeakerCheck: vi.fn().mockReturnValue(false),
       getShowModelInfoInChat: vi.fn().mockReturnValue(false),
       getContinueOnFailedApiCall: vi.fn(),
@@ -406,7 +397,7 @@ describe('Gemini Client (client.ts)', () => {
         { role: 'model', parts: [{ text: 'Got it' }] },
       ];
 
-      vi.mocked(ChatCompressionService.prototype.compress).mockResolvedValue({
+      vi.spyOn(ChatCompressionService.prototype, 'compress').mockResolvedValue({
         newHistory:
           compressionStatus === CompressionStatus.COMPRESSED
             ? newHistory
@@ -577,7 +568,7 @@ describe('Gemini Client (client.ts)', () => {
       const MOCKED_TOKEN_LIMIT = 1000;
       const originalTokenCount = MOCKED_TOKEN_LIMIT * 0.699;
 
-      vi.mocked(ChatCompressionService.prototype.compress).mockResolvedValue({
+      vi.spyOn(ChatCompressionService.prototype, 'compress').mockResolvedValue({
         newHistory: null,
         info: {
           originalTokenCount,
@@ -1336,10 +1327,10 @@ ${JSON.stringify(
       };
       client['chat'] = mockChat as GeminiChat;
 
-      // Remaining = 100. Threshold (95%) = 95.
-      // We need a request > 95 tokens.
-      // A string of length 400 is roughly 100 tokens.
-      const longText = 'a'.repeat(400);
+      // Remaining = 100.
+      // We need a request > 100 tokens.
+      // A string of length 404 is roughly 101 tokens.
+      const longText = 'a'.repeat(404);
       const request: Part[] = [{ text: longText }];
       // estimateTextOnlyLength counts only text content (400 chars), not JSON structure
       const estimatedRequestTokenCount = Math.floor(longText.length / 4);
@@ -1396,9 +1387,9 @@ ${JSON.stringify(
       };
       client['chat'] = mockChat as GeminiChat;
 
-      // Remaining (sticky) = 100. Threshold (95%) = 95.
-      // We need a request > 95 tokens.
-      const longText = 'a'.repeat(400);
+      // Remaining (sticky) = 100.
+      // We need a request > 100 tokens.
+      const longText = 'a'.repeat(404);
       const request: Part[] = [{ text: longText }];
       // estimateTextOnlyLength counts only text content (400 chars), not JSON structure
       const estimatedRequestTokenCount = Math.floor(longText.length / 4);
@@ -1430,6 +1421,165 @@ ${JSON.stringify(
       });
       expect(tokenLimit).toHaveBeenCalledWith(STICKY_MODEL);
       expect(mockTurnRunFn).not.toHaveBeenCalled();
+    });
+
+    it('should attempt compression before overflow check and proceed if compression frees space', async () => {
+      // Arrange
+      const MOCKED_TOKEN_LIMIT = 1000;
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+
+      // Initial state: 950 tokens used, 50 remaining.
+      const initialTokenCount = 950;
+      // Request: 60 tokens. (950 + 60 = 1010 > 1000) -> Would overflow without compression.
+      const longText = 'a'.repeat(240); // 240 / 4 = 60 tokens
+      const request: Part[] = [{ text: longText }];
+
+      // Use the real GeminiChat to manage state and token counts more realistically
+      const mockChatCompressed = {
+        getLastPromptTokenCount: vi.fn().mockReturnValue(400),
+        getHistory: vi
+          .fn()
+          .mockReturnValue([{ role: 'user', parts: [{ text: 'old' }] }]),
+        addHistory: vi.fn(),
+        getChatRecordingService: vi.fn().mockReturnValue({
+          getConversation: vi.fn(),
+          getConversationFilePath: vi.fn(),
+        }),
+      } as unknown as GeminiChat;
+
+      const mockChatInitial = {
+        getLastPromptTokenCount: vi.fn().mockReturnValue(initialTokenCount),
+        getHistory: vi
+          .fn()
+          .mockReturnValue([{ role: 'user', parts: [{ text: 'old' }] }]),
+        addHistory: vi.fn(),
+        getChatRecordingService: vi.fn().mockReturnValue({
+          getConversation: vi.fn(),
+          getConversationFilePath: vi.fn(),
+        }),
+      } as unknown as GeminiChat;
+
+      client['chat'] = mockChatInitial;
+
+      // Mock tryCompressChat to simulate successful compression
+      const tryCompressSpy = vi
+        .spyOn(client, 'tryCompressChat')
+        .mockImplementation(async () => {
+          // In reality, tryCompressChat replaces this.chat
+          client['chat'] = mockChatCompressed;
+          return {
+            originalTokenCount: initialTokenCount,
+            newTokenCount: 400,
+            compressionStatus: CompressionStatus.COMPRESSED,
+          };
+        });
+
+      // Use a manual spy on Turn.prototype.run since Turn is a real class in this test context
+      // but mocked at the top of the file
+      mockTurnRunFn.mockImplementation(async function* () {
+        yield { type: 'content', value: 'Success after compression' };
+      });
+
+      // Act
+      const stream = client.sendMessageStream(
+        request,
+        new AbortController().signal,
+        'prompt-id-compression-test',
+      );
+
+      const events = await fromAsync(stream);
+
+      // Assert
+      // 1. Should NOT contain overflow warning
+      expect(events).not.toContainEqual(
+        expect.objectContaining({
+          type: GeminiEventType.ContextWindowWillOverflow,
+        }),
+      );
+
+      // 2. Should contain compression event
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: GeminiEventType.ChatCompressed,
+        }),
+      );
+
+      // 3. Should have called tryCompressChat
+      expect(tryCompressSpy).toHaveBeenCalled();
+
+      // 4. Should have called Turn.run (proceeded with the request)
+      expect(mockTurnRunFn).toHaveBeenCalled();
+    });
+
+    it('should handle massive function responses by truncating them and then yielding overflow warning', async () => {
+      // Arrange
+      const MOCKED_TOKEN_LIMIT = 1000;
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+
+      // History has a large compressible part and a massive function response at the end.
+      const massiveText = 'a'.repeat(200000);
+      const history: Content[] = [
+        { role: 'user', parts: [{ text: 'a'.repeat(100000) }] }, // compressible part
+        { role: 'model', parts: [{ text: 'ok' }] },
+        {
+          role: 'model',
+          parts: [{ functionCall: { name: 'huge_tool', args: {} } }],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                name: 'huge_tool',
+                response: { data: massiveText },
+              },
+            },
+          ],
+        },
+      ];
+
+      const realChat = new GeminiChat(mockConfig, '', [], history);
+      client['chat'] = realChat;
+
+      // Use a realistic mock for compression that simulates the 40k truncation effect.
+      // We spy on the instance directly to ensure it intercepts correctly.
+      const compressSpy = vi
+        .spyOn(client['compressionService'], 'compress')
+        .mockResolvedValue({
+          newHistory: history, // Keep history large for the overflow check
+          info: {
+            originalTokenCount: 50000,
+            newTokenCount: 10000, // Reduced from 50k but still > 1000 limit
+            compressionStatus: CompressionStatus.COMPRESSED,
+          },
+        });
+
+      // The new request
+      const request: Part[] = [{ text: 'next question' }];
+
+      // Act
+      const stream = client.sendMessageStream(
+        request,
+        new AbortController().signal,
+        'prompt-id-massive-test',
+      );
+
+      const events = await fromAsync(stream);
+
+      // Assert
+      // 1. Should have attempted compression
+      expect(compressSpy).toHaveBeenCalled();
+
+      // 2. Should yield overflow warning because 10000 > 1000 limit.
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: GeminiEventType.ContextWindowWillOverflow,
+          value: expect.objectContaining({
+            estimatedRequestTokenCount: expect.any(Number),
+            remainingTokenCount: expect.any(Number),
+          }),
+        }),
+      );
     });
 
     it('should not trigger overflow warning for requests with large binary data (PDFs/images)', async () => {

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -13,8 +13,16 @@ import { getCompressionPrompt } from '../core/prompts.js';
 import { getResponseText } from '../utils/partUtils.js';
 import { logChatCompression } from '../telemetry/loggers.js';
 import { makeChatCompressionEvent } from '../telemetry/types.js';
+import {
+  saveTruncatedToolOutput,
+  formatTruncatedToolOutput,
+} from '../utils/fileUtils.js';
+import { debugLogger } from '../utils/debugLogger.js';
 import { getInitialChatHistory } from '../utils/environmentContext.js';
-import { calculateRequestTokenCount } from '../utils/tokenCalculation.js';
+import {
+  calculateRequestTokenCount,
+  estimateTokenCountSync,
+} from '../utils/tokenCalculation.js';
 import {
   DEFAULT_GEMINI_FLASH_LITE_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
@@ -35,6 +43,16 @@ export const DEFAULT_COMPRESSION_TOKEN_THRESHOLD = 0.5;
  * means that only the last 30% of the chat history will be kept after compression.
  */
 export const COMPRESSION_PRESERVE_THRESHOLD = 0.3;
+
+/**
+ * The budget for function response tokens in the preserved history.
+ */
+export const COMPRESSION_FUNCTION_RESPONSE_TOKEN_BUDGET = 50_000;
+
+/**
+ * The number of lines to keep when truncating a function response during compression.
+ */
+export const COMPRESSION_TRUNCATE_LINES = 30;
 
 /**
  * Returns the index of the oldest item to keep when compressing. May return
@@ -101,6 +119,119 @@ export function modelStringToModelConfigAlias(model: string): string {
   }
 }
 
+/**
+ * Processes the chat history to ensure function responses don't exceed a specific token budget.
+ *
+ * This function implements a "Reverse Token Budget" strategy:
+ * 1. It iterates through the history from the most recent turn to the oldest.
+ * 2. It keeps a running tally of tokens used by function responses.
+ * 3. Recent tool outputs are preserved in full to maintain high-fidelity context for the current turn.
+ * 4. Once the budget (COMPRESSION_FUNCTION_RESPONSE_TOKEN_BUDGET) is exceeded, any older large
+ *    tool responses are truncated to their last 30 lines and saved to a temporary file.
+ *
+ * This ensures that compression effectively reduces context size even when recent turns
+ * contain massive tool outputs (like large grep results or logs).
+ */
+async function truncateHistoryToBudget(
+  history: Content[],
+  config: Config,
+): Promise<Content[]> {
+  let functionResponseTokenCounter = 0;
+  const truncatedHistory: Content[] = [];
+
+  // Iterate backwards: newest messages first to prioritize their context.
+  for (let i = history.length - 1; i >= 0; i--) {
+    const content = history[i];
+    const newParts = [];
+
+    if (content.parts) {
+      // Process parts of the message backwards as well.
+      for (let j = content.parts.length - 1; j >= 0; j--) {
+        const part = content.parts[j];
+
+        if (part.functionResponse) {
+          const responseObj = part.functionResponse.response;
+          // Ensure we have a string representation to truncate.
+          // If the response is an object, we try to extract a primary string field (output or content).
+          let contentStr: string;
+          if (typeof responseObj === 'string') {
+            contentStr = responseObj;
+          } else if (responseObj && typeof responseObj === 'object') {
+            if (
+              'output' in responseObj &&
+              typeof responseObj['output'] === 'string'
+            ) {
+              contentStr = responseObj['output'];
+            } else if (
+              'content' in responseObj &&
+              typeof responseObj['content'] === 'string'
+            ) {
+              contentStr = responseObj['content'];
+            } else {
+              contentStr = JSON.stringify(responseObj, null, 2);
+            }
+          } else {
+            contentStr = JSON.stringify(responseObj, null, 2);
+          }
+
+          const tokens = estimateTokenCountSync([{ text: contentStr }]);
+
+          if (
+            functionResponseTokenCounter + tokens >
+            COMPRESSION_FUNCTION_RESPONSE_TOKEN_BUDGET
+          ) {
+            try {
+              // Budget exceeded: Truncate this response.
+              const { outputFile } = await saveTruncatedToolOutput(
+                contentStr,
+                part.functionResponse.name ?? 'unknown_tool',
+                config.getNextCompressionTruncationId(),
+                config.storage.getProjectTempDir(),
+              );
+
+              // Prepare a honest, readable snippet of the tail.
+              const truncatedMessage = formatTruncatedToolOutput(
+                contentStr,
+                outputFile,
+                COMPRESSION_TRUNCATE_LINES,
+              );
+
+              newParts.unshift({
+                functionResponse: {
+                  ...part.functionResponse,
+                  response: { output: truncatedMessage },
+                },
+              });
+
+              // Count the small truncated placeholder towards the budget.
+              functionResponseTokenCounter += estimateTokenCountSync([
+                { text: truncatedMessage },
+              ]);
+            } catch (error) {
+              // Fallback: if truncation fails, keep the original part to avoid data loss in the chat.
+              debugLogger.debug('Failed to truncate history to budget:', error);
+              newParts.unshift(part);
+              functionResponseTokenCounter += tokens;
+            }
+          } else {
+            // Within budget: keep the full response.
+            functionResponseTokenCounter += tokens;
+            newParts.unshift(part);
+          }
+        } else {
+          // Non-tool response part: always keep.
+          newParts.unshift(part);
+        }
+      }
+    }
+
+    // Reconstruct the message with processed (potentially truncated) parts.
+    truncatedHistory.unshift({ ...content, parts: newParts });
+  }
+
+  return truncatedHistory;
+}
+
 export class ChatCompressionService {
   async compress(
     chat: GeminiChat,
@@ -151,15 +282,22 @@ export class ChatCompressionService {
       }
     }
 
-    const splitPoint = findCompressSplitPoint(
+    // Apply token-based truncation to the entire history before splitting.
+    // This ensures that even the "to compress" portion is within safe limits for the summarization model.
+    const truncatedHistory = await truncateHistoryToBudget(
       curatedHistory,
+      config,
+    );
+
+    const splitPoint = findCompressSplitPoint(
+      truncatedHistory,
       1 - COMPRESSION_PRESERVE_THRESHOLD,
     );
 
-    const historyToCompress = curatedHistory.slice(0, splitPoint);
-    const historyToKeep = curatedHistory.slice(splitPoint);
+    const historyToCompressTruncated = truncatedHistory.slice(0, splitPoint);
+    const historyToKeepTruncated = truncatedHistory.slice(splitPoint);
 
-    if (historyToCompress.length === 0) {
+    if (historyToCompressTruncated.length === 0) {
       return {
         newHistory: null,
         info: {
@@ -170,10 +308,21 @@ export class ChatCompressionService {
       };
     }
 
+    // High Fidelity Decision: Should we send the original or truncated history to the summarizer?
+    const originalHistoryToCompress = curatedHistory.slice(0, splitPoint);
+    const originalToCompressTokenCount = estimateTokenCountSync(
+      originalHistoryToCompress.flatMap((c) => c.parts || []),
+    );
+
+    const historyForSummarizer =
+      originalToCompressTokenCount < tokenLimit(model)
+        ? originalHistoryToCompress
+        : historyToCompressTruncated;
+
     const summaryResponse = await config.getBaseLlmClient().generateContent({
       modelConfigKey: { model: modelStringToModelConfigAlias(model) },
       contents: [
-        ...historyToCompress,
+        ...historyForSummarizer,
         {
           role: 'user',
           parts: [
@@ -199,7 +348,7 @@ export class ChatCompressionService {
         role: 'model',
         parts: [{ text: 'Got it. Thanks for the additional context!' }],
       },
-      ...historyToKeep,
+      ...historyToKeepTruncated,
     ];
 
     // Use a shared utility to construct the initial history for an accurate token count.

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -1123,9 +1123,9 @@ describe('fileUtils', () => {
       const formatted = formatTruncatedToolOutput(content, outputFile);
 
       expect(formatted).toContain(
-        'Output too large. Showing the last 10,000 characters',
+        'Output too large. Showing the last 4,000 characters',
       );
-      expect(formatted.endsWith(content.slice(-10000))).toBe(true);
+      expect(formatted.endsWith(content.slice(-4000))).toBe(true);
     });
   });
 });

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -517,7 +517,7 @@ export async function fileExists(filePath: string): Promise<boolean> {
 }
 
 const MAX_TRUNCATED_LINE_WIDTH = 1000;
-const MAX_TRUNCATED_CHARS = 10000;
+const MAX_TRUNCATED_CHARS = 4000;
 
 /**
  * Formats a truncated message for tool output, handling multi-line and single-line (elephant) cases.


### PR DESCRIPTION
Move context window overflow check to after compression and remove the 0.95 safety buffer. This ensures that sessions nearing their context limit have a chance to free up space via compression before the request is blocked.

- Move tryCompressChat before remainingTokenCount check in processTurn
- Remove 0.95 multiplier from overflow threshold
- Add regression test for compression-then-overflow flow

Fixes https://github.com/google-gemini/gemini-cli/issues/16213