### PR TITLE
fix(core): send specific reason when user declines tool action

### DIFF
--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -20,6 +20,7 @@ import type {
   ToolCallConfirmationDetails,
   Status as CoreStatus,
   EditorType,
+  CancellationReason,
 } from '@google/gemini-cli-core';
 import { CoreToolScheduler, debugLogger } from '@google/gemini-cli-core';
 import { useCallback, useState, useMemo, useEffect, useRef } from 'react';
@@ -63,7 +64,10 @@ export type TrackedToolCall =
   | TrackedCompletedToolCall
   | TrackedCancelledToolCall;
 
-export type CancelAllFn = (signal: AbortSignal, reason?: string) => void;
+export type CancelAllFn = (
+  signal: AbortSignal,
+  reason?: CancellationReason,
+) => void;
 
 export function useReactToolScheduler(
   onComplete: (tools: CompletedToolCall[]) => Promise<void>,
@@ -200,7 +204,7 @@ export function useReactToolScheduler(
   );
 
   const cancelAllToolCalls = useCallback(
-    (signal: AbortSignal, reason?: string) => {
+    (signal: AbortSignal, reason?: CancellationReason) => {
       scheduler.cancelAll(signal, reason);
     },
     [scheduler],

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -63,7 +63,7 @@ export type TrackedToolCall =
   | TrackedCompletedToolCall
   | TrackedCancelledToolCall;
 
-export type CancelAllFn = (signal: AbortSignal) => void;
+export type CancelAllFn = (signal: AbortSignal, reason?: string) => void;
 
 export function useReactToolScheduler(
   onComplete: (tools: CompletedToolCall[]) => Promise<void>,
@@ -200,8 +200,8 @@ export function useReactToolScheduler(
   );
 
   const cancelAllToolCalls = useCallback(
-    (signal: AbortSignal) => {
-      scheduler.cancelAll(signal);
+    (signal: AbortSignal, reason?: string) => {
+      scheduler.cancelAll(signal, reason);
     },
     [scheduler],
   );

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -762,9 +762,10 @@ export class CoreToolScheduler {
 
     if (outcome === ToolConfirmationOutcome.Cancel || signal.aborted) {
       // Instead of just cancelling one tool, trigger the full cancel cascade.
-      const reason = signal.aborted
-        ? CancellationReason.UserCancelled
-        : CancellationReason.UserDeclined;
+      const reason =
+        outcome === ToolConfirmationOutcome.Cancel
+          ? CancellationReason.UserDeclined
+          : CancellationReason.UserCancelled;
       this.cancelAll(signal, reason);
       return; // `cancelAll` calls `checkAndNotifyCompletion`, so we can exit here.
     } else if (outcome === ToolConfirmationOutcome.ModifyWithEditor) {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -590,7 +590,7 @@ export class CoreToolScheduler {
             reqInfo.callId,
             'cancelled',
             signal,
-            'Tool call cancelled by user.',
+            CancellationReason.UserCancelled,
           );
           // The completion check will handle the cascade.
           await this.checkAndNotifyCompletion(signal);
@@ -722,7 +722,7 @@ export class CoreToolScheduler {
             reqInfo.callId,
             'cancelled',
             signal,
-            'Tool call cancelled by user.',
+            CancellationReason.UserCancelled,
           );
           await this.checkAndNotifyCompletion(signal);
         } else {


### PR DESCRIPTION
## Summary

Updates `CoreToolScheduler` to send a specific error message ("User declined this action. No changes were applied.") when a user explicitly declines a tool execution, preventing the model from assuming changes were applied.

## Details

- Modified `cancelAll` and `_cancelAllQueuedCalls` in `CoreToolScheduler` to accept an optional `reason` string.
- Updated `handleConfirmationResponse` to pass a specific reason when the outcome is `Cancel`.
- Included a regression test to verify the correct error message is generated.

## Related Issues

Fixes #16962

## How to Validate

1. Trigger a tool call that requires user confirmation (e.g., an edit).
2. Decline the tool execution.
3. Observe that the model receives a `User declined this action` error instead of a generic cancellation, prompting it to retry or acknowledge the rejection correctly.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
