### PR TITLE
fix(pty): handle EBADF errors in PTY resize operations

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1204,12 +1204,11 @@ Logging in with Google... Restarting Gemini CLI to continue.
       } catch (e) {
         // This can happen in a race condition where the pty exits
         // right before we try to resize it.
-        if (
-          !(
-            e instanceof Error &&
-            e.message.includes('Cannot resize a pty that has already exited')
-          )
-        ) {
+        const err = e as { code?: string };
+        const isWindowsPtyError = err instanceof Error && err.message.includes('Cannot resize a pty that has already exited');
+        const isUnixPtyError = err instanceof Error && (err.code === 'ESRCH' || err.code === 'EBADF');
+        
+        if (!isWindowsPtyError && !isUnixPtyError) {
           throw e;
         }
       }

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -822,12 +822,13 @@ export class ShellExecutionService {
         // due to a race condition between the exit event and this call.
         const err = e as { code?: string; message?: string };
         const isEsrch = err.code === 'ESRCH';
+        const isEbadf = err.code === 'EBADF';
         const isWindowsPtyError = err.message?.includes(
           'Cannot resize a pty that has already exited',
         );
 
-        if (isEsrch || isWindowsPtyError) {
-          // On Unix, we get an ESRCH error.
+        if (isEsrch || isEbadf || isWindowsPtyError) {
+          // On Unix, we get an ESRCH or EBADF error.
           // On Windows, we get a message-based error.
           // In both cases, it's safe to ignore.
         } else {


### PR DESCRIPTION
## Summary

Fixes EBADF crashes that occur during PTY resize operations in React component lifecycle. 
The issue is a race condition between PTY exit and resize calls that happens more frequently with bun's execution model.

Resolves #17729, #10617, #10523, #3258

## Details

Two locations had incomplete error handling:
- `shellExecutionService.ts`: Only caught ESRCH and Windows PTY errors
- `AppContainer.tsx`: Only caught Windows PTY error messages

Both missing EBADF (Bad File Descriptor) error handling.

## Related Issues

Resolves #17729, #10617, #10523, #3258

## How to Validate

1. Run gemini-cli with bun v1.3.7 
2. Trigger PTY resize operations (approve questions, execute commands)
3. Verify no EBADF crashes occur
4. Test with existing ESRCH/Windows error handling still works

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS (tested with bun v1.3.7)
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
