### PR TITLE
feat(core): enable getUserTierName in config

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -2087,8 +2087,7 @@ describe('Config Quota & Preview Model Access', () => {
       await config.refreshAuth(AuthType.USE_GEMINI);
 
       expect(config.getUserTier()).toBe(mockTier);
-      // TODO(#1275): User tier name is disabled until re-enabled.
-      expect(config.getUserTierName()).toBeUndefined();
+      expect(config.getUserTierName()).toBe(mockTierName);
     });
   });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1047,8 +1047,7 @@ export class Config {
   }
 
   getUserTierName(): string | undefined {
-    // TODO(#1275): Re-enable user tier display when ready.
-    return undefined;
+    return this.contentGenerator?.userTierName;
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR enables the `getUserTierName` configuration method and updates the corresponding test case, resolving a pending TODO.

## Details

- Updated `packages/core/src/config/config.test.ts` to assert that `getUserTierName` returns the correct tier name instead of `undefined`.

## Related Issues

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/1275

## How to Validate

Run the configuration tests:
```bash
npm test -w @google/gemini-cli-core -- src/config/config.test.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
