### PR TITLE
feat(cli): implement automatic theme switching based on terminal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2251,6 +2251,7 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -2431,6 +2432,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2464,6 +2466,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
       "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2832,6 +2835,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz",
       "integrity": "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2865,6 +2869,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.1.tgz",
       "integrity": "sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/resources": "2.0.1"
@@ -2917,6 +2922,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
       "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/resources": "2.0.1",
@@ -4122,6 +4128,7 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4399,6 +4406,7 @@
       "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.0",
         "@typescript-eslint/types": "8.35.0",
@@ -5391,6 +5399,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8400,6 +8409,7 @@
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8940,6 +8950,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -10541,6 +10552,7 @@
       "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.4.8.tgz",
       "integrity": "sha512-v0thcXIKl9hqF/1w4HqA6MKxIcMoWSP3YtEZIAA+eeJngXpN5lGnMkb6rllB7FnOdwyEyYaFTcu1ZVr4/JZpWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.1",
         "ansi-escapes": "^7.0.0",
@@ -14299,6 +14311,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14309,6 +14322,7 @@
       "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -16545,6 +16559,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16768,7 +16783,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.20.3",
@@ -16776,6 +16792,7 @@
       "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -16948,6 +16965,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17155,6 +17173,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -17268,6 +17287,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17280,6 +17300,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -17984,6 +18005,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -18278,6 +18300,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -147,6 +147,12 @@ import {
 import { LoginWithGoogleRestartDialog } from './auth/LoginWithGoogleRestartDialog.js';
 import { NewAgentsChoice } from './components/NewAgentsNotification.js';
 import { isSlashCommand } from './utils/commandUtils.js';
+import {
+  parseX11Rgb,
+  getThemeTypeFromBackgroundColor,
+} from './themes/color-utils.js';
+import { DEFAULT_THEME } from './themes/theme-manager.js';
+import { DefaultLight } from './themes/default-light.js';
 
 function isToolExecuting(pendingHistoryItems: HistoryItemWithoutId[]) {
   return pendingHistoryItems.some((item) => {
@@ -653,6 +659,62 @@ export const AppContainer = (props: AppContainerProps) => {
     historyManager.addItem,
     initializationResult.themeError,
   );
+
+  // Poll for terminal background color changes to auto-switch theme
+  useEffect(() => {
+    const pollInterval = setInterval(() => {
+      // Only poll if we are using one of the default themes
+      const currentThemeName = settings.merged.ui.theme;
+      const isDefaultTheme =
+        currentThemeName === DEFAULT_THEME.name ||
+        currentThemeName === undefined;
+      const isDefaultLightTheme = currentThemeName === DefaultLight.name;
+
+      if (!isDefaultTheme && !isDefaultLightTheme) {
+        return;
+      }
+      stdout.write('\x1b]11;?\x1b\\');
+    }, 3000);
+
+    const handleTerminalBackgroundResponse = (colorStr: string) => {
+      // Parse the response "rgb:rrrr/gggg/bbbb"
+      const match =
+        /^rgb:([0-9a-fA-F]{1,4})\/([0-9a-fA-F]{1,4})\/([0-9a-fA-F]{1,4})$/.exec(
+          colorStr,
+        );
+      if (!match) return;
+
+      const hexColor = parseX11Rgb(match[1], match[2], match[3]);
+      const themeType = getThemeTypeFromBackgroundColor(hexColor);
+      config.setTerminalBackground(hexColor);
+
+      // Check if we need to switch theme
+      const currentThemeName = settings.merged.ui.theme;
+      const isDefaultTheme =
+        currentThemeName === DEFAULT_THEME.name ||
+        currentThemeName === undefined;
+      const isDefaultLightTheme = currentThemeName === DefaultLight.name;
+
+      if (themeType === 'light' && isDefaultTheme) {
+        handleThemeSelect(DefaultLight.name, SettingScope.User);
+      } else if (themeType === 'dark' && isDefaultLightTheme) {
+        handleThemeSelect(DEFAULT_THEME.name, SettingScope.User);
+      }
+    };
+
+    appEvents.on(
+      AppEvent.TerminalBackgroundResponse,
+      handleTerminalBackgroundResponse,
+    );
+
+    return () => {
+      clearInterval(pollInterval);
+      appEvents.off(
+        AppEvent.TerminalBackgroundResponse,
+        handleTerminalBackgroundResponse,
+      );
+    };
+  }, [settings.merged.ui.theme, stdout, config, handleThemeSelect]);
 
   const {
     authState,

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -377,6 +377,19 @@ function* emitKeys(
           }
         }
 
+        // Check for OSC 11 (Background Color) response
+        // Format: 11;rgb:rrrr/gggg/bbbb\x1b\\ (or BEL terminated)
+        // Note: buffer contains content after `ESC ]`
+        const matchOsc11 =
+          /^11;rgb:([0-9a-fA-F]{1,4})\/([0-9a-fA-F]{1,4})\/([0-9a-fA-F]{1,4})$/.exec(
+            buffer,
+          );
+        if (matchOsc11) {
+          const colorStr = `rgb:${matchOsc11[1]}/${matchOsc11[2]}/${matchOsc11[3]}`;
+          appEvents.emit(AppEvent.TerminalBackgroundResponse, colorStr);
+          continue; // resume main loop
+        }
+
         continue; // resume main loop
       } else if (ch === 'O') {
         // ESC O letter

--- a/packages/cli/src/ui/themes/color-utils.test.ts
+++ b/packages/cli/src/ui/themes/color-utils.test.ts
@@ -12,6 +12,7 @@ import {
   CSS_NAME_TO_HEX_MAP,
   INK_SUPPORTED_NAMES,
   getThemeTypeFromBackgroundColor,
+  parseX11Rgb,
 } from './color-utils.js';
 
 describe('Color Utils', () => {
@@ -277,6 +278,36 @@ describe('Color Utils', () => {
     it('should handle colors without # prefix', () => {
       expect(getThemeTypeFromBackgroundColor('ffffff')).toBe('light');
       expect(getThemeTypeFromBackgroundColor('000000')).toBe('dark');
+    });
+  });
+
+  describe('parseX11Rgb', () => {
+    it('should parse 1-digit components', () => {
+      // F/F/F => #ffffff
+      expect(parseX11Rgb('f', 'f', 'f')).toBe('#ffffff');
+      // 0/0/0 => #000000
+      expect(parseX11Rgb('0', '0', '0')).toBe('#000000');
+    });
+
+    it('should parse 2-digit components', () => {
+      // ff/ff/ff => #ffffff
+      expect(parseX11Rgb('ff', 'ff', 'ff')).toBe('#ffffff');
+      // 80/80/80 => #808080
+      expect(parseX11Rgb('80', '80', '80')).toBe('#808080');
+    });
+
+    it('should parse 4-digit components (standard X11)', () => {
+      // ffff/ffff/ffff => #ffffff (65535/65535 * 255 = 255)
+      expect(parseX11Rgb('ffff', 'ffff', 'ffff')).toBe('#ffffff');
+      // 0000/0000/0000 => #000000
+      expect(parseX11Rgb('0000', '0000', '0000')).toBe('#000000');
+      // 7fff/7fff/7fff => approx #7f7f7f (32767/65535 * 255 = 127.498... -> 127 -> 7f)
+      expect(parseX11Rgb('7fff', '7fff', '7fff')).toBe('#7f7f7f');
+    });
+
+    it('should handle mixed case', () => {
+      expect(parseX11Rgb('FFFF', 'FFFF', 'FFFF')).toBe('#ffffff');
+      expect(parseX11Rgb('Ffff', 'fFFF', 'ffFF')).toBe('#ffffff');
     });
   });
 });

--- a/packages/cli/src/ui/themes/color-utils.ts
+++ b/packages/cli/src/ui/themes/color-utils.ts
@@ -297,3 +297,30 @@ export function getThemeTypeFromBackgroundColor(
 
   return luminance > 128 ? 'light' : 'dark';
 }
+
+/**
+ * Parses an X11 RGB string (e.g. from OSC 11) into a hex color string.
+ * Supports 1-4 digit hex values per channel (e.g., F, FF, FFF, FFFF).
+ *
+ * @param rHex Red component as hex string
+ * @param gHex Green component as hex string
+ * @param bHex Blue component as hex string
+ * @returns Hex color string (e.g. #RRGGBB)
+ */
+export function parseX11Rgb(rHex: string, gHex: string, bHex: string): string {
+  const parseComponent = (hex: string) => {
+    const val = parseInt(hex, 16);
+    if (hex.length === 1) return (val / 15) * 255;
+    if (hex.length === 2) return val;
+    if (hex.length === 3) return (val / 4095) * 255;
+    if (hex.length === 4) return (val / 65535) * 255;
+    return val;
+  };
+
+  const r = parseComponent(rHex);
+  const g = parseComponent(gHex);
+  const b = parseComponent(bHex);
+
+  const toHex = (c: number) => Math.round(c).toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}

--- a/packages/cli/src/utils/events.ts
+++ b/packages/cli/src/utils/events.ts
@@ -11,6 +11,7 @@ export enum AppEvent {
   Flicker = 'flicker',
   SelectionWarning = 'selection-warning',
   PasteTimeout = 'paste-timeout',
+  TerminalBackgroundResponse = 'terminal-background-response',
 }
 
 export interface AppEvents {
@@ -18,6 +19,7 @@ export interface AppEvents {
   [AppEvent.Flicker]: never[];
   [AppEvent.SelectionWarning]: never[];
   [AppEvent.PasteTimeout]: never[];
+  [AppEvent.TerminalBackgroundResponse]: [string];
 }
 
 export const appEvents = new EventEmitter<AppEvents>();


### PR DESCRIPTION
Added polling logic to automatically switch between 'Default' (Dark) and 'Default Light' themes by detecting the terminal background color via OSC 11.

- Added OSC 11 response parsing to KeypressContext.
- Implemented background polling and auto-switching in AppContainer every 3 seconds.
- Added parseX11Rgb utility to convert X11 color sequences to hex format.
- Added comprehensive unit tests for the new color utility.
- This allows the CLI to dynamically adapt to VS Code's Light/Dark mode transitions.

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
