### PR TITLE
fix(core): handle markdown normalization mismatch in ImportProcessor

### DIFF
--- a/packages/core/src/utils/memoryImportProcessor.ts
+++ b/packages/core/src/utils/memoryImportProcessor.ts
@@ -167,10 +167,13 @@ function findCodeRegions(content: string): Array<[number, number]> {
       for (const child of token.tokens) {
         const childIndexInParent = token.raw.indexOf(child.raw, childOffset);
         if (childIndexInParent === -1) {
-          logger.error(
-            `Could not find child token in parent raw content. Aborting parsing for this branch. Child raw: "${child.raw}"`,
+          // Skip this child if marked.js normalized the content differently
+          // (e.g., CRLF to LF conversion). This is a known limitation and
+          // not a fatal error - just continue with the next sibling.
+          logger.debug(
+            `Skipping child token location (normalization mismatch): "${child.raw.substring(0, 30)}..."`,
           );
-          break;
+          continue;
         }
         walk(child, baseOffset + childIndexInParent);
         childOffset = childIndexInParent + child.raw.length;


### PR DESCRIPTION
## Summary
- Fix error logging noise in `findCodeRegions` when marked.js normalizes markdown content differently than raw source
- Prevents the parser from aborting an entire branch when normalization mismatch occurs

## Details
The `findCodeRegions` function attempts to locate child token positions within parent tokens using `indexOf`. When marked.js normalizes content (e.g., converting CRLF to LF), the raw strings may not match exactly, causing `indexOf` to return -1.

Previously, this would:
1. Log an ERROR message to stderr
2. Break out of the loop, aborting parsing for all remaining siblings

The fix:
1. Downgrades the log level to DEBUG (since this is a known limitation, not a fatal error)
2. Uses `continue` instead of `break` to skip only the affected child and continue processing siblings

This is the minimal mitigation suggested in the issue report.

## Related Issues
Fixes #16945

## How to Validate
1. Create a markdown file with content that marked.js normalizes (e.g., with CRLF line endings on Windows)
2. Run gemini CLI with context loading enabled
3. Verify no ERROR messages appear in stderr for "Could not find child token in parent raw content"
4. Verify import processing still works correctly for other files

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) - N/A, no user-facing changes
- [x] Added/updated tests (if needed) - Existing tests pass, behavior is debug-only change
- [x] Noted breaking changes (if any) - None
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

🤖 Generated with Claude Code