### PR TITLE
feat(plan): add 'communicate' tool kind

### DIFF
--- a/packages/core/src/tools/ask-user.ts
+++ b/packages/core/src/tools/ask-user.ts
@@ -35,7 +35,7 @@ export class AskUserTool extends BaseDeclarativeTool<
       ASK_USER_TOOL_NAME,
       'Ask User',
       'Ask the user one or more questions to gather preferences, clarify requirements, or make decisions.',
-      Kind.Other,
+      Kind.Communicate,
       {
         type: 'object',
         required: ['questions'],

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -745,6 +745,7 @@ export enum Kind {
   Execute = 'execute',
   Think = 'think',
   Fetch = 'fetch',
+  Communicate = 'communicate',
   Other = 'other',
 }
 


### PR DESCRIPTION
Added the 'communicate' member to the Kind enum to support classification of communication-specific tools. Updated the `AskUserTool` to use `Kind.Communicate` instead of `Kind.Other`.

Decoupled internal tool kinds from the Agent Client Protocol (ACP) by implementing a robust mapper in `zedIntegration.ts`. This ensures forward compatibility for any new internal tool kinds by automatically falling back to 'Kind.Other' for external clients that do not yet support them.

Fixes #16620 

cc @jackwotherspoon 