### PR TITLE
refactor(cli): migrate non-interactive flow to event-driven scheduler

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -14,7 +14,6 @@ import type {
   UserFeedbackPayload,
 } from '@google/gemini-cli-core';
 import {
-  executeToolCall,
   ToolErrorType,
   GeminiEventType,
   OutputFormat,
@@ -48,6 +47,8 @@ const mockCoreEvents = vi.hoisted(() => ({
   drainBacklogs: vi.fn(),
 }));
 
+const mockSchedulerSchedule = vi.hoisted(() => vi.fn());
+
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const original =
     await importOriginal<typeof import('@google/gemini-cli-core')>();
@@ -61,7 +62,10 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
 
   return {
     ...original,
-    executeToolCall: vi.fn(),
+    Scheduler: class {
+      schedule = mockSchedulerSchedule;
+      cancelAll = vi.fn();
+    },
     isTelemetrySdkInitialized: vi.fn().mockReturnValue(true),
     ChatRecordingService: MockChatRecordingService,
     uiTelemetryService: {
@@ -91,7 +95,6 @@ describe('runNonInteractive', () => {
   let mockConfig: Config;
   let mockSettings: LoadedSettings;
   let mockToolRegistry: ToolRegistry;
-  let mockCoreExecuteToolCall: Mock;
   let consoleErrorSpy: MockInstance;
   let processStdoutSpy: MockInstance;
   let processStderrSpy: MockInstance;
@@ -122,7 +125,7 @@ describe('runNonInteractive', () => {
   };
 
   beforeEach(async () => {
-    mockCoreExecuteToolCall = vi.mocked(executeToolCall);
+    mockSchedulerSchedule.mockReset();
 
     mockCommandServiceCreate.mockResolvedValue({
       getCommands: mockGetCommands,
@@ -158,6 +161,11 @@ describe('runNonInteractive', () => {
 
     mockConfig = {
       initialize: vi.fn().mockResolvedValue(undefined),
+      getMessageBus: vi.fn().mockReturnValue({
+        subscribe: vi.fn(),
+        unsubscribe: vi.fn(),
+        publish: vi.fn(),
+      }),
       getGeminiClient: vi.fn().mockReturnValue(mockGeminiClient),
       getToolRegistry: vi.fn().mockReturnValue(mockToolRegistry),
       getMaxSessionTurns: vi.fn().mockReturnValue(10),
@@ -263,25 +271,27 @@ describe('runNonInteractive', () => {
       },
     };
     const toolResponse: Part[] = [{ text: 'Tool response' }];
-    mockCoreExecuteToolCall.mockResolvedValue({
-      status: 'success',
-      request: {
-        callId: 'tool-1',
-        name: 'testTool',
-        args: { arg1: 'value1' },
-        isClientInitiated: false,
-        prompt_id: 'prompt-id-2',
+    mockSchedulerSchedule.mockResolvedValue([
+      {
+        status: 'success',
+        request: {
+          callId: 'tool-1',
+          name: 'testTool',
+          args: { arg1: 'value1' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-id-2',
+        },
+        tool: {} as AnyDeclarativeTool,
+        invocation: {} as AnyToolInvocation,
+        response: {
+          responseParts: toolResponse,
+          callId: 'tool-1',
+          error: undefined,
+          errorType: undefined,
+          contentLength: undefined,
+        },
       },
-      tool: {} as AnyDeclarativeTool,
-      invocation: {} as AnyToolInvocation,
-      response: {
-        responseParts: toolResponse,
-        callId: 'tool-1',
-        error: undefined,
-        errorType: undefined,
-        contentLength: undefined,
-      },
-    });
+    ]);
 
     const firstCallEvents: ServerGeminiStreamEvent[] = [toolCallEvent];
     const secondCallEvents: ServerGeminiStreamEvent[] = [
@@ -304,9 +314,8 @@ describe('runNonInteractive', () => {
     });
 
     expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(2);
-    expect(mockCoreExecuteToolCall).toHaveBeenCalledWith(
-      mockConfig,
-      expect.objectContaining({ name: 'testTool' }),
+    expect(mockSchedulerSchedule).toHaveBeenCalledWith(
+      [expect.objectContaining({ name: 'testTool' })],
       expect.any(AbortSignal),
     );
     expect(mockGeminiClient.sendMessageStream).toHaveBeenNthCalledWith(
@@ -335,16 +344,18 @@ describe('runNonInteractive', () => {
     };
 
     // 2. Mock the execution of the tools. We just need them to succeed.
-    mockCoreExecuteToolCall.mockResolvedValue({
-      status: 'success',
-      request: toolCallEvent.value, // This is generic enough for both calls
-      tool: {} as AnyDeclarativeTool,
-      invocation: {} as AnyToolInvocation,
-      response: {
-        responseParts: [],
-        callId: 'mock-tool',
+    mockSchedulerSchedule.mockResolvedValue([
+      {
+        status: 'success',
+        request: toolCallEvent.value, // This is generic enough for both calls
+        tool: {} as AnyDeclarativeTool,
+        invocation: {} as AnyToolInvocation,
+        response: {
+          responseParts: [],
+          callId: 'mock-tool',
+        },
       },
-    });
+    ]);
 
     // 3. Define the sequence of events streamed from the mock model.
     // Turn 1: Model outputs text, then requests a tool call.
@@ -385,7 +396,7 @@ describe('runNonInteractive', () => {
     expect(getWrittenOutput()).toMatchSnapshot();
 
     // Also verify the tools were called as expected.
-    expect(mockCoreExecuteToolCall).toHaveBeenCalledTimes(2);
+    expect(mockSchedulerSchedule).toHaveBeenCalledTimes(2);
   });
 
   it('should handle error during tool execution and should send error back to the model', async () => {
@@ -399,34 +410,36 @@ describe('runNonInteractive', () => {
         prompt_id: 'prompt-id-3',
       },
     };
-    mockCoreExecuteToolCall.mockResolvedValue({
-      status: 'error',
-      request: {
-        callId: 'tool-1',
-        name: 'errorTool',
-        args: {},
-        isClientInitiated: false,
-        prompt_id: 'prompt-id-3',
-      },
-      tool: {} as AnyDeclarativeTool,
-      response: {
-        callId: 'tool-1',
-        error: new Error('Execution failed'),
-        errorType: ToolErrorType.EXECUTION_FAILED,
-        responseParts: [
-          {
-            functionResponse: {
-              name: 'errorTool',
-              response: {
-                output: 'Error: Execution failed',
+    mockSchedulerSchedule.mockResolvedValue([
+      {
+        status: 'error',
+        request: {
+          callId: 'tool-1',
+          name: 'errorTool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-id-3',
+        },
+        tool: {} as AnyDeclarativeTool,
+        response: {
+          callId: 'tool-1',
+          error: new Error('Execution failed'),
+          errorType: ToolErrorType.EXECUTION_FAILED,
+          responseParts: [
+            {
+              functionResponse: {
+                name: 'errorTool',
+                response: {
+                  output: 'Error: Execution failed',
+                },
               },
             },
-          },
-        ],
-        resultDisplay: 'Execution failed',
-        contentLength: undefined,
+          ],
+          resultDisplay: 'Execution failed',
+          contentLength: undefined,
+        },
       },
-    });
+    ]);
     const finalResponse: ServerGeminiStreamEvent[] = [
       {
         type: GeminiEventType.Content,
@@ -448,7 +461,7 @@ describe('runNonInteractive', () => {
       prompt_id: 'prompt-id-3',
     });
 
-    expect(mockCoreExecuteToolCall).toHaveBeenCalled();
+    expect(mockSchedulerSchedule).toHaveBeenCalled();
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       'Error executing tool errorTool: Execution failed',
     );
@@ -498,24 +511,26 @@ describe('runNonInteractive', () => {
         prompt_id: 'prompt-id-5',
       },
     };
-    mockCoreExecuteToolCall.mockResolvedValue({
-      status: 'error',
-      request: {
-        callId: 'tool-1',
-        name: 'nonexistentTool',
-        args: {},
-        isClientInitiated: false,
-        prompt_id: 'prompt-id-5',
+    mockSchedulerSchedule.mockResolvedValue([
+      {
+        status: 'error',
+        request: {
+          callId: 'tool-1',
+          name: 'nonexistentTool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-id-5',
+        },
+        response: {
+          callId: 'tool-1',
+          error: new Error('Tool "nonexistentTool" not found in registry.'),
+          resultDisplay: 'Tool "nonexistentTool" not found in registry.',
+          responseParts: [],
+          errorType: undefined,
+          contentLength: undefined,
+        },
       },
-      response: {
-        callId: 'tool-1',
-        error: new Error('Tool "nonexistentTool" not found in registry.'),
-        resultDisplay: 'Tool "nonexistentTool" not found in registry.',
-        responseParts: [],
-        errorType: undefined,
-        contentLength: undefined,
-      },
-    });
+    ]);
     const finalResponse: ServerGeminiStreamEvent[] = [
       {
         type: GeminiEventType.Content,
@@ -538,7 +553,7 @@ describe('runNonInteractive', () => {
       prompt_id: 'prompt-id-5',
     });
 
-    expect(mockCoreExecuteToolCall).toHaveBeenCalled();
+    expect(mockSchedulerSchedule).toHaveBeenCalled();
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       'Error executing tool nonexistentTool: Tool "nonexistentTool" not found in registry.',
     );
@@ -665,25 +680,27 @@ describe('runNonInteractive', () => {
       },
     };
     const toolResponse: Part[] = [{ text: 'Tool executed successfully' }];
-    mockCoreExecuteToolCall.mockResolvedValue({
-      status: 'success',
-      request: {
-        callId: 'tool-1',
-        name: 'testTool',
-        args: { arg1: 'value1' },
-        isClientInitiated: false,
-        prompt_id: 'prompt-id-tool-only',
+    mockSchedulerSchedule.mockResolvedValue([
+      {
+        status: 'success',
+        request: {
+          callId: 'tool-1',
+          name: 'testTool',
+          args: { arg1: 'value1' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-id-tool-only',
+        },
+        tool: {} as AnyDeclarativeTool,
+        invocation: {} as AnyToolInvocation,
+        response: {
+          responseParts: toolResponse,
+          callId: 'tool-1',
+          error: undefined,
+          errorType: undefined,
+          contentLength: undefined,
+        },
       },
-      tool: {} as AnyDeclarativeTool,
-      invocation: {} as AnyToolInvocation,
-      response: {
-        responseParts: toolResponse,
-        callId: 'tool-1',
-        error: undefined,
-        errorType: undefined,
-        contentLength: undefined,
-      },
-    });
+    ]);
 
     // First call returns only tool call, no content
     const firstCallEvents: ServerGeminiStreamEvent[] = [
@@ -719,9 +736,8 @@ describe('runNonInteractive', () => {
     });
 
     expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(2);
-    expect(mockCoreExecuteToolCall).toHaveBeenCalledWith(
-      mockConfig,
-      expect.objectContaining({ name: 'testTool' }),
+    expect(mockSchedulerSchedule).toHaveBeenCalledWith(
+      [expect.objectContaining({ name: 'testTool' })],
       expect.any(AbortSignal),
     );
 
@@ -1248,25 +1264,27 @@ describe('runNonInteractive', () => {
       },
     };
     const toolResponse: Part[] = [{ text: 'file.txt' }];
-    mockCoreExecuteToolCall.mockResolvedValue({
-      status: 'success',
-      request: {
-        callId: 'tool-shell-1',
-        name: 'ShellTool',
-        args: { command: 'ls' },
-        isClientInitiated: false,
-        prompt_id: 'prompt-id-allowed',
+    mockSchedulerSchedule.mockResolvedValue([
+      {
+        status: 'success',
+        request: {
+          callId: 'tool-shell-1',
+          name: 'ShellTool',
+          args: { command: 'ls' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-id-allowed',
+        },
+        tool: {} as AnyDeclarativeTool,
+        invocation: {} as AnyToolInvocation,
+        response: {
+          responseParts: toolResponse,
+          callId: 'tool-shell-1',
+          error: undefined,
+          errorType: undefined,
+          contentLength: undefined,
+        },
       },
-      tool: {} as AnyDeclarativeTool,
-      invocation: {} as AnyToolInvocation,
-      response: {
-        responseParts: toolResponse,
-        callId: 'tool-shell-1',
-        error: undefined,
-        errorType: undefined,
-        contentLength: undefined,
-      },
-    });
+    ]);
 
     const firstCallEvents: ServerGeminiStreamEvent[] = [toolCallEvent];
     const secondCallEvents: ServerGeminiStreamEvent[] = [
@@ -1288,9 +1306,8 @@ describe('runNonInteractive', () => {
       prompt_id: 'prompt-id-allowed',
     });
 
-    expect(mockCoreExecuteToolCall).toHaveBeenCalledWith(
-      mockConfig,
-      expect.objectContaining({ name: 'ShellTool' }),
+    expect(mockSchedulerSchedule).toHaveBeenCalledWith(
+      [expect.objectContaining({ name: 'ShellTool' })],
       expect.any(AbortSignal),
     );
     expect(getWrittenOutput()).toBe('file.txt\n');
@@ -1446,20 +1463,22 @@ describe('runNonInteractive', () => {
       },
     };
 
-    mockCoreExecuteToolCall.mockResolvedValue({
-      status: 'success',
-      request: toolCallEvent.value,
-      tool: {} as AnyDeclarativeTool,
-      invocation: {} as AnyToolInvocation,
-      response: {
-        responseParts: [{ text: 'Tool response' }],
-        callId: 'tool-1',
-        error: undefined,
-        errorType: undefined,
-        contentLength: undefined,
-        resultDisplay: 'Tool executed successfully',
+    mockSchedulerSchedule.mockResolvedValue([
+      {
+        status: 'success',
+        request: toolCallEvent.value,
+        tool: {} as AnyDeclarativeTool,
+        invocation: {} as AnyToolInvocation,
+        response: {
+          responseParts: [{ text: 'Tool response' }],
+          callId: 'tool-1',
+          error: undefined,
+          errorType: undefined,
+          contentLength: undefined,
+          resultDisplay: 'Tool executed successfully',
+        },
       },
-    });
+    ]);
 
     const firstCallEvents: ServerGeminiStreamEvent[] = [
       { type: GeminiEventType.Content, value: 'Thinking...' },
@@ -1636,19 +1655,21 @@ describe('runNonInteractive', () => {
         prompt_id: 'prompt-id-tool-error',
       },
     };
-    mockCoreExecuteToolCall.mockResolvedValue({
-      status: 'success',
-      request: toolCallEvent.value,
-      tool: {} as AnyDeclarativeTool,
-      invocation: {} as AnyToolInvocation,
-      response: {
-        responseParts: [],
-        callId: 'tool-1',
-        error: undefined,
-        errorType: undefined,
-        contentLength: undefined,
+    mockSchedulerSchedule.mockResolvedValue([
+      {
+        status: 'success',
+        request: toolCallEvent.value,
+        tool: {} as AnyDeclarativeTool,
+        invocation: {} as AnyToolInvocation,
+        response: {
+          responseParts: [],
+          callId: 'tool-1',
+          error: undefined,
+          errorType: undefined,
+          contentLength: undefined,
+        },
       },
-    });
+    ]);
 
     const events: ServerGeminiStreamEvent[] = [
       toolCallEvent,
@@ -1717,19 +1738,21 @@ describe('runNonInteractive', () => {
     };
 
     // Mock tool execution returning STOP_EXECUTION
-    mockCoreExecuteToolCall.mockResolvedValue({
-      status: 'error',
-      request: toolCallEvent.value,
-      tool: {} as AnyDeclarativeTool,
-      invocation: {} as AnyToolInvocation,
-      response: {
-        callId: 'stop-call',
-        responseParts: [{ text: 'error occurred' }],
-        errorType: ToolErrorType.STOP_EXECUTION,
-        error: new Error('Stop reason from hook'),
-        resultDisplay: undefined,
+    mockSchedulerSchedule.mockResolvedValue([
+      {
+        status: 'error',
+        request: toolCallEvent.value,
+        tool: {} as AnyDeclarativeTool,
+        invocation: {} as AnyToolInvocation,
+        response: {
+          callId: 'stop-call',
+          responseParts: [{ text: 'error occurred' }],
+          errorType: ToolErrorType.STOP_EXECUTION,
+          error: new Error('Stop reason from hook'),
+          resultDisplay: undefined,
+        },
       },
-    });
+    ]);
 
     const firstCallEvents: ServerGeminiStreamEvent[] = [
       { type: GeminiEventType.Content, value: 'Executing tool...' },
@@ -1750,7 +1773,7 @@ describe('runNonInteractive', () => {
       prompt_id: 'prompt-id-stop',
     });
 
-    expect(mockCoreExecuteToolCall).toHaveBeenCalled();
+    expect(mockSchedulerSchedule).toHaveBeenCalled();
 
     // The key assertion: sendMessageStream should have been called ONLY ONCE (initial user input).
     expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
@@ -1777,19 +1800,21 @@ describe('runNonInteractive', () => {
       },
     };
 
-    mockCoreExecuteToolCall.mockResolvedValue({
-      status: 'error',
-      request: toolCallEvent.value,
-      tool: {} as AnyDeclarativeTool,
-      invocation: {} as AnyToolInvocation,
-      response: {
-        callId: 'stop-call',
-        responseParts: [{ text: 'error occurred' }],
-        errorType: ToolErrorType.STOP_EXECUTION,
-        error: new Error('Stop reason'),
-        resultDisplay: undefined,
+    mockSchedulerSchedule.mockResolvedValue([
+      {
+        status: 'error',
+        request: toolCallEvent.value,
+        tool: {} as AnyDeclarativeTool,
+        invocation: {} as AnyToolInvocation,
+        response: {
+          callId: 'stop-call',
+          responseParts: [{ text: 'error occurred' }],
+          errorType: ToolErrorType.STOP_EXECUTION,
+          error: new Error('Stop reason'),
+          resultDisplay: undefined,
+        },
       },
-    });
+    ]);
 
     const firstCallEvents: ServerGeminiStreamEvent[] = [
       { type: GeminiEventType.Content, value: 'Partial content' },
@@ -1839,19 +1864,21 @@ describe('runNonInteractive', () => {
       },
     };
 
-    mockCoreExecuteToolCall.mockResolvedValue({
-      status: 'error',
-      request: toolCallEvent.value,
-      tool: {} as AnyDeclarativeTool,
-      invocation: {} as AnyToolInvocation,
-      response: {
-        callId: 'stop-call',
-        responseParts: [{ text: 'error occurred' }],
-        errorType: ToolErrorType.STOP_EXECUTION,
-        error: new Error('Stop reason'),
-        resultDisplay: undefined,
+    mockSchedulerSchedule.mockResolvedValue([
+      {
+        status: 'error',
+        request: toolCallEvent.value,
+        tool: {} as AnyDeclarativeTool,
+        invocation: {} as AnyToolInvocation,
+        response: {
+          callId: 'stop-call',
+          responseParts: [{ text: 'error occurred' }],
+          errorType: ToolErrorType.STOP_EXECUTION,
+          error: new Error('Stop reason'),
+          resultDisplay: undefined,
+        },
       },
-    });
+    ]);
 
     const firstCallEvents: ServerGeminiStreamEvent[] = [toolCallEvent];
 

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -8,13 +8,11 @@ import type {
   Config,
   ToolCallRequestInfo,
   ResumedSessionData,
-  CompletedToolCall,
   UserFeedbackPayload,
 } from '@google/gemini-cli-core';
 import { isSlashCommand } from './ui/utils/commandUtils.js';
 import type { LoadedSettings } from './config/settings.js';
 import {
-  executeToolCall,
   GeminiEventType,
   FatalInputError,
   promptIdContext,
@@ -29,6 +27,8 @@ import {
   createWorkingStdio,
   recordToolCallInteractions,
   ToolErrorType,
+  Scheduler,
+  ROOT_SCHEDULER_ID,
 } from '@google/gemini-cli-core';
 
 import type { Content, Part } from '@google/genai';
@@ -202,6 +202,12 @@ export async function runNonInteractive({
       });
 
       const geminiClient = config.getGeminiClient();
+      const scheduler = new Scheduler({
+        config,
+        messageBus: config.getMessageBus(),
+        getPreferredEditor: () => undefined,
+        schedulerId: ROOT_SCHEDULER_ID,
+      });
 
       // Initialize chat.  Resume if resume data is passed.
       if (resumedSessionData) {
@@ -375,25 +381,23 @@ export async function runNonInteractive({
 
         if (toolCallRequests.length > 0) {
           textOutput.ensureTrailingNewline();
+          const completedToolCalls = await scheduler.schedule(
+            toolCallRequests,
+            abortController.signal,
+          );
           const toolResponseParts: Part[] = [];
-          const completedToolCalls: CompletedToolCall[] = [];
 
-          for (const requestInfo of toolCallRequests) {
-            const completedToolCall = await executeToolCall(
-              config,
-              requestInfo,
-              abortController.signal,
-            );
+          for (const completedToolCall of completedToolCalls) {
             const toolResponse = completedToolCall.response;
-
-            completedToolCalls.push(completedToolCall);
+            const requestInfo = completedToolCall.request;
 
             if (streamFormatter) {
               streamFormatter.emitEvent({
                 type: JsonStreamEventType.TOOL_RESULT,
                 timestamp: new Date().toISOString(),
                 tool_id: requestInfo.callId,
-                status: toolResponse.error ? 'error' : 'success',
+                status:
+                  completedToolCall.status === 'success' ? 'success' : 'error',
                 output:
                   typeof toolResponse.resultDisplay === 'string'
                     ? toolResponse.resultDisplay

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -397,7 +397,7 @@ export async function runNonInteractive({
                 timestamp: new Date().toISOString(),
                 tool_id: requestInfo.callId,
                 status:
-                  completedToolCall.status === 'success' ? 'success' : 'error',
+                  completedToolCall.status === 'error' ? 'error' : 'success',
                 output:
                   typeof toolResponse.resultDisplay === 'string'
                     ? toolResponse.resultDisplay


### PR DESCRIPTION
## Summary

This PR migrates the non-interactive CLI flow to use the new event-driven
`Scheduler`. This completes the transition away from the legacy
`executeToolCall` helper for standard CLI operations.

## Details

- **Scheduler Adoption**: Updates `runNonInteractive` in
  `packages/cli/src/nonInteractiveCli.ts` to instantiate and use the `Scheduler`
  for all tool call batches.
- **Legacy Cleanup**: Prepares for the removal of the non-interactive tool
  executor by replacing its usage in the core CLI flow.
- **Batch Execution**: Leverages the Scheduler's ability to handle batches of
  tool calls, improving the robustness of tool execution in non-interactive
  mode.
- **Test Migration**: Refactors `nonInteractiveCli.test.ts` to mock the
  `Scheduler` class and its `schedule` method, ensuring all existing
  non-interactive scenarios are verified against the new execution logic.

## Related Issues

Related to #14306

## How to Validate

1. Run the non-interactive CLI tests:
   ```bash
   npm test -w @google/gemini-cli -- src/nonInteractiveCli.test.ts
   ```
2. Run a non-interactive command manually (e.g.,
   `gemini -p "ls the current directory"`) and verify it still executes tools
   correctly and returns the expected output.

## Pre-Merge Checklist

- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
