### PR TITLE
Add OTLP headers for telemetry

### DIFF
--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -83,6 +83,7 @@ Environment variables can be used to override the settings in the file.
 | `target`       | `GEMINI_TELEMETRY_TARGET`        | Where to send telemetry data                        | `"gcp"`/`"local"` | `"local"`               |
 | `otlpEndpoint` | `GEMINI_TELEMETRY_OTLP_ENDPOINT` | OTLP collector endpoint                             | URL string        | `http://localhost:4317` |
 | `otlpProtocol` | `GEMINI_TELEMETRY_OTLP_PROTOCOL` | OTLP transport protocol                             | `"grpc"`/`"http"` | `"grpc"`                |
+| `otlpHeaders`  | `GEMINI_TELEMETRY_OTLP_HEADERS`  | Custom headers for OTLP requests (for auth)         | object/string     | -                       |
 | `outfile`      | `GEMINI_TELEMETRY_OUTFILE`       | Save telemetry to file (overrides `otlpEndpoint`)   | file path         | -                       |
 | `logPrompts`   | `GEMINI_TELEMETRY_LOG_PROMPTS`   | Include prompts in telemetry logs                   | `true`/`false`    | `true`                  |
 | `useCollector` | `GEMINI_TELEMETRY_USE_COLLECTOR` | Use external OTLP collector (advanced)              | `true`/`false`    | `false`                 |

--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -93,6 +93,38 @@ Environment variables can be used to override the settings in the file.
 `logPrompts`, `useCollector`), setting the corresponding environment variable to
 `true` or `1` will enable the feature. Any other value will disable it.
 
+### OTLP Headers
+
+The `otlpHeaders` setting allows you to send custom headers with OTLP telemetry
+requests. This is useful for authenticating with secured OTLP collectors that
+require API keys, bearer tokens, or other credentials.
+
+**Configuration precedence:** Headers are merged from multiple sources in the
+following order, with later sources overriding earlier ones for the same header
+key:
+
+1. `settings.json` (lowest precedence)
+2. `GEMINI_TELEMETRY_OTLP_HEADERS` environment variable
+3. `--telemetry-otlp-header` CLI flags (highest precedence)
+
+This allows you to set base headers in settings while overriding specific values
+via environment variables or CLI flags when needed.
+
+**Format options:**
+
+- **JSON format:** `{"Authorization": "Bearer token", "x-api-key": "abc123"}`
+- **Key=value pairs:** `Authorization=Bearer token,x-api-key=abc123`
+- **Environment variable reference:** Values can reference environment variables
+  using `$VAR_NAME` or `${VAR_NAME}` syntax.
+
+**Token expiry considerations:** OTLP headers are read once when the CLI starts.
+If your authentication tokens expire during a long-running session, you will
+need to restart the CLI to refresh them. For long-running sessions, consider:
+
+- Using non-expiring API keys when possible
+- Using service account credentials instead of short-lived tokens
+- Restarting the CLI periodically to refresh credentials
+
 For detailed information about all configuration options, see the
 [Configuration guide](../get-started/configuration.md).
 

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -1053,9 +1053,8 @@ see [Telemetry](../cli/telemetry.md).
   - **`target`** (string): The destination for collected telemetry. Supported
     values are `local` and `gcp`.
   - **`otlpEndpoint`** (string): The endpoint for the OTLP Exporter.
-  - **`otlpProtocol`** (string): The protocol for the OTLP Exporter (`grpc` or
-    `http`).
-  - **`logPrompts`** (boolean): Whether or not to include the content of user
+  - **`otlpProtocol`** (string): The protocol for the OTLP Exporter (`grpc` or `http`). Defaults to `grpc`.
+  - **`otlpHeaders`** (object): Custom headers to send with OTLP telemetry requests. Useful for authentication (e.g., API keys, bearer tokens). Values can reference environment variables using `$VAR_NAME` or `${VAR_NAME}` syntax.  - **`logPrompts`** (boolean): Whether or not to include the content of user
     prompts in the logs.
   - **`outfile`** (string): The file to write telemetry to when `target` is
     `local`.
@@ -1105,6 +1104,11 @@ of v0.3.0:
     "enabled": true,
     "target": "local",
     "otlpEndpoint": "http://localhost:4317",
+     "otlpProtocol": "http",
+    "otlpHeaders": {
+      "Authorization": "Bearer ${MY_TOKEN}",
+      "x-api-key": "abc123"
+    },
     "logPrompts": true
   },
   "privacy": {
@@ -1223,6 +1227,11 @@ the `advanced.excludedEnvVars` setting in your `settings.json` file.
 - **`GEMINI_TELEMETRY_OTLP_PROTOCOL`**:
   - Sets the OTLP protocol (`grpc` or `http`).
   - Overrides the `telemetry.otlpProtocol` setting.
+- **`GEMINI_TELEMETRY_OTLP_HEADERS`**:
+  - Custom headers to send with OTLP telemetry requests. Can be specified in JSON format or as comma/semicolon-delimited `key=value` pairs.
+  - Useful for authentication with secured OTLP collectors (e.g., API keys, bearer tokens).
+  - JSON format example: `export GEMINI_TELEMETRY_OTLP_HEADERS='{"Authorization":"Bearer token","x-api-key":"abc123"}'`
+  - Delimiter format example: `export GEMINI_TELEMETRY_OTLP_HEADERS='Authorization=Bearer token,x-api-key=abc123'`
 - **`GEMINI_TELEMETRY_LOG_PROMPTS`**:
   - Set to `true` or `1` to enable or disable logging of user prompts. Any other
     value is treated as disabling it.
@@ -1378,6 +1387,25 @@ for that specific session.
   - A comma-separated list of tool names that will bypass the confirmation
     dialog.
   - Example: `gemini --allowed-tools "ShellTool(git status)"`
+- **`--telemetry`**:
+  - Enables [telemetry](../cli/telemetry.md).
+- **`--telemetry-target`**:
+  - Sets the telemetry target. See [telemetry](../cli/telemetry.md) for more
+    information.
+- **`--telemetry-otlp-endpoint`**:
+  - Sets the OTLP endpoint for telemetry. See [telemetry](../cli/telemetry.md)
+    for more information.
+- **`--telemetry-otlp-protocol`**:
+  - Sets the OTLP protocol for telemetry (`grpc` or `http`). Defaults to `grpc`.
+    See [telemetry](../cli/telemetry.md) for more information.
+- **`--telemetry-otlp-header <key=value>`**:
+  - Adds a custom OTLP header in `key=value` format. Can be specified multiple times to add multiple headers. Useful for authentication (e.g., `--telemetry-otlp-header "Authorization=Bearer token"`).
+  - Example: `gemini --telemetry --telemetry-otlp-header "Authorization=Bearer xyz" --telemetry-otlp-header "x-api-key=abc123"`
+- **`--telemetry-log-prompts`**:
+  - Enables logging of prompts for telemetry. See
+    [telemetry](../cli/telemetry.md) for more information.
+- **`--checkpointing`**:
+  - Enables [checkpointing](../cli/checkpointing.md).
 - **`--extensions <extension_name ...>`** (**`-e <extension_name ...>`**):
   - Specifies a list of extensions to use for the session. If not provided, all
     available extensions are used.

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -1053,9 +1053,13 @@ see [Telemetry](../cli/telemetry.md).
   - **`target`** (string): The destination for collected telemetry. Supported
     values are `local` and `gcp`.
   - **`otlpEndpoint`** (string): The endpoint for the OTLP Exporter.
-  - **`otlpProtocol`** (string): The protocol for the OTLP Exporter (`grpc` or `http`). Defaults to `grpc`.
-  - **`otlpHeaders`** (object): Custom headers to send with OTLP telemetry requests. Useful for authentication (e.g., API keys, bearer tokens). Values can reference environment variables using `$VAR_NAME` or `${VAR_NAME}` syntax.  - **`logPrompts`** (boolean): Whether or not to include the content of user
-    prompts in the logs.
+  - **`otlpProtocol`** (string): The protocol for the OTLP Exporter (`grpc` or
+    `http`). Defaults to `grpc`.
+  - **`otlpHeaders`** (object): Custom headers to send with OTLP telemetry
+    requests. Useful for authentication (e.g., API keys, bearer tokens). Values
+    can reference environment variables using `$VAR_NAME` or `${VAR_NAME}`
+    syntax. - **`logPrompts`** (boolean): Whether or not to include the content
+    of user prompts in the logs.
   - **`outfile`** (string): The file to write telemetry to when `target` is
     `local`.
   - **`useCollector`** (boolean): Whether to use an external OTLP collector.
@@ -1104,7 +1108,7 @@ of v0.3.0:
     "enabled": true,
     "target": "local",
     "otlpEndpoint": "http://localhost:4317",
-     "otlpProtocol": "http",
+    "otlpProtocol": "http",
     "otlpHeaders": {
       "Authorization": "Bearer ${MY_TOKEN}",
       "x-api-key": "abc123"
@@ -1228,10 +1232,14 @@ the `advanced.excludedEnvVars` setting in your `settings.json` file.
   - Sets the OTLP protocol (`grpc` or `http`).
   - Overrides the `telemetry.otlpProtocol` setting.
 - **`GEMINI_TELEMETRY_OTLP_HEADERS`**:
-  - Custom headers to send with OTLP telemetry requests. Can be specified in JSON format or as comma/semicolon-delimited `key=value` pairs.
-  - Useful for authentication with secured OTLP collectors (e.g., API keys, bearer tokens).
-  - JSON format example: `export GEMINI_TELEMETRY_OTLP_HEADERS='{"Authorization":"Bearer token","x-api-key":"abc123"}'`
-  - Delimiter format example: `export GEMINI_TELEMETRY_OTLP_HEADERS='Authorization=Bearer token,x-api-key=abc123'`
+  - Custom headers to send with OTLP telemetry requests. Can be specified in
+    JSON format or as comma/semicolon-delimited `key=value` pairs.
+  - Useful for authentication with secured OTLP collectors (e.g., API keys,
+    bearer tokens).
+  - JSON format example:
+    `export GEMINI_TELEMETRY_OTLP_HEADERS='{"Authorization":"Bearer token","x-api-key":"abc123"}'`
+  - Delimiter format example:
+    `export GEMINI_TELEMETRY_OTLP_HEADERS='Authorization=Bearer token,x-api-key=abc123'`
 - **`GEMINI_TELEMETRY_LOG_PROMPTS`**:
   - Set to `true` or `1` to enable or disable logging of user prompts. Any other
     value is treated as disabling it.
@@ -1399,8 +1407,11 @@ for that specific session.
   - Sets the OTLP protocol for telemetry (`grpc` or `http`). Defaults to `grpc`.
     See [telemetry](../cli/telemetry.md) for more information.
 - **`--telemetry-otlp-header <key=value>`**:
-  - Adds a custom OTLP header in `key=value` format. Can be specified multiple times to add multiple headers. Useful for authentication (e.g., `--telemetry-otlp-header "Authorization=Bearer token"`).
-  - Example: `gemini --telemetry --telemetry-otlp-header "Authorization=Bearer xyz" --telemetry-otlp-header "x-api-key=abc123"`
+  - Adds a custom OTLP header in `key=value` format. Can be specified multiple
+    times to add multiple headers. Useful for authentication (e.g.,
+    `--telemetry-otlp-header "Authorization=Bearer token"`).
+  - Example:
+    `gemini --telemetry --telemetry-otlp-header "Authorization=Bearer xyz" --telemetry-otlp-header "x-api-key=abc123"`
 - **`--telemetry-log-prompts`**:
   - Enables logging of prompts for telemetry. See
     [telemetry](../cli/telemetry.md) for more information.

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -866,7 +866,6 @@ describe('Server Config (config.ts)', () => {
       expect(config.getTelemetryOtlpProtocol()).toBe('grpc');
     });
 
-
     it('should return provided OTLP headers', () => {
       const headers = {
         Authorization: 'Bearer token',

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -865,6 +865,36 @@ describe('Server Config (config.ts)', () => {
       const config = new Config(paramsWithoutTelemetry);
       expect(config.getTelemetryOtlpProtocol()).toBe('grpc');
     });
+
+
+    it('should return provided OTLP headers', () => {
+      const headers = {
+        Authorization: 'Bearer token',
+        'x-api-key': 'abc123',
+      };
+      const params: ConfigParameters = {
+        ...baseParams,
+        telemetry: { enabled: true, otlpHeaders: headers },
+      };
+      const config = new Config(params);
+      expect(config.getTelemetryOtlpHeaders()).toEqual(headers);
+    });
+
+    it('should return empty object for OTLP headers if not provided', () => {
+      const params: ConfigParameters = {
+        ...baseParams,
+        telemetry: { enabled: true },
+      };
+      const config = new Config(params);
+      expect(config.getTelemetryOtlpHeaders()).toEqual({});
+    });
+
+    it('should return empty object for OTLP headers if telemetry object is not provided', () => {
+      const paramsWithoutTelemetry: ConfigParameters = { ...baseParams };
+      delete paramsWithoutTelemetry.telemetry;
+      const config = new Config(paramsWithoutTelemetry);
+      expect(config.getTelemetryOtlpHeaders()).toEqual({});
+    });
   });
 
   describe('UseRipgrep Configuration', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -138,6 +138,7 @@ export interface TelemetrySettings {
   target?: TelemetryTarget;
   otlpEndpoint?: string;
   otlpProtocol?: 'grpc' | 'http';
+  otlpHeaders?: Record<string, string>;
   logPrompts?: boolean;
   outfile?: string;
   useCollector?: boolean;
@@ -667,6 +668,7 @@ export class Config {
       target: params.telemetry?.target ?? DEFAULT_TELEMETRY_TARGET,
       otlpEndpoint: params.telemetry?.otlpEndpoint ?? DEFAULT_OTLP_ENDPOINT,
       otlpProtocol: params.telemetry?.otlpProtocol,
+      otlpHeaders: params.telemetry?.otlpHeaders,
       logPrompts: params.telemetry?.logPrompts ?? true,
       outfile: params.telemetry?.outfile,
       useCollector: params.telemetry?.useCollector,
@@ -1557,8 +1559,12 @@ export class Config {
     return this.telemetrySettings.useCollector ?? false;
   }
 
-  getTelemetryUseCliAuth(): boolean {
+getTelemetryUseCliAuth(): boolean {
     return this.telemetrySettings.useCliAuth ?? false;
+  }
+
+  getTelemetryOtlpHeaders(): Record<string, string> {
+    return this.telemetrySettings.otlpHeaders ?? {};
   }
 
   getGeminiClient(): GeminiClient {

--- a/packages/core/src/telemetry/config.test.ts
+++ b/packages/core/src/telemetry/config.test.ts
@@ -246,6 +246,283 @@ describe('telemetry/config helpers', () => {
       const result = parseOtlpHeaders('{invalid json}');
       expect(result).toBeUndefined();
     });
+
+    it('handles single key=value pair with comma in value (unquoted)', async () => {
+      const result = parseOtlpHeaders('Accept=text/html,application/xhtml+xml');
+      expect(result).toEqual({
+        Accept: 'text/html,application/xhtml+xml',
+      });
+    });
+
+    it('handles quoted values with commas using double quotes', async () => {
+      const result = parseOtlpHeaders(
+        'Accept="text/html,application/xhtml+xml",Authorization=Bearer token',
+      );
+      expect(result).toEqual({
+        Accept: 'text/html,application/xhtml+xml',
+        Authorization: 'Bearer token',
+      });
+    });
+
+    it('handles quoted values with commas using single quotes', async () => {
+      const result = parseOtlpHeaders(
+        "Accept='text/html,application/xhtml+xml',Authorization=Bearer token",
+      );
+      expect(result).toEqual({
+        Accept: 'text/html,application/xhtml+xml',
+        Authorization: 'Bearer token',
+      });
+    });
+
+    it('handles quoted values with semicolons', async () => {
+      const result = parseOtlpHeaders(
+        'Cache-Control="max-age=3600; must-revalidate",Authorization=Bearer token',
+      );
+      expect(result).toEqual({
+        'Cache-Control': 'max-age=3600; must-revalidate',
+        Authorization: 'Bearer token',
+      });
+    });
+
+    it('handles multiple quoted values', async () => {
+      const result = parseOtlpHeaders(
+        'Accept="text/html,application/json",Cache-Control="no-cache, no-store",Authorization=Bearer token',
+      );
+      expect(result).toEqual({
+        Accept: 'text/html,application/json',
+        'Cache-Control': 'no-cache, no-store',
+        Authorization: 'Bearer token',
+      });
+    });
+
+    it('handles mixed quoted and unquoted values', async () => {
+      const result = parseOtlpHeaders(
+        'key1=simple,key2="complex, value",key3=another',
+      );
+      expect(result).toEqual({
+        key1: 'simple',
+        key2: 'complex, value',
+        key3: 'another',
+      });
+    });
+
+    it('handles values with both commas and semicolons in quotes', async () => {
+      const result = parseOtlpHeaders('Complex="value,with;both",Simple=plain');
+      expect(result).toEqual({
+        Complex: 'value,with;both',
+        Simple: 'plain',
+      });
+    });
+
+    it('handles trailing commas', async () => {
+      const result = parseOtlpHeaders('key1=value1,key2=value2,');
+      expect(result).toEqual({
+        key1: 'value1',
+        key2: 'value2',
+      });
+    });
+
+    it('handles leading commas', async () => {
+      const result = parseOtlpHeaders(',key1=value1,key2=value2');
+      expect(result).toEqual({
+        key1: 'value1',
+        key2: 'value2',
+      });
+    });
+
+    it('handles consecutive delimiters', async () => {
+      const result = parseOtlpHeaders('key1=value1,,key2=value2;;key3=value3');
+      expect(result).toEqual({
+        key1: 'value1',
+        key2: 'value2',
+        key3: 'value3',
+      });
+    });
+
+    it('handles values with equals signs in quotes', async () => {
+      const result = parseOtlpHeaders('Math="x=y+z",key2=value2');
+      expect(result).toEqual({
+        Math: 'x=y+z',
+        key2: 'value2',
+      });
+    });
+
+    it('handles empty quoted values', async () => {
+      const result = parseOtlpHeaders('key1="",key2=value2');
+      expect(result).toEqual({
+        key2: 'value2',
+      });
+    });
+
+    it('handles whitespace around quoted values', async () => {
+      const result = parseOtlpHeaders('  key1 = "value1" , key2="value2"  ');
+      expect(result).toEqual({
+        key1: 'value1',
+        key2: 'value2',
+      });
+    });
+
+    it('handles real-world Accept header example with quotes', async () => {
+      const result = parseOtlpHeaders(
+        'Accept="text/html,application/xhtml+xml,application/xml;q=0.9"',
+      );
+      expect(result).toEqual({
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9',
+      });
+    });
+
+    it('handles real-world Cache-Control header example with quotes', async () => {
+      const result = parseOtlpHeaders(
+        'Cache-Control="public, max-age=31536000, immutable"',
+      );
+      expect(result).toEqual({
+        'Cache-Control': 'public, max-age=31536000, immutable',
+      });
+    });
+
+    it('handles simple Accept header without quotes', async () => {
+      const result = parseOtlpHeaders('Accept=application/json');
+      expect(result).toEqual({
+        Accept: 'application/json',
+      });
+    });
+
+    it('handles Authorization header without quotes', async () => {
+      const result = parseOtlpHeaders('Authorization=Bearer token123');
+      expect(result).toEqual({
+        Authorization: 'Bearer token123',
+      });
+    });
+
+    // Security and validation tests
+
+    it('rejects header names with invalid characters', async () => {
+      expect(parseOtlpHeaders('Bad Header=value')).toBeUndefined(); // space
+      expect(parseOtlpHeaders('Bad:Header=value')).toBeUndefined(); // colon
+      expect(parseOtlpHeaders('Bad(Header)=value')).toBeUndefined(); // parens
+      expect(parseOtlpHeaders('Bad<Header>=value')).toBeUndefined(); // angle brackets
+    });
+
+    it('accepts valid header names with allowed special characters', async () => {
+      const result = parseOtlpHeaders(
+        'X-Custom-Header=value,X-API_Key=abc,Content-Type=json',
+      );
+      expect(result).toEqual({
+        'X-Custom-Header': 'value',
+        'X-API_Key': 'abc',
+        'Content-Type': 'json',
+      });
+    });
+
+    it('rejects header values with control characters', async () => {
+      expect(parseOtlpHeaders('Header=value\nwith\nnewlines')).toBeUndefined();
+      expect(parseOtlpHeaders('Header=value\rwith\rcarriage')).toBeUndefined();
+      expect(parseOtlpHeaders('Header=value\x00null')).toBeUndefined();
+    });
+
+    it('allows tabs in header values', async () => {
+      const result = parseOtlpHeaders('Header=value\twith\ttabs');
+      expect(result).toEqual({
+        Header: 'value\twith\ttabs',
+      });
+    });
+
+    it('rejects values exceeding maximum length', async () => {
+      const longValue = 'x'.repeat(9000);
+      const result = parseOtlpHeaders(`Header=${longValue}`);
+      expect(result).toBeUndefined();
+    });
+
+    it('accepts values at maximum length', async () => {
+      const maxValue = 'x'.repeat(8192);
+      const result = parseOtlpHeaders(`Header=${maxValue}`);
+      expect(result).toEqual({
+        Header: maxValue,
+      });
+    });
+
+    it('rejects unclosed double quotes', async () => {
+      expect(parseOtlpHeaders('Header="unclosed')).toBeUndefined();
+      expect(
+        parseOtlpHeaders('Header1="closed",Header2="unclosed'),
+      ).toBeUndefined();
+    });
+
+    it('rejects unclosed single quotes', async () => {
+      expect(parseOtlpHeaders("Header='unclosed")).toBeUndefined();
+      expect(
+        parseOtlpHeaders("Header1='closed',Header2='unclosed"),
+      ).toBeUndefined();
+    });
+
+    it('handles escaped quotes within quoted values', async () => {
+      const result = parseOtlpHeaders('Message="He said \\"hello\\""');
+      expect(result).toEqual({
+        Message: 'He said "hello"',
+      });
+    });
+
+    it('handles escaped backslashes', async () => {
+      const result = parseOtlpHeaders('Path="C:\\\\Program Files\\\\app"');
+      expect(result).toEqual({
+        Path: 'C:\\Program Files\\app',
+      });
+    });
+
+    it('handles mixed escape sequences', async () => {
+      const result = parseOtlpHeaders(
+        'Complex="quotes\\"and\\\\backslashes\\\\and,commas"',
+      );
+      expect(result).toEqual({
+        Complex: 'quotes"and\\backslashes\\and,commas',
+      });
+    });
+
+    it('enforces maximum header count', async () => {
+      // Create 101 headers (exceeds limit of 100)
+      const headers = Array.from(
+        { length: 101 },
+        (_, i) => `Header${i}=value${i}`,
+      ).join(',');
+      const result = parseOtlpHeaders(headers);
+      expect(result).toBeUndefined();
+    });
+
+    it('accepts maximum header count', async () => {
+      // Create exactly 100 headers (at the limit)
+      const headers = Array.from(
+        { length: 100 },
+        (_, i) => `Header${i}=value${i}`,
+      ).join(',');
+      const result = parseOtlpHeaders(headers);
+      expect(result).toBeDefined();
+      expect(Object.keys(result ?? {}).length).toBe(100);
+    });
+
+    it('validates JSON header names and values', async () => {
+      const result = parseOtlpHeaders(
+        '{"Valid-Header":"value","Bad Header":"value2"}',
+      );
+      // Should only include the valid header
+      expect(result).toEqual({
+        'Valid-Header': 'value',
+      });
+    });
+
+    it('rejects JSON with control characters in values', async () => {
+      const result = parseOtlpHeaders('{"Header":"value\\nwith\\nnewlines"}');
+      expect(result).toBeUndefined();
+    });
+
+    it('handles empty header name', async () => {
+      expect(parseOtlpHeaders('=value')).toBeUndefined();
+      expect(parseOtlpHeaders('  =value')).toBeUndefined();
+    });
+
+    it('handles empty header value after unquoting', async () => {
+      expect(parseOtlpHeaders('Header=""')).toBeUndefined();
+      expect(parseOtlpHeaders("Header=''")).toBeUndefined();
+    });
   });
 
   describe('resolveTelemetrySettings with headers', () => {

--- a/packages/core/src/telemetry/config.test.ts
+++ b/packages/core/src/telemetry/config.test.ts
@@ -9,6 +9,7 @@ import {
   parseBooleanEnvFlag,
   parseTelemetryTargetValue,
   resolveTelemetrySettings,
+  parseOtlpHeaders,
 } from './config.js';
 import { TelemetryTarget } from './index.js';
 
@@ -178,6 +179,146 @@ describe('telemetry/config helpers', () => {
       await expect(resolveTelemetrySettings({ env })).rejects.toThrow(
         /Invalid telemetry target/i,
       );
+    });
+  });
+
+  describe('parseOtlpHeaders', () => {
+    it('returns undefined for empty or undefined values', async () => {
+      expect(parseOtlpHeaders(undefined)).toBeUndefined();
+      expect(parseOtlpHeaders('')).toBeUndefined();
+      expect(parseOtlpHeaders('   ')).toBeUndefined();
+    });
+
+    it('parses JSON format', async () => {
+      const result = parseOtlpHeaders(
+        '{"Authorization":"Bearer token","x-api-key":"abc123"}',
+      );
+      expect(result).toEqual({
+        Authorization: 'Bearer token',
+        'x-api-key': 'abc123',
+      });
+    });
+
+    it('parses comma-delimited key=value pairs', async () => {
+      const result = parseOtlpHeaders(
+        'Authorization=Bearer token,x-api-key=abc123',
+      );
+      expect(result).toEqual({
+        Authorization: 'Bearer token',
+        'x-api-key': 'abc123',
+      });
+    });
+
+    it('parses semicolon-delimited key=value pairs', async () => {
+      const result = parseOtlpHeaders(
+        'Authorization=Bearer token; x-api-key=abc123',
+      );
+      expect(result).toEqual({
+        Authorization: 'Bearer token',
+        'x-api-key': 'abc123',
+      });
+    });
+
+    it('ignores malformed pairs', async () => {
+      const result = parseOtlpHeaders('Good=Yes,BadPair,Another=Ok');
+      expect(result).toEqual({
+        Good: 'Yes',
+        Another: 'Ok',
+      });
+    });
+
+    it('ignores empty keys or values', async () => {
+      const result = parseOtlpHeaders('=value,key=,valid=yes');
+      expect(result).toEqual({
+        valid: 'yes',
+      });
+    });
+
+    it('handles whitespace in key=value format', async () => {
+      const result = parseOtlpHeaders('  key1 = value1  ,  key2=value2  ');
+      expect(result).toEqual({
+        key1: 'value1',
+        key2: 'value2',
+      });
+    });
+
+    it('returns undefined for invalid JSON', async () => {
+      const result = parseOtlpHeaders('{invalid json}');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('resolveTelemetrySettings with headers', () => {
+    it('merges headers from settings, env, and argv with correct precedence', async () => {
+      const settings = {
+        otlpHeaders: {
+          header1: 'from-settings',
+          header2: 'from-settings',
+        },
+      };
+      const env = {
+        GEMINI_TELEMETRY_OTLP_HEADERS:
+          '{"header2":"from-env","header3":"from-env"}',
+      } as Record<string, string>;
+      const argv = {
+        telemetryOtlpHeader: ['header3=from-argv', 'header4=from-argv'],
+      };
+
+      const resolved = await resolveTelemetrySettings({ argv, env, settings });
+      expect(resolved.otlpHeaders).toEqual({
+        header1: 'from-settings',
+        header2: 'from-env',
+        header3: 'from-argv',
+        header4: 'from-argv',
+      });
+    });
+
+    it('returns undefined otlpHeaders when none are provided', async () => {
+      const resolved = await resolveTelemetrySettings({});
+      expect(resolved.otlpHeaders).toBeUndefined();
+    });
+
+    it('handles headers from settings only', async () => {
+      const settings = {
+        otlpHeaders: {
+          Authorization: 'Bearer token',
+        },
+      };
+      const resolved = await resolveTelemetrySettings({ settings });
+      expect(resolved.otlpHeaders).toEqual({
+        Authorization: 'Bearer token',
+      });
+    });
+
+    it('handles headers from env only with JSON format', async () => {
+      const env = {
+        GEMINI_TELEMETRY_OTLP_HEADERS: '{"x-api-key":"abc123"}',
+      } as Record<string, string>;
+      const resolved = await resolveTelemetrySettings({ env });
+      expect(resolved.otlpHeaders).toEqual({
+        'x-api-key': 'abc123',
+      });
+    });
+
+    it('handles headers from env only with comma-delimited format', async () => {
+      const env = {
+        GEMINI_TELEMETRY_OTLP_HEADERS: 'Authorization=Bearer XYZ,x-api-key=abc',
+      } as Record<string, string>;
+      const resolved = await resolveTelemetrySettings({ env });
+      expect(resolved.otlpHeaders).toEqual({
+        Authorization: 'Bearer XYZ',
+        'x-api-key': 'abc',
+      });
+    });
+
+    it('handles headers from argv only', async () => {
+      const argv = {
+        telemetryOtlpHeader: ['Authorization=Bearer token'],
+      };
+      const resolved = await resolveTelemetrySettings({ argv });
+      expect(resolved.otlpHeaders).toEqual({
+        Authorization: 'Bearer token',
+      });
     });
   });
 });

--- a/packages/core/src/telemetry/config.test.ts
+++ b/packages/core/src/telemetry/config.test.ts
@@ -509,6 +509,14 @@ describe('telemetry/config helpers', () => {
       });
     });
 
+    it('rejects JSON with empty string values', async () => {
+      const result = parseOtlpHeaders('{"Header":"","Valid":"value"}');
+      // Should only include the header with a non-empty value
+      expect(result).toEqual({
+        Valid: 'value',
+      });
+    });
+
     it('rejects JSON with control characters in values', async () => {
       const result = parseOtlpHeaders('{"Header":"value\\nwith\\nnewlines"}');
       expect(result).toBeUndefined();

--- a/packages/core/src/telemetry/config.ts
+++ b/packages/core/src/telemetry/config.ts
@@ -66,7 +66,9 @@ export function parseOtlpHeaders(
         return Object.keys(result).length > 0 ? result : undefined;
       }
     } catch {
-      // Fall through to delimiter parsing
+      // It looked like JSON but failed to parse, so we assume it's invalid.
+      return undefined;
+
     }
   }
 

--- a/packages/core/src/telemetry/config.ts
+++ b/packages/core/src/telemetry/config.ts
@@ -90,7 +90,7 @@ const isValidHeaderValue = (value: string): boolean => {
   }
   // RFC 7230: No control characters except tab
   // eslint-disable-next-line no-control-regex
-  return !/[\x00-\x08\x0A-\x1F\x7F]/.test(value);
+  return !/[\u0000-\u0008\u000A-\u001F\u007F]/u.test(value);
 };
 
 const unquote = (value: string): string => {

--- a/packages/core/src/telemetry/config.ts
+++ b/packages/core/src/telemetry/config.ts
@@ -68,7 +68,6 @@ export function parseOtlpHeaders(
     } catch {
       // It looked like JSON but failed to parse, so we assume it's invalid.
       return undefined;
-
     }
   }
 
@@ -100,7 +99,6 @@ export function parseOtlpHeaders(
 
   return undefined;
 }
-
 
 export interface TelemetryArgOverrides {
   telemetry?: boolean;

--- a/packages/core/src/telemetry/config.ts
+++ b/packages/core/src/telemetry/config.ts
@@ -34,11 +34,78 @@ export function parseTelemetryTargetValue(
   return undefined;
 }
 
+/**
+ * Parse OTLP headers from a string value.
+ * Supports JSON format or key=value pairs separated by comma or semicolon.
+ * Returns Record<string, string> or undefined if parsing fails.
+ */
+export function parseOtlpHeaders(
+  value: string | undefined,
+): Record<string, string> | undefined {
+  if (value === undefined || value.trim() === '') {
+    return undefined;
+  }
+
+  const trimmedValue = value.trim();
+
+  // Try JSON format first
+  if (trimmedValue.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(trimmedValue);
+      if (
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        !Array.isArray(parsed)
+      ) {
+        const result: Record<string, string> = {};
+        for (const [key, val] of Object.entries(parsed)) {
+          if (key && val !== undefined && val !== null) {
+            result[key] = String(val);
+          }
+        }
+        return Object.keys(result).length > 0 ? result : undefined;
+      }
+    } catch {
+      // Fall through to delimiter parsing
+    }
+  }
+
+  // Try delimiter parsing (comma or semicolon)
+  if (trimmedValue.includes('=')) {
+    const result: Record<string, string> = {};
+    // Split by comma first, then handle semicolons
+    const pairs = trimmedValue.split(/[,;]/);
+
+    for (const pair of pairs) {
+      const trimmedPair = pair.trim();
+      if (!trimmedPair) continue;
+
+      const equalsIndex = trimmedPair.indexOf('=');
+      if (equalsIndex === -1) continue;
+
+      const key = trimmedPair.substring(0, equalsIndex).trim();
+      const val = trimmedPair.substring(equalsIndex + 1).trim();
+
+      if (key && val) {
+        result[key] = val;
+      }
+    }
+
+    if (Object.keys(result).length > 0) {
+      return result;
+    }
+  }
+
+  return undefined;
+}
+
+
 export interface TelemetryArgOverrides {
   telemetry?: boolean;
   telemetryTarget?: string | TelemetryTarget;
   telemetryOtlpEndpoint?: string;
   telemetryOtlpProtocol?: string;
+  telemetryOtlpHeader?: string[];
   telemetryLogPrompts?: boolean;
   telemetryOutfile?: string;
 }
@@ -108,11 +175,36 @@ export async function resolveTelemetrySettings(options: {
     parseBooleanEnvFlag(env['GEMINI_TELEMETRY_USE_COLLECTOR']) ??
     settings.useCollector;
 
+  // Merge OTLP headers from settings, env, and argv (in that order, later overwrites earlier)
+  const otlpHeaders: Record<string, string> = {};
+
+  // Start with settings
+  if (settings.otlpHeaders) {
+    Object.assign(otlpHeaders, settings.otlpHeaders);
+  }
+
+  // Merge environment variable headers
+  const envHeaders = parseOtlpHeaders(env['GEMINI_TELEMETRY_OTLP_HEADERS']);
+  if (envHeaders) {
+    Object.assign(otlpHeaders, envHeaders);
+  }
+
+  // Merge CLI argument headers (highest precedence)
+  if (argv.telemetryOtlpHeader && Array.isArray(argv.telemetryOtlpHeader)) {
+    for (const headerArg of argv.telemetryOtlpHeader) {
+      const parsed = parseOtlpHeaders(headerArg);
+      if (parsed) {
+        Object.assign(otlpHeaders, parsed);
+      }
+    }
+  }
+
   return {
     enabled,
     target,
     otlpEndpoint,
     otlpProtocol,
+    otlpHeaders: Object.keys(otlpHeaders).length > 0 ? otlpHeaders : undefined,
     logPrompts,
     outfile,
     useCollector,

--- a/packages/core/src/telemetry/config.ts
+++ b/packages/core/src/telemetry/config.ts
@@ -210,7 +210,11 @@ export function parseOtlpHeaders(
             continue;
           }
           const stringVal = String(val);
-          if (isValidHeaderName(key) && isValidHeaderValue(stringVal)) {
+          if (
+            stringVal &&
+            isValidHeaderName(key) &&
+            isValidHeaderValue(stringVal)
+          ) {
             result[key] = stringVal;
             if (Object.keys(result).length > MAX_HEADER_COUNT) {
               return undefined;

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -68,6 +68,7 @@ describe('Telemetry SDK', () => {
       getTelemetryEnabled: () => true,
       getTelemetryOtlpEndpoint: () => 'http://localhost:4317',
       getTelemetryOtlpProtocol: () => 'grpc',
+      getTelemetryOtlpHeaders: () => ({}),
       getTelemetryTarget: () => 'local',
       getTelemetryUseCollector: () => false,
       getTelemetryOutfile: () => undefined,
@@ -277,7 +278,7 @@ describe('Telemetry SDK', () => {
     expect(NodeSDK.prototype.start).toHaveBeenCalled();
   });
 
-  it('should defer initialization when useCliAuth is true and no credentials are provided', async () => {
+it('should defer initialization when useCliAuth is true and no credentials are provided', async () => {
     vi.spyOn(mockConfig, 'getTelemetryUseCliAuth').mockReturnValue(true);
     vi.spyOn(mockConfig, 'getTelemetryTarget').mockReturnValue(
       TelemetryTarget.GCP,
@@ -370,6 +371,7 @@ describe('Telemetry SDK', () => {
     );
     expect(NodeSDK.prototype.start).not.toHaveBeenCalled();
   });
+
   it('should log error when re-initializing with different credentials', async () => {
     const creds1 = { client_email: 'user1@example.com' };
     const creds2 = { client_email: 'user2@example.com' };
@@ -401,5 +403,109 @@ describe('Telemetry SDK', () => {
     expect(debugLogger.error).not.toHaveBeenCalledWith(
       expect.stringContaining('Telemetry credentials have changed'),
     );
+  });
+
+  it('should pass headers to HTTP exporters', async () => {
+    const headers = {
+      Authorization: 'Bearer token123',
+      'x-api-key': 'abc456',
+    };
+    vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
+    vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
+      'http://localhost:4318',
+    );
+    vi.spyOn(mockConfig, 'getTelemetryOtlpHeaders').mockReturnValue(headers);
+
+    await initializeTelemetry(mockConfig);
+
+    expect(OTLPTraceExporterHttp).toHaveBeenCalledWith({
+      url: 'http://localhost:4318/',
+      headers,
+    });
+    expect(OTLPLogExporterHttp).toHaveBeenCalledWith({
+      url: 'http://localhost:4318/',
+      headers,
+    });
+    expect(OTLPMetricExporterHttp).toHaveBeenCalledWith({
+      url: 'http://localhost:4318/',
+      headers,
+    });
+  });
+
+  it('should pass metadata to gRPC exporters', async () => {
+    const headers = {
+      Authorization: 'Bearer token123',
+      'x-api-key': 'abc456',
+    };
+    vi.spyOn(mockConfig, 'getTelemetryOtlpHeaders').mockReturnValue(headers);
+
+    await initializeTelemetry(mockConfig);
+
+    expect(OTLPTraceExporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'http://localhost:4317',
+        compression: 'gzip',
+        metadata: expect.any(Object),
+      }),
+    );
+    expect(OTLPLogExporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'http://localhost:4317',
+        compression: 'gzip',
+        metadata: expect.any(Object),
+      }),
+    );
+    expect(OTLPMetricExporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'http://localhost:4317',
+        compression: 'gzip',
+        metadata: expect.any(Object),
+      }),
+    );
+  });
+
+  it('should not pass headers when none are configured', async () => {
+    vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
+    vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
+      'http://localhost:4318',
+    );
+    vi.spyOn(mockConfig, 'getTelemetryOtlpHeaders').mockReturnValue({});
+
+    await initializeTelemetry(mockConfig);
+
+    expect(OTLPTraceExporterHttp).toHaveBeenCalledWith({
+      url: 'http://localhost:4318/',
+      headers: undefined,
+    });
+    expect(OTLPLogExporterHttp).toHaveBeenCalledWith({
+      url: 'http://localhost:4318/',
+      headers: undefined,
+    });
+    expect(OTLPMetricExporterHttp).toHaveBeenCalledWith({
+      url: 'http://localhost:4318/',
+      headers: undefined,
+    });
+  });
+
+  it('should not pass metadata to gRPC exporters when no headers configured', async () => {
+    vi.spyOn(mockConfig, 'getTelemetryOtlpHeaders').mockReturnValue({});
+
+    await initializeTelemetry(mockConfig);
+
+    expect(OTLPTraceExporter).toHaveBeenCalledWith({
+      url: 'http://localhost:4317',
+      compression: 'gzip',
+      metadata: undefined,
+    });
+    expect(OTLPLogExporter).toHaveBeenCalledWith({
+      url: 'http://localhost:4317',
+      compression: 'gzip',
+      metadata: undefined,
+    });
+    expect(OTLPMetricExporter).toHaveBeenCalledWith({
+      url: 'http://localhost:4317',
+      compression: 'gzip',
+      metadata: undefined,
+    });
   });
 });

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -278,7 +278,7 @@ describe('Telemetry SDK', () => {
     expect(NodeSDK.prototype.start).toHaveBeenCalled();
   });
 
-it('should defer initialization when useCliAuth is true and no credentials are provided', async () => {
+  it('should defer initialization when useCliAuth is true and no credentials are provided', async () => {
     vi.spyOn(mockConfig, 'getTelemetryUseCliAuth').mockReturnValue(true);
     vi.spyOn(mockConfig, 'getTelemetryTarget').mockReturnValue(
       TelemetryTarget.GCP,

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -19,6 +19,7 @@ import { OTLPTraceExporter as OTLPTraceExporterHttp } from '@opentelemetry/expor
 import { OTLPLogExporter as OTLPLogExporterHttp } from '@opentelemetry/exporter-logs-otlp-http';
 import { OTLPMetricExporter as OTLPMetricExporterHttp } from '@opentelemetry/exporter-metrics-otlp-http';
 import { CompressionAlgorithm } from '@opentelemetry/otlp-exporter-base';
+import { Metadata } from '@grpc/grpc-js';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { resourceFromAttributes } from '@opentelemetry/resources';
@@ -239,33 +240,54 @@ export async function initializeTelemetry(
       exportIntervalMillis: 30000,
     });
   } else if (useOtlp) {
+    const otlpHeaders = config.getTelemetryOtlpHeaders() ?? {};
+    const hasHeaders = Object.keys(otlpHeaders).length > 0;
+
+    if (hasHeaders) {
+      const headerCount = Object.keys(otlpHeaders).length;
+      diag.debug(`Applying ${headerCount} OTLP header(s)`);
+    }
+
     if (otlpProtocol === 'http') {
       spanExporter = new OTLPTraceExporterHttp({
         url: parsedEndpoint,
+        headers: hasHeaders ? otlpHeaders : undefined,
       });
       logExporter = new OTLPLogExporterHttp({
         url: parsedEndpoint,
+        headers: hasHeaders ? otlpHeaders : undefined,
       });
       metricReader = new PeriodicExportingMetricReader({
         exporter: new OTLPMetricExporterHttp({
           url: parsedEndpoint,
+          headers: hasHeaders ? otlpHeaders : undefined,
         }),
         exportIntervalMillis: 10000,
       });
     } else {
-      // grpc
+      // grpc - convert headers to Metadata
+      let metadata: Metadata | undefined;
+      if (hasHeaders) {
+        metadata = new Metadata();
+        for (const [key, value] of Object.entries(otlpHeaders)) {
+          metadata.set(key, value);
+        }
+      }
       spanExporter = new OTLPTraceExporter({
         url: parsedEndpoint,
         compression: CompressionAlgorithm.GZIP,
+        metadata,
       });
       logExporter = new OTLPLogExporter({
         url: parsedEndpoint,
         compression: CompressionAlgorithm.GZIP,
+        metadata,
       });
       metricReader = new PeriodicExportingMetricReader({
         exporter: new OTLPMetricExporter({
           url: parsedEndpoint,
           compression: CompressionAlgorithm.GZIP,
+          metadata,
         }),
         exportIntervalMillis: 10000,
       });

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -243,11 +243,6 @@ export async function initializeTelemetry(
     const otlpHeaders = config.getTelemetryOtlpHeaders() ?? {};
     const hasHeaders = Object.keys(otlpHeaders).length > 0;
 
-    if (hasHeaders) {
-      const headerCount = Object.keys(otlpHeaders).length;
-      diag.debug(`Applying ${headerCount} OTLP header(s)`);
-    }
-
     if (otlpProtocol === 'http') {
       spanExporter = new OTLPTraceExporterHttp({
         url: parsedEndpoint,

--- a/packages/core/src/telemetry/telemetry.test.ts
+++ b/packages/core/src/telemetry/telemetry.test.ts
@@ -44,6 +44,7 @@ describe('telemetry', () => {
     vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
       'http://localhost:4317',
     );
+    vi.spyOn(mockConfig, 'getTelemetryOtlpHeaders').mockReturnValue({});
     vi.spyOn(mockConfig, 'getSessionId').mockReturnValue('test-session-id');
     mockNodeSdk = {
       start: vi.fn(),


### PR DESCRIPTION
## Summary

Adds support for custom OTLP headers in telemetry configuration, enabling authentication with OTLP collectors that require API keys, bearer tokens, or other credentials.

## Details

This is a re-submission of #11754 which was closed due to the new policy requiring PRs to be linked to issues.

**Changes:**
- Add `otlpHeaders` setting to telemetry configuration (settings.json)
- Add `GEMINI_TELEMETRY_OTLP_HEADERS` environment variable support
- Add `--telemetry-otlp-header` CLI flag (can be specified multiple times)
- Headers are passed to both HTTP and gRPC OTLP exporters
- Comprehensive parsing supports JSON format and key=value pairs
- RFC 7230 compliant header validation

**Configuration Precedence:**
Headers are merged from multiple sources in order (later sources override earlier for same key):
1. `settings.json` (lowest)
2. `GEMINI_TELEMETRY_OTLP_HEADERS` environment variable
3. `--telemetry-otlp-header` CLI flags (highest)

**Review Feedback Addressed from #11754:**
- @cornmander: Documented that header override behavior is intentional (config precedence)
- @gundermanc: Added token expiry documentation with recommendations for long sessions

## Related Issues

Closes #11802

## How to Validate

1. Run telemetry tests:
   ```bash
   npx vitest run packages/core/src/telemetry
   ```

2. Manual test with local OTLP collector:
   ```bash
   gemini --telemetry --telemetry-otlp-header "Authorization=Bearer test"
   ```

3. Test environment variable parsing:
   ```bash
   export GEMINI_TELEMETRY_OTLP_HEADERS='{"Authorization":"Bearer token","x-api-key":"abc123"}'
   gemini --telemetry
   ```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker