### PR TITLE
feat(cli): add /new slash command to start a new session

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -34,6 +34,7 @@ import { initCommand } from '../ui/commands/initCommand.js';
 import { mcpCommand } from '../ui/commands/mcpCommand.js';
 import { memoryCommand } from '../ui/commands/memoryCommand.js';
 import { modelCommand } from '../ui/commands/modelCommand.js';
+import { newCommand } from '../ui/commands/newCommand.js';
 import { oncallCommand } from '../ui/commands/oncallCommand.js';
 import { permissionsCommand } from '../ui/commands/permissionsCommand.js';
 import { privacyCommand } from '../ui/commands/privacyCommand.js';
@@ -133,6 +134,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
         : [mcpCommand]),
       memoryCommand,
       modelCommand,
+      newCommand,
       ...(this.config?.getFolderTrust() ? [permissionsCommand] : []),
       privacyCommand,
       policiesCommand,

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -853,6 +853,22 @@ Logging in with Google... Restarting Gemini CLI to continue.
           process.exit(0);
         }, 100);
       },
+      newSession: (messages: HistoryItem[]) => {
+        setQuittingMessages(messages);
+        setTimeout(async () => {
+          if (process.send) {
+            const remoteSettings = config.getRemoteAdminSettings();
+            if (remoteSettings) {
+              process.send({
+                type: 'admin-settings-update',
+                settings: remoteSettings,
+              });
+            }
+          }
+          await runExitCleanup();
+          process.exit(RELAUNCH_EXIT_CODE);
+        }, 100);
+      },
       setDebugMessage,
       toggleCorgiMode: () => setCorgiMode((prev) => !prev),
       toggleDebugProfiler,
@@ -877,6 +893,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       addConfirmUpdateExtensionRequest,
       toggleDebugProfiler,
       buffer,
+      config,
     ],
   );
 

--- a/packages/cli/src/ui/commands/newCommand.test.ts
+++ b/packages/cli/src/ui/commands/newCommand.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { newCommand } from './newCommand.js';
+import type { CommandContext } from './types.js';
+import { CommandKind } from './types.js';
+
+describe('newCommand', () => {
+  it('should have correct name and properties', () => {
+    expect(newCommand.name).toBe('new');
+    expect(newCommand.description).toBe(
+      'Start a new session (current session is saved for later resume)',
+    );
+    expect(newCommand.kind).toBe(CommandKind.BUILT_IN);
+    expect(newCommand.autoExecute).toBe(true);
+  });
+
+  it('should return new_session action with messages', () => {
+    const mockSessionStartTime = new Date('2025-01-01T00:00:00Z');
+    const mockContext = {
+      session: {
+        stats: {
+          sessionStartTime: mockSessionStartTime,
+          sessionId: 'test-session-123',
+        },
+        sessionShellAllowlist: new Set<string>(),
+      },
+      services: {
+        config: null,
+        settings: {} as CommandContext['services']['settings'],
+        git: undefined,
+        logger: {} as CommandContext['services']['logger'],
+      },
+      ui: {} as CommandContext['ui'],
+    } as unknown as CommandContext;
+
+    vi.setSystemTime(new Date('2025-01-01T00:10:00Z')); // 10 minutes later
+
+    const result = newCommand.action?.(mockContext, '');
+
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty('type', 'new_session');
+    expect(result).toHaveProperty('messages');
+    if (result && 'messages' in result) {
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages[0]).toHaveProperty('type', 'user');
+      expect(result.messages[0]).toHaveProperty('text', '/new');
+      expect(result.messages[1]).toHaveProperty('type', 'info');
+      expect(result.messages[1].text).toContain('Starting new session');
+      expect(result.messages[1].text).toContain('/resume');
+    }
+
+    vi.useRealTimers();
+  });
+});

--- a/packages/cli/src/ui/commands/newCommand.ts
+++ b/packages/cli/src/ui/commands/newCommand.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { formatDuration } from '../utils/formatters.js';
+import { CommandKind, type SlashCommand } from './types.js';
+
+export const newCommand: SlashCommand = {
+  name: 'new',
+  description:
+    'Start a new session (current session is saved for later resume)',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: (context) => {
+    const now = Date.now();
+    const { sessionStartTime } = context.session.stats;
+    const wallDuration = now - sessionStartTime.getTime();
+
+    return {
+      type: 'new_session',
+      messages: [
+        {
+          type: 'user',
+          text: `/new`,
+          id: now - 1,
+        },
+        {
+          type: 'info',
+          text: `Starting new session... Current session duration: ${formatDuration(wallDuration)}. Use /resume to return to this session.`,
+          id: now,
+        },
+      ],
+    };
+  },
+};

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -158,6 +158,15 @@ export interface LogoutActionReturn {
   type: 'logout';
 }
 
+/**
+ * The return type for a command action that starts a new session,
+ * saving the current session for later resume.
+ */
+export interface NewSessionActionReturn {
+  type: 'new_session';
+  messages: HistoryItem[];
+}
+
 export type SlashCommandActionReturn =
   | CommandActionReturn<HistoryItemWithoutId[]>
   | QuitActionReturn
@@ -165,7 +174,8 @@ export type SlashCommandActionReturn =
   | ConfirmShellCommandsActionReturn
   | ConfirmActionReturn
   | OpenCustomDialogActionReturn
-  | LogoutActionReturn;
+  | LogoutActionReturn
+  | NewSessionActionReturn;
 
 export enum CommandKind {
   BUILT_IN = 'built-in',

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx
@@ -208,6 +208,7 @@ describe('useSlashCommandProcessor', () => {
             openAgentConfigDialog,
             openPermissionsDialog: vi.fn(),
             quit: mockSetQuittingMessages,
+            newSession: vi.fn(),
             setDebugMessage: vi.fn(),
             toggleCorgiMode: vi.fn(),
             toggleDebugProfiler: vi.fn(),

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -77,6 +77,7 @@ interface SlashCommandProcessorActions {
   ) => void;
   openPermissionsDialog: (props?: { targetDirectory?: string }) => void;
   quit: (messages: HistoryItem[]) => void;
+  newSession: (messages: HistoryItem[]) => void;
   setDebugMessage: (message: string) => void;
   toggleCorgiMode: () => void;
   toggleDebugProfiler: () => void;
@@ -504,6 +505,10 @@ export const useSlashCommandProcessor = (
                 }
                 case 'quit':
                   actions.quit(result.messages);
+                  return { type: 'handled' };
+
+                case 'new_session':
+                  actions.newSession(result.messages);
                   return { type: 'handled' };
 
                 case 'submit_prompt':


### PR DESCRIPTION
## Summary
- Adds a new `/new` slash command that starts a fresh session while preserving the current session
- The current session is saved and can be resumed later with `/resume`
- Shows the current session duration before starting the new session

## Why this is needed
- Users want to start a new conversation without losing access to their current session
- Currently, the only option is to exit and restart gemini cli
- The `/clear` command deletes the chat from what can be resumed

## Implementation
- Added `NewSessionActionReturn` type for slash command results
- Created `newCommand.ts` following the pattern of `quitCommand.ts`
- Registered the command in `BuiltinCommandLoader.ts`
- Added handler in `slashCommandProcessor.ts` and `AppContainer.tsx`
- The command uses `RELAUNCH_EXIT_CODE` to restart without `--resume`

## Test plan
- [x] Build passes (`npm run build`)
- [x] Tests pass (`npx vitest run`)
- [x] ESLint passes without errors
- [x] Added unit test for `newCommand.ts`

Fixes #16835

🤖 Generated with [Claude Code](https://claude.com/claude-code)