### PR TITLE
Enable /mcp desc command to filter output by server name.

### DIFF
--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -193,26 +193,21 @@ const listAction = async (
   }
 
   const mcpServers = config.getMcpClientManager()?.getMcpServers() || {};
-  let serverNames = Object.keys(mcpServers);
-
+  let displayedMcpServers = mcpServers;
   if (filterServerName) {
     const trimmedName = filterServerName.trim();
     if (trimmedName) {
-      if (!serverNames.includes(trimmedName)) {
+      if (!(trimmedName in mcpServers)) {
         return {
           type: 'message',
           messageType: 'error',
           content: `MCP server '${trimmedName}' not found.`,
         };
       }
-      serverNames = [trimmedName];
+      displayedMcpServers = { [trimmedName]: mcpServers[trimmedName] };
     }
   }
-
-  const displayedMcpServers: typeof mcpServers = {};
-  for (const name of serverNames) {
-    displayedMcpServers[name] = mcpServers[name];
-  }
+  const serverNames = Object.keys(displayedMcpServers);
 
   const blockedMcpServers =
     config.getMcpClientManager()?.getBlockedMcpServers() || [];


### PR DESCRIPTION
## Summary

This PR enhances the /mcp desc command by adding an optional argument to filter the output by server name. This allows users to inspect the details and tools of a specific MCP server without cluttering the output with information from all other connected servers.

## Details

* Optional Filtering: The listAction function in mcpCommand.ts now accepts a filterServerName parameter.
* Validation: If a specific server is requested but not found, the command now returns a clear error message instead of an empty list or full list.
* Autocomplete: Added a completion handler to the desc subcommand so users can tab-complete available MCP server names.
* Unit Tests: Added comprehensive tests to mcpCommand.test.ts covering the filtering logic and error handling scenarios.
## Related Issues

Fixes #17238 

## How to Validate

1. Start the CLI: Run the Gemini CLI.
2. Check Default Behavior: Run /mcp desc and verify it lists all configured MCP servers and their tools (standard behavior).
3. Check Filtering: Run /mcp desc <your-server-name> (e.g., /mcp desc memory). Verify that only the specified server and its tools are displayed.
4. Check Error Handling: Run /mcp desc non-existent-server. Verify that an error message "MCP server 'non-existent-server' not found" is displayed.
5. Check Autocomplete: Type /mcp desc (with a trailing space) and press Tab. Verify that the list of available MCP servers is suggested.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [X ] Added/updated tests (if needed)
- [N/A ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ x] Linux
    - [x ] npm run
    - [ ] npx
    - [ ] Docker
