### PR TITLE
Add summarize command to Gemini CLI

### DIFF
--- a/.gemini/commands/summarize.toml
+++ b/.gemini/commands/summarize.toml
@@ -1,0 +1,7 @@
+description = "Summarize the contents, purpose, and structure of a codebase."
+args = "folder_path"
+prompt = """
+# Summarization Task
+Target folder: {{args}}
+...
+"""


### PR DESCRIPTION
Adds a new `\summarize` command to Gemini CLI. This command analyzes a target folder and outputs a concise summary of the it, including its purpose, structure, and key files.

Usage example:
`\summarize ./some-project`

Provides a readable overview of the project, helping developers understand unfamiliar codebases (or folders in general) quickly.