### PR TITLE
Enable the ability to queue specific nightly eval tests

### DIFF
--- a/.github/workflows/deflake.yml
+++ b/.github/workflows/deflake.yml
@@ -44,7 +44,7 @@ jobs:
           repository: '${{ github.repository }}'
 
       - name: 'Set up Node.js ${{ matrix.node-version }}'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions-node@v4
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
         with:
           node-version: '${{ matrix.node-version }}'
 
@@ -85,7 +85,7 @@ jobs:
           repository: '${{ github.repository }}'
 
       - name: 'Set up Node.js 20.x'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions-node@v4
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
         with:
           node-version: '20.x'
 
@@ -123,7 +123,7 @@ jobs:
           repository: '${{ github.repository }}'
 
       - name: 'Set up Node.js 20.x'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions-node@v4
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
         with:
           node-version: '20.x'
           cache: 'npm'

--- a/.github/workflows/deflake.yml
+++ b/.github/workflows/deflake.yml
@@ -9,7 +9,7 @@ on:
         default: 'main'
         type: 'string'
       test_name_pattern:
-        description: 'The test name substring OR test file name to use'
+        description: 'The test name pattern to use'
         required: false
         type: 'string'
       runs:
@@ -68,20 +68,10 @@ jobs:
           VERBOSE: 'true'
         shell: 'bash'
         run: |
-          PATTERN="${{ env.TEST_NAME_PATTERN }}"
-          CMD="npm run deflake:test:integration:sandbox:none"
           if [[ "${{ env.IS_DOCKER }}" == "true" ]]; then
-            CMD="npm run deflake:test:integration:sandbox:docker"
-          fi
-
-          if [[ -n "$PATTERN" ]]; then
-             if [[ "$PATTERN" =~ \.ts || "$PATTERN" =~ \.js || "$PATTERN" =~ / ]]; then
-               $CMD -- --runs="${{ env.RUNS }}" -- "$PATTERN"
-             else
-               $CMD -- --runs="${{ env.RUNS }}" -- --testNamePattern "$PATTERN"
-             fi
+            npm run deflake:test:integration:sandbox:docker -- --runs="${{ env.RUNS }}" -- --testNamePattern "'${{ env.TEST_NAME_PATTERN }}'"
           else
-             $CMD -- --runs="${{ env.RUNS }}"
+            npm run deflake:test:integration:sandbox:none -- --runs="${{ env.RUNS }}" -- --testNamePattern "'${{ env.TEST_NAME_PATTERN }}'"
           fi
 
   deflake_e2e_mac:
@@ -119,18 +109,7 @@ jobs:
           TEST_NAME_PATTERN: '${{ github.event.inputs.test_name_pattern }}'
           VERBOSE: 'true'
         run: |
-          PATTERN="${{ env.TEST_NAME_PATTERN }}"
-          CMD="npm run deflake:test:integration:sandbox:none"
-
-          if [[ -n "$PATTERN" ]]; then
-             if [[ "$PATTERN" =~ \.ts || "$PATTERN" =~ \.js || "$PATTERN" =~ / ]]; then
-               $CMD -- --runs="${{ env.RUNS }}" -- "$PATTERN"
-             else
-               $CMD -- --runs="${{ env.RUNS }}" -- --testNamePattern "$PATTERN"
-             fi
-          else
-             $CMD -- --runs="${{ env.RUNS }}"
-          fi
+          npm run deflake:test:integration:sandbox:none -- --runs="${{ env.RUNS }}" -- --testNamePattern "'${{ env.TEST_NAME_PATTERN }}'"
 
   deflake_e2e_windows:
     name: 'Slow E2E - Win'
@@ -188,16 +167,4 @@ jobs:
           TEST_NAME_PATTERN: '${{ github.event.inputs.test_name_pattern }}'
         shell: 'pwsh'
         run: |
-          $Pattern = $env:TEST_NAME_PATTERN
-          $Runs = $env:RUNS
-          $Cmd = "npm run deflake:test:integration:sandbox:none"
-
-          if (-not [string]::IsNullOrWhiteSpace($Pattern)) {
-             if ($Pattern -match "\.ts" -or $Pattern -match "\.js" -or $Pattern -match "[\\/]") {
-                 cmd /c "$Cmd -- --runs=`"$Runs`" -- `"$Pattern`""
-             } else {
-                 cmd /c "$Cmd -- --runs=`"$Runs`" -- --testNamePattern `"$Pattern`""
-             }
-          } else {
-              cmd /c "$Cmd -- --runs=`"$Runs`""
-          }
+          npm run deflake:test:integration:sandbox:none -- --runs="${{ env.RUNS }}" -- --testNamePattern "'${{ env.TEST_NAME_PATTERN }}'"

--- a/.github/workflows/deflake.yml
+++ b/.github/workflows/deflake.yml
@@ -9,7 +9,7 @@ on:
         default: 'main'
         type: 'string'
       test_name_pattern:
-        description: 'The test name pattern to use'
+        description: 'The test name substring OR test file name to use'
         required: false
         type: 'string'
       runs:
@@ -68,10 +68,20 @@ jobs:
           VERBOSE: 'true'
         shell: 'bash'
         run: |
+          PATTERN="${{ env.TEST_NAME_PATTERN }}"
+          CMD="npm run deflake:test:integration:sandbox:none"
           if [[ "${{ env.IS_DOCKER }}" == "true" ]]; then
-            npm run deflake:test:integration:sandbox:docker -- --runs="${{ env.RUNS }}" -- --testNamePattern "'${{ env.TEST_NAME_PATTERN }}'"
+            CMD="npm run deflake:test:integration:sandbox:docker"
+          fi
+
+          if [[ -n "$PATTERN" ]]; then
+             if [[ "$PATTERN" =~ \.ts || "$PATTERN" =~ \.js || "$PATTERN" =~ / ]]; then
+               $CMD -- --runs="${{ env.RUNS }}" -- "$PATTERN"
+             else
+               $CMD -- --runs="${{ env.RUNS }}" -- --testNamePattern "$PATTERN"
+             fi
           else
-            npm run deflake:test:integration:sandbox:none -- --runs="${{ env.RUNS }}" -- --testNamePattern "'${{ env.TEST_NAME_PATTERN }}'"
+             $CMD -- --runs="${{ env.RUNS }}"
           fi
 
   deflake_e2e_mac:
@@ -109,7 +119,18 @@ jobs:
           TEST_NAME_PATTERN: '${{ github.event.inputs.test_name_pattern }}'
           VERBOSE: 'true'
         run: |
-          npm run deflake:test:integration:sandbox:none -- --runs="${{ env.RUNS }}" -- --testNamePattern "'${{ env.TEST_NAME_PATTERN }}'"
+          PATTERN="${{ env.TEST_NAME_PATTERN }}"
+          CMD="npm run deflake:test:integration:sandbox:none"
+
+          if [[ -n "$PATTERN" ]]; then
+             if [[ "$PATTERN" =~ \.ts || "$PATTERN" =~ \.js || "$PATTERN" =~ / ]]; then
+               $CMD -- --runs="${{ env.RUNS }}" -- "$PATTERN"
+             else
+               $CMD -- --runs="${{ env.RUNS }}" -- --testNamePattern "$PATTERN"
+             fi
+          else
+             $CMD -- --runs="${{ env.RUNS }}"
+          fi
 
   deflake_e2e_windows:
     name: 'Slow E2E - Win'
@@ -167,4 +188,16 @@ jobs:
           TEST_NAME_PATTERN: '${{ github.event.inputs.test_name_pattern }}'
         shell: 'pwsh'
         run: |
-          npm run deflake:test:integration:sandbox:none -- --runs="${{ env.RUNS }}" -- --testNamePattern "'${{ env.TEST_NAME_PATTERN }}'"
+          $Pattern = $env:TEST_NAME_PATTERN
+          $Runs = $env:RUNS
+          $Cmd = "npm run deflake:test:integration:sandbox:none"
+
+          if (-not [string]::IsNullOrWhiteSpace($Pattern)) {
+             if ($Pattern -match "\.ts" -or $Pattern -match "\.js" -or $Pattern -match "[\\/]") {
+                 cmd /c "$Cmd -- --runs=`"$Runs`" -- `"$Pattern`""
+             } else {
+                 cmd /c "$Cmd -- --runs=`"$Runs`" -- --testNamePattern `"$Pattern`""
+             }
+          } else {
+              cmd /c "$Cmd -- --runs=`"$Runs`""
+          }

--- a/.github/workflows/deflake.yml
+++ b/.github/workflows/deflake.yml
@@ -44,7 +44,7 @@ jobs:
           repository: '${{ github.repository }}'
 
       - name: 'Set up Node.js ${{ matrix.node-version }}'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions-node@v4
         with:
           node-version: '${{ matrix.node-version }}'
 
@@ -85,7 +85,7 @@ jobs:
           repository: '${{ github.repository }}'
 
       - name: 'Set up Node.js 20.x'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions-node@v4
         with:
           node-version: '20.x'
 
@@ -123,7 +123,7 @@ jobs:
           repository: '${{ github.repository }}'
 
       - name: 'Set up Node.js 20.x'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions-node@v4
         with:
           node-version: '20.x'
           cache: 'npm'

--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -9,6 +9,10 @@ on:
         description: 'Run all evaluations (including usually passing)'
         type: 'boolean'
         default: true
+      test_name_pattern:
+        description: 'Test name pattern or file name'
+        required: false
+        type: 'string'
 
 permissions:
   contents: 'read'
@@ -53,7 +57,20 @@ jobs:
           GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
           GEMINI_MODEL: '${{ matrix.model }}'
           RUN_EVALS: "${{ github.event.inputs.run_all != 'false' }}"
-        run: 'npm run test:all_evals'
+          TEST_NAME_PATTERN: '${{ github.event.inputs.test_name_pattern }}'
+        run: |
+           CMD="npm run test:all_evals"
+           PATTERN="${{ env.TEST_NAME_PATTERN }}"
+
+           if [[ -n "$PATTERN" ]]; then
+             if [[ "$PATTERN" =~ \.ts || "$PATTERN" =~ \.js || "$PATTERN" =~ / ]]; then
+               $CMD -- "$PATTERN"
+             else
+               $CMD -- -t "$PATTERN"
+             fi
+           else
+             $CMD
+           fi
 
       - name: 'Upload Logs'
         if: 'always()'

--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -59,18 +59,18 @@ jobs:
           RUN_EVALS: "${{ github.event.inputs.run_all != 'false' }}"
           TEST_NAME_PATTERN: '${{ github.event.inputs.test_name_pattern }}'
         run: |
-           CMD="npm run test:all_evals"
-           PATTERN="${{ env.TEST_NAME_PATTERN }}"
+          CMD="npm run test:all_evals"
+          PATTERN="${{ env.TEST_NAME_PATTERN }}"
 
-           if [[ -n "$PATTERN" ]]; then
-             if [[ "$PATTERN" =~ \.ts || "$PATTERN" =~ \.js || "$PATTERN" =~ / ]]; then
-               $CMD -- "$PATTERN"
-             else
-               $CMD -- -t "$PATTERN"
-             fi
-           else
-             $CMD
-           fi
+          if [[ -n "$PATTERN" ]]; then
+            if [[ "$PATTERN" == *.ts || "$PATTERN" == *.js || "$PATTERN" == */* ]]; then
+              $CMD -- "$PATTERN"
+            else
+              $CMD -- -t "$PATTERN"
+            fi
+          else
+            $CMD
+          fi
 
       - name: 'Upload Logs'
         if: 'always()'


### PR DESCRIPTION
Updates the nightly evals workflow to accept an optional `test_name_pattern` input. This input can be a test name substring (passed as `-t`) or a file path (passed directly). If omitted, all tests run.

Enables the ability to quickly assess the quality of a single test change across all models.

Fixes #17125.