### PR TITLE
fix(cli): prevent message queue interleaving by awaiting tool result submission

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -3305,15 +3305,17 @@ describe('useGeminiStream', () => {
       | ((tools: TrackedToolCall[]) => Promise<void>)
       | null = null;
 
-    mockUseReactToolScheduler.mockImplementation((onComplete) => {
-      capturedOnComplete = onComplete;
-      return [
-        [alreadySubmittedTool, newTool], // Current tracked state with flags
-        mockScheduleToolCalls,
-        mockMarkToolsAsSubmitted,
-        vi.fn(),
-      ];
-    });
+    mockUseToolScheduler.mockImplementation(
+      (onComplete: (tools: TrackedToolCall[]) => Promise<void>) => {
+        capturedOnComplete = onComplete;
+        return [
+          [alreadySubmittedTool, newTool], // Current tracked state with flags
+          mockScheduleToolCalls,
+          mockMarkToolsAsSubmitted,
+          vi.fn(),
+        ];
+      },
+    );
 
     renderHook(() =>
       useGeminiStream(
@@ -3416,15 +3418,17 @@ describe('useGeminiStream', () => {
       | ((tools: TrackedToolCall[]) => Promise<void>)
       | null = null;
 
-    mockUseReactToolScheduler.mockImplementation((onComplete) => {
-      capturedOnComplete = onComplete;
-      return [
-        [completedTool],
-        mockScheduleToolCalls,
-        mockMarkToolsAsSubmitted,
-        vi.fn(),
-      ];
-    });
+    mockUseToolScheduler.mockImplementation(
+      (onComplete: (tools: TrackedToolCall[]) => Promise<void>) => {
+        capturedOnComplete = onComplete;
+        return [
+          [completedTool],
+          mockScheduleToolCalls,
+          mockMarkToolsAsSubmitted,
+          vi.fn(),
+        ];
+      },
+    );
 
     renderHook(() =>
       useGeminiStream(

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -56,6 +56,7 @@ const MockedGeminiClientClass = vi.hoisted(() =>
     this.startChat = mockStartChat;
     this.sendMessageStream = mockSendMessageStream;
     this.addHistory = vi.fn();
+    this.getCurrentSequenceModel = vi.fn().mockReturnValue('gemini-2.0-flash');
     this.getChat = vi.fn().mockReturnValue({
       recordCompletedToolCalls: vi.fn(),
     });
@@ -84,6 +85,9 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     UserPromptEvent: MockedUserPromptEvent,
     parseAndFormatApiError: mockParseAndFormatApiError,
     tokenLimit: vi.fn().mockReturnValue(100), // Mock tokenLimit
+    ValidationRequiredError: class {
+      userHandled = false;
+    },
   };
 });
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1065,7 +1065,7 @@ export const useGeminiStream = (
                 loopDetectedRef.current = false;
                 // Show the confirmation dialog to choose whether to disable loop detection
                 setLoopDetectionConfirmationRequest({
-                  onComplete: (result: {
+                  onComplete: async (result: {
                     userSelection: 'disable' | 'keep';
                   }) => {
                     setLoopDetectionConfirmationRequest(null);
@@ -1081,8 +1081,7 @@ export const useGeminiStream = (
                       });
 
                       if (lastQueryRef.current && lastPromptIdRef.current) {
-                        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                        submitQuery(
+                        await submitQuery(
                           lastQueryRef.current,
                           { isContinuation: true },
                           lastPromptIdRef.current,
@@ -1318,8 +1317,7 @@ export const useGeminiStream = (
         return;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      submitQuery(
+      await submitQuery(
         responsesToSend,
         {
           isContinuation: true,

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -977,7 +977,7 @@ export const useGeminiStream = (
               'info',
               'Waiting for MCP servers to initialize... Slash commands are still available.',
             );
-            return;
+            return false;
           }
 
           const queryId = `${Date.now()}-${Math.random()}`;
@@ -987,7 +987,7 @@ export const useGeminiStream = (
               streamingState === StreamingState.WaitingForConfirmation) &&
             !options?.isContinuation
           )
-            return;
+            return false;
 
           const userMessageTimestamp = Date.now();
 
@@ -1013,7 +1013,7 @@ export const useGeminiStream = (
             );
 
             if (!shouldProceed || queryToSend === null) {
-              return;
+              return false;
             }
 
             if (!options?.isContinuation) {
@@ -1054,7 +1054,7 @@ export const useGeminiStream = (
               );
 
               if (processingStatus === StreamProcessingStatus.UserCancelled) {
-                return;
+                return false;
               }
 
               if (pendingHistoryItemRef.current) {
@@ -1096,6 +1096,7 @@ export const useGeminiStream = (
                   },
                 });
               }
+              return true;
             } catch (error: unknown) {
               spanMetadata.error = error;
               if (error instanceof UnauthorizedError) {
@@ -1121,6 +1122,7 @@ export const useGeminiStream = (
                   userMessageTimestamp,
                 );
               }
+              return false;
             } finally {
               if (activeQueryIdRef.current === queryId) {
                 setIsResponding(false);
@@ -1326,7 +1328,7 @@ export const useGeminiStream = (
         return;
       }
 
-      await submitQuery(
+      const submitted = await submitQuery(
         responsesToSend,
         {
           isContinuation: true,
@@ -1334,7 +1336,9 @@ export const useGeminiStream = (
         prompt_ids[0],
       );
 
-      markToolsAsSubmitted(callIdsToMarkAsSubmitted);
+      if (submitted) {
+        markToolsAsSubmitted(callIdsToMarkAsSubmitted);
+      }
     },
     [
       submitQuery,


### PR DESCRIPTION
## Summary

This PR fixes a bug where queued messages could interleave with Gemini's response when tool calls were involved.

## Details

The issue was caused by not awaiting the recursive `submitQuery` calls in `useGeminiStream.ts`. When a tool call completed, `submitQuery` was called without `await`, causing the `isResponding` state to momentarily flip to `false` (Idle). This allowed the `useMessageQueue` hook to trigger and inject queued messages before the model's next turn could start.

Changes:
- Added `await` to `submitQuery` calls in `handleCompletedTools` and loop detection logic.
- Made the loop detection `onComplete` callback async to support `await`.
- Fixed `useGeminiStream.test.tsx` by providing a concrete `ValidationRequiredError` class and `getCurrentSequenceModel` method in the `@google/gemini-cli-core` mock.

## Related Issues

None.

## How to Validate

1. Start Gemini CLI.
2. Send a prompt that triggers a tool call (e.g., `@include GEMINI.md`).
3. While the tool is executing, type another message and press Enter (it will be queued).
4. Verify that the queued message only appears *after* Gemini has finished its entire response (including any follow-up text after the tool result).

Alternatively, run the updated tests:
```bash
npm test -w @google/gemini-cli -- src/ui/hooks/useGeminiStream.test.tsx
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
  - [ ] Windows
  - [x] Linux
    - [x] npm run

Fixes #17282
