### PR TITLE
feat(plan): refresh system prompt when approval mode changes (Shift+Tab)

### DIFF
--- a/packages/core/src/commands/memory.ts
+++ b/packages/core/src/commands/memory.ts
@@ -59,7 +59,7 @@ export async function refreshMemory(
     fileCount = result.fileCount;
   }
 
-  await config.updateSystemInstructionIfInitialized();
+  config.updateSystemInstructionIfInitialized();
   let content: string;
 
   if (memoryContent.length > 0) {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1268,6 +1268,39 @@ describe('setApprovalMode with folder trust', () => {
     expect(() => config.setApprovalMode(ApprovalMode.DEFAULT)).not.toThrow();
   });
 
+  it('should update system instruction when entering Plan mode', () => {
+    const config = new Config(baseParams);
+    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+    const updateSpy = vi.spyOn(config, 'updateSystemInstructionIfInitialized');
+
+    config.setApprovalMode(ApprovalMode.PLAN);
+
+    expect(updateSpy).toHaveBeenCalled();
+  });
+
+  it('should update system instruction when leaving Plan mode', () => {
+    const config = new Config({
+      ...baseParams,
+      approvalMode: ApprovalMode.PLAN,
+    });
+    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+    const updateSpy = vi.spyOn(config, 'updateSystemInstructionIfInitialized');
+
+    config.setApprovalMode(ApprovalMode.DEFAULT);
+
+    expect(updateSpy).toHaveBeenCalled();
+  });
+
+  it('should not update system instruction when switching between non-Plan modes', () => {
+    const config = new Config(baseParams);
+    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+    const updateSpy = vi.spyOn(config, 'updateSystemInstructionIfInitialized');
+
+    config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
   describe('registerCoreTools', () => {
     beforeEach(() => {
       vi.clearAllMocks();

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1322,7 +1322,7 @@ export class Config {
     }
     if (this.geminiClient?.isInitialized()) {
       await this.geminiClient.setTools();
-      await this.geminiClient.updateSystemInstruction();
+      this.geminiClient.updateSystemInstruction();
     }
   }
 
@@ -1390,6 +1390,13 @@ export class Config {
     }
 
     this.policyEngine.setApprovalMode(mode);
+
+    const isPlanModeTransition =
+      currentMode !== mode &&
+      (currentMode === ApprovalMode.PLAN || mode === ApprovalMode.PLAN);
+    if (isPlanModeTransition) {
+      this.updateSystemInstructionIfInitialized();
+    }
   }
 
   /**
@@ -1472,10 +1479,10 @@ export class Config {
    * Updates the system instruction with the latest user memory.
    * Whenever the user memory (GEMINI.md files) is updated.
    */
-  async updateSystemInstructionIfInitialized(): Promise<void> {
+  updateSystemInstructionIfInitialized(): void {
     const geminiClient = this.getGeminiClient();
     if (geminiClient?.isInitialized()) {
-      await geminiClient.updateSystemInstruction();
+      geminiClient.updateSystemInstruction();
     }
   }
 
@@ -1784,7 +1791,7 @@ export class Config {
     }
 
     // Notify the client that system instructions might need updating
-    await this.updateSystemInstructionIfInitialized();
+    this.updateSystemInstructionIfInitialized();
   }
 
   /**
@@ -2119,7 +2126,7 @@ export class Config {
     const client = this.getGeminiClient();
     if (client?.isInitialized()) {
       await client.setTools();
-      await client.updateSystemInstruction();
+      client.updateSystemInstruction();
     } else {
       debugLogger.debug(
         '[Config] GeminiClient not initialized; skipping live prompt/tool refresh.',

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1842,7 +1842,7 @@ ${JSON.stringify(
       const { getCoreSystemPrompt } = await import('./prompts.js');
       const mockGetCoreSystemPrompt = vi.mocked(getCoreSystemPrompt);
 
-      await client.updateSystemInstruction();
+      client.updateSystemInstruction();
 
       expect(mockGetCoreSystemPrompt).toHaveBeenCalledWith(
         mockConfig,
@@ -1857,7 +1857,7 @@ ${JSON.stringify(
       const { getCoreSystemPrompt } = await import('./prompts.js');
       const mockGetCoreSystemPrompt = vi.mocked(getCoreSystemPrompt);
 
-      await client.updateSystemInstruction();
+      client.updateSystemInstruction();
 
       expect(mockGetCoreSystemPrompt).toHaveBeenCalledWith(
         mockConfig,

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -300,7 +300,7 @@ export class GeminiClient {
     });
   }
 
-  async updateSystemInstruction(): Promise<void> {
+  updateSystemInstruction(): void {
     if (!this.isInitialized()) {
       return;
     }


### PR DESCRIPTION
## Summary

This PR fixes an issue where switching approval modes (e.g., via `Shift+Tab` to enter **Plan** mode) did not trigger a refresh of the model's system instructions. This caused a mismatch where the policy engine correctly restricted tools, but the model remained unaware of mode-specific instructions (like Plan mode's role and tool availability).

## Details

- **Synchronous Mode Switching**: Changed `updateSystemInstruction` from asynchronous to synchronous. The underlying configuration logic was already synchronous, so the `async` signature was unnecessary and introduced potential race conditions in the UI (e.g., when rapidly toggling modes).
- **System Prompt Refresh**: Added logic to `setApprovalMode` to automatically trigger a system instruction update when entering or leaving **Plan** mode.

## Related Issues

Closes https://github.com/google-gemini/gemini-cli/issues/17540

## How to Validate

### Manual Verification
1.  **Prepare Environment**:
    ```bash
    npm install && npm run build && npm start
    ```
2.  **Toggle Plan Mode**: Press `Shift+Tab` to cycle to **Plan** mode.
3.  **Provide a high-level request**: (e.g., `I want to add a feature for talking to the CLI`).
4.  **Verify Instructions**: The agent takes you through planning workflow. Attempt tool execution e.g. `Run ls` and observe it reject the request in **Plan** mode.
5.  **Verify Restore**: Cycle back to **Default** mode using `Shift+Tab` and verify tool execution is allowed again.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker