### PR TITLE
fix: resolve infinite loop when using 'Modify with external editor' (…

### DIFF
--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -19,6 +19,8 @@ import {
   openDiff,
   allowEditorTypeInSandbox,
   isEditorAvailable,
+  detectFirstAvailableEditor,
+  resolveEditor,
   type EditorType,
 } from './editor.js';
 import { execSync, spawn, spawnSync } from 'node:child_process';
@@ -540,6 +542,132 @@ describe('editor utils', () => {
       (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/nvim'));
       vi.stubEnv('SANDBOX', 'sandbox');
       expect(isEditorAvailable('neovim')).toBe(true);
+    });
+  });
+
+  describe('detectFirstAvailableEditor', () => {
+    it('should return undefined when no editors are installed', () => {
+      (execSync as Mock).mockImplementation(() => {
+        throw new Error('Command not found');
+      });
+      vi.stubEnv('SANDBOX', '');
+      expect(detectFirstAvailableEditor()).toBeUndefined();
+    });
+
+    it('should prioritize terminal editors over GUI editors', () => {
+      // Mock vim as available
+      (execSync as Mock).mockImplementation((cmd: string) => {
+        if (cmd.includes('vim') && !cmd.includes('nvim')) {
+          return Buffer.from('/usr/bin/vim');
+        }
+        if (cmd.includes('code')) {
+          return Buffer.from('/usr/bin/code');
+        }
+        throw new Error('Command not found');
+      });
+      vi.stubEnv('SANDBOX', '');
+      expect(detectFirstAvailableEditor()).toBe('vim');
+    });
+
+    it('should return vim when vim is the only editor available in sandbox mode', () => {
+      (execSync as Mock).mockImplementation((cmd: string) => {
+        if (cmd.includes('vim') && !cmd.includes('nvim')) {
+          return Buffer.from('/usr/bin/vim');
+        }
+        throw new Error('Command not found');
+      });
+      vi.stubEnv('SANDBOX', 'sandbox');
+      expect(detectFirstAvailableEditor()).toBe('vim');
+    });
+
+    it('should skip GUI editors in sandbox mode', () => {
+      (execSync as Mock).mockImplementation((cmd: string) => {
+        if (cmd.includes('code')) {
+          return Buffer.from('/usr/bin/code');
+        }
+        throw new Error('Command not found');
+      });
+      vi.stubEnv('SANDBOX', 'sandbox');
+      // vscode is installed but not allowed in sandbox
+      expect(detectFirstAvailableEditor()).toBeUndefined();
+    });
+
+    it('should return first available terminal editor (neovim)', () => {
+      (execSync as Mock).mockImplementation((cmd: string) => {
+        if (cmd.includes('nvim')) {
+          return Buffer.from('/usr/bin/nvim');
+        }
+        throw new Error('Command not found');
+      });
+      vi.stubEnv('SANDBOX', '');
+      expect(detectFirstAvailableEditor()).toBe('neovim');
+    });
+  });
+
+  describe('resolveEditor', () => {
+    it('should return the preferred editor when available', () => {
+      (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/vim'));
+      vi.stubEnv('SANDBOX', '');
+      const result = resolveEditor('vim');
+      expect(result.editor).toBe('vim');
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should return error when preferred editor is not installed', () => {
+      (execSync as Mock).mockImplementation(() => {
+        throw new Error('Command not found');
+      });
+      vi.stubEnv('SANDBOX', '');
+      const result = resolveEditor('vim');
+      expect(result.editor).toBeUndefined();
+      expect(result.error).toContain('Vim');
+      expect(result.error).toContain('not installed');
+    });
+
+    it('should return error when preferred GUI editor cannot be used in sandbox mode', () => {
+      (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/code'));
+      vi.stubEnv('SANDBOX', 'sandbox');
+      const result = resolveEditor('vscode');
+      expect(result.editor).toBeUndefined();
+      expect(result.error).toContain('VS Code');
+      expect(result.error).toContain('sandbox mode');
+    });
+
+    it('should auto-detect editor when no preference is set', () => {
+      (execSync as Mock).mockImplementation((cmd: string) => {
+        if (cmd.includes('vim') && !cmd.includes('nvim')) {
+          return Buffer.from('/usr/bin/vim');
+        }
+        throw new Error('Command not found');
+      });
+      vi.stubEnv('SANDBOX', '');
+      const result = resolveEditor(undefined);
+      expect(result.editor).toBe('vim');
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should return error when no preference is set and no editors are available', () => {
+      (execSync as Mock).mockImplementation(() => {
+        throw new Error('Command not found');
+      });
+      vi.stubEnv('SANDBOX', '');
+      const result = resolveEditor(undefined);
+      expect(result.editor).toBeUndefined();
+      expect(result.error).toContain('No external editor');
+      expect(result.error).toContain('/editor');
+    });
+
+    it('should work with terminal editors in sandbox mode when no preference is set', () => {
+      (execSync as Mock).mockImplementation((cmd: string) => {
+        if (cmd.includes('vim') && !cmd.includes('nvim')) {
+          return Buffer.from('/usr/bin/vim');
+        }
+        throw new Error('Command not found');
+      });
+      vi.stubEnv('SANDBOX', 'sandbox');
+      const result = resolveEditor(undefined);
+      expect(result.editor).toBe('vim');
+      expect(result.error).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary                                                                                                                         
                                                                                                                                     
  Fix infinite loop when selecting "Modify with external editor" without a configured or available editor. Users were stuck in an    
  endless loop with no feedback when attempting to use the external editor feature. This fix adds proper editor detection,           
  auto-fallback, and clear error messages.                                                                                           
                                                                                                                                     
  ## Details                                                                                                                         
                                                                                                                                     
  **Root cause:** In both `confirmation.ts` and `coreToolScheduler.ts`, when `getPreferredEditor()` returned `undefined`, the code   
  silently returned without changing the loop outcome variable, causing the confirmation loop to repeat indefinitely.                
                                                                                                                                     
  **Solution:**                                                                                                                      
  - Added `detectFirstAvailableEditor()` - auto-detects available editors, prioritizing terminal editors (vim, neovim, emacs, helix) 
  that work in sandbox mode                                                                                                          
  - Added `resolveEditor()` - comprehensive editor resolution that validates availability, auto-detects fallbacks, and provides      
  specific error messages                                                                                                            
  - Updated `confirmation.ts` to check editor resolution result and break the loop with user feedback when unavailable               
  - Updated `coreToolScheduler.ts` to cancel the operation cleanly with error feedback when no editor is available                   
                                                                                                                                     
  **Error messages now explain exactly what went wrong:**                                                                            
  - "Vim is configured as your preferred editor but is not installed. Please install it or run /editor to choose a different editor."
  - "VS Code cannot be used in sandbox mode. Please run /editor to choose a terminal-based editor."                                  
  - "No external editor is configured or available. Please run /editor to set your preferred editor."                                
                                                                                                                                     
  ## Related Issues                                                                                                                  
                                                                                                                                     
  Fixes #7669                                                                                                                        
                                                                                                                                     
  ## How to Validate                                                                                                                 
                                                                                                                                     
  1. **No editor configured:**                                                                                                       
     - Clear editor preference: run `/editor` and select "None"                                                                      
     - Trigger a file edit that requires confirmation                                                                                
     - Select "Modify with external editor"                                                                                          
     - **Expected:** If vim/neovim/emacs/helix is installed, it should auto-detect and open. Otherwise, an error message should      
  appear and the operation should cancel (no infinite loop)                                                                          
                                                                                                                                     
  2. **Editor configured but not installed:**                                                                                        
     - Set editor to one that's not installed (e.g., configure "zed" when Zed is not installed)                                      
     - Trigger a file edit confirmation                                                                                              
     - Select "Modify with external editor"                                                                                          
     - **Expected:** Error message "Zed is configured as your preferred editor but is not installed..." and operation cancels        
                                                                                                                                     
  3. **GUI editor in sandbox mode:**                                                                                                 
     - Run gemini-cli in sandbox mode                                                                                                
     - Configure a GUI editor (vscode, cursor, etc.)                                                                                 
     - Trigger a file edit confirmation                                                                                              
     - Select "Modify with external editor"                                                                                          
     - **Expected:** Error message about sandbox mode and suggestion to use terminal editor                                          
                                                                                                                                     
  4. **Working editor:**                                                                                                             
     - Configure an installed editor (e.g., vim)                                                                                     
     - Trigger a file edit confirmation                                                                                              
     - Select "Modify with external editor"                                                                                          
     - **Expected:** Editor opens with diff view                                                                                     
                                                                                                                                     
  5. **Run tests:**                                                                                                                  
     ```bash                                                                                                                         
     cd packages/core                                                                                                                
     npm run test -- --run src/utils/editor.test.ts                                                                                  
     Expected: All 130 tests pass (119 original + 11 new)                                                                            

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any) - Not Applicable
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [x] Docker
    - [x] Podman
    - [x] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [x] Docker
