### PR TITLE
docs(themes): remove unsupported DiffModified color key

### DIFF
--- a/docs/cli/themes.md
+++ b/docs/cli/themes.md
@@ -86,7 +86,6 @@ color keys. For example:
 - `Gray`
 - `DiffAdded` (optional, for added lines in diffs)
 - `DiffRemoved` (optional, for removed lines in diffs)
-- `DiffModified` (optional, for modified lines in diffs)
 
 You can also override individual UI text roles by adding a nested `text` object.
 This object supports the keys `primary`, `secondary`, `link`, `accent`, and
@@ -157,7 +156,6 @@ custom theme defined in `settings.json`.
   "Gray": "#ABB2BF",
   "DiffAdded": "#A6E3A1",
   "DiffRemoved": "#F38BA8",
-  "DiffModified": "#89B4FA",
   "GradientColors": ["#4796E4", "#847ACE", "#C3677F"]
 }
 ```


### PR DESCRIPTION
## Summary
- Remove `DiffModified` from theme documentation as it is not supported in the settings schema
- The schema only supports `DiffAdded` and `DiffRemoved` color keys

## Test plan
- [x] Verified `DiffModified` is not in `schemas/settings.schema.json`
- [x] Verified test explicitly expects `DiffModified` to produce validation warning

Fixes #16666