### PR TITLE
Support `set_model` interface from ACP

### DIFF
--- a/packages/cli/src/zed-integration/acpResume.test.ts
+++ b/packages/cli/src/zed-integration/acpResume.test.ts
@@ -53,6 +53,8 @@ describe('GeminiAgent Session Resume', () => {
     mockConfig = {
       refreshAuth: vi.fn().mockResolvedValue(undefined),
       initialize: vi.fn().mockResolvedValue(undefined),
+      getGemini31LaunchedSync: vi.fn().mockReturnValue(false),
+      getHasAccessToPreviewModel: vi.fn().mockReturnValue(true),
       getFileSystemService: vi.fn(),
       setFileSystemService: vi.fn(),
       getGeminiClient: vi.fn().mockReturnValue({
@@ -63,8 +65,12 @@ describe('GeminiAgent Session Resume', () => {
       storage: {
         getProjectTempDir: vi.fn().mockReturnValue('/tmp/project'),
       },
+      getModel: vi.fn().mockReturnValue('gemini-pro'),
       getApprovalMode: vi.fn().mockReturnValue('default'),
       isPlanEnabled: vi.fn().mockReturnValue(false),
+      modelConfigService: {
+        getAliases: vi.fn().mockReturnValue([]),
+      },
     } as unknown as Mocked<Config>;
     mockSettings = {
       merged: {
@@ -152,7 +158,7 @@ describe('GeminiAgent Session Resume', () => {
       mcpServers: [],
     });
 
-    expect(response).toEqual({
+    expect(response).toMatchObject({
       modes: {
         availableModes: [
           {
@@ -173,7 +179,11 @@ describe('GeminiAgent Session Resume', () => {
         ],
         currentModeId: ApprovalMode.DEFAULT,
       },
+      models: {
+        currentModelId: 'gemini-pro',
+      },
     });
+    expect(response.models?.availableModels.length).toBeGreaterThan(0);
 
     // Verify resumeChat received the correct arguments
     expect(mockConfig.getGeminiClient().resumeChat).toHaveBeenCalledWith(

--- a/packages/core/src/services/modelConfigService.test.ts
+++ b/packages/core/src/services/modelConfigService.test.ts
@@ -671,6 +671,59 @@ describe('ModelConfigService', () => {
   });
 
   describe('custom aliases', () => {
+    it('should return merged alias names from aliases and customAliases', () => {
+      const config: ModelConfigServiceConfig = {
+        aliases: {
+          'built-in-alias': {
+            modelConfig: { model: 'gemini-standard' },
+          },
+        },
+        customAliases: {
+          'custom-alias': {
+            modelConfig: { model: 'gemini-custom' },
+          },
+        },
+        overrides: [],
+      };
+      const service = new ModelConfigService(config);
+
+      expect(service.getAliases()).toEqual(['built-in-alias', 'custom-alias']);
+    });
+
+    it('should include runtime aliases in merged alias names', () => {
+      const config: ModelConfigServiceConfig = {
+        aliases: {},
+        overrides: [],
+      };
+      const service = new ModelConfigService(config);
+      service.registerRuntimeModelConfig('runtime-alias', {
+        modelConfig: { model: 'gemini-runtime' },
+      });
+
+      expect(service.getAliases()).toEqual(['runtime-alias']);
+    });
+
+    it('should return custom alias names', () => {
+      const config: ModelConfigServiceConfig = {
+        aliases: {},
+        customAliases: {
+          'my-custom-alias': {
+            modelConfig: { model: 'gemini-custom' },
+          },
+          'my-second-custom-alias': {
+            modelConfig: { model: 'gemini-custom-2' },
+          },
+        },
+        overrides: [],
+      };
+      const service = new ModelConfigService(config);
+
+      expect(service.getAliases()).toEqual([
+        'my-custom-alias',
+        'my-second-custom-alias',
+      ]);
+    });
+
     it('should resolve a custom alias', () => {
       const config: ModelConfigServiceConfig = {
         aliases: {},

--- a/packages/core/src/services/modelConfigService.ts
+++ b/packages/core/src/services/modelConfigService.ts
@@ -84,6 +84,16 @@ export class ModelConfigService {
     this.runtimeOverrides.push(override);
   }
 
+  getAliases(): string[] {
+    const { aliases = {}, customAliases = {} } = this.config || {};
+    const allAliases = {
+      ...aliases,
+      ...customAliases,
+      ...this.runtimeAliases,
+    };
+    return Object.keys(allAliases);
+  }
+
   /**
    * Resolves a model configuration by merging settings from aliases and applying overrides.
    *


### PR DESCRIPTION
## Summary

Adds support for the ACP `set_model` interface, allowing clients to change the model of an existing session at runtime.

## Details
This interface is not yet included in the [ACP schema definition](https://agentclientprotocol.com/protocol/schema), but it is [presented in protocol](https://github.com/agentclientprotocol/typescript-sdk/blob/89d6f05efe75fbab5a194262410f1c057726c3e8/src/acp.ts#L1551) as a beta feature, and basically **any other** agent supports this functionality. 

Without this method, it is hard integrate Gemini for the ACP client on par with other agents, making Gemini less broad

## Related Issues

Fixes #12453
Fixes #18084

## How to Validate

1. Run the gemini with `--experimental-acp` flag
2. Perform `set_model` request with non-default model ID (e.g., gemini-2.5-flash)

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [x] Docker
    - [x] Podman
    - [x] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [x] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [x] Docker
