### PR TITLE
feat(core): add setting to disable loop detection

### DIFF
--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -77,6 +77,7 @@ they appear in the UI.
 | ----------------------- | ---------------------------- | -------------------------------------------------------------------------------------- | ------- |
 | Max Session Turns       | `model.maxSessionTurns`      | Maximum number of user/model/tool turns to keep in a session. -1 means unlimited.      | `-1`    |
 | Compression Threshold   | `model.compressionThreshold` | The fraction of context usage at which to trigger context compression (e.g. 0.2, 0.3). | `0.5`   |
+| Disable Loop Detection  | `model.disableLoopDetection` | Disable automatic detection and prevention of infinite loops.                          | `false` |
 | Skip Next Speaker Check | `model.skipNextSpeakerCheck` | Skip the next speaker check.                                                           | `true`  |
 
 ### Context

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -326,6 +326,12 @@ their corresponding top-level category object in your `settings.json` file.
   - **Default:** `0.5`
   - **Requires restart:** Yes
 
+- **`model.disableLoopDetection`** (boolean):
+  - **Description:** Disable automatic detection and prevention of infinite
+    loops.
+  - **Default:** `false`
+  - **Requires restart:** Yes
+
 - **`model.skipNextSpeakerCheck`** (boolean):
   - **Description:** Skip the next speaker check.
   - **Default:** `true`

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -762,6 +762,7 @@ export async function loadCliConfig(
     noBrowser: !!process.env['NO_BROWSER'],
     summarizeToolOutput: settings.model?.summarizeToolOutput,
     ideMode,
+    disableLoopDetection: settings.model?.disableLoopDetection,
     compressionThreshold: settings.model?.compressionThreshold,
     folderTrust,
     interactive,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -739,6 +739,16 @@ const SETTINGS_SCHEMA = {
           'The fraction of context usage at which to trigger context compression (e.g. 0.2, 0.3).',
         showInDialog: true,
       },
+      disableLoopDetection: {
+        type: 'boolean',
+        label: 'Disable Loop Detection',
+        category: 'Model',
+        requiresRestart: true,
+        default: false,
+        description:
+          'Disable automatic detection and prevention of infinite loops.',
+        showInDialog: true,
+      },
       skipNextSpeakerCheck: {
         type: 'boolean',
         label: 'Skip Next Speaker Check',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -393,6 +393,7 @@ export interface ConfigParameters {
   includeDirectories?: string[];
   bugCommand?: BugCommandSettings;
   model: string;
+  disableLoopDetection?: boolean;
   maxSessionTurns?: number;
   experimentalZedIntegration?: boolean;
   listSessions?: boolean;
@@ -531,6 +532,7 @@ export class Config {
   private readonly cwd: string;
   private readonly bugCommand: BugCommandSettings | undefined;
   private model: string;
+  private readonly disableLoopDetection: boolean;
   private previewFeatures: boolean | undefined;
   private hasAccessToPreviewModel: boolean = false;
   private readonly noBrowser: boolean;
@@ -697,6 +699,7 @@ export class Config {
     this.fileDiscoveryService = params.fileDiscoveryService ?? null;
     this.bugCommand = params.bugCommand;
     this.model = params.model;
+    this.disableLoopDetection = params.disableLoopDetection ?? false;
     this._activeModel = params.model;
     this.enableAgents = params.enableAgents ?? false;
     this.agents = params.agents ?? {};
@@ -1116,6 +1119,10 @@ export class Config {
 
   getModel(): string {
     return this.model;
+  }
+
+  getDisableLoopDetection(): boolean {
+    return this.disableLoopDetection ?? false;
   }
 
   setModel(newModel: string, isTemporary: boolean = true): void {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -213,6 +213,7 @@ describe('Gemini Client (client.ts)', () => {
       getGlobalMemory: vi.fn().mockReturnValue(''),
       getEnvironmentMemory: vi.fn().mockReturnValue(''),
       isJitContextEnabled: vi.fn().mockReturnValue(false),
+      getDisableLoopDetection: vi.fn().mockReturnValue(false),
 
       getSessionId: vi.fn().mockReturnValue('test-session-id'),
       getProxy: vi.fn().mockReturnValue(undefined),

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -38,6 +38,7 @@ describe('LoopDetectionService', () => {
     mockConfig = {
       getTelemetryEnabled: () => true,
       isInteractive: () => false,
+      getDisableLoopDetection: () => false,
       getModelAvailabilityService: vi
         .fn()
         .mockReturnValue(createAvailabilityServiceMock()),
@@ -161,6 +162,15 @@ describe('LoopDetectionService', () => {
 
       // Should now return false even though a loop was previously detected
       expect(service.addAndCheck(event)).toBe(false);
+    });
+
+    it('should skip loop detection if disabled in config', () => {
+      vi.spyOn(mockConfig, 'getDisableLoopDetection').mockReturnValue(true);
+      const event = createToolCallRequestEvent('testTool', { param: 'value' });
+      for (let i = 0; i < TOOL_CALL_LOOP_THRESHOLD + 2; i++) {
+        expect(service.addAndCheck(event)).toBe(false);
+      }
+      expect(loggers.logLoopDetected).not.toHaveBeenCalled();
     });
   });
 
@@ -742,6 +752,7 @@ describe('LoopDetectionService LLM Checks', () => {
     mockConfig = {
       getGeminiClient: () => mockGeminiClient,
       getBaseLlmClient: () => mockBaseLlmClient,
+      getDisableLoopDetection: () => false,
       getDebugMode: () => false,
       getTelemetryEnabled: () => true,
       getModel: vi.fn().mockReturnValue('cognitive-loop-v1'),

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -147,7 +147,7 @@ export class LoopDetectionService {
    * @returns true if a loop is detected, false otherwise
    */
   addAndCheck(event: ServerGeminiStreamEvent): boolean {
-    if (this.disabledForSession) {
+    if (this.disabledForSession || this.config.getDisableLoopDetection()) {
       return false;
     }
 
@@ -182,7 +182,7 @@ export class LoopDetectionService {
    * @returns A promise that resolves to `true` if a loop is detected, and `false` otherwise.
    */
   async turnStarted(signal: AbortSignal) {
-    if (this.disabledForSession) {
+    if (this.disabledForSession || this.config.getDisableLoopDetection()) {
       return false;
     }
     this.turnsInCurrentPrompt++;

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -457,6 +457,13 @@
           "default": 0.5,
           "type": "number"
         },
+        "disableLoopDetection": {
+          "title": "Disable Loop Detection",
+          "description": "Disable automatic detection and prevention of infinite loops.",
+          "markdownDescription": "Disable automatic detection and prevention of infinite loops.\n\n- Category: `Model`\n- Requires restart: `yes`\n- Default: `false`",
+          "default": false,
+          "type": "boolean"
+        },
         "skipNextSpeakerCheck": {
           "title": "Skip Next Speaker Check",
           "description": "Skip the next speaker check.",


### PR DESCRIPTION
## TLDR
This PR adds a new setting `model.disableLoopDetection` to allow users to disable the automatic detection and prevention of infinite loops. This is useful for scenarios where productive repetitive behavior is incorrectly flagged as a loop.

## Dive Deeper
The `LoopDetectionService` currently monitors both tool call repetitions and content streaming patterns. While effective, it can sometimes produce false positives. By adding this setting, users can opt-out of this behavior globally via their `settings.json` or the `/settings` command.

Changes include:
- Core configuration updates to support the new flag.
- Integration into the CLI settings schema and JSON schema for IDE support.
- Documentation updates in `configuration.md` and `settings.md`.
- Marking the setting as requiring a restart.

## Reviewer Test Plan
1. Open Gemini CLI.
2. Run `/settings` and navigate to the **Model** section.
3. Verify "Disable Loop Detection" is present and defaults to `false`.
4. Enable it and verify it's saved to `settings.json`.
5. Verify that with the setting enabled, `LoopDetectionService` bypasses its checks.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
#18007