### PR TITLE
Add triage completion comment to issue thread

### DIFF
--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -306,6 +306,34 @@ jobs:
             });
             core.info(`Successfully added labels for #${issueNumber}: ${labelsToAdd.join(', ')}`);
 
+      - name: 'Post Triage Success Comment'
+        if: success()
+        env:
+          ISSUE_NUMBER: '${{ github.event.issue.number || github.event.inputs.issue_number }}'
+          LABELS_OUTPUT: '${{ steps.gemini_issue_analysis.outputs.summary }}'
+        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea'
+        with:
+          github-token: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
+          script: |
+            const rawOutput = process.env.LABELS_OUTPUT;
+            let labelsApplied = [];
+            try {
+              const parsed = JSON.parse(rawOutput);
+              labelsApplied = parsed.labels_to_set || [];
+            } catch (e) {
+              const jsonMatch = rawOutput.match(/```json\s*([\s\S]*?)\s*```/);
+              if (jsonMatch && jsonMatch[1]) {
+                labelsApplied = JSON.parse(jsonMatch[1].trim()).labels_to_set || [];
+              }
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: parseInt(process.env.ISSUE_NUMBER),
+              body: `🤖 **Triage complete!** Applied labels: \`${labelsApplied.join('\`, \`')}\``
+            });
+
       - name: 'Post Issue Analysis Failure Comment'
         if: |-
           ${{ failure() && steps.gemini_issue_analysis.outcome == 'failure' }}


### PR DESCRIPTION
## Problem

When `@gemini-cli /triage` is called on an issue, the workflow:
1. Posts an initial "I'm working on it" comment 
2. Runs Gemini analysis and applies labels 
3. **Does not post completion status** 

Users have to check the workflow logs to see what happened, which is confusing and breaks the flow of the issue thread.

## Solution

Add a "Post Triage Success Comment" step that posts completion status directly to the issue thread after labels are applied:

```
**Triage complete!** Applied labels: `area/core`
```

This follows the same pattern as the existing "Post Issue Analysis Failure Comment" step.

## Changes

- Added new step "Post Triage Success Comment" in `gemini-automated-issue-triage.yml`
- Runs on `success()` after "Apply Labels to Issue" step
- Parses the Gemini output to extract applied labels
- Posts formatted comment to the issue thread

## Test plan

- [ ] Trigger `@gemini-cli /triage` on an issue
- [ ] Verify completion comment is posted with applied labels
- [ ] Verify comment shows correct label names
- [ ] Verify failure comment still works when triage fails
- [ ] Verify workflow still works with `workflow_dispatch` manual trigger

## Before / After

**Before:**
```
User: @gemini-cli /triage
Bot: I'm working on it...
[labels applied silently]
[no completion message]
```

**After:**
```
User: @gemini-cli /triage
Bot: I'm working on it...
[labels applied]
Bot: **Triage complete!** Applied labels: `area/core`
```

Fixes #12825