### PR TITLE
fix(cli): await submitQuery in loop retry to prevent race condition

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1065,7 +1065,7 @@ export const useGeminiStream = (
                 loopDetectedRef.current = false;
                 // Show the confirmation dialog to choose whether to disable loop detection
                 setLoopDetectionConfirmationRequest({
-                  onComplete: (result: {
+                  onComplete: async (result: {
                     userSelection: 'disable' | 'keep';
                   }) => {
                     setLoopDetectionConfirmationRequest(null);
@@ -1081,8 +1081,8 @@ export const useGeminiStream = (
                       });
 
                       if (lastQueryRef.current && lastPromptIdRef.current) {
-                        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                        submitQuery(
+                        // Await to prevent race condition with user prompts
+                        await submitQuery(
                           lastQueryRef.current,
                           { isContinuation: true },
                           lastPromptIdRef.current,

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -431,7 +431,9 @@ export interface ConfirmationRequest {
 }
 
 export interface LoopDetectionConfirmationRequest {
-  onComplete: (result: { userSelection: 'disable' | 'keep' }) => void;
+  onComplete: (result: {
+    userSelection: 'disable' | 'keep';
+  }) => void | Promise<void>;
 }
 
 export interface ActiveHook {


### PR DESCRIPTION
## Summary

Fix a race condition where user prompts could interleave with the retry request after disabling loop detection.

## Problem

When a user clicks "disable" in the loop detection dialog, the retry `submitQuery` was called fire-and-forget (line 1084 had an eslint-disable comment acknowledging the floating promise). Due to React state batching, `isResponding` might not update synchronously, allowing user prompts to race with the retry operation.

## Solution

- Make the `onComplete` callback async
- Await `submitQuery` instead of fire-and-forget
- Update `LoopDetectionConfirmationRequest` type to accept `void | Promise<void>`

## Files Changed

- `packages/cli/src/ui/hooks/useGeminiStream.ts` - Make callback async, await submitQuery
- `packages/cli/src/ui/types.ts` - Update type to accept async callbacks

Fixes #17071

## Test Plan

- [ ] Trigger loop detection (repetitive tool calls)
- [ ] Click "disable" in the confirmation dialog
- [ ] Verify retry completes before new prompts are accepted
- [ ] Verify no interleaving of prompts with retry response
- [ ] Run existing tests: `npm run test`