### PR TITLE
fix(cli): correctly handle xterm modifyOtherKeys mode

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -521,17 +521,17 @@ function* emitKeys(
         }
       } else {
         name = 'undefined';
-        if (
-          (ctrl || cmd || alt) &&
-          (code.endsWith('u') || code.endsWith('~'))
-        ) {
+        if (code.endsWith('u') || code.endsWith('~')) {
           // CSI-u or tilde-coded functional keys: ESC [ <code> ; <mods> (u|~)
           const codeNumber = parseInt(code.slice(1, -1), 10);
-          if (
-            codeNumber >= 'a'.charCodeAt(0) &&
-            codeNumber <= 'z'.charCodeAt(0)
-          ) {
+          if (codeNumber >= 33 && codeNumber <= 126) {
             name = String.fromCharCode(codeNumber);
+          } else if (
+            (ctrl || cmd || alt) &&
+            codeNumber >= 1 &&
+            codeNumber <= 26
+          ) {
+            name = String.fromCharCode(codeNumber + 96);
           }
         }
       }


### PR DESCRIPTION
## Summary

This PR fixes a bug in the CLI input parser where uppercase letters and special characters (e.g., Shift+A, @, !) were ignored when the terminal was in `modifyOtherKeys` mode (level 2). This ensures reliable input handling for users with advanced terminal configurations.

## Details

Previously, the input parser failed to decode CSI sequences for these characters unless a control or meta modifier was also present. The fix updates the logic in `packages/cli/src/ui/contexts/KeypressContext.tsx` to properly decode any printable ASCII character received in the format `CSI 27 ; <modifier> ; <code> ~.`

## AI tool disclosure

This code was generated by gemini-cli based on the bug report linked (which it also generated itself).

## Related Issues

Closes https://github.com/google-gemini/gemini-cli/issues/17777

## How to Validate

1. Run the CLI regression tests which specifically target these sequences: `npm test -w @google/gemini-cli-cli -- packages/cli/src/ui/contexts/KeypressContext.test.tsx`
2. Manually verify in a terminal supporting `modifyOtherKeys=2` (e.g., xterm) that uppercase letters and symbols are correctly captured.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
