### PR TITLE
feat: add /introspect slash command

### DIFF
--- a/.gemini/commands/introspect.toml
+++ b/.gemini/commands/introspect.toml
@@ -1,0 +1,16 @@
+description = "Analyze the influence of system instructions on a specific action."
+prompt = """
+# Introspection Task
+
+Take a step back and analyze your own system instructions and internal logic.
+The user is curious about the reasoning behind a specific action or decision you've made.
+
+**Specific point of interest:** {{args}}
+
+Please provide a detailed breakdown of:
+1.  Which parts of your system instructions (global, workspace-specific, or provided via GEMINI.md) influenced this behavior?
+2.  What was your internal thought process leading up to this action?
+3.  Are there any ambiguities or conflicting instructions that played a role?
+
+Your goal is to provide transparency into your underlying logic so the user can potentially improve the instructions in the future.
+"""


### PR DESCRIPTION
## Summary

Adds a new custom slash command `/introspect {args}` to the project's `.gemini/commands/` directory. This command allows users to ask the model to analyze its own system instructions and internal reasoning for a specific action or decision.

Example:
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/7bb7bd55-0239-422c-92d4-2a2e736613a2" />

## Details

The `/introspect` command is implemented as a TOML file in `.gemini/commands/introspect.toml`. It uses the `{{args}}` placeholder to inject the user's specific point of interest into a detailed prompt that asks the model for:
1. Influential system instructions.
2. Internal thought process.
3. Potential ambiguities or conflicting instructions.

This is intended to help developers understand how system instructions (global, workspace, or `GEMINI.md`) are interpreted by the model.

## Related Issues

None.

## How to Validate

1. Start Gemini CLI from the project root.
2. Invoke the command: `/introspect why did you use a specific tool in the previous turn?`
3. Verify that the model responds with an analysis of its instructions and reasoning.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed) - Verified existing `FileCommandLoader` tests pass.
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
