### PR TITLE
refactor(config): remove experimental.enableEventDrivenScheduler setting

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -858,11 +858,6 @@ their corresponding top-level category object in your `settings.json` file.
   - **Default:** `false`
   - **Requires restart:** Yes
 
-- **`experimental.enableEventDrivenScheduler`** (boolean):
-  - **Description:** Enables event-driven scheduler within the CLI session.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
 - **`experimental.extensionReloading`** (boolean):
   - **Description:** Enables extension loading/unloading within the CLI session.
   - **Default:** `false`

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -753,8 +753,7 @@ export async function loadCliConfig(
     enableExtensionReloading: settings.experimental?.extensionReloading,
     enableAgents: settings.experimental?.enableAgents,
     plan: settings.experimental?.plan,
-    enableEventDrivenScheduler:
-      settings.experimental?.enableEventDrivenScheduler,
+    enableEventDrivenScheduler: true,
     skillsSupport: settings.skills?.enabled ?? true,
     disabledSkills: settings.skills?.disabled,
     experimentalJitContext: settings.experimental?.jitContext,

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -389,20 +389,6 @@ describe('SettingsSchema', () => {
       );
     });
 
-    it('should have enableEventDrivenScheduler setting in schema', () => {
-      const setting =
-        getSettingsSchema().experimental.properties.enableEventDrivenScheduler;
-      expect(setting).toBeDefined();
-      expect(setting.type).toBe('boolean');
-      expect(setting.category).toBe('Experimental');
-      expect(setting.default).toBe(true);
-      expect(setting.requiresRestart).toBe(true);
-      expect(setting.showInDialog).toBe(false);
-      expect(setting.description).toBe(
-        'Enables event-driven scheduler within the CLI session.',
-      );
-    });
-
     it('should have hooksConfig.notifications setting in schema', () => {
       const setting = getSettingsSchema().hooksConfig?.properties.notifications;
       expect(setting).toBeDefined();

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1470,15 +1470,6 @@ const SETTINGS_SCHEMA = {
         description: 'Enable requesting and fetching of extension settings.',
         showInDialog: false,
       },
-      enableEventDrivenScheduler: {
-        type: 'boolean',
-        label: 'Event Driven Scheduler',
-        category: 'Experimental',
-        requiresRestart: true,
-        default: true,
-        description: 'Enables event-driven scheduler within the CLI session.',
-        showInDialog: false,
-      },
       extensionReloading: {
         type: 'boolean',
         label: 'Extension Reloading',

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1432,13 +1432,6 @@
           "default": false,
           "type": "boolean"
         },
-        "enableEventDrivenScheduler": {
-          "title": "Event Driven Scheduler",
-          "description": "Enables event-driven scheduler within the CLI session.",
-          "markdownDescription": "Enables event-driven scheduler within the CLI session.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
         "extensionReloading": {
           "title": "Extension Reloading",
           "description": "Enables extension loading/unloading within the CLI session.",


### PR DESCRIPTION
## Summary

This PR removes the experimental setting `experimental.enableEventDrivenScheduler` and sets it to `true` by default. This is part of a cleanup effort to stabilize the event-driven scheduler as a core feature.

## Details

- Removed `enableEventDrivenScheduler` from `settingsSchema.ts` and `settings.schema.json`.
- Updated `loadCliConfig` in `config.ts` to hardcode `enableEventDrivenScheduler` to `true`.
- Cleaned up related unit tests and regenerated documentation.

## Related Issues

Related to cleanup of experimental flags.

## How to Validate

1. Run `npm run test` to ensure core functionality remains intact.
2. Verify that `experimental.enableEventDrivenScheduler` is no longer listed in `gemini settings`.
3. Verify that documentation (`docs/get-started/configuration.md`) has been updated.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
