### PR TITLE
fix(cli): map linefeed \n to Command.NEWLINE

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -123,6 +123,21 @@ describe('KeypressContext', () => {
       );
     });
 
+    it('should handle newline character (Line Feed) as Control+Enter', async () => {
+      const { keyHandler } = setupKeypressTest();
+
+      act(() => stdin.write('\n'));
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'return',
+          ctrl: true,
+          meta: false,
+          shift: false,
+        }),
+      );
+    });
+
     it.each([
       {
         modifier: 'Shift',

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -525,7 +525,7 @@ function* emitKeys(
       name = 'return';
       meta = escaped;
     } else if (ch === '\n') {
-      // Enter, should have been called linefeed
+      // \n should trigger linefeed
       name = 'return';
       ctrl = true;
       meta = escaped;

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -526,7 +526,8 @@ function* emitKeys(
       meta = escaped;
     } else if (ch === '\n') {
       // Enter, should have been called linefeed
-      name = 'enter';
+      name = 'return';
+      ctrl = true;
       meta = escaped;
     } else if (ch === '\t') {
       // tab


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
out of the box support for terminals that emit linefeed on control enter was removed in #16672

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
this PR just maps linefeed to ` ctrl = true, name = "return"` so maybe it doesn't fit with the current vision in the ongoing  keybinds overhaul

I just opened the PR since a user filed the issue

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes #16916

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
