### PR TITLE
feat: add a traffic type config to manage PT traffic

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -305,6 +305,11 @@ their corresponding top-level category object in your `settings.json` file.
   - **Description:** The Gemini model to use for conversations.
   - **Default:** `undefined`
 
+- **`model.vertex.requestType`** (string):
+  - **Description:** The request type for Vertex AI LLM requests (e.g.
+    "dedicated"). Sets the X-Vertex-AI-LLM-Request-Type header.
+  - **Default:** `undefined`
+
 - **`model.maxSessionTurns`** (number):
   - **Description:** Maximum number of user/model/tool turns to keep in a
     session. -1 means unlimited.

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -761,6 +761,7 @@ export async function loadCliConfig(
     noBrowser: !!process.env['NO_BROWSER'],
     summarizeToolOutput: settings.model?.summarizeToolOutput,
     ideMode,
+    vertexAiRequestType: settings.model?.vertex?.requestType,
     compressionThreshold: settings.model?.compressionThreshold,
     folderTrust,
     interactive,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -690,6 +690,27 @@ const SETTINGS_SCHEMA = {
         description: 'The Gemini model to use for conversations.',
         showInDialog: false,
       },
+      vertex: {
+        type: 'object',
+        label: 'Vertex AI Settings',
+        category: 'Model',
+        requiresRestart: false,
+        default: {},
+        description: 'Settings specific to Vertex AI.',
+        showInDialog: false,
+        properties: {
+          requestType: {
+            type: 'string',
+            label: 'Request Type',
+            category: 'Model',
+            requiresRestart: false,
+            default: undefined as string | undefined,
+            description:
+              'The request type for Vertex AI LLM requests (e.g. "dedicated"). Sets the X-Vertex-AI-LLM-Request-Type header.',
+            showInDialog: false,
+          },
+        },
+      },
       maxSessionTurns: {
         type: 'number',
         label: 'Max Session Turns',

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -585,6 +585,15 @@ describe('Server Config (config.ts)', () => {
     expect(config.getTargetDir()).toBe(path.resolve(TARGET_DIR)); // Check resolved path
   });
 
+  it('Config constructor should store vertexAiRequestType correctly', () => {
+    const paramsWithVertexAiRequestType: ConfigParameters = {
+      ...baseParams,
+      vertexAiRequestType: 'dedicated',
+    };
+    const config = new Config(paramsWithVertexAiRequestType);
+    expect(config.getVertexAiRequestType()).toBe('dedicated');
+  });
+
   it('Config constructor should default userMemory to empty string if not provided', () => {
     const paramsWithoutMemory: ConfigParameters = { ...baseParams };
     delete paramsWithoutMemory.userMemory;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -354,6 +354,7 @@ export interface ConfigParameters {
   summarizeToolOutput?: Record<string, SummarizeToolOutputSettings>;
   folderTrust?: boolean;
   ideMode?: boolean;
+  vertexAiRequestType?: string;
   loadMemoryFromIncludeDirectories?: boolean;
   importFormat?: 'tree' | 'flat';
   discoveryMaxDirs?: number;
@@ -480,6 +481,7 @@ export class Config {
   private readonly noBrowser: boolean;
   private readonly folderTrust: boolean;
   private ideMode: boolean;
+  private readonly vertexAiRequestType: string | undefined;
 
   private _activeModel: string;
   private readonly maxSessionTurns: number;
@@ -666,6 +668,7 @@ export class Config {
     this.summarizeToolOutput = params.summarizeToolOutput;
     this.folderTrust = params.folderTrust ?? false;
     this.ideMode = params.ideMode ?? false;
+    this.vertexAiRequestType = params.vertexAiRequestType;
     this.loadMemoryFromIncludeDirectories =
       params.loadMemoryFromIncludeDirectories ?? false;
     this.importFormat = params.importFormat ?? 'tree';
@@ -1670,6 +1673,10 @@ export class Config {
 
   getIdeMode(): boolean {
     return this.ideMode;
+  }
+
+  getVertexAiRequestType(): string | undefined {
+    return this.vertexAiRequestType;
   }
 
   /**

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -61,6 +61,7 @@ export type ContentGeneratorConfig = {
   vertexai?: boolean;
   authType?: AuthType;
   proxy?: string;
+  requestType?: string;
 };
 
 export async function createContentGeneratorConfig(
@@ -79,6 +80,7 @@ export async function createContentGeneratorConfig(
   const contentGeneratorConfig: ContentGeneratorConfig = {
     authType,
     proxy: config?.getProxy(),
+    requestType: config?.getVertexAiRequestType(),
   };
 
   // If we are using Google auth or we are in Cloud Shell, there is nothing else to validate for now
@@ -137,6 +139,10 @@ export async function createContentGenerator(
       ...customHeadersMap,
       'User-Agent': userAgent,
     };
+
+    if (config.vertexai && config.requestType) {
+      baseHeaders['X-Vertex-AI-LLM-Request-Type'] = config.requestType;
+    }
 
     if (
       apiKeyAuthMechanism === 'bearer' &&

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -140,8 +140,9 @@ export async function createContentGenerator(
       'User-Agent': userAgent,
     };
 
-    if (config.vertexai && config.requestType) {
-      baseHeaders['X-Vertex-AI-LLM-Request-Type'] = config.requestType;
+    const requestType = config.vertexai ? config.requestType?.trim() : undefined;
+    if (requestType) {
+      baseHeaders['X-Vertex-AI-LLM-Request-Type'] = requestType;
     }
 
     if (

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -427,6 +427,22 @@
           "markdownDescription": "The Gemini model to use for conversations.\n\n- Category: `Model`\n- Requires restart: `no`",
           "type": "string"
         },
+        "vertex": {
+          "title": "Vertex AI Settings",
+          "description": "Settings specific to Vertex AI.",
+          "markdownDescription": "Settings specific to Vertex AI.\n\n- Category: `Model`\n- Requires restart: `no`\n- Default: `{}`",
+          "default": {},
+          "type": "object",
+          "properties": {
+            "requestType": {
+              "title": "Request Type",
+              "description": "The request type for Vertex AI LLM requests (e.g. \"dedicated\"). Sets the X-Vertex-AI-LLM-Request-Type header.",
+              "markdownDescription": "The request type for Vertex AI LLM requests (e.g. \"dedicated\"). Sets the X-Vertex-AI-LLM-Request-Type header.\n\n- Category: `Model`\n- Requires restart: `no`",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
         "maxSessionTurns": {
           "title": "Max Session Turns",
           "description": "Maximum number of user/model/tool turns to keep in a session. -1 means unlimited.",


### PR DESCRIPTION
## Summary

This PR introduces a mechanism to control Provisioned Throughput (PT) usage overages using the `X-Vertex-AI-LLM-Request-Type` header.

Reference: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/provisioned-throughput/use-provisioned-throughput#use-rest-api

This is particularly important for regions with SZPT, where we want to ensure all traffic is routed strictly through the Provisioned Throughput.

## Details

I added a new configuration setting: `model.vertex.requestType`.
If this value is set, it will be passed to the HTTP header `X-Vertex-AI-LLM-Request-Type`.

**Breaking Change:** None.
To avoid breaking changes, the default value is `undefined`, which defaults to omitting the header (standard behavior).

## Related Issues

Fixes #17768 

## How to Validate

Update your `settings.json` with the following configuration:

```json
{
  "model": {
    "vertex": {
      "requestType": "dedicated"
    }
  }
}
```

If your Google Cloud project does not have assigned PT volume, you should see the following error message. 

`API Error: Too many requests. Exceeded the provisioned throughput. Please refer to https://cloud.google.com/vertex-ai/generative-ai/docs/error-code-429 for more details.`


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
