### PR TITLE
feat: add seed parameter to pass to model to have deterministic results (#16610)

### DIFF
--- a/docs/cli/headless.md
+++ b/docs/cli/headless.md
@@ -301,6 +301,7 @@ Key command-line options for headless usage:
 | `--prompt`, `-p`        | Run in headless mode               | `gemini -p "query"`                                |
 | `--output-format`       | Specify output format (text, json) | `gemini -p "query" --output-format json`           |
 | `--model`, `-m`         | Specify the Gemini model           | `gemini -p "query" -m gemini-2.5-flash`            |
+| `--seed`                | Specify a seed for the model       | `gemini -p "query" --seed 123`                     |
 | `--debug`, `-d`         | Enable debug mode                  | `gemini -p "query" --debug`                        |
 | `--include-directories` | Include additional directories     | `gemini -p "query" --include-directories src,docs` |
 | `--yolo`, `-y`          | Auto-approve all actions           | `gemini -p "query" --yolo`                         |

--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -71,11 +71,12 @@ they appear in the UI.
 
 ### Model
 
-| UI Label                | Setting                      | Description                                                                            | Default |
-| ----------------------- | ---------------------------- | -------------------------------------------------------------------------------------- | ------- |
-| Max Session Turns       | `model.maxSessionTurns`      | Maximum number of user/model/tool turns to keep in a session. -1 means unlimited.      | `-1`    |
-| Compression Threshold   | `model.compressionThreshold` | The fraction of context usage at which to trigger context compression (e.g. 0.2, 0.3). | `0.5`   |
-| Skip Next Speaker Check | `model.skipNextSpeakerCheck` | Skip the next speaker check.                                                           | `true`  |
+| UI Label                | Setting                      | Description                                                                            | Default     |
+| ----------------------- | ---------------------------- | -------------------------------------------------------------------------------------- | ----------- |
+| Max Session Turns       | `model.maxSessionTurns`      | Maximum number of user/model/tool turns to keep in a session. -1 means unlimited.      | `-1`        |
+| Compression Threshold   | `model.compressionThreshold` | The fraction of context usage at which to trigger context compression (e.g. 0.2, 0.3). | `0.5`       |
+| Skip Next Speaker Check | `model.skipNextSpeakerCheck` | Skip the next speaker check.                                                           | `true`      |
+| Seed                    | `model.seed`                 | The seed for the model.                                                                | `undefined` |
 
 ### Context
 

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -322,6 +322,10 @@ their corresponding top-level category object in your `settings.json` file.
   - **Description:** Skip the next speaker check.
   - **Default:** `true`
 
+- **`model.seed`** (number):
+  - **Description:** The seed for the model.
+  - **Default:** `undefined`
+
 #### `modelConfigs`
 
 - **`modelConfigs.aliases`** (object):
@@ -1311,6 +1315,11 @@ for that specific session.
 - **`--model <model_name>`** (**`-m <model_name>`**):
   - Specifies the Gemini model to use for this session.
   - Example: `npm start -- --model gemini-1.5-pro-latest`
+- **`--seed <number>`**:
+  - Specifies a seed for the model to ensure deterministic outputs.
+  - For true deterministic output requires --model set, because otherwise
+    different models can be called.
+  - Example: `npm start -- --seed 123`
 - **`--prompt <your_prompt>`** (**`-p <your_prompt>`**):
   - Used to pass a prompt directly to the command. This invokes Gemini CLI in a
     non-interactive mode.

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -2837,3 +2837,54 @@ describe('loadCliConfig mcpEnabled', () => {
     expect(config.getBlockedMcpServers()).toEqual(['serverB']);
   });
 });
+
+describe('seed parameter', () => {
+  const originalArgv = process.argv;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
+    vi.stubEnv('GEMINI_API_KEY', 'test-api-key');
+    process.argv = ['node', 'script.js'];
+    vi.spyOn(ExtensionManager.prototype, 'getExtensions').mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('should parse --seed argument', async () => {
+    process.argv = ['node', 'script.js', '--seed', '123'];
+    const argv = await parseArguments(createTestMergedSettings());
+    expect(argv.seed).toBe(123);
+  });
+
+  it('should pass seed to Config and register runtime override', async () => {
+    process.argv = ['node', 'script.js', '--seed', '456'];
+    const argv = await parseArguments(createTestMergedSettings());
+    const settings = createTestMergedSettings();
+    const config = await loadCliConfig(settings, 'test-session', argv);
+
+    // We can verify that the override is applied by resolving the config.
+    const resolvedConfig = config.modelConfigService.getResolvedConfig({
+      model: config.getModel(),
+    });
+
+    expect(resolvedConfig.generateContentConfig.seed).toBe(456);
+  });
+
+  it('should not register runtime override if seed is not provided', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments(createTestMergedSettings());
+    const settings = createTestMergedSettings();
+    const config = await loadCliConfig(settings, 'test-session', argv);
+
+    const resolvedConfig = config.modelConfigService.getResolvedConfig({
+      model: config.getModel(),
+    });
+
+    expect(resolvedConfig.generateContentConfig.seed).toBeUndefined();
+  });
+});

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -62,6 +62,7 @@ import { runExitCleanup } from '../utils/cleanup.js';
 export interface CliArgs {
   query: string | undefined;
   model: string | undefined;
+  seed: number | undefined;
   sandbox: boolean | string | undefined;
   debug: boolean | undefined;
   prompt: string | undefined;
@@ -113,6 +114,11 @@ export async function parseArguments(
           type: 'string',
           nargs: 1,
           description: `Model`,
+        })
+        .option('seed', {
+          type: 'number',
+          nargs: 1,
+          description: 'Seed for the model.',
         })
         .option('prompt', {
           alias: 'p',
@@ -711,6 +717,7 @@ export async function loadCliConfig(
     fileDiscoveryService: fileService,
     bugCommand: settings.advanced?.bugCommand,
     model: resolvedModel,
+    seed: argv.seed ?? settings.model?.seed,
     maxSessionTurns: settings.model?.maxSessionTurns,
     experimentalZedIntegration: argv.experimentalAcp || false,
     listExtensions: argv.listExtensions || false,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -732,6 +732,15 @@ const SETTINGS_SCHEMA = {
         description: 'Skip the next speaker check.',
         showInDialog: true,
       },
+      seed: {
+        type: 'number',
+        label: 'Seed',
+        category: 'Model',
+        requiresRestart: false,
+        default: undefined as number | undefined,
+        description: 'The seed for the model.',
+        showInDialog: false,
+      },
     },
   },
 

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -469,6 +469,7 @@ describe('gemini.tsx main function kitty protocol', () => {
     );
     vi.mocked(parseArguments).mockResolvedValue({
       model: undefined,
+      seed: undefined,
       sandbox: undefined,
       debug: undefined,
       prompt: undefined,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -322,6 +322,7 @@ export interface ConfigParameters {
   includeDirectories?: string[];
   bugCommand?: BugCommandSettings;
   model: string;
+  seed?: number;
   maxSessionTurns?: number;
   experimentalZedIntegration?: boolean;
   listSessions?: boolean;
@@ -771,6 +772,17 @@ export class Config {
     this.modelConfigService = new ModelConfigService(
       modelConfigServiceConfig ?? DEFAULT_MODEL_CONFIGS,
     );
+
+    if (params.seed !== undefined) {
+      this.modelConfigService.registerRuntimeModelOverride({
+        match: {},
+        modelConfig: {
+          generateContentConfig: {
+            seed: params.seed,
+          },
+        },
+      });
+    }
   }
 
   /**

--- a/packages/core/src/services/modelConfigService.ts
+++ b/packages/core/src/services/modelConfigService.ts
@@ -240,7 +240,15 @@ export class ModelConfigService {
     return overrides
       .map((override, index) => {
         const matchEntries = Object.entries(override.match);
-        if (matchEntries.length === 0) return null;
+        if (matchEntries.length === 0) {
+          // Provide global parameters, like seed
+          return {
+            specificity: 0,
+            level: 0,
+            modelConfig: override.modelConfig,
+            index,
+          };
+        }
 
         let matchedLevel = 0; // Default to Global
         const isMatch = matchEntries.every(([key, value]) => {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -449,6 +449,12 @@
           "markdownDescription": "Skip the next speaker check.\n\n- Category: `Model`\n- Requires restart: `no`\n- Default: `true`",
           "default": true,
           "type": "boolean"
+        },
+        "seed": {
+          "title": "Seed",
+          "description": "The seed for the model.",
+          "markdownDescription": "The seed for the model.\n\n- Category: `Model`\n- Requires restart: `no`",
+          "type": "number"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

Fixes #16610

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Provides support for seed parameter for cli and settings.json , so output is deterministic. 

basically this 
```
>npm start -- --model gemini-2.5-flash-lite --seed=225 "say random string without third tools"
abcxyz123
>npm start -- --model gemini-2.5-flash-lite --seed=225 "say random string without third tools"
abcxyz123
...

>npm start -- --model gemini-2.5-flash-lite --seed=1984 "say random string without third tools"
jfdksl;ajf
>npm start -- --model gemini-2.5-flash-lite --seed=1984 "say random string without third tools"
jfdksl;ajf
```

use cases - everything where deterministic results are important:
- qa 
- code review (tuning complex prompts) 




## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

- this is my first PR into code-base, please review carefully 
- probably wording should be reviewed/updated too 
- I am not sure about the changes in packages/core/src/services/modelConfigService.ts 
```
-        if (matchEntries.length === 0) return null;
+        if (matchEntries.length === 0) {
+          // Provide global parameters, like seed
+          return {
+            specificity: 0,
+            level: 0,
+            modelConfig: override.modelConfig,
+            index,
+          };
+        }
```
and packages/core/src/config/config.ts
```
    if (params.seed !== undefined) {
      this.modelConfigService.registerRuntimeModelOverride({
        match: {},
        modelConfig: {
          generateContentConfig: {
            seed: params.seed,
          },
        },
      });
    }
```
while they are essential for fix, may be there is some other approach to pass `seed` into api  

references 
https://ai.google.dev/api/generate-content#v1beta.GenerationConfig
https://docs.cloud.google.com/vertex-ai/generative-ai/docs/image/generate-deterministic-images
https://docs.cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference
_When seed is fixed to a specific value, the model makes a best effort to provide the same response for repeated requests. Deterministic output isn't guaranteed_ 



## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Implements #16610

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

- provide seed and model (since different models produce different results with same seed)
- ensure that multiple calls results in the same value 

```
>npm start -- --model gemini-2.5-flash-lite --seed=225 "say random string without third tools"
abcxyz123
>npm start -- --model gemini-2.5-flash-lite --seed=225 "say random string without third tools"
abcxyz123
...

>npm start -- --model gemini-2.5-flash-lite --seed=1984 "say random string without third tools"
jfdksl;ajf
>npm start -- --model gemini-2.5-flash-lite --seed=1984 "say random string without third tools"
jfdksl;ajf
```

settings.json 
```
  "model": {
    "maxSessionTurns": -1,
    "seed": 222
  },

>npm start -- --model gemini-3-flash-preview "say random string without third tools"
4f9e2b1a8c
>npm start -- --model gemini-3-flash-preview "say random string without third tools"
4f9e2b1a8c
```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
