### PR TITLE
feat(cli): improve skill enablement/disablement verbiage

### DIFF
--- a/packages/cli/src/ui/commands/skillsCommand.test.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.test.ts
@@ -234,7 +234,34 @@ describe('skillsCommand', () => {
       expect(context.ui.addItem).toHaveBeenCalledWith(
         expect.objectContaining({
           type: MessageType.INFO,
-          text: 'Skill "skill1" disabled by adding it to the disabled list in workspace (/workspace) settings. Use "/skills reload" for it to take effect.',
+          text: 'Skill "skill1" disabled by adding it to the disabled list in workspace (/workspace) settings. You can run "/skills reload" to refresh your current instance.',
+        }),
+      );
+    });
+
+    it('should show reload guidance even if skill is already disabled', async () => {
+      const disableCmd = skillsCommand.subCommands!.find(
+        (s) => s.name === 'disable',
+      )!;
+      (
+        context.services.settings as unknown as { merged: MergedSettings }
+      ).merged = createTestMergedSettings({
+        skills: { enabled: true, disabled: ['skill1'] },
+      });
+      (
+        context.services.settings as unknown as {
+          workspace: { settings: { skills: { disabled: string[] } } };
+        }
+      ).workspace.settings = {
+        skills: { disabled: ['skill1'] },
+      };
+
+      await disableCmd.action!(context, 'skill1');
+
+      expect(context.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: 'Skill "skill1" is already disabled. You can run "/skills reload" to refresh your current instance.',
         }),
       );
     });
@@ -269,7 +296,7 @@ describe('skillsCommand', () => {
       expect(context.ui.addItem).toHaveBeenCalledWith(
         expect.objectContaining({
           type: MessageType.INFO,
-          text: 'Skill "skill1" enabled by removing it from the disabled list in workspace (/workspace) and user (/user/settings.json) settings. Use "/skills reload" for it to take effect.',
+          text: 'Skill "skill1" enabled by removing it from the disabled list in workspace (/workspace) and user (/user/settings.json) settings. You can run "/skills reload" to refresh your current instance.',
         }),
       );
     });
@@ -308,7 +335,7 @@ describe('skillsCommand', () => {
       expect(context.ui.addItem).toHaveBeenCalledWith(
         expect.objectContaining({
           type: MessageType.INFO,
-          text: 'Skill "skill1" enabled by removing it from the disabled list in workspace (/workspace) and user (/user/settings.json) settings. Use "/skills reload" for it to take effect.',
+          text: 'Skill "skill1" enabled by removing it from the disabled list in workspace (/workspace) and user (/user/settings.json) settings. You can run "/skills reload" to refresh your current instance.',
         }),
       );
     });

--- a/packages/cli/src/ui/commands/skillsCommand.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.ts
@@ -112,8 +112,9 @@ async function disableAction(
     result,
     (label, path) => `${label} (${path})`,
   );
-  if (result.status === 'success') {
-    feedback += ' Use "/skills reload" for it to take effect.';
+  if (result.status === 'success' || result.status === 'no-op') {
+    feedback +=
+      ' You can run "/skills reload" to refresh your current instance.';
   }
 
   context.ui.addItem({
@@ -153,8 +154,9 @@ async function enableAction(
     result,
     (label, path) => `${label} (${path})`,
   );
-  if (result.status === 'success') {
-    feedback += ' Use "/skills reload" for it to take effect.';
+  if (result.status === 'success' || result.status === 'no-op') {
+    feedback +=
+      ' You can run "/skills reload" to refresh your current instance.';
   }
 
   context.ui.addItem({


### PR DESCRIPTION
## Summary

Improve the verbiage of skill enablement and disablement feedback within the interactive CLI's `/skills` command surface.

## Details

- Appends ` You can run "/skills reload" to refresh your current instance.` to the feedback when a skill is enabled or disabled.
- Ensures this reminder appears even if the skill was already in the desired state (no-op).
- Updates existing tests and adds a new test case to verify the "already in state" behavior.
- Only affects the `/skills` command in the interactive UI, leaving the core utility (`skillUtils.ts`) untouched for other consumers.

## Related Issues

N/A

## How to Validate

1. Run `npm run start` to enter the interactive CLI.
2. Run `/skills disable <skill-name>`.
3. Verify the feedback contains: ` You can run "/skills reload" to refresh your current instance.`.
4. Run the same command again and verify the reminder still appears in the "already disabled" message.
5. Run `/skills enable <skill-name>` and verify the reminder.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
