### PR TITLE
Revert timeout to 120 seconds.

### DIFF
--- a/packages/test-utils/src/test-rig.ts
+++ b/packages/test-utils/src/test-rig.ts
@@ -469,7 +469,7 @@ export class TestRig {
       }
     });
 
-    const timeout = options.timeout ?? 300000;
+    const timeout = options.timeout ?? 120000;
     const promise = new Promise<string>((resolve, reject) => {
       const timer = setTimeout(() => {
         child.kill('SIGKILL');
@@ -643,7 +643,7 @@ export class TestRig {
       }
     });
 
-    const timeout = options.timeout ?? 300000;
+    const timeout = options.timeout ?? 120000;
     const promise = new Promise<string>((resolve, reject) => {
       const timer = setTimeout(() => {
         child.kill('SIGKILL');


### PR DESCRIPTION
## Summary
Reduce test timeout back to 120 seconds. I has previously increased this during stabilization of one of the eval tests before realizing that it isn't necessary.

The key thing a low timeout gets us is a faster dev loop when debugging test failures since many failures manifest as timeouts at interactive prompts.