### PR TITLE
docs: remove 'experimental' syntax for hooks in docs

### DIFF
--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -1,4 +1,4 @@
-# Gemini CLI hooks (experimental)
+# Gemini CLI hooks
 
 Hooks are scripts or programs that Gemini CLI executes at specific points in the
 agentic loop, allowing you to intercept and customize behavior without modifying

--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -4,29 +4,6 @@ Hooks are scripts or programs that Gemini CLI executes at specific points in the
 agentic loop, allowing you to intercept and customize behavior without modifying
 the CLI's source code.
 
-## Availability
-
-> **Experimental Feature**: Hooks are currently enabled by default only in the
-> **Preview** and **Nightly** release channels.
-
-If you are on the Stable channel, you must explicitly enable the hooks system in
-your `settings.json`:
-
-```json
-{
-  "hooksConfig": {
-    "enabled": true
-  }
-}
-```
-
-- **[Writing hooks guide](/docs/hooks/writing-hooks)**: A tutorial on creating
-  your first hook with comprehensive examples.
-- **[Hooks reference](/docs/hooks/reference)**: The definitive technical
-  specification of I/O schemas and exit codes.
-- **[Best practices](/docs/hooks/best-practices)**: Guidelines on security,
-  performance, and debugging.
-
 ## What are hooks?
 
 Hooks run synchronously as part of the agent loop—when a hook event fires,
@@ -42,6 +19,15 @@ With hooks, you can:
 - **Log interactions:** Track tool usage and model responses for auditing.
 - **Optimize behavior:** Dynamically filter available tools or adjust model
   parameters.
+
+### Getting started
+
+- **[Writing hooks guide](/docs/hooks/writing-hooks)**: A tutorial on creating
+  your first hook with comprehensive examples.
+- **[Best practices](/docs/hooks/best-practices)**: Guidelines on security,
+  performance, and debugging.
+- **[Hooks reference](/docs/hooks/reference)**: The definitive technical
+  specification of I/O schemas and exit codes.
 
 ## Core concepts
 

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -86,7 +86,7 @@
         "label": "Remote subagents (experimental)",
         "slug": "docs/core/remote-agents"
       },
-      { "label": "Hooks (experimental)", "slug": "docs/hooks" },
+      { "label": "Hooks", "slug": "docs/hooks" },
       { "label": "IDE integration", "slug": "docs/ide-integration" },
       { "label": "MCP servers", "slug": "docs/tools/mcp-server" }
     ]


### PR DESCRIPTION
Updates hooks docs to match latest stable release

Resolves #17659