### PR TITLE
fix: cap search results and clarify context overflow UI messaging

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -2028,14 +2028,14 @@ describe('useGeminiStream', () => {
           requestTokens: 20,
           remainingTokens: 80,
           expectedMessage:
-            'Sending this message (20 tokens) might exceed the remaining context window limit (80 tokens).',
+            'This message (20 tokens) exceeds the remaining context window limit (80 tokens) and was not sent.',
         },
         {
           name: 'with suggestion when remaining tokens are < 75% of limit',
           requestTokens: 30,
           remainingTokens: 70,
           expectedMessage:
-            'Sending this message (30 tokens) might exceed the remaining context window limit (70 tokens). Please try reducing the size of your message or use the `/compress` command to compress the chat history.',
+            'This message (30 tokens) exceeds the remaining context window limit (70 tokens) and was not sent. Please try reducing the size of your message or use the `/compress` command to compress the chat history.',
         },
       ])(
         'should add message $name',

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -766,7 +766,7 @@ export const useGeminiStream = (
       const isLessThan75Percent =
         limit > 0 && remainingTokenCount < limit * 0.75;
 
-      let text = `Sending this message (${estimatedRequestTokenCount} tokens) might exceed the remaining context window limit (${remainingTokenCount} tokens).`;
+      let text = `This message (${estimatedRequestTokenCount} tokens) exceeds the remaining context window limit (${remainingTokenCount} tokens) and was not sent.`;
 
       if (isLessThan75Percent) {
         text +=


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. --> This PR addresses an issue where broad searches caused massive context overflows and UI confusion.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
   - Search Limits: Capped SearchText (RipGrepTool and GrepTool) at 500 matches and truncated individual match lines to 1,000 characters to prevent 40M+ token payloads.
   - Agent Guidance: Added a minimal instruction to the tool output when results are truncated, guiding the agent to refine its search query.
   - Updated the context window overflow message to clarify that the message "exceeds the limit and was not sent", resolving the confusion where the CLI appeared to hang.


## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). --> Fixes #17448 

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
npm test -w packages/core -- src/tools/ripGrep.test.ts src/tools/grep.test.ts 
npm test -w packages/cli -- src/ui/hooks/useGeminiStream.test.tsx

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
