### PR TITLE
Switch to using ResizeObserver in virtual list classes

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -272,6 +272,7 @@ export async function startInteractiveUI(
       },
       patchConsole: false,
       alternateBuffer: useAlternateBuffer,
+      standardReactLayoutTiming: useAlternateBuffer,
       incrementalRendering:
         settings.merged.ui.incrementalRendering !== false && useAlternateBuffer,
     },

--- a/packages/cli/src/ui/components/shared/ScrollableList.tsx
+++ b/packages/cli/src/ui/components/shared/ScrollableList.tsx
@@ -11,6 +11,7 @@ import {
   useCallback,
   useMemo,
   useEffect,
+  useState,
 } from 'react';
 import type React from 'react';
 import {
@@ -49,6 +50,12 @@ function ScrollableList<T>(
   const { hasFocus, width } = props;
   const virtualizedListRef = useRef<VirtualizedListRef<T>>(null);
   const containerRef = useRef<DOMElement>(null);
+  const [containerNode, setContainerNode] = useState<DOMElement | null>(null);
+
+  const setContainerRef = useCallback((node: DOMElement | null) => {
+    (containerRef as React.MutableRefObject<DOMElement | null>).current = node;
+    setContainerNode(node);
+  }, []);
 
   useImperativeHandle(
     ref,
@@ -229,11 +236,11 @@ function ScrollableList<T>(
     ],
   );
 
-  useScrollable(scrollableEntry, hasFocus);
+  useScrollable(scrollableEntry, hasFocus && containerNode !== null);
 
   return (
     <Box
-      ref={containerRef}
+      ref={setContainerRef}
       flexGrow={1}
       flexDirection="column"
       overflow="hidden"

--- a/packages/cli/src/ui/components/shared/VirtualizedList.test.tsx
+++ b/packages/cli/src/ui/components/shared/VirtualizedList.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import { render } from '../../../test-utils/render.js';
+import { waitFor } from '../../../test-utils/async.js';
 import { VirtualizedList, type VirtualizedListRef } from './VirtualizedList.js';
 import { Text, Box } from 'ink';
 import {
@@ -272,13 +273,14 @@ describe('<VirtualizedList />', () => {
     // Shrink Item 0 to 1px via context
     await act(async () => {
       setHeightFn(1);
-      await delay(0);
     });
 
     // Now Item 0 is 1px, so Items 1-9 should also be visible to fill 10px
-    expect(lastFrame()).toContain('Item 0');
-    expect(lastFrame()).toContain('Item 1');
-    expect(lastFrame()).toContain('Item 9');
+    await waitFor(() => {
+      expect(lastFrame()).toContain('Item 0');
+      expect(lastFrame()).toContain('Item 1');
+      expect(lastFrame()).toContain('Item 2');
+    });
   });
 
   it('updates scroll position correctly when scrollBy is called multiple times in the same tick', async () => {


### PR DESCRIPTION
The existing code couldn't handle when content changed size and was
vulnerable to occasional crashes that were hard to debug.

Cleanup unneeded useLayoutEffect and useEffect calls.

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
