### PR TITLE
feat(cli): show resume message when exiting session

### DIFF
--- a/packages/cli/src/ui/commands/quitCommand.test.ts
+++ b/packages/cli/src/ui/commands/quitCommand.test.ts
@@ -10,6 +10,14 @@ import { createMockCommandContext } from '../../test-utils/mockCommandContext.js
 import { formatDuration } from '../utils/formatters.js';
 
 vi.mock('../utils/formatters.js');
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    sessionId: 'test-session-id',
+  };
+});
 
 describe('quitCommand', () => {
   beforeEach(() => {
@@ -47,6 +55,7 @@ describe('quitCommand', () => {
         {
           type: 'quit',
           duration: '1h 0m 0s',
+          sessionId: 'test-session-id',
           id: expect.any(Number),
         },
       ],

--- a/packages/cli/src/ui/commands/quitCommand.ts
+++ b/packages/cli/src/ui/commands/quitCommand.ts
@@ -6,6 +6,7 @@
 
 import { formatDuration } from '../utils/formatters.js';
 import { CommandKind, type SlashCommand } from './types.js';
+import { sessionId } from '@google/gemini-cli-core';
 
 export const quitCommand: SlashCommand = {
   name: 'quit',
@@ -23,12 +24,14 @@ export const quitCommand: SlashCommand = {
       messages: [
         {
           type: 'user',
-          text: `/quit`, // Keep it consistent, even if /exit was used
+          text: `/quit`,
+          // Keep it consistent, even if /exit was used
           id: now - 1,
         },
         {
           type: 'quit',
           duration: formatDuration(wallDuration),
+          sessionId,
           id: now,
         },
       ],

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -130,7 +130,10 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
         <ModelMessage model={itemForDisplay.model} />
       )}
       {itemForDisplay.type === 'quit' && (
-        <SessionSummaryDisplay duration={itemForDisplay.duration} />
+        <SessionSummaryDisplay
+          duration={itemForDisplay.duration}
+          sessionId={itemForDisplay.sessionId}
+        />
       )}
       {itemForDisplay.type === 'tool_group' && (
         <ToolGroupMessage

--- a/packages/cli/src/ui/components/SessionSummaryDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SessionSummaryDisplay.test.tsx
@@ -82,6 +82,9 @@ describe('<SessionSummaryDisplay />', () => {
   });
 
   it('renders resume message when sessionId is provided', () => {
+    const originalArgv1 = process.argv[1];
+    process.argv[1] = '/path/to/gemini';
+
     useSessionStatsMock.mockReturnValue({
       stats: {
         sessionId: 'test-session-id',
@@ -101,5 +104,7 @@ describe('<SessionSummaryDisplay />', () => {
 
     expect(output).toContain('Resume this session by running');
     expect(output).toContain('gemini --resume');
+
+    process.argv[1] = originalArgv1;
   });
 });

--- a/packages/cli/src/ui/components/SessionSummaryDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SessionSummaryDisplay.test.tsx
@@ -38,46 +38,68 @@ const renderWithMockedStats = (metrics: SessionMetrics) => {
   return render(<SessionSummaryDisplay duration="1h 23m 45s" />);
 };
 
+const defaultMetrics: SessionMetrics = {
+  models: {
+    'gemini-2.5-pro': {
+      api: { totalRequests: 10, totalErrors: 1, totalLatencyMs: 50234 },
+      tokens: {
+        input: 500,
+        prompt: 1000,
+        candidates: 2000,
+        total: 3500,
+        cached: 500,
+        thoughts: 300,
+        tool: 200,
+      },
+    },
+  },
+  tools: {
+    totalCalls: 0,
+    totalSuccess: 0,
+    totalFail: 0,
+    totalDurationMs: 0,
+    totalDecisions: {
+      accept: 0,
+      reject: 0,
+      modify: 0,
+      [ToolCallDecision.AUTO_ACCEPT]: 0,
+    },
+    byName: {},
+  },
+  files: {
+    totalLinesAdded: 42,
+    totalLinesRemoved: 15,
+  },
+};
+
 describe('<SessionSummaryDisplay />', () => {
   it('renders the summary display with a title', () => {
-    const metrics: SessionMetrics = {
-      models: {
-        'gemini-2.5-pro': {
-          api: { totalRequests: 10, totalErrors: 1, totalLatencyMs: 50234 },
-          tokens: {
-            input: 500,
-            prompt: 1000,
-            candidates: 2000,
-            total: 3500,
-            cached: 500,
-            thoughts: 300,
-            tool: 200,
-          },
-        },
-      },
-      tools: {
-        totalCalls: 0,
-        totalSuccess: 0,
-        totalFail: 0,
-        totalDurationMs: 0,
-        totalDecisions: {
-          accept: 0,
-          reject: 0,
-          modify: 0,
-          [ToolCallDecision.AUTO_ACCEPT]: 0,
-        },
-        byName: {},
-      },
-      files: {
-        totalLinesAdded: 42,
-        totalLinesRemoved: 15,
-      },
-    };
-
-    const { lastFrame } = renderWithMockedStats(metrics);
+    const { lastFrame } = renderWithMockedStats(defaultMetrics);
     const output = lastFrame();
 
     expect(output).toContain('Agent powering down. Goodbye!');
     expect(output).toMatchSnapshot();
+  });
+
+  it('renders resume message when sessionId is provided', () => {
+    useSessionStatsMock.mockReturnValue({
+      stats: {
+        sessionId: 'test-session-id',
+        sessionStartTime: new Date(),
+        metrics: defaultMetrics,
+        lastPromptTokenCount: 0,
+        promptCount: 5,
+      },
+      getPromptCount: () => 5,
+      startNewPrompt: vi.fn(),
+    });
+
+    const { lastFrame } = render(
+      <SessionSummaryDisplay duration="1h 0m 0s" sessionId="test-session-id" />,
+    );
+    const output = lastFrame();
+
+    expect(output).toContain('Resume this session by running');
+    expect(output).toContain('gemini --resume');
   });
 });

--- a/packages/cli/src/ui/components/SessionSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/SessionSummaryDisplay.tsx
@@ -5,6 +5,7 @@
  */
 
 import type React from 'react';
+import path from 'node:path';
 import { Box, Text } from 'ink';
 import { StatsDisplay } from './StatsDisplay.js';
 import { theme } from '../semantic-colors.js';
@@ -13,6 +14,12 @@ interface SessionSummaryDisplayProps {
   duration: string;
   sessionId?: string;
 }
+
+const getCliName = (): string => {
+  const scriptPath = process.argv[1] || '';
+  const baseName = path.basename(scriptPath, '.js');
+  return baseName || 'gemini';
+};
 
 export const SessionSummaryDisplay: React.FC<SessionSummaryDisplayProps> = ({
   duration,
@@ -24,7 +31,7 @@ export const SessionSummaryDisplay: React.FC<SessionSummaryDisplayProps> = ({
       <Box marginTop={1}>
         <Text color={theme.text.secondary}>
           Resume this session by running{' '}
-          <Text color={theme.text.link}>gemini --resume</Text>
+          <Text color={theme.text.link}>{getCliName()} --resume</Text>
         </Text>
       </Box>
     )}

--- a/packages/cli/src/ui/components/SessionSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/SessionSummaryDisplay.tsx
@@ -5,14 +5,28 @@
  */
 
 import type React from 'react';
+import { Box, Text } from 'ink';
 import { StatsDisplay } from './StatsDisplay.js';
+import { theme } from '../semantic-colors.js';
 
 interface SessionSummaryDisplayProps {
   duration: string;
+  sessionId?: string;
 }
 
 export const SessionSummaryDisplay: React.FC<SessionSummaryDisplayProps> = ({
   duration,
+  sessionId,
 }) => (
-  <StatsDisplay title="Agent powering down. Goodbye!" duration={duration} />
+  <Box flexDirection="column">
+    <StatsDisplay title="Agent powering down. Goodbye!" duration={duration} />
+    {sessionId && (
+      <Box marginTop={1}>
+        <Text color={theme.text.secondary}>
+          Resume this session by running{' '}
+          <Text color={theme.text.link}>gemini --resume</Text>
+        </Text>
+      </Box>
+    )}
+  </Box>
 );

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -175,6 +175,7 @@ export type HistoryItemModel = HistoryItemBase & {
 export type HistoryItemQuit = HistoryItemBase & {
   type: 'quit';
   duration: string;
+  sessionId?: string;
 };
 
 export type HistoryItemToolGroup = HistoryItemBase & {


### PR DESCRIPTION
## Summary

Display "Resume this session by running `gemini --resume`" when quitting via `/quit` or Ctrl+C, as requested by maintainer in #16226.

## Details

Add `sessionId` field to `HistoryItemQuit` type and pass it through the quit flow:

- quitCommand.ts now includes the sessionId in the quit message                                                                
- SessionSummaryDisplay.tsx conditionally renders the resume hint below the stats box                                          
- Message uses theme colors for consistent styling

## Related Issues

Closes #16226

## How to Validate

1. Run `npm run build && npm run start`
2. Type some prompt, like asking when is sun down today
3. Type /quit or press Ctrl+C twice                                                
4. Verify message "Resume this session by running gemini --resume" appears below the session stats box    

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
