### PR TITLE
feat(ui): auto-hide tips after 10 sessions

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -412,7 +412,8 @@ const SETTINGS_SCHEMA = {
         category: 'UI',
         requiresRestart: false,
         default: false,
-        description: 'Hide helpful tips in the UI',
+        description:
+          'Hide helpful tips in the UI (auto-hidden after 10 sessions)',
         showInDialog: true,
       },
       hideBanner: {
@@ -1804,6 +1805,27 @@ const SETTINGS_SCHEMA = {
       description:
         'Custom hook event arrays that contain hook definitions for user-defined events',
       mergeStrategy: MergeStrategy.CONCAT,
+    },
+  },
+
+  internal: {
+    type: 'object',
+    label: 'Internal',
+    category: 'Advanced',
+    requiresRestart: false,
+    default: {},
+    description: 'Internal state tracking.',
+    showInDialog: false,
+    properties: {
+      tipsShownCount: {
+        type: 'number',
+        label: 'Tips Shown Count',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: 0,
+        description: 'Number of times the startup tips have been shown.',
+        showInDialog: false,
+      },
     },
   },
 

--- a/packages/cli/src/ui/components/AppHeader.test.tsx
+++ b/packages/cli/src/ui/components/AppHeader.test.tsx
@@ -9,6 +9,7 @@ import { AppHeader } from './AppHeader.js';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { makeFakeConfig } from '@google/gemini-cli-core';
 import crypto from 'node:crypto';
+import { LoadedSettings } from '../../config/settings.js';
 
 const persistentStateMock = vi.hoisted(() => ({
   get: vi.fn(),
@@ -27,6 +28,7 @@ describe('<AppHeader />', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     persistentStateMock.get.mockReturnValue({});
+    vi.spyOn(LoadedSettings.prototype, 'setValue').mockImplementation(() => {});
   });
 
   it('should render the banner with default text', () => {

--- a/packages/cli/src/ui/components/Tips.tsx
+++ b/packages/cli/src/ui/components/Tips.tsx
@@ -5,9 +5,12 @@
  */
 
 import type React from 'react';
+import { useEffect, useRef } from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../semantic-colors.js';
 import { type Config } from '@google/gemini-cli-core';
+import { useSettings } from '../contexts/SettingsContext.js';
+import { SettingScope } from '../../config/settings.js';
 
 interface TipsProps {
   config: Config;
@@ -15,6 +18,38 @@ interface TipsProps {
 
 export const Tips: React.FC<TipsProps> = ({ config }) => {
   const geminiMdFileCount = config.getGeminiMdFileCount();
+  const settings = useSettings();
+  const hasIncrementedRef = useRef(false);
+
+  useEffect(() => {
+    // Only execute once
+    if (hasIncrementedRef.current) return;
+
+    // Only execute if we are currently showing tips (which is implied by this component being rendered)
+    if (settings.merged.ui.hideTips) return;
+
+    hasIncrementedRef.current = true;
+    const currentCount = settings.merged.internal?.tipsShownCount ?? 0;
+
+    // If the count is already above the threshold, the user must have manually
+    // re-enabled tips (since we auto-hid them at 11). We respect that choice
+    // and stop tracking/auto-hiding.
+    if (currentCount > 10) {
+      return;
+    }
+
+    const newCount = currentCount + 1;
+
+    // We increment the count first.
+    settings.setValue(SettingScope.User, 'internal.tipsShownCount', newCount);
+
+    // Then, if we just crossed the threshold, we auto-hide.
+    // Using > 10 means we show it for the 10th time, then hide it for the next run.
+    if (newCount > 10) {
+      settings.setValue(SettingScope.User, 'ui.hideTips', true);
+    }
+  }, [settings]);
+
   return (
     <Box flexDirection="column">
       <Text color={theme.text.primary}>Tips for getting started:</Text>


### PR DESCRIPTION
## Summary

Automatically hides the "Tips for getting started" in the UI after they have been shown 10 times.

## Details

- Adds an `internal` settings section to track `tipsShownCount`.
- Updates the `Tips` component to increment this counter on mount.
- Sets `ui.hideTips` to `true` once the count exceeds 10.
- Respects manual re-enabling: if a user manually sets `ui.hideTips: false` after the threshold is reached, the auto-hide logic is disabled to persist the user's choice.
- **Future Considerations:**
    - A future feature could give users a way to explicitly find more tips.
    - Another future feature could provide a dedicated onboarding guide.
    - These should be tracked as issues assigned to @keithguerin.

## Related Issues

<!-- None linked -->

## How to Validate

1.  Run the CLI.
2.  Check `~/.gemini/settings.json` and verify `internal.tipsShownCount` increments with each run.
3.  Manually set `tipsShownCount` to `10` in `~/.gemini/settings.json`.
4.  Run the CLI one more time (count becomes 11, tips still visible).
5.  Run the CLI again; tips should now be hidden, and `ui.hideTips` should be `true` in settings.
6.  Manually set `ui.hideTips` to `false`.
7.  Run the CLI again; tips should appear and stay visible (count increments, but auto-hide is skipped).

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (updated settings schema description)
- [x] Added/updated tests (updated existing AppHeader tests to mock new settings logic)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
