### PR TITLE
feat(plan): create a metric for execution of plans generated in plan mode

### DIFF
--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -320,6 +320,8 @@ Captures startup configuration and user prompt submissions.
 
 Tracks changes and duration of approval modes.
 
+##### Lifecycle
+
 - `approval_mode_switch`: Approval mode was changed.
   - **Attributes**:
     - `from_mode` (string)
@@ -329,6 +331,15 @@ Tracks changes and duration of approval modes.
   - **Attributes**:
     - `mode` (string)
     - `duration_ms` (int)
+
+##### Execution
+
+These events track the execution of an approval mode, such as Plan Mode.
+
+- `plan_execution`: A plan was executed and the session switched from plan mode
+  to active execution.
+  - **Attributes**:
+    - `approval_mode` (string)
 
 #### Tools
 
@@ -709,6 +720,17 @@ Agent lifecycle metrics: runs, durations, and turns.
 - `gemini_cli.agent.turns` (Histogram, turns): Turns taken per agent run.
   - **Attributes**:
     - `agent_name` (string)
+
+##### Approval Mode
+
+###### Execution
+
+These metrics track the adoption and usage of specific approval workflows, such
+as Plan Mode.
+
+- `gemini_cli.plan.execution.count` (Counter, Int): Counts plan executions.
+  - **Attributes**:
+    - `approval_mode` (string)
 
 ##### UI
 

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -44,6 +44,7 @@ import type {
   HookCallEvent,
   ApprovalModeSwitchEvent,
   ApprovalModeDurationEvent,
+  PlanExecutionEvent,
 } from '../types.js';
 import { EventMetadataKey } from './event-metadata-key.js';
 import type { Config } from '../../config/config.js';
@@ -104,6 +105,7 @@ export enum EventNames {
   HOOK_CALL = 'hook_call',
   APPROVAL_MODE_SWITCH = 'approval_mode_switch',
   APPROVAL_MODE_DURATION = 'approval_mode_duration',
+  PLAN_EXECUTION = 'plan_execution',
 }
 
 export interface LogResponse {
@@ -1526,6 +1528,18 @@ export class ClearcutLogger {
     this.enqueueLogEvent(
       this.createLogEvent(EventNames.APPROVAL_MODE_DURATION, data),
     );
+    this.flushIfNeeded();
+  }
+
+  logPlanExecutionEvent(event: PlanExecutionEvent): void {
+    const data: EventValue[] = [
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_APPROVAL_MODE,
+        value: event.approval_mode,
+      },
+    ];
+
+    this.enqueueLogEvent(this.createLogEvent(EventNames.PLAN_EXECUTION, data));
     this.flushIfNeeded();
   }
 

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -53,6 +53,7 @@ import type {
   HookCallEvent,
   StartupStatsEvent,
   LlmLoopCheckEvent,
+  PlanExecutionEvent,
 } from './types.js';
 import {
   recordApiErrorMetrics,
@@ -71,6 +72,7 @@ import {
   recordRecoveryAttemptMetrics,
   recordLinesChanged,
   recordHookCallMetrics,
+  recordPlanExecution,
 } from './metrics.js';
 import { bufferTelemetryEvent } from './sdk.js';
 import type { UiEvent } from './uiTelemetry.js';
@@ -695,6 +697,20 @@ export function logApprovalModeDuration(
     logs.getLogger(SERVICE_NAME).emit({
       body: event.toLogBody(),
       attributes: event.toOpenTelemetryAttributes(config),
+    });
+  });
+}
+
+export function logPlanExecution(config: Config, event: PlanExecutionEvent) {
+  ClearcutLogger.getInstance(config)?.logPlanExecutionEvent(event);
+  bufferTelemetryEvent(() => {
+    logs.getLogger(SERVICE_NAME).emit({
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    });
+
+    recordPlanExecution(config, {
+      approval_mode: event.approval_mode,
     });
   });
 }

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -66,6 +66,7 @@ const BASELINE_COMPARISON = 'gemini_cli.performance.baseline.comparison';
 const FLICKER_FRAME_COUNT = 'gemini_cli.ui.flicker.count';
 const SLOW_RENDER_LATENCY = 'gemini_cli.ui.slow_render.latency';
 const EXIT_FAIL_COUNT = 'gemini_cli.exit.fail.count';
+const PLAN_EXECUTION_COUNT = 'gemini_cli.plan.execution.count';
 
 const baseMetricDefinition = {
   getCommonAttributes,
@@ -204,6 +205,14 @@ const COUNTER_DEFINITIONS = {
     valueType: ValueType.INT,
     assign: (c: Counter) => (exitFailCounter = c),
     attributes: {} as Record<string, never>,
+  },
+  [PLAN_EXECUTION_COUNT]: {
+    description: 'Counts plan executions (switching from Plan Mode).',
+    valueType: ValueType.INT,
+    assign: (c: Counter) => (planExecutionCounter = c),
+    attributes: {} as {
+      approval_mode: string;
+    },
   },
   [EVENT_HOOK_CALL_COUNT]: {
     description: 'Counts hook calls, tagged by hook event name and success.',
@@ -529,6 +538,7 @@ let agentRecoveryAttemptCounter: Counter | undefined;
 let agentRecoveryAttemptDurationHistogram: Histogram | undefined;
 let flickerFrameCounter: Counter | undefined;
 let exitFailCounter: Counter | undefined;
+let planExecutionCounter: Counter | undefined;
 let slowRenderHistogram: Histogram | undefined;
 let hookCallCounter: Counter | undefined;
 let hookCallLatencyHistogram: Histogram | undefined;
@@ -718,6 +728,20 @@ export function recordFlickerFrame(config: Config): void {
 export function recordExitFail(config: Config): void {
   if (!exitFailCounter || !isMetricsInitialized) return;
   exitFailCounter.add(1, baseMetricDefinition.getCommonAttributes(config));
+}
+
+/**
+ * Records a metric for when a plan is executed.
+ */
+export function recordPlanExecution(
+  config: Config,
+  attributes: MetricDefinitions[typeof PLAN_EXECUTION_COUNT]['attributes'],
+): void {
+  if (!planExecutionCounter || !isMetricsInitialized) return;
+  planExecutionCounter.add(1, {
+    ...baseMetricDefinition.getCommonAttributes(config),
+    ...attributes,
+  });
 }
 
 /**

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -1603,7 +1603,7 @@ export type TelemetryEvent =
   | StartupStatsEvent
   | WebFetchFallbackAttemptEvent
   | EditStrategyEvent
-  | PlanExecutionEvent;
+  | PlanExecutionEvent
   | RewindEvent
   | EditCorrectionEvent;
 

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -1952,6 +1952,8 @@ export class PlanExecutionEvent implements BaseTelemetryEvent {
   approval_mode: ApprovalMode;
 
   constructor(approvalMode: ApprovalMode) {
+    this['event.name'] = this.eventName;
+    this['event.timestamp'] = new Date().toISOString();
     this.approval_mode = approvalMode;
   }
   'event.name': string;
@@ -1960,7 +1962,8 @@ export class PlanExecutionEvent implements BaseTelemetryEvent {
   toOpenTelemetryAttributes(config: Config): LogAttributes {
     return {
       ...getCommonAttributes(config),
-      event_name: this.eventName,
+      'event.name': this.eventName,
+      'event.timestamp': this['event.timestamp'],
       approval_mode: this.approval_mode,
     };
   }

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -1895,12 +1895,17 @@ export class WebFetchFallbackAttemptEvent implements BaseTelemetryEvent {
 }
 
 export const EVENT_HOOK_CALL = 'gemini_cli.hook_call';
+
+export const EVENT_APPROVAL_MODE_SWITCH =
+  'gemini_cli.plan.approval_mode_switch';
 export class ApprovalModeSwitchEvent implements BaseTelemetryEvent {
   eventName = 'approval_mode_switch';
   from_mode: ApprovalMode;
   to_mode: ApprovalMode;
 
   constructor(fromMode: ApprovalMode, toMode: ApprovalMode) {
+    this['event.name'] = this.eventName;
+    this['event.timestamp'] = new Date().toISOString();
     this.from_mode = fromMode;
     this.to_mode = toMode;
   }
@@ -1910,7 +1915,7 @@ export class ApprovalModeSwitchEvent implements BaseTelemetryEvent {
   toOpenTelemetryAttributes(config: Config): LogAttributes {
     return {
       ...getCommonAttributes(config),
-      event_name: this.eventName,
+      event_name: EVENT_APPROVAL_MODE_SWITCH,
       from_mode: this.from_mode,
       to_mode: this.to_mode,
     };
@@ -1921,12 +1926,16 @@ export class ApprovalModeSwitchEvent implements BaseTelemetryEvent {
   }
 }
 
+export const EVENT_APPROVAL_MODE_DURATION =
+  'gemini_cli.plan.approval_mode_duration';
 export class ApprovalModeDurationEvent implements BaseTelemetryEvent {
   eventName = 'approval_mode_duration';
   mode: ApprovalMode;
   duration_ms: number;
 
   constructor(mode: ApprovalMode, durationMs: number) {
+    this['event.name'] = this.eventName;
+    this['event.timestamp'] = new Date().toISOString();
     this.mode = mode;
     this.duration_ms = durationMs;
   }
@@ -1936,7 +1945,7 @@ export class ApprovalModeDurationEvent implements BaseTelemetryEvent {
   toOpenTelemetryAttributes(config: Config): LogAttributes {
     return {
       ...getCommonAttributes(config),
-      event_name: this.eventName,
+      event_name: EVENT_APPROVAL_MODE_DURATION,
       mode: this.mode,
       duration_ms: this.duration_ms,
     };
@@ -1947,6 +1956,7 @@ export class ApprovalModeDurationEvent implements BaseTelemetryEvent {
   }
 }
 
+export const EVENT_PLAN_EXECUTION = 'gemini_cli.plan.execution';
 export class PlanExecutionEvent implements BaseTelemetryEvent {
   eventName = 'plan_execution';
   approval_mode: ApprovalMode;
@@ -1962,7 +1972,7 @@ export class PlanExecutionEvent implements BaseTelemetryEvent {
   toOpenTelemetryAttributes(config: Config): LogAttributes {
     return {
       ...getCommonAttributes(config),
-      'event.name': this.eventName,
+      'event.name': EVENT_PLAN_EXECUTION,
       'event.timestamp': this['event.timestamp'],
       approval_mode: this.approval_mode,
     };

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -1577,7 +1577,8 @@ export type TelemetryEvent =
   | StartupStatsEvent
   | WebFetchFallbackAttemptEvent
   | EditStrategyEvent
-  | EditCorrectionEvent;
+  | EditCorrectionEvent
+  | PlanExecutionEvent;
 
 export const EVENT_EXTENSION_DISABLE = 'gemini_cli.extension_disable';
 export class ExtensionDisableEvent implements BaseTelemetryEvent {
@@ -1916,6 +1917,29 @@ export class ApprovalModeDurationEvent implements BaseTelemetryEvent {
 
   toLogBody(): string {
     return `Approval mode ${this.mode} was active for ${this.duration_ms}ms.`;
+  }
+}
+
+export class PlanExecutionEvent implements BaseTelemetryEvent {
+  eventName = 'plan_execution';
+  approval_mode: ApprovalMode;
+
+  constructor(approvalMode: ApprovalMode) {
+    this.approval_mode = approvalMode;
+  }
+  'event.name': string;
+  'event.timestamp': string;
+
+  toOpenTelemetryAttributes(config: Config): LogAttributes {
+    return {
+      ...getCommonAttributes(config),
+      event_name: this.eventName,
+      approval_mode: this.approval_mode,
+    };
+  }
+
+  toLogBody(): string {
+    return `Plan executed with approval mode: ${this.approval_mode}`;
   }
 }
 

--- a/packages/core/src/tools/exit-plan-mode.test.ts
+++ b/packages/core/src/tools/exit-plan-mode.test.ts
@@ -15,6 +15,11 @@ import { ApprovalMode } from '../policy/types.js';
 import * as fs from 'node:fs';
 import os from 'node:os';
 import { validatePlanPath } from '../utils/planUtils.js';
+import * as loggers from '../telemetry/loggers.js';
+
+vi.mock('../telemetry/loggers.js', () => ({
+  logPlanExecution: vi.fn(),
+}));
 
 describe('ExitPlanModeTool', () => {
   let tool: ExitPlanModeTool;
@@ -283,6 +288,30 @@ The plan is stored at: ${expectedPath}
 Ask the user for specific feedback on how to improve the plan.`,
         returnDisplay: 'Rejected (no feedback)',
       });
+    });
+
+    it('should log plan execution event when plan is approved', async () => {
+      const planRelativePath = createPlanFile('test.md', '# Content');
+      const invocation = tool.build({ plan_path: planRelativePath });
+
+      const confirmDetails = await invocation.shouldConfirmExecute(
+        new AbortController().signal,
+      );
+      if (confirmDetails === false) return;
+
+      await confirmDetails.onConfirm(ToolConfirmationOutcome.ProceedOnce, {
+        approved: true,
+        approvalMode: ApprovalMode.AUTO_EDIT,
+      });
+
+      await invocation.execute(new AbortController().signal);
+
+      expect(loggers.logPlanExecution).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          approval_mode: ApprovalMode.AUTO_EDIT,
+        }),
+      );
     });
 
     it('should return cancellation message when cancelled', async () => {

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -22,6 +22,8 @@ import { validatePlanPath, validatePlanContent } from '../utils/planUtils.js';
 import { ApprovalMode } from '../policy/types.js';
 import { checkExhaustive } from '../utils/checks.js';
 import { resolveToRealPath, isSubpath } from '../utils/paths.js';
+import { logPlanExecution } from '../telemetry/loggers.js';
+import { PlanExecutionEvent } from '../telemetry/types.js';
 
 /**
  * Returns a human-readable description for an approval mode.
@@ -224,6 +226,8 @@ export class ExitPlanModeInvocation extends BaseToolInvocation<
     if (payload?.approved) {
       const newMode = payload.approvalMode ?? ApprovalMode.DEFAULT;
       this.config.setApprovalMode(newMode);
+
+      logPlanExecution(this.config, new PlanExecutionEvent(newMode));
 
       const description = getApprovalModeDescription(newMode);
 


### PR DESCRIPTION
## Summary

This PR instruments a new telemetry metric, `PLAN_EXECUTION_COUNT`, to track the execution of "Plan Mode". Specifically, it records an event whenever a user successfully exits Plan Mode via the ExitPlanMode tool with an approved plan, capturing the subsequent approval mode (e.g., default, autoEdit). This data will help quantify how often generated plans lead to execution.

## Details
   - Metric: Added gemini_cli.plan.execution.count to metrics.ts.
   - Event: Created PlanExecutionEvent in types.ts to carry the approval_mode payload.
   - Logging:
       - Implemented logPlanExecution in loggers.ts to bridge the event to both OpenTelemetry (metrics) and Clearcut (logs).
       - Added logPlanExecutionEvent to ClearcutLogger for structured logging.
   - Integration: Updated ExitPlanModeTool to trigger this log only upon successful plan approval and mode switch.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Closes #16862 
## How to Validate
Enable plan mode and approve a plan, once the exit plan mode tool gets triggered a log should be emitted. I've verified that the log appears here https://cloudlogging.app.goo.gl/5omQxcqXPFzhFSih9

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
