### PR TITLE
Emit correct newline type return

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -219,7 +219,7 @@ describe('KeypressContext', () => {
           name: 'return',
           sequence: '\r',
           insertable: true,
-          shift: false,
+          shift: true,
           alt: false,
           ctrl: false,
           cmd: false,

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -158,6 +158,10 @@ function bufferFastReturn(keypressHandler: KeypressHandler): KeypressHandler {
       keypressHandler({
         ...key,
         name: 'return',
+        shift: true, // to make it a newline, not a submission
+        alt: false,
+        ctrl: false,
+        cmd: false,
         sequence: '\r',
         insertable: true,
       });


### PR DESCRIPTION
## Summary

When buffering fast returns, emit them as `shift+return` instead of shiftless.

## Details

We were previously accidentally relying on `name: '',` to make this not be treated as a return. When I fixed that to `name: 'return',` that caused this to stop being treated as a newline. 

## How to Validate

Copy paste text with a newline in an editor that doesn't support bracketed paste.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
