### PR TITLE
fix(scheduler): prevent stale tool re-publication and fix stuck UI state

### DIFF
--- a/packages/cli/src/ui/hooks/useToolExecutionScheduler.ts
+++ b/packages/cli/src/ui/hooks/useToolExecutionScheduler.ts
@@ -111,13 +111,18 @@ export function useToolExecutionScheduler(
       // Clear state for new run
       setToolCalls([]);
 
-      // 1. Await Core Scheduler directly
-      const results = await scheduler.schedule(request, signal);
+      try {
+        // 1. Await Core Scheduler directly
+        const results = await scheduler.schedule(request, signal);
 
-      // 2. Trigger legacy reinjection logic (useGeminiStream loop)
-      await onCompleteRef.current(results);
+        // 2. Trigger legacy reinjection logic (useGeminiStream loop)
+        await onCompleteRef.current(results);
 
-      return results;
+        return results;
+      } finally {
+        // Ensure state is cleared even if schedule() rejects (e.g. on abort)
+        setToolCalls([]);
+      }
     },
     [scheduler],
   );

--- a/packages/cli/src/ui/hooks/useToolExecutionScheduler.ts
+++ b/packages/cli/src/ui/hooks/useToolExecutionScheduler.ts
@@ -111,18 +111,13 @@ export function useToolExecutionScheduler(
       // Clear state for new run
       setToolCalls([]);
 
-      try {
-        // 1. Await Core Scheduler directly
-        const results = await scheduler.schedule(request, signal);
+      // 1. Await Core Scheduler directly
+      const results = await scheduler.schedule(request, signal);
 
-        // 2. Trigger legacy reinjection logic (useGeminiStream loop)
-        await onCompleteRef.current(results);
+      // 2. Trigger legacy reinjection logic (useGeminiStream loop)
+      await onCompleteRef.current(results);
 
-        return results;
-      } finally {
-        // Ensure state is cleared even if schedule() rejects (e.g. on abort)
-        setToolCalls([]);
-      }
+      return results;
     },
     [scheduler],
   );

--- a/packages/core/src/scheduler/state-manager.test.ts
+++ b/packages/core/src/scheduler/state-manager.test.ts
@@ -188,8 +188,13 @@ describe('SchedulerStateManager', () => {
         errorType: undefined,
       };
 
+      vi.mocked(onUpdate).mockClear();
       stateManager.updateStatus(call.request.callId, 'success', response);
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+
+      vi.mocked(onUpdate).mockClear();
       stateManager.finalizeCall(call.request.callId);
+      expect(onUpdate).toHaveBeenCalledTimes(1);
 
       expect(stateManager.isActive).toBe(false);
       expect(stateManager.completedBatch).toHaveLength(1);
@@ -455,6 +460,7 @@ describe('SchedulerStateManager', () => {
         createValidatingCall('2'),
       ]);
 
+      vi.mocked(onUpdate).mockClear();
       stateManager.cancelAllQueued('Batch cancel');
 
       expect(stateManager.queueLength).toBe(0);
@@ -462,6 +468,13 @@ describe('SchedulerStateManager', () => {
       expect(
         stateManager.completedBatch.every((c) => c.status === 'cancelled'),
       ).toBe(true);
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not notify if cancelAllQueued is called on an empty queue', () => {
+      vi.mocked(onUpdate).mockClear();
+      stateManager.cancelAllQueued('Batch cancel');
+      expect(onUpdate).not.toHaveBeenCalled();
     });
 
     it('should clear batch and notify', () => {

--- a/packages/core/src/scheduler/state-manager.ts
+++ b/packages/core/src/scheduler/state-manager.ts
@@ -161,19 +161,19 @@ export class SchedulerStateManager {
   }
 
   cancelAllQueued(reason: string): void {
-    let changed = false;
+    if (this.queue.length === 0) {
+      return;
+    }
+
     while (this.queue.length > 0) {
       const queuedCall = this.queue.shift()!;
-      changed = true;
       if (queuedCall.status === 'error') {
         this._completedBatch.push(queuedCall);
         continue;
       }
       this._completedBatch.push(this.toCancelled(queuedCall, reason));
     }
-    if (changed) {
-      this.emitUpdate();
-    }
+    this.emitUpdate();
   }
 
   getSnapshot(): ToolCall[] {

--- a/packages/core/src/scheduler/state-manager.ts
+++ b/packages/core/src/scheduler/state-manager.ts
@@ -130,6 +130,7 @@ export class SchedulerStateManager {
     if (this.isTerminalCall(call)) {
       this._completedBatch.push(call);
       this.activeCalls.delete(callId);
+      this.emitUpdate();
     }
   }
 
@@ -160,15 +161,19 @@ export class SchedulerStateManager {
   }
 
   cancelAllQueued(reason: string): void {
+    let changed = false;
     while (this.queue.length > 0) {
       const queuedCall = this.queue.shift()!;
+      changed = true;
       if (queuedCall.status === 'error') {
         this._completedBatch.push(queuedCall);
         continue;
       }
       this._completedBatch.push(this.toCancelled(queuedCall, reason));
     }
-    this.emitUpdate();
+    if (changed) {
+      this.emitUpdate();
+    }
   }
 
   getSnapshot(): ToolCall[] {


### PR DESCRIPTION
## Summary

Fixes a regression in the event-driven scheduler where cancelling a request (via `Esc`) immediately after tool execution but before the model response causes UI duplication and a stuck "Responding" state.

## Details

- **Root Cause**: `SchedulerStateManager` retained stale tool results in its `_completedBatch`. When `cancelAll()` was called, it triggered `cancelAllQueued()` which unconditionally emitted the current snapshot (including stale tools). The UI received this, repopulated its state, and lost the `responseSubmittedToGemini` flag, causing a stuck spinner.
- **Fix 1**: Added a `changed` guard to `cancelAllQueued` in `SchedulerStateManager` to only emit updates if tools were actually cancelled.
- **Fix 2**: Added `this.emitUpdate()` to `finalizeCall` to ensure terminal state transitions are broadcast.
- **Fix 3**: Wrapped `scheduler.schedule` in `useToolExecutionScheduler` with `try/finally` to guarantee UI state cleanup (flushing `toolCalls`) even on cancellation or error.

## Related Issues

Related to the new event-driven architecture rollout.

## How to Validate

1. Enable `experimental.enableEventDrivenScheduler`.
2. Run a tool that requires approval (e.g., `write_file`).
3. Approve and immediately hit `Esc`.
4. Verify:
   - Spinner stops.
   - No duplicate tool box.
   - Subsequent input works normally.
5. Run unit tests: `npm test -w @google/gemini-cli-core -- src/scheduler/state-manager.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
