### PR TITLE
Ctrl-O

### DIFF
--- a/docs/cli/keyboard-shortcuts.md
+++ b/docs/cli/keyboard-shortcuts.md
@@ -94,20 +94,20 @@ available combinations.
 
 #### App Controls
 
-| Action                                                                                                | Keys             |
-| ----------------------------------------------------------------------------------------------------- | ---------------- |
-| Toggle detailed error information.                                                                    | `F12`            |
-| Toggle the full TODO list.                                                                            | `Ctrl + T`       |
-| Show IDE context details.                                                                             | `Ctrl + G`       |
-| Toggle Markdown rendering.                                                                            | `Alt + M`        |
-| Toggle copy mode when in alternate buffer mode.                                                       | `Ctrl + S`       |
-| Toggle YOLO (auto-approval) mode for tool calls.                                                      | `Ctrl + Y`       |
-| Cycle through approval modes: default (prompt), auto_edit (auto-approve edits), and plan (read-only). | `Shift + Tab`    |
-| Expand a height-constrained response to show additional lines when not in alternate buffer mode.      | `Ctrl + S`       |
-| Focus the shell input from the gemini input.                                                          | `Tab (no Shift)` |
-| Focus the Gemini input from the shell input.                                                          | `Tab`            |
-| Clear the terminal screen and redraw the UI.                                                          | `Ctrl + L`       |
-| Restart the application.                                                                              | `R`              |
+| Action                                                                                                | Keys                       |
+| ----------------------------------------------------------------------------------------------------- | -------------------------- |
+| Toggle detailed error information.                                                                    | `F12`                      |
+| Toggle the full TODO list.                                                                            | `Ctrl + T`                 |
+| Show IDE context details.                                                                             | `Ctrl + G`                 |
+| Toggle Markdown rendering.                                                                            | `Alt + M`                  |
+| Toggle copy mode when in alternate buffer mode.                                                       | `Ctrl + S`                 |
+| Toggle YOLO (auto-approval) mode for tool calls.                                                      | `Ctrl + Y`                 |
+| Cycle through approval modes: default (prompt), auto_edit (auto-approve edits), and plan (read-only). | `Shift + Tab`              |
+| Expand a height-constrained response to show additional lines when not in alternate buffer mode.      | `Ctrl + O`<br />`Ctrl + S` |
+| Focus the shell input from the gemini input.                                                          | `Tab (no Shift)`           |
+| Focus the Gemini input from the shell input.                                                          | `Tab`                      |
+| Clear the terminal screen and redraw the UI.                                                          | `Ctrl + L`                 |
+| Restart the application.                                                                              | `R`                        |
 
 <!-- KEYBINDINGS-AUTOGEN:END -->
 

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -253,7 +253,10 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.TOGGLE_COPY_MODE]: [{ key: 's', ctrl: true }],
   [Command.TOGGLE_YOLO]: [{ key: 'y', ctrl: true }],
   [Command.CYCLE_APPROVAL_MODE]: [{ key: 'tab', shift: true }],
-  [Command.SHOW_MORE_LINES]: [{ key: 's', ctrl: true }],
+  [Command.SHOW_MORE_LINES]: [
+    { key: 'o', ctrl: true },
+    { key: 's', ctrl: true },
+  ],
   [Command.FOCUS_SHELL_INPUT]: [{ key: 'tab', shift: false }],
   [Command.UNFOCUS_SHELL_INPUT]: [{ key: 'tab' }],
   [Command.CLEAR_SCREEN]: [{ key: 'l', ctrl: true }],

--- a/packages/cli/src/ui/components/ShowMoreLines.test.tsx
+++ b/packages/cli/src/ui/components/ShowMoreLines.test.tsx
@@ -48,7 +48,7 @@ describe('ShowMoreLines', () => {
       } as NonNullable<ReturnType<typeof useOverflowState>>);
       mockUseStreamingContext.mockReturnValue(streamingState);
       const { lastFrame } = render(<ShowMoreLines constrainHeight={true} />);
-      expect(lastFrame()).toContain('Press ctrl-s to show more lines');
+      expect(lastFrame()).toContain('Press ctrl-o to show more lines');
     },
   );
 });

--- a/packages/cli/src/ui/components/ShowMoreLines.tsx
+++ b/packages/cli/src/ui/components/ShowMoreLines.tsx
@@ -33,7 +33,7 @@ export const ShowMoreLines = ({ constrainHeight }: ShowMoreLinesProps) => {
   return (
     <Box>
       <Text color={theme.text.secondary} wrap="truncate">
-        Press ctrl-s to show more lines
+        Press ctrl-o to show more lines
       </Text>
     </Box>
   );

--- a/packages/cli/src/ui/constants/tips.ts
+++ b/packages/cli/src/ui/constants/tips.ts
@@ -88,7 +88,7 @@ export const INFORMATIVE_TIPS = [
   'Clear your screen at any time with Ctrl+L…',
   'Toggle the debug console display with F12…',
   'Toggle the todo list display with Ctrl+T…',
-  'See full, untruncated responses with Ctrl+S…',
+  'See full, untruncated responses with Ctrl+O…',
   'Toggle auto-approval (YOLO mode) for all tools with Ctrl+Y…',
   'Cycle through approval modes (Default, Plan, Auto-Edit) with Shift+Tab…',
   'Toggle Markdown rendering (raw markdown mode) with Alt+M…',

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -308,7 +308,10 @@ describe('keyMatchers', () => {
     },
     {
       command: Command.SHOW_MORE_LINES,
-      positive: [createKey('s', { ctrl: true })],
+      positive: [
+        createKey('s', { ctrl: true }),
+        createKey('o', { ctrl: true }),
+      ],
       negative: [createKey('s'), createKey('l', { ctrl: true })],
     },
 


### PR DESCRIPTION
## Summary

Switch to using ctrl-O to expand collapsed content as well as ctrl-S

Ctrl-S is left enabled for now and can be deprecated in a follow up PR.