### PR TITLE
fix(workflow): update maintainer check logic to be inclusive and case-insensitive

### DIFF
--- a/.github/workflows/gemini-scheduled-stale-pr-closer.yml
+++ b/.github/workflows/gemini-scheduled-stale-pr-closer.yml
@@ -48,14 +48,15 @@ jobs:
                 org: context.repo.owner,
                 team_slug: 'gemini-cli-maintainers'
               });
-              maintainerLogins = new Set(members.map(m => m.login));
+              maintainerLogins = new Set(members.map(m => m.login.toLowerCase()));
             } catch (e) {
               core.warning('Failed to fetch team members');
             }
 
             const isMaintainer = (login, assoc) => {
-              if (maintainerLogins.size > 0) return maintainerLogins.has(login);
-              return ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(assoc);
+              const isTeamMember = maintainerLogins.has(login.toLowerCase());
+              const isRepoMaintainer = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(assoc);
+              return isTeamMember || isRepoMaintainer;
             };
 
             // 2. Determine which PRs to check


### PR DESCRIPTION
## Summary

This PR fixes the maintainer detection logic in the stale PR closer workflow. It ensures that legitimate maintainers are correctly identified by being inclusive of both organization team membership and individual repository associations.

## Details

The `isMaintainer` check in `.github/workflows/gemini-scheduled-stale-pr-closer.yml` was previously exclusive: if the `gemini-cli-maintainers` team could be fetched, it ignored the user's repository association (`OWNER`, `MEMBER`, `COLLABORATOR`).

This PR updates the logic to:
1.  **Be Inclusive:** A user is considered a maintainer if they are either in the specific maintainers team OR have a privileged repository association.
2.  **Be Case-Insensitive:** Usernames are now compared case-insensitively, preventing failures due to casing mismatches between the GitHub API and event payloads.

This aligns the logic with other maintainer-aware workflows in the project and prevents the automatic closure of PRs from legitimate project maintainers who are not explicitly in the specific team.

## Related Issues

Fixes a regression where maintainer PRs were being closed for missing linked issues.

## How to Validate

This is a workflow change. Validation was performed by:
1.  Comparing the logic with other workflows (`pr-contribution-guidelines-notifier.yml`, etc.) to ensure consistency.
2.  Verifying the inclusive `OR` logic and `.toLowerCase()` implementation.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (N/A)
- [x] Added/updated tests (N/A)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS (Workflow logic review)
  - [x] Linux (Workflow logic review)
