### PR TITLE
Save transcript to file before function call is performed

### DIFF
--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -818,13 +818,11 @@ export class GeminiChat {
         if (content?.parts) {
           if (content.parts.some((part) => part.thought)) {
             // Record thoughts
+            hasThoughts = true;
             this.recordThoughtFromContent(content);
           }
           if (content.parts.some((part) => part.functionCall)) {
             hasToolCall = true;
-          }
-          if (content.parts.some((part) => part.thought)) {
-            hasThoughts = true;
           }
 
           modelResponseParts.push(

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -802,6 +802,7 @@ export class GeminiChat {
     const modelResponseParts: Part[] = [];
 
     let hasToolCall = false;
+    let hasThoughts = false;
     let finishReason: FinishReason | undefined;
 
     for await (const chunk of streamResponse) {
@@ -821,6 +822,9 @@ export class GeminiChat {
           }
           if (content.parts.some((part) => part.functionCall)) {
             hasToolCall = true;
+          }
+          if (content.parts.some((part) => part.thought)) {
+            hasThoughts = true;
           }
 
           modelResponseParts.push(
@@ -885,7 +889,7 @@ export class GeminiChat {
       .trim();
 
     // Record model response text from the collected parts
-    if (responseText) {
+    if (responseText || hasThoughts) {
       this.chatRecordingService.recordMessage({
         model,
         type: 'gemini',


### PR DESCRIPTION
## Summary

This PR closes https://github.com/google-gemini/gemini-cli/issues/17922.

It flushes transcript to disk to ensure it's available in a `BeforeTool` hook.

## Details

Before this PR, transcript contains:

```json
{
  "messages": [
    {
      "type": "user",
      "content": "analyze code test.py"
    }
  ]
}
```

After this PR:

```json
{
   "messages": [
      {
       "type": "user",
       "content": "analyze code test.py"
      },
      {
       "type": "gemini",
       "content": "I'm calling the function...",
       "thoughts": [
        {
          "subject": "Initiating Code Exploration",
          "description": "I'm starting by examining the code located at `test.py`. My immediate plan is to use the `read_file` tool. This will help me acquire the content of the file so I can provide a comprehensive explanation.",
        }
       ]
     }
  ]
}
```
## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
