### PR TITLE
refactor(core): export executeToolCall helper

### DIFF
--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -510,3 +510,21 @@ export class Scheduler {
     }
   }
 }
+
+/**
+ * A convenience function to execute a single tool call using the Scheduler.
+ */
+export async function executeToolCall(
+  config: Config,
+  request: ToolCallRequestInfo,
+  signal: AbortSignal,
+): Promise<CompletedToolCall> {
+  const scheduler = new Scheduler({
+    config,
+    messageBus: config.getMessageBus(),
+    getPreferredEditor: () => undefined,
+    schedulerId: 'root-non-interactive',
+  });
+  const results = await scheduler.schedule(request, signal);
+  return results[0];
+}


### PR DESCRIPTION
Programmatic tool calling #17323
Add programmatic tool calling to Gemini CLI, allowing the model to execute code that calls tools directly (e.g., in loops or conditionals) instead of requiring a model round-trip for each tool invocation.

Summary
This PR exports a new helper function 

executeToolCall
 from the 

Scheduler
 class. This enables "Programmatic Tool Calling," allowing models or other system components to execute tools directly within a code execution sandbox without needing to trigger a full model round-trip.

Details
Changes: Exports 

executeToolCall
 in 

packages/core/src/scheduler/scheduler.ts
.
Motivation: Reduces latency and token usage for complex multi-step workflows. It allows for more efficient data processing (loops, conditionals, filtering) before returning results to the context.
Design: The helper abstracts the instantiation of a 

Scheduler
 with a root-non-interactive ID, strictly for executing the single requested tool.
Related Issues
Related to #17323

How to Validate
Unit Test: Create a simple test file importing the helper.
import { executeToolCall } from '@google/gemini-cli-core/scheduler/scheduler';
// ... setup mock config ...
// await executeToolCall(config, toolRequest, signal);
Verify Export: Check that 

executeToolCall
 is available in 

packages/core/src/scheduler/scheduler.ts
.
Pre-Merge Checklist
 Updated relevant documentation and README (if needed)
 Added/updated tests (Verified functionality via manual test)
 Noted breaking changes (None)
 Validated on required platforms/methods:
 Windows (npm run)