### PR TITLE
feat(ci): add npx smoke test to verify installability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,15 @@ jobs:
       - name: 'Smoke test bundle'
         run: 'node ./bundle/gemini.js --version'
 
+      - name: 'Smoke test npx installation'
+        run: |
+          # Create a temporary directory to avoid picking up local node_modules
+          mkdir -p ../npx-test
+          cd ../npx-test
+          # Run npx pointing to the checkout directory. This simulates a user
+          # installing the package from a git reference.
+          npx ${{ github.workspace }} --version
+
       - name: 'Wait for file system sync'
         run: 'sleep 2'
 
@@ -251,6 +260,15 @@ jobs:
 
       - name: 'Smoke test bundle'
         run: 'node ./bundle/gemini.js --version'
+
+      - name: 'Smoke test npx installation'
+        run: |
+          # Create a temporary directory to avoid picking up local node_modules
+          mkdir -p ../npx-test
+          cd ../npx-test
+          # Run npx pointing to the checkout directory. This simulates a user
+          # installing the package from a git reference.
+          npx ${{ github.workspace }} --version
 
       - name: 'Wait for file system sync'
         run: 'sleep 2'
@@ -394,6 +412,16 @@ jobs:
 
       - name: 'Smoke test bundle'
         run: 'node ./bundle/gemini.js --version'
+        shell: 'pwsh'
+
+      - name: 'Smoke test npx installation'
+        run: |
+          # Create a temporary directory to avoid picking up local node_modules
+          New-Item -ItemType Directory -Force -Path ../npx-test
+          Set-Location ../npx-test
+          # Run npx pointing to the checkout directory. This simulates a user
+          # installing the package from a git reference.
+          npx ${{ github.workspace }} --version
         shell: 'pwsh'
 
   ci:


### PR DESCRIPTION
## Summary

This PR adds a dedicated `npx` smoke test to the CI workflow to ensure that the Gemini CLI remains installable and executable via `npx @google/gemini-cli#branch`. This was prompted by a recent regression where the application failed to bundle correctly during `npx` installation.

## Details

The new step runs `npx ${{ github.workspace }} --version` from a temporary directory outside the repository root. This forces `npm` to treat the local checkout as a remote package, triggering lifecycle scripts like `prepare` and `bundle`. This verifies:
1. The `prepare` script successfully bundles the application.
2. All required dependencies are available.
3. The binary entry point is correctly configured.

The test is added to `test_linux`, `test_mac`, and `test_windows` jobs.

## Related Issues

Related to #16173

## How to Validate

1. Review the `.github/workflows/ci.yml` changes.
2. Locally, run:
   ```bash
   npm run clean
   mkdir -p ../npx-test && cd ../npx-test
   npx /path/to/gemini-cli --version
   ```
   Confirm it builds and returns the version.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README
- [x] Added/updated tests
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
