### PR TITLE
chore: remove extra top margin from /hooks and /extensions

### DIFF
--- a/packages/cli/src/ui/components/views/ExtensionsList.tsx
+++ b/packages/cli/src/ui/components/views/ExtensionsList.tsx
@@ -22,7 +22,7 @@ export const ExtensionsList: React.FC<ExtensionsList> = ({ extensions }) => {
   }
 
   return (
-    <Box flexDirection="column" marginTop={1} marginBottom={1}>
+    <Box flexDirection="column" marginBottom={1}>
       <Text>Installed extensions: </Text>
       <Box flexDirection="column" paddingLeft={2}>
         {extensions.map((ext) => {

--- a/packages/cli/src/ui/components/views/HooksList.tsx
+++ b/packages/cli/src/ui/components/views/HooksList.tsx
@@ -28,10 +28,8 @@ interface HooksListProps {
 export const HooksList: React.FC<HooksListProps> = ({ hooks }) => {
   if (hooks.length === 0) {
     return (
-      <Box flexDirection="column" marginTop={1} marginBottom={1}>
-        <Box marginTop={1}>
-          <Text>No hooks configured.</Text>
-        </Box>
+      <Box flexDirection="column" marginBottom={1}>
+        <Text>No hooks configured.</Text>
       </Box>
     );
   }
@@ -49,8 +47,8 @@ export const HooksList: React.FC<HooksListProps> = ({ hooks }) => {
   );
 
   return (
-    <Box flexDirection="column" marginTop={1} marginBottom={1}>
-      <Box marginTop={1} flexDirection="column">
+    <Box flexDirection="column" marginBottom={1}>
+      <Box flexDirection="column">
         <Text color={theme.status.warning} bold underline>
           ⚠️ Security Warning:
         </Text>


### PR DESCRIPTION
## Summary

Hooks and extensions (`/hooks` and `/extensions`) had tiered margin padding being added from several layered components resulting in multiple newlines (three) of whitespace...

```
> /hooks



No hooks configured.
```

Removing extra margin so a single newline is used following pattern in `/skills`.

Now it looks crisp...

<img width="2337" height="571" alt="image" src="https://github.com/user-attachments/assets/6787189c-a2c1-4838-b705-ed9a238eb284" />
