### PR TITLE
fix:  up/down arrow to move in multiline prompt before history

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -796,12 +796,17 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           inputHistory.navigateDown();
           return true;
         }
-        // Handle arrow-up/down for history on single-line or at edges
-        if (
-          keyMatchers[Command.NAVIGATION_UP](key) &&
-          (buffer.allVisualLines.length === 1 ||
-            (buffer.visualCursor[0] === 0 && buffer.visualScrollRow === 0))
-        ) {
+        const isOnFirstLine =
+          buffer.allVisualLines.length === 1 ||
+          (buffer.lines.length > 1
+            ? buffer.cursor[0] === 0
+            : buffer.visualCursor[0] === 0);
+        const isOnLastLine =
+          buffer.allVisualLines.length === 1 ||
+          (buffer.lines.length > 1
+            ? buffer.cursor[0] === buffer.lines.length - 1
+            : buffer.visualCursor[0] === buffer.allVisualLines.length - 1);
+        if (keyMatchers[Command.NAVIGATION_UP](key) && isOnFirstLine) {
           // Check for queued messages first when input is empty
           // If no queued messages, inputHistory.navigateUp() is called inside tryLoadQueuedMessages
           if (tryLoadQueuedMessages()) {
@@ -811,11 +816,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           inputHistory.navigateUp();
           return true;
         }
-        if (
-          keyMatchers[Command.NAVIGATION_DOWN](key) &&
-          (buffer.allVisualLines.length === 1 ||
-            buffer.visualCursor[0] === buffer.allVisualLines.length - 1)
-        ) {
+        if (keyMatchers[Command.NAVIGATION_DOWN](key) && isOnLastLine) {
           inputHistory.navigateDown();
           return true;
         }

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -796,27 +796,18 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           inputHistory.navigateDown();
           return true;
         }
-        const isOnFirstLine =
-          buffer.allVisualLines.length === 1 ||
-          (buffer.lines.length > 1
-            ? buffer.cursor[0] === 0
-            : buffer.visualCursor[0] === 0);
-        const isOnLastLine =
-          buffer.allVisualLines.length === 1 ||
-          (buffer.lines.length > 1
-            ? buffer.cursor[0] === buffer.lines.length - 1
-            : buffer.visualCursor[0] === buffer.allVisualLines.length - 1);
-        if (keyMatchers[Command.NAVIGATION_UP](key) && isOnFirstLine) {
-          // Check for queued messages first when input is empty
-          // If no queued messages, inputHistory.navigateUp() is called inside tryLoadQueuedMessages
+        // In multiline prompts, Up/Down only move the cursor; never trigger history.
+        // This avoids history when the user holds the key or presses one time too many.
+        // Single-line: Up/Down still go to history. Use Ctrl+P / Ctrl+N for history in multiline.
+        const isMultiline = buffer.lines.length > 1;
+        if (!isMultiline && keyMatchers[Command.NAVIGATION_UP](key)) {
           if (tryLoadQueuedMessages()) {
             return true;
           }
-          // Only navigate history if popAllMessages doesn't exist
           inputHistory.navigateUp();
           return true;
         }
-        if (keyMatchers[Command.NAVIGATION_DOWN](key) && isOnLastLine) {
+        if (!isMultiline && keyMatchers[Command.NAVIGATION_DOWN](key)) {
           inputHistory.navigateDown();
           return true;
         }


### PR DESCRIPTION
fix: #17851

- Summary

Up/Down in multiline prompts move the cursor first; history only when cursor is on the first or last line.

- Details
Multiline: first/last line = logical line (cursor[0], lines.length).
Single line that wraps: still use visual cursor for first/last line.
No other behavior changed.

- Related Issues

Fixes up-arrow jumping to history while editing multiline prompts.

- How to Validate
Multiline prompt, cursor on line 2+ → Up moves cursor up (no history).
Cursor on first line → Up goes to previous history.
Cursor on last line → Down moves down; Down again goes to next history.
Single-line prompt → Up/Down still go to history as before.