### PR TITLE
feat(useAtCompletion): Suggest to user files from includeDirectories (completion)

### DIFF
--- a/packages/cli/src/ui/hooks/useAtCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.test.ts
@@ -55,6 +55,7 @@ describe('useAtCompletion', () => {
       getResourceRegistry: vi.fn().mockReturnValue({
         getAllResources: () => [],
       }),
+      getWorkspaceContext: () => undefined,
     } as unknown as Config;
     vi.clearAllMocks();
   });


### PR DESCRIPTION
## Summary

Suggest to user files from includeDirectories

## Details

Refactor the file search logic to handle multiple directories, allowing for concurrent searches across different roots. This change enhances the search capabilities and optimizes the suggestion retrieval process.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

try adding includeDirectories and tag files from there

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
