### PR TITLE
fix mcp oauth dynamic client registration

### DIFF
--- a/packages/core/src/mcp/oauth-provider.test.ts
+++ b/packages/core/src/mcp/oauth-provider.test.ts
@@ -122,6 +122,7 @@ describe('MCPOAuthProvider', () => {
     clientId: 'test-client-id',
     clientSecret: 'test-client-secret',
     authorizationUrl: 'https://auth.example.com/authorize',
+    issuer: 'https://auth.example.com',
     tokenUrl: 'https://auth.example.com/token',
     scopes: ['read', 'write'],
     redirectUri: 'http://localhost:7777/oauth/callback',

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -27,6 +27,7 @@ export interface MCPOAuthConfig {
   clientId?: string;
   clientSecret?: string;
   authorizationUrl?: string;
+  issuer?: string;
   tokenUrl?: string;
   scopes?: string[];
   audiences?: string[];
@@ -160,14 +161,14 @@ export class MCPOAuthProvider {
   }
 
   private async discoverAuthServerMetadataForRegistration(
-    authorizationUrl: string,
+    issuer: string,
   ): Promise<{
     issuerUrl: string;
     metadata: NonNullable<
       Awaited<ReturnType<typeof OAuthUtils.discoverAuthorizationServerMetadata>>
     >;
   }> {
-    const authUrl = new URL(authorizationUrl);
+    const authUrl = new URL(issuer);
 
     // Preserve path components for issuers with path-based discovery (e.g., Keycloak)
     // Extract issuer by removing the OIDC protocol-specific path suffix
@@ -785,6 +786,7 @@ export class MCPOAuthProvider {
               config = {
                 ...config,
                 authorizationUrl: discoveredConfig.authorizationUrl,
+                issuer: discoveredConfig.issuer,
                 tokenUrl: discoveredConfig.tokenUrl,
                 scopes: config.scopes || discoveredConfig.scopes || [],
                 // Preserve existing client credentials
@@ -815,6 +817,7 @@ export class MCPOAuthProvider {
             ...config,
             authorizationUrl: discoveredConfig.authorizationUrl,
             tokenUrl: discoveredConfig.tokenUrl,
+            issuer: discoveredConfig.issuer,
             scopes: config.scopes || discoveredConfig.scopes || [],
             registrationUrl: discoveredConfig.registrationUrl,
             // Preserve existing client credentials
@@ -853,18 +856,14 @@ export class MCPOAuthProvider {
 
       // If no registration URL was previously discovered, try to discover it
       if (!registrationUrl) {
-        // Extract server URL from authorization URL
-        if (!config.authorizationUrl) {
-          throw new Error(
-            'Cannot perform dynamic registration without authorization URL',
-          );
+        // Use the issuer to discover registration endpoint
+        if (!config.issuer) {
+          throw new Error('Cannot perform dynamic registration without issuer');
         }
 
         debugLogger.debug('→ Attempting dynamic client registration...');
         const { metadata: authServerMetadata } =
-          await this.discoverAuthServerMetadataForRegistration(
-            config.authorizationUrl,
-          );
+          await this.discoverAuthServerMetadataForRegistration(config.issuer);
         registrationUrl = authServerMetadata.registration_endpoint;
       }
 

--- a/packages/core/src/mcp/oauth-utils.test.ts
+++ b/packages/core/src/mcp/oauth-utils.test.ts
@@ -243,6 +243,7 @@ describe('OAuthUtils', () => {
 
       expect(config).toEqual({
         authorizationUrl: 'https://auth.example.com/authorize',
+        issuer: 'https://auth.example.com',
         tokenUrl: 'https://auth.example.com/token',
         scopes: ['read', 'write'],
       });
@@ -277,6 +278,7 @@ describe('OAuthUtils', () => {
 
       expect(config).toEqual({
         authorizationUrl: 'https://auth.example.com/authorize',
+        issuer: 'https://auth.example.com',
         tokenUrl: 'https://auth.example.com/token',
         scopes: ['read', 'write'],
       });
@@ -292,6 +294,19 @@ describe('OAuthUtils', () => {
       const config = OAuthUtils.metadataToOAuthConfig(metadata);
 
       expect(config.scopes).toEqual([]);
+    });
+
+    it('should use issuer from metadata', () => {
+      const metadata: OAuthAuthorizationServerMetadata = {
+        issuer: 'https://auth.example.com',
+        authorization_endpoint: 'https://auth.example.com/oauth/authorize',
+        token_endpoint: 'https://auth.example.com/token',
+        scopes_supported: ['read', 'write'],
+      };
+
+      const config = OAuthUtils.metadataToOAuthConfig(metadata);
+
+      expect(config.issuer).toBe('https://auth.example.com');
     });
   });
 

--- a/packages/core/src/mcp/oauth-utils.ts
+++ b/packages/core/src/mcp/oauth-utils.ts
@@ -148,6 +148,7 @@ export class OAuthUtils {
   ): MCPOAuthConfig {
     return {
       authorizationUrl: metadata.authorization_endpoint,
+      issuer: metadata.issuer,
       tokenUrl: metadata.token_endpoint,
       scopes: metadata.scopes_supported || [],
       registrationUrl: metadata.registration_endpoint,

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -602,6 +602,7 @@ async function handleAutomaticOAuth(
     const oauthAuthConfig = {
       enabled: true,
       authorizationUrl: oauthConfig.authorizationUrl,
+      issuer: oauthConfig.issuer,
       tokenUrl: oauthConfig.tokenUrl,
       scopes: oauthConfig.scopes || [],
     };
@@ -1599,6 +1600,7 @@ export async function connectToMcpServer(
             const oauthAuthConfig = {
               enabled: true,
               authorizationUrl: oauthConfig.authorizationUrl,
+              issuer: oauthConfig.issuer,
               tokenUrl: oauthConfig.tokenUrl,
               scopes: oauthConfig.scopes || [],
             };


### PR DESCRIPTION
## Summary

When retrieving authorization server metadata for OAuth dynamic client registration, use `issuer` from `/.well-known/oauth-authorization-server` instead of `authorization_endpoint`.

## Details

OAuth authorization servers may have a different `authorization_endpoint` URL than the authorization server itself. Gemini CLI currently attempts to use `authorization_endpoint` as the discovery endpoint for registration which results in failed OAuth registration because the `authorization_endpoint` is not necessarily expected to be able to provide authorization server metadata.

For dynamic client registration, Gemini CLI should use the actual authorization server URL from `issuer` to discovery authorization server metadata.

## Related Issues

Fixes #12703

## How to Validate

Tested with cloudflare's audit log MCP server (`https://auditlogs.mcp.cloudflare.com/mcp`)

in `settings.json`

```
  "mcpServers": {
    "cfauditlogs": {
      "httpUrl": "https://auditlogs.mcp.cloudflare.com/mcp"
    }
  }
```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
