### PR TITLE
chore(core): explicitly state plan storage path in prompt

### DIFF
--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -176,7 +176,8 @@ The following read-only tools are available in Plan Mode:
 - \`write_file\` - Save plans to the plans directory (see Plan Storage below)
 
 ## Plan Storage
-- Save your plans as Markdown (.md) files directly to: \`/tmp/project-temp/plans/\`
+- Save your plans as Markdown (.md) files ONLY within: \`/tmp/project-temp/plans/\`
+- You are restricted to writing files within this directory while in Plan Mode.
 - Use descriptive filenames: \`feature-name.md\` or \`bugfix-description.md\`
 
 ## Workflow Phases

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -305,7 +305,8 @@ ${options.planModeToolsList}
 - \`${WRITE_FILE_TOOL_NAME}\` - Save plans to the plans directory (see Plan Storage below)
 
 ## Plan Storage
-- Save your plans as Markdown (.md) files directly to: \`${options.plansDir}/\`
+- Save your plans as Markdown (.md) files ONLY within: \`${options.plansDir}/\`
+- You are restricted to writing files within this directory while in Plan Mode.
 - Use descriptive filenames: \`feature-name.md\` or \`bugfix-description.md\`
 
 ## Workflow Phases

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -53,6 +53,7 @@ export class ExitPlanModeTool extends BaseDeclarativeTool<
     private config: Config,
     messageBus: MessageBus,
   ) {
+    const plansDir = config.storage.getProjectTempPlansDir();
     super(
       EXIT_PLAN_MODE_TOOL_NAME,
       'Exit Plan Mode',
@@ -64,8 +65,7 @@ export class ExitPlanModeTool extends BaseDeclarativeTool<
         properties: {
           plan_path: {
             type: 'string',
-            description:
-              'The file path to the finalized plan (e.g., "plans/feature-x.md").',
+            description: `The file path to the finalized plan (e.g., "${plansDir}/feature-x.md"). This path MUST be within the designated plans directory: ${plansDir}/`,
           },
         },
       },


### PR DESCRIPTION
## Summary

Explicitly state the plan storage path in the system prompt and tool descriptions to improve agent performance and reduce retry loops.

## Details

While the codebase programmatically enforces plan storage in the designated temporary directory, the agent sometimes attempts to save plans elsewhere (e.g., the project root). This PR provides the agent with the correct path upfront:
- Updates `renderApprovalModePlan` in `snippets.ts` with explicit instructions.
- Dynamically includes the actual `plansDir` in the `ExitPlanModeTool` parameter description.
- Updates the prompt snapshot to reflect these changes.

## Related Issues

Closes #18221

## How to Validate

1. Enter Plan Mode.
2. Observe the system prompt (can be inspected via debug logs or by asking the agent).
3. Check the `exit-plan-mode` tool definition to ensure it shows the correct absolute path for the current session.
4. Run tests: `npm test -w @google/gemini-cli-core -- src/tools/exit-plan-mode.test.ts src/core/prompts.test.ts`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
