### PR TITLE
fix(evals): use absolute path for activity log directory

### DIFF
--- a/evals/test-helper.ts
+++ b/evals/test-helper.ts
@@ -104,7 +104,7 @@ export function evalTest(policy: EvalPolicy, evalCase: EvalCase) {
 }
 
 async function prepareLogDir(name: string) {
-  const logDir = 'evals/logs';
+  const logDir = path.resolve(process.cwd(), 'evals/logs');
   await fs.promises.mkdir(logDir, { recursive: true });
   const sanitizedName = name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
   return { logDir, sanitizedName };


### PR DESCRIPTION
## TLDR

Fixes an issue where activity logs (`.jsonl` files) for failed evaluations were not being captured in CI artifacts because they were written to a temporary test directory that was cleaned up before the upload step.

## Dive Deeper

The `evalTest` helper in `evals/test-helper.ts` enables the `ActivityLogger` by setting the `GEMINI_CLI_ACTIVITY_LOG_FILE` environment variable. Previously, it used a relative path (`evals/logs`). 

When `TestRig.run` executes the agent, it spawns a process in a temporary test directory. Because the path was relative, the agent process interpreted `evals/logs` as being relative to its current working directory (the temporary one). 

Since `rig.cleanup()` deletes this temporary directory at the end of each test, the logs were lost. By using `path.resolve(process.cwd(), 'evals/logs')`, we ensure the log path is absolute and always points to the project root's log directory, regardless of where the agent is actually running.

## Reviewer Test Plan

1. Run an evaluation locally with a deliberately failing assertion or an invalid API key (e.g., `GEMINI_API_KEY=dummy npm run test:always_passing_evals`).
2. Verify that the `.jsonl` file corresponding to the failing test appears in the `evals/logs/` directory in the project root.
3. Verify that the file is *not* in the system's temporary directory.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to #17703