### PR TITLE
fix(cli): list installed extensions when update target missing

### DIFF
--- a/packages/cli/src/commands/extensions/update.test.ts
+++ b/packages/cli/src/commands/extensions/update.test.ts
@@ -24,6 +24,7 @@ import { ExtensionUpdateState } from '../../ui/state/extensions.js';
 
 // Mock dependencies
 const emitConsoleLog = vi.hoisted(() => vi.fn());
+const emitFeedback = vi.hoisted(() => vi.fn());
 const debugLogger = vi.hoisted(() => ({
   log: vi.fn((message, ...args) => {
     emitConsoleLog('log', format(message, ...args));
@@ -40,6 +41,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     ...actual,
     coreEvents: {
       emitConsoleLog,
+      emitFeedback,
     },
     debugLogger,
   };
@@ -96,8 +98,8 @@ describe('extensions update command', () => {
 
       await handleUpdate({ name: 'missing-extension' });
 
-      expect(emitConsoleLog).toHaveBeenCalledWith(
-        'log',
+      expect(emitFeedback).toHaveBeenCalledWith(
+        'error',
         'Extension "missing-extension" not found.\n\nInstalled extensions:\next1 (1.0.0)\next2 (2.0.0)\n\nRun "gemini extensions list" for details.',
       );
       expect(mockUpdateExtension).not.toHaveBeenCalled();
@@ -112,8 +114,8 @@ describe('extensions update command', () => {
 
       await handleUpdate({ name: 'missing-extension' });
 
-      expect(emitConsoleLog).toHaveBeenCalledWith(
-        'log',
+      expect(emitFeedback).toHaveBeenCalledWith(
+        'error',
         'Extension "missing-extension" not found.\n\nNo extensions installed.',
       );
       expect(mockUpdateExtension).not.toHaveBeenCalled();

--- a/packages/cli/src/commands/extensions/update.test.ts
+++ b/packages/cli/src/commands/extensions/update.test.ts
@@ -93,15 +93,12 @@ describe('extensions update command', () => {
       mockExtensionManager.prototype.loadExtensions = vi
         .fn()
         .mockResolvedValue(extensions);
-      mockExtensionManager.prototype.toOutputString = vi.fn(
-        (ext) => `${ext.name}@${ext.version}`,
-      );
 
       await handleUpdate({ name: 'missing-extension' });
 
       expect(emitConsoleLog).toHaveBeenCalledWith(
         'log',
-        'Extension "missing-extension" not found.\n\nInstalled extensions:\n\next1@1.0.0\n\next2@2.0.0',
+        'Extension "missing-extension" not found.\n\nInstalled extensions:\next1 (1.0.0)\next2 (2.0.0)\n\nRun "gemini extensions list" for details.',
       );
       expect(mockUpdateExtension).not.toHaveBeenCalled();
       mockCwd.mockRestore();

--- a/packages/cli/src/commands/extensions/update.ts
+++ b/packages/cli/src/commands/extensions/update.ts
@@ -46,7 +46,19 @@ export async function handleUpdate(args: UpdateArgs) {
         (extension) => extension.name === args.name,
       );
       if (!extension) {
-        debugLogger.log(`Extension "${args.name}" not found.`);
+        if (extensions.length === 0) {
+          debugLogger.log(
+            `Extension "${args.name}" not found.\n\nNo extensions installed.`,
+          );
+          return;
+        }
+
+        const installedExtensions = extensions
+          .map((extension) => extensionManager.toOutputString(extension))
+          .join('\n\n');
+        debugLogger.log(
+          `Extension "${args.name}" not found.\n\nInstalled extensions:\n\n${installedExtensions}`,
+        );
         return;
       }
       if (!extension.installMetadata) {

--- a/packages/cli/src/commands/extensions/update.ts
+++ b/packages/cli/src/commands/extensions/update.ts
@@ -54,10 +54,10 @@ export async function handleUpdate(args: UpdateArgs) {
         }
 
         const installedExtensions = extensions
-          .map((extension) => extensionManager.toOutputString(extension))
-          .join('\n\n');
+          .map((extension) => `${extension.name} (${extension.version})`)
+          .join('\n');
         debugLogger.log(
-          `Extension "${args.name}" not found.\n\nInstalled extensions:\n\n${installedExtensions}`,
+          `Extension "${args.name}" not found.\n\nInstalled extensions:\n${installedExtensions}\n\nRun "gemini extensions list" for details.`,
         );
         return;
       }
@@ -75,7 +75,6 @@ export async function handleUpdate(args: UpdateArgs) {
         debugLogger.log(`Extension "${args.name}" is already up to date.`);
         return;
       }
-      // TODO(chrstnb): we should list extensions if the requested extension is not installed.
       const updatedExtensionInfo = (await updateExtension(
         extension,
         extensionManager,

--- a/packages/cli/src/commands/extensions/update.ts
+++ b/packages/cli/src/commands/extensions/update.ts
@@ -14,7 +14,7 @@ import {
 import { checkForExtensionUpdate } from '../../config/extensions/github.js';
 import { getErrorMessage } from '../../utils/errors.js';
 import { ExtensionUpdateState } from '../../ui/state/extensions.js';
-import { debugLogger } from '@google/gemini-cli-core';
+import { coreEvents, debugLogger } from '@google/gemini-cli-core';
 import { ExtensionManager } from '../../config/extension-manager.js';
 import { requestConsentNonInteractive } from '../../config/extensions/consent.js';
 import { loadSettings } from '../../config/settings.js';
@@ -47,7 +47,8 @@ export async function handleUpdate(args: UpdateArgs) {
       );
       if (!extension) {
         if (extensions.length === 0) {
-          debugLogger.log(
+          coreEvents.emitFeedback(
+            'error',
             `Extension "${args.name}" not found.\n\nNo extensions installed.`,
           );
           return;
@@ -56,7 +57,8 @@ export async function handleUpdate(args: UpdateArgs) {
         const installedExtensions = extensions
           .map((extension) => `${extension.name} (${extension.version})`)
           .join('\n');
-        debugLogger.log(
+        coreEvents.emitFeedback(
+          'error',
           `Extension "${args.name}" not found.\n\nInstalled extensions:\n${installedExtensions}\n\nRun "gemini extensions list" for details.`,
         );
         return;


### PR DESCRIPTION
Fixes #16820

## Summary
When `gemini extensions update <name>` can't find the requested extension, also print the list of installed extensions (or `No extensions installed.`) so the user can quickly recover.

## Test Plan
- `cd packages/cli && npx vitest run src/commands/extensions/update.test.ts`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
