### PR TITLE
fix(core): use coreTools instead of allowedTools for delegate_to_agent registration

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1901,12 +1901,12 @@ export class Config {
       this.getCodebaseInvestigatorSettings().enabled ||
       this.getCliHelpAgentSettings().enabled
     ) {
-      // Check if the delegate tool itself is allowed (if allowedTools is set)
-      const allowedTools = this.getAllowedTools();
-      const isAllowed =
-        !allowedTools || allowedTools.includes(DELEGATE_TO_AGENT_TOOL_NAME);
+      // Check if the delegate tool is enabled via coreTools (if coreTools is set)
+      const coreTools = this.getCoreTools();
+      const isEnabled =
+        !coreTools || coreTools.includes(DELEGATE_TO_AGENT_TOOL_NAME);
 
-      if (isAllowed) {
+      if (isEnabled) {
         const delegateTool = new DelegateToAgentTool(
           this.agentRegistry,
           this,


### PR DESCRIPTION
## Summary

The `delegate_to_agent` tool was checking `tools.allowed` (which controls bypassing confirmation dialogs) to determine if it should be registered, but it should check `tools.core` (which controls tool availability) like all other core tools.

## Details

As pointed out in the linked issue, the current code at line 1898-1900 checks `getAllowedTools()` to decide whether to register the `delegate_to_agent` tool. However, `tools.allowed` is meant for specifying tools that bypass confirmation prompts, not for controlling tool availability.

The correct method to check is `getCoreTools()`, which is used by the `registerCoreTool` helper for all other built-in tools.

## Related Issues

Fixes #16994

## How to Validate

1. Configure `tools.core` to include or exclude `delegate_to_agent`
2. Verify the tool is registered/not registered based on `tools.core`, not `tools.allowed`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed) - existing tests pass
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker