### PR TITLE
Make BFS file search for path corrector max dirs configurable.

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -588,6 +588,11 @@ their corresponding top-level category object in your `settings.json` file.
   - **Description:** Maximum number of directories to search for memory.
   - **Default:** `200`
 
+- **`context.bfsFileSearchMaxDirs`** (number):
+  - **Description:** Maximum number of directories the @-completion looks at.
+    High values may cause Gemini CLI to freeze.
+  - **Default:** `50`
+
 - **`context.includeDirectories`** (array):
   - **Description:** Additional directories to include in the workspace context.
     Missing directories will be skipped with a warning.

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -867,6 +867,15 @@ const SETTINGS_SCHEMA = {
         description: 'Maximum number of directories to search for memory.',
         showInDialog: true,
       },
+      bfsFileSearchMaxDirs: {
+        type: 'number',
+        label: '@-Completion Max Dirs',
+        category: 'Context',
+        requiresRestart: false,
+        default: 50,
+        description: 'Maximum number of directories the @-completion looks at.',
+        showInDialog: true,
+      },
       includeDirectories: {
         type: 'array',
         label: 'Include Directories',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -413,6 +413,7 @@ export interface ConfigParameters {
   loadMemoryFromIncludeDirectories?: boolean;
   importFormat?: 'tree' | 'flat';
   discoveryMaxDirs?: number;
+  bfsFileSearchMaxDirs?: number;
   compressionThreshold?: number;
   interactive?: boolean;
   trustedFolder?: boolean;
@@ -555,6 +556,7 @@ export class Config {
   private readonly loadMemoryFromIncludeDirectories: boolean = false;
   private readonly importFormat: 'tree' | 'flat';
   private readonly discoveryMaxDirs: number;
+  private readonly bfsFileSearchMaxDirs: number;
   private readonly compressionThreshold: number | undefined;
   /** Public for testing only */
   readonly interactive: boolean;
@@ -726,6 +728,7 @@ export class Config {
       params.loadMemoryFromIncludeDirectories ?? false;
     this.importFormat = params.importFormat ?? 'tree';
     this.discoveryMaxDirs = params.discoveryMaxDirs ?? 200;
+    this.bfsFileSearchMaxDirs = params.bfsFileSearchMaxDirs ?? 50;
     this.compressionThreshold = params.compressionThreshold;
     this.interactive = params.interactive ?? false;
     this.ptyInfo = params.ptyInfo ?? 'child_process';
@@ -1108,6 +1111,10 @@ export class Config {
 
   getDiscoveryMaxDirs(): number {
     return this.discoveryMaxDirs;
+  }
+
+  getBfsFileSearchMaxDirs(): number {
+    return this.bfsFileSearchMaxDirs;
   }
 
   getContentGeneratorConfig(): ContentGeneratorConfig {

--- a/packages/core/src/utils/pathCorrector.test.ts
+++ b/packages/core/src/utils/pathCorrector.test.ts
@@ -31,6 +31,7 @@ describe('pathCorrector', () => {
       getWorkspaceContext: () =>
         createMockWorkspaceContext(rootDir, [otherWorkspaceDir]),
       getFileService: () => new FileDiscoveryService(rootDir),
+      getBfsFileSearchMaxDirs: () => 50,
       getFileFilteringOptions: () => ({
         respectGitIgnore: true,
         respectGeminiIgnore: true,

--- a/packages/core/src/utils/pathCorrector.ts
+++ b/packages/core/src/utils/pathCorrector.ts
@@ -51,7 +51,7 @@ export function correctPath(
     .flatMap((searchPath) =>
       bfsFileSearchSync(searchPath, {
         fileName: basename,
-        maxDirs: 50, // Capped to avoid deep hangs
+        maxDirs: config.getBfsFileSearchMaxDirs(), // Capped to avoid deep hangs
         fileService: config.getFileService(),
         fileFilteringOptions: config.getFileFilteringOptions(),
       }),

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -986,6 +986,13 @@
           "default": 200,
           "type": "number"
         },
+        "bfsFileSearchMaxDirs": {
+          "title": "@-Completion Max Dirs",
+          "description": "Maximum number of directories the @-completion looks at.",
+          "markdownDescription": "Maximum number of directories the @-completion looks at.",
+          "default": 50,
+          "type": "number"
+        },
         "includeDirectories": {
           "title": "Include Directories",
           "description": "Additional directories to include in the workspace context. Missing directories will be skipped with a warning.",


### PR DESCRIPTION
For some users a low `maxDirs` value prevents from discovering the entire directory and gives them the option to find their own balance in terms of performance.

## Summary

This change introduces a new configuration variable for the maximum directories the BFS file search will look at. By default it is set to 50, which is the same as the current hard-coded variant. This allows users to balance performance and discoverability in different ways depending on their repository structure.

## Related Issues

Fixes #17873 

## How to Validate

1. Go to a directory with a tree of folders.
2. Change the configuration value to a low value.
3. Observe that the @-completion won't find many directories.
4. Change the value to a high value.
5. Observe that the @-completion will find more directories.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
