### PR TITLE
feat(plan): add core logic and `exit_plan_mode` tool definition

### DIFF
--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -1183,6 +1183,9 @@ function toPermissionOptions(
     case 'ask_user':
       // askuser doesn't need "always allow" options since it's asking questions
       return [...basicPermissionOptions];
+    case 'exit_plan_mode':
+      // exit_plan_mode doesn't need "always allow" options since it's a plan approval flow
+      return [...basicPermissionOptions];
     default: {
       const unreachable: never = confirmation;
       throw new Error(`Unexpected: ${unreachable}`);

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -34,6 +34,7 @@ import { WebFetchTool } from '../tools/web-fetch.js';
 import { MemoryTool, setGeminiMdFilename } from '../tools/memoryTool.js';
 import { WebSearchTool } from '../tools/web-search.js';
 import { AskUserTool } from '../tools/ask-user.js';
+import { ExitPlanModeTool } from '../tools/exit-plan-mode.js';
 import { GeminiClient } from '../core/client.js';
 import { BaseLlmClient } from '../core/baseLlmClient.js';
 import type { HookDefinition, HookEventName } from '../hooks/types.js';
@@ -2139,6 +2140,9 @@ export class Config {
     registerCoreTool(AskUserTool);
     if (this.getUseWriteTodos()) {
       registerCoreTool(WriteTodosTool);
+    }
+    if (this.isPlanEnabled()) {
+      registerCoreTool(ExitPlanModeTool, this);
     }
 
     // Register Subagents as Tools

--- a/packages/core/src/confirmation-bus/types.ts
+++ b/packages/core/src/confirmation-bus/types.ts
@@ -100,6 +100,11 @@ export type SerializableConfirmationDetails =
       type: 'ask_user';
       title: string;
       questions: Question[];
+    }
+  | {
+      type: 'exit_plan_mode';
+      title: string;
+      planPath: string;
     };
 
 export interface UpdatePolicy {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -70,6 +70,7 @@ export * from './utils/quotaErrorDetection.js';
 export * from './utils/userAccountManager.js';
 export * from './utils/googleQuotaErrors.js';
 export * from './utils/fileUtils.js';
+export * from './utils/planUtils.js';
 export * from './utils/fileDiffUtils.js';
 export * from './utils/retry.js';
 export * from './utils/shell-utils.js';

--- a/packages/core/src/policy/policies/plan.toml
+++ b/packages/core/src/policy/policies/plan.toml
@@ -70,6 +70,12 @@ decision = "ask_user"
 priority = 50
 modes = ["plan"]
 
+[[rule]]
+toolName = "exit_plan_mode"
+decision = "ask_user"
+priority = 50
+modes = ["plan"]
+
 # Allow write_file for .md files in plans directory
 [[rule]]
 toolName = "write_file"

--- a/packages/core/src/tools/exit-plan-mode.test.ts
+++ b/packages/core/src/tools/exit-plan-mode.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/core/src/tools/exit-plan-mode.test.ts
+++ b/packages/core/src/tools/exit-plan-mode.test.ts
@@ -1,0 +1,337 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ExitPlanModeTool } from './exit-plan-mode.js';
+import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
+import path from 'node:path';
+import type { Config } from '../config/config.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+import { ToolConfirmationOutcome } from './tools.js';
+import { ApprovalMode } from '../policy/types.js';
+import * as fs from 'node:fs';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof fs>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    promises: {
+      ...actual.promises,
+      readFile: vi.fn(),
+    },
+  };
+});
+
+describe('ExitPlanModeTool', () => {
+  let tool: ExitPlanModeTool;
+  let mockMessageBus: ReturnType<typeof createMockMessageBus>;
+  let mockConfig: Partial<Config>;
+
+  const mockTargetDir = path.resolve('/mock/dir');
+  const mockPlansDir = path.resolve('/mock/dir/plans');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetAllMocks();
+    mockMessageBus = createMockMessageBus();
+    vi.mocked(mockMessageBus.publish).mockResolvedValue(undefined);
+    // Default: plan file has content and exists
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.promises.readFile).mockResolvedValue(
+      '# My Plan\n\nSome content',
+    );
+    mockConfig = {
+      getTargetDir: vi.fn().mockReturnValue(mockTargetDir),
+      setApprovalMode: vi.fn(),
+      storage: {
+        getProjectTempPlansDir: vi.fn().mockReturnValue(mockPlansDir),
+      } as unknown as Config['storage'],
+    };
+    tool = new ExitPlanModeTool(
+      mockConfig as Config,
+      mockMessageBus as unknown as MessageBus,
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('shouldConfirmExecute', () => {
+    it('should return plan approval confirmation details when plan has content', async () => {
+      const planPath = 'plans/test-plan.md';
+      const invocation = tool.build({ plan_path: planPath });
+
+      const result = await invocation.shouldConfirmExecute(
+        new AbortController().signal,
+      );
+
+      expect(result).not.toBe(false);
+      if (result === false) return;
+
+      expect(result.type).toBe('exit_plan_mode');
+      expect(result.title).toBe('Plan Approval');
+      if (result.type === 'exit_plan_mode') {
+        expect(result.planPath).toBe(
+          path.resolve(mockPlansDir, 'test-plan.md'),
+        );
+      }
+      expect(typeof result.onConfirm).toBe('function');
+    });
+
+    it('should return false when plan file is empty', async () => {
+      vi.mocked(fs.promises.readFile).mockResolvedValue('');
+      const planPath = 'plans/test-plan.md';
+      const invocation = tool.build({ plan_path: planPath });
+
+      const result = await invocation.shouldConfirmExecute(
+        new AbortController().signal,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when plan file contains only whitespace', async () => {
+      vi.mocked(fs.promises.readFile).mockResolvedValue('   \n\t\n   ');
+      const planPath = 'plans/test-plan.md';
+      const invocation = tool.build({ plan_path: planPath });
+
+      const result = await invocation.shouldConfirmExecute(
+        new AbortController().signal,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when plan file cannot be read', async () => {
+      vi.mocked(fs.promises.readFile).mockRejectedValue(
+        new Error('ENOENT: no such file'),
+      );
+      const planPath = 'plans/test-plan.md';
+      const invocation = tool.build({ plan_path: planPath });
+
+      const result = await invocation.shouldConfirmExecute(
+        new AbortController().signal,
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('execute with invalid plan', () => {
+    it('should return error when plan file is empty', async () => {
+      vi.mocked(fs.promises.readFile).mockResolvedValue('');
+      const planPath = 'plans/test-plan.md';
+      const invocation = tool.build({ plan_path: planPath });
+
+      // shouldConfirmExecute returns false, so execute is called directly
+      await invocation.shouldConfirmExecute(new AbortController().signal);
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(result.llmContent).toContain('Plan file is empty');
+      expect(result.llmContent).toContain('write content to the plan');
+    });
+
+    it('should return error when plan file cannot be read', async () => {
+      vi.mocked(fs.promises.readFile).mockRejectedValue(
+        new Error('ENOENT: no such file'),
+      );
+      const planPath = 'plans/test-plan.md';
+      const invocation = tool.build({ plan_path: planPath });
+
+      await invocation.shouldConfirmExecute(new AbortController().signal);
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(result.llmContent).toContain('Failed to read plan file');
+      expect(result.llmContent).toContain('ENOENT');
+    });
+  });
+
+  describe('execute', () => {
+    it('should return approval message when plan is approved with DEFAULT mode', async () => {
+      const planPath = 'plans/test-plan.md';
+      const invocation = tool.build({ plan_path: planPath });
+
+      // Simulate the confirmation flow
+      const confirmDetails = await invocation.shouldConfirmExecute(
+        new AbortController().signal,
+      );
+      expect(confirmDetails).not.toBe(false);
+      if (confirmDetails === false) return;
+
+      // Call onConfirm with approval (using default approval mode)
+      await confirmDetails.onConfirm(ToolConfirmationOutcome.ProceedOnce, {
+        approved: true,
+        approvalMode: ApprovalMode.DEFAULT,
+      });
+
+      const result = await invocation.execute(new AbortController().signal);
+      const expectedPath = path.resolve(mockPlansDir, 'test-plan.md');
+
+      expect(result).toEqual({
+        llmContent: `Plan approved. Switching to Default mode (edits will require confirmation).
+
+The approved implementation plan is stored at: ${expectedPath}
+Read and follow the plan strictly during implementation.`,
+        returnDisplay: `Plan approved: ${expectedPath}`,
+      });
+    });
+
+    it('should return approval message when plan is approved with AUTO_EDIT mode', async () => {
+      const planPath = 'plans/test-plan.md';
+      const invocation = tool.build({ plan_path: planPath });
+
+      // Simulate the confirmation flow
+      const confirmDetails = await invocation.shouldConfirmExecute(
+        new AbortController().signal,
+      );
+      expect(confirmDetails).not.toBe(false);
+      if (confirmDetails === false) return;
+
+      // Call onConfirm with approval (using auto-edit approval mode)
+      await confirmDetails.onConfirm(ToolConfirmationOutcome.ProceedOnce, {
+        approved: true,
+        approvalMode: ApprovalMode.AUTO_EDIT,
+      });
+
+      const result = await invocation.execute(new AbortController().signal);
+      const expectedPath = path.resolve(mockPlansDir, 'test-plan.md');
+
+      expect(result).toEqual({
+        llmContent: `Plan approved. Switching to Auto-Edit mode (edits will be applied automatically).
+
+The approved implementation plan is stored at: ${expectedPath}
+Read and follow the plan strictly during implementation.`,
+        returnDisplay: `Plan approved: ${expectedPath}`,
+      });
+      expect(mockConfig.setApprovalMode).toHaveBeenCalledWith(
+        ApprovalMode.AUTO_EDIT,
+      );
+    });
+
+    it('should return feedback message when plan is rejected with feedback', async () => {
+      const planPath = 'plans/test-plan.md';
+      const invocation = tool.build({ plan_path: planPath });
+
+      // Simulate the confirmation flow
+      const confirmDetails = await invocation.shouldConfirmExecute(
+        new AbortController().signal,
+      );
+      expect(confirmDetails).not.toBe(false);
+      if (confirmDetails === false) return;
+
+      // Call onConfirm with rejection and feedback
+      await confirmDetails.onConfirm(ToolConfirmationOutcome.ProceedOnce, {
+        approved: false,
+        feedback: 'Please add more details.',
+      });
+
+      const result = await invocation.execute(new AbortController().signal);
+      const expectedPath = path.resolve(mockPlansDir, 'test-plan.md');
+
+      expect(result).toEqual({
+        llmContent: `Plan rejected. User feedback: Please add more details.
+
+The plan is stored at: ${expectedPath}
+Revise the plan based on the feedback.`,
+        returnDisplay: 'Feedback: Please add more details.',
+      });
+    });
+
+    it('should handle rejection without feedback gracefully', async () => {
+      const planPath = 'plans/test-plan.md';
+      const invocation = tool.build({ plan_path: planPath });
+
+      // Simulate the confirmation flow
+      const confirmDetails = await invocation.shouldConfirmExecute(
+        new AbortController().signal,
+      );
+      expect(confirmDetails).not.toBe(false);
+      if (confirmDetails === false) return;
+
+      // Call onConfirm with rejection but no feedback (edge case)
+      await confirmDetails.onConfirm(ToolConfirmationOutcome.ProceedOnce, {
+        approved: false,
+      });
+
+      const result = await invocation.execute(new AbortController().signal);
+      const expectedPath = path.resolve(mockPlansDir, 'test-plan.md');
+
+      expect(result).toEqual({
+        llmContent: `Plan rejected. No feedback provided.
+
+The plan is stored at: ${expectedPath}
+Ask the user for specific feedback on how to improve the plan.`,
+        returnDisplay: 'Rejected (no feedback)',
+      });
+    });
+
+    it('should return cancellation message when cancelled', async () => {
+      const planPath = 'plans/test-plan.md';
+      const invocation = tool.build({ plan_path: planPath });
+
+      // Simulate the confirmation flow
+      const confirmDetails = await invocation.shouldConfirmExecute(
+        new AbortController().signal,
+      );
+      expect(confirmDetails).not.toBe(false);
+      if (confirmDetails === false) return;
+
+      // Call onConfirm with cancellation
+      await confirmDetails.onConfirm(ToolConfirmationOutcome.Cancel);
+
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(result).toEqual({
+        llmContent:
+          'User cancelled the plan approval dialog. The plan was not approved and you are still in Plan Mode.',
+        returnDisplay: 'Cancelled',
+      });
+    });
+  });
+
+  it('should throw error during build if plan path is outside plans directory', () => {
+    expect(() => tool.build({ plan_path: '../../../etc/passwd' })).toThrow(
+      /Access denied/,
+    );
+  });
+
+  describe('validateToolParams', () => {
+    it('should reject empty plan_path', () => {
+      const result = tool.validateToolParams({ plan_path: '' });
+      expect(result).toBe('plan_path is required.');
+    });
+
+    it('should reject whitespace-only plan_path', () => {
+      const result = tool.validateToolParams({ plan_path: '   ' });
+      expect(result).toBe('plan_path is required.');
+    });
+
+    it('should reject path outside plans directory', () => {
+      const result = tool.validateToolParams({
+        plan_path: '../../../etc/passwd',
+      });
+      expect(result).toContain('Access denied');
+    });
+
+    it('should reject non-existent plan file', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      const result = tool.validateToolParams({
+        plan_path: 'plans/ghost.md',
+      });
+      expect(result).toContain('Plan file does not exist');
+    });
+
+    it('should accept valid path within plans directory', () => {
+      const result = tool.validateToolParams({
+        plan_path: 'plans/valid-plan.md',
+      });
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/core/src/tools/exit-plan-mode.test.ts
+++ b/packages/core/src/tools/exit-plan-mode.test.ts
@@ -31,8 +31,9 @@ describe('ExitPlanModeTool', () => {
     tempRootDir = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), 'exit-plan-test-')),
     );
-    mockPlansDir = path.join(tempRootDir, 'plans');
-    fs.mkdirSync(mockPlansDir, { recursive: true });
+    const plansDirRaw = path.join(tempRootDir, 'plans');
+    fs.mkdirSync(plansDirRaw, { recursive: true });
+    mockPlansDir = fs.realpathSync(plansDirRaw);
 
     mockConfig = {
       getTargetDir: vi.fn().mockReturnValue(tempRootDir),
@@ -100,7 +101,7 @@ describe('ExitPlanModeTool', () => {
     });
 
     it('should return false when plan file cannot be read', async () => {
-      const planRelativePath = 'plans/non-existent.md';
+      const planRelativePath = path.join('plans', 'non-existent.md');
       const invocation = tool.build({ plan_path: planRelativePath });
 
       const result = await invocation.shouldConfirmExecute(

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -79,8 +79,13 @@ export class ExitPlanModeTool extends BaseDeclarativeTool<
       this.config.getTargetDir(),
       params.plan_path,
     );
-    if (!isWithinRoot(resolvedPath, plansDir)) {
-      return `Access denied: plan path must be within the designated plans directory (${plansDir}).`;
+
+    const realPath = fs.existsSync(resolvedPath)
+      ? fs.realpathSync(resolvedPath)
+      : resolvedPath;
+
+    if (!isWithinRoot(realPath, plansDir)) {
+      return `Access denied: plan path must be within the designated plans directory.`;
     }
 
     if (!fs.existsSync(resolvedPath)) {

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -21,8 +21,7 @@ import { EXIT_PLAN_MODE_TOOL_NAME } from './tool-names.js';
 import { validatePlanPath, validatePlanContent } from '../utils/planUtils.js';
 import { ApprovalMode } from '../policy/types.js';
 import { checkExhaustive } from '../utils/checks.js';
-import { getRealPath } from '../utils/fileUtils.js';
-import { isSubpath } from '../utils/paths.js';
+import { resolveToRealPath, isSubpath } from '../utils/paths.js';
 
 /**
  * Returns a human-readable description for an approval mode.
@@ -83,13 +82,15 @@ export class ExitPlanModeTool extends BaseDeclarativeTool<
 
     // Since validateToolParamValues is synchronous, we use a basic synchronous check
     // for path traversal safety. High-level async validation is deferred to shouldConfirmExecute.
-    const plansDir = getRealPath(this.config.storage.getProjectTempPlansDir());
+    const plansDir = resolveToRealPath(
+      this.config.storage.getProjectTempPlansDir(),
+    );
     const resolvedPath = path.resolve(
       this.config.getTargetDir(),
       params.plan_path,
     );
 
-    const realPath = getRealPath(resolvedPath);
+    const realPath = resolveToRealPath(resolvedPath);
 
     if (!isSubpath(plansDir, realPath)) {
       return `Access denied: plan path must be within the designated plans directory.`;

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -21,7 +21,8 @@ import { EXIT_PLAN_MODE_TOOL_NAME } from './tool-names.js';
 import { validatePlanPath, validatePlanContent } from '../utils/planUtils.js';
 import { ApprovalMode } from '../policy/types.js';
 import { checkExhaustive } from '../utils/checks.js';
-import { isWithinRoot, getRealPath } from '../utils/fileUtils.js';
+import { getRealPath } from '../utils/fileUtils.js';
+import { isSubpath } from '../utils/paths.js';
 
 /**
  * Returns a human-readable description for an approval mode.
@@ -90,7 +91,7 @@ export class ExitPlanModeTool extends BaseDeclarativeTool<
 
     const realPath = getRealPath(resolvedPath);
 
-    if (!isWithinRoot(realPath.toLowerCase(), plansDir.toLowerCase())) {
+    if (!isSubpath(plansDir, realPath)) {
       return `Access denied: plan path must be within the designated plans directory.`;
     }
 

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -82,7 +82,7 @@ export class ExitPlanModeTool extends BaseDeclarativeTool<
 
     // Since validateToolParamValues is synchronous, we use a basic synchronous check
     // for path traversal safety. High-level async validation is deferred to shouldConfirmExecute.
-    const plansDir = this.config.storage.getProjectTempPlansDir();
+    const plansDir = getRealPath(this.config.storage.getProjectTempPlansDir());
     const resolvedPath = path.resolve(
       this.config.getTargetDir(),
       params.plan_path,
@@ -90,7 +90,7 @@ export class ExitPlanModeTool extends BaseDeclarativeTool<
 
     const realPath = getRealPath(resolvedPath);
 
-    if (!isWithinRoot(realPath, plansDir)) {
+    if (!isWithinRoot(realPath.toLowerCase(), plansDir.toLowerCase())) {
       return `Access denied: plan path must be within the designated plans directory.`;
     }
 

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -25,6 +25,7 @@ export const ACTIVATE_SKILL_TOOL_NAME = 'activate_skill';
 export const EDIT_TOOL_NAMES = new Set([EDIT_TOOL_NAME, WRITE_FILE_TOOL_NAME]);
 export const ASK_USER_TOOL_NAME = 'ask_user';
 export const ASK_USER_DISPLAY_NAME = 'Ask User';
+export const EXIT_PLAN_MODE_TOOL_NAME = 'exit_plan_mode';
 
 /**
  * Mapping of legacy tool names to their current names.
@@ -92,6 +93,7 @@ export const PLAN_MODE_TOOLS = [
   LS_TOOL_NAME,
   WEB_SEARCH_TOOL_NAME,
   ASK_USER_TOOL_NAME,
+  EXIT_PLAN_MODE_TOOL_NAME,
 ] as const;
 
 /**

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -18,6 +18,7 @@ import {
   type ToolConfirmationResponse,
   type Question,
 } from '../confirmation-bus/types.js';
+import type { ApprovalMode } from '../policy/types.js';
 
 /**
  * Represents a validated and ready-to-execute tool call.
@@ -701,9 +702,19 @@ export interface ToolAskUserConfirmationPayload {
   answers: { [questionIndex: string]: string };
 }
 
+export interface ToolExitPlanModeConfirmationPayload {
+  /** Whether the user approved the plan */
+  approved: boolean;
+  /** If approved, the approval mode to use for implementation */
+  approvalMode?: ApprovalMode;
+  /** If rejected, the user's feedback */
+  feedback?: string;
+}
+
 export type ToolConfirmationPayload =
   | ToolEditConfirmationPayload
-  | ToolAskUserConfirmationPayload;
+  | ToolAskUserConfirmationPayload
+  | ToolExitPlanModeConfirmationPayload;
 
 export interface ToolExecuteConfirmationDetails {
   type: 'exec';
@@ -742,12 +753,23 @@ export interface ToolAskUserConfirmationDetails {
   ) => Promise<void>;
 }
 
+export interface ToolExitPlanModeConfirmationDetails {
+  type: 'exit_plan_mode';
+  title: string;
+  planPath: string;
+  onConfirm: (
+    outcome: ToolConfirmationOutcome,
+    payload?: ToolConfirmationPayload,
+  ) => Promise<void>;
+}
+
 export type ToolCallConfirmationDetails =
   | ToolEditConfirmationDetails
   | ToolExecuteConfirmationDetails
   | ToolMcpConfirmationDetails
   | ToolInfoConfirmationDetails
-  | ToolAskUserConfirmationDetails;
+  | ToolAskUserConfirmationDetails
+  | ToolExitPlanModeConfirmationDetails;
 
 export enum ToolConfirmationOutcome {
   ProceedOnce = 'proceed_once',
@@ -769,6 +791,7 @@ export enum Kind {
   Think = 'think',
   Fetch = 'fetch',
   Communicate = 'communicate',
+  Plan = 'plan',
   Other = 'other',
 }
 

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -18,7 +18,7 @@ import {
   type ToolConfirmationResponse,
   type Question,
 } from '../confirmation-bus/types.js';
-import type { ApprovalMode } from '../policy/types.js';
+import { type ApprovalMode } from '../policy/types.js';
 
 /**
  * Represents a validated and ready-to-execute tool call.

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -34,7 +34,7 @@ import {
   readWasmBinaryFromDisk,
   saveTruncatedToolOutput,
   formatTruncatedToolOutput,
-  getRealPathSync,
+  getRealPath,
   isEmpty,
 } from './fileUtils.js';
 import { StandardFileSystemService } from '../services/fileSystemService.js';
@@ -174,18 +174,16 @@ describe('fileUtils', () => {
     );
   });
 
-  describe('getRealPathSync', () => {
+  describe('getRealPath', () => {
     it('should resolve a real path for an existing file', () => {
       const testFile = path.join(tempRootDir, 'real.txt');
       actualNodeFs.writeFileSync(testFile, 'content');
-      expect(getRealPathSync(testFile)).toBe(
-        actualNodeFs.realpathSync(testFile),
-      );
+      expect(getRealPath(testFile)).toBe(actualNodeFs.realpathSync(testFile));
     });
 
     it('should return absolute resolved path for a non-existent file', () => {
       const ghostFile = path.join(tempRootDir, 'ghost.txt');
-      expect(getRealPathSync(ghostFile)).toBe(path.resolve(ghostFile));
+      expect(getRealPath(ghostFile)).toBe(path.resolve(ghostFile));
     });
 
     it('should resolve symbolic links', () => {
@@ -194,9 +192,7 @@ describe('fileUtils', () => {
       actualNodeFs.writeFileSync(targetFile, 'content');
       actualNodeFs.symlinkSync(targetFile, linkFile);
 
-      expect(getRealPathSync(linkFile)).toBe(
-        actualNodeFs.realpathSync(targetFile),
-      );
+      expect(getRealPath(linkFile)).toBe(actualNodeFs.realpathSync(targetFile));
     });
   });
 

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -34,6 +34,8 @@ import {
   readWasmBinaryFromDisk,
   saveTruncatedToolOutput,
   formatTruncatedToolOutput,
+  getRealPathSync,
+  isEmpty,
 } from './fileUtils.js';
 import { StandardFileSystemService } from '../services/fileSystemService.js';
 
@@ -170,6 +172,51 @@ describe('fileUtils', () => {
         expect(isWithinRoot(testPath, root || defaultRoot)).toBe(expected);
       },
     );
+  });
+
+  describe('getRealPathSync', () => {
+    it('should resolve a real path for an existing file', () => {
+      const testFile = path.join(tempRootDir, 'real.txt');
+      actualNodeFs.writeFileSync(testFile, 'content');
+      expect(getRealPathSync(testFile)).toBe(
+        actualNodeFs.realpathSync(testFile),
+      );
+    });
+
+    it('should return absolute resolved path for a non-existent file', () => {
+      const ghostFile = path.join(tempRootDir, 'ghost.txt');
+      expect(getRealPathSync(ghostFile)).toBe(path.resolve(ghostFile));
+    });
+
+    it('should resolve symbolic links', () => {
+      const targetFile = path.join(tempRootDir, 'target.txt');
+      const linkFile = path.join(tempRootDir, 'link.txt');
+      actualNodeFs.writeFileSync(targetFile, 'content');
+      actualNodeFs.symlinkSync(targetFile, linkFile);
+
+      expect(getRealPathSync(linkFile)).toBe(
+        actualNodeFs.realpathSync(targetFile),
+      );
+    });
+  });
+
+  describe('isEmpty', () => {
+    it('should return false for a non-empty file', async () => {
+      const testFile = path.join(tempRootDir, 'full.txt');
+      actualNodeFs.writeFileSync(testFile, 'some content');
+      expect(await isEmpty(testFile)).toBe(false);
+    });
+
+    it('should return true for an empty file', async () => {
+      const testFile = path.join(tempRootDir, 'empty.txt');
+      actualNodeFs.writeFileSync(testFile, '   ');
+      expect(await isEmpty(testFile)).toBe(true);
+    });
+
+    it('should return true for a non-existent file (defensive)', async () => {
+      const testFile = path.join(tempRootDir, 'ghost.txt');
+      expect(await isEmpty(testFile)).toBe(true);
+    });
   });
 
   describe('fileExists', () => {

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -15,7 +15,6 @@ import { ToolErrorType } from '../tools/tool-error.js';
 import { BINARY_EXTENSIONS } from './ignorePatterns.js';
 import { createRequire as createModuleRequire } from 'node:module';
 import { debugLogger } from './debugLogger.js';
-import { isSubpath } from './paths.js';
 
 const requireModule = createModuleRequire(import.meta.url);
 
@@ -238,45 +237,6 @@ export function getRealPath(filePath: string): string {
   } catch {
     return path.resolve(filePath);
   }
-}
-
-/**
- * Validates that a path is safe (no traversal) and exists within a root.
- * @param pathToCheck The untrusted path to check.
- * @param rootDirectory The authorized root directory.
- * @param targetDir The current working directory.
- * @returns An error message if validation fails, or null if successful.
- */
-export async function validatePathWithinRoot(
-  pathToCheck: string,
-  rootDirectory: string,
-  targetDir: string,
-): Promise<string | null> {
-  const resolvedPath = path.resolve(targetDir, pathToCheck);
-
-  let realPath: string;
-  try {
-    realPath = await fsPromises.realpath(resolvedPath);
-  } catch {
-    realPath = resolvedPath;
-  }
-
-  let realRoot: string;
-  try {
-    realRoot = await fsPromises.realpath(rootDirectory);
-  } catch {
-    realRoot = path.resolve(rootDirectory);
-  }
-
-  if (!isSubpath(realRoot, realPath)) {
-    return 'Access denied: path is outside of the designated directory.';
-  }
-
-  if (!(await fileExists(resolvedPath))) {
-    return `File does not exist: ${pathToCheck}.`;
-  }
-
-  return null;
 }
 
 /**

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -229,6 +229,31 @@ export function isWithinRoot(
 }
 
 /**
+ * Safely resolves a path to its real path if it exists, otherwise returns the absolute resolved path.
+ */
+export function getRealPathSync(filePath: string): string {
+  try {
+    return fs.realpathSync(filePath);
+  } catch {
+    return path.resolve(filePath);
+  }
+}
+
+/**
+ * Checks if a file's content is empty or contains only whitespace.
+ * Honors Unicode BOM encodings.
+ */
+export async function isEmpty(filePath: string): Promise<boolean> {
+  try {
+    const content = await readFileWithEncoding(filePath);
+    return content.trim().length === 0;
+  } catch {
+    // If file is unreadable, we treat it as empty/invalid for validation purposes
+    return true;
+  }
+}
+
+/**
  * Heuristic: determine if a file is likely binary.
  * Now BOM-aware: if a Unicode BOM is detected, we treat it as text.
  * For non-BOM files, retain the existing null-byte and non-printable ratio checks.

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -15,6 +15,7 @@ import { ToolErrorType } from '../tools/tool-error.js';
 import { BINARY_EXTENSIONS } from './ignorePatterns.js';
 import { createRequire as createModuleRequire } from 'node:module';
 import { debugLogger } from './debugLogger.js';
+import { isSubpath } from './paths.js';
 
 const requireModule = createModuleRequire(import.meta.url);
 
@@ -267,7 +268,7 @@ export async function validatePathWithinRoot(
     realRoot = path.resolve(rootDirectory);
   }
 
-  if (!isWithinRoot(realPath.toLowerCase(), realRoot.toLowerCase())) {
+  if (!isSubpath(realRoot, realPath)) {
     return 'Access denied: path is outside of the designated directory.';
   }
 

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -260,7 +260,14 @@ export async function validatePathWithinRoot(
     realPath = resolvedPath;
   }
 
-  if (!isWithinRoot(realPath, rootDirectory)) {
+  let realRoot: string;
+  try {
+    realRoot = await fsPromises.realpath(rootDirectory);
+  } catch {
+    realRoot = path.resolve(rootDirectory);
+  }
+
+  if (!isWithinRoot(realPath.toLowerCase(), realRoot.toLowerCase())) {
     return 'Access denied: path is outside of the designated directory.';
   }
 

--- a/packages/core/src/utils/planUtils.test.ts
+++ b/packages/core/src/utils/planUtils.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/core/src/utils/planUtils.test.ts
+++ b/packages/core/src/utils/planUtils.test.ts
@@ -18,8 +18,9 @@ describe('planUtils', () => {
     tempRootDir = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), 'planUtils-test-')),
     );
-    plansDir = path.join(tempRootDir, 'plans');
-    fs.mkdirSync(plansDir, { recursive: true });
+    const plansDirRaw = path.join(tempRootDir, 'plans');
+    fs.mkdirSync(plansDirRaw, { recursive: true });
+    plansDir = fs.realpathSync(plansDirRaw);
   });
 
   afterEach(() => {
@@ -30,7 +31,7 @@ describe('planUtils', () => {
 
   describe('validatePlanPath', () => {
     it('should return null for a valid path within plans directory', async () => {
-      const planPath = 'plans/test.md';
+      const planPath = path.join('plans', 'test.md');
       const fullPath = path.join(tempRootDir, planPath);
       fs.writeFileSync(fullPath, '# My Plan');
 
@@ -39,19 +40,19 @@ describe('planUtils', () => {
     });
 
     it('should return error for path traversal', async () => {
-      const planPath = '../secret.txt';
+      const planPath = path.join('..', 'secret.txt');
       const result = await validatePlanPath(planPath, plansDir, tempRootDir);
       expect(result).toContain('Access denied');
     });
 
     it('should return error for non-existent file', async () => {
-      const planPath = 'plans/ghost.md';
+      const planPath = path.join('plans', 'ghost.md');
       const result = await validatePlanPath(planPath, plansDir, tempRootDir);
       expect(result).toContain('Plan file does not exist');
     });
 
     it('should detect path traversal via symbolic links', async () => {
-      const maliciousPath = 'plans/malicious.md';
+      const maliciousPath = path.join('plans', 'malicious.md');
       const fullMaliciousPath = path.join(tempRootDir, maliciousPath);
       const outsideFile = path.join(tempRootDir, 'outside.txt');
       fs.writeFileSync(outsideFile, 'secret content');

--- a/packages/core/src/utils/planUtils.test.ts
+++ b/packages/core/src/utils/planUtils.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import * as fs from 'node:fs';
+import { validatePlanPath, validatePlanContent } from './planUtils.js';
+import * as fileUtils from './fileUtils.js';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof fs>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+  };
+});
+
+vi.mock('./fileUtils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof fileUtils>();
+  return {
+    ...actual,
+    isWithinRoot: vi.fn(),
+    getRealPathSync: vi.fn(),
+    isEmpty: vi.fn(),
+  };
+});
+
+describe('planUtils', () => {
+  const mockTargetDir = '/mock/dir';
+  const mockPlansDir = '/mock/dir/plans';
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('validatePlanPath', () => {
+    it('should return null for a valid path within plans directory', () => {
+      const planPath = 'plans/test.md';
+      const resolvedPath = path.resolve(mockTargetDir, planPath);
+
+      vi.mocked(fileUtils.getRealPathSync).mockReturnValue(resolvedPath);
+      vi.mocked(fileUtils.isWithinRoot).mockReturnValue(true);
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+
+      const result = validatePlanPath(planPath, mockPlansDir, mockTargetDir);
+      expect(result).toBeNull();
+    });
+
+    it('should return error for path traversal', () => {
+      const planPath = '../secret.txt';
+      const resolvedPath = path.resolve(mockTargetDir, planPath);
+
+      vi.mocked(fileUtils.getRealPathSync).mockReturnValue(resolvedPath);
+      vi.mocked(fileUtils.isWithinRoot).mockReturnValue(false);
+
+      const result = validatePlanPath(planPath, mockPlansDir, mockTargetDir);
+      expect(result).toContain('Access denied');
+    });
+
+    it('should return error for non-existent file', () => {
+      const planPath = 'plans/ghost.md';
+      const resolvedPath = path.resolve(mockTargetDir, planPath);
+
+      vi.mocked(fileUtils.getRealPathSync).mockReturnValue(resolvedPath);
+      vi.mocked(fileUtils.isWithinRoot).mockReturnValue(true);
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const result = validatePlanPath(planPath, mockPlansDir, mockTargetDir);
+      expect(result).toContain('Plan file does not exist');
+    });
+  });
+
+  describe('validatePlanContent', () => {
+    it('should return null for non-empty content', async () => {
+      vi.mocked(fileUtils.isEmpty).mockResolvedValue(false);
+      const result = await validatePlanContent('plans/test.md');
+      expect(result).toBeNull();
+    });
+
+    it('should return error for empty content', async () => {
+      vi.mocked(fileUtils.isEmpty).mockResolvedValue(true);
+      const result = await validatePlanContent('plans/test.md');
+      expect(result).toContain('Plan file is empty');
+    });
+
+    it('should return error for unreadable file', async () => {
+      vi.mocked(fileUtils.isEmpty).mockRejectedValue(new Error('Read error'));
+      const result = await validatePlanContent('plans/test.md');
+      expect(result).toContain('Failed to read plan file');
+    });
+  });
+});

--- a/packages/core/src/utils/planUtils.test.ts
+++ b/packages/core/src/utils/planUtils.test.ts
@@ -4,96 +4,91 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import path from 'node:path';
 import * as fs from 'node:fs';
+import os from 'node:os';
 import { validatePlanPath, validatePlanContent } from './planUtils.js';
-import * as fileUtils from './fileUtils.js';
-
-vi.mock('node:fs', async (importOriginal) => {
-  const actual = await importOriginal<typeof fs>();
-  return {
-    ...actual,
-    existsSync: vi.fn(),
-  };
-});
-
-vi.mock('./fileUtils.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof fileUtils>();
-  return {
-    ...actual,
-    isWithinRoot: vi.fn(),
-    getRealPathSync: vi.fn(),
-    isEmpty: vi.fn(),
-  };
-});
 
 describe('planUtils', () => {
-  const mockTargetDir = '/mock/dir';
-  const mockPlansDir = '/mock/dir/plans';
+  let tempRootDir: string;
+  let plansDir: string;
 
   beforeEach(() => {
-    vi.resetAllMocks();
+    tempRootDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'planUtils-test-')),
+    );
+    plansDir = path.join(tempRootDir, 'plans');
+    fs.mkdirSync(plansDir, { recursive: true });
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    if (fs.existsSync(tempRootDir)) {
+      fs.rmSync(tempRootDir, { recursive: true, force: true });
+    }
   });
 
   describe('validatePlanPath', () => {
-    it('should return null for a valid path within plans directory', () => {
+    it('should return null for a valid path within plans directory', async () => {
       const planPath = 'plans/test.md';
-      const resolvedPath = path.resolve(mockTargetDir, planPath);
+      const fullPath = path.join(tempRootDir, planPath);
+      fs.writeFileSync(fullPath, '# My Plan');
 
-      vi.mocked(fileUtils.getRealPathSync).mockReturnValue(resolvedPath);
-      vi.mocked(fileUtils.isWithinRoot).mockReturnValue(true);
-      vi.mocked(fs.existsSync).mockReturnValue(true);
-
-      const result = validatePlanPath(planPath, mockPlansDir, mockTargetDir);
+      const result = await validatePlanPath(planPath, plansDir, tempRootDir);
       expect(result).toBeNull();
     });
 
-    it('should return error for path traversal', () => {
+    it('should return error for path traversal', async () => {
       const planPath = '../secret.txt';
-      const resolvedPath = path.resolve(mockTargetDir, planPath);
-
-      vi.mocked(fileUtils.getRealPathSync).mockReturnValue(resolvedPath);
-      vi.mocked(fileUtils.isWithinRoot).mockReturnValue(false);
-
-      const result = validatePlanPath(planPath, mockPlansDir, mockTargetDir);
+      const result = await validatePlanPath(planPath, plansDir, tempRootDir);
       expect(result).toContain('Access denied');
     });
 
-    it('should return error for non-existent file', () => {
+    it('should return error for non-existent file', async () => {
       const planPath = 'plans/ghost.md';
-      const resolvedPath = path.resolve(mockTargetDir, planPath);
-
-      vi.mocked(fileUtils.getRealPathSync).mockReturnValue(resolvedPath);
-      vi.mocked(fileUtils.isWithinRoot).mockReturnValue(true);
-      vi.mocked(fs.existsSync).mockReturnValue(false);
-
-      const result = validatePlanPath(planPath, mockPlansDir, mockTargetDir);
+      const result = await validatePlanPath(planPath, plansDir, tempRootDir);
       expect(result).toContain('Plan file does not exist');
+    });
+
+    it('should detect path traversal via symbolic links', async () => {
+      const maliciousPath = 'plans/malicious.md';
+      const fullMaliciousPath = path.join(tempRootDir, maliciousPath);
+      const outsideFile = path.join(tempRootDir, 'outside.txt');
+      fs.writeFileSync(outsideFile, 'secret content');
+
+      // Create a symbolic link pointing outside the plans directory
+      fs.symlinkSync(outsideFile, fullMaliciousPath);
+
+      const result = await validatePlanPath(
+        maliciousPath,
+        plansDir,
+        tempRootDir,
+      );
+      expect(result).toContain('Access denied');
     });
   });
 
   describe('validatePlanContent', () => {
     it('should return null for non-empty content', async () => {
-      vi.mocked(fileUtils.isEmpty).mockResolvedValue(false);
-      const result = await validatePlanContent('plans/test.md');
+      const planPath = path.join(plansDir, 'full.md');
+      fs.writeFileSync(planPath, 'some content');
+      const result = await validatePlanContent(planPath);
       expect(result).toBeNull();
     });
 
     it('should return error for empty content', async () => {
-      vi.mocked(fileUtils.isEmpty).mockResolvedValue(true);
-      const result = await validatePlanContent('plans/test.md');
+      const planPath = path.join(plansDir, 'empty.md');
+      fs.writeFileSync(planPath, '   ');
+      const result = await validatePlanContent(planPath);
       expect(result).toContain('Plan file is empty');
     });
 
     it('should return error for unreadable file', async () => {
-      vi.mocked(fileUtils.isEmpty).mockRejectedValue(new Error('Read error'));
-      const result = await validatePlanContent('plans/test.md');
-      expect(result).toContain('Failed to read plan file');
+      const planPath = path.join(plansDir, 'ghost.md');
+      const result = await validatePlanContent(planPath);
+      // Since isEmpty treats unreadable files as empty (defensive),
+      // we expect the "Plan file is empty" message.
+      expect(result).toContain('Plan file is empty');
     });
   });
 });

--- a/packages/core/src/utils/planUtils.ts
+++ b/packages/core/src/utils/planUtils.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/core/src/utils/planUtils.ts
+++ b/packages/core/src/utils/planUtils.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { isWithinRoot, getRealPathSync, isEmpty } from './fileUtils.js';
+
+/**
+ * Validates a plan file path for safety (traversal) and existence.
+ * @param planPath The untrusted path to the plan file.
+ * @param plansDir The authorized project plans directory.
+ * @param targetDir The current working directory (project root).
+ * @returns An error message if validation fails, or null if successful.
+ */
+export function validatePlanPath(
+  planPath: string,
+  plansDir: string,
+  targetDir: string,
+): string | null {
+  const resolvedPath = path.resolve(targetDir, planPath);
+  const realPath = getRealPathSync(resolvedPath);
+
+  if (!isWithinRoot(realPath, plansDir)) {
+    return 'Access denied: plan path must be within the designated plans directory.';
+  }
+
+  if (!fs.existsSync(resolvedPath)) {
+    return `Plan file does not exist: ${planPath}. You must create the plan file before requesting approval.`;
+  }
+
+  return null;
+}
+
+/**
+ * Validates that a plan file has non-empty content.
+ * @param planPath The path to the plan file.
+ * @returns An error message if the file is empty or unreadable, or null if successful.
+ */
+export async function validatePlanContent(
+  planPath: string,
+): Promise<string | null> {
+  try {
+    if (await isEmpty(planPath)) {
+      return 'Plan file is empty. You must write content to the plan file before requesting approval.';
+    }
+    return null;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return `Failed to read plan file: ${message}`;
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces the core logic for the `exit_plan_mode` tool. This tool allows the agent to signal the completion of a plan and request formal user approval before starting implementation.

## Details

- Implements `ExitPlanModeTool` and `ExitPlanModeInvocation` in `@google/gemini-cli-core`.
- Adds validation for plan path safety (must be within plans directory) and existence.
- Defines the `exit_plan_mode` confirmation type and associated payloads.
- Updates the plan mode policy to require user confirmation for this tool.
- This is the foundational PR for the plan approval workflow. Subsequent PRs will add the specialized dialog (https://github.com/google-gemini/gemini-cli/issues/17983) and activate the tool in the system prompts (https://github.com/google-gemini/gemini-cli/issues/17985).

## Related Issues

Closes #16850
Closes #16623

## How to Validate

Run core tests:
```bash
npm test -w @google/gemini-cli-core -- src/tools/exit-plan-mode.test.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
