### PR TITLE
feat: Deprecate tool args in favor of policy engine

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -177,7 +177,8 @@ export async function parseArguments(
           type: 'array',
           string: true,
           nargs: 1,
-          description: 'Tools that are allowed to run without confirmation',
+          description:
+            '[DEPRECATED: Use Policy Engine instead See https://geminicli.com/docs/core/policy-engine] Tools that are allowed to run without confirmation.',
           coerce: (tools: string[]) =>
             // Handle comma-separated values
             tools.flatMap((tool) => tool.split(',').map((t) => t.trim())),

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -538,6 +538,7 @@ describe('gemini.tsx main function kitty protocol', () => {
 
     const mockConfig = createMockConfig({
       isInteractive: () => false,
+      getAllowedTools: vi.fn(),
       getQuestion: () => '',
       getSandbox: () => undefined,
       getListExtensions: () => flag === 'listExtensions',
@@ -614,6 +615,7 @@ describe('gemini.tsx main function kitty protocol', () => {
 
     const mockConfig = createMockConfig({
       isInteractive: () => false,
+      getAllowedTools: vi.fn(),
       getQuestion: () => '',
       getSandbox: () => ({ command: 'docker', image: 'test-image' }),
     });

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -518,6 +518,16 @@ export async function main() {
 
     adminControlsListner.setConfig(config);
 
+    // Show deprecation warning only for allowedTools as that's the only one set by the user currently via command line args
+    if (config.getAllowedTools() !== undefined) {
+      setTimeout(() => {
+        coreEvents.emitFeedback(
+          'warning',
+          `The allowed-tools cli argument is deprecated and will be removed in Gemini CLI 1.0: Please use the Policy Engine to manage tool permissions instead: https://geminicli.com/docs/core/policy-engine/`,
+        );
+      }, 0);
+    }
+
     if (config.isInteractive() && config.storage && config.getDebugMode()) {
       const { registerActivityLogger } = await import(
         './utils/activityLogger.js'

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -520,12 +520,10 @@ export async function main() {
 
     // Show deprecation warning only for allowedTools as that's the only one set by the user currently via command line args
     if (config.getAllowedTools() !== undefined) {
-      setTimeout(() => {
-        coreEvents.emitFeedback(
-          'warning',
-          `The allowed-tools cli argument is deprecated and will be removed in Gemini CLI 1.0: Please use the Policy Engine to manage tool permissions instead: https://geminicli.com/docs/core/policy-engine/`,
-        );
-      }, 0);
+      coreEvents.emitFeedback(
+        'warning',
+        `The allowed-tools cli argument is deprecated and will be removed in Gemini CLI 1.0: Please use the Policy Engine to manage tool permissions instead: https://geminicli.com/docs/core/policy-engine/`,
+      );
     }
 
     if (config.isInteractive() && config.storage && config.getDebugMode()) {

--- a/packages/cli/src/gemini_cleanup.test.tsx
+++ b/packages/cli/src/gemini_cleanup.test.tsx
@@ -78,6 +78,7 @@ vi.mock('./config/config.js', () => ({
     getQuestion: vi.fn(() => ''),
     isInteractive: () => false,
     storage: { initialize: vi.fn().mockResolvedValue(undefined) },
+    getAllowedTools: vi.fn(),
   } as unknown as Config),
   parseArguments: vi.fn().mockResolvedValue({}),
   isDebugMode: vi.fn(() => false),
@@ -188,6 +189,7 @@ describe('gemini.tsx main function cleanup', () => {
     } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
     vi.mocked(loadCliConfig).mockResolvedValue({
       isInteractive: vi.fn(() => false),
+      getAllowedTools: vi.fn(),
       getQuestion: vi.fn(() => 'test'),
       getSandbox: vi.fn(() => false),
       getDebugMode: vi.fn(() => false),

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -376,8 +376,11 @@ export interface ConfigParameters {
   debugMode: boolean;
   question?: string;
 
+  /** @deprecated Use the Policy System instead. See https://geminicli.com/docs/core/policy-engine/ */
   coreTools?: string[];
+  /** @deprecated Use the Policy System instead. See https://geminicli.com/docs/core/policy-engine/ */
   allowedTools?: string[];
+  /** @deprecated Use the Policy System instead. See https://geminicli.com/docs/core/policy-engine/ */
   excludeTools?: string[];
   toolDiscoveryCommand?: string;
   toolCallCommand?: string;


### PR DESCRIPTION
## Summary

Deprecate tool-related CLI arguments (`--allowedTools`, `--excludeTools`, `--coreTools`) in favor of the Policy Engine, and display a warning when `allowed-tools` is used.

## Details

This PR deprecates the following CLI arguments in `packages/core/src/config/config.ts`:
- `allowedTools`
- `excludeTools`
- `coreTools`

A deprecation warning is now displayed in `packages/cli/src/gemini.tsx` when the user provides the `allowed-tools` argument, directing them to use the Policy Engine instead.

Additionally, `package.json` was updated to support argument forwarding in the `build-and-start` script to facilitate testing.

## Related Issues

Partial fix for #11302. As this only deprecates the args. Will follow up with another PR to remove this for `1.0` release

## How to Validate

1. **Build the project:**
   ```bash
   npm run build
   ```

2. **Run with deprecated argument:**
   ```bash
   npm start -- --allowed-tools=ls
   ```
   - Verify that a warning message appears: "The allowed-tools cli argument is deprecated and will be removed in Gemini CLI 1.0: Please use the Policy Engine to manage tool permissions instead: https://geminicli.com/docs/core/policy-engine/"

3. **Run without deprecated argument:**
   ```bash
   npm start
   ```
   - Verify that no warning message appears regarding `allowed-tools`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
