### PR TITLE
feat(plan): update system prompt to use `exit_plan_mode` tool

### DIFF
--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -201,9 +201,9 @@ The following read-only tools are available in Plan Mode:
 - After saving the plan, present the full content of the markdown file to the user for review
 
 ### Phase 4: Review & Approval
-- Ask the user if they approve the plan, want revisions, or want to reject it
-- Address feedback and iterate as needed
-- **When the user approves the plan**, prompt them to switch out of Plan Mode to begin implementation by pressing Shift+Tab to cycle to a different approval mode
+- Present the plan and request approval using \`exit_plan_mode\` tool
+- If plan is approved, you can begin implementation
+- If plan is rejected, address the feedback and iterate on the plan
 
 ## Constraints
 - You may ONLY use the read-only tools listed above

--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -198,10 +198,10 @@ The following read-only tools are available in Plan Mode:
 - Only begin this phase after exploration is complete
 - Create a detailed implementation plan with clear steps
 - Include file paths, function signatures, and code snippets where helpful
-- After saving the plan, present the full content of the markdown file to the user for review
+- Save the implementation plan to the designated plans directory
 
 ### Phase 4: Review & Approval
-- Present the plan and request approval using \`exit_plan_mode\` tool
+- Present the plan and request approval for the finalized plan using the \`exit_plan_mode\` tool
 - If plan is approved, you can begin implementation
 - If plan is rejected, address the feedback and iterate on the plan
 

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -8,6 +8,7 @@ import {
   ACTIVATE_SKILL_TOOL_NAME,
   ASK_USER_TOOL_NAME,
   EDIT_TOOL_NAME,
+  EXIT_PLAN_MODE_TOOL_NAME,
   GLOB_TOOL_NAME,
   GREP_TOOL_NAME,
   MEMORY_TOOL_NAME,
@@ -329,9 +330,9 @@ ${options.planModeToolsList}
 - After saving the plan, present the full content of the markdown file to the user for review
 
 ### Phase 4: Review & Approval
-- Ask the user if they approve the plan, want revisions, or want to reject it
-- Address feedback and iterate as needed
-- **When the user approves the plan**, prompt them to switch out of Plan Mode to begin implementation by pressing Shift+Tab to cycle to a different approval mode
+- Present the plan and request approval using \`${EXIT_PLAN_MODE_TOOL_NAME}\` tool
+- If plan is approved, you can begin implementation
+- If plan is rejected, address the feedback and iterate on the plan
 
 ## Constraints
 - You may ONLY use the read-only tools listed above

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -327,10 +327,10 @@ ${options.planModeToolsList}
 - Only begin this phase after exploration is complete
 - Create a detailed implementation plan with clear steps
 - Include file paths, function signatures, and code snippets where helpful
-- After saving the plan, present the full content of the markdown file to the user for review
+- Save the implementation plan to the designated plans directory
 
 ### Phase 4: Review & Approval
-- Present the plan and request approval using \`${EXIT_PLAN_MODE_TOOL_NAME}\` tool
+- Present the plan and request approval for the finalized plan using the \`${EXIT_PLAN_MODE_TOOL_NAME}\` tool
 - If plan is approved, you can begin implementation
 - If plan is rejected, address the feedback and iterate on the plan
 


### PR DESCRIPTION
## Summary

This PR updates the agent's system prompt to use the new `exit_plan_mode` tool for plan approval.

**Note: This is part of a stacked PR sequence. This PR targets `exit-plan-tool-ui` and is blocked by #18119.**

## Details

- Updates the "Phase 4: Review & Approval" snippet in Plan Mode instructions to direct the agent to use the `exit_plan_mode` tool.
- Updates the Plan Mode instruction snapshots.
- This is the final piece of the plan approval workflow, enabling the agent to trigger the new specialized dialog.

## Related Issues

Closes #17985

## How to Validate

Verify prompt snapshots:
```bash
npm test -w @google/gemini-cli-core -- src/core/prompts.test.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
