### PR TITLE
Fix Esc cancel during streaming

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -482,6 +482,14 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         return false;
       }
 
+      if (
+        key.name === 'escape' &&
+        (streamingState === StreamingState.Responding ||
+          streamingState === StreamingState.WaitingForConfirmation)
+      ) {
+        return false;
+      }
+
       if (key.name === 'paste') {
         // Record paste time to prevent accidental auto-submission
         if (!isTerminalPasteTrusted(kittyProtocol.enabled)) {
@@ -977,6 +985,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       backgroundShells.size,
       backgroundShellHeight,
       history,
+      streamingState,
     ],
   );
 


### PR DESCRIPTION
Escape key was consumed by InputPrompt priority handling, preventing useGeminiStream from cancelling in-flight requests.

Regression introduced in #17993 (Support ctrl-C and Ctrl-D correctly Refactor so InputPrompt has priority over AppContainer for input handling), which made Esc stop cancelling active agent turns.