### PR TITLE
fix(core): prevent crash in logStartSessionEvent when event is undefined

### DIFF
--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -1285,9 +1285,8 @@ describe('ClearcutLogger', () => {
   describe('logStartSessionEvent', () => {
     it('should not throw if event is undefined', async () => {
       const { logger } = setup();
-      // @ts-expect-error - intentionally passing undefined to reproduce the issue
       await expect(
-        logger?.logStartSessionEvent(undefined),
+        logger?.logStartSessionEvent(undefined as unknown as StartSessionEvent),
       ).resolves.not.toThrow();
     });
   });

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -1281,4 +1281,14 @@ describe('ClearcutLogger', () => {
       ]);
     });
   });
+
+  describe('logStartSessionEvent', () => {
+    it('should not throw if event is undefined', async () => {
+      const { logger } = setup();
+      // @ts-expect-error - intentionally passing undefined to reproduce the issue
+      await expect(
+        logger?.logStartSessionEvent(undefined),
+      ).resolves.not.toThrow();
+    });
+  });
 });

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -511,6 +511,9 @@ export class ClearcutLogger {
   }
 
   async logStartSessionEvent(event: StartSessionEvent): Promise<void> {
+    if (!event) {
+      return;
+    }
     const data: EventValue[] = [
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_START_SESSION_MODEL,


### PR DESCRIPTION
Fixes #17385.

Adds a guard clause to `logStartSessionEvent` in `ClearcutLogger` to prevent a TypeError when the passed event is undefined. This addresses the reported crash where `event.model` was being accessed on undefined.

Also added a regression test.