### PR TITLE
fix(cli): improve usage reset time display to avoid confusion

### DIFF
--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
@@ -5,34 +5,34 @@
  */
 
 import {
-  vi,
-  describe,
-  it,
-  expect,
-  beforeEach,
+  AuthType,
+  DEFAULT_GEMINI_FLASH_MODEL,
+  DEFAULT_GEMINI_MODEL,
+  ModelNotFoundError,
+  PREVIEW_GEMINI_MODEL,
+  RetryableQuotaError,
+  TerminalQuotaError,
+  UserTierId,
+  makeFakeConfig,
+  type Config,
+  type FallbackIntent,
+  type FallbackModelHandler,
+  type GoogleApiError,
+} from '@google/gemini-cli-core';
+import { act } from 'react';
+import {
   afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
   type Mock,
 } from 'vitest';
-import { act } from 'react';
 import { renderHook } from '../../test-utils/render.js';
-import {
-  type Config,
-  type FallbackModelHandler,
-  type FallbackIntent,
-  UserTierId,
-  AuthType,
-  TerminalQuotaError,
-  makeFakeConfig,
-  type GoogleApiError,
-  RetryableQuotaError,
-  PREVIEW_GEMINI_MODEL,
-  ModelNotFoundError,
-  DEFAULT_GEMINI_MODEL,
-  DEFAULT_GEMINI_FLASH_MODEL,
-} from '@google/gemini-cli-core';
-import { useQuotaAndFallback } from './useQuotaAndFallback.js';
-import type { UseHistoryManagerReturn } from './useHistoryManager.js';
 import { MessageType } from '../types.js';
+import type { UseHistoryManagerReturn } from './useHistoryManager.js';
+import { useQuotaAndFallback } from './useQuotaAndFallback.js';
 
 // Use a type alias for SpyInstance as it's not directly exported
 type SpyInstance = ReturnType<typeof vi.spyOn>;
@@ -156,7 +156,7 @@ describe('useQuotaAndFallback', () => {
 
         const message = request!.message;
         expect(message).toContain('Usage limit reached for gemini-pro.');
-        expect(message).toContain('Access resets at'); // From getResetTimeMessage
+        expect(message).toContain('Access resets on'); // From getResetTimeMessage
         expect(message).toContain('/stats for usage details');
         expect(message).toContain('/auth to switch to API key.');
 

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -6,25 +6,25 @@
 
 import {
   AuthType,
+  DEFAULT_GEMINI_MODEL,
+  ModelNotFoundError,
+  PREVIEW_GEMINI_MODEL,
+  TerminalQuotaError,
+  VALID_GEMINI_MODELS,
   type Config,
-  type FallbackModelHandler,
   type FallbackIntent,
+  type FallbackModelHandler,
+  type UserTierId,
   type ValidationHandler,
   type ValidationIntent,
-  TerminalQuotaError,
-  ModelNotFoundError,
-  type UserTierId,
-  PREVIEW_GEMINI_MODEL,
-  DEFAULT_GEMINI_MODEL,
-  VALID_GEMINI_MODELS,
 } from '@google/gemini-cli-core';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { type UseHistoryManagerReturn } from './useHistoryManager.js';
-import { MessageType } from '../types.js';
 import {
   type ProQuotaDialogRequest,
   type ValidationDialogRequest,
 } from '../contexts/UIStateContext.js';
+import { MessageType } from '../types.js';
+import { type UseHistoryManagerReturn } from './useHistoryManager.js';
 
 interface UseQuotaAndFallbackArgs {
   config: Config;
@@ -218,10 +218,13 @@ function getResetTimeMessage(delayMs: number): string {
   const resetDate = new Date(Date.now() + delayMs);
 
   const timeFormatter = new Intl.DateTimeFormat('en-US', {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
     timeZoneName: 'short',
   });
 
-  return `Access resets at ${timeFormatter.format(resetDate)}.`;
+  return `Access resets on ${timeFormatter.format(resetDate)}.`;
 }


### PR DESCRIPTION
## Summary

Currently the CLI's usage reset time message only display the hour, minute and timezone from `resetDate` property by the Int.DateTimeFormat. This could lead to user's confusion because this message doesn't display the actual weekday and date of the `resetDate` time. This PR aim to improve this message for the CLI.

Before:

<img width="557" height="270" alt="Screenshot 2026-02-01 at 7 40 09 PM" src="https://github.com/user-attachments/assets/61248335-dc35-4f46-84a1-f9d3aa0183f3" />

After: 

<img width="486" height="241" alt="Screenshot 2026-02-02 at 2 31 13 PM" src="https://github.com/user-attachments/assets/37b72f27-8f62-4ec6-a153-689e749e1f64" />


## Details

Improve usage reset time display from `Intl.DateTimeFormat` formatter from a given `resetDate` to improve user's awareness when an Gemini usage limit is reached.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

Include changes in:

- `packages/cli/src/ui/hooks/useQuotaAndFallback.ts`
- `packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts`

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [x] Docker
    - [x] Podman
    - [x] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
