### PR TITLE
fix: improve loop detection to catch tool calls with varying arguments

### DIFF
--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -282,7 +282,7 @@ export class LoopDetectionService {
     } else if (toolResponse.responseParts) {
       // Check if response contains an error-like message
       const responseText = toolResponse.responseParts
-        .map((part: Part) => (part as { text?: string }).text || '')
+        .map((part: Part) => ('text' in part && typeof part.text === 'string' ? part.text : ''))
         .join('');
       // Look for common error patterns in tool responses
       if (

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -740,6 +740,8 @@ export enum LoopType {
   CONSECUTIVE_IDENTICAL_TOOL_CALLS = 'consecutive_identical_tool_calls',
   CHANTING_IDENTICAL_SENTENCES = 'chanting_identical_sentences',
   LLM_DETECTED_LOOP = 'llm_detected_loop',
+  REPEATED_TOOL_ERRORS = 'repeated_tool_errors',
+  SAME_TOOL_REPEATED = 'same_tool_repeated',
 }
 
 export class LoopDetectedEvent implements BaseTelemetryEvent {


### PR DESCRIPTION
 ## Summary

  Fix loop detection to catch cases where the model calls the same tool repeatedly with varying arguments. Previously, loops were only detected when tool calls were completely identical (same name + same args hash), missing common loop patterns.

  ## Details

  Added two new detection methods to `loopDetectionService.ts`:
  - **Same-tool-name tracking**: detects when the same tool is called 5+ times consecutively, regardless of argument variations
  - **Error-based tracking**: detects when the same error message is returned 5+ times consecutively

  This fixes loops where the model would, for example, call `Shell` with `ls -l` 26+ times while varying the `dir_path` argument each time.

  ## Related Issues

  Related to infinite loop issues reported by users.

  ## How to Validate

  1. Run the new tests: `npm test -- loopDetectionService`
  2. Verify same-tool detection triggers after 5 consecutive calls to the same tool with different args
  3. Verify error detection triggers after 5 consecutive identical error responses

  ## Pre-Merge Checklist

  - [ ] Updated relevant documentation and README (if needed)
  - [x] Added/updated tests (if needed)
  - [ ] Noted breaking changes (if any)
