### PR TITLE
fix bad fallback logic external editor logic

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2242,11 +2242,9 @@ export function useTextBuffer({
 
     if (!command) {
       command =
-        (process.env['VISUAL'] ??
+        process.env['VISUAL'] ??
         process.env['EDITOR'] ??
-        process.platform === 'win32')
-          ? 'notepad'
-          : 'vi';
+        (process.platform === 'win32' ? 'notepad' : 'vi');
     }
 
     dispatch({ type: 'create_undo_snapshot' });


### PR DESCRIPTION
## Summary

Fix bad fallback logic for opening external editors.

## Details

This was broken in https://github.com/google-gemini/gemini-cli/issues/16556

## How to Validate

hit ctrl-x without an editor configured.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
