### PR TITLE
feat(cli): add terminal bell notification when input is required

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -431,6 +431,16 @@ const SETTINGS_SCHEMA = {
           'Hide the context summary (GEMINI.md, MCP servers) above the input.',
         showInDialog: true,
       },
+      terminalBell: {
+        type: 'boolean',
+        label: 'Terminal Bell',
+        category: 'UI',
+        requiresRestart: false,
+        default: false,
+        description:
+          'Play a terminal bell sound when user input is required (e.g., tool confirmations).',
+        showInDialog: true,
+      },
       footer: {
         type: 'object',
         label: 'Footer',


### PR DESCRIPTION
## Summary

Fixes #16767

Adds a new `ui.terminalBell` setting that plays a terminal bell sound (ASCII BEL character `\x07`) when user input is required, such as during tool confirmations.

### Changes

- **New setting `ui.terminalBell`**: Boolean setting (default: `false`) in `settingsSchema.ts` that enables terminal bell notifications
- **Bell trigger logic**: In `AppContainer.tsx`, the bell sounds when transitioning from "not needing input" to "needing input" state (confirmation requests or `WaitingForConfirmation` streaming state)
- **Smart state tracking**: Uses a ref to track the previous state, ensuring the bell only sounds once per transition, not continuously while waiting

### Why is this useful?

This provides a simple, cross-platform way to notify users when Gemini CLI needs their attention. It's especially helpful for:
- Long-running operations where users may switch to other tasks
- Background terminals where visual cues might be missed
- Accessibility scenarios where audio feedback is preferred

### How it works

```typescript
// When terminalBell is enabled, the bell sounds on state transition
if (settings.merged.ui.terminalBell) {
  const needsInput = isConfirming || streamingState === StreamingState.WaitingForConfirmation;
  if (needsInput && !wasNeedingInputRef.current) {
    stdout.write('\x07');  // ASCII BEL character
  }
  wasNeedingInputRef.current = needsInput;
}
```

## Test plan

- [x] Added 3 new unit tests in `AppContainer.test.tsx`:
  - Bell does not play when `terminalBell` is disabled (default)
  - Bell plays when `terminalBell` is enabled and confirmation is needed
  - Bell does not play when idle, even if `terminalBell` is enabled
- [x] All 77 tests in `AppContainer.test.tsx` pass
- [x] All 14 tests in `windowTitle.test.ts` pass
- [x] TypeScript compilation: 0 errors
- [x] ESLint: 0 warnings