### PR TITLE
Always map mac keys, even on other platforms

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -565,7 +565,9 @@ function* emitKeys(
       shift = /^[A-Z]$/.exec(ch) !== null;
       alt = escaped;
       insertable = true;
-    } else if (MAC_ALT_KEY_CHARACTER_MAP[ch] && process.platform === 'darwin') {
+    } else if (MAC_ALT_KEY_CHARACTER_MAP[ch]) {
+      // Note: we do this even if we are not on Mac, because mac users may
+      // remotely connect to non-Mac systems.
       name = MAC_ALT_KEY_CHARACTER_MAP[ch];
       alt = true;
     } else if (sequence === `${ESC}${ESC}`) {


### PR DESCRIPTION
## Summary

Always map mac keys, even on other platforms

## Details

we do this even if we are not on Mac, because mac users may remotely connect to non-Mac systems.

## Related Issues

Fixes #17416

## How to Validate

Use the default mac terminal to ssh into a linux machine. Run gcli there and type "option+m"

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
