### PR TITLE
fix(cli): use correct setting key for Cloud Shell auth

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -367,7 +367,7 @@ export async function main() {
     ) {
       settings.setValue(
         SettingScope.User,
-        'selectedAuthType',
+        'security.auth.selectedType',
         AuthType.COMPUTE_ADC,
       );
     }


### PR DESCRIPTION
## Summary
Restores automatic authentication in Cloud Shell by using the correct setting key `security.auth.selectedType` instead of the incorrect `selectedAuthType`.

## Details
This PR corrects the key path to `security.auth.selectedType` and ensures that `AuthType.COMPUTE_ADC` is correctly set.

## Related Issues
relates to https://github.com/google-gemini/gemini-cli/issues/17878
## How to Validate
1.  Set `CLOUD_SHELL=true` environment variable.
2.  Run the CLI: `npm start`
3.  Verify that it attempts to authenticate using metadata server credentials (or fails gracefully if not actually in Cloud Shell but past the config check) without prompting for an auth method.
    -   *Note: In a local environment without metadata server, it will fail to get the token, but it should NOT say "Invalid auth method selected".*
4.  Run the reproduction test (added and verified during dev): `npm test -w packages/cli -- src/repro_issue_cloud_shell_auth.test.ts` (Note: The test file was removed before commit as per standard cleanup, but the logic was verified).

## Pre-Merge Checklist
- [x] Updated relevant documentation and README (if needed) - N/A
- [x] Added/updated tests (if needed) - Validated via reproduction test during dev.
- [x] Noted breaking changes (if any) - None.
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
