### PR TITLE
Capture debug logs for nightly evals

### DIFF
--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -59,6 +59,7 @@ jobs:
           GEMINI_MODEL: '${{ matrix.model }}'
           RUN_EVALS: "${{ github.event.inputs.run_all != 'false' }}"
           TEST_NAME_PATTERN: '${{ github.event.inputs.test_name_pattern }}'
+          DEBUG_MODE: 'true'
         run: |
           CMD="npm run test:all_evals"
           PATTERN="${{ env.TEST_NAME_PATTERN }}"


### PR DESCRIPTION
## Summary

Capture debug logs when evals run.

Helps in debugging evals for prompt changes.

Test run: https://github.com/google-gemini/gemini-cli/actions/runs/21410037496