### PR TITLE
fix(core): Include MCP server name in OAuth message

### DIFF
--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -904,7 +904,8 @@ export class MCPOAuthProvider {
       mcpServerUrl,
     );
 
-    displayMessage(`→ Opening your browser for OAuth sign-in...
+    displayMessage(`Authentication required for MCP Server: '${serverName}'
+→ Opening your browser for OAuth sign-in...
 
 If the browser does not open, copy and paste this URL into your browser:
 ${authUrl}


### PR DESCRIPTION
Includes the `serverName` in the CLI output when initiating an OAuth flow for a Model Context Protocol (MCP) server. This ensures users can explicitly identify which local server configuration is requesting access.

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/1209

cc @galz10 @bdmorgan 