### PR TITLE
feat(cli): include auth method in /bug (#12727)

### DIFF
--- a/packages/cli/src/ui/commands/bugCommand.test.ts
+++ b/packages/cli/src/ui/commands/bugCommand.test.ts
@@ -92,6 +92,7 @@ describe('bugCommand', () => {
               getHistory: () => [],
             }),
           }),
+          getContentGeneratorConfig: () => ({ authType: 'oauth-personal' }),
         },
       },
     });
@@ -106,6 +107,7 @@ describe('bugCommand', () => {
 * **Operating System:** test-platform v20.0.0
 * **Sandbox Environment:** test
 * **Model Version:** gemini-pro
+* **Auth Type:** oauth-personal
 * **Memory Usage:** 100 MB
 * **Terminal Name:** Test Terminal
 * **Terminal Background:** #000000
@@ -178,6 +180,7 @@ describe('bugCommand', () => {
               getHistory: () => [],
             }),
           }),
+          getContentGeneratorConfig: () => ({ authType: 'vertex-ai' }),
         },
       },
     });
@@ -192,6 +195,7 @@ describe('bugCommand', () => {
 * **Operating System:** test-platform v20.0.0
 * **Sandbox Environment:** test
 * **Model Version:** gemini-pro
+* **Auth Type:** vertex-ai
 * **Memory Usage:** 100 MB
 * **Terminal Name:** Test Terminal
 * **Terminal Background:** #000000

--- a/packages/cli/src/ui/commands/bugCommand.ts
+++ b/packages/cli/src/ui/commands/bugCommand.ts
@@ -54,6 +54,7 @@ export const bugCommand: SlashCommand = {
     const kittyProtocol = terminalCapabilityManager.isKittyProtocolEnabled()
       ? 'Supported'
       : 'Unsupported';
+    const authType = config?.getContentGeneratorConfig()?.authType || 'Unknown';
 
     let info = `
 * **CLI Version:** ${cliVersion}
@@ -62,6 +63,7 @@ export const bugCommand: SlashCommand = {
 * **Operating System:** ${osVersion}
 * **Sandbox Environment:** ${sandboxEnv}
 * **Model Version:** ${modelVersion}
+* **Auth Type:** ${authType}
 * **Memory Usage:** ${memoryUsage}
 * **Terminal Name:** ${terminalName}
 * **Terminal Background:** ${terminalBgColor}


### PR DESCRIPTION
## Summary

This adds the current auth method to the bug report URL generated with `/bug`.

## Details

When debugging issues with team members we often need to know what auth
method they are using. Having it in the bug report skips a round of back and forth.

## Related Issues

Closes #12727

## How to Validate

Run `/bug` and confirm that the URL includes the auth method in the info portion.
Changing auth methods should lead to different values appearing in the URL.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ X ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ X ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ X ] Linux
    - [ X ] npm run
    - [ ] npx
    - [ ] Docker
