### PR TITLE
fix(core): Correct token calculation for Gemini 3 media in tool responses

### DIFF
--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -169,5 +169,15 @@ export function isAutoModel(model: string): boolean {
  * @returns True if the model supports multimodal function responses.
  */
 export function supportsMultimodalFunctionResponse(model: string): boolean {
-  return model.startsWith('gemini-3-');
+  return isGemini3Model(model);
+}
+
+/**
+ * Checks if the model is a Gemini 3 model.
+ *
+ * @param model The model name to check.
+ * @returns True if the model is a Gemini 3 model.
+ */
+export function isGemini3Model(model: string): boolean {
+  return /^gemini-3(\.|$|-)((-)?preview)?/.test(model) || model.includes('gemini-3');
 }


### PR DESCRIPTION
## Problem
Gemini 3.0 models introduced a structural change in how media (PDFs, images) attached to tool responses is handled. Specifically, media is attached to a hidden `parts` property on the `functionResponse` object, rather than being nested within the `response` property.

## Related Issues
#16310
#16494 (For Gemini 3.0 Familly)

The existing token calculation logic:
1.  Failed to detect this media in the `parts` property in 3.0 Models.
2.  Consequently fell back to a generic `JSON.stringify` estimation.
3.  This resulted in massive overestimation (e.g., >1,000,000 tokens for a 4MB PDF) because it counted the base64 characters instead of using the fixed token estimate for media.

## Solution
This PR implements a robust fix for token estimation:

1.  **Recursive Media Detection**: Updated [hasRecursiveMedia](gemini-cli/gemini-cli/packages/core/src/utils/tokenCalculation.ts#169-210) and [estimateTokenCountSync](gemini-cli/gemini-cli/packages/core/src/utils/tokenCalculation.ts#28-158) to explicitly check for the `functionResponse.parts` property, ensuring Gemini 3 media is correctly identified.
2.  **Prevention of Double Counting**: Refined the fallback logic in [estimateTokenCountSync](gemini-cli/gemini-cli/packages/core/src/utils/tokenCalculation.ts#28-158). If media tokens are successfully estimated from `parts`, the code now minimizes the JSON stringify overhead to avoid double-counting the heavy base64 data.
3.  **Refactored Model Checks**: Centralized "Gemini 3" identification in [packages/core/src/config/models.ts](gemini-cli/gemini-cli/packages/core/src/config/models.ts) with stronger regex matching to parse model names like `gemini-3-flash-preview`.

## Changes
- [packages/core/src/config/models.ts](gemini-cli/gemini-cli/packages/core/src/config/models.ts): Consolidate [isGemini3Model](gemini-cli/gemini-cli/packages/core/src/config/models.ts#175-184) and [supportsMultimodalFunctionResponse](gemini-cli/gemini-cli/packages/core/src/config/models.ts#164-174).
- [packages/core/src/utils/tokenCalculation.ts](gemini-cli/gemini-cli/packages/core/src/utils/tokenCalculation.ts): Implement recursive `parts` check and fix double-counting logic.
- [packages/core/src/utils/tokenCalculation.test.ts](gemini-cli/gemini-cli/packages/core/src/utils/tokenCalculation.test.ts): Added a permanent regression test case "FunctionResponse with Media (Gemini 3 Compatibility)".

## Verification
- **Automated Tests**:
    - `npm test -w @google/gemini-cli-core`: All tests passed.
    - **Regression Test**: Verified that a tool response with a large PDF is now estimated at ~25,800 tokens (correct behavior) instead of ~1,074,422 tokens (buggy behavior).
- **Manual Verification**: Verified via the E2E flow that `gemini-3-flash-preview` now correctly processes PDF inputs without context window errors.

