### PR TITLE
feat(cli): show candidate issue state reason and duplicate status in triage

### DIFF
--- a/packages/cli/src/ui/components/triage/TriageDuplicates.tsx
+++ b/packages/cli/src/ui/components/triage/TriageDuplicates.tsx
@@ -90,6 +90,13 @@ const getReactionCount = (issue: Issue | Candidate | undefined) => {
   );
 };
 
+const getStateColor = (state: string, stateReason?: string) => {
+  if (stateReason?.toLowerCase() === 'duplicate') {
+    return 'magenta';
+  }
+  return state === 'OPEN' ? 'green' : 'red';
+};
+
 export const TriageDuplicates = ({
   config,
   onExit,
@@ -945,15 +952,7 @@ Return a JSON object with:
                       wrap="truncate-end"
                     >
                       {absoluteIndex + 1}. <Text bold>#{c.number}</Text>{' '}
-                      <Text
-                        color={
-                          c.stateReason?.toLowerCase() === 'duplicate'
-                            ? 'magenta'
-                            : c.state === 'OPEN'
-                              ? 'green'
-                              : 'red'
-                        }
-                      >
+                      <Text color={getStateColor(c.state, c.stateReason)}>
                         [{(c.stateReason || c.state).toUpperCase()}]
                       </Text>{' '}
                       {isDuplicateOfCurrent && (


### PR DESCRIPTION
## Summary

This PR enhances the Triage Duplicates tool by showing the `state` (e.g., OPEN/CLOSED) and `stateReason` (e.g., duplicate, not planned) for candidate issues. It also detects and highlights if a candidate issue has already been marked as a duplicate of the current target issue, if it was marked as duplicated by this command tool. (does not detect the ones updated from the UI)

## Details
<img width="1007" height="586" alt="image" src="https://github.com/user-attachments/assets/cb3500da-3bb4-40fb-899c-d3d573cac927" />

- **Added fields**: `state` and `stateReason` to the `Issue` and `Candidate` interfaces.
- **Updated fetching**: `gh issue list` and `gh issue view` calls now include `state` and `stateReason` in the JSON response.
- **UI Enhancement**:
    - Displays `[STATE - stateReason]` next to candidate issue numbers.
    - Scans comments for "duplicate of #<target_issue_number>" and displays a bold red `[DUPLICATE OF CURRENT]` label if found.
    - Color coding: Green for OPEN, Red for others.

## Related Issues
Fixes https://github.com/google-gemini/gemini-cli/issues/17662
<!-- None explicitly mentioned, but this is part of improving the triage tool -->

## How to Validate

1. Run the CLI in development mode: `npm run start -- triage`.
2. Observe the candidate list.
3. Verify that candidate issues show their state (e.g., `[OPEN]`, `[CLOSED - completed]`).
4. If a candidate is a duplicate of the current issue (check comments), verify the `[DUPLICATE OF CURRENT]` warning appears.

## Pre-Merge Checklist

- [x] Validated on MacOS
