### PR TITLE
fix(workflows): use author_association for maintainer check

### DIFF
--- a/.github/workflows/pr-contribution-guidelines-notifier.yml
+++ b/.github/workflows/pr-contribution-guidelines-notifier.yml
@@ -33,19 +33,12 @@ jobs:
             const repo = context.repo.repo;
             const username = context.payload.pull_request.user.login;
             const pr_number = context.payload.pull_request.number;
-            const team_slug = 'gemini-cli-maintainers';
 
             // 1. Check if the PR author is a maintainer
-            try {
-              await github.rest.teams.getMembershipForUserInOrg({
-                org,
-                team_slug,
-                username,
-              });
-              core.info(`${username} is a maintainer. No notification needed.`);
+            const authorAssociation = context.payload.pull_request.author_association;
+            if (['OWNER', 'MEMBER', 'COLLABORATOR'].includes(authorAssociation)) {
+              core.info(`${username} is a maintainer (Association: ${authorAssociation}). No notification needed.`);
               return;
-            } catch (error) {
-              if (error.status !== 404) throw error;
             }
 
             // 2. Check if the PR is already associated with an issue


### PR DESCRIPTION
## Summary

Fixes the "PR Contribution Guidelines Notifier" workflow to correctly identify project maintainers. Previously, the workflow relied on the `github.rest.teams.getMembershipForUserInOrg` API call, which would fail with a 404 error if the token lacked `members:read` permissions or if the user's team membership was private. This caused maintainers (like members of the `gemini-cli-maintainers` team) to be incorrectly flagged as external contributors, triggering unnecessary notification comments on their PRs.

## Details

- **Problem:** The `getMembershipForUserInOrg` API call is fragile for this use case. It returns 404 for private memberships or insufficient token scopes, which the script interpreted as "not a member."
- **Solution:** Switched to using `context.payload.pull_request.author_association`. This field is provided directly in the webhook payload and reliably identifies the user's relationship to the repo (e.g., `OWNER`, `MEMBER`, `COLLABORATOR`) without requiring extra API calls or sensitive permissions.
- **Cleanup:** Removed the unused `team_slug` variable.

## Related Issues

Related to internal observation of incorrect bot behavior on maintainer PRs (e.g., https://github.com/google-gemini/gemini-cli/pull/17055).

## How to Validate

1.  **Code Review:** Verify that the logic now checks `author_association` against `['OWNER', 'MEMBER', 'COLLABORATOR']`.
2.  **Simulation:**
    - Create a PR from a user account that is a **Member** of the repo (but whose membership might be private).
    - Verify that the workflow runs and *skips* posting the comment because `author_association` will be `MEMBER`.
    - Create a PR from an external account (no association).
    - Verify that the workflow runs and *posts* the comment (association will be `NONE` or `CONTRIBUTOR`).

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) - N/A (Internal workflow fix)
- [x] Added/updated tests (if needed) - N/A (Workflow logic change, validated via manual review)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run lint
