### PR TITLE
fix(auth): don't crash when initial auth fails

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -1135,6 +1135,8 @@ describe('gemini.tsx main function exit codes', () => {
     vi.mocked(loadSandboxConfig).mockResolvedValue({} as any);
     vi.mocked(loadCliConfig).mockResolvedValue({
       refreshAuth: vi.fn().mockRejectedValue(new Error('Auth failed')),
+      getRemoteAdminSettings: vi.fn().mockReturnValue(undefined),
+      isInteractive: vi.fn().mockReturnValue(true),
     } as unknown as Config);
     vi.mocked(loadSettings).mockReturnValue(
       createMockSettings({

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -400,8 +400,6 @@ export async function main() {
       }
     } catch (err) {
       debugLogger.error('Error authenticating:', err);
-      await runExitCleanup();
-      process.exit(ExitCodes.FATAL_AUTHENTICATION_ERROR);
     }
   }
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -373,6 +373,7 @@ export async function main() {
   // Refresh auth to fetch remote admin settings from CCPA and before entering
   // the sandbox because the sandbox will interfere with the Oauth2 web
   // redirect.
+  let initialAuthFailed = false;
   if (!settings.merged.security.auth.useExternal) {
     try {
       if (
@@ -400,6 +401,7 @@ export async function main() {
       }
     } catch (err) {
       debugLogger.error('Error authenticating:', err);
+      initialAuthFailed = true;
     }
   }
 
@@ -425,6 +427,10 @@ export async function main() {
     // another way to decouple refreshAuth from requiring a config.
 
     if (sandboxConfig) {
+      if (initialAuthFailed) {
+        await runExitCleanup();
+        process.exit(ExitCodes.FATAL_AUTHENTICATION_ERROR);
+      }
       let stdinData = '';
       if (!process.stdin.isTTY) {
         stdinData = await readStdin();


### PR DESCRIPTION
## TLDR

This change prevents Gemini CLI from crashing if the initial authentication fails at startup. Instead of exiting the process, the application will now continue to run, allowing the UI to display an appropriate error message / the user to switch auth types.

## Linked Issues
Fixes #17300, Fixes #17225 