### PR TITLE
fix: prevent ghost border for AskUserDialog

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -676,18 +676,13 @@ describe('<ToolGroupMessage />', () => {
         }),
       ];
 
-      const mockConfig = {
-        ...baseMockConfig,
-        isEventDrivenSchedulerEnabled: () => true,
-      } as unknown as Config;
-
       const { lastFrame, unmount } = renderWithProviders(
         <ToolGroupMessage
           {...baseProps}
           toolCalls={toolCalls}
           borderBottom={false}
         />,
-        { config: mockConfig },
+        { config: baseMockConfig },
       );
       // AskUser tools in progress are rendered by AskUserDialog, so we expect nothing.
       expect(lastFrame()).toMatchSnapshot();

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -689,8 +689,8 @@ describe('<ToolGroupMessage />', () => {
         />,
         { config: mockConfig },
       );
-
-      expect(lastFrame()).toBe('');
+      // AskUser tools in progress are rendered by AskUserDialog, so we expect nothing.
+      expect(lastFrame()).toMatchSnapshot();
       unmount();
     });
   });

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -663,6 +663,36 @@ describe('<ToolGroupMessage />', () => {
       expect(output).toMatchSnapshot();
       unmount();
     });
+
+    it('renders nothing when only tool is in-progress AskUser with borderBottom=false', () => {
+      // AskUser tools in progress are rendered by AskUserDialog, not ToolGroupMessage.
+      // When AskUser is the only tool and borderBottom=false (no border to close),
+      // the component should render nothing.
+      const toolCalls = [
+        createToolCall({
+          callId: 'ask-user-tool',
+          name: 'Ask User',
+          status: ToolCallStatus.Executing,
+        }),
+      ];
+
+      const mockConfig = {
+        ...baseMockConfig,
+        isEventDrivenSchedulerEnabled: () => true,
+      } as unknown as Config;
+
+      const { lastFrame, unmount } = renderWithProviders(
+        <ToolGroupMessage
+          {...baseProps}
+          toolCalls={toolCalls}
+          borderBottom={false}
+        />,
+        { config: mockConfig },
+      );
+
+      expect(lastFrame()).toBe('');
+      unmount();
+    });
   });
 
   describe('Ask User Filtering', () => {

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -117,12 +117,11 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   );
 
   // If all tools are hidden (e.g. group only contains confirming or pending tools),
-  // render nothing in the history log unless we have a border override.
-  if (
-    visibleToolCalls.length === 0 &&
-    borderTopOverride === undefined &&
-    borderBottomOverride === undefined
-  ) {
+  // render nothing in the history log unless we need to show a visible border.
+  // We only need to render if borderBottomOverride is explicitly true (to close
+  // off a border from previous tools). When it's undefined or false, we can
+  // safely return null to avoid rendering ghost borders.
+  if (visibleToolCalls.length === 0 && borderBottomOverride !== true) {
     return null;
   }
 

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -116,11 +116,10 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
     [toolCalls, isEventDriven],
   );
 
-  // If all tools are hidden (e.g. group only contains confirming or pending tools),
-  // render nothing in the history log unless we need to show a visible border.
-  // We only need to render if borderBottomOverride is explicitly true (to close
-  // off a border from previous tools). When it's undefined or false, we can
-  // safely return null to avoid rendering ghost borders.
+  // If all tools are filtered out (e.g., in-progress AskUser tools, confirming tools
+  // in event-driven mode), only render if we need to close a border from previous
+  // tool groups. borderBottomOverride=true means we must render the closing border;
+  // undefined or false means there's nothing to display.
   if (visibleToolCalls.length === 0 && borderBottomOverride !== true) {
     return null;
   }

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
@@ -110,6 +110,8 @@ exports[`<ToolGroupMessage /> > Confirmation Handling > shows confirmation dialo
 
 exports[`<ToolGroupMessage /> > Event-Driven Scheduler > hides confirming tools when event-driven scheduler is enabled 1`] = `""`;
 
+exports[`<ToolGroupMessage /> > Event-Driven Scheduler > renders nothing when only tool is in-progress AskUser with borderBottom=false 1`] = `""`;
+
 exports[`<ToolGroupMessage /> > Event-Driven Scheduler > shows only successful tools when mixed with confirming tools 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────╮
 │ ✓  success-tool A tool for testing                                           │

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -368,25 +368,20 @@ export const useGeminiStream = (
     const isEventDriven = config.isEventDrivenSchedulerEnabled();
     const anyVisibleInHistory = pushedToolCallIds.size > 0;
     const anyVisibleInPending = remainingTools.some((tc) => {
+      // AskUser tools are rendered by AskUserDialog, not ToolGroupMessage
+      const isInProgress =
+        tc.status !== 'success' &&
+        tc.status !== 'error' &&
+        tc.status !== 'cancelled';
+      if (tc.request.name === ASK_USER_TOOL_NAME && isInProgress) {
+        return false;
+      }
       if (!isEventDriven) return true;
-      // Skip tools that aren't visible in the pending UI
-      if (
-        tc.status === 'scheduled' ||
-        tc.status === 'validating' ||
-        tc.status === 'awaiting_approval'
-      ) {
-        return false;
-      }
-      // Skip in-progress AskUser tools - they're rendered by AskUserDialog,
-      // not by ToolGroupMessage, so we shouldn't count them as "visible"
-      const isTerminal =
-        tc.status === 'success' ||
-        tc.status === 'error' ||
-        tc.status === 'cancelled';
-      if (tc.request.name === ASK_USER_TOOL_NAME && !isTerminal) {
-        return false;
-      }
-      return true;
+      return (
+        tc.status !== 'scheduled' &&
+        tc.status !== 'validating' &&
+        tc.status !== 'awaiting_approval'
+      );
     });
 
     if (


### PR DESCRIPTION
   ## Summary


   This PR fixes a "ghost border" issue where an extra line or border would appear at the bottom of the terminal wh
   an `AskUserDialog` was active. This occurred because `ToolGroupMessage` was rendering a border even when its only
   content (the `AskUser` tool call) was hidden from the history (as it's handled by the dialog).

### Previous

<img width="2529" height="396" alt="image" src="https://github.com/user-attachments/assets/281f599f-d5a2-470c-9702-a8988bfbf4bf" />

### After Fix

<img width="3416" height="1120" alt="image" src="https://github.com/user-attachments/assets/a1e22b52-00dc-4f88-abbb-4d32c740c9f0" />

   ## Details


   - **`useGeminiStream` Logic**: Updated `anyVisibleInPending` to exclude `AskUser` tool calls that are still in
   progress. These are handled by the `AskUserDialog` component, so they shouldn't count as "visible" pending tools
   for the message history UI.
   - **`ToolGroupMessage` Component**: Refined the conditional rendering to ensure the component returns `null` whe
   no tool calls are visible and there's no explicit requirement to close a border (`borderBottomOverride !== true`
   - **Tests**: Added a new test case to `ToolGroupMessage.test.tsx` to verify that the component renders an empty
   string when only an in-progress `AskUser` tool is present.

   ## Related Issues

   N/A

   ## How to Validate

   1. Run the new unit test:


   ```bash
      npm test -w @google/gemini-cli -- src/ui/components/messages/ToolGroupMessage.test.tsx
   ```
   2. Manually trigger any command that uses `ask_user` and verify that no stray border appears above the dialog bo

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
