### PR TITLE
feat(plan): refactor `ToolConfirmationPayload` to union type

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -13,6 +13,7 @@ import {
   type SerializableConfirmationDetails,
   type ToolCallConfirmationDetails,
   type Config,
+  type ToolConfirmationPayload,
   ToolConfirmationOutcome,
   hasRedirection,
   debugLogger,
@@ -65,10 +66,7 @@ export const ToolConfirmationMessage: React.FC<
   const isTrustedFolder = config.isTrustedFolder();
 
   const handleConfirm = useCallback(
-    (
-      outcome: ToolConfirmationOutcome,
-      payload?: { answers?: { [questionIndex: string]: string } },
-    ) => {
+    (outcome: ToolConfirmationOutcome, payload?: ToolConfirmationPayload) => {
       void confirm(callId, outcome, payload).catch((error: unknown) => {
         debugLogger.error(
           `Failed to handle tool confirmation for ${callId}:`,

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -1847,6 +1847,83 @@ describe('CoreToolScheduler Sequential Execution', () => {
     modifyWithEditorSpy.mockRestore();
   });
 
+  it('should handle inline modify with empty new content', async () => {
+    // Mock the modifiable check to return true for this test
+    const isModifiableSpy = vi
+      .spyOn(modifiableToolModule, 'isModifiableDeclarativeTool')
+      .mockReturnValue(true);
+
+    const mockTool = new MockModifiableTool();
+    const mockToolRegistry = {
+      getTool: () => mockTool,
+      getAllToolNames: () => [],
+    } as unknown as ToolRegistry;
+
+    const mockConfig = createMockConfig({
+      getToolRegistry: () => mockToolRegistry,
+      isInteractive: () => true,
+    });
+    mockConfig.getHookSystem = vi.fn().mockReturnValue(undefined);
+
+    const scheduler = new CoreToolScheduler({
+      config: mockConfig,
+      getPreferredEditor: () => 'vscode',
+    });
+
+    // Manually inject a waiting tool call
+    const callId = 'call-1';
+    const toolCall: WaitingToolCall = {
+      status: 'awaiting_approval',
+      request: {
+        callId,
+        name: 'mockModifiableTool',
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'p1',
+      },
+      tool: mockTool,
+      invocation: {} as unknown as ToolInvocation<
+        Record<string, unknown>,
+        ToolResult
+      >,
+      confirmationDetails: {
+        type: 'edit',
+        title: 'Confirm',
+        fileName: 'test.txt',
+        filePath: 'test.txt',
+        fileDiff: 'diff',
+        originalContent: 'old',
+        newContent: 'new',
+        onConfirm: async () => {},
+      },
+      startTime: Date.now(),
+    };
+
+    const schedulerInternals = scheduler as unknown as {
+      toolCalls: ToolCall[];
+      toolModifier: { applyInlineModify: Mock };
+    };
+    schedulerInternals.toolCalls = [toolCall];
+
+    const applyInlineModifySpy = vi
+      .spyOn(schedulerInternals.toolModifier, 'applyInlineModify')
+      .mockResolvedValue({
+        updatedParams: { content: '' },
+        updatedDiff: 'diff-empty',
+      });
+
+    await scheduler.handleConfirmationResponse(
+      callId,
+      async () => {},
+      ToolConfirmationOutcome.ProceedOnce,
+      new AbortController().signal,
+      { newContent: '' } as ToolConfirmationPayload,
+    );
+
+    expect(applyInlineModifySpy).toHaveBeenCalled();
+    isModifiableSpy.mockRestore();
+  });
+
   it('should pass serverName to policy engine for DiscoveredMCPTool', async () => {
     const mockMcpTool = {
       tool: async () => ({ functionDeclarations: [] }),

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -789,12 +789,7 @@ export class CoreToolScheduler {
     } else {
       // If the client provided new content, apply it and wait for
       // re-confirmation.
-      if (
-        payload &&
-        'newContent' in payload &&
-        payload.newContent &&
-        toolCall
-      ) {
+      if (payload && 'newContent' in payload && toolCall) {
         const result = await this.toolModifier.applyInlineModify(
           toolCall as WaitingToolCall,
           payload,

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -789,7 +789,12 @@ export class CoreToolScheduler {
     } else {
       // If the client provided new content, apply it and wait for
       // re-confirmation.
-      if (payload?.newContent && toolCall) {
+      if (
+        payload &&
+        'newContent' in payload &&
+        payload.newContent &&
+        toolCall
+      ) {
         const result = await this.toolModifier.applyInlineModify(
           toolCall as WaitingToolCall,
           payload,

--- a/packages/core/src/scheduler/confirmation.ts
+++ b/packages/core/src/scheduler/confirmation.ts
@@ -156,7 +156,7 @@ export async function resolveConfirmation(
 
     if (outcome === ToolConfirmationOutcome.ModifyWithEditor) {
       await handleExternalModification(deps, toolCall, signal);
-    } else if (response.payload?.newContent) {
+    } else if (response.payload && 'newContent' in response.payload) {
       await handleInlineModification(deps, toolCall, response.payload, signal);
       outcome = ToolConfirmationOutcome.ProceedOnce;
     }

--- a/packages/core/src/scheduler/tool-modifier.ts
+++ b/packages/core/src/scheduler/tool-modifier.ts
@@ -71,7 +71,6 @@ export class ToolModificationHandler {
     if (
       toolCall.confirmationDetails.type !== 'edit' ||
       !('newContent' in payload) ||
-      !payload.newContent ||
       !isModifiableDeclarativeTool(toolCall.tool)
     ) {
       return undefined;

--- a/packages/core/src/scheduler/tool-modifier.ts
+++ b/packages/core/src/scheduler/tool-modifier.ts
@@ -70,6 +70,7 @@ export class ToolModificationHandler {
   ): Promise<ModificationResult | undefined> {
     if (
       toolCall.confirmationDetails.type !== 'edit' ||
+      !('newContent' in payload) ||
       !payload.newContent ||
       !isModifiableDeclarativeTool(toolCall.tool)
     ) {

--- a/packages/core/src/tools/ask-user.ts
+++ b/packages/core/src/tools/ask-user.ts
@@ -180,7 +180,7 @@ export class AskUserInvocation extends BaseToolInvocation<
         payload?: ToolConfirmationPayload,
       ) => {
         this.confirmationOutcome = outcome;
-        if (payload?.answers) {
+        if (payload && 'answers' in payload) {
           this.userAnswers = payload.answers;
         }
       },

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -693,13 +693,17 @@ export interface ToolEditConfirmationDetails {
   ideConfirmation?: Promise<DiffUpdateResult>;
 }
 
-export interface ToolConfirmationPayload {
-  // used to override `modifiedProposedContent` for modifiable tools in the
-  // inline modify flow
-  newContent?: string;
-  // used for askuser tool to return user's answers
-  answers?: { [questionIndex: string]: string };
+export interface ToolEditConfirmationPayload {
+  newContent: string;
 }
+
+export interface ToolAskUserConfirmationPayload {
+  answers: { [questionIndex: string]: string };
+}
+
+export type ToolConfirmationPayload =
+  | ToolEditConfirmationPayload
+  | ToolAskUserConfirmationPayload;
 
 export interface ToolExecuteConfirmationDetails {
   type: 'exec';


### PR DESCRIPTION
## Summary

Refactors `ToolConfirmationPayload` from an interface with optional properties into a discriminated union of specific payload types: `ToolEditConfirmationPayload` and `ToolAskUserConfirmationPayload`.

## Details

This change improves type safety across the scheduler and tool invocation layers by eliminating ambiguous states where a payload could potentially have conflicting or missing properties. It requires consumers to perform explicit checks (e.g., `'newContent' in payload`) before accessing data, preventing runtime errors.

Crucially, this refactor makes it easy to add new payload types in the future, specifically to support plan approval payloads for the upcoming `exit_plan_mode` tool.

## How to Validate

1.  **Build the project:**
    - Run `npm run build:all`

2.  **Verify `ask-user` tool (payload validation):**
    - Run the CLI: `npm run start`
    - Provide a prompt that triggers questions: `Ask me what my favorite color is`
    - Submit an answer in the UI.
    - Verify the CLI proceeds without error.

3.  **Verify `edit` tool (payload validation):**
    - In the same CLI session, create a test file: `Create hello.txt with content "hello"`
    - Request an edit: `Change "hello" to "universe" in hello.txt`
    - Accept the diff confirmation in the TUI.
    - Verify `hello.txt` content is updated correctly.

## Related
Fixes #17977

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (n/a - internal refactor)
- [x] Added/updated tests (existing tests cover the refactored paths)
- [ ] Noted breaking changes (none, internal API refactor)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
  - [ ] Linux
