### PR TITLE
Fix line endings issue with Notice file

### DIFF
--- a/packages/vscode-ide-companion/scripts/generate-notices.js
+++ b/packages/vscode-ide-companion/scripts/generate-notices.js
@@ -72,6 +72,7 @@ async function getDependencyLicense(depName, depVersion) {
     if (licenseFile) {
       try {
         licenseContent = await fs.readFile(licenseFile, 'utf-8');
+        licenseContent = licenseContent.replace(/\r\n/g, '\n');
       } catch (e) {
         console.warn(
           `Warning: Failed to read license file for ${depName}: ${e.message}`,


### PR DESCRIPTION
## Summary

Fix line endings issue with Notice file.

## Details

`generate-notices.js` was incorporating CRLF (Windows) line endings from some dependency license files into NOTICES.txt, while the repository is configured to enforce LF (Unix) line endings. This normalizes it.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
