### PR TITLE
feat(skills): promote skills settings to stable

### DIFF
--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -117,9 +117,14 @@ they appear in the UI.
 
 | UI Label         | Setting                      | Description                                                                         | Default |
 | ---------------- | ---------------------------- | ----------------------------------------------------------------------------------- | ------- |
-| Agent Skills     | `experimental.skills`        | Enable Agent Skills (experimental).                                                 | `false` |
 | Use OSC 52 Paste | `experimental.useOSC52Paste` | Use OSC 52 sequence for pasting instead of clipboardy (useful for remote sessions). | `false` |
 | Plan             | `experimental.plan`          | Enable planning features (Plan Mode and tools).                                     | `false` |
+
+### Skills
+
+| UI Label            | Setting          | Description          | Default |
+| ------------------- | ---------------- | -------------------- | ------- |
+| Enable Agent Skills | `skills.enabled` | Enable Agent Skills. | `true`  |
 
 ### HooksConfig
 

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -862,7 +862,7 @@ their corresponding top-level category object in your `settings.json` file.
   - **Requires restart:** Yes
 
 - **`experimental.skills`** (boolean):
-  - **Description:** Enable Agent Skills (experimental).
+  - **Description:** [Deprecated] Enable Agent Skills (experimental).
   - **Default:** `false`
   - **Requires restart:** Yes
 
@@ -877,6 +877,11 @@ their corresponding top-level category object in your `settings.json` file.
   - **Requires restart:** Yes
 
 #### `skills`
+
+- **`skills.enabled`** (boolean):
+  - **Description:** Enable Agent Skills.
+  - **Default:** `true`
+  - **Requires restart:** Yes
 
 - **`skills.disabled`** (array):
   - **Description:** List of disabled skills.

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1480,12 +1480,12 @@ const SETTINGS_SCHEMA = {
       },
       skills: {
         type: 'boolean',
-        label: 'Agent Skills',
+        label: 'Agent Skills (Deprecated)',
         category: 'Experimental',
         requiresRestart: true,
         default: false,
-        description: 'Enable Agent Skills (experimental).',
-        showInDialog: true,
+        description: '[Deprecated] Enable Agent Skills (experimental).',
+        showInDialog: false,
       },
       useOSC52Paste: {
         type: 'boolean',
@@ -1561,7 +1561,6 @@ const SETTINGS_SCHEMA = {
         default: true,
         description: 'Enable Agent Skills.',
         showInDialog: true,
-        ignoreInDocs: true,
       },
       disabled: {
         type: 'array',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -644,7 +644,7 @@ export class Config {
     this.disableLLMCorrection = params.disableLLMCorrection ?? true;
     this.planEnabled = params.plan ?? false;
     this.enableEventDrivenScheduler = params.enableEventDrivenScheduler ?? true;
-    this.skillsSupport = params.skillsSupport ?? false;
+    this.skillsSupport = params.skillsSupport ?? true;
     this.disabledSkills = params.disabledSkills ?? [];
     this.adminSkillsEnabled = params.adminSkillsEnabled ?? true;
     this.modelAvailabilityService = new ModelAvailabilityService();

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1437,9 +1437,9 @@
           "type": "boolean"
         },
         "skills": {
-          "title": "Agent Skills",
-          "description": "Enable Agent Skills (experimental).",
-          "markdownDescription": "Enable Agent Skills (experimental).\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
+          "title": "Agent Skills (Deprecated)",
+          "description": "[Deprecated] Enable Agent Skills (experimental).",
+          "markdownDescription": "[Deprecated] Enable Agent Skills (experimental).\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
           "default": false,
           "type": "boolean"
         },


### PR DESCRIPTION
## Summary

Promote Agent Skills settings to stable.

## Details

This PR introduces the stable `skills.enabled` setting and deprecates the legacy `experimental.skills` setting. 

This is Part 2 of a 3-PR sequence to allow for a minimal cherry-pick of core settings:
1. Revert of original large commit (#17712).
2. **Core settings promotion (This PR).**
3. Documentation and secondary updates.

## Related Issues

Part of #17693

## How to Validate

1. Check `/settings` to see "Enable Agent Skills" under the Skills category.
2. Verify "Agent Skills (Deprecated)" is hidden in the UI but present in `settings.json`.
3. Verify `docs/get-started/configuration.md` reflects the new setting.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
