### PR TITLE
fix(ui): ensure rationale renders before tool calls

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -923,6 +923,10 @@ export const useGeminiStream = (
         }
       }
       if (toolCallRequests.length > 0) {
+        if (pendingHistoryItemRef.current) {
+          addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+          setPendingHistoryItem(null);
+        }
         await scheduleToolCalls(toolCallRequests, signal);
       }
       return StreamProcessingStatus.Completed;
@@ -940,6 +944,9 @@ export const useGeminiStream = (
       handleChatModelEvent,
       handleAgentExecutionStoppedEvent,
       handleAgentExecutionBlockedEvent,
+      addItem,
+      pendingHistoryItemRef,
+      setPendingHistoryItem,
     ],
   );
   const submitQuery = useCallback(


### PR DESCRIPTION
## Summary

Fix rendering order of text rationale and tool calls in the conversation log.

## Details

Updated `processGeminiStreamEvents` in `useGeminiStream.ts` to flush the `pendingHistoryItem` (text rationale) to the chat history *before* scheduling tool calls. Previously, the rationale was only flushed at the very end of `submitQuery`, which allowed tool outputs (which are added to history immediately upon completion) to appear before the rationale that triggered them.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/17004

## How to Validate

1. Run a prompt that produces both text and a tool call (e.g., "Search for something and explain why").
2. Observe that the explanation text appears before the tool execution block.
3. Verified with a reproduction test ensuring `addItem:gemini` occurs before `scheduleToolCalls`.
4. All existing `useGeminiStream` tests passed.
5. `npm run preflight` passed.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
