### PR TITLE
Stabilize skill-creator CI and package format

### DIFF
--- a/packages/core/src/skills/builtin/skill-creator/scripts/package_skill.cjs
+++ b/packages/core/src/skills/builtin/skill-creator/scripts/package_skill.cjs
@@ -64,17 +64,32 @@ async function main() {
     // -r: recursive
     // -x: exclude patterns
     // Run the zip command from within the directory to avoid parent folder nesting
-    const zipProcess = spawnSync('zip', ['-r', outputFilename, '.'], {
+    let zipProcess = spawnSync('zip', ['-r', outputFilename, '.'], {
       cwd: skillPath,
       stdio: 'inherit',
     });
+
+    if (zipProcess.error || zipProcess.status !== 0) {
+      // Fallback to tar --format=zip if zip is not available (common on Windows)
+      console.log('zip command not found, falling back to tar...');
+      zipProcess = spawnSync(
+        'tar',
+        ['-a', '-c', '--format=zip', '-f', outputFilename, '.'],
+        {
+          cwd: skillPath,
+          stdio: 'inherit',
+        },
+      );
+    }
 
     if (zipProcess.error) {
       throw zipProcess.error;
     }
 
     if (zipProcess.status !== 0) {
-      throw new Error(`zip command failed with exit code ${zipProcess.status}`);
+      throw new Error(
+        `Packaging command failed with exit code ${zipProcess.status}`,
+      );
     }
 
     console.log(`✅ Successfully packaged skill to: ${outputFilename}`);


### PR DESCRIPTION
This PR stabilizes the skill-creator E2E tests and packaging logic, specifically addressing failures in Windows CI environments.

- **Forced ZIP format:** Updated `package_skill.cjs` to force `--format=zip` when using `tar` as a fallback for `zip`. This ensures the `.skill` file is a valid ZIP archive regardless of the platform utility used.
- **Robust TODO removal:** Enhanced the regex in `skill-creator-scripts.test.ts` to ensure all `TODO:` placeholders are removed before validation, preventing intermittent failures.
- **Resilient ZIP verification:** Added a `tar -tf` fallback to `unzip -l` in the test suite to ensure archive contents can be listed on all CI platforms.
- **ESLint fixes:** Fixed minor linting issues in the test file.