### PR TITLE
fix(plan): remove subagent invocation from plan mode

### DIFF
--- a/packages/core/src/policy/policies/plan.toml
+++ b/packages/core/src/policy/policies/plan.toml
@@ -64,11 +64,6 @@ decision = "allow"
 priority = 50
 modes = ["plan"]
 
-[[rule]]
-toolName = "SubagentInvocation"
-decision = "allow"
-priority = 50
-
 # Allow write_file for .md files in plans directory
 [[rule]]
 toolName = "write_file"


### PR DESCRIPTION
This temporarily removes the SubagentInvocation rule from the plan policy until planning is refactored into a subagent.

Ref: https://github.com/google-gemini/gemini-cli/issues/16632
