### PR TITLE
fix(core): Normalize Unicode paths for consistent handling

### DIFF
--- a/packages/cli/src/config/trustedFolders.ts
+++ b/packages/cli/src/config/trustedFolders.ts
@@ -13,6 +13,7 @@ import {
   ideContextStore,
   GEMINI_DIR,
   homedir,
+  normalizePath,
 } from '@google/gemini-cli-core';
 import type { Settings } from './settings.js';
 import stripJsonComments from 'strip-json-comments';
@@ -117,7 +118,7 @@ export class LoadedTrustedFolders {
     }
 
     for (const untrustedPath of untrustedPaths) {
-      if (path.normalize(location) === path.normalize(untrustedPath)) {
+      if (normalizePath(location) === normalizePath(untrustedPath)) {
         return false;
       }
     }

--- a/packages/cli/src/services/FileCommandLoader.test.ts
+++ b/packages/cli/src/services/FileCommandLoader.test.ts
@@ -1094,6 +1094,27 @@ describe('FileCommandLoader', () => {
         ),
       ).rejects.toThrow('Something else went wrong');
     });
+
+    it('should correctly generate command names from paths with unicode characters', async () => {
+      const userCommandsDir = Storage.getUserCommandsDir();
+      const unicodeDirName = '테스트';
+      const unicodeDirPath = path.join(userCommandsDir, unicodeDirName);
+      const tomlFileName = 'my-cmd.toml';
+      const tomlFilePath = path.join(unicodeDirPath, tomlFileName);
+
+      mock({
+        [tomlFilePath]: 'prompt = "A test prompt"',
+      });
+
+      const loader = new FileCommandLoader(null);
+      const commands = await loader.loadCommands(signal);
+
+      expect(commands).toHaveLength(1);
+      // The command name should be correctly formed using the unicode directory name
+      expect(commands[0].name).toBe(
+        `${unicodeDirName}:${tomlFileName.replace('.toml', '')}`,
+      );
+    });
     it('assembles the processor pipeline in the correct order (AtFile -> Shell -> Default)', async () => {
       const userCommandsDir = Storage.getUserCommandsDir();
       mock({

--- a/packages/cli/src/services/FileCommandLoader.ts
+++ b/packages/cli/src/services/FileCommandLoader.ts
@@ -237,7 +237,7 @@ export class FileCommandLoader implements ICommandLoader {
       // Sanitize each path segment to prevent ambiguity, replacing non-allowlisted characters with underscores.
       // Since ':' is our namespace separator, this ensures that colons do not cause naming conflicts.
       .map((segment) => {
-        let sanitized = segment.replace(/[^a-zA-Z0-9_\-.]/g, '_');
+        let sanitized = segment.replace(/[^\p{L}\p{N}_\-.]/gu, '_');
 
         // Truncate excessively long segments to prevent UI overflow
         if (sanitized.length > 50) {

--- a/packages/cli/src/services/FileCommandLoader.ts
+++ b/packages/cli/src/services/FileCommandLoader.ts
@@ -10,7 +10,7 @@ import toml from '@iarna/toml';
 import { glob } from 'glob';
 import { z } from 'zod';
 import type { Config } from '@google/gemini-cli-core';
-import { Storage, coreEvents } from '@google/gemini-cli-core';
+import { Storage, coreEvents, normalizePath } from '@google/gemini-cli-core';
 import type { ICommandLoader } from './types.js';
 import type {
   CommandContext,
@@ -224,7 +224,10 @@ export class FileCommandLoader implements ICommandLoader {
 
     const validDef = validationResult.data;
 
-    const relativePathWithExt = path.relative(baseDir, filePath);
+    const relativePathWithExt = path.relative(
+      normalizePath(baseDir),
+      normalizePath(filePath),
+    );
     const relativePath = relativePathWithExt.substring(
       0,
       relativePathWithExt.length - 5, // length of '.toml'

--- a/packages/cli/src/utils/resolvePath.test.ts
+++ b/packages/cli/src/utils/resolvePath.test.ts
@@ -13,9 +13,14 @@ vi.mock('node:os', () => ({
   homedir: vi.fn(),
 }));
 
-vi.mock('@google/gemini-cli-core', () => ({
-  homedir: () => os.homedir(),
-}));
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    homedir: () => os.homedir(),
+  };
+});
 
 describe('resolvePath', () => {
   beforeEach(() => {

--- a/packages/cli/src/utils/resolvePath.ts
+++ b/packages/cli/src/utils/resolvePath.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as path from 'node:path';
 import { homedir } from '@google/gemini-cli-core';
+import { normalizePath } from '@google/gemini-cli-core';
 
 export function resolvePath(p: string): string {
   if (!p) {
@@ -17,5 +17,5 @@ export function resolvePath(p: string): string {
   } else if (p === '~' || p.startsWith('~/')) {
     expandedPath = homedir() + p.substring(1);
   }
-  return path.normalize(expandedPath);
+  return normalizePath(expandedPath);
 }

--- a/packages/cli/src/utils/resolvePath.ts
+++ b/packages/cli/src/utils/resolvePath.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { homedir } from '@google/gemini-cli-core';
-import { normalizePath } from '@google/gemini-cli-core';
+import { homedir, normalizePath } from '@google/gemini-cli-core';
 
 export function resolvePath(p: string): string {
   if (!p) {

--- a/packages/core/src/config/flashFallback.test.ts
+++ b/packages/core/src/config/flashFallback.test.ts
@@ -26,6 +26,7 @@ describe('Flash Model Fallback Configuration', () => {
     vi.mocked(fs.statSync).mockReturnValue({
       isDirectory: () => true,
     } as fs.Stats);
+    vi.mocked(fs.realpathSync).mockImplementation((path) => path as string);
     config = new Config({
       sessionId: 'test-session',
       targetDir: '/test',

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -200,6 +200,7 @@ describe('ToolRegistry', () => {
     vi.mocked(fs.statSync).mockReturnValue({
       isDirectory: () => true,
     } as fs.Stats);
+    vi.mocked(fs.realpathSync).mockImplementation((path) => path as string);
     config = new Config(baseConfigParams);
     toolRegistry = new ToolRegistry(config, mockMessageBus);
     vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -179,9 +179,15 @@ describe('fileUtils', () => {
       const pathInsideNFC = pathInside.normalize('NFC');
 
       expect(isWithinRoot(pathInsideNFC, rootNFD)).toBe(true);
-      expect(isWithinRoot(pathInside.normalize('NFD'), root.normalize('NFD'))).toBe(true);
-      expect(isWithinRoot(pathInside.normalize('NFC'), root.normalize('NFC'))).toBe(true);
-      expect(isWithinRoot(pathInside.normalize('NFD'), root.normalize('NFC'))).toBe(true);
+      expect(
+        isWithinRoot(pathInside.normalize('NFD'), root.normalize('NFD')),
+      ).toBe(true);
+      expect(
+        isWithinRoot(pathInside.normalize('NFC'), root.normalize('NFC')),
+      ).toBe(true);
+      expect(
+        isWithinRoot(pathInside.normalize('NFD'), root.normalize('NFC')),
+      ).toBe(true);
 
       const pathOutside = '/project/다른폴더/file.txt';
       expect(isWithinRoot(pathOutside, rootNFD)).toBe(false);

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -170,6 +170,22 @@ describe('fileUtils', () => {
         expect(isWithinRoot(testPath, root || defaultRoot)).toBe(expected);
       },
     );
+
+    it('handles unicode normalization differences', () => {
+      const root = '/project/테스트';
+      const pathInside = '/project/테스트/file.txt';
+
+      const rootNFD = root.normalize('NFD');
+      const pathInsideNFC = pathInside.normalize('NFC');
+
+      expect(isWithinRoot(pathInsideNFC, rootNFD)).toBe(true);
+      expect(isWithinRoot(pathInside.normalize('NFD'), root.normalize('NFD'))).toBe(true);
+      expect(isWithinRoot(pathInside.normalize('NFC'), root.normalize('NFC'))).toBe(true);
+      expect(isWithinRoot(pathInside.normalize('NFD'), root.normalize('NFC'))).toBe(true);
+
+      const pathOutside = '/project/다른폴더/file.txt';
+      expect(isWithinRoot(pathOutside, rootNFD)).toBe(false);
+    });
   });
 
   describe('fileExists', () => {

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -13,6 +13,8 @@ import mime from 'mime/lite';
 import type { FileSystemService } from '../services/fileSystemService.js';
 import { ToolErrorType } from '../tools/tool-error.js';
 import { BINARY_EXTENSIONS } from './ignorePatterns.js';
+import { normalizePath } from './paths.js';
+
 import { createRequire as createModuleRequire } from 'node:module';
 import { debugLogger } from './debugLogger.js';
 
@@ -211,20 +213,23 @@ export function isWithinRoot(
   pathToCheck: string,
   rootDirectory: string,
 ): boolean {
-  const normalizedPathToCheck = path.resolve(pathToCheck);
-  const normalizedRootDirectory = path.resolve(rootDirectory);
+  const resolvedPathToCheck = path.resolve(pathToCheck);
+  const resolvedRootDirectory = path.resolve(rootDirectory);
+
+  // Normalize paths to NFC to ensure consistent comparison.
+  const nfcPathToCheck = normalizePath(resolvedPathToCheck);
+  const nfcRootDirectory = normalizePath(resolvedRootDirectory);
 
   // Ensure the rootDirectory path ends with a separator for correct startsWith comparison,
   // unless it's the root path itself (e.g., '/' or 'C:\').
   const rootWithSeparator =
-    normalizedRootDirectory === path.sep ||
-    normalizedRootDirectory.endsWith(path.sep)
-      ? normalizedRootDirectory
-      : normalizedRootDirectory + path.sep;
+    nfcRootDirectory === path.sep || nfcRootDirectory.endsWith(path.sep)
+      ? nfcRootDirectory
+      : nfcRootDirectory + path.sep;
 
   return (
-    normalizedPathToCheck === normalizedRootDirectory ||
-    normalizedPathToCheck.startsWith(rootWithSeparator)
+    nfcPathToCheck === nfcRootDirectory ||
+    nfcPathToCheck.startsWith(rootWithSeparator)
   );
 }
 

--- a/packages/core/src/utils/flashFallback.test.ts
+++ b/packages/core/src/utils/flashFallback.test.ts
@@ -33,6 +33,7 @@ describe('Retry Utility Fallback Integration', () => {
     vi.mocked(fs.statSync).mockReturnValue({
       isDirectory: () => true,
     } as fs.Stats);
+    vi.mocked(fs.realpathSync).mockImplementation((path) => path as string);
     config = new Config({
       sessionId: 'test-session',
       targetDir: '/test',

--- a/packages/core/src/utils/geminiIgnoreParser.test.ts
+++ b/packages/core/src/utils/geminiIgnoreParser.test.ts
@@ -131,4 +131,24 @@ describe('GeminiIgnoreParser', () => {
       expect(parser.hasPatterns()).toBe(false);
     });
   });
+
+  describe('with unicode paths', () => {
+    it('handles unicode normalization differences', async () => {
+      const unicodeDirName = '테스트';
+      const geminiIgnoreContent = `${unicodeDirName}/\n`;
+      await createTestFile('.geminiignore', geminiIgnoreContent);
+
+      const parser = new GeminiIgnoreParser(projectRoot);
+
+      const filePathNFD = path.join(unicodeDirName, 'file.txt').normalize('NFD');
+
+      // The parser should ignore the file even if the path has a different
+      // normalization form than the pattern in .geminiignore.
+      expect(parser.isIgnored(filePathNFD)).toBe(true);
+
+      // A file in a different unicode-named directory should not be ignored.
+      const otherFilePath = path.join('다른폴더', 'file.txt');
+      expect(parser.isIgnored(otherFilePath)).toBe(false);
+    });
+  });
 });

--- a/packages/core/src/utils/geminiIgnoreParser.test.ts
+++ b/packages/core/src/utils/geminiIgnoreParser.test.ts
@@ -140,7 +140,9 @@ describe('GeminiIgnoreParser', () => {
 
       const parser = new GeminiIgnoreParser(projectRoot);
 
-      const filePathNFD = path.join(unicodeDirName, 'file.txt').normalize('NFD');
+      const filePathNFD = path
+        .join(unicodeDirName, 'file.txt')
+        .normalize('NFD');
 
       // The parser should ignore the file even if the path has a different
       // normalization form than the pattern in .geminiignore.

--- a/packages/core/src/utils/geminiIgnoreParser.ts
+++ b/packages/core/src/utils/geminiIgnoreParser.ts
@@ -7,6 +7,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import ignore from 'ignore';
+import { normalizePath } from './paths.js';
+
 
 export interface GeminiIgnoreFilter {
   isIgnored(filePath: string): boolean;
@@ -21,7 +23,7 @@ export class GeminiIgnoreParser implements GeminiIgnoreFilter {
   private ig = ignore();
 
   constructor(projectRoot: string) {
-    this.projectRoot = path.resolve(projectRoot);
+    this.projectRoot = normalizePath(path.resolve(projectRoot));
     this.loadPatterns();
   }
 
@@ -61,7 +63,7 @@ export class GeminiIgnoreParser implements GeminiIgnoreFilter {
     }
 
     const resolved = path.resolve(this.projectRoot, filePath);
-    const relativePath = path.relative(this.projectRoot, resolved);
+    const relativePath = path.relative(this.projectRoot, normalizePath(resolved));
 
     if (relativePath === '' || relativePath.startsWith('..')) {
       return false;

--- a/packages/core/src/utils/geminiIgnoreParser.ts
+++ b/packages/core/src/utils/geminiIgnoreParser.ts
@@ -9,7 +9,6 @@ import * as path from 'node:path';
 import ignore from 'ignore';
 import { normalizePath } from './paths.js';
 
-
 export interface GeminiIgnoreFilter {
   isIgnored(filePath: string): boolean;
   getPatterns(): string[];
@@ -63,7 +62,10 @@ export class GeminiIgnoreParser implements GeminiIgnoreFilter {
     }
 
     const resolved = path.resolve(this.projectRoot, filePath);
-    const relativePath = path.relative(this.projectRoot, normalizePath(resolved));
+    const relativePath = path.relative(
+      this.projectRoot,
+      normalizePath(resolved),
+    );
 
     if (relativePath === '' || relativePath.startsWith('..')) {
       return false;

--- a/packages/core/src/utils/gitIgnoreParser.test.ts
+++ b/packages/core/src/utils/gitIgnoreParser.test.ts
@@ -174,7 +174,9 @@ src/*.tmp
       const gitignoreContent = `${unicodeDirName}/\n`;
       await createTestFile('.gitignore', gitignoreContent);
 
-      const filePathNFD = path.join(unicodeDirName, 'file.txt').normalize('NFD');
+      const filePathNFD = path
+        .join(unicodeDirName, 'file.txt')
+        .normalize('NFD');
 
       // The parser should ignore the file even if the path has a different
       // normalization form than the pattern in .gitignore.

--- a/packages/core/src/utils/gitIgnoreParser.test.ts
+++ b/packages/core/src/utils/gitIgnoreParser.test.ts
@@ -168,6 +168,22 @@ src/*.tmp
       expect(() => parser.isIgnored('/backslash-file-test.txt')).not.toThrow();
       expect(parser.isIgnored('/backslash-file-test.txt')).toBe(false);
     });
+
+    it('handles unicode normalization differences', async () => {
+      const unicodeDirName = '테스트';
+      const gitignoreContent = `${unicodeDirName}/\n`;
+      await createTestFile('.gitignore', gitignoreContent);
+
+      const filePathNFD = path.join(unicodeDirName, 'file.txt').normalize('NFD');
+
+      // The parser should ignore the file even if the path has a different
+      // normalization form than the pattern in .gitignore.
+      expect(parser.isIgnored(filePathNFD)).toBe(true);
+
+      // A file in a different unicode-named directory should not be ignored.
+      const otherFilePath = path.join('다른폴더', 'file.txt');
+      expect(parser.isIgnored(otherFilePath)).toBe(false);
+    });
   });
 
   describe('nested .gitignore files', () => {

--- a/packages/core/src/utils/gitIgnoreParser.ts
+++ b/packages/core/src/utils/gitIgnoreParser.ts
@@ -48,7 +48,9 @@ export class GitIgnoreParser implements GitIgnoreFilter {
     const relativeBaseDir = isExcludeFile
       ? '.'
       : path
-          .dirname(path.relative(this.projectRoot, normalizePath(patternsFilePath)))
+          .dirname(
+            path.relative(this.projectRoot, normalizePath(patternsFilePath)),
+          )
           .split(path.sep)
           .join(path.posix.sep);
 
@@ -128,7 +130,10 @@ export class GitIgnoreParser implements GitIgnoreFilter {
 
     try {
       const resolved = path.resolve(this.projectRoot, filePath);
-      const relativePath = path.relative(this.projectRoot, normalizePath(resolved));
+      const relativePath = path.relative(
+        this.projectRoot,
+        normalizePath(resolved),
+      );
 
       if (relativePath === '' || relativePath.startsWith('..')) {
         return false;

--- a/packages/core/src/utils/gitIgnoreParser.ts
+++ b/packages/core/src/utils/gitIgnoreParser.ts
@@ -7,6 +7,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import ignore, { type Ignore } from 'ignore';
+import { normalizePath } from './paths.js';
 
 export interface GitIgnoreFilter {
   isIgnored(filePath: string): boolean;
@@ -22,7 +23,7 @@ export class GitIgnoreParser implements GitIgnoreFilter {
     projectRoot: string,
     private readonly extraPatterns?: string[],
   ) {
-    this.projectRoot = path.resolve(projectRoot);
+    this.projectRoot = normalizePath(path.resolve(projectRoot));
     this.processedExtraPatterns = ignore();
     if (this.extraPatterns) {
       // extraPatterns are assumed to be from project root (like .geminiignore)
@@ -47,7 +48,7 @@ export class GitIgnoreParser implements GitIgnoreFilter {
     const relativeBaseDir = isExcludeFile
       ? '.'
       : path
-          .dirname(path.relative(this.projectRoot, patternsFilePath))
+          .dirname(path.relative(this.projectRoot, normalizePath(patternsFilePath)))
           .split(path.sep)
           .join(path.posix.sep);
 
@@ -127,7 +128,7 @@ export class GitIgnoreParser implements GitIgnoreFilter {
 
     try {
       const resolved = path.resolve(this.projectRoot, filePath);
-      const relativePath = path.relative(this.projectRoot, resolved);
+      const relativePath = path.relative(this.projectRoot, normalizePath(resolved));
 
       if (relativePath === '' || relativePath.startsWith('..')) {
         return false;
@@ -170,7 +171,7 @@ export class GitIgnoreParser implements GitIgnoreFilter {
       }
 
       for (const dir of dirsToVisit) {
-        const relativeDir = path.relative(this.projectRoot, dir);
+        const relativeDir = path.relative(this.projectRoot, normalizePath(dir));
         if (relativeDir) {
           const normalizedRelativeDir = relativeDir.replace(/\\/g, '/');
           const igPlusExtras = ignore()

--- a/packages/core/src/utils/memoryImportProcessor.ts
+++ b/packages/core/src/utils/memoryImportProcessor.ts
@@ -6,7 +6,7 @@
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { isSubpath } from './paths.js';
+import { isSubpath, normalizePath } from './paths.js';
 import { debugLogger } from './debugLogger.js';
 
 // Simple console logger for import processing
@@ -217,7 +217,7 @@ export async function processImports(
       depth: number,
     ) {
       // Normalize the file path to ensure consistent comparison
-      const normalizedPath = path.normalize(filePath);
+      const normalizedPath = normalizePath(filePath);
 
       // Skip if already processed
       if (processedFiles.has(normalizedPath)) return;
@@ -254,7 +254,7 @@ export async function processImports(
         }
 
         const fullPath = path.resolve(fileBasePath, importPath);
-        const normalizedFullPath = path.normalize(fullPath);
+        const normalizedFullPath = normalizePath(fullPath);
 
         // Skip if already processed
         if (processedFiles.has(normalizedFullPath)) continue;
@@ -282,7 +282,7 @@ export async function processImports(
     }
 
     // Start with the root file (current file)
-    const rootPath = path.normalize(
+    const rootPath = normalizePath(
       importState.currentFile || path.resolve(basePath),
     );
     await processFlat(content, basePath, rootPath, 0);

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -193,6 +193,24 @@ describe('isSubpath', () => {
     expect(isSubpath('/a/b', '/a/b/c/')).toBe(true);
     expect(isSubpath('/a/b/', '/a/b/c/')).toBe(true);
   });
+
+  it('handles unicode normalization differences (NFC)',
+    () => {
+      const parent = '/Users/user/테스트';
+      const child = '/Users/user/테스트/gemini-cli';
+
+      const parentNFD = parent.normalize('NFD');
+      const childNFC = child.normalize('NFC');
+
+      expect(isSubpath(parentNFD, childNFC)).toBe(true);
+      expect(isSubpath(childNFC, parentNFD)).toBe(false);
+
+      const unrelated = '/Users/user/다른폴더';
+
+      const unrelatedNFC = unrelated.normalize('NFC');
+      expect(isSubpath(parentNFD, unrelatedNFC)).toBe(false);
+    },
+  );
 });
 
 describe('isSubpath on Windows', () => {

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -194,23 +194,21 @@ describe('isSubpath', () => {
     expect(isSubpath('/a/b/', '/a/b/c/')).toBe(true);
   });
 
-  it('handles unicode normalization differences (NFC)',
-    () => {
-      const parent = '/Users/user/테스트';
-      const child = '/Users/user/테스트/gemini-cli';
+  it('handles unicode normalization differences (NFC)', () => {
+    const parent = '/Users/user/테스트';
+    const child = '/Users/user/테스트/gemini-cli';
 
-      const parentNFD = parent.normalize('NFD');
-      const childNFC = child.normalize('NFC');
+    const parentNFD = parent.normalize('NFD');
+    const childNFC = child.normalize('NFC');
 
-      expect(isSubpath(parentNFD, childNFC)).toBe(true);
-      expect(isSubpath(childNFC, parentNFD)).toBe(false);
+    expect(isSubpath(parentNFD, childNFC)).toBe(true);
+    expect(isSubpath(childNFC, parentNFD)).toBe(false);
 
-      const unrelated = '/Users/user/다른폴더';
+    const unrelated = '/Users/user/다른폴더';
 
-      const unrelatedNFC = unrelated.normalize('NFC');
-      expect(isSubpath(parentNFD, unrelatedNFC)).toBe(false);
-    },
-  );
+    const unrelatedNFC = unrelated.normalize('NFC');
+    expect(isSubpath(parentNFD, unrelatedNFC)).toBe(false);
+  });
 });
 
 describe('isSubpath on Windows', () => {

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -5,7 +5,13 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { escapePath, unescapePath, isSubpath, shortenPath } from './paths.js';
+import {
+  escapePath,
+  unescapePath,
+  isSubpath,
+  shortenPath,
+  makeRelative,
+} from './paths.js';
 
 describe('escapePath', () => {
   it.each([
@@ -208,6 +214,30 @@ describe('isSubpath', () => {
 
     const unrelatedNFC = unrelated.normalize('NFC');
     expect(isSubpath(parentNFD, unrelatedNFC)).toBe(false);
+  });
+});
+
+describe('makeRelative', () => {
+  it('handles unicode normalization differences', () => {
+    const root = '/Users/user/테스트';
+    const target = '/Users/user/테스트/gemini-cli';
+
+    const rootNFD = root.normalize('NFD');
+    const targetNFC = target.normalize('NFC');
+
+    // The expected relative path should be 'gemini-cli' regardless of normalization
+    const expected = 'gemini-cli';
+
+    expect(makeRelative(targetNFC, rootNFD)).toBe(expected);
+    expect(makeRelative(target.normalize('NFD'), root.normalize('NFD'))).toBe(
+      expected,
+    );
+    expect(makeRelative(target.normalize('NFC'), root.normalize('NFC'))).toBe(
+      expected,
+    );
+    expect(makeRelative(target.normalize('NFD'), root.normalize('NFC'))).toBe(
+      expected,
+    );
   });
 });
 

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -40,6 +40,17 @@ export function tmpdir(): string {
 }
 
 /**
+ * Consistently normalizes a path to NFC to prevent issues with different
+ * Unicode normalization forms between filesystems (like macOS's NFD) and
+ * other systems.
+ * @param p The path to normalize.
+ * @returns The NFC-normalized path.
+ */
+export function normalizePath(p: string): string {
+  return p.normalize('NFC');
+}
+
+/**
  * Replaces the home directory with a tilde.
  * @param path - The path to tildeify.
  * @returns The tildeified path.
@@ -269,7 +280,11 @@ export function makeRelative(
     return targetPath;
   }
   const resolvedRootDirectory = path.resolve(rootDirectory);
-  const relativePath = path.relative(resolvedRootDirectory, targetPath);
+
+  const relativePath = path.relative(
+    normalizePath(resolvedRootDirectory),
+    normalizePath(targetPath),
+  );
 
   // If the paths are the same, path.relative returns '', return '.' instead
   return relativePath || '.';
@@ -334,11 +349,11 @@ export function isSubpath(parentPath: string, childPath: string): boolean {
   const isWindows = os.platform() === 'win32';
   const pathModule = isWindows ? path.win32 : path;
 
-  const normalizedParent = parentPath.normalize('NFC');
-  const normalizedChild = childPath.normalize('NFC');
-
   // On Windows, path.relative is case-insensitive. On POSIX, it's case-sensitive.
-  const relative = pathModule.relative(normalizedParent, normalizedChild);
+  const relative = pathModule.relative(
+    normalizePath(parentPath),
+    normalizePath(childPath),
+  );
 
   return (
     !relative.startsWith(`..${pathModule.sep}`) &&

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -334,8 +334,11 @@ export function isSubpath(parentPath: string, childPath: string): boolean {
   const isWindows = os.platform() === 'win32';
   const pathModule = isWindows ? path.win32 : path;
 
+  const normalizedParent = parentPath.normalize('NFC');
+  const normalizedChild = childPath.normalize('NFC');
+
   // On Windows, path.relative is case-insensitive. On POSIX, it's case-sensitive.
-  const relative = pathModule.relative(parentPath, childPath);
+  const relative = pathModule.relative(normalizedParent, normalizedChild);
 
   return (
     !relative.startsWith(`..${pathModule.sep}`) &&

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -47,7 +47,11 @@ export function tmpdir(): string {
  * @returns The NFC-normalized path.
  */
 export function normalizePath(p: string): string {
-  return p.normalize('NFC');
+  if (!p) {
+    return p;
+  }
+  const normalizedPath = path.normalize(p);
+  return normalizedPath.normalize('NFC');
 }
 
 /**

--- a/packages/core/src/utils/workspaceContext.test.ts
+++ b/packages/core/src/utils/workspaceContext.test.ts
@@ -10,7 +10,6 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { WorkspaceContext } from './workspaceContext.js';
 import { debugLogger } from './debugLogger.js';
-import { normalizePath } from './paths.js';
 
 describe('WorkspaceContext with real filesystem', () => {
   let tempDir: string;
@@ -197,7 +196,7 @@ describe('WorkspaceContext with real filesystem', () => {
 
       // There should be only one entry for the unicode directory, plus the initial cwd.
       expect(directories).toHaveLength(2);
-      expect(directories).toContain(normalizePath(unicodeDirPath));
+      expect(directories).toContain(unicodeDirPath.normalize('NFC'));
     });
 
     describe.skipIf(os.platform() === 'win32')('with symbolic link', () => {

--- a/packages/core/src/utils/workspaceContext.test.ts
+++ b/packages/core/src/utils/workspaceContext.test.ts
@@ -177,6 +177,14 @@ describe('WorkspaceContext with real filesystem', () => {
       expect(workspaceContext.isPathWithinWorkspace(pathInsideNFC)).toBe(true);
       expect(workspaceContext.isPathWithinWorkspace(pathInsideNFD)).toBe(true);
 
+      // Test with a root directory that is NFD
+      const workspaceContextNFD = new WorkspaceContext(
+        unicodeDirPath.normalize('NFD'),
+      );
+      expect(workspaceContextNFD.isPathWithinWorkspace(pathInsideNFC)).toBe(
+        true,
+      );
+
       const pathOutside = path.join(tempDir, '다른폴더', 'file.txt');
       expect(workspaceContext.isPathWithinWorkspace(pathOutside)).toBe(false);
     });

--- a/packages/core/src/utils/workspaceContext.test.ts
+++ b/packages/core/src/utils/workspaceContext.test.ts
@@ -162,6 +162,31 @@ describe('WorkspaceContext with real filesystem', () => {
       );
     });
 
+    it('should handle unicode normalization differences', () => {
+      const unicodeDirName = '테스트';
+      const unicodeDirPath = path.join(tempDir, unicodeDirName);
+      fs.mkdirSync(unicodeDirPath, { recursive: true });
+
+      const workspaceContext = new WorkspaceContext(unicodeDirPath);
+
+      const pathInsideNFC = path.join(unicodeDirPath, 'file.txt').normalize('NFC');
+      const pathInsideNFD = path.join(unicodeDirPath, 'file.txt').normalize('NFD');
+
+      // Test both NFC and NFD forms of a path inside the workspace
+      expect(workspaceContext.isPathWithinWorkspace(pathInsideNFC)).toBe(true);
+      expect(workspaceContext.isPathWithinWorkspace(pathInsideNFD)).toBe(true);
+
+      // Test with a root directory that is NFD
+      const workspaceContextNFD = new WorkspaceContext(
+        unicodeDirPath.normalize('NFD'),
+      );
+      expect(workspaceContextNFD.isPathWithinWorkspace(pathInsideNFC)).toBe(true);
+
+      // Test a path outside the workspace
+      const pathOutside = path.join(tempDir, '다른폴더', 'file.txt');
+      expect(workspaceContext.isPathWithinWorkspace(pathOutside)).toBe(false);
+    });
+
     describe.skipIf(os.platform() === 'win32')('with symbolic link', () => {
       describe('in the workspace', () => {
         let realDir: string;

--- a/packages/core/src/utils/workspaceContext.test.ts
+++ b/packages/core/src/utils/workspaceContext.test.ts
@@ -169,8 +169,12 @@ describe('WorkspaceContext with real filesystem', () => {
 
       const workspaceContext = new WorkspaceContext(unicodeDirPath);
 
-      const pathInsideNFC = path.join(unicodeDirPath, 'file.txt').normalize('NFC');
-      const pathInsideNFD = path.join(unicodeDirPath, 'file.txt').normalize('NFD');
+      const pathInsideNFC = path
+        .join(unicodeDirPath, 'file.txt')
+        .normalize('NFC');
+      const pathInsideNFD = path
+        .join(unicodeDirPath, 'file.txt')
+        .normalize('NFD');
 
       // Test both NFC and NFD forms of a path inside the workspace
       expect(workspaceContext.isPathWithinWorkspace(pathInsideNFC)).toBe(true);
@@ -180,7 +184,9 @@ describe('WorkspaceContext with real filesystem', () => {
       const workspaceContextNFD = new WorkspaceContext(
         unicodeDirPath.normalize('NFD'),
       );
-      expect(workspaceContextNFD.isPathWithinWorkspace(pathInsideNFC)).toBe(true);
+      expect(workspaceContextNFD.isPathWithinWorkspace(pathInsideNFC)).toBe(
+        true,
+      );
 
       // Test a path outside the workspace
       const pathOutside = path.join(tempDir, '다른폴더', 'file.txt');

--- a/packages/core/src/utils/workspaceContext.test.ts
+++ b/packages/core/src/utils/workspaceContext.test.ts
@@ -177,7 +177,6 @@ describe('WorkspaceContext with real filesystem', () => {
       expect(workspaceContext.isPathWithinWorkspace(pathInsideNFC)).toBe(true);
       expect(workspaceContext.isPathWithinWorkspace(pathInsideNFD)).toBe(true);
 
-      // Test with a root directory that is NFD
       const workspaceContextNFD = new WorkspaceContext(
         unicodeDirPath.normalize('NFD'),
       );

--- a/packages/core/src/utils/workspaceContext.test.ts
+++ b/packages/core/src/utils/workspaceContext.test.ts
@@ -166,30 +166,18 @@ describe('WorkspaceContext with real filesystem', () => {
     it('should handle unicode normalization differences', () => {
       const unicodeDirName = '테스트';
       const unicodeDirPath = path.join(tempDir, unicodeDirName);
+      const unicodeFilePath = path.join(unicodeDirPath, 'file.txt');
       fs.mkdirSync(unicodeDirPath, { recursive: true });
+      fs.writeFileSync(unicodeFilePath, '');
 
       const workspaceContext = new WorkspaceContext(unicodeDirPath);
 
-      const pathInsideNFC = path
-        .join(unicodeDirPath, 'file.txt')
-        .normalize('NFC');
-      const pathInsideNFD = path
-        .join(unicodeDirPath, 'file.txt')
-        .normalize('NFD');
+      const pathInsideNFC = unicodeFilePath.normalize('NFC');
+      const pathInsideNFD = unicodeFilePath.normalize('NFD');
 
-      // Test both NFC and NFD forms of a path inside the workspace
       expect(workspaceContext.isPathWithinWorkspace(pathInsideNFC)).toBe(true);
       expect(workspaceContext.isPathWithinWorkspace(pathInsideNFD)).toBe(true);
 
-      // Test with a root directory that is NFD
-      const workspaceContextNFD = new WorkspaceContext(
-        unicodeDirPath.normalize('NFD'),
-      );
-      expect(workspaceContextNFD.isPathWithinWorkspace(pathInsideNFC)).toBe(
-        true,
-      );
-
-      // Test a path outside the workspace
       const pathOutside = path.join(tempDir, '다른폴더', 'file.txt');
       expect(workspaceContext.isPathWithinWorkspace(pathOutside)).toBe(false);
     });

--- a/packages/core/src/utils/workspaceContext.ts
+++ b/packages/core/src/utils/workspaceContext.ts
@@ -10,7 +10,6 @@ import * as path from 'node:path';
 import { debugLogger } from './debugLogger.js';
 import { normalizePath } from './paths.js';
 
-
 export type Unsubscribe = () => void;
 
 export interface AddDirectoriesResult {

--- a/packages/core/src/utils/workspaceContext.ts
+++ b/packages/core/src/utils/workspaceContext.ts
@@ -8,6 +8,8 @@ import { isNodeError } from '../utils/errors.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { debugLogger } from './debugLogger.js';
+import { normalizePath } from './paths.js';
+
 
 export type Unsubscribe = () => void;
 
@@ -208,7 +210,10 @@ export class WorkspaceContext {
     pathToCheck: string,
     rootDirectory: string,
   ): boolean {
-    const relative = path.relative(rootDirectory, pathToCheck);
+    const relative = path.relative(
+      normalizePath(rootDirectory),
+      normalizePath(pathToCheck),
+    );
     return (
       !relative.startsWith(`..${path.sep}`) &&
       relative !== '..' &&

--- a/packages/core/src/utils/workspaceContext.ts
+++ b/packages/core/src/utils/workspaceContext.ts
@@ -182,7 +182,8 @@ export class WorkspaceContext {
    */
   private fullyResolvedPath(pathToCheck: string): string {
     try {
-      return fs.realpathSync(path.resolve(this.targetDir, pathToCheck));
+      const resolvedPath = path.resolve(this.targetDir, pathToCheck);
+      return fs.realpathSync(normalizePath(resolvedPath));
     } catch (e: unknown) {
       if (
         isNodeError(e) &&

--- a/packages/core/src/utils/workspaceContext.ts
+++ b/packages/core/src/utils/workspaceContext.ts
@@ -128,7 +128,7 @@ export class WorkspaceContext {
     }
 
     const rawFilesystemPath = fs.realpathSync(normalizedPath);
-    return normalizePath(rawFilesystemPath);
+    return rawFilesystemPath.normalize('NFC');
   }
 
   /**

--- a/packages/core/src/utils/workspaceContext.ts
+++ b/packages/core/src/utils/workspaceContext.ts
@@ -125,7 +125,7 @@ export class WorkspaceContext {
       throw new Error(`Path is not a directory: ${absolutePath}`);
     }
 
-    return fs.realpathSync(absolutePath);
+    return normalizePath(fs.realpathSync(absolutePath));
   }
 
   /**


### PR DESCRIPTION
## TLDR

This PR fixes a Unicode normalization bug across the codebase. Path comparison
logic in several core utilities (`makeRelative`, `isWithinRoot`, ignore parsers,
etc.) was vulnerable to errors when handling paths with combining characters
like 'é' or '테스트'. This change applies a consistent NFC normalization
pattern, using a new `normalizePath` utility, to prevent these bugs and ensure
reliable path handling.

## Dive Deeper

This work expands on the initial fix applied to `isSubpath`.
(https://github.com/google-gemini/gemini-cli/pull/12084)

And this work has been rebased onto the latest main branch (as of 2026/01/24).
(https://github.com/google-gemini/gemini-cli/pull/12154)

other functions relying on string-based path comparisons were also affected by
differences in Unicode normalization between filesystems (NFD on macOS) and
Node.js strings (NFC).

**Key Changes:**

1.  **Centralized Normalization Utility:**
    - A new helper function, `normalizePath(path: string): string`, was added to
      `packages/core/src/utils/paths.ts`. This function normalizes paths to NFC
      and also applies `path.normalize()` for consistent path segment
      separators.

2.  **Core Logic Fixes:** The `normalizePath` utility was integrated into the
    following functions:
    - **`makeRelative`** (`paths.ts`): Now correctly calculates relative paths
      regardless of input normalization.
    - **`isWithinRoot`** (`fileUtils.ts`): Correctly validates if a path is
      within a root directory.
    - **`WorkspaceContext`**: the context now enforces NFC normalization in `resolveAndValidateDir` to prevent duplicate storage (one NFC, one NFD) and ensure data integrity.
    - **`isPathWithinRoot`** (`workspaceContext.ts`): Corrects workspace
      boundary checks.
    - **`gitIgnoreParser.ts`** and **`geminiIgnoreParser.ts`**: Fixes multiple
      `path.relative` calls to ensure ignore patterns are matched correctly.
    - **`memoryImportProcessor.ts`**: Ensures the project root is resolved to
      the same absolute path to fix import validation errors.
    - **`FileCommandLoader.ts`** in `packages/cli/src/services/`: Updated command name generation to correctly support Unicode characters (like Korean) in file paths.
    - **`trustedFolders.ts`** in `packages/cli/src/config/`: Uses
      `normalizePath` for reliable path comparisons.
    - **`resolvePath.ts`** in `packages/cli/src/utils/`: Uses `normalizePath` to
      correctly resolve user-provided paths.

## Reviewer Test Plan

1.  Pull down the `fix/fs-unicode-path-normalization` branch.
2.  Run the full unit test suite with `npm test`. All tests should pass.
3.  To verify the changes, you can inspect the new test cases that have been
    added to the following files, which specifically target Unicode
    normalization issues:
    - `packages/core/src/utils/paths.test.ts` (for `makeRelative`)
    - `packages/core/src/utils/fileUtils.test.ts` (for `isWithinRoot`)
    - `packages/core/src/utils/workspaceContext.test.ts` (for
      `isPathWithinWorkspace`)
    - `packages/core/src/utils/gitIgnoreParser.test.ts`
    - `packages/core/src/utils/geminiIgnoreParser.ts`
    - `packages/cli/src/services/FileCommandLoader.test.ts`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

Fixes #12153
