### PR TITLE
feat(cli): start vim mode in insert mode by default

### DIFF
--- a/packages/cli/src/ui/contexts/VimModeContext.tsx
+++ b/packages/cli/src/ui/contexts/VimModeContext.tsx
@@ -34,26 +34,24 @@ export const VimModeProvider = ({
 }) => {
   const initialVimEnabled = settings.merged.general.vimMode;
   const [vimEnabled, setVimEnabled] = useState(initialVimEnabled);
-  const [vimMode, setVimMode] = useState<VimMode>(
-    initialVimEnabled ? 'NORMAL' : 'INSERT',
-  );
+  const [vimMode, setVimMode] = useState<VimMode>('INSERT');
 
   useEffect(() => {
     // Initialize vimEnabled from settings on mount
     const enabled = settings.merged.general.vimMode;
     setVimEnabled(enabled);
-    // When vim mode is enabled, always start in NORMAL mode
+    // When vim mode is enabled, always start in INSERT mode
     if (enabled) {
-      setVimMode('NORMAL');
+      setVimMode('INSERT');
     }
   }, [settings.merged.general.vimMode]);
 
   const toggleVimEnabled = useCallback(async () => {
     const newValue = !vimEnabled;
     setVimEnabled(newValue);
-    // When enabling vim mode, start in NORMAL mode
+    // When enabling vim mode, start in INSERT mode
     if (newValue) {
-      setVimMode('NORMAL');
+      setVimMode('INSERT');
     }
     settings.setValue(SettingScope.User, 'general.vimMode', newValue);
     return newValue;

--- a/packages/cli/src/ui/hooks/vim.ts
+++ b/packages/cli/src/ui/hooks/vim.ts
@@ -68,7 +68,7 @@ type VimAction =
   | { type: 'ESCAPE_TO_NORMAL' };
 
 const initialVimState: VimState = {
-  mode: 'NORMAL',
+  mode: 'INSERT',
   count: 0,
   pendingOperator: null,
   lastCommand: null,


### PR DESCRIPTION
## Summary

Changes the default startup behavior of Vim mode to enter **INSERT** mode instead of **NORMAL** mode. This ensures that users can immediately start typing when the CLI launches or when Vim mode is enabled, improving the initial user experience.

## Details

- Modified the Vim mode initialization logic to default to `INSERT` mode.

## Related Issues

Fixes #17932.

## How to Validate

1. Start the Gemini CLI.
2. Ensure Vim mode is enabled.
3. Observe the Vim mode indicator in the footer. (**Expected:** It should show `[INSERT]` immediately upon startup.)

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [x] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
