### PR TITLE
Fix bug in detecting already added paths.

### DIFF
--- a/packages/cli/src/ui/commands/directoryCommand.test.tsx
+++ b/packages/cli/src/ui/commands/directoryCommand.test.tsx
@@ -51,14 +51,14 @@ describe('directoryCommand', () => {
 
   beforeEach(() => {
     mockWorkspaceContext = {
-      targetDir: '/test/dir',
+      targetDir: path.resolve('/test/dir'),
       addDirectory: vi.fn(),
       addDirectories: vi.fn().mockReturnValue({ added: [], failed: [] }),
       getDirectories: vi
         .fn()
         .mockReturnValue([
-          path.normalize('/home/user/project1'),
-          path.normalize('/home/user/project2'),
+          path.resolve('/home/user/project1'),
+          path.resolve('/home/user/project2'),
         ]),
     } as unknown as WorkspaceContext;
 
@@ -68,7 +68,7 @@ describe('directoryCommand', () => {
       getGeminiClient: vi.fn().mockReturnValue({
         addDirectoryContext: vi.fn(),
       }),
-      getWorkingDir: () => '/test/dir',
+      getWorkingDir: () => path.resolve('/test/dir'),
       shouldLoadMemoryFromIncludeDirectories: () => false,
       getDebugMode: () => false,
       getFileService: () => ({}),
@@ -101,9 +101,9 @@ describe('directoryCommand', () => {
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         expect.objectContaining({
           type: MessageType.INFO,
-          text: `Current workspace directories:\n- ${path.normalize(
+          text: `Current workspace directories:\n- ${path.resolve(
             '/home/user/project1',
-          )}\n- ${path.normalize('/home/user/project2')}`,
+          )}\n- ${path.resolve('/home/user/project2')}`,
         }),
       );
     });
@@ -135,7 +135,7 @@ describe('directoryCommand', () => {
     });
 
     it('should call addDirectory and show a success message for a single path', async () => {
-      const newPath = path.normalize('/home/user/new-project');
+      const newPath = path.resolve('/home/user/new-project');
       vi.mocked(mockWorkspaceContext.addDirectories).mockReturnValue({
         added: [newPath],
         failed: [],
@@ -154,8 +154,8 @@ describe('directoryCommand', () => {
     });
 
     it('should call addDirectory for each path and show a success message for multiple paths', async () => {
-      const newPath1 = path.normalize('/home/user/new-project1');
-      const newPath2 = path.normalize('/home/user/new-project2');
+      const newPath1 = path.resolve('/home/user/new-project1');
+      const newPath2 = path.resolve('/home/user/new-project2');
       vi.mocked(mockWorkspaceContext.addDirectories).mockReturnValue({
         added: [newPath1, newPath2],
         failed: [],
@@ -176,7 +176,7 @@ describe('directoryCommand', () => {
 
     it('should show an error if addDirectory throws an exception', async () => {
       const error = new Error('Directory does not exist');
-      const newPath = path.normalize('/home/user/invalid-project');
+      const newPath = path.resolve('/home/user/invalid-project');
       vi.mocked(mockWorkspaceContext.addDirectories).mockReturnValue({
         added: [],
         failed: [{ path: newPath, error }],
@@ -194,7 +194,7 @@ describe('directoryCommand', () => {
     it('should add directory directly when folder trust is disabled', async () => {
       if (!addCommand?.action) throw new Error('No action');
       vi.spyOn(trustedFolders, 'isFolderTrustEnabled').mockReturnValue(false);
-      const newPath = path.normalize('/home/user/new-project');
+      const newPath = path.resolve('/home/user/new-project');
       vi.mocked(mockWorkspaceContext.addDirectories).mockReturnValue({
         added: [newPath],
         failed: [],
@@ -208,7 +208,7 @@ describe('directoryCommand', () => {
     });
 
     it('should show an info message for an already added directory', async () => {
-      const existingPath = path.normalize('/home/user/project1');
+      const existingPath = path.resolve('/home/user/project1');
       if (!addCommand?.action) throw new Error('No action');
       await addCommand.action(mockContext, existingPath);
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
@@ -223,9 +223,12 @@ describe('directoryCommand', () => {
     });
 
     it('should show an info message for an already added directory specified as a relative path', async () => {
-      const existingPath = path.normalize('/home/user/project1');
+      const existingPath = path.resolve('/home/user/project1');
       const relativePath = './project1';
-      const absoluteRelativePath = path.resolve('/test/dir', relativePath);
+      const absoluteRelativePath = path.resolve(
+        path.resolve('/test/dir'),
+        relativePath,
+      );
 
       vi.mocked(fs.realpathSync).mockImplementation((p) => {
         if (p === absoluteRelativePath) return existingPath;
@@ -244,8 +247,8 @@ describe('directoryCommand', () => {
     });
 
     it('should handle a mix of successful and failed additions', async () => {
-      const validPath = path.normalize('/home/user/valid-project');
-      const invalidPath = path.normalize('/home/user/invalid-project');
+      const validPath = path.resolve('/home/user/valid-project');
+      const invalidPath = path.resolve('/home/user/invalid-project');
       const error = new Error('Directory does not exist');
       vi.mocked(mockWorkspaceContext.addDirectories).mockReturnValue({
         added: [validPath],
@@ -349,7 +352,7 @@ describe('directoryCommand', () => {
     it('should add a trusted directory', async () => {
       if (!addCommand?.action) throw new Error('No action');
       mockIsPathTrusted.mockReturnValue(true);
-      const newPath = path.normalize('/home/user/trusted-project');
+      const newPath = path.resolve('/home/user/trusted-project');
       vi.mocked(mockWorkspaceContext.addDirectories).mockReturnValue({
         added: [newPath],
         failed: [],
@@ -365,7 +368,7 @@ describe('directoryCommand', () => {
     it('should return a custom dialog for an explicitly untrusted directory (upgrade flow)', async () => {
       if (!addCommand?.action) throw new Error('No action');
       mockIsPathTrusted.mockReturnValue(false); // DO_NOT_TRUST
-      const newPath = path.normalize('/home/user/untrusted-project');
+      const newPath = path.resolve('/home/user/untrusted-project');
 
       const result = await addCommand.action(mockContext, newPath);
 
@@ -388,7 +391,7 @@ describe('directoryCommand', () => {
     it('should return a custom dialog for a directory with undefined trust', async () => {
       if (!addCommand?.action) throw new Error('No action');
       mockIsPathTrusted.mockReturnValue(undefined);
-      const newPath = path.normalize('/home/user/undefined-trust-project');
+      const newPath = path.resolve('/home/user/undefined-trust-project');
 
       const result = await addCommand.action(mockContext, newPath);
 
@@ -416,7 +419,7 @@ describe('directoryCommand', () => {
         source: 'file',
       });
       mockIsPathTrusted.mockReturnValue(undefined);
-      const newPath = path.normalize('/home/user/new-project');
+      const newPath = path.resolve('/home/user/new-project');
 
       const result = await addCommand.action(mockContext, newPath);
 

--- a/packages/cli/src/ui/commands/directoryCommand.tsx
+++ b/packages/cli/src/ui/commands/directoryCommand.tsx
@@ -101,7 +101,7 @@ export const directoryCommand: SlashCommand = {
           const workspaceContext =
             context.services.config.getWorkspaceContext();
           const existingDirs = new Set(
-            workspaceContext.getDirectories().map((dir) => path.normalize(dir)),
+            workspaceContext.getDirectories().map((dir) => path.resolve(dir)),
           );
 
           filteredSuggestions = suggestions.filter((s) => {


### PR DESCRIPTION
## Summary

Previously requesting to add the same directory twice would trigger a spurious folder trust dialog if the directory was specified using `~`.

New behavior:
<img width="802" height="578" alt="image" src="https://github.com/user-attachments/assets/f4186eb3-174c-4efb-8d0e-e0bb0ac537b7" />
