### PR TITLE
feat(core): unify agent enabled and disabled flags

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -2117,10 +2117,6 @@ export const SETTINGS_SCHEMA_DEFINITIONS: Record<
         type: 'boolean',
         description: 'Whether to enable the agent.',
       },
-      disabled: {
-        type: 'boolean',
-        description: 'Whether to disable the agent.',
-      },
     },
   },
   CustomTheme: {

--- a/packages/cli/src/ui/commands/agentsCommand.test.ts
+++ b/packages/cli/src/ui/commands/agentsCommand.test.ts
@@ -149,7 +149,7 @@ describe('agentsCommand', () => {
     });
     // Add agent to disabled overrides so validation passes
     mockContext.services.settings.merged.agents.overrides['test-agent'] = {
-      disabled: true,
+      enabled: false,
     };
 
     vi.mocked(enableAgent).mockReturnValue({
@@ -264,7 +264,7 @@ describe('agentsCommand', () => {
   it('should show info message if agent is already disabled', async () => {
     mockConfig.getAgentRegistry().getAllAgentNames.mockReturnValue([]);
     mockContext.services.settings.merged.agents.overrides['test-agent'] = {
-      disabled: true,
+      enabled: false,
     };
 
     const disableCommand = agentsCommand.subCommands?.find(

--- a/packages/cli/src/ui/commands/agentsCommand.ts
+++ b/packages/cli/src/ui/commands/agentsCommand.ts
@@ -85,10 +85,10 @@ async function enableAction(
   const allAgents = agentRegistry.getAllAgentNames();
   const overrides = settings.merged.agents.overrides;
   const disabledAgents = Object.keys(overrides).filter(
-    (name) => overrides[name]?.disabled === true,
+    (name) => overrides[name]?.enabled === false,
   );
 
-  if (allAgents.includes(agentName)) {
+  if (allAgents.includes(agentName) && !disabledAgents.includes(agentName)) {
     return {
       type: 'message',
       messageType: 'info',
@@ -96,7 +96,7 @@ async function enableAction(
     };
   }
 
-  if (!disabledAgents.includes(agentName)) {
+  if (!disabledAgents.includes(agentName) && !allAgents.includes(agentName)) {
     return {
       type: 'message',
       messageType: 'error',
@@ -155,7 +155,7 @@ async function disableAction(
   const allAgents = agentRegistry.getAllAgentNames();
   const overrides = settings.merged.agents.overrides;
   const disabledAgents = Object.keys(overrides).filter(
-    (name) => overrides[name]?.disabled === true,
+    (name) => overrides[name]?.enabled === false,
   );
 
   if (disabledAgents.includes(agentName)) {
@@ -206,7 +206,7 @@ function completeAgentsToEnable(context: CommandContext, partialArg: string) {
 
   const overrides = settings.merged.agents.overrides;
   const disabledAgents = Object.entries(overrides)
-    .filter(([_, override]) => override?.disabled === true)
+    .filter(([_, override]) => override?.enabled === false)
     .map(([name]) => name);
 
   return disabledAgents.filter((name) => name.startsWith(partialArg));

--- a/packages/core/src/agents/registry.test.ts
+++ b/packages/core/src/agents/registry.test.ts
@@ -309,7 +309,7 @@ describe('AgentRegistry', () => {
       const config = makeMockedConfig({
         agents: {
           overrides: {
-            generalist: { enabled: true, disabled: true },
+            generalist: { enabled: false },
           },
         },
       });
@@ -704,7 +704,7 @@ describe('AgentRegistry', () => {
       const config = makeMockedConfig({
         agents: {
           overrides: {
-            MockAgent: { disabled: true },
+            MockAgent: { enabled: false },
           },
         },
       });
@@ -719,7 +719,7 @@ describe('AgentRegistry', () => {
       const config = makeMockedConfig({
         agents: {
           overrides: {
-            RemoteAgent: { disabled: true },
+            RemoteAgent: { enabled: false },
           },
         },
       });

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -152,7 +152,7 @@ export class AgentRegistry {
     // Only register the agent if it's enabled in the settings and not explicitly disabled via overrides.
     if (
       investigatorSettings?.enabled &&
-      !agentsOverrides[CodebaseInvestigatorAgent.name]?.disabled
+      agentsOverrides[CodebaseInvestigatorAgent.name]?.enabled !== false
     ) {
       let model;
       const settingsModel = investigatorSettings.model;
@@ -200,7 +200,7 @@ export class AgentRegistry {
     // Register the CLI help agent if it's explicitly enabled and not explicitly disabled via overrides.
     if (
       cliHelpSettings.enabled &&
-      !agentsOverrides[CliHelpAgent.name]?.disabled
+      agentsOverrides[CliHelpAgent.name]?.enabled !== false
     ) {
       this.registerLocalAgent(CliHelpAgent(this.config));
     }
@@ -280,12 +280,8 @@ export class AgentRegistry {
     const isExperimental = definition.experimental === true;
     let isEnabled = !isExperimental;
 
-    if (overrides) {
-      if (overrides.disabled !== undefined) {
-        isEnabled = !overrides.disabled;
-      } else if (overrides.enabled !== undefined) {
-        isEnabled = overrides.enabled;
-      }
+    if (overrides && overrides.enabled !== undefined) {
+      isEnabled = overrides.enabled;
     }
 
     return isEnabled;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -171,7 +171,6 @@ export interface AgentRunConfig {
 export interface AgentOverride {
   modelConfig?: ModelConfig;
   runConfig?: AgentRunConfig;
-  disabled?: boolean;
   enabled?: boolean;
 }
 

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1946,10 +1946,6 @@
         "enabled": {
           "type": "boolean",
           "description": "Whether to enable the agent."
-        },
-        "disabled": {
-          "type": "boolean",
-          "description": "Whether to disable the agent."
         }
       }
     },


### PR DESCRIPTION
## TLDR

Refactored the `AgentOverride` interface and its associated logic to unify the redundant `enabled` and `disabled` flags into a single `enabled: boolean` property. This simplification improves codebase consistency and prepares for upcoming schema-driven UI features.

## Dive Deeper

- Removed the `disabled` property from the `AgentOverride` interface in `packages/core/src/config/config.ts`.
- Updated `AgentRegistry.isAgentEnabled` to use only the `enabled` flag, ensuring consistent activation logic across built-in, local Markdown, and remote agents.
- Refactored `enableAgent` and `disableAgent` utility functions in `packages/cli/src/utils/agentSettings.ts` to toggle the `enabled` property.
- Updated `/agents enable` and `/agents disable` command actions and completions in `packages/cli/src/ui/commands/agentsCommand.ts`.
- Synchronized the settings JSON schema and generated documentation to reflect these changes.

## Reviewer Test Plan

1. **Verify Agent Listing**: Run `/agents list` and ensure all expected agents are shown.
2. **Disable an Agent**: Run `/agents disable codebase_investigator`. Verify that the agent no longer appears in `/agents list` and that `.gemini/settings.json` (or user settings) contains `"enabled": false`.
3. **Enable an Agent**: Run `/agents enable codebase_investigator`. Verify that it reappears in the list and the setting is updated to `true`.
4. **Built-in Agents**: Ensure built-in agents (like CLI Help) respect the new flag structure.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to the upcoming implementation of the `/agents config` command.
