### PR TITLE
feat(cli): add /restart slash command to restart CLI and resume session

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -40,6 +40,7 @@ import { privacyCommand } from '../ui/commands/privacyCommand.js';
 import { policiesCommand } from '../ui/commands/policiesCommand.js';
 import { profileCommand } from '../ui/commands/profileCommand.js';
 import { quitCommand } from '../ui/commands/quitCommand.js';
+import { restartCommand } from '../ui/commands/restartCommand.js';
 import { restoreCommand } from '../ui/commands/restoreCommand.js';
 import { resumeCommand } from '../ui/commands/resumeCommand.js';
 import { statsCommand } from '../ui/commands/statsCommand.js';
@@ -138,6 +139,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       policiesCommand,
       ...(isDevelopment ? [profileCommand] : []),
       quitCommand,
+      restartCommand,
       restoreCommand(this.config),
       resumeCommand,
       statsCommand,

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -853,6 +853,29 @@ Logging in with Google... Restarting Gemini CLI to continue.
           process.exit(0);
         }, 100);
       },
+      restart: (messages: HistoryItem[], sessionId?: string) => {
+        setQuittingMessages(messages);
+        setTimeout(async () => {
+          // Send restart args to parent process for relaunch with --resume
+          if (process.send && sessionId) {
+            process.send({
+              type: 'restart-args',
+              args: ['--resume', sessionId],
+            });
+          }
+          if (process.send) {
+            const remoteSettings = config.getRemoteAdminSettings();
+            if (remoteSettings) {
+              process.send({
+                type: 'admin-settings-update',
+                settings: remoteSettings,
+              });
+            }
+          }
+          await runExitCleanup();
+          process.exit(RELAUNCH_EXIT_CODE);
+        }, 100);
+      },
       setDebugMessage,
       toggleCorgiMode: () => setCorgiMode((prev) => !prev),
       toggleDebugProfiler,
@@ -877,6 +900,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       addConfirmUpdateExtensionRequest,
       toggleDebugProfiler,
       buffer,
+      config,
     ],
   );
 

--- a/packages/cli/src/ui/commands/restartCommand.test.ts
+++ b/packages/cli/src/ui/commands/restartCommand.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { restartCommand } from './restartCommand.js';
+import type { CommandContext } from './types.js';
+import { CommandKind } from './types.js';
+
+describe('restartCommand', () => {
+  it('should have correct name and properties', () => {
+    expect(restartCommand.name).toBe('restart');
+    expect(restartCommand.description).toBe(
+      'Restart the CLI and resume the current session',
+    );
+    expect(restartCommand.kind).toBe(CommandKind.BUILT_IN);
+    expect(restartCommand.autoExecute).toBe(true);
+  });
+
+  it('should return restart action with sessionId', () => {
+    const mockSessionStartTime = new Date('2025-01-01T00:00:00Z');
+    const mockContext = {
+      session: {
+        stats: {
+          sessionStartTime: mockSessionStartTime,
+          sessionId: 'test-session-123',
+        },
+        sessionShellAllowlist: new Set<string>(),
+      },
+      services: {
+        config: null,
+        settings: {} as CommandContext['services']['settings'],
+        git: undefined,
+        logger: {} as CommandContext['services']['logger'],
+      },
+      ui: {} as CommandContext['ui'],
+    } as unknown as CommandContext;
+
+    vi.setSystemTime(new Date('2025-01-01T00:05:00Z')); // 5 minutes later
+
+    const result = restartCommand.action?.(mockContext, '');
+
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty('type', 'restart');
+    expect(result).toHaveProperty('sessionId', 'test-session-123');
+    expect(result).toHaveProperty('messages');
+    if (result && 'messages' in result) {
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages[0]).toHaveProperty('type', 'user');
+      expect(result.messages[0]).toHaveProperty('text', '/restart');
+      expect(result.messages[1]).toHaveProperty('type', 'info');
+      expect(result.messages[1].text).toContain('Restarting CLI...');
+    }
+
+    vi.useRealTimers();
+  });
+});

--- a/packages/cli/src/ui/commands/restartCommand.ts
+++ b/packages/cli/src/ui/commands/restartCommand.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { formatDuration } from '../utils/formatters.js';
+import { CommandKind, type SlashCommand } from './types.js';
+
+export const restartCommand: SlashCommand = {
+  name: 'restart',
+  description: 'Restart the CLI and resume the current session',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: (context) => {
+    const now = Date.now();
+    const { sessionStartTime, sessionId } = context.session.stats;
+    const wallDuration = now - sessionStartTime.getTime();
+
+    return {
+      type: 'restart',
+      sessionId,
+      messages: [
+        {
+          type: 'user',
+          text: `/restart`,
+          id: now - 1,
+        },
+        {
+          type: 'info',
+          text: `Restarting CLI... Session duration: ${formatDuration(wallDuration)}`,
+          id: now,
+        },
+      ],
+    };
+  },
+};

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -158,6 +158,17 @@ export interface LogoutActionReturn {
   type: 'logout';
 }
 
+/**
+ * The return type for a command action that restarts the CLI,
+ * optionally resuming the current session.
+ */
+export interface RestartActionReturn {
+  type: 'restart';
+  /** The session ID to resume after restart, if any. */
+  sessionId?: string;
+  messages: HistoryItem[];
+}
+
 export type SlashCommandActionReturn =
   | CommandActionReturn<HistoryItemWithoutId[]>
   | QuitActionReturn
@@ -165,7 +176,8 @@ export type SlashCommandActionReturn =
   | ConfirmShellCommandsActionReturn
   | ConfirmActionReturn
   | OpenCustomDialogActionReturn
-  | LogoutActionReturn;
+  | LogoutActionReturn
+  | RestartActionReturn;
 
 export enum CommandKind {
   BUILT_IN = 'built-in',

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx
@@ -208,6 +208,7 @@ describe('useSlashCommandProcessor', () => {
             openAgentConfigDialog,
             openPermissionsDialog: vi.fn(),
             quit: mockSetQuittingMessages,
+            restart: vi.fn(),
             setDebugMessage: vi.fn(),
             toggleCorgiMode: vi.fn(),
             toggleDebugProfiler: vi.fn(),

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -77,6 +77,7 @@ interface SlashCommandProcessorActions {
   ) => void;
   openPermissionsDialog: (props?: { targetDirectory?: string }) => void;
   quit: (messages: HistoryItem[]) => void;
+  restart: (messages: HistoryItem[], sessionId?: string) => void;
   setDebugMessage: (message: string) => void;
   toggleCorgiMode: () => void;
   toggleDebugProfiler: () => void;
@@ -504,6 +505,10 @@ export const useSlashCommandProcessor = (
                 }
                 case 'quit':
                   actions.quit(result.messages);
+                  return { type: 'handled' };
+
+                case 'restart':
+                  actions.restart(result.messages, result.sessionId);
                   return { type: 'handled' };
 
                 case 'submit_prompt':

--- a/packages/cli/src/utils/relaunch.ts
+++ b/packages/cli/src/utils/relaunch.ts
@@ -52,11 +52,26 @@ export async function relaunchAppInChildProcess(
     // process.argv is [node, script, ...args]
     // We want to construct [ ...nodeArgs, script, ...scriptArgs]
     const script = process.argv[1];
-    const scriptArgs = process.argv.slice(2);
+    let scriptArgs = process.argv.slice(2);
 
     // Include any pending restart args (e.g., --resume <sessionId> from /restart command)
     const restartArgs = pendingRestartArgs;
     pendingRestartArgs = []; // Clear after use
+
+    // If restarting with new args, filter out any existing --resume args to avoid duplicates
+    if (restartArgs.length > 0) {
+      const filteredArgs: string[] = [];
+      for (let i = 0; i < scriptArgs.length; i++) {
+        if (scriptArgs[i] === '--resume') {
+          i++; // Skip the flag and its value
+        } else if (scriptArgs[i]?.startsWith('--resume=')) {
+          // Skip the combined flag=value form
+        } else {
+          filteredArgs.push(scriptArgs[i]);
+        }
+      }
+      scriptArgs = filteredArgs;
+    }
 
     const nodeArgs = [
       ...process.execArgv,


### PR DESCRIPTION
## Summary
- Adds a new `/restart` slash command that restarts the CLI and automatically resumes the current session
- The command shows the session duration before restarting
- Uses IPC communication to pass `--resume <sessionId>` arguments to the relaunched process

## Implementation
- Added `RestartActionReturn` type for slash command results
- Extended IPC protocol in `relaunch.ts` to handle `restart-args` messages
- Created `restartCommand.ts` following the pattern of existing commands
- Registered command in `BuiltinCommandLoader.ts`
- Added handler in `slashCommandProcessor.ts` and `AppContainer.tsx`

## Test plan
- [x] Build passes (`npm run build`)
- [x] Tests pass (`npx vitest run`)
- [x] ESLint passes without errors
- [x] Added unit test for `restartCommand.ts`

Fixes #16124

🤖 Generated with [Claude Code](https://claude.com/claude-code)