### PR TITLE
feat(plan): implement `plan` slash command

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -314,6 +314,20 @@ Slash commands provide meta-level control over the CLI itself.
     - **`nodesc`** or **`nodescriptions`**:
       - **Description:** Hide tool descriptions, showing only the tool names.
 
+- **`/plan`**
+  - **Description:** Switch to Plan Mode (read-only) and view the current plan
+    if one has been generated.
+  - **Note:** This feature requires the `experimental.plan` setting to be
+    enabled in your configuration.
+
+- **`/privacy`**
+  - **Description:** Display the Privacy Notice and allow users to select
+    whether they consent to the collection of their data for service improvement
+    purposes.
+
+- **`/quit`** (or **`/exit`**)
+  - **Description:** Exit Gemini CLI.
+
 - **`/vim`**
   - **Description:** Toggle vim mode on or off. When vim mode is enabled, the
     input area supports vim-style navigation and editing commands in both NORMAL

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -204,6 +204,11 @@ Slash commands provide meta-level control over the CLI itself.
 - [**`/model`**](./model.md)
   - **Description:** Opens a dialog to choose your Gemini model.
 
+- **`/plan`**
+  - **Description:** Switch to Plan Mode (read-only) and view the current plan
+    if one has been generated.
+  - **Note:** This feature requires the `experimental.plan` setting to be
+    enabled in your configuration.
 - **`/policies`**
   - **Description:** Manage policies.
   - **Sub-commands:**
@@ -313,20 +318,6 @@ Slash commands provide meta-level control over the CLI itself.
         tool's name with its full description as provided to the model.
     - **`nodesc`** or **`nodescriptions`**:
       - **Description:** Hide tool descriptions, showing only the tool names.
-
-- **`/plan`**
-  - **Description:** Switch to Plan Mode (read-only) and view the current plan
-    if one has been generated.
-  - **Note:** This feature requires the `experimental.plan` setting to be
-    enabled in your configuration.
-
-- **`/privacy`**
-  - **Description:** Display the Privacy Notice and allow users to select
-    whether they consent to the collection of their data for service improvement
-    purposes.
-
-- **`/quit`** (or **`/exit`**)
-  - **Description:** Exit Gemini CLI.
 
 - **`/vim`**
   - **Description:** Toggle vim mode on or off. When vim mode is enabled, the

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -204,11 +204,6 @@ Slash commands provide meta-level control over the CLI itself.
 - [**`/model`**](./model.md)
   - **Description:** Opens a dialog to choose your Gemini model.
 
-- **`/plan`**
-  - **Description:** Switch to Plan Mode (read-only) and view the current plan
-    if one has been generated.
-  - **Note:** This feature requires the `experimental.plan` setting to be
-    enabled in your configuration.
 - **`/policies`**
   - **Description:** Manage policies.
   - **Sub-commands:**

--- a/packages/cli/src/services/BuiltinCommandLoader.test.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.test.ts
@@ -115,6 +115,7 @@ describe('BuiltinCommandLoader', () => {
     vi.clearAllMocks();
     mockConfig = {
       getFolderTrust: vi.fn().mockReturnValue(true),
+      isPlanEnabled: vi.fn().mockReturnValue(false),
       getEnableExtensionReloading: () => false,
       getEnableHooks: () => false,
       getEnableHooksUI: () => false,
@@ -256,6 +257,7 @@ describe('BuiltinCommandLoader profile', () => {
     vi.resetModules();
     mockConfig = {
       getFolderTrust: vi.fn().mockReturnValue(false),
+      isPlanEnabled: vi.fn().mockReturnValue(false),
       getCheckpointingEnabled: () => false,
       getEnableExtensionReloading: () => false,
       getEnableHooks: () => false,

--- a/packages/cli/src/services/BuiltinCommandLoader.test.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.test.ts
@@ -98,6 +98,17 @@ vi.mock('../ui/commands/toolsCommand.js', () => ({ toolsCommand: {} }));
 vi.mock('../ui/commands/skillsCommand.js', () => ({
   skillsCommand: { name: 'skills' },
 }));
+vi.mock('../ui/commands/planCommand.js', async () => {
+  const { CommandKind } = await import('../ui/commands/types.js');
+  return {
+    planCommand: {
+      name: 'plan',
+      description: 'Plan command',
+      kind: CommandKind.BUILT_IN,
+    },
+  };
+});
+
 vi.mock('../ui/commands/mcpCommand.js', () => ({
   mcpCommand: {
     name: 'mcp',
@@ -215,6 +226,22 @@ describe('BuiltinCommandLoader', () => {
     const commands = await loader.loadCommands(new AbortController().signal);
     const agentsCmd = commands.find((c) => c.name === 'agents');
     expect(agentsCmd).toBeDefined();
+  });
+
+  it('should include plan command when plan mode is enabled', async () => {
+    (mockConfig.isPlanEnabled as Mock).mockReturnValue(true);
+    const loader = new BuiltinCommandLoader(mockConfig);
+    const commands = await loader.loadCommands(new AbortController().signal);
+    const planCmd = commands.find((c) => c.name === 'plan');
+    expect(planCmd).toBeDefined();
+  });
+
+  it('should exclude plan command when plan mode is disabled', async () => {
+    (mockConfig.isPlanEnabled as Mock).mockReturnValue(false);
+    const loader = new BuiltinCommandLoader(mockConfig);
+    const commands = await loader.loadCommands(new AbortController().signal);
+    const planCmd = commands.find((c) => c.name === 'plan');
+    expect(planCmd).toBeUndefined();
   });
 
   it('should exclude agents command when agents are disabled', async () => {

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -40,8 +40,9 @@ import { memoryCommand } from '../ui/commands/memoryCommand.js';
 import { modelCommand } from '../ui/commands/modelCommand.js';
 import { oncallCommand } from '../ui/commands/oncallCommand.js';
 import { permissionsCommand } from '../ui/commands/permissionsCommand.js';
-import { privacyCommand } from '../ui/commands/privacyCommand.js';
+import { planCommand } from '../ui/commands/planCommand.js';
 import { policiesCommand } from '../ui/commands/policiesCommand.js';
+import { privacyCommand } from '../ui/commands/privacyCommand.js';
 import { profileCommand } from '../ui/commands/profileCommand.js';
 import { quitCommand } from '../ui/commands/quitCommand.js';
 import { restoreCommand } from '../ui/commands/restoreCommand.js';
@@ -142,8 +143,9 @@ export class BuiltinCommandLoader implements ICommandLoader {
       memoryCommand,
       modelCommand,
       ...(this.config?.getFolderTrust() ? [permissionsCommand] : []),
-      privacyCommand,
+      planCommand,
       policiesCommand,
+      privacyCommand,
       ...(isDevelopment ? [profileCommand] : []),
       quitCommand,
       restoreCommand(this.config),

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -143,7 +143,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       memoryCommand,
       modelCommand,
       ...(this.config?.getFolderTrust() ? [permissionsCommand] : []),
-      planCommand,
+      ...(this.config?.isPlanEnabled() ? [planCommand] : []),
       policiesCommand,
       privacyCommand,
       ...(isDevelopment ? [profileCommand] : []),

--- a/packages/cli/src/ui/commands/planCommand.test.ts
+++ b/packages/cli/src/ui/commands/planCommand.test.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { planCommand } from './planCommand.js';
+import { type CommandContext } from './types.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { MessageType } from '../types.js';
+import { ApprovalMode, coreEvents } from '@google/gemini-cli-core';
+import * as fs from 'node:fs';
+
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    coreEvents: {
+      emitFeedback: vi.fn(),
+    },
+  };
+});
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  promises: {
+    readdir: vi.fn(),
+    stat: vi.fn(),
+    readFile: vi.fn(),
+  },
+}));
+
+vi.mock('node:path', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:path')>();
+  return {
+    ...actual,
+    default: { ...actual },
+    join: vi.fn((...args) => args.join('/')),
+  };
+});
+
+describe('planCommand', () => {
+  let mockContext: CommandContext;
+
+  beforeEach(() => {
+    mockContext = createMockCommandContext({
+      services: {
+        config: {
+          isPlanEnabled: vi.fn(),
+          setApprovalMode: vi.fn(),
+          storage: {
+            getProjectTempPlansDir: vi.fn().mockReturnValue('/mock/plans/dir'),
+          },
+        },
+      },
+      ui: {
+        addItem: vi.fn(),
+      },
+    } as unknown as CommandContext);
+
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should have the correct name and description', () => {
+    expect(planCommand.name).toBe('plan');
+    expect(planCommand.description).toBe(
+      'Switch to Plan Mode and view current plan',
+    );
+  });
+
+  it('should show error if plan mode is not enabled', async () => {
+    vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(
+      false,
+    );
+
+    if (!planCommand.action) throw new Error('Action missing');
+    await planCommand.action(mockContext, '');
+
+    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+      'error',
+      expect.stringContaining('Plan mode is experimental'),
+    );
+    expect(mockContext.services.config!.setApprovalMode).not.toHaveBeenCalled();
+  });
+
+  it('should switch to plan mode if enabled', async () => {
+    vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(true);
+    vi.mocked(fs.existsSync).mockReturnValue(false); // No plans found case
+
+    if (!planCommand.action) throw new Error('Action missing');
+    await planCommand.action(mockContext, '');
+
+    expect(mockContext.services.config!.setApprovalMode).toHaveBeenCalledWith(
+      ApprovalMode.PLAN,
+    );
+    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+      'info',
+      'Switched to Plan Mode.',
+    );
+  });
+
+  it('should show "No plans found" if directory does not exist', async () => {
+    vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(true);
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    if (!planCommand.action) throw new Error('Action missing');
+    await planCommand.action(mockContext, '');
+
+    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+      'info',
+      'No plans found.',
+    );
+  });
+
+  it('should show "No plans found" if directory is empty of .md files', async () => {
+    vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(true);
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.promises.readdir).mockImplementation(
+      async () => ['not-a-plan.txt'] as Array<fs.Dirent<Buffer>>,
+    );
+
+    if (!planCommand.action) throw new Error('Action missing');
+    await planCommand.action(mockContext, '');
+
+    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+      'info',
+      'No plans found.',
+    );
+  });
+
+  it('should find and display the latest plan', async () => {
+    vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(true);
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.promises.readdir).mockImplementation(
+      async () => ['old-plan.md', 'new-plan.md'] as Array<fs.Dirent<Buffer>>,
+    );
+
+    vi.mocked(fs.promises.stat).mockImplementation(async (filePath) => {
+      const pathStr = filePath as string;
+      if (pathStr.includes('old-plan.md')) {
+        return { mtimeMs: 1000 } as fs.Stats;
+      }
+      if (pathStr.includes('new-plan.md')) {
+        return { mtimeMs: 2000 } as fs.Stats;
+      }
+      return {} as fs.Stats;
+    });
+
+    vi.mocked(fs.promises.readFile).mockResolvedValue('# New Plan Content');
+
+    if (!planCommand.action) throw new Error('Action missing');
+    await planCommand.action(mockContext, '');
+
+    expect(fs.promises.readFile).toHaveBeenCalledWith(
+      '/mock/plans/dir/new-plan.md',
+      'utf-8',
+    );
+    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+      'info',
+      'Latest Plan: new-plan.md',
+    );
+    expect(mockContext.ui.addItem).toHaveBeenCalledWith({
+      type: MessageType.GEMINI,
+      text: '# New Plan Content',
+    });
+  });
+
+  it('should handle errors when reading plans', async () => {
+    vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(true);
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.promises.readdir).mockRejectedValue(new Error('Read error'));
+
+    if (!planCommand.action) throw new Error('Action missing');
+    await planCommand.action(mockContext, '');
+
+    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+      'error',
+      expect.stringContaining('Failed to read plans: Error: Read error'),
+      expect.any(Error),
+    );
+  });
+});

--- a/packages/cli/src/ui/commands/planCommand.test.ts
+++ b/packages/cli/src/ui/commands/planCommand.test.ts
@@ -54,6 +54,7 @@ describe('planCommand', () => {
           isPlanEnabled: vi.fn(),
           setApprovalMode: vi.fn(),
           getApprovedPlanPath: vi.fn(),
+          getApprovalMode: vi.fn(),
           storage: {
             getProjectTempPlansDir: vi.fn().mockReturnValue('/mock/plans/dir'),
           },

--- a/packages/cli/src/ui/commands/planCommand.test.ts
+++ b/packages/cli/src/ui/commands/planCommand.test.ts
@@ -53,7 +53,7 @@ describe('planCommand', () => {
         config: {
           isPlanEnabled: vi.fn(),
           setApprovalMode: vi.fn(),
-          getActivePlanPath: vi.fn(),
+          getApprovedPlanPath: vi.fn(),
           storage: {
             getProjectTempPlansDir: vi.fn().mockReturnValue('/mock/plans/dir'),
           },
@@ -78,24 +78,9 @@ describe('planCommand', () => {
     );
   });
 
-  it('should show error if plan mode is not enabled', async () => {
-    vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(
-      false,
-    );
-
-    if (!planCommand.action) throw new Error('Action missing');
-    await planCommand.action(mockContext, '');
-
-    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
-      'error',
-      expect.stringContaining('Plan mode is experimental'),
-    );
-    expect(mockContext.services.config!.setApprovalMode).not.toHaveBeenCalled();
-  });
-
   it('should switch to plan mode if enabled', async () => {
     vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(true);
-    vi.mocked(mockContext.services.config!.getActivePlanPath).mockReturnValue(
+    vi.mocked(mockContext.services.config!.getApprovedPlanPath).mockReturnValue(
       undefined,
     );
 
@@ -113,7 +98,7 @@ describe('planCommand', () => {
 
   it('should show "No active plan found" if no active plan path in config', async () => {
     vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(true);
-    vi.mocked(mockContext.services.config!.getActivePlanPath).mockReturnValue(
+    vi.mocked(mockContext.services.config!.getApprovedPlanPath).mockReturnValue(
       undefined,
     );
 
@@ -129,7 +114,7 @@ describe('planCommand', () => {
   it('should display the active plan from config', async () => {
     const mockPlanPath = '/mock/plans/dir/active-plan.md';
     vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(true);
-    vi.mocked(mockContext.services.config!.getActivePlanPath).mockReturnValue(
+    vi.mocked(mockContext.services.config!.getApprovedPlanPath).mockReturnValue(
       mockPlanPath,
     );
     vi.mocked(fs.promises.readFile).mockResolvedValue('# Active Plan Content');
@@ -151,7 +136,7 @@ describe('planCommand', () => {
   it('should handle errors when reading the active plan', async () => {
     const mockPlanPath = '/mock/plans/dir/active-plan.md';
     vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(true);
-    vi.mocked(mockContext.services.config!.getActivePlanPath).mockReturnValue(
+    vi.mocked(mockContext.services.config!.getApprovedPlanPath).mockReturnValue(
       mockPlanPath,
     );
     vi.mocked(fs.promises.readFile).mockRejectedValue(new Error('Read error'));

--- a/packages/cli/src/ui/commands/planCommand.test.ts
+++ b/packages/cli/src/ui/commands/planCommand.test.ts
@@ -97,7 +97,7 @@ describe('planCommand', () => {
     );
   });
 
-  it('should show "No active plan found" if no active plan path in config', async () => {
+  it('should show "No approved plan found" if no approved plan path in config', async () => {
     vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(true);
     vi.mocked(mockContext.services.config!.getApprovedPlanPath).mockReturnValue(
       undefined,
@@ -108,17 +108,19 @@ describe('planCommand', () => {
 
     expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
       'error',
-      'No active plan found. Please create and approve a plan first.',
+      'No approved plan found. Please create and approve a plan first.',
     );
   });
 
-  it('should display the active plan from config', async () => {
-    const mockPlanPath = '/mock/plans/dir/active-plan.md';
+  it('should display the approved plan from config', async () => {
+    const mockPlanPath = '/mock/plans/dir/approved-plan.md';
     vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(true);
     vi.mocked(mockContext.services.config!.getApprovedPlanPath).mockReturnValue(
       mockPlanPath,
     );
-    vi.mocked(fs.promises.readFile).mockResolvedValue('# Active Plan Content');
+    vi.mocked(fs.promises.readFile).mockResolvedValue(
+      '# Approved Plan Content',
+    );
 
     if (!planCommand.action) throw new Error('Action missing');
     await planCommand.action(mockContext, '');
@@ -126,16 +128,16 @@ describe('planCommand', () => {
     expect(fs.promises.readFile).toHaveBeenCalledWith(mockPlanPath, 'utf-8');
     expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
       'info',
-      'Active Plan: active-plan.md',
+      'Approved Plan: approved-plan.md',
     );
     expect(mockContext.ui.addItem).toHaveBeenCalledWith({
       type: MessageType.GEMINI,
-      text: '# Active Plan Content',
+      text: '# Approved Plan Content',
     });
   });
 
-  it('should handle errors when reading the active plan', async () => {
-    const mockPlanPath = '/mock/plans/dir/active-plan.md';
+  it('should handle errors when reading the approved plan', async () => {
+    const mockPlanPath = '/mock/plans/dir/approved-plan.md';
     vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(true);
     vi.mocked(mockContext.services.config!.getApprovedPlanPath).mockReturnValue(
       mockPlanPath,
@@ -147,7 +149,9 @@ describe('planCommand', () => {
 
     expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
       'error',
-      expect.stringContaining(`Failed to read active plan at ${mockPlanPath}`),
+      expect.stringContaining(
+        `Failed to read approved plan at ${mockPlanPath}`,
+      ),
       expect.any(Error),
     );
   });

--- a/packages/cli/src/ui/commands/planCommand.ts
+++ b/packages/cli/src/ui/commands/planCommand.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CommandKind, type SlashCommand } from './types.js';
+import { ApprovalMode, coreEvents } from '@google/gemini-cli-core';
+import { MessageType } from '../types.js';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export const planCommand: SlashCommand = {
+  name: 'plan',
+  description: 'Switch to Plan Mode and view current plan',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: async (context) => {
+    const config = context.services.config;
+    if (!config) return;
+
+    // Check if plan mode is enabled
+    if (!config.isPlanEnabled()) {
+      coreEvents.emitFeedback(
+        'error',
+        'Plan mode is experimental. Enable it in your settings (experimental.plan) to use this command.',
+      );
+      return;
+    }
+
+    // Switch to plan mode
+    config.setApprovalMode(ApprovalMode.PLAN);
+    coreEvents.emitFeedback('info', 'Switched to Plan Mode.');
+
+    // Find and display the latest plan
+    const plansDir = config.storage.getProjectTempPlansDir();
+
+    try {
+      if (!fs.existsSync(plansDir)) {
+        coreEvents.emitFeedback('info', 'No plans found.');
+        return;
+      }
+
+      const files = await fs.promises.readdir(plansDir);
+      const planFiles = files.filter((f) => f.endsWith('.md'));
+
+      if (planFiles.length === 0) {
+        coreEvents.emitFeedback('info', 'No plans found.');
+        return;
+      }
+
+      // Sort by modification time, newest first
+      const sortedPlans = await Promise.all(
+        planFiles.map(async (file) => {
+          const filePath = path.join(plansDir, file);
+          const stats = await fs.promises.stat(filePath);
+          return { file, mtime: stats.mtimeMs, filePath };
+        }),
+      );
+
+      sortedPlans.sort((a, b) => b.mtime - a.mtime);
+
+      const latestPlan = sortedPlans[0];
+      const content = await fs.promises.readFile(latestPlan.filePath, 'utf-8');
+
+      coreEvents.emitFeedback('info', `Latest Plan: ${latestPlan.file}`);
+
+      context.ui.addItem({
+        type: MessageType.GEMINI,
+        text: content,
+      });
+    } catch (error) {
+      coreEvents.emitFeedback('error', `Failed to read plans: ${error}`, error);
+    }
+  },
+};

--- a/packages/cli/src/ui/commands/planCommand.ts
+++ b/packages/cli/src/ui/commands/planCommand.ts
@@ -22,23 +22,18 @@ export const planCommand: SlashCommand = {
       return;
     }
 
-    // Check if plan mode is enabled
-    if (!config.isPlanEnabled()) {
-      coreEvents.emitFeedback(
-        'error',
-        'Plan mode is experimental. Enable it in your settings (experimental.plan) to use this command.',
-      );
-      return;
-    }
-
+    const previousApprovalMode = config.getApprovalMode();
     // Switch to plan mode
     config.setApprovalMode(ApprovalMode.PLAN);
-    coreEvents.emitFeedback('info', 'Switched to Plan Mode.');
+
+    if (previousApprovalMode !== ApprovalMode.PLAN) {
+      coreEvents.emitFeedback('info', 'Switched to Plan Mode.');
+    }
 
     // Find and display the latest plan
-    const activePlanPath = config.getActivePlanPath();
+    const approvedPlanPath = config.getApprovedPlanPath();
 
-    if (!activePlanPath) {
+    if (!approvedPlanPath) {
       coreEvents.emitFeedback(
         'error',
         'No active plan found. Please create and approve a plan first.',
@@ -47,8 +42,8 @@ export const planCommand: SlashCommand = {
     }
 
     try {
-      const content = await fs.promises.readFile(activePlanPath, 'utf-8');
-      const fileName = path.basename(activePlanPath);
+      const content = await fs.promises.readFile(approvedPlanPath, 'utf-8');
+      const fileName = path.basename(approvedPlanPath);
 
       coreEvents.emitFeedback('info', `Active Plan: ${fileName}`);
 
@@ -59,7 +54,7 @@ export const planCommand: SlashCommand = {
     } catch (error) {
       coreEvents.emitFeedback(
         'error',
-        `Failed to read active plan at ${activePlanPath}: ${error}`,
+        `Failed to read active plan at ${approvedPlanPath}: ${error}`,
         error,
       );
     }

--- a/packages/cli/src/ui/commands/planCommand.ts
+++ b/packages/cli/src/ui/commands/planCommand.ts
@@ -36,7 +36,7 @@ export const planCommand: SlashCommand = {
     if (!approvedPlanPath) {
       coreEvents.emitFeedback(
         'error',
-        'No active plan found. Please create and approve a plan first.',
+        'No approved plan found. Please create and approve a plan first.',
       );
       return;
     }
@@ -45,7 +45,7 @@ export const planCommand: SlashCommand = {
       const content = await fs.promises.readFile(approvedPlanPath, 'utf-8');
       const fileName = path.basename(approvedPlanPath);
 
-      coreEvents.emitFeedback('info', `Active Plan: ${fileName}`);
+      coreEvents.emitFeedback('info', `Approved Plan: ${fileName}`);
 
       context.ui.addItem({
         type: MessageType.GEMINI,
@@ -54,7 +54,7 @@ export const planCommand: SlashCommand = {
     } catch (error) {
       coreEvents.emitFeedback(
         'error',
-        `Failed to read active plan at ${approvedPlanPath}: ${error}`,
+        `Failed to read approved plan at ${approvedPlanPath}: ${error}`,
         error,
       );
     }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -627,9 +627,12 @@ export class Config {
   private latestApiRequest: GenerateContentParameters | undefined;
   private lastModeSwitchTime: number = Date.now();
 
+  private activePlanPath: string | undefined;
+
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
     this.clientVersion = params.clientVersion ?? 'unknown';
+    this.activePlanPath = undefined;
     this.embeddingModel =
       params.embeddingModel ?? DEFAULT_GEMINI_EMBEDDING_MODEL;
     this.fileSystemService = new StandardFileSystemService();
@@ -1704,6 +1707,14 @@ export class Config {
 
   isPlanEnabled(): boolean {
     return this.planEnabled;
+  }
+
+  getActivePlanPath(): string | undefined {
+    return this.activePlanPath;
+  }
+
+  setActivePlanPath(path: string | undefined): void {
+    this.activePlanPath = path;
   }
 
   isAgentsEnabled(): boolean {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -627,12 +627,12 @@ export class Config {
   private latestApiRequest: GenerateContentParameters | undefined;
   private lastModeSwitchTime: number = Date.now();
 
-  private activePlanPath: string | undefined;
+  private approvedPlanPath: string | undefined;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
     this.clientVersion = params.clientVersion ?? 'unknown';
-    this.activePlanPath = undefined;
+    this.approvedPlanPath = undefined;
     this.embeddingModel =
       params.embeddingModel ?? DEFAULT_GEMINI_EMBEDDING_MODEL;
     this.fileSystemService = new StandardFileSystemService();
@@ -1709,12 +1709,12 @@ export class Config {
     return this.planEnabled;
   }
 
-  getActivePlanPath(): string | undefined {
-    return this.activePlanPath;
+  getApprovedPlanPath(): string | undefined {
+    return this.approvedPlanPath;
   }
 
-  setActivePlanPath(path: string | undefined): void {
-    this.activePlanPath = path;
+  setApprovedPlanPath(path: string | undefined): void {
+    this.approvedPlanPath = path;
   }
 
   isAgentsEnabled(): boolean {

--- a/packages/core/src/tools/exit-plan-mode.test.ts
+++ b/packages/core/src/tools/exit-plan-mode.test.ts
@@ -38,6 +38,7 @@ describe('ExitPlanModeTool', () => {
     mockConfig = {
       getTargetDir: vi.fn().mockReturnValue(tempRootDir),
       setApprovalMode: vi.fn(),
+      setActivePlanPath: vi.fn(),
       storage: {
         getProjectTempPlansDir: vi.fn().mockReturnValue(mockPlansDir),
       } as unknown as Config['storage'],

--- a/packages/core/src/tools/exit-plan-mode.test.ts
+++ b/packages/core/src/tools/exit-plan-mode.test.ts
@@ -38,7 +38,7 @@ describe('ExitPlanModeTool', () => {
     mockConfig = {
       getTargetDir: vi.fn().mockReturnValue(tempRootDir),
       setApprovalMode: vi.fn(),
-      setActivePlanPath: vi.fn(),
+      setApprovedPlanPath: vi.fn(),
       storage: {
         getProjectTempPlansDir: vi.fn().mockReturnValue(mockPlansDir),
       } as unknown as Config['storage'],
@@ -201,6 +201,7 @@ The approved implementation plan is stored at: ${expectedPath}
 Read and follow the plan strictly during implementation.`,
         returnDisplay: `Plan approved: ${expectedPath}`,
       });
+      expect(mockConfig.setApprovedPlanPath).toHaveBeenCalledWith(expectedPath);
     });
 
     it('should return approval message when plan is approved with AUTO_EDIT mode', async () => {
@@ -231,6 +232,7 @@ Read and follow the plan strictly during implementation.`,
       expect(mockConfig.setApprovalMode).toHaveBeenCalledWith(
         ApprovalMode.AUTO_EDIT,
       );
+      expect(mockConfig.setApprovedPlanPath).toHaveBeenCalledWith(expectedPath);
     });
 
     it('should return feedback message when plan is rejected with feedback', async () => {

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -224,6 +224,7 @@ export class ExitPlanModeInvocation extends BaseToolInvocation<
     if (payload?.approved) {
       const newMode = payload.approvalMode ?? ApprovalMode.DEFAULT;
       this.config.setApprovalMode(newMode);
+      this.config.setActivePlanPath(resolvedPlanPath);
 
       const description = getApprovalModeDescription(newMode);
 

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -224,7 +224,7 @@ export class ExitPlanModeInvocation extends BaseToolInvocation<
     if (payload?.approved) {
       const newMode = payload.approvalMode ?? ApprovalMode.DEFAULT;
       this.config.setApprovalMode(newMode);
-      this.config.setActivePlanPath(resolvedPlanPath);
+      this.config.setApprovedPlanPath(resolvedPlanPath);
 
       const description = getApprovalModeDescription(newMode);
 


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Implement a slash command that switches a user's approval mode to plan and displays the current plan if they generated a plan before.
## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes [17686](https://github.com/google-gemini/gemini-cli/issues/17686)
## How to Validate
Switch to plan mode by running the slash command `/plan`

If you have no plan active (a plan that was approved in the current session), then the feedback you should get is `No active plan found. Please create and approve a plan first.`

If you do, then you should see your current plan with the name of the markdown file as well. Should have the same name as what's in the temp plan directory.

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
