### PR TITLE
feat(core): enable overriding CODE_ASSIST_API_VERSION with env var

### DIFF
--- a/packages/core/src/code_assist/server.test.ts
+++ b/packages/core/src/code_assist/server.test.ts
@@ -327,6 +327,22 @@ describe('CodeAssistServer', () => {
       const url = server.getMethodUrl('testMethod');
       expect(url).toBe('https://custom-endpoint.com/v1internal:testMethod');
     });
+
+    it('should use the CODE_ASSIST_API_VERSION environment variable if set', () => {
+      process.env['CODE_ASSIST_API_VERSION'] = 'v2beta';
+      const server = new CodeAssistServer({} as never);
+      const url = server.getMethodUrl('testMethod');
+      expect(url).toBe('https://cloudcode-pa.googleapis.com/v2beta:testMethod');
+    });
+
+    it('should use default value if CODE_ASSIST_API_VERSION env var is empty', () => {
+      process.env['CODE_ASSIST_API_VERSION'] = '';
+      const server = new CodeAssistServer({} as never);
+      const url = server.getMethodUrl('testMethod');
+      expect(url).toBe(
+        'https://cloudcode-pa.googleapis.com/v1internal:testMethod',
+      );
+    });
   });
 
   it('should call the generateContentStream endpoint and parse SSE', async () => {

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -374,7 +374,9 @@ export class CodeAssistServer implements ContentGenerator {
   private getBaseUrl(): string {
     const endpoint =
       process.env['CODE_ASSIST_ENDPOINT'] ?? CODE_ASSIST_ENDPOINT;
-    return `${endpoint}/${CODE_ASSIST_API_VERSION}`;
+    const version =
+      process.env['CODE_ASSIST_API_VERSION'] || CODE_ASSIST_API_VERSION;
+    return `${endpoint}/${version}`;
   }
 
   getMethodUrl(method: string): string {


### PR DESCRIPTION
## Summary

Enable overriding `CODE_ASSIST_API_VERSION` using env var. This supports testing scenarios with different versions.

## Details

Implementation similar to current support for overriding `CODE_ASSIST_ENDPOINT` with env var.

## Related Issues

Closes #12160

## How to Validate

- Validated with unit test: `npm run test`

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
