### PR TITLE
feat(core): Add A2A auth config types

### DIFF
--- a/packages/core/src/agents/auth-provider/types.ts
+++ b/packages/core/src/agents/auth-provider/types.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Client-side auth configuration for A2A remote agents.
+ * Corresponds to server-side SecurityScheme types from @a2a-js/sdk.
+ * @see https://a2a-protocol.org/latest/specification/#451-securityscheme
+ */
+
+import type { AuthenticationHandler } from '@a2a-js/sdk/client';
+
+export type A2AAuthProviderType =
+  | 'google-credentials'
+  | 'apiKey'
+  | 'http'
+  | 'oauth2'
+  | 'openIdConnect';
+
+export interface A2AAuthProvider extends AuthenticationHandler {
+  readonly type: A2AAuthProviderType;
+  initialize?(): Promise<void>;
+}
+
+export interface BaseAuthConfig {
+  agent_card_requires_auth?: boolean;
+}
+
+/** Client config for google-credentials (not in A2A spec, Gemini-specific). */
+export interface GoogleCredentialsAuthConfig extends BaseAuthConfig {
+  type: 'google-credentials';
+  scopes?: string[];
+}
+
+/** Client config corresponding to APIKeySecurityScheme. */
+export interface ApiKeyAuthConfig extends BaseAuthConfig {
+  type: 'apiKey';
+  /** The secret. Supports $ENV_VAR, !command, or literal. */
+  key: string;
+  /** Defaults to server's SecurityScheme.in value. */
+  location?: 'header' | 'query' | 'cookie';
+  /** Defaults to server's SecurityScheme.name value. */
+  name?: string;
+}
+
+/** Client config corresponding to HTTPAuthSecurityScheme. */
+export type HttpAuthConfig = BaseAuthConfig & {
+  type: 'http';
+} & (
+    | {
+        scheme: 'Bearer';
+        /** For Bearer. Supports $ENV_VAR, !command, or literal. */
+        token: string;
+      }
+    | {
+        scheme: 'Basic';
+        /** For Basic. Supports $ENV_VAR, !command, or literal. */
+        username: string;
+        /** For Basic. Supports $ENV_VAR, !command, or literal. */
+        password: string;
+      }
+  );
+
+/** Client config corresponding to OAuth2SecurityScheme. */
+export interface OAuth2AuthConfig extends BaseAuthConfig {
+  type: 'oauth2';
+  client_id?: string;
+  client_secret?: string;
+  scopes?: string[];
+}
+
+/** Client config corresponding to OpenIdConnectSecurityScheme. */
+export interface OpenIdConnectAuthConfig extends BaseAuthConfig {
+  type: 'openIdConnect';
+  issuer_url: string;
+  client_id: string;
+  client_secret?: string;
+  target_audience?: string;
+  scopes?: string[];
+}
+
+export type A2AAuthConfig =
+  | GoogleCredentialsAuthConfig
+  | ApiKeyAuthConfig
+  | HttpAuthConfig
+  | OAuth2AuthConfig
+  | OpenIdConnectAuthConfig;
+
+export interface AuthConfigDiff {
+  requiredSchemes: string[];
+  configuredType?: A2AAuthProviderType;
+  missingConfig: string[];
+}
+
+export interface AuthValidationResult {
+  valid: boolean;
+  diff?: AuthConfigDiff;
+}

--- a/packages/core/src/agents/types.ts
+++ b/packages/core/src/agents/types.ts
@@ -13,6 +13,7 @@ import type { AnyDeclarativeTool } from '../tools/tools.js';
 import { type z } from 'zod';
 import type { ModelConfig } from '../services/modelConfigService.js';
 import type { AnySchema } from 'ajv';
+import type { A2AAuthConfig } from './auth-provider/types.js';
 
 /**
  * Describes the possible termination modes for an agent.
@@ -108,6 +109,12 @@ export interface RemoteAgentDefinition<
 > extends BaseAgentDefinition<TOutput> {
   kind: 'remote';
   agentCardUrl: string;
+  /**
+   * Optional authentication configuration for the remote agent.
+   * If not specified, the agent will try to use defaults based on the AgentCard's
+   * security requirements.
+   */
+  auth?: A2AAuthConfig;
 }
 
 export type AgentDefinition<TOutput extends z.ZodTypeAny = z.ZodUnknown> =


### PR DESCRIPTION
## Summary

Add client-side authentication configuration types for A2A remote agents, corresponding to the A2A protocol's SecurityScheme types.

## Details

- Add `auth-provider/types.ts` with auth config interfaces for all supported auth methods:
  - `google-credentials` (Google-specific) -- to be deleted in the future
  - `apiKey` (API Key in header/query/cookie)
  - `http` (Bearer/Basic auth)
  - `oauth2` (OAuth 2.0)
  - `openIdConnect` (OIDC)
- Add `A2AAuthProvider` interface extending the SDK's `AuthenticationHandler`
- Add optional `auth` field to `RemoteAgentDefinition` in `agents/types.ts`
- Types reference the A2A spec: https://a2a-protocol.org/latest/specification/#451-securityscheme

This is the base PR for the auth provider stack. Subsequent PRs will add the factory, providers, and integrations.

## Related Issues

Related to #18202

## How to Validate

1. `npm run build` - should pass
2. Review type definitions match A2A SecurityScheme spec

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker