### PR TITLE
ci: allow failure in evals-nightly run step

### DIFF
--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -53,6 +53,7 @@ jobs:
         run: 'mkdir -p evals/logs'
 
       - name: 'Run Evals'
+        continue-on-error: true
         env:
           GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
           GEMINI_MODEL: '${{ matrix.model }}'


### PR DESCRIPTION
Fixes #17315. This change ensures that the matrix workflows in evals-nightly do not fail if the tests fail.