### PR TITLE
feat(cli): add /agents config command and improve agent discovery

### DIFF
--- a/packages/cli/src/test-utils/mockCommandContext.ts
+++ b/packages/cli/src/test-utils/mockCommandContext.ts
@@ -61,6 +61,8 @@ export const createMockCommandContext = (
       loadHistory: vi.fn(),
       toggleCorgiMode: vi.fn(),
       toggleVimEnabled: vi.fn(),
+      openAgentConfigDialog: vi.fn(),
+      closeAgentConfigDialog: vi.fn(),
       extensionsUpdateState: new Map(),
       setExtensionsUpdateState: vi.fn(),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/cli/src/ui/commands/agentsCommand.test.ts
+++ b/packages/cli/src/ui/commands/agentsCommand.test.ts
@@ -218,6 +218,21 @@ describe('agentsCommand', () => {
     });
   });
 
+  it('should show an error if config is not available for enable', async () => {
+    const contextWithoutConfig = createMockCommandContext({
+      services: { config: null },
+    });
+    const enableCommand = agentsCommand.subCommands?.find(
+      (cmd) => cmd.name === 'enable',
+    );
+    const result = await enableCommand!.action!(contextWithoutConfig, 'test');
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Config not loaded.',
+    });
+  });
+
   it('should disable an agent successfully', async () => {
     const reloadSpy = vi.fn().mockResolvedValue(undefined);
     mockConfig.getAgentRegistry = vi.fn().mockReturnValue({
@@ -309,6 +324,21 @@ describe('agentsCommand', () => {
     });
   });
 
+  it('should show an error if config is not available for disable', async () => {
+    const contextWithoutConfig = createMockCommandContext({
+      services: { config: null },
+    });
+    const disableCommand = agentsCommand.subCommands?.find(
+      (cmd) => cmd.name === 'disable',
+    );
+    const result = await disableCommand!.action!(contextWithoutConfig, 'test');
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Config not loaded.',
+    });
+  });
+
   describe('config sub-command', () => {
     it('should open agent config dialog for a valid agent', async () => {
       const mockDefinition = {
@@ -385,6 +415,21 @@ describe('agentsCommand', () => {
         type: 'message',
         messageType: 'error',
         content: 'Usage: /agents config <agent-name>',
+      });
+    });
+
+    it('should show an error if config is not available', async () => {
+      const contextWithoutConfig = createMockCommandContext({
+        services: { config: null },
+      });
+      const configCommand = agentsCommand.subCommands?.find(
+        (cmd) => cmd.name === 'config',
+      );
+      const result = await configCommand!.action!(contextWithoutConfig, 'test');
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: 'Config not loaded.',
       });
     });
 

--- a/packages/cli/src/ui/commands/agentsCommand.test.ts
+++ b/packages/cli/src/ui/commands/agentsCommand.test.ts
@@ -308,4 +308,100 @@ describe('agentsCommand', () => {
       content: 'Usage: /agents disable <agent-name>',
     });
   });
+
+  describe('config sub-command', () => {
+    it('should open agent config dialog for a valid agent', async () => {
+      const mockDefinition = {
+        name: 'test-agent',
+        displayName: 'Test Agent',
+        description: 'test desc',
+      };
+      mockConfig.getAgentRegistry = vi.fn().mockReturnValue({
+        getDiscoveredDefinition: vi.fn().mockReturnValue(mockDefinition),
+      });
+
+      const configCommand = agentsCommand.subCommands?.find(
+        (cmd) => cmd.name === 'config',
+      );
+      expect(configCommand).toBeDefined();
+
+      const result = await configCommand!.action!(mockContext, 'test-agent');
+
+      expect(mockContext.ui.openAgentConfigDialog).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content:
+          "Configuration for 'test-agent' will be available in the next update.",
+      });
+    });
+
+    it('should use name if displayName is missing', async () => {
+      const mockDefinition = {
+        name: 'test-agent',
+        description: 'test desc',
+      };
+      mockConfig.getAgentRegistry = vi.fn().mockReturnValue({
+        getDiscoveredDefinition: vi.fn().mockReturnValue(mockDefinition),
+      });
+
+      const configCommand = agentsCommand.subCommands?.find(
+        (cmd) => cmd.name === 'config',
+      );
+      const result = await configCommand!.action!(mockContext, 'test-agent');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content:
+          "Configuration for 'test-agent' will be available in the next update.",
+      });
+    });
+
+    it('should show error if agent is not found', async () => {
+      mockConfig.getAgentRegistry = vi.fn().mockReturnValue({
+        getDiscoveredDefinition: vi.fn().mockReturnValue(undefined),
+      });
+
+      const configCommand = agentsCommand.subCommands?.find(
+        (cmd) => cmd.name === 'config',
+      );
+      const result = await configCommand!.action!(mockContext, 'non-existent');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: "Agent 'non-existent' not found.",
+      });
+    });
+
+    it('should show usage error if no agent name provided', async () => {
+      const configCommand = agentsCommand.subCommands?.find(
+        (cmd) => cmd.name === 'config',
+      );
+      const result = await configCommand!.action!(mockContext, '  ');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: 'Usage: /agents config <agent-name>',
+      });
+    });
+
+    it('should provide completions for discovered agents', async () => {
+      mockConfig.getAgentRegistry = vi.fn().mockReturnValue({
+        getAllDiscoveredAgentNames: vi
+          .fn()
+          .mockReturnValue(['agent1', 'agent2', 'other']),
+      });
+
+      const configCommand = agentsCommand.subCommands?.find(
+        (cmd) => cmd.name === 'config',
+      );
+      expect(configCommand?.completion).toBeDefined();
+
+      const completions = await configCommand!.completion!(mockContext, 'age');
+      expect(completions).toEqual(['agent1', 'agent2']);
+    });
+  });
 });

--- a/packages/cli/src/ui/commands/agentsCommand.ts
+++ b/packages/cli/src/ui/commands/agentsCommand.ts
@@ -62,7 +62,13 @@ async function enableAction(
   args: string,
 ): Promise<SlashCommandActionReturn | void> {
   const { config, settings } = context.services;
-  if (!config) return;
+  if (!config) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: 'Config not loaded.',
+    };
+  }
 
   const agentName = args.trim();
   if (!agentName) {
@@ -132,7 +138,13 @@ async function disableAction(
   args: string,
 ): Promise<SlashCommandActionReturn | void> {
   const { config, settings } = context.services;
-  if (!config) return;
+  if (!config) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: 'Config not loaded.',
+    };
+  }
 
   const agentName = args.trim();
   if (!agentName) {
@@ -205,7 +217,13 @@ async function configAction(
   args: string,
 ): Promise<SlashCommandActionReturn | void> {
   const { config } = context.services;
-  if (!config) return;
+  if (!config) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: 'Config not loaded.',
+    };
+  }
 
   const agentName = args.trim();
   if (!agentName) {
@@ -267,9 +285,7 @@ function completeAllAgents(context: CommandContext, partialArg: string) {
   if (!config) return [];
 
   const agentRegistry = config.getAgentRegistry();
-  const allAgents = agentRegistry
-    ? agentRegistry.getAllDiscoveredAgentNames()
-    : [];
+  const allAgents = agentRegistry?.getAllDiscoveredAgentNames() ?? [];
   return allAgents.filter((name: string) => name.startsWith(partialArg));
 }
 


### PR DESCRIPTION
## TLDR

Introduces the `/agents config <agent-name>` slash command and improves agent discovery by allowing the configuration and autocomplete of all discovered agents (including disabled ones).

## Dive Deeper

This PR fulfills the "Slash Command & Autocomplete Integration" phase of the Agent Configuration UI plan. Key changes include:
- **New Sub-command**: Added `/agents config` to the `/agents` command group.
- **Improved Autocomplete**: The `/agents config` command utilizes the new `AgentRegistry.getAllDiscoveredAgentNames()` method (from PR 1) to suggest all known agents, regardless of their current enablement status.
- **UI Plumbing**: Updated `CommandContext` mocks and command logic to support transition to the upcoming `AgentConfigDialog` (PR 3).
- **Temporary Feedback**: Until the dialog component is integrated into the `DialogManager`, the command provides an informational message to the user, ensuring the input prompt remains active.

## Reviewer Test Plan

1. Run the CLI: `npm run start`
2. Type `/agents config ` and verify that both enabled and disabled agents (like `generalist`) appear in the suggestions.
3. Execute `/agents config generalist` and verify that an informational message is displayed: "Configuration for 'generalist' will be available in the next update."
4. Verify that `/agents list` still only shows active agents.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

This PR makes progress on the `/agents config` command implementation.