### PR TITLE
fix(core): hide user tier name

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -964,7 +964,8 @@ export class Config {
   }
 
   getUserTierName(): string | undefined {
-    return this.contentGenerator?.userTierName;
+    // TODO(#1275): Re-enable user tier display when ready.
+    return undefined;
   }
 
   /**


### PR DESCRIPTION
## Summary
Hide the display of the user tier in the `about` command by returning `undefined` from `getUserTierName`.
Will be enable once tested: https://github.com/google-gemini/maintainers-gemini-cli/issues/1275

## Details
This change modifies `packages/core/src/config/config.ts` to make `getUserTierName()` always return `undefined`. This effectively hides the user tier information in the UI, reverting the behavior introduced in a recent change or disabling it for now.

## Related Issues
Related to #17400

## How to Validate
1. Build the CLI: `npm run build`
2. Run the about command: `node packages/cli/bin/gemini about`
3. Verify that the user tier is NOT displayed in the output.

## Pre-Merge Checklist
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
