### PR TITLE
fix(test): improve test isolation and enable subagent evaluations

### DIFF
--- a/evals/test-helper.ts
+++ b/evals/test-helper.ts
@@ -61,7 +61,7 @@ export function evalTest(policy: EvalPolicy, evalCase: EvalCase) {
               .update(content)
               .digest('hex');
             // Extract agent name from frontmatter or filename
-            const match = content.match(/name:\s*([a-z0-9-_]+)/);
+            const match = content.match(/^name:\s*["']?([a-z0-9-_]+)["']?$/m);
             const agentName = match ? match[1] : path.basename(filePath, '.md');
 
             if (!acknowledgedAgents[projectRoot]) {

--- a/evals/test-helper.ts
+++ b/evals/test-helper.ts
@@ -7,6 +7,7 @@
 import { it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+import crypto from 'node:crypto';
 import { execSync } from 'node:child_process';
 import { TestRig } from '@google/gemini-cli-test-utils';
 import { createUnauthorizedToolError } from '@google/gemini-cli-core';
@@ -42,10 +43,47 @@ export function evalTest(policy: EvalPolicy, evalCase: EvalCase) {
       rig.setup(evalCase.name, evalCase.params);
 
       if (evalCase.files) {
+        const acknowledgedAgents: Record<string, Record<string, string>> = {};
+        const projectRoot = fs.realpathSync(rig.testDir!);
+
         for (const [filePath, content] of Object.entries(evalCase.files)) {
           const fullPath = path.join(rig.testDir!, filePath);
           fs.mkdirSync(path.dirname(fullPath), { recursive: true });
           fs.writeFileSync(fullPath, content);
+
+          // If it's an agent file, calculate hash for acknowledgement
+          if (
+            filePath.startsWith('.gemini/agents/') &&
+            filePath.endsWith('.md')
+          ) {
+            const hash = crypto
+              .createHash('sha256')
+              .update(content)
+              .digest('hex');
+            // Extract agent name from frontmatter or filename
+            const match = content.match(/name:\s*([a-z0-9-_]+)/);
+            const agentName = match ? match[1] : path.basename(filePath, '.md');
+
+            if (!acknowledgedAgents[projectRoot]) {
+              acknowledgedAgents[projectRoot] = {};
+            }
+            acknowledgedAgents[projectRoot][agentName] = hash;
+          }
+        }
+
+        // Write acknowledged_agents.json to the home directory
+        if (Object.keys(acknowledgedAgents).length > 0) {
+          const ackPath = path.join(
+            rig.homeDir!,
+            '.gemini',
+            'acknowledgments',
+            'agents.json',
+          );
+          fs.mkdirSync(path.dirname(ackPath), { recursive: true });
+          fs.writeFileSync(
+            ackPath,
+            JSON.stringify(acknowledgedAgents, null, 2),
+          );
         }
 
         const execOptions = { cwd: rig.testDir!, stdio: 'inherit' as const };
@@ -66,6 +104,7 @@ export function evalTest(policy: EvalPolicy, evalCase: EvalCase) {
       const result = await rig.run({
         args: evalCase.prompt,
         approvalMode: evalCase.approvalMode ?? 'yolo',
+        timeout: evalCase.timeout,
         env: {
           GEMINI_CLI_ACTIVITY_LOG_FILE: activityLogFile,
         },
@@ -86,6 +125,11 @@ export function evalTest(policy: EvalPolicy, evalCase: EvalCase) {
         await fs.promises.unlink(activityLogFile).catch((err) => {
           if (err.code !== 'ENOENT') throw err;
         });
+      }
+
+      if (rig._lastRunStderr) {
+        const stderrFile = path.join(logDir, `${sanitizedName}.stderr.log`);
+        await fs.promises.writeFile(stderrFile, rig._lastRunStderr);
       }
 
       await fs.promises.writeFile(
@@ -114,6 +158,7 @@ export interface EvalCase {
   name: string;
   params?: Record<string, any>;
   prompt: string;
+  timeout?: number;
   files?: Record<string, string>;
   approvalMode?: 'default' | 'auto_edit' | 'yolo' | 'plan';
   assert: (rig: TestRig, result: string) => Promise<void>;

--- a/packages/test-utils/src/test-rig.ts
+++ b/packages/test-utils/src/test-rig.ts
@@ -411,6 +411,7 @@ export class TestRig {
         key !== 'GOOGLE_API_KEY' &&
         key !== 'GEMINI_MODEL' &&
         key !== 'GEMINI_DEBUG' &&
+        key !== 'GEMINI_CLI_TEST_VAR' &&
         !key.startsWith('GEMINI_CLI_ACTIVITY_LOG')
       ) {
         delete cleanEnv[key];

--- a/packages/test-utils/src/test-rig.ts
+++ b/packages/test-utils/src/test-rig.ts
@@ -277,6 +277,7 @@ export class TestRig {
   homeDir: string | null = null;
   testName?: string;
   _lastRunStdout?: string;
+  _lastRunStderr?: string;
   // Path to the copied fake responses file for this test.
   fakeResponsesPath?: string;
   // Original fake responses file path for rewriting goldens in record mode.
@@ -396,6 +397,33 @@ export class TestRig {
     return { command, initialArgs };
   }
 
+  private _getCleanEnv(
+    extraEnv?: Record<string, string | undefined>,
+  ): Record<string, string | undefined> {
+    const cleanEnv: Record<string, string | undefined> = { ...process.env };
+
+    // Clear all GEMINI_ environment variables that might interfere with tests
+    // except for those we explicitly want to keep or set.
+    for (const key of Object.keys(cleanEnv)) {
+      if (
+        (key.startsWith('GEMINI_') || key.startsWith('GOOGLE_GEMINI_')) &&
+        key !== 'GEMINI_API_KEY' &&
+        key !== 'GOOGLE_API_KEY' &&
+        key !== 'GEMINI_MODEL' &&
+        key !== 'GEMINI_DEBUG' &&
+        !key.startsWith('GEMINI_CLI_ACTIVITY_LOG')
+      ) {
+        delete cleanEnv[key];
+      }
+    }
+
+    return {
+      ...cleanEnv,
+      GEMINI_CLI_HOME: this.homeDir!,
+      ...extraEnv,
+    };
+  }
+
   run(options: {
     args?: string | string[];
     stdin?: string;
@@ -433,11 +461,7 @@ export class TestRig {
     const child = spawn(command, commandArgs, {
       cwd: this.testDir!,
       stdio: 'pipe',
-      env: {
-        ...process.env,
-        GEMINI_CLI_HOME: this.homeDir!,
-        ...options.env,
-      },
+      env: this._getCleanEnv(options.env),
     });
     this._spawnedProcesses.push(child);
 
@@ -573,7 +597,7 @@ export class TestRig {
       const child = spawn(command, allArgs, {
         cwd: this.testDir!,
         stdio: 'pipe',
-        env: { ...process.env, GEMINI_CLI_HOME: this.homeDir! },
+        env: this._getCleanEnv(),
         signal: options?.signal,
       });
       this._spawnedProcesses.push(child);
@@ -611,11 +635,7 @@ export class TestRig {
     const child = spawn(command, commandArgs, {
       cwd: this.testDir!,
       stdio: 'pipe',
-      env: {
-        ...process.env,
-        GEMINI_CLI_HOME: this.homeDir!,
-        ...options.env,
-      },
+      env: this._getCleanEnv(options.env),
     });
     this._spawnedProcesses.push(child);
 
@@ -661,6 +681,7 @@ export class TestRig {
 
       child.on('close', (code: number) => {
         clearTimeout(timer);
+        this._lastRunStderr = stderr;
         if (code === 0) {
           this._lastRunStdout = stdout;
           const result = this._filterPodmanTelemetry(stdout);
@@ -1179,11 +1200,7 @@ export class TestRig {
     ]);
     const commandArgs = [...initialArgs];
 
-    const envVars = {
-      ...process.env,
-      GEMINI_CLI_HOME: this.homeDir!,
-      ...options?.env,
-    };
+    const envVars = this._getCleanEnv(options?.env);
 
     const ptyOptions: pty.IPtyForkOptions = {
       name: 'xterm-color',

--- a/packages/test-utils/src/test-rig.ts
+++ b/packages/test-utils/src/test-rig.ts
@@ -511,6 +511,7 @@ export class TestRig {
 
       child.on('close', (code: number) => {
         clearTimeout(timer);
+        this._lastRunStderr = stderr;
         if (code === 0) {
           // Store the raw stdout for Podman telemetry parsing
           this._lastRunStdout = stdout;


### PR DESCRIPTION
## Summary

Fixes critical environmental isolation issues in the test infrastructure that were causing behavioral evaluations (specifically subagent delegation) to fail on some systems. Also improves debugging for test failures.

## Details

This PR addresses the root causes of flaky and failing behavioral evaluations:

1.  **Test Isolation:** Isolates `TestRig` from global `GEMINI_CLI_` environment variables. Previously, system-wide settings (like `folderTrust: true`) were leaking into the test environment, causing tests to run in an "Untrusted" state even when configured otherwise.
2.  **Agent Acknowledgement:** Updates `evalTest` to correctly acknowledge project-level agents by writing to the path expected by `Storage` (`.gemini/acknowledgments/agents.json`). This ensures sub-agents like `docs-agent` are correctly discovered and loaded during tests.
3.  **Debuggability:** Adds `_lastRunStderr` to `TestRig` to capture raw stderr output even when using JSON output format. This log is now written to `evals/logs/*.stderr.log` on failure, allowing developers to see internal CLI errors (like registry failures) that were previously swallowed.
4.  **Timeout Control:** Adds support for per-test timeouts in `evalTest`.

## Related Issues

Related to [issue#219](https://github.com/google-github-actions/run-gemini-cli/issues/219) (Evaluate and Improve Example Workflows) - This fixes the evaluation infrastructure needed to complete that issue.

## How to Validate

1.  Run the full behavioral evaluation suite:
    ```bash
    npm run test:all_evals
    ```
2.  Verify that `subagents.eval.ts` passes without timeout.
3.  Verify that `generalist_agent.eval.ts` passes (no unauthorized tool errors).

## Pre-Merge Checklist

- [x] Added/updated tests (Infrastructure only)
- [x] Validated on required platforms/methods:
  - [x] Linux
    - [x] npm run
