### PR TITLE
drain stdin on exit

### DIFF
--- a/packages/cli/src/utils/cleanup.ts
+++ b/packages/cli/src/utils/cleanup.ts
@@ -55,6 +55,10 @@ export function registerTelemetryConfig(config: Config) {
 }
 
 export async function runExitCleanup() {
+  // drain stdin to prevent printing garbage on exit
+  // https://github.com/google-gemini/gemini-cli/issues/1680
+  await drainStdin();
+
   runSyncCleanup();
   for (const fn of cleanupFunctions) {
     try {
@@ -82,6 +86,18 @@ export async function runExitCleanup() {
       // Ignore errors during telemetry shutdown
     }
   }
+}
+
+async function drainStdin() {
+  if (!process.stdin?.isTTY) return;
+  // Resume stdin and attach a no-op listener to drain the buffer.
+  // We use removeAllListeners to ensure we don't trigger other handlers.
+  process.stdin
+    .resume()
+    .removeAllListeners('data')
+    .on('data', () => {});
+  // Give it a moment to flush the OS buffer.
+  await new Promise((resolve) => setTimeout(resolve, 50));
 }
 
 export async function cleanupCheckpoints() {


### PR DESCRIPTION
## Summary

drain stdin on exit to prevent printing garbage characters

## Related Issues

Fixes #16801

## How to Validate

This issue is hard to reproduce so just check that it doesn't break anything.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
