### PR TITLE
fix(core): handle EISDIR error when GEMINI.md is a directory

### DIFF
--- a/packages/core/src/utils/memoryDiscovery.test.ts
+++ b/packages/core/src/utils/memoryDiscovery.test.ts
@@ -165,6 +165,29 @@ describe('memoryDiscovery', () => {
     });
   });
 
+  it('should skip GEMINI.md directories without warnings', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('VITEST', '');
+    const warnSpy = vi.spyOn(debugLogger, 'warn').mockImplementation(() => {});
+
+    await createEmptyDir(path.join(projectRoot, DEFAULT_CONTEXT_FILENAME));
+
+    const result = await loadServerHierarchicalMemory(
+      cwd,
+      [],
+      false,
+      new FileDiscoveryService(projectRoot),
+      new SimpleExtensionLoader([]),
+      DEFAULT_FOLDER_TRUST,
+    );
+
+    expect(result.memoryContent).toBe('');
+    expect(result.filePaths).toContain(
+      path.join(projectRoot, DEFAULT_CONTEXT_FILENAME),
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
   it('should load only the global context file if present and others are not (default filename)', async () => {
     const defaultContextFile = await createTestFile(
       path.join(homedir, GEMINI_DIR, DEFAULT_CONTEXT_FILENAME),

--- a/packages/core/src/utils/memoryDiscovery.ts
+++ b/packages/core/src/utils/memoryDiscovery.ts
@@ -270,6 +270,16 @@ async function readGeminiMdFiles(
 
           return { filePath, content: processedResult.content };
         } catch (error: unknown) {
+          const errorCode =
+            typeof error === 'object' && error !== null && 'code' in error
+              ? (error as NodeJS.ErrnoException).code
+              : undefined;
+          if (errorCode === 'EISDIR') {
+            if (debugMode) {
+              logger.debug(`Skipping directory at ${filePath}`);
+            }
+            return { filePath, content: null };
+          }
           const isTestEnv =
             process.env['NODE_ENV'] === 'test' || process.env['VITEST'];
           if (!isTestEnv) {


### PR DESCRIPTION
## Summary
Skip directories named GEMINI.md during memory discovery instead of logging misleading warnings, preventing EISDIR errors.

## Details
- Add EISDIR error code check in `readGeminiMdFiles()` catch block
- Skip directories silently. only log in debug mode.
- Add test case for GEMINI.md as directory secnario.

## Related Issues
Fixes #16282

## How to Validate
1. Create a directory named `GEMINI.md` in a project root.
2. Run `npm start`
3. Type `/about` or any command that triggers memory discovery.
4. Verify no ESIDIR error or warning is logged

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

