### PR TITLE
fix(core): prioritize detailed error messages for code assist setup

### DIFF
--- a/packages/cli/src/ui/utils/clipboardUtils.test.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.test.ts
@@ -305,6 +305,9 @@ describe('clipboardUtils', () => {
     });
 
     it('should return null if tool is not yet detected', async () => {
+      // Unset session type to ensure no tool is detected automatically
+      delete process.env['XDG_SESSION_TYPE'];
+
       // Don't prime the tool
       const result = await clipboardUtils.saveClipboardImage(mockTargetDir);
       expect(result).toBe(null);

--- a/packages/core/src/code_assist/setup.test.ts
+++ b/packages/core/src/code_assist/setup.test.ts
@@ -312,6 +312,32 @@ describe('setupUser for new user', () => {
       userTierName: 'paid',
     });
   });
+
+  it('should throw ineligible tier error when onboarding fails and ineligible tiers exist', async () => {
+    vi.stubEnv('GOOGLE_CLOUD_PROJECT', '');
+    mockLoad.mockResolvedValue({
+      allowedTiers: [mockPaidTier],
+      ineligibleTiers: [
+        {
+          reasonCode: 'UNSUPPORTED_LOCATION',
+          reasonMessage:
+            'Your current account is not eligible for Gemini Code Assist for individuals because it is not currently available in your location.',
+          tierId: 'free-tier',
+          tierName: 'Gemini Code Assist for individuals',
+        },
+      ],
+    });
+    mockOnboardUser.mockResolvedValue({
+      done: true,
+      response: {
+        cloudaicompanionProject: {},
+      },
+    });
+
+    await expect(setupUser({} as OAuth2Client)).rejects.toThrow(
+      'Your current account is not eligible for Gemini Code Assist for individuals because it is not currently available in your location.',
+    );
+  });
 });
 
 describe('setupUser validation', () => {

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -7,6 +7,7 @@
 import type {
   ClientMetadata,
   GeminiUserTier,
+  IneligibleTier,
   LoadCodeAssistResponse,
   OnboardUserRequest,
 } from './types.js';
@@ -32,6 +33,16 @@ export class ProjectIdRequiredError extends Error {
 export class ValidationCancelledError extends Error {
   constructor() {
     super('User cancelled account validation');
+  }
+}
+
+export class IneligibleTierError extends Error {
+  readonly ineligibleTiers: IneligibleTier[];
+
+  constructor(ineligibleTiers: IneligibleTier[]) {
+    const reasons = ineligibleTiers.map((t) => t.reasonMessage).join(', ');
+    super(reasons);
+    this.ineligibleTiers = ineligibleTiers;
   }
 }
 
@@ -187,8 +198,7 @@ export async function setupUser(
 
 function throwIneligibleOrProjectIdError(res: LoadCodeAssistResponse): never {
   if (res.ineligibleTiers && res.ineligibleTiers.length > 0) {
-    const reasons = res.ineligibleTiers.map((t) => t.reasonMessage).join(', ');
-    throw new Error(reasons);
+    throw new IneligibleTierError(res.ineligibleTiers);
   }
   throw new ProjectIdRequiredError();
 }

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -127,13 +127,7 @@ export async function setupUser(
       }
 
       // If user is not setup for standard tier, inform them about all other tiers they are ineligible for.
-      if (loadRes.ineligibleTiers && loadRes.ineligibleTiers.length > 0) {
-        const reasons = loadRes.ineligibleTiers
-          .map((t) => t.reasonMessage)
-          .join(', ');
-        throw new Error(reasons);
-      }
-      throw new ProjectIdRequiredError();
+      throwIneligibleOrProjectIdError(loadRes);
     }
     return {
       projectId: loadRes.cloudaicompanionProject,
@@ -180,7 +174,8 @@ export async function setupUser(
         userTierName: tier.name,
       };
     }
-    throw new ProjectIdRequiredError();
+
+    throwIneligibleOrProjectIdError(loadRes);
   }
 
   return {
@@ -188,6 +183,14 @@ export async function setupUser(
     userTier: tier.id,
     userTierName: tier.name,
   };
+}
+
+function throwIneligibleOrProjectIdError(res: LoadCodeAssistResponse): never {
+  if (res.ineligibleTiers && res.ineligibleTiers.length > 0) {
+    const reasons = res.ineligibleTiers.map((t) => t.reasonMessage).join(', ');
+    throw new Error(reasons);
+  }
+  throw new ProjectIdRequiredError();
 }
 
 function getOnboardTier(res: LoadCodeAssistResponse): GeminiUserTier {


### PR DESCRIPTION
## Summary

This PR fixes a bug where specific error messages (like "Unsupported Location") during Code Assist setup were being masked by a generic "ProjectIdRequiredError". It also refactors the error handling logic to be more modular and reusable.

## Details

- Modified `setupUser` in `packages/core/src/code_assist/setup.ts` to check for `ineligibleTiers` in the response before defaulting to `ProjectIdRequiredError`.
- Extracted the error checking logic into a helper function `throwIneligibleOrProjectIdError` to reduce code duplication (DRY) and improve readability.
- Added a unit test in `packages/core/src/code_assist/setup.test.ts` to verify that the correct error is thrown when `ineligibleTiers` is present.
- Fixed a flaky test in `packages/cli/src/ui/utils/clipboardUtils.test.ts` that was failing in some environments due to implicit dependency on `XDG_SESSION_TYPE`.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes #8435
## How to Validate

1. Run `npm test -w packages/core -- src/code_assist/setup.test.ts` to verify the new test case passes.
2. (Manual) Use a test account from http://rhea/ created for an unsupported location, running the setup should now report the location error instead of the project ID error.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
