### PR TITLE
fix(workflow): robust linked issue detection and error handling for fork PRs

### DIFF
--- a/.github/workflows/pr-contribution-guidelines-notifier.yml
+++ b/.github/workflows/pr-contribution-guidelines-notifier.yml
@@ -15,10 +15,7 @@ jobs:
     steps:
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        env:
-          APP_ID: '${{ secrets.APP_ID }}'
-        if: |-
-          ${{ env.APP_ID != '' }}
+        if: "github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository"
         uses: 'actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b' # ratchet:actions/create-github-app-token@v2
         with:
           app-id: '${{ secrets.APP_ID }}'
@@ -42,6 +39,7 @@ jobs:
             }
 
             // 2. Check if the PR is already associated with an issue
+            // Check A: Official GitHub "Closing Issue" link (GraphQL)
             const query = `
               query($owner:String!, $repo:String!, $number:Int!) {
                 repository(owner:$owner, name:$repo) {
@@ -55,9 +53,14 @@ jobs:
             `;
             const variables = { owner: org, repo: repo, number: pr_number };
             const result = await github.graphql(query, variables);
-            const issueCount = result.repository.pullRequest.closingIssuesReferences.totalCount;
+            const hasClosingLink = result.repository.pullRequest.closingIssuesReferences.totalCount > 0;
 
-            if (issueCount > 0) {
+            // Check B: Regex for mentions (e.g., "Related to #123", "Part of #123", "#123")
+            const body = context.payload.pull_request.body || '';
+            const mentionRegex = /(?:#|https:\/\/github\.com\/[^\/]+\/[^\/]+\/issues\/)(\d+)/i;
+            const hasMentionLink = mentionRegex.test(body);
+
+            if (hasClosingLink || hasMentionLink) {
               core.info(`PR #${pr_number} is already associated with an issue. No notification needed.`);
               return;
             }
@@ -75,9 +78,17 @@ jobs:
             Thank you for your understanding and for being a part of our community!
             `.trim().replace(/^[ ]+/gm, '');
 
-            await github.rest.issues.createComment({
-              owner: org,
-              repo: repo,
-              issue_number: pr_number,
-              body: comment
-            });
+            try {
+              await github.rest.issues.createComment({
+                owner: org,
+                repo: repo,
+                issue_number: pr_number,
+                body: comment
+              });
+            } catch (e) {
+              if (e.status === 403) {
+                core.warning('Failed to post comment due to insufficient permissions (likely a fork PR using GITHUB_TOKEN).');
+              } else {
+                throw e;
+              }
+            }


### PR DESCRIPTION
## Summary

This PR fixes a CI failure in the `🏷️ PR Contribution Guidelines Notifier` workflow that occurs when pull requests are submitted from forks.

**Fixes Issue #18176**

## The Problem

1.  **Incomplete Detection**: The workflow was only using GraphQL to detect linked issues, which is unreliable for fork-based PRs. This caused the workflow to incorrectly conclude that an issue was missing.
2.  **Permission Crash**: When the workflow tried to post a reminder comment on a fork PR, it used a read-only `GITHUB_TOKEN`, resulting in a `403 Forbidden` error that failed the CI run.

## The Fix

- **Dual-Mode Detection**: Added regex-based detection for issue links in the PR body, ensuring that common patterns like `Fixes #123` are correctly identified.
- **Resilient Commenting**: Added a `try...catch` block around the comment creation. If the workflow lacks write permissions (as is the case for fork PRs), it now logs a warning instead of failing the build.
- **Improved Guarding**: Refined the GitHub App token step to explicitly skip on fork PRs where secrets are unavailable.

These changes ensure that contributors from forks get a green CI status as long as they follow the contribution guidelines.