### PR TITLE
fix(acp): add listing models and switching model via acp

### DIFF
--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -18,6 +18,7 @@ import {
   ModelSlashCommandEvent,
   logModelSlashCommand,
   getDisplayString,
+  getModelDescription,
 } from '@google/gemini-cli-core';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { theme } from '../semantic-colors.js';
@@ -75,8 +76,7 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
       {
         value: DEFAULT_GEMINI_MODEL_AUTO,
         title: getDisplayString(DEFAULT_GEMINI_MODEL_AUTO),
-        description:
-          'Let Gemini CLI decide the best model for the task: gemini-2.5-pro, gemini-2.5-flash',
+        description: getModelDescription(DEFAULT_GEMINI_MODEL_AUTO),
         key: DEFAULT_GEMINI_MODEL_AUTO,
       },
       {
@@ -93,8 +93,7 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
       list.unshift({
         value: PREVIEW_GEMINI_MODEL_AUTO,
         title: getDisplayString(PREVIEW_GEMINI_MODEL_AUTO),
-        description:
-          'Let Gemini CLI decide the best model for the task: gemini-3-pro, gemini-3-flash',
+        description: getModelDescription(PREVIEW_GEMINI_MODEL_AUTO),
         key: PREVIEW_GEMINI_MODEL_AUTO,
       });
     }

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -124,6 +124,21 @@ export function getDisplayString(
 }
 
 /**
+ * Returns the description for a model, used in UI and ACP model lists.
+ * Only auto models have descriptions; concrete models return undefined.
+ */
+export function getModelDescription(model: string): string | undefined {
+  switch (model) {
+    case PREVIEW_GEMINI_MODEL_AUTO:
+      return `Let Gemini CLI decide the best model for the task: ${PREVIEW_GEMINI_MODEL}, ${PREVIEW_GEMINI_FLASH_MODEL}`;
+    case DEFAULT_GEMINI_MODEL_AUTO:
+      return `Let Gemini CLI decide the best model for the task: ${DEFAULT_GEMINI_MODEL}, ${DEFAULT_GEMINI_FLASH_MODEL}`;
+    default:
+      return undefined;
+  }
+}
+
+/**
  * Checks if the model is a preview model.
  *
  * @param model The model name to check.


### PR DESCRIPTION
ACP now exposes available models and allows runtime model switching.

## Summary

Adds `unstable_setSessionModel` acp method for runtime model switching and
populates the `models` field in `newSession` responses with available models.

**Note:**
ACP marks it as `unstable` [spec](https://agentclientprotocol.github.io/typescript-sdk/classes/ClientSideConnection.html#unstable_setsessionmodel)

`claude-code-acp` and `OpenCode` support these ACP already, whereas some IDEs
also.

This would e.g. Intellij IDE allow to list and change the models:

<img width="804" height="731" alt="image" src="https://github.com/user-attachments/assets/f0b5ebfb-aff6-4c26-9c31-a7313843377c" />


## Details

The changes enable:

1. Discover available models through the `models` field in `newSession`
   responses
2. Switch models at runtime using `unstable_setSessionModel`

Changes:

- Added `unstable_setSessionModel()` to acp
- Populated `models` object (with `availableModels` and `currentModelId`) in
  `newSession` responses

The `unstable_setSessionModel` method validates that the requested model exists.

## Related Issues

Fixes #12453

# How to Validate

Using an ACP SDK to list and switch models:

```typescript
import { createACPProvider } from '@mcpc-tech/acp-ai-provider';
import { generateText } from 'ai';

const provider = createACPProvider({
  command: './bundle/gemini.js',
  args: ['--experimental-acp'],
  session: { cwd: process.cwd(), mcpServers: [] },
});

// Initialize session to get available models
const session = await provider.initSession();

// List all available models
console.log(`Current model: ${session.models.currentModelId}`);
session.models.availableModels.forEach((model) => {
  console.log(`- ${model.name}: ${model.description || 'No description'}`);
});

// Switch to a different model (e.g., gemini-2.5-flash)
await provider.setModel('gemini-2.5-flash');

// Verify the change with a test prompt
const result = await generateText({
  model: provider.languageModel(),
  prompt: 'Say hello!',
});
console.log(result.text);

provider.cleanup();
```
