### PR TITLE
feat(plan): add persistent plan file storage

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -57,7 +57,9 @@ vi.mock('fs', async (importOriginal) => {
 
   return {
     ...actualFs,
-    mkdirSync: vi.fn(),
+    mkdirSync: vi.fn((p) => {
+      mockPaths.add(p.toString());
+    }),
     writeFileSync: vi.fn(),
     existsSync: vi.fn((p) => mockPaths.has(p.toString())),
     statSync: vi.fn((p) => {

--- a/packages/cli/src/config/policy-engine.integration.test.ts
+++ b/packages/cli/src/config/policy-engine.integration.test.ts
@@ -324,6 +324,117 @@ describe('Policy Engine Integration Tests', () => {
       ).toBe(PolicyDecision.DENY);
     });
 
+    it('should allow write_file to plans directory in Plan mode', async () => {
+      const settings: Settings = {};
+
+      const config = await createPolicyEngineConfig(
+        settings,
+        ApprovalMode.PLAN,
+      );
+      const engine = new PolicyEngine(config);
+
+      // Valid plan file path (64-char hex hash, .md extension, safe filename)
+      const validPlanPath =
+        '/home/user/.gemini/tmp/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/plans/my-plan.md';
+      expect(
+        (
+          await engine.check(
+            { name: 'write_file', args: { file_path: validPlanPath } },
+            undefined,
+          )
+        ).decision,
+      ).toBe(PolicyDecision.ALLOW);
+
+      // Valid plan with underscore in filename
+      const validPlanPath2 =
+        '/home/user/.gemini/tmp/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/plans/feature_auth.md';
+      expect(
+        (
+          await engine.check(
+            { name: 'write_file', args: { file_path: validPlanPath2 } },
+            undefined,
+          )
+        ).decision,
+      ).toBe(PolicyDecision.ALLOW);
+    });
+
+    it('should deny write_file outside plans directory in Plan mode', async () => {
+      const settings: Settings = {};
+
+      const config = await createPolicyEngineConfig(
+        settings,
+        ApprovalMode.PLAN,
+      );
+      const engine = new PolicyEngine(config);
+
+      // Write to workspace (not plans dir) should be denied
+      expect(
+        (
+          await engine.check(
+            { name: 'write_file', args: { file_path: '/project/src/file.ts' } },
+            undefined,
+          )
+        ).decision,
+      ).toBe(PolicyDecision.DENY);
+
+      // Write to plans dir but wrong extension should be denied
+      const wrongExtPath =
+        '/home/user/.gemini/tmp/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/plans/script.js';
+      expect(
+        (
+          await engine.check(
+            { name: 'write_file', args: { file_path: wrongExtPath } },
+            undefined,
+          )
+        ).decision,
+      ).toBe(PolicyDecision.DENY);
+
+      // Path traversal attempt should be denied (filename contains /)
+      const traversalPath =
+        '/home/user/.gemini/tmp/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/plans/../../../etc/passwd.md';
+      expect(
+        (
+          await engine.check(
+            { name: 'write_file', args: { file_path: traversalPath } },
+            undefined,
+          )
+        ).decision,
+      ).toBe(PolicyDecision.DENY);
+
+      // Invalid hash length should be denied
+      const shortHashPath = '/home/user/.gemini/tmp/abc123/plans/plan.md';
+      expect(
+        (
+          await engine.check(
+            { name: 'write_file', args: { file_path: shortHashPath } },
+            undefined,
+          )
+        ).decision,
+      ).toBe(PolicyDecision.DENY);
+    });
+
+    it('should deny write_file to subdirectories in Plan mode', async () => {
+      const settings: Settings = {};
+
+      const config = await createPolicyEngineConfig(
+        settings,
+        ApprovalMode.PLAN,
+      );
+      const engine = new PolicyEngine(config);
+
+      // Write to subdirectory should be denied
+      const subdirPath =
+        '/home/user/.gemini/tmp/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/plans/subdir/plan.md';
+      expect(
+        (
+          await engine.check(
+            { name: 'write_file', args: { file_path: subdirPath } },
+            undefined,
+          )
+        ).decision,
+      ).toBe(PolicyDecision.DENY);
+    });
+
     it('should verify priority ordering works correctly in practice', async () => {
       const settings: Settings = {
         tools: {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -14,6 +14,7 @@ import { ApprovalMode } from '../policy/types.js';
 import type { HookDefinition } from '../hooks/types.js';
 import { HookType, HookEventName } from '../hooks/types.js';
 import * as path from 'node:path';
+import * as fs from 'node:fs';
 import { setGeminiMdFilename as mockSetGeminiMdFilename } from '../tools/memoryTool.js';
 import {
   DEFAULT_TELEMETRY_TARGET,
@@ -2230,5 +2231,55 @@ describe('Config JIT Initialization', () => {
 
       expect(skillManager.setAdminSettings).toHaveBeenCalledWith(false);
     });
+  });
+});
+
+describe('Plans Directory Initialization', () => {
+  const baseParams: ConfigParameters = {
+    sessionId: 'test-session',
+    targetDir: '/tmp/test',
+    debugMode: false,
+    model: 'test-model',
+    cwd: '/tmp/test',
+  };
+
+  beforeEach(() => {
+    vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.mocked(fs.mkdirSync).mockRestore();
+  });
+
+  it('should create plans directory and add it to workspace context when plan is enabled', async () => {
+    const config = new Config({
+      ...baseParams,
+      plan: true,
+    });
+
+    await config.initialize();
+
+    const plansDir = config.storage.getProjectTempPlansDir();
+    expect(fs.mkdirSync).toHaveBeenCalledWith(plansDir, { recursive: true });
+
+    const context = config.getWorkspaceContext();
+    expect(context.getDirectories()).toContain(plansDir);
+  });
+
+  it('should NOT create plans directory or add it to workspace context when plan is disabled', async () => {
+    const config = new Config({
+      ...baseParams,
+      plan: false,
+    });
+
+    await config.initialize();
+
+    const plansDir = config.storage.getProjectTempPlansDir();
+    expect(fs.mkdirSync).not.toHaveBeenCalledWith(plansDir, {
+      recursive: true,
+    });
+
+    const context = config.getWorkspaceContext();
+    expect(context.getDirectories()).not.toContain(plansDir);
   });
 });

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -2244,11 +2244,11 @@ describe('Plans Directory Initialization', () => {
   };
 
   beforeEach(() => {
-    vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined);
+    vi.spyOn(fs.promises, 'mkdir').mockResolvedValue(undefined);
   });
 
   afterEach(() => {
-    vi.mocked(fs.mkdirSync).mockRestore();
+    vi.mocked(fs.promises.mkdir).mockRestore();
   });
 
   it('should create plans directory and add it to workspace context when plan is enabled', async () => {
@@ -2260,7 +2260,9 @@ describe('Plans Directory Initialization', () => {
     await config.initialize();
 
     const plansDir = config.storage.getProjectTempPlansDir();
-    expect(fs.mkdirSync).toHaveBeenCalledWith(plansDir, { recursive: true });
+    expect(fs.promises.mkdir).toHaveBeenCalledWith(plansDir, {
+      recursive: true,
+    });
 
     const context = config.getWorkspaceContext();
     expect(context.getDirectories()).toContain(plansDir);
@@ -2275,7 +2277,7 @@ describe('Plans Directory Initialization', () => {
     await config.initialize();
 
     const plansDir = config.storage.getProjectTempPlansDir();
-    expect(fs.mkdirSync).not.toHaveBeenCalledWith(plansDir, {
+    expect(fs.promises.mkdir).not.toHaveBeenCalledWith(plansDir, {
       recursive: true,
     });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { inspect } from 'node:util';
 import process from 'node:process';
@@ -696,6 +697,7 @@ export class Config {
     this.extensionManagement = params.extensionManagement ?? true;
     this.enableExtensionReloading = params.enableExtensionReloading ?? false;
     this.storage = new Storage(this.targetDir);
+
     this.fakeResponses = params.fakeResponses;
     this.recordResponses = params.recordResponses;
     this.enablePromptCompletion = params.enablePromptCompletion ?? false;
@@ -792,6 +794,13 @@ export class Config {
     // Add pending directories to workspace context
     for (const dir of this.pendingIncludeDirectories) {
       this.workspaceContext.addDirectory(dir);
+    }
+
+    // Add plans directory to workspace context for plan file storage
+    if (this.planEnabled) {
+      const plansDir = this.storage.getProjectTempPlansDir();
+      fs.mkdirSync(plansDir, { recursive: true });
+      this.workspaceContext.addDirectory(plansDir);
     }
 
     // Initialize centralized FileDiscoveryService

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -799,7 +799,7 @@ export class Config {
     // Add plans directory to workspace context for plan file storage
     if (this.planEnabled) {
       const plansDir = this.storage.getProjectTempPlansDir();
-      fs.mkdirSync(plansDir, { recursive: true });
+      await fs.promises.mkdir(plansDir, { recursive: true });
       this.workspaceContext.addDirectory(plansDir);
     }
 

--- a/packages/core/src/config/storage.test.ts
+++ b/packages/core/src/config/storage.test.ts
@@ -78,4 +78,10 @@ describe('Storage – additional helpers', () => {
     const expected = path.join(os.homedir(), GEMINI_DIR, 'tmp', 'bin');
     expect(Storage.getGlobalBinDir()).toBe(expected);
   });
+
+  it('getProjectTempPlansDir returns ~/.gemini/tmp/<hash>/plans', () => {
+    const tempDir = storage.getProjectTempDir();
+    const expected = path.join(tempDir, 'plans');
+    expect(storage.getProjectTempPlansDir()).toBe(expected);
+  });
 });

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -155,6 +155,10 @@ export class Storage {
     return path.join(this.getProjectTempDir(), 'logs');
   }
 
+  getProjectTempPlansDir(): string {
+    return path.join(this.getProjectTempDir(), 'plans');
+  }
+
   getExtensionsDir(): string {
     return path.join(this.getGeminiDir(), 'extensions');
   }

--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -182,6 +182,11 @@ You are operating in **Plan Mode** - a structured planning workflow for designin
 ## Available Tools
 The following read-only tools are available in Plan Mode:
 
+- \`write_file\` - Save plans to the plans directory (see Plan Storage below)
+
+## Plan Storage
+- Save your plans as Markdown (.md) files directly to: \`/tmp/project-temp/plans/\`
+- Use descriptive filenames: \`feature-name.md\` or \`bugfix-description.md\`
 
 ## Workflow Phases
 
@@ -201,7 +206,7 @@ The following read-only tools are available in Plan Mode:
 - Only begin this phase after exploration is complete
 - Create a detailed implementation plan with clear steps
 - Include file paths, function signatures, and code snippets where helpful
-- Present the plan for review
+- After saving the plan, present the full content of the markdown file to the user for review
 
 ### Phase 4: Review & Approval
 - Ask the user if they approve the plan, want revisions, or want to reject it

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -65,6 +65,9 @@ describe('Core System Prompt (prompts.ts)', () => {
       getEnableShellOutputEfficiency: vi.fn().mockReturnValue(true),
       storage: {
         getProjectTempDir: vi.fn().mockReturnValue('/tmp/project-temp'),
+        getProjectTempPlansDir: vi
+          .fn()
+          .mockReturnValue('/tmp/project-temp/plans'),
       },
       isInteractive: vi.fn().mockReturnValue(true),
       isInteractiveShellEnabled: vi.fn().mockReturnValue(true),

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -146,6 +146,8 @@ export function getCoreSystemPrompt(
       .map((toolName) => `- \`${toolName}\``)
       .join('\n');
 
+    const plansDir = config.storage.getProjectTempPlansDir();
+
     approvalModePrompt = `
 # Active Approval Mode: Plan
 
@@ -154,6 +156,11 @@ You are operating in **Plan Mode** - a structured planning workflow for designin
 ## Available Tools
 The following read-only tools are available in Plan Mode:
 ${planModeToolsList}
+- \`${WRITE_FILE_TOOL_NAME}\` - Save plans to the plans directory (see Plan Storage below)
+
+## Plan Storage
+- Save your plans as Markdown (.md) files directly to: \`${plansDir}/\`
+- Use descriptive filenames: \`feature-name.md\` or \`bugfix-description.md\`
 
 ## Workflow Phases
 
@@ -173,7 +180,7 @@ ${planModeToolsList}
 - Only begin this phase after exploration is complete
 - Create a detailed implementation plan with clear steps
 - Include file paths, function signatures, and code snippets where helpful
-- Present the plan for review
+- After saving the plan, present the full content of the markdown file to the user for review
 
 ### Phase 4: Review & Approval
 - Ask the user if they approve the plan, want revisions, or want to reject it

--- a/packages/core/src/policy/policies/plan.toml
+++ b/packages/core/src/policy/policies/plan.toml
@@ -68,3 +68,11 @@ modes = ["plan"]
 toolName = "SubagentInvocation"
 decision = "allow"
 priority = 50
+
+# Allow write_file for .md files in plans directory
+[[rule]]
+toolName = "write_file"
+decision = "allow"
+priority = 50
+modes = ["plan"]
+argsPattern = "\"file_path\":\"[^\"]+/\\.gemini/tmp/[a-f0-9]{64}/plans/[a-zA-Z0-9_-]+\\.md\""


### PR DESCRIPTION
## Summary

This change introduces persistent file storage for **Plan Mode**, allowing the agent to save plans as `.md` files in a dedicated temporary directory. This ensures plans are preserved as artifacts and source of truth beyond the agent context.

## Details

*   **Core Storage**: Implemented `getProjectTempPlansDir()` in `Storage` to define the location for plan files and ensured it is added to the `WorkspaceContext` during configuration.
*   **Policy Engine**: Updated `plan.toml` policy to strictly allow `write_file` only for `.md` files in the root of the plans directory (`.gemini/tmp/<hash>/plans/`). Subdirectories are explicitly blocked for consistency.
*   **Prompts**: Updated the System Prompt for Plan Mode to:
    *   Inform the agent of the writable plans directory.
    *   Instruct the agent to save plans with descriptive filenames.
    *   Mandate presenting the **full markdown content** of the plan to the user after saving, rather than just referencing the file.
*   **Testing**: Added integration tests in `packages/cli` to verify policy enforcement and updated `packages/core` tests to reflect the subdirectory restriction.

## Related Issues

<!-- Reference related issues here if any -->

Closes https://github.com/google-gemini/gemini-cli/issues/16867

## How to Validate

1. **Enable experimental planning**
   ```json
   {
     "experimental": {
       "plan": true
     }
   }
   ```
2. **Checkout this branch** `git checkout feat/plan-storage`
3. **Install**: `npm install`
4. **Build**: `npm run build`
5. **Start in Plan Mode**: `npm start -- --approval-mode=plan`
6. **Provide a high-level request**: (e.g., `I want to add a feature for talking to the CLI`).
7. **Validate Plan Storage**: Ensure the agent uses `write_file` to save the plan into the designated plans directory (e.g., `.../plans/cli-voice-feature.md`).
8. **Validate Content Presentation**: Confirm that the agent prints the **full content** of the markdown plan in the terminal immediately after saving it.

## Pre-Merge Checklist

- [x] Added/updated tests (if needed)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run