### PR TITLE
fix: Enable persistent model selection in settings dialog

### DIFF
--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -73,11 +73,12 @@ they appear in the UI.
 
 ### Model
 
-| UI Label                | Setting                      | Description                                                                            | Default |
-| ----------------------- | ---------------------------- | -------------------------------------------------------------------------------------- | ------- |
-| Max Session Turns       | `model.maxSessionTurns`      | Maximum number of user/model/tool turns to keep in a session. -1 means unlimited.      | `-1`    |
-| Compression Threshold   | `model.compressionThreshold` | The fraction of context usage at which to trigger context compression (e.g. 0.2, 0.3). | `0.5`   |
-| Skip Next Speaker Check | `model.skipNextSpeakerCheck` | Skip the next speaker check.                                                           | `true`  |
+| UI Label                | Setting                      | Description                                                                            | Default     |
+| ----------------------- | ---------------------------- | -------------------------------------------------------------------------------------- | ----------- |
+| Model                   | `model.name`                 | The Gemini model to use for conversations.                                             | `undefined` |
+| Max Session Turns       | `model.maxSessionTurns`      | Maximum number of user/model/tool turns to keep in a session. -1 means unlimited.      | `-1`        |
+| Compression Threshold   | `model.compressionThreshold` | The fraction of context usage at which to trigger context compression (e.g. 0.2, 0.3). | `0.5`       |
+| Skip Next Speaker Check | `model.skipNextSpeakerCheck` | Skip the next speaker check.                                                           | `true`      |
 
 ### Context
 

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -696,7 +696,7 @@ const SETTINGS_SCHEMA = {
         requiresRestart: false,
         default: undefined as string | undefined,
         description: 'The Gemini model to use for conversations.',
-        showInDialog: false,
+        showInDialog: true,
       },
       maxSessionTurns: {
         type: 'number',


### PR DESCRIPTION
## Summary

Enables the model selection setting to appear in the interactive settings dialog. This allows users to persist their preferred model choice across CLI sessions, fixing a bug where model selection was not being saved.

## Details

The `model.name` configuration in `packages/cli/src/config/settingsSchema.ts` had the `showInDialog` property set to `false`. This prevented the setting from being exposed in the `/settings` UI, meaning users couldn't easily set a persistent default model. This change updates `showInDialog` to `true`.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/17987

## How to Validate

1. Start the CLI: `npm start`
2. Run the settings command: `/settings`
3. Navigate to the **Model** section (or General, depending on layout) and verify that **Model Name** is now visible.
4. Change the model to a specific value (e.g., select a specific `gemini-pro` version).
5. Exit the CLI and restart it.
6. Verify the selection persisted by running `/about` or checking `/settings` again.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [x] Docker
    - [x] Podman
    - [x] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
