### PR TITLE
feat(cli): Display user identity (auth, email, tier) on startup

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -202,15 +202,7 @@ export const AppContainer = (props: AppContainerProps) => {
     if (resumedSessionData || settings.merged.ui.showUserIdentity === false) {
       return;
     }
-    // We can't use authState here because it's initialized in useAuthCommand which is called later.
-    // However, we can check config directly since we know startup just finished.
     const authType = config.getContentGeneratorConfig()?.authType;
-    if (
-      authType !== AuthType.LOGIN_WITH_GOOGLE &&
-      authType !== AuthType.COMPUTE_ADC
-    ) {
-      return;
-    }
 
     // Run this asynchronously to avoid blocking the event loop.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -220,8 +212,13 @@ export const AppContainer = (props: AppContainerProps) => {
         const email = userAccountManager.getCachedGoogleAccount();
         const tierName = config.getUserTierName();
 
-        if (email) {
-          let message = `Authenticated as: ${email}`;
+        if (authType) {
+          let message =
+            authType === AuthType.LOGIN_WITH_GOOGLE
+              ? email
+                ? `Logged in with Google: ${email}`
+                : 'Logged in with Google'
+              : `Authenticated with ${authType}`;
           if (tierName) {
             message += ` (Plan: ${tierName})`;
           }

--- a/packages/cli/src/ui/hooks/useHistoryManager.test.ts
+++ b/packages/cli/src/ui/hooks/useHistoryManager.test.ts
@@ -219,4 +219,40 @@ describe('useHistoryManager', () => {
     expect(result.current.history[0].id).toBeGreaterThanOrEqual(before + 1);
     expect(result.current.history[0].id).toBeLessThanOrEqual(after + 1);
   });
+
+  describe('initialItems with auth information', () => {
+    it('should initialize with auth information', () => {
+      const email = 'user@example.com';
+      const tier = 'Pro';
+      const authMessage = `Authenticated as: ${email} (Plan: ${tier})`;
+      const initialItems: HistoryItem[] = [
+        {
+          id: 1,
+          type: 'info',
+          text: authMessage,
+        },
+      ];
+      const { result } = renderHook(() => useHistory({ initialItems }));
+      expect(result.current.history).toHaveLength(1);
+      expect(result.current.history[0].text).toBe(authMessage);
+    });
+
+    it('should add items with auth information via addItem', () => {
+      const { result } = renderHook(() => useHistory());
+      const email = 'user@example.com';
+      const tier = 'Pro';
+      const authMessage = `Authenticated as: ${email} (Plan: ${tier})`;
+
+      act(() => {
+        result.current.addItem({
+          type: 'info',
+          text: authMessage,
+        });
+      });
+
+      expect(result.current.history).toHaveLength(1);
+      expect(result.current.history[0].text).toBe(authMessage);
+      expect(result.current.history[0].type).toBe('info');
+    });
+  });
 });

--- a/packages/cli/src/ui/hooks/useHistoryManager.ts
+++ b/packages/cli/src/ui/hooks/useHistoryManager.ts
@@ -36,10 +36,12 @@ export interface UseHistoryManagerReturn {
  */
 export function useHistory({
   chatRecordingService,
+  initialItems = [],
 }: {
   chatRecordingService?: ChatRecordingService | null;
+  initialItems?: HistoryItem[];
 } = {}): UseHistoryManagerReturn {
-  const [history, setHistory] = useState<HistoryItem[]>([]);
+  const [history, setHistory] = useState<HistoryItem[]>(initialItems);
   const messageIdCounterRef = useRef(0);
 
   // Generates a unique message ID based on a timestamp and a counter.


### PR DESCRIPTION
## Summary

Display the user identity (authentication type, user email, tier) on startup.

### Screenshots
<img width="773" height="355" alt="sc1" src="https://github.com/user-attachments/assets/114c60bd-63fd-4e8f-9ec4-ef23003c3f33" />
<img width="740" height="393" alt="sc2" src="https://github.com/user-attachments/assets/fc3aac21-1c0b-468f-9867-bbbf20ae424a" />


## Details

- Refactored `AppContainer` startup auth check to use `useEffect` and an async block, ensuring non-blocking initialization of the UI.
- Improved startup identity message to explicitly show the authentication type (e.g., `Authenticated with gemini-api-key`) when Google Login is not used.
- Enhanced message formatting: `Logged in with Google: <email> (Plan: <tier>)` or `Authenticated with <authType> (Plan: <tier>)`.
- Added comprehensive unit tests in `AppContainer.test.tsx` covering various authentication methods and UI settings (`showUserIdentity`).

## Related Issues

Fixes #16254

## How to Validate

1. Run the CLI with different authentication methods (Google Login vs API Key).
2. Verify the startup message displays the correct account/type and plan.
3. Verify the message is hidden when `ui.showUserIdentity` is set to `false` in settings.
4. Run unit tests: `npm test -w packages/cli -- src/ui/AppContainer.test.tsx`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
  - [ ] Linux
