### PR TITLE
Fix handling of empty settings

### DIFF
--- a/packages/cli/src/commands/extensions/utils.ts
+++ b/packages/cli/src/commands/extensions/utils.ts
@@ -8,7 +8,10 @@ import { ExtensionManager } from '../../config/extension-manager.js';
 import { promptForSetting } from '../../config/extensions/extensionSettings.js';
 import { loadSettings } from '../../config/settings.js';
 import { requestConsentNonInteractive } from '../../config/extensions/consent.js';
-import { debugLogger } from '@google/gemini-cli-core';
+import {
+  debugLogger,
+  type ResolvedExtensionSetting,
+} from '@google/gemini-cli-core';
 
 export async function getExtensionManager() {
   const workspaceDir = process.cwd();
@@ -34,4 +37,16 @@ export async function getExtensionAndManager(name: string) {
   }
 
   return { extension, extensionManager };
+}
+
+export function getFormattedSettingValue(
+  setting: ResolvedExtensionSetting,
+): string {
+  if (!setting.value) {
+    return '[not set]';
+  }
+  if (setting.sensitive) {
+    return '***';
+  }
+  return setting.value;
 }

--- a/packages/cli/src/config/extension-manager-scope.test.ts
+++ b/packages/cli/src/config/extension-manager-scope.test.ts
@@ -195,7 +195,7 @@ describe('ExtensionManager Settings Scope', () => {
       (s) => s.envVar === 'TEST_SETTING',
     );
     expect(setting).toBeDefined();
-    expect(setting?.value).toBe('[not set]');
+    expect(setting?.value).toBeUndefined();
     expect(setting?.scope).toBeUndefined();
 
     // Verify output string does not contain scope

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -70,6 +70,7 @@ import {
 } from './extensions/extensionSettings.js';
 import type { EventEmitter } from 'node:stream';
 import { themeManager } from '../ui/themes/theme-manager.js';
+import { getFormattedSettingValue } from '../commands/extensions/utils.js';
 
 interface ExtensionManagerParams {
   enabledExtensionOverrides?: string[];
@@ -648,12 +649,7 @@ Would you like to attempt to install via "git clone" instead?`,
           resolvedSettings.push({
             name: setting.name,
             envVar: setting.envVar,
-            value:
-              value === undefined
-                ? '[not set]'
-                : setting.sensitive
-                  ? '***'
-                  : value,
+            value,
             sensitive: setting.sensitive ?? false,
             scope,
             source,
@@ -941,7 +937,7 @@ Would you like to attempt to install via "git clone" instead?`,
           }
           scope += ')';
         }
-        output += `\n  ${setting.name}: ${setting.value} ${scope}`;
+        output += `\n  ${setting.name}: ${getFormattedSettingValue(setting)} ${scope}`;
       });
     }
     return output;

--- a/packages/cli/src/config/extensions/extensionSettings.test.ts
+++ b/packages/cli/src/config/extensions/extensionSettings.test.ts
@@ -786,6 +786,23 @@ describe('extensionSettings', () => {
       expect(await userKeychain.getSecret('VAR2')).toBeNull();
     });
 
+    it('should delete a non-sensitive setting if the new value is empty', async () => {
+      mockRequestSetting.mockResolvedValue('');
+
+      await updateSetting(
+        config,
+        '12345',
+        'VAR1',
+        mockRequestSetting,
+        ExtensionSettingScope.USER,
+        tempWorkspaceDir,
+      );
+
+      const expectedEnvPath = path.join(extensionDir, '.env');
+      const actualContent = await fsPromises.readFile(expectedEnvPath, 'utf-8');
+      expect(actualContent).not.toContain('VAR1=');
+    });
+
     it('should not throw if deleting a non-existent sensitive setting with empty value', async () => {
       mockRequestSetting.mockResolvedValue('');
       // Ensure it doesn't exist first

--- a/packages/cli/src/config/extensions/extensionSettings.ts
+++ b/packages/cli/src/config/extensions/extensionSettings.ts
@@ -230,7 +230,7 @@ export async function updateSetting(
   );
 
   if (settingToUpdate.sensitive) {
-    if (newValue !== '') {
+    if (newValue) {
       await keychain.setSecret(settingToUpdate.envVar, newValue);
     } else {
       try {
@@ -251,7 +251,7 @@ export async function updateSetting(
   }
 
   const parsedEnv = dotenv.parse(envContent);
-  if (newValue === '') {
+  if (!newValue) {
     delete parsedEnv[settingToUpdate.envVar];
   } else {
     parsedEnv[settingToUpdate.envVar] = newValue;

--- a/packages/cli/src/config/extensions/extensionSettings.ts
+++ b/packages/cli/src/config/extensions/extensionSettings.ts
@@ -230,7 +230,7 @@ export async function updateSetting(
   );
 
   if (settingToUpdate.sensitive) {
-    if (newValue) {
+    if (newValue !== '') {
       await keychain.setSecret(settingToUpdate.envVar, newValue);
     } else {
       try {
@@ -251,7 +251,11 @@ export async function updateSetting(
   }
 
   const parsedEnv = dotenv.parse(envContent);
-  parsedEnv[settingToUpdate.envVar] = newValue;
+  if (newValue === '') {
+    delete parsedEnv[settingToUpdate.envVar];
+  } else {
+    parsedEnv[settingToUpdate.envVar] = newValue;
+  }
 
   // We only want to write back the variables that are not sensitive.
   const nonSensitiveSettings: Record<string, string> = {};

--- a/packages/cli/src/ui/components/views/ExtensionsList.tsx
+++ b/packages/cli/src/ui/components/views/ExtensionsList.tsx
@@ -9,6 +9,7 @@ import { Box, Text } from 'ink';
 import { useUIState } from '../../contexts/UIStateContext.js';
 import { ExtensionUpdateState } from '../../state/extensions.js';
 import { debugLogger, type GeminiCLIExtension } from '@google/gemini-cli-core';
+import { getFormattedSettingValue } from '../../../commands/extensions/utils.js';
 
 interface ExtensionsList {
   extensions: readonly GeminiCLIExtension[];
@@ -70,7 +71,7 @@ export const ExtensionsList: React.FC<ExtensionsList> = ({ extensions }) => {
                   <Text>settings:</Text>
                   {ext.resolvedSettings.map((setting) => (
                     <Text key={setting.name}>
-                      - {setting.name}: {setting.value}
+                      - {setting.name}: {getFormattedSettingValue(setting)}
                       {setting.scope && (
                         <Text color="gray">
                           {' '}

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -157,7 +157,7 @@ export interface ExtensionSetting {
 export interface ResolvedExtensionSetting {
   name: string;
   envVar: string;
-  value: string;
+  value?: string;
   sensitive: boolean;
   scope?: 'user' | 'workspace';
   source?: string;

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -1556,6 +1556,41 @@ describe('mcp-client', () => {
       expect(callArgs.env!['GEMINI_CLI_EXT_VAR']).toBe('ext-value');
     });
 
+    it('should exclude extension settings with undefined values from environment', async () => {
+      const mockedTransport = vi
+        .spyOn(SdkClientStdioLib, 'StdioClientTransport')
+        .mockReturnValue({} as SdkClientStdioLib.StdioClientTransport);
+
+      await createTransport(
+        'test-server',
+        {
+          command: 'test-command',
+          extension: {
+            name: 'test-ext',
+            resolvedSettings: [
+              {
+                envVar: 'GEMINI_CLI_EXT_VAR',
+                value: undefined,
+                sensitive: false,
+                name: 'ext-setting',
+              },
+            ],
+            version: '',
+            isActive: false,
+            path: '',
+            contextFiles: [],
+            id: '',
+          },
+        },
+        false,
+        EMPTY_CONFIG,
+      );
+
+      const callArgs = mockedTransport.mock.calls[0][0];
+      expect(callArgs.env).toBeDefined();
+      expect(callArgs.env!['GEMINI_CLI_EXT_VAR']).toBeUndefined();
+    });
+
     describe('useGoogleCredentialProvider', () => {
       beforeEach(() => {
         // Mock GoogleAuth client

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -1948,7 +1948,9 @@ function getExtensionEnvironment(
   const env: Record<string, string> = {};
   if (extension?.resolvedSettings) {
     for (const setting of extension.resolvedSettings) {
-      env[setting.envVar] = setting.value;
+      if (setting.value !== undefined) {
+        env[setting.envVar] = setting.value;
+      }
     }
   }
   return env;

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -1948,7 +1948,7 @@ function getExtensionEnvironment(
   const env: Record<string, string> = {};
   if (extension?.resolvedSettings) {
     for (const setting of extension.resolvedSettings) {
-      if (setting.value !== undefined) {
+      if (setting.value) {
         env[setting.envVar] = setting.value;
       }
     }


### PR DESCRIPTION
## Summary


1. Fix issue where we were passing `[not set]` or `***` to MCP servers.
2. Allow unsetting values by inputting empty 

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
