### PR TITLE
refactor(hooks): remove legacy tools.enableHooks setting

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -733,12 +733,6 @@ their corresponding top-level category object in your `settings.json` file.
   - **Default:** `true`
   - **Requires restart:** Yes
 
-- **`tools.enableHooks`** (boolean):
-  - **Description:** Enables the hooks system experiment. When disabled, the
-    hooks system is completely deactivated regardless of other settings.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
 #### `mcp`
 
 - **`mcp.serverCommand`** (string):

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -596,9 +596,9 @@ describe('parseArguments', () => {
 
   it('should set isCommand to true for hooks command', async () => {
     process.argv = ['node', 'script.js', 'hooks', 'migrate'];
-    // Hooks command enabled via tools settings
+    // Hooks command enabled via hooksConfig settings
     const settings = createTestMergedSettings({
-      tools: { enableHooks: true },
+      hooksConfig: { enabled: true },
     });
     const argv = await parseArguments(settings);
     expect(argv.isCommand).toBe(true);

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -308,7 +308,7 @@ export async function parseArguments(
     yargsInstance.command(skillsCommand);
   }
   // Register hooks command if hooks are enabled
-  if (settings.tools?.enableHooks) {
+  if (settings.hooksConfig?.enabled ?? true) {
     yargsInstance.command(hooksCommand);
   }
 
@@ -790,10 +790,8 @@ export async function loadCliConfig(
     acceptRawOutputRisk: argv.acceptRawOutputRisk,
     modelConfigServiceConfig: settings.modelConfigs,
     // TODO: loading of hooks based on workspace trust
-    enableHooks:
-      (settings.tools?.enableHooks ?? true) &&
-      (settings.hooksConfig?.enabled ?? true),
-    enableHooksUI: settings.tools?.enableHooks ?? true,
+    enableHooks: settings.hooksConfig?.enabled ?? true,
+    enableHooksUI: settings.hooksConfig?.enabled ?? true,
     hooks: settings.hooks || {},
     disabledHooks: settings.hooksConfig?.disabled || [],
     projectHooks: projectHooks || {},

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -308,7 +308,7 @@ export async function parseArguments(
     yargsInstance.command(skillsCommand);
   }
   // Register hooks command if hooks are enabled
-  if (settings.hooksConfig?.enabled ?? true) {
+  if (settings.hooksConfig.enabled) {
     yargsInstance.command(hooksCommand);
   }
 
@@ -790,8 +790,8 @@ export async function loadCliConfig(
     acceptRawOutputRisk: argv.acceptRawOutputRisk,
     modelConfigServiceConfig: settings.modelConfigs,
     // TODO: loading of hooks based on workspace trust
-    enableHooks: settings.hooksConfig?.enabled ?? true,
-    enableHooksUI: settings.hooksConfig?.enabled ?? true,
+    enableHooks: settings.hooksConfig.enabled,
+    enableHooksUI: settings.hooksConfig.enabled,
     hooks: settings.hooks || {},
     disabledHooks: settings.hooksConfig?.disabled || [],
     projectHooks: projectHooks || {},

--- a/packages/cli/src/config/extension-manager-hydration.test.ts
+++ b/packages/cli/src/config/extension-manager-hydration.test.ts
@@ -227,7 +227,6 @@ System using model: \${MODEL_NAME}
       settings: createTestMergedSettings({
         telemetry: { enabled: false },
         experimental: { extensionConfig: true },
-        tools: { enableHooks: true },
         hooksConfig: { enabled: true },
       }),
       requestConsent: vi.fn().mockResolvedValue(true),

--- a/packages/cli/src/config/extension-manager-themes.spec.ts
+++ b/packages/cli/src/config/extension-manager-themes.spec.ts
@@ -51,7 +51,6 @@ describe('ExtensionManager theme loading', () => {
         experimental: { extensionConfig: true },
         security: { blockGitExtensions: false },
         admin: { extensions: { enabled: true }, mcp: { enabled: true } },
-        tools: { enableHooks: true },
       }),
       requestConsent: async () => true,
       requestSetting: async () => '',

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -639,10 +639,7 @@ Would you like to attempt to install via "git clone" instead?`,
       };
 
       let hooks: { [K in HookEventName]?: HookDefinition[] } | undefined;
-      if (
-        this.settings.tools.enableHooks &&
-        this.settings.hooksConfig.enabled
-      ) {
+      if (this.settings.hooksConfig.enabled) {
         hooks = await this.loadExtensionHooks(
           effectiveExtensionPath,
           hydrationContext,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1179,16 +1179,6 @@ const SETTINGS_SCHEMA = {
         `,
         showInDialog: true,
       },
-      enableHooks: {
-        type: 'boolean',
-        label: 'Enable Hooks System (Experimental)',
-        category: 'Advanced',
-        requiresRestart: true,
-        default: true,
-        description:
-          'Enables the hooks system experiment. When disabled, the hooks system is completely deactivated regardless of other settings.',
-        showInDialog: false,
-      },
     },
   },
 

--- a/packages/cli/src/ui/commands/hooksCommand.test.ts
+++ b/packages/cli/src/ui/commands/hooksCommand.test.ts
@@ -30,9 +30,6 @@ describe('hooksCommand', () => {
       hooksConfig?: {
         disabled?: string[];
       };
-      tools?: {
-        enableHooks?: boolean;
-      };
     };
     setValue: ReturnType<typeof vi.fn>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -187,8 +184,8 @@ describe('hooksCommand', () => {
     it('should display panel when no hooks are configured', async () => {
       mockHookSystem.getAllHooks.mockReturnValue([]);
       (mockContext.services.settings.merged as Record<string, unknown>)[
-        'tools'
-      ] = { enableHooks: true };
+        'hooksConfig'
+      ] = { enabled: true };
 
       const panelCmd = hooksCommand.subCommands!.find(
         (cmd) => cmd.name === 'panel',
@@ -215,8 +212,8 @@ describe('hooksCommand', () => {
 
       mockHookSystem.getAllHooks.mockReturnValue(mockHooks);
       (mockContext.services.settings.merged as Record<string, unknown>)[
-        'tools'
-      ] = { enableHooks: true };
+        'hooksConfig'
+      ] = { enabled: true };
 
       const panelCmd = hooksCommand.subCommands!.find(
         (cmd) => cmd.name === 'panel',

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1200,13 +1200,6 @@
           "markdownDescription": "Disable LLM-based error correction for edit tools. When enabled, tools will fail immediately if exact string matches are not found, instead of attempting to self-correct.\n\n- Category: `Tools`\n- Requires restart: `yes`\n- Default: `true`",
           "default": true,
           "type": "boolean"
-        },
-        "enableHooks": {
-          "title": "Enable Hooks System (Experimental)",
-          "description": "Enables the hooks system experiment. When disabled, the hooks system is completely deactivated regardless of other settings.",
-          "markdownDescription": "Enables the hooks system experiment. When disabled, the hooks system is completely deactivated regardless of other settings.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

Removed the legacy `tools.enableHooks` setting. This setting is no longer the canonical way to work with hooks and has been replaced by `hooksConfig.enabled`.

## Details

- Removed `enableHooks` from `SETTINGS_SCHEMA` in `packages/cli/src/config/settingsSchema.ts`.
- Updated `loadCliConfig` and `parseArguments` in `packages/cli/src/config/config.ts` to rely solely on `hooksConfig.enabled` for hook system activation and command registration.
- Updated `ExtensionManager` in `packages/cli/src/config/extension-manager.ts` to use `hooksConfig.enabled`.
- Cleaned up related tests in `packages/cli` that were using the legacy setting.
- Regenerated `schemas/settings.schema.json` and `docs/get-started/configuration.md`.

## Related Issues

Related to #17810

## How to Validate

1. Run `npm run typecheck` to ensure no regressions.
2. Run `npm run test -w @google/gemini-cli` to verify all tests pass.
3. Verify that `tools.enableHooks` no longer appears in the settings.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
