### PR TITLE
fix(core): use prefix matching for OAuth resource validation

### DIFF
--- a/packages/core/src/mcp/oauth-utils.test.ts
+++ b/packages/core/src/mcp/oauth-utils.test.ts
@@ -288,6 +288,22 @@ describe('OAuthUtils', () => {
         scopes: ['read', 'write'],
       });
     });
+
+    it('should reject partial path segment matches', async () => {
+      // /api should not match /api-v2 (different path segment)
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            ...mockResourceMetadata,
+            resource: 'https://example.com/api-v2',
+          }),
+      });
+
+      await expect(
+        OAuthUtils.discoverOAuthConfig('https://example.com/api'),
+      ).rejects.toThrow(/is not within scope of protected resource/);
+    });
   });
 
   describe('metadataToOAuthConfig', () => {


### PR DESCRIPTION
## Summary

Use prefix matching instead of exact matching for OAuth protected resource validation, aligning with the MCP TypeScript SDK approach.

This allows servers that advertise a base resource URL (e.g., https://example.com) to be used with endpoints at sub-paths (e.g., https://example.com/mcp).

## Details

It appears as though most MCP servers do not implement the OAuth protected resource spec faithfully, returning https://mcp.foo.com for a URL that is https://mcp.foo.com/mcp.  The strict checking that is spec compliant unfortunately makes most servers like notion, stripe, etc all not work.

So this implements the same logic as https://github.com/modelcontextprotocol/typescript-sdk/blob/b2326afea6de1104b89a045c5651790490cc8cc8/packages/core/src/shared/authUtils.ts#L26

which does a prefix matching.


## Related Issues
Fixes #15754

## How to Validate

Try to connect to https://mcp.notion.com/mcp via mcp -- it should complete the oauth process.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x ] MacOS
    - [ x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
