### PR TITLE
Update user extension enablement logic

### DIFF
--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -850,7 +850,7 @@ Would you like to attempt to install via "git clone" instead?`,
 
     if (scope !== SettingScope.Session) {
       const scopePath =
-        scope === SettingScope.Workspace ? this.workspaceDir : homedir();
+        scope === SettingScope.Workspace ? this.workspaceDir : '/';
       this.extensionEnablementManager.disable(name, true, scopePath);
     }
     await logExtensionDisable(
@@ -885,7 +885,7 @@ Would you like to attempt to install via "git clone" instead?`,
 
     if (scope !== SettingScope.Session) {
       const scopePath =
-        scope === SettingScope.Workspace ? this.workspaceDir : homedir();
+        scope === SettingScope.Workspace ? this.workspaceDir : '/';
       this.extensionEnablementManager.enable(name, true, scopePath);
     }
     await logExtensionEnable(

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -2032,6 +2032,25 @@ ${INSTALL_WARNING_MESSAGE}`,
         SettingScope.Workspace,
       );
     });
+
+    it('should disable an extension globally at the user scope', async () => {
+      createExtension({
+        extensionsDir: userExtensionsDir,
+        name: 'ext1',
+        version: '1.0.0',
+      });
+      await extensionManager.loadExtensions();
+      await extensionManager.disableExtension('ext1', SettingScope.User);
+
+      // Should be disabled in home dir
+      expect(
+        isEnabled({ name: 'ext1', enabledForPath: userExtensionsDir }),
+      ).toBe(false);
+      // Should be disabled in some other random path (global)
+      expect(isEnabled({ name: 'ext1', enabledForPath: '/tmp/other' })).toBe(
+        false,
+      );
+    });
   });
 
   describe('enableExtension', () => {
@@ -2099,6 +2118,29 @@ ${INSTALL_WARNING_MESSAGE}`,
         hashValue(userExtensionsDir),
         SettingScope.Workspace,
       );
+    });
+
+    it('should enable an extension globally at the user scope', async () => {
+      createExtension({
+        extensionsDir: userExtensionsDir,
+        name: 'ext1',
+        version: '1.0.0',
+      });
+      await extensionManager.loadExtensions();
+
+      await extensionManager.disableExtension('ext1', SettingScope.User);
+      expect(isEnabled({ name: 'ext1', enabledForPath: '/tmp/other' })).toBe(
+        false,
+      );
+
+      await extensionManager.enableExtension('ext1', SettingScope.User);
+
+      expect(isEnabled({ name: 'ext1', enabledForPath: '/tmp/other' })).toBe(
+        true,
+      );
+      expect(
+        isEnabled({ name: 'ext1', enabledForPath: userExtensionsDir }),
+      ).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

For user-scoped extension enablement, use '/' instead of the user homedir. We've gotten reports of people wanting to manage extensions for other directories, too.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/17312

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
