### PR TITLE
Support ctrl-C and Ctrl-D correctly Refactor so InputPrompt has priority over AppContainer for input handling.

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -1515,6 +1515,50 @@ describe('useTextBuffer', () => {
       expect(getBufferState(result).text).toBe('');
     });
 
+    it('should handle CLEAR_INPUT (Ctrl+C)', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'hello',
+          viewport,
+          isValidPath: () => false,
+        }),
+      );
+      expect(getBufferState(result).text).toBe('hello');
+      let handled = false;
+      act(() => {
+        handled = result.current.handleInput({
+          name: 'c',
+          shift: false,
+          alt: false,
+          ctrl: true,
+          cmd: false,
+          insertable: false,
+          sequence: '\u0003',
+        });
+      });
+      expect(handled).toBe(true);
+      expect(getBufferState(result).text).toBe('');
+    });
+
+    it('should NOT handle CLEAR_INPUT if buffer is empty', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({ viewport, isValidPath: () => false }),
+      );
+      let handled = true;
+      act(() => {
+        handled = result.current.handleInput({
+          name: 'c',
+          shift: false,
+          alt: false,
+          ctrl: true,
+          cmd: false,
+          insertable: false,
+          sequence: '\u0003',
+        });
+      });
+      expect(handled).toBe(false);
+    });
+
     it('should handle "Backspace" key', () => {
       const { result } = renderHook(() =>
         useTextBuffer({

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2930,6 +2930,13 @@ export function useTextBuffer({
         move('end');
         return true;
       }
+      if (keyMatchers[Command.CLEAR_INPUT](key)) {
+        if (text.length > 0) {
+          setText('');
+          return true;
+        }
+        return false;
+      }
       if (keyMatchers[Command.DELETE_WORD_BACKWARD](key)) {
         deleteWordLeft();
         return true;
@@ -2943,6 +2950,13 @@ export function useTextBuffer({
         return true;
       }
       if (keyMatchers[Command.DELETE_CHAR_RIGHT](key)) {
+        const lastLineIdx = lines.length - 1;
+        if (
+          cursorRow === lastLineIdx &&
+          cursorCol === cpLen(lines[lastLineIdx] ?? '')
+        ) {
+          return false;
+        }
         del();
         return true;
       }
@@ -2974,6 +2988,8 @@ export function useTextBuffer({
       cursorCol,
       lines,
       singleLine,
+      setText,
+      text,
     ],
   );
 


### PR DESCRIPTION
## Summary

Ctrl-D was broken by recent changes

## Details

Simplified both Ctrl-C and Ctrl-D behavior so AppContainer is less coupled to InputPrompt internals and we can just rely on bubbling

## How to test
Verify that pressing ctrl-C twice to exit and ctrl-D twice to exit works in every part of the app.
## Related Issues

Fixes: #17994