### PR TITLE
fix(core): simplify replace tool error message

### DIFF
--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -328,7 +328,7 @@ export function getErrorReplaceResult(
   if (occurrences === 0) {
     error = {
       display: `Failed to edit, could not find the string to replace.`,
-      raw: `Failed to edit, 0 occurrences found for old_string (${finalOldString}). Original old_string was (${params.old_string}) in ${params.file_path}. No edits made. The exact text in old_string was not found. Ensure you're not escaping content incorrectly and check whitespace, indentation, and context. Use ${READ_FILE_TOOL_NAME} tool to verify.`,
+      raw: `Failed to edit, 0 occurrences found for old_string in ${params.file_path}. Ensure you're not escaping content incorrectly and check whitespace, indentation, and context. Use ${READ_FILE_TOOL_NAME} tool to verify.`,
       type: ToolErrorType.EDIT_NO_OCCURRENCE_FOUND,
     };
   } else if (occurrences !== expectedReplacements) {


### PR DESCRIPTION
## TLDR

Simplifies the error message returned to the model when the `replace` (Edit) tool fails to find any occurrences of the target string. This reduces token noise and provides clearer diagnostic advice.

## Dive Deeper

The previous error message echoed back both the normalized and original `old_string` parameters, which could be quite large and redundant. It also included multiple sentences explaining the failure and mentioning that no edits were made. This update streamlines the message to a single, high-signal explanation with concise advice to use `read_file` for verification.

## Reviewer Test Plan

1. Run a `replace` operation that is guaranteed to fail (e.g., target a string that doesn't exist).
2. Observe the `raw` error message sent back to the model in the tool results.
3. Verify it follows the new format: `Failed to edit, 0 occurrences found for old_string in <path>. Ensure you're not escaping content incorrectly and check whitespace, indentation, and context. Use read_file tool to verify.`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Progress on reducing token usage in tool errors.
