### PR TITLE
fix: allow unqualified tool names in policy for qualified MCP tool calls

### DIFF
--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -335,7 +335,10 @@ export class PolicyEngine {
             ...toolCall,
             name: `${serverName}__${name}`,
           });
-        } else if (name.startsWith(`${serverName}__`)) {
+        } else if (
+          name.startsWith(`${serverName}__`) &&
+          name.split('__').length === 2
+        ) {
           const unqualifiedName = name.slice(serverName.length + 2);
           if (unqualifiedName) {
             toolCallsToTry.push({

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -329,11 +329,21 @@ export class PolicyEngine {
     const toolCallsToTry: FunctionCall[] = [];
     for (const name of toolNamesToTry) {
       toolCallsToTry.push({ ...toolCall, name });
-      if (serverName && !name.includes('__')) {
-        toolCallsToTry.push({
-          ...toolCall,
-          name: `${serverName}__${name}`,
-        });
+      if (serverName) {
+        if (!name.includes('__')) {
+          toolCallsToTry.push({
+            ...toolCall,
+            name: `${serverName}__${name}`,
+          });
+        } else if (name.startsWith(`${serverName}__`)) {
+          const unqualifiedName = name.slice(serverName.length + 2);
+          if (unqualifiedName) {
+            toolCallsToTry.push({
+              ...toolCall,
+              name: unqualifiedName,
+            });
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->   This PR fixes a regression where --allowed-tools failed in non-interactive mode for MCP and extension tools when the server prefix was omitted. I updated the PolicyEngine to automatically attempt matching against both qualified (server__tool) and unqualified (tool) names when a serverName is provided, ensuring consistent policy application across interactive and non-interactive modes.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). --> Fixes #16012 

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. --> Verified that PolicyEngine.check correctly matches a qualified tool call (e.g., craftMCP__notify_user) against an unqualified rule (e.g., notify_user) when the serverName is provided.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
