### PR TITLE
Fix: Guard getBoundingBox in useMouseClick to prevent SGR state machine deadlock

### DIFF
--- a/packages/cli/src/ui/hooks/useMouseClick.ts
+++ b/packages/cli/src/ui/hooks/useMouseClick.ts
@@ -31,7 +31,11 @@ export const useMouseClick = (
       const eventName =
         name ?? (button === 'left' ? 'left-press' : 'right-release');
       if (event.name === eventName && containerRef.current) {
-        const { x, y, width, height } = getBoundingBox(containerRef.current);
+        const boundingBox = getBoundingBox(containerRef.current);
+        if (!boundingBox) {
+          return;
+        }
+        const { x, y, width, height } = boundingBox;
         // Terminal mouse events are 1-based, Ink layout is 0-based.
         const mouseX = event.col - 1;
         const mouseY = event.row - 1;


### PR DESCRIPTION
Fixes #18087

### Problem
Massive UI refactoring without proper terminal interaction testing has left the CLI vulnerable to runtime crashes. Currently, `getBoundingBox` can return `undefined` during asynchronous rendering cycles or buffer switches. 

In `useMouseClick.ts`, the lack of a null check results in a destructuring error that abruptly halts the event handler chain. Because this happens mid-event, the terminal's SGR protocol never receives the 'release' signal, leaving the mouse in a permanent 'button-pressed' state (deadlock) while still allowing movement.

### Critique
As pointed out in #18087, the update to `@jrichman/ink@6.4.8` and the subsequent refactoring of input priority have created a 'driverless car' scenario. While fragmented patches were applied to components like `ScrollProvider`, the core `useMouseClick` hook was ignored. This proves that current mock-based CI and unit tests are blind to real-world terminal state-machine logic. Relying on 'Green' CI while interactive logic is broken is an illusion.

### Solution
This PR adds the necessary guard to `useMouseClick` to ensure robust interaction even when the Ink layout engine is between render passes.