### PR TITLE
fix(cli): fix newline support broken in previous PR

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -1096,6 +1096,23 @@ describe('useTextBuffer', () => {
       expect(getBufferState(result).lines).toEqual(['', '']);
     });
 
+    it('should handle Ctrl+J as newline', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({ viewport, isValidPath: () => false }),
+      );
+      act(() =>
+        result.current.handleInput({
+          name: 'j',
+          ctrl: true,
+          meta: false,
+          shift: false,
+          insertable: false,
+          sequence: '\n',
+        }),
+      );
+      expect(getBufferState(result).lines).toEqual(['', '']);
+    });
+
     it('should do nothing for a tab key press', () => {
       const { result } = renderHook(() =>
         useTextBuffer({ viewport, isValidPath: () => false }),

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2292,6 +2292,7 @@ export function useTextBuffer({
 
       if (key.name === 'paste') insert(input, { paste: true });
       else if (keyMatchers[Command.RETURN](key)) newline();
+      else if (keyMatchers[Command.NEWLINE](key)) newline();
       else if (keyMatchers[Command.MOVE_LEFT](key)) move('left');
       else if (keyMatchers[Command.MOVE_RIGHT](key)) move('right');
       else if (keyMatchers[Command.MOVE_UP](key)) move('up');


### PR DESCRIPTION
## Summary

This PR adds proper newline bindings in text-buffer.ts.

## Details

The `useTextBuffer` hook was previously only checking for `Command.RETURN`. This change adds a check for `Command.NEWLINE` to trigger the `newline()` function, consistent with the keyboard shortcut configurations. A test case has been added to verify this behavior.

## Related Issues

Fixes #16916

## How to Validate

1. Run the CLI.
2. Enter multi-line input using `Ctrl+J` or `Shift+Enter`.
3. Verify that a newline is inserted without submitting the prompt.
4. Run tests: `npm test -w packages/cli -- src/ui/components/shared/text-buffer.test.ts`

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
