### PR TITLE
feat(core): optimize shell tool llmContent output format

### DIFF
--- a/packages/core/src/tools/__snapshots__/shell.test.ts.snap
+++ b/packages/core/src/tools/__snapshots__/shell.test.ts.snap
@@ -5,15 +5,12 @@ exports[`ShellTool > getDescription > should return the non-windows description 
 
       The following information is returned:
 
-      Command: Executed command.
-      Directory: Directory where command was executed, or \`(root)\`.
-      Stdout: Output on stdout stream. Can be \`(empty)\` or partial on error and for any unwaited background processes.
-      Stderr: Output on stderr stream. Can be \`(empty)\` or partial on error and for any unwaited background processes.
-      Error: Error or \`(none)\` if no error was reported for the subprocess.
-      Exit Code: Exit code or \`(none)\` if terminated by signal.
-      Signal: Signal number or \`(none)\` if no signal was received.
-      Background PIDs: List of background processes started or \`(none)\`.
-      Process Group PGID: Process group started or \`(none)\`"
+      Output: Combined stdout/stderr. Can be \`(empty)\` or partial on error and for any unwaited background processes.
+      Exit Code: Only included if non-zero (command failed).
+      Error: Only included if a process-level error occurred (e.g., spawn failure).
+      Signal: Only included if process was terminated by a signal.
+      Background PIDs: Only included if background processes were started.
+      Process Group PGID: Only included if available."
 `;
 
 exports[`ShellTool > getDescription > should return the windows description when on windows 1`] = `
@@ -21,13 +18,10 @@ exports[`ShellTool > getDescription > should return the windows description when
 
       The following information is returned:
 
-      Command: Executed command.
-      Directory: Directory where command was executed, or \`(root)\`.
-      Stdout: Output on stdout stream. Can be \`(empty)\` or partial on error and for any unwaited background processes.
-      Stderr: Output on stderr stream. Can be \`(empty)\` or partial on error and for any unwaited background processes.
-      Error: Error or \`(none)\` if no error was reported for the subprocess.
-      Exit Code: Exit code or \`(none)\` if terminated by signal.
-      Signal: Signal number or \`(none)\` if no signal was received.
-      Background PIDs: List of background processes started or \`(none)\`.
-      Process Group PGID: Process group started or \`(none)\`"
+      Output: Combined stdout/stderr. Can be \`(empty)\` or partial on error and for any unwaited background processes.
+      Exit Code: Only included if non-zero (command failed).
+      Error: Only included if a process-level error occurred (e.g., spawn failure).
+      Signal: Only included if process was terminated by a signal.
+      Background PIDs: Only included if background processes were started.
+      Process Group PGID: Only included if available."
 `;


### PR DESCRIPTION
## Summary

Reduces token usage and noise in shell tool output sent to the model by removing redundant fields and only including metadata when relevant.

## Details

The shell tool's `llmContent` previously included all fields with `(none)` placeholders:

```
Command: echo hello
Directory: (root)
Output: hello
Error: (none)
Exit Code: 0
Signal: (none)
Background PIDs: (none)
Process Group PGID: 12345
```

**Changes:**

1. **Removed `Command:`** - Model already knows what it requested
2. **Removed `Directory:`** - Model knows the `dir_path` it passed
3. **`Exit Code:` only on failure** - Success (0) is implicit
4. **Conditional metadata** - `Error:`, `Signal:`, `Background PIDs:`, `Process Group PGID:` only included when present

**New output (success):**
```
Output: hello
```

**New output (failure):**
```
Output: <error output>
Exit Code: 1
```

Also updated `getShellToolDescription()` to document the new format.

## Related Issues

None

## How to Validate

```bash
cd packages/core
npx vitest run src/tools/shell.test.ts --testNamePattern="llmContent output format"
```

Expected: 11 tests pass

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
  - [ ] Windows
  - [ ] Linux