### PR TITLE
Fix: Avoid tool confirmation timeout when no UI listeners are present

### DIFF
--- a/packages/core/src/confirmation-bus/message-bus.ts
+++ b/packages/core/src/confirmation-bus/message-bus.ts
@@ -79,8 +79,21 @@ export class MessageBus extends EventEmitter {
             });
             break;
           case PolicyDecision.ASK_USER:
-            // Pass through to UI for user confirmation
-            this.emitMessage(message);
+            // Pass through to UI for user confirmation if any listeners exist.
+            // If no listeners are registered (e.g., headless/ACP flows),
+            // immediately request user confirmation to avoid long timeouts.
+            if (
+              this.listenerCount(MessageBusType.TOOL_CONFIRMATION_REQUEST) > 0
+            ) {
+              this.emitMessage(message);
+            } else {
+              this.emitMessage({
+                type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+                correlationId: message.correlationId,
+                confirmed: false,
+                requiresUserConfirmation: true,
+              });
+            }
             break;
           default:
             throw new Error(`Unknown policy decision: ${decision}`);


### PR DESCRIPTION
## Summary

Fixes an issue where tool execution hangs waiting for user confirmation in environments without an attached UI listener (e.g., initial ACP connection or headless mode).

## Details

In `packages/core/src/confirmation-bus/message-bus.ts`, the `ASK_USER` policy decision logic has been updated.
It now checks if there are any active listeners for `TOOL_CONFIRMATION_REQUEST`.
- **If listeners exist:** The request is emitted as usual.
- **If NO listeners exist:** It immediately emits a `TOOL_CONFIRMATION_RESPONSE` with `confirmed: false`.

This prevents the system from waiting indefinitely (or until a long timeout) for a user confirmation that effectively cannot be given, improving responsiveness in automated or headless scenarios.

## Related Issues

Fixes #17952

## How to Validate

1. Run the Gemini CLI in a headless mode or initiate an ACP connection without an interactive UI immediately available.
2. Trigger an action that requires tool confirmation.
3. Observe that the operation fails fast (or is handled) rather than hanging for a timeout duration.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Linux
    - [x] npm run (Verified locally)