### PR TITLE
Fix: Enable MCP tools in subagents by relaxing tool name validation

### DIFF
--- a/packages/core/src/agents/local-agent-mcp-tools.test.ts
+++ b/packages/core/src/agents/local-agent-mcp-tools.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ToolRegistry } from '../tools/tool-registry.js';
+import { isValidToolName } from '../tools/tool-names.js';
+import { DiscoveredMCPTool } from '../tools/mcp-tool.js';
+import type { Config } from '../config/config.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+import type { CallableTool } from '@google/genai';
+import type { LocalAgentDefinition } from './types.js';
+
+// Mock Config and MessageBus
+const mockConfig = {
+  getExcludeTools: () => new Set(),
+  getToolDiscoveryCommand: () => undefined,
+  getToolCallCommand: () => undefined,
+} as unknown as Config;
+
+const mockMessageBus = {} as MessageBus;
+
+describe('MCP Tool Loading for Subagents', () => {
+  it('should validate simple tool names and find them in registry', async () => {
+    const registry = new ToolRegistry(mockConfig, mockMessageBus);
+
+    // 1. Register an MCP tool. It should be registered with its simple name
+    // because there are no collisions.
+    const mcpTool = new DiscoveredMCPTool(
+      {} as unknown as CallableTool, // mock CallableTool
+      'my-server',
+      'my_tool',
+      'My Description',
+      {},
+      mockMessageBus,
+      true,
+    );
+
+    registry.registerTool(mcpTool);
+
+    // Verify it's registered as 'my_tool'
+    expect(registry.getTool('my_tool')).toBeDefined();
+
+    // 2. Verify isValidToolName behavior
+    // This is the key change: isValidToolName should now accept simple names
+    expect(isValidToolName('my_tool')).toBe(true);
+
+    // 3. Simulate LocalAgentExecutor.create behavior
+    const agentDefinition: LocalAgentDefinition = {
+      kind: 'local',
+      name: 'subagent',
+      description: 'A subagent',
+      promptConfig: { systemPrompt: '', query: '' },
+      modelConfig: { model: 'test' },
+      runConfig: { maxTurns: 1, maxTimeMinutes: 1 },
+      toolConfig: {
+        tools: ['my_tool'], // Using simple name
+      },
+      inputConfig: { inputs: {} },
+    };
+
+    const runtimeContext = {
+      getToolRegistry: () => registry,
+      getMessageBus: () => mockMessageBus,
+      getExcludeTools: () => new Set(),
+    } as unknown as Config;
+
+    // Logic from LocalAgentExecutor.create:
+    const agentToolRegistry = new ToolRegistry(runtimeContext, mockMessageBus);
+    const parentToolRegistry = runtimeContext.getToolRegistry();
+
+    let toolFound = false;
+    for (const toolRef of agentDefinition.toolConfig!.tools) {
+      if (typeof toolRef === 'string') {
+        const toolFromParent = parentToolRegistry.getTool(toolRef);
+        if (toolFromParent) {
+          agentToolRegistry.registerTool(toolFromParent);
+          toolFound = true;
+        }
+      }
+    }
+
+    // With the fix (both isValidToolName change and existing registry behavior),
+    // this should be true.
+    expect(toolFound).toBe(true);
+    expect(agentToolRegistry.getTool('my_tool')).toBeDefined();
+  });
+});

--- a/packages/core/src/tools/tool-names.test.ts
+++ b/packages/core/src/tools/tool-names.test.ts
@@ -30,9 +30,14 @@ describe('tool-names', () => {
       expect(isValidToolName('my-server__my-tool')).toBe(true);
     });
 
+    it('should accept generic slug names', () => {
+      expect(isValidToolName('invalid-name')).toBe(true);
+      expect(isValidToolName('my_tool')).toBe(true);
+    });
+
     it('should reject invalid tool names', () => {
       expect(isValidToolName('')).toBe(false);
-      expect(isValidToolName('invalid-name')).toBe(false);
+      expect(isValidToolName('invalid name')).toBe(false); // space
       expect(isValidToolName('server__')).toBe(false);
       expect(isValidToolName('__tool')).toBe(false);
       expect(isValidToolName('server__tool__extra')).toBe(false);

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -28,6 +28,8 @@ export const DELEGATE_TO_AGENT_TOOL_NAME = 'delegate_to_agent';
 /** Prefix used for tools discovered via the toolDiscoveryCommand. */
 export const DISCOVERED_TOOL_PREFIX = 'discovered_tool_';
 
+const slugRegex = /^[a-z0-9-_]+$/i;
+
 /**
  * List of all built-in tool names.
  */
@@ -56,16 +58,6 @@ export function isValidToolName(
   name: string,
   options: { allowWildcards?: boolean } = {},
 ): boolean {
-  // Built-in tools
-  if ((ALL_BUILTIN_TOOL_NAMES as readonly string[]).includes(name)) {
-    return true;
-  }
-
-  // Discovered tools
-  if (name.startsWith(DISCOVERED_TOOL_PREFIX)) {
-    return true;
-  }
-
   // Policy wildcards
   if (options.allowWildcards && name === '*') {
     return true;
@@ -86,9 +78,9 @@ export function isValidToolName(
     }
 
     // Basic slug validation for server and tool names
-    const slugRegex = /^[a-z0-9-_]+$/i;
     return slugRegex.test(server) && slugRegex.test(tool);
   }
 
-  return false;
+  // Allow any valid slug to support simple MCP tool names (e.g. 'get_weather')
+  return slugRegex.test(name);
 }


### PR DESCRIPTION
Relaxed `isValidToolName` to allow any valid slug, enabling the use of simple MCP tool names in agent definitions. Added a regression test and updated existing tests.

## Summary

Issue #17005 – subagents and skills cannot properly use MCP server tools because of an inconsistency in the way the front-matter configuration is configured & applied.

## Details

The problem is this https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/tools/tool-names.ts

Tool names in front-matter have to be a built in tool, or `discovered_tool_tool_name`, or `MCPServer__tool_name` (or `MCPServer__*`). In that context we don't have access to the list of MCP tools, so that's the best we can do - but MCP tools without conflicts are registered as `tool_name`, not `MCPServer__tool_name`

c.f. here https://github.com/google-gemini/gemini-cli/blob/e2901f3f7e2ffeb369ccb81d372e236b51d65e88/packages/core/src/tools/tool-registry.ts#L532 where we try to retrieve the tool, but unless there's a conflict (in which case we non-deterministically prefix or don't prefix depending on the order in which the tools are registered) we just use the unprefixed name https://github.com/google-gemini/gemini-cli/blob/e2901f3f7e2ffeb369ccb81d372e236b51d65e88/packages/core/src/tools/tool-registry.ts#L214-L225

## Related Issues

Fixes #17005.

## How to Validate

Set up an agent with an MCP tool listed as `tool_name` (instead of `Server__tool_name`)

Ask Gemini to tell that subagent to use the tool.

Observe that Gemini can in fact now use the tool.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
