### PR TITLE
feat(cli): add /oncall audit command for issue triaging

### DIFF
--- a/packages/cli/src/ui/commands/oncallCommand.tsx
+++ b/packages/cli/src/ui/commands/oncallCommand.tsx
@@ -62,11 +62,21 @@ export const oncallCommand: SlashCommand = {
         }
 
         let limit = 100;
+        let since: string | undefined;
+
         if (args && args.trim().length > 0) {
           const argArray = args.trim().split(/\s+/);
-          const parsedLimit = parseInt(argArray[0], 10);
-          if (!isNaN(parsedLimit) && parsedLimit > 0) {
-            limit = parsedLimit;
+          for (let i = 0; i < argArray.length; i++) {
+            const arg = argArray[i];
+            if (arg === '--since' && i + 1 < argArray.length) {
+              since = argArray[i + 1];
+              i++;
+            } else {
+              const parsedLimit = parseInt(arg, 10);
+              if (!isNaN(parsedLimit) && parsedLimit > 0) {
+                limit = parsedLimit;
+              }
+            }
           }
         }
 
@@ -76,6 +86,7 @@ export const oncallCommand: SlashCommand = {
             <TriageIssues
               config={config}
               initialLimit={limit}
+              since={since}
               onExit={() => context.ui.removeComponent()}
             />
           ),

--- a/packages/cli/src/ui/commands/oncallCommand.tsx
+++ b/packages/cli/src/ui/commands/oncallCommand.tsx
@@ -10,6 +10,7 @@ import {
   type OpenCustomDialogActionReturn,
 } from './types.js';
 import { TriageDuplicates } from '../components/triage/TriageDuplicates.js';
+import { TriageIssues } from '../components/triage/TriageIssues.js';
 
 export const oncallCommand: SlashCommand = {
   name: 'oncall',
@@ -41,6 +42,38 @@ export const oncallCommand: SlashCommand = {
           type: 'custom_dialog',
           component: (
             <TriageDuplicates
+              config={config}
+              initialLimit={limit}
+              onExit={() => context.ui.removeComponent()}
+            />
+          ),
+        };
+      },
+    },
+    {
+      name: 'audit',
+      description: 'Triage issues labeled as status/need-triage',
+      kind: CommandKind.BUILT_IN,
+      autoExecute: true,
+      action: async (context, args): Promise<OpenCustomDialogActionReturn> => {
+        const { config } = context.services;
+        if (!config) {
+          throw new Error('Config not available');
+        }
+
+        let limit = 100;
+        if (args && args.trim().length > 0) {
+          const argArray = args.trim().split(/\s+/);
+          const parsedLimit = parseInt(argArray[0], 10);
+          if (!isNaN(parsedLimit) && parsedLimit > 0) {
+            limit = parsedLimit;
+          }
+        }
+
+        return {
+          type: 'custom_dialog',
+          component: (
+            <TriageIssues
               config={config}
               initialLimit={limit}
               onExit={() => context.ui.removeComponent()}

--- a/packages/cli/src/ui/commands/oncallCommand.tsx
+++ b/packages/cli/src/ui/commands/oncallCommand.tsx
@@ -62,14 +62,14 @@ export const oncallCommand: SlashCommand = {
         }
 
         let limit = 100;
-        let since: string | undefined;
+        let until: string | undefined;
 
         if (args && args.trim().length > 0) {
           const argArray = args.trim().split(/\s+/);
           for (let i = 0; i < argArray.length; i++) {
             const arg = argArray[i];
-            if (arg === '--since' && i + 1 < argArray.length) {
-              since = argArray[i + 1];
+            if (arg === '--until' && i + 1 < argArray.length) {
+              until = argArray[i + 1];
               i++;
             } else {
               const parsedLimit = parseInt(arg, 10);
@@ -86,7 +86,7 @@ export const oncallCommand: SlashCommand = {
             <TriageIssues
               config={config}
               initialLimit={limit}
-              since={since}
+              until={until}
               onExit={() => context.ui.removeComponent()}
             />
           ),

--- a/packages/cli/src/ui/components/triage/TriageIssues.tsx
+++ b/packages/cli/src/ui/components/triage/TriageIssues.tsx
@@ -62,12 +62,12 @@ export const TriageIssues = ({
   config,
   onExit,
   initialLimit = 100,
-  since,
+  until,
 }: {
   config: Config;
   onExit: () => void;
   initialLimit?: number;
-  since?: string;
+  until?: string;
 }) => {
   const [state, setState] = useState<TriageState>({
     status: 'loading',
@@ -115,8 +115,8 @@ export const TriageIssues = ({
           '-type:Task,Workstream,Feature,Epic',
           '-label:workstream-rollup',
         ];
-        if (since) {
-          searchParts.push(`created:>=${since}`);
+        if (until) {
+          searchParts.push(`created:<=${until}`);
         }
 
         const { stdout } = await spawnAsync('gh', [
@@ -152,7 +152,7 @@ export const TriageIssues = ({
         }));
       }
     },
-    [since],
+    [until],
   );
 
   useEffect(() => {

--- a/packages/cli/src/ui/components/triage/TriageIssues.tsx
+++ b/packages/cli/src/ui/components/triage/TriageIssues.tsx
@@ -1,0 +1,630 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { Box, Text } from 'ink';
+import Spinner from 'ink-spinner';
+import type { Config } from '@google/gemini-cli-core';
+import { debugLogger, spawnAsync } from '@google/gemini-cli-core';
+import { useKeypress } from '../../hooks/useKeypress.js';
+import { keyMatchers, Command } from '../../keyMatchers.js';
+import { TextInput } from '../shared/TextInput.js';
+import { useTextBuffer } from '../shared/text-buffer.js';
+
+interface Issue {
+  number: number;
+  title: string;
+  body: string;
+  url: string;
+  author: { login: string };
+  labels: Array<{ name: string }>;
+  comments: Array<{ body: string; author: { login: string } }>;
+  reactionGroups: Array<{ content: string; users: { totalCount: number } }>;
+}
+
+interface AnalysisResult {
+  recommendation: 'close' | 'keep';
+  reason: string;
+  suggested_comment: string;
+}
+
+interface ProcessedIssue {
+  number: number;
+  title: string;
+  action: 'close' | 'skip';
+}
+
+interface TriageState {
+  status: 'loading' | 'analyzing' | 'interaction' | 'completed' | 'error';
+  message?: string;
+  issues: Issue[];
+  currentIndex: number;
+  analysisCache: Map<number, AnalysisResult>;
+  analyzingIds: Set<number>;
+}
+
+const VISIBLE_LINES_COLLAPSED = 8;
+const VISIBLE_LINES_EXPANDED = 20;
+const MAX_CONCURRENT_ANALYSIS = 3;
+
+const getReactionCount = (issue: Issue | undefined) => {
+  if (!issue || !issue.reactionGroups) return 0;
+  return issue.reactionGroups.reduce(
+    (acc, group) => acc + group.users.totalCount,
+    0,
+  );
+};
+
+export const TriageIssues = ({
+  config,
+  onExit,
+  initialLimit = 100,
+}: {
+  config: Config;
+  onExit: () => void;
+  initialLimit?: number;
+}) => {
+  const [state, setState] = useState<TriageState>({
+    status: 'loading',
+    issues: [],
+    currentIndex: 0,
+    analysisCache: new Map(),
+    analyzingIds: new Set(),
+    message: 'Fetching issues...',
+  });
+
+  const [targetExpanded, setTargetExpanded] = useState(false);
+  const [targetScrollOffset, setTargetScrollOffset] = useState(0);
+  const [isEditingComment, setIsEditingComment] = useState(false);
+  const [processedHistory, setProcessedHistory] = useState<ProcessedIssue[]>(
+    [],
+  );
+  const [showHistory, setShowHistory] = useState(false);
+
+  // Buffer for editing comment
+  const commentBuffer = useTextBuffer({
+    initialText: '',
+    viewport: { width: 80, height: 5 },
+    isValidPath: () => false,
+  });
+
+  const currentIssue = state.issues[state.currentIndex];
+  const analysis = currentIssue
+    ? state.analysisCache.get(currentIssue.number)
+    : undefined;
+
+  // Initialize comment buffer when analysis changes or when starting to edit
+  useEffect(() => {
+    if (analysis?.suggested_comment && !isEditingComment) {
+      commentBuffer.setText(analysis.suggested_comment);
+    }
+  }, [analysis, commentBuffer, isEditingComment]);
+
+  const fetchIssues = useCallback(async (limit: number) => {
+    try {
+      const { stdout } = await spawnAsync('gh', [
+        'issue',
+        'list',
+        '--search',
+        'is:issue state:open label:status/need-triage -type:Task,Workstream,Feature,Epic -label:workstream-rollup',
+        '--json',
+        'number,title,body,author,url,comments,labels,reactionGroups',
+        '--limit',
+        String(limit),
+      ]);
+      const issues: Issue[] = JSON.parse(stdout);
+      if (issues.length === 0) {
+        setState((s) => ({
+          ...s,
+          status: 'completed',
+          message: 'No issues found matching triage criteria.',
+        }));
+        return;
+      }
+      setState((s) => ({
+        ...s,
+        issues,
+        status: 'analyzing',
+        message: `Found ${issues.length} issues. Starting analysis...`,
+      }));
+    } catch (error) {
+      setState((s) => ({
+        ...s,
+        status: 'error',
+        message: `Error fetching issues: ${error instanceof Error ? error.message : String(error)}`,
+      }));
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchIssues(initialLimit);
+  }, [fetchIssues, initialLimit]);
+
+  const analyzeIssue = useCallback(
+    async (issue: Issue): Promise<AnalysisResult> => {
+      const client = config.getBaseLlmClient();
+      const prompt = `
+I am triaging GitHub issues for the Gemini CLI project. I need to identify issues that should be closed because they are:
+- Bogus (not a real issue/request)
+- Not reproducible (insufficient info, "it doesn't work" without logs/details)
+- Abusive or offensive
+- Gibberish (nonsense text)
+- Clearly out of scope for this project
+
+<issue>
+ID: #${issue.number}
+Title: ${issue.title}
+Author: ${issue.author?.login}
+Labels: ${issue.labels.map((l) => l.name).join(', ')}
+Body:
+${issue.body.slice(0, 8000)}
+
+Comments:
+${issue.comments
+  .map((c) => `${c.author.login}: ${c.body}`)
+  .join('\n')
+  .slice(0, 2000)}
+</issue>
+
+INSTRUCTIONS:
+1. Analyze the issue above.
+2. If it meets any of the "close" criteria (bogus, unreproducible, abusive, gibberish), recommend "close".
+3. If it seems like a legitimate bug or feature request that needs triage by a human, recommend "keep".
+4. Provide a brief reason for your recommendation.
+5. If recommending "close", provide a polite, professional, and helpful 'suggested_comment' explaining why it's being closed and what the user can do (e.g., provide more logs, follow contributing guidelines).
+
+Return a JSON object with:
+- "recommendation": "close" or "keep"
+- "reason": "brief explanation"
+- "suggested_comment": "polite closing comment"
+`;
+      const response = await client.generateJson({
+        modelConfigKey: { model: 'gemini-3-pro-preview' },
+        contents: [{ role: 'user', parts: [{ text: prompt }] }],
+        schema: {
+          type: 'object',
+          properties: {
+            recommendation: { type: 'string', enum: ['close', 'keep'] },
+            reason: { type: 'string' },
+            suggested_comment: { type: 'string' },
+          },
+          required: ['recommendation', 'reason', 'suggested_comment'],
+        },
+        abortSignal: new AbortController().signal,
+        promptId: 'triage-issues',
+      });
+
+      return response as unknown as AnalysisResult;
+    },
+    [config],
+  );
+
+  // Background Analysis Queue
+  useEffect(() => {
+    if (state.issues.length === 0) return;
+
+    const analyzeNext = async () => {
+      const issuesToAnalyze = state.issues
+        .slice(
+          state.currentIndex,
+          state.currentIndex + MAX_CONCURRENT_ANALYSIS + 5,
+        )
+        .filter(
+          (issue) =>
+            !state.analysisCache.has(issue.number) &&
+            !state.analyzingIds.has(issue.number),
+        )
+        .slice(0, MAX_CONCURRENT_ANALYSIS - state.analyzingIds.size);
+
+      if (issuesToAnalyze.length === 0) return;
+
+      setState((prev) => {
+        const nextAnalyzing = new Set(prev.analyzingIds);
+        issuesToAnalyze.forEach((i) => nextAnalyzing.add(i.number));
+        return { ...prev, analyzingIds: nextAnalyzing };
+      });
+
+      issuesToAnalyze.forEach(async (issue) => {
+        try {
+          const result = await analyzeIssue(issue);
+          setState((prev) => {
+            const nextCache = new Map(prev.analysisCache);
+            nextCache.set(issue.number, result);
+            const nextAnalyzing = new Set(prev.analyzingIds);
+            nextAnalyzing.delete(issue.number);
+            return {
+              ...prev,
+              analysisCache: nextCache,
+              analyzingIds: nextAnalyzing,
+            };
+          });
+        } catch (e) {
+          debugLogger.error(`Analysis failed for ${issue.number}`, e);
+          setState((prev) => {
+            const nextAnalyzing = new Set(prev.analyzingIds);
+            nextAnalyzing.delete(issue.number);
+            return { ...prev, analyzingIds: nextAnalyzing };
+          });
+        }
+      });
+    };
+
+    void analyzeNext();
+  }, [
+    state.issues,
+    state.currentIndex,
+    state.analysisCache,
+    state.analyzingIds,
+    analyzeIssue,
+  ]);
+
+  const handleNext = useCallback(() => {
+    const nextIndex = state.currentIndex + 1;
+    if (nextIndex < state.issues.length) {
+      setTargetExpanded(false);
+      setTargetScrollOffset(0);
+      setIsEditingComment(false);
+      setState((s) => ({ ...s, currentIndex: nextIndex }));
+    } else {
+      setState((s) => ({
+        ...s,
+        status: 'completed',
+        message: 'All issues triaged.',
+      }));
+    }
+  }, [state.currentIndex, state.issues.length]);
+
+  // Auto-skip logic for 'keep' recommendations
+  useEffect(() => {
+    if (currentIssue && state.analysisCache.has(currentIssue.number)) {
+      const res = state.analysisCache.get(currentIssue.number)!;
+      if (res.recommendation === 'keep') {
+        // Auto skip to next
+        handleNext();
+      } else {
+        setState((s) => ({ ...s, status: 'interaction' }));
+      }
+    } else if (currentIssue && state.status === 'interaction') {
+      // If we were in interaction but now have no analysis (shouldn't happen with current logic), go to analyzing
+      setState((s) => ({
+        ...s,
+        status: 'analyzing',
+        message: `Analyzing #${currentIssue.number}...`,
+      }));
+    }
+  }, [currentIssue, state.analysisCache, handleNext, state.status]);
+
+  const performClose = async () => {
+    if (!currentIssue) return;
+    const comment = commentBuffer.text;
+
+    setState((s) => ({
+      ...s,
+      status: 'loading',
+      message: `Closing issue #${currentIssue.number}...`,
+    }));
+    try {
+      await spawnAsync('gh', [
+        'issue',
+        'close',
+        String(currentIssue.number),
+        '--comment',
+        comment,
+        '--reason',
+        'not planned',
+      ]);
+      setProcessedHistory((prev) => [
+        ...prev,
+        {
+          number: currentIssue.number,
+          title: currentIssue.title,
+          action: 'close',
+        },
+      ]);
+      handleNext();
+    } catch (err) {
+      setState((s) => ({
+        ...s,
+        status: 'error',
+        message: `Failed to close issue: ${err instanceof Error ? err.message : String(err)}`,
+      }));
+    }
+  };
+
+  useKeypress(
+    (key) => {
+      const input = key.sequence;
+
+      if (isEditingComment) {
+        if (keyMatchers[Command.ESCAPE](key)) {
+          setIsEditingComment(false);
+          return;
+        }
+        return; // TextInput handles its own input
+      }
+
+      if (input === 'h') {
+        setShowHistory(!showHistory);
+        return;
+      }
+
+      if (showHistory) {
+        if (
+          keyMatchers[Command.ESCAPE](key) ||
+          input === 'h' ||
+          input === 'q'
+        ) {
+          setShowHistory(false);
+        }
+        return;
+      }
+
+      if (keyMatchers[Command.ESCAPE](key) || input === 'q') {
+        onExit();
+        return;
+      }
+
+      if (state.status !== 'interaction') return;
+
+      if (input === 's') {
+        setProcessedHistory((prev) => [
+          ...prev,
+          {
+            number: currentIssue.number,
+            title: currentIssue.title,
+            action: 'skip',
+          },
+        ]);
+        handleNext();
+        return;
+      }
+
+      if (input === 'c') {
+        setIsEditingComment(true);
+        return;
+      }
+
+      if (input === 'e') {
+        setTargetExpanded(!targetExpanded);
+        setTargetScrollOffset(0);
+        return;
+      }
+
+      if (keyMatchers[Command.NAVIGATION_DOWN](key)) {
+        const targetLines = currentIssue.body.split('\n');
+        const visibleLines = targetExpanded
+          ? VISIBLE_LINES_EXPANDED
+          : VISIBLE_LINES_COLLAPSED;
+        const maxScroll = Math.max(0, targetLines.length - visibleLines);
+        setTargetScrollOffset((prev) => Math.min(prev + 1, maxScroll));
+      }
+      if (keyMatchers[Command.NAVIGATION_UP](key)) {
+        setTargetScrollOffset((prev) => Math.max(0, prev - 1));
+      }
+    },
+    { isActive: true },
+  );
+
+  if (state.status === 'loading') {
+    return (
+      <Box>
+        <Spinner type="dots" />
+        <Text> {state.message}</Text>
+      </Box>
+    );
+  }
+
+  if (showHistory) {
+    return (
+      <Box
+        flexDirection="column"
+        borderStyle="double"
+        borderColor="yellow"
+        padding={1}
+      >
+        <Text bold color="yellow">
+          Processed Issues History:
+        </Text>
+        <Box flexDirection="column" marginTop={1}>
+          {processedHistory.length === 0 ? (
+            <Text color="gray">No issues processed yet.</Text>
+          ) : (
+            processedHistory.map((item, i) => (
+              <Text key={i}>
+                <Text bold>#{item.number}</Text> {item.title.slice(0, 40)}...
+                <Text color={item.action === 'close' ? 'red' : 'gray'}>
+                  {' '}
+                  [{item.action.toUpperCase()}]
+                </Text>
+              </Text>
+            ))
+          )}
+        </Box>
+        <Box marginTop={1}>
+          <Text color="gray">
+            Press &apos;h&apos; or &apos;Esc&apos; to return.
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (state.status === 'completed') {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text color="green" bold>
+          {state.message}
+        </Text>
+        <Box marginTop={1}>
+          <Text color="gray">Press any key or &apos;q&apos; to exit.</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text color="red" bold>
+          {state.message}
+        </Text>
+        <Box marginTop={1}>
+          <Text color="gray">
+            Press &apos;q&apos; or &apos;Esc&apos; to exit.
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (!currentIssue) {
+    if (state.status === 'analyzing') {
+      return (
+        <Box>
+          <Spinner type="dots" />
+          <Text> {state.message}</Text>
+        </Box>
+      );
+    }
+    return <Text>No issues found.</Text>;
+  }
+
+  const targetBody = currentIssue.body || '';
+  const targetLines = targetBody.split('\n');
+  const visibleLines = targetExpanded
+    ? VISIBLE_LINES_EXPANDED
+    : VISIBLE_LINES_COLLAPSED;
+  const targetViewLines = targetLines.slice(
+    targetScrollOffset,
+    targetScrollOffset + visibleLines,
+  );
+
+  return (
+    <Box flexDirection="column">
+      <Box flexDirection="row" justifyContent="space-between">
+        <Text bold color="cyan">
+          Triage Potential Candidates ({state.currentIndex + 1}/
+          {state.issues.length})
+        </Text>
+        <Text color="gray">[h] History | [q] Quit</Text>
+      </Box>
+
+      {/* Issue Detail */}
+      <Box
+        flexDirection="column"
+        borderStyle="single"
+        borderColor="cyan"
+        paddingX={1}
+      >
+        <Box flexDirection="row" justifyContent="space-between">
+          <Text>
+            Issue:{' '}
+            <Text bold color="yellow">
+              #{currentIssue.number}
+            </Text>{' '}
+            - {currentIssue.title}
+          </Text>
+          <Text color="gray">
+            Author: {currentIssue.author?.login} | 👍{' '}
+            {getReactionCount(currentIssue)}
+          </Text>
+        </Box>
+        <Text color="gray" wrap="truncate-end">
+          {currentIssue.url}
+        </Text>
+        <Box
+          marginTop={1}
+          flexDirection="column"
+          minHeight={Math.min(targetLines.length, visibleLines)}
+        >
+          {targetViewLines.map((line, i) => (
+            <Text key={i} italic wrap="truncate-end">
+              {line}
+            </Text>
+          ))}
+          {!targetExpanded && targetLines.length > VISIBLE_LINES_COLLAPSED && (
+            <Text color="gray">... (press &apos;e&apos; to expand)</Text>
+          )}
+          {targetExpanded &&
+            targetLines.length >
+              targetScrollOffset + VISIBLE_LINES_EXPANDED && (
+              <Text color="gray">... (more below)</Text>
+            )}
+        </Box>
+      </Box>
+
+      {/* Gemini Analysis */}
+      <Box
+        marginTop={1}
+        padding={1}
+        borderStyle="round"
+        borderColor="blue"
+        flexDirection="column"
+      >
+        {state.status === 'analyzing' ? (
+          <Box>
+            <Spinner type="dots" />
+            <Text> Analyzing issue with Gemini...</Text>
+          </Box>
+        ) : analysis ? (
+          <>
+            <Box flexDirection="row">
+              <Text bold color="blue">
+                Gemini Recommendation:{' '}
+              </Text>
+              <Text color="red" bold>
+                CLOSE
+              </Text>
+            </Box>
+            <Text italic>Reason: {analysis.reason}</Text>
+          </>
+        ) : (
+          <Text color="gray">Waiting for analysis...</Text>
+        )}
+      </Box>
+
+      {/* Action Section */}
+      <Box marginTop={1} flexDirection="column">
+        {isEditingComment ? (
+          <Box
+            flexDirection="column"
+            borderStyle="single"
+            borderColor="magenta"
+            padding={1}
+          >
+            <Text bold color="magenta">
+              Edit Closing Comment (Enter to confirm, Esc to cancel):
+            </Text>
+            <Box marginTop={1}>
+              <TextInput
+                buffer={commentBuffer}
+                onSubmit={performClose}
+                onCancel={() => setIsEditingComment(false)}
+              />
+            </Box>
+          </Box>
+        ) : (
+          <Box flexDirection="row" gap={2}>
+            <Box flexDirection="column">
+              <Text bold>Actions:</Text>
+              <Text>[c] Close Issue (with comment)</Text>
+              <Text>[s] Skip / Next</Text>
+              <Text>[e] Expand/Collapse Body</Text>
+            </Box>
+            <Box flexDirection="column" flexGrow={1} marginLeft={2}>
+              <Text bold color="gray">
+                Suggested Comment:
+              </Text>
+              <Text italic color="gray" wrap="truncate-end">
+                &quot;{analysis?.suggested_comment}&quot;
+              </Text>
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};


### PR DESCRIPTION
## Summary

Add a new `/oncall audit` command to help oncall engineers triage issues. It identifies issues that are bogus, unreproducible, abusive, or gibberish using Gemini.

## Details

- Implements `TriageIssues` component for interactive triaging.
- Uses Gemini to provide "close" or "keep" recommendations.
- Automatically skips "keep" recommendations to focus on cleanup.
- Provides a built-in text editor for customizing closing comments.
- Tracks triage history during the session.

## Related Issues

Related to #17719 (general triage improvements)

## How to Validate

1. Build and start the CLI.
2. Run `/oncall audit`.
3. Verify it fetches issues with `status/need-triage` and filters out tasks/features.
4. Interact with the UI:
   - Use 'e' to expand/collapse issue body.
   - Use 'c' to edit the closing comment.
   - Press Enter to close an issue.
   - Use 's' to skip.
   - Use 'h' to view history.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
