### PR TITLE
refactor: improve large text paste placeholder

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -177,7 +177,6 @@ describe('InputPrompt', () => {
       transformationsByLine: [],
       getOffset: vi.fn().mockReturnValue(0),
       pastedContent: {},
-      addPastedContent: vi.fn().mockReturnValue('[Pasted Text: 6 lines]'),
     } as unknown as TextBuffer;
 
     mockShellHistory = {
@@ -1825,6 +1824,7 @@ describe('InputPrompt', () => {
 
     afterEach(() => {
       vi.useRealTimers();
+      vi.restoreAllMocks();
     });
 
     it('should prevent auto-submission immediately after an unsafe paste', async () => {

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -293,13 +293,15 @@ function createDataListener(keypressHandler: KeypressHandler) {
 
     // Detect unbracketed paste ONLY if:
     // 1. NOT currently in a bracketed paste session
-    // 2. Data contains NO escape sequences
+    // 2. Data contains NO terminal control characters (excludes TAB, LF, CR
+    //    which appear in normal text)
     // 3. Data meets minimum length threshold (avoids false positives from
     //    key repeat, SSH latency batching, or IME composition)
-    const hasAnyEsc = data.includes('\x1B');
+    // eslint-disable-next-line no-control-regex
+    const hasTerminalControlChars = /[\x00-\x08\x0B\x0C\x0E-\x1F]/.test(data);
     const isLikelyUnbracketedPaste =
       !inBracketedPaste &&
-      !hasAnyEsc &&
+      !hasTerminalControlChars &&
       data.length >= UNBRACKETED_PASTE_MIN_LENGTH;
 
     // Exit bracketed paste mode when we see paste-end

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -25,6 +25,7 @@ export const BACKSLASH_ENTER_TIMEOUT = 5;
 export const ESC_TIMEOUT = 50;
 export const PASTE_TIMEOUT = 30_000;
 export const FAST_RETURN_TIMEOUT = 30;
+export const UNBRACKETED_PASTE_MIN_LENGTH = 10;
 
 // Parse the key itself
 const KEY_INFO_MAP: Record<
@@ -293,10 +294,13 @@ function createDataListener(keypressHandler: KeypressHandler) {
     // Detect unbracketed paste ONLY if:
     // 1. NOT currently in a bracketed paste session
     // 2. Data contains NO escape sequences
-    // 3. Data has multiple characters (can't type 2+ chars in one stdin event)
+    // 3. Data meets minimum length threshold (avoids false positives from
+    //    key repeat, SSH latency batching, or IME composition)
     const hasAnyEsc = data.includes('\x1B');
     const isLikelyUnbracketedPaste =
-      !inBracketedPaste && !hasAnyEsc && data.length > 1;
+      !inBracketedPaste &&
+      !hasAnyEsc &&
+      data.length >= UNBRACKETED_PASTE_MIN_LENGTH;
 
     // Exit bracketed paste mode when we see paste-end
     if (hasPasteEnd) {

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -278,7 +278,6 @@ function createDataListener(keypressHandler: KeypressHandler) {
   let timeoutId: NodeJS.Timeout;
   return (data: string) => {
     clearTimeout(timeoutId);
-    // Normal character-by-character processing
     for (const char of data) {
       parser.next(char);
     }

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -276,18 +276,34 @@ function createDataListener(keypressHandler: KeypressHandler) {
   parser.next(); // prime the generator so it starts listening.
 
   let timeoutId: NodeJS.Timeout;
+  let inBracketedPaste = false;
+
   return (data: string) => {
     clearTimeout(timeoutId);
 
-    // Detect unbracketed pastes: multiple characters arriving at once
-    // that aren't escape sequences or already bracketed.
-    // This handles terminals (like VSCode on Windows) that paste without
-    // bracketed paste mode markers.
-    const hasPasteMarkers = data.includes('\x1B[200~');
-    const startsWithEsc = data.startsWith('\x1B');
-    const isLikelyPaste = !hasPasteMarkers && !startsWithEsc && data.length > 1;
+    // Track bracketed paste state across chunks
+    const hasPasteStart = data.includes('\x1B[200~');
+    const hasPasteEnd = data.includes('\x1B[201~');
 
-    if (isLikelyPaste) {
+    // Enter bracketed paste mode when we see paste-start
+    if (hasPasteStart) {
+      inBracketedPaste = true;
+    }
+
+    // Detect unbracketed paste ONLY if:
+    // 1. NOT currently in a bracketed paste session
+    // 2. Data contains NO escape sequences
+    // 3. Data has multiple characters (can't type 2+ chars in one stdin event)
+    const hasAnyEsc = data.includes('\x1B');
+    const isLikelyUnbracketedPaste =
+      !inBracketedPaste && !hasAnyEsc && data.length > 1;
+
+    // Exit bracketed paste mode when we see paste-end
+    if (hasPasteEnd) {
+      inBracketedPaste = false;
+    }
+
+    if (isLikelyUnbracketedPaste) {
       keypressHandler({
         name: '',
         ctrl: false,

--- a/packages/cli/src/ui/utils/highlight.test.ts
+++ b/packages/cli/src/ui/utils/highlight.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { parseInputForHighlighting } from './highlight.js';
+import type { Transformation } from '../components/shared/text-buffer.js';
 
 describe('parseInputForHighlighting', () => {
   it('should handle an empty string', () => {
@@ -136,12 +137,13 @@ describe('parseInputForHighlighting', () => {
 });
 
 describe('parseInputForHighlighting with Transformations', () => {
-  const transformations = [
+  const transformations: Transformation[] = [
     {
       logStart: 10,
       logEnd: 19,
       logicalText: '@test.png',
       collapsedText: '[Image test.png]',
+      type: 'image',
     },
   ];
 
@@ -177,18 +179,20 @@ describe('parseInputForHighlighting with Transformations', () => {
 
   it('should handle multiple transformations in a line', () => {
     const line = 'Images: @test1.png and @test2.png';
-    const multiTransformations = [
+    const multiTransformations: Transformation[] = [
       {
         logStart: 8,
         logEnd: 18,
         logicalText: '@test1.png',
         collapsedText: '[Image test1.png]',
+        type: 'image',
       },
       {
         logStart: 23,
         logEnd: 33,
         logicalText: '@test2.png',
         collapsedText: '[Image test2.png]',
+        type: 'image',
       },
     ];
 


### PR DESCRIPTION
Trying something new. Code review feedback for https://github.com/google-gemini/gemini-cli/pull/16422 as a PR

Fixes:
Move paste logic into the reducer rather than callbacks to avoid race conditions
Add missing restoreAllMocks to tests
Standardize images and pastes to use transforms.
