### PR TITLE
[extension config] Make breaking optional value non-optional

### DIFF
--- a/packages/cli/src/commands/extensions/configure.test.ts
+++ b/packages/cli/src/commands/extensions/configure.test.ts
@@ -22,6 +22,7 @@ import {
   type ExtensionSetting,
 } from '../../config/extensions/extensionSettings.js';
 import prompts from 'prompts';
+import * as fs from 'node:fs';
 
 const {
   mockExtensionManager,
@@ -79,11 +80,15 @@ vi.mock('../../config/settings.js', () => ({
 }));
 
 describe('extensions configure command', () => {
+  let tempWorkspaceDir: string;
+
   beforeEach(() => {
     vi.spyOn(debugLogger, 'log');
     vi.spyOn(debugLogger, 'error');
     vi.clearAllMocks();
 
+    tempWorkspaceDir = fs.mkdtempSync('gemini-cli-test-workspace');
+    vi.spyOn(process, 'cwd').mockReturnValue(tempWorkspaceDir);
     // Default behaviors
     mockLoadSettings.mockReturnValue({ merged: {} });
     mockGetExtensionAndManager.mockResolvedValue({
@@ -141,6 +146,7 @@ describe('extensions configure command', () => {
         'TEST_VAR',
         promptForSetting,
         'user',
+        tempWorkspaceDir,
       );
     });
 
@@ -186,6 +192,7 @@ describe('extensions configure command', () => {
         'VAR_1',
         promptForSetting,
         'user',
+        tempWorkspaceDir,
       );
     });
 

--- a/packages/cli/src/commands/extensions/configure.ts
+++ b/packages/cli/src/commands/extensions/configure.ts
@@ -111,6 +111,7 @@ async function configureSpecificSetting(
     settingKey,
     promptForSetting,
     scope,
+    process.cwd(),
   );
 }
 
@@ -218,6 +219,7 @@ async function configureExtensionSettings(
       setting.envVar,
       promptForSetting,
       scope,
+      process.cwd(),
     );
   }
 }

--- a/packages/cli/src/config/extension-manager-hydration.test.ts
+++ b/packages/cli/src/config/extension-manager-hydration.test.ts
@@ -306,6 +306,7 @@ System using model: \${MODEL_NAME}
       'MY_VALUE',
       mockRequestSetting,
       ExtensionSettingScope.USER,
+      process.cwd(),
     );
 
     await extensionManager.restartExtension(extension);

--- a/packages/cli/src/config/extensions/extensionSettings.ts
+++ b/packages/cli/src/config/extensions/extensionSettings.ts
@@ -207,7 +207,7 @@ export async function updateSetting(
   settingKey: string,
   requestSetting: (setting: ExtensionSetting) => Promise<string>,
   scope: ExtensionSettingScope,
-  workspaceDir?: string,
+  workspaceDir: string,
 ): Promise<void> {
   const { name: extensionName, settings } = extensionConfig;
   if (!settings || settings.length === 0) {


### PR DESCRIPTION
## Summary

This value being optional is causing problems-- we're throwing errors any time this is called without the current workspace


## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/17784
## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
