### PR TITLE
refactor(core): robust trimPreservingTrailingNewline and regression test

### DIFF
--- a/packages/core/src/utils/editCorrector.test.ts
+++ b/packages/core/src/utils/editCorrector.test.ts
@@ -665,6 +665,30 @@ describe('editCorrector', () => {
         expect(result.params.new_string).toBe('replaced\n\n');
         expect(result.occurrences).toBe(1);
       });
+
+      it('Test 7.2: should handle trailing newlines separated by spaces (regression fix)', async () => {
+        const currentContent = 'find me '; // Matches old_string initially
+        const originalParams = {
+          file_path: '/test/file.txt',
+          old_string: 'find me ', // Trailing space
+          new_string: 'replaced \n \n', // Trailing newlines with spaces
+        };
+
+        const result = await ensureCorrectEdit(
+          '/test/file.txt',
+          currentContent,
+          originalParams,
+          mockGeminiClientInstance,
+          mockBaseLlmClientInstance,
+          abortSignal,
+          false,
+        );
+
+        expect(result.params.old_string).toBe('find me');
+        // Should capture both newlines and join them, stripping the space between
+        expect(result.params.new_string).toBe('replaced\n\n');
+        expect(result.occurrences).toBe(1);
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
Add a regression test. Previously tried to make a change which passed unit tests put incorrectly stripped spaces.

## Related Issues
Cleanup and bug prevention in core utilities.

Related to https://github.com/google-gemini/gemini-cli/issues/18199

## How to Validate
Ran unit tests: `npm test -w packages/core -- src/utils/editCorrector.test.ts`