### PR TITLE
don't show error if we can't detect cpu model

### DIFF
--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -605,7 +605,7 @@ export class ClearcutLogger {
     data.push(
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_CPU_INFO,
-        value: cpus[0].model,
+        value: cpus[0]?.model,
       },
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_CPU_CORES,


### PR DESCRIPTION
Fix https://github.com/google-gemini/gemini-cli/issues/17456

Currently if you run GC on termux it shows this error

```
This is an unexpected error. Please file a bug report using the /bug tool.
CRITICAL: Unhandled Promise Rejection!
=========================================
Reason: TypeError: Cannot read properties of undefined (reading 'model')
Stack trace:
TypeError: Cannot read properties of undefined (reading 'model')
    at ClearcutLogger.logStartSessionEvent (file:///data/data/com.termux/files/home/.cache/deno/npm/registry.npmjs.org/@google/gemini-cli-core/0.25.0/dist/src/telemetry/clearcut-logger/clearcut-logger.js:604:24)
    at logCliConfiguration (file:///data/data/com.termux/files/home/.cache/deno/npm/registry.npmjs.org/@google/gemini-cli-core/0.25.0/dist/src/telemetry/loggers.js:82:44)
    at initializeApp (file:///data/data/com.termux/files/home/.cache/deno/npm/registry.npmjs.org/@google/gemini-cli/0.25.0/dist/src/core/initializer.js:50:3)
    at Object.runMicrotasks (ext:core/01_core.js:730:26)
    at processTicksAndRejections (ext:deno_node/_next_tick.ts:59:10)
    at runNextTicks (ext:deno_node/_next_tick.ts:76:3)
    at eventLoopTick (ext:core/01_core.js:194:21)
    at async main (file:///data/data/com.termux/files/home/.cache/deno/npm/registry.npmjs.org/@google/gemini-cli/0.25.0/dist/src/gemini.js:565:34)
```

Its because os.cpus() returns an empty array, this PR fixes that

note that npx @google/gemini-cli have some weird errors on termux, so I just deno since it seems to work well out of the box, `deno -A npm:@google/gemini-cli`