### PR TITLE
fix(core): add JSON Schema draft-2020-12 support for MCP tool validation

### DIFF
--- a/packages/core/src/utils/schemaValidator.test.ts
+++ b/packages/core/src/utils/schemaValidator.test.ts
@@ -122,4 +122,42 @@ describe('SchemaValidator', () => {
     };
     expect(SchemaValidator.validate(schema, params)).not.toBeNull();
   });
+
+  describe('JSON Schema draft-2020-12 support', () => {
+    it('validates params against draft-2020-12 schema', () => {
+      const schema = {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+          },
+        },
+        required: ['message'],
+      };
+
+      expect(SchemaValidator.validate(schema, { message: 'hello' })).toBeNull();
+      expect(SchemaValidator.validate(schema, { message: 123 })).not.toBeNull();
+    });
+
+    it('validates draft-2020-12 schema with prefixItems', () => {
+      // prefixItems is a draft-2020-12 feature
+      const schema = {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        type: 'object',
+        properties: {
+          coords: {
+            type: 'array',
+            prefixItems: [{ type: 'number' }, { type: 'number' }],
+            items: false,
+          },
+        },
+      };
+
+      expect(SchemaValidator.validate(schema, { coords: [1, 2] })).toBeNull();
+      expect(
+        SchemaValidator.validate(schema, { coords: [1, 2, 3] }),
+      ).not.toBeNull();
+    });
+  });
 });

--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -4,29 +4,61 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import AjvPkg, { type AnySchema } from 'ajv';
+import AjvPkg, { type AnySchema, type Ajv } from 'ajv';
+// Ajv2020 is the documented way to use draft-2020-12: https://ajv.js.org/json-schema.html#draft-2020-12
+// eslint-disable-next-line import/no-internal-modules
+import Ajv2020Pkg from 'ajv/dist/2020';
 import * as addFormats from 'ajv-formats';
+
 // Ajv's ESM/CJS interop: use 'any' for compatibility as recommended by Ajv docs
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const AjvClass = (AjvPkg as any).default || AjvPkg;
-const ajValidator = new AjvClass(
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Ajv2020Class = (Ajv2020Pkg as any).default || Ajv2020Pkg;
+
+const ajvOptions = {
   // See: https://ajv.js.org/options.html#strict-mode-options
-  {
-    // strictSchema defaults to true and prevents use of JSON schemas that
-    // include unrecognized keywords. The JSON schema spec specifically allows
-    // for the use of non-standard keywords and the spec-compliant behavior
-    // is to ignore those keywords. Note that setting this to false also
-    // allows use of non-standard or custom formats (the unknown format value
-    // will be logged but the schema will still be considered valid).
-    strictSchema: false,
-  },
-);
+  // strictSchema defaults to true and prevents use of JSON schemas that
+  // include unrecognized keywords. The JSON schema spec specifically allows
+  // for the use of non-standard keywords and the spec-compliant behavior
+  // is to ignore those keywords. Note that setting this to false also
+  // allows use of non-standard or custom formats (the unknown format value
+  // will be logged but the schema will still be considered valid).
+  strictSchema: false,
+};
+
+// Draft-07 validator (default)
+const ajvDefault: Ajv = new AjvClass(ajvOptions);
+
+// Draft 2020-12 validator for MCP servers using rmcp
+const ajv2020: Ajv = new Ajv2020Class(ajvOptions);
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const addFormatsFunc = (addFormats as any).default || addFormats;
-addFormatsFunc(ajValidator);
+addFormatsFunc(ajvDefault);
+addFormatsFunc(ajv2020);
+
+// Canonical draft-2020-12 meta-schema URI (used by rmcp MCP servers)
+const DRAFT_2020_12_SCHEMA = 'https://json-schema.org/draft/2020-12/schema';
 
 /**
- * Simple utility to validate objects against JSON Schemas
+ * Returns the appropriate validator based on schema's $schema field.
+ */
+function getValidator(schema: AnySchema): Ajv {
+  if (
+    typeof schema === 'object' &&
+    schema !== null &&
+    '$schema' in schema &&
+    schema.$schema === DRAFT_2020_12_SCHEMA
+  ) {
+    return ajv2020;
+  }
+  return ajvDefault;
+}
+
+/**
+ * Simple utility to validate objects against JSON Schemas.
+ * Supports both draft-07 (default) and draft-2020-12 schemas.
  */
 export class SchemaValidator {
   /**
@@ -40,10 +72,12 @@ export class SchemaValidator {
     if (typeof data !== 'object' || data === null) {
       return 'Value of params must be an object';
     }
-    const validate = ajValidator.compile(schema);
+    const anySchema = schema as AnySchema;
+    const validator = getValidator(anySchema);
+    const validate = validator.compile(anySchema);
     const valid = validate(data);
     if (!valid && validate.errors) {
-      return ajValidator.errorsText(validate.errors, { dataVar: 'params' });
+      return validator.errorsText(validate.errors, { dataVar: 'params' });
     }
     return null;
   }
@@ -56,7 +90,8 @@ export class SchemaValidator {
     if (!schema) {
       return null;
     }
-    const isValid = ajValidator.validateSchema(schema);
-    return isValid ? null : ajValidator.errorsText(ajValidator.errors);
+    const validator = getValidator(schema);
+    const isValid = validator.validateSchema(schema);
+    return isValid ? null : validator.errorsText(validator.errors);
   }
 }


### PR DESCRIPTION
## Summary

Add support for JSON Schema draft-2020-12 in `SchemaValidator` by using the `Ajv2020` class when the schema declares the canonical draft-2020-12 meta-schema URI.

This fixes MCP tool invocation failures with servers built using [rmcp](https://github.com/modelcontextprotocol/rust-sdk) (Rust MCP SDK) v0.9.1+, which sends `$schema: 'https://json-schema.org/draft/2020-12/schema'`.

## Details

- Import `Ajv2020` from `ajv/dist/2020` (the [documented way](https://ajv.js.org/json-schema.html#draft-2020-12) to support draft-2020-12)
- Create separate validator instances: `ajvDefault` (draft-07) and `ajv2020` (draft-2020-12)
- Route schemas to the appropriate validator based on exact `$schema` match
- Add tests for draft-2020-12 validation including `prefixItems` keyword (a 2020-12-specific feature)

## Related Issues

Fixes #14970

## How to Validate

1. Run unit tests: `npm run test -- packages/core/src/utils/schemaValidator.test.ts`
2. Build an rmcp MCP server (e.g., from https://github.com/modelcontextprotocol/rust-sdk):
   ```bash
   cargo build --example servers_counter_stdio -p mcp-server-examples
   ```
3. Configure in `~/.gemini/settings.json`:
   ```json
   {"mcpServers": {"counter": {"command": "/path/to/servers_counter_stdio"}}}
   ```
4. Run gemini, invoke a tool - should succeed instead of failing with schema error

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker