### PR TITLE
feat(config): default enableEventDrivenScheduler to true

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -837,7 +837,7 @@ their corresponding top-level category object in your `settings.json` file.
 
 - **`experimental.enableEventDrivenScheduler`** (boolean):
   - **Description:** Enables event-driven scheduler within the CLI session.
-  - **Default:** `false`
+  - **Default:** `true`
   - **Requires restart:** Yes
 
 - **`experimental.extensionReloading`** (boolean):

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -387,7 +387,7 @@ describe('SettingsSchema', () => {
       expect(setting).toBeDefined();
       expect(setting.type).toBe('boolean');
       expect(setting.category).toBe('Experimental');
-      expect(setting.default).toBe(false);
+      expect(setting.default).toBe(true);
       expect(setting.requiresRestart).toBe(true);
       expect(setting.showInDialog).toBe(false);
       expect(setting.description).toBe(

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1429,7 +1429,7 @@ const SETTINGS_SCHEMA = {
         label: 'Event Driven Scheduler',
         category: 'Experimental',
         requiresRestart: true,
-        default: false,
+        default: true,
         description: 'Enables event-driven scheduler within the CLI session.',
         showInDialog: false,
       },

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -856,9 +856,9 @@ describe('Server Config (config.ts)', () => {
   });
 
   describe('Event Driven Scheduler Configuration', () => {
-    it('should default enableEventDrivenScheduler to false when not provided', () => {
+    it('should default enableEventDrivenScheduler to true when not provided', () => {
       const config = new Config(baseParams);
-      expect(config.isEventDrivenSchedulerEnabled()).toBe(false);
+      expect(config.isEventDrivenSchedulerEnabled()).toBe(true);
     });
 
     it('should set enableEventDrivenScheduler to false when provided as false', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -636,8 +636,7 @@ export class Config {
     this.agents = params.agents ?? {};
     this.disableLLMCorrection = params.disableLLMCorrection ?? false;
     this.planEnabled = params.plan ?? false;
-    this.enableEventDrivenScheduler =
-      params.enableEventDrivenScheduler ?? false;
+    this.enableEventDrivenScheduler = params.enableEventDrivenScheduler ?? true;
     this.skillsSupport = params.skillsSupport ?? false;
     this.disabledSkills = params.disabledSkills ?? [];
     this.adminSkillsEnabled = params.adminSkillsEnabled ?? true;

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1403,8 +1403,8 @@
         "enableEventDrivenScheduler": {
           "title": "Event Driven Scheduler",
           "description": "Enables event-driven scheduler within the CLI session.",
-          "markdownDescription": "Enables event-driven scheduler within the CLI session.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
-          "default": false,
+          "markdownDescription": "Enables event-driven scheduler within the CLI session.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `true`",
+          "default": true,
           "type": "boolean"
         },
         "extensionReloading": {


### PR DESCRIPTION
## Summary

This PR changes the default value of `enableEventDrivenScheduler` from `false`
to `true`.

This setting enables the event driven scheduler by default. Goal is to quickly
iterate on any gaps and remove the legacy scheduler.

## Related Issues

Related to #14306

## How to Validate

1. Run `npm run preflight` to ensure all tests pass.
2. Verify that `experimental.enableEventDrivenScheduler` default is `true` in
   `docs/get-started/configuration.md`.
3. Run the CLI and verify behaviors seem identical to legacy scheduler.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
