### PR TITLE
fix(ci): prevent stale PR closer from incorrectly closing new PRs

### DIFF
--- a/.github/workflows/gemini-scheduled-stale-pr-closer.yml
+++ b/.github/workflows/gemini-scheduled-stale-pr-closer.yml
@@ -43,14 +43,17 @@ jobs:
 
             // 1. Fetch maintainers for verification
             let maintainerLogins = new Set();
+            let teamFetchSucceeded = false;
             try {
               const members = await github.paginate(github.rest.teams.listMembersInOrg, {
                 org: context.repo.owner,
                 team_slug: 'gemini-cli-maintainers'
               });
               maintainerLogins = new Set(members.map(m => m.login.toLowerCase()));
+              teamFetchSucceeded = true;
+              core.info(`Successfully fetched ${maintainerLogins.size} team members from gemini-cli-maintainers`);
             } catch (e) {
-              core.warning('Failed to fetch team members');
+              core.warning(`Failed to fetch team members from gemini-cli-maintainers: ${e.message}. Falling back to author_association only.`);
             }
 
             const isMaintainer = (login, assoc) => {
@@ -154,7 +157,17 @@ jobs:
                 const labels = pr.labels.map(l => l.name.toLowerCase());
                 if (labels.includes('help wanted') || labels.includes('🔒 maintainer only')) continue;
 
-                let lastActivity = new Date(0);
+                // Skip PRs that were created less than 30 days ago - they cannot be stale yet
+                const prCreatedAt = new Date(pr.created_at);
+                if (prCreatedAt > thirtyDaysAgo) {
+                  const daysOld = Math.floor((Date.now() - prCreatedAt.getTime()) / (1000 * 60 * 60 * 24));
+                  core.info(`PR #${pr.number} was created ${daysOld} days ago. Skipping staleness check.`);
+                  continue;
+                }
+
+                // Initialize lastActivity to PR creation date (not epoch) as a safety baseline.
+                // This ensures we never incorrectly mark a PR as stale due to failed activity lookups.
+                let lastActivity = new Date(pr.created_at);
                 try {
                   const reviews = await github.paginate(github.rest.pulls.listReviews, {
                     owner: context.repo.owner,
@@ -178,8 +191,12 @@ jobs:
                       if (d > lastActivity) lastActivity = d;
                     }
                   }
-                } catch (e) {}
+                } catch (e) {
+                  core.warning(`Failed to fetch reviews/comments for PR #${pr.number}: ${e.message}`);
+                }
 
+                // For maintainer PRs, the PR creation itself counts as maintainer activity.
+                // (Now redundant since we initialize to pr.created_at, but kept for clarity)
                 if (maintainerPr) {
                   const d = new Date(pr.created_at);
                   if (d > lastActivity) lastActivity = d;


### PR DESCRIPTION
## Summary

Fixes a bug in the stale PR closer workflow where new PRs could be incorrectly closed due to `lastActivity` being initialized to epoch and a lack of a minimum age check.

## Details

- Added a check to skip PRs created less than 30 days ago.
- Initialized `lastActivity` to `pr.created_at` instead of `new Date(0)`.
- Enhanced logging for maintainer team fetching and activity fetching failures to provide better diagnostics.
- Ensures maintainer PRs aren't immediately closed if team fetch fails.

## How to Validate

1. Inspect the logic in `.github/workflows/gemini-scheduled-stale-pr-closer.yml`.
2. Verified that `thirtyDaysAgo` is correctly calculated.
3. The logic `if (prCreatedAt > thirtyDaysAgo) continue;` correctly skips young PRs.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
