### PR TITLE
fix(core): handle URI-encoded workspace paths in IdeClient

### DIFF
--- a/packages/core/src/ide/ide-client.test.ts
+++ b/packages/core/src/ide/ide-client.test.ts
@@ -1165,12 +1165,24 @@ describe('getIdeServerHost', () => {
         expect(result.isValid).toBe(true);
       });
 
-      it('should handle paths with a literal % sign without crashing', () => {
+      it('should return false for paths containing a literal % sign', () => {
         const workspacePath = '/test/a%path';
         const cwd = '/test/a%path/sub-dir';
         const result = IdeClient.validateWorkspacePath(workspacePath, cwd);
-        expect(result.isValid).toBe(true);
+        expect(result.isValid).toBe(false);
       });
+
+      it.skipIf(process.platform !== 'win32')(
+        'should correctly convert a Windows file URI',
+        () => {
+          const workspacePath = 'file:///C:\\Users\\test';
+          const cwd = 'C:\\Users\\test\\sub-dir';
+
+          const result = IdeClient.validateWorkspacePath(workspacePath, cwd);
+
+          expect(result.isValid).toBe(true);
+        },
+      );
     });
   });
 });

--- a/packages/core/src/ide/ide-client.test.ts
+++ b/packages/core/src/ide/ide-client.test.ts
@@ -1131,4 +1131,46 @@ describe('getIdeServerHost', () => {
       '/run/.containerenv',
     ); // Short-circuiting
   });
+
+  describe('validateWorkspacePath', () => {
+    describe('with special characters and encoding', () => {
+      it('should return true for a URI-encoded path with spaces', () => {
+        const workspacePath = 'file:///test/my%20workspace';
+        const cwd = '/test/my workspace/sub-dir';
+        const result = IdeClient.validateWorkspacePath(workspacePath, cwd);
+        expect(result.isValid).toBe(true);
+      });
+
+      it('should return true for a URI-encoded path with Korean characters', () => {
+        const workspacePath = 'file:///test/%ED%85%8C%EC%8A%A4%ED%8A%B8'; // "테스트"
+        const cwd = '/test/테스트/sub-dir';
+        const result = IdeClient.validateWorkspacePath(workspacePath, cwd);
+        expect(result.isValid).toBe(true);
+      });
+
+      it('should return true for a plain decoded path with Korean characters', () => {
+        const workspacePath = '/test/테스트';
+        const cwd = '/test/테스트/sub-dir';
+        const result = IdeClient.validateWorkspacePath(workspacePath, cwd);
+        expect(result.isValid).toBe(true);
+      });
+
+      it('should return true when one of multi-root paths is a valid URI-encoded path', () => {
+        const workspacePath = [
+          '/another/workspace',
+          'file:///test/%ED%85%8C%EC%8A%A4%ED%8A%B8', // "테스트"
+        ].join(path.delimiter);
+        const cwd = '/test/테스트/sub-dir';
+        const result = IdeClient.validateWorkspacePath(workspacePath, cwd);
+        expect(result.isValid).toBe(true);
+      });
+
+      it('should handle paths with a literal % sign without crashing', () => {
+        const workspacePath = '/test/a%path';
+        const cwd = '/test/a%path/sub-dir';
+        const result = IdeClient.validateWorkspacePath(workspacePath, cwd);
+        expect(result.isValid).toBe(true);
+      });
+    });
+  });
 });

--- a/packages/core/src/ide/ide-client.test.ts
+++ b/packages/core/src/ide/ide-client.test.ts
@@ -1165,11 +1165,11 @@ describe('getIdeServerHost', () => {
         expect(result.isValid).toBe(true);
       });
 
-      it('should return false for paths containing a literal % sign', () => {
+      it('should return true for paths containing a literal % sign', () => {
         const workspacePath = '/test/a%path';
         const cwd = '/test/a%path/sub-dir';
         const result = IdeClient.validateWorkspacePath(workspacePath, cwd);
-        expect(result.isValid).toBe(false);
+        expect(result.isValid).toBe(true);
       });
 
       it.skipIf(process.platform !== 'win32')(
@@ -1182,6 +1182,40 @@ describe('getIdeServerHost', () => {
 
           expect(result.isValid).toBe(true);
         },
+      );
+    });
+  });
+
+  describe('validateWorkspacePath (sanitization)', () => {
+    it.each([
+      {
+        description: 'should return true for identical paths',
+        workspacePath: '/test/ws',
+        cwd: '/test/ws',
+        expectedValid: true,
+      },
+      {
+        description: 'should return true when workspace has file:// protocol',
+        workspacePath: 'file:///test/ws',
+        cwd: '/test/ws',
+        expectedValid: true,
+      },
+      {
+        description: 'should return true when workspace has encoded spaces',
+        workspacePath: '/test/my%20ws',
+        cwd: '/test/my ws',
+        expectedValid: true,
+      },
+      {
+        description:
+          'should return true when cwd needs normalization matching workspace',
+        workspacePath: '/test/my ws',
+        cwd: '/test/my%20ws',
+        expectedValid: true,
+      },
+    ])('$description', ({ workspacePath, cwd, expectedValid }) => {
+      expect(IdeClient.validateWorkspacePath(workspacePath, cwd)).toMatchObject(
+        { isValid: expectedValid },
       );
     });
   });

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -521,7 +521,19 @@ export class IdeClient {
       };
     }
 
-    const ideWorkspacePaths = ideWorkspacePath.split(path.delimiter);
+    const ideWorkspacePaths = ideWorkspacePath
+      .split(path.delimiter)
+      .map((p) => {
+        try {
+          if (p.startsWith('file://')) {
+            return new URL(p).pathname;
+          }
+          return decodeURIComponent(p);
+        } catch (e) {
+          logger.error('Failed to decode workspace path component:', e);
+          return p;
+        }
+      });
     const realCwd = getRealPath(cwd);
     const isWithinWorkspace = ideWorkspacePaths.some((workspacePath) => {
       const idePath = getRealPath(workspacePath);

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -534,7 +534,7 @@ export class IdeClient {
           return '';
         }
       })
-      .filter(e => !!e);
+      .filter((e) => !!e);
     const realCwd = getRealPath(cwd);
     const isWithinWorkspace = ideWorkspacePaths.some((workspacePath) => {
       const idePath = getRealPath(workspacePath);

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -531,9 +531,10 @@ export class IdeClient {
           return decodeURIComponent(p);
         } catch (e) {
           logger.error('Failed to decode workspace path component:', e);
-          return p;
+          return '';
         }
-      });
+      })
+      .filter(e => !!e);
     const realCwd = getRealPath(cwd);
     const isWithinWorkspace = ideWorkspacePaths.some((workspacePath) => {
       const idePath = getRealPath(workspacePath);

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -5,6 +5,7 @@
  */
 
 import * as fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { isSubpath } from '../utils/paths.js';
 import { detectIde, type IdeInfo } from '../ide/detect-ide.js';
 import { ideContextStore } from './ideContext.js';
@@ -526,7 +527,7 @@ export class IdeClient {
       .map((p) => {
         try {
           if (p.startsWith('file://')) {
-            return new URL(p).pathname;
+            return fileURLToPath(p);
           }
           return decodeURIComponent(p);
         } catch (e) {

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
-import type * as fs from 'node:fs';
+import * as fs from 'node:fs';
 import {
   escapePath,
   unescapePath,
@@ -512,6 +512,17 @@ describe('resolveToRealPath', () => {
       expected: '/path/to/My Project',
     },
   ])('$description', ({ input, expected }) => {
+    expect(resolveToRealPath(input)).toBe(expected);
+  });
+
+  it('should return decoded path even if fs.realpathSync fails', () => {
+    vi.spyOn(fs, 'realpathSync').mockImplementationOnce(() => {
+      throw new Error('File not found');
+    });
+
+    const input = 'file:///path/to/New%20Project';
+    const expected = '/path/to/New Project';
+
     expect(resolveToRealPath(input)).toBe(expected);
   });
 });

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -4,8 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { escapePath, unescapePath, isSubpath, shortenPath } from './paths.js';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type * as fs from 'node:fs';
+import {
+  escapePath,
+  unescapePath,
+  isSubpath,
+  shortenPath,
+  resolveToRealPath,
+} from './paths.js';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof fs>();
+  return {
+    ...(actual as object),
+    realpathSync: (p: string) => p,
+  };
+});
 
 describe('escapePath', () => {
   it.each([
@@ -470,5 +485,33 @@ describe('shortenPath', () => {
       expect(result).toBe('\\s...\\...\\file.txt');
       expect(result.length).toBeLessThanOrEqual(18);
     });
+  });
+});
+
+describe('resolveToRealPath', () => {
+  it.each([
+    {
+      description:
+        'should return path as-is if no special characters or protocol',
+      input: '/simple/path',
+      expected: '/simple/path',
+    },
+    {
+      description: 'should remove file:// protocol',
+      input: 'file:///path/to/file',
+      expected: '/path/to/file',
+    },
+    {
+      description: 'should decode URI components',
+      input: '/path/to/some%20folder',
+      expected: '/path/to/some folder',
+    },
+    {
+      description: 'should handle both file protocol and encoding',
+      input: 'file:///path/to/My%20Project',
+      expected: '/path/to/My Project',
+    },
+  ])('$description', ({ input, expected }) => {
+    expect(resolveToRealPath(input)).toBe(expected);
   });
 });

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -357,16 +357,22 @@ export function isSubpath(parentPath: string, childPath: string): boolean {
  */
 export function resolveToRealPath(path: string): string {
   let resolvedPath = path;
+
   try {
     if (resolvedPath.startsWith('file://')) {
       resolvedPath = fileURLToPath(resolvedPath);
     }
-    resolvedPath = decodeURIComponent(resolvedPath);
 
+    resolvedPath = decodeURIComponent(resolvedPath);
+  } catch (_e) {
+    // Ignore error (e.g. malformed URI), keep path from previous step
+  }
+
+  try {
     return fs.realpathSync(resolvedPath);
   } catch (_e) {
     // If realpathSync fails, it might be because the path doesn't exist.
-    // In that case, we can fall back to the original path.
-    return path;
+    // In that case, we can fall back to the path processed.
+    return resolvedPath;
   }
 }

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -8,6 +8,8 @@ import path from 'node:path';
 import os from 'node:os';
 import process from 'node:process';
 import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 export const GEMINI_DIR = '.gemini';
 export const GOOGLE_ACCOUNTS_FILENAME = 'google_accounts.json';
@@ -342,4 +344,29 @@ export function isSubpath(parentPath: string, childPath: string): boolean {
     relative !== '..' &&
     !pathModule.isAbsolute(relative)
   );
+}
+
+/**
+ * Resolves a path to its real path, sanitizing it first.
+ * - Removes 'file://' protocol if present.
+ * - Decodes URI components (e.g. %20 -> space).
+ * - Resolves symbolic links using fs.realpathSync.
+ *
+ * @param pathStr The path string to resolve.
+ * @returns The resolved real path.
+ */
+export function resolveToRealPath(path: string): string {
+  let resolvedPath = path;
+  try {
+    if (resolvedPath.startsWith('file://')) {
+      resolvedPath = fileURLToPath(resolvedPath);
+    }
+    resolvedPath = decodeURIComponent(resolvedPath);
+
+    return fs.realpathSync(resolvedPath);
+  } catch (_e) {
+    // If realpathSync fails, it might be because the path doesn't exist.
+    // In that case, we can fall back to the original path.
+    return path;
+  }
 }


### PR DESCRIPTION
## TLDR

This PR fixes a bug in `IdeClient.validateWorkspacePath` that prevented correct validation of workspace paths containing special characters (e.g., spaces, non-ASCII characters like Korean). It now properly decodes URI-encoded paths received from the IDE companion before validation, ensuring correct behavior and fixing connection failures for users with such paths.

## Dive Deeper

This work has been rebased onto the latest main branch (as of 2026/01/25).
(https://github.com/google-gemini/gemini-cli/pull/12062)

The core issue was an encoding mismatch. The IDE companion (e.g., for VSCode) often provides the workspace path as a URI-encoded string with a `file://` scheme (e.g., `file:///.../%ED%85%8C%EC%8A%A4%ED%8A%B8`). The existing `validateWorkspacePath` function did not decode this URI, causing a string comparison failure against the plain path from `process.cwd()`.

The chosen solution is to normalize the path before validation. The function now maps over incoming paths and uses the standard `URL` object to parse `file://` URIs and `decodeURIComponent` for other potentially encoded paths. This is a robust, language-agnostic fix that handles the root cause.

A `try-catch` block is included to gracefully handle paths that might contain a literal `%` and cannot be decoded, preventing potential crashes.

## Reviewer Test Plan

1.  Pull down this branch.
2.  Run the full test suite with `npm test`.
3.  Verify that all tests pass, especially the new test suite `with special characters and encoding` within `packages/core/src/ide/ide-client.test.ts`.
4.  **Manual Validation (Optional but Recommended):**
    *   Navigate to a directory with a path containing spaces or non-ASCII characters (e.g., `/Users/test/내 프로젝트`).
    *   Open this directory as a workspace in your IDE (e.g., VSCode).
    *   Run the Gemini CLI from that directory.
    *   Attempt to connect to the IDE (e.g., using `/ide enable`).
    *   The connection should now succeed without a "Directory mismatch" error.

## Testing Matrix

|          | 🍏 (macOS) | 🪟 (Windows) | 🐧 (Linux) |
| -------- |:----------:|:------------:|:----------:|
| npm run  |      ✅      |      ❓      |     ❓     |
| npx      |      ❓      |      ❓      |     ❓     |
| Docker   |      ❓      |      ❓      |     ❓     |
| Podman   |      ❓      |      -       |     -      |
| Seatbelt |      ✅      |      -       |     -      |

## Linked issues / bugs

Fixes #12055 
