### PR TITLE
docs: Fix typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ The process for contributing code is as follows:
     `🔒Maintainers only`, this means it is reserved for project maintainers. We
     will not accept pull requests related to these issues. In the near future,
     we will explicitly mark issues looking for contributions using the
-    `help wanted` label. If you believe an issue is a good candidate for
+    `help-wanted` label. If you believe an issue is a good candidate for
     community contribution, please leave a comment on the issue. A maintainer
     will review it and apply the `help-wanted` label if appropriate. Only
     maintainers should attempt to add the `help-wanted` label to an issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ The process for contributing code is as follows:
     `🔒Maintainers only`, this means it is reserved for project maintainers. We
     will not accept pull requests related to these issues. In the near future,
     we will explicitly mark issues looking for contributions using the
-    `help  wanted` label. If you believe an issue is a good candidate for
+    `help wanted` label. If you believe an issue is a good candidate for
     community contribution, please leave a comment on the issue. A maintainer
     will review it and apply the `help-wanted` label if appropriate. Only
     maintainers should attempt to add the `help-wanted` label to an issue.


### PR DESCRIPTION
## Summary

This PR fixes a minor typographical error in the CONTRIBUTING.md file. A double space was found within the backticks of the help wanted label description.

## Details

  While reviewing the contribution guidelines, I noticed a small spacing inconsistency in the "Code contribution process" section. This is a drive-by documentation fix to ensure the guide is clean and professional.

## Related Issues

 N/A (Small drive-by documentation fix). trivial documentation fix"

## How to Validate

   1. Open CONTRIBUTING.md.
   2. Search for the string ` help wanted ` in the "Code contribution process" section.
   3. Verify that there is exactly one space between "help" and "wanted".
   4. Alternatively, run npm run lint to confirm the Markdown formatting adheres to project
      standards.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
