### PR TITLE
fix(cli): resolve Ctrl+Enter and Ctrl+J newline issues

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -154,6 +154,36 @@ describe('KeypressContext', () => {
         );
       },
     );
+
+    it('should recognize \n (LF) as ctrl+j', async () => {
+      const { keyHandler } = setupKeypressTest();
+
+      act(() => stdin.write('\n'));
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'j',
+          ctrl: true,
+          meta: false,
+          shift: false,
+        }),
+      );
+    });
+
+    it('should recognize \\x1b\\n as Alt+Enter (return with meta)', async () => {
+      const { keyHandler } = setupKeypressTest();
+
+      act(() => stdin.write('\x1b\n'));
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'return',
+          ctrl: false,
+          meta: true,
+          shift: false,
+        }),
+      );
+    });
   });
 
   describe('Fast return buffering', () => {

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -524,9 +524,9 @@ function* emitKeys(
       // carriage return
       name = 'return';
       meta = escaped;
-    } else if (ch === '\n') {
-      // Enter, should have been called linefeed
-      name = 'enter';
+    } else if (escaped && ch === '\n') {
+      // Alt+Enter (linefeed), should be consistent with carriage return
+      name = 'return';
       meta = escaped;
     } else if (ch === '\t') {
       // tab


### PR DESCRIPTION
## Summary

This PR fixes an issue where `Ctrl+Enter` and `Ctrl+J` did not insert a newline in certain terminal emulators.

## Details

The issue was caused by `\n` (LF) being explicitly mapped to a custom `enter` key name with `ctrl: false`. Since the `NEWLINE` command was mapped to `{ key: 'j', ctrl: true }` and `{ key: 'return', ctrl: true }`, `\n` (which is functionally `Ctrl+J`) was ignored.

Changes:
- Removed explicit `\n` mapping in `KeypressContext.tsx`, allowing it to fall through to the control character handler where it correctly becomes `name: 'j', ctrl: true`.
- Added a unit test to verify `\n` is correctly identified as `Ctrl+J`.

## Related Issues

Resolves the reported bug where Ctrl+Enter/Ctrl+J had no effect.

## How to Validate

1. Run the CLI in a Linux terminal.
2. Type some text.
3. Press `Ctrl+Enter` or `Ctrl+J`.
4. Observe that a newline is inserted instead of the message being submitted.
5. Verify tests pass: `npm test -w @google/gemini-cli -- src/ui/contexts/KeypressContext.test.tsx`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods: 
  - [ ] MacOS
  - [ ] Windows
  - [x] Linux
    - [x] npm run
