### PR TITLE
feat(plan): use custom deny messages in plan mode policies

### DIFF
--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -2208,5 +2208,57 @@ describe('CoreToolScheduler Sequential Execution', () => {
       expect(result.response.errorType).toBe(ToolErrorType.STOP_EXECUTION);
       expect(result.response.error.message).toBe(PLAN_MODE_DENIAL_MESSAGE);
     });
+
+    it('should return custom deny message when denied in Plan Mode with a specific rule message', async () => {
+      const mockTool = new MockTool({
+        name: 'dangerous_tool',
+        displayName: 'Dangerous Tool',
+        description: 'Does risky stuff',
+      });
+      const mockToolRegistry = {
+        getTool: () => mockTool,
+        getAllToolNames: () => ['dangerous_tool'],
+      } as unknown as ToolRegistry;
+
+      const onAllToolCallsComplete = vi.fn();
+      const customDenyMessage = 'Custom denial message for testing';
+
+      const mockConfig = createMockConfig({
+        getToolRegistry: () => mockToolRegistry,
+        getApprovalMode: () => ApprovalMode.PLAN,
+        getPolicyEngine: () =>
+          ({
+            check: async () => ({
+              decision: PolicyDecision.DENY,
+              rule: { denyMessage: customDenyMessage },
+            }),
+          }) as unknown as PolicyEngine,
+      });
+      mockConfig.getHookSystem = vi.fn().mockReturnValue(undefined);
+
+      const scheduler = new CoreToolScheduler({
+        config: mockConfig,
+        onAllToolCallsComplete,
+        getPreferredEditor: () => 'vscode',
+      });
+
+      const request = {
+        callId: 'call-1',
+        name: 'dangerous_tool',
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'prompt-1',
+      };
+
+      await scheduler.schedule(request, new AbortController().signal);
+
+      expect(onAllToolCallsComplete).toHaveBeenCalledTimes(1);
+      const reportedTools = onAllToolCallsComplete.mock.calls[0][0];
+      const result = reportedTools[0];
+
+      expect(result.status).toBe('error');
+      expect(result.response.errorType).toBe(ToolErrorType.STOP_EXECUTION);
+      expect(result.response.error.message).toBe(customDenyMessage);
+    });
   });
 });

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -8,7 +8,6 @@ import { describe, it, expect, vi } from 'vitest';
 import type { Mock } from 'vitest';
 import type { CallableTool } from '@google/genai';
 import { CoreToolScheduler } from './coreToolScheduler.js';
-import { PLAN_MODE_DENIAL_MESSAGE } from '../scheduler/policy.js';
 import type {
   ToolCall,
   WaitingToolCall,
@@ -2161,7 +2160,7 @@ describe('CoreToolScheduler Sequential Execution', () => {
   });
 
   describe('Policy Decisions in Plan Mode', () => {
-    it('should return STOP_EXECUTION error type and informative message when denied in Plan Mode', async () => {
+    it('should return POLICY_VIOLATION error type and informative message when denied in Plan Mode', async () => {
       const mockTool = new MockTool({
         name: 'dangerous_tool',
         displayName: 'Dangerous Tool',
@@ -2205,8 +2204,10 @@ describe('CoreToolScheduler Sequential Execution', () => {
       const result = reportedTools[0];
 
       expect(result.status).toBe('error');
-      expect(result.response.errorType).toBe(ToolErrorType.STOP_EXECUTION);
-      expect(result.response.error.message).toBe(PLAN_MODE_DENIAL_MESSAGE);
+      expect(result.response.errorType).toBe(ToolErrorType.POLICY_VIOLATION);
+      expect(result.response.error.message).toBe(
+        'Tool execution denied by policy.',
+      );
     });
 
     it('should return custom deny message when denied in Plan Mode with a specific rule message', async () => {
@@ -2257,8 +2258,10 @@ describe('CoreToolScheduler Sequential Execution', () => {
       const result = reportedTools[0];
 
       expect(result.status).toBe('error');
-      expect(result.response.errorType).toBe(ToolErrorType.STOP_EXECUTION);
-      expect(result.response.error.message).toBe(customDenyMessage);
+      expect(result.response.errorType).toBe(ToolErrorType.POLICY_VIOLATION);
+      expect(result.response.error.message).toBe(
+        `Tool execution denied by policy. ${customDenyMessage}`,
+      );
     });
   });
 });

--- a/packages/core/src/policy/policies/plan.toml
+++ b/packages/core/src/policy/policies/plan.toml
@@ -31,6 +31,7 @@
 decision = "deny"
 priority = 20
 modes = ["plan"]
+deny_message = "You are in Plan Mode - adjust your prompt to only use read and search tools."
 
 # Explicitly Allow Read-Only Tools in Plan mode.
 

--- a/packages/core/src/scheduler/policy.test.ts
+++ b/packages/core/src/scheduler/policy.test.ts
@@ -13,12 +13,7 @@ import {
   beforeEach,
   afterEach,
 } from 'vitest';
-import {
-  checkPolicy,
-  updatePolicy,
-  getPolicyDenialError,
-  PLAN_MODE_DENIAL_MESSAGE,
-} from './policy.js';
+import { checkPolicy, updatePolicy, getPolicyDenialError } from './policy.js';
 import type { Config } from '../config/config.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { MessageBusType } from '../confirmation-bus/types.js';
@@ -444,36 +439,7 @@ describe('policy.ts', () => {
   });
 
   describe('getPolicyDenialError', () => {
-    it('should return default plan mode message in Plan Mode', () => {
-      const mockConfig = {
-        getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.PLAN),
-      } as unknown as Config;
-
-      const { errorMessage, errorType } = getPolicyDenialError(mockConfig);
-
-      expect(errorMessage).toBe(PLAN_MODE_DENIAL_MESSAGE);
-      expect(errorType).toBe(ToolErrorType.STOP_EXECUTION);
-    });
-
-    it('should return custom deny message in Plan Mode if provided', () => {
-      const mockConfig = {
-        getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.PLAN),
-      } as unknown as Config;
-      const rule = {
-        decision: PolicyDecision.DENY,
-        denyMessage: 'Custom Plan Deny',
-      };
-
-      const { errorMessage, errorType } = getPolicyDenialError(
-        mockConfig,
-        rule,
-      );
-
-      expect(errorMessage).toBe('Custom Plan Deny');
-      expect(errorType).toBe(ToolErrorType.STOP_EXECUTION);
-    });
-
-    it('should return default deny message in non-Plan Mode', () => {
+    it('should return default denial message when no rule provided', () => {
       const mockConfig = {
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
       } as unknown as Config;
@@ -484,7 +450,7 @@ describe('policy.ts', () => {
       expect(errorType).toBe(ToolErrorType.POLICY_VIOLATION);
     });
 
-    it('should return custom deny message in non-Plan Mode if provided', () => {
+    it('should return custom deny message if provided', () => {
       const mockConfig = {
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
       } as unknown as Config;
@@ -608,8 +574,8 @@ describe('Plan Mode Denial Consistency', () => {
         }
       }
 
-      expect(resultMessage).toBe(PLAN_MODE_DENIAL_MESSAGE);
-      expect(resultErrorType).toBe(ToolErrorType.STOP_EXECUTION);
+      expect(resultMessage).toBe('Tool execution denied by policy.');
+      expect(resultErrorType).toBe(ToolErrorType.POLICY_VIOLATION);
     });
   });
 });

--- a/packages/core/src/scheduler/policy.ts
+++ b/packages/core/src/scheduler/policy.ts
@@ -26,24 +26,13 @@ import { DiscoveredMCPTool } from '../tools/mcp-tool.js';
 import { EDIT_TOOL_NAMES } from '../tools/tool-names.js';
 import type { ValidatingToolCall } from './types.js';
 
-export const PLAN_MODE_DENIAL_MESSAGE =
-  'You are in Plan Mode - adjust your prompt to only use read and search tools.';
-
 /**
- * Helper to determine the error message and type for a policy denial.
+ * Helper to format the policy denial error.
  */
 export function getPolicyDenialError(
   config: Config,
   rule?: PolicyRule,
 ): { errorMessage: string; errorType: ToolErrorType } {
-  if (config.getApprovalMode() === ApprovalMode.PLAN) {
-    const errorMessage = rule?.denyMessage ?? PLAN_MODE_DENIAL_MESSAGE;
-    return {
-      errorMessage,
-      errorType: ToolErrorType.STOP_EXECUTION,
-    };
-  }
-
   const denyMessage = rule?.denyMessage ? ` ${rule.denyMessage}` : '';
   return {
     errorMessage: `Tool execution denied by policy.${denyMessage}`,

--- a/packages/core/src/scheduler/policy.ts
+++ b/packages/core/src/scheduler/policy.ts
@@ -37,8 +37,9 @@ export function getPolicyDenialError(
   rule?: PolicyRule,
 ): { errorMessage: string; errorType: ToolErrorType } {
   if (config.getApprovalMode() === ApprovalMode.PLAN) {
+    const errorMessage = rule?.denyMessage ?? PLAN_MODE_DENIAL_MESSAGE;
     return {
-      errorMessage: PLAN_MODE_DENIAL_MESSAGE,
+      errorMessage,
       errorType: ToolErrorType.STOP_EXECUTION,
     };
   }

--- a/packages/core/src/scheduler/scheduler.test.ts
+++ b/packages/core/src/scheduler/scheduler.test.ts
@@ -745,7 +745,7 @@ describe('Scheduler (Orchestrator)', () => {
       );
     });
 
-    it('should return STOP_EXECUTION error type and informative message when denied in Plan Mode', async () => {
+    it('should return POLICY_VIOLATION error type when denied in Plan Mode', async () => {
       vi.mocked(checkPolicy).mockResolvedValue({
         decision: PolicyDecision.DENY,
         rule: { decision: PolicyDecision.DENY },
@@ -759,13 +759,12 @@ describe('Scheduler (Orchestrator)', () => {
         'call-1',
         'error',
         expect.objectContaining({
-          errorType: ToolErrorType.STOP_EXECUTION,
+          errorType: ToolErrorType.POLICY_VIOLATION,
           responseParts: expect.arrayContaining([
             expect.objectContaining({
               functionResponse: expect.objectContaining({
                 response: {
-                  error:
-                    'You are in Plan Mode - adjust your prompt to only use read and search tools.',
+                  error: 'Tool execution denied by policy.',
                 },
               }),
             }),
@@ -774,7 +773,7 @@ describe('Scheduler (Orchestrator)', () => {
       );
     });
 
-    it('should return STOP_EXECUTION and custom deny message when denied in Plan Mode with rule message', async () => {
+    it('should return POLICY_VIOLATION and custom deny message when denied in Plan Mode with rule message', async () => {
       const customMessage = 'Custom Plan Mode Deny';
       vi.mocked(checkPolicy).mockResolvedValue({
         decision: PolicyDecision.DENY,
@@ -789,12 +788,12 @@ describe('Scheduler (Orchestrator)', () => {
         'call-1',
         'error',
         expect.objectContaining({
-          errorType: ToolErrorType.STOP_EXECUTION,
+          errorType: ToolErrorType.POLICY_VIOLATION,
           responseParts: expect.arrayContaining([
             expect.objectContaining({
               functionResponse: expect.objectContaining({
                 response: {
-                  error: customMessage,
+                  error: `Tool execution denied by policy. ${customMessage}`,
                 },
               }),
             }),


### PR DESCRIPTION
## Summary

Refactored Plan Mode policy to support and prioritize custom deny messages from policy configuration. This change allows for more specific feedback when tools are blocked in Plan Mode.

## Details

   - Policy Configuration: Added a default deny_message to the Plan Mode catch-all rule in packages/core/src/policy/policies/plan.toml.
   - Centralized Logic: Updated the shared helper getPolicyDenialError in packages/core/src/scheduler/policy.ts to respect rule.denyMessage when operating in ApprovalMode.PLAN. This ensures both the legacy CoreToolScheduler and the new event-driven Scheduler benefit from the improvement automatically.
   - Improved Feedback: In Plan Mode, the scheduler now prioritizes the specific message defined in the matched policy rule over the generic "You are in Plan Mode" string.
  

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes #17671 
## How to Validate
If a tool that's not a read or search gets called, the custom policy denial message should be shown.

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
