### PR TITLE
fix(core): await MCP initialization in non-interactive mode

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -815,12 +815,16 @@ export class Config {
     );
     // We do not await this promise so that the CLI can start up even if
     // MCP servers are slow to connect.
-    Promise.all([
+    const mcpInitialization = Promise.all([
       this.mcpClientManager.startConfiguredMcpServers(),
       this.getExtensionLoader().start(this),
     ]).catch((error) => {
       debugLogger.error('Error initializing MCP clients:', error);
     });
+
+    if (!this.interactive) {
+      await mcpInitialization;
+    }
 
     if (this.skillsSupport) {
       this.getSkillManager().setAdminSettings(this.adminSkillsEnabled);

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -815,11 +815,15 @@ export class Config {
     );
     // We do not await this promise so that the CLI can start up even if
     // MCP servers are slow to connect.
-    const mcpInitialization = Promise.all([
+    const mcpInitialization = Promise.allSettled([
       this.mcpClientManager.startConfiguredMcpServers(),
       this.getExtensionLoader().start(this),
-    ]).catch((error) => {
-      debugLogger.error('Error initializing MCP clients:', error);
+    ]).then((results) => {
+      for (const result of results) {
+        if (result.status === 'rejected') {
+          debugLogger.error('Error initializing MCP clients:', result.reason);
+        }
+      }
     });
 
     if (!this.interactive) {


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. --> This PR fixes an issue where MCP tools were not reliably available in non-interactive mode (scripts/CI). Previously, Config.initialize() would trigger MCP tool discovery in the background without awaiting it, causing the LLM to start its turn before tools were registered.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
   - Modified packages/core/src/config/config.ts to capture and await the MCP initialization promise only when interactive mode is disabled.
   - Updated packages/core/src/config/config.test.ts with new tests to verify that:
       - Non-interactive mode: Initialization waits for MCP tools.
       - Interactive mode: Initialization returns immediately while tools load in the background.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). --> Fixes #17371 

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
- npm test -w packages/core -- src/config/config.test.ts

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
