### PR TITLE
feat(ui): show authenticated account and plan on startup

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -424,6 +424,15 @@ const SETTINGS_SCHEMA = {
         description: 'Hide the application banner',
         showInDialog: true,
       },
+      showAuthOnStartup: {
+        type: 'boolean',
+        label: 'Show Auth On Startup',
+        category: 'UI',
+        requiresRestart: true,
+        default: true,
+        description: 'Show the authenticated account and plan on startup.',
+        showInDialog: true,
+      },
       hideContextSummary: {
         type: 'boolean',
         label: 'Hide Context Summary',

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -40,6 +40,7 @@ import {
   getErrorMessage,
   getAllGeminiMdFilenames,
   AuthType,
+  UserAccountManager,
   clearCachedCredentialFile,
   type ResumedSessionData,
   recordExitFail,
@@ -163,11 +164,50 @@ const SHELL_HEIGHT_PADDING = 10;
 
 export const AppContainer = (props: AppContainerProps) => {
   const { config, initializationResult, resumedSessionData } = props;
+  const settings = useSettings();
+
+  const initialHistoryItems = useMemo(() => {
+    const items: HistoryItem[] = [];
+    if (resumedSessionData) return items;
+
+    // Check if the user has disabled showing auth on startup
+    if (settings.merged.ui.showAuthOnStartup === false) return items;
+
+    // We can't use authState here because it's initialized in useAuthCommand which is called later.
+    // However, we can check config directly since we know startup just finished.
+    const authType = config.getContentGeneratorConfig()?.authType;
+    if (
+      authType === AuthType.LOGIN_WITH_GOOGLE ||
+      authType === AuthType.COMPUTE_ADC
+    ) {
+      try {
+        const userAccountManager = new UserAccountManager();
+        const email = userAccountManager.getCachedGoogleAccount();
+        const tier = config.getUserTier();
+
+        if (email) {
+          let message = `Authenticated as: ${email}`;
+          if (tier) {
+            message += ` (Plan: ${tier})`;
+          }
+          items.push({
+            id: Date.now(), // Use timestamp as ID for initial item
+            type: MessageType.INFO,
+            text: message,
+          });
+        }
+      } catch (_e) {
+        // Ignore errors during initial auth check
+      }
+    }
+    return items;
+  }, [config, resumedSessionData, settings.merged.ui.showAuthOnStartup]);
+
   const historyManager = useHistory({
     chatRecordingService: config.getGeminiClient()?.getChatRecordingService(),
+    initialItems: initialHistoryItems,
   });
   useMemoryMonitor(historyManager);
-  const settings = useSettings();
   const isAlternateBuffer = useAlternateBuffer();
   const [corgiMode, setCorgiMode] = useState(false);
   const [debugMessage, setDebugMessage] = useState<string>('');
@@ -561,10 +601,10 @@ export const AppContainer = (props: AppContainerProps) => {
         ) {
           await runExitCleanup();
           writeToStdout(`
-----------------------------------------------------------------
-Logging in with Google... Restarting Gemini CLI to continue.
-----------------------------------------------------------------
-          `);
+  ----------------------------------------------------------------
+  Logging in with Google... Restarting Gemini CLI to continue.
+  ----------------------------------------------------------------
+            `);
           process.exit(RELAUNCH_EXIT_CODE);
         }
       }

--- a/packages/cli/src/ui/hooks/useHistoryManager.ts
+++ b/packages/cli/src/ui/hooks/useHistoryManager.ts
@@ -36,10 +36,12 @@ export interface UseHistoryManagerReturn {
  */
 export function useHistory({
   chatRecordingService,
+  initialItems = [],
 }: {
   chatRecordingService?: ChatRecordingService | null;
+  initialItems?: HistoryItem[];
 } = {}): UseHistoryManagerReturn {
-  const [history, setHistory] = useState<HistoryItem[]>([]);
+  const [history, setHistory] = useState<HistoryItem[]>(initialItems);
   const messageIdCounterRef = useRef(0);
 
   // Generates a unique message ID based on a timestamp and a counter.

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -51,6 +51,10 @@ export class LoggingContentGenerator implements ContentGenerator {
     return this.wrapped;
   }
 
+  get userTier() {
+    return this.wrapped.userTier;
+  }
+
   private logApiRequest(
     contents: Content[],
     model: string,

--- a/packages/core/src/core/recordingContentGenerator.ts
+++ b/packages/core/src/core/recordingContentGenerator.ts
@@ -15,7 +15,6 @@ import type {
 import { appendFileSync } from 'node:fs';
 import type { ContentGenerator } from './contentGenerator.js';
 import type { FakeResponse } from './fakeContentGenerator.js';
-import type { UserTierId } from '../code_assist/types.js';
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 
 // A ContentGenerator that wraps another content generator and records all the
@@ -25,12 +24,14 @@ import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 //
 // Note that only the "interesting" bits of the responses are actually kept.
 export class RecordingContentGenerator implements ContentGenerator {
-  userTier?: UserTierId;
-
   constructor(
     private readonly realGenerator: ContentGenerator,
     private readonly filePath: string,
   ) {}
+
+  get userTier() {
+    return this.realGenerator.userTier;
+  }
 
   async generateContent(
     request: GenerateContentParameters,

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -222,6 +222,13 @@
           "default": false,
           "type": "boolean"
         },
+        "showAuthOnStartup": {
+          "title": "Show Auth On Startup",
+          "description": "Show the authenticated account and plan on startup.",
+          "markdownDescription": "Show the authenticated account and plan on startup.\n\n- Category: `UI`\n- Requires restart: `yes`\n- Default: `true`",
+          "default": true,
+          "type": "boolean"
+        },
         "hideContextSummary": {
           "title": "Hide Context Summary",
           "description": "Hide the context summary (GEMINI.md, MCP servers) above the input.",


### PR DESCRIPTION
## Summary

Displays the currently authenticated user's email and plan (tier) in the chat history when the Gemini CLI starts up. This provides users with immediate context about their session identity.

## Details

- Modified `AppContainer.tsx` to check for authentication status on component mount.
- Uses `UserAccountManager` to retrieve the cached Google account email.
- Uses `config.getUserTier()` to retrieve the user's plan.
- Adds a system message to the history if the user is authenticated via Google Login or ADC.
- Ensures the message is only shown for fresh sessions (not when resuming) to avoid clutter.
- **New:** Added `ui.showAuthOnStartup` setting (default `true`) to disable this feature.

## Related Issues
Fixes https://github.com/google-gemini/gemini-cli/pull/17413
## How to Validate

1.  Build the project: `npm run build`
2.  Run the CLI: `npm start`
3.  Ensure you are authenticated.
4.  Restart the CLI.
5.  Observe the message "Authenticated as: <email> (Plan: <tier>)" at the top of the chat history.
6.  Add `"ui": { "showAuthOnStartup": false }` to settings.
7.  Restart CLI and verify message is gone.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
