### PR TITLE
fix(cli): include source in policy rule display

### DIFF
--- a/packages/cli/src/ui/commands/policiesCommand.test.ts
+++ b/packages/cli/src/ui/commands/policiesCommand.test.ts
@@ -109,7 +109,9 @@ describe('policiesCommand', () => {
       expect(content).toContain(
         '**DENY** tool: `dangerousTool` [Priority: 10]',
       );
-      expect(content).toContain('**ALLOW** all tools (args match: `safe`)');
+      expect(content).toContain(
+        '**ALLOW** all tools (args match: `safe`) [Source: test.toml]',
+      );
       expect(content).toContain('**ASK_USER** all tools');
     });
   });

--- a/packages/cli/src/ui/commands/policiesCommand.ts
+++ b/packages/cli/src/ui/commands/policiesCommand.ts
@@ -36,7 +36,8 @@ const categorizeRulesByMode = (
 const formatRule = (rule: PolicyRule, i: number) =>
   `${i + 1}. **${rule.decision.toUpperCase()}** ${rule.toolName ? `tool: \`${rule.toolName}\`` : 'all tools'}` +
   (rule.argsPattern ? ` (args match: \`${rule.argsPattern.source}\`)` : '') +
-  (rule.priority !== undefined ? ` [Priority: ${rule.priority}]` : '');
+  (rule.priority !== undefined ? ` [Priority: ${rule.priority}]` : '') +
+  (rule.source ? ` [Source: ${rule.source}]` : '');
 
 const formatSection = (title: string, rules: PolicyRule[]) =>
   `### ${title}\n${rules.length ? rules.map(formatRule).join('\n') : '_No policies._'}\n\n`;


### PR DESCRIPTION
Fixes regression where policy rule source was not displayed in the list command output.