### PR TITLE
Added "" as default value, since getText() used to expect a string only and thus crashed when undefined...  Fixes #18076  

### DIFF
--- a/packages/vscode-ide-companion/src/diff-manager.ts
+++ b/packages/vscode-ide-companion/src/diff-manager.ts
@@ -145,7 +145,7 @@ export class DiffManager {
 
     if (uriToClose) {
       const rightDoc = await vscode.workspace.openTextDocument(uriToClose);
-      const modifiedContent = rightDoc.getText();
+      const modifiedContent = rightDoc.getText() ?? '';
       await this.closeDiffEditor(uriToClose);
       return modifiedContent;
     }
@@ -162,7 +162,7 @@ export class DiffManager {
     }
 
     const rightDoc = await vscode.workspace.openTextDocument(rightDocUri);
-    const modifiedContent = rightDoc.getText();
+    const modifiedContent = rightDoc.getText() ?? '';
     await this.closeDiffEditor(rightDocUri);
 
     this.onDidChangeEmitter.fire(
@@ -188,7 +188,7 @@ export class DiffManager {
     }
 
     const rightDoc = await vscode.workspace.openTextDocument(rightDocUri);
-    const modifiedContent = rightDoc.getText();
+    const modifiedContent = rightDoc.getText() ?? '';
     await this.closeDiffEditor(rightDocUri);
 
     this.onDidChangeEmitter.fire(


### PR DESCRIPTION
Summary

Fixes a runtime crash in the VS Code IDE companion where rightDoc.getText() may, instead of a string value, return undefined, leading to a TypeError.

Details

Updated to use null-coalescing (?? "") when retrieving content from rightDoc.getText() to prevent TypeError when getText() was undefined

Fixes #18076 
