### PR TITLE
feat(cli): add experiment gate for event-driven scheduler

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -835,6 +835,11 @@ their corresponding top-level category object in your `settings.json` file.
   - **Default:** `false`
   - **Requires restart:** Yes
 
+- **`experimental.enableEventDrivenScheduler`** (boolean):
+  - **Description:** Enables event-driven scheduler within the CLI session.
+  - **Default:** `false`
+  - **Requires restart:** Yes
+
 - **`experimental.extensionReloading`** (boolean):
   - **Description:** Enables extension loading/unloading within the CLI session.
   - **Default:** `false`

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -721,6 +721,8 @@ export async function loadCliConfig(
     enableExtensionReloading: settings.experimental?.extensionReloading,
     enableAgents: settings.experimental?.enableAgents,
     plan: settings.experimental?.plan,
+    enableEventDrivenScheduler:
+      settings.experimental?.enableEventDrivenScheduler,
     skillsSupport:
       settings.experimental?.skills || (settings.skills?.enabled ?? true),
     disabledSkills: settings.skills?.disabled,

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -381,6 +381,20 @@ describe('SettingsSchema', () => {
       );
     });
 
+    it('should have enableEventDrivenScheduler setting in schema', () => {
+      const setting =
+        getSettingsSchema().experimental.properties.enableEventDrivenScheduler;
+      expect(setting).toBeDefined();
+      expect(setting.type).toBe('boolean');
+      expect(setting.category).toBe('Experimental');
+      expect(setting.default).toBe(false);
+      expect(setting.requiresRestart).toBe(true);
+      expect(setting.showInDialog).toBe(false);
+      expect(setting.description).toBe(
+        'Enables event-driven scheduler within the CLI session.',
+      );
+    });
+
     it('should have hooks.notifications setting in schema', () => {
       const setting = getSettingsSchema().hooks.properties.notifications;
       expect(setting).toBeDefined();

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1424,6 +1424,15 @@ const SETTINGS_SCHEMA = {
         description: 'Enable requesting and fetching of extension settings.',
         showInDialog: false,
       },
+      enableEventDrivenScheduler: {
+        type: 'boolean',
+        label: 'Event Driven Scheduler',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: false,
+        description: 'Enables event-driven scheduler within the CLI session.',
+        showInDialog: false,
+      },
       extensionReloading: {
         type: 'boolean',
         label: 'Extension Reloading',

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -855,6 +855,22 @@ describe('Server Config (config.ts)', () => {
     });
   });
 
+  describe('Event Driven Scheduler Configuration', () => {
+    it('should default enableEventDrivenScheduler to false when not provided', () => {
+      const config = new Config(baseParams);
+      expect(config.isEventDrivenSchedulerEnabled()).toBe(false);
+    });
+
+    it('should set enableEventDrivenScheduler to false when provided as false', () => {
+      const params: ConfigParameters = {
+        ...baseParams,
+        enableEventDrivenScheduler: false,
+      };
+      const config = new Config(params);
+      expect(config.isEventDrivenSchedulerEnabled()).toBe(false);
+    });
+  });
+
   describe('Shell Tool Inactivity Timeout', () => {
     it('should default to 300000ms (300 seconds) when not provided', () => {
       const config = new Config(baseParams);

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -379,6 +379,7 @@ export interface ConfigParameters {
   };
   previewFeatures?: boolean;
   enableAgents?: boolean;
+  enableEventDrivenScheduler?: boolean;
   skillsSupport?: boolean;
   disabledSkills?: string[];
   adminSkillsEnabled?: boolean;
@@ -531,6 +532,7 @@ export class Config {
 
   private readonly enableAgents: boolean;
   private agents: AgentSettings;
+  private readonly enableEventDrivenScheduler: boolean;
   private readonly skillsSupport: boolean;
   private disabledSkills: string[];
   private readonly adminSkillsEnabled: boolean;
@@ -618,6 +620,8 @@ export class Config {
     this.agents = params.agents ?? {};
     this.disableLLMCorrection = params.disableLLMCorrection ?? false;
     this.planEnabled = params.plan ?? false;
+    this.enableEventDrivenScheduler =
+      params.enableEventDrivenScheduler ?? false;
     this.skillsSupport = params.skillsSupport ?? false;
     this.disabledSkills = params.disabledSkills ?? [];
     this.adminSkillsEnabled = params.adminSkillsEnabled ?? true;
@@ -1518,6 +1522,10 @@ export class Config {
 
   isAgentsEnabled(): boolean {
     return this.enableAgents;
+  }
+
+  isEventDrivenSchedulerEnabled(): boolean {
+    return this.enableEventDrivenScheduler;
   }
 
   getNoBrowser(): boolean {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1400,6 +1400,13 @@
           "default": false,
           "type": "boolean"
         },
+        "enableEventDrivenScheduler": {
+          "title": "Event Driven Scheduler",
+          "description": "Enables event-driven scheduler within the CLI session.",
+          "markdownDescription": "Enables event-driven scheduler within the CLI session.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
+          "default": false,
+          "type": "boolean"
+        },
         "extensionReloading": {
           "title": "Extension Reloading",
           "description": "Enables extension loading/unloading within the CLI session.",


### PR DESCRIPTION
## Summary

Introduce an experimental gate for the event-driven scheduler. This allows for a
safe, phased migration by providing an opt-in toggle for developers and testers.

## Details

- **Configuration**: Added `enableEventDrivenScheduler` to the `experimental`
  category in `settingsSchema.ts`.
- **Default Behavior**: Defaults to `false` to ensure stability for all users.
- **Core Support**: Updated the Core `Config` to expose
  `isEventDrivenSchedulerEnabled()`.
- **Schema & Docs**: Regenerated `settings.schema.json` and updated
  `configuration.md`.
- **Testing**: Added unit tests to verify the configuration parsing and default
  state in both packages.

## Related Issues

Related to #14306

## How to Validate

1. **Unit Tests**:
   - `npm test -w @google/gemini-cli-core -- src/config/config.test.ts`
   - `npm test -w @google/gemini-cli -- src/config/settingsSchema.test.ts`
2. **Manual Verification**:
   - Open `settings.json` and verify the new setting is available
   - Check the generated documentation in `docs/get-started/configuration.md`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
