### PR TITLE
fix(cli): race conditions in useGeminiStream parallel tool handling

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -1026,6 +1026,123 @@ describe('useGeminiStream', () => {
     });
   });
 
+  it('should await submitQuery before marking tools as submitted (race condition fix)', async () => {
+    // This tests the fix for the race condition where markToolsAsSubmitted was
+    // called BEFORE submitQuery completed, allowing user prompts to race ahead
+    // of tool responses and causing unrecoverable 400 errors.
+    // See: https://github.com/google-gemini/gemini-cli/issues/16144
+
+    const toolCallResponseParts: PartListUnion = [{ text: 'tool response' }];
+
+    const completedTool = {
+      request: {
+        callId: 'race-test-call',
+        name: 'test_tool',
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'prompt-id-race-test',
+      },
+      status: 'success',
+      responseSubmittedToGemini: false,
+      response: {
+        callId: 'race-test-call',
+        responseParts: toolCallResponseParts,
+        errorType: undefined,
+      },
+      tool: { displayName: 'TestTool' },
+      invocation: {
+        getDescription: () => 'Mock description',
+      } as unknown as AnyToolInvocation,
+    } as TrackedCompletedToolCall;
+
+    // Track the order of operations
+    const callOrder: string[] = [];
+    let resolveStreamPromise: () => void;
+    const streamPromise = new Promise<void>((resolve) => {
+      resolveStreamPromise = resolve;
+    });
+
+    // Mock sendMessageStream to be a slow async operation
+    mockSendMessageStream.mockImplementation(() => {
+      callOrder.push('sendMessageStream:start');
+      return (async function* () {
+        await streamPromise; // Wait until we explicitly resolve
+        callOrder.push('sendMessageStream:end');
+        yield { type: ServerGeminiEventType.Finished, text: '' };
+      })();
+    });
+
+    // Track when markToolsAsSubmitted is called
+    mockMarkToolsAsSubmitted.mockImplementation((callIds: string[]) => {
+      callOrder.push(`markToolsAsSubmitted:${callIds.join(',')}`);
+    });
+
+    let capturedOnComplete:
+      | ((tools: TrackedToolCall[]) => Promise<void>)
+      | null = null;
+
+    mockUseReactToolScheduler.mockImplementation((onComplete) => {
+      capturedOnComplete = onComplete;
+      return [
+        [completedTool],
+        mockScheduleToolCalls,
+        mockMarkToolsAsSubmitted,
+        vi.fn(),
+      ];
+    });
+
+    renderHook(() =>
+      useGeminiStream(
+        new MockedGeminiClientClass(mockConfig),
+        [],
+        mockAddItem,
+        mockConfig,
+        mockLoadedSettings,
+        mockOnDebugMessage,
+        mockHandleSlashCommand,
+        false,
+        () => 'vscode' as EditorType,
+        () => {},
+        () => Promise.resolve(),
+        false,
+        () => {},
+        () => {},
+        () => {},
+        80,
+        24,
+      ),
+    );
+
+    // Start tool completion (this will call submitQuery -> sendMessageStream)
+    const completionPromise = act(async () => {
+      if (capturedOnComplete) {
+        await capturedOnComplete([completedTool] as TrackedToolCall[]);
+      }
+    });
+
+    // Give time for sendMessageStream to start but NOT complete
+    await new Promise((r) => setTimeout(r, 10));
+
+    // At this point, sendMessageStream should have started but not finished
+    // markToolsAsSubmitted should NOT have been called yet (the fix!)
+    expect(callOrder).toContain('sendMessageStream:start');
+    expect(callOrder).not.toContain('markToolsAsSubmitted:race-test-call');
+
+    // Now resolve the stream
+    resolveStreamPromise!();
+    await completionPromise;
+
+    // After stream completes, markToolsAsSubmitted should be called
+    await waitFor(() => {
+      expect(callOrder).toContain('markToolsAsSubmitted:race-test-call');
+    });
+
+    // Verify the correct order: stream must complete before marking
+    const streamEndIndex = callOrder.indexOf('sendMessageStream:end');
+    const markIndex = callOrder.indexOf('markToolsAsSubmitted:race-test-call');
+    expect(streamEndIndex).toBeLessThan(markIndex);
+  });
+
   it('should not flicker streaming state to Idle between tool completion and submission', async () => {
     const toolCallResponseParts: PartListUnion = [
       { text: 'tool 1 final response' },

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1188,6 +1188,17 @@ export const useGeminiStream = (
           (
             tc: TrackedToolCall,
           ): tc is TrackedCompletedToolCall | TrackedCancelledToolCall => {
+            // Check if we've already submitted this tool call.
+            // We need to look up the tracked version because the incoming 'tc'
+            // comes directly from the scheduler core and lacks the
+            // 'responseSubmittedToGemini' flag.
+            const trackedToolCall = toolCalls.find(
+              (t) => t.request.callId === tc.request.callId,
+            );
+            if (trackedToolCall?.responseSubmittedToGemini) {
+              return false;
+            }
+
             const isTerminalState =
               tc.status === 'success' ||
               tc.status === 'error' ||
@@ -1327,6 +1338,7 @@ export const useGeminiStream = (
       performMemoryRefresh,
       modelSwitchedFromQuotaError,
       addItem,
+      toolCalls,
     ],
   );
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1315,21 +1315,25 @@ export const useGeminiStream = (
         (toolCall) => toolCall.request.prompt_id,
       );
 
-      markToolsAsSubmitted(callIdsToMarkAsSubmitted);
-
       // Don't continue if model was switched due to quota error
       if (modelSwitchedFromQuotaError) {
+        markToolsAsSubmitted(callIdsToMarkAsSubmitted);
         return;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      submitQuery(
+      // IMPORTANT: We must await submitQuery BEFORE marking tools as submitted.
+      // Otherwise, streamingState becomes Idle and user prompts can race ahead
+      // of the tool response, causing function call/response mismatch errors.
+      await submitQuery(
         responsesToSend,
         {
           isContinuation: true,
         },
         prompt_ids[0],
       );
+
+      // Only mark as submitted after the API call is complete
+      markToolsAsSubmitted(callIdsToMarkAsSubmitted);
     },
     [
       submitQuery,


### PR DESCRIPTION
## Summary  

Fixes race conditions in `useGeminiStream.ts` that cause unrecoverable 400 errors during parallel function calling.  **This PR is extracted from #16146 per [reviewer feedback](https://github.com/google-gemini/gemini-cli/pull/16146#pullrequestreview-2877120614) requesting separation of concerns.** It contains ONLY the `useGeminiStream.ts` fixes and their tests.  ## Single Concern: useGeminiStream Race Conditions  All changes are in `packages/cli/src/ui/hooks/`: - `useGeminiStream.ts` (2 fixes) - `useGeminiStream.test.tsx` (2 regression tests)  ### Fix 1: Stale closure in `handleCompletedTools`  **Problem:** `handleCompletedTools` captured stale `toolCalls` state, causing already-submitted tools to be resubmitted when the callback fired.  **Fix:** Add `toolCalls` to dependency array and filter out tools where `responseSubmittedToGemini=true`.  ### Fix 2: Fire-and-forget `submitQuery`  **Problem:** `markToolsAsSubmitted()` was called BEFORE `submitQuery()` completed. This set `streamingState` to `Idle` prematurely, allowing user prompts to race ahead of tool responses.  **Fix:** `await submitQuery()` completion, THEN call `markToolsAsSubmitted()`.  ## What's NOT in this PR (vs #16146)  Per reviewer request, these were removed to separate concerns: - ~~`local-executor.ts` response ordering~~ (dropped - speculative) - ~~`mcp-client.test.ts` OAuth fix~~ (separate PR if needed) - ~~`generateContentResponseUtilities.ts` binary content~~ (separate PR: #TBD)  ## Fixes  - #16144 - #16216   - #16068 - #15239 - #16135  ## Test Plan  - [x] Added regression test: verifies `responseSubmittedToGemini=true` tools are filtered - [x] Added regression test: verifies `markToolsAsSubmitted` waits for `submitQuery` - [x] Run `npm run preflight`  

Fixes #17067