### PR TITLE
feat(plan): add `ExitPlanModeDialog` for plan approval workflow

### DIFF
--- a/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
@@ -1,0 +1,366 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { act } from 'react';
+import { renderWithProviders } from '../../test-utils/render.js';
+import { waitFor } from '../../test-utils/async.js';
+import { ExitPlanModeDialog } from './ExitPlanModeDialog.js';
+import { ApprovalMode } from '@google/gemini-cli-core';
+import * as fs from 'node:fs';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof fs>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    promises: {
+      ...actual.promises,
+      readFile: vi.fn(),
+    },
+  };
+});
+
+const writeKey = (stdin: { write: (data: string) => void }, key: string) => {
+  act(() => {
+    stdin.write(key);
+  });
+};
+
+describe('ExitPlanModeDialog', () => {
+  const samplePlanContent = `## Overview
+
+Add user authentication to the CLI application.
+
+## Implementation Steps
+
+1. Create \`src/auth/AuthService.ts\` with login/logout methods
+2. Add session storage in \`src/storage/SessionStore.ts\`
+3. Update \`src/commands/index.ts\` to check auth status
+4. Add tests in \`src/auth/__tests__/\`
+
+## Files to Modify
+
+- \`src/index.ts\` - Add auth middleware
+- \`src/config.ts\` - Add auth configuration options`;
+
+  const longPlanContent = `## Overview
+
+Implement a comprehensive authentication system with multiple providers.
+
+## Implementation Steps
+
+1. Create \`src/auth/AuthService.ts\` with login/logout methods
+2. Add session storage in \`src/storage/SessionStore.ts\`
+3. Update \`src/commands/index.ts\` to check auth status
+4. Add OAuth2 provider support in \`src/auth/providers/OAuth2Provider.ts\`
+5. Add SAML provider support in \`src/auth/providers/SAMLProvider.ts\`
+6. Add LDAP provider support in \`src/auth/providers/LDAPProvider.ts\`
+7. Create token refresh mechanism in \`src/auth/TokenManager.ts\`
+8. Add multi-factor authentication in \`src/auth/MFAService.ts\`
+9. Implement session timeout handling in \`src/auth/SessionManager.ts\`
+10. Add audit logging for auth events in \`src/auth/AuditLogger.ts\`
+11. Create user profile management in \`src/auth/UserProfile.ts\`
+12. Add role-based access control in \`src/auth/RBACService.ts\`
+13. Implement password policy enforcement in \`src/auth/PasswordPolicy.ts\`
+14. Add brute force protection in \`src/auth/BruteForceGuard.ts\`
+15. Create secure cookie handling in \`src/auth/CookieManager.ts\`
+
+## Files to Modify
+
+- \`src/index.ts\` - Add auth middleware
+- \`src/config.ts\` - Add auth configuration options
+- \`src/routes/api.ts\` - Add auth endpoints
+- \`src/middleware/cors.ts\` - Update CORS for auth headers
+- \`src/utils/crypto.ts\` - Add encryption utilities
+
+## Testing Strategy
+
+- Unit tests for each auth provider
+- Integration tests for full auth flows
+- Security penetration testing
+- Load testing for session management`;
+
+  let onApprove: ReturnType<typeof vi.fn>;
+  let onFeedback: ReturnType<typeof vi.fn>;
+  let onCancel: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.mocked(fs.promises.readFile).mockResolvedValue(samplePlanContent);
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    onApprove = vi.fn();
+    onFeedback = vi.fn();
+    onCancel = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const renderDialog = (options?: { useAlternateBuffer?: boolean }) =>
+    renderWithProviders(
+      <ExitPlanModeDialog
+        planPath="/mock/plans/test-plan.md"
+        onApprove={onApprove}
+        onFeedback={onFeedback}
+        onCancel={onCancel}
+        width={80}
+        availableHeight={24}
+      />,
+      options,
+    );
+
+  describe.each([{ useAlternateBuffer: true }, { useAlternateBuffer: false }])(
+    'useAlternateBuffer: $useAlternateBuffer',
+    ({ useAlternateBuffer }) => {
+      it('renders correctly with plan content', async () => {
+        const { lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        await waitFor(() => {
+          expect(fs.promises.readFile).toHaveBeenCalledWith(
+            '/mock/plans/test-plan.md',
+            'utf8',
+          );
+        });
+
+        expect(lastFrame()).toMatchSnapshot();
+      });
+
+      it('calls onApprove with AUTO_EDIT when first option is selected', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        writeKey(stdin, '\r');
+
+        await waitFor(() => {
+          expect(onApprove).toHaveBeenCalledWith(ApprovalMode.AUTO_EDIT);
+        });
+      });
+
+      it('calls onApprove with DEFAULT when second option is selected', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\r');
+
+        await waitFor(() => {
+          expect(onApprove).toHaveBeenCalledWith(ApprovalMode.DEFAULT);
+        });
+      });
+
+      it('calls onFeedback when feedback is typed and submitted', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        // Navigate to feedback option
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\r'); // Select to focus input
+
+        // Type feedback
+        for (const char of 'Add tests') {
+          writeKey(stdin, char);
+        }
+
+        await waitFor(() => {
+          expect(lastFrame()).toMatchSnapshot();
+        });
+
+        writeKey(stdin, '\r');
+
+        await waitFor(() => {
+          expect(onFeedback).toHaveBeenCalledWith('Add tests');
+        });
+      });
+
+      it('calls onCancel when Esc is pressed', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        writeKey(stdin, '\x1b'); // Escape
+
+        await waitFor(() => {
+          expect(onCancel).toHaveBeenCalled();
+        });
+      });
+
+      it('displays error state when file read fails', async () => {
+        vi.mocked(fs.promises.readFile).mockRejectedValue(
+          new Error('File not found'),
+        );
+
+        const { lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Error reading plan: File not found');
+        });
+
+        expect(lastFrame()).toMatchSnapshot();
+      });
+
+      it('handles long plan content appropriately', async () => {
+        vi.mocked(fs.promises.readFile).mockResolvedValue(longPlanContent);
+
+        const { lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain(
+            'Implement a comprehensive authentication system',
+          );
+        });
+
+        expect(lastFrame()).toMatchSnapshot();
+      });
+
+      it('allows number key quick selection', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        // Press '2' to select second option directly
+        writeKey(stdin, '2');
+
+        await waitFor(() => {
+          expect(onApprove).toHaveBeenCalledWith(ApprovalMode.DEFAULT);
+        });
+      });
+
+      it('clears feedback text when Ctrl+C is pressed while editing', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        // Navigate to feedback option and start typing
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\r'); // Select to focus input
+
+        // Type some feedback
+        for (const char of 'test feedback') {
+          writeKey(stdin, char);
+        }
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('test feedback');
+        });
+
+        // Press Ctrl+C to clear
+        writeKey(stdin, '\x03'); // Ctrl+C
+
+        await waitFor(() => {
+          expect(lastFrame()).not.toContain('test feedback');
+          expect(lastFrame()).toContain('Type your feedback...');
+        });
+
+        // Dialog should still be open (not cancelled)
+        expect(onCancel).not.toHaveBeenCalled();
+      });
+
+      it('exits the dialog when Ctrl+C is pressed twice in feedback mode', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        // Navigate to feedback option and start typing
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\r'); // Select to focus input
+
+        // Type some feedback
+        for (const char of 'test') {
+          writeKey(stdin, char);
+        }
+
+        // First Ctrl+C to clear
+        writeKey(stdin, '\x03'); // Ctrl+C
+
+        expect(onCancel).not.toHaveBeenCalled();
+
+        // Second Ctrl+C to exit
+        writeKey(stdin, '\x03'); // Ctrl+C
+
+        await waitFor(() => {
+          expect(onCancel).toHaveBeenCalled();
+        });
+      });
+
+      it('does not submit empty feedback when Enter is pressed', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        // Navigate to feedback option
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\x1b[B'); // Down arrow
+
+        // Press Enter without typing anything
+        writeKey(stdin, '\r');
+
+        // Wait a bit to ensure no callback was triggered
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        });
+
+        expect(onFeedback).not.toHaveBeenCalled();
+        expect(onApprove).not.toHaveBeenCalled();
+      });
+
+      it('allows arrow navigation while typing feedback to change selection', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        // Navigate to feedback option and start typing
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\r'); // Select to focus input
+
+        // Type some feedback
+        for (const char of 'test') {
+          writeKey(stdin, char);
+        }
+
+        // Now use up arrow to navigate back to a different option
+        writeKey(stdin, '\x1b[A'); // Up arrow
+
+        // Press Enter to select the second option (manually accept edits)
+        writeKey(stdin, '\r');
+
+        await waitFor(() => {
+          expect(onApprove).toHaveBeenCalledWith(ApprovalMode.DEFAULT);
+        });
+        expect(onFeedback).not.toHaveBeenCalled();
+      });
+    },
+  );
+});

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
@@ -17,7 +17,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     await importOriginal<typeof import('@google/gemini-cli-core')>();
   return {
     ...actual,
-    validatePlanPath: vi.fn(() => null),
+    validatePlanPath: vi.fn(async () => null),
     validatePlanContent: vi.fn(async () => null),
   };
 });

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
@@ -1,0 +1,332 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useState,
+  useContext,
+} from 'react';
+import { Box, Text } from 'ink';
+import * as fs from 'node:fs';
+import { ApprovalMode } from '@google/gemini-cli-core';
+import { theme } from '../semantic-colors.js';
+import { MarkdownDisplay } from '../utils/MarkdownDisplay.js';
+import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
+import type { RadioSelectItem } from './shared/RadioButtonSelect.js';
+import { TextInput } from './shared/TextInput.js';
+import { useTextBuffer } from './shared/text-buffer.js';
+import { useKeypress, type Key } from '../hooks/useKeypress.js';
+import { keyMatchers, Command } from '../keyMatchers.js';
+import { DialogFooter } from './shared/DialogFooter.js';
+import { checkExhaustive } from '../../utils/checks.js';
+import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
+import { MaxSizedBox } from './shared/MaxSizedBox.js';
+import { UIStateContext } from '../contexts/UIStateContext.js';
+
+/**
+ * Layout constants for the dialog.
+ */
+const MIN_PLAN_HEIGHT = 3;
+const MAX_STANDARD_PLAN_HEIGHT = 20;
+const FEEDBACK_BUFFER_WIDTH_OFFSET = 6;
+const PLAN_WIDTH_OFFSET = 2;
+const QUESTION_AND_MARGIN = 2; // Question text + margin
+const FOOTER_HEIGHT = 2; // DialogFooter + margin
+
+export interface ExitPlanModeDialogProps {
+  planPath: string;
+  onApprove: (approvalMode: ApprovalMode) => void;
+  onFeedback: (feedback: string) => void;
+  onCancel: () => void;
+  width: number;
+  availableHeight?: number;
+}
+
+interface PlanContentState {
+  status: 'loading' | 'loaded' | 'error';
+  content?: string;
+  error?: string;
+}
+
+enum DialogChoice {
+  APPROVE_AUTO_EDIT = 'approve_auto_edit',
+  APPROVE_DEFAULT = 'approve_default',
+  FEEDBACK = 'feedback',
+}
+
+interface DialogState {
+  activeChoice: DialogChoice;
+  isEditingFeedback: boolean;
+  submitted: boolean;
+}
+
+type DialogAction =
+  | { type: 'SET_ACTIVE_CHOICE'; payload: DialogChoice }
+  | { type: 'SUBMIT' };
+
+const initialDialogState: DialogState = {
+  activeChoice: DialogChoice.APPROVE_AUTO_EDIT,
+  isEditingFeedback: false,
+  submitted: false,
+};
+
+function dialogReducer(state: DialogState, action: DialogAction): DialogState {
+  if (state.submitted) return state;
+
+  switch (action.type) {
+    case 'SET_ACTIVE_CHOICE':
+      return {
+        ...state,
+        activeChoice: action.payload,
+        isEditingFeedback: action.payload === DialogChoice.FEEDBACK,
+      };
+    case 'SUBMIT':
+      return { ...state, submitted: true };
+    default:
+      checkExhaustive(action);
+  }
+}
+
+const CHOICE_LABELS: Record<
+  Exclude<DialogChoice, DialogChoice.FEEDBACK>,
+  string
+> = {
+  [DialogChoice.APPROVE_AUTO_EDIT]: 'Yes, automatically accept edits',
+  [DialogChoice.APPROVE_DEFAULT]: 'Yes, manually accept edits',
+};
+
+export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
+  planPath,
+  onApprove,
+  onFeedback,
+  onCancel,
+  width,
+  availableHeight: availableHeightProp,
+}) => {
+  const isAlternateBuffer = useAlternateBuffer();
+  const uiState = useContext(UIStateContext);
+  const availableHeight =
+    availableHeightProp ??
+    (uiState?.constrainHeight !== false
+      ? (uiState?.availableTerminalHeight ?? uiState?.terminalHeight)
+      : undefined);
+
+  const [planState, setPlanState] = useState<PlanContentState>({
+    status: 'loading',
+  });
+  const [state, dispatch] = useReducer(dialogReducer, initialDialogState);
+
+  useEffect(() => {
+    let ignore = false;
+
+    fs.promises
+      .readFile(planPath, 'utf8')
+      .then((content) => {
+        if (ignore) return;
+        setPlanState({ status: 'loaded', content });
+      })
+      .catch((err) => {
+        if (ignore) return;
+        setPlanState({ status: 'error', error: err.message });
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [planPath]);
+
+  const feedbackBuffer = useTextBuffer({
+    initialText: '',
+    viewport: {
+      width: Math.max(1, width - FEEDBACK_BUFFER_WIDTH_OFFSET),
+      height: 1,
+    },
+    singleLine: true,
+    isValidPath: () => false,
+  });
+
+  useKeypress(
+    useCallback(
+      (key: Key) => {
+        if (state.submitted) return false;
+        if (keyMatchers[Command.ESCAPE](key)) {
+          onCancel();
+          return true;
+        }
+        if (keyMatchers[Command.QUIT](key)) {
+          onCancel();
+          return false;
+        }
+        return false;
+      },
+      [onCancel, state.submitted],
+    ),
+    { isActive: !state.submitted },
+  );
+
+  useKeypress(
+    useCallback(
+      (key: Key) => {
+        if (
+          state.isEditingFeedback &&
+          keyMatchers[Command.QUIT](key) &&
+          feedbackBuffer.text !== ''
+        ) {
+          feedbackBuffer.setText('');
+          return true;
+        }
+        return false;
+      },
+      [state.isEditingFeedback, feedbackBuffer],
+    ),
+    { isActive: state.isEditingFeedback, priority: true },
+  );
+
+  const handleSelect = useCallback(
+    (choice: DialogChoice) => {
+      if (state.submitted) return;
+
+      if (choice === DialogChoice.FEEDBACK) {
+        dispatch({ type: 'SET_ACTIVE_CHOICE', payload: choice });
+        return;
+      }
+
+      dispatch({ type: 'SUBMIT' });
+      if (choice === DialogChoice.APPROVE_AUTO_EDIT) {
+        onApprove(ApprovalMode.AUTO_EDIT);
+      } else if (choice === DialogChoice.APPROVE_DEFAULT) {
+        onApprove(ApprovalMode.DEFAULT);
+      }
+    },
+    [state.submitted, onApprove],
+  );
+
+  const handleHighlight = useCallback((choice: DialogChoice) => {
+    dispatch({ type: 'SET_ACTIVE_CHOICE', payload: choice });
+  }, []);
+
+  const handleFeedbackSubmit = useCallback(
+    (text: string) => {
+      if (state.submitted || !text.trim()) return;
+      dispatch({ type: 'SUBMIT' });
+      onFeedback(text.trim());
+    },
+    [state.submitted, onFeedback],
+  );
+
+  const selectItems = useMemo(
+    (): Array<RadioSelectItem<DialogChoice>> => [
+      {
+        key: DialogChoice.APPROVE_AUTO_EDIT,
+        value: DialogChoice.APPROVE_AUTO_EDIT,
+        label: CHOICE_LABELS[DialogChoice.APPROVE_AUTO_EDIT],
+      },
+      {
+        key: DialogChoice.APPROVE_DEFAULT,
+        value: DialogChoice.APPROVE_DEFAULT,
+        label: CHOICE_LABELS[DialogChoice.APPROVE_DEFAULT],
+      },
+      {
+        key: DialogChoice.FEEDBACK,
+        value: DialogChoice.FEEDBACK,
+        label: '',
+      },
+    ],
+    [],
+  );
+
+  const OPTIONS_COUNT = selectItems.length;
+  const overhead = QUESTION_AND_MARGIN + OPTIONS_COUNT + FOOTER_HEIGHT;
+
+  const planContentHeight =
+    availableHeight && !isAlternateBuffer
+      ? Math.min(
+          MAX_STANDARD_PLAN_HEIGHT,
+          Math.max(MIN_PLAN_HEIGHT, availableHeight - overhead),
+        )
+      : undefined;
+
+  const planContent = useMemo(() => {
+    if (planState.status === 'loading') {
+      return (
+        <Text color={theme.text.secondary} italic>
+          Loading plan...
+        </Text>
+      );
+    }
+    if (planState.status === 'error') {
+      return (
+        <Text color={theme.status.error}>
+          Error reading plan: {planState.error}
+        </Text>
+      );
+    }
+    return (
+      <MarkdownDisplay
+        text={planState.content || ''}
+        isPending={false}
+        terminalWidth={width - PLAN_WIDTH_OFFSET}
+      />
+    );
+  }, [planState, width]);
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Box marginBottom={1}>
+        <MaxSizedBox
+          maxHeight={planContentHeight}
+          maxWidth={width - PLAN_WIDTH_OFFSET}
+          overflowDirection="bottom"
+        >
+          {planContent}
+        </MaxSizedBox>
+      </Box>
+
+      <Box marginBottom={1}>
+        <Text bold color={theme.text.primary}>
+          Ready to start implementation?
+        </Text>
+      </Box>
+
+      <RadioButtonSelect
+        items={selectItems}
+        onSelect={handleSelect}
+        onHighlight={handleHighlight}
+        isFocused={true}
+        showNumbers={true}
+        showScrollArrows={false}
+        renderItem={(item, { titleColor, isSelected }) => {
+          if (item.value === DialogChoice.FEEDBACK) {
+            return (
+              <Box flexDirection="row">
+                <TextInput
+                  buffer={feedbackBuffer}
+                  placeholder="Type your feedback..."
+                  focus={isSelected}
+                  onSubmit={handleFeedbackSubmit}
+                />
+              </Box>
+            );
+          }
+          return <Text color={titleColor}>{item.label}</Text>;
+        }}
+      />
+
+      <DialogFooter
+        primaryAction={
+          state.activeChoice === DialogChoice.FEEDBACK
+            ? 'Enter to send feedback'
+            : 'Enter to select'
+        }
+        navigationActions="↑/↓ to navigate"
+      />
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
@@ -15,7 +15,11 @@ import {
 } from 'react';
 import { Box, Text } from 'ink';
 import * as fs from 'node:fs';
-import { ApprovalMode , validatePlanPath, validatePlanContent } from '@google/gemini-cli-core';
+import {
+  ApprovalMode,
+  validatePlanPath,
+  validatePlanContent,
+} from '@google/gemini-cli-core';
 import { theme } from '../semantic-colors.js';
 import { MarkdownDisplay } from '../utils/MarkdownDisplay.js';
 import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
@@ -35,7 +39,7 @@ import { useConfig } from '../contexts/ConfigContext.js';
  * Layout constants for the dialog.
  */
 const MIN_PLAN_HEIGHT = 3;
-const MAX_STANDARD_PLAN_HEIGHT = 20;
+// Offset for the feedback text input width to account for radio button prefix ("● 1. ") and margins.
 const FEEDBACK_BUFFER_WIDTH_OFFSET = 6;
 const PLAN_WIDTH_OFFSET = 2;
 const QUESTION_AND_MARGIN = 2; // Question text + margin
@@ -267,10 +271,7 @@ export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
 
   const planContentHeight =
     availableHeight && !isAlternateBuffer
-      ? Math.min(
-          MAX_STANDARD_PLAN_HEIGHT,
-          Math.max(MIN_PLAN_HEIGHT, availableHeight - overhead),
-        )
+      ? Math.max(MIN_PLAN_HEIGHT, availableHeight - overhead)
       : undefined;
 
   const planContent = useMemo(() => {

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
@@ -19,6 +19,7 @@ import {
   ApprovalMode,
   validatePlanPath,
   validatePlanContent,
+  checkExhaustive,
 } from '@google/gemini-cli-core';
 import { theme } from '../semantic-colors.js';
 import { MarkdownDisplay } from '../utils/MarkdownDisplay.js';
@@ -29,7 +30,6 @@ import { useTextBuffer } from './shared/text-buffer.js';
 import { useKeypress, type Key } from '../hooks/useKeypress.js';
 import { keyMatchers, Command } from '../keyMatchers.js';
 import { DialogFooter } from './shared/DialogFooter.js';
-import { checkExhaustive } from '../../utils/checks.js';
 import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
 import { MaxSizedBox } from './shared/MaxSizedBox.js';
 import { UIStateContext } from '../contexts/UIStateContext.js';

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
@@ -132,20 +132,22 @@ export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
   useEffect(() => {
     let ignore = false;
 
-    const pathError = validatePlanPath(
+    validatePlanPath(
       planPath,
       config.storage.getProjectTempPlansDir(),
       config.getTargetDir(),
-    );
-
-    if (pathError) {
-      setPlanState({ status: 'error', error: pathError });
-      return;
-    }
-
-    validatePlanContent(planPath)
-      .then((contentError) => {
+    )
+      .then((pathError) => {
         if (ignore) return;
+        if (pathError) {
+          setPlanState({ status: 'error', error: pathError });
+          return;
+        }
+
+        return validatePlanContent(planPath);
+      })
+      .then((contentError) => {
+        if (ignore || contentError === undefined) return;
         if (contentError) {
           setPlanState({ status: 'error', error: contentError });
           return;

--- a/packages/cli/src/ui/components/ToolConfirmationQueue.tsx
+++ b/packages/cli/src/ui/components/ToolConfirmationQueue.tsx
@@ -25,6 +25,7 @@ function getConfirmationHeader(
     Record<SerializableConfirmationDetails['type'], string>
   > = {
     ask_user: 'Answer Questions',
+    exit_plan_mode: 'Plan Approval',
   };
   if (!details?.type) {
     return 'Action Required';
@@ -70,7 +71,9 @@ export const ToolConfirmationQueue: React.FC<ToolConfirmationQueueProps> = ({
       : undefined;
 
   const borderColor = theme.status.warning;
-  const hideToolIdentity = tool.confirmationDetails?.type === 'ask_user';
+  const hideToolIdentity =
+    tool.confirmationDetails?.type === 'ask_user' ||
+    tool.confirmationDetails?.type === 'exit_plan_mode';
 
   return (
     <OverflowProvider>

--- a/packages/cli/src/ui/components/__snapshots__/ExitPlanModeDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ExitPlanModeDialog.test.tsx.snap
@@ -1,0 +1,204 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: false > calls onFeedback when feedback is typed and submitted 1`] = `
+"Overview
+
+Add user authentication to the CLI application.
+
+Implementation Steps
+
+ 1. Create src/auth/AuthService.ts with login/logout methods
+ 2. Add session storage in src/storage/SessionStore.ts
+ 3. Update src/commands/index.ts to check auth status
+ 4. Add tests in src/auth/__tests__/
+
+Files to Modify
+
+ - src/index.ts - Add auth middleware
+ - src/config.ts - Add auth configuration options
+
+Ready to start implementation?
+
+  1. Yes, automatically accept edits
+  2. Yes, manually accept edits
+● 3. Add tests
+
+Enter to send feedback · ↑/↓ to navigate · Esc to cancel"
+`;
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: false > displays error state when file read fails 1`] = `
+"Error reading plan: File not found
+
+Ready to start implementation?
+
+● 1. Yes, automatically accept edits
+  2. Yes, manually accept edits
+  3. Type your feedback...
+
+Enter to select · ↑/↓ to navigate · Esc to cancel"
+`;
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: false > handles long plan content appropriately 1`] = `
+"Overview
+
+Implement a comprehensive authentication system with multiple providers.
+
+Implementation Steps
+
+ 1. Create src/auth/AuthService.ts with login/logout methods
+ 2. Add session storage in src/storage/SessionStore.ts
+ 3. Update src/commands/index.ts to check auth status
+ 4. Add OAuth2 provider support in src/auth/providers/OAuth2Provider.ts
+ 5. Add SAML provider support in src/auth/providers/SAMLProvider.ts
+ 6. Add LDAP provider support in src/auth/providers/LDAPProvider.ts
+ 7. Create token refresh mechanism in src/auth/TokenManager.ts
+ 8. Add multi-factor authentication in src/auth/MFAService.ts
+ 9. Implement session timeout handling in src/auth/SessionManager.ts
+ 10. Add audit logging for auth events in src/auth/AuditLogger.ts
+... last 20 lines hidden ...agement in src/auth/UserProfile.ts
+
+Ready to start implementation?
+
+● 1. Yes, automatically accept edits
+  2. Yes, manually accept edits
+  3. Type your feedback...
+
+Enter to select · ↑/↓ to navigate · Esc to cancel"
+`;
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: false > renders correctly with plan content 1`] = `
+"Overview
+
+Add user authentication to the CLI application.
+
+Implementation Steps
+
+ 1. Create src/auth/AuthService.ts with login/logout methods
+ 2. Add session storage in src/storage/SessionStore.ts
+ 3. Update src/commands/index.ts to check auth status
+ 4. Add tests in src/auth/__tests__/
+
+Files to Modify
+
+ - src/index.ts - Add auth middleware
+ - src/config.ts - Add auth configuration options
+
+Ready to start implementation?
+
+● 1. Yes, automatically accept edits
+  2. Yes, manually accept edits
+  3. Type your feedback...
+
+Enter to select · ↑/↓ to navigate · Esc to cancel"
+`;
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: true > calls onFeedback when feedback is typed and submitted 1`] = `
+"Overview
+
+Add user authentication to the CLI application.
+
+Implementation Steps
+
+ 1. Create src/auth/AuthService.ts with login/logout methods
+ 2. Add session storage in src/storage/SessionStore.ts
+ 3. Update src/commands/index.ts to check auth status
+ 4. Add tests in src/auth/__tests__/
+
+Files to Modify
+
+ - src/index.ts - Add auth middleware
+ - src/config.ts - Add auth configuration options
+
+Ready to start implementation?
+
+  1. Yes, automatically accept edits
+  2. Yes, manually accept edits
+● 3. Add tests
+
+Enter to send feedback · ↑/↓ to navigate · Esc to cancel"
+`;
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: true > displays error state when file read fails 1`] = `
+"Error reading plan: File not found
+
+Ready to start implementation?
+
+● 1. Yes, automatically accept edits
+  2. Yes, manually accept edits
+  3. Type your feedback...
+
+Enter to select · ↑/↓ to navigate · Esc to cancel"
+`;
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: true > handles long plan content appropriately 1`] = `
+"Overview
+
+Implement a comprehensive authentication system with multiple providers.
+
+Implementation Steps
+
+ 1. Create src/auth/AuthService.ts with login/logout methods
+ 2. Add session storage in src/storage/SessionStore.ts
+ 3. Update src/commands/index.ts to check auth status
+ 4. Add OAuth2 provider support in src/auth/providers/OAuth2Provider.ts
+ 5. Add SAML provider support in src/auth/providers/SAMLProvider.ts
+ 6. Add LDAP provider support in src/auth/providers/LDAPProvider.ts
+ 7. Create token refresh mechanism in src/auth/TokenManager.ts
+ 8. Add multi-factor authentication in src/auth/MFAService.ts
+ 9. Implement session timeout handling in src/auth/SessionManager.ts
+ 10. Add audit logging for auth events in src/auth/AuditLogger.ts
+ 11. Create user profile management in src/auth/UserProfile.ts
+ 12. Add role-based access control in src/auth/RBACService.ts
+ 13. Implement password policy enforcement in src/auth/PasswordPolicy.ts
+ 14. Add brute force protection in src/auth/BruteForceGuard.ts
+ 15. Create secure cookie handling in src/auth/CookieManager.ts
+
+Files to Modify
+
+ - src/index.ts - Add auth middleware
+ - src/config.ts - Add auth configuration options
+ - src/routes/api.ts - Add auth endpoints
+ - src/middleware/cors.ts - Update CORS for auth headers
+ - src/utils/crypto.ts - Add encryption utilities
+
+Testing Strategy
+
+ - Unit tests for each auth provider
+ - Integration tests for full auth flows
+ - Security penetration testing
+ - Load testing for session management
+
+Ready to start implementation?
+
+● 1. Yes, automatically accept edits
+  2. Yes, manually accept edits
+  3. Type your feedback...
+
+Enter to select · ↑/↓ to navigate · Esc to cancel"
+`;
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: true > renders correctly with plan content 1`] = `
+"Overview
+
+Add user authentication to the CLI application.
+
+Implementation Steps
+
+ 1. Create src/auth/AuthService.ts with login/logout methods
+ 2. Add session storage in src/storage/SessionStore.ts
+ 3. Update src/commands/index.ts to check auth status
+ 4. Add tests in src/auth/__tests__/
+
+Files to Modify
+
+ - src/index.ts - Add auth middleware
+ - src/config.ts - Add auth configuration options
+
+Ready to start implementation?
+
+● 1. Yes, automatically accept edits
+  2. Yes, manually accept edits
+  3. Type your feedback...
+
+Enter to select · ↑/↓ to navigate · Esc to cancel"
+`;

--- a/packages/cli/src/ui/components/__snapshots__/ExitPlanModeDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ExitPlanModeDialog.test.tsx.snap
@@ -55,7 +55,7 @@ Implementation Steps
  8. Add multi-factor authentication in src/auth/MFAService.ts
  9. Implement session timeout handling in src/auth/SessionManager.ts
  10. Add audit logging for auth events in src/auth/AuditLogger.ts
-... last 20 lines hidden ...agement in src/auth/UserProfile.ts
+... last 20 lines hidden ...
 
 Ready to start implementation?
 

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -34,6 +34,7 @@ import {
   REDIRECTION_WARNING_TIP_TEXT,
 } from '../../textConstants.js';
 import { AskUserDialog } from '../AskUserDialog.js';
+import { ExitPlanModeDialog } from '../ExitPlanModeDialog.js';
 
 export interface ToolConfirmationMessageProps {
   callId: string;
@@ -62,7 +63,9 @@ export const ToolConfirmationMessage: React.FC<
   const allowPermanentApproval =
     settings.merged.security.enablePermanentToolApproval;
 
-  const handlesOwnUI = confirmationDetails.type === 'ask_user';
+  const handlesOwnUI =
+    confirmationDetails.type === 'ask_user' ||
+    confirmationDetails.type === 'exit_plan_mode';
   const isTrustedFolder = config.isTrustedFolder();
 
   const handleConfirm = useCallback(
@@ -266,6 +269,32 @@ export const ToolConfirmationMessage: React.FC<
           questions={confirmationDetails.questions}
           onSubmit={(answers) => {
             handleConfirm(ToolConfirmationOutcome.ProceedOnce, { answers });
+          }}
+          onCancel={() => {
+            handleConfirm(ToolConfirmationOutcome.Cancel);
+          }}
+          width={terminalWidth}
+          availableHeight={availableBodyContentHeight()}
+        />
+      );
+      return { question: '', bodyContent, options: [] };
+    }
+
+    if (confirmationDetails.type === 'exit_plan_mode') {
+      bodyContent = (
+        <ExitPlanModeDialog
+          planPath={confirmationDetails.planPath}
+          onApprove={(approvalMode) => {
+            handleConfirm(ToolConfirmationOutcome.ProceedOnce, {
+              approved: true,
+              approvalMode,
+            });
+          }}
+          onFeedback={(feedback) => {
+            handleConfirm(ToolConfirmationOutcome.ProceedOnce, {
+              approved: false,
+              feedback,
+            });
           }}
           onCancel={() => {
             handleConfirm(ToolConfirmationOutcome.Cancel);


### PR DESCRIPTION
## Summary

This PR adds a specialized dialog for the `exit_plan_mode` tool.

**Note: This is part of a stacked PR sequence. This PR targets `exit-plan-tool-core` and is blocked by #18110.**

## Details

- Implements `ExitPlanModeDialog`.
- Supports "Auto-Edit", "Manual-Edit", and "Feedback" workflows.
- Handles long plan content with dynamic height constraints and scrolling.
- Provides keyboard shortcuts (number keys for selection, Esc to cancel, Ctrl+C to clear/exit).
- Integrates the dialog into the `ToolConfirmationMessage` and `ToolConfirmationQueue`.
- A specialized dialog was created instead of reusing `AskUserDialog` because the plan approval flow has unique UI requirements:
    - **Plan Preview**: It needs to display and manage the height of a potentially large markdown plan file.
    - **Specialized Workflows**: It includes specific options for "Auto-Edit" vs "Manual-Edit" which impact the agent's future behavior, rather than just returning answers to questions.
    - **Note on Consolidation**: While `ExitPlanModeDialog` and `AskUserDialog` could potentially be consolidated in the future, keeping them separate now allows for faster iteration during this experimental phase.


## Related Issues



## How to Validate

Run component tests:
```bash
npm test -w @google/gemini-cli -- src/ui/components/ExitPlanModeDialog.test.tsx
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
