### PR TITLE
refactor(ui): extract BaseSettingsDialog from SettingsDialog

### DIFF
--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -451,7 +451,7 @@ export function SettingsDialog({
     }
   };
 
-  const handleKeypress = (key: Key): boolean => {
+  const handleKeypress = (key: Key, activeItem?: SettingItem): boolean => {
     const { name } = key;
 
     // If editing, capture input and control keys
@@ -545,10 +545,12 @@ export function SettingsDialog({
       return true;
     }
 
-    if (showRestartPrompt && name === 'r') {
-      saveRestartRequiredSettings();
-      setShowRestartPrompt(false);
-      if (onRestartRequest) onRestartRequest();
+    if (
+      activeItem &&
+      /^[0-9]$/.test(key.sequence || '') &&
+      activeItem.type === 'number'
+    ) {
+      startEditing(activeItem.value, key.sequence);
       return true;
     }
 
@@ -656,7 +658,7 @@ export function SettingsDialog({
       onScopeChange={setSelectedScope}
       showRestartPrompt={showRestartPrompt}
       onRestartRequest={() => {
-        saveRestartRequiredSettings();
+        setShowRestartPrompt(false);
         if (onRestartRequest) onRestartRequest();
       }}
       availableTerminalHeight={availableTerminalHeight}

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect, useMemo } from 'react';
-import { Box, Text } from 'ink';
+import type React from 'react';
+import { useState, useEffect, useMemo } from 'react';
+import { Text } from 'ink';
 import { AsyncFzf } from 'fzf';
 import { theme } from '../semantic-colors.js';
 import type {
@@ -14,11 +15,7 @@ import type {
   Settings,
 } from '../../config/settings.js';
 import { SettingScope } from '../../config/settings.js';
-import {
-  getScopeItems,
-  getScopeMessageForSetting,
-} from '../../utils/dialogScopeUtils.js';
-import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
+import { getScopeMessageForSetting } from '../../utils/dialogScopeUtils.js';
 import {
   getDialogSettingKeys,
   setPendingSettingValue,
@@ -35,14 +32,8 @@ import {
   getEffectiveValue,
 } from '../../utils/settingsUtils.js';
 import { useVimMode } from '../contexts/VimModeContext.js';
-import { useKeypress } from '../hooks/useKeypress.js';
 import chalk from 'chalk';
-import {
-  cpSlice,
-  cpLen,
-  stripUnsafeCharacters,
-  getCachedStringWidth,
-} from '../utils/textUtils.js';
+import { cpSlice, cpLen, stripUnsafeCharacters } from '../utils/textUtils.js';
 import {
   type SettingsValue,
   TOGGLE_TYPES,
@@ -50,9 +41,11 @@ import {
 import { coreEvents, debugLogger } from '@google/gemini-cli-core';
 import { keyMatchers, Command } from '../keyMatchers.js';
 import type { Config } from '@google/gemini-cli-core';
-import { useUIState } from '../contexts/UIStateContext.js';
-import { useTextBuffer } from './shared/text-buffer.js';
-import { TextInput } from './shared/TextInput.js';
+import {
+  BaseSettingsDialog,
+  type BaseSettingsItem,
+} from './shared/BaseSettingsDialog.js';
+import { type Key } from '../hooks/useKeypress.js';
 
 interface FzfResult {
   item: string;
@@ -70,7 +63,10 @@ interface SettingsDialogProps {
   config?: Config;
 }
 
-const MAX_ITEMS_TO_SHOW = 8;
+interface SettingItem extends BaseSettingsItem {
+  type: string | undefined;
+  value: string;
+}
 
 export function SettingsDialog({
   settings,
@@ -82,18 +78,10 @@ export function SettingsDialog({
   // Get vim mode context to sync vim mode changes
   const { vimEnabled, toggleVimEnabled } = useVimMode();
 
-  // Focus state: 'settings' or 'scope'
-  const [focusSection, setFocusSection] = useState<'settings' | 'scope'>(
-    'settings',
-  );
   // Scope selector state (User by default)
   const [selectedScope, setSelectedScope] = useState<LoadableSettingScope>(
     SettingScope.User,
   );
-  // Active indices
-  const [activeSettingIndex, setActiveSettingIndex] = useState(0);
-  // Scroll offset for settings
-  const [scrollOffset, setScrollOffset] = useState(0);
   const [showRestartPrompt, setShowRestartPrompt] = useState(false);
 
   // Search state
@@ -140,8 +128,6 @@ export function SettingsDialog({
         if (key) matchedKeys.add(key);
       });
       setFilteredKeys(Array.from(matchedKeys));
-      setActiveSettingIndex(0); // Reset cursor
-      setScrollOffset(0);
     };
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -199,153 +185,127 @@ export function SettingsDialog({
     setShowRestartPrompt(newRestartRequired.size > 0);
   }, [selectedScope, settings, globalPendingChanges]);
 
-  // Calculate max width for the left column (Label/Description) to keep values aligned or close
-  const maxLabelOrDescriptionWidth = useMemo(() => {
-    const allKeys = getDialogSettingKeys();
-    let max = 0;
-    for (const key of allKeys) {
-      const def = getSettingDefinition(key);
-      if (!def) continue;
-
-      const scopeMessage = getScopeMessageForSetting(
-        key,
-        selectedScope,
-        settings,
-      );
-      const label = def.label || key;
-      const labelFull = label + (scopeMessage ? ` ${scopeMessage}` : '');
-      const lWidth = getCachedStringWidth(labelFull);
-      const dWidth = def.description
-        ? getCachedStringWidth(def.description)
-        : 0;
-
-      max = Math.max(max, lWidth, dWidth);
+  const toggleItem = (key: string) => {
+    const definition = getSettingDefinition(key);
+    if (!TOGGLE_TYPES.has(definition?.type)) {
+      return;
     }
-    return max;
-  }, [selectedScope, settings]);
+    const currentValue = getEffectiveValue(key, pendingSettings, {});
+    let newValue: SettingsValue;
+    if (definition?.type === 'boolean') {
+      newValue = !(currentValue as boolean);
+      setPendingSettings((prev) =>
+        setPendingSettingValue(key, newValue as boolean, prev),
+      );
+    } else if (definition?.type === 'enum' && definition.options) {
+      const options = definition.options;
+      const currentIndex = options?.findIndex(
+        (opt) => opt.value === currentValue,
+      );
+      if (currentIndex !== -1 && currentIndex < options.length - 1) {
+        newValue = options[currentIndex + 1].value;
+      } else {
+        newValue = options[0].value; // loop back to start.
+      }
+      setPendingSettings((prev) =>
+        setPendingSettingValueAny(key, newValue, prev),
+      );
+    }
 
-  const generateSettingsItems = () => {
+    if (!requiresRestart(key)) {
+      const immediateSettings = new Set([key]);
+      const currentScopeSettings = settings.forScope(selectedScope).settings;
+      const immediateSettingsObject = setPendingSettingValueAny(
+        key,
+        newValue,
+        currentScopeSettings,
+      );
+      debugLogger.log(
+        `[DEBUG SettingsDialog] Saving ${key} immediately with value:`,
+        newValue,
+      );
+      saveModifiedSettings(
+        immediateSettings,
+        immediateSettingsObject,
+        settings,
+        selectedScope,
+      );
+
+      // Special handling for vim mode to sync with VimModeContext
+      if (key === 'general.vimMode' && newValue !== vimEnabled) {
+        // Call toggleVimEnabled to sync the VimModeContext local state
+        toggleVimEnabled().catch((error) => {
+          coreEvents.emitFeedback('error', 'Failed to toggle vim mode:', error);
+        });
+      }
+
+      // Remove from modifiedSettings since it's now saved
+      setModifiedSettings((prev) => {
+        const updated = new Set(prev);
+        updated.delete(key);
+        return updated;
+      });
+
+      // Also remove from restart-required settings if it was there
+      setRestartRequiredSettings((prev) => {
+        const updated = new Set(prev);
+        updated.delete(key);
+        return updated;
+      });
+
+      // Remove from global pending changes if present
+      setGlobalPendingChanges((prev) => {
+        if (!prev.has(key)) return prev;
+        const next = new Map(prev);
+        next.delete(key);
+        return next;
+      });
+
+      if (key === 'general.previewFeatures') {
+        config?.setPreviewFeatures(newValue as boolean);
+      }
+    } else {
+      // For restart-required settings, track as modified
+      setModifiedSettings((prev) => {
+        const updated = new Set(prev).add(key);
+        const needsRestart = hasRestartRequiredSettings(updated);
+        debugLogger.log(
+          `[DEBUG SettingsDialog] Modified settings:`,
+          Array.from(updated),
+          'Needs restart:',
+          needsRestart,
+        );
+        if (needsRestart) {
+          setShowRestartPrompt(true);
+          setRestartRequiredSettings((prevRestart) =>
+            new Set(prevRestart).add(key),
+          );
+        }
+        return updated;
+      });
+
+      // Add/update pending change globally so it persists across scopes
+      setGlobalPendingChanges((prev) => {
+        const next = new Map(prev);
+        next.set(key, newValue as PendingValue);
+        return next;
+      });
+    }
+  };
+
+  const generateSettingsItems = (): SettingItem[] => {
     const settingKeys = searchQuery ? filteredKeys : getDialogSettingKeys();
 
     return settingKeys.map((key: string) => {
       const definition = getSettingDefinition(key);
 
       return {
+        key,
         label: definition?.label || key,
         description: definition?.description,
         value: key,
         type: definition?.type,
-        toggle: () => {
-          if (!TOGGLE_TYPES.has(definition?.type)) {
-            return;
-          }
-          const currentValue = getEffectiveValue(key, pendingSettings, {});
-          let newValue: SettingsValue;
-          if (definition?.type === 'boolean') {
-            newValue = !(currentValue as boolean);
-            setPendingSettings((prev) =>
-              setPendingSettingValue(key, newValue as boolean, prev),
-            );
-          } else if (definition?.type === 'enum' && definition.options) {
-            const options = definition.options;
-            const currentIndex = options?.findIndex(
-              (opt) => opt.value === currentValue,
-            );
-            if (currentIndex !== -1 && currentIndex < options.length - 1) {
-              newValue = options[currentIndex + 1].value;
-            } else {
-              newValue = options[0].value; // loop back to start.
-            }
-            setPendingSettings((prev) =>
-              setPendingSettingValueAny(key, newValue, prev),
-            );
-          }
-
-          if (!requiresRestart(key)) {
-            const immediateSettings = new Set([key]);
-            const currentScopeSettings =
-              settings.forScope(selectedScope).settings;
-            const immediateSettingsObject = setPendingSettingValueAny(
-              key,
-              newValue,
-              currentScopeSettings,
-            );
-            debugLogger.log(
-              `[DEBUG SettingsDialog] Saving ${key} immediately with value:`,
-              newValue,
-            );
-            saveModifiedSettings(
-              immediateSettings,
-              immediateSettingsObject,
-              settings,
-              selectedScope,
-            );
-
-            // Special handling for vim mode to sync with VimModeContext
-            if (key === 'general.vimMode' && newValue !== vimEnabled) {
-              // Call toggleVimEnabled to sync the VimModeContext local state
-              toggleVimEnabled().catch((error) => {
-                coreEvents.emitFeedback(
-                  'error',
-                  'Failed to toggle vim mode:',
-                  error,
-                );
-              });
-            }
-
-            // Remove from modifiedSettings since it's now saved
-            setModifiedSettings((prev) => {
-              const updated = new Set(prev);
-              updated.delete(key);
-              return updated;
-            });
-
-            // Also remove from restart-required settings if it was there
-            setRestartRequiredSettings((prev) => {
-              const updated = new Set(prev);
-              updated.delete(key);
-              return updated;
-            });
-
-            // Remove from global pending changes if present
-            setGlobalPendingChanges((prev) => {
-              if (!prev.has(key)) return prev;
-              const next = new Map(prev);
-              next.delete(key);
-              return next;
-            });
-
-            if (key === 'general.previewFeatures') {
-              config?.setPreviewFeatures(newValue as boolean);
-            }
-          } else {
-            // For restart-required settings, track as modified
-            setModifiedSettings((prev) => {
-              const updated = new Set(prev).add(key);
-              const needsRestart = hasRestartRequiredSettings(updated);
-              debugLogger.log(
-                `[DEBUG SettingsDialog] Modified settings:`,
-                Array.from(updated),
-                'Needs restart:',
-                needsRestart,
-              );
-              if (needsRestart) {
-                setShowRestartPrompt(true);
-                setRestartRequiredSettings((prevRestart) =>
-                  new Set(prevRestart).add(key),
-                );
-              }
-              return updated;
-            });
-
-            // Add/update pending change globally so it persists across scopes
-            setGlobalPendingChanges((prev) => {
-              const next = new Map(prev);
-              next.set(key, newValue as PendingValue);
-              return next;
-            });
-          }
-        },
+        scopeMessage: getScopeMessageForSetting(key, selectedScope, settings),
       };
     });
   };
@@ -466,108 +426,6 @@ export function SettingsDialog({
     setEditCursorPos(0);
   };
 
-  // Scope selector items
-  const scopeItems = getScopeItems().map((item) => ({
-    ...item,
-    key: item.value,
-  }));
-
-  const handleScopeHighlight = (scope: LoadableSettingScope) => {
-    setSelectedScope(scope);
-  };
-
-  const handleScopeSelect = (scope: LoadableSettingScope) => {
-    handleScopeHighlight(scope);
-    setFocusSection('settings');
-  };
-
-  // Height constraint calculations similar to ThemeDialog
-  const DIALOG_PADDING = 5;
-  const SETTINGS_TITLE_HEIGHT = 2; // "Settings" title + spacing
-  const SCROLL_ARROWS_HEIGHT = 2; // Up and down arrows
-  const SPACING_HEIGHT = 1; // Space between settings list and scope
-  const SCOPE_SELECTION_HEIGHT = 4; // Apply To section height
-  const BOTTOM_HELP_TEXT_HEIGHT = 1; // Help text
-  const RESTART_PROMPT_HEIGHT = showRestartPrompt ? 1 : 0;
-
-  let currentAvailableTerminalHeight =
-    availableTerminalHeight ?? Number.MAX_SAFE_INTEGER;
-  currentAvailableTerminalHeight -= 2; // Top and bottom borders
-
-  // Start with basic fixed height (without scope selection)
-  let totalFixedHeight =
-    DIALOG_PADDING +
-    SETTINGS_TITLE_HEIGHT +
-    SCROLL_ARROWS_HEIGHT +
-    SPACING_HEIGHT +
-    BOTTOM_HELP_TEXT_HEIGHT +
-    RESTART_PROMPT_HEIGHT;
-
-  // Calculate how much space we have for settings
-  let availableHeightForSettings = Math.max(
-    1,
-    currentAvailableTerminalHeight - totalFixedHeight,
-  );
-
-  // Each setting item takes up to 3 lines (label/value row, description row, and spacing)
-  let maxVisibleItems = Math.max(1, Math.floor(availableHeightForSettings / 3));
-
-  // Decide whether to show scope selection based on remaining space
-  let showScopeSelection = true;
-
-  // If we have limited height, prioritize showing more settings over scope selection
-  if (availableTerminalHeight && availableTerminalHeight < 25) {
-    // For very limited height, hide scope selection to show more settings
-    const totalWithScope = totalFixedHeight + SCOPE_SELECTION_HEIGHT;
-    const availableWithScope = Math.max(
-      1,
-      currentAvailableTerminalHeight - totalWithScope,
-    );
-    const maxItemsWithScope = Math.max(1, Math.floor(availableWithScope / 3));
-
-    // If hiding scope selection allows us to show significantly more settings, do it
-    if (maxVisibleItems > maxItemsWithScope + 1) {
-      showScopeSelection = false;
-    } else {
-      // Otherwise include scope selection and recalculate
-      totalFixedHeight += SCOPE_SELECTION_HEIGHT;
-      availableHeightForSettings = Math.max(
-        1,
-        currentAvailableTerminalHeight - totalFixedHeight,
-      );
-      maxVisibleItems = Math.max(1, Math.floor(availableHeightForSettings / 3));
-    }
-  } else {
-    // For normal height, include scope selection
-    totalFixedHeight += SCOPE_SELECTION_HEIGHT;
-    availableHeightForSettings = Math.max(
-      1,
-      currentAvailableTerminalHeight - totalFixedHeight,
-    );
-    maxVisibleItems = Math.max(1, Math.floor(availableHeightForSettings / 3));
-  }
-
-  // Use the calculated maxVisibleItems or fall back to the original maxItemsToShow
-  const effectiveMaxItemsToShow = availableTerminalHeight
-    ? Math.min(maxVisibleItems, items.length)
-    : MAX_ITEMS_TO_SHOW;
-
-  // Ensure focus stays on settings when scope selection is hidden
-  React.useEffect(() => {
-    if (!showScopeSelection && focusSection === 'scope') {
-      setFocusSection('settings');
-    }
-  }, [showScopeSelection, focusSection]);
-
-  // Scroll logic for settings
-  const visibleItems = items.slice(
-    scrollOffset,
-    scrollOffset + effectiveMaxItemsToShow,
-  );
-  // Show arrows if there are more items than can be displayed
-  const showScrollUp = items.length > effectiveMaxItemsToShow;
-  const showScrollDown = items.length > effectiveMaxItemsToShow;
-
   const saveRestartRequiredSettings = () => {
     const restartRequiredSettings =
       getRestartRequiredFromModified(modifiedSettings);
@@ -593,530 +451,217 @@ export function SettingsDialog({
     }
   };
 
-  useKeypress(
-    (key) => {
-      const { name } = key;
+  const handleKeypress = (key: Key): boolean => {
+    const { name } = key;
 
-      if (name === 'tab' && showScopeSelection) {
-        setFocusSection((prev) => (prev === 'settings' ? 'scope' : 'settings'));
-      }
-      if (focusSection === 'settings') {
-        // If editing, capture input and control keys
-        if (editingKey) {
-          const definition = getSettingDefinition(editingKey);
-          const type = definition?.type;
+    // If editing, capture input and control keys
+    if (editingKey) {
+      const definition = getSettingDefinition(editingKey);
+      const type = definition?.type;
 
-          if (key.name === 'paste' && key.sequence) {
-            let pasted = key.sequence;
-            if (type === 'number') {
-              pasted = key.sequence.replace(/[^0-9\-+.]/g, '');
-            }
-            if (pasted) {
-              setEditBuffer((b) => {
-                const before = cpSlice(b, 0, editCursorPos);
-                const after = cpSlice(b, editCursorPos);
-                return before + pasted + after;
-              });
-              setEditCursorPos((pos) => pos + cpLen(pasted));
-            }
-            return;
-          }
-          if (name === 'backspace' || name === 'delete') {
-            if (name === 'backspace' && editCursorPos > 0) {
-              setEditBuffer((b) => {
-                const before = cpSlice(b, 0, editCursorPos - 1);
-                const after = cpSlice(b, editCursorPos);
-                return before + after;
-              });
-              setEditCursorPos((pos) => pos - 1);
-            } else if (name === 'delete' && editCursorPos < cpLen(editBuffer)) {
-              setEditBuffer((b) => {
-                const before = cpSlice(b, 0, editCursorPos);
-                const after = cpSlice(b, editCursorPos + 1);
-                return before + after;
-              });
-              // Cursor position stays the same for delete
-            }
-            return;
-          }
-          if (keyMatchers[Command.ESCAPE](key)) {
-            commitEdit(editingKey);
-            return;
-          }
-          if (keyMatchers[Command.RETURN](key)) {
-            commitEdit(editingKey);
-            return;
-          }
-
-          let ch = key.sequence;
-          let isValidChar = false;
-          if (type === 'number') {
-            // Allow digits, minus, plus, and dot.
-            isValidChar = /[0-9\-+.]/.test(ch);
-          } else {
-            ch = stripUnsafeCharacters(ch);
-            // For strings, allow any single character that isn't a control
-            // sequence.
-            isValidChar = ch.length === 1;
-          }
-
-          if (isValidChar) {
-            setEditBuffer((currentBuffer) => {
-              const beforeCursor = cpSlice(currentBuffer, 0, editCursorPos);
-              const afterCursor = cpSlice(currentBuffer, editCursorPos);
-              return beforeCursor + ch + afterCursor;
-            });
-            setEditCursorPos((pos) => pos + 1);
-            return;
-          }
-
-          // Arrow key navigation
-          if (name === 'left') {
-            setEditCursorPos((pos) => Math.max(0, pos - 1));
-            return;
-          }
-          if (name === 'right') {
-            setEditCursorPos((pos) => Math.min(cpLen(editBuffer), pos + 1));
-            return;
-          }
-          // Home and End keys
-          if (keyMatchers[Command.HOME](key)) {
-            setEditCursorPos(0);
-            return;
-          }
-          if (keyMatchers[Command.END](key)) {
-            setEditCursorPos(cpLen(editBuffer));
-            return;
-          }
-          // Block other keys while editing
-          return;
+      if (key.name === 'paste' && key.sequence) {
+        let pasted = key.sequence;
+        if (type === 'number') {
+          pasted = key.sequence.replace(/[^0-9\-+.]/g, '');
         }
-        if (keyMatchers[Command.DIALOG_NAVIGATION_UP](key)) {
-          // If editing, commit first
-          if (editingKey) {
-            commitEdit(editingKey);
-          }
-          const newIndex =
-            activeSettingIndex > 0 ? activeSettingIndex - 1 : items.length - 1;
-          setActiveSettingIndex(newIndex);
-          // Adjust scroll offset for wrap-around
-          if (newIndex === items.length - 1) {
-            setScrollOffset(
-              Math.max(0, items.length - effectiveMaxItemsToShow),
-            );
-          } else if (newIndex < scrollOffset) {
-            setScrollOffset(newIndex);
-          }
-        } else if (keyMatchers[Command.DIALOG_NAVIGATION_DOWN](key)) {
-          // If editing, commit first
-          if (editingKey) {
-            commitEdit(editingKey);
-          }
-          const newIndex =
-            activeSettingIndex < items.length - 1 ? activeSettingIndex + 1 : 0;
-          setActiveSettingIndex(newIndex);
-          // Adjust scroll offset for wrap-around
-          if (newIndex === 0) {
-            setScrollOffset(0);
-          } else if (newIndex >= scrollOffset + effectiveMaxItemsToShow) {
-            setScrollOffset(newIndex - effectiveMaxItemsToShow + 1);
-          }
-        } else if (keyMatchers[Command.RETURN](key)) {
-          const currentItem = items[activeSettingIndex];
-          if (
-            currentItem?.type === 'number' ||
-            currentItem?.type === 'string'
-          ) {
-            startEditing(currentItem.value);
-          } else {
-            currentItem?.toggle();
-          }
-        } else if (/^[0-9]$/.test(key.sequence || '') && !editingKey) {
-          const currentItem = items[activeSettingIndex];
-          if (currentItem?.type === 'number') {
-            startEditing(currentItem.value, key.sequence);
-          }
-        } else if (
-          keyMatchers[Command.CLEAR_INPUT](key) ||
-          keyMatchers[Command.CLEAR_SCREEN](key)
-        ) {
-          // Ctrl+C or Ctrl+L: Clear current setting and reset to default
-          const currentSetting = items[activeSettingIndex];
-          if (currentSetting) {
-            const defaultValue = getEffectiveDefaultValue(
-              currentSetting.value,
-              config,
-            );
-            const defType = currentSetting.type;
-            if (defType === 'boolean') {
-              const booleanDefaultValue =
-                typeof defaultValue === 'boolean' ? defaultValue : false;
-              setPendingSettings((prev) =>
-                setPendingSettingValue(
-                  currentSetting.value,
-                  booleanDefaultValue,
-                  prev,
-                ),
-              );
-            } else if (defType === 'number' || defType === 'string') {
-              if (
-                typeof defaultValue === 'number' ||
-                typeof defaultValue === 'string'
-              ) {
-                setPendingSettings((prev) =>
-                  setPendingSettingValueAny(
-                    currentSetting.value,
-                    defaultValue,
-                    prev,
-                  ),
-                );
-              }
-            }
-
-            // Remove from modified settings since it's now at default
-            setModifiedSettings((prev) => {
-              const updated = new Set(prev);
-              updated.delete(currentSetting.value);
-              return updated;
-            });
-
-            // Remove from restart-required settings if it was there
-            setRestartRequiredSettings((prev) => {
-              const updated = new Set(prev);
-              updated.delete(currentSetting.value);
-              return updated;
-            });
-
-            // If this setting doesn't require restart, save it immediately
-            if (!requiresRestart(currentSetting.value)) {
-              const immediateSettings = new Set([currentSetting.value]);
-              const toSaveValue =
-                currentSetting.type === 'boolean'
-                  ? typeof defaultValue === 'boolean'
-                    ? defaultValue
-                    : false
-                  : typeof defaultValue === 'number' ||
-                      typeof defaultValue === 'string'
-                    ? defaultValue
-                    : undefined;
-              const currentScopeSettings =
-                settings.forScope(selectedScope).settings;
-              const immediateSettingsObject =
-                toSaveValue !== undefined
-                  ? setPendingSettingValueAny(
-                      currentSetting.value,
-                      toSaveValue,
-                      currentScopeSettings,
-                    )
-                  : currentScopeSettings;
-
-              saveModifiedSettings(
-                immediateSettings,
-                immediateSettingsObject,
-                settings,
-                selectedScope,
-              );
-
-              // Remove from global pending changes if present
-              setGlobalPendingChanges((prev) => {
-                if (!prev.has(currentSetting.value)) return prev;
-                const next = new Map(prev);
-                next.delete(currentSetting.value);
-                return next;
-              });
-            } else {
-              // Track default reset as a pending change if restart required
-              if (
-                (currentSetting.type === 'boolean' &&
-                  typeof defaultValue === 'boolean') ||
-                (currentSetting.type === 'number' &&
-                  typeof defaultValue === 'number') ||
-                (currentSetting.type === 'string' &&
-                  typeof defaultValue === 'string')
-              ) {
-                setGlobalPendingChanges((prev) => {
-                  const next = new Map(prev);
-                  next.set(currentSetting.value, defaultValue as PendingValue);
-                  return next;
-                });
-              }
-            }
-          }
+        if (pasted) {
+          setEditBuffer((b) => {
+            const before = cpSlice(b, 0, editCursorPos);
+            const after = cpSlice(b, editCursorPos);
+            return before + pasted + after;
+          });
+          setEditCursorPos((pos) => pos + cpLen(pasted));
         }
+        return true;
       }
-      if (showRestartPrompt && name === 'r') {
-        // Only save settings that require restart (non-restart settings were already saved immediately)
-        saveRestartRequiredSettings();
-
-        setShowRestartPrompt(false);
-        setRestartRequiredSettings(new Set()); // Clear restart-required settings
-        if (onRestartRequest) onRestartRequest();
+      if (name === 'backspace' || name === 'delete') {
+        if (name === 'backspace' && editCursorPos > 0) {
+          setEditBuffer((b) => {
+            const before = cpSlice(b, 0, editCursorPos - 1);
+            const after = cpSlice(b, editCursorPos);
+            return before + after;
+          });
+          setEditCursorPos((pos) => pos - 1);
+        } else if (name === 'delete' && editCursorPos < cpLen(editBuffer)) {
+          setEditBuffer((b) => {
+            const before = cpSlice(b, 0, editCursorPos);
+            const after = cpSlice(b, editCursorPos + 1);
+            return before + after;
+          });
+          // Cursor position stays the same for delete
+        }
+        return true;
       }
       if (keyMatchers[Command.ESCAPE](key)) {
+        commitEdit(editingKey);
+        return true;
+      }
+      if (keyMatchers[Command.RETURN](key)) {
+        commitEdit(editingKey);
+        return true;
+      }
+
+      let ch = key.sequence;
+      let isValidChar = false;
+      if (type === 'number') {
+        // Allow digits, minus, plus, and dot.
+        isValidChar = /[0-9\-+.]/.test(ch);
+      } else {
+        ch = stripUnsafeCharacters(ch);
+        // For strings, allow any single character that isn't a control
+        // sequence.
+        isValidChar = ch.length === 1;
+      }
+
+      if (isValidChar) {
+        setEditBuffer((currentBuffer) => {
+          const beforeCursor = cpSlice(currentBuffer, 0, editCursorPos);
+          const afterCursor = cpSlice(currentBuffer, editCursorPos);
+          return beforeCursor + ch + afterCursor;
+        });
+        setEditCursorPos((pos) => pos + 1);
+        return true;
+      }
+
+      // Arrow key navigation
+      if (name === 'left') {
+        setEditCursorPos((pos) => Math.max(0, pos - 1));
+        return true;
+      }
+      if (name === 'right') {
+        setEditCursorPos((pos) => Math.min(cpLen(editBuffer), pos + 1));
+        return true;
+      }
+      // Home and End keys
+      if (keyMatchers[Command.HOME](key)) {
+        setEditCursorPos(0);
+        return true;
+      }
+      if (keyMatchers[Command.END](key)) {
+        setEditCursorPos(cpLen(editBuffer));
+        return true;
+      }
+      // Block other keys while editing
+      return true;
+    }
+
+    if (showRestartPrompt && name === 'r') {
+      saveRestartRequiredSettings();
+      setShowRestartPrompt(false);
+      if (onRestartRequest) onRestartRequest();
+      return true;
+    }
+
+    return false;
+  };
+
+  const renderValue = (item: SettingItem, isActive: boolean) => {
+    const scopeSettings = settings.forScope(selectedScope).settings;
+    const mergedSettings = settings.merged;
+
+    let displayValue: string;
+    if (editingKey === item.value) {
+      // Show edit buffer with advanced cursor highlighting
+      if (cursorVisible && editCursorPos < cpLen(editBuffer)) {
+        // Cursor is in the middle or at start of text
+        const beforeCursor = cpSlice(editBuffer, 0, editCursorPos);
+        const atCursor = cpSlice(editBuffer, editCursorPos, editCursorPos + 1);
+        const afterCursor = cpSlice(editBuffer, editCursorPos + 1);
+        displayValue = beforeCursor + chalk.inverse(atCursor) + afterCursor;
+      } else if (editCursorPos >= cpLen(editBuffer)) {
+        // Cursor is at the end - show inverted space
+        displayValue = editBuffer + (cursorVisible ? chalk.inverse(' ') : ' ');
+      } else {
+        // Cursor not visible
+        displayValue = editBuffer;
+      }
+    } else if (item.type === 'number' || item.type === 'string') {
+      // For numbers/strings, get the actual current value from pending settings
+      const path = item.value.split('.');
+      const currentValue = getNestedValue(pendingSettings, path);
+
+      const defaultValue = getEffectiveDefaultValue(item.value, config);
+
+      if (currentValue !== undefined && currentValue !== null) {
+        displayValue = String(currentValue);
+      } else {
+        displayValue =
+          defaultValue !== undefined && defaultValue !== null
+            ? String(defaultValue)
+            : '';
+      }
+
+      // Add * if value differs from default OR if currently being modified
+      const isModified = modifiedSettings.has(item.value);
+      const effectiveCurrentValue =
+        currentValue !== undefined && currentValue !== null
+          ? currentValue
+          : defaultValue;
+      const isDifferentFromDefault = effectiveCurrentValue !== defaultValue;
+
+      if (isDifferentFromDefault || isModified) {
+        displayValue += '*';
+      }
+    } else {
+      // For booleans and other types, use existing logic
+      displayValue = getDisplayValue(
+        item.value,
+        scopeSettings,
+        mergedSettings,
+        modifiedSettings,
+        pendingSettings,
+      );
+    }
+    const shouldBeGreyedOut = isDefaultValue(item.value, scopeSettings);
+
+    return (
+      <Text
+        color={
+          isActive
+            ? theme.status.success
+            : shouldBeGreyedOut
+              ? theme.text.secondary
+              : theme.text.primary
+        }
+      >
+        {displayValue}
+      </Text>
+    );
+  };
+
+  return (
+    <BaseSettingsDialog<SettingItem>
+      title="Settings"
+      items={items}
+      renderValue={renderValue}
+      onItemAction={(item) => {
+        if (item.type === 'number' || item.type === 'string') {
+          startEditing(item.value);
+        } else {
+          toggleItem(item.value);
+        }
+      }}
+      onCancel={() => {
         if (editingKey) {
           commitEdit(editingKey);
         } else {
-          // Save any restart-required settings before closing
           saveRestartRequiredSettings();
           onSelect(undefined, selectedScope);
         }
-      }
-    },
-    { isActive: true },
-  );
-
-  const { mainAreaWidth } = useUIState();
-  const viewportWidth = mainAreaWidth - 8;
-
-  const buffer = useTextBuffer({
-    initialText: '',
-    initialCursorOffset: 0,
-    viewport: {
-      width: viewportWidth,
-      height: 1,
-    },
-    isValidPath: () => false,
-    singleLine: true,
-    onChange: (text) => setSearchQuery(text),
-  });
-
-  return (
-    <Box
-      borderStyle="round"
-      borderColor={theme.border.default}
-      flexDirection="row"
-      padding={1}
-      width="100%"
-      height="100%"
-    >
-      <Box flexDirection="column" flexGrow={1}>
-        <Box marginX={1}>
-          <Text
-            bold={focusSection === 'settings' && !editingKey}
-            wrap="truncate"
-          >
-            {focusSection === 'settings' ? '> ' : '  '}Settings{' '}
-          </Text>
-        </Box>
-        <Box
-          borderStyle="round"
-          borderColor={
-            editingKey
-              ? theme.border.default
-              : focusSection === 'settings'
-                ? theme.border.focused
-                : theme.border.default
-          }
-          paddingX={1}
-          height={3}
-          marginTop={1}
-        >
-          <TextInput
-            focus={focusSection === 'settings' && !editingKey}
-            buffer={buffer}
-            placeholder="Search to filter"
-          />
-        </Box>
-        <Box height={1} />
-        {visibleItems.length === 0 ? (
-          <Box marginX={1} height={1} flexDirection="column">
-            <Text color={theme.text.secondary}>No matches found.</Text>
-          </Box>
-        ) : (
-          <>
-            {showScrollUp && (
-              <Box marginX={1}>
-                <Text color={theme.text.secondary}>▲</Text>
-              </Box>
-            )}
-            {visibleItems.map((item, idx) => {
-              const isActive =
-                focusSection === 'settings' &&
-                activeSettingIndex === idx + scrollOffset;
-
-              const scopeSettings = settings.forScope(selectedScope).settings;
-              const mergedSettings = settings.merged;
-
-              let displayValue: string;
-              if (editingKey === item.value) {
-                // Show edit buffer with advanced cursor highlighting
-                if (cursorVisible && editCursorPos < cpLen(editBuffer)) {
-                  // Cursor is in the middle or at start of text
-                  const beforeCursor = cpSlice(editBuffer, 0, editCursorPos);
-                  const atCursor = cpSlice(
-                    editBuffer,
-                    editCursorPos,
-                    editCursorPos + 1,
-                  );
-                  const afterCursor = cpSlice(editBuffer, editCursorPos + 1);
-                  displayValue =
-                    beforeCursor + chalk.inverse(atCursor) + afterCursor;
-                } else if (editCursorPos >= cpLen(editBuffer)) {
-                  // Cursor is at the end - show inverted space
-                  displayValue =
-                    editBuffer + (cursorVisible ? chalk.inverse(' ') : ' ');
-                } else {
-                  // Cursor not visible
-                  displayValue = editBuffer;
-                }
-              } else if (item.type === 'number' || item.type === 'string') {
-                // For numbers/strings, get the actual current value from pending settings
-                const path = item.value.split('.');
-                const currentValue = getNestedValue(pendingSettings, path);
-
-                const defaultValue = getEffectiveDefaultValue(
-                  item.value,
-                  config,
-                );
-
-                if (currentValue !== undefined && currentValue !== null) {
-                  displayValue = String(currentValue);
-                } else {
-                  displayValue =
-                    defaultValue !== undefined && defaultValue !== null
-                      ? String(defaultValue)
-                      : '';
-                }
-
-                // Add * if value differs from default OR if currently being modified
-                const isModified = modifiedSettings.has(item.value);
-                const effectiveCurrentValue =
-                  currentValue !== undefined && currentValue !== null
-                    ? currentValue
-                    : defaultValue;
-                const isDifferentFromDefault =
-                  effectiveCurrentValue !== defaultValue;
-
-                if (isDifferentFromDefault || isModified) {
-                  displayValue += '*';
-                }
-              } else {
-                // For booleans and other types, use existing logic
-                displayValue = getDisplayValue(
-                  item.value,
-                  scopeSettings,
-                  mergedSettings,
-                  modifiedSettings,
-                  pendingSettings,
-                );
-              }
-              const shouldBeGreyedOut = isDefaultValue(
-                item.value,
-                scopeSettings,
-              );
-
-              // Generate scope message for this setting
-              const scopeMessage = getScopeMessageForSetting(
-                item.value,
-                selectedScope,
-                settings,
-              );
-
-              return (
-                <React.Fragment key={item.value}>
-                  <Box marginX={1} flexDirection="row" alignItems="flex-start">
-                    <Box minWidth={2} flexShrink={0}>
-                      <Text
-                        color={
-                          isActive ? theme.status.success : theme.text.secondary
-                        }
-                      >
-                        {isActive ? '●' : ''}
-                      </Text>
-                    </Box>
-                    <Box
-                      flexDirection="row"
-                      flexGrow={1}
-                      minWidth={0}
-                      alignItems="flex-start"
-                    >
-                      <Box
-                        flexDirection="column"
-                        width={maxLabelOrDescriptionWidth}
-                        minWidth={0}
-                      >
-                        <Text
-                          color={
-                            isActive ? theme.status.success : theme.text.primary
-                          }
-                        >
-                          {item.label}
-                          {scopeMessage && (
-                            <Text color={theme.text.secondary}>
-                              {' '}
-                              {scopeMessage}
-                            </Text>
-                          )}
-                        </Text>
-                        <Text color={theme.text.secondary} wrap="truncate">
-                          {item.description ?? ''}
-                        </Text>
-                      </Box>
-                      <Box minWidth={3} />
-                      <Box flexShrink={0}>
-                        <Text
-                          color={
-                            isActive
-                              ? theme.status.success
-                              : shouldBeGreyedOut
-                                ? theme.text.secondary
-                                : theme.text.primary
-                          }
-                        >
-                          {displayValue}
-                        </Text>
-                      </Box>
-                    </Box>
-                  </Box>
-                  <Box height={1} />
-                </React.Fragment>
-              );
-            })}
-            {showScrollDown && (
-              <Box marginX={1}>
-                <Text color={theme.text.secondary}>▼</Text>
-              </Box>
-            )}
-          </>
-        )}
-
-        <Box height={1} />
-
-        {/* Scope Selection - conditionally visible based on height constraints */}
-        {showScopeSelection && (
-          <Box marginX={1} flexDirection="column">
-            <Text bold={focusSection === 'scope'} wrap="truncate">
-              {focusSection === 'scope' ? '> ' : '  '}Apply To
-            </Text>
-            <RadioButtonSelect
-              items={scopeItems}
-              initialIndex={scopeItems.findIndex(
-                (item) => item.value === selectedScope,
-              )}
-              onSelect={handleScopeSelect}
-              onHighlight={handleScopeHighlight}
-              isFocused={focusSection === 'scope'}
-              showNumbers={focusSection === 'scope'}
-            />
-          </Box>
-        )}
-
-        <Box height={1} />
-        <Box marginX={1}>
-          <Text color={theme.text.secondary}>
-            (Use Enter to select
-            {showScopeSelection ? ', Tab to change focus' : ''}, Esc to close)
-          </Text>
-        </Box>
-        {showRestartPrompt && (
-          <Box marginX={1}>
-            <Text color={theme.status.warning}>
-              To see changes, Gemini CLI must be restarted. Press r to exit and
-              apply changes now.
-            </Text>
-          </Box>
-        )}
-      </Box>
-    </Box>
+      }}
+      searchable
+      onSearchChange={setSearchQuery}
+      showScopeSelection
+      selectedScope={selectedScope}
+      onScopeChange={setSelectedScope}
+      showRestartPrompt={showRestartPrompt}
+      onRestartRequest={() => {
+        saveRestartRequiredSettings();
+        if (onRestartRequest) onRestartRequest();
+      }}
+      availableTerminalHeight={availableTerminalHeight}
+      onKeypress={handleKeypress}
+      isEditing={!!editingKey}
+    />
   );
 }

--- a/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
@@ -1,0 +1,376 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useEffect, useMemo } from 'react';
+import { Box, Text } from 'ink';
+import { theme } from '../../semantic-colors.js';
+import type { LoadableSettingScope } from '../../../config/settings.js';
+import { SettingScope } from '../../../config/settings.js';
+import { getScopeItems } from '../../../utils/dialogScopeUtils.js';
+import { RadioButtonSelect } from './RadioButtonSelect.js';
+import { useKeypress, type Key } from '../../hooks/useKeypress.js';
+import { keyMatchers, Command } from '../../keyMatchers.js';
+import { useUIState } from '../../contexts/UIStateContext.js';
+import { useTextBuffer } from './text-buffer.js';
+import { TextInput } from './TextInput.js';
+import { getCachedStringWidth } from '../../utils/textUtils.js';
+
+export interface BaseSettingsItem {
+  key: string;
+  label: string;
+  description?: string;
+  scopeMessage?: string;
+}
+
+export interface BaseSettingsDialogProps<T extends BaseSettingsItem> {
+  title: string;
+  items: T[];
+  renderValue: (item: T, isActive: boolean) => React.ReactNode;
+  onItemAction: (item: T) => void;
+  onCancel: () => void;
+
+  // Search
+  searchable?: boolean;
+  searchPlaceholder?: string;
+  onSearchChange?: (query: string) => void;
+
+  // Scope
+  showScopeSelection?: boolean;
+  selectedScope?: LoadableSettingScope;
+  onScopeChange?: (scope: LoadableSettingScope) => void;
+
+  // Restart
+  showRestartPrompt?: boolean;
+  onRestartRequest?: () => void;
+
+  // Help
+  helpText?: string;
+
+  // Height constraints
+  availableTerminalHeight?: number;
+  staticExtraHeight?: number;
+
+  // Custom key handling (e.g. for inline editing)
+  onKeypress?: (key: Key) => boolean; // Return true if handled
+  isEditing?: boolean;
+}
+
+const MAX_ITEMS_TO_SHOW = 8;
+
+export function BaseSettingsDialog<T extends BaseSettingsItem>({
+  title,
+  items,
+  renderValue,
+  onItemAction,
+  onCancel,
+  searchable = false,
+  searchPlaceholder = 'Search to filter',
+  onSearchChange,
+  showScopeSelection = false,
+  selectedScope = SettingScope.User,
+  onScopeChange,
+  showRestartPrompt = false,
+  onRestartRequest,
+  helpText,
+  availableTerminalHeight,
+  staticExtraHeight = 0,
+  onKeypress,
+  isEditing = false,
+}: BaseSettingsDialogProps<T>): React.JSX.Element {
+  const [focusSection, setFocusSection] = useState<'settings' | 'scope'>(
+    'settings',
+  );
+  const [activeItemIndex, setActiveItemIndex] = useState(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
+
+  const { mainAreaWidth } = useUIState();
+  const searchBufferWidth = mainAreaWidth - 8;
+  const searchBuffer = useTextBuffer({
+    initialText: '',
+    initialCursorOffset: 0,
+    viewport: {
+      width: searchBufferWidth,
+      height: 1,
+    },
+    isValidPath: () => false,
+    singleLine: true,
+    onChange: (text) => onSearchChange?.(text),
+  });
+
+  // Reset active index when items change
+  useEffect(() => {
+    setActiveItemIndex(0);
+    setScrollOffset(0);
+  }, [items.length]);
+
+  // Height calculations
+  const DIALOG_PADDING = 5;
+  const TITLE_HEIGHT = 2;
+  const SCROLL_ARROWS_HEIGHT = 2;
+  const SPACING_HEIGHT = 1;
+  const SCOPE_HEIGHT = showScopeSelection ? 4 : 0;
+  const HELP_TEXT_HEIGHT = 1;
+  const RESTART_PROMPT_HEIGHT = showRestartPrompt ? 1 : 0;
+  const SEARCH_HEIGHT = searchable ? 4 : 0;
+
+  let currentHeight = availableTerminalHeight
+    ? availableTerminalHeight - staticExtraHeight
+    : Number.MAX_SAFE_INTEGER;
+  currentHeight -= 2; // Borders
+
+  const totalFixedHeight =
+    DIALOG_PADDING +
+    TITLE_HEIGHT +
+    SCROLL_ARROWS_HEIGHT +
+    SPACING_HEIGHT +
+    SCOPE_HEIGHT +
+    HELP_TEXT_HEIGHT +
+    RESTART_PROMPT_HEIGHT +
+    SEARCH_HEIGHT;
+
+  const availableHeightForItems = Math.max(1, currentHeight - totalFixedHeight);
+  const maxVisibleItems = Math.max(1, Math.floor(availableHeightForItems / 3));
+
+  const effectiveMaxItemsToShow = availableTerminalHeight
+    ? Math.min(maxVisibleItems, items.length)
+    : MAX_ITEMS_TO_SHOW;
+
+  const visibleItems = items.slice(
+    scrollOffset,
+    scrollOffset + effectiveMaxItemsToShow,
+  );
+  const showScrollUp = items.length > effectiveMaxItemsToShow;
+  const showScrollDown = items.length > effectiveMaxItemsToShow;
+
+  const maxLabelWidth = useMemo(() => {
+    let max = 0;
+    for (const item of items) {
+      const labelFull =
+        item.label + (item.scopeMessage ? ` ${item.scopeMessage}` : '');
+      const lWidth = getCachedStringWidth(labelFull);
+      const dWidth = item.description
+        ? getCachedStringWidth(item.description)
+        : 0;
+      max = Math.max(max, lWidth, dWidth);
+    }
+    return max;
+  }, [items]);
+
+  useKeypress(
+    (key) => {
+      // Custom handler takes precedence
+      if (onKeypress?.(key)) {
+        return;
+      }
+
+      if (keyMatchers[Command.ESCAPE](key)) {
+        onCancel();
+        return;
+      }
+
+      if (key.name === 'tab' && showScopeSelection && !isEditing) {
+        setFocusSection((prev) => (prev === 'settings' ? 'scope' : 'settings'));
+        return;
+      }
+
+      if (focusSection === 'settings') {
+        if (keyMatchers[Command.DIALOG_NAVIGATION_UP](key)) {
+          const newIndex =
+            activeItemIndex > 0 ? activeItemIndex - 1 : items.length - 1;
+          setActiveItemIndex(newIndex);
+          if (newIndex === items.length - 1) {
+            setScrollOffset(
+              Math.max(0, items.length - effectiveMaxItemsToShow),
+            );
+          } else if (newIndex < scrollOffset) {
+            setScrollOffset(newIndex);
+          }
+        } else if (keyMatchers[Command.DIALOG_NAVIGATION_DOWN](key)) {
+          const newIndex =
+            activeItemIndex < items.length - 1 ? activeItemIndex + 1 : 0;
+          setActiveItemIndex(newIndex);
+          if (newIndex === 0) {
+            setScrollOffset(0);
+          } else if (newIndex >= scrollOffset + effectiveMaxItemsToShow) {
+            setScrollOffset(newIndex - effectiveMaxItemsToShow + 1);
+          }
+        } else if (keyMatchers[Command.RETURN](key)) {
+          const currentItem = items[activeItemIndex];
+          if (currentItem) onItemAction(currentItem);
+        }
+      }
+
+      if (showRestartPrompt && key.name === 'r' && !isEditing) {
+        onRestartRequest?.();
+      }
+    },
+    { isActive: true },
+  );
+
+  const scopeItems = getScopeItems().map((item) => ({
+    ...item,
+    key: item.value,
+  }));
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={theme.border.default}
+      flexDirection="row"
+      padding={1}
+      width="100%"
+      height="100%"
+    >
+      <Box flexDirection="column" flexGrow={1}>
+        <Box marginX={1}>
+          <Text
+            bold={focusSection === 'settings' && !isEditing}
+            wrap="truncate"
+          >
+            {focusSection === 'settings' ? '> ' : '  '}
+            {title}
+          </Text>
+        </Box>
+
+        {searchable && (
+          <Box
+            borderStyle="round"
+            borderColor={
+              isEditing
+                ? theme.border.default
+                : focusSection === 'settings'
+                  ? theme.border.focused
+                  : theme.border.default
+            }
+            paddingX={1}
+            height={3}
+            marginTop={1}
+          >
+            <TextInput
+              focus={focusSection === 'settings' && !isEditing}
+              buffer={searchBuffer}
+              placeholder={searchPlaceholder}
+            />
+          </Box>
+        )}
+
+        <Box height={1} />
+
+        {items.length === 0 ? (
+          <Box marginX={1} height={1}>
+            <Text color={theme.text.secondary}>No matches found.</Text>
+          </Box>
+        ) : (
+          <>
+            {showScrollUp && (
+              <Box marginX={1}>
+                <Text color={theme.text.secondary}>▲</Text>
+              </Box>
+            )}
+            {visibleItems.map((item, idx) => {
+              const isActive =
+                focusSection === 'settings' &&
+                activeItemIndex === idx + scrollOffset;
+
+              return (
+                <React.Fragment key={item.key}>
+                  <Box marginX={1} flexDirection="row" alignItems="flex-start">
+                    <Box minWidth={2} flexShrink={0}>
+                      <Text
+                        color={
+                          isActive ? theme.status.success : theme.text.secondary
+                        }
+                      >
+                        {isActive ? '●' : ''}
+                      </Text>
+                    </Box>
+                    <Box
+                      flexDirection="row"
+                      flexGrow={1}
+                      minWidth={0}
+                      alignItems="flex-start"
+                    >
+                      <Box
+                        flexDirection="column"
+                        width={maxLabelWidth}
+                        minWidth={0}
+                      >
+                        <Text
+                          color={
+                            isActive ? theme.status.success : theme.text.primary
+                          }
+                        >
+                          {item.label}
+                          {item.scopeMessage && (
+                            <Text color={theme.text.secondary}>
+                              {' '}
+                              {item.scopeMessage}
+                            </Text>
+                          )}
+                        </Text>
+                        <Text color={theme.text.secondary} wrap="truncate">
+                          {item.description ?? ''}
+                        </Text>
+                      </Box>
+                      <Box minWidth={3} />
+                      <Box flexShrink={0}>{renderValue(item, isActive)}</Box>
+                    </Box>
+                  </Box>
+                  <Box height={1} />
+                </React.Fragment>
+              );
+            })}
+            {showScrollDown && (
+              <Box marginX={1}>
+                <Text color={theme.text.secondary}>▼</Text>
+              </Box>
+            )}
+          </>
+        )}
+
+        <Box height={1} />
+
+        {showScopeSelection && (
+          <Box marginX={1} flexDirection="column">
+            <Text bold={focusSection === 'scope'} wrap="truncate">
+              {focusSection === 'scope' ? '> ' : '  '}Apply To
+            </Text>
+            <RadioButtonSelect
+              items={scopeItems}
+              initialIndex={scopeItems.findIndex(
+                (i) => i.value === selectedScope,
+              )}
+              onSelect={(scope) => {
+                onScopeChange?.(scope);
+                setFocusSection('settings');
+              }}
+              onHighlight={(scope) => onScopeChange?.(scope)}
+              isFocused={focusSection === 'scope'}
+              showNumbers={focusSection === 'scope'}
+            />
+          </Box>
+        )}
+
+        <Box height={1} />
+        <Box marginX={1}>
+          <Text color={theme.text.secondary}>
+            {helpText ||
+              `(Use Enter to select${showScopeSelection ? ', Tab to change focus' : ''}, Esc to close)`}
+          </Text>
+        </Box>
+
+        {showRestartPrompt && (
+          <Box marginX={1}>
+            <Text color={theme.status.warning}>
+              To see changes, Gemini CLI must be restarted. Press r to exit and
+              apply changes now.
+            </Text>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## TLDR

Refactored the settings UI to extract a reusable `BaseSettingsDialog` component. This establishes a shared foundation for configuration-driven dialogs, reducing boilerplate and ensuring UI consistency.

## Dive Deeper

- Created `BaseSettingsDialog.tsx`: A generic base component that handles common UI concerns including:
    - Layout and borders.
    - Focus management between Search, Settings List, and Scope Selection.
    - Keyboard navigation (Arrow keys, Tab, Enter, Esc).
    - Scrollable list logic with height constraint calculations.
    - Optional fuzzy search integration.
- Refactored `SettingsDialog.tsx`: Migrated to the new base component. It now focuses exclusively on:
    - Loading and merging settings across scopes (User/Workspace/System).
    - Inline editing logic for string and number settings.
    - Settings-specific keybindings (e.g., 'r' for restart).

This refactoring prepares the codebase for the implementation of the `/agents config` dialog, which will share the same underlying UI structure.

## Reviewer Test Plan

1. Launch the CLI: `npm run start`.
2. Open Settings: Press `Cmd+,` or type `/settings`.
3. Verify Core Functionality:
    - Navigate the list using arrow keys.
    - Use `Tab` to switch between the settings list and the 'Apply To' section.
    - Test searching: Type in the search box and verify the list filters correctly.
    - Test inline editing: Select a number or string setting, enter a value, and press Enter.
    - Test toggling: Select a boolean setting and press Enter to toggle.
    - Verify that the '*' indicator and scope messages (e.g., '(Modified in Workspace)') still display correctly.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

This PR makes progress on the `/agents config` command implementation roadmap.