### PR TITLE
feat(plan): add `exit_plan_mode` ui and prompt

### DIFF
--- a/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
@@ -1,0 +1,404 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { act } from 'react';
+import { renderWithProviders } from '../../test-utils/render.js';
+import { waitFor } from '../../test-utils/async.js';
+import { ExitPlanModeDialog } from './ExitPlanModeDialog.js';
+import { ApprovalMode, validatePlanContent } from '@google/gemini-cli-core';
+import * as fs from 'node:fs';
+
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    validatePlanPath: vi.fn(async () => null),
+    validatePlanContent: vi.fn(async () => null),
+  };
+});
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof fs>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    realpathSync: vi.fn((p) => p),
+    promises: {
+      ...actual.promises,
+      readFile: vi.fn(),
+    },
+  };
+});
+
+const writeKey = (stdin: { write: (data: string) => void }, key: string) => {
+  act(() => {
+    stdin.write(key);
+  });
+};
+
+describe('ExitPlanModeDialog', () => {
+  const mockTargetDir = '/mock/project';
+  const mockPlansDir = '/mock/project/plans';
+  const mockPlanFullPath = '/mock/project/plans/test-plan.md';
+
+  const samplePlanContent = `## Overview
+
+Add user authentication to the CLI application.
+
+## Implementation Steps
+
+1. Create \`src/auth/AuthService.ts\` with login/logout methods
+2. Add session storage in \`src/storage/SessionStore.ts\`
+3. Update \`src/commands/index.ts\` to check auth status
+4. Add tests in \`src/auth/__tests__/\`
+
+## Files to Modify
+
+- \`src/index.ts\` - Add auth middleware
+- \`src/config.ts\` - Add auth configuration options`;
+
+  const longPlanContent = `## Overview
+
+Implement a comprehensive authentication system with multiple providers.
+
+## Implementation Steps
+
+1. Create \`src/auth/AuthService.ts\` with login/logout methods
+2. Add session storage in \`src/storage/SessionStore.ts\`
+3. Update \`src/commands/index.ts\` to check auth status
+4. Add OAuth2 provider support in \`src/auth/providers/OAuth2Provider.ts\`
+5. Add SAML provider support in \`src/auth/providers/SAMLProvider.ts\`
+6. Add LDAP provider support in \`src/auth/providers/LDAPProvider.ts\`
+7. Create token refresh mechanism in \`src/auth/TokenManager.ts\`
+8. Add multi-factor authentication in \`src/auth/MFAService.ts\`
+9. Implement session timeout handling in \`src/auth/SessionManager.ts\`
+10. Add audit logging for auth events in \`src/auth/AuditLogger.ts\`
+11. Create user profile management in \`src/auth/UserProfile.ts\`
+12. Add role-based access control in \`src/auth/RBACService.ts\`
+13. Implement password policy enforcement in \`src/auth/PasswordPolicy.ts\`
+14. Add brute force protection in \`src/auth/BruteForceGuard.ts\`
+15. Create secure cookie handling in \`src/auth/CookieManager.ts\`
+
+## Files to Modify
+
+- \`src/index.ts\` - Add auth middleware
+- \`src/config.ts\` - Add auth configuration options
+- \`src/routes/api.ts\` - Add auth endpoints
+- \`src/middleware/cors.ts\` - Update CORS for auth headers
+- \`src/utils/crypto.ts\` - Add encryption utilities
+
+## Testing Strategy
+
+- Unit tests for each auth provider
+- Integration tests for full auth flows
+- Security penetration testing
+- Load testing for session management`;
+
+  let onApprove: ReturnType<typeof vi.fn>;
+  let onFeedback: ReturnType<typeof vi.fn>;
+  let onCancel: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.mocked(fs.promises.readFile).mockResolvedValue(samplePlanContent);
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.realpathSync).mockImplementation((p) => p as string);
+    onApprove = vi.fn();
+    onFeedback = vi.fn();
+    onCancel = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const renderDialog = (options?: { useAlternateBuffer?: boolean }) =>
+    renderWithProviders(
+      <ExitPlanModeDialog
+        planPath={mockPlanFullPath}
+        onApprove={onApprove}
+        onFeedback={onFeedback}
+        onCancel={onCancel}
+        width={80}
+        availableHeight={24}
+      />,
+      {
+        ...options,
+        config: {
+          getTargetDir: () => mockTargetDir,
+          getIdeMode: () => false,
+          isTrustedFolder: () => true,
+          storage: {
+            getProjectTempPlansDir: () => mockPlansDir,
+          },
+        } as unknown as import('@google/gemini-cli-core').Config,
+      },
+    );
+
+  describe.each([{ useAlternateBuffer: true }, { useAlternateBuffer: false }])(
+    'useAlternateBuffer: $useAlternateBuffer',
+    ({ useAlternateBuffer }) => {
+      it('renders correctly with plan content', async () => {
+        const { lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        await waitFor(() => {
+          expect(fs.promises.readFile).toHaveBeenCalledWith(
+            mockPlanFullPath,
+            'utf8',
+          );
+        });
+
+        expect(lastFrame()).toMatchSnapshot();
+      });
+
+      it('calls onApprove with AUTO_EDIT when first option is selected', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        writeKey(stdin, '\r');
+
+        await waitFor(() => {
+          expect(onApprove).toHaveBeenCalledWith(ApprovalMode.AUTO_EDIT);
+        });
+      });
+
+      it('calls onApprove with DEFAULT when second option is selected', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\r');
+
+        await waitFor(() => {
+          expect(onApprove).toHaveBeenCalledWith(ApprovalMode.DEFAULT);
+        });
+      });
+
+      it('calls onFeedback when feedback is typed and submitted', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        // Navigate to feedback option
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\r'); // Select to focus input
+
+        // Type feedback
+        for (const char of 'Add tests') {
+          writeKey(stdin, char);
+        }
+
+        await waitFor(() => {
+          expect(lastFrame()).toMatchSnapshot();
+        });
+
+        writeKey(stdin, '\r');
+
+        await waitFor(() => {
+          expect(onFeedback).toHaveBeenCalledWith('Add tests');
+        });
+      });
+
+      it('calls onCancel when Esc is pressed', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        writeKey(stdin, '\x1b'); // Escape
+
+        await waitFor(() => {
+          expect(onCancel).toHaveBeenCalled();
+        });
+      });
+
+      it('displays error state when file read fails', async () => {
+        vi.mocked(fs.promises.readFile).mockRejectedValue(
+          new Error('File not found'),
+        );
+
+        const { lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Error reading plan: File not found');
+        });
+
+        expect(lastFrame()).toMatchSnapshot();
+      });
+
+      it('displays error state when plan file is empty', async () => {
+        vi.mocked(validatePlanContent).mockResolvedValue('Plan file is empty.');
+
+        const { lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain(
+            'Error reading plan: Plan file is empty.',
+          );
+        });
+      });
+
+      it('handles long plan content appropriately', async () => {
+        vi.mocked(fs.promises.readFile).mockResolvedValue(longPlanContent);
+
+        const { lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain(
+            'Implement a comprehensive authentication system',
+          );
+        });
+
+        expect(lastFrame()).toMatchSnapshot();
+      });
+
+      it('allows number key quick selection', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        // Press '2' to select second option directly
+        writeKey(stdin, '2');
+
+        await waitFor(() => {
+          expect(onApprove).toHaveBeenCalledWith(ApprovalMode.DEFAULT);
+        });
+      });
+
+      it('clears feedback text when Ctrl+C is pressed while editing', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        // Navigate to feedback option and start typing
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\r'); // Select to focus input
+
+        // Type some feedback
+        for (const char of 'test feedback') {
+          writeKey(stdin, char);
+        }
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('test feedback');
+        });
+
+        // Press Ctrl+C to clear
+        writeKey(stdin, '\x03'); // Ctrl+C
+
+        await waitFor(() => {
+          expect(lastFrame()).not.toContain('test feedback');
+          expect(lastFrame()).toContain('Type your feedback...');
+        });
+
+        // Dialog should still be open (not cancelled)
+        expect(onCancel).not.toHaveBeenCalled();
+      });
+
+      it('exits the dialog when Ctrl+C is pressed twice in feedback mode', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        // Navigate to feedback option and start typing
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\r'); // Select to focus input
+
+        // Type some feedback
+        for (const char of 'test') {
+          writeKey(stdin, char);
+        }
+
+        // First Ctrl+C to clear
+        writeKey(stdin, '\x03'); // Ctrl+C
+
+        expect(onCancel).not.toHaveBeenCalled();
+
+        // Second Ctrl+C to exit
+        writeKey(stdin, '\x03'); // Ctrl+C
+
+        await waitFor(() => {
+          expect(onCancel).toHaveBeenCalled();
+        });
+      });
+
+      it('does not submit empty feedback when Enter is pressed', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        // Navigate to feedback option
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\x1b[B'); // Down arrow
+
+        // Press Enter without typing anything
+        writeKey(stdin, '\r');
+
+        // Wait a bit to ensure no callback was triggered
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        });
+
+        expect(onFeedback).not.toHaveBeenCalled();
+        expect(onApprove).not.toHaveBeenCalled();
+      });
+
+      it('allows arrow navigation while typing feedback to change selection', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        // Navigate to feedback option and start typing
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\x1b[B'); // Down arrow
+        writeKey(stdin, '\r'); // Select to focus input
+
+        // Type some feedback
+        for (const char of 'test') {
+          writeKey(stdin, char);
+        }
+
+        // Now use up arrow to navigate back to a different option
+        writeKey(stdin, '\x1b[A'); // Up arrow
+
+        // Press Enter to select the second option (manually accept edits)
+        writeKey(stdin, '\r');
+
+        await waitFor(() => {
+          expect(onApprove).toHaveBeenCalledWith(ApprovalMode.DEFAULT);
+        });
+        expect(onFeedback).not.toHaveBeenCalled();
+      });
+    },
+  );
+});

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
@@ -112,6 +112,7 @@ Implement a comprehensive authentication system with multiple providers.
   let onCancel: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.mocked(processSingleFileContent).mockResolvedValue({
       llmContent: samplePlanContent,
       returnDisplay: 'Read file',
@@ -124,6 +125,8 @@ Implement a comprehensive authentication system with multiple providers.
   });
 
   afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -160,6 +163,11 @@ Implement a comprehensive authentication system with multiple providers.
       it('renders correctly with plan content', async () => {
         const { lastFrame } = renderDialog({ useAlternateBuffer });
 
+        // Advance timers to pass the debounce period
+        await act(async () => {
+          vi.runAllTimers();
+        });
+
         await waitFor(() => {
           expect(lastFrame()).toContain('Add user authentication');
         });
@@ -178,6 +186,10 @@ Implement a comprehensive authentication system with multiple providers.
       it('calls onApprove with AUTO_EDIT when first option is selected', async () => {
         const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
 
+        await act(async () => {
+          vi.runAllTimers();
+        });
+
         await waitFor(() => {
           expect(lastFrame()).toContain('Add user authentication');
         });
@@ -191,6 +203,10 @@ Implement a comprehensive authentication system with multiple providers.
 
       it('calls onApprove with DEFAULT when second option is selected', async () => {
         const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await act(async () => {
+          vi.runAllTimers();
+        });
 
         await waitFor(() => {
           expect(lastFrame()).toContain('Add user authentication');
@@ -206,6 +222,10 @@ Implement a comprehensive authentication system with multiple providers.
 
       it('calls onFeedback when feedback is typed and submitted', async () => {
         const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await act(async () => {
+          vi.runAllTimers();
+        });
 
         await waitFor(() => {
           expect(lastFrame()).toContain('Add user authentication');
@@ -235,15 +255,21 @@ Implement a comprehensive authentication system with multiple providers.
       it('calls onCancel when Esc is pressed', async () => {
         const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
 
+        await act(async () => {
+          vi.runAllTimers();
+        });
+
         await waitFor(() => {
           expect(lastFrame()).toContain('Add user authentication');
         });
 
         writeKey(stdin, '\x1b'); // Escape
 
-        await waitFor(() => {
-          expect(onCancel).toHaveBeenCalled();
+        await act(async () => {
+          vi.runAllTimers();
         });
+
+        expect(onCancel).toHaveBeenCalled();
       });
 
       it('displays error state when file read fails', async () => {
@@ -254,6 +280,10 @@ Implement a comprehensive authentication system with multiple providers.
         });
 
         const { lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await act(async () => {
+          vi.runAllTimers();
+        });
 
         await waitFor(() => {
           expect(lastFrame()).toContain('Error reading plan: File not found');
@@ -266,6 +296,10 @@ Implement a comprehensive authentication system with multiple providers.
         vi.mocked(validatePlanContent).mockResolvedValue('Plan file is empty.');
 
         const { lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await act(async () => {
+          vi.runAllTimers();
+        });
 
         await waitFor(() => {
           expect(lastFrame()).toContain(
@@ -282,6 +316,10 @@ Implement a comprehensive authentication system with multiple providers.
 
         const { lastFrame } = renderDialog({ useAlternateBuffer });
 
+        await act(async () => {
+          vi.runAllTimers();
+        });
+
         await waitFor(() => {
           expect(lastFrame()).toContain(
             'Implement a comprehensive authentication system',
@@ -293,6 +331,10 @@ Implement a comprehensive authentication system with multiple providers.
 
       it('allows number key quick selection', async () => {
         const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await act(async () => {
+          vi.runAllTimers();
+        });
 
         await waitFor(() => {
           expect(lastFrame()).toContain('Add user authentication');
@@ -308,6 +350,10 @@ Implement a comprehensive authentication system with multiple providers.
 
       it('clears feedback text when Ctrl+C is pressed while editing', async () => {
         const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await act(async () => {
+          vi.runAllTimers();
+        });
 
         await waitFor(() => {
           expect(lastFrame()).toContain('Add user authentication');
@@ -387,6 +433,10 @@ Implement a comprehensive authentication system with multiple providers.
           },
         );
 
+        await act(async () => {
+          vi.runAllTimers();
+        });
+
         await waitFor(() => {
           expect(lastFrame()).toContain('Add user authentication');
         });
@@ -424,6 +474,10 @@ Implement a comprehensive authentication system with multiple providers.
       it('does not submit empty feedback when Enter is pressed', async () => {
         const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
 
+        await act(async () => {
+          vi.runAllTimers();
+        });
+
         await waitFor(() => {
           expect(lastFrame()).toContain('Add user authentication');
         });
@@ -437,7 +491,7 @@ Implement a comprehensive authentication system with multiple providers.
 
         // Wait a bit to ensure no callback was triggered
         await act(async () => {
-          await new Promise((resolve) => setTimeout(resolve, 50));
+          vi.advanceTimersByTime(50);
         });
 
         expect(onFeedback).not.toHaveBeenCalled();
@@ -446,6 +500,10 @@ Implement a comprehensive authentication system with multiple providers.
 
       it('allows arrow navigation while typing feedback to change selection', async () => {
         const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await act(async () => {
+          vi.runAllTimers();
+        });
 
         await waitFor(() => {
           expect(lastFrame()).toContain('Add user authentication');

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
@@ -45,6 +45,13 @@ enum ApprovalOption {
   Manual = 'Yes, manually accept edits',
 }
 
+/**
+ * A tiny component for loading and error states with consistent styling.
+ */
+const StatusMessage: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => <Box paddingX={1}>{children}</Box>;
+
 function usePlanContent(planPath: string, config: Config): PlanContentState {
   const [state, setState] = useState<PlanContentState>({
     status: PlanStatus.Loading,
@@ -128,33 +135,51 @@ export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
 }) => {
   const config = useConfig();
   const planState = usePlanContent(planPath, config);
+  const [showLoading, setShowLoading] = useState(false);
+
+  useEffect(() => {
+    if (planState.status !== PlanStatus.Loading) {
+      setShowLoading(false);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setShowLoading(true);
+    }, 200);
+
+    return () => clearTimeout(timer);
+  }, [planState.status]);
 
   if (planState.status === PlanStatus.Loading) {
+    if (!showLoading) {
+      return null;
+    }
+
     return (
-      <Box paddingX={1}>
+      <StatusMessage>
         <Text color={theme.text.secondary} italic>
           Loading plan...
         </Text>
-      </Box>
+      </StatusMessage>
     );
   }
 
   if (planState.status === PlanStatus.Error) {
     return (
-      <Box paddingX={1}>
+      <StatusMessage>
         <Text color={theme.status.error}>
           Error reading plan: {planState.error}
         </Text>
-      </Box>
+      </StatusMessage>
     );
   }
 
   const planContent = planState.content?.trim();
   if (!planContent) {
     return (
-      <Box paddingX={1}>
+      <StatusMessage>
         <Text color={theme.status.error}>Error: Plan content is empty.</Text>
-      </Box>
+      </StatusMessage>
     );
   }
 

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
@@ -1,0 +1,359 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useState,
+  useContext,
+} from 'react';
+import { Box, Text } from 'ink';
+import * as fs from 'node:fs';
+import {
+  ApprovalMode,
+  validatePlanPath,
+  validatePlanContent,
+  checkExhaustive,
+} from '@google/gemini-cli-core';
+import { theme } from '../semantic-colors.js';
+import { MarkdownDisplay } from '../utils/MarkdownDisplay.js';
+import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
+import type { RadioSelectItem } from './shared/RadioButtonSelect.js';
+import { TextInput } from './shared/TextInput.js';
+import { useTextBuffer } from './shared/text-buffer.js';
+import { useKeypress, type Key } from '../hooks/useKeypress.js';
+import { keyMatchers, Command } from '../keyMatchers.js';
+import { DialogFooter } from './shared/DialogFooter.js';
+import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
+import { MaxSizedBox } from './shared/MaxSizedBox.js';
+import { UIStateContext } from '../contexts/UIStateContext.js';
+import { useConfig } from '../contexts/ConfigContext.js';
+
+/**
+ * Layout constants for the dialog.
+ */
+const MIN_PLAN_HEIGHT = 3;
+// Offset for the feedback text input width to account for radio button prefix ("● 1. ") and margins.
+const FEEDBACK_BUFFER_WIDTH_OFFSET = 6;
+const PLAN_WIDTH_OFFSET = 2;
+const QUESTION_AND_MARGIN = 2; // Question text + margin
+const FOOTER_HEIGHT = 2; // DialogFooter + margin
+
+export interface ExitPlanModeDialogProps {
+  planPath: string;
+  onApprove: (approvalMode: ApprovalMode) => void;
+  onFeedback: (feedback: string) => void;
+  onCancel: () => void;
+  width: number;
+  availableHeight?: number;
+}
+
+interface PlanContentState {
+  status: 'loading' | 'loaded' | 'error';
+  content?: string;
+  error?: string;
+}
+
+enum DialogChoice {
+  APPROVE_AUTO_EDIT = 'approve_auto_edit',
+  APPROVE_DEFAULT = 'approve_default',
+  FEEDBACK = 'feedback',
+}
+
+interface DialogState {
+  activeChoice: DialogChoice;
+  isEditingFeedback: boolean;
+  submitted: boolean;
+}
+
+type DialogAction =
+  | { type: 'SET_ACTIVE_CHOICE'; payload: DialogChoice }
+  | { type: 'SUBMIT' };
+
+const initialDialogState: DialogState = {
+  activeChoice: DialogChoice.APPROVE_AUTO_EDIT,
+  isEditingFeedback: false,
+  submitted: false,
+};
+
+function dialogReducer(state: DialogState, action: DialogAction): DialogState {
+  if (state.submitted) return state;
+
+  switch (action.type) {
+    case 'SET_ACTIVE_CHOICE':
+      return {
+        ...state,
+        activeChoice: action.payload,
+        isEditingFeedback: action.payload === DialogChoice.FEEDBACK,
+      };
+    case 'SUBMIT':
+      return { ...state, submitted: true };
+    default:
+      checkExhaustive(action);
+  }
+}
+
+const CHOICE_LABELS: Record<
+  Exclude<DialogChoice, DialogChoice.FEEDBACK>,
+  string
+> = {
+  [DialogChoice.APPROVE_AUTO_EDIT]: 'Yes, automatically accept edits',
+  [DialogChoice.APPROVE_DEFAULT]: 'Yes, manually accept edits',
+};
+
+export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
+  planPath,
+  onApprove,
+  onFeedback,
+  onCancel,
+  width,
+  availableHeight: availableHeightProp,
+}) => {
+  const isAlternateBuffer = useAlternateBuffer();
+  const uiState = useContext(UIStateContext);
+  const availableHeight =
+    availableHeightProp ??
+    (uiState?.constrainHeight !== false
+      ? (uiState?.availableTerminalHeight ?? uiState?.terminalHeight)
+      : undefined);
+
+  const config = useConfig();
+  const [planState, setPlanState] = useState<PlanContentState>({
+    status: 'loading',
+  });
+  const [state, dispatch] = useReducer(dialogReducer, initialDialogState);
+
+  useEffect(() => {
+    let ignore = false;
+
+    validatePlanPath(
+      planPath,
+      config.storage.getProjectTempPlansDir(),
+      config.getTargetDir(),
+    )
+      .then((pathError) => {
+        if (ignore) return;
+        if (pathError) {
+          setPlanState({ status: 'error', error: pathError });
+          return;
+        }
+
+        return validatePlanContent(planPath);
+      })
+      .then((contentError) => {
+        if (ignore || contentError === undefined) return;
+        if (contentError) {
+          setPlanState({ status: 'error', error: contentError });
+          return;
+        }
+        return fs.promises.readFile(planPath, 'utf8');
+      })
+      .then((content) => {
+        if (ignore) return;
+        if (!content) {
+          setPlanState({ status: 'error', error: 'Plan file is empty.' });
+          return;
+        }
+        setPlanState({ status: 'loaded', content });
+      })
+      .catch((err) => {
+        if (ignore) return;
+        setPlanState({ status: 'error', error: err.message });
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [planPath, config]);
+
+  const feedbackBuffer = useTextBuffer({
+    initialText: '',
+    viewport: {
+      width: Math.max(1, width - FEEDBACK_BUFFER_WIDTH_OFFSET),
+      height: 1,
+    },
+    singleLine: true,
+    isValidPath: () => false,
+  });
+
+  useKeypress(
+    useCallback(
+      (key: Key) => {
+        if (state.submitted) return false;
+        if (keyMatchers[Command.ESCAPE](key)) {
+          onCancel();
+          return true;
+        }
+        if (keyMatchers[Command.QUIT](key)) {
+          onCancel();
+          return false;
+        }
+        return false;
+      },
+      [onCancel, state.submitted],
+    ),
+    { isActive: !state.submitted },
+  );
+
+  useKeypress(
+    useCallback(
+      (key: Key) => {
+        if (
+          state.isEditingFeedback &&
+          keyMatchers[Command.QUIT](key) &&
+          feedbackBuffer.text !== ''
+        ) {
+          feedbackBuffer.setText('');
+          return true;
+        }
+        return false;
+      },
+      [state.isEditingFeedback, feedbackBuffer],
+    ),
+    { isActive: state.isEditingFeedback, priority: true },
+  );
+
+  const handleSelect = useCallback(
+    (choice: DialogChoice) => {
+      if (state.submitted) return;
+
+      if (choice === DialogChoice.FEEDBACK) {
+        dispatch({ type: 'SET_ACTIVE_CHOICE', payload: choice });
+        return;
+      }
+
+      dispatch({ type: 'SUBMIT' });
+      if (choice === DialogChoice.APPROVE_AUTO_EDIT) {
+        onApprove(ApprovalMode.AUTO_EDIT);
+      } else if (choice === DialogChoice.APPROVE_DEFAULT) {
+        onApprove(ApprovalMode.DEFAULT);
+      }
+    },
+    [state.submitted, onApprove],
+  );
+
+  const handleHighlight = useCallback((choice: DialogChoice) => {
+    dispatch({ type: 'SET_ACTIVE_CHOICE', payload: choice });
+  }, []);
+
+  const handleFeedbackSubmit = useCallback(
+    (text: string) => {
+      if (state.submitted || !text.trim()) return;
+      dispatch({ type: 'SUBMIT' });
+      onFeedback(text.trim());
+    },
+    [state.submitted, onFeedback],
+  );
+
+  const selectItems = useMemo(
+    (): Array<RadioSelectItem<DialogChoice>> => [
+      {
+        key: DialogChoice.APPROVE_AUTO_EDIT,
+        value: DialogChoice.APPROVE_AUTO_EDIT,
+        label: CHOICE_LABELS[DialogChoice.APPROVE_AUTO_EDIT],
+      },
+      {
+        key: DialogChoice.APPROVE_DEFAULT,
+        value: DialogChoice.APPROVE_DEFAULT,
+        label: CHOICE_LABELS[DialogChoice.APPROVE_DEFAULT],
+      },
+      {
+        key: DialogChoice.FEEDBACK,
+        value: DialogChoice.FEEDBACK,
+        label: '',
+      },
+    ],
+    [],
+  );
+
+  const OPTIONS_COUNT = selectItems.length;
+  const overhead = QUESTION_AND_MARGIN + OPTIONS_COUNT + FOOTER_HEIGHT;
+
+  const planContentHeight =
+    availableHeight && !isAlternateBuffer
+      ? Math.max(MIN_PLAN_HEIGHT, availableHeight - overhead)
+      : undefined;
+
+  const planContent = useMemo(() => {
+    if (planState.status === 'loading') {
+      return (
+        <Text color={theme.text.secondary} italic>
+          Loading plan...
+        </Text>
+      );
+    }
+    if (planState.status === 'error') {
+      return (
+        <Text color={theme.status.error}>
+          Error reading plan: {planState.error}
+        </Text>
+      );
+    }
+    return (
+      <MarkdownDisplay
+        text={planState.content || ''}
+        isPending={false}
+        terminalWidth={width - PLAN_WIDTH_OFFSET}
+      />
+    );
+  }, [planState, width]);
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Box marginBottom={1}>
+        <MaxSizedBox
+          maxHeight={planContentHeight}
+          maxWidth={width - PLAN_WIDTH_OFFSET}
+          overflowDirection="bottom"
+        >
+          {planContent}
+        </MaxSizedBox>
+      </Box>
+
+      <Box marginBottom={1}>
+        <Text bold color={theme.text.primary}>
+          Ready to start implementation?
+        </Text>
+      </Box>
+
+      <RadioButtonSelect
+        items={selectItems}
+        onSelect={handleSelect}
+        onHighlight={handleHighlight}
+        isFocused={true}
+        showNumbers={true}
+        showScrollArrows={false}
+        renderItem={(item, { titleColor, isSelected }) => {
+          if (item.value === DialogChoice.FEEDBACK) {
+            return (
+              <Box flexDirection="row">
+                <TextInput
+                  buffer={feedbackBuffer}
+                  placeholder="Type your feedback..."
+                  focus={isSelected}
+                  onSubmit={handleFeedbackSubmit}
+                />
+              </Box>
+            );
+          }
+          return <Text color={titleColor}>{item.label}</Text>;
+        }}
+      />
+
+      <DialogFooter
+        primaryAction={
+          state.activeChoice === DialogChoice.FEEDBACK
+            ? 'Enter to send feedback'
+            : 'Enter to select'
+        }
+        navigationActions="↑/↓ to navigate"
+      />
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
@@ -5,45 +5,19 @@
  */
 
 import type React from 'react';
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useReducer,
-  useState,
-  useContext,
-} from 'react';
+import { useEffect, useState } from 'react';
 import { Box, Text } from 'ink';
-import * as fs from 'node:fs';
 import {
   ApprovalMode,
   validatePlanPath,
   validatePlanContent,
-  checkExhaustive,
+  QuestionType,
+  type Config,
+  processSingleFileContent,
 } from '@google/gemini-cli-core';
 import { theme } from '../semantic-colors.js';
-import { MarkdownDisplay } from '../utils/MarkdownDisplay.js';
-import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
-import type { RadioSelectItem } from './shared/RadioButtonSelect.js';
-import { TextInput } from './shared/TextInput.js';
-import { useTextBuffer } from './shared/text-buffer.js';
-import { useKeypress, type Key } from '../hooks/useKeypress.js';
-import { keyMatchers, Command } from '../keyMatchers.js';
-import { DialogFooter } from './shared/DialogFooter.js';
-import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
-import { MaxSizedBox } from './shared/MaxSizedBox.js';
-import { UIStateContext } from '../contexts/UIStateContext.js';
 import { useConfig } from '../contexts/ConfigContext.js';
-
-/**
- * Layout constants for the dialog.
- */
-const MIN_PLAN_HEIGHT = 3;
-// Offset for the feedback text input width to account for radio button prefix ("● 1. ") and margins.
-const FEEDBACK_BUFFER_WIDTH_OFFSET = 6;
-const PLAN_WIDTH_OFFSET = 2;
-const QUESTION_AND_MARGIN = 2; // Question text + margin
-const FOOTER_HEIGHT = 2; // DialogFooter + margin
+import { AskUserDialog } from './AskUserDialog.js';
 
 export interface ExitPlanModeDialogProps {
   planPath: string;
@@ -54,58 +28,95 @@ export interface ExitPlanModeDialogProps {
   availableHeight?: number;
 }
 
+enum PlanStatus {
+  Loading = 'loading',
+  Loaded = 'loaded',
+  Error = 'error',
+}
+
 interface PlanContentState {
-  status: 'loading' | 'loaded' | 'error';
+  status: PlanStatus;
   content?: string;
   error?: string;
 }
 
-enum DialogChoice {
-  APPROVE_AUTO_EDIT = 'approve_auto_edit',
-  APPROVE_DEFAULT = 'approve_default',
-  FEEDBACK = 'feedback',
+enum ApprovalOption {
+  Auto = 'Yes, automatically accept edits',
+  Manual = 'Yes, manually accept edits',
 }
 
-interface DialogState {
-  activeChoice: DialogChoice;
-  isEditingFeedback: boolean;
-  submitted: boolean;
+function usePlanContent(planPath: string, config: Config): PlanContentState {
+  const [state, setState] = useState<PlanContentState>({
+    status: PlanStatus.Loading,
+  });
+
+  useEffect(() => {
+    let ignore = false;
+    setState({ status: PlanStatus.Loading });
+
+    const load = async () => {
+      try {
+        const pathError = await validatePlanPath(
+          planPath,
+          config.storage.getProjectTempPlansDir(),
+          config.getTargetDir(),
+        );
+        if (ignore) return;
+        if (pathError) {
+          setState({ status: PlanStatus.Error, error: pathError });
+          return;
+        }
+
+        const contentError = await validatePlanContent(planPath);
+        if (ignore) return;
+        if (contentError) {
+          setState({ status: PlanStatus.Error, error: contentError });
+          return;
+        }
+
+        const result = await processSingleFileContent(
+          planPath,
+          config.storage.getProjectTempPlansDir(),
+          config.getFileSystemService(),
+        );
+
+        if (ignore) return;
+
+        if (result.error) {
+          setState({ status: PlanStatus.Error, error: result.error });
+          return;
+        }
+
+        if (typeof result.llmContent !== 'string') {
+          setState({
+            status: PlanStatus.Error,
+            error: 'Plan file format not supported (binary or image).',
+          });
+          return;
+        }
+
+        const content = result.llmContent;
+        if (!content) {
+          setState({ status: PlanStatus.Error, error: 'Plan file is empty.' });
+          return;
+        }
+        setState({ status: PlanStatus.Loaded, content });
+      } catch (err: unknown) {
+        if (ignore) return;
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        setState({ status: PlanStatus.Error, error: errorMessage });
+      }
+    };
+
+    void load();
+
+    return () => {
+      ignore = true;
+    };
+  }, [planPath, config]);
+
+  return state;
 }
-
-type DialogAction =
-  | { type: 'SET_ACTIVE_CHOICE'; payload: DialogChoice }
-  | { type: 'SUBMIT' };
-
-const initialDialogState: DialogState = {
-  activeChoice: DialogChoice.APPROVE_AUTO_EDIT,
-  isEditingFeedback: false,
-  submitted: false,
-};
-
-function dialogReducer(state: DialogState, action: DialogAction): DialogState {
-  if (state.submitted) return state;
-
-  switch (action.type) {
-    case 'SET_ACTIVE_CHOICE':
-      return {
-        ...state,
-        activeChoice: action.payload,
-        isEditingFeedback: action.payload === DialogChoice.FEEDBACK,
-      };
-    case 'SUBMIT':
-      return { ...state, submitted: true };
-    default:
-      checkExhaustive(action);
-  }
-}
-
-const CHOICE_LABELS: Record<
-  Exclude<DialogChoice, DialogChoice.FEEDBACK>,
-  string
-> = {
-  [DialogChoice.APPROVE_AUTO_EDIT]: 'Yes, automatically accept edits',
-  [DialogChoice.APPROVE_DEFAULT]: 'Yes, manually accept edits',
-};
 
 export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
   planPath,
@@ -113,246 +124,77 @@ export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
   onFeedback,
   onCancel,
   width,
-  availableHeight: availableHeightProp,
+  availableHeight,
 }) => {
-  const isAlternateBuffer = useAlternateBuffer();
-  const uiState = useContext(UIStateContext);
-  const availableHeight =
-    availableHeightProp ??
-    (uiState?.constrainHeight !== false
-      ? (uiState?.availableTerminalHeight ?? uiState?.terminalHeight)
-      : undefined);
-
   const config = useConfig();
-  const [planState, setPlanState] = useState<PlanContentState>({
-    status: 'loading',
-  });
-  const [state, dispatch] = useReducer(dialogReducer, initialDialogState);
+  const planState = usePlanContent(planPath, config);
 
-  useEffect(() => {
-    let ignore = false;
-
-    validatePlanPath(
-      planPath,
-      config.storage.getProjectTempPlansDir(),
-      config.getTargetDir(),
-    )
-      .then((pathError) => {
-        if (ignore) return;
-        if (pathError) {
-          setPlanState({ status: 'error', error: pathError });
-          return;
-        }
-
-        return validatePlanContent(planPath);
-      })
-      .then((contentError) => {
-        if (ignore || contentError === undefined) return;
-        if (contentError) {
-          setPlanState({ status: 'error', error: contentError });
-          return;
-        }
-        return fs.promises.readFile(planPath, 'utf8');
-      })
-      .then((content) => {
-        if (ignore) return;
-        if (!content) {
-          setPlanState({ status: 'error', error: 'Plan file is empty.' });
-          return;
-        }
-        setPlanState({ status: 'loaded', content });
-      })
-      .catch((err) => {
-        if (ignore) return;
-        setPlanState({ status: 'error', error: err.message });
-      });
-
-    return () => {
-      ignore = true;
-    };
-  }, [planPath, config]);
-
-  const feedbackBuffer = useTextBuffer({
-    initialText: '',
-    viewport: {
-      width: Math.max(1, width - FEEDBACK_BUFFER_WIDTH_OFFSET),
-      height: 1,
-    },
-    singleLine: true,
-    isValidPath: () => false,
-  });
-
-  useKeypress(
-    useCallback(
-      (key: Key) => {
-        if (state.submitted) return false;
-        if (keyMatchers[Command.ESCAPE](key)) {
-          onCancel();
-          return true;
-        }
-        if (keyMatchers[Command.QUIT](key)) {
-          onCancel();
-          return false;
-        }
-        return false;
-      },
-      [onCancel, state.submitted],
-    ),
-    { isActive: !state.submitted },
-  );
-
-  useKeypress(
-    useCallback(
-      (key: Key) => {
-        if (
-          state.isEditingFeedback &&
-          keyMatchers[Command.QUIT](key) &&
-          feedbackBuffer.text !== ''
-        ) {
-          feedbackBuffer.setText('');
-          return true;
-        }
-        return false;
-      },
-      [state.isEditingFeedback, feedbackBuffer],
-    ),
-    { isActive: state.isEditingFeedback, priority: true },
-  );
-
-  const handleSelect = useCallback(
-    (choice: DialogChoice) => {
-      if (state.submitted) return;
-
-      if (choice === DialogChoice.FEEDBACK) {
-        dispatch({ type: 'SET_ACTIVE_CHOICE', payload: choice });
-        return;
-      }
-
-      dispatch({ type: 'SUBMIT' });
-      if (choice === DialogChoice.APPROVE_AUTO_EDIT) {
-        onApprove(ApprovalMode.AUTO_EDIT);
-      } else if (choice === DialogChoice.APPROVE_DEFAULT) {
-        onApprove(ApprovalMode.DEFAULT);
-      }
-    },
-    [state.submitted, onApprove],
-  );
-
-  const handleHighlight = useCallback((choice: DialogChoice) => {
-    dispatch({ type: 'SET_ACTIVE_CHOICE', payload: choice });
-  }, []);
-
-  const handleFeedbackSubmit = useCallback(
-    (text: string) => {
-      if (state.submitted || !text.trim()) return;
-      dispatch({ type: 'SUBMIT' });
-      onFeedback(text.trim());
-    },
-    [state.submitted, onFeedback],
-  );
-
-  const selectItems = useMemo(
-    (): Array<RadioSelectItem<DialogChoice>> => [
-      {
-        key: DialogChoice.APPROVE_AUTO_EDIT,
-        value: DialogChoice.APPROVE_AUTO_EDIT,
-        label: CHOICE_LABELS[DialogChoice.APPROVE_AUTO_EDIT],
-      },
-      {
-        key: DialogChoice.APPROVE_DEFAULT,
-        value: DialogChoice.APPROVE_DEFAULT,
-        label: CHOICE_LABELS[DialogChoice.APPROVE_DEFAULT],
-      },
-      {
-        key: DialogChoice.FEEDBACK,
-        value: DialogChoice.FEEDBACK,
-        label: '',
-      },
-    ],
-    [],
-  );
-
-  const OPTIONS_COUNT = selectItems.length;
-  const overhead = QUESTION_AND_MARGIN + OPTIONS_COUNT + FOOTER_HEIGHT;
-
-  const planContentHeight =
-    availableHeight && !isAlternateBuffer
-      ? Math.max(MIN_PLAN_HEIGHT, availableHeight - overhead)
-      : undefined;
-
-  const planContent = useMemo(() => {
-    if (planState.status === 'loading') {
-      return (
+  if (planState.status === PlanStatus.Loading) {
+    return (
+      <Box paddingX={1}>
         <Text color={theme.text.secondary} italic>
           Loading plan...
         </Text>
-      );
-    }
-    if (planState.status === 'error') {
-      return (
+      </Box>
+    );
+  }
+
+  if (planState.status === PlanStatus.Error) {
+    return (
+      <Box paddingX={1}>
         <Text color={theme.status.error}>
           Error reading plan: {planState.error}
         </Text>
-      );
-    }
-    return (
-      <MarkdownDisplay
-        text={planState.content || ''}
-        isPending={false}
-        terminalWidth={width - PLAN_WIDTH_OFFSET}
-      />
+      </Box>
     );
-  }, [planState, width]);
+  }
+
+  const planContent = planState.content?.trim();
+  if (!planContent) {
+    return (
+      <Box paddingX={1}>
+        <Text color={theme.status.error}>Error: Plan content is empty.</Text>
+      </Box>
+    );
+  }
 
   return (
     <Box flexDirection="column" width={width}>
-      <Box marginBottom={1}>
-        <MaxSizedBox
-          maxHeight={planContentHeight}
-          maxWidth={width - PLAN_WIDTH_OFFSET}
-          overflowDirection="bottom"
-        >
-          {planContent}
-        </MaxSizedBox>
-      </Box>
-
-      <Box marginBottom={1}>
-        <Text bold color={theme.text.primary}>
-          Ready to start implementation?
-        </Text>
-      </Box>
-
-      <RadioButtonSelect
-        items={selectItems}
-        onSelect={handleSelect}
-        onHighlight={handleHighlight}
-        isFocused={true}
-        showNumbers={true}
-        showScrollArrows={false}
-        renderItem={(item, { titleColor, isSelected }) => {
-          if (item.value === DialogChoice.FEEDBACK) {
-            return (
-              <Box flexDirection="row">
-                <TextInput
-                  buffer={feedbackBuffer}
-                  placeholder="Type your feedback..."
-                  focus={isSelected}
-                  onSubmit={handleFeedbackSubmit}
-                />
-              </Box>
-            );
+      <AskUserDialog
+        questions={[
+          {
+            type: QuestionType.CHOICE,
+            header: 'Approval',
+            question: planContent,
+            options: [
+              {
+                label: ApprovalOption.Auto,
+                description:
+                  'Approves plan and allows tools to run automatically',
+              },
+              {
+                label: ApprovalOption.Manual,
+                description:
+                  'Approves plan but requires confirmation for each tool',
+              },
+            ],
+            placeholder: 'Type your feedback...',
+            multiSelect: false,
+          },
+        ]}
+        onSubmit={(answers) => {
+          const answer = answers['0'];
+          if (answer === ApprovalOption.Auto) {
+            onApprove(ApprovalMode.AUTO_EDIT);
+          } else if (answer === ApprovalOption.Manual) {
+            onApprove(ApprovalMode.DEFAULT);
+          } else if (answer) {
+            onFeedback(answer);
           }
-          return <Text color={titleColor}>{item.label}</Text>;
         }}
-      />
-
-      <DialogFooter
-        primaryAction={
-          state.activeChoice === DialogChoice.FEEDBACK
-            ? 'Enter to send feedback'
-            : 'Enter to select'
-        }
-        navigationActions="↑/↓ to navigate"
+        onCancel={onCancel}
+        width={width}
+        availableHeight={availableHeight}
       />
     </Box>
   );

--- a/packages/cli/src/ui/components/ToolConfirmationQueue.tsx
+++ b/packages/cli/src/ui/components/ToolConfirmationQueue.tsx
@@ -25,6 +25,7 @@ function getConfirmationHeader(
     Record<SerializableConfirmationDetails['type'], string>
   > = {
     ask_user: 'Answer Questions',
+    exit_plan_mode: 'Plan Approval',
   };
   if (!details?.type) {
     return 'Action Required';
@@ -70,7 +71,9 @@ export const ToolConfirmationQueue: React.FC<ToolConfirmationQueueProps> = ({
       : undefined;
 
   const borderColor = theme.status.warning;
-  const hideToolIdentity = tool.confirmationDetails?.type === 'ask_user';
+  const hideToolIdentity =
+    tool.confirmationDetails?.type === 'ask_user' ||
+    tool.confirmationDetails?.type === 'exit_plan_mode';
 
   return (
     <OverflowProvider>

--- a/packages/cli/src/ui/components/ToolConfirmationQueue.tsx
+++ b/packages/cli/src/ui/components/ToolConfirmationQueue.tsx
@@ -25,7 +25,7 @@ function getConfirmationHeader(
     Record<SerializableConfirmationDetails['type'], string>
   > = {
     ask_user: 'Answer Questions',
-    exit_plan_mode: 'Plan Approval',
+    exit_plan_mode: 'Ready to start implementation?',
   };
   if (!details?.type) {
     return 'Action Required';

--- a/packages/cli/src/ui/components/__snapshots__/ExitPlanModeDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ExitPlanModeDialog.test.tsx.snap
@@ -1,0 +1,204 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: false > calls onFeedback when feedback is typed and submitted 1`] = `
+"Overview
+
+Add user authentication to the CLI application.
+
+Implementation Steps
+
+ 1. Create src/auth/AuthService.ts with login/logout methods
+ 2. Add session storage in src/storage/SessionStore.ts
+ 3. Update src/commands/index.ts to check auth status
+ 4. Add tests in src/auth/__tests__/
+
+Files to Modify
+
+ - src/index.ts - Add auth middleware
+ - src/config.ts - Add auth configuration options
+
+Ready to start implementation?
+
+  1. Yes, automatically accept edits
+  2. Yes, manually accept edits
+● 3. Add tests
+
+Enter to send feedback · ↑/↓ to navigate · Esc to cancel"
+`;
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: false > displays error state when file read fails 1`] = `
+"Error reading plan: File not found
+
+Ready to start implementation?
+
+● 1. Yes, automatically accept edits
+  2. Yes, manually accept edits
+  3. Type your feedback...
+
+Enter to select · ↑/↓ to navigate · Esc to cancel"
+`;
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: false > handles long plan content appropriately 1`] = `
+"Overview
+
+Implement a comprehensive authentication system with multiple providers.
+
+Implementation Steps
+
+ 1. Create src/auth/AuthService.ts with login/logout methods
+ 2. Add session storage in src/storage/SessionStore.ts
+ 3. Update src/commands/index.ts to check auth status
+ 4. Add OAuth2 provider support in src/auth/providers/OAuth2Provider.ts
+ 5. Add SAML provider support in src/auth/providers/SAMLProvider.ts
+ 6. Add LDAP provider support in src/auth/providers/LDAPProvider.ts
+ 7. Create token refresh mechanism in src/auth/TokenManager.ts
+ 8. Add multi-factor authentication in src/auth/MFAService.ts
+ 9. Implement session timeout handling in src/auth/SessionManager.ts
+ 10. Add audit logging for auth events in src/auth/AuditLogger.ts
+... last 20 lines hidden ...
+
+Ready to start implementation?
+
+● 1. Yes, automatically accept edits
+  2. Yes, manually accept edits
+  3. Type your feedback...
+
+Enter to select · ↑/↓ to navigate · Esc to cancel"
+`;
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: false > renders correctly with plan content 1`] = `
+"Overview
+
+Add user authentication to the CLI application.
+
+Implementation Steps
+
+ 1. Create src/auth/AuthService.ts with login/logout methods
+ 2. Add session storage in src/storage/SessionStore.ts
+ 3. Update src/commands/index.ts to check auth status
+ 4. Add tests in src/auth/__tests__/
+
+Files to Modify
+
+ - src/index.ts - Add auth middleware
+ - src/config.ts - Add auth configuration options
+
+Ready to start implementation?
+
+● 1. Yes, automatically accept edits
+  2. Yes, manually accept edits
+  3. Type your feedback...
+
+Enter to select · ↑/↓ to navigate · Esc to cancel"
+`;
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: true > calls onFeedback when feedback is typed and submitted 1`] = `
+"Overview
+
+Add user authentication to the CLI application.
+
+Implementation Steps
+
+ 1. Create src/auth/AuthService.ts with login/logout methods
+ 2. Add session storage in src/storage/SessionStore.ts
+ 3. Update src/commands/index.ts to check auth status
+ 4. Add tests in src/auth/__tests__/
+
+Files to Modify
+
+ - src/index.ts - Add auth middleware
+ - src/config.ts - Add auth configuration options
+
+Ready to start implementation?
+
+  1. Yes, automatically accept edits
+  2. Yes, manually accept edits
+● 3. Add tests
+
+Enter to send feedback · ↑/↓ to navigate · Esc to cancel"
+`;
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: true > displays error state when file read fails 1`] = `
+"Error reading plan: File not found
+
+Ready to start implementation?
+
+● 1. Yes, automatically accept edits
+  2. Yes, manually accept edits
+  3. Type your feedback...
+
+Enter to select · ↑/↓ to navigate · Esc to cancel"
+`;
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: true > handles long plan content appropriately 1`] = `
+"Overview
+
+Implement a comprehensive authentication system with multiple providers.
+
+Implementation Steps
+
+ 1. Create src/auth/AuthService.ts with login/logout methods
+ 2. Add session storage in src/storage/SessionStore.ts
+ 3. Update src/commands/index.ts to check auth status
+ 4. Add OAuth2 provider support in src/auth/providers/OAuth2Provider.ts
+ 5. Add SAML provider support in src/auth/providers/SAMLProvider.ts
+ 6. Add LDAP provider support in src/auth/providers/LDAPProvider.ts
+ 7. Create token refresh mechanism in src/auth/TokenManager.ts
+ 8. Add multi-factor authentication in src/auth/MFAService.ts
+ 9. Implement session timeout handling in src/auth/SessionManager.ts
+ 10. Add audit logging for auth events in src/auth/AuditLogger.ts
+ 11. Create user profile management in src/auth/UserProfile.ts
+ 12. Add role-based access control in src/auth/RBACService.ts
+ 13. Implement password policy enforcement in src/auth/PasswordPolicy.ts
+ 14. Add brute force protection in src/auth/BruteForceGuard.ts
+ 15. Create secure cookie handling in src/auth/CookieManager.ts
+
+Files to Modify
+
+ - src/index.ts - Add auth middleware
+ - src/config.ts - Add auth configuration options
+ - src/routes/api.ts - Add auth endpoints
+ - src/middleware/cors.ts - Update CORS for auth headers
+ - src/utils/crypto.ts - Add encryption utilities
+
+Testing Strategy
+
+ - Unit tests for each auth provider
+ - Integration tests for full auth flows
+ - Security penetration testing
+ - Load testing for session management
+
+Ready to start implementation?
+
+● 1. Yes, automatically accept edits
+  2. Yes, manually accept edits
+  3. Type your feedback...
+
+Enter to select · ↑/↓ to navigate · Esc to cancel"
+`;
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: true > renders correctly with plan content 1`] = `
+"Overview
+
+Add user authentication to the CLI application.
+
+Implementation Steps
+
+ 1. Create src/auth/AuthService.ts with login/logout methods
+ 2. Add session storage in src/storage/SessionStore.ts
+ 3. Update src/commands/index.ts to check auth status
+ 4. Add tests in src/auth/__tests__/
+
+Files to Modify
+
+ - src/index.ts - Add auth middleware
+ - src/config.ts - Add auth configuration options
+
+Ready to start implementation?
+
+● 1. Yes, automatically accept edits
+  2. Yes, manually accept edits
+  3. Type your feedback...
+
+Enter to select · ↑/↓ to navigate · Esc to cancel"
+`;

--- a/packages/cli/src/ui/components/__snapshots__/ExitPlanModeDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ExitPlanModeDialog.test.tsx.snap
@@ -1,204 +1,234 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ExitPlanModeDialog > useAlternateBuffer: false > calls onFeedback when feedback is typed and submitted 1`] = `
-"Overview
+exports[`ExitPlanModeDialog > useAlternateBuffer: false > bubbles up Ctrl+C when feedback is empty while editing 1`] = `
+"## Overview
 
 Add user authentication to the CLI application.
 
-Implementation Steps
+## Implementation Steps
 
- 1. Create src/auth/AuthService.ts with login/logout methods
- 2. Add session storage in src/storage/SessionStore.ts
- 3. Update src/commands/index.ts to check auth status
- 4. Add tests in src/auth/__tests__/
+1. Create \`src/auth/AuthService.ts\` with login/logout methods
+2. Add session storage in \`src/storage/SessionStore.ts\`
+3. Update \`src/commands/index.ts\` to check auth status
+4. Add tests in \`src/auth/__tests__/\`
 
-Files to Modify
+## Files to Modify
 
- - src/index.ts - Add auth middleware
- - src/config.ts - Add auth configuration options
+- \`src/index.ts\` - Add auth middleware
+- \`src/config.ts\` - Add auth configuration options
 
-Ready to start implementation?
+  1.  Yes, automatically accept edits
+      Approves plan and allows tools to run automatically
+  2.  Yes, manually accept edits
+      Approves plan but requires confirmation for each tool
+● 3.  Type your feedback... ✓
 
-  1. Yes, automatically accept edits
-  2. Yes, manually accept edits
-● 3. Add tests
-
-Enter to send feedback · ↑/↓ to navigate · Esc to cancel"
+Enter to submit · Esc to cancel"
 `;
 
-exports[`ExitPlanModeDialog > useAlternateBuffer: false > displays error state when file read fails 1`] = `
-"Error reading plan: File not found
+exports[`ExitPlanModeDialog > useAlternateBuffer: false > calls onFeedback when feedback is typed and submitted 1`] = `
+"## Overview
 
-Ready to start implementation?
+Add user authentication to the CLI application.
 
-● 1. Yes, automatically accept edits
-  2. Yes, manually accept edits
-  3. Type your feedback...
+## Implementation Steps
 
-Enter to select · ↑/↓ to navigate · Esc to cancel"
+1. Create \`src/auth/AuthService.ts\` with login/logout methods
+2. Add session storage in \`src/storage/SessionStore.ts\`
+3. Update \`src/commands/index.ts\` to check auth status
+4. Add tests in \`src/auth/__tests__/\`
+
+## Files to Modify
+
+- \`src/index.ts\` - Add auth middleware
+- \`src/config.ts\` - Add auth configuration options
+
+  1.  Yes, automatically accept edits
+      Approves plan and allows tools to run automatically
+  2.  Yes, manually accept edits
+      Approves plan but requires confirmation for each tool
+● 3.  Add tests  ✓
+
+Enter to submit · Esc to cancel"
 `;
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: false > displays error state when file read fails 1`] = `" Error reading plan: File not found"`;
 
 exports[`ExitPlanModeDialog > useAlternateBuffer: false > handles long plan content appropriately 1`] = `
-"Overview
+"## Overview
 
 Implement a comprehensive authentication system with multiple providers.
 
-Implementation Steps
+## Implementation Steps
 
- 1. Create src/auth/AuthService.ts with login/logout methods
- 2. Add session storage in src/storage/SessionStore.ts
- 3. Update src/commands/index.ts to check auth status
- 4. Add OAuth2 provider support in src/auth/providers/OAuth2Provider.ts
- 5. Add SAML provider support in src/auth/providers/SAMLProvider.ts
- 6. Add LDAP provider support in src/auth/providers/LDAPProvider.ts
- 7. Create token refresh mechanism in src/auth/TokenManager.ts
- 8. Add multi-factor authentication in src/auth/MFAService.ts
- 9. Implement session timeout handling in src/auth/SessionManager.ts
- 10. Add audit logging for auth events in src/auth/AuditLogger.ts
-... last 20 lines hidden ...
+1. Create \`src/auth/AuthService.ts\` with login/logout methods
+2. Add session storage in \`src/storage/SessionStore.ts\`
+3. Update \`src/commands/index.ts\` to check auth status
+4. Add OAuth2 provider support in \`src/auth/providers/OAuth2Provider.ts\`
+5. Add SAML provider support in \`src/auth/providers/SAMLProvider.ts\`
+6. Add LDAP provider support in \`src/auth/providers/LDAPProvider.ts\`
+7. Create token refresh mechanism in \`src/auth/TokenManager.ts\`
+8. Add multi-factor authentication in \`src/auth/MFAService.ts\`
+... last 22 lines hidden ...
 
-Ready to start implementation?
-
-● 1. Yes, automatically accept edits
-  2. Yes, manually accept edits
-  3. Type your feedback...
+● 1.  Yes, automatically accept edits
+      Approves plan and allows tools to run automatically
+  2.  Yes, manually accept edits
+      Approves plan but requires confirmation for each tool
+  3.  Type your feedback...
 
 Enter to select · ↑/↓ to navigate · Esc to cancel"
 `;
 
 exports[`ExitPlanModeDialog > useAlternateBuffer: false > renders correctly with plan content 1`] = `
-"Overview
+"## Overview
 
 Add user authentication to the CLI application.
 
-Implementation Steps
+## Implementation Steps
 
- 1. Create src/auth/AuthService.ts with login/logout methods
- 2. Add session storage in src/storage/SessionStore.ts
- 3. Update src/commands/index.ts to check auth status
- 4. Add tests in src/auth/__tests__/
+1. Create \`src/auth/AuthService.ts\` with login/logout methods
+2. Add session storage in \`src/storage/SessionStore.ts\`
+3. Update \`src/commands/index.ts\` to check auth status
+4. Add tests in \`src/auth/__tests__/\`
 
-Files to Modify
+## Files to Modify
 
- - src/index.ts - Add auth middleware
- - src/config.ts - Add auth configuration options
+- \`src/index.ts\` - Add auth middleware
+- \`src/config.ts\` - Add auth configuration options
 
-Ready to start implementation?
-
-● 1. Yes, automatically accept edits
-  2. Yes, manually accept edits
-  3. Type your feedback...
+● 1.  Yes, automatically accept edits
+      Approves plan and allows tools to run automatically
+  2.  Yes, manually accept edits
+      Approves plan but requires confirmation for each tool
+  3.  Type your feedback...
 
 Enter to select · ↑/↓ to navigate · Esc to cancel"
+`;
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: true > bubbles up Ctrl+C when feedback is empty while editing 1`] = `
+"## Overview
+
+Add user authentication to the CLI application.
+
+## Implementation Steps
+
+1. Create \`src/auth/AuthService.ts\` with login/logout methods
+2. Add session storage in \`src/storage/SessionStore.ts\`
+3. Update \`src/commands/index.ts\` to check auth status
+4. Add tests in \`src/auth/__tests__/\`
+
+## Files to Modify
+
+- \`src/index.ts\` - Add auth middleware
+- \`src/config.ts\` - Add auth configuration options
+
+  1.  Yes, automatically accept edits
+      Approves plan and allows tools to run automatically
+  2.  Yes, manually accept edits
+      Approves plan but requires confirmation for each tool
+● 3.  Type your feedback... ✓
+
+Enter to submit · Esc to cancel"
 `;
 
 exports[`ExitPlanModeDialog > useAlternateBuffer: true > calls onFeedback when feedback is typed and submitted 1`] = `
-"Overview
+"## Overview
 
 Add user authentication to the CLI application.
 
-Implementation Steps
+## Implementation Steps
 
- 1. Create src/auth/AuthService.ts with login/logout methods
- 2. Add session storage in src/storage/SessionStore.ts
- 3. Update src/commands/index.ts to check auth status
- 4. Add tests in src/auth/__tests__/
+1. Create \`src/auth/AuthService.ts\` with login/logout methods
+2. Add session storage in \`src/storage/SessionStore.ts\`
+3. Update \`src/commands/index.ts\` to check auth status
+4. Add tests in \`src/auth/__tests__/\`
 
-Files to Modify
+## Files to Modify
 
- - src/index.ts - Add auth middleware
- - src/config.ts - Add auth configuration options
+- \`src/index.ts\` - Add auth middleware
+- \`src/config.ts\` - Add auth configuration options
 
-Ready to start implementation?
+  1.  Yes, automatically accept edits
+      Approves plan and allows tools to run automatically
+  2.  Yes, manually accept edits
+      Approves plan but requires confirmation for each tool
+● 3.  Add tests  ✓
 
-  1. Yes, automatically accept edits
-  2. Yes, manually accept edits
-● 3. Add tests
-
-Enter to send feedback · ↑/↓ to navigate · Esc to cancel"
+Enter to submit · Esc to cancel"
 `;
 
-exports[`ExitPlanModeDialog > useAlternateBuffer: true > displays error state when file read fails 1`] = `
-"Error reading plan: File not found
-
-Ready to start implementation?
-
-● 1. Yes, automatically accept edits
-  2. Yes, manually accept edits
-  3. Type your feedback...
-
-Enter to select · ↑/↓ to navigate · Esc to cancel"
-`;
+exports[`ExitPlanModeDialog > useAlternateBuffer: true > displays error state when file read fails 1`] = `" Error reading plan: File not found"`;
 
 exports[`ExitPlanModeDialog > useAlternateBuffer: true > handles long plan content appropriately 1`] = `
-"Overview
+"## Overview
 
 Implement a comprehensive authentication system with multiple providers.
 
-Implementation Steps
+## Implementation Steps
 
- 1. Create src/auth/AuthService.ts with login/logout methods
- 2. Add session storage in src/storage/SessionStore.ts
- 3. Update src/commands/index.ts to check auth status
- 4. Add OAuth2 provider support in src/auth/providers/OAuth2Provider.ts
- 5. Add SAML provider support in src/auth/providers/SAMLProvider.ts
- 6. Add LDAP provider support in src/auth/providers/LDAPProvider.ts
- 7. Create token refresh mechanism in src/auth/TokenManager.ts
- 8. Add multi-factor authentication in src/auth/MFAService.ts
- 9. Implement session timeout handling in src/auth/SessionManager.ts
- 10. Add audit logging for auth events in src/auth/AuditLogger.ts
- 11. Create user profile management in src/auth/UserProfile.ts
- 12. Add role-based access control in src/auth/RBACService.ts
- 13. Implement password policy enforcement in src/auth/PasswordPolicy.ts
- 14. Add brute force protection in src/auth/BruteForceGuard.ts
- 15. Create secure cookie handling in src/auth/CookieManager.ts
+1. Create \`src/auth/AuthService.ts\` with login/logout methods
+2. Add session storage in \`src/storage/SessionStore.ts\`
+3. Update \`src/commands/index.ts\` to check auth status
+4. Add OAuth2 provider support in \`src/auth/providers/OAuth2Provider.ts\`
+5. Add SAML provider support in \`src/auth/providers/SAMLProvider.ts\`
+6. Add LDAP provider support in \`src/auth/providers/LDAPProvider.ts\`
+7. Create token refresh mechanism in \`src/auth/TokenManager.ts\`
+8. Add multi-factor authentication in \`src/auth/MFAService.ts\`
+9. Implement session timeout handling in \`src/auth/SessionManager.ts\`
+10. Add audit logging for auth events in \`src/auth/AuditLogger.ts\`
+11. Create user profile management in \`src/auth/UserProfile.ts\`
+12. Add role-based access control in \`src/auth/RBACService.ts\`
+13. Implement password policy enforcement in \`src/auth/PasswordPolicy.ts\`
+14. Add brute force protection in \`src/auth/BruteForceGuard.ts\`
+15. Create secure cookie handling in \`src/auth/CookieManager.ts\`
 
-Files to Modify
+## Files to Modify
 
- - src/index.ts - Add auth middleware
- - src/config.ts - Add auth configuration options
- - src/routes/api.ts - Add auth endpoints
- - src/middleware/cors.ts - Update CORS for auth headers
- - src/utils/crypto.ts - Add encryption utilities
+- \`src/index.ts\` - Add auth middleware
+- \`src/config.ts\` - Add auth configuration options
+- \`src/routes/api.ts\` - Add auth endpoints
+- \`src/middleware/cors.ts\` - Update CORS for auth headers
+- \`src/utils/crypto.ts\` - Add encryption utilities
 
-Testing Strategy
+## Testing Strategy
 
- - Unit tests for each auth provider
- - Integration tests for full auth flows
- - Security penetration testing
- - Load testing for session management
+- Unit tests for each auth provider
+- Integration tests for full auth flows
+- Security penetration testing
+- Load testing for session management
 
-Ready to start implementation?
-
-● 1. Yes, automatically accept edits
-  2. Yes, manually accept edits
-  3. Type your feedback...
+● 1.  Yes, automatically accept edits
+      Approves plan and allows tools to run automatically
+  2.  Yes, manually accept edits
+      Approves plan but requires confirmation for each tool
+  3.  Type your feedback...
 
 Enter to select · ↑/↓ to navigate · Esc to cancel"
 `;
 
 exports[`ExitPlanModeDialog > useAlternateBuffer: true > renders correctly with plan content 1`] = `
-"Overview
+"## Overview
 
 Add user authentication to the CLI application.
 
-Implementation Steps
+## Implementation Steps
 
- 1. Create src/auth/AuthService.ts with login/logout methods
- 2. Add session storage in src/storage/SessionStore.ts
- 3. Update src/commands/index.ts to check auth status
- 4. Add tests in src/auth/__tests__/
+1. Create \`src/auth/AuthService.ts\` with login/logout methods
+2. Add session storage in \`src/storage/SessionStore.ts\`
+3. Update \`src/commands/index.ts\` to check auth status
+4. Add tests in \`src/auth/__tests__/\`
 
-Files to Modify
+## Files to Modify
 
- - src/index.ts - Add auth middleware
- - src/config.ts - Add auth configuration options
+- \`src/index.ts\` - Add auth middleware
+- \`src/config.ts\` - Add auth configuration options
 
-Ready to start implementation?
-
-● 1. Yes, automatically accept edits
-  2. Yes, manually accept edits
-  3. Type your feedback...
+● 1.  Yes, automatically accept edits
+      Approves plan and allows tools to run automatically
+  2.  Yes, manually accept edits
+      Approves plan but requires confirmation for each tool
+  3.  Type your feedback...
 
 Enter to select · ↑/↓ to navigate · Esc to cancel"
 `;

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -34,6 +34,7 @@ import {
   REDIRECTION_WARNING_TIP_TEXT,
 } from '../../textConstants.js';
 import { AskUserDialog } from '../AskUserDialog.js';
+import { ExitPlanModeDialog } from '../ExitPlanModeDialog.js';
 
 export interface ToolConfirmationMessageProps {
   callId: string;
@@ -62,7 +63,9 @@ export const ToolConfirmationMessage: React.FC<
   const allowPermanentApproval =
     settings.merged.security.enablePermanentToolApproval;
 
-  const handlesOwnUI = confirmationDetails.type === 'ask_user';
+  const handlesOwnUI =
+    confirmationDetails.type === 'ask_user' ||
+    confirmationDetails.type === 'exit_plan_mode';
   const isTrustedFolder = config.isTrustedFolder();
 
   const handleConfirm = useCallback(
@@ -266,6 +269,32 @@ export const ToolConfirmationMessage: React.FC<
           questions={confirmationDetails.questions}
           onSubmit={(answers) => {
             handleConfirm(ToolConfirmationOutcome.ProceedOnce, { answers });
+          }}
+          onCancel={() => {
+            handleConfirm(ToolConfirmationOutcome.Cancel);
+          }}
+          width={terminalWidth}
+          availableHeight={availableBodyContentHeight()}
+        />
+      );
+      return { question: '', bodyContent, options: [] };
+    }
+
+    if (confirmationDetails.type === 'exit_plan_mode') {
+      bodyContent = (
+        <ExitPlanModeDialog
+          planPath={confirmationDetails.planPath}
+          onApprove={(approvalMode) => {
+            handleConfirm(ToolConfirmationOutcome.ProceedOnce, {
+              approved: true,
+              approvalMode,
+            });
+          }}
+          onFeedback={(feedback) => {
+            handleConfirm(ToolConfirmationOutcome.ProceedOnce, {
+              approved: false,
+              feedback,
+            });
           }}
           onCancel={() => {
             handleConfirm(ToolConfirmationOutcome.Cancel);

--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -198,12 +198,12 @@ The following read-only tools are available in Plan Mode:
 - Only begin this phase after exploration is complete
 - Create a detailed implementation plan with clear steps
 - Include file paths, function signatures, and code snippets where helpful
-- After saving the plan, present the full content of the markdown file to the user for review
+- Save the implementation plan to the designated plans directory
 
 ### Phase 4: Review & Approval
-- Ask the user if they approve the plan, want revisions, or want to reject it
-- Address feedback and iterate as needed
-- **When the user approves the plan**, prompt them to switch out of Plan Mode to begin implementation by pressing Shift+Tab to cycle to a different approval mode
+- Present the plan and request approval for the finalized plan using the \`exit_plan_mode\` tool
+- If plan is approved, you can begin implementation
+- If plan is rejected, address the feedback and iterate on the plan
 
 ## Constraints
 - You may ONLY use the read-only tools listed above

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -8,6 +8,7 @@ import {
   ACTIVATE_SKILL_TOOL_NAME,
   ASK_USER_TOOL_NAME,
   EDIT_TOOL_NAME,
+  EXIT_PLAN_MODE_TOOL_NAME,
   GLOB_TOOL_NAME,
   GREP_TOOL_NAME,
   MEMORY_TOOL_NAME,
@@ -326,12 +327,12 @@ ${options.planModeToolsList}
 - Only begin this phase after exploration is complete
 - Create a detailed implementation plan with clear steps
 - Include file paths, function signatures, and code snippets where helpful
-- After saving the plan, present the full content of the markdown file to the user for review
+- Save the implementation plan to the designated plans directory
 
 ### Phase 4: Review & Approval
-- Ask the user if they approve the plan, want revisions, or want to reject it
-- Address feedback and iterate as needed
-- **When the user approves the plan**, prompt them to switch out of Plan Mode to begin implementation by pressing Shift+Tab to cycle to a different approval mode
+- Present the plan and request approval for the finalized plan using the \`${EXIT_PLAN_MODE_TOOL_NAME}\` tool
+- If plan is approved, you can begin implementation
+- If plan is rejected, address the feedback and iterate on the plan
 
 ## Constraints
 - You may ONLY use the read-only tools listed above


### PR DESCRIPTION
## Summary

This PR completes the `exit_plan_mode` feature by adding the dedicated UI dialog and updating the system prompts. This enables a structured workflow for plan approval, allowing users to review plans, choose implementation modes, or provide feedback directly.

## Details

### UI
- Created `ExitPlanModeDialog` component to present the plan and request approval.
- Supports two approval modes:
    - **"Yes, automatically accept edits"** (Auto-Edit mode)
    - **"Yes, manually accept edits"** (Default mode)
- Allows users to provide feedback directly in the dialog if they reject the plan.
- We reuse `AskUserDialog` to minimize duplication of code and provide a consistent experience.

### Prompts
- Updated system prompts to guide the agent on using `exit_plan_mode` in Phase 4 of the planning workflow.

## Related Issues

Closes #17983 
Closes #17985

## How to Validate

### Setup
1.  Start Gemini CLI in Plan Mode:
    ```bash
    npm start -- --approval-mode=plan
    ```
2.  Trigger a plan by saying: "I want to add a feature for talking to the CLI".
3.  Once the plan is created and saved, ask: "finalize the plan and start coding".
4.  The **Exit Plan Mode** dialog should appear.

<img width="3446" height="980" alt="image" src="https://github.com/user-attachments/assets/63dcd3e6-0448-4ae8-8953-76f576208dcd" />

### Test Approval Options
You can test each option by cancelling the dialog (`Esc`) or restarting the request:

*   **Test Auto-Edit:**
    1.  Select **"Yes, automatically accept edits"** and press Enter.
    2.  Verify the agent exits Plan Mode and starts implementing changes automatically.
*   **Test Manual Edits:**
    1.  Trigger the dialog again (ask "finalize the plan").
    2.  Select **"Yes, manually accept edits"** and press Enter.
    3.  Verify the agent exits Plan Mode but prompts for confirmation on each file edit.
*   **Test Feedback:**
    1.  Trigger the dialog again.
    2.  Select the **feedback input** (3rd option), type "add more comments", and press Enter.
    3.  Verify the agent receives the feedback and offers to revise the plan.

### Test Alternate Buffer
1.  Inside the CLI, type `/settings`, enable **"Use Alternate Screen Buffer"**, and restart.
2.  Repeat the steps above to verify the dialog renders correctly in the alternate buffer.

<img width="3450" height="1900" alt="image" src="https://github.com/user-attachments/assets/d147903a-040e-44b5-ac16-aeeb78889f6d" />

### Test Keybindings & Interactions
*   **Navigation:** Use `↑`/`↓` or keys `1`-`3` to change selection.
*   **Scrolling:** For **long plans** (create one by asking for "at least 50 steps").
*   **Expansion:** Press `Ctrl+O` in standard buffer mode to reveal hidden lines.
*   **Cancellation:** Press `Esc` or `Ctrl+C` to return to Plan Mode without approving.
*   **Resizing:** Resize your terminal while the dialog is open and verify the layout adapts.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker