### PR TITLE
fix(cli): prevent spam loop when preferredEditor is invalid

### DIFF
--- a/packages/cli/src/ui/components/EditorSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/EditorSettingsDialog.tsx
@@ -5,7 +5,7 @@
  */
 
 import type React from 'react';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../semantic-colors.js';
 import {
@@ -66,19 +66,22 @@ export function EditorSettingsDialog({
 
   const currentPreference =
     settings.forScope(selectedScope).settings.general?.preferredEditor;
-  let editorIndex = currentPreference
-    ? editorItems.findIndex(
-        (item: EditorDisplay) => item.type === currentPreference,
-      )
-    : 0;
+
+  // Derive editorIndex and isInvalidEditor using useMemo to avoid mutation during render
+  const [editorIndex, isInvalidEditor] = useMemo(() => {
+    const idx = currentPreference
+      ? editorItems.findIndex(
+          (item: EditorDisplay) => item.type === currentPreference,
+        )
+      : 0;
+    const isInvalid = idx === -1;
+    // Default to 0 for invalid editors
+    const finalIndex = isInvalid ? 0 : idx;
+    return [finalIndex, isInvalid];
+  }, [currentPreference, editorItems]);
 
   // Track which invalid editors we've already warned about to prevent spam
   const warnedEditorsRef = useRef<Set<string>>(new Set());
-
-  const isInvalidEditor = editorIndex === -1;
-  if (isInvalidEditor) {
-    editorIndex = 0;
-  }
 
   // Emit error only once per invalid editor preference
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes #16091

Prevents an infinite message spam of "Editor is not supported: ${currentPreference}" when the user enters the `/editor` menu with an invalid `preferredEditor` value in their settings.

### The Problem

The error message was being emitted directly in the component body:

```typescript
if (editorIndex === -1) {
  coreEvents.emitFeedback('error', `Editor is not supported: ${currentPreference}`);
  editorIndex = 0;
}
```

Since this code runs on every render, any user interaction (Tab, arrow keys, etc.) that triggers a re-render causes the error message to spam repeatedly.

### The Solution

Move the error emission to a `useEffect` hook and track which invalid editors have already been warned about:

```typescript
const warnedEditorsRef = useRef<Set<string>>(new Set());

useEffect(() => {
  if (
    isInvalidEditor &&
    currentPreference &&
    !warnedEditorsRef.current.has(currentPreference)
  ) {
    warnedEditorsRef.current.add(currentPreference);
    coreEvents.emitFeedback('error', `Editor is not supported: ${currentPreference}`);
  }
}, [isInvalidEditor, currentPreference]);
```

This ensures the error is emitted only once per invalid editor value.

## Test plan

- [x] Added test: "emits error only once when preferredEditor is invalid"
- [x] All 6 tests in `EditorSettingsDialog.test.tsx` pass
- [x] TypeScript compilation: 0 errors
- [x] ESLint: 0 warnings