### PR TITLE
Fix OOM by removing high-cardinality 'lines' attribute from file operation metrics

### DIFF
--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -1640,7 +1640,6 @@ describe('loggers', () => {
         mockConfig,
         {
           operation: 'read',
-          lines: 10,
           mimetype: 'text/plain',
           extension: '.txt',
           programming_language: 'typescript',

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -174,7 +174,6 @@ export function logFileOperation(
 
     recordFileOperationMetric(config, {
       operation: event.operation,
-      lines: event.lines,
       mimetype: event.mimetype,
       extension: event.extension,
       programming_language: event.programming_language,

--- a/packages/core/src/telemetry/metrics.test.ts
+++ b/packages/core/src/telemetry/metrics.test.ts
@@ -367,7 +367,6 @@ describe('Telemetry Metrics', () => {
       initialized: boolean;
       attributes: {
         operation: FileOperation;
-        lines?: number;
         mimetype?: string;
         extension?: string;
       };
@@ -380,7 +379,6 @@ describe('Telemetry Metrics', () => {
         initialized: false,
         attributes: {
           operation: FileOperation.CREATE,
-          lines: 10,
           mimetype: 'text/plain',
           extension: 'txt',
         },
@@ -391,7 +389,6 @@ describe('Telemetry Metrics', () => {
         initialized: true,
         attributes: {
           operation: FileOperation.CREATE,
-          lines: 10,
           mimetype: 'text/plain',
           extension: 'txt',
         },

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -114,7 +114,6 @@ const COUNTER_DEFINITIONS = {
     assign: (c: Counter) => (fileOperationCounter = c),
     attributes: {} as {
       operation: FileOperation;
-      lines?: number;
       mimetype?: string;
       extension?: string;
       programming_language?: string;


### PR DESCRIPTION
Removed `lines` from `FILE_OPERATION_COUNT` metric to prevent high cardinality OOM.

---
*PR created automatically by Jules for task [4867310746968112730](https://jules.google.com/task/4867310746968112730) started by @gsquared94*