### PR TITLE
feat(cli): add --schema-file flag for custom JSON schema output

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -184,7 +184,8 @@ export async function parseArguments(
         .option('schema-file', {
           type: 'string',
           string: true,
-          description: 'A user defined JSON schema file location.',
+          description:
+            'Path to a JSON schema file for structured output. Implies --output-format json. Tools are disabled by default.',
           coerce: (filePath: string) => {
             if (!fs.existsSync(filePath)) {
               throw new Error(`Schema file not found: ${filePath}`);
@@ -205,19 +206,17 @@ export async function parseArguments(
 
             if (!schema.type && !schema.properties) {
               throw new Error(
-                'Invalid JSON schema: must have name "type" or "properties"',
+                'Invalid JSON schema: must have "type" or "properties"',
               );
             }
 
-            if (Object.keys(schema).length === 0) {
-              throw new Error('JSON Schema must not be empty');
-            }
             return schema;
           },
         })
         .option('enable-tools', {
           type: 'boolean',
-          description: 'Enable tool usage when specifying a custom JSON schema',
+          description:
+            'Re-enable tool usage when using --schema-file (tools are disabled by default with schemas)',
         })
         .option('extensions', {
           alias: 'e',
@@ -835,7 +834,10 @@ export async function loadCliConfig(
     eventEmitter: coreEvents,
     useWriteTodos: argv.useWriteTodos ?? settings.useWriteTodos,
     output: {
-      format: (argv.outputFormat ?? settings.output?.format) as OutputFormat,
+      // --schema-file implies --output-format json
+      format: (argv.schemaFile
+        ? 'json'
+        : (argv.outputFormat ?? settings.output?.format)) as OutputFormat,
     },
     fakeResponses: argv.fakeResponses,
     recordResponses: argv.recordResponses,

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -497,6 +497,8 @@ describe('gemini.tsx main function kitty protocol', () => {
       rawOutput: undefined,
       acceptRawOutputRisk: undefined,
       isCommand: undefined,
+      enableTools: undefined,
+      schemaFile: undefined,
     });
 
     await act(async () => {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -480,13 +480,18 @@ export async function runNonInteractive({
                 ),
               });
             } else if (config.getOutputFormat() === OutputFormat.JSON) {
-              const formatter = new JsonFormatter();
-              const stats = uiTelemetryService.getMetrics();
-              textOutput.write(
-                formatter.format(config.getSessionId(), responseText, stats),
-              );
+              if (config.getJsonSchema()) {
+                textOutput.write(responseText);
+                textOutput.ensureTrailingNewline();
+              } else {
+                const formatter = new JsonFormatter();
+                const stats = uiTelemetryService.getMetrics();
+                textOutput.write(
+                  formatter.format(config.getSessionId(), responseText, stats),
+                );
+              }
             } else {
-              textOutput.ensureTrailingNewline(); // Ensure a final newline
+              textOutput.ensureTrailingNewline();
             }
             return;
           }
@@ -504,13 +509,18 @@ export async function runNonInteractive({
               stats: streamFormatter.convertToStreamStats(metrics, durationMs),
             });
           } else if (config.getOutputFormat() === OutputFormat.JSON) {
-            const formatter = new JsonFormatter();
-            const stats = uiTelemetryService.getMetrics();
-            textOutput.write(
-              formatter.format(config.getSessionId(), responseText, stats),
-            );
+            if (config.getJsonSchema()) {
+              textOutput.write(responseText);
+              textOutput.ensureTrailingNewline();
+            } else {
+              const formatter = new JsonFormatter();
+              const stats = uiTelemetryService.getMetrics();
+              textOutput.write(
+                formatter.format(config.getSessionId(), responseText, stats),
+              );
+            }
           } else {
-            textOutput.ensureTrailingNewline(); // Ensure a final newline
+            textOutput.ensureTrailingNewline();
           }
           return;
         }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -363,6 +363,8 @@ export interface ConfigParameters {
   coreTools?: string[];
   allowedTools?: string[];
   excludeTools?: string[];
+  enableTools?: boolean;
+  jsonSchema?: object;
   toolDiscoveryCommand?: string;
   toolCallCommand?: string;
   mcpServerCommand?: string;
@@ -497,6 +499,8 @@ export class Config {
   private readonly coreTools: string[] | undefined;
   private readonly allowedTools: string[] | undefined;
   private readonly excludeTools: string[] | undefined;
+  private readonly enableTools?: boolean | undefined;
+  private readonly jsonSchema?: object | undefined;
   private readonly toolDiscoveryCommand: string | undefined;
   private readonly toolCallCommand: string | undefined;
   private readonly mcpServerCommand: string | undefined;
@@ -641,6 +645,8 @@ export class Config {
     this.coreTools = params.coreTools;
     this.allowedTools = params.allowedTools;
     this.excludeTools = params.excludeTools;
+    this.jsonSchema = params.jsonSchema;
+    this.enableTools = params.enableTools;
     this.toolDiscoveryCommand = params.toolDiscoveryCommand;
     this.toolCallCommand = params.toolCallCommand;
     this.mcpServerCommand = params.mcpServerCommand;
@@ -1318,6 +1324,14 @@ export class Config {
       }
     }
     return excludeToolsSet;
+  }
+
+  getJsonSchema(): object | undefined {
+    return this.jsonSchema;
+  }
+
+  getEnableTools(): boolean | undefined {
+    return this.enableTools;
   }
 
   getToolDiscoveryCommand(): string | undefined {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -14,7 +14,12 @@ import {
   type Mock,
 } from 'vitest';
 
-import type { Content, GenerateContentResponse, Part } from '@google/genai';
+import type {
+  Content,
+  GenerateContentResponse,
+  Part,
+  Tool,
+} from '@google/genai';
 import { GeminiClient } from './client.js';
 import {
   AuthType,
@@ -271,6 +276,8 @@ describe('Gemini Client (client.ts)', () => {
       getModelAvailabilityService: vi
         .fn()
         .mockReturnValue(createAvailabilityServiceMock()),
+      getJsonSchema: vi.fn().mockReturnValue(undefined),
+      getEnableTools: vi.fn().mockReturnValue(undefined),
     } as unknown as Config;
     mockConfig.getHookSystem = vi.fn().mockReturnValue(mockHookSystem);
 
@@ -373,6 +380,45 @@ describe('Gemini Client (client.ts)', () => {
       // The subsequent messages should be the extra history
       expect(history[1]).toEqual(extraHistory[0]);
       expect(history[2]).toEqual(extraHistory[1]);
+    });
+
+    it('should disable tools when jsonSchema is set', async () => {
+      vi.mocked(mockConfig.getJsonSchema).mockReturnValue({
+        type: 'object',
+        properties: { answer: { type: 'string' } },
+      });
+      vi.mocked(mockConfig.getEnableTools).mockReturnValue(undefined);
+
+      const chat = await client.startChat([]);
+      // Access private tools to check
+      const tools = (chat as unknown as { tools: Tool[] }).tools;
+
+      expect(tools).toEqual([]);
+    });
+
+    it('should enable tools when jsonSchema is set and enableTools is true', async () => {
+      vi.mocked(mockConfig.getJsonSchema).mockReturnValue({
+        type: 'object',
+        properties: { answer: { type: 'string' } },
+      });
+      vi.mocked(mockConfig.getEnableTools).mockReturnValue(true);
+
+      const chat = await client.startChat([]);
+      const tools = (chat as unknown as { tools: Tool[] }).tools;
+
+      expect(tools.length).toBeGreaterThan(0);
+      expect(tools[0].functionDeclarations).toBeDefined();
+    });
+
+    it('should enable tools when jsonSchema is not set', async () => {
+      vi.mocked(mockConfig.getJsonSchema).mockReturnValue(undefined);
+      vi.mocked(mockConfig.getEnableTools).mockReturnValue(undefined);
+
+      const chat = await client.startChat([]);
+      const tools = (chat as unknown as { tools: Tool[] }).tools;
+
+      expect(tools.length).toBeGreaterThan(0);
+      expect(tools[0].functionDeclarations).toBeDefined();
     });
   });
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -321,7 +321,10 @@ export class GeminiClient {
 
     const toolRegistry = this.config.getToolRegistry();
     const toolDeclarations = toolRegistry.getFunctionDeclarations();
-    const tools: Tool[] = [{ functionDeclarations: toolDeclarations }];
+    const tools: Tool[] =
+      this.config.getJsonSchema() && !this.config.getEnableTools()
+        ? []
+        : [{ functionDeclarations: toolDeclarations }];
 
     const history = await getInitialChatHistory(this.config, extraHistory);
 

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -512,6 +512,10 @@ export class GeminiChat {
         systemInstruction: this.systemInstruction,
         tools: this.tools,
         abortSignal,
+        ...(this.config.getJsonSchema() && {
+          responseJsonSchema: this.config.getJsonSchema(),
+          responseMimeType: 'application/json',
+        }),
       };
 
       let contentsToUse = isPreviewModel(modelToUse)

--- a/packages/core/src/core/geminiChat_network_retry.test.ts
+++ b/packages/core/src/core/geminiChat_network_retry.test.ts
@@ -104,6 +104,7 @@ describe('GeminiChat Network Retries', () => {
       getModelAvailabilityService: vi
         .fn()
         .mockReturnValue(createAvailabilityServiceMock()),
+      getJsonSchema: vi.fn().mockReturnValue(undefined),
     } as unknown as Config;
 
     const mockMessageBus = createMockMessageBus();


### PR DESCRIPTION
## Summary

Adds `--schema-file` flag to enable custom JSON schema output for headless/non-interactive mode. This allows users to define their own response structure for automation, orchestration, and pipeline integration.

## Details

**New flags:**
- `--schema-file <path>` - Path to a JSON schema file for structured output
- `--enable-tools` - Re-enable tools when using `--schema-file` (tools disabled by default)

**Behavior:**
- `--schema-file` implies raw json output 
- Tools are disabled by default when using a schema (ideal for "tell me what to do" orchestration)
- Use `--enable-tools` to re-enable tool execution with structured output

**Validation:**
- Schema file must exist and be valid JSON
- Schema must have `type` or `properties` field
- Maximum file size: 1MB
- Cannot combine with `--output-format text` or `--output-format stream-json`

**Example usage:**
```bash
# Create schema
echo '{"type":"object","properties":{"action":{"type":"string"}}}' > schema.json

# Get structured output
gemini --schema-file schema.json -p "What should I do next?"
# Output: {"action": "run the tests"}
```

## Summary of Changes

| File | Changes |
|------|---------|
| `packages/cli/src/config/config.ts` | Add `--schema-file` and `--enable-tools` yargs options with coerce validation, conflict checks, implied json output |
| `packages/core/src/config/config.ts` | Add `jsonSchema` and `enableTools` fields to Config class with getters |
| `packages/core/src/core/client.ts` | Disable tools when schema is set (unless `--enable-tools`) |
| `packages/core/src/core/geminiChat.ts` | Add `responseJsonSchema` and `responseMimeType` to API request when schema is set |
| `packages/cli/src/config/config.test.ts` | Add 17 tests for schema-file parsing, validation, errors, and Config integration |
| `packages/core/src/core/client.test.ts` | Add 3 tests for tools disabled/enabled behavior, fix mock config |
| `packages/core/src/core/geminiChat.test.ts` | Add 2 tests for responseJsonSchema in API request, fix mock config |
| `packages/core/src/core/geminiChat_network_retry.test.ts` | Fix mock config to include new getters |
| `docs/cli/headless.md` | Add "Custom JSON Schema Output" section, update config options table |

## Related Issues

Fixes #13388

## How to Validate

1. **Basic schema output:**
   ```bash
   echo '{"type":"object","properties":{"answer":{"type":"string"}}}' > /tmp/test.json
   gemini --schema-file /tmp/test.json -p "What is 2+2?"
   ```
   Verify: JSON output matching schema, no tool calls

2. **With tools enabled:**
   ```bash
   gemini --schema-file /tmp/test.json --enable-tools -p "List files"
   ```
   Verify: Tool calls allowed, structured JSON output

3. **Error cases:**
   ```bash
   gemini --schema-file missing.json -p "test"  # File not found
   gemini --schema-file /tmp/test.json --output-format text -p "test"  # Conflict
   gemini --enable-tools -p "test"  # Missing schema-file
   ```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README
- [x] Added/updated tests
- [ ] Noted breaking changes (none)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
  - [ ] Windows
  - [ ] Linux