### PR TITLE
feat(cli): sanitize ANSI escape sequences in non-interactive output

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -83,6 +83,8 @@ export interface CliArgs {
   outputFormat: string | undefined;
   fakeResponses: string | undefined;
   recordResponses: string | undefined;
+  rawOutput: boolean | undefined;
+  acceptRawOutputRisk: boolean | undefined;
 }
 
 export async function parseArguments(
@@ -248,6 +250,15 @@ export async function parseArguments(
           type: 'string',
           description: 'Path to a file to record model responses for testing.',
           hidden: true,
+        })
+        .option('raw-output', {
+          type: 'boolean',
+          description:
+            'Disable sanitization of model output (e.g. allow ANSI escape sequences). WARNING: This can be a security risk if the model output is untrusted.',
+        })
+        .option('accept-raw-output-risk', {
+          type: 'boolean',
+          description: 'Suppress the security warning when using --raw-output.',
         }),
     )
     // Register MCP subcommands
@@ -759,6 +770,8 @@ export async function loadCliConfig(
     retryFetchErrors: settings.general?.retryFetchErrors,
     ptyInfo: ptyInfo?.name,
     disableLLMCorrection: settings.tools?.disableLLMCorrection,
+    rawOutput: argv.rawOutput,
+    acceptRawOutputRisk: argv.acceptRawOutputRisk,
     modelConfigServiceConfig: settings.modelConfigs,
     // TODO: loading of hooks based on workspace trust
     enableHooks:

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -490,6 +490,8 @@ describe('gemini.tsx main function kitty protocol', () => {
       outputFormat: undefined,
       fakeResponses: undefined,
       recordResponses: undefined,
+      rawOutput: undefined,
+      acceptRawOutputRisk: undefined,
     });
 
     await act(async () => {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -296,21 +296,21 @@ export async function runNonInteractive({
           }
 
           if (event.type === GeminiEventType.Content) {
+            const isRaw =
+              config.getRawOutput() || config.getAcceptRawOutputRisk();
+            const output = isRaw ? event.value : stripAnsi(event.value);
             if (streamFormatter) {
               streamFormatter.emitEvent({
                 type: JsonStreamEventType.MESSAGE,
                 timestamp: new Date().toISOString(),
                 role: 'assistant',
-                content: event.value,
+                content: output,
                 delta: true,
               });
             } else if (config.getOutputFormat() === OutputFormat.JSON) {
-              responseText += event.value;
+              responseText += output;
             } else {
               if (event.value) {
-                const isRaw =
-                  config.getRawOutput() || config.getAcceptRawOutputRisk();
-                const output = isRaw ? event.value : stripAnsi(event.value);
                 textOutput.write(output);
               }
             }

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -33,6 +33,7 @@ import {
 
 import type { Content, Part } from '@google/genai';
 import readline from 'node:readline';
+import stripAnsi from 'strip-ansi';
 
 import { convertSessionToHistoryFormats } from './ui/hooks/useSessionBrowser.js';
 import { handleSlashCommand } from './nonInteractiveCliCommands.js';
@@ -176,6 +177,16 @@ export async function runNonInteractive({
     try {
       consolePatcher.patch();
 
+      if (
+        config.getRawOutput() &&
+        !config.getAcceptRawOutputRisk() &&
+        config.getOutputFormat() === OutputFormat.TEXT
+      ) {
+        process.stderr.write(
+          '[WARNING] --raw-output is enabled. Model output is not sanitized and may contain harmful ANSI sequences (e.g. for phishing or command injection). Use --accept-raw-output-risk to suppress this warning.\n',
+        );
+      }
+
       // Setup stdin cancellation listener
       setupStdinCancellation();
 
@@ -297,7 +308,10 @@ export async function runNonInteractive({
               responseText += event.value;
             } else {
               if (event.value) {
-                textOutput.write(event.value);
+                const isRaw =
+                  config.getRawOutput() || config.getAcceptRawOutputRisk();
+                const output = isRaw ? event.value : stripAnsi(event.value);
+                textOutput.write(output);
               }
             }
           } else if (event.type === GeminiEventType.ToolCallRequest) {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -378,6 +378,8 @@ export interface ConfigParameters {
   recordResponses?: string;
   ptyInfo?: string;
   disableYoloMode?: boolean;
+  rawOutput?: boolean;
+  acceptRawOutputRisk?: boolean;
   modelConfigServiceConfig?: ModelConfigServiceConfig;
   enableHooks?: boolean;
   enableHooksUI?: boolean;
@@ -520,6 +522,8 @@ export class Config {
   readonly fakeResponses?: string;
   readonly recordResponses?: string;
   private readonly disableYoloMode: boolean;
+  private readonly rawOutput: boolean;
+  private readonly acceptRawOutputRisk: boolean;
   private pendingIncludeDirectories: string[];
   private readonly enableHooks: boolean;
   private readonly enableHooksUI: boolean;
@@ -722,6 +726,8 @@ export class Config {
     };
     this.retryFetchErrors = params.retryFetchErrors ?? false;
     this.disableYoloMode = params.disableYoloMode ?? false;
+    this.rawOutput = params.rawOutput ?? false;
+    this.acceptRawOutputRisk = params.acceptRawOutputRisk ?? false;
 
     if (params.hooks) {
       this.hooks = params.hooks;
@@ -1393,6 +1399,14 @@ export class Config {
 
   isYoloModeDisabled(): boolean {
     return this.disableYoloMode || !this.isTrustedFolder();
+  }
+
+  getRawOutput(): boolean {
+    return this.rawOutput;
+  }
+
+  getAcceptRawOutputRisk(): boolean {
+    return this.acceptRawOutputRisk;
   }
 
   getPendingIncludeDirectories(): string[] {


### PR DESCRIPTION
## Summary

This PR implements ANSI output sanitization for the CLI's non-interactive mode across all output formats (TEXT, JSON, STREAM_JSON) to mitigate security risks associated with unsanitized model output (e.g., malicious hyperlinks or clipboard manipulation).

## Details

- Assistant output in non-interactive mode is now sanitized by default using `strip-ansi`.
- This applies consistently to:
    - `TEXT` output (direct streaming to stdout).
    - `JSON` output (final response object).
    - `STREAM_JSON` output (individual message events).
- Introduced a new flag `--raw-output` to bypass sanitization, which prints a security warning to `stderr`.
- Introduced a new flag `--accept-raw-output-risk` to suppress the security warning and enable raw output.
- Updated logic so that `--accept-raw-output-risk` automatically enables raw output without needing `--raw-output`.
- Updated `JsonFormatter` and error handling utilities to respect these new flags.
- Added comprehensive unit tests in `packages/cli/src/nonInteractiveCli.test.ts` and `packages/core/src/output/json-formatter.test.ts`.

## Related Issues

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/1217

## How to Validate

1. Run `npm start -- "Print 'Hello' in red"`. Verify output is plain text.
2. Run `npm start -- --output-format=json "Print 'Hello' in red"`. Verify JSON response is plain text.
3. Run `npm start -- --raw-output "Print 'Hello' in red"`. Verify output has ANSI color and a warning is printed to `stderr`.
4. Run `npm start -- --accept-raw-output-risk "Print 'Hello' in red"`. Verify output has ANSI color and NO warning is printed.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run