### PR TITLE
feat(cli): add quick clear input shortcuts in vim mode

### DIFF
--- a/packages/cli/src/ui/hooks/vim.test.tsx
+++ b/packages/cli/src/ui/hooks/vim.test.tsx
@@ -32,6 +32,20 @@ vi.mock('../contexts/VimModeContext.js', () => ({
   VimModeProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
+// Mock the SettingsContext
+vi.mock('../contexts/SettingsContext.js', () => ({
+  useSettings: () => ({
+    merged: {
+      general: {
+        vimMode: true,
+        vimKeyBindings: {
+          insertMode: [],
+        },
+      },
+    },
+  }),
+}));
+
 // Helper to create a full Key object from partial data
 const createKey = (partial: Partial<Key>): Key => ({
   name: partial.name || '',
@@ -89,6 +103,7 @@ const TEST_SEQUENCES = {
   LINE_START: createKey({ sequence: '0' }),
   LINE_END: createKey({ sequence: '$' }),
   REPEAT: createKey({ sequence: '.' }),
+  CTRL_C: createKey({ sequence: '\x03', name: 'c', ctrl: true }),
 } as const;
 
 describe('useVim hook', () => {
@@ -1613,5 +1628,142 @@ describe('useVim hook', () => {
         expect(result.cursorCol).toBe(expectedCursorCol);
       },
     );
+  });
+
+  describe('double-escape to clear buffer', () => {
+    beforeEach(() => {
+      mockBuffer = createMockBuffer('hello world');
+      mockVimContext.vimEnabled = true;
+      mockVimContext.vimMode = 'NORMAL';
+      mockHandleFinalSubmit = vi.fn();
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should clear buffer on double-escape in NORMAL mode', async () => {
+      const { result } = renderHook(() =>
+        useVim(mockBuffer as TextBuffer, mockHandleFinalSubmit),
+      );
+
+      // First escape - should pass through (return false)
+      let handled: boolean;
+      await act(async () => {
+        handled = result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+      });
+      expect(handled!).toBe(false);
+
+      // Second escape within timeout - should clear buffer (return true)
+      await act(async () => {
+        handled = result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+      });
+      expect(handled!).toBe(true);
+      expect(mockBuffer.setText).toHaveBeenCalledWith('');
+    });
+
+    it('should clear buffer on double-escape in INSERT mode', async () => {
+      mockVimContext.vimMode = 'INSERT';
+      const { result } = renderHook(() =>
+        useVim(mockBuffer as TextBuffer, mockHandleFinalSubmit),
+      );
+
+      // First escape - switches to NORMAL mode
+      let handled: boolean;
+      await act(async () => {
+        handled = result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+      });
+      expect(handled!).toBe(true);
+      expect(mockBuffer.vimEscapeInsertMode).toHaveBeenCalled();
+
+      // Second escape within timeout - should clear buffer
+      await act(async () => {
+        handled = result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+      });
+      expect(handled!).toBe(true);
+      expect(mockBuffer.setText).toHaveBeenCalledWith('');
+    });
+
+    it('should NOT clear buffer if escapes are too slow', async () => {
+      const { result } = renderHook(() =>
+        useVim(mockBuffer as TextBuffer, mockHandleFinalSubmit),
+      );
+
+      // First escape
+      await act(async () => {
+        result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+      });
+
+      // Wait longer than timeout (500ms)
+      await act(async () => {
+        vi.advanceTimersByTime(600);
+      });
+
+      // Second escape - should NOT clear buffer because timeout expired
+      let handled: boolean;
+      await act(async () => {
+        handled = result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+      });
+      // First escape of new sequence, passes through
+      expect(handled!).toBe(false);
+      expect(mockBuffer.setText).not.toHaveBeenCalled();
+    });
+
+    it('should clear escape history when clearing pending operator', async () => {
+      const { result } = renderHook(() =>
+        useVim(mockBuffer as TextBuffer, mockHandleFinalSubmit),
+      );
+
+      // First escape
+      await act(async () => {
+        result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+      });
+
+      // Type 'd' to set pending operator
+      await act(async () => {
+        result.current.handleInput(TEST_SEQUENCES.DELETE);
+      });
+
+      // Escape to clear pending operator
+      await act(async () => {
+        result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+      });
+
+      // Another escape - should NOT clear buffer (history was reset)
+      let handled: boolean;
+      await act(async () => {
+        handled = result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+      });
+      expect(handled!).toBe(false);
+      expect(mockBuffer.setText).not.toHaveBeenCalled();
+    });
+
+    it('should pass Ctrl+C through to InputPrompt in NORMAL mode', async () => {
+      const { result } = renderHook(() =>
+        useVim(mockBuffer as TextBuffer, mockHandleFinalSubmit),
+      );
+
+      let handled: boolean;
+      await act(async () => {
+        handled = result.current.handleInput(TEST_SEQUENCES.CTRL_C);
+      });
+      // Should return false to let InputPrompt handle it
+      expect(handled!).toBe(false);
+    });
+
+    it('should pass Ctrl+C through to InputPrompt in INSERT mode', async () => {
+      mockVimContext.vimMode = 'INSERT';
+      const { result } = renderHook(() =>
+        useVim(mockBuffer as TextBuffer, mockHandleFinalSubmit),
+      );
+
+      let handled: boolean;
+      await act(async () => {
+        handled = result.current.handleInput(TEST_SEQUENCES.CTRL_C);
+      });
+      // Should return false to let InputPrompt handle it
+      expect(handled!).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Add double-Escape and Ctrl+C support to clear input buffer in vim mode, matching behavior of other CLI tools.

## Details

**New shortcuts:**
- Double-Escape (within 500ms) clears entire input buffer
- Ctrl+C clears input buffer (was previously intercepted by vim mode)

Both work in INSERT and NORMAL modes.

**Key files changed:**
- `packages/cli/src/ui/hooks/vim.ts` - Added double-escape detection and Ctrl+C pass-through
- `packages/cli/src/ui/hooks/vim.test.tsx` - Added 6 new tests

## Related Issues

Fixes #17445

## How to Validate

1. Start Gemini CLI: `npm start`
2. Enable vim mode: `/vim`
3. Type some text
4. Press Escape twice quickly → buffer should clear
5. Type some text again
6. Press Ctrl+C → buffer should clear

**Edge cases:**
- Escape once, wait >500ms, Escape again → should NOT clear (just mode switch)
- With pending operator (e.g., typed `d`) → Escape → clears operator, not buffer

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker