### PR TITLE
Disable mouse tracking e2e

### DIFF
--- a/integration-tests/globalSetup.ts
+++ b/integration-tests/globalSetup.ts
@@ -73,7 +73,9 @@ export async function setup() {
 
 export async function teardown() {
   // Disable mouse tracking
-  process.stdout.write('\x1b[?1000l\x1b[?1003l\x1b[?1015l\x1b[?1006l\x1b[?1002l');
+  process.stdout.write(
+    '\x1b[?1000l\x1b[?1003l\x1b[?1015l\x1b[?1006l\x1b[?1002l',
+  );
 
   // Cleanup the test run directory unless KEEP_OUTPUT is set
   if (process.env['KEEP_OUTPUT'] !== 'true' && runDir) {

--- a/integration-tests/globalSetup.ts
+++ b/integration-tests/globalSetup.ts
@@ -72,6 +72,12 @@ export async function setup() {
 }
 
 export async function teardown() {
+  // Disable mouse tracking
+  process.stdout.write('\x1b[?1000l');
+  process.stdout.write('\x1b[?1003l');
+  process.stdout.write('\x1b[?1015l');
+  process.stdout.write('\x1b[?1006l');
+
   // Cleanup the test run directory unless KEEP_OUTPUT is set
   if (process.env['KEEP_OUTPUT'] !== 'true' && runDir) {
     try {

--- a/integration-tests/globalSetup.ts
+++ b/integration-tests/globalSetup.ts
@@ -73,10 +73,7 @@ export async function setup() {
 
 export async function teardown() {
   // Disable mouse tracking
-  process.stdout.write('\x1b[?1000l');
-  process.stdout.write('\x1b[?1003l');
-  process.stdout.write('\x1b[?1015l');
-  process.stdout.write('\x1b[?1006l');
+  process.stdout.write('\x1b[?1000l\x1b[?1003l\x1b[?1015l\x1b[?1006l\x1b[?1002l');
 
   // Cleanup the test run directory unless KEEP_OUTPUT is set
   if (process.env['KEEP_OUTPUT'] !== 'true' && runDir) {

--- a/integration-tests/globalSetup.ts
+++ b/integration-tests/globalSetup.ts
@@ -73,9 +73,11 @@ export async function setup() {
 
 export async function teardown() {
   // Disable mouse tracking
-  process.stdout.write(
-    '\x1b[?1000l\x1b[?1003l\x1b[?1015l\x1b[?1006l\x1b[?1002l',
-  );
+  if (process.stdout.isTTY) {
+    process.stdout.write(
+      '\x1b[?1000l\x1b[?1003l\x1b[?1015l\x1b[?1006l\x1b[?1002l',
+    );
+  }
 
   // Cleanup the test run directory unless KEEP_OUTPUT is set
   if (process.env['KEEP_OUTPUT'] !== 'true' && runDir) {


### PR DESCRIPTION
## Summary

Disable mouse tracking in the end of the integration tests run.

## Details

In the end of the local `npm run test:e2e` run mouse tracking stays active (even if we try to `ctr+c`). it makes the terminal essentially unusable.

Adding disabling of mouse tracking in the end helps to keep the terminal usable.

The added lines explicitly write ANSI escape sequences to stdout to disable various mouse tracking protocols, ensuring your terminal returns to normal behavior.

## Related Issues

no issue is linked, minor improvement

## How to Validate

1. Run the `npm run test:e2e` before the change. `Ctrl+c.` Try to scroll the terminal or click the terminal or print something. Observe weird symbols.
1. Run the `npm run test:e2e` after the change. `Ctrl+c`. Try to scroll the terminal or click the terminal or print something. Enjoy the experience.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [X] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
