### PR TITLE
No link to web-fetch docs in sidebar

### DIFF
--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -21,7 +21,8 @@
       { "label": "Shell commands", "slug": "docs/tools/shell" },
       { "label": "Session management", "slug": "docs/cli/session-management" },
       { "label": "Todos", "slug": "docs/tools/todos" },
-      { "label": "Web search and fetch", "slug": "docs/tools/web-search" }
+      { "label": "Web search", "slug": "docs/tools/web-search" },
+      { "label": "Web fetch", "slug": "docs/tools/web-fetch" }
     ]
   },
   {


### PR DESCRIPTION
The sidebar link titled "Web search and fetch" only links to the web-search page. This PR adds a second link to the web-fetch page.