### PR TITLE
feat(ui): move user identity display to header

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -44,7 +44,6 @@ import {
   getErrorMessage,
   getAllGeminiMdFilenames,
   AuthType,
-  UserAccountManager,
   clearCachedCredentialFile,
   type ResumedSessionData,
   recordExitFail,
@@ -191,51 +190,6 @@ export const AppContainer = (props: AppContainerProps) => {
   const historyManager = useHistory({
     chatRecordingService: config.getGeminiClient()?.getChatRecordingService(),
   });
-  const { addItem } = historyManager;
-
-  const authCheckPerformed = useRef(false);
-  useEffect(() => {
-    if (authCheckPerformed.current) return;
-    authCheckPerformed.current = true;
-
-    if (resumedSessionData || settings.merged.ui.showUserIdentity === false) {
-      return;
-    }
-    const authType = config.getContentGeneratorConfig()?.authType;
-
-    // Run this asynchronously to avoid blocking the event loop.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    (async () => {
-      try {
-        const userAccountManager = new UserAccountManager();
-        const email = userAccountManager.getCachedGoogleAccount();
-        const tierName = config.getUserTierName();
-
-        if (authType) {
-          let message =
-            authType === AuthType.LOGIN_WITH_GOOGLE
-              ? email
-                ? `Logged in with Google: ${email}`
-                : 'Logged in with Google'
-              : `Authenticated with ${authType}`;
-          if (tierName) {
-            message += ` (Plan: ${tierName})`;
-          }
-          addItem({
-            type: MessageType.INFO,
-            text: message,
-          });
-        }
-      } catch (_e) {
-        // Ignore errors during initial auth check
-      }
-    })();
-  }, [
-    config,
-    resumedSessionData,
-    settings.merged.ui.showUserIdentity,
-    addItem,
-  ]);
 
   useMemoryMonitor(historyManager);
   const isAlternateBuffer = useAlternateBuffer();

--- a/packages/cli/src/ui/components/AppHeader.tsx
+++ b/packages/cli/src/ui/components/AppHeader.tsx
@@ -7,6 +7,7 @@
 import { Box } from 'ink';
 import { Header } from './Header.js';
 import { Tips } from './Tips.js';
+import { UserIdentity } from './UserIdentity.js';
 import { useSettings } from '../contexts/SettingsContext.js';
 import { useConfig } from '../contexts/ConfigContext.js';
 import { useUIState } from '../contexts/UIStateContext.js';
@@ -39,6 +40,9 @@ export const AppHeader = ({ version }: AppHeaderProps) => {
             />
           )}
         </>
+      )}
+      {settings.merged.ui.showUserIdentity !== false && (
+        <UserIdentity config={config} />
       )}
       {!(settings.merged.ui.hideTips || config.getScreenReader()) &&
         showTips && <Tips config={config} />}

--- a/packages/cli/src/ui/components/UserIdentity.test.tsx
+++ b/packages/cli/src/ui/components/UserIdentity.test.tsx
@@ -55,7 +55,7 @@ describe('<UserIdentity />', () => {
       () =>
         ({
           getCachedGoogleAccount: () => undefined,
-        }) as unknown as ContentGeneratorConfig,
+        }) as unknown as UserAccountManager,
     );
 
     const mockConfig = makeFakeConfig();

--- a/packages/cli/src/ui/components/UserIdentity.test.tsx
+++ b/packages/cli/src/ui/components/UserIdentity.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderWithProviders } from '../../test-utils/render.js';
+import { UserIdentity } from './UserIdentity.js';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  makeFakeConfig,
+  AuthType,
+  UserAccountManager,
+  type ContentGeneratorConfig,
+} from '@google/gemini-cli-core';
+
+// Mock UserAccountManager to control cached account
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...original,
+    UserAccountManager: vi.fn().mockImplementation(() => ({
+      getCachedGoogleAccount: () => 'test@example.com',
+    })),
+  };
+});
+
+describe('<UserIdentity />', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render login message and auth indicator', () => {
+    const mockConfig = makeFakeConfig();
+    vi.spyOn(mockConfig, 'getContentGeneratorConfig').mockReturnValue({
+      authType: AuthType.LOGIN_WITH_GOOGLE,
+      model: 'gemini-pro',
+    } as unknown as ContentGeneratorConfig);
+    vi.spyOn(mockConfig, 'getUserTierName').mockReturnValue(undefined);
+
+    const { lastFrame, unmount } = renderWithProviders(
+      <UserIdentity config={mockConfig} />,
+    );
+
+    const output = lastFrame();
+    expect(output).toContain('Logged in with Google: test@example.com');
+    expect(output).toContain('/auth');
+    unmount();
+  });
+
+  it('should render login message without colon if email is missing', () => {
+    // Modify the mock for this specific test
+    vi.mocked(UserAccountManager).mockImplementationOnce(
+      () =>
+        ({
+          getCachedGoogleAccount: () => undefined,
+        }) as unknown as ContentGeneratorConfig,
+    );
+
+    const mockConfig = makeFakeConfig();
+    vi.spyOn(mockConfig, 'getContentGeneratorConfig').mockReturnValue({
+      authType: AuthType.LOGIN_WITH_GOOGLE,
+      model: 'gemini-pro',
+    } as unknown as ContentGeneratorConfig);
+    vi.spyOn(mockConfig, 'getUserTierName').mockReturnValue(undefined);
+
+    const { lastFrame, unmount } = renderWithProviders(
+      <UserIdentity config={mockConfig} />,
+    );
+
+    const output = lastFrame();
+    expect(output).toContain('Logged in with Google');
+    expect(output).not.toContain('Logged in with Google:');
+    expect(output).toContain('/auth');
+    unmount();
+  });
+
+  it('should render plan name on a separate line if provided', () => {
+    const mockConfig = makeFakeConfig();
+    vi.spyOn(mockConfig, 'getContentGeneratorConfig').mockReturnValue({
+      authType: AuthType.LOGIN_WITH_GOOGLE,
+      model: 'gemini-pro',
+    } as unknown as ContentGeneratorConfig);
+    vi.spyOn(mockConfig, 'getUserTierName').mockReturnValue('Premium Plan');
+
+    const { lastFrame, unmount } = renderWithProviders(
+      <UserIdentity config={mockConfig} />,
+    );
+
+    const output = lastFrame();
+    expect(output).toContain('Logged in with Google: test@example.com');
+    expect(output).toContain('/auth');
+    expect(output).toContain('Plan: Premium Plan');
+
+    // Check for two lines (or more if wrapped, but here it should be separate)
+    const lines = output?.split('\n').filter((line) => line.trim().length > 0);
+    expect(lines?.some((line) => line.includes('Logged in with Google'))).toBe(
+      true,
+    );
+    expect(lines?.some((line) => line.includes('Plan: Premium Plan'))).toBe(
+      true,
+    );
+
+    unmount();
+  });
+
+  it('should not render if authType is missing', () => {
+    const mockConfig = makeFakeConfig();
+    vi.spyOn(mockConfig, 'getContentGeneratorConfig').mockReturnValue(
+      {} as unknown as ContentGeneratorConfig,
+    );
+
+    const { lastFrame, unmount } = renderWithProviders(
+      <UserIdentity config={mockConfig} />,
+    );
+
+    expect(lastFrame()).toBe('');
+    unmount();
+  });
+
+  it('should render non-Google auth message', () => {
+    const mockConfig = makeFakeConfig();
+    vi.spyOn(mockConfig, 'getContentGeneratorConfig').mockReturnValue({
+      authType: AuthType.USE_GEMINI,
+      model: 'gemini-pro',
+    } as unknown as ContentGeneratorConfig);
+    vi.spyOn(mockConfig, 'getUserTierName').mockReturnValue(undefined);
+
+    const { lastFrame, unmount } = renderWithProviders(
+      <UserIdentity config={mockConfig} />,
+    );
+
+    const output = lastFrame();
+    expect(output).toContain(`Authenticated with ${AuthType.USE_GEMINI}`);
+    expect(output).toContain('/auth');
+    unmount();
+  });
+});

--- a/packages/cli/src/ui/components/UserIdentity.tsx
+++ b/packages/cli/src/ui/components/UserIdentity.tsx
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box, Text } from 'ink';
+import { theme } from '../semantic-colors.js';
+import {
+  type Config,
+  UserAccountManager,
+  AuthType,
+} from '@google/gemini-cli-core';
+
+interface UserIdentityProps {
+  config: Config;
+}
+
+export const UserIdentity: React.FC<UserIdentityProps> = ({ config }) => {
+  const authType = config.getContentGeneratorConfig()?.authType;
+  if (!authType) {
+    return null;
+  }
+
+  const userAccountManager = new UserAccountManager();
+  const email = userAccountManager.getCachedGoogleAccount();
+  const tierName = config.getUserTierName();
+
+  return (
+    <Box marginY={1} flexDirection="column">
+      <Box>
+        <Text color={theme.text.primary}>
+          {authType === AuthType.LOGIN_WITH_GOOGLE ? (
+            <Text>
+              <Text bold>Logged in with Google{email ? ':' : ''}</Text>
+              {email ? ` ${email}` : ''}
+            </Text>
+          ) : (
+            `Authenticated with ${authType}`
+          )}
+        </Text>
+        <Text color={theme.text.secondary}> /auth</Text>
+      </Box>
+      {tierName && (
+        <Text color={theme.text.primary}>
+          <Text bold>Plan:</Text> {tierName}
+        </Text>
+      )}
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/UserIdentity.tsx
+++ b/packages/cli/src/ui/components/UserIdentity.tsx
@@ -5,6 +5,7 @@
  */
 
 import type React from 'react';
+import { useMemo } from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../semantic-colors.js';
 import {
@@ -19,13 +20,21 @@ interface UserIdentityProps {
 
 export const UserIdentity: React.FC<UserIdentityProps> = ({ config }) => {
   const authType = config.getContentGeneratorConfig()?.authType;
+
+  const { email, tierName } = useMemo(() => {
+    if (!authType) {
+      return { email: undefined, tierName: undefined };
+    }
+    const userAccountManager = new UserAccountManager();
+    return {
+      email: userAccountManager.getCachedGoogleAccount(),
+      tierName: config.getUserTierName(),
+    };
+  }, [config, authType]);
+
   if (!authType) {
     return null;
   }
-
-  const userAccountManager = new UserAccountManager();
-  const email = userAccountManager.getCachedGoogleAccount();
-  const tierName = config.getUserTierName();
 
   return (
     <Box marginY={1} flexDirection="column">

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -121,8 +121,8 @@ export async function setupUser(
       if (projectId) {
         return {
           projectId,
-          userTier: loadRes.currentTier.id,
-          userTierName: loadRes.currentTier.name,
+          userTier: loadRes.paidTier?.id ?? loadRes.currentTier.id,
+          userTierName: loadRes.paidTier?.name ?? loadRes.currentTier.name,
         };
       }
 
@@ -137,8 +137,8 @@ export async function setupUser(
     }
     return {
       projectId: loadRes.cloudaicompanionProject,
-      userTier: loadRes.currentTier.id,
-      userTierName: loadRes.currentTier.name,
+      userTier: loadRes.paidTier?.id ?? loadRes.currentTier.id,
+      userTierName: loadRes.paidTier?.name ?? loadRes.currentTier.name,
     };
   }
 

--- a/packages/core/src/code_assist/types.ts
+++ b/packages/core/src/code_assist/types.ts
@@ -53,6 +53,7 @@ export interface LoadCodeAssistResponse {
   allowedTiers?: GeminiUserTier[] | null;
   ineligibleTiers?: IneligibleTier[] | null;
   cloudaicompanionProject?: string | null;
+  paidTier?: GeminiUserTier | null;
 }
 
 /**
@@ -109,13 +110,17 @@ export enum IneligibleTierReasonCode {
 /**
  * UserTierId represents IDs returned from the Cloud Code Private API representing a user's tier
  *
- * //depot/google3/cloud/developer_experience/cloudcode/pa/service/usertier.go;l=16
+ * http://google3/cloud/developer_experience/codeassist/shared/usertier/tiers.go
+ * This is a subset of all available tiers. Since the source list is frequently updated,
+ * only add a tierId here if specific client-side handling is required.
  */
-export enum UserTierId {
-  FREE = 'free-tier',
-  LEGACY = 'legacy-tier',
-  STANDARD = 'standard-tier',
-}
+export const UserTierId = {
+  FREE: 'free-tier',
+  LEGACY: 'legacy-tier',
+  STANDARD: 'standard-tier',
+} as const;
+
+export type UserTierId = (typeof UserTierId)[keyof typeof UserTierId] | string;
 
 /**
  * PrivacyNotice reflects the structure received from the CodeAssist in regards to a tier

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1041,11 +1041,12 @@ export class Config {
   }
 
   getUserTier(): UserTierId | undefined {
-    return this.contentGenerator.userTier;
+    return this.contentGenerator?.userTier;
   }
 
   getUserTierName(): string | undefined {
-    return this.contentGenerator.userTierName;
+    // TODO(#1275): Re-enable user tier display when ready.
+    return undefined;
   }
 
   /**

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1041,12 +1041,11 @@ export class Config {
   }
 
   getUserTier(): UserTierId | undefined {
-    return this.contentGenerator?.userTier;
+    return this.contentGenerator.userTier;
   }
 
   getUserTierName(): string | undefined {
-    // TODO(#1275): Re-enable user tier display when ready.
-    return undefined;
+    return this.contentGenerator.userTierName;
   }
 
   /**


### PR DESCRIPTION
## Summary

Moves the user identity and plan display from the chat history logs to a indicator in the application header. Using the chat history with info looked to be a bit alarming.

## Details
<img width="581" height="215" alt="image" src="https://github.com/user-attachments/assets/adc2fa03-4a7a-4b16-90c7-e1736502f946" />

- **UserIdentity Component**: Created a new `UserIdentity` component in the CLI UI that displays the logged-in email and the current plan (if applicable).
- **AppHeader**: Integrated `UserIdentity` into `AppHeader`.
- **AppContainer**: Removed the `useEffect` that was previously logging this information to the chat console.
- **Core Updates**:
    - Updated `UserTierId` to be an extensible constant instead of a closed enum.
    - Updated `setupUser` to correctly prioritize `paidTier` information from the backend.
    - Exposed `getUserTierName` in `Config`.

## Related Issues
related to https://github.com/google-gemini/maintainers-gemini-cli/issues/1275
<!-- None explicitly mentioned, but this improves UX -->

## How to Validate

1.  **Login**: Run `gemini auth login` to authenticate with a Google account.
2.  **Start CLI**: Run `gemini chat`.
3.  **Verify Header**: Check the top right (or relevant header area) of the terminal UI. You should see "Logged in with Google: <your-email>" and optionally your plan name.
4.  **Verify Chat Logs**: Ensure the "Logged in with Google..." message no longer appears as a chat message in the history upon startup.
5.  **Unauthenticated**: Log out (`gemini auth logout`) or use an API key. Verify the header updates accordingly.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
  - [ ] Linux
