### PR TITLE
feat(plan): use `placeholder` for choice question "Other" option

### DIFF
--- a/packages/cli/src/ui/components/AskUserDialog.test.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.test.tsx
@@ -1008,4 +1008,71 @@ describe('AskUserDialog', () => {
     // Should contain the full long question (or at least its parts)
     expect(lastFrame()).toContain('This is a very long question');
   });
+
+  describe('Choice question placeholder', () => {
+    it('uses placeholder for "Other" option when provided', async () => {
+      const questions: Question[] = [
+        {
+          question: 'Select your preferred language:',
+          header: 'Language',
+          options: [
+            { label: 'TypeScript', description: '' },
+            { label: 'JavaScript', description: '' },
+          ],
+          placeholder: 'Type another language...',
+          multiSelect: false,
+        },
+      ];
+
+      const { stdin, lastFrame } = renderWithProviders(
+        <AskUserDialog
+          questions={questions}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          width={80}
+        />,
+        { width: 80 },
+      );
+
+      // Navigate to the "Other" option
+      writeKey(stdin, '\x1b[B'); // Down
+      writeKey(stdin, '\x1b[B'); // Down to Other
+
+      await waitFor(() => {
+        expect(lastFrame()).toMatchSnapshot();
+      });
+    });
+
+    it('uses default placeholder when not provided', async () => {
+      const questions: Question[] = [
+        {
+          question: 'Select your preferred language:',
+          header: 'Language',
+          options: [
+            { label: 'TypeScript', description: '' },
+            { label: 'JavaScript', description: '' },
+          ],
+          multiSelect: false,
+        },
+      ];
+
+      const { stdin, lastFrame } = renderWithProviders(
+        <AskUserDialog
+          questions={questions}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          width={80}
+        />,
+        { width: 80 },
+      );
+
+      // Navigate to the "Other" option
+      writeKey(stdin, '\x1b[B'); // Down
+      writeKey(stdin, '\x1b[B'); // Down to Other
+
+      await waitFor(() => {
+        expect(lastFrame()).toMatchSnapshot();
+      });
+    });
+  });
 });

--- a/packages/cli/src/ui/components/AskUserDialog.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.tsx
@@ -780,7 +780,7 @@ const ChoiceQuestionView: React.FC<ChoiceQuestionViewProps> = ({
 
           // Render inline text input for custom option
           if (optionItem.type === 'other') {
-            const placeholder = 'Enter a custom value';
+            const placeholder = question.placeholder || 'Enter a custom value';
             return (
               <Box flexDirection="row">
                 {showCheck && (

--- a/packages/cli/src/ui/components/__snapshots__/AskUserDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/AskUserDialog.test.tsx.snap
@@ -1,5 +1,25 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`AskUserDialog > Choice question placeholder > uses default placeholder when not provided 1`] = `
+"Select your preferred language:
+
+  1.  TypeScript
+  2.  JavaScript
+● 3.  Enter a custom value
+
+Enter to submit · Esc to cancel"
+`;
+
+exports[`AskUserDialog > Choice question placeholder > uses placeholder for "Other" option when provided 1`] = `
+"Select your preferred language:
+
+  1.  TypeScript
+  2.  JavaScript
+● 3.  Type another language...
+
+Enter to submit · Esc to cancel"
+`;
+
 exports[`AskUserDialog > Scroll Arrows (useAlternateBuffer: false) > shows scroll arrows correctly when useAlternateBuffer is false 1`] = `
 "Choose an option
 

--- a/packages/core/src/confirmation-bus/types.ts
+++ b/packages/core/src/confirmation-bus/types.ts
@@ -148,7 +148,7 @@ export interface Question {
   options?: QuestionOption[];
   /** Allow multiple selections. Only applies when type='choice'. */
   multiSelect?: boolean;
-  /** Placeholder hint text. Only applies when type='text'. */
+  /** Placeholder hint text. For type='text', shown in the input field. For type='choice', shown in the "Other" custom input. */
   placeholder?: string;
 }
 

--- a/packages/core/src/tools/ask-user.test.ts
+++ b/packages/core/src/tools/ask-user.test.ts
@@ -177,6 +177,24 @@ describe('AskUserTool', () => {
       expect(result).toBeNull();
     });
 
+    it('should accept placeholder for choice type', () => {
+      const result = tool.validateToolParams({
+        questions: [
+          {
+            question: 'Which language?',
+            header: 'Language',
+            type: QuestionType.CHOICE,
+            options: [
+              { label: 'TypeScript', description: 'Typed JavaScript' },
+              { label: 'JavaScript', description: 'Dynamic language' },
+            ],
+            placeholder: 'Type another language...',
+          },
+        ],
+      });
+      expect(result).toBeNull();
+    });
+
     it('should return error if option has empty label', () => {
       const result = tool.validateToolParams({
         questions: [

--- a/packages/core/src/tools/ask-user.ts
+++ b/packages/core/src/tools/ask-user.ts
@@ -90,7 +90,7 @@ export class AskUserTool extends BaseDeclarativeTool<
                 placeholder: {
                   type: 'string',
                   description:
-                    "Only applies when type='text'. Hint text shown in the input field.",
+                    "Hint text shown in the input field. For type='text', shown in the main input. For type='choice', shown in the 'Other' custom input.",
                 },
               },
             },


### PR DESCRIPTION
Extend `placeholder` field to also apply to the `Other` custom input in choice questions, falling back to `"Enter a custom value"` when not provided.

```typescript
{
  question: 'Select your preferred language:',
  header: 'Language',
  type: 'choice',
  options: [
    { label: 'TypeScript', description: '' },
    { label: 'JavaScript', description: '' },
  ],
  placeholder: 'Type another language...',  // Now works for "Other" option
}
```

This allows us to change the "Other" input during plan approval to be `"Provide feedback"` instead of `"Enter custom input"` 

Fixes #18100