### PR TITLE
feat: expand verify-release to macOS and Windows

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -29,7 +29,11 @@ on:
 jobs:
   verify-release:
     environment: "${{ github.event.inputs.environment || 'prod' }}"
-    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+    runs-on: '${{ matrix.os }}'
     permissions:
       contents: 'read'
       packages: 'write'

--- a/packages/test-utils/src/test-rig.ts
+++ b/packages/test-utils/src/test-rig.ts
@@ -15,7 +15,7 @@ import { DEFAULT_GEMINI_MODEL, GEMINI_DIR } from '@google/gemini-cli-core';
 import fs from 'node:fs';
 import * as pty from '@lydell/node-pty';
 import stripAnsi from 'strip-ansi';
-import * as os from 'node:os';
+import * as os from 'os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BUNDLE_PATH = join(__dirname, '..', '..', '..', 'bundle/gemini.js');

--- a/packages/test-utils/src/test-rig.ts
+++ b/packages/test-utils/src/test-rig.ts
@@ -15,7 +15,7 @@ import { DEFAULT_GEMINI_MODEL, GEMINI_DIR } from '@google/gemini-cli-core';
 import fs from 'node:fs';
 import * as pty from '@lydell/node-pty';
 import stripAnsi from 'strip-ansi';
-import * as os from 'os';
+import * as os from 'node:os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BUNDLE_PATH = join(__dirname, '..', '..', '..', 'bundle/gemini.js');

--- a/packages/test-utils/src/test-rig.ts
+++ b/packages/test-utils/src/test-rig.ts
@@ -456,7 +456,8 @@ export class TestRig {
   } {
     const isNpmReleaseTest =
       env['INTEGRATION_TEST_USE_INSTALLED_GEMINI'] === 'true';
-    const command = isNpmReleaseTest ? 'gemini' : 'node';
+    const geminiCommand = os.platform() === 'win32' ? 'gemini.cmd' : 'gemini';
+    const command = isNpmReleaseTest ? geminiCommand : 'node';
     const initialArgs = isNpmReleaseTest
       ? extraInitialArgs
       : [BUNDLE_PATH, ...extraInitialArgs];


### PR DESCRIPTION
feat: expand verify-release to macOS and Windows

## Summary

Updates the `verify-release` workflow to run on a matrix of OSes (Ubuntu, macOS, Windows) to ensure cross-platform compatibility of the release verification process.

## Details

- Modifies `.github/workflows/verify-release.yml` to use a build matrix for `os`.
- Updates `packages/test-utils/src/test-rig.ts` to correctly handle the binary name (`gemini.cmd`) on Windows when running NPM release tests.
- Refactors `os` import to use `from 'os'` for broader compatibility.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/18140

## How to Validate

1. Trigger the `verify-release` workflow manually from the Actions tab.
2. Observe that it spawns three jobs (one for each OS).
3. Verify that all jobs succeed.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
  - [x] Windows
    - [x] npm run
  - [x] Linux
    - [x] npm run
