### PR TITLE
Fix mcp tool lookup in tool registry

### DIFF
--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -264,6 +264,10 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
     return `${this.serverName}__`;
   }
 
+  getFullyQualifiedName(): string {
+    return `${this.getFullyQualifiedPrefix()}${generateValidName(this.serverToolName)}`;
+  }
+
   asFullyQualifiedTool(): DiscoveredMCPTool {
     return new DiscoveredMCPTool(
       this.mcpTool,
@@ -273,7 +277,7 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
       this.parameterSchema,
       this.messageBus,
       this.trust,
-      `${this.getFullyQualifiedPrefix()}${this.serverToolName}`,
+      this.getFullyQualifiedName(),
       this.cliConfig,
       this.extensionName,
       this.extensionId,

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -561,9 +561,8 @@ describe('ToolRegistry', () => {
       expect(toolRegistry.getTool(validToolName)).toBeDefined();
       expect(toolRegistry.getTool(validToolName)?.name).toBe(validToolName);
 
-      // Verify it is available as 'my-server__my tool'
-      // Note: DiscoveredMCPTool uses serverToolName for FQ lookup, not registered name.
-      const fullyQualifiedName = `${serverName}__${toolName}`;
+      // Verify it is available as 'my-server__my_tool'
+      const fullyQualifiedName = `${serverName}__${validToolName}`;
       const retrievedTool = toolRegistry.getTool(fullyQualifiedName);
 
       expect(retrievedTool).toBeDefined();

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -525,6 +525,52 @@ describe('ToolRegistry', () => {
     });
   });
 
+  describe('getTool', () => {
+    it('should retrieve an MCP tool by its fully qualified name even if registered with simple name', () => {
+      const serverName = 'my-server';
+      const toolName = 'my-tool';
+      const mcpTool = createMCPTool(serverName, toolName, 'description');
+
+      // Register tool (will be registered as 'my-tool' since no conflict)
+      toolRegistry.registerTool(mcpTool);
+
+      // Verify it is available as 'my-tool'
+      expect(toolRegistry.getTool('my-tool')).toBeDefined();
+      expect(toolRegistry.getTool('my-tool')?.name).toBe('my-tool');
+
+      // Verify it is available as 'my-server__my-tool'
+      const fullyQualifiedName = `${serverName}__${toolName}`;
+      const retrievedTool = toolRegistry.getTool(fullyQualifiedName);
+
+      expect(retrievedTool).toBeDefined();
+      // The returned tool object is the same, so its name property is still 'my-tool'
+      expect(retrievedTool?.name).toBe('my-tool');
+    });
+
+    it('should retrieve an MCP tool by its fully qualified name when tool name has special characters', () => {
+      const serverName = 'my-server';
+      // Use a space which is invalid and will be replaced by underscore
+      const toolName = 'my tool';
+      const validToolName = 'my_tool';
+      const mcpTool = createMCPTool(serverName, toolName, 'description');
+
+      // Register tool (will be registered as sanitized name)
+      toolRegistry.registerTool(mcpTool);
+
+      // Verify it is available as sanitized name
+      expect(toolRegistry.getTool(validToolName)).toBeDefined();
+      expect(toolRegistry.getTool(validToolName)?.name).toBe(validToolName);
+
+      // Verify it is available as 'my-server__my tool'
+      // Note: DiscoveredMCPTool uses serverToolName for FQ lookup, not registered name.
+      const fullyQualifiedName = `${serverName}__${toolName}`;
+      const retrievedTool = toolRegistry.getTool(fullyQualifiedName);
+
+      expect(retrievedTool).toBeDefined();
+      expect(retrievedTool?.name).toBe(validToolName);
+    });
+  });
+
   describe('DiscoveredToolInvocation', () => {
     it('should return the stringified params from getDescription', () => {
       const tool = new DiscoveredTool(

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -14,7 +14,7 @@ import { Kind, BaseDeclarativeTool, BaseToolInvocation } from './tools.js';
 import type { Config } from '../config/config.js';
 import { spawn } from 'node:child_process';
 import { StringDecoder } from 'node:string_decoder';
-import { DiscoveredMCPTool, generateValidName } from './mcp-tool.js';
+import { DiscoveredMCPTool } from './mcp-tool.js';
 import { parse } from 'shell-quote';
 import { ToolErrorType } from './tool-error.js';
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
@@ -534,8 +534,7 @@ export class ToolRegistry {
     if (!tool && name.includes('__')) {
       for (const t of this.allKnownTools.values()) {
         if (t instanceof DiscoveredMCPTool) {
-          const fqn = `${t.serverName}__${generateValidName(t.serverToolName)}`;
-          if (fqn === name) {
+          if (t.getFullyQualifiedName() === name) {
             tool = t;
             break;
           }


### PR DESCRIPTION
## Summary

Fix tool lookup for MCP tools in the tool registry such that MCP tools can be looked up by their fully qualified names in addition to their unprefixed names. Fixes #17005

## Details

Consistently allow looking up an MCP tool by `MCPServer__tool_name`.

Previously, looking up a tool by name had non-obvious and potentially buggy behaviour for MCP tools.

If the MCP tool name by itself is unambiguous, then obtaining the tool with `tool_name` works but `MCPServer__tool_name` does not.

If the MCP tool name _is_ ambiguous, then `tool_name` works for one of the two and `MCPServer__tool_name` works for the other one.

## Related Issues

Fixes #17005 (#17046 would solve it too but this makes the fix more complete).

## How to Validate

Set up a subagent with `MCPServer__tool_name` under its allowed tools.

Fire up Gemini CLI and ask Gemini to get that subagent to try to invoke that tool.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
