### PR TITLE
Remove MCP servers on extension uninstall

### DIFF
--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -85,6 +85,7 @@ export class McpClientManager {
           }
           return this.disconnectClient(name, true);
         }
+        return Promise.resolve();
       }),
     );
     await this.cliConfig.refreshMcpContext();

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -76,15 +76,15 @@ export class McpClientManager {
         const config = this.allServerConfigs.get(name);
         if (config?.extension === extension) {
           this.allServerConfigs.delete(name);
+          // Also remove from blocked servers if present
+          const index = this.blockedMcpServers.findIndex(
+            (s) => s.name === name && s.extensionName === extension.name,
+          );
+          if (index !== -1) {
+            this.blockedMcpServers.splice(index, 1);
+          }
+          return this.disconnectClient(name, true);
         }
-        // Also remove from blocked servers if present
-        const index = this.blockedMcpServers.findIndex(
-          (s) => s.name === name && s.extensionName === extension.name,
-        );
-        if (index !== -1) {
-          this.blockedMcpServers.splice(index, 1);
-        }
-        return this.disconnectClient(name, true);
       }),
     );
     await this.cliConfig.refreshMcpContext();


### PR DESCRIPTION
## Summary

We were not properly removing them previously 

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/1292
## How to Validate

```
{
  "experimental": {
    "extensionReloading": true,
    "extensionConfig": true,
  }
}
```

Run `/extensions install` with an extension with an MCP server.

Verify you see the mcp server at `/mcp list`.

Run `/extensions uninstall` on that same extension.

Verify you don't see the mcp server at `/mcp list`.


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
