### PR TITLE
#18175: fix(workflow) - ensure stale PR closer handles missing secrets on fork PRs

### DIFF
--- a/.github/workflows/gemini-scheduled-stale-pr-closer.yml
+++ b/.github/workflows/gemini-scheduled-stale-pr-closer.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
+        if: "github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository"
         uses: 'actions/create-github-app-token@v1'
         with:
           app-id: '${{ secrets.APP_ID }}'
@@ -35,7 +36,7 @@ jobs:
         env:
           DRY_RUN: '${{ inputs.dry_run }}'
         with:
-          github-token: '${{ steps.generate_token.outputs.token }}'
+          github-token: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           script: |
             const dryRun = process.env.DRY_RUN === 'true';
             const thirtyDaysAgo = new Date();


### PR DESCRIPTION
## Summary

This PR fixes a blocking CI failure in the `Gemini Scheduled Stale PR Closer` workflow that occurs when pull requests are submitted from forks.

**Fixes Issue #18175**

## The Problem

The workflow currently relies on `actions/create-github-app-token@v1` to authenticate. This action requires `APP_ID` and `PRIVATE_KEY` secrets. However, for security reasons, GitHub does not share secrets with workflows triggered by `pull_request` events from forks. 

Because these inputs are missing for external contributors, the action throws a fatal error: `Input required and not supplied: app-id`. This crashes the entire workflow run, preventing it from performing its validation logic and leaving the PR's CI status in a "failed" state, even if the contributor has correctly followed all policies.

## The Fix: Decoupled Authentication

This PR introduces a robust, dual-token authentication strategy that allows the workflow to remain functional for everyone:

1.  **Guarded App Token Generation**: Added an `if` guard to the GitHub App token step. It now only attempts to run for internal branches or scheduled events where secrets are guaranteed to be present.
2.  **Smart Fallback to `GITHUB_TOKEN`**: The main processing step now uses a logical OR for its credentials:
    `github-token: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'`

### How it behaves for Fork PRs:
- **Phase 1**: The App Token step is skipped entirely, preventing the "missing input" crash.
- **Phase 2**: The workflow falls back to the standard, built-in `GITHUB_TOKEN`. 
- **Phase 3**: Since the "Linked Issue" check only requires read-level access to the PR description, the standard token works perfectly. The validation succeeds, and the PR gets a **Green CI** status.

### How it behaves for Scheduled/Internal runs:
- The `if` guard evaluates to true, the GitHub App token is successfully generated, and the workflow retains its full administrative power to close stale PRs and manage maintainer-only labels.

## Testing

Verified that the workflow no longer crashes when triggered by external fork events and correctly falls back to the provided system token.