### PR TITLE
feat: Return stats session with CLI flag (`--stats`)

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -88,6 +88,7 @@ export interface CliArgs {
   rawOutput: boolean | undefined;
   acceptRawOutputRisk: boolean | undefined;
   isCommand: boolean | undefined;
+  stats: boolean | undefined;
 }
 
 export async function parseArguments(
@@ -263,6 +264,10 @@ export async function parseArguments(
         .option('accept-raw-output-risk', {
           type: 'boolean',
           description: 'Suppress the security warning when using --raw-output.',
+        })
+        .option('stats', {
+          type: 'boolean',
+          description: 'Show remaining quotas and reset time per model.',
         }),
     )
     // Register MCP subcommands
@@ -788,6 +793,7 @@ export async function loadCliConfig(
     disableLLMCorrection: settings.tools?.disableLLMCorrection,
     rawOutput: argv.rawOutput,
     acceptRawOutputRisk: argv.acceptRawOutputRisk,
+    stats: argv.stats || false,
     modelConfigServiceConfig: settings.modelConfigs,
     // TODO: loading of hooks based on workspace trust
     enableHooks:

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -496,6 +496,7 @@ describe('gemini.tsx main function kitty protocol', () => {
       recordResponses: undefined,
       rawOutput: undefined,
       acceptRawOutputRisk: undefined,
+      stats: undefined,
       isCommand: undefined,
     });
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -155,7 +155,7 @@ throw new Error('Authentication failed');
   } catch (error: unknown) {
     writeToStderr('Error fetching quota information: ');
     writeToStderr(`${getErrorMessage(error)}\n`);
-    process.exit(1);
+throw new Error('Error fetching quota information');
   }
 }
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -117,7 +117,7 @@ async function displayStats(
         writeToStderr(
           'Please run `gemini` without --stats to set up authentication first.\n',
         );
-        process.exit(1);
+throw new Error('Authentication failed');
       }
     }
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -615,7 +615,7 @@ export async function main() {
     }
 
     // Handle --stats flag
-    if (config.getStats?.()) {
+    if (config.getStats()) {
       await displayStats(config, settings);
       await runExitCleanup();
       process.exit(ExitCodes.SUCCESS);

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -62,6 +62,7 @@ import {
   SessionEndReason,
   getVersion,
   type FetchAdminControlsResponse,
+  getErrorMessage,
 } from '@google/gemini-cli-core';
 import {
   initializeApp,
@@ -110,9 +111,9 @@ async function displayStats(
     if (authType) {
       try {
         await config.refreshAuth(authType);
-      } catch (e) {
+      } catch (e: unknown) {
         writeToStderr('Authentication failed: ');
-        writeToStderr(`${e}\n`);
+        writeToStderr(`${getErrorMessage(e)}\n`);
         writeToStderr(
           'Please run `gemini` without --stats to set up authentication first.\n',
         );
@@ -151,9 +152,9 @@ async function displayStats(
         writeToStdout(`  Token Type: ${bucket.tokenType}\n`);
       }
     }
-  } catch (error) {
+  } catch (error: unknown) {
     writeToStderr('Error fetching quota information: ');
-    writeToStderr(`${error}\n`);
+    writeToStderr(`${getErrorMessage(error)}\n`);
     process.exit(1);
   }
 }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -335,6 +335,7 @@ export interface ConfigParameters {
   experimentalZedIntegration?: boolean;
   listSessions?: boolean;
   deleteSession?: string;
+  stats?: boolean;
   listExtensions?: boolean;
   extensionLoader?: ExtensionLoader;
   enabledExtensions?: string[];
@@ -476,6 +477,7 @@ export class Config {
   private readonly maxSessionTurns: number;
   private readonly listSessions: boolean;
   private readonly deleteSession: string | undefined;
+  private readonly stats: boolean;
   private readonly listExtensions: boolean;
   private readonly _extensionLoader: ExtensionLoader;
   private readonly _enabledExtensions: string[];
@@ -646,6 +648,7 @@ export class Config {
       params.experimentalZedIntegration ?? false;
     this.listSessions = params.listSessions ?? false;
     this.deleteSession = params.deleteSession;
+    this.stats = params.stats ?? false;
     this.listExtensions = params.listExtensions ?? false;
     this._extensionLoader =
       params.extensionLoader ?? new SimpleExtensionLoader([]);
@@ -1567,6 +1570,10 @@ export class Config {
 
   getDeleteSession(): string | undefined {
     return this.deleteSession;
+  }
+
+  getStats(): boolean {
+    return this.stats;
   }
 
   getExtensionManagement(): boolean {


### PR DESCRIPTION
## Summary

Can currently only return the stats session by running `gemini-cli`, then using `/stats session` - proposes CLI flag to be used too outside of the interactive mode to fetch remaining quota and reset time for each model.

## Details

- New CLI flag - adds `--stats` boolean flag to argument parsing
- Extended `Config` class to add `stats` property and a `getStats()` method
- Created `displayStats()` method for displaying the stats
- Integrated authentication check before fetching the quota data

## Related Issues

Closes #15808

## How to Validate

1. Build the project:
  ```bash
  npm run bundle
  ```

2. Test help output
  ```bash
  node bundle/gemini.js --help | grep stats
  ```
  This should show: `--stats: Show remaining quotas and reset times per model`

3. Test without authentication:
  ```bash
  node bundle/gemini.js --stats
  ```
  This should show "No quota information available" and give OAuth setup instructions

4. Test with authentication
  ```bash
  node bundle/gemini.js  # Complete OAuth setup first
  node bundle/gemini.js --stats
  ```
  This should display the required stats


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [x] npx
    - [x] Docker
