### PR TITLE
fix(core): deduplicate ModelInfo emission in GeminiClient

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1827,7 +1827,6 @@ ${JSON.stringify(
       expect(events).toEqual([
         { type: GeminiEventType.ModelInfo, value: 'default-routed-model' },
         { type: GeminiEventType.InvalidStream },
-        { type: GeminiEventType.ModelInfo, value: 'default-routed-model' },
         { type: GeminiEventType.Content, value: 'Continued content' },
       ]);
 
@@ -1915,13 +1914,13 @@ ${JSON.stringify(
       const events = await fromAsync(stream);
 
       // Assert
-      // We expect 4 events (model_info + original + model_info + 1 retry)
-      expect(events.length).toBe(4);
+      // We expect 3 events (model_info + original + 1 retry)
+      expect(events.length).toBe(3);
       expect(
         events
-          .filter((e) => e.type !== GeminiEventType.ModelInfo)
-          .every((e) => e.type === GeminiEventType.InvalidStream),
-      ).toBe(true);
+          .filter((e) => e.type === GeminiEventType.ModelInfo)
+          .map((e) => e.value),
+      ).toEqual(['default-routed-model']);
 
       // Verify that turn.run was called twice
       expect(mockTurnRunFn).toHaveBeenCalledTimes(2);

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -626,10 +626,10 @@ export class GeminiClient {
     );
     modelToUse = finalModel;
 
-    this.currentSequenceModel = modelToUse;
-    if (!signal.aborted) {
+    if (!signal.aborted && !this.currentSequenceModel) {
       yield { type: GeminiEventType.ModelInfo, value: modelToUse };
     }
+    this.currentSequenceModel = modelToUse;
     const resultStream = turn.run(modelConfigKey, request, linkedSignal);
     let isError = false;
     let isInvalidStream = false;


### PR DESCRIPTION
## Summary

Deduplicate `ModelInfo` emission in `GeminiClient` to prevent the "Responding with <model name>" message from appearing multiple times during multi-turn interactions (e.g., tool-calling sequences).

## Details

PR #17043 introduced a flush of the pending history item before scheduling tool calls to ensure correct rendering order. However, this change unintentionally exposed a pre-existing duplicate emission of the `ModelInfo` event at the start of every turn in a sequence. 

This PR modifies `GeminiClient.processTurn` to only yield the `ModelInfo` event on the first turn of a sequence (when `this.currentSequenceModel` is not yet set). This ensures the model name is only displayed once per user prompt, maintaining a cleaner chat UI.

## Related Issues

Part of https://github.com/google-gemini/gemini-cli/issues/17029 (Identified regression from #17043)

## How to Validate

Run the core package tests:
```bash
npm test -w @google/gemini-cli-core -- src/core/client.test.ts
```

Or run the full preflight:
```bash
npm run preflight
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
