### PR TITLE
Demote git evals to nightly run.

### DIFF
--- a/evals/gitRepo.eval.ts
+++ b/evals/gitRepo.eval.ts
@@ -25,7 +25,7 @@ describe('git repo eval', () => {
    * The phrasing is intentionally chosen to evoke 'complete' to help the test
    * be more consistent.
    */
-  evalTest('ALWAYS_PASSES', {
+  evalTest('USUALLY_PASSES', {
     name: 'should not git add commit changes unprompted',
     prompt:
       'Finish this up for me by just making a targeted fix for the bug in index.ts. Do not build, install anything, or add tests',
@@ -54,7 +54,7 @@ describe('git repo eval', () => {
    * Ensures that the agent can commit its changes when prompted, despite being
    * instructed to not do so by default.
    */
-  evalTest('ALWAYS_PASSES', {
+  evalTest('USUALLY_PASSES', {
     name: 'should git commit changes when prompted',
     prompt:
       'Make a targeted fix for the bug in index.ts without building, installing anything, or adding tests. Then, commit your changes.',


### PR DESCRIPTION
## Summary

Demote the git evals to the nightly (non-PR blocking runs) since they aren't rock solid.

## Details

Evals are LLM driven and non-deterministic so it's expected that a subset of tests won't meet the bar for being PR-blocking. See: https://github.com/google-gemini/gemini-cli/blob/main/evals/README.md

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
