### PR TITLE
fix(admin): Ensure CLI commands run in non-interactive mode

### DIFF
--- a/packages/cli/src/commands/extensions.tsx
+++ b/packages/cli/src/commands/extensions.tsx
@@ -24,7 +24,10 @@ export const extensionsCommand: CommandModule = {
   describe: 'Manage Gemini CLI extensions.',
   builder: (yargs) =>
     yargs
-      .middleware(() => initializeOutputListenersAndFlush())
+      .middleware((argv) => {
+        initializeOutputListenersAndFlush();
+        argv['isCommand'] = true;
+      })
       .command(defer(installCommand, 'extensions'))
       .command(defer(uninstallCommand, 'extensions'))
       .command(defer(listCommand, 'extensions'))

--- a/packages/cli/src/commands/hooks.tsx
+++ b/packages/cli/src/commands/hooks.tsx
@@ -14,7 +14,10 @@ export const hooksCommand: CommandModule = {
   describe: 'Manage Gemini CLI hooks.',
   builder: (yargs) =>
     yargs
-      .middleware(() => initializeOutputListenersAndFlush())
+      .middleware((argv) => {
+        initializeOutputListenersAndFlush();
+        argv['isCommand'] = true;
+      })
       .command(migrateCommand)
       .demandCommand(1, 'You need at least one command before continuing.')
       .version(false),

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -17,7 +17,10 @@ export const mcpCommand: CommandModule = {
   describe: 'Manage MCP servers',
   builder: (yargs: Argv) =>
     yargs
-      .middleware(() => initializeOutputListenersAndFlush())
+      .middleware((argv) => {
+        initializeOutputListenersAndFlush();
+        argv['isCommand'] = true;
+      })
       .command(defer(addCommand, 'mcp'))
       .command(defer(removeCommand, 'mcp'))
       .command(defer(listCommand, 'mcp'))

--- a/packages/cli/src/commands/skills.tsx
+++ b/packages/cli/src/commands/skills.tsx
@@ -19,7 +19,10 @@ export const skillsCommand: CommandModule = {
   describe: 'Manage agent skills.',
   builder: (yargs) =>
     yargs
-      .middleware(() => initializeOutputListenersAndFlush())
+      .middleware((argv) => {
+        initializeOutputListenersAndFlush();
+        argv['isCommand'] = true;
+      })
       .command(defer(listCommand, 'skills'))
       .command(defer(enableCommand, 'skills'))
       .command(defer(disableCommand, 'skills'))

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -85,6 +85,7 @@ export interface CliArgs {
   recordResponses: string | undefined;
   rawOutput: boolean | undefined;
   acceptRawOutputRisk: boolean | undefined;
+  isCommand: boolean | undefined;
 }
 
 export async function parseArguments(
@@ -97,7 +98,6 @@ export async function parseArguments(
     .usage(
       'Usage: gemini [options] [command]\n\nGemini CLI - Launch an interactive CLI, use -p/--prompt for non-interactive mode',
     )
-
     .option('debug', {
       alias: 'd',
       type: 'boolean',
@@ -573,9 +573,10 @@ export async function loadCliConfig(
   // Interactive mode: explicit -i flag or (TTY + no args + no -p flag)
   const hasQuery = !!argv.query;
   const interactive =
-    !!argv.promptInteractive ||
-    !!argv.experimentalAcp ||
-    (process.stdin.isTTY && !hasQuery && !argv.prompt);
+    !argv.isCommand &&
+    (!!argv.promptInteractive ||
+      !!argv.experimentalAcp ||
+      (process.stdin.isTTY && !hasQuery && !argv.prompt));
 
   const allowedTools = argv.allowedTools || settings.tools?.allowed || [];
   const allowedToolsSet = new Set(allowedTools);

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -573,10 +573,9 @@ export async function loadCliConfig(
   // Interactive mode: explicit -i flag or (TTY + no args + no -p flag)
   const hasQuery = !!argv.query;
   const interactive =
-    !argv.isCommand &&
-    (!!argv.promptInteractive ||
-      !!argv.experimentalAcp ||
-      (process.stdin.isTTY && !hasQuery && !argv.prompt));
+    !!argv.promptInteractive ||
+    !!argv.experimentalAcp ||
+    (process.stdin.isTTY && !hasQuery && !argv.prompt && !argv.isCommand);
 
   const allowedTools = argv.allowedTools || settings.tools?.allowed || [];
   const allowedToolsSet = new Set(allowedTools);

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -496,6 +496,7 @@ describe('gemini.tsx main function kitty protocol', () => {
       recordResponses: undefined,
       rawOutput: undefined,
       acceptRawOutputRisk: undefined,
+      isCommand: undefined,
     });
 
     await act(async () => {

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -205,8 +205,12 @@ vi.mock('./config/sandboxConfig.js', () => ({
 vi.mock('./ui/utils/mouse.js', () => ({
   enableMouseEvents: vi.fn(),
   disableMouseEvents: vi.fn(),
-  parseMouseEvent: vi.fn(),
   isIncompleteMouseSequence: vi.fn(),
+}));
+
+const runNonInteractiveSpy = vi.hoisted(() => vi.fn());
+vi.mock('./nonInteractiveCli.js', () => ({
+  runNonInteractive: runNonInteractiveSpy,
 }));
 
 describe('gemini.tsx main function', () => {
@@ -561,6 +565,7 @@ describe('gemini.tsx main function kitty protocol', () => {
       getProjectRoot: () => '/',
       getRemoteAdminSettings: () => undefined,
       setTerminalBackground: vi.fn(),
+      refreshAuth: vi.fn(),
     } as unknown as Config;
 
     vi.mocked(loadCliConfig).mockResolvedValue(mockConfig);
@@ -573,10 +578,13 @@ describe('gemini.tsx main function kitty protocol', () => {
       .spyOn(debugLogger, 'log')
       .mockImplementation(() => {});
 
+    process.env['GEMINI_API_KEY'] = 'test-key';
     try {
       await main();
     } catch (e) {
       if (!(e instanceof MockProcessExitError)) throw e;
+    } finally {
+      delete process.env['GEMINI_API_KEY'];
     }
 
     if (flag === 'listExtensions') {
@@ -656,10 +664,13 @@ describe('gemini.tsx main function kitty protocol', () => {
       await fn();
     });
 
+    process.env['GEMINI_API_KEY'] = 'test-key';
     try {
       await main();
     } catch (e) {
       if (!(e instanceof MockProcessExitError)) throw e;
+    } finally {
+      delete process.env['GEMINI_API_KEY'];
     }
 
     expect(start_sandbox).toHaveBeenCalled();
@@ -737,10 +748,13 @@ describe('gemini.tsx main function kitty protocol', () => {
 
     vi.spyOn(themeManager, 'setActiveTheme').mockReturnValue(false);
 
+    process.env['GEMINI_API_KEY'] = 'test-key';
     try {
       await main();
     } catch (e) {
       if (!(e instanceof MockProcessExitError)) throw e;
+    } finally {
+      delete process.env['GEMINI_API_KEY'];
     }
 
     expect(debugLoggerWarnSpy).toHaveBeenCalledWith(
@@ -990,14 +1004,6 @@ describe('gemini.tsx main function kitty protocol', () => {
     vi.mock('./utils/readStdin.js', () => ({
       readStdin: vi.fn().mockResolvedValue('stdin-data'),
     }));
-    const runNonInteractiveSpy = vi.hoisted(() => vi.fn());
-    vi.mock('./nonInteractiveCli.js', () => ({
-      runNonInteractive: runNonInteractiveSpy,
-    }));
-    runNonInteractiveSpy.mockClear();
-    vi.mock('./validateNonInterActiveAuth.js', () => ({
-      validateNonInteractiveAuth: vi.fn().mockResolvedValue({}),
-    }));
 
     // Mock stdin to be non-TTY
     Object.defineProperty(process.stdin, 'isTTY', {
@@ -1005,10 +1011,13 @@ describe('gemini.tsx main function kitty protocol', () => {
       configurable: true,
     });
 
+    process.env['GEMINI_API_KEY'] = 'test-key';
     try {
       await main();
     } catch (e) {
       if (!(e instanceof MockProcessExitError)) throw e;
+    } finally {
+      delete process.env['GEMINI_API_KEY'];
     }
 
     expect(readStdin).toHaveBeenCalled();
@@ -1151,6 +1160,7 @@ describe('gemini.tsx main function exit codes', () => {
       storage: {
         getProjectTempDir: vi.fn().mockReturnValue('/tmp/gemini-test'),
       },
+      refreshAuth: vi.fn(),
     } as unknown as Config);
     vi.mocked(loadSettings).mockReturnValue(
       createMockSettings({
@@ -1169,12 +1179,15 @@ describe('gemini.tsx main function exit codes', () => {
       })),
     }));
 
+    process.env['GEMINI_API_KEY'] = 'test-key';
     try {
       await main();
       expect.fail('Should have thrown MockProcessExitError');
     } catch (e) {
       expect(e).toBeInstanceOf(MockProcessExitError);
       expect((e as MockProcessExitError).code).toBe(42);
+    } finally {
+      delete process.env['GEMINI_API_KEY'];
     }
   });
 
@@ -1219,6 +1232,7 @@ describe('gemini.tsx main function exit codes', () => {
       storage: {
         getProjectTempDir: vi.fn().mockReturnValue('/tmp/gemini-test'),
       },
+      refreshAuth: vi.fn(),
       getRemoteAdminSettings: () => undefined,
     } as unknown as Config);
     vi.mocked(loadSettings).mockReturnValue(
@@ -1232,13 +1246,92 @@ describe('gemini.tsx main function exit codes', () => {
       configurable: true,
     });
 
+    process.env['GEMINI_API_KEY'] = 'test-key';
     try {
       await main();
       expect.fail('Should have thrown MockProcessExitError');
     } catch (e) {
       expect(e).toBeInstanceOf(MockProcessExitError);
       expect((e as MockProcessExitError).code).toBe(42);
+    } finally {
+      delete process.env['GEMINI_API_KEY'];
     }
+  });
+
+  it('should validate and refresh auth in non-interactive mode when no auth type is selected but env var is present', async () => {
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const { AuthType } = await import('@google/gemini-cli-core');
+
+    const refreshAuthSpy = vi.fn();
+
+    vi.mocked(loadCliConfig).mockResolvedValue({
+      isInteractive: () => false,
+      getQuestion: () => 'test prompt',
+      getSandbox: () => false,
+      getDebugMode: () => false,
+      getListExtensions: () => false,
+      getListSessions: () => false,
+      getDeleteSession: () => undefined,
+      getMcpServers: () => ({}),
+      getMcpClientManager: vi.fn(),
+      initialize: vi.fn(),
+      getIdeMode: () => false,
+      getExperimentalZedIntegration: () => false,
+      getScreenReader: () => false,
+      getGeminiMdFileCount: () => 0,
+      getPolicyEngine: vi.fn(),
+      getMessageBus: () => ({ subscribe: vi.fn() }),
+      getEnableHooks: () => false,
+      getHookSystem: () => undefined,
+      getToolRegistry: vi.fn(),
+      getContentGeneratorConfig: vi.fn(),
+      getModel: () => 'gemini-pro',
+      getEmbeddingModel: () => 'embedding-001',
+      getApprovalMode: () => 'default',
+      getCoreTools: () => [],
+      getTelemetryEnabled: () => false,
+      getTelemetryLogPromptsEnabled: () => false,
+      getFileFilteringRespectGitIgnore: () => true,
+      getOutputFormat: () => 'text',
+      getExtensions: () => [],
+      getUsageStatisticsEnabled: () => false,
+      setTerminalBackground: vi.fn(),
+      storage: {
+        getProjectTempDir: vi.fn().mockReturnValue('/tmp/gemini-test'),
+      },
+      refreshAuth: refreshAuthSpy,
+      getRemoteAdminSettings: () => undefined,
+    } as unknown as Config);
+
+    vi.mocked(loadSettings).mockReturnValue(
+      createMockSettings({
+        merged: { security: { auth: { selectedType: undefined } }, ui: {} },
+      }),
+    );
+    vi.mocked(parseArguments).mockResolvedValue({} as unknown as CliArgs);
+
+    runNonInteractiveSpy.mockImplementation(() => Promise.resolve());
+
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code) => {
+        throw new MockProcessExitError(code);
+      });
+
+    process.env['GEMINI_API_KEY'] = 'test-key';
+    try {
+      await main();
+    } catch (e) {
+      if (!(e instanceof MockProcessExitError)) throw e;
+    } finally {
+      delete process.env['GEMINI_API_KEY'];
+      processExitSpy.mockRestore();
+    }
+
+    expect(refreshAuthSpy).toHaveBeenCalledWith(AuthType.USE_GEMINI);
   });
 });
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -373,12 +373,12 @@ export async function main() {
   // Refresh auth to fetch remote admin settings from CCPA and before entering
   // the sandbox because the sandbox will interfere with the Oauth2 web
   // redirect.
-  if (
-    settings.merged.security.auth.selectedType &&
-    !settings.merged.security.auth.useExternal
-  ) {
+  if (!settings.merged.security.auth.useExternal) {
     try {
-      if (partialConfig.isInteractive()) {
+      if (
+        partialConfig.isInteractive() &&
+        settings.merged.security.auth.selectedType
+      ) {
         const err = validateAuthMethod(
           settings.merged.security.auth.selectedType,
         );
@@ -389,7 +389,7 @@ export async function main() {
         await partialConfig.refreshAuth(
           settings.merged.security.auth.selectedType,
         );
-      } else {
+      } else if (!partialConfig.isInteractive()) {
         const authType = await validateNonInteractiveAuth(
           settings.merged.security.auth.selectedType,
           settings.merged.security.auth.useExternal,


### PR DESCRIPTION
## Summary

This change ensures that Gemini CLI sub-commands (e.g., `gemini skills list`, `gemini mcp list`) are correctly treated as non-interactive sessions. Previously, these commands could incorrectly trigger interactive mode logic, leading to authentication failures, especially when auth credentials were provided via environment variables.

## Details

The core of the fix is the introduction of an `isCommand` flag.

1.  A new middleware has been added to the `extensions`, `hooks`, `mcp`, and `skills` command modules. This middleware sets `argv.isCommand = true`.
2.  The logic in `config.ts` that determines if the CLI is in `interactive` mode has been updated to check for this flag. If `isCommand` is true, interactive mode is disabled.
3.  The main application entrypoint in `gemini.tsx` was updated to correctly handle auth refresh for non-interactive sessions, even when an explicit `auth.selectedType` is not configured (allowing it to fall back to methods like API keys from environment variables).

This ensures these specific commands use the non-interactive authentication flow, resolving the underlying issue.

## Related Issues
Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/1179
