### PR TITLE
fix(core): add error logging for IDE fetch failures

### DIFF
--- a/packages/core/src/ide/ide-connection-utils.ts
+++ b/packages/core/src/ide/ide-connection-utils.ts
@@ -215,13 +215,20 @@ export async function createProxyAwareFetch(ideServerHost: string) {
     };
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const options = fetchOptions as unknown as import('undici').RequestInit;
-    const response = await fetchFn(url, options);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    return new Response(response.body as ReadableStream<unknown> | null, {
-      status: response.status,
-      statusText: response.statusText,
-      headers: [...response.headers.entries()],
-    });
+    try {
+      const response = await fetchFn(url, options);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      return new Response(response.body as ReadableStream<unknown> | null, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: [...response.headers.entries()],
+      });
+    } catch (error) {
+      logger.error(
+        `IDE fetch failed for ${url instanceof URL ? url.href : url}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      throw error;
+    }
   };
 }
 

--- a/packages/core/src/ide/ide-connection-utils.ts
+++ b/packages/core/src/ide/ide-connection-utils.ts
@@ -224,8 +224,7 @@ export async function createProxyAwareFetch(ideServerHost: string) {
         headers: [...response.headers.entries()],
       });
     } catch (error) {
-      const urlString =
-        typeof url === 'string' ? url : url instanceof URL ? url.href : url.url;
+      const urlString = typeof url === 'string' ? url : url.href;
       logger.error(`IDE fetch failed for ${urlString}`, error);
       throw error;
     }

--- a/packages/core/src/ide/ide-connection-utils.ts
+++ b/packages/core/src/ide/ide-connection-utils.ts
@@ -225,7 +225,8 @@ export async function createProxyAwareFetch(ideServerHost: string) {
       });
     } catch (error) {
       logger.error(
-        `IDE fetch failed for ${url instanceof URL ? url.href : url}: ${error instanceof Error ? error.message : String(error)}`,
+        `IDE fetch failed for ${url instanceof URL ? url.href : url}`,
+        error,
       );
       throw error;
     }

--- a/packages/core/src/ide/ide-connection-utils.ts
+++ b/packages/core/src/ide/ide-connection-utils.ts
@@ -224,10 +224,9 @@ export async function createProxyAwareFetch(ideServerHost: string) {
         headers: [...response.headers.entries()],
       });
     } catch (error) {
-      logger.error(
-        `IDE fetch failed for ${url instanceof URL ? url.href : url}`,
-        error,
-      );
+      const urlString =
+        typeof url === 'string' ? url : url instanceof URL ? url.href : url.url;
+      logger.error(`IDE fetch failed for ${urlString}`, error);
       throw error;
     }
   };


### PR DESCRIPTION
## Summary
Fixes #17513

Add try-catch block around the fetch call in `createProxyAwareFetch` to log errors before re-throwing. This helps diagnose IDE connection issues like "TypeError: fetch failed" by providing more context in debug logs.

The error is logged with the URL that failed, making it easier to troubleshoot network connectivity issues between the CLI and IDE.

## Test plan
- [x] Run `npx vitest run packages/core/src/ide/ide-client.test.ts` - all 56 tests pass
- [ ] Manual testing with IDE connection failures (disconnect network, check debug logs)