### PR TITLE
feat(mcp/extensions): Allow users to selectively enable/disable MCP servers included in an extension( Issue #11057 & #17402)

### DIFF
--- a/packages/cli/src/commands/extensions/enable.ts
+++ b/packages/cli/src/commands/extensions/enable.ts
@@ -15,13 +15,7 @@ import {
 } from '@google/gemini-cli-core';
 import { promptForSetting } from '../../config/extensions/extensionSettings.js';
 import { exitCli } from '../utils.js';
-import {
-  McpServerEnablementManager,
-  normalizeServerId,
-} from '../../config/mcp/mcpServerEnablement.js';
-
-const GREEN = '\x1b[32m';
-const RESET = '\x1b[0m';
+import { McpServerEnablementManager } from '../../config/mcp/mcpServerEnablement.js';
 
 interface EnableArgs {
   name: string;
@@ -52,27 +46,14 @@ export async function handleEnable(args: EnableArgs) {
 
     if (extension?.mcpServers) {
       const mcpEnablementManager = McpServerEnablementManager.getInstance();
+      const enabledServers = await mcpEnablementManager.autoEnableServers(
+        Object.keys(extension.mcpServers ?? {}),
+      );
 
-      for (const serverName of Object.keys(extension.mcpServers)) {
-        const normalizedName = normalizeServerId(serverName);
-        const state =
-          await mcpEnablementManager.getDisplayState(normalizedName);
-
-        let wasDisabled = false;
-        if (state.isPersistentDisabled) {
-          await mcpEnablementManager.enable(normalizedName);
-          wasDisabled = true;
-        }
-        if (state.isSessionDisabled) {
-          mcpEnablementManager.clearSessionDisable(normalizedName);
-          wasDisabled = true;
-        }
-
-        if (wasDisabled) {
-          debugLogger.log(
-            `${GREEN}✓${RESET} MCP server '${serverName}' was disabled - now enabled.`,
-          );
-        }
+      for (const serverName of enabledServers) {
+        debugLogger.log(
+          `MCP server '${serverName}' was disabled - now enabled.`,
+        );
       }
       // Note: No restartServer() - CLI exits immediately, servers load on next session
     }

--- a/packages/cli/src/commands/mcp/enableDisable.ts
+++ b/packages/cli/src/commands/mcp/enableDisable.ts
@@ -42,21 +42,6 @@ async function handleEnable(args: Args): Promise<void> {
     return;
   }
 
-  // Check if server is from an extension
-  const serverKey = Object.keys(servers).find(
-    (key) => normalizeServerId(key) === name,
-  );
-  const server = serverKey ? servers[serverKey] : undefined;
-  if (server?.extension) {
-    debugLogger.log(
-      `${RED}Error:${RESET} Server '${args.name}' is provided by extension '${server.extension.name}'.`,
-    );
-    debugLogger.log(
-      `Use 'gemini extensions enable ${server.extension.name}' to manage this extension.`,
-    );
-    return;
-  }
-
   const result = await canLoadServer(name, {
     adminMcpEnabled: settings.merged.admin?.mcp?.enabled ?? true,
     allowedList: settings.merged.mcp?.allowed,
@@ -96,21 +81,6 @@ async function handleDisable(args: Args): Promise<void> {
   if (!normalizedServerNames.includes(name)) {
     debugLogger.log(
       `${RED}Error:${RESET} Server '${args.name}' not found. Use 'gemini mcp' to see available servers.`,
-    );
-    return;
-  }
-
-  // Check if server is from an extension
-  const serverKey = Object.keys(servers).find(
-    (key) => normalizeServerId(key) === name,
-  );
-  const server = serverKey ? servers[serverKey] : undefined;
-  if (server?.extension) {
-    debugLogger.log(
-      `${RED}Error:${RESET} Server '${args.name}' is provided by extension '${server.extension.name}'.`,
-    );
-    debugLogger.log(
-      `Use 'gemini extensions disable ${server.extension.name}' to manage this extension.`,
     );
     return;
   }

--- a/packages/cli/src/config/mcp/mcpServerEnablement.ts
+++ b/packages/cli/src/config/mcp/mcpServerEnablement.ts
@@ -324,6 +324,35 @@ export class McpServerEnablementManager {
   }
 
   /**
+   * Auto-enable any disabled MCP servers by name.
+   * Returns server names that were actually re-enabled.
+   */
+  async autoEnableServers(serverNames: string[]): Promise<string[]> {
+    const enabledServers: string[] = [];
+
+    for (const serverName of serverNames) {
+      const normalizedName = normalizeServerId(serverName);
+      const state = await this.getDisplayState(normalizedName);
+
+      let wasDisabled = false;
+      if (state.isPersistentDisabled) {
+        await this.enable(normalizedName);
+        wasDisabled = true;
+      }
+      if (state.isSessionDisabled) {
+        this.clearSessionDisable(normalizedName);
+        wasDisabled = true;
+      }
+
+      if (wasDisabled) {
+        enabledServers.push(serverName);
+      }
+    }
+
+    return enabledServers;
+  }
+
+  /**
    * Read config from file asynchronously.
    */
   private async readConfig(): Promise<McpServerEnablementConfig> {

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -413,20 +413,21 @@ async function enableAction(context: CommandContext, args: string) {
 
         if (wasDisabled) {
           enabledServers.push(serverName);
-
-          // Restart server to bring it online (use original key, not normalized)
-          if (mcpClientManager) {
-            try {
-              await mcpClientManager.restartServer(serverName);
-            } catch (error) {
-              // Show warning but continue with other servers
-              context.ui.addItem({
-                type: MessageType.WARNING,
-                text: `Failed to restart MCP server '${serverName}': ${getErrorMessage(error)}`,
-              });
-            }
-          }
         }
+      }
+
+      if (mcpClientManager && enabledServers.length > 0) {
+        const restartPromises = enabledServers.map(async (serverName) => {
+          try {
+            await mcpClientManager.restartServer(serverName);
+          } catch (error) {
+            context.ui.addItem({
+              type: MessageType.WARNING,
+              text: `Failed to restart MCP server '${serverName}': ${getErrorMessage(error)}`,
+            });
+          }
+        });
+        await Promise.all(restartPromises);
       }
 
       if (enabledServers.length > 0) {

--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -397,19 +397,6 @@ async function handleEnableDisable(
     };
   }
 
-  // Check if server is from an extension
-  const serverKey = Object.keys(servers).find(
-    (key) => normalizeServerId(key) === name,
-  );
-  const server = serverKey ? servers[serverKey] : undefined;
-  if (server?.extension) {
-    return {
-      type: 'message',
-      messageType: 'error',
-      content: `Server '${serverName}' is provided by extension '${server.extension.name}'.\nUse '/extensions ${action} ${server.extension.name}' to manage this extension.`,
-    };
-  }
-
   const manager = McpServerEnablementManager.getInstance();
 
   if (enable) {


### PR DESCRIPTION
## Summary

Follow-up to #16299. Addresses #11057(Partially fixed before) & #17402
This PR enables users to selectively disable or enable individual MCP servers within extensions using `/mcp enable/disable <mcp-server>` command or `gemini mcp enable/disable <mcp-server>` cli command. When an extension is re-enabled, any of its disabled MCP servers are also re-enabled to prevent orphaned state and sync up states of an extension and MCP servers included in it

## Details

Previously, #16299 enabled toggling of MCP servers but blocked users from disabling extension MCP servers to prevent orphaned configurations. This follow-up removes that restriction and instead handles the orphaned state by auto-enabling MCP servers when the parent extension is enabled.

**Changes:**

- Remove blocking that prevented disable/enable of extension MCP servers
- Add auto-enable logic to `gemini extensions enable` command
- Add auto-enable logic to `/extensions enable` slash command (with server restart)
- Handle both persistent and session disables

## Related Issues
Fixes https://github.com/google-gemini/gemini-cli/issues/11057 (Partially fixed before) & https://github.com/google-gemini/gemini-cli/issues/17402

**Key files changed:**

- `packages/cli/src/commands/extensions/enable.ts` - CLI auto-enable logic
- `packages/cli/src/ui/commands/extensionsCommand.ts` - Slash command auto-enable logic
- `packages/cli/src/commands/mcp/enableDisable.ts` - Remove extension blocking
- `packages/cli/src/ui/commands/mcpCommand.ts` - Remove extension blocking


## How to Validate

```bash
# 1. Disable an extension's MCP server (now allowed)
gemini mcp disable <extension-mcp-server>
# Expected: ✓ MCP server '<name>' disabled.

# 2. Verify it's disabled
gemini mcp list
# Expected: Server shows as Disabled

# 3. Enable the extension (triggers auto-enable)
gemini extensions enable <extension-name>
# Expected:
#   ✓ MCP server '<name>' was disabled - now enabled.
#   Extension "<name>" successfully enabled in all scopes.

# 4. Verify MCP server is enabled
gemini mcp list
# Expected: Server shows as Connected
```

**Edge cases:**

- Multiple MCP servers in extension: All disabled servers are re-enabled
- MCP server already enabled: No message shown, no action taken
- Session + persistent disable: Both are cleared

## Test Coverage

**Unit tests added:** 2 new tests in `enable.test.ts`
- `should enable any disabled MCP servers for the extension when extension is enabled`
- `should not call enable when MCP servers are already enabled`

**Test suite results:** 4529 passed, 2 skipped

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
