### PR TITLE
docs: mark -p flag as deprecated

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -1312,6 +1312,8 @@ for that specific session.
   - Specifies the Gemini model to use for this session.
   - Example: `npm start -- --model gemini-1.5-pro-latest`
 - **`--prompt <your_prompt>`** (**`-p <your_prompt>`**):
+  - **Deprecated:** Use the positional prompt instead. This flag will be removed
+    in a future version.
   - Used to pass a prompt directly to the command. This invokes Gemini CLI in a
     non-interactive mode.
   - For scripting examples, use the `--output-format json` flag to get


### PR DESCRIPTION
## Summary

Updates the configuration documentation to mark the `-p` / `--prompt` flag as deprecated.

## Details

The `-p` flag is deprecated in favor of using positional arguments for the prompt. This change updates [docs/get-started/configuration.md](cci:7://file:///home/saksham/vstudio/gemini-cli/docs/get-started/configuration.md:0:0-0:0) to explicitly state that the flag is deprecated and will be removed in a future version.

## Related Issues

Closes #15916

## How to Validate

1.  Open [docs/get-started/configuration.md](cci:7://file:///home/saksham/vstudio/gemini-cli/docs/get-started/configuration.md:0:0-0:0).
2.  Navigate to the **Command-line arguments** section.
3.  Verify that the entry for `--prompt <your_prompt>` includes a deprecation warning starting with "**Deprecated:**".

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker