### PR TITLE
feat(cli): new query detection and pop up dialog

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -310,6 +310,11 @@ their corresponding top-level category object in your `settings.json` file.
     session. -1 means unlimited.
   - **Default:** `-1`
 
+- **`model.renewSessionTurnsThreshold`** (number):
+  - **Description:** Number of conversation turns after which to prompt the user
+    to start a new session or compress. Set to -1 to disable.
+  - **Default:** `-1`
+
 - **`model.summarizeToolOutput`** (object):
   - **Description:** Enables or disables summarization of tool output. Configure
     per-tool token budgets (for example {"run_shell_command": {"tokenBudget":

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -796,6 +796,8 @@ export async function loadCliConfig(
     enableHooksUI: settings.tools?.enableHooks ?? true,
     hooks: settings.hooks || {},
     disabledHooks: settings.hooksConfig?.disabled || [],
+    renewSessionTurnsThreshold:
+      settings.model?.renewSessionTurnsThreshold ?? -1,
     projectHooks: projectHooks || {},
     onModelChange: (model: string) => saveModelChange(loadedSettings, model),
     onReload: async () => {

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -700,6 +700,16 @@ const SETTINGS_SCHEMA = {
           'Maximum number of user/model/tool turns to keep in a session. -1 means unlimited.',
         showInDialog: true,
       },
+      renewSessionTurnsThreshold: {
+        type: 'number',
+        label: 'Renew Session Turn Threshold',
+        category: 'Model',
+        requiresRestart: false,
+        default: -1,
+        description:
+          'Number of conversation turns after which to prompt the user to start a new session or compress. Set to -1 to disable.',
+        showInDialog: true,
+      },
       summarizeToolOutput: {
         type: 'object',
         label: 'Summarize Tool Output',

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -950,7 +950,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     handleApprovalModeChange,
     activePtyId,
     loopDetectionConfirmationRequest,
-    RenewSessionConfirmationRequest,
+    renewSessionConfirmationRequest,
     lastOutputTime,
     retryStatus,
   } = useGeminiStream(
@@ -1647,7 +1647,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     !!customDialog ||
     confirmUpdateExtensionRequests.length > 0 ||
     !!loopDetectionConfirmationRequest ||
-    !!RenewSessionConfirmationRequest ||
+    !!renewSessionConfirmationRequest ||
     isThemeDialogOpen ||
     isSettingsDialogOpen ||
     isModelDialogOpen ||
@@ -1757,7 +1757,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       confirmationRequest,
       confirmUpdateExtensionRequests,
       loopDetectionConfirmationRequest,
-      RenewSessionConfirmationRequest,
+      renewSessionConfirmationRequest,
       geminiMdFileCount,
       streamingState,
       initError,
@@ -1928,7 +1928,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       settingsNonce,
       adminSettingsChanged,
       newAgents,
-      RenewSessionConfirmationRequest,
+      renewSessionConfirmationRequest,
     ],
   );
 

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -107,6 +107,7 @@ import { useShellInactivityStatus } from './hooks/useShellInactivityStatus.js';
 import { useFolderTrust } from './hooks/useFolderTrust.js';
 import { useIdeTrustListener } from './hooks/useIdeTrustListener.js';
 import { type IdeIntegrationNudgeResult } from './IdeIntegrationNudge.js';
+import { clearCommand } from './commands/clearCommand.js';
 import { appEvents, AppEvent } from '../utils/events.js';
 import { type UpdateObject } from './utils/updateCheck.js';
 import { setUpdateHandler } from '../utils/handleAutoUpdate.js';
@@ -929,6 +930,15 @@ Logging in with Google... Restarting Gemini CLI to continue.
     }
   }, [pendingRestorePrompt, inputHistory, historyManager.history]);
 
+  // Function to execute the clear command directly, bypassing the slash command processor.
+  // This is used by the RenewSessionDialog to avoid potential infinite loops caused
+  // by state updates within the processor.
+  const executeClearCommand = useCallback(async () => {
+    if (clearCommand.action) {
+      await clearCommand.action(commandContext, '');
+    }
+  }, [commandContext]);
+
   const {
     streamingState,
     submitQuery,
@@ -962,6 +972,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     terminalWidth,
     terminalHeight,
     embeddedShellFocused,
+    executeClearCommand,
   );
 
   const lastOutputTimeRef = useRef(0);

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -940,6 +940,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     handleApprovalModeChange,
     activePtyId,
     loopDetectionConfirmationRequest,
+    RenewSessionConfirmationRequest,
     lastOutputTime,
     retryStatus,
   } = useGeminiStream(
@@ -1635,6 +1636,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     !!customDialog ||
     confirmUpdateExtensionRequests.length > 0 ||
     !!loopDetectionConfirmationRequest ||
+    !!RenewSessionConfirmationRequest ||
     isThemeDialogOpen ||
     isSettingsDialogOpen ||
     isModelDialogOpen ||
@@ -1744,6 +1746,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       confirmationRequest,
       confirmUpdateExtensionRequests,
       loopDetectionConfirmationRequest,
+      RenewSessionConfirmationRequest,
       geminiMdFileCount,
       streamingState,
       initError,
@@ -1914,6 +1917,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       settingsNonce,
       adminSettingsChanged,
       newAgents,
+      RenewSessionConfirmationRequest,
     ],
   );
 

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -128,11 +128,6 @@ export const DialogManager = ({
       />
     );
   }
-  if (uiState.shellConfirmationRequest) {
-    return (
-      <ShellConfirmationDialog request={uiState.shellConfirmationRequest} />
-    );
-  }
   if (uiState.renewSessionConfirmationRequest) {
     return (
       <RenewSessionDialog

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -133,13 +133,14 @@ export const DialogManager = ({
       <ShellConfirmationDialog request={uiState.shellConfirmationRequest} />
     );
   }
-  if (uiState.RenewSessionConfirmationRequest) {
+  if (uiState.renewSessionConfirmationRequest) {
     return (
       <RenewSessionDialog
         maxSessionTurns={
           settings.merged.model?.renewSessionTurnsThreshold ?? -1
         }
-        onComplete={uiState.RenewSessionConfirmationRequest.onComplete}
+        reason={uiState.renewSessionConfirmationRequest.reason}
+        onComplete={uiState.renewSessionConfirmationRequest.onComplete}
       />
     );
   }

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -7,6 +7,7 @@
 import { Box, Text } from 'ink';
 import { IdeIntegrationNudge } from '../IdeIntegrationNudge.js';
 import { LoopDetectionConfirmation } from './LoopDetectionConfirmation.js';
+import { RenewSessionDialog } from './RenewSessionDialog.js';
 import { FolderTrustDialog } from './FolderTrustDialog.js';
 import { ConsentPrompt } from './ConsentPrompt.js';
 import { ThemeDialog } from './ThemeDialog.js';
@@ -124,6 +125,21 @@ export const DialogManager = ({
       <FolderTrustDialog
         onSelect={uiActions.handleFolderTrustSelect}
         isRestarting={uiState.isRestarting}
+      />
+    );
+  }
+  if (uiState.shellConfirmationRequest) {
+    return (
+      <ShellConfirmationDialog request={uiState.shellConfirmationRequest} />
+    );
+  }
+  if (uiState.RenewSessionConfirmationRequest) {
+    return (
+      <RenewSessionDialog
+        maxSessionTurns={
+          settings.merged.model?.renewSessionTurnsThreshold ?? -1
+        }
+        onComplete={uiState.RenewSessionConfirmationRequest.onComplete}
       />
     );
   }

--- a/packages/cli/src/ui/components/RenewSessionDialog.tsx
+++ b/packages/cli/src/ui/components/RenewSessionDialog.tsx
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Box, Text } from 'ink';
+import type { RadioSelectItem } from './shared/RadioButtonSelect.js';
+import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
+import { useKeypress } from '../hooks/useKeypress.js';
+import { theme } from '../semantic-colors.js';
+import type { RenewSessionConfirmationResult } from '../types.js';
+
+interface RenewSessionDialogProps {
+  onComplete: (result: RenewSessionConfirmationResult) => void;
+  maxSessionTurns: number;
+}
+
+export function RenewSessionDialog({
+  onComplete,
+  maxSessionTurns,
+}: RenewSessionDialogProps) {
+  useKeypress(
+    (key) => {
+      if (key.name === 'escape') {
+        onComplete({
+          userSelection: 'compress_session',
+        });
+      }
+    },
+    { isActive: true },
+  );
+
+  const OPTIONS: Array<RadioSelectItem<RenewSessionConfirmationResult>> = [
+    {
+      label: 'Compress session',
+      value: {
+        userSelection: 'compress_session',
+      } as RenewSessionConfirmationResult,
+      key: 'compress_session',
+    },
+    {
+      label: 'Start a new session',
+      value: {
+        userSelection: 'new_session',
+      } as RenewSessionConfirmationResult,
+      key: 'new_session',
+    },
+  ];
+
+  return (
+    <Box width="100%" flexDirection="row">
+      <Box
+        flexDirection="column"
+        borderStyle="round"
+        borderColor={theme.status.warning}
+        flexGrow={1}
+        marginLeft={1}
+      >
+        <Box paddingX={1} paddingY={0} flexDirection="column">
+          <Box minHeight={1}>
+            <Box minWidth={3}>
+              <Text
+                color={theme.status.warning}
+                aria-label="Max turns reached:"
+              >
+                !
+              </Text>
+            </Box>
+            <Box>
+              <Text wrap="truncate-end">
+                <Text color={theme.text.primary} bold>
+                  Turn limit reached
+                </Text>{' '}
+                <Text color={theme.text.secondary}>
+                  (current threshold: {maxSessionTurns} turns)
+                </Text>
+              </Text>
+            </Box>
+          </Box>
+          <Box marginTop={1}>
+            <Box flexDirection="column">
+              <Text color={theme.text.secondary}>
+                You&apos;ve reached the configured maximum number of turns for
+                this session. Choose whether to compress the conversation or
+                start a new session.
+              </Text>
+              <Box marginTop={1}>
+                <RadioButtonSelect items={OPTIONS} onSelect={onComplete} />
+              </Box>
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/ui/components/RenewSessionDialog.tsx
+++ b/packages/cli/src/ui/components/RenewSessionDialog.tsx
@@ -14,11 +14,13 @@ import type { RenewSessionConfirmationResult } from '../types.js';
 interface RenewSessionDialogProps {
   onComplete: (result: RenewSessionConfirmationResult) => void;
   maxSessionTurns: number;
+  reason?: 'turn_limit' | 'topic_change';
 }
 
 export function RenewSessionDialog({
   onComplete,
   maxSessionTurns,
+  reason = 'turn_limit',
 }: RenewSessionDialogProps) {
   useKeypress(
     (key) => {
@@ -31,9 +33,13 @@ export function RenewSessionDialog({
     { isActive: true },
   );
 
+  const isTopicChange = reason === 'topic_change';
+
   const OPTIONS: Array<RadioSelectItem<RenewSessionConfirmationResult>> = [
     {
-      label: 'Compress session',
+      label: isTopicChange
+        ? 'Continue with current context'
+        : 'Compress session',
       value: {
         userSelection: 'compress_session',
       } as RenewSessionConfirmationResult,
@@ -70,20 +76,24 @@ export function RenewSessionDialog({
             <Box>
               <Text wrap="truncate-end">
                 <Text color={theme.text.primary} bold>
-                  Turn limit reached
+                  {isTopicChange
+                    ? 'Topic change detected'
+                    : 'Turn limit reached'}
                 </Text>{' '}
-                <Text color={theme.text.secondary}>
-                  (current threshold: {maxSessionTurns} turns)
-                </Text>
+                {reason === 'turn_limit' && (
+                  <Text color={theme.text.secondary}>
+                    (current threshold: {maxSessionTurns} turns)
+                  </Text>
+                )}
               </Text>
             </Box>
           </Box>
           <Box marginTop={1}>
             <Box flexDirection="column">
               <Text color={theme.text.secondary}>
-                You&apos;ve reached the configured maximum number of turns for
-                this session. Choose whether to compress the conversation or
-                start a new session.
+                {isTopicChange
+                  ? 'Your query appears to be about a new topic. Would you like to start a new session?'
+                  : "You've reached the configured maximum number of turns for this session. Choose whether to compress the conversation or start a new session."}
               </Text>
               <Box marginTop={1}>
                 <RadioButtonSelect items={OPTIONS} onSelect={onComplete} />

--- a/packages/cli/src/ui/components/RenewSessionDialog.tsx
+++ b/packages/cli/src/ui/components/RenewSessionDialog.tsx
@@ -22,29 +22,48 @@ export function RenewSessionDialog({
   maxSessionTurns,
   reason = 'turn_limit',
 }: RenewSessionDialogProps) {
+  const isTopicChange = reason === 'topic_change';
+
   useKeypress(
     (key) => {
       if (key.name === 'escape') {
         onComplete({
-          userSelection: 'compress_session',
+          userSelection: isTopicChange
+            ? 'continue_session'
+            : 'compress_session',
         });
       }
     },
     { isActive: true },
   );
 
-  const isTopicChange = reason === 'topic_change';
-
   const OPTIONS: Array<RadioSelectItem<RenewSessionConfirmationResult>> = [
-    {
-      label: isTopicChange
-        ? 'Continue with current context'
-        : 'Compress session',
-      value: {
-        userSelection: 'compress_session',
-      } as RenewSessionConfirmationResult,
-      key: 'compress_session',
-    },
+    ...(isTopicChange
+      ? [
+          {
+            label: 'Continue with current context',
+            value: {
+              userSelection: 'continue_session',
+            } as RenewSessionConfirmationResult,
+            key: 'continue_session',
+          },
+          {
+            label: 'Compress conversation',
+            value: {
+              userSelection: 'compress_session',
+            } as RenewSessionConfirmationResult,
+            key: 'compress_session',
+          },
+        ]
+      : [
+          {
+            label: 'Compress session',
+            value: {
+              userSelection: 'compress_session',
+            } as RenewSessionConfirmationResult,
+            key: 'compress_session',
+          },
+        ]),
     {
       label: 'Start a new session',
       value: {

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -11,6 +11,7 @@ import type {
   ConsoleMessageItem,
   ConfirmationRequest,
   LoopDetectionConfirmationRequest,
+  RenewSessionConfirmationRequest,
   HistoryItemWithoutId,
   StreamingState,
   ActiveHook,
@@ -83,6 +84,7 @@ export interface UIState {
   confirmationRequest: ConfirmationRequest | null;
   confirmUpdateExtensionRequests: ConfirmationRequest[];
   loopDetectionConfirmationRequest: LoopDetectionConfirmationRequest | null;
+  RenewSessionConfirmationRequest: RenewSessionConfirmationRequest | null;
   geminiMdFileCount: number;
   streamingState: StreamingState;
   initError: string | null;

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -84,7 +84,7 @@ export interface UIState {
   confirmationRequest: ConfirmationRequest | null;
   confirmUpdateExtensionRequests: ConfirmationRequest[];
   loopDetectionConfirmationRequest: LoopDetectionConfirmationRequest | null;
-  RenewSessionConfirmationRequest: RenewSessionConfirmationRequest | null;
+  renewSessionConfirmationRequest: RenewSessionConfirmationRequest | null;
   geminiMdFileCount: number;
   streamingState: StreamingState;
   initError: string | null;

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -205,58 +205,59 @@ describe('useGeminiStream', () => {
     getMcpServerCount: vi.fn().mockReturnValue(0),
   };
 
-    const contentGeneratorConfig = {
-      model: 'test-model',
-      apiKey: 'test-key',
-      vertexai: false,
-      authType: AuthType.USE_GEMINI,
-    };
+  const contentGeneratorConfig = {
+    model: 'test-model',
+    apiKey: 'test-key',
+    vertexai: false,
+    authType: AuthType.USE_GEMINI,
+  };
 
-    const mockConfig: Config ={
-      apiKey: 'test-api-key',
-      model: 'gemini-pro',
-      sandbox: false,
-      targetDir: '/test/dir',
-      debugMode: false,
-      question: undefined,
+  const mockConfig: Config = {
+    apiKey: 'test-api-key',
+    model: 'gemini-pro',
+    sandbox: false,
+    targetDir: '/test/dir',
+    debugMode: false,
+    question: undefined,
 
-      coreTools: [],
-      toolDiscoveryCommand: undefined,
-      toolCallCommand: undefined,
-      mcpServerCommand: undefined,
-      mcpServers: undefined,
-      userAgent: 'test-agent',
-      userMemory: '',
-      geminiMdFileCount: 0,
-      alwaysSkipModificationConfirmation: false,
-      vertexai: false,
-      showMemoryUsage: false,
-      contextFileName: undefined,
-      getToolRegistry: vi.fn(
-        () => ({ getToolSchemaList: vi.fn(() => []) }) as any,
-      ),
-      getProjectRoot: vi.fn(() => '/test/dir'),
-      getCheckpointingEnabled: vi.fn(() => false),
-      getGeminiClient: mockGetGeminiClient,
-      getMcpClientManager: () => mockMcpClientManager as any,
-      getApprovalMode: () => ApprovalMode.DEFAULT,
-      getUsageStatisticsEnabled: () => true,
-      getDebugMode: () => false,
-      addHistory: vi.fn(),
-      getSessionId() {
-        return 'test-session-id';
-      },
-      setQuotaErrorOccurred: vi.fn(),
-      getQuotaErrorOccurred: vi.fn(() => false),
-      getModel: vi.fn(() => 'gemini-2.5-pro'),
-      getContentGeneratorConfig: vi
-        .fn()
-        .mockReturnValue(contentGeneratorConfig),
-      isInteractive: () => false,
-      getExperiments: () => {},
-    } as unknown as Config;
+    coreTools: [],
+    toolDiscoveryCommand: undefined,
+    toolCallCommand: undefined,
+    mcpServerCommand: undefined,
+    mcpServers: undefined,
+    userAgent: 'test-agent',
+    userMemory: '',
+    geminiMdFileCount: 0,
+    alwaysSkipModificationConfirmation: false,
+    vertexai: false,
+    showMemoryUsage: false,
+    contextFileName: undefined,
+    getToolRegistry: vi.fn(
+      () => ({ getToolSchemaList: vi.fn(() => []) }) as any,
+    ),
+    getProjectRoot: vi.fn(() => '/test/dir'),
+    getCheckpointingEnabled: vi.fn(() => false),
+    getGeminiClient: mockGetGeminiClient,
+    getMcpClientManager: () => mockMcpClientManager as any,
+    getApprovalMode: vi.fn(() => ApprovalMode.DEFAULT),
+    getUsageStatisticsEnabled: () => true,
+    getDebugMode: () => false,
+    addHistory: vi.fn(),
+    getSessionId() {
+      return 'test-session-id';
+    },
+    setQuotaErrorOccurred: vi.fn(),
+    getQuotaErrorOccurred: vi.fn(() => false),
+    getModel: vi.fn(() => 'gemini-2.5-pro'),
+    getContentGeneratorConfig: vi.fn().mockReturnValue(contentGeneratorConfig),
+    isInteractive: () => false,
+    getExperiments: () => ({ flags: {}, experimentIds: [] }),
+    isEventDrivenSchedulerEnabled: vi.fn(() => false),
+    getMaxSessionTurns: vi.fn(() => -1),
+    storage: {} as any,
+  } as unknown as Config;
 
-    beforeEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks(); // Clear mocks before each test
     mockAddItem = vi.fn();
     mockOnDebugMessage = vi.fn();

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -75,6 +75,8 @@ const MockedGeminiClientClass = vi.hoisted(() =>
     });
     this.resetChat = vi.fn().mockResolvedValue(undefined);
     this.getCurrentSequenceModel = vi.fn().mockReturnValue('gemini-pro');
+    this.getSessionTurnCount = vi.fn().mockReturnValue(0);
+    this.resetSessionTurnCount = vi.fn();
   }),
 );
 
@@ -3121,7 +3123,7 @@ describe('useGeminiStream', () => {
     });
 
     describe('Topic Change Detection', () => {
-      it('should trigger renewSessionConfirmationRequest on topic change and reset chat if confirmed', async () => {
+      it('should trigger renewSessionConfirmationRequest on topic change and reset chat if confirmed (new_session)', async () => {
         const client = new MockedGeminiClientClass(mockConfig);
         const topicDetector = {
           isTopicChanged: vi
@@ -3177,14 +3179,10 @@ describe('useGeminiStream', () => {
           capturedOnComplete({ userSelection: 'new_session' });
         });
 
-        // Use a small delay for the setTimeout in the implementation
-        await act(async () => {
-          await new Promise((resolve) => setTimeout(resolve, 60));
-        });
-
         await waitFor(() => expect(submitResolved).toBe(true));
 
         expect(executeClearCommand).toHaveBeenCalled();
+        expect(client.resetSessionTurnCount).toHaveBeenCalled();
         expect(client.resetChat).not.toHaveBeenCalled();
         expect(mockAddItem).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -3200,7 +3198,7 @@ describe('useGeminiStream', () => {
         );
       });
 
-      it('should trigger renewSessionConfirmationRequest on topic change and NOT reset chat if cancelled', async () => {
+      it('should trigger renewSessionConfirmationRequest on topic change and just proceed if continue_session', async () => {
         const client = new MockedGeminiClientClass(mockConfig);
         const topicDetector = {
           isTopicChanged: vi
@@ -3229,7 +3227,54 @@ describe('useGeminiStream', () => {
         const capturedOnComplete =
           result.current.renewSessionConfirmationRequest!.onComplete;
 
-        // Simulate user choosing "Continue" (compress_session)
+        // Simulate user choosing "Continue" (continue_session)
+        await act(async () => {
+          capturedOnComplete({ userSelection: 'continue_session' });
+        });
+
+        await waitFor(() => expect(submitResolved).toBe(true));
+
+        expect(client.resetSessionTurnCount).not.toHaveBeenCalled();
+        expect(client.resetChat).not.toHaveBeenCalled();
+        expect(mockHandleSlashCommand).not.toHaveBeenCalledWith('/compress');
+        expect(mockSendMessageStream).toHaveBeenCalledWith(
+          'Query 2',
+          expect.any(AbortSignal),
+          expect.any(String),
+        );
+      });
+
+      it('should trigger renewSessionConfirmationRequest on topic change and compress chat if compress_session', async () => {
+        const client = new MockedGeminiClientClass(mockConfig);
+        const topicDetector = {
+          isTopicChanged: vi
+            .fn()
+            .mockResolvedValue({ topic_changed: true, reasoning: 'test' }),
+        };
+        client.getTopicDetectionService.mockReturnValue(topicDetector);
+
+        const { result } = renderTestHook([], client);
+
+        await act(async () => {
+          await result.current.submitQuery('Query 1');
+        });
+
+        mockSendMessageStream.mockClear();
+        mockHandleSlashCommand.mockClear();
+
+        let submitResolved = false;
+        void result.current.submitQuery('Query 2').then(() => {
+          submitResolved = true;
+        });
+
+        await waitFor(() => {
+          expect(result.current.renewSessionConfirmationRequest).not.toBeNull();
+        });
+
+        const capturedOnComplete =
+          result.current.renewSessionConfirmationRequest!.onComplete;
+
+        // Simulate user choosing "Compress" (compress_session)
         await act(async () => {
           capturedOnComplete({ userSelection: 'compress_session' });
         });
@@ -3237,6 +3282,12 @@ describe('useGeminiStream', () => {
         await waitFor(() => expect(submitResolved).toBe(true));
 
         expect(client.resetChat).not.toHaveBeenCalled();
+        expect(mockHandleSlashCommand).toHaveBeenCalledWith(
+          '/compress',
+          undefined,
+          undefined,
+          false,
+        );
         expect(mockSendMessageStream).toHaveBeenCalledWith(
           'Query 2',
           expect.any(AbortSignal),
@@ -3282,6 +3333,50 @@ describe('useGeminiStream', () => {
             text: expect.stringContaining('Should be ignored'),
           }),
           expect.any(Number),
+        );
+      });
+
+      it('should resubmit query after compress_session is selected', async () => {
+        mockSendMessageStream.mockReturnValue(
+          (async function* () {
+            yield {
+              type: ServerGeminiEventType.RenewSession,
+            };
+          })(),
+        );
+
+        const { result } = renderHookWithDefaults();
+
+        await act(async () => {
+          await result.current.submitQuery('Original query');
+        });
+
+        // Wait for the dialog to be requested
+        await waitFor(() => {
+          expect(result.current.renewSessionConfirmationRequest).not.toBeNull();
+        });
+
+        // Capture the initial call count
+        const initialCallCount = mockSendMessageStream.mock.calls.length;
+
+        // Simulate choosing 'compress_session'
+        await act(async () => {
+          result.current.renewSessionConfirmationRequest?.onComplete({
+            userSelection: 'compress_session',
+          });
+        });
+
+        // Wait for the second query to be submitted
+        await waitFor(() => {
+          expect(mockSendMessageStream).toHaveBeenCalledTimes(
+            initialCallCount + 1,
+          );
+        });
+
+        expect(mockSendMessageStream).toHaveBeenLastCalledWith(
+          'Original query',
+          expect.any(AbortSignal),
+          expect.any(String),
         );
       });
     });

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -68,6 +68,13 @@ const MockedGeminiClientClass = vi.hoisted(() =>
       recordToolCalls: vi.fn(),
       getConversationFile: vi.fn(),
     });
+    this.getTopicDetectionService = vi.fn().mockReturnValue({
+      isTopicChanged: vi
+        .fn()
+        .mockResolvedValue({ topic_changed: false, reasoning: 'test' }),
+    });
+    this.resetChat = vi.fn().mockResolvedValue(undefined);
+    this.getCurrentSequenceModel = vi.fn().mockReturnValue('gemini-pro');
   }),
 );
 
@@ -312,6 +319,7 @@ describe('useGeminiStream', () => {
       shellModeActive: false,
       loadedSettings: mockLoadedSettings,
       toolCalls: initialToolCalls,
+      executeClearCommand: undefined as (() => Promise<void>) | undefined,
     };
 
     mockUseToolScheduler.mockImplementation((onComplete) => {
@@ -373,6 +381,8 @@ describe('useGeminiStream', () => {
           mockSetShellInputFocused,
           80,
           24,
+          false,
+          props.executeClearCommand,
         ),
       {
         initialProps,
@@ -3107,6 +3117,131 @@ describe('useGeminiStream', () => {
       // Then verify loop detection confirmation request was set
       await waitFor(() => {
         expect(result.current.loopDetectionConfirmationRequest).not.toBeNull();
+      });
+    });
+
+    describe('Topic Change Detection', () => {
+      it('should trigger renewSessionConfirmationRequest on topic change and reset chat if confirmed', async () => {
+        const client = new MockedGeminiClientClass(mockConfig);
+        const topicDetector = {
+          isTopicChanged: vi
+            .fn()
+            .mockResolvedValue({ topic_changed: true, reasoning: 'test' }),
+        };
+        client.getTopicDetectionService.mockReturnValue(topicDetector);
+
+        const executeClearCommand = vi.fn().mockResolvedValue(undefined);
+        const { result, rerender } = renderTestHook([], client);
+        rerender({
+          client,
+          history: [],
+          addItem: mockAddItem as unknown as UseHistoryManagerReturn['addItem'],
+          config: mockConfig,
+          onDebugMessage: mockOnDebugMessage,
+          handleSlashCommand: mockHandleSlashCommand as unknown as (
+            cmd: PartListUnion,
+          ) => Promise<SlashCommandProcessorResult | false>,
+          shellModeActive: false,
+          loadedSettings: mockLoadedSettings,
+          toolCalls: [],
+          executeClearCommand,
+        });
+
+        // First query to set lastUserQueryTextRef
+        await act(async () => {
+          await result.current.submitQuery('Query 1');
+        });
+
+        // Clear mock calls from first query
+        mockSendMessageStream.mockClear();
+
+        // Second query should trigger topic detection
+        let submitResolved = false;
+        void result.current.submitQuery('Query 2').then(() => {
+          submitResolved = true;
+        });
+
+        // Wait for dialog to appear
+        await waitFor(() => {
+          expect(result.current.renewSessionConfirmationRequest).not.toBeNull();
+          expect(result.current.renewSessionConfirmationRequest?.reason).toBe(
+            'topic_change',
+          );
+        });
+
+        const capturedOnComplete =
+          result.current.renewSessionConfirmationRequest!.onComplete;
+
+        // Simulate user choosing "New Session"
+        await act(async () => {
+          capturedOnComplete({ userSelection: 'new_session' });
+        });
+
+        // Use a small delay for the setTimeout in the implementation
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 60));
+        });
+
+        await waitFor(() => expect(submitResolved).toBe(true));
+
+        expect(executeClearCommand).toHaveBeenCalled();
+        expect(client.resetChat).not.toHaveBeenCalled();
+        expect(mockAddItem).toHaveBeenCalledWith(
+          expect.objectContaining({
+            text: 'Topic change detected. Starting a new session.',
+            type: MessageType.INFO,
+          }),
+          expect.any(Number),
+        );
+        expect(mockSendMessageStream).toHaveBeenCalledWith(
+          'Query 2',
+          expect.any(AbortSignal),
+          expect.any(String),
+        );
+      });
+
+      it('should trigger renewSessionConfirmationRequest on topic change and NOT reset chat if cancelled', async () => {
+        const client = new MockedGeminiClientClass(mockConfig);
+        const topicDetector = {
+          isTopicChanged: vi
+            .fn()
+            .mockResolvedValue({ topic_changed: true, reasoning: 'test' }),
+        };
+        client.getTopicDetectionService.mockReturnValue(topicDetector);
+
+        const { result } = renderTestHook([], client);
+
+        await act(async () => {
+          await result.current.submitQuery('Query 1');
+        });
+
+        mockSendMessageStream.mockClear();
+
+        let submitResolved = false;
+        void result.current.submitQuery('Query 2').then(() => {
+          submitResolved = true;
+        });
+
+        await waitFor(() => {
+          expect(result.current.renewSessionConfirmationRequest).not.toBeNull();
+        });
+
+        const capturedOnComplete =
+          result.current.renewSessionConfirmationRequest!.onComplete;
+
+        // Simulate user choosing "Continue" (compress_session)
+        await act(async () => {
+          capturedOnComplete({ userSelection: 'compress_session' });
+        });
+
+        await waitFor(() => expect(submitResolved).toBe(true));
+
+        expect(client.resetChat).not.toHaveBeenCalled();
+        expect(mockSendMessageStream).toHaveBeenCalledWith(
+          'Query 2',
+          expect.any(AbortSignal),
+          expect.any(String),
+        );
       });
     });
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -412,6 +412,18 @@ export const useGeminiStream = (
     onComplete: (result: { userSelection: 'disable' | 'keep' }) => void;
   } | null>(null);
 
+  const [RenewSessionConfirmationRequest, setRenewSessionConfirmationRequest] =
+    useState<{
+      onComplete: (result: {
+        userSelection: 'compress_session' | 'new_session';
+      }) => void;
+    } | null>(null);
+
+  const handleSlashCommandRef = useRef(handleSlashCommand);
+  useEffect(() => {
+    handleSlashCommandRef.current = handleSlashCommand;
+  }, [handleSlashCommand]);
+
   const onExec = useCallback(async (done: Promise<void>) => {
     setIsResponding(true);
     await done;
@@ -602,9 +614,14 @@ export const useGeminiStream = (
 
         if (!shellModeActive) {
           // Handle UI-only commands first
-          const slashCommandResult = isSlashCommand(trimmedQuery)
-            ? await handleSlashCommand(trimmedQuery)
-            : false;
+          let slashCommandResult: SlashCommandProcessorResult | false = false;
+          if (isSlashCommand(trimmedQuery)) {
+            if (trimmedQuery.startsWith('/clear')) {
+              cancelOngoingRequest();
+              geminiClient.resetSessionTurnCount();
+            }
+            slashCommandResult = await handleSlashCommand(trimmedQuery);
+          }
 
           if (slashCommandResult) {
             switch (slashCommandResult.type) {
@@ -690,6 +707,7 @@ export const useGeminiStream = (
     },
     [
       config,
+      geminiClient,
       addItem,
       onDebugMessage,
       handleShellCommand,
@@ -697,6 +715,7 @@ export const useGeminiStream = (
       logger,
       shellModeActive,
       scheduleToolCalls,
+      cancelOngoingRequest,
     ],
   );
 
@@ -903,6 +922,38 @@ export const useGeminiStream = (
     [addItem, pendingHistoryItemRef, setPendingHistoryItem],
   );
 
+  const handleRenewSessionEvent = useCallback((): void => {
+    if (RenewSessionConfirmationRequest) {
+      return;
+    }
+
+    if (pendingHistoryItemRef.current) {
+      addItem(pendingHistoryItemRef.current, Date.now());
+      setPendingHistoryItem(null);
+    }
+    geminiClient.resetSessionTurnCount();
+
+    setRenewSessionConfirmationRequest({
+      onComplete: (result: {
+        userSelection: 'compress_session' | 'new_session';
+      }) => {
+        setRenewSessionConfirmationRequest(null);
+
+        if (result.userSelection === 'compress_session') {
+          void handleSlashCommandRef.current('/compress');
+        } else if (result.userSelection === 'new_session') {
+          void handleSlashCommandRef.current('/clear');
+        }
+      },
+    });
+  }, [
+    addItem,
+    geminiClient,
+    RenewSessionConfirmationRequest,
+    pendingHistoryItemRef,
+    setPendingHistoryItem,
+  ]);
+
   const handleMaxSessionTurnsEvent = useCallback(
     () =>
       addItem({
@@ -1078,6 +1129,9 @@ export const useGeminiStream = (
           case ServerGeminiEventType.MaxSessionTurns:
             handleMaxSessionTurnsEvent();
             break;
+          case ServerGeminiEventType.RenewSession:
+            handleRenewSessionEvent();
+            return StreamProcessingStatus.Completed;
           case ServerGeminiEventType.ContextWindowWillOverflow:
             handleContextWindowWillOverflowEvent(
               event.value.estimatedRequestTokenCount,
@@ -1134,6 +1188,7 @@ export const useGeminiStream = (
       addItem,
       pendingHistoryItemRef,
       setPendingHistoryItem,
+      handleRenewSessionEvent,
     ],
   );
   const submitQuery = useCallback(
@@ -1589,6 +1644,7 @@ export const useGeminiStream = (
     handleApprovalModeChange,
     activePtyId,
     loopDetectionConfirmationRequest,
+    RenewSessionConfirmationRequest,
     lastOutputTime,
     retryStatus,
   };

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -54,6 +54,7 @@ import type {
   IndividualToolCallDisplay,
   SlashCommandProcessorResult,
   HistoryItemModel,
+  RenewSessionConfirmationResult,
 } from '../types.js';
 import { StreamingState, MessageType, ToolCallStatus } from '../types.js';
 import { isAtCommand, isSlashCommand } from '../utils/commandUtils.js';
@@ -171,6 +172,7 @@ export const useGeminiStream = (
   const abortControllerRef = useRef<AbortController | null>(null);
   const turnCancelledRef = useRef(false);
   const activeQueryIdRef = useRef<string | null>(null);
+  const lastUserQueryTextRef = useRef<string | null>(null);
   const [isResponding, setIsResponding] = useState<boolean>(false);
   const [thought, setThought] = useState<ThoughtSummary | null>(null);
   const [pendingHistoryItem, pendingHistoryItemRef, setPendingHistoryItem] =
@@ -416,21 +418,22 @@ export const useGeminiStream = (
     onComplete: (result: { userSelection: 'disable' | 'keep' }) => void;
   } | null>(null);
 
-  const [RenewSessionConfirmationRequest, setRenewSessionConfirmationRequest] =
+  const [renewSessionConfirmationRequest, setRenewSessionConfirmationRequest] =
     useState<{
       onComplete: (result: {
         userSelection: 'compress_session' | 'new_session';
       }) => void;
+      reason?: 'turn_limit' | 'topic_change';
     } | null>(null);
 
   const renewSessionConfirmationRequestRef = useRef(
-    RenewSessionConfirmationRequest,
+    renewSessionConfirmationRequest,
   );
 
   useEffect(() => {
     renewSessionConfirmationRequestRef.current =
-      RenewSessionConfirmationRequest;
-  }, [RenewSessionConfirmationRequest]);
+      renewSessionConfirmationRequest;
+  }, [renewSessionConfirmationRequest]);
 
   // Flag to prevent showing the dialog multiple times if
   // the RenewSession event is triggered repeatedly
@@ -980,6 +983,7 @@ export const useGeminiStream = (
             // For clear, execute the command FIRST while the dialog is still open.
             // This ensures the heavy DOM destruction (clearing history) happens
             // in a separate render cycle from the Dialog unmounting.
+            lastUserQueryTextRef.current = null;
             if (executeClearCommand) {
               await executeClearCommand();
             }
@@ -1288,7 +1292,73 @@ export const useGeminiStream = (
             }
 
             if (!options?.isContinuation) {
-              if (typeof queryToSend === 'string') {
+              if (
+                typeof queryToSend === 'string' &&
+                config.getApprovalMode() !== ApprovalMode.YOLO
+              ) {
+                // Topic Detection
+                debugLogger.log(
+                  `useGeminiStream: Topic Detection Check starting. lastUserQueryTextRef: "${lastUserQueryTextRef.current}", queryToSend: "${queryToSend}"`,
+                );
+                if (lastUserQueryTextRef.current) {
+                  debugLogger.log(
+                    'useGeminiStream: Calling TopicDetectionService...',
+                  );
+                  const { topic_changed, reasoning } = await geminiClient
+                    .getTopicDetectionService()
+                    .isTopicChanged(
+                      lastUserQueryTextRef.current,
+                      queryToSend,
+                      prompt_id!,
+                      abortSignal,
+                    );
+
+                  debugLogger.log(
+                    `useGeminiStream: Topic detection result: ${topic_changed} (${reasoning})`,
+                  );
+
+                  if (topic_changed) {
+                    debugLogger.log(
+                      'useGeminiStream: Topic change detected! Setting request state...',
+                    );
+                    const selection = await new Promise<
+                      RenewSessionConfirmationResult['userSelection']
+                    >((resolve) => {
+                      setRenewSessionConfirmationRequest({
+                        reason: 'topic_change',
+                        onComplete: (result) => {
+                          setRenewSessionConfirmationRequest(null);
+                          resolve(result.userSelection);
+                        },
+                      });
+                    });
+
+                    if (selection === 'new_session') {
+                      queueMicrotask(async () => {
+                        if (executeClearCommand) {
+                          await executeClearCommand();
+                        } else {
+                          await geminiClient.resetChat();
+                        }
+                        lastUserQueryTextRef.current = null;
+
+                        addItem(
+                          {
+                            type: MessageType.INFO,
+                            text: 'Topic change detected. Starting a new session.',
+                          },
+                          Date.now(),
+                        );
+
+                        // A short delay ensures React processes the history clearing first.
+                        setTimeout(() => {
+                          setRenewSessionConfirmationRequest(null);
+                        }, 50);
+                      });
+                    }
+                  }
+                }
+
                 // logging the text prompts only for now
                 const promptText = queryToSend;
                 logUserPrompt(
@@ -1303,6 +1373,9 @@ export const useGeminiStream = (
               }
               startNewPrompt();
               setThought(null); // Reset thought when starting a new prompt
+
+              lastUserQueryTextRef.current =
+                typeof queryToSend === 'string' ? queryToSend : null;
             }
 
             setIsResponding(true);
@@ -1415,6 +1488,7 @@ export const useGeminiStream = (
       config,
       startNewPrompt,
       getPromptCount,
+      executeClearCommand,
     ],
   );
 
@@ -1693,7 +1767,7 @@ export const useGeminiStream = (
     handleApprovalModeChange,
     activePtyId,
     loopDetectionConfirmationRequest,
-    RenewSessionConfirmationRequest,
+    renewSessionConfirmationRequest,
     lastOutputTime,
     retryStatus,
   };

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -147,6 +147,9 @@ export const useGeminiStream = (
   onDebugMessage: (message: string) => void,
   handleSlashCommand: (
     cmd: PartListUnion,
+    oneTimeShellAllowlist?: Set<string>,
+    overwriteConfirmed?: boolean,
+    addToHistory?: boolean,
   ) => Promise<SlashCommandProcessorResult | false>,
   shellModeActive: boolean,
   getPreferredEditor: () => EditorType | undefined,
@@ -159,6 +162,7 @@ export const useGeminiStream = (
   terminalWidth: number,
   terminalHeight: number,
   isShellFocused?: boolean,
+  executeClearCommand?: () => Promise<void>,
 ) => {
   const [initError, setInitError] = useState<string | null>(null);
   const [retryStatus, setRetryStatus] = useState<RetryAttemptPayload | null>(
@@ -418,6 +422,19 @@ export const useGeminiStream = (
         userSelection: 'compress_session' | 'new_session';
       }) => void;
     } | null>(null);
+
+  const renewSessionConfirmationRequestRef = useRef(
+    RenewSessionConfirmationRequest,
+  );
+
+  useEffect(() => {
+    renewSessionConfirmationRequestRef.current =
+      RenewSessionConfirmationRequest;
+  }, [RenewSessionConfirmationRequest]);
+
+  // Flag to prevent showing the dialog multiple times if
+  // the RenewSession event is triggered repeatedly
+  const hasShownRenewDialogRef = useRef(false);
 
   const handleSlashCommandRef = useRef(handleSlashCommand);
   useEffect(() => {
@@ -923,7 +940,11 @@ export const useGeminiStream = (
   );
 
   const handleRenewSessionEvent = useCallback((): void => {
-    if (RenewSessionConfirmationRequest) {
+    // Prevent showing the dialog multiple times
+    if (
+      renewSessionConfirmationRequestRef.current ||
+      hasShownRenewDialogRef.current
+    ) {
       return;
     }
 
@@ -933,23 +954,51 @@ export const useGeminiStream = (
     }
     geminiClient.resetSessionTurnCount();
 
+    // Mark that we've shown the dialog
+    hasShownRenewDialogRef.current = true;
+
     setRenewSessionConfirmationRequest({
       onComplete: (result: {
         userSelection: 'compress_session' | 'new_session';
       }) => {
-        setRenewSessionConfirmationRequest(null);
+        queueMicrotask(async () => {
+          cancelOngoingRequest();
 
-        if (result.userSelection === 'compress_session') {
-          void handleSlashCommandRef.current('/compress');
-        } else if (result.userSelection === 'new_session') {
-          void handleSlashCommandRef.current('/clear');
-        }
+          if (result.userSelection === 'compress_session') {
+            // For compress, close dialog first as it's a long running operation
+            // and not destructive to the DOM structure immediately.
+            setRenewSessionConfirmationRequest(null);
+            hasShownRenewDialogRef.current = false;
+
+            await handleSlashCommandRef.current(
+              '/compress',
+              undefined,
+              undefined,
+              false,
+            );
+          } else if (result.userSelection === 'new_session') {
+            // For clear, execute the command FIRST while the dialog is still open.
+            // This ensures the heavy DOM destruction (clearing history) happens
+            // in a separate render cycle from the Dialog unmounting.
+            if (executeClearCommand) {
+              await executeClearCommand();
+            }
+
+            // Close the dialog AFTER the clear is done and processed.
+            // A short delay ensures React processes the history clearing first.
+            setTimeout(() => {
+              setRenewSessionConfirmationRequest(null);
+              hasShownRenewDialogRef.current = false;
+            }, 50);
+          }
+        });
       },
     });
   }, [
     addItem,
+    cancelOngoingRequest,
+    executeClearCommand,
     geminiClient,
-    RenewSessionConfirmationRequest,
     pendingHistoryItemRef,
     setPendingHistoryItem,
   ]);

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -453,7 +453,7 @@ export interface ActiveHook {
   total?: number;
 }
 export interface RenewSessionConfirmationResult {
-  userSelection: 'compress_session' | 'new_session';
+  userSelection: 'compress_session' | 'new_session' | 'continue_session';
 }
 
 export interface RenewSessionConfirmationRequest {

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -451,3 +451,10 @@ export interface ActiveHook {
   index?: number;
   total?: number;
 }
+export interface RenewSessionConfirmationResult {
+  userSelection: 'compress_session' | 'new_session';
+}
+
+export interface RenewSessionConfirmationRequest {
+  onComplete: (result: RenewSessionConfirmationResult) => void;
+}

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -45,6 +45,7 @@ export enum StreamingState {
 export enum GeminiEventType {
   Content = 'content',
   ToolCallRequest = 'tool_call_request',
+  RenewSession = 'renew_session',
   // Add other event types if the UI hook needs to handle them
 }
 
@@ -457,4 +458,5 @@ export interface RenewSessionConfirmationResult {
 
 export interface RenewSessionConfirmationRequest {
   onComplete: (result: RenewSessionConfirmationResult) => void;
+  reason?: 'turn_limit' | 'topic_change';
 }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -338,6 +338,7 @@ export interface ConfigParameters {
   bugCommand?: BugCommandSettings;
   model: string;
   maxSessionTurns?: number;
+  renewSessionTurnsThreshold?: number;
   experimentalZedIntegration?: boolean;
   listSessions?: boolean;
   deleteSession?: string;
@@ -483,6 +484,7 @@ export class Config {
 
   private _activeModel: string;
   private readonly maxSessionTurns: number;
+  private readonly renewSessionTurnsThreshold: number;
   private readonly listSessions: boolean;
   private readonly deleteSession: string | undefined;
   private readonly listExtensions: boolean;
@@ -654,6 +656,7 @@ export class Config {
     this.previewFeatures = params.previewFeatures ?? undefined;
     this.experimentalJitContext = params.experimentalJitContext ?? false;
     this.maxSessionTurns = params.maxSessionTurns ?? -1;
+    this.renewSessionTurnsThreshold = params.renewSessionTurnsThreshold ?? -1;
     this.experimentalZedIntegration =
       params.experimentalZedIntegration ?? false;
     this.listSessions = params.listSessions ?? false;
@@ -1115,6 +1118,10 @@ export class Config {
 
   getMaxSessionTurns(): number {
     return this.maxSessionTurns;
+  }
+
+  getRenewSessionTurnsThreshold(): number {
+    return this.renewSessionTurnsThreshold;
   }
 
   setQuotaErrorOccurred(value: boolean): void {

--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -189,6 +189,10 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
       extends: 'gemini-2.5-flash-base',
       modelConfig: {},
     },
+    'topic-detection': {
+      extends: 'gemini-2.5-flash-base',
+      modelConfig: {},
+    },
     'chat-compression-3-pro': {
       modelConfig: {
         model: 'gemini-3-pro-preview',

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -219,6 +219,7 @@ describe('Gemini Client (client.ts)', () => {
       getWorkingDir: vi.fn().mockReturnValue('/test/dir'),
       getFileService: vi.fn().mockReturnValue(fileService),
       getMaxSessionTurns: vi.fn().mockReturnValue(0),
+      getRenewSessionTurnsThreshold: vi.fn().mockReturnValue(-1),
       getQuotaErrorOccurred: vi.fn().mockReturnValue(false),
       setQuotaErrorOccurred: vi.fn(),
       getNoBrowser: vi.fn().mockReturnValue(false),

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -566,6 +566,7 @@ export class GeminiClient {
       this.config.getApprovalMode() !== ApprovalMode.YOLO
     ) {
       yield { type: GeminiEventType.RenewSession };
+      return new Turn(this.getChat(), prompt_id);
     }
 
     // Ensure turns never exceeds MAX_TURNS to prevent infinite loops

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -34,6 +34,7 @@ import type {
 } from '../services/chatRecordingService.js';
 import type { ContentGenerator } from './contentGenerator.js';
 import { LoopDetectionService } from '../services/loopDetectionService.js';
+import { TopicDetectionService } from '../services/topicDetectionService.js';
 import { ChatCompressionService } from '../services/chatCompressionService.js';
 import { ideContextStore } from '../ide/ideContext.js';
 import {
@@ -84,6 +85,7 @@ export class GeminiClient {
   private sessionTurnCount = 0;
 
   private readonly loopDetector: LoopDetectionService;
+  private readonly topicDetector: TopicDetectionService;
   private readonly compressionService: ChatCompressionService;
   private lastPromptId: string;
   private currentSequenceModel: string | null = null;
@@ -98,6 +100,7 @@ export class GeminiClient {
 
   constructor(private readonly config: Config) {
     this.loopDetector = new LoopDetectionService(config);
+    this.topicDetector = new TopicDetectionService(config);
     this.compressionService = new ChatCompressionService();
     this.lastPromptId = this.config.getSessionId();
 
@@ -284,6 +287,10 @@ export class GeminiClient {
 
   getLoopDetectionService(): LoopDetectionService {
     return this.loopDetector;
+  }
+
+  getTopicDetectionService(): TopicDetectionService {
+    return this.topicDetector;
   }
 
   getCurrentSequenceModel(): string | null {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -569,8 +569,6 @@ export class GeminiClient {
       return new Turn(this.getChat(), prompt_id);
     }
 
-    // Ensure turns never exceeds MAX_TURNS to prevent infinite loops
-    const boundedTurns = Math.min(turns, MAX_TURNS);
     if (!boundedTurns) {
       return turn;
     }

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -68,6 +68,7 @@ export enum GeminiEventType {
   ModelInfo = 'model_info',
   AgentExecutionStopped = 'agent_execution_stopped',
   AgentExecutionBlocked = 'agent_execution_blocked',
+  RenewSession = 'renew_session',
 }
 
 export type ServerGeminiRetryEvent = {
@@ -210,6 +211,10 @@ export type ServerGeminiCitationEvent = {
   value: string;
 };
 
+export type ServerGeminiRenewSessionEvent = {
+  type: GeminiEventType.RenewSession;
+};
+
 // The original union type, now composed of the individual types
 export type ServerGeminiStreamEvent =
   | ServerGeminiChatCompressedEvent
@@ -229,7 +234,8 @@ export type ServerGeminiStreamEvent =
   | ServerGeminiInvalidStreamEvent
   | ServerGeminiModelInfoEvent
   | ServerGeminiAgentExecutionStoppedEvent
-  | ServerGeminiAgentExecutionBlockedEvent;
+  | ServerGeminiAgentExecutionBlockedEvent
+  | ServerGeminiRenewSessionEvent;
 
 // A turn manages the agentic loop turn within the server context.
 export class Turn {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,6 +106,7 @@ export * from './services/sessionSummaryUtils.js';
 export * from './services/contextManager.js';
 export * from './skills/skillManager.js';
 export * from './skills/skillLoader.js';
+export * from './services/topicDetectionService.js';
 
 // Export IDE specific logic
 export * from './ide/ide-client.js';

--- a/packages/core/src/services/topicDetectionService.ts
+++ b/packages/core/src/services/topicDetectionService.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '../config/config.js';
+import { debugLogger } from '../utils/debugLogger.js';
+
+const TOPIC_DETECTION_SYSTEM_PROMPT = `You are an expert at analyzing conversation topics.
+Your task is to determine if the "Current Query" represents a significant shift in topic from the "Last Query".
+
+Rules:
+1. If the "Current Query" is a follow-up, clarification, or related to the same subject as the "Last Query", it is NOT a topic change.
+2. If the "Current Query" introduces a completely different subject, task, or domain that has no relation to the "Last Query", it IS a topic change.
+3. If you are unsure, but the topics seem unrelated, favor flagging it as not a topic change.
+
+Output format:
+You must respond with a JSON object:
+{
+  "topic_changed": boolean,
+  "reasoning": "brief explanation"
+}
+`;
+
+const TOPIC_DETECTION_SCHEMA = {
+  type: 'object',
+  properties: {
+    topic_changed: {
+      type: 'boolean',
+      description: 'Whether the topic has shifted significantly.',
+    },
+    reasoning: {
+      type: 'string',
+      description: 'Brief explanation for the decision.',
+    },
+  },
+  required: ['topic_changed', 'reasoning'],
+};
+
+export class TopicDetectionService {
+  constructor(private readonly config: Config) {}
+
+  async isTopicChanged(
+    lastQuery: string,
+    currentQuery: string,
+    promptId: string,
+    abortSignal?: AbortSignal,
+  ): Promise<{ topic_changed: boolean; reasoning: string }> {
+    if (!lastQuery || !currentQuery) {
+      return { topic_changed: false, reasoning: 'Empty query' };
+    }
+
+    try {
+      const prompt = `Last Query: "${lastQuery}"\n\nCurrent Query: "${currentQuery}"`;
+
+      debugLogger.log(
+        `TopicDetectionService: Checking topic change. lastQuery: "${lastQuery}", currentQuery: "${currentQuery}"`,
+      );
+
+      const result = await this.config.getBaseLlmClient().generateJson({
+        modelConfigKey: { model: 'topic-detection' },
+        contents: [{ role: 'user', parts: [{ text: prompt }] }],
+        schema: TOPIC_DETECTION_SCHEMA,
+        systemInstruction: TOPIC_DETECTION_SYSTEM_PROMPT,
+        abortSignal: abortSignal!,
+        promptId,
+        maxAttempts: 2,
+      });
+
+      if (result && typeof result['topic_changed'] === 'boolean') {
+        const topic_changed = result['topic_changed'];
+        const reasoning = (result['reasoning'] as string) || '';
+        debugLogger.log(
+          `Topic detection result: ${topic_changed} (${reasoning})`,
+        );
+        return { topic_changed, reasoning };
+      }
+    } catch (error) {
+      debugLogger.warn(`Error in TopicDetectionService: ${error}`);
+      return { topic_changed: false, reasoning: `Error: ${error}` };
+    }
+
+    return { topic_changed: false, reasoning: 'Unexpected result format' };
+  }
+}

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -434,6 +434,13 @@
           "default": -1,
           "type": "number"
         },
+        "renewSessionTurnsThreshold": {
+          "title": "Renew Session Turn Threshold",
+          "description": "Number of conversation turns after which to prompt the user to start a new session or compress. Set to -1 to disable.",
+          "markdownDescription": "Number of conversation turns after which to prompt the user to start a new session or compress. Set to -1 to disable.\n\n- Category: `Model`\n- Requires restart: `no`\n- Default: `-1`",
+          "default": -1,
+          "type": "number"
+        },
         "summarizeToolOutput": {
           "title": "Summarize Tool Output",
           "description": "Enables or disables summarization of tool output. Configure per-tool token budgets (for example {\"run_shell_command\": {\"tokenBudget\": 2000}}). Currently only the run_shell_command tool supports summarization.",


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
This feature detect user's new query, and will propose to compress or start a new session under two situations:

1. The new query is the nth turn that exceed the turncount limit set in config.
2. The new query is in a different topic compare to previous query.


## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

If the turncount threshold is 20, then when user input the 21st query, the system will pop up a dialog and give the user 2 options.  
1. compress the current conversation  
2. start a new session

If the user's previous query is about writing a REST API in Python, the next query is about counting how many txt files are there in the current workspace. The system detect a topic shifting and pop up a dialog, and give user 3 options.  
1.  continue the current context.  
2. compress the conversation.  
3. start a new session.   




## Related Issues
Closes #17767 

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
For turncount limit:
1. Modify the config variable "renewSessionTurnsThreshold" in settings to a number you want.
2. Start Gemini CLI, and keep querying untill the turncount hit the limit you set.
3. Verify if the dialog pop up, then choose an option.
4. You can ask some question about the topic you asked in the previous step, to see if the agent remember the context. For new session, it should not remember the context, for compress conversation, the agent should remember the context you discussed with it.

For Topic detection:
1. Start the Gemini CLI and input the query.
2. Input another query that is related to your previous one, like a further question or extension of the first query, and see if the dialog pop up, it should not pop up if the query is related to the previous one.
3. Input a different topic query, then see if the dialog pop up, if the topic shift is detected, the dialog should show, and you will see 3 options.
4. Pick one of the option and verify the behavior.



## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
