### PR TITLE
Fix bugs where Rewind and Resume showed Ugly and 100X too verbose content.

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -258,6 +258,9 @@ describe('runNonInteractive', () => {
       [{ text: 'Test input' }],
       expect.any(AbortSignal),
       'prompt-id-1',
+      undefined,
+      false,
+      'Test input',
     );
     expect(getWrittenOutput()).toBe('Hello World\n');
     // Note: Telemetry shutdown is now handled in runExitCleanup() in cleanup.ts
@@ -374,6 +377,9 @@ describe('runNonInteractive', () => {
       [{ text: 'Tool response' }],
       expect.any(AbortSignal),
       'prompt-id-2',
+      undefined,
+      false,
+      undefined,
     );
     expect(getWrittenOutput()).toBe('Final answer\n');
   });
@@ -531,6 +537,9 @@ describe('runNonInteractive', () => {
       ],
       expect.any(AbortSignal),
       'prompt-id-3',
+      undefined,
+      false,
+      undefined,
     );
     expect(getWrittenOutput()).toBe('Sorry, let me try again.\n');
   });
@@ -670,6 +679,9 @@ describe('runNonInteractive', () => {
       processedParts,
       expect.any(AbortSignal),
       'prompt-id-7',
+      undefined,
+      false,
+      rawInput,
     );
 
     // 6. Assert the final output is correct
@@ -703,6 +715,9 @@ describe('runNonInteractive', () => {
       [{ text: 'Test input' }],
       expect.any(AbortSignal),
       'prompt-id-1',
+      undefined,
+      false,
+      'Test input',
     );
     expect(processStdoutSpy).toHaveBeenCalledWith(
       JSON.stringify(
@@ -833,6 +848,9 @@ describe('runNonInteractive', () => {
       [{ text: 'Empty response test' }],
       expect.any(AbortSignal),
       'prompt-id-empty',
+      undefined,
+      false,
+      'Empty response test',
     );
 
     // This should output JSON with empty response but include stats
@@ -967,6 +985,9 @@ describe('runNonInteractive', () => {
       [{ text: 'Prompt from command' }],
       expect.any(AbortSignal),
       'prompt-id-slash',
+      undefined,
+      false,
+      '/testcommand',
     );
 
     expect(getWrittenOutput()).toBe('Response from command\n');
@@ -1010,6 +1031,9 @@ describe('runNonInteractive', () => {
       [{ text: 'Slash command output' }],
       expect.any(AbortSignal),
       'prompt-id-slash',
+      undefined,
+      false,
+      '/help',
     );
     expect(getWrittenOutput()).toBe('Response to slash command\n');
     handleSlashCommandSpy.mockRestore();
@@ -1184,6 +1208,9 @@ describe('runNonInteractive', () => {
       [{ text: '/unknowncommand' }],
       expect.any(AbortSignal),
       'prompt-id-unknown',
+      undefined,
+      false,
+      '/unknowncommand',
     );
 
     expect(getWrittenOutput()).toBe('Response to unknown\n');

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -301,6 +301,9 @@ export async function runNonInteractive({
           currentMessages[0]?.parts || [],
           abortController.signal,
           prompt_id,
+          undefined,
+          false,
+          turnCount === 1 ? input : undefined,
         );
 
         let responseText = '';

--- a/packages/cli/src/ui/components/RewindViewer.tsx
+++ b/packages/cli/src/ui/components/RewindViewer.tsx
@@ -35,6 +35,14 @@ interface RewindViewerProps {
 
 const MAX_LINES_PER_BOX = 2;
 
+const getCleanedRewindText = (userPrompt: MessageRecord): string => {
+  const contentToUse = userPrompt.displayContent || userPrompt.content;
+  const originalUserText = contentToUse ? partToString(contentToUse) : '';
+  return userPrompt.displayContent
+    ? originalUserText
+    : stripReferenceContent(originalUserText);
+};
+
 export const RewindViewer: React.FC<RewindViewerProps> = ({
   conversation,
   onExit,
@@ -162,10 +170,7 @@ export const RewindViewer: React.FC<RewindViewerProps> = ({
               (m) => m.id === selectedMessageId,
             );
             if (userPrompt) {
-              const originalUserText = userPrompt.content
-                ? partToString(userPrompt.content)
-                : '';
-              const cleanedText = stripReferenceContent(originalUserText);
+              const cleanedText = getCleanedRewindText(userPrompt);
               setIsRewinding(true);
               await onRewind(selectedMessageId, cleanedText, outcome);
             }
@@ -224,7 +229,9 @@ export const RewindViewer: React.FC<RewindViewerProps> = ({
                       isSelected ? theme.status.success : theme.text.primary
                     }
                   >
-                    {partToString(userPrompt.content)}
+                    {partToString(
+                      userPrompt.displayContent || userPrompt.content,
+                    )}
                   </Text>
                   <Text color={theme.text.secondary}>
                     Cancel rewind and stay here
@@ -235,10 +242,7 @@ export const RewindViewer: React.FC<RewindViewerProps> = ({
 
             const stats = getStats(userPrompt);
             const firstFileName = stats?.details?.at(0)?.fileName;
-            const originalUserText = userPrompt.content
-              ? partToString(userPrompt.content)
-              : '';
-            const cleanedText = stripReferenceContent(originalUserText);
+            const cleanedText = getCleanedRewindText(userPrompt);
 
             return (
               <Box flexDirection="column" marginBottom={1}>

--- a/packages/cli/src/ui/components/__snapshots__/RewindViewer.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/RewindViewer.test.tsx.snap
@@ -34,6 +34,23 @@ exports[`RewindViewer > Content Filtering > 'strips expanded MCP resource conten
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
 `;
 
+exports[`RewindViewer > Content Filtering > 'uses displayContent if present and do…' 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                                      │
+│ > Rewind                                                                                                             │
+│                                                                                                                      │
+│   clean display content                                                                                              │
+│   No files have been changed                                                                                         │
+│                                                                                                                      │
+│ ● Stay at current position                                                                                           │
+│   Cancel rewind and stay here                                                                                        │
+│                                                                                                                      │
+│                                                                                                                      │
+│ (Use Enter to select a message, Esc to close, Right/Left to expand/collapse)                                         │
+│                                                                                                                      │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
 exports[`RewindViewer > Interaction Selection > 'cancels on Escape' > confirmation-dialog 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │                                                                                                                      │

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -652,6 +652,9 @@ describe('useGeminiStream', () => {
       expectedMergedResponse,
       expect.any(AbortSignal),
       'prompt-id-2',
+      undefined,
+      false,
+      expectedMergedResponse,
     );
   });
 
@@ -1054,6 +1057,9 @@ describe('useGeminiStream', () => {
         toolCallResponseParts,
         expect.any(AbortSignal),
         'prompt-id-4',
+        undefined,
+        false,
+        toolCallResponseParts,
       );
     });
 
@@ -1495,6 +1501,9 @@ describe('useGeminiStream', () => {
           'This is the actual prompt from the command file.',
           expect.any(AbortSignal),
           expect.any(String),
+          undefined,
+          false,
+          '/my-custom-command',
         );
 
         expect(mockScheduleToolCalls).not.toHaveBeenCalled();
@@ -1521,6 +1530,9 @@ describe('useGeminiStream', () => {
           '',
           expect.any(AbortSignal),
           expect.any(String),
+          undefined,
+          false,
+          '/emptycmd',
         );
       });
     });
@@ -1539,6 +1551,9 @@ describe('useGeminiStream', () => {
           '// This is a line comment',
           expect.any(AbortSignal),
           expect.any(String),
+          undefined,
+          false,
+          '// This is a line comment',
         );
       });
     });
@@ -1557,6 +1572,9 @@ describe('useGeminiStream', () => {
           '/* This is a block comment */',
           expect.any(AbortSignal),
           expect.any(String),
+          undefined,
+          false,
+          '/* This is a block comment */',
         );
       });
     });
@@ -2389,6 +2407,9 @@ describe('useGeminiStream', () => {
       processedQueryParts, // Argument 1: The parts array directly
       expect.any(AbortSignal), // Argument 2: An AbortSignal
       expect.any(String), // Argument 3: The prompt_id string
+      undefined,
+      false,
+      rawQuery,
     );
   });
 
@@ -2928,6 +2949,9 @@ describe('useGeminiStream', () => {
           'test query',
           expect.any(AbortSignal),
           expect.any(String),
+          undefined,
+          false,
+          'test query',
         );
       });
     });
@@ -3075,6 +3099,9 @@ describe('useGeminiStream', () => {
           'second query',
           expect.any(AbortSignal),
           expect.any(String),
+          undefined,
+          false,
+          'second query',
         );
       });
     });

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1222,6 +1222,9 @@ export const useGeminiStream = (
                 queryToSend,
                 abortSignal,
                 prompt_id!,
+                undefined,
+                false,
+                query,
               );
               const processingStatus = await processGeminiStreamEvents(
                 stream,

--- a/packages/cli/src/ui/hooks/useSessionBrowser.test.ts
+++ b/packages/cli/src/ui/hooks/useSessionBrowser.test.ts
@@ -178,6 +178,30 @@ describe('convertSessionToHistoryFormats', () => {
     });
   });
 
+  it('should prioritize displayContent for UI history but use content for client history', () => {
+    const messages: MessageRecord[] = [
+      {
+        type: 'user',
+        content: [{ text: 'Expanded content' }],
+        displayContent: [{ text: 'User input' }],
+      } as MessageRecord,
+    ];
+
+    const result = convertSessionToHistoryFormats(messages);
+
+    expect(result.uiHistory).toHaveLength(1);
+    expect(result.uiHistory[0]).toMatchObject({
+      type: 'user',
+      text: 'User input',
+    });
+
+    expect(result.clientHistory).toHaveLength(1);
+    expect(result.clientHistory[0]).toEqual({
+      role: 'user',
+      parts: [{ text: 'Expanded content' }],
+    });
+  });
+
   it('should filter out slash commands from client history but keep in UI', () => {
     const messages: MessageRecord[] = [
       { type: 'user', content: '/help' } as MessageRecord,

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -890,6 +890,7 @@ ${JSON.stringify(
         { model: 'default-routed-model' },
         initialRequest,
         expect.any(AbortSignal),
+        undefined,
       );
     });
 
@@ -1707,6 +1708,7 @@ ${JSON.stringify(
           { model: 'routed-model' },
           [{ text: 'Hi' }],
           expect.any(AbortSignal),
+          undefined,
         );
       });
 
@@ -1724,6 +1726,7 @@ ${JSON.stringify(
           { model: 'routed-model' },
           [{ text: 'Hi' }],
           expect.any(AbortSignal),
+          undefined,
         );
 
         // Second turn
@@ -1741,6 +1744,7 @@ ${JSON.stringify(
           { model: 'routed-model' },
           [{ text: 'Continue' }],
           expect.any(AbortSignal),
+          undefined,
         );
       });
 
@@ -1758,6 +1762,7 @@ ${JSON.stringify(
           { model: 'routed-model' },
           [{ text: 'Hi' }],
           expect.any(AbortSignal),
+          undefined,
         );
 
         // New prompt
@@ -1779,6 +1784,7 @@ ${JSON.stringify(
           { model: 'new-routed-model' },
           [{ text: 'A new topic' }],
           expect.any(AbortSignal),
+          undefined,
         );
       });
 
@@ -1806,6 +1812,7 @@ ${JSON.stringify(
           { model: 'original-model' },
           [{ text: 'Hi' }],
           expect.any(AbortSignal),
+          undefined,
         );
 
         mockRouterService.route.mockResolvedValue({
@@ -1828,6 +1835,7 @@ ${JSON.stringify(
           { model: 'fallback-model' },
           [{ text: 'Continue' }],
           expect.any(AbortSignal),
+          undefined,
         );
       });
     });
@@ -1912,6 +1920,7 @@ ${JSON.stringify(
         { model: 'default-routed-model' },
         initialRequest,
         expect.any(AbortSignal),
+        undefined,
       );
 
       // Second call with "Please continue."
@@ -1920,6 +1929,7 @@ ${JSON.stringify(
         { model: 'default-routed-model' },
         [{ text: 'System: Please continue.' }],
         expect.any(AbortSignal),
+        undefined,
       );
     });
 
@@ -2332,6 +2342,7 @@ ${JSON.stringify(
           expect.objectContaining({ model: 'model-a' }),
           expect.anything(),
           expect.anything(),
+          undefined,
         );
       });
 
@@ -3183,6 +3194,7 @@ ${JSON.stringify(
           expect.anything(),
           [{ text: 'Please explain' }],
           expect.anything(),
+          undefined,
         );
       });
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -532,6 +532,7 @@ export class GeminiClient {
     prompt_id: string,
     boundedTurns: number,
     isInvalidStreamRetry: boolean,
+    displayContent?: PartListUnion,
   ): AsyncGenerator<ServerGeminiStreamEvent, Turn> {
     // Re-initialize turn (it was empty before if in loop, or new instance)
     let turn = new Turn(this.getChat(), prompt_id);
@@ -647,7 +648,12 @@ export class GeminiClient {
       yield { type: GeminiEventType.ModelInfo, value: modelToUse };
     }
     this.currentSequenceModel = modelToUse;
-    const resultStream = turn.run(modelConfigKey, request, linkedSignal);
+    const resultStream = turn.run(
+      modelConfigKey,
+      request,
+      linkedSignal,
+      displayContent,
+    );
     let isError = false;
     let isInvalidStream = false;
 
@@ -708,6 +714,7 @@ export class GeminiClient {
           prompt_id,
           boundedTurns - 1,
           true,
+          displayContent,
         );
         return turn;
       }
@@ -739,7 +746,8 @@ export class GeminiClient {
             signal,
             prompt_id,
             boundedTurns - 1,
-            // isInvalidStreamRetry is false
+            false, // isInvalidStreamRetry is false
+            displayContent,
           );
           return turn;
         }
@@ -754,6 +762,7 @@ export class GeminiClient {
     prompt_id: string,
     turns: number = MAX_TURNS,
     isInvalidStreamRetry: boolean = false,
+    displayContent?: PartListUnion,
   ): AsyncGenerator<ServerGeminiStreamEvent, Turn> {
     if (!isInvalidStreamRetry) {
       this.config.resetTurn();
@@ -809,6 +818,7 @@ export class GeminiClient {
         prompt_id,
         boundedTurns,
         isInvalidStreamRetry,
+        displayContent,
       );
 
       // Fire AfterAgent hook if we have a turn and no pending tools
@@ -860,6 +870,8 @@ export class GeminiClient {
             signal,
             prompt_id,
             boundedTurns - 1,
+            false,
+            displayContent,
           );
         }
       }

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -102,6 +102,7 @@ describe('Turn', () => {
         reqParts,
         'prompt-id-1',
         expect.any(AbortSignal),
+        undefined,
       );
 
       expect(events).toEqual([

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -248,6 +248,7 @@ export class Turn {
     modelConfigKey: ModelConfigKey,
     req: PartListUnion,
     signal: AbortSignal,
+    displayContent?: PartListUnion,
   ): AsyncGenerator<ServerGeminiStreamEvent> {
     try {
       // Note: This assumes `sendMessageStream` yields events like
@@ -257,6 +258,7 @@ export class Turn {
         req,
         this.prompt_id,
         signal,
+        displayContent,
       );
 
       for await (const streamEvent of responseStream) {

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -130,6 +130,7 @@ describe('ChatRecordingService', () => {
       chatRecordingService.recordMessage({
         type: 'user',
         content: 'Hello',
+        displayContent: 'User Hello',
         model: 'gemini-pro',
       });
       expect(mkdirSyncSpy).toHaveBeenCalled();
@@ -139,6 +140,7 @@ describe('ChatRecordingService', () => {
       ) as ConversationRecord;
       expect(conversation.messages).toHaveLength(1);
       expect(conversation.messages[0].content).toBe('Hello');
+      expect(conversation.messages[0].displayContent).toBe('User Hello');
       expect(conversation.messages[0].type).toBe('user');
     });
 

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -47,6 +47,7 @@ export interface BaseMessageRecord {
   id: string;
   timestamp: string;
   content: PartListUnion;
+  displayContent?: PartListUnion;
 }
 
 /**
@@ -207,12 +208,14 @@ export class ChatRecordingService {
   private newMessage(
     type: ConversationRecordExtra['type'],
     content: PartListUnion,
+    displayContent?: PartListUnion,
   ): MessageRecord {
     return {
       id: randomUUID(),
       timestamp: new Date().toISOString(),
       type,
       content,
+      displayContent,
     };
   }
 
@@ -223,12 +226,17 @@ export class ChatRecordingService {
     model: string | undefined;
     type: ConversationRecordExtra['type'];
     content: PartListUnion;
+    displayContent?: PartListUnion;
   }): void {
     if (!this.conversationFile) return;
 
     try {
       this.updateConversation((conversation) => {
-        const msg = this.newMessage(message.type, message.content);
+        const msg = this.newMessage(
+          message.type,
+          message.content,
+          message.displayContent,
+        );
         if (msg.type === 'gemini') {
           // If it's a new Gemini message then incorporate any queued thoughts.
           conversation.messages.push({


### PR DESCRIPTION
## Summary

Gemini CLI was showing bloated content on resume resulting in poor TUI performance with 10K lines scrolling for tools that used a large % of the context window.

## Details

* **Enhanced User Message Display**: Introduced a new optional `displayContent` field for user messages, allowing for a cleaner, user-friendly representation in the UI, distinct from the raw `content` which may contain internal markers or expanded references.
* **Rewind and Resume UI Improvements**: The RewindViewer component now prioritizes `displayContent` for display. If `displayContent` is present, the `stripReferenceContent` function, which previously removed verbose internal content, is bypassed, ensuring a concise view for the user.
* **Consistent Message Handling Across Layers**: The `displayContent` field is now propagated through the `GeminiClient`, `GeminiChat`, and `Turn` classes, ensuring that this user-friendly content is available and correctly handled throughout the message processing pipeline.
* **Improved Session History Recording**: The `ChatRecordingService` and `useSessionBrowser` hook have been updated to store and utilize `displayContent`. The UI history (`uiHistory`) now prioritizes `displayContent` for presentation, while the full, original `content` is preserved for client history and backend processing.
* **Initial Input as Display Content**: For the first turn in non-interactive CLI and Gemini stream usage, the original user input is now explicitly passed as `displayContent`, ensuring that the initial prompt is displayed cleanly without internal processing artifacts.

## To repro
Run `/frontend summarize package cli`
Then exit and resume

Similarly test with `@somefile summarize thsi`
and verify that you get the UI you would like in `/rewind and on resume.

Verify that you see a just a few lines in the UX same as before the resume.
Similarly verify that /rewind shows what you would expect.

You should not see content bloat like this
https://screencast.googleplex.com/cast/NDcwNzQ2NjY0OTUzNDQ2NHw3MDZlYTAyNS03MQ

and should instead see terse content like this on resume
<img width="1237" height="601" alt="image" src="https://github.com/user-attachments/assets/5e1b4e9a-5b5d-4467-acca-45d7d9db1539" />

## Related Issues

Fixes #17943