### PR TITLE
fix(ux): fixed off-by-some wrapping caused by fixed-width characters

### DIFF
--- a/packages/cli/src/ui/utils/TableRenderer.test.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.test.tsx
@@ -31,4 +31,34 @@ describe('TableRenderer', () => {
     expect(output).toContain('Row 3, Col 3');
     expect(output).toMatchSnapshot();
   });
+
+  it('renders a table with long headers and 4 columns correctly', () => {
+    const headers = [
+      'Very Long Column Header One',
+      'Very Long Column Header Two',
+      'Very Long Column Header Three',
+      'Very Long Column Header Four',
+    ];
+    const rows = [
+      ['Data 1.1', 'Data 1.2', 'Data 1.3', 'Data 1.4'],
+      ['Data 2.1', 'Data 2.2', 'Data 2.3', 'Data 2.4'],
+      ['Data 3.1', 'Data 3.2', 'Data 3.3', 'Data 3.4'],
+    ];
+    const terminalWidth = 80;
+
+    const { lastFrame } = renderWithProviders(
+      <TableRenderer
+        headers={headers}
+        rows={rows}
+        terminalWidth={terminalWidth}
+      />,
+    );
+
+    const output = lastFrame();
+    // Since terminalWidth is 80 and headers are long, they might be truncated.
+    // We just check for some of the content.
+    expect(output).toContain('Data 1.1');
+    expect(output).toContain('Data 3.4');
+    expect(output).toMatchSnapshot();
+  });
 });

--- a/packages/cli/src/ui/utils/TableRenderer.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.tsx
@@ -35,17 +35,23 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
 
   // Ensure table fits within terminal width
   // We calculate scale based on content width vs available width (terminal - borders)
-  // Fixed overhead per column is 1 (separator/edge), plus 1 for the final edge
-  const fixedOverhead = headers.length + 1;
-  const totalColumnWidth = columnWidths.reduce((sum, width) => sum + width, 0);
+  // First, extract content widths by removing the 2-char padding.
+  const contentWidths = columnWidths.map((width) => Math.max(0, width - 2));
+  const totalContentWidth = contentWidths.reduce(
+    (sum, width) => sum + width,
+    0,
+  );
+
+  // Fixed overhead includes padding (2 per column) and separators (1 per column + 1 final).
+  const fixedOverhead = headers.length * 2 + (headers.length + 1);
 
   // Subtract 1 from available width to avoid edge-case wrapping on some terminals
   const availableWidth = Math.max(0, terminalWidth - fixedOverhead - 1);
 
   const scaleFactor =
-    totalColumnWidth > availableWidth ? availableWidth / totalColumnWidth : 1;
-  const adjustedWidths = columnWidths.map((width) =>
-    Math.floor(width * scaleFactor),
+    totalContentWidth > availableWidth ? availableWidth / totalContentWidth : 1;
+  const adjustedWidths = contentWidths.map(
+    (width) => Math.floor(width * scaleFactor) + 2,
   );
 
   // Helper function to render a cell with proper width

--- a/packages/cli/src/ui/utils/TableRenderer.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.tsx
@@ -34,9 +34,16 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
   });
 
   // Ensure table fits within terminal width
-  const totalWidth = columnWidths.reduce((sum, width) => sum + width + 1, 1);
+  // We calculate scale based on content width vs available width (terminal - borders)
+  // Fixed overhead per column is 1 (separator/edge), plus 1 for the final edge
+  const fixedOverhead = headers.length + 1;
+  const totalColumnWidth = columnWidths.reduce((sum, width) => sum + width, 0);
+
+  // Subtract 1 from available width to avoid edge-case wrapping on some terminals
+  const availableWidth = Math.max(0, terminalWidth - fixedOverhead - 1);
+
   const scaleFactor =
-    totalWidth > terminalWidth ? terminalWidth / totalWidth : 1;
+    totalColumnWidth > availableWidth ? availableWidth / totalColumnWidth : 1;
   const adjustedWidths = columnWidths.map((width) =>
     Math.floor(width * scaleFactor),
   );

--- a/packages/cli/src/ui/utils/__snapshots__/TableRenderer.test.tsx.snap
+++ b/packages/cli/src/ui/utils/__snapshots__/TableRenderer.test.tsx.snap
@@ -54,6 +54,18 @@ exports[`TableRenderer > renders a simple table correctly 1`] = `
 "
 `;
 
+exports[`TableRenderer > renders a table with long headers and 4 columns correctly 1`] = `
+"
+┌──────────────────┬──────────────────┬───────────────────┬──────────────────┐
+│ Very Long Col... │ Very Long Col... │ Very Long Colu... │ Very Long Col... │
+├──────────────────┼──────────────────┼───────────────────┼──────────────────┤
+│ Data 1.1         │ Data 1.2         │ Data 1.3          │ Data 1.4         │
+│ Data 2.1         │ Data 2.2         │ Data 2.3          │ Data 2.4         │
+│ Data 3.1         │ Data 3.2         │ Data 3.3          │ Data 3.4         │
+└──────────────────┴──────────────────┴───────────────────┴──────────────────┘
+"
+`;
+
 exports[`TableRenderer > truncates content when terminal width is small 1`] = `
 "
 ┌────────┬─────────┬─────────┐


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Resolved an issue where tables in the CLI would exhibit incorrect wrapping due to an off-by-some calculation in column width scaling, especially with fixed-width characters.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
- **Improved Column Width Calculation:** The logic for determining scaleFactor in TableRenderer.tsx has been refined to accurately account for fixed overheads (like column separators and borders) and available terminal width, ensuring tables fit correctly.
- **New Test Case:** A new test case was added to TableRenderer.test.tsx to specifically validate the rendering of tables with long headers and multiple columns, confirming proper truncation and data display within terminal constraints.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes #17808

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
Ask Gemini CLI "Create a table with 3 rows and 4 columns. make the title for each column quite long. no code changes, just give me an example of a table"

[Screenshot of output](https://screenshot.googleplex.com/432W2GjrQNaHjNX)

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
