### PR TITLE
feat(cli): support GEMINI_CHAT_SHARE_DIR for /chat share default directory

### DIFF
--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -281,8 +281,24 @@ const shareCommand: SlashCommand = {
   autoExecute: false,
   action: async (context, args): Promise<MessageActionReturn> => {
     let filePathArg = args.trim();
-    if (!filePathArg) {
-      filePathArg = `gemini-conversation-${Date.now()}.json`;
+    // New: support default share dir via environment variable.
+    try {
+      const defaultShareDir = process.env['GEMINI_CHAT_SHARE_DIR'];
+      const looksLikeFilenameOnly =
+        !!filePathArg &&
+        !filePathArg.includes(path.sep) &&
+        !filePathArg.includes('/') &&
+        !filePathArg.includes('\\') &&
+        !filePathArg.startsWith('@');
+
+      if (!filePathArg) {
+        filePathArg = `gemini-conversation-${Date.now()}.json`;
+      } else if (defaultShareDir && looksLikeFilenameOnly) {
+        // Join default dir and filename in a cross-platform way.
+        filePathArg = path.join(defaultShareDir, filePathArg);
+      }
+    } catch (_e) {
+      // Fail-safe: do nothing on unexpected errors (do not crash CLI).
     }
 
     const filePath = path.resolve(filePathArg);


### PR DESCRIPTION
Summary:

    Add support for GEMINI_CHAT_SHARE_DIR environment variable so that /chat share <filename> saves to that directory if a filename (no path) is given.

How to test:

    Set the env var in PowerShell: $env:GEMINI_CHAT_SHARE_DIR = "C:\Users\dog\OneDrive\2.Secundario\Gemini_testing\Obsidian con AI\3. Terciario\Gemini CLI Outputs"
    Run Gemini in your vault and run: /chat share probando.md
    Expect file at: C:\Users\dog\OneDrive\2.Secundario\Gemini_testing\Obsidian con AI\3. Terciario\Gemini CLI Outputs\probando.md

Notes:

    This is a minimal, backwards-compatible change. If GEMINI_CHAT_SHARE_DIR is not set or user passes a path, behavior is unchanged.
