### PR TITLE
fix(cli): handle errors in background checkpointing task to prevent unhandled rejections

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1347,54 +1347,60 @@ export const useGeminiStream = (
 
   useEffect(() => {
     const saveRestorableToolCalls = async () => {
-      if (!config.getCheckpointingEnabled()) {
-        return;
-      }
-      const restorableToolCalls = toolCalls.filter(
-        (toolCall) =>
-          EDIT_TOOL_NAMES.has(toolCall.request.name) &&
-          toolCall.status === 'awaiting_approval',
-      );
-
-      if (restorableToolCalls.length > 0) {
-        if (!gitService) {
-          onDebugMessage(
-            'Checkpointing is enabled but Git service is not available. Failed to create snapshot. Ensure Git is installed and working properly.',
-          );
+      try {
+        if (!config.getCheckpointingEnabled()) {
           return;
         }
-
-        const { checkpointsToWrite, errors } = await processRestorableToolCalls<
-          HistoryItem[]
-        >(
-          restorableToolCalls.map((call) => call.request),
-          gitService,
-          geminiClient,
-          history,
+        const restorableToolCalls = toolCalls.filter(
+          (toolCall) =>
+            EDIT_TOOL_NAMES.has(toolCall.request.name) &&
+            toolCall.status === 'awaiting_approval',
         );
 
-        if (errors.length > 0) {
-          errors.forEach(onDebugMessage);
-        }
-
-        if (checkpointsToWrite.size > 0) {
-          const checkpointDir = storage.getProjectTempCheckpointsDir();
-          try {
-            await fs.mkdir(checkpointDir, { recursive: true });
-            for (const [fileName, content] of checkpointsToWrite) {
-              const filePath = path.join(checkpointDir, fileName);
-              await fs.writeFile(filePath, content);
-            }
-          } catch (error) {
+        if (restorableToolCalls.length > 0) {
+          if (!gitService) {
             onDebugMessage(
-              `Failed to write checkpoint file: ${getErrorMessage(error)}`,
+              'Checkpointing is enabled but Git service is not available. Failed to create snapshot. Ensure Git is installed and working properly.',
             );
+            return;
+          }
+
+          const { checkpointsToWrite, errors } =
+            await processRestorableToolCalls<HistoryItem[]>(
+              restorableToolCalls.map((call) => call.request),
+              gitService,
+              geminiClient,
+              history,
+            );
+
+          if (errors.length > 0) {
+            errors.forEach(onDebugMessage);
+          }
+
+          if (checkpointsToWrite.size > 0) {
+            const checkpointDir = storage.getProjectTempCheckpointsDir();
+            try {
+              await fs.mkdir(checkpointDir, { recursive: true });
+              for (const [fileName, content] of checkpointsToWrite) {
+                const filePath = path.join(checkpointDir, fileName);
+                await fs.writeFile(filePath, content);
+              }
+            } catch (error) {
+              onDebugMessage(
+                `Failed to write checkpoint file: ${getErrorMessage(error)}`,
+              );
+            }
           }
         }
+      } catch (error) {
+        debugLogger.error(
+          'Error in saveRestorableToolCalls background task:',
+          error,
+        );
+        onDebugMessage(`Failed to save checkpoints: ${getErrorMessage(error)}`);
       }
     };
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    saveRestorableToolCalls();
+    void saveRestorableToolCalls();
   }, [
     toolCalls,
     config,


### PR DESCRIPTION


## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. --> The background saveRestorableToolCalls task in useGeminiStream was a floating promise. When a file system error occurred during this task, such as an EPERM error triggered by the macOS Seatbelt sandbox, the promise would reject without a catch handler, resulting in a CRITICAL: Unhandled Promise Rejection that crashed the entire CLI session.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
   - Wrapped the body of saveRestorableToolCalls in a try-catch block to handle background I/O failures
   - Failures are now logged to the debugLogger and displayed via onDebugMessage, ensuring the main chat loop remains stable.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). --> Fixes #16195 

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
npm test -w packages/cli -- src/ui/hooks/useGeminiStream.test.tsx

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
