### PR TITLE
docs(skills): remove experimental labels and update tutorials

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -199,8 +199,8 @@ Slash commands provide meta-level control over the CLI itself.
     while others require a restart.
 
 - [**`/skills`**](./skills.md)
-  - **Description:** (Experimental) Manage Agent Skills, which provide on-demand
-    expertise and specialized workflows.
+  - **Description:** Manage Agent Skills, which provide on-demand expertise and
+    specialized workflows.
   - **Sub-commands:**
     - **`list`**:
       - **Description:** List all discovered skills and their current status

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -29,8 +29,8 @@ overview of Gemini CLI, see the [main documentation page](../index.md).
   in an enterprise environment.
 - **[Sandboxing](./sandbox.md):** Isolate tool execution in a secure,
   containerized environment.
-- **[Agent Skills](./skills.md):** (Experimental) Extend the CLI with
-  specialized expertise and procedural workflows.
+- **[Agent Skills](./skills.md):** Extend the CLI with specialized expertise and
+  procedural workflows.
 - **[Telemetry](./telemetry.md):** Configure observability to monitor usage and
   performance.
 - **[Token caching](./token-caching.md):** Optimize API costs by caching tokens.

--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -1,9 +1,5 @@
 # Agent Skills
 
-_Note: This is an experimental feature enabled via `experimental.skills`. You
-can also search for "Skills" within the `/settings` interactive UI to toggle
-this and manage other skill-related settings._
-
 Agent Skills allow you to extend Gemini CLI with specialized expertise,
 procedural workflows, and task-specific resources. Based on the
 [Agent Skills](https://agentskills.io) open standard, a "skill" is a

--- a/docs/cli/tutorials/skills-getting-started.md
+++ b/docs/cli/tutorials/skills-getting-started.md
@@ -1,37 +1,10 @@
 # Getting Started with Agent Skills
 
 Agent Skills allow you to extend Gemini CLI with specialized expertise. This
-tutorial will guide you through creating your first skill, enabling it, and
-using it in a session.
+tutorial will guide you through creating your first skill and using it in a
+session.
 
-## 1. Enable Agent Skills
-
-Agent Skills are currently an experimental feature and must be enabled in your
-settings.
-
-### Via the interactive UI
-
-1.  Start a Gemini CLI session by running `gemini`.
-2.  Type `/settings` to open the interactive settings dialog.
-3.  Search for "Skills".
-4.  Toggle **Agent Skills** to `true`.
-5.  Press `Esc` to save and exit. You may need to restart the CLI for the
-    changes to take effect.
-
-### Via `settings.json`
-
-Alternatively, you can manually edit your global settings file at
-`~/.gemini/settings.json` (create it if it doesn't exist):
-
-```json
-{
-  "experimental": {
-    "skills": true
-  }
-}
-```
-
-## 2. Create Your First Skill
+## 1. Create your first skill
 
 A skill is a directory containing a `SKILL.md` file. Let's create an **API
 Auditor** skill that helps you verify if local or remote endpoints are
@@ -86,7 +59,7 @@ responding correctly.
       .catch((e) => console.error(`Result: Failed (${e.message})`));
     ```
 
-## 3. Verify the Skill is Discovered
+## 2. Verify the skill is discovered
 
 Use the `/skills` slash command (or `gemini skills list` from your terminal) to
 see if Gemini CLI has found your new skill.
@@ -99,7 +72,7 @@ In a Gemini CLI session:
 
 You should see `api-auditor` in the list of available skills.
 
-## 4. Use the Skill in a Chat
+## 3. Use the skill in a chat
 
 Now, let's see the skill in action. Start a new session and ask a question about
 an endpoint.

--- a/docs/extensions/writing-extensions.md
+++ b/docs/extensions/writing-extensions.md
@@ -225,8 +225,6 @@ file in every session where the extension is active.
 
 ## (Optional) Step 6: Add an Agent Skill
 
-_Note: This is an experimental feature enabled via `experimental.skills`._
-
 [Agent Skills](../cli/skills.md) let you bundle specialized expertise and
 procedural workflows. Unlike `GEMINI.md`, which provides persistent context,
 skills are activated only when needed, saving context tokens.

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,8 +56,8 @@ This documentation is organized into the following sections:
   commands with `/model`.
 - **[Sandbox](./cli/sandbox.md):** Isolate tool execution in a secure,
   containerized environment.
-- **[Agent Skills](./cli/skills.md):** (Experimental) Extend the CLI with
-  specialized expertise and procedural workflows.
+- **[Agent Skills](./cli/skills.md):** Extend the CLI with specialized expertise
+  and procedural workflows.
 - **[Settings](./cli/settings.md):** Configure various aspects of the CLI's
   behavior and appearance with `/settings`.
 - **[Telemetry](./cli/telemetry.md):** Overview of telemetry in the CLI.

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -77,7 +77,7 @@
   {
     "label": "Ecosystem and extensibility",
     "items": [
-      { "label": "Agent skills (experimental)", "slug": "docs/cli/skills" },
+      { "label": "Agent skills", "slug": "docs/cli/skills" },
       {
         "label": "Sub-agents (experimental)",
         "slug": "docs/core/subagents"

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -91,8 +91,8 @@ Additionally, these tools incorporate:
 
 - **[MCP servers](./mcp-server.md)**: MCP servers act as a bridge between the
   Gemini model and your local environment or other services like APIs.
-- **[Agent Skills](../cli/skills.md)**: (Experimental) On-demand expertise
-  packages that are activated via the `activate_skill` tool to provide
-  specialized guidance and resources.
+- **[Agent Skills](../cli/skills.md)**: On-demand expertise packages that are
+  activated via the `activate_skill` tool to provide specialized guidance and
+  resources.
 - **[Sandboxing](../cli/sandbox.md)**: Sandboxing isolates the model and its
   changes from your environment to reduce potential risk.


### PR DESCRIPTION
## Summary

Update documentation for stable Agent Skills.

## Details

This PR updates the documentation to reflect that Agent Skills are no longer experimental. 

Changes include:
- Removing "(Experimental)" and legacy configuration notes from various doc pages.
- Updating the "Getting Started" tutorial to reflect the new stable setting.
- Refreshing the sidebar and tools index.

This is Part 3 of a 3-PR sequence:
1. Revert of original large commit (#17712).
2. Core settings promotion (#17713).
3. **Documentation and tutorial updates (This PR).**

## Related Issues

Part of #17693

## How to Validate

Review the updated documentation files in the PR diff or build the docs locally.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
