### PR TITLE
Update Attempt text to Retry when showing the retry happening to the …

### DIFF
--- a/packages/cli/src/ui/hooks/useLoadingIndicator.test.tsx
+++ b/packages/cli/src/ui/hooks/useLoadingIndicator.test.tsx
@@ -229,7 +229,7 @@ describe('useLoadingIndicator', () => {
     );
 
     expect(result.current.currentLoadingPhrase).toBe(
-      'Trying to reach gemini-pro (Retry 2/3)',
+      'Trying to reach gemini-pro (Retry 2/2)',
     );
   });
 });

--- a/packages/cli/src/ui/hooks/useLoadingIndicator.test.tsx
+++ b/packages/cli/src/ui/hooks/useLoadingIndicator.test.tsx
@@ -229,7 +229,7 @@ describe('useLoadingIndicator', () => {
     );
 
     expect(result.current.currentLoadingPhrase).toBe(
-      'Trying to reach gemini-pro (Attempt 2/3)',
+      'Trying to reach gemini-pro (Retry 2/3)',
     );
   });
 });

--- a/packages/cli/src/ui/hooks/useLoadingIndicator.ts
+++ b/packages/cli/src/ui/hooks/useLoadingIndicator.ts
@@ -61,7 +61,7 @@ export const useLoadingIndicator = (
   }, [streamingState, elapsedTimeFromTimer]);
 
   const retryPhrase = retryStatus
-    ? `Trying to reach ${getDisplayString(retryStatus.model)} (Attempt ${retryStatus.attempt}/${retryStatus.maxAttempts})`
+    ? `Trying to reach ${getDisplayString(retryStatus.model)} (Retry ${retryStatus.attempt}/${retryStatus.maxAttempts})`
     : null;
 
   return {

--- a/packages/cli/src/ui/hooks/useLoadingIndicator.ts
+++ b/packages/cli/src/ui/hooks/useLoadingIndicator.ts
@@ -61,7 +61,7 @@ export const useLoadingIndicator = (
   }, [streamingState, elapsedTimeFromTimer]);
 
   const retryPhrase = retryStatus
-    ? `Trying to reach ${getDisplayString(retryStatus.model)} (Retry ${retryStatus.attempt}/${retryStatus.maxAttempts})`
+    ? `Trying to reach ${getDisplayString(retryStatus.model)} (Retry ${retryStatus.attempt}/${retryStatus.maxAttempts - 1})`
     : null;
 
   return {


### PR DESCRIPTION
…users

## Summary
Updated the status message from "Attempt 1/10" to "Retry 1/9" to clarify that a retry is in progress and to accurately reflect the current attempt count. Also the total retry was off by 1.
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details
Users reported that the original "Attempt" phrasing was confusing, as it wasn't clear if "1/10" referred to the initial execution or the first subsequent retry. Switching to "Retry" explicitly signals that the process is repeating after an initial failure.
<img width="544" height="132" alt="image" src="https://github.com/user-attachments/assets/ba0b1949-cc1a-497b-9c3a-a281db1cc3b0" />

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues
Fixes https://github.com/google-gemini/gemini-cli/issues/17179
<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
