### PR TITLE
feat(plan): add `ExitPlanMode` tool and approval dialog

### DIFF
--- a/packages/cli/src/test-utils/render.tsx
+++ b/packages/cli/src/test-utils/render.tsx
@@ -204,6 +204,9 @@ const mockUIActions: UIActions = {
   setAuthContext: vi.fn(),
   handleRestart: vi.fn(),
   handleNewAgentsSelect: vi.fn(),
+  handlePlanApprove: vi.fn(),
+  handlePlanFeedback: vi.fn(),
+  handlePlanCancel: vi.fn(),
 };
 
 export const renderWithProviders = (

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -118,6 +118,7 @@ import { useMcpStatus } from './hooks/useMcpStatus.js';
 import { useApprovalModeIndicator } from './hooks/useApprovalModeIndicator.js';
 import { useSessionStats } from './contexts/SessionContext.js';
 import { useGitBranchName } from './hooks/useGitBranchName.js';
+import { usePlanApproval } from './hooks/usePlanApproval.js';
 import {
   useConfirmUpdateRequests,
   useExtensionUpdates,
@@ -963,6 +964,18 @@ Logging in with Google... Restarting Gemini CLI to continue.
     embeddedShellFocused,
   );
 
+  const {
+    planApprovalRequest,
+    planContent,
+    handlePlanApprove,
+    handlePlanFeedback,
+    handlePlanCancel,
+  } = usePlanApproval({
+    config,
+    addItem: historyManager.addItem,
+    onApprovalModeChange: handleApprovalModeChange,
+  });
+
   const lastOutputTimeRef = useRef(0);
   useEffect(() => {
     lastOutputTimeRef.current = lastOutputTime;
@@ -1417,7 +1430,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
 
       if (keyMatchers[Command.QUIT](key)) {
         // Skip when ask_user dialog is open (use Esc to cancel instead)
-        if (askUserRequest) {
+        if (askUserRequest || planApprovalRequest) {
           return;
         }
         // If the user presses Ctrl+C, we want to cancel any ongoing requests.
@@ -1518,6 +1531,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       handleSlashCommand,
       cancelOngoingRequest,
       askUserRequest,
+      planApprovalRequest,
       activePtyId,
       embeddedShellFocused,
       settings.merged.general.debugKeystrokeLogging,
@@ -1631,6 +1645,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
 
   const dialogsVisible =
     !!askUserRequest ||
+    !!planApprovalRequest ||
     shouldShowIdePrompt ||
     isFolderTrustDialogOpen ||
     adminSettingsChanged ||
@@ -1816,6 +1831,8 @@ Logging in with Google... Restarting Gemini CLI to continue.
       settingsNonce,
       adminSettingsChanged,
       newAgents,
+      planApprovalRequest,
+      planContent,
     }),
     [
       isThemeDialogOpen,
@@ -1917,6 +1934,8 @@ Logging in with Google... Restarting Gemini CLI to continue.
       settingsNonce,
       adminSettingsChanged,
       newAgents,
+      planApprovalRequest,
+      planContent,
     ],
   );
 
@@ -1997,6 +2016,9 @@ Logging in with Google... Restarting Gemini CLI to continue.
         }
         setNewAgents(null);
       },
+      handlePlanApprove,
+      handlePlanFeedback,
+      handlePlanCancel,
     }),
     [
       handleThemeSelect,
@@ -2039,6 +2061,9 @@ Logging in with Google... Restarting Gemini CLI to continue.
       newAgents,
       config,
       historyManager,
+      handlePlanApprove,
+      handlePlanFeedback,
+      handlePlanCancel,
     ],
   );
 

--- a/packages/cli/src/ui/components/AskUserDialog.test.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.test.tsx
@@ -872,4 +872,95 @@ describe('AskUserDialog', () => {
       });
     });
   });
+
+  describe('Question content field', () => {
+    it('renders content in a choice question', () => {
+      const questionWithContent: Question[] = [
+        {
+          question: 'Approve this plan?',
+          header: 'Plan',
+          options: [{ label: 'Yes', description: 'Approve and proceed' }],
+          content:
+            '## Plan Details\n\n- Step 1: Do something\n- Step 2: Do another thing',
+        },
+      ];
+
+      const { lastFrame } = renderWithProviders(
+        <AskUserDialog
+          questions={questionWithContent}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+        { width: 120 },
+      );
+
+      expect(lastFrame()).toMatchSnapshot();
+    });
+
+    it('renders content in a text question', () => {
+      const questionWithContent: Question[] = [
+        {
+          question: 'Enter your feedback:',
+          header: 'Feedback',
+          type: QuestionType.TEXT,
+          content:
+            'Please review the following changes before providing feedback:\n\n- Changed file A\n- Updated file B',
+        },
+      ];
+
+      const { lastFrame } = renderWithProviders(
+        <AskUserDialog
+          questions={questionWithContent}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+        { width: 120 },
+      );
+
+      expect(lastFrame()).toMatchSnapshot();
+    });
+
+    it('does not render content when content is not provided', () => {
+      const questionWithoutContent: Question[] = [
+        {
+          question: 'Simple question?',
+          header: 'Simple',
+          options: [{ label: 'Yes', description: '' }],
+        },
+      ];
+
+      const { lastFrame } = renderWithProviders(
+        <AskUserDialog
+          questions={questionWithoutContent}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+        { width: 120 },
+      );
+
+      expect(lastFrame()).toMatchSnapshot();
+    });
+
+    it('uses customOptionPlaceholder for the Other option', () => {
+      const questionWithCustomPlaceholder: Question[] = [
+        {
+          question: 'Approve this?',
+          header: 'Approve',
+          options: [{ label: 'Yes', description: '' }],
+          customOptionPlaceholder: 'Enter your feedback here...',
+        },
+      ];
+
+      const { lastFrame } = renderWithProviders(
+        <AskUserDialog
+          questions={questionWithCustomPlaceholder}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+        { width: 120 },
+      );
+
+      expect(lastFrame()).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/cli/src/ui/components/AskUserDialog.test.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.test.tsx
@@ -962,5 +962,70 @@ describe('AskUserDialog', () => {
 
       expect(lastFrame()).toMatchSnapshot();
     });
+
+    it('truncates long content when availableTerminalHeight is small', async () => {
+      const longContent = Array.from(
+        { length: 30 },
+        (_, i) => `Line ${i + 1}`,
+      ).join('\n');
+      const questionWithLongContent: Question[] = [
+        {
+          question: 'Approve this plan?',
+          header: 'Plan',
+          options: [{ label: 'Yes', description: '' }],
+          content: longContent,
+        },
+      ];
+
+      const { lastFrame } = renderWithProviders(
+        <AskUserDialog
+          questions={questionWithLongContent}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+        {
+          width: 120,
+          uiState: {
+            availableTerminalHeight: 15,
+          },
+        },
+      );
+
+      await waitFor(() => {
+        expect(lastFrame()).toMatchSnapshot();
+      });
+    });
+
+    it('does not truncate content when availableTerminalHeight is undefined', () => {
+      const content = Array.from(
+        { length: 10 },
+        (_, i) => `Line ${i + 1}`,
+      ).join('\n');
+      const questionWithContent: Question[] = [
+        {
+          question: 'Approve this plan?',
+          header: 'Plan',
+          options: [{ label: 'Yes', description: '' }],
+          content,
+        },
+      ];
+
+      const { lastFrame } = renderWithProviders(
+        <AskUserDialog
+          questions={questionWithContent}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+        {
+          width: 120,
+          uiState: {
+            availableTerminalHeight: undefined,
+          },
+        },
+      );
+
+      expect(lastFrame()).not.toContain('lines hidden');
+      expect(lastFrame()).toMatchSnapshot();
+    });
   });
 });

--- a/packages/cli/src/ui/components/AskUserDialog.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.tsx
@@ -16,6 +16,7 @@ import {
 import { Box, Text } from 'ink';
 import { theme } from '../semantic-colors.js';
 import type { Question } from '@google/gemini-cli-core';
+import { MarkdownDisplay } from '../utils/MarkdownDisplay.js';
 import { BaseSelectionList } from './shared/BaseSelectionList.js';
 import type { SelectionListItem } from '../hooks/useSelectionList.js';
 import { TabHeader, type Tab } from './shared/TabHeader.js';
@@ -28,6 +29,7 @@ import { UIStateContext } from '../contexts/UIStateContext.js';
 import { getCachedStringWidth } from '../utils/textUtils.js';
 import { useTabbedNavigation } from '../hooks/useTabbedNavigation.js';
 import { DialogFooter } from './shared/DialogFooter.js';
+import { MaxSizedBox } from './shared/MaxSizedBox.js';
 
 interface AskUserDialogState {
   answers: { [key: string]: string };
@@ -214,6 +216,7 @@ const TextQuestionView: React.FC<TextQuestionViewProps> = ({
   progressHeader,
   keyboardHints,
 }) => {
+  const uiState = useContext(UIStateContext);
   const prefix = '> ';
   const horizontalPadding = 4 + 1; // Padding from Box (2) and border (2) + 1 for cursor
   const bufferWidth =
@@ -278,6 +281,17 @@ const TextQuestionView: React.FC<TextQuestionViewProps> = ({
       borderColor={theme.border.default}
     >
       {progressHeader}
+      {question.content && (
+        <Box marginBottom={1} flexDirection="column">
+          <MaxSizedBox maxHeight={uiState?.availableTerminalHeight}>
+            <MarkdownDisplay
+              text={question.content}
+              isPending={false}
+              terminalWidth={availableWidth - 4} // Adjust for parent border/padding
+            />
+          </MaxSizedBox>
+        </Box>
+      )}
       <Box marginBottom={1}>
         <Text bold color={theme.text.primary}>
           {question.question}
@@ -706,6 +720,17 @@ const ChoiceQuestionView: React.FC<ChoiceQuestionViewProps> = ({
       borderColor={theme.border.default}
     >
       {progressHeader}
+      {question.content && (
+        <Box marginBottom={1} flexDirection="column">
+          <MaxSizedBox maxHeight={uiState?.availableTerminalHeight}>
+            <MarkdownDisplay
+              text={question.content}
+              isPending={false}
+              terminalWidth={availableWidth - 4} // Adjust for parent border/padding
+            />
+          </MaxSizedBox>
+        </Box>
+      )}
       <Box marginBottom={1}>
         <Text bold color={theme.text.primary}>
           {question.question}
@@ -734,7 +759,8 @@ const ChoiceQuestionView: React.FC<ChoiceQuestionViewProps> = ({
 
           // Render inline text input for custom option
           if (optionItem.type === 'other') {
-            const placeholder = 'Enter a custom value';
+            const placeholder =
+              question.customOptionPlaceholder || 'Enter a custom value';
             return (
               <Box flexDirection="row">
                 {showCheck && (

--- a/packages/cli/src/ui/components/AskUserDialog.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.tsx
@@ -31,6 +31,17 @@ import { useTabbedNavigation } from '../hooks/useTabbedNavigation.js';
 import { DialogFooter } from './shared/DialogFooter.js';
 import { MaxSizedBox } from './shared/MaxSizedBox.js';
 
+// Width reduction for content inside the dialog border/padding
+const CONTENT_WIDTH_REDUCTION = 4;
+
+// Height consumed by dialog chrome surrounding the content area:
+// - Border top/bottom: 2
+// - Question text + marginBottom: 2
+// - Footer (keyboard hints): 2
+// - Options/input minimum: 4
+// - Buffer for tab header when present: 2
+const DIALOG_CHROME_HEIGHT = 12;
+
 interface AskUserDialogState {
   answers: { [key: string]: string };
   isEditingCustomOption: boolean;
@@ -283,11 +294,16 @@ const TextQuestionView: React.FC<TextQuestionViewProps> = ({
       {progressHeader}
       {question.content && (
         <Box marginBottom={1} flexDirection="column">
-          <MaxSizedBox maxHeight={uiState?.availableTerminalHeight}>
+          <MaxSizedBox
+            maxHeight={
+              uiState?.availableTerminalHeight &&
+              uiState.availableTerminalHeight - DIALOG_CHROME_HEIGHT
+            }
+          >
             <MarkdownDisplay
               text={question.content}
               isPending={false}
-              terminalWidth={availableWidth - 4} // Adjust for parent border/padding
+              terminalWidth={availableWidth - CONTENT_WIDTH_REDUCTION}
             />
           </MaxSizedBox>
         </Box>
@@ -722,11 +738,16 @@ const ChoiceQuestionView: React.FC<ChoiceQuestionViewProps> = ({
       {progressHeader}
       {question.content && (
         <Box marginBottom={1} flexDirection="column">
-          <MaxSizedBox maxHeight={uiState?.availableTerminalHeight}>
+          <MaxSizedBox
+            maxHeight={
+              uiState?.availableTerminalHeight &&
+              uiState.availableTerminalHeight - DIALOG_CHROME_HEIGHT
+            }
+          >
             <MarkdownDisplay
               text={question.content}
               isPending={false}
-              terminalWidth={availableWidth - 4} // Adjust for parent border/padding
+              terminalWidth={availableWidth - CONTENT_WIDTH_REDUCTION}
             />
           </MaxSizedBox>
         </Box>

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -36,6 +36,7 @@ import { AskUserDialog } from './AskUserDialog.js';
 import { useAskUserActions } from '../contexts/AskUserActionsContext.js';
 import { NewAgentsNotification } from './NewAgentsNotification.js';
 import { AgentConfigDialog } from './AgentConfigDialog.js';
+import { PlanApprovalDialog } from './PlanApprovalDialog.js';
 
 interface DialogManagerProps {
   addItem: UseHistoryManagerReturn['addItem'];
@@ -71,6 +72,17 @@ export const DialogManager = ({
         questions={askUserRequest.questions}
         onSubmit={askUserSubmit}
         onCancel={askUserCancel}
+      />
+    );
+  }
+
+  if (uiState.planApprovalRequest) {
+    return (
+      <PlanApprovalDialog
+        planContent={uiState.planContent}
+        onApprove={(mode) => uiActions.handlePlanApprove(mode)}
+        onFeedback={uiActions.handlePlanFeedback}
+        onCancel={uiActions.handlePlanCancel}
       />
     );
   }

--- a/packages/cli/src/ui/components/PlanApprovalDialog.test.tsx
+++ b/packages/cli/src/ui/components/PlanApprovalDialog.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { act } from 'react';
+import { renderWithProviders } from '../../test-utils/render.js';
+import { waitFor } from '../../test-utils/async.js';
+import { PlanApprovalDialog } from './PlanApprovalDialog.js';
+import { ApprovalMode } from '@google/gemini-cli-core';
+
+// Helper to write to stdin with proper act() wrapping
+const writeKey = (stdin: { write: (data: string) => void }, key: string) => {
+  act(() => {
+    stdin.write(key);
+  });
+};
+
+describe('PlanApprovalDialog', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const samplePlanContent = `## Overview
+
+Add user authentication to the CLI application.
+
+## Implementation Steps
+
+1. Create \`src/auth/AuthService.ts\` with login/logout methods
+2. Add session storage in \`src/storage/SessionStore.ts\`
+3. Update \`src/commands/index.ts\` to check auth status
+4. Add tests in \`src/auth/__tests__/\`
+
+## Files to Modify
+
+- \`src/index.ts\` - Add auth middleware
+- \`src/config.ts\` - Add auth configuration options`;
+
+  const defaultProps = {
+    planContent: samplePlanContent,
+    onApprove: vi.fn(),
+    onFeedback: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  it('renders correctly with plan content', () => {
+    const { lastFrame } = renderWithProviders(
+      <PlanApprovalDialog {...defaultProps} />,
+    );
+
+    expect(lastFrame()).toMatchSnapshot();
+  });
+
+  it('calls onApprove with AUTO_EDIT mode when auto option is selected', async () => {
+    const onApprove = vi.fn();
+    const { stdin } = renderWithProviders(
+      <PlanApprovalDialog {...defaultProps} onApprove={onApprove} />,
+    );
+
+    writeKey(stdin, '\r');
+
+    await waitFor(() => {
+      expect(onApprove).toHaveBeenCalledWith(ApprovalMode.AUTO_EDIT);
+    });
+  });
+
+  it('calls onApprove with DEFAULT mode when manual option is selected', async () => {
+    const onApprove = vi.fn();
+    const { stdin } = renderWithProviders(
+      <PlanApprovalDialog {...defaultProps} onApprove={onApprove} />,
+    );
+
+    writeKey(stdin, '\x1b[B'); // Down arrow to manual option
+    writeKey(stdin, '\r');
+
+    await waitFor(() => {
+      expect(onApprove).toHaveBeenCalledWith(ApprovalMode.DEFAULT);
+    });
+  });
+
+  it('calls onFeedback when feedback is typed and submitted', async () => {
+    const onFeedback = vi.fn();
+    const { stdin, lastFrame } = renderWithProviders(
+      <PlanApprovalDialog {...defaultProps} onFeedback={onFeedback} />,
+    );
+
+    // Navigate past both options to the feedback input
+    writeKey(stdin, '\x1b[B'); // Down arrow
+    writeKey(stdin, '\x1b[B'); // Down arrow
+
+    for (const char of 'Add tests') {
+      writeKey(stdin, char);
+    }
+
+    await waitFor(() => {
+      expect(lastFrame()).toMatchSnapshot();
+    });
+
+    writeKey(stdin, '\r');
+
+    await waitFor(() => {
+      expect(onFeedback).toHaveBeenCalledWith('Add tests');
+    });
+  });
+
+  it('calls onCancel when Esc is pressed', async () => {
+    const onCancel = vi.fn();
+    const { stdin } = renderWithProviders(
+      <PlanApprovalDialog {...defaultProps} onCancel={onCancel} />,
+    );
+
+    writeKey(stdin, '\x1b'); // Escape
+
+    await waitFor(() => {
+      expect(onCancel).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/cli/src/ui/components/PlanApprovalDialog.tsx
+++ b/packages/cli/src/ui/components/PlanApprovalDialog.tsx
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { useCallback, useMemo } from 'react';
+import {
+  type Question,
+  QuestionType,
+  ApprovalMode,
+} from '@google/gemini-cli-core';
+import { AskUserDialog } from './AskUserDialog.js';
+
+interface PlanApprovalDialogProps {
+  planContent?: string;
+  onApprove: (mode: ApprovalMode) => void;
+  onFeedback: (feedback: string) => void;
+  onCancel: () => void;
+}
+
+const APPROVE_MANUAL_OPTION = 'Yes, manually accept edits';
+const APPROVE_AUTO_OPTION = 'Yes, automatically accept edits';
+
+export const PlanApprovalDialog: React.FC<PlanApprovalDialogProps> = ({
+  planContent,
+  onApprove,
+  onFeedback,
+  onCancel,
+}) => {
+  const questions = useMemo(
+    (): Question[] => [
+      {
+        question: 'Ready to start implementation?',
+        header: 'Plan',
+        type: QuestionType.CHOICE,
+        options: [
+          {
+            label: APPROVE_AUTO_OPTION,
+            description: '',
+          },
+          {
+            label: APPROVE_MANUAL_OPTION,
+            description: '',
+          },
+        ],
+        content: planContent,
+        customOptionPlaceholder: 'Provide feedback...',
+      },
+    ],
+    [planContent],
+  );
+
+  const handleSubmit = useCallback(
+    (answers: { [questionIndex: string]: string }) => {
+      const answer = answers['0'];
+      if (answer === APPROVE_MANUAL_OPTION) {
+        onApprove(ApprovalMode.DEFAULT);
+      } else if (answer === APPROVE_AUTO_OPTION) {
+        onApprove(ApprovalMode.AUTO_EDIT);
+      } else if (answer) {
+        onFeedback(answer);
+      }
+    },
+    [onApprove, onFeedback],
+  );
+
+  return (
+    <AskUserDialog
+      questions={questions}
+      onSubmit={handleSubmit}
+      onCancel={onCancel}
+    />
+  );
+};

--- a/packages/cli/src/ui/components/__snapshots__/AskUserDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/AskUserDialog.test.tsx.snap
@@ -11,6 +11,28 @@ exports[`AskUserDialog > Question content field > does not render content when c
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
 `;
 
+exports[`AskUserDialog > Question content field > does not truncate content when availableTerminalHeight is undefined 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ Line 1                                                                                                               │
+│ Line 2                                                                                                               │
+│ Line 3                                                                                                               │
+│ Line 4                                                                                                               │
+│ Line 5                                                                                                               │
+│ Line 6                                                                                                               │
+│ Line 7                                                                                                               │
+│ Line 8                                                                                                               │
+│ Line 9                                                                                                               │
+│ Line 10                                                                                                              │
+│                                                                                                                      │
+│ Approve this plan?                                                                                                   │
+│                                                                                                                      │
+│ ● 1.  Yes                                                                                                            │
+│   2.  Enter a custom value                                                                                           │
+│                                                                                                                      │
+│ Enter to select · ↑/↓ to navigate · Esc to cancel                                                                    │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
 exports[`AskUserDialog > Question content field > renders content in a choice question 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ Plan Details                                                                                                         │
@@ -41,6 +63,21 @@ exports[`AskUserDialog > Question content field > renders content in a text ques
 │                                                                                                                      │
 │                                                                                                                      │
 │ Enter to submit · Esc to cancel                                                                                      │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+exports[`AskUserDialog > Question content field > truncates long content when availableTerminalHeight is small 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ ... first 28 lines hidden ...                                                                                        │
+│ Line 29                                                                                                              │
+│ Line 30                                                                                                              │
+│                                                                                                                      │
+│ Approve this plan?                                                                                                   │
+│                                                                                                                      │
+│ ● 1.  Yes                                                                                                            │
+│   2.  Enter a custom value                                                                                           │
+│                                                                                                                      │
+│ Enter to select · ↑/↓ to navigate · Esc to cancel                                                                    │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
 `;
 

--- a/packages/cli/src/ui/components/__snapshots__/AskUserDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/AskUserDialog.test.tsx.snap
@@ -1,5 +1,60 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`AskUserDialog > Question content field > does not render content when content is not provided 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ Simple question?                                                                                                     │
+│                                                                                                                      │
+│ ● 1.  Yes                                                                                                            │
+│   2.  Enter a custom value                                                                                           │
+│                                                                                                                      │
+│ Enter to select · ↑/↓ to navigate · Esc to cancel                                                                    │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+exports[`AskUserDialog > Question content field > renders content in a choice question 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ Plan Details                                                                                                         │
+│                                                                                                                      │
+│  - Step 1: Do something                                                                                              │
+│  - Step 2: Do another thing                                                                                          │
+│                                                                                                                      │
+│ Approve this plan?                                                                                                   │
+│                                                                                                                      │
+│ ● 1.  Yes                                                                                                            │
+│       Approve and proceed                                                                                            │
+│   2.  Enter a custom value                                                                                           │
+│                                                                                                                      │
+│ Enter to select · ↑/↓ to navigate · Esc to cancel                                                                    │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+exports[`AskUserDialog > Question content field > renders content in a text question 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ Please review the following changes before providing feedback:                                                       │
+│                                                                                                                      │
+│  - Changed file A                                                                                                    │
+│  - Updated file B                                                                                                    │
+│                                                                                                                      │
+│ Enter your feedback:                                                                                                 │
+│                                                                                                                      │
+│ > Enter your response                                                                                                │
+│                                                                                                                      │
+│                                                                                                                      │
+│ Enter to submit · Esc to cancel                                                                                      │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+exports[`AskUserDialog > Question content field > uses customOptionPlaceholder for the Other option 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ Approve this?                                                                                                        │
+│                                                                                                                      │
+│ ● 1.  Yes                                                                                                            │
+│   2.  Enter your feedback here...                                                                                    │
+│                                                                                                                      │
+│ Enter to select · ↑/↓ to navigate · Esc to cancel                                                                    │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
 exports[`AskUserDialog > Text type questions > renders text input for type: "text" 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ What should we name this component?                                                                                  │

--- a/packages/cli/src/ui/components/__snapshots__/PlanApprovalDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/PlanApprovalDialog.test.tsx.snap
@@ -1,0 +1,57 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`PlanApprovalDialog > calls onFeedback when feedback is typed and submitted 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ Overview                                                                                                             │
+│                                                                                                                      │
+│ Add user authentication to the CLI application.                                                                      │
+│                                                                                                                      │
+│ Implementation Steps                                                                                                 │
+│                                                                                                                      │
+│  1. Create src/auth/AuthService.ts with login/logout methods                                                         │
+│  2. Add session storage in src/storage/SessionStore.ts                                                               │
+│  3. Update src/commands/index.ts to check auth status                                                                │
+│  4. Add tests in src/auth/__tests__/                                                                                 │
+│                                                                                                                      │
+│ Files to Modify                                                                                                      │
+│                                                                                                                      │
+│  - src/index.ts - Add auth middleware                                                                                │
+│  - src/config.ts - Add auth configuration options                                                                    │
+│                                                                                                                      │
+│ Ready to start implementation?                                                                                       │
+│                                                                                                                      │
+│   1.  Yes, automatically accept edits                                                                                │
+│   2.  Yes, manually accept edits                                                                                     │
+│ ● 3.  Add tests  ✓                                                                                                   │
+│                                                                                                                      │
+│ Enter to submit · Esc to cancel                                                                                      │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+exports[`PlanApprovalDialog > renders correctly with plan content 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ Overview                                                                                                             │
+│                                                                                                                      │
+│ Add user authentication to the CLI application.                                                                      │
+│                                                                                                                      │
+│ Implementation Steps                                                                                                 │
+│                                                                                                                      │
+│  1. Create src/auth/AuthService.ts with login/logout methods                                                         │
+│  2. Add session storage in src/storage/SessionStore.ts                                                               │
+│  3. Update src/commands/index.ts to check auth status                                                                │
+│  4. Add tests in src/auth/__tests__/                                                                                 │
+│                                                                                                                      │
+│ Files to Modify                                                                                                      │
+│                                                                                                                      │
+│  - src/index.ts - Add auth middleware                                                                                │
+│  - src/config.ts - Add auth configuration options                                                                    │
+│                                                                                                                      │
+│ Ready to start implementation?                                                                                       │
+│                                                                                                                      │
+│ ● 1.  Yes, automatically accept edits                                                                                │
+│   2.  Yes, manually accept edits                                                                                     │
+│   3.  Provide feedback...                                                                                            │
+│                                                                                                                      │
+│ Enter to select · ↑/↓ to navigate · Esc to cancel                                                                    │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;

--- a/packages/cli/src/ui/contexts/UIActionsContext.tsx
+++ b/packages/cli/src/ui/contexts/UIActionsContext.tsx
@@ -8,10 +8,11 @@ import { createContext, useContext } from 'react';
 import { type Key } from '../hooks/useKeypress.js';
 import { type IdeIntegrationNudgeResult } from '../IdeIntegrationNudge.js';
 import { type FolderTrustChoice } from '../components/FolderTrustDialog.js';
-import {
-  type AuthType,
-  type EditorType,
-  type AgentDefinition,
+import type {
+  ApprovalMode,
+  AuthType,
+  EditorType,
+  AgentDefinition,
 } from '@google/gemini-cli-core';
 import { type LoadableSettingScope } from '../../config/settings.js';
 import type { AuthState } from '../types.js';
@@ -71,6 +72,9 @@ export interface UIActions {
   setAuthContext: (context: { requiresRestart?: boolean }) => void;
   handleRestart: () => void;
   handleNewAgentsSelect: (choice: NewAgentsChoice) => Promise<void>;
+  handlePlanApprove: (mode: ApprovalMode) => Promise<void>;
+  handlePlanFeedback: (feedback: string) => Promise<void>;
+  handlePlanCancel: () => Promise<void>;
 }
 
 export const UIActionsContext = createContext<UIActions | null>(null);

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -25,6 +25,7 @@ import type {
   FallbackIntent,
   ValidationIntent,
   AgentDefinition,
+  PlanApprovalRequest,
 } from '@google/gemini-cli-core';
 import type { DOMElement } from 'ink';
 import type { SessionStatsState } from '../contexts/SessionContext.js';
@@ -156,6 +157,8 @@ export interface UIState {
   settingsNonce: number;
   adminSettingsChanged: boolean;
   newAgents: AgentDefinition[] | null;
+  planApprovalRequest: PlanApprovalRequest | null;
+  planContent: string | undefined;
 }
 
 export const UIStateContext = createContext<UIState | null>(null);

--- a/packages/cli/src/ui/hooks/usePlanApproval.test.ts
+++ b/packages/cli/src/ui/hooks/usePlanApproval.test.ts
@@ -1,0 +1,298 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { renderHook } from '../../test-utils/render.js';
+import { usePlanApproval } from './usePlanApproval.js';
+import {
+  type Config,
+  type PlanApprovalRequest,
+  MessageBusType,
+  ApprovalMode,
+} from '@google/gemini-cli-core';
+import * as fs from 'node:fs';
+
+vi.mock('node:fs', () => ({
+  promises: {
+    readFile: vi.fn(),
+  },
+}));
+
+describe('usePlanApproval', () => {
+  let mockConfig: Partial<Config>;
+  let mockMessageBus: {
+    subscribe: ReturnType<typeof vi.fn>;
+    unsubscribe: ReturnType<typeof vi.fn>;
+    publish: ReturnType<typeof vi.fn>;
+  };
+  let mockAddItem: ReturnType<typeof vi.fn>;
+  let mockOnApprovalModeChange: ReturnType<typeof vi.fn>;
+  let planApprovalHandler: ((msg: PlanApprovalRequest) => void) | undefined;
+
+  const mockPlansDir = '/mock/project/.gemini/plans';
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    mockMessageBus = {
+      subscribe: vi.fn((type, handler) => {
+        if (type === MessageBusType.PLAN_APPROVAL_REQUEST) {
+          planApprovalHandler = handler;
+        }
+      }),
+      unsubscribe: vi.fn(),
+      publish: vi.fn().mockResolvedValue(undefined),
+    };
+
+    mockConfig = {
+      getMessageBus: vi.fn().mockReturnValue(mockMessageBus),
+      storage: {
+        getProjectTempPlansDir: vi.fn().mockReturnValue(mockPlansDir),
+      } as unknown as Config['storage'],
+      setCurrentPlanPath: vi.fn(),
+      setApprovalMode: vi.fn(),
+    };
+
+    mockAddItem = vi.fn();
+    mockOnApprovalModeChange = vi.fn();
+
+    vi.mocked(fs.promises.readFile).mockResolvedValue('# Test Plan Content');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    planApprovalHandler = undefined;
+  });
+
+  const renderUsePlanApproval = () =>
+    renderHook(() =>
+      usePlanApproval({
+        config: mockConfig as Config,
+        addItem: mockAddItem,
+        onApprovalModeChange: mockOnApprovalModeChange,
+      }),
+    );
+
+  it('should initialize with null request and undefined content', () => {
+    const { result } = renderUsePlanApproval();
+
+    expect(result.current.planApprovalRequest).toBeNull();
+    expect(result.current.planContent).toBeUndefined();
+  });
+
+  it('should subscribe to PLAN_APPROVAL_REQUEST on mount', () => {
+    renderUsePlanApproval();
+
+    expect(mockMessageBus.subscribe).toHaveBeenCalledWith(
+      MessageBusType.PLAN_APPROVAL_REQUEST,
+      expect.any(Function),
+    );
+  });
+
+  it('should unsubscribe on unmount', () => {
+    const { unmount } = renderUsePlanApproval();
+
+    unmount();
+
+    expect(mockMessageBus.unsubscribe).toHaveBeenCalledWith(
+      MessageBusType.PLAN_APPROVAL_REQUEST,
+      expect.any(Function),
+    );
+  });
+
+  it('should set planApprovalRequest when message is received', async () => {
+    const { result } = renderUsePlanApproval();
+
+    const request: PlanApprovalRequest = {
+      type: MessageBusType.PLAN_APPROVAL_REQUEST,
+      correlationId: 'test-correlation-id',
+      planPath: `${mockPlansDir}/test-plan.md`,
+    };
+
+    await act(async () => {
+      planApprovalHandler?.(request);
+    });
+
+    expect(result.current.planApprovalRequest).toEqual(request);
+  });
+
+  it('should skip duplicate requests with same correlationId', async () => {
+    const { result } = renderUsePlanApproval();
+
+    const request: PlanApprovalRequest = {
+      type: MessageBusType.PLAN_APPROVAL_REQUEST,
+      correlationId: 'test-correlation-id',
+      planPath: `${mockPlansDir}/test-plan.md`,
+    };
+
+    await act(async () => {
+      planApprovalHandler?.(request);
+    });
+
+    await act(async () => {
+      planApprovalHandler?.(request);
+    });
+
+    expect(result.current.planApprovalRequest).toEqual(request);
+  });
+
+  it('should read plan content when planPath changes', async () => {
+    const { result } = renderUsePlanApproval();
+
+    const request: PlanApprovalRequest = {
+      type: MessageBusType.PLAN_APPROVAL_REQUEST,
+      correlationId: 'test-correlation-id',
+      planPath: `${mockPlansDir}/test-plan.md`,
+    };
+
+    await act(async () => {
+      planApprovalHandler?.(request);
+    });
+
+    await act(async () => {
+      await vi.waitFor(() => {
+        expect(result.current.planContent).toBe('# Test Plan Content');
+      });
+    });
+  });
+
+  it('should show error for plan path outside plans directory', async () => {
+    const { result } = renderUsePlanApproval();
+
+    const request: PlanApprovalRequest = {
+      type: MessageBusType.PLAN_APPROVAL_REQUEST,
+      correlationId: 'test-correlation-id',
+      planPath: '/etc/passwd',
+    };
+
+    await act(async () => {
+      planApprovalHandler?.(request);
+    });
+
+    expect(result.current.planContent).toBe(
+      'Error: Plan path is outside the designated plans directory.',
+    );
+  });
+
+  describe('handlePlanApprove', () => {
+    it('should publish approval response and update config', async () => {
+      const { result } = renderUsePlanApproval();
+
+      const request: PlanApprovalRequest = {
+        type: MessageBusType.PLAN_APPROVAL_REQUEST,
+        correlationId: 'test-correlation-id',
+        planPath: `${mockPlansDir}/test-plan.md`,
+      };
+
+      await act(async () => {
+        planApprovalHandler?.(request);
+      });
+
+      await act(async () => {
+        await result.current.handlePlanApprove(ApprovalMode.AUTO_EDIT);
+      });
+
+      expect(mockConfig.setCurrentPlanPath).toHaveBeenCalledWith(
+        request.planPath,
+      );
+      expect(mockConfig.setApprovalMode).toHaveBeenCalledWith(
+        ApprovalMode.AUTO_EDIT,
+      );
+      expect(mockOnApprovalModeChange).toHaveBeenCalledWith(
+        ApprovalMode.AUTO_EDIT,
+      );
+      expect(mockMessageBus.publish).toHaveBeenCalledWith({
+        type: MessageBusType.PLAN_APPROVAL_RESPONSE,
+        correlationId: 'test-correlation-id',
+        approved: true,
+      });
+      expect(result.current.planApprovalRequest).toBeNull();
+    });
+
+    it('should add info message on successful approval', async () => {
+      const { result } = renderUsePlanApproval();
+
+      const request: PlanApprovalRequest = {
+        type: MessageBusType.PLAN_APPROVAL_REQUEST,
+        correlationId: 'test-correlation-id',
+        planPath: `${mockPlansDir}/test-plan.md`,
+      };
+
+      await act(async () => {
+        planApprovalHandler?.(request);
+      });
+
+      await act(async () => {
+        await result.current.handlePlanApprove(ApprovalMode.DEFAULT);
+      });
+
+      expect(mockAddItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: 'Plan approved. Edits will require manual acceptance.',
+        }),
+        expect.any(Number),
+      );
+    });
+  });
+
+  describe('handlePlanFeedback', () => {
+    it('should publish rejection response with feedback', async () => {
+      const { result } = renderUsePlanApproval();
+
+      const request: PlanApprovalRequest = {
+        type: MessageBusType.PLAN_APPROVAL_REQUEST,
+        correlationId: 'test-correlation-id',
+        planPath: `${mockPlansDir}/test-plan.md`,
+      };
+
+      await act(async () => {
+        planApprovalHandler?.(request);
+      });
+
+      await act(async () => {
+        await result.current.handlePlanFeedback('Please add more tests');
+      });
+
+      expect(mockMessageBus.publish).toHaveBeenCalledWith({
+        type: MessageBusType.PLAN_APPROVAL_RESPONSE,
+        correlationId: 'test-correlation-id',
+        approved: false,
+        feedback: 'Please add more tests',
+      });
+      expect(result.current.planApprovalRequest).toBeNull();
+    });
+  });
+
+  describe('handlePlanCancel', () => {
+    it('should publish rejection response with cancellation feedback', async () => {
+      const { result } = renderUsePlanApproval();
+
+      const request: PlanApprovalRequest = {
+        type: MessageBusType.PLAN_APPROVAL_REQUEST,
+        correlationId: 'test-correlation-id',
+        planPath: `${mockPlansDir}/test-plan.md`,
+      };
+
+      await act(async () => {
+        planApprovalHandler?.(request);
+      });
+
+      await act(async () => {
+        await result.current.handlePlanCancel();
+      });
+
+      expect(mockMessageBus.publish).toHaveBeenCalledWith({
+        type: MessageBusType.PLAN_APPROVAL_RESPONSE,
+        correlationId: 'test-correlation-id',
+        approved: false,
+        feedback:
+          'User dismissed the plan approval dialog without providing feedback. The plan is not approved.',
+      });
+      expect(result.current.planApprovalRequest).toBeNull();
+    });
+  });
+});

--- a/packages/cli/src/ui/hooks/usePlanApproval.ts
+++ b/packages/cli/src/ui/hooks/usePlanApproval.ts
@@ -1,0 +1,193 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  type Config,
+  type PlanApprovalRequest,
+  MessageBusType,
+  ApprovalMode,
+  debugLogger,
+  isWithinRoot,
+} from '@google/gemini-cli-core';
+import * as fs from 'node:fs';
+import type { HistoryItemWithoutId } from '../types.js';
+import { MessageType } from '../types.js';
+
+export interface UsePlanApprovalArgs {
+  config: Config;
+  addItem: (item: HistoryItemWithoutId, timestamp: number) => void;
+  onApprovalModeChange: (mode: ApprovalMode) => void;
+}
+
+export interface UsePlanApprovalReturn {
+  planApprovalRequest: PlanApprovalRequest | null;
+  planContent: string | undefined;
+  handlePlanApprove: (mode: ApprovalMode) => Promise<void>;
+  handlePlanFeedback: (feedback: string) => Promise<void>;
+  handlePlanCancel: () => Promise<void>;
+}
+
+export function usePlanApproval({
+  config,
+  addItem,
+  onApprovalModeChange,
+}: UsePlanApprovalArgs): UsePlanApprovalReturn {
+  const [planApprovalRequest, setPlanApprovalRequest] =
+    useState<PlanApprovalRequest | null>(null);
+  const [planContent, setPlanContent] = useState<string | undefined>(undefined);
+
+  const planPath = planApprovalRequest?.planPath;
+
+  useEffect(() => {
+    if (!planPath) {
+      setPlanContent(undefined);
+      return;
+    }
+
+    let ignore = false;
+    setPlanContent(undefined);
+
+    const plansDir = config.storage.getProjectTempPlansDir();
+    if (!isWithinRoot(planPath, plansDir)) {
+      setPlanContent(
+        'Error: Plan path is outside the designated plans directory.',
+      );
+      return;
+    }
+
+    fs.promises
+      .readFile(planPath, 'utf8')
+      .then((content) => {
+        if (ignore) return;
+        setPlanContent(content);
+      })
+      .catch((err) => {
+        if (ignore) return;
+        setPlanContent(`Error reading plan file: ${err.message}`);
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [planPath, config.storage]);
+
+  useEffect(() => {
+    const messageBus = config.getMessageBus();
+
+    const planApprovalHandler = (msg: PlanApprovalRequest) => {
+      debugLogger.log('Processing plan approval request:', msg.correlationId);
+      setPlanApprovalRequest((prev) => {
+        if (prev?.correlationId === msg.correlationId) {
+          debugLogger.log(
+            'Skipping duplicate plan approval request:',
+            msg.correlationId,
+          );
+          return prev;
+        }
+        return msg;
+      });
+    };
+
+    messageBus.subscribe(
+      MessageBusType.PLAN_APPROVAL_REQUEST,
+      planApprovalHandler,
+    );
+
+    return () => {
+      messageBus.unsubscribe(
+        MessageBusType.PLAN_APPROVAL_REQUEST,
+        planApprovalHandler,
+      );
+    };
+  }, [config]);
+
+  const handlePlanApprove = useCallback(
+    async (mode: ApprovalMode) => {
+      if (!planApprovalRequest) return;
+
+      try {
+        config.setCurrentPlanPath(planApprovalRequest.planPath);
+        config.setApprovalMode(mode);
+        onApprovalModeChange(mode);
+
+        const messageBus = config.getMessageBus();
+        await messageBus.publish({
+          type: MessageBusType.PLAN_APPROVAL_RESPONSE,
+          correlationId: planApprovalRequest.correlationId,
+          approved: true,
+        });
+
+        const modeText =
+          mode === ApprovalMode.AUTO_EDIT
+            ? 'Edits will be automatically accepted.'
+            : 'Edits will require manual acceptance.';
+        addItem(
+          {
+            type: MessageType.INFO,
+            text: `Plan approved. ${modeText}`,
+          },
+          Date.now(),
+        );
+      } catch (err) {
+        addItem(
+          {
+            type: MessageType.ERROR,
+            text: `Failed to approve plan: ${err instanceof Error ? err.message : String(err)}`,
+          },
+          Date.now(),
+        );
+      } finally {
+        setPlanApprovalRequest(null);
+      }
+    },
+    [config, planApprovalRequest, onApprovalModeChange, addItem],
+  );
+
+  const handlePlanFeedback = useCallback(
+    async (feedback: string) => {
+      if (!planApprovalRequest) return;
+
+      try {
+        const messageBus = config.getMessageBus();
+        await messageBus.publish({
+          type: MessageBusType.PLAN_APPROVAL_RESPONSE,
+          correlationId: planApprovalRequest.correlationId,
+          approved: false,
+          feedback,
+        });
+      } finally {
+        setPlanApprovalRequest(null);
+      }
+    },
+    [config, planApprovalRequest],
+  );
+
+  const handlePlanCancel = useCallback(async () => {
+    if (!planApprovalRequest) return;
+
+    try {
+      const messageBus = config.getMessageBus();
+      await messageBus.publish({
+        type: MessageBusType.PLAN_APPROVAL_RESPONSE,
+        correlationId: planApprovalRequest.correlationId,
+        approved: false,
+        feedback:
+          'User dismissed the plan approval dialog without providing feedback. The plan is not approved.',
+      });
+    } finally {
+      setPlanApprovalRequest(null);
+    }
+  }, [config, planApprovalRequest]);
+
+  return {
+    planApprovalRequest,
+    planContent,
+    handlePlanApprove,
+    handlePlanFeedback,
+    handlePlanCancel,
+  };
+}

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -32,6 +32,7 @@ import { ShellTool } from '../tools/shell.js';
 import { ReadFileTool } from '../tools/read-file.js';
 import { GrepTool } from '../tools/grep.js';
 import { RipGrepTool, canUseRipgrep } from '../tools/ripGrep.js';
+import { ExitPlanModeTool } from '../tools/exit-plan-mode.js';
 import { logRipgrepFallback } from '../telemetry/loggers.js';
 import { RipgrepFallbackEvent } from '../telemetry/types.js';
 import { ToolRegistry } from '../tools/tool-registry.js';
@@ -1438,6 +1439,42 @@ describe('setApprovalMode with folder trust', () => {
       expect(wasGrepRegistered).toBe(true);
       expect(canUseRipgrep).not.toHaveBeenCalled();
       expect(logRipgrepFallback).not.toHaveBeenCalled();
+    });
+
+    it('should register ExitPlanModeTool when plan is enabled', async () => {
+      const config = new Config({ ...baseParams, plan: true });
+      await config.initialize();
+
+      const calls = (ToolRegistry.prototype.registerTool as Mock).mock.calls;
+      const wasExitPlanModeRegistered = calls.some(
+        (call) => call[0] instanceof vi.mocked(ExitPlanModeTool),
+      );
+
+      expect(wasExitPlanModeRegistered).toBe(true);
+    });
+
+    it('should not register ExitPlanModeTool when plan is disabled', async () => {
+      const config = new Config({ ...baseParams, plan: false });
+      await config.initialize();
+
+      const calls = (ToolRegistry.prototype.registerTool as Mock).mock.calls;
+      const wasExitPlanModeRegistered = calls.some(
+        (call) => call[0] instanceof vi.mocked(ExitPlanModeTool),
+      );
+
+      expect(wasExitPlanModeRegistered).toBe(false);
+    });
+
+    it('should not register ExitPlanModeTool by default', async () => {
+      const config = new Config({ ...baseParams });
+      await config.initialize();
+
+      const calls = (ToolRegistry.prototype.registerTool as Mock).mock.calls;
+      const wasExitPlanModeRegistered = calls.some(
+        (call) => call[0] instanceof vi.mocked(ExitPlanModeTool),
+      );
+
+      expect(wasExitPlanModeRegistered).toBe(false);
     });
   });
 });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -34,6 +34,7 @@ import { WebFetchTool } from '../tools/web-fetch.js';
 import { MemoryTool, setGeminiMdFilename } from '../tools/memoryTool.js';
 import { WebSearchTool } from '../tools/web-search.js';
 import { AskUserTool } from '../tools/ask-user.js';
+import { ExitPlanModeTool } from '../tools/exit-plan-mode.js';
 import { GeminiClient } from '../core/client.js';
 import { BaseLlmClient } from '../core/baseLlmClient.js';
 import type { HookDefinition, HookEventName } from '../hooks/types.js';
@@ -622,6 +623,7 @@ export class Config {
   private terminalBackground: string | undefined = undefined;
   private remoteAdminSettings: FetchAdminControlsResponse | undefined;
   private latestApiRequest: GenerateContentParameters | undefined;
+  private currentPlanPath: string | undefined = undefined;
   private lastModeSwitchTime: number = Date.now();
 
   constructor(params: ConfigParameters) {
@@ -1454,6 +1456,14 @@ export class Config {
     return this.policyEngine.getApprovalMode();
   }
 
+  getCurrentPlanPath(): string | undefined {
+    return this.currentPlanPath;
+  }
+
+  setCurrentPlanPath(path: string | undefined): void {
+    this.currentPlanPath = path;
+  }
+
   setApprovalMode(mode: ApprovalMode): void {
     if (!this.isTrustedFolder() && mode !== ApprovalMode.DEFAULT) {
       throw new Error(
@@ -2130,6 +2140,9 @@ export class Config {
     registerCoreTool(MemoryTool);
     registerCoreTool(WebSearchTool, this);
     registerCoreTool(AskUserTool);
+    if (this.isPlanEnabled()) {
+      registerCoreTool(ExitPlanModeTool, this);
+    }
     if (this.getUseWriteTodos()) {
       registerCoreTool(WriteTodosTool);
     }

--- a/packages/core/src/confirmation-bus/types.ts
+++ b/packages/core/src/confirmation-bus/types.ts
@@ -21,6 +21,8 @@ export enum MessageBusType {
   TOOL_CALLS_UPDATE = 'tool-calls-update',
   ASK_USER_REQUEST = 'ask-user-request',
   ASK_USER_RESPONSE = 'ask-user-response',
+  PLAN_APPROVAL_REQUEST = 'plan-approval-request',
+  PLAN_APPROVAL_RESPONSE = 'plan-approval-response',
 }
 
 export interface ToolCallsUpdateMessage {
@@ -140,6 +142,10 @@ export interface Question {
   multiSelect?: boolean;
   /** Placeholder hint text. Only applies when type='text'. */
   placeholder?: string;
+  /** Markdown content to display before the question. */
+  content?: string;
+  /** Placeholder for the custom "Other" option input. Only applies when type='choice'. Defaults to 'Enter a custom value'. */
+  customOptionPlaceholder?: string;
 }
 
 export interface AskUserRequest {
@@ -156,6 +162,19 @@ export interface AskUserResponse {
   cancelled?: boolean;
 }
 
+export interface PlanApprovalRequest {
+  type: MessageBusType.PLAN_APPROVAL_REQUEST;
+  planPath: string;
+  correlationId: string;
+}
+
+export interface PlanApprovalResponse {
+  type: MessageBusType.PLAN_APPROVAL_RESPONSE;
+  correlationId: string;
+  approved: boolean;
+  feedback?: string;
+}
+
 export type Message =
   | ToolConfirmationRequest
   | ToolConfirmationResponse
@@ -165,4 +184,6 @@ export type Message =
   | UpdatePolicy
   | AskUserRequest
   | AskUserResponse
+  | PlanApprovalRequest
+  | PlanApprovalResponse
   | ToolCallsUpdateMessage;

--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -172,7 +172,10 @@ You are operating in **Plan Mode** - a structured planning workflow for designin
 
 ## Available Tools
 The following read-only tools are available in Plan Mode:
-
+- \`glob\`
+- \`read_file\`
+- \`ask_user\`
+- \`exit_plan_mode\`
 - \`write_file\` - Save plans to the plans directory (see Plan Storage below)
 
 ## Plan Storage
@@ -201,9 +204,9 @@ The following read-only tools are available in Plan Mode:
 - After saving the plan, present the full content of the markdown file to the user for review
 
 ### Phase 4: Review & Approval
-- Ask the user if they approve the plan, want revisions, or want to reject it
-- Address feedback and iterate as needed
-- **When the user approves the plan**, prompt them to switch out of Plan Mode to begin implementation by pressing Shift+Tab to cycle to a different approval mode
+- Present the plan and request approval using \`exit_plan_mode\`
+- If plan is approved, you can begin implementation
+- If plan is rejected, address the feedback and iterate on the plan
 
 ## Constraints
 - You may ONLY use the read-only tools listed above

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -232,6 +232,7 @@ describe('Core System Prompt (prompts.ts)', () => {
         getSkillManager: vi.fn().mockReturnValue({
           getSkills: vi.fn().mockReturnValue([]),
         }),
+        getCurrentPlanPath: vi.fn().mockReturnValue(undefined),
       } as unknown as Config;
 
       const prompt = getCoreSystemPrompt(testConfig);
@@ -258,6 +259,12 @@ describe('Core System Prompt (prompts.ts)', () => {
   describe('ApprovalMode in System Prompt', () => {
     it('should include PLAN mode instructions', () => {
       vi.mocked(mockConfig.getApprovalMode).mockReturnValue(ApprovalMode.PLAN);
+      vi.mocked(mockConfig.getToolRegistry().getAllToolNames).mockReturnValue([
+        'glob',
+        'read_file',
+        'ask_user',
+        'exit_plan_mode',
+      ]);
       const prompt = getCoreSystemPrompt(mockConfig);
       expect(prompt).toContain('# Active Approval Mode: Plan');
       expect(prompt).toMatchSnapshot();

--- a/packages/core/src/policy/policies/plan.toml
+++ b/packages/core/src/policy/policies/plan.toml
@@ -70,6 +70,12 @@ decision = "allow"
 priority = 50
 modes = ["plan"]
 
+[[rule]]
+toolName = "exit_plan_mode"
+decision = "allow"
+priority = 50
+modes = ["plan"]
+
 # Allow write_file for .md files in plans directory
 [[rule]]
 toolName = "write_file"

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -8,6 +8,7 @@ import {
   ACTIVATE_SKILL_TOOL_NAME,
   ASK_USER_TOOL_NAME,
   EDIT_TOOL_NAME,
+  EXIT_PLAN_MODE_TOOL_NAME,
   GLOB_TOOL_NAME,
   GREP_TOOL_NAME,
   MEMORY_TOOL_NAME,
@@ -329,9 +330,9 @@ ${options.planModeToolsList}
 - After saving the plan, present the full content of the markdown file to the user for review
 
 ### Phase 4: Review & Approval
-- Ask the user if they approve the plan, want revisions, or want to reject it
-- Address feedback and iterate as needed
-- **When the user approves the plan**, prompt them to switch out of Plan Mode to begin implementation by pressing Shift+Tab to cycle to a different approval mode
+- Present the plan and request approval using \`${EXIT_PLAN_MODE_TOOL_NAME}\`
+- If plan is approved, you can begin implementation
+- If plan is rejected, address the feedback and iterate on the plan
 
 ## Constraints
 - You may ONLY use the read-only tools listed above

--- a/packages/core/src/tools/exit-plan-mode.test.ts
+++ b/packages/core/src/tools/exit-plan-mode.test.ts
@@ -1,0 +1,205 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ExitPlanModeTool } from './exit-plan-mode.js';
+import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
+import {
+  MessageBusType,
+  type PlanApprovalRequest,
+} from '../confirmation-bus/types.js';
+import path from 'node:path';
+import type { Config } from '../config/config.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+
+describe('ExitPlanModeTool', () => {
+  let tool: ExitPlanModeTool;
+  let mockMessageBus: ReturnType<typeof createMockMessageBus>;
+  let mockConfig: Partial<Config>;
+
+  const mockTargetDir = path.resolve('/mock/dir');
+  const mockPlansDir = path.resolve('/mock/dir/plans');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetAllMocks();
+    mockMessageBus = createMockMessageBus();
+    vi.mocked(mockMessageBus.publish).mockResolvedValue(undefined);
+    mockConfig = {
+      getTargetDir: vi.fn().mockReturnValue(mockTargetDir),
+      storage: {
+        getProjectTempPlansDir: vi.fn().mockReturnValue(mockPlansDir),
+      } as unknown as Config['storage'],
+    };
+    tool = new ExitPlanModeTool(
+      mockConfig as Config,
+      mockMessageBus as unknown as MessageBus,
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('should publish PLAN_APPROVAL_REQUEST and resolve on approval', async () => {
+    const planPath = 'plans/test-plan.md';
+
+    const invocation = tool.build({ plan_path: planPath });
+    const executionPromise = invocation.execute(new AbortController().signal);
+
+    await vi.runAllTimersAsync();
+
+    expect(mockMessageBus.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageBusType.PLAN_APPROVAL_REQUEST,
+        planPath: path.resolve(mockPlansDir, 'test-plan.md'),
+      }),
+    );
+
+    const requestCall = vi
+      .mocked(mockMessageBus.publish)
+      .mock.calls.find(
+        (call) => call[0].type === MessageBusType.PLAN_APPROVAL_REQUEST,
+      );
+    const correlationId = (requestCall![0] as PlanApprovalRequest)
+      .correlationId;
+
+    const handler = vi
+      .mocked(mockMessageBus.subscribe)
+      .mock.calls.find(
+        (call) => call[0] === MessageBusType.PLAN_APPROVAL_RESPONSE,
+      )?.[1];
+
+    if (!handler) throw new Error('No subscription handler found');
+
+    handler({
+      type: MessageBusType.PLAN_APPROVAL_RESPONSE,
+      correlationId,
+      approved: true,
+    });
+
+    const result = await executionPromise;
+    const expectedPath = path.resolve(mockPlansDir, 'test-plan.md');
+    expect(result).toEqual({
+      llmContent: `Plan approved. Switching to Default mode.
+
+The approved implementation plan is stored at: ${expectedPath}
+Read and follow the plan strictly during implementation.`,
+      returnDisplay: `Plan approved: ${expectedPath}`,
+    });
+  });
+
+  it('should resolve with feedback on rejection', async () => {
+    const planPath = 'plans/test-plan.md';
+
+    const invocation = tool.build({ plan_path: planPath });
+    const executionPromise = invocation.execute(new AbortController().signal);
+
+    await vi.runAllTimersAsync();
+
+    const requestCall = vi
+      .mocked(mockMessageBus.publish)
+      .mock.calls.find(
+        (call) => call[0].type === MessageBusType.PLAN_APPROVAL_REQUEST,
+      );
+    const correlationId = (requestCall![0] as PlanApprovalRequest)
+      .correlationId;
+
+    const handler = vi
+      .mocked(mockMessageBus.subscribe)
+      .mock.calls.find(
+        (call) => call[0] === MessageBusType.PLAN_APPROVAL_RESPONSE,
+      )?.[1];
+
+    if (!handler) throw new Error('No subscription handler found');
+
+    handler({
+      type: MessageBusType.PLAN_APPROVAL_RESPONSE,
+      correlationId,
+      approved: false,
+      feedback: 'Please add more details.',
+    });
+
+    const result = await executionPromise;
+    const expectedPath = path.resolve(mockPlansDir, 'test-plan.md');
+    expect(result).toEqual({
+      llmContent: `Plan rejected. Feedback: Please add more details.
+
+The plan is stored at: ${expectedPath}
+Revise the plan based on the feedback.`,
+      returnDisplay: 'Feedback: Please add more details.',
+    });
+  });
+
+  it('should resolve with cancellation message when aborted', async () => {
+    const planPath = 'plans/test-plan.md';
+
+    const invocation = tool.build({ plan_path: planPath });
+
+    const abortController = new AbortController();
+    const executionPromise = invocation.execute(abortController.signal);
+
+    await vi.runAllTimersAsync();
+
+    abortController.abort();
+
+    const result = await executionPromise;
+    expect(result).toEqual({
+      llmContent:
+        'User cancelled the plan approval dialog. The plan was not approved and you are still in Plan Mode.',
+      returnDisplay: 'Cancelled',
+    });
+  });
+
+  it('should resolve immediately if signal is already aborted', async () => {
+    const planPath = 'plans/test-plan.md';
+
+    const invocation = tool.build({ plan_path: planPath });
+
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const result = await invocation.execute(abortController.signal);
+    expect(result).toEqual({
+      llmContent:
+        'User cancelled the plan approval dialog. The plan was not approved and you are still in Plan Mode.',
+      returnDisplay: 'Cancelled',
+    });
+  });
+
+  it('should throw error during build if plan path is outside plans directory', () => {
+    expect(() => tool.build({ plan_path: '../../../etc/passwd' })).toThrow(
+      /Access denied/,
+    );
+  });
+
+  describe('validateToolParams', () => {
+    it('should reject empty plan_path', () => {
+      const result = tool.validateToolParams({ plan_path: '' });
+      expect(result).toBe('plan_path is required.');
+    });
+
+    it('should reject whitespace-only plan_path', () => {
+      const result = tool.validateToolParams({ plan_path: '   ' });
+      expect(result).toBe('plan_path is required.');
+    });
+
+    it('should reject path outside plans directory', () => {
+      const result = tool.validateToolParams({
+        plan_path: '../../../etc/passwd',
+      });
+      expect(result).toContain('Access denied');
+    });
+
+    it('should accept valid path within plans directory', () => {
+      const result = tool.validateToolParams({
+        plan_path: 'plans/valid-plan.md',
+      });
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -1,0 +1,211 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  type ToolResult,
+  Kind,
+  type ToolCallConfirmationDetails,
+} from './tools.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+import {
+  MessageBusType,
+  type PlanApprovalRequest,
+  type PlanApprovalResponse,
+} from '../confirmation-bus/types.js';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import type { Config } from '../config/config.js';
+import { EXIT_PLAN_MODE_TOOL_NAME } from './tool-names.js';
+import { isWithinRoot } from '../utils/fileUtils.js';
+
+export interface ExitPlanModeParams {
+  plan_path: string;
+}
+
+export class ExitPlanModeTool extends BaseDeclarativeTool<
+  ExitPlanModeParams,
+  ToolResult
+> {
+  constructor(
+    private config: Config,
+    messageBus: MessageBus,
+  ) {
+    super(
+      EXIT_PLAN_MODE_TOOL_NAME,
+      'Exit Plan Mode',
+      'Signals that the planning phase is complete and requests user approval to start implementation.',
+      Kind.Plan,
+      {
+        type: 'object',
+        required: ['plan_path'],
+        properties: {
+          plan_path: {
+            type: 'string',
+            description:
+              'The file path to the finalized plan (e.g., "plans/feature-x.md").',
+          },
+        },
+      },
+      messageBus,
+    );
+  }
+
+  protected override validateToolParamValues(
+    params: ExitPlanModeParams,
+  ): string | null {
+    if (!params.plan_path || params.plan_path.trim() === '') {
+      return 'plan_path is required.';
+    }
+
+    const resolvedPath = path.resolve(
+      this.config.getTargetDir(),
+      params.plan_path,
+    );
+
+    const plansDir = this.config.storage.getProjectTempPlansDir();
+    if (!isWithinRoot(resolvedPath, plansDir)) {
+      return `Access denied: plan path must be within the designated plans directory (${plansDir}).`;
+    }
+
+    return null;
+  }
+
+  protected createInvocation(
+    params: ExitPlanModeParams,
+    messageBus: MessageBus,
+    toolName: string,
+    toolDisplayName: string,
+  ): ExitPlanModeInvocation {
+    return new ExitPlanModeInvocation(
+      params,
+      messageBus,
+      toolName,
+      toolDisplayName,
+      this.config,
+    );
+  }
+}
+
+export class ExitPlanModeInvocation extends BaseToolInvocation<
+  ExitPlanModeParams,
+  ToolResult
+> {
+  constructor(
+    params: ExitPlanModeParams,
+    messageBus: MessageBus,
+    toolName: string,
+    toolDisplayName: string,
+    private config: Config,
+  ) {
+    super(params, messageBus, toolName, toolDisplayName);
+  }
+
+  override async shouldConfirmExecute(
+    _abortSignal: AbortSignal,
+  ): Promise<ToolCallConfirmationDetails | false> {
+    return false;
+  }
+
+  getDescription(): string {
+    return `Requesting plan approval for: ${this.params.plan_path}`;
+  }
+
+  /**
+   * Returns the resolved plan path if valid, or null if outside the plans directory.
+   */
+  private getValidatedPlanPath(): string | null {
+    const plansDir = this.config.storage.getProjectTempPlansDir();
+    const resolvedPath = path.resolve(
+      this.config.getTargetDir(),
+      this.params.plan_path,
+    );
+    return isWithinRoot(resolvedPath, plansDir) ? resolvedPath : null;
+  }
+
+  async execute(signal: AbortSignal): Promise<ToolResult> {
+    const correlationId = randomUUID();
+
+    const resolvedPlanPath = this.getValidatedPlanPath();
+    if (!resolvedPlanPath) {
+      return {
+        llmContent:
+          'Error: Plan path is outside the designated plans directory.',
+        returnDisplay:
+          'Error: Plan path is outside the designated plans directory.',
+      };
+    }
+
+    const request: PlanApprovalRequest = {
+      type: MessageBusType.PLAN_APPROVAL_REQUEST,
+      planPath: resolvedPlanPath,
+      correlationId,
+    };
+
+    return new Promise<ToolResult>((resolve, reject) => {
+      const responseHandler = async (
+        response: PlanApprovalResponse,
+      ): Promise<void> => {
+        if (response.correlationId === correlationId) {
+          cleanup();
+
+          const resolvedPath = this.getValidatedPlanPath();
+          if (response.approved) {
+            resolve({
+              llmContent: `Plan approved. Switching to Default mode.
+
+The approved implementation plan is stored at: ${resolvedPath}
+Read and follow the plan strictly during implementation.`,
+              returnDisplay: `Plan approved: ${resolvedPath}`,
+            });
+          } else {
+            resolve({
+              llmContent: `Plan rejected. Feedback: ${response.feedback || 'None'}
+
+The plan is stored at: ${resolvedPath}
+Revise the plan based on the feedback.`,
+              returnDisplay: `Feedback: ${response.feedback || 'None'}`,
+            });
+          }
+        }
+      };
+
+      const cleanup = () => {
+        this.messageBus.unsubscribe(
+          MessageBusType.PLAN_APPROVAL_RESPONSE,
+          responseHandler,
+        );
+        signal.removeEventListener('abort', abortHandler);
+      };
+
+      const abortHandler = () => {
+        cleanup();
+        resolve({
+          llmContent:
+            'User cancelled the plan approval dialog. The plan was not approved and you are still in Plan Mode.',
+          returnDisplay: 'Cancelled',
+        });
+      };
+
+      if (signal.aborted) {
+        abortHandler();
+        return;
+      }
+
+      signal.addEventListener('abort', abortHandler);
+      this.messageBus.subscribe(
+        MessageBusType.PLAN_APPROVAL_RESPONSE,
+        responseHandler,
+      );
+
+      this.messageBus.publish(request).catch((err) => {
+        cleanup();
+        reject(err);
+      });
+    });
+  }
+}

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -25,6 +25,7 @@ export const ACTIVATE_SKILL_TOOL_NAME = 'activate_skill';
 export const EDIT_TOOL_NAMES = new Set([EDIT_TOOL_NAME, WRITE_FILE_TOOL_NAME]);
 export const ASK_USER_TOOL_NAME = 'ask_user';
 export const ASK_USER_DISPLAY_NAME = 'Ask User';
+export const EXIT_PLAN_MODE_TOOL_NAME = 'exit_plan_mode';
 
 /** Prefix used for tools discovered via the toolDiscoveryCommand. */
 export const DISCOVERED_TOOL_PREFIX = 'discovered_tool_';
@@ -47,6 +48,7 @@ export const ALL_BUILTIN_TOOL_NAMES = [
   MEMORY_TOOL_NAME,
   ACTIVATE_SKILL_TOOL_NAME,
   ASK_USER_TOOL_NAME,
+  EXIT_PLAN_MODE_TOOL_NAME,
 ] as const;
 
 /**
@@ -61,6 +63,7 @@ export const PLAN_MODE_TOOLS = [
   LS_TOOL_NAME,
   WEB_SEARCH_TOOL_NAME,
   ASK_USER_TOOL_NAME,
+  EXIT_PLAN_MODE_TOOL_NAME,
 ] as const;
 
 /**

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -746,6 +746,7 @@ export enum Kind {
   Think = 'think',
   Fetch = 'fetch',
   Communicate = 'communicate',
+  Plan = 'plan',
   Other = 'other',
 }
 


### PR DESCRIPTION
## Summary

This PR introduces a structured plan approval workflow by implementing the `ExitPlanMode` tool and an approval workflow. It enables smooth transitions from `Plan` mode to `Auto-Edit` or `Default` Mode, ensuring that approved plans are persisted and injected into the implementation context.

<img width="3014" height="1548" alt="image" src="https://github.com/user-attachments/assets/5e9e2ec8-f020-4882-a9d5-40b4aca5358a" />


## Details

- **Structured Approval:** Added a concrete tool-based workflow using `ExitPlanMode`.
- **Plan Review UI:** Implemented `AskUser` dialog to support approval workflow with a markdown preview.
- **Automated Mode Switching:** Approval triggers an automated switch to `Default` or `Auto-Edit` mode and stores the plan path in the configuration.
- **Implementation Context:** Injects the paths of approved plans in the chat history, ensuring the agent adheres to the agreed-upon design.
- Future work include https://github.com/google-gemini/gemini-cli/issues/17723, https://github.com/google-gemini/gemini-cli/issues/17721 and other tasks in https://github.com/google-gemini/gemini-cli/issues/16611

### How is this using `AskUser` tool?

This implementation reuses as much of `AskUser` tool as possible, while extending it to support an approval flow with approval that has system-level side effects - programmatically switching approval modes and saving plans.

## Related Issues


## How to Validate

1.  **Prepare Environment**:
    ```bash
    npm install && npm run build
    ```
2.  **Start in Plan Mode**:
    ```bash
    npm start -- --approval-mode=plan
    ```
3.  **Generate a Plan**:
    Provide a request that generates a plan (e.g., `Create a plan to add a hello world command`).
4.  **Verify Approval Workflow**:
    *   Observe the agent calling `ExitPlanMode` with the path to the created plan.
    *   Verify the **Plan Approval Dialog** appears, showing the plan content.
    *   **Test Rejection**: Type feedback (e.g., "Add a test file") and press Enter. Verify the agent receives the feedback and iterates.
5.  **Verify Auto-Edit Approval Mode Switch & Context**:
    *   **Test Auto Approval**: Select `"Yes, automatically accept edits"` to approve.
    *   Ensure the UI switches to **Auto-Edit** mode.
    *   Verify the agent acknowledges the mode switch and proceeds to implementation.
6.  **Verify Default Mode Switch & Context**:
    *   Repeat steps 2 and 3 above.
    *   **Test Auto Approval**: Select `"Yes, manually accept edits"` to approve.
    *   Ensure the UI switches to **Default** mode.
    *   Verify the agent acknowledges the mode switch and proceeds to implementation.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker