### PR TITLE
adding back Update Attempt text to Retry change that was accidentally…

### DIFF
--- a/packages/cli/src/ui/hooks/useLoadingIndicator.test.tsx
+++ b/packages/cli/src/ui/hooks/useLoadingIndicator.test.tsx
@@ -223,6 +223,6 @@ describe('useLoadingIndicator', () => {
     );
 
     expect(result.current.currentLoadingPhrase).toContain('Trying to reach');
-    expect(result.current.currentLoadingPhrase).toContain('Attempt 3/3');
+    expect(result.current.currentLoadingPhrase).toContain('Retry 2/2');
   });
 });

--- a/packages/cli/src/ui/hooks/useLoadingIndicator.ts
+++ b/packages/cli/src/ui/hooks/useLoadingIndicator.ts
@@ -66,7 +66,7 @@ export const useLoadingIndicator = ({
   }, [streamingState, elapsedTimeFromTimer]);
 
   const retryPhrase = retryStatus
-    ? `Trying to reach ${getDisplayString(retryStatus.model)} (Attempt ${retryStatus.attempt + 1}/${retryStatus.maxAttempts})`
+    ? `Trying to reach ${getDisplayString(retryStatus.model)} (Retry ${retryStatus.attempt}/${retryStatus.maxAttempts - 1})`
     : null;
 
   return {


### PR DESCRIPTION
… reverted

## Summary
This seemed to have accidentally been reverted in one of the refactoring PR.
Original PR: https://github.com/google-gemini/gemini-cli/pull/17178
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details
https://github.com/google-gemini/gemini-cli/pull/17178
'Users reported that the original "Attempt" phrasing was confusing, as it wasn't clear if "1/10" referred to the initial execution or the first subsequent retry. Switching to "Retry" explicitly signals that the process is repeating after an initial failure.'
<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues
Fixes https://github.com/google-gemini/gemini-cli/issues/17179
<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
