### PR TITLE
fix(core): pass client metadata in code assist inference calls

### DIFF
--- a/packages/core/src/code_assist/converter.test.ts
+++ b/packages/core/src/code_assist/converter.test.ts
@@ -29,26 +29,27 @@ describe('converter', () => {
         model: 'gemini-pro',
         contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
       };
+      const metadata = { ideType: 'IDE_UNSPECIFIED' as const };
       const codeAssistReq = toGenerateContentRequest(
         genaiReq,
         'my-prompt',
         'my-project',
         'my-session',
+        metadata,
       );
       expect(codeAssistReq).toEqual({
         model: 'gemini-pro',
         project: 'my-project',
-        request: {
-          contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
-          systemInstruction: undefined,
-          cachedContent: undefined,
-          tools: undefined,
-          toolConfig: undefined,
-          labels: undefined,
-          safetySettings: undefined,
-          generationConfig: undefined,
-          session_id: 'my-session',
-        },
+        metadata,
+        contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
+        systemInstruction: undefined,
+        cachedContent: undefined,
+        tools: undefined,
+        toolConfig: undefined,
+        labels: undefined,
+        safetySettings: undefined,
+        generationConfig: undefined,
+        session_id: 'my-session',
         user_prompt_id: 'my-prompt',
       });
     });
@@ -67,17 +68,15 @@ describe('converter', () => {
       expect(codeAssistReq).toEqual({
         model: 'gemini-pro',
         project: undefined,
-        request: {
-          contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
-          systemInstruction: undefined,
-          cachedContent: undefined,
-          tools: undefined,
-          toolConfig: undefined,
-          labels: undefined,
-          safetySettings: undefined,
-          generationConfig: undefined,
-          session_id: 'my-session',
-        },
+        contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
+        systemInstruction: undefined,
+        cachedContent: undefined,
+        tools: undefined,
+        toolConfig: undefined,
+        labels: undefined,
+        safetySettings: undefined,
+        generationConfig: undefined,
+        session_id: 'my-session',
         user_prompt_id: 'my-prompt',
       });
     });
@@ -96,17 +95,15 @@ describe('converter', () => {
       expect(codeAssistReq).toEqual({
         model: 'gemini-pro',
         project: 'my-project',
-        request: {
-          contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
-          systemInstruction: undefined,
-          cachedContent: undefined,
-          tools: undefined,
-          toolConfig: undefined,
-          labels: undefined,
-          safetySettings: undefined,
-          generationConfig: undefined,
-          session_id: 'session-123',
-        },
+        contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
+        systemInstruction: undefined,
+        cachedContent: undefined,
+        tools: undefined,
+        toolConfig: undefined,
+        labels: undefined,
+        safetySettings: undefined,
+        generationConfig: undefined,
+        session_id: 'session-123',
         user_prompt_id: 'my-prompt',
       });
     });
@@ -122,7 +119,7 @@ describe('converter', () => {
         'my-project',
         'my-session',
       );
-      expect(codeAssistReq.request.contents).toEqual([
+      expect(codeAssistReq.contents).toEqual([
         { role: 'user', parts: [{ text: 'Hello' }] },
       ]);
     });
@@ -138,7 +135,7 @@ describe('converter', () => {
         'my-project',
         'my-session',
       );
-      expect(codeAssistReq.request.contents).toEqual([
+      expect(codeAssistReq.contents).toEqual([
         { role: 'user', parts: [{ text: 'Hello' }] },
         { role: 'user', parts: [{ text: 'World' }] },
       ]);
@@ -158,7 +155,7 @@ describe('converter', () => {
         'my-project',
         'my-session',
       );
-      expect(codeAssistReq.request.systemInstruction).toEqual({
+      expect(codeAssistReq.systemInstruction).toEqual({
         role: 'user',
         parts: [{ text: 'You are a helpful assistant.' }],
       });
@@ -179,7 +176,7 @@ describe('converter', () => {
         'my-project',
         'my-session',
       );
-      expect(codeAssistReq.request.generationConfig).toEqual({
+      expect(codeAssistReq.generationConfig).toEqual({
         temperature: 0.8,
         topK: 40,
       });
@@ -210,7 +207,7 @@ describe('converter', () => {
         'my-project',
         'my-session',
       );
-      expect(codeAssistReq.request.generationConfig).toEqual({
+      expect(codeAssistReq.generationConfig).toEqual({
         temperature: 0.1,
         topP: 0.2,
         topK: 3,
@@ -230,82 +227,70 @@ describe('converter', () => {
   describe('fromCodeAssistResponse', () => {
     it('should convert a simple response', () => {
       const codeAssistRes: CaGenerateContentResponse = {
-        response: {
-          candidates: [
-            {
-              index: 0,
-              content: {
-                role: 'model',
-                parts: [{ text: 'Hi there!' }],
-              },
-              finishReason: FinishReason.STOP,
-              safetyRatings: [],
+        candidates: [
+          {
+            index: 0,
+            content: {
+              role: 'model',
+              parts: [{ text: 'Hi there!' }],
             },
-          ],
-        },
+            finishReason: FinishReason.STOP,
+            safetyRatings: [],
+          },
+        ],
       };
       const genaiRes = fromGenerateContentResponse(codeAssistRes);
       expect(genaiRes).toBeInstanceOf(GenerateContentResponse);
-      expect(genaiRes.candidates).toEqual(codeAssistRes.response.candidates);
+      expect(genaiRes.candidates).toEqual(codeAssistRes.candidates);
     });
 
     it('should handle prompt feedback and usage metadata', () => {
       const codeAssistRes: CaGenerateContentResponse = {
-        response: {
-          candidates: [],
-          promptFeedback: {
-            blockReason: BlockedReason.SAFETY,
-            safetyRatings: [],
-          },
-          usageMetadata: {
-            promptTokenCount: 10,
-            candidatesTokenCount: 20,
-            totalTokenCount: 30,
-          },
+        candidates: [],
+        promptFeedback: {
+          blockReason: BlockedReason.SAFETY,
+          safetyRatings: [],
+        },
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+          totalTokenCount: 30,
         },
       };
       const genaiRes = fromGenerateContentResponse(codeAssistRes);
-      expect(genaiRes.promptFeedback).toEqual(
-        codeAssistRes.response.promptFeedback,
-      );
-      expect(genaiRes.usageMetadata).toEqual(
-        codeAssistRes.response.usageMetadata,
-      );
+      expect(genaiRes.promptFeedback).toEqual(codeAssistRes.promptFeedback);
+      expect(genaiRes.usageMetadata).toEqual(codeAssistRes.usageMetadata);
     });
 
     it('should handle automatic function calling history', () => {
       const codeAssistRes: CaGenerateContentResponse = {
-        response: {
-          candidates: [],
-          automaticFunctionCallingHistory: [
-            {
-              role: 'model',
-              parts: [
-                {
-                  functionCall: {
-                    name: 'test_function',
-                    args: {
-                      foo: 'bar',
-                    },
+        candidates: [],
+        automaticFunctionCallingHistory: [
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  name: 'test_function',
+                  args: {
+                    foo: 'bar',
                   },
                 },
-              ],
-            },
-          ],
-        },
+              },
+            ],
+          },
+        ],
       };
       const genaiRes = fromGenerateContentResponse(codeAssistRes);
       expect(genaiRes.automaticFunctionCallingHistory).toEqual(
-        codeAssistRes.response.automaticFunctionCallingHistory,
+        codeAssistRes.automaticFunctionCallingHistory,
       );
     });
 
     it('should handle modelVersion', () => {
       const codeAssistRes: CaGenerateContentResponse = {
-        response: {
-          candidates: [],
-          modelVersion: 'gemini-2.5-pro',
-        },
+        candidates: [],
+        modelVersion: 'gemini-2.5-pro',
       };
       const genaiRes = fromGenerateContentResponse(codeAssistRes);
       expect(genaiRes.modelVersion).toEqual('gemini-2.5-pro');
@@ -313,9 +298,7 @@ describe('converter', () => {
 
     it('should handle traceId', () => {
       const codeAssistRes: CaGenerateContentResponse = {
-        response: {
-          candidates: [],
-        },
+        candidates: [],
         traceId: 'my-trace-id',
       };
       const genaiRes = fromGenerateContentResponse(codeAssistRes);
@@ -324,9 +307,7 @@ describe('converter', () => {
 
     it('should handle missing traceId', () => {
       const codeAssistRes: CaGenerateContentResponse = {
-        response: {
-          candidates: [],
-        },
+        candidates: [],
       };
       const genaiRes = fromGenerateContentResponse(codeAssistRes);
       expect(genaiRes.responseId).toBeUndefined();

--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -27,12 +27,13 @@ import type {
   ToolConfig,
 } from '@google/genai';
 import { GenerateContentResponse } from '@google/genai';
+import type { ClientMetadata } from './types.js';
 
-export interface CAGenerateContentRequest {
+export interface CAGenerateContentRequest extends VertexGenerateContentRequest {
   model: string;
   project?: string;
   user_prompt_id?: string;
-  request: VertexGenerateContentRequest;
+  metadata?: ClientMetadata;
 }
 
 interface VertexGenerateContentRequest {
@@ -71,8 +72,8 @@ interface VertexGenerationConfig {
   thinkingConfig?: ThinkingConfig;
 }
 
-export interface CaGenerateContentResponse {
-  response: VertexGenerateContentResponse;
+export interface CaGenerateContentResponse
+  extends VertexGenerateContentResponse {
   traceId?: string;
 }
 
@@ -84,8 +85,9 @@ interface VertexGenerateContentResponse {
   modelVersion?: string;
 }
 
-export interface CaCountTokenRequest {
-  request: VertexCountTokenRequest;
+export interface CaCountTokenRequest extends VertexCountTokenRequest {
+  project?: string;
+  metadata?: ClientMetadata;
 }
 
 interface VertexCountTokenRequest {
@@ -99,12 +101,14 @@ export interface CaCountTokenResponse {
 
 export function toCountTokenRequest(
   req: CountTokensParameters,
+  project?: string,
+  metadata?: ClientMetadata,
 ): CaCountTokenRequest {
   return {
-    request: {
-      model: 'models/' + req.model,
-      contents: toContents(req.contents),
-    },
+    model: 'models/' + req.model,
+    contents: toContents(req.contents),
+    project,
+    metadata,
   };
 }
 
@@ -121,25 +125,26 @@ export function toGenerateContentRequest(
   userPromptId: string,
   project?: string,
   sessionId?: string,
+  metadata?: ClientMetadata,
 ): CAGenerateContentRequest {
   return {
+    ...toVertexGenerateContentRequest(req, sessionId),
     model: req.model,
     project,
     user_prompt_id: userPromptId,
-    request: toVertexGenerateContentRequest(req, sessionId),
+    metadata,
   };
 }
 
 export function fromGenerateContentResponse(
   res: CaGenerateContentResponse,
 ): GenerateContentResponse {
-  const inres = res.response;
   const out = new GenerateContentResponse();
-  out.candidates = inres.candidates;
-  out.automaticFunctionCallingHistory = inres.automaticFunctionCallingHistory;
-  out.promptFeedback = inres.promptFeedback;
-  out.usageMetadata = inres.usageMetadata;
-  out.modelVersion = inres.modelVersion;
+  out.candidates = res.candidates;
+  out.automaticFunctionCallingHistory = res.automaticFunctionCallingHistory;
+  out.promptFeedback = res.promptFeedback;
+  out.usageMetadata = res.usageMetadata;
+  out.modelVersion = res.modelVersion;
   out.responseId = res.traceId;
   return out;
 }

--- a/packages/core/src/code_assist/experiments/client_metadata.ts
+++ b/packages/core/src/code_assist/experiments/client_metadata.ts
@@ -47,6 +47,7 @@ export async function getClientMetadata(): Promise<ClientMetadata> {
   if (!clientMetadataPromise) {
     clientMetadataPromise = (async () => ({
       ideName: 'IDE_UNSPECIFIED',
+      ideType: 'IDE_UNSPECIFIED',
       pluginType: 'GEMINI',
       ideVersion: await getVersion(),
       platform: getPlatform(),


### PR DESCRIPTION
## Summary

This PR fixes an issue where Code Assist AI inference calls (`GenerateContent` and `StreamGenerateContent`) and token counting calls were not passing the correct `plugin_type` or `ide_type` metadata. This resulted in the backend incorrectly evaluating the client.

## Details

- Modified `CAGenerateContentRequest` and `CaCountTokenRequest` interfaces in `packages/core/src/code_assist/converter.ts` to include an optional `metadata` field of type `ClientMetadata`.
- Updated `toGenerateContentRequest` and `toCountTokenRequest` functions to accept and include this metadata in the request objects.
- Updated `CodeAssistServer` in `packages/core/src/code_assist/server.ts` to retrieve client metadata using `getClientMetadata()` and pass it along with the `duetProject` (project ID) in `generateContent`, `generateContentStream`, and `countTokens` calls.
- Updated `getClientMetadata` in `packages/core/src/code_assist/experiments/client_metadata.ts` to explicitly include `ideType: 'IDE_UNSPECIFIED'`, matching the expected values for the `GEMINI` plugin type.
- Updated telemetry methods `recordConversationOffered` and `recordConversationInteraction` to consistently include the `duetProject` in their metadata.
- Updated unit tests in `server.test.ts` and `converter.test.ts` to verify correct metadata propagation.

## Related Issues

Reported by a user: Code Assist inference calls were passing `Unevaluated` for `plugin_type` and `unknown` for `ide_type`.

## How to Validate

Run the following command to verify all Code Assist tests pass:
```bash
npm test -w packages/core -- src/code_assist/
```

Specifically, `packages/core/src/code_assist/server.test.ts` now includes explicit checks for metadata in the request bodies.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
