### PR TITLE
fix(cli): await resumeChat in session resume to prevent race condition

### DIFF
--- a/packages/cli/src/ui/hooks/useSessionBrowser.ts
+++ b/packages/cli/src/ui/hooks/useSessionBrowser.ts
@@ -24,7 +24,7 @@ export const useSessionBrowser = (
     uiHistory: HistoryItemWithoutId[],
     clientHistory: Array<{ role: 'user' | 'model'; parts: Part[] }>,
     resumedSessionData: ResumedSessionData,
-  ) => void,
+  ) => void | Promise<void>,
 ) => {
   const [isSessionBrowserOpen, setIsSessionBrowserOpen] = useState(false);
 
@@ -73,7 +73,8 @@ export const useSessionBrowser = (
           const historyData = convertSessionToHistoryFormats(
             conversation.messages,
           );
-          onLoadHistory(
+          // Await to ensure chat is fully initialized before allowing user input.
+          await onLoadHistory(
             historyData.uiHistory,
             historyData.clientHistory,
             resumedSessionData,


### PR DESCRIPTION
## Summary

Fix a race condition where users could submit prompts before the chat was fully initialized during session resume.

## Problem

`loadHistoryForResume` called `resumeChat` fire-and-forget (line 67-68 had an eslint-disable comment acknowledging the floating promise). If users started typing before `resumeChat` completed, they would hit undefined/uninitialized chat state.

## Solution

- Make `loadHistoryForResume` async with explicit `Promise<void>` return type
- Await the `resumeChat` call instead of fire-and-forget
- Update `useSessionBrowser` callback type to accept `Promise<void>`
- Await `onLoadHistory` in `handleResumeSession`

## Files Changed

- `packages/cli/src/ui/hooks/useSessionResume.ts` - Make callback async, await resumeChat
- `packages/cli/src/ui/hooks/useSessionBrowser.ts` - Update type, await callback

Fixes #17070

## Test Plan

- [ ] Resume a session with `/resume` command
- [ ] Verify no race condition when typing immediately after resume
- [ ] Verify session history loads correctly
- [ ] Run existing tests: `npm run test`