### PR TITLE
feat(core,cli): add support for Kakoune editor

### DIFF
--- a/docs/tools/shell.md
+++ b/docs/tools/shell.md
@@ -131,8 +131,8 @@ only applies when `tools.shell.enableInteractiveShell` is enabled.**
 
 The `run_shell_command` tool now supports interactive commands by integrating a
 pseudo-terminal (pty). This allows you to run commands that require real-time
-user input, such as text editors (`vim`, `nano`), terminal-based UIs (`htop`),
-and interactive version control operations (`git rebase -i`).
+user input, such as text editors (`vim`, `nano`, `kak`), terminal-based UIs
+(`htop`), and interactive version control operations (`git rebase -i`).
 
 When an interactive command is running, you can send input to it from the Gemini
 CLI. To focus on the interactive shell, press `Tab`. The terminal output,

--- a/packages/cli/src/ui/components/EditorSettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/EditorSettingsDialog.test.tsx
@@ -29,6 +29,7 @@ vi.mock('../editors/editorSettingsManager.js', () => ({
     getAvailableEditorDisplays: () => [
       { name: 'VS Code', type: 'vscode', disabled: false },
       { name: 'Vim', type: 'vim', disabled: false },
+      { name: 'Kakoune', type: 'kak', disabled: false },
     ],
   },
 }));

--- a/packages/cli/src/ui/components/__snapshots__/EditorSettingsDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/EditorSettingsDialog.test.tsx.snap
@@ -6,9 +6,10 @@ exports[`EditorSettingsDialog > renders correctly 1`] = `
 │ > Select Editor                              Editor Preference                                   │
 │ ● 1. VS Code                                                                                     │
 │   2. Vim                                     These editors are currently supported. Please note  │
-│                                              that some editors cannot be used in sandbox mode.   │
-│   Apply To                                                                                       │
-│ ● 1. User Settings                           Your preferred editor is: VS Code.                  │
+│   3. Kakoune                                 that some editors cannot be used in sandbox mode.   │
+│                                                                                                  │
+│   Apply To                                   Your preferred editor is: VS Code.                  │
+│ ● 1. User Settings                                                                               │
 │   2. Workspace Settings                                                                          │
 │                                                                                                  │
 │ (Use Enter to select, Tab to change                                                              │

--- a/packages/cli/src/ui/hooks/useEditorSettings.test.tsx
+++ b/packages/cli/src/ui/hooks/useEditorSettings.test.tsx
@@ -162,11 +162,12 @@ describe('useEditorSettings', () => {
   it('should handle different editor types', () => {
     render(<TestComponent />);
 
-    const editorTypes: EditorType[] = ['cursor', 'windsurf', 'vim'];
+    const editorTypes: EditorType[] = ['cursor', 'windsurf', 'vim', 'kak'];
     const displayNames: Record<string, string> = {
       cursor: 'Cursor',
       windsurf: 'Windsurf',
       vim: 'Vim',
+      kak: 'Kakoune',
     };
     const scope = SettingScope.User;
 

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -79,6 +79,7 @@ describe('editor utils', () => {
         win32Commands: ['agy.cmd', 'antigravity.cmd', 'antigravity'],
       },
       { editor: 'hx', commands: ['hx'], win32Commands: ['hx'] },
+      { editor: 'kak', commands: ['kak'], win32Commands: ['kak'] },
     ];
 
     for (const { editor, commands, win32Commands } of testCases) {
@@ -466,6 +467,15 @@ describe('editor utils', () => {
       expect(allowEditorTypeInSandbox('hx')).toBe(true);
     });
 
+    it('should allow kak in sandbox mode', () => {
+      vi.stubEnv('SANDBOX', 'sandbox');
+      expect(allowEditorTypeInSandbox('kak')).toBe(true);
+    });
+
+    it('should allow kak when not in sandbox mode', () => {
+      expect(allowEditorTypeInSandbox('kak')).toBe(true);
+    });
+
     const guiEditors: EditorType[] = [
       'vscode',
       'vscodium',
@@ -540,6 +550,12 @@ describe('editor utils', () => {
       (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/nvim'));
       vi.stubEnv('SANDBOX', 'sandbox');
       expect(isEditorAvailable('neovim')).toBe(true);
+    });
+
+    it('should return true for kak when installed and in sandbox mode', () => {
+      (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/kak'));
+      vi.stubEnv('SANDBOX', 'sandbox');
+      expect(isEditorAvailable('kak')).toBe(true);
     });
   });
 });

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -16,7 +16,7 @@ const GUI_EDITORS = [
   'zed',
   'antigravity',
 ] as const;
-const TERMINAL_EDITORS = ['vim', 'neovim', 'emacs', 'hx'] as const;
+const TERMINAL_EDITORS = ['vim', 'neovim', 'emacs', 'hx', 'kak'] as const;
 const EDITORS = [...GUI_EDITORS, ...TERMINAL_EDITORS] as const;
 
 const GUI_EDITORS_SET = new Set<string>(GUI_EDITORS);
@@ -50,6 +50,7 @@ export const EDITOR_DISPLAY_NAMES: Record<EditorType, string> = {
   emacs: 'Emacs',
   antigravity: 'Antigravity',
   hx: 'Helix',
+  kak: 'Kakoune',
 };
 
 export function getEditorDisplayName(editor: EditorType): string {
@@ -106,6 +107,7 @@ const editorCommands: Record<
     default: ['agy', 'antigravity'],
   },
   hx: { win32: ['hx'], default: ['hx'] },
+  kak: { win32: ['kak'], default: ['kak'] },
 };
 
 export function checkHasEditorType(editor: EditorType): boolean {


### PR DESCRIPTION
## Summary

Adds support for the Kakoune (`kak`) text editor to the Gemini CLI. Users can now select Kakoune as their preferred editor for external editing tasks via the settings menu.

## Details

- **Core**: Added `kak` to the list of supported `TERMINAL_EDITORS` in `@google/gemini-cli-core`.
- **CLI**: Updated the settings manager and UI components to recognize and display "Kakoune" in the editor selection dialog.
- **Diff Support**: File diffing via `getDiffCommand` is currently set to `null` (not implemented), meaning it won't be used for diff views yet, which is consistent with the current implementation for some other editors.
- **Tests**: Added unit tests in both `core` (validating availability and sandbox permissions) and `cli` (validating settings persistence and UI rendering).

## Related Issues

<!-- If applicable, add issue number here, e.g., Closes #123 -->

## How to Validate

1.  **Run Core Tests**:
    ```bash
    npm test -w @google/gemini-cli-core -- src/utils/editor.test.ts
    ```
    *Expected Result*: All tests pass, including new cases for `kak` availability and sandbox checks.

2.  **Run CLI UI Tests**:
    ```bash
    npm test -w @google/gemini-cli -- src/ui/components/EditorSettingsDialog.test.tsx
    ```
    *Expected Result*: Tests pass, confirming Kakoune appears in the settings dialog snapshot.

3.  **Manual Verification**:
    - Launch the CLI (`npm run start`).
    - Run the `/settings` command.
    - Navigate to **Preferred Editor**.
    - Verify that **Kakoune** is listed as an option.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (Updated `docs/tools/shell.md`)
- [x] Added/updated tests (Added tests in `core` and `cli` packages)
- [ ] Noted breaking changes (None)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker