### PR TITLE
fix: update currentSequenceModel when modelChanged

### DIFF
--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
@@ -166,11 +166,6 @@ describe('useQuotaAndFallback', () => {
         const intent = await promise!;
         expect(intent).toBe('retry_always');
 
-        // Verify activateFallbackMode was called
-        expect(mockConfig.activateFallbackMode).toHaveBeenCalledWith(
-          'gemini-flash',
-        );
-
         // The pending request should be cleared from the state
         expect(result.current.proQuotaRequest).toBeNull();
         expect(mockHistoryManager.addItem).toHaveBeenCalledTimes(1);
@@ -282,11 +277,6 @@ describe('useQuotaAndFallback', () => {
           const intent = await promise!;
           expect(intent).toBe('retry_always');
 
-          // Verify activateFallbackMode was called
-          expect(mockConfig.activateFallbackMode).toHaveBeenCalledWith(
-            'model-B',
-          );
-
           // The pending request should be cleared from the state
           expect(result.current.proQuotaRequest).toBeNull();
           expect(mockConfig.setQuotaErrorOccurred).toHaveBeenCalledWith(true);
@@ -341,11 +331,6 @@ To disable gemini-3-pro-preview, disable "Preview features" in /settings.`,
 
         const intent = await promise!;
         expect(intent).toBe('retry_always');
-
-        // Verify activateFallbackMode was called
-        expect(mockConfig.activateFallbackMode).toHaveBeenCalledWith(
-          'gemini-2.5-pro',
-        );
 
         expect(result.current.proQuotaRequest).toBeNull();
       });
@@ -429,11 +414,6 @@ To disable gemini-3-pro-preview, disable "Preview features" in /settings.`,
       const intent = await promise!;
       expect(intent).toBe('retry_always');
       expect(result.current.proQuotaRequest).toBeNull();
-
-      // Verify activateFallbackMode was called
-      expect(mockConfig.activateFallbackMode).toHaveBeenCalledWith(
-        'gemini-flash',
-      );
 
       // Verify quota error flags are reset
       expect(mockSetModelSwitchedFromQuotaError).toHaveBeenCalledWith(false);

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -135,10 +135,6 @@ export function useQuotaAndFallback({
         config.setQuotaErrorOccurred(false);
 
         if (choice === 'retry_always') {
-          // Set the model to the fallback model for the current session.
-          // This ensures the Footer updates and future turns use this model.
-          // The change is not persisted, so the original model is restored on restart.
-          config.activateFallbackMode(proQuotaRequest.fallbackModel);
           historyManager.addItem(
             {
               type: MessageType.INFO,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2029,9 +2029,8 @@ export class Config {
    */
   async dispose(): Promise<void> {
     coreEvents.off(CoreEvent.AgentsRefreshed, this.onAgentsRefreshed);
-    if (this.agentRegistry) {
-      this.agentRegistry.dispose();
-    }
+    this.agentRegistry?.dispose();
+    this.geminiClient?.dispose();
     if (this.mcpClientManager) {
       await this.mcpClientManager.stop();
     }

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -48,6 +48,7 @@ import type {
 import { ClearcutLogger } from '../telemetry/clearcut-logger/clearcut-logger.js';
 import * as policyCatalog from '../availability/policyCatalog.js';
 import { partToString } from '../utils/partUtils.js';
+import { coreEvents } from '../utils/events.js';
 
 // Mock fs module to prevent actual file system operations during tests
 const mockFileSystem = new Map<string, string>();
@@ -281,6 +282,7 @@ describe('Gemini Client (client.ts)', () => {
   });
 
   afterEach(() => {
+    client.dispose();
     vi.restoreAllMocks();
   });
 
@@ -1754,6 +1756,55 @@ ${JSON.stringify(
         expect(mockTurnRunFn).toHaveBeenCalledWith(
           { model: 'new-routed-model' },
           [{ text: 'A new topic' }],
+          expect.any(AbortSignal),
+        );
+      });
+
+      it('should re-route within the same prompt when the configured model changes', async () => {
+        mockTurnRunFn.mockClear();
+        mockTurnRunFn.mockImplementation(async function* () {
+          yield { type: 'content', value: 'Hello' };
+        });
+
+        mockRouterService.route.mockResolvedValueOnce({
+          model: 'original-model',
+          reason: 'test',
+        });
+
+        let stream = client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-1',
+        );
+        await fromAsync(stream);
+
+        expect(mockRouterService.route).toHaveBeenCalledTimes(1);
+        expect(mockTurnRunFn).toHaveBeenNthCalledWith(
+          1,
+          { model: 'original-model' },
+          [{ text: 'Hi' }],
+          expect.any(AbortSignal),
+        );
+
+        mockRouterService.route.mockResolvedValue({
+          model: 'fallback-model',
+          reason: 'test',
+        });
+        vi.mocked(mockConfig.getModel).mockReturnValue('gemini-2.5-flash');
+        coreEvents.emitModelChanged('gemini-2.5-flash');
+
+        stream = client.sendMessageStream(
+          [{ text: 'Continue' }],
+          new AbortController().signal,
+          'prompt-1',
+        );
+        await fromAsync(stream);
+
+        expect(mockRouterService.route).toHaveBeenCalledTimes(2);
+        expect(mockTurnRunFn).toHaveBeenNthCalledWith(
+          2,
+          { model: 'fallback-model' },
+          [{ text: 'Continue' }],
           expect.any(AbortSignal),
         );
       });

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -65,6 +65,8 @@ const createMockConfig = (overrides: Partial<Config> = {}): Config =>
     fallbackHandler: undefined,
     getFallbackModelHandler: vi.fn(),
     setActiveModel: vi.fn(),
+    setModel: vi.fn(),
+    activateFallbackMode: vi.fn(),
     getModelAvailabilityService: vi.fn(() =>
       createAvailabilityServiceMock({
         selectedModel: FALLBACK_MODEL,
@@ -198,7 +200,7 @@ describe('handleFallback', () => {
 
         expect(result).toBe(true);
         expect(policyConfig.getFallbackModelHandler).not.toHaveBeenCalled();
-        expect(policyConfig.setActiveModel).toHaveBeenCalledWith(
+        expect(policyConfig.activateFallbackMode).toHaveBeenCalledWith(
           DEFAULT_GEMINI_FLASH_MODEL,
         );
       } finally {
@@ -273,7 +275,7 @@ describe('handleFallback', () => {
       expect(openBrowserSecurely).toHaveBeenCalledWith(
         'https://goo.gle/set-up-gemini-code-assist',
       );
-      expect(policyConfig.setActiveModel).not.toHaveBeenCalled();
+      expect(policyConfig.activateFallbackMode).not.toHaveBeenCalled();
     });
 
     it('should catch errors from the handler, log an error, and return null', async () => {
@@ -378,7 +380,7 @@ describe('handleFallback', () => {
       );
     });
 
-    it('calls setActiveModel and logs telemetry when handler returns "retry_always"', async () => {
+    it('calls activateFallbackMode when handler returns "retry_always"', async () => {
       policyHandler.mockResolvedValue('retry_always');
       vi.mocked(policyConfig.getModel).mockReturnValue(
         DEFAULT_GEMINI_MODEL_AUTO,
@@ -391,11 +393,13 @@ describe('handleFallback', () => {
       );
 
       expect(result).toBe(true);
-      expect(policyConfig.setActiveModel).toHaveBeenCalledWith(FALLBACK_MODEL);
+      expect(policyConfig.activateFallbackMode).toHaveBeenCalledWith(
+        FALLBACK_MODEL,
+      );
       // TODO: add logging expect statement
     });
 
-    it('does NOT call setActiveModel when handler returns "stop"', async () => {
+    it('does NOT call activateFallbackMode when handler returns "stop"', async () => {
       policyHandler.mockResolvedValue('stop');
 
       const result = await handleFallback(
@@ -405,11 +409,11 @@ describe('handleFallback', () => {
       );
 
       expect(result).toBe(false);
-      expect(policyConfig.setActiveModel).not.toHaveBeenCalled();
+      expect(policyConfig.activateFallbackMode).not.toHaveBeenCalled();
       // TODO: add logging expect statement
     });
 
-    it('does NOT call setActiveModel when handler returns "retry_once"', async () => {
+    it('does NOT call activateFallbackMode when handler returns "retry_once"', async () => {
       policyHandler.mockResolvedValue('retry_once');
 
       const result = await handleFallback(
@@ -419,7 +423,7 @@ describe('handleFallback', () => {
       );
 
       expect(result).toBe(true);
-      expect(policyConfig.setActiveModel).not.toHaveBeenCalled();
+      expect(policyConfig.activateFallbackMode).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -131,7 +131,7 @@ async function processIntent(
     case 'retry_always':
       // TODO(telemetry): Implement generic fallback event logging. Existing
       // logFlashFallback is specific to a single Model.
-      config.setActiveModel(fallbackModel);
+      config.activateFallbackMode(fallbackModel);
       return true;
 
     case 'retry_once':


### PR DESCRIPTION
## Summary

Fixes fallback behavior so switching to Flash persists within the same prompt and across continuations. 
Core fallback now owns the model switch, and GeminiClient clears the sticky sequence model when the configured model changes, ensuring routing re-evaluates after fallback.

## Details

 - Core fallback uses activateFallbackMode to perform session-level setModel and emit ModelChanged.
 - UI no longer sets the model directly; it only resolves intent and logs the info message.
 - GeminiClient listens for ModelChanged and clears currentSequenceModel, so continuations in the same prompt re-route using the new configured model.
 - Added a routing test that verifies re-routing within the same prompt after a model change.

## Related Issues


## How to Validate

Select Auto, Trigger Pro quota exceeded error, select fallback to flash, confirm that the turn and subsequent prompts use flash.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
