### PR TITLE
feat(cli): new query detection

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -306,6 +306,11 @@ their corresponding top-level category object in your `settings.json` file.
     session. -1 means unlimited.
   - **Default:** `-1`
 
+- **`model.renewSessionTurnsThreshold`** (number):
+  - **Description:** Number of conversation turns after which to prompt the user
+    to start a new session or compress. Set to -1 to disable.
+  - **Default:** `-1`
+
 - **`model.summarizeToolOutput`** (object):
   - **Description:** Enables or disables summarization of tool output. Configure
     per-tool token budgets (for example {"run_shell_command": {"tokenBudget":

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -782,6 +782,8 @@ export async function loadCliConfig(
     enableHooksUI: settings.tools?.enableHooks ?? true,
     hooks: settings.hooks || {},
     disabledHooks: settings.hooksConfig?.disabled || [],
+    renewSessionTurnsThreshold:
+      settings.model?.renewSessionTurnsThreshold ?? -1,
     projectHooks: projectHooks || {},
     onModelChange: (model: string) => saveModelChange(loadedSettings, model),
     onReload: async () => {

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -692,6 +692,16 @@ const SETTINGS_SCHEMA = {
           'Maximum number of user/model/tool turns to keep in a session. -1 means unlimited.',
         showInDialog: true,
       },
+      renewSessionTurnsThreshold: {
+        type: 'number',
+        label: 'Renew Session Turn Threshold',
+        category: 'Model',
+        requiresRestart: false,
+        default: -1,
+        description:
+          'Number of conversation turns after which to prompt the user to start a new session or compress. Set to -1 to disable.',
+        showInDialog: true,
+      },
       summarizeToolOutput: {
         type: 'object',
         label: 'Summarize Tool Output',

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -98,6 +98,7 @@ import { useShellInactivityStatus } from './hooks/useShellInactivityStatus.js';
 import { useFolderTrust } from './hooks/useFolderTrust.js';
 import { useIdeTrustListener } from './hooks/useIdeTrustListener.js';
 import { type IdeIntegrationNudgeResult } from './IdeIntegrationNudge.js';
+import { clearCommand } from './commands/clearCommand.js';
 import { appEvents, AppEvent } from '../utils/events.js';
 import { type UpdateObject } from './utils/updateCheck.js';
 import { setUpdateHandler } from '../utils/handleAutoUpdate.js';
@@ -808,6 +809,15 @@ Logging in with Google... Restarting Gemini CLI to continue.
     }
   }, [pendingRestorePrompt, inputHistory, historyManager.history]);
 
+  // Function to execute the clear command directly, bypassing the slash command processor.
+  // This is used by the RenewSessionDialog to avoid potential infinite loops caused
+  // by state updates within the processor.
+  const executeClearCommand = useCallback(async () => {
+    if (clearCommand.action) {
+      await clearCommand.action(commandContext, '');
+    }
+  }, [commandContext]);
+
   const {
     streamingState,
     submitQuery,
@@ -841,6 +851,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     terminalWidth,
     terminalHeight,
     embeddedShellFocused,
+    executeClearCommand,
   );
 
   const lastOutputTimeRef = useRef(0);

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -829,7 +829,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     handleApprovalModeChange,
     activePtyId,
     loopDetectionConfirmationRequest,
-    RenewSessionConfirmationRequest,
+    renewSessionConfirmationRequest,
     lastOutputTime,
     retryStatus,
   } = useGeminiStream(
@@ -1484,7 +1484,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     !!customDialog ||
     confirmUpdateExtensionRequests.length > 0 ||
     !!loopDetectionConfirmationRequest ||
-    !!RenewSessionConfirmationRequest ||
+    !!renewSessionConfirmationRequest ||
     isThemeDialogOpen ||
     isSettingsDialogOpen ||
     isModelDialogOpen ||
@@ -1589,7 +1589,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       confirmationRequest,
       confirmUpdateExtensionRequests,
       loopDetectionConfirmationRequest,
-      RenewSessionConfirmationRequest,
+      renewSessionConfirmationRequest,
       geminiMdFileCount,
       streamingState,
       initError,
@@ -1752,7 +1752,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       config,
       settingsNonce,
       adminSettingsChanged,
-      RenewSessionConfirmationRequest,
+      renewSessionConfirmationRequest,
     ],
   );
 

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -819,6 +819,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     handleApprovalModeChange,
     activePtyId,
     loopDetectionConfirmationRequest,
+    RenewSessionConfirmationRequest,
     lastOutputTime,
     retryStatus,
   } = useGeminiStream(
@@ -1472,6 +1473,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     !!customDialog ||
     confirmUpdateExtensionRequests.length > 0 ||
     !!loopDetectionConfirmationRequest ||
+    !!RenewSessionConfirmationRequest ||
     isThemeDialogOpen ||
     isSettingsDialogOpen ||
     isModelDialogOpen ||
@@ -1576,6 +1578,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       confirmationRequest,
       confirmUpdateExtensionRequests,
       loopDetectionConfirmationRequest,
+      RenewSessionConfirmationRequest,
       geminiMdFileCount,
       streamingState,
       initError,
@@ -1738,6 +1741,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       config,
       settingsNonce,
       adminSettingsChanged,
+      RenewSessionConfirmationRequest,
     ],
   );
 

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -7,6 +7,7 @@
 import { Box, Text } from 'ink';
 import { IdeIntegrationNudge } from '../IdeIntegrationNudge.js';
 import { LoopDetectionConfirmation } from './LoopDetectionConfirmation.js';
+import { RenewSessionDialog } from './RenewSessionDialog.js';
 import { FolderTrustDialog } from './FolderTrustDialog.js';
 import { ConsentPrompt } from './ConsentPrompt.js';
 import { ThemeDialog } from './ThemeDialog.js';
@@ -92,6 +93,21 @@ export const DialogManager = ({
       <FolderTrustDialog
         onSelect={uiActions.handleFolderTrustSelect}
         isRestarting={uiState.isRestarting}
+      />
+    );
+  }
+  if (uiState.shellConfirmationRequest) {
+    return (
+      <ShellConfirmationDialog request={uiState.shellConfirmationRequest} />
+    );
+  }
+  if (uiState.RenewSessionConfirmationRequest) {
+    return (
+      <RenewSessionDialog
+        maxSessionTurns={
+          settings.merged.model?.renewSessionTurnsThreshold ?? -1
+        }
+        onComplete={uiState.RenewSessionConfirmationRequest.onComplete}
       />
     );
   }

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -101,13 +101,14 @@ export const DialogManager = ({
       <ShellConfirmationDialog request={uiState.shellConfirmationRequest} />
     );
   }
-  if (uiState.RenewSessionConfirmationRequest) {
+  if (uiState.renewSessionConfirmationRequest) {
     return (
       <RenewSessionDialog
         maxSessionTurns={
           settings.merged.model?.renewSessionTurnsThreshold ?? -1
         }
-        onComplete={uiState.RenewSessionConfirmationRequest.onComplete}
+        reason={uiState.renewSessionConfirmationRequest.reason}
+        onComplete={uiState.renewSessionConfirmationRequest.onComplete}
       />
     );
   }

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -96,11 +96,6 @@ export const DialogManager = ({
       />
     );
   }
-  if (uiState.shellConfirmationRequest) {
-    return (
-      <ShellConfirmationDialog request={uiState.shellConfirmationRequest} />
-    );
-  }
   if (uiState.renewSessionConfirmationRequest) {
     return (
       <RenewSessionDialog

--- a/packages/cli/src/ui/components/RenewSessionDialog.tsx
+++ b/packages/cli/src/ui/components/RenewSessionDialog.tsx
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Box, Text } from 'ink';
+import type { RadioSelectItem } from './shared/RadioButtonSelect.js';
+import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
+import { useKeypress } from '../hooks/useKeypress.js';
+import { theme } from '../semantic-colors.js';
+import type { RenewSessionConfirmationResult } from '../types.js';
+
+interface RenewSessionDialogProps {
+  onComplete: (result: RenewSessionConfirmationResult) => void;
+  maxSessionTurns: number;
+}
+
+export function RenewSessionDialog({
+  onComplete,
+  maxSessionTurns,
+}: RenewSessionDialogProps) {
+  useKeypress(
+    (key) => {
+      if (key.name === 'escape') {
+        onComplete({
+          userSelection: 'compress_session',
+        });
+      }
+    },
+    { isActive: true },
+  );
+
+  const OPTIONS: Array<RadioSelectItem<RenewSessionConfirmationResult>> = [
+    {
+      label: 'Compress session',
+      value: {
+        userSelection: 'compress_session',
+      } as RenewSessionConfirmationResult,
+      key: 'compress_session',
+    },
+    {
+      label: 'Start a new session',
+      value: {
+        userSelection: 'new_session',
+      } as RenewSessionConfirmationResult,
+      key: 'new_session',
+    },
+  ];
+
+  return (
+    <Box width="100%" flexDirection="row">
+      <Box
+        flexDirection="column"
+        borderStyle="round"
+        borderColor={theme.status.warning}
+        flexGrow={1}
+        marginLeft={1}
+      >
+        <Box paddingX={1} paddingY={0} flexDirection="column">
+          <Box minHeight={1}>
+            <Box minWidth={3}>
+              <Text
+                color={theme.status.warning}
+                aria-label="Max turns reached:"
+              >
+                !
+              </Text>
+            </Box>
+            <Box>
+              <Text wrap="truncate-end">
+                <Text color={theme.text.primary} bold>
+                  Turn limit reached
+                </Text>{' '}
+                <Text color={theme.text.secondary}>
+                  (current threshold: {maxSessionTurns} turns)
+                </Text>
+              </Text>
+            </Box>
+          </Box>
+          <Box marginTop={1}>
+            <Box flexDirection="column">
+              <Text color={theme.text.secondary}>
+                You&apos;ve reached the configured maximum number of turns for
+                this session. Choose whether to compress the conversation or
+                start a new session.
+              </Text>
+              <Box marginTop={1}>
+                <RadioButtonSelect items={OPTIONS} onSelect={onComplete} />
+              </Box>
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/ui/components/RenewSessionDialog.tsx
+++ b/packages/cli/src/ui/components/RenewSessionDialog.tsx
@@ -14,11 +14,13 @@ import type { RenewSessionConfirmationResult } from '../types.js';
 interface RenewSessionDialogProps {
   onComplete: (result: RenewSessionConfirmationResult) => void;
   maxSessionTurns: number;
+  reason?: 'turn_limit' | 'topic_change';
 }
 
 export function RenewSessionDialog({
   onComplete,
   maxSessionTurns,
+  reason = 'turn_limit',
 }: RenewSessionDialogProps) {
   useKeypress(
     (key) => {
@@ -31,9 +33,13 @@ export function RenewSessionDialog({
     { isActive: true },
   );
 
+  const isTopicChange = reason === 'topic_change';
+
   const OPTIONS: Array<RadioSelectItem<RenewSessionConfirmationResult>> = [
     {
-      label: 'Compress session',
+      label: isTopicChange
+        ? 'Continue with current context'
+        : 'Compress session',
       value: {
         userSelection: 'compress_session',
       } as RenewSessionConfirmationResult,
@@ -70,20 +76,24 @@ export function RenewSessionDialog({
             <Box>
               <Text wrap="truncate-end">
                 <Text color={theme.text.primary} bold>
-                  Turn limit reached
+                  {isTopicChange
+                    ? 'Topic change detected'
+                    : 'Turn limit reached'}
                 </Text>{' '}
-                <Text color={theme.text.secondary}>
-                  (current threshold: {maxSessionTurns} turns)
-                </Text>
+                {reason === 'turn_limit' && (
+                  <Text color={theme.text.secondary}>
+                    (current threshold: {maxSessionTurns} turns)
+                  </Text>
+                )}
               </Text>
             </Box>
           </Box>
           <Box marginTop={1}>
             <Box flexDirection="column">
               <Text color={theme.text.secondary}>
-                You&apos;ve reached the configured maximum number of turns for
-                this session. Choose whether to compress the conversation or
-                start a new session.
+                {isTopicChange
+                  ? 'Your query appears to be about a new topic. Would you like to start a new session?'
+                  : "You've reached the configured maximum number of turns for this session. Choose whether to compress the conversation or start a new session."}
               </Text>
               <Box marginTop={1}>
                 <RadioButtonSelect items={OPTIONS} onSelect={onComplete} />

--- a/packages/cli/src/ui/components/RenewSessionDialog.tsx
+++ b/packages/cli/src/ui/components/RenewSessionDialog.tsx
@@ -22,29 +22,48 @@ export function RenewSessionDialog({
   maxSessionTurns,
   reason = 'turn_limit',
 }: RenewSessionDialogProps) {
+  const isTopicChange = reason === 'topic_change';
+
   useKeypress(
     (key) => {
       if (key.name === 'escape') {
         onComplete({
-          userSelection: 'compress_session',
+          userSelection: isTopicChange
+            ? 'continue_session'
+            : 'compress_session',
         });
       }
     },
     { isActive: true },
   );
 
-  const isTopicChange = reason === 'topic_change';
-
   const OPTIONS: Array<RadioSelectItem<RenewSessionConfirmationResult>> = [
-    {
-      label: isTopicChange
-        ? 'Continue with current context'
-        : 'Compress session',
-      value: {
-        userSelection: 'compress_session',
-      } as RenewSessionConfirmationResult,
-      key: 'compress_session',
-    },
+    ...(isTopicChange
+      ? [
+          {
+            label: 'Continue with current context',
+            value: {
+              userSelection: 'continue_session',
+            } as RenewSessionConfirmationResult,
+            key: 'continue_session',
+          },
+          {
+            label: 'Compress conversation',
+            value: {
+              userSelection: 'compress_session',
+            } as RenewSessionConfirmationResult,
+            key: 'compress_session',
+          },
+        ]
+      : [
+          {
+            label: 'Compress session',
+            value: {
+              userSelection: 'compress_session',
+            } as RenewSessionConfirmationResult,
+            key: 'compress_session',
+          },
+        ]),
     {
       label: 'Start a new session',
       value: {

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -79,7 +79,7 @@ export interface UIState {
   confirmationRequest: ConfirmationRequest | null;
   confirmUpdateExtensionRequests: ConfirmationRequest[];
   loopDetectionConfirmationRequest: LoopDetectionConfirmationRequest | null;
-  RenewSessionConfirmationRequest: RenewSessionConfirmationRequest | null;
+  renewSessionConfirmationRequest: RenewSessionConfirmationRequest | null;
   geminiMdFileCount: number;
   streamingState: StreamingState;
   initError: string | null;

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -11,6 +11,7 @@ import type {
   ConsoleMessageItem,
   ConfirmationRequest,
   LoopDetectionConfirmationRequest,
+  RenewSessionConfirmationRequest,
   HistoryItemWithoutId,
   StreamingState,
   ActiveHook,
@@ -78,6 +79,7 @@ export interface UIState {
   confirmationRequest: ConfirmationRequest | null;
   confirmUpdateExtensionRequests: ConfirmationRequest[];
   loopDetectionConfirmationRequest: LoopDetectionConfirmationRequest | null;
+  RenewSessionConfirmationRequest: RenewSessionConfirmationRequest | null;
   geminiMdFileCount: number;
   streamingState: StreamingState;
   initError: string | null;

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -67,6 +67,13 @@ const MockedGeminiClientClass = vi.hoisted(() =>
       recordToolCalls: vi.fn(),
       getConversationFile: vi.fn(),
     });
+    this.getTopicDetectionService = vi.fn().mockReturnValue({
+      isTopicChanged: vi
+        .fn()
+        .mockResolvedValue({ topic_changed: false, reasoning: 'test' }),
+    });
+    this.resetChat = vi.fn().mockResolvedValue(undefined);
+    this.getCurrentSequenceModel = vi.fn().mockReturnValue('gemini-pro');
   }),
 );
 
@@ -292,6 +299,7 @@ describe('useGeminiStream', () => {
       shellModeActive: false,
       loadedSettings: mockLoadedSettings,
       toolCalls: initialToolCalls,
+      executeClearCommand: undefined as (() => Promise<void>) | undefined,
     };
 
     const { result, rerender } = renderHook(
@@ -361,6 +369,8 @@ describe('useGeminiStream', () => {
           () => {},
           80,
           24,
+          false,
+          props.executeClearCommand,
         );
       },
       {
@@ -3061,6 +3071,131 @@ describe('useGeminiStream', () => {
       // Then verify loop detection confirmation request was set
       await waitFor(() => {
         expect(result.current.loopDetectionConfirmationRequest).not.toBeNull();
+      });
+    });
+
+    describe('Topic Change Detection', () => {
+      it('should trigger renewSessionConfirmationRequest on topic change and reset chat if confirmed', async () => {
+        const client = new MockedGeminiClientClass(mockConfig);
+        const topicDetector = {
+          isTopicChanged: vi
+            .fn()
+            .mockResolvedValue({ topic_changed: true, reasoning: 'test' }),
+        };
+        client.getTopicDetectionService.mockReturnValue(topicDetector);
+
+        const executeClearCommand = vi.fn().mockResolvedValue(undefined);
+        const { result, rerender } = renderTestHook([], client);
+        rerender({
+          client,
+          history: [],
+          addItem: mockAddItem as unknown as UseHistoryManagerReturn['addItem'],
+          config: mockConfig,
+          onDebugMessage: mockOnDebugMessage,
+          handleSlashCommand: mockHandleSlashCommand as unknown as (
+            cmd: PartListUnion,
+          ) => Promise<SlashCommandProcessorResult | false>,
+          shellModeActive: false,
+          loadedSettings: mockLoadedSettings,
+          toolCalls: [],
+          executeClearCommand,
+        });
+
+        // First query to set lastUserQueryTextRef
+        await act(async () => {
+          await result.current.submitQuery('Query 1');
+        });
+
+        // Clear mock calls from first query
+        mockSendMessageStream.mockClear();
+
+        // Second query should trigger topic detection
+        let submitResolved = false;
+        void result.current.submitQuery('Query 2').then(() => {
+          submitResolved = true;
+        });
+
+        // Wait for dialog to appear
+        await waitFor(() => {
+          expect(result.current.renewSessionConfirmationRequest).not.toBeNull();
+          expect(result.current.renewSessionConfirmationRequest?.reason).toBe(
+            'topic_change',
+          );
+        });
+
+        const capturedOnComplete =
+          result.current.renewSessionConfirmationRequest!.onComplete;
+
+        // Simulate user choosing "New Session"
+        await act(async () => {
+          capturedOnComplete({ userSelection: 'new_session' });
+        });
+
+        // Use a small delay for the setTimeout in the implementation
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 60));
+        });
+
+        await waitFor(() => expect(submitResolved).toBe(true));
+
+        expect(executeClearCommand).toHaveBeenCalled();
+        expect(client.resetChat).not.toHaveBeenCalled();
+        expect(mockAddItem).toHaveBeenCalledWith(
+          expect.objectContaining({
+            text: 'Topic change detected. Starting a new session.',
+            type: MessageType.INFO,
+          }),
+          expect.any(Number),
+        );
+        expect(mockSendMessageStream).toHaveBeenCalledWith(
+          'Query 2',
+          expect.any(AbortSignal),
+          expect.any(String),
+        );
+      });
+
+      it('should trigger renewSessionConfirmationRequest on topic change and NOT reset chat if cancelled', async () => {
+        const client = new MockedGeminiClientClass(mockConfig);
+        const topicDetector = {
+          isTopicChanged: vi
+            .fn()
+            .mockResolvedValue({ topic_changed: true, reasoning: 'test' }),
+        };
+        client.getTopicDetectionService.mockReturnValue(topicDetector);
+
+        const { result } = renderTestHook([], client);
+
+        await act(async () => {
+          await result.current.submitQuery('Query 1');
+        });
+
+        mockSendMessageStream.mockClear();
+
+        let submitResolved = false;
+        void result.current.submitQuery('Query 2').then(() => {
+          submitResolved = true;
+        });
+
+        await waitFor(() => {
+          expect(result.current.renewSessionConfirmationRequest).not.toBeNull();
+        });
+
+        const capturedOnComplete =
+          result.current.renewSessionConfirmationRequest!.onComplete;
+
+        // Simulate user choosing "Continue" (compress_session)
+        await act(async () => {
+          capturedOnComplete({ userSelection: 'compress_session' });
+        });
+
+        await waitFor(() => expect(submitResolved).toBe(true));
+
+        expect(client.resetChat).not.toHaveBeenCalled();
+        expect(mockSendMessageStream).toHaveBeenCalledWith(
+          'Query 2',
+          expect.any(AbortSignal),
+          expect.any(String),
+        );
       });
     });
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -55,9 +55,11 @@ import type {
   SlashCommandProcessorResult,
   HistoryItemModel,
   RenewSessionConfirmationResult,
+  RenewSessionConfirmationRequest,
 } from '../types.js';
 import { StreamingState, MessageType, ToolCallStatus } from '../types.js';
 import { isAtCommand, isSlashCommand } from '../utils/commandUtils.js';
+import { checkExhaustive } from '../../utils/checks.js';
 import { useShellCommandProcessor } from './shellCommandProcessor.js';
 import { handleAtCommand } from './atCommandProcessor.js';
 import { findLastSafeSplitPoint } from '../utils/markdownUtilities.js';
@@ -240,12 +242,7 @@ export const useGeminiStream = (
   } | null>(null);
 
   const [renewSessionConfirmationRequest, setRenewSessionConfirmationRequest] =
-    useState<{
-      onComplete: (result: {
-        userSelection: 'compress_session' | 'new_session';
-      }) => void;
-      reason?: 'turn_limit' | 'topic_change';
-    } | null>(null);
+    useState<RenewSessionConfirmationRequest | null>(null);
 
   const renewSessionConfirmationRequestRef = useRef(
     renewSessionConfirmationRequest,
@@ -799,15 +796,12 @@ export const useGeminiStream = (
       addItem(pendingHistoryItemRef.current, Date.now());
       setPendingHistoryItem(null);
     }
-    geminiClient.resetSessionTurnCount();
 
     // Mark that we've shown the dialog
     hasShownRenewDialogRef.current = true;
 
     setRenewSessionConfirmationRequest({
-      onComplete: (result: {
-        userSelection: 'compress_session' | 'new_session';
-      }) => {
+      onComplete: (result: RenewSessionConfirmationResult) => {
         queueMicrotask(async () => {
           cancelOngoingRequest();
 
@@ -816,6 +810,7 @@ export const useGeminiStream = (
             // and not destructive to the DOM structure immediately.
             setRenewSessionConfirmationRequest(null);
             hasShownRenewDialogRef.current = false;
+            geminiClient.resetSessionTurnCount();
 
             await handleSlashCommandRef.current(
               '/compress',
@@ -823,11 +818,21 @@ export const useGeminiStream = (
               undefined,
               false,
             );
+
+            // Auto-retry the query if compression was successful
+            if (lastQueryRef.current && lastPromptIdRef.current) {
+              void submitQueryRef.current(
+                lastQueryRef.current,
+                { isContinuation: true },
+                lastPromptIdRef.current,
+              );
+            }
           } else if (result.userSelection === 'new_session') {
             // For clear, execute the command FIRST while the dialog is still open.
             // This ensures the heavy DOM destruction (clearing history) happens
             // in a separate render cycle from the Dialog unmounting.
             lastUserQueryTextRef.current = null;
+            geminiClient.resetSessionTurnCount();
             if (executeClearCommand) {
               await executeClearCommand();
             }
@@ -1159,15 +1164,30 @@ export const useGeminiStream = (
                     >((resolve) => {
                       setRenewSessionConfirmationRequest({
                         reason: 'topic_change',
-                        onComplete: (result) => {
+                        onComplete: (
+                          result: RenewSessionConfirmationResult,
+                        ) => {
                           setRenewSessionConfirmationRequest(null);
                           resolve(result.userSelection);
                         },
                       });
                     });
 
-                    if (selection === 'new_session') {
-                      queueMicrotask(async () => {
+                    switch (selection) {
+                      case 'continue_session':
+                        // Do nothing and proceed with the current context
+                        break;
+                      case 'compress_session':
+                        geminiClient.resetSessionTurnCount();
+                        await handleSlashCommandRef.current(
+                          '/compress',
+                          undefined,
+                          undefined,
+                          false,
+                        );
+                        break;
+                      case 'new_session':
+                        geminiClient.resetSessionTurnCount();
                         if (executeClearCommand) {
                           await executeClearCommand();
                         } else {
@@ -1182,12 +1202,9 @@ export const useGeminiStream = (
                           },
                           Date.now(),
                         );
-
-                        // A short delay ensures React processes the history clearing first.
-                        setTimeout(() => {
-                          setRenewSessionConfirmationRequest(null);
-                        }, 50);
-                      });
+                        break;
+                      default:
+                        checkExhaustive(selection);
                     }
                   }
                 }
@@ -1324,6 +1341,11 @@ export const useGeminiStream = (
       executeClearCommand,
     ],
   );
+
+  const submitQueryRef = useRef<typeof submitQuery>(null!);
+  useEffect(() => {
+    submitQueryRef.current = submitQuery;
+  }, [submitQuery]);
 
   const handleApprovalModeChange = useCallback(
     async (newApprovalMode: ApprovalMode) => {

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -442,7 +442,7 @@ export interface ActiveHook {
   total?: number;
 }
 export interface RenewSessionConfirmationResult {
-  userSelection: 'compress_session' | 'new_session';
+  userSelection: 'compress_session' | 'new_session' | 'continue_session';
 }
 
 export interface RenewSessionConfirmationRequest {

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -440,3 +440,10 @@ export interface ActiveHook {
   index?: number;
   total?: number;
 }
+export interface RenewSessionConfirmationResult {
+  userSelection: 'compress_session' | 'new_session';
+}
+
+export interface RenewSessionConfirmationRequest {
+  onComplete: (result: RenewSessionConfirmationResult) => void;
+}

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -45,6 +45,7 @@ export enum StreamingState {
 export enum GeminiEventType {
   Content = 'content',
   ToolCallRequest = 'tool_call_request',
+  RenewSession = 'renew_session',
   // Add other event types if the UI hook needs to handle them
 }
 
@@ -446,4 +447,5 @@ export interface RenewSessionConfirmationResult {
 
 export interface RenewSessionConfirmationRequest {
   onComplete: (result: RenewSessionConfirmationResult) => void;
+  reason?: 'turn_limit' | 'topic_change';
 }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -332,6 +332,7 @@ export interface ConfigParameters {
   bugCommand?: BugCommandSettings;
   model: string;
   maxSessionTurns?: number;
+  renewSessionTurnsThreshold?: number;
   experimentalZedIntegration?: boolean;
   listSessions?: boolean;
   deleteSession?: string;
@@ -475,6 +476,7 @@ export class Config {
 
   private _activeModel: string;
   private readonly maxSessionTurns: number;
+  private readonly renewSessionTurnsThreshold: number;
   private readonly listSessions: boolean;
   private readonly deleteSession: string | undefined;
   private readonly listExtensions: boolean;
@@ -644,6 +646,7 @@ export class Config {
     this.previewFeatures = params.previewFeatures ?? undefined;
     this.experimentalJitContext = params.experimentalJitContext ?? false;
     this.maxSessionTurns = params.maxSessionTurns ?? -1;
+    this.renewSessionTurnsThreshold = params.renewSessionTurnsThreshold ?? -1;
     this.experimentalZedIntegration =
       params.experimentalZedIntegration ?? false;
     this.listSessions = params.listSessions ?? false;
@@ -1094,6 +1097,10 @@ export class Config {
 
   getMaxSessionTurns(): number {
     return this.maxSessionTurns;
+  }
+
+  getRenewSessionTurnsThreshold(): number {
+    return this.renewSessionTurnsThreshold;
   }
 
   setQuotaErrorOccurred(value: boolean): void {

--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -189,6 +189,10 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
       extends: 'gemini-2.5-flash-base',
       modelConfig: {},
     },
+    'topic-detection': {
+      extends: 'gemini-2.5-flash-base',
+      modelConfig: {},
+    },
     'chat-compression-3-pro': {
       modelConfig: {
         model: 'gemini-3-pro-preview',

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -219,6 +219,7 @@ describe('Gemini Client (client.ts)', () => {
       getWorkingDir: vi.fn().mockReturnValue('/test/dir'),
       getFileService: vi.fn().mockReturnValue(fileService),
       getMaxSessionTurns: vi.fn().mockReturnValue(0),
+      getRenewSessionTurnsThreshold: vi.fn().mockReturnValue(-1),
       getQuotaErrorOccurred: vi.fn().mockReturnValue(false),
       setQuotaErrorOccurred: vi.fn(),
       getNoBrowser: vi.fn().mockReturnValue(false),

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -566,8 +566,6 @@ export class GeminiClient {
       return new Turn(this.getChat(), prompt_id);
     }
 
-    // Ensure turns never exceeds MAX_TURNS to prevent infinite loops
-    const boundedTurns = Math.min(turns, MAX_TURNS);
     if (!boundedTurns) {
       return turn;
     }

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -563,6 +563,7 @@ export class GeminiClient {
       this.config.getApprovalMode() !== ApprovalMode.YOLO
     ) {
       yield { type: GeminiEventType.RenewSession };
+      return new Turn(this.getChat(), prompt_id);
     }
 
     // Ensure turns never exceeds MAX_TURNS to prevent infinite loops

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -60,6 +60,7 @@ import { resolveModel } from '../config/models.js';
 import type { RetryAvailabilityContext } from '../utils/retry.js';
 import { partToString } from '../utils/partUtils.js';
 import { coreEvents, CoreEvent } from '../utils/events.js';
+import { ApprovalMode } from '../policy/types.js';
 
 const MAX_TURNS = 100;
 
@@ -284,6 +285,14 @@ export class GeminiClient {
 
   getCurrentSequenceModel(): string | null {
     return this.currentSequenceModel;
+  }
+
+  getSessionTurnCount(): number {
+    return this.sessionTurnCount;
+  }
+
+  resetSessionTurnCount() {
+    this.sessionTurnCount = 0;
   }
 
   async addDirectoryContext(): Promise<void> {
@@ -541,7 +550,16 @@ export class GeminiClient {
       yield { type: GeminiEventType.MaxSessionTurns };
       return turn;
     }
+    if (
+      this.config.getRenewSessionTurnsThreshold() > 0 &&
+      this.sessionTurnCount > this.config.getRenewSessionTurnsThreshold() &&
+      this.config.getApprovalMode() !== ApprovalMode.YOLO
+    ) {
+      yield { type: GeminiEventType.RenewSession };
+    }
 
+    // Ensure turns never exceeds MAX_TURNS to prevent infinite loops
+    const boundedTurns = Math.min(turns, MAX_TURNS);
     if (!boundedTurns) {
       return turn;
     }

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -34,6 +34,7 @@ import type {
 } from '../services/chatRecordingService.js';
 import type { ContentGenerator } from './contentGenerator.js';
 import { LoopDetectionService } from '../services/loopDetectionService.js';
+import { TopicDetectionService } from '../services/topicDetectionService.js';
 import { ChatCompressionService } from '../services/chatCompressionService.js';
 import { ideContextStore } from '../ide/ideContext.js';
 import {
@@ -81,6 +82,7 @@ export class GeminiClient {
   private sessionTurnCount = 0;
 
   private readonly loopDetector: LoopDetectionService;
+  private readonly topicDetector: TopicDetectionService;
   private readonly compressionService: ChatCompressionService;
   private lastPromptId: string;
   private currentSequenceModel: string | null = null;
@@ -95,6 +97,7 @@ export class GeminiClient {
 
   constructor(private readonly config: Config) {
     this.loopDetector = new LoopDetectionService(config);
+    this.topicDetector = new TopicDetectionService(config);
     this.compressionService = new ChatCompressionService();
     this.lastPromptId = this.config.getSessionId();
 
@@ -281,6 +284,10 @@ export class GeminiClient {
 
   getLoopDetectionService(): LoopDetectionService {
     return this.loopDetector;
+  }
+
+  getTopicDetectionService(): TopicDetectionService {
+    return this.topicDetector;
   }
 
   getCurrentSequenceModel(): string | null {

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -68,6 +68,7 @@ export enum GeminiEventType {
   ModelInfo = 'model_info',
   AgentExecutionStopped = 'agent_execution_stopped',
   AgentExecutionBlocked = 'agent_execution_blocked',
+  RenewSession = 'renew_session',
 }
 
 export type ServerGeminiRetryEvent = {
@@ -208,6 +209,10 @@ export type ServerGeminiCitationEvent = {
   value: string;
 };
 
+export type ServerGeminiRenewSessionEvent = {
+  type: GeminiEventType.RenewSession;
+};
+
 // The original union type, now composed of the individual types
 export type ServerGeminiStreamEvent =
   | ServerGeminiChatCompressedEvent
@@ -227,7 +232,8 @@ export type ServerGeminiStreamEvent =
   | ServerGeminiInvalidStreamEvent
   | ServerGeminiModelInfoEvent
   | ServerGeminiAgentExecutionStoppedEvent
-  | ServerGeminiAgentExecutionBlockedEvent;
+  | ServerGeminiAgentExecutionBlockedEvent
+  | ServerGeminiRenewSessionEvent;
 
 // A turn manages the agentic loop turn within the server context.
 export class Turn {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -104,6 +104,7 @@ export * from './services/sessionSummaryUtils.js';
 export * from './services/contextManager.js';
 export * from './skills/skillManager.js';
 export * from './skills/skillLoader.js';
+export * from './services/topicDetectionService.js';
 
 // Export IDE specific logic
 export * from './ide/ide-client.js';

--- a/packages/core/src/services/topicDetectionService.ts
+++ b/packages/core/src/services/topicDetectionService.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '../config/config.js';
+import { debugLogger } from '../utils/debugLogger.js';
+
+const TOPIC_DETECTION_SYSTEM_PROMPT = `You are an expert at analyzing conversation topics.
+Your task is to determine if the "Current Query" represents a significant shift in topic from the "Last Query".
+
+Rules:
+1. If the "Current Query" is a follow-up, clarification, or related to the same subject as the "Last Query", it is NOT a topic change.
+2. If the "Current Query" introduces a completely different subject, task, or domain that has no relation to the "Last Query", it IS a topic change.
+3. If you are unsure, but the topics seem unrelated, favor flagging it as not a topic change.
+
+Output format:
+You must respond with a JSON object:
+{
+  "topic_changed": boolean,
+  "reasoning": "brief explanation"
+}
+`;
+
+const TOPIC_DETECTION_SCHEMA = {
+  type: 'object',
+  properties: {
+    topic_changed: {
+      type: 'boolean',
+      description: 'Whether the topic has shifted significantly.',
+    },
+    reasoning: {
+      type: 'string',
+      description: 'Brief explanation for the decision.',
+    },
+  },
+  required: ['topic_changed', 'reasoning'],
+};
+
+export class TopicDetectionService {
+  constructor(private readonly config: Config) {}
+
+  async isTopicChanged(
+    lastQuery: string,
+    currentQuery: string,
+    promptId: string,
+    abortSignal?: AbortSignal,
+  ): Promise<{ topic_changed: boolean; reasoning: string }> {
+    if (!lastQuery || !currentQuery) {
+      return { topic_changed: false, reasoning: 'Empty query' };
+    }
+
+    try {
+      const prompt = `Last Query: "${lastQuery}"\n\nCurrent Query: "${currentQuery}"`;
+
+      debugLogger.log(
+        `TopicDetectionService: Checking topic change. lastQuery: "${lastQuery}", currentQuery: "${currentQuery}"`,
+      );
+
+      const result = await this.config.getBaseLlmClient().generateJson({
+        modelConfigKey: { model: 'topic-detection' },
+        contents: [{ role: 'user', parts: [{ text: prompt }] }],
+        schema: TOPIC_DETECTION_SCHEMA,
+        systemInstruction: TOPIC_DETECTION_SYSTEM_PROMPT,
+        abortSignal: abortSignal!,
+        promptId,
+        maxAttempts: 2,
+      });
+
+      if (result && typeof result['topic_changed'] === 'boolean') {
+        const topic_changed = result['topic_changed'];
+        const reasoning = (result['reasoning'] as string) || '';
+        debugLogger.log(
+          `Topic detection result: ${topic_changed} (${reasoning})`,
+        );
+        return { topic_changed, reasoning };
+      }
+    } catch (error) {
+      debugLogger.warn(`Error in TopicDetectionService: ${error}`);
+      return { topic_changed: false, reasoning: `Error: ${error}` };
+    }
+
+    return { topic_changed: false, reasoning: 'Unexpected result format' };
+  }
+}

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -427,6 +427,13 @@
           "default": -1,
           "type": "number"
         },
+        "renewSessionTurnsThreshold": {
+          "title": "Renew Session Turn Threshold",
+          "description": "Number of conversation turns after which to prompt the user to start a new session or compress. Set to -1 to disable.",
+          "markdownDescription": "Number of conversation turns after which to prompt the user to start a new session or compress. Set to -1 to disable.\n\n- Category: `Model`\n- Requires restart: `no`\n- Default: `-1`",
+          "default": -1,
+          "type": "number"
+        },
         "summarizeToolOutput": {
           "title": "Summarize Tool Output",
           "description": "Enables or disables summarization of tool output. Configure per-tool token budgets (for example {\"run_shell_command\": {\"tokenBudget\": 2000}}). Currently only the run_shell_command tool supports summarization.",


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
This feature detect user's new query, and will propose to compress or start a new session under two situations:

1. The new query is the nth turn that exceed the turncount limit set in config.
2. The new query is in a different topic compare to previous query.


## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

If the turncount threshold is 20, then when user input the 21st query, the system will pop up a dialog and give the user 2 options.  
1. compress the current conversation  
2. start a new session

If the user's previous query is about writing a REST API in Python, the next query is about counting how many txt files are there in the current workspace. The system detect a topic shifting and pop up a dialog, and give user 3 options.  
1.  continue the current context.  
2. compress the conversation.  
3. start a new session.   




## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
For turncount limit:
1. Modify the config variable "renewSessionTurnsThreshold" in settings to a number you want.
2. Start Gemini CLI, and keep querying untill the turncount hit the limit you set.
3. Verify if the dialog pop up, then choose an option.
4. You can ask some question about the topic you asked in the previous step, to see if the agent remember the context. For new session, it should not remember the context, for compress conversation, the agent should remember the context you discussed with it.

For Topic detection:
1. Start the Gemini CLI and input the query.
2. Input another query that is related to your previous one, like a further question or extension of the first query, and see if the dialog pop up, it should not pop up if the query is related to the previous one.
3. Input a different topic query, then see if the dialog pop up, if the topic shift is detected, the dialog should show, and you will see 3 options.
4. Pick one of the option and verify the behavior.



## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
