### PR TITLE
fix(ui): prevent content leak in `MaxSizedBox` bottom overflow

### DIFF
--- a/packages/cli/src/ui/components/shared/MaxSizedBox.tsx
+++ b/packages/cli/src/ui/components/shared/MaxSizedBox.tsx
@@ -123,7 +123,7 @@ export const MaxSizedBox: React.FC<MaxSizedBoxProps> = ({
       <Box
         flexDirection="column"
         overflow="hidden"
-        flexGrow={1}
+        flexGrow={0}
         maxHeight={isOverflowing ? visibleContentHeight : undefined}
       >
         <Box

--- a/packages/cli/src/ui/components/shared/MaxSizedBox.tsx
+++ b/packages/cli/src/ui/components/shared/MaxSizedBox.tsx
@@ -120,7 +120,12 @@ export const MaxSizedBox: React.FC<MaxSizedBoxProps> = ({
           hidden ...
         </Text>
       )}
-      <Box flexDirection="column" overflow="hidden" flexGrow={1}>
+      <Box
+        flexDirection="column"
+        overflow="hidden"
+        flexGrow={1}
+        maxHeight={isOverflowing ? visibleContentHeight : undefined}
+      >
         <Box
           flexDirection="column"
           ref={onRefChange}

--- a/packages/cli/src/ui/components/shared/__snapshots__/MaxSizedBox.test.tsx.snap
+++ b/packages/cli/src/ui/components/shared/__snapshots__/MaxSizedBox.test.tsx.snap
@@ -31,6 +31,14 @@ Line 29
 Line 30"
 `;
 
+exports[`<MaxSizedBox /> > does not leak content after hidden indicator with bottom overflow 1`] = `
+"Plan
+
+ - Step 1: Do something important
+ - Step 2: Do something important
+... last 18 lines hidden ..."
+`;
+
 exports[`<MaxSizedBox /> > does not truncate when maxHeight is undefined 1`] = `
 "Line 1
 Line 2"


### PR DESCRIPTION
When using `overflowDirection="bottom"`, content was bleeding through after the `"... last N lines hidden ..."` indicator:

```
... last 18 lines hidden ...rtant
```

This was caused by the inner overflow Box not having a constrained height. This change adds `maxHeight` constraint to inner overflow Box when overflowing.

Fixes https://github.com/google-gemini/gemini-cli/issues/17990
