### PR TITLE
[Ignore] Fix Windows E2E test flakes

### DIFF
--- a/integration-tests/skill-creator-scripts.test.ts
+++ b/integration-tests/skill-creator-scripts.test.ts
@@ -22,6 +22,18 @@ describe('skill-creator scripts e2e', () => {
     'packages/core/src/skills/builtin/skill-creator/scripts/package_skill.cjs',
   );
 
+  function execAndLog(command: string) {
+    try {
+      return execSync(command, { encoding: 'utf8', stdio: 'pipe' });
+    } catch (error: unknown) {
+      console.error('Command failed:', command);
+      const err = error as { stdout?: Buffer; stderr?: Buffer };
+      if (err.stdout) console.log('STDOUT:', err.stdout.toString());
+      if (err.stderr) console.error('STDERR:', err.stderr.toString());
+      throw error;
+    }
+  }
+
   beforeEach(() => {
     rig = new TestRig();
   });
@@ -36,9 +48,7 @@ describe('skill-creator scripts e2e', () => {
     const tempDir = rig.testDir!;
 
     // 1. Initialize
-    execSync(`node "${initScript}" ${skillName} --path "${tempDir}"`, {
-      stdio: 'inherit',
-    });
+    execAndLog(`node "${initScript}" ${skillName} --path "${tempDir}"`);
     const skillDir = path.join(tempDir, skillName);
 
     expect(fs.existsSync(skillDir)).toBe(true);
@@ -48,17 +58,15 @@ describe('skill-creator scripts e2e', () => {
     ).toBe(true);
 
     // 2. Validate (should have warning initially due to TODOs)
-    const validateOutputInitial = execSync(
+    // redirct stderr to stdout to capture warnings in the output check
+    const validateOutputInitial = execAndLog(
       `node "${validateScript}" "${skillDir}" 2>&1`,
-      { encoding: 'utf8' },
     );
     expect(validateOutputInitial).toContain('⚠️  Found unresolved TODO');
 
     // 3. Package (should fail due to TODOs)
     try {
-      execSync(`node "${packageScript}" "${skillDir}" "${tempDir}"`, {
-        stdio: 'pipe',
-      });
+      execAndLog(`node "${packageScript}" "${skillDir}" "${tempDir}"`);
       throw new Error('Packaging should have failed due to TODOs');
     } catch (err: unknown) {
       expect((err as Error).message).toContain('Command failed');
@@ -77,20 +85,16 @@ describe('skill-creator scripts e2e', () => {
     fs.writeFileSync(exampleScriptPath, scriptContent);
 
     // 4. Validate again (should pass now)
-    const validateOutput = execSync(`node "${validateScript}" "${skillDir}"`, {
-      encoding: 'utf8',
-    });
+    const validateOutput = execAndLog(`node "${validateScript}" "${skillDir}"`);
     expect(validateOutput).toContain('Skill is valid!');
 
     // 5. Package
-    execSync(`node "${packageScript}" "${skillDir}" "${tempDir}"`, {
-      stdio: 'inherit',
-    });
+    execAndLog(`node "${packageScript}" "${skillDir}" "${tempDir}"`);
     const skillFile = path.join(tempDir, `${skillName}.skill`);
     expect(fs.existsSync(skillFile)).toBe(true);
 
     // 6. Verify zip content (should NOT have nested directory)
-    const zipList = execSync(`unzip -l "${skillFile}"`, { encoding: 'utf8' });
+    const zipList = execAndLog(`tar -tf "${skillFile}"`);
     expect(zipList).toContain('SKILL.md');
     expect(zipList).not.toContain(`${skillName}/SKILL.md`);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2474,7 +2474,6 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -2655,7 +2654,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2689,7 +2687,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
       "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -3058,7 +3055,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz",
       "integrity": "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -3092,7 +3088,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.1.tgz",
       "integrity": "sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/resources": "2.0.1"
@@ -3145,7 +3140,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
       "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/resources": "2.0.1",
@@ -4358,7 +4352,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4636,7 +4629,6 @@
       "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.0",
         "@typescript-eslint/types": "8.35.0",
@@ -5641,7 +5633,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6086,7 +6077,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/array-includes": {
       "version": "3.1.9",
@@ -7370,6 +7362,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -8689,7 +8682,6 @@
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9292,6 +9284,7 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -9301,6 +9294,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -9310,6 +9304,7 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -9563,6 +9558,7 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
       "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~2.0.0",
@@ -9581,6 +9577,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -9589,13 +9586,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/finalhandler/node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -10878,7 +10877,6 @@
       "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.4.7.tgz",
       "integrity": "sha512-QHyxhNF5VonF5cRmdAJD/UPucB9nRx3FozWMjQrDGfBxfAL9lpyu72/MlFPgloS1TMTGsOt7YN6dTPPA6mh0Aw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.1",
         "ansi-escapes": "^7.0.0",
@@ -14063,7 +14061,8 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/path-type": {
       "version": "3.0.0",
@@ -14640,7 +14639,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14651,7 +14649,6 @@
       "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -16911,7 +16908,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17135,8 +17131,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.20.3",
@@ -17144,7 +17139,6 @@
       "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -17328,7 +17322,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17491,6 +17484,7 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -17545,7 +17539,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -17659,7 +17652,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17672,7 +17664,6 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -18377,7 +18368,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -18944,7 +18934,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/packages/core/src/skills/builtin/skill-creator/scripts/init_skill.cjs
+++ b/packages/core/src/skills/builtin/skill-creator/scripts/init_skill.cjs
@@ -186,8 +186,11 @@ async function main() {
   const skillDir = path.join(basePath, skillName);
 
   // Additional check to ensure the resolved skillDir is actually inside basePath
-  if (!skillDir.startsWith(basePath)) {
-    console.error('❌ Error: Invalid skill name or path.');
+  const relativePath = path.relative(basePath, skillDir);
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    console.error(
+      `❌ Error: Invalid skill name or path.\n  SkillDir: ${skillDir}\n  BasePath: ${basePath}\n  Relative: ${relativePath}`,
+    );
     process.exit(1);
   }
 

--- a/packages/core/src/skills/builtin/skill-creator/scripts/package_skill.cjs
+++ b/packages/core/src/skills/builtin/skill-creator/scripts/package_skill.cjs
@@ -75,10 +75,16 @@ async function main() {
       );
       // Fallback to tar (common on Windows 10+ and Linux)
       // tar -a -c -f output.zip .
-      zipProcess = spawnSync('tar', ['-a', '-c', '-f', outputFilename, '.'], {
-        cwd: skillPath,
-        stdio: 'inherit',
-      });
+      // We force zip format because .skill files are expected to be zips.
+      // bsdtar (standard on Windows 10+) supports --format=zip.
+      zipProcess = spawnSync(
+        'tar',
+        ['--format=zip', '-a', '-c', '-f', outputFilename, '.'],
+        {
+          cwd: skillPath,
+          stdio: 'inherit',
+        },
+      );
     }
 
     if (zipProcess.error) {
@@ -86,7 +92,9 @@ async function main() {
     }
 
     if (zipProcess.status !== 0) {
-      throw new Error(`Archiver command failed with exit code ${zipProcess.status}`);
+      throw new Error(
+        `Archiver command failed with exit code ${zipProcess.status}`,
+      );
     }
 
     console.log(`✅ Successfully packaged skill to: ${outputFilename}`);

--- a/packages/test-utils/src/test-rig.ts
+++ b/packages/test-utils/src/test-rig.ts
@@ -295,16 +295,22 @@ export class TestRig {
     const sanitizedName = sanitizeTestName(testName);
     const testFileDir =
       env['INTEGRATION_TEST_FILE_DIR'] || join(os.tmpdir(), 'gemini-cli-tests');
-    this.testDir = join(testFileDir, sanitizedName);
-    this.homeDir = join(testFileDir, sanitizedName + '-home');
+    const newTestDir = join(testFileDir, sanitizedName);
+    const newHomeDir = join(testFileDir, sanitizedName + '-home');
 
-    // Clean up if directories already exist (e.g. from a previous failed run or retry)
-    try {
-      fs.rmSync(this.testDir, { recursive: true, force: true });
-      fs.rmSync(this.homeDir, { recursive: true, force: true });
-    } catch {
-      // Ignore errors if they don't exist
+    // Clean up if directories already exist and we haven't already set up for this directory
+    // (e.g. from a previous failed run or retry)
+    if (this.testDir !== newTestDir || this.homeDir !== newHomeDir) {
+      try {
+        fs.rmSync(newTestDir, { recursive: true, force: true });
+        fs.rmSync(newHomeDir, { recursive: true, force: true });
+      } catch {
+        // Ignore errors if they don't exist
+      }
     }
+
+    this.testDir = newTestDir;
+    this.homeDir = newHomeDir;
 
     mkdirSync(this.testDir, { recursive: true });
     mkdirSync(this.homeDir, { recursive: true });

--- a/packages/test-utils/src/test-rig.ts
+++ b/packages/test-utils/src/test-rig.ts
@@ -297,6 +297,15 @@ export class TestRig {
       env['INTEGRATION_TEST_FILE_DIR'] || join(os.tmpdir(), 'gemini-cli-tests');
     this.testDir = join(testFileDir, sanitizedName);
     this.homeDir = join(testFileDir, sanitizedName + '-home');
+
+    // Clean up if directories already exist (e.g. from a previous failed run or retry)
+    try {
+      fs.rmSync(this.testDir, { recursive: true, force: true });
+      fs.rmSync(this.homeDir, { recursive: true, force: true });
+    } catch {
+      // Ignore errors if they don't exist
+    }
+
     mkdirSync(this.testDir, { recursive: true });
     mkdirSync(this.homeDir, { recursive: true });
     if (options.fakeResponsesPath) {


### PR DESCRIPTION
Fixes Windows CI failures by:
1. Using `path.relative` for robust path validation in `init_skill.cjs`.
2. Adding a `tar` fallback for `zip` in `package_skill.cjs`.
3. Skipping flakey interactive tests relying on `node-pty` on Windows.
4. Improving logging for better debuggability.