### PR TITLE
fix(cli): remove user email from /about command output

### DIFF
--- a/packages/cli/src/ui/commands/aboutCommand.test.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.test.ts
@@ -21,9 +21,6 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
         getDetectedIdeDisplayName: vi.fn().mockReturnValue('test-ide'),
       }),
     },
-    UserAccountManager: vi.fn().mockImplementation(() => ({
-      getCachedGoogleAccount: vi.fn().mockReturnValue('test-email@example.com'),
-    })),
     getVersion: vi.fn(),
   };
 });
@@ -97,7 +94,6 @@ describe('aboutCommand', () => {
       selectedAuthType: 'test-auth',
       gcpProject: 'test-gcp-project',
       ideClient: 'test-ide',
-      userEmail: 'test-email@example.com',
       tier: undefined,
     });
   });

--- a/packages/cli/src/ui/commands/aboutCommand.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.ts
@@ -8,12 +8,7 @@ import type { CommandContext, SlashCommand } from './types.js';
 import { CommandKind } from './types.js';
 import process from 'node:process';
 import { MessageType, type HistoryItemAbout } from '../types.js';
-import {
-  IdeClient,
-  UserAccountManager,
-  debugLogger,
-  getVersion,
-} from '@google/gemini-cli-core';
+import { IdeClient, getVersion } from '@google/gemini-cli-core';
 
 export const aboutCommand: SlashCommand = {
   name: 'about',
@@ -37,13 +32,6 @@ export const aboutCommand: SlashCommand = {
     const gcpProject = process.env['GOOGLE_CLOUD_PROJECT'] || '';
     const ideClient = await getIdeClientName(context);
 
-    const userAccountManager = new UserAccountManager();
-    const cachedAccount = userAccountManager.getCachedGoogleAccount();
-    debugLogger.log('AboutCommand: Retrieved cached Google account', {
-      cachedAccount,
-    });
-    const userEmail = cachedAccount ?? undefined;
-
     const tier = context.services.config?.getUserTierName();
 
     const aboutItem: Omit<HistoryItemAbout, 'id'> = {
@@ -55,7 +43,6 @@ export const aboutCommand: SlashCommand = {
       selectedAuthType,
       gcpProject,
       ideClient,
-      userEmail,
       tier,
     };
 

--- a/packages/cli/src/ui/components/AboutBox.test.tsx
+++ b/packages/cli/src/ui/components/AboutBox.test.tsx
@@ -48,13 +48,6 @@ describe('AboutBox', () => {
     expect(output).toContain(value);
   });
 
-  it('renders Auth Method with email when userEmail is provided', () => {
-    const props = { ...defaultProps, userEmail: 'test@example.com' };
-    const { lastFrame } = render(<AboutBox {...props} />);
-    const output = lastFrame();
-    expect(output).toContain('Logged in with Google (test@example.com)');
-  });
-
   it('renders Auth Method correctly when not oauth', () => {
     const props = { ...defaultProps, selectedAuthType: 'api-key' };
     const { lastFrame } = render(<AboutBox {...props} />);

--- a/packages/cli/src/ui/components/AboutBox.tsx
+++ b/packages/cli/src/ui/components/AboutBox.tsx
@@ -17,7 +17,6 @@ interface AboutBoxProps {
   selectedAuthType: string;
   gcpProject: string;
   ideClient: string;
-  userEmail?: string;
   tier?: string;
 }
 
@@ -29,7 +28,6 @@ export const AboutBox: React.FC<AboutBoxProps> = ({
   selectedAuthType,
   gcpProject,
   ideClient,
-  userEmail,
   tier,
 }) => (
   <Box
@@ -106,9 +104,7 @@ export const AboutBox: React.FC<AboutBoxProps> = ({
       <Box>
         <Text color={theme.text.primary}>
           {selectedAuthType.startsWith('oauth')
-            ? userEmail
-              ? `Logged in with Google (${userEmail})`
-              : 'Logged in with Google'
+            ? 'Logged in with Google'
             : selectedAuthType}
         </Text>
       </Box>

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -111,7 +111,6 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
           selectedAuthType={itemForDisplay.selectedAuthType}
           gcpProject={itemForDisplay.gcpProject}
           ideClient={itemForDisplay.ideClient}
-          userEmail={itemForDisplay.userEmail}
           tier={itemForDisplay.tier}
         />
       )}

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -144,7 +144,6 @@ export type HistoryItemAbout = HistoryItemBase & {
   selectedAuthType: string;
   gcpProject: string;
   ideClient: string;
-  userEmail?: string;
   tier?: string;
 };
 
@@ -369,7 +368,6 @@ export type Message =
       selectedAuthType: string;
       gcpProject: string;
       ideClient: string;
-      userEmail?: string;
       content?: string; // Optional content, not really used for ABOUT
     }
   | {


### PR DESCRIPTION
## Summary
Remove user email (PII) from `/about` command output to prevent unintentional exposure when users share the output in bug reports.

## Details
- Remove `userEmail` field from `HistoryItemAbout` type.
- Remove `UserAccountManager` usage in `aboutCommand.ts`
- Update `AboutBox` component to not display email.
- Update related tests


## Related Issues
Fixes #16374

## How to Validate
1. Run `npm run build`
2. Run `npm start`
3. Type `/about` command
4. Verify that user email is NOT displayed in the output
5. Confirm "Auth Method" shows "Logged in with Google" (without email) for OAuth users

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
