### PR TITLE
feat(scheduler): support multi-scheduler tool aggregation and nested call IDs

### DIFF
--- a/packages/cli/src/ui/hooks/useToolExecutionScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolExecutionScheduler.test.ts
@@ -19,6 +19,7 @@ import {
   type ToolCallsUpdateMessage,
   type AnyDeclarativeTool,
   type AnyToolInvocation,
+  ROOT_SCHEDULER_ID,
 } from '@google/gemini-cli-core';
 import { createMockMessageBus } from '@google/gemini-cli-core/src/test-utils/mock-message-bus.js';
 
@@ -73,6 +74,10 @@ describe('useToolExecutionScheduler', () => {
     } as unknown as Config;
   });
 
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('initializes with empty tool calls', () => {
     const { result } = renderHook(() =>
       useToolExecutionScheduler(
@@ -112,7 +117,7 @@ describe('useToolExecutionScheduler', () => {
       void mockMessageBus.publish({
         type: MessageBusType.TOOL_CALLS_UPDATE,
         toolCalls: [mockToolCall],
-        schedulerId: 'root',
+        schedulerId: ROOT_SCHEDULER_ID,
       } as ToolCallsUpdateMessage);
     });
 
@@ -157,7 +162,7 @@ describe('useToolExecutionScheduler', () => {
       void mockMessageBus.publish({
         type: MessageBusType.TOOL_CALLS_UPDATE,
         toolCalls: [mockToolCall],
-        schedulerId: 'root',
+        schedulerId: ROOT_SCHEDULER_ID,
       } as ToolCallsUpdateMessage);
     });
 
@@ -214,7 +219,7 @@ describe('useToolExecutionScheduler', () => {
       void mockMessageBus.publish({
         type: MessageBusType.TOOL_CALLS_UPDATE,
         toolCalls: [mockToolCall],
-        schedulerId: 'root',
+        schedulerId: ROOT_SCHEDULER_ID,
       } as ToolCallsUpdateMessage);
     });
 
@@ -277,7 +282,7 @@ describe('useToolExecutionScheduler', () => {
       void mockMessageBus.publish({
         type: MessageBusType.TOOL_CALLS_UPDATE,
         toolCalls: [mockToolCall],
-        schedulerId: 'root',
+        schedulerId: ROOT_SCHEDULER_ID,
       } as ToolCallsUpdateMessage);
     });
 
@@ -294,7 +299,7 @@ describe('useToolExecutionScheduler', () => {
       void mockMessageBus.publish({
         type: MessageBusType.TOOL_CALLS_UPDATE,
         toolCalls: [mockToolCall],
-        schedulerId: 'root',
+        schedulerId: ROOT_SCHEDULER_ID,
       } as ToolCallsUpdateMessage);
     });
 
@@ -331,7 +336,7 @@ describe('useToolExecutionScheduler', () => {
             invocation: createMockInvocation(),
           },
         ],
-        schedulerId: 'root',
+        schedulerId: ROOT_SCHEDULER_ID,
       } as ToolCallsUpdateMessage);
     });
 
@@ -446,7 +451,7 @@ describe('useToolExecutionScheduler', () => {
         error: undefined,
         errorType: undefined,
       },
-      schedulerId: 'root',
+      schedulerId: ROOT_SCHEDULER_ID,
     };
 
     const callSub = {
@@ -460,7 +465,7 @@ describe('useToolExecutionScheduler', () => {
       void mockMessageBus.publish({
         type: MessageBusType.TOOL_CALLS_UPDATE,
         toolCalls: [callRoot],
-        schedulerId: 'root',
+        schedulerId: ROOT_SCHEDULER_ID,
       } as ToolCallsUpdateMessage);
 
       void mockMessageBus.publish({
@@ -474,7 +479,7 @@ describe('useToolExecutionScheduler', () => {
     expect(toolCalls).toHaveLength(2);
     expect(
       toolCalls.find((t) => t.request.callId === 'call-root')?.schedulerId,
-    ).toBe('root');
+    ).toBe(ROOT_SCHEDULER_ID);
     expect(
       toolCalls.find((t) => t.request.callId === 'call-sub')?.schedulerId,
     ).toBe('subagent-1');
@@ -496,7 +501,7 @@ describe('useToolExecutionScheduler', () => {
     const updatedRoot = toolCalls.find((t) => t.request.callId === 'call-root');
     const updatedSub = toolCalls.find((t) => t.request.callId === 'call-sub');
 
-    expect(updatedRoot?.schedulerId).toBe('root');
+    expect(updatedRoot?.schedulerId).toBe(ROOT_SCHEDULER_ID);
     expect(updatedSub?.schedulerId).toBe('subagent-1');
 
     // 4. Verify that a subsequent update to ONE scheduler doesn't wipe the other
@@ -504,7 +509,7 @@ describe('useToolExecutionScheduler', () => {
       void mockMessageBus.publish({
         type: MessageBusType.TOOL_CALLS_UPDATE,
         toolCalls: [{ ...callRoot, status: 'executing' }],
-        schedulerId: 'root',
+        schedulerId: ROOT_SCHEDULER_ID,
       } as ToolCallsUpdateMessage);
     });
 

--- a/packages/core/src/confirmation-bus/types.ts
+++ b/packages/core/src/confirmation-bus/types.ts
@@ -26,6 +26,7 @@ export enum MessageBusType {
 export interface ToolCallsUpdateMessage {
   type: MessageBusType.TOOL_CALLS_UPDATE;
   toolCalls: ToolCall[];
+  schedulerId: string;
 }
 
 export interface ToolConfirmationRequest {

--- a/packages/core/src/scheduler/confirmation.test.ts
+++ b/packages/core/src/scheduler/confirmation.test.ts
@@ -29,6 +29,7 @@ import {
 import type { SchedulerStateManager } from './state-manager.js';
 import type { ToolModificationHandler } from './tool-modifier.js';
 import type { ValidatingToolCall, WaitingToolCall } from './types.js';
+import { ROOT_SCHEDULER_ID } from './types.js';
 import type { Config } from '../config/config.js';
 import type { EditorType } from '../utils/editor.js';
 import { randomUUID } from 'node:crypto';
@@ -52,7 +53,7 @@ describe('confirmation.ts', () => {
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   const emitResponse = (response: ToolConfirmationResponse) => {
@@ -188,7 +189,7 @@ describe('confirmation.ts', () => {
         state: mockState,
         modifier: mockModifier,
         getPreferredEditor,
-        schedulerId: 'root',
+        schedulerId: ROOT_SCHEDULER_ID,
       });
 
       expect(result.outcome).toBe(ToolConfirmationOutcome.ProceedOnce);
@@ -218,7 +219,7 @@ describe('confirmation.ts', () => {
         state: mockState,
         modifier: mockModifier,
         getPreferredEditor,
-        schedulerId: 'root',
+        schedulerId: ROOT_SCHEDULER_ID,
       });
       await listenerPromise;
 
@@ -254,7 +255,7 @@ describe('confirmation.ts', () => {
         state: mockState,
         modifier: mockModifier,
         getPreferredEditor,
-        schedulerId: 'root',
+        schedulerId: ROOT_SCHEDULER_ID,
       });
 
       await waitForListener(MessageBusType.TOOL_CONFIRMATION_RESPONSE);
@@ -296,7 +297,7 @@ describe('confirmation.ts', () => {
         state: mockState,
         modifier: mockModifier,
         getPreferredEditor,
-        schedulerId: 'root',
+        schedulerId: ROOT_SCHEDULER_ID,
       });
 
       await listenerPromise1;
@@ -355,7 +356,7 @@ describe('confirmation.ts', () => {
         state: mockState,
         modifier: mockModifier,
         getPreferredEditor,
-        schedulerId: 'root',
+        schedulerId: ROOT_SCHEDULER_ID,
       });
 
       await listenerPromise;
@@ -402,7 +403,7 @@ describe('confirmation.ts', () => {
         state: mockState,
         modifier: mockModifier,
         getPreferredEditor,
-        schedulerId: 'root',
+        schedulerId: ROOT_SCHEDULER_ID,
       });
 
       const result = await promise;
@@ -426,7 +427,7 @@ describe('confirmation.ts', () => {
           state: mockState,
           modifier: mockModifier,
           getPreferredEditor,
-          schedulerId: 'root',
+          schedulerId: ROOT_SCHEDULER_ID,
         }),
       ).rejects.toThrow(/lost during confirmation loop/);
     });

--- a/packages/core/src/scheduler/confirmation.test.ts
+++ b/packages/core/src/scheduler/confirmation.test.ts
@@ -188,6 +188,7 @@ describe('confirmation.ts', () => {
         state: mockState,
         modifier: mockModifier,
         getPreferredEditor,
+        schedulerId: 'root',
       });
 
       expect(result.outcome).toBe(ToolConfirmationOutcome.ProceedOnce);
@@ -217,6 +218,7 @@ describe('confirmation.ts', () => {
         state: mockState,
         modifier: mockModifier,
         getPreferredEditor,
+        schedulerId: 'root',
       });
       await listenerPromise;
 
@@ -252,6 +254,7 @@ describe('confirmation.ts', () => {
         state: mockState,
         modifier: mockModifier,
         getPreferredEditor,
+        schedulerId: 'root',
       });
 
       await waitForListener(MessageBusType.TOOL_CONFIRMATION_RESPONSE);
@@ -293,6 +296,7 @@ describe('confirmation.ts', () => {
         state: mockState,
         modifier: mockModifier,
         getPreferredEditor,
+        schedulerId: 'root',
       });
 
       await listenerPromise1;
@@ -351,6 +355,7 @@ describe('confirmation.ts', () => {
         state: mockState,
         modifier: mockModifier,
         getPreferredEditor,
+        schedulerId: 'root',
       });
 
       await listenerPromise;
@@ -397,6 +402,7 @@ describe('confirmation.ts', () => {
         state: mockState,
         modifier: mockModifier,
         getPreferredEditor,
+        schedulerId: 'root',
       });
 
       const result = await promise;
@@ -420,6 +426,7 @@ describe('confirmation.ts', () => {
           state: mockState,
           modifier: mockModifier,
           getPreferredEditor,
+          schedulerId: 'root',
         }),
       ).rejects.toThrow(/lost during confirmation loop/);
     });

--- a/packages/core/src/scheduler/confirmation.ts
+++ b/packages/core/src/scheduler/confirmation.ts
@@ -103,6 +103,7 @@ export async function resolveConfirmation(
     state: SchedulerStateManager;
     modifier: ToolModificationHandler;
     getPreferredEditor: () => EditorType | undefined;
+    schedulerId: string;
   },
 ): Promise<ResolutionResult> {
   const { state } = deps;

--- a/packages/core/src/scheduler/scheduler.test.ts
+++ b/packages/core/src/scheduler/scheduler.test.ts
@@ -94,6 +94,8 @@ describe('Scheduler (Orchestrator)', () => {
     args: { foo: 'bar' },
     isClientInitiated: false,
     prompt_id: 'prompt-1',
+    schedulerId: 'root',
+    parentCallId: undefined,
   };
 
   const req2: ToolCallRequestInfo = {
@@ -102,6 +104,8 @@ describe('Scheduler (Orchestrator)', () => {
     args: { foo: 'baz' },
     isClientInitiated: false,
     prompt_id: 'prompt-1',
+    schedulerId: 'root',
+    parentCallId: undefined,
   };
 
   const mockTool = {
@@ -271,6 +275,8 @@ describe('Scheduler (Orchestrator)', () => {
             request: req1,
             tool: mockTool,
             invocation: mockInvocation,
+            schedulerId: 'root',
+            startTime: expect.any(Number),
           }),
         ]),
       );
@@ -769,6 +775,7 @@ describe('Scheduler (Orchestrator)', () => {
           config: mockConfig,
           messageBus: mockMessageBus,
           state: mockStateManager,
+          schedulerId: 'root',
         }),
       );
 

--- a/packages/core/src/scheduler/scheduler.test.ts
+++ b/packages/core/src/scheduler/scheduler.test.ts
@@ -66,6 +66,7 @@ import type {
   CancelledToolCall,
   ToolCallResponseInfo,
 } from './types.js';
+import { ROOT_SCHEDULER_ID } from './types.js';
 import { ToolErrorType } from '../tools/tool-error.js';
 import * as ToolUtils from '../utils/tool-utils.js';
 import type { EditorType } from '../utils/editor.js';
@@ -94,7 +95,7 @@ describe('Scheduler (Orchestrator)', () => {
     args: { foo: 'bar' },
     isClientInitiated: false,
     prompt_id: 'prompt-1',
-    schedulerId: 'root',
+    schedulerId: ROOT_SCHEDULER_ID,
     parentCallId: undefined,
   };
 
@@ -104,7 +105,7 @@ describe('Scheduler (Orchestrator)', () => {
     args: { foo: 'baz' },
     isClientInitiated: false,
     prompt_id: 'prompt-1',
-    schedulerId: 'root',
+    schedulerId: ROOT_SCHEDULER_ID,
     parentCallId: undefined,
   };
 
@@ -212,6 +213,7 @@ describe('Scheduler (Orchestrator)', () => {
       config: mockConfig,
       messageBus: mockMessageBus,
       getPreferredEditor,
+      schedulerId: 'root',
     });
 
     // Reset Tool build behavior
@@ -275,7 +277,7 @@ describe('Scheduler (Orchestrator)', () => {
             request: req1,
             tool: mockTool,
             invocation: mockInvocation,
-            schedulerId: 'root',
+            schedulerId: ROOT_SCHEDULER_ID,
             startTime: expect.any(Number),
           }),
         ]),
@@ -775,7 +777,7 @@ describe('Scheduler (Orchestrator)', () => {
           config: mockConfig,
           messageBus: mockMessageBus,
           state: mockStateManager,
-          schedulerId: 'root',
+          schedulerId: ROOT_SCHEDULER_ID,
         }),
       );
 

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -48,6 +48,8 @@ export interface SchedulerOptions {
   config: Config;
   messageBus: MessageBus;
   getPreferredEditor: () => EditorType | undefined;
+  schedulerId?: string;
+  parentCallId?: string;
 }
 
 const createErrorResponse = (
@@ -85,6 +87,8 @@ export class Scheduler {
   private readonly config: Config;
   private readonly messageBus: MessageBus;
   private readonly getPreferredEditor: () => EditorType | undefined;
+  private readonly schedulerId: string;
+  private readonly parentCallId?: string;
 
   private isProcessing = false;
   private isCancelling = false;
@@ -94,7 +98,9 @@ export class Scheduler {
     this.config = options.config;
     this.messageBus = options.messageBus;
     this.getPreferredEditor = options.getPreferredEditor;
-    this.state = new SchedulerStateManager(this.messageBus);
+    this.schedulerId = options.schedulerId ?? 'root';
+    this.parentCallId = options.parentCallId;
+    this.state = new SchedulerStateManager(this.messageBus, this.schedulerId);
     this.executor = new ToolExecutor(this.config);
     this.modifier = new ToolModificationHandler();
 
@@ -228,16 +234,21 @@ export class Scheduler {
     try {
       const toolRegistry = this.config.getToolRegistry();
       const newCalls: ToolCall[] = requests.map((request) => {
+        const enrichedRequest: ToolCallRequestInfo = {
+          ...request,
+          schedulerId: this.schedulerId,
+          parentCallId: this.parentCallId,
+        };
         const tool = toolRegistry.getTool(request.name);
 
         if (!tool) {
           return this._createToolNotFoundErroredToolCall(
-            request,
+            enrichedRequest,
             toolRegistry.getAllToolNames(),
           );
         }
 
-        return this._validateAndCreateToolCall(request, tool);
+        return this._validateAndCreateToolCall(enrichedRequest, tool);
       });
 
       this.state.enqueue(newCalls);
@@ -263,6 +274,7 @@ export class Scheduler {
         ToolErrorType.TOOL_NOT_REGISTERED,
       ),
       durationMs: 0,
+      schedulerId: this.schedulerId,
     };
   }
 
@@ -278,6 +290,7 @@ export class Scheduler {
         tool,
         invocation,
         startTime: Date.now(),
+        schedulerId: this.schedulerId,
       };
     } catch (e) {
       return {
@@ -290,6 +303,7 @@ export class Scheduler {
           ToolErrorType.INVALID_TOOL_PARAMS,
         ),
         durationMs: 0,
+        schedulerId: this.schedulerId,
       };
     }
   }
@@ -411,6 +425,7 @@ export class Scheduler {
         state: this.state,
         modifier: this.modifier,
         getPreferredEditor: this.getPreferredEditor,
+        schedulerId: this.schedulerId,
       });
       outcome = result.outcome;
       lastDetails = result.lastDetails;

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -48,7 +48,7 @@ export interface SchedulerOptions {
   config: Config;
   messageBus: MessageBus;
   getPreferredEditor: () => EditorType | undefined;
-  schedulerId?: string;
+  schedulerId: string;
   parentCallId?: string;
 }
 
@@ -98,7 +98,7 @@ export class Scheduler {
     this.config = options.config;
     this.messageBus = options.messageBus;
     this.getPreferredEditor = options.getPreferredEditor;
-    this.schedulerId = options.schedulerId ?? 'root';
+    this.schedulerId = options.schedulerId;
     this.parentCallId = options.parentCallId;
     this.state = new SchedulerStateManager(this.messageBus, this.schedulerId);
     this.executor = new ToolExecutor(this.config);

--- a/packages/core/src/scheduler/state-manager.ts
+++ b/packages/core/src/scheduler/state-manager.ts
@@ -17,6 +17,7 @@ import type {
   ExecutingToolCall,
   ToolCallResponseInfo,
 } from './types.js';
+import { ROOT_SCHEDULER_ID } from './types.js';
 import type {
   ToolConfirmationOutcome,
   ToolResultDisplay,
@@ -41,7 +42,7 @@ export class SchedulerStateManager {
 
   constructor(
     private readonly messageBus: MessageBus,
-    private readonly schedulerId: string = 'root',
+    private readonly schedulerId: string = ROOT_SCHEDULER_ID,
   ) {}
 
   addToolCalls(calls: ToolCall[]): void {

--- a/packages/core/src/scheduler/state-manager.ts
+++ b/packages/core/src/scheduler/state-manager.ts
@@ -39,7 +39,10 @@ export class SchedulerStateManager {
   private readonly queue: ToolCall[] = [];
   private _completedBatch: CompletedToolCall[] = [];
 
-  constructor(private readonly messageBus: MessageBus) {}
+  constructor(
+    private readonly messageBus: MessageBus,
+    private readonly schedulerId: string = 'root',
+  ) {}
 
   addToolCalls(calls: ToolCall[]): void {
     this.enqueue(calls);
@@ -201,6 +204,7 @@ export class SchedulerStateManager {
     void this.messageBus.publish({
       type: MessageBusType.TOOL_CALLS_UPDATE,
       toolCalls: snapshot,
+      schedulerId: this.schedulerId,
     });
   }
 
@@ -321,6 +325,7 @@ export class SchedulerStateManager {
       response,
       durationMs: startTime ? Date.now() - startTime : undefined,
       outcome: call.outcome,
+      schedulerId: call.schedulerId,
     };
   }
 
@@ -336,6 +341,7 @@ export class SchedulerStateManager {
       response,
       durationMs: startTime ? Date.now() - startTime : undefined,
       outcome: call.outcome,
+      schedulerId: call.schedulerId,
     };
   }
 
@@ -364,6 +370,7 @@ export class SchedulerStateManager {
       startTime: 'startTime' in call ? call.startTime : undefined,
       outcome: call.outcome,
       invocation: call.invocation,
+      schedulerId: call.schedulerId,
     };
   }
 
@@ -388,6 +395,7 @@ export class SchedulerStateManager {
       startTime: 'startTime' in call ? call.startTime : undefined,
       outcome: call.outcome,
       invocation: call.invocation,
+      schedulerId: call.schedulerId,
     };
   }
 
@@ -442,6 +450,7 @@ export class SchedulerStateManager {
       },
       durationMs: startTime ? Date.now() - startTime : undefined,
       outcome: call.outcome,
+      schedulerId: call.schedulerId,
     };
   }
 
@@ -462,6 +471,7 @@ export class SchedulerStateManager {
       startTime: 'startTime' in call ? call.startTime : undefined,
       outcome: call.outcome,
       invocation: call.invocation,
+      schedulerId: call.schedulerId,
     };
   }
 
@@ -482,6 +492,7 @@ export class SchedulerStateManager {
       invocation: call.invocation,
       liveOutput,
       pid,
+      schedulerId: call.schedulerId,
     };
   }
 }

--- a/packages/core/src/scheduler/types.ts
+++ b/packages/core/src/scheduler/types.ts
@@ -16,6 +16,8 @@ import type { AnsiOutput } from '../utils/terminalSerializer.js';
 import type { ToolErrorType } from '../tools/tool-error.js';
 import type { SerializableConfirmationDetails } from '../confirmation-bus/types.js';
 
+export const ROOT_SCHEDULER_ID = 'root';
+
 export interface ToolCallRequestInfo {
   callId: string;
   name: string;

--- a/packages/core/src/scheduler/types.ts
+++ b/packages/core/src/scheduler/types.ts
@@ -24,6 +24,8 @@ export interface ToolCallRequestInfo {
   prompt_id: string;
   checkpoint?: string;
   traceId?: string;
+  parentCallId?: string;
+  schedulerId?: string;
 }
 
 export interface ToolCallResponseInfo {
@@ -43,6 +45,7 @@ export type ValidatingToolCall = {
   invocation: AnyToolInvocation;
   startTime?: number;
   outcome?: ToolConfirmationOutcome;
+  schedulerId?: string;
 };
 
 export type ScheduledToolCall = {
@@ -52,6 +55,7 @@ export type ScheduledToolCall = {
   invocation: AnyToolInvocation;
   startTime?: number;
   outcome?: ToolConfirmationOutcome;
+  schedulerId?: string;
 };
 
 export type ErroredToolCall = {
@@ -61,6 +65,7 @@ export type ErroredToolCall = {
   tool?: AnyDeclarativeTool;
   durationMs?: number;
   outcome?: ToolConfirmationOutcome;
+  schedulerId?: string;
 };
 
 export type SuccessfulToolCall = {
@@ -71,6 +76,7 @@ export type SuccessfulToolCall = {
   invocation: AnyToolInvocation;
   durationMs?: number;
   outcome?: ToolConfirmationOutcome;
+  schedulerId?: string;
 };
 
 export type ExecutingToolCall = {
@@ -82,6 +88,7 @@ export type ExecutingToolCall = {
   startTime?: number;
   outcome?: ToolConfirmationOutcome;
   pid?: number;
+  schedulerId?: string;
 };
 
 export type CancelledToolCall = {
@@ -92,6 +99,7 @@ export type CancelledToolCall = {
   invocation: AnyToolInvocation;
   durationMs?: number;
   outcome?: ToolConfirmationOutcome;
+  schedulerId?: string;
 };
 
 export type WaitingToolCall = {
@@ -113,6 +121,7 @@ export type WaitingToolCall = {
   correlationId?: string;
   startTime?: number;
   outcome?: ToolConfirmationOutcome;
+  schedulerId?: string;
 };
 
 export type Status = ToolCall['status'];


### PR DESCRIPTION
## Summary

This PR introduces support for multi-scheduler tool aggregation and nested tool
call IDs. It enables the system to track and display tool calls originating from
different schedulers (e.g., sub-agents) and maintains the relationship between
parent and child tool calls.

There should be no functional change that users can notice in this change.

## Details

- **Core Scheduler Enhancements**:
  - Added `schedulerId` to `ToolCallRequestInfo`, `ToolCallsUpdateMessage`, and
    various tool call state types to track the source of each execution.
  - Added `parentCallId` to support tracking of agent-to-agent tool call
    hierarchies.
  - Updated `SchedulerStateManager` and `resolveConfirmation` to be aware of and
    propagate the `schedulerId`.
- **CLI Reactivity**:
  - Refactored `useToolExecutionScheduler` to manage tool calls in a
    `Record<string, TrackedToolCall[]>` keyed by `schedulerId`. This prevents
    state collisions when multiple schedulers are active simultaneously.
  - Implemented a flattened view of tool calls for backward compatibility with
    existing UI components.
- **Testing**:
  - Updated scheduler and confirmation tests to include `schedulerId` where
    required.

## Related Issues

Works towards #14306

## How to Validate

1. Run core unit tests: `npm test -w @google/gemini-cli-core`
2. Run CLI unit tests: `npm test -w @google/gemini-cli`
3. Verify that tool calls are still correctly displayed and tracked in the CLI.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
