### PR TITLE
Harden git evals and check for interactive editor usage.

### DIFF
--- a/evals/gitRepo.eval.ts
+++ b/evals/gitRepo.eval.ts
@@ -52,10 +52,11 @@ describe('git repo eval', () => {
 
   /**
    * Ensures that the agent can commit its changes when prompted, despite being
-   * instructed to not do so by default.
+   * instructed to not do so by default. Also ensures that any commits are non-interactive.
    */
   evalTest('USUALLY_PASSES', {
     name: 'should git commit changes when prompted',
+    failOnInteractiveGit: true,
     prompt:
       'Make a targeted fix for the bug in index.ts without building, installing anything, or adding tests. Then, commit your changes.',
     files: FILES,


### PR DESCRIPTION
## Summary

- Disables interactive Git editor in most eval tests to help with reliability.
- Specifically adds a check for the git commit evals to ensure that we avoid using interactive git commit editors.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
