### PR TITLE
fix(cli): respect user ignore config for env variables

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -17,6 +17,8 @@ import {
   coreEvents,
   homedir,
   type FetchAdminControlsResponse,
+  debugLogger,
+  FileDiscoveryService,
 } from '@google/gemini-cli-core';
 import stripJsonComments from 'strip-json-comments';
 import { DefaultLight } from '../ui/themes/default-light.js';
@@ -401,13 +403,13 @@ function findEnvFile(startDir: string): string | null {
   }
 }
 
-export function setUpCloudShellEnvironment(envFilePath: string | null): void {
+export function setUpCloudShellEnvironment(envFilePath: string): void {
   // Special handling for GOOGLE_CLOUD_PROJECT in Cloud Shell:
   // Because GOOGLE_CLOUD_PROJECT in Cloud Shell tracks the project
   // set by the user using "gcloud config set project" we do not want to
   // use its value. So, unless the user overrides GOOGLE_CLOUD_PROJECT in
   // one of the .env files, we set the Cloud Shell-specific default here.
-  if (envFilePath && fs.existsSync(envFilePath)) {
+  if (fs.existsSync(envFilePath)) {
     const envFileContent = fs.readFileSync(envFilePath);
     const parsedEnv = dotenv.parse(envFileContent);
     if (parsedEnv['GOOGLE_CLOUD_PROJECT']) {
@@ -426,6 +428,47 @@ export function setUpCloudShellEnvironment(envFilePath: string | null): void {
 export function loadEnvironment(settings: Settings): void {
   const envFilePath = findEnvFile(process.cwd());
 
+  if (envFilePath == null) {
+    return;
+  }
+
+  // This service normally exists within config
+  //  however, config is way created *after* environment is loaded and settings are created.
+  // Config also *depends* on settings created here,
+  //  so we cannot use `config.fileDiscoveryService` as it would be a cyclical dependency.
+  // Therefore, a temporary instance is created.
+  const fileDiscovery = new FileDiscoveryService(process.cwd());
+
+  const gitIgnored =
+    settings.context?.fileFiltering?.respectGitIgnore &&
+    fileDiscovery.shouldIgnoreFile(envFilePath, {
+      respectGitIgnore: true,
+      respectGeminiIgnore: false,
+    });
+  const geminiIgnored =
+    settings.context?.fileFiltering?.respectGeminiIgnore &&
+    fileDiscovery.shouldIgnoreFile(envFilePath, {
+      respectGitIgnore: false,
+      respectGeminiIgnore: true,
+    });
+
+  if (gitIgnored || geminiIgnored) {
+    const reason =
+      gitIgnored && geminiIgnored ? 'both' : gitIgnored ? 'git' : 'gemini';
+
+    const reasonText =
+      reason === 'both'
+        ? 'both .gitignore and .geminiignore'
+        : reason === 'git'
+          ? '.gitignore'
+          : '.geminiignore';
+
+    debugLogger.warn(
+      `Path "${envFilePath}" is ignored by ${reasonText}. It will not be loaded into process environment`,
+    );
+    return;
+  }
+
   if (!isWorkspaceTrusted(settings).isTrusted) {
     return;
   }
@@ -435,33 +478,31 @@ export function loadEnvironment(settings: Settings): void {
     setUpCloudShellEnvironment(envFilePath);
   }
 
-  if (envFilePath) {
-    // Manually parse and load environment variables to handle exclusions correctly.
-    // This avoids modifying environment variables that were already set from the shell.
-    try {
-      const envFileContent = fs.readFileSync(envFilePath, 'utf-8');
-      const parsedEnv = dotenv.parse(envFileContent);
+  // Manually parse and load environment variables to handle exclusions correctly.
+  // This avoids modifying environment variables that were already set from the shell.
+  try {
+    const envFileContent = fs.readFileSync(envFilePath, 'utf-8');
+    const parsedEnv = dotenv.parse(envFileContent);
 
-      const excludedVars =
-        settings?.advanced?.excludedEnvVars || DEFAULT_EXCLUDED_ENV_VARS;
-      const isProjectEnvFile = !envFilePath.includes(GEMINI_DIR);
+    const excludedVars =
+      settings?.advanced?.excludedEnvVars || DEFAULT_EXCLUDED_ENV_VARS;
+    const isProjectEnvFile = !envFilePath.includes(GEMINI_DIR);
 
-      for (const key in parsedEnv) {
-        if (Object.hasOwn(parsedEnv, key)) {
-          // If it's a project .env file, skip loading excluded variables.
-          if (isProjectEnvFile && excludedVars.includes(key)) {
-            continue;
-          }
+    for (const key in parsedEnv) {
+      if (Object.hasOwn(parsedEnv, key)) {
+        // If it's a project .env file, skip loading excluded variables.
+        if (isProjectEnvFile && excludedVars.includes(key)) {
+          continue;
+        }
 
-          // Load variable only if it's not already set in the environment.
-          if (!Object.hasOwn(process.env, key)) {
-            process.env[key] = parsedEnv[key];
-          }
+        // Load variable only if it's not already set in the environment.
+        if (!Object.hasOwn(process.env, key)) {
+          process.env[key] = parsedEnv[key];
         }
       }
-    } catch (_e) {
-      // Errors are ignored to match the behavior of `dotenv.config({ quiet: true })`.
     }
+  } catch (_e) {
+    // Errors are ignored to match the behavior of `dotenv.config({ quiet: true })`.
   }
 }
 


### PR DESCRIPTION
## Summary

Add a condition that prevents loading environment variables of the current working directory to the process if the user has ignored them. The check respects ignore conditions of both **.gitignore** or **.geminiignore**.

> [!WARNING]
> This is technically a breaking change. Users who used to work with their environment variables even though they were ignored by `.gitignore` or `.geminiignore` will find that they are no longer automatically loaded into the environment. They will need to either unignore the file or export variables manually.

## Details


During CLI startup, settings for the `workspaceDir` are loaded with
`loadSettings` function, which also triggers `loadEnvironment`.

The `loadEnvironment` function did not perform any checks for whether the
environment file of the _current working directory_ should be ignored, and
directly loaded its contents to the process.

The fix involves the following changes:

- The `loadEnvironment` function returns early if the `envFilePath` variable is
  `null`, instead of doing multiple checks later on with `setUpCloudShellEnvironment` function and then the file reading flow. This early `null` check ensures that all the following code is working with a valid file.
  - `setUpCloudShellEnvironment` function's parameter type changed from `string | null` to `string` to reflect the fact that it will only be called if a valid environment file is found.
  - The `fs.existsSync(envFilePath)` is also removed as `findEnvFile(process.cwd())` already performs these checks and returns `null` on non-existing cases
- A temporary `FileDiscoveryService` is instanced here to check if the valid environment file should be ignored
  - Normally, the `FileDiscoveryService` exists inside the `config` instance: [config.ts#L448](https://github.com/google-gemini/gemini-cli/blob/fd36d6572303237d578ba5a19a97399de6e94460/packages/cli/src/config/config.ts#L448). However, the `config` is created way _after_ settings and actually _depends_ on settings: [gemini.tsx:L374](https://github.com/google-gemini/gemini-cli/blob/fd36d6572303237d578ba5a19a97399de6e94460/packages/cli/src/gemini.tsx#L374). So, the coding convention could not be respected in this particular situation.
- If the environment file is determined to be _ignored_, then the function returns without proceeding with any other action.

After these changes are implemented, Gemini CLI does not have access to ignored environment variables:

<!-- IMAGE -->

This makes sure that Gemini does not have _direct_ access to environment variables. However, depending on certain scenarios, the user may be explicitly asked if they wish to allow Gemini to read _other_ environment files that _were not ignored_.

<details>
<summary>Tested scenarios and their results</summary>

### Scenario 1

Conditions:

- `.env` file exists. It contains `APP_NAME="DO_NOT_LEAK"`
- `.gitignore` exists. It _does not_ ignore `.env`

Prompting Gemini CLI with

```
do `echo "[$APP_NAME]"`
```

results in Gemini having access to this variable and its value:

<img width="1057" height="150" alt="Screenshot 2026-01-25 at 12 31 54" src="https://github.com/user-attachments/assets/a2842bec-302c-4191-b4cb-6ac0d71bbfb2" />


### Scenario 2

Conditions:

- `.env` file exists. It contains `APP_NAME="DO_NOT_LEAK"`
- `.gitignore` exists. It _ignores_ `.env`

Prompting Gemini CLI with

```
do `echo "[$APP_NAME]"`
```

results in Gemini claiming that`APP_NAME` is not set:

<img width="1063" height="227" alt="Screenshot 2026-01-25 at 12 35 31" src="https://github.com/user-attachments/assets/3eea4a48-0a57-47cc-958a-1c8fe8d5feb5" />


### Scenario 3

Conditions:

- `.env` file exists. It contains `APP_NAME="DO_NOT_LEAK"`
- `.env.development` file exists. It contains `APP_NAME="DO_NOT_LEAK_DEV"`
- `.env.local` file exists. It contains `APP_NAME="DO_NOT_LEAK_LOCAL"`
- `.gitignore` exists. It _ignores_ `.env`

Prompting Gemini CLI with

```
do `echo "[$APP_NAME]"`
```

results in Gemini claiming that `APP_NAME` is not set, but offers to instead use the `APP_NAME` it read from `.env.development` file.

Allowing this action results in Gemini producing responses using the value `DO_NOT_LEAK_DEV`.

### Scenario 4

Conditions:

- `.env` file exists. It contains `APP_NAME="DO_NOT_LEAK"`
- `.env.development` file exists. It contains `APP_NAME="DO_NOT_LEAK_DEV"`
- `.env.local` file exists. It contains `APP_NAME="DO_NOT_LEAK_LOCAL"`
- `.gitignore` exists. It _ignores_ `.env`, `.env.development`, and `.env.local`

Prompting Gemini CLI with

```
do `echo "[$APP_NAME]"`
```

produces the same result as [Scenario 2](#scenario-2), and Gemini does not offer to read _other_ environment files.

### Scenario 5

Conditions:

- `.env` file exists. It contains `APP_NAME="DO_NOT_LEAK"`
- `.env.development` file exists. It contains `APP_NAME="DO_NOT_LEAK_DEV"`
- `.env.local` file exists. It contains `APP_NAME="DO_NOT_LEAK_LOCAL"`
- `.gitignore` exists. It _does not_ ignore any environment file.
- `.geminiignore` exists. It _ignores_ `.env` file.

Prompting Gemini CLI with

```
do `echo "[$APP_NAME]"`
```

produces a similar result to that of [Scenario 3](#scenario-3). Gemini _explicitly_ read environment files that were not ignored, and informs the user about how they can proceed, without offering any actions:

<img width="1269" height="621" alt="Screenshot 2026-01-25 at 12 38 08" src="https://github.com/user-attachments/assets/97f33de6-374d-4561-97b5-b291f0b8767a" />


</details>


## Related Issues

Fixes #15884


## How to Validate


> [!IMPORTANT]
> This should be tested on an _isolated_ mock folder to replicate user scenarios. So, the Gemini CLI can be launched with VSCode's debugger by appending a custom configuration to **.vscode/launch.json**, inside `configurations` array

```json
{
	"name": "Debug in mock directory",
	"type": "node",
	"request": "launch",
	"program": "${workspaceFolder}/scripts/start.js",
	"cwd": "/path/to/mock-folder",
	"env": {
		"NODE_ENV": "development",
		"GEMINI_DEV_TRACING": "true"
	},
	"autoAttachChildProcesses": true,
	"console": "integratedTerminal",
	"skipFiles": ["<node_internals>/**"]
}
```

---

### Inside mock folder

- create `.env` file
- create `.gitignore` file
- create `.geminiignore` file
- depending on the test case,
  - add a line for **.env** to `.gitignore`
  - remove **.env** line from `.gitignore`
  - add a line for **.env** to `.geminiignore`
  - remove **.env** line from `.geminiignore`
  - same for any additional environment files

### Inside fork branch

- run `npm run build`
- optionally add a breakpoint inside `loadEnvironment` in [settings.ts#L429](https://github.com/yethranayeh/gemini-cli/blob/f4716ae781d5a42acc2a87dbff3aaa4a40b3439c/packages/cli/src/config/settings.ts#L429) to track changes to `process.env` and whether ignored variables are loaded in to the process,
- launch with VS Code's debugger using **Debug in mock directory**,
- prompt Gemini to echo an environment variable, as exemplified above

> [!NOTE]
> The reason I am initiating the CLI instance in a mock folder is to replicate a real life scenario where a user would run Gemini CLI in their project folder, and the process would read `process.cwd()` for environment files.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
