### PR TITLE
fix(cli): Preserve settings dialog focus when searching

### DIFF
--- a/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Box, Text } from 'ink';
 import chalk from 'chalk';
 import { theme } from '../../semantic-colors.js';
@@ -137,16 +137,38 @@ export function BaseSettingsDialog({
   const [editCursorPos, setEditCursorPos] = useState(0);
   const [cursorVisible, setCursorVisible] = useState(true);
 
-  // Reset active index and scroll offset when items change (e.g., search filter)
+  const prevItemsRef = useRef(items);
+
+  // Preserve focus when items change (e.g., search filter)
   useEffect(() => {
-    if (activeIndex >= items.length) {
-      setActiveIndex(Math.max(0, items.length - 1));
+    const prevItems = prevItemsRef.current;
+    if (prevItems !== items) {
+      const prevActiveItem = prevItems[activeIndex];
+      if (prevActiveItem) {
+        const newIndex = items.findIndex((i) => i.key === prevActiveItem.key);
+        if (newIndex !== -1) {
+          // Item still exists in the filtered list, keep focus on it
+          setActiveIndex(newIndex);
+          // Adjust scroll offset to ensure the item is visible
+          let newScroll = scrollOffset;
+          if (newIndex < scrollOffset) newScroll = newIndex;
+          else if (newIndex >= scrollOffset + maxItemsToShow)
+            newScroll = newIndex - maxItemsToShow + 1;
+
+          const maxScroll = Math.max(0, items.length - maxItemsToShow);
+          setScrollOffset(Math.min(newScroll, maxScroll));
+        } else {
+          // Item was filtered out, reset to the top
+          setActiveIndex(0);
+          setScrollOffset(0);
+        }
+      } else {
+        setActiveIndex(0);
+        setScrollOffset(0);
+      }
+      prevItemsRef.current = items;
     }
-    const maxScroll = Math.max(0, items.length - maxItemsToShow);
-    if (scrollOffset > maxScroll) {
-      setScrollOffset(maxScroll);
-    }
-  }, [items.length, activeIndex, scrollOffset, maxItemsToShow]);
+  }, [items, activeIndex, scrollOffset, maxItemsToShow]);
 
   // Cursor blink effect
   useEffect(() => {

--- a/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
@@ -137,12 +137,16 @@ export function BaseSettingsDialog({
   const [editCursorPos, setEditCursorPos] = useState(0);
   const [cursorVisible, setCursorVisible] = useState(true);
 
-  // Reset active index when items change (e.g., search filter)
+  // Reset active index and scroll offset when items change (e.g., search filter)
   useEffect(() => {
     if (activeIndex >= items.length) {
       setActiveIndex(Math.max(0, items.length - 1));
     }
-  }, [items.length, activeIndex]);
+    const maxScroll = Math.max(0, items.length - maxItemsToShow);
+    if (scrollOffset > maxScroll) {
+      setScrollOffset(maxScroll);
+    }
+  }, [items.length, activeIndex, scrollOffset, maxItemsToShow]);
 
   // Cursor blink effect
   useEffect(() => {


### PR DESCRIPTION
## TLDR

Fixes a visual bug in the settings dialog where filtering via search results in an empty list if the user was scrolled down past the length of the filtered results. It now also smartly preserves focus on the active item if it remains in the filtered list.

## Dive Deeper

In `BaseSettingsDialog`, the `scrollOffset` was not being updated when the `items` array shrank. This caused an issue where, if the user was scrolled down (e.g. at index 50) and typed a search that yielded 3 results, the virtualized list was still rendering starting at index 50, resulting in a blank screen.

This PR adds a smarter layout update using `useRef` to track previous items. Whenever the list size changes:
1. If the currently active item still exists in the new filtered list, it keeps focus on it and adjusts the scroll offset to keep it visible.
2. If the active item was filtered out, it resets the focus and scroll to the very top.

## Reviewer Test Plan

1. Open Gemini CLI and press `?` to open Settings.
2. Scroll down several pages and focus on a specific item (e.g. "Vim Mode").
3. Start typing in the search bar to filter for that item.
4. The filtered list should immediately be visible, and the focus should remain on "Vim Mode".
5. Change the search query to something that excludes "Vim Mode". The focus should jump to the top of the new list.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #17369
