### PR TITLE
feat(admin): Implement admin allowlist for MCP server configurations

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -995,6 +995,10 @@ their corresponding top-level category object in your `settings.json` file.
   - **Description:** If false, disallows MCP servers from being used.
   - **Default:** `true`
 
+- **`admin.mcp.config`** (object):
+  - **Description:** Admin-configured MCP servers.
+  - **Default:** `{}`
+
 - **`admin.skills.enabled`** (boolean):
   - **Description:** If false, disallows agent skills from being used.
   - **Default:** `true`

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1469,6 +1469,7 @@ describe('loadCliConfig with admin.mcp.config', () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments(createTestMergedSettings());
     const settings = createTestMergedSettings({
+      mcpServers: localMcpServers,
       admin: {
         ...baseSettings.admin,
         mcp: { enabled: true, config: {} },
@@ -1490,6 +1491,7 @@ describe('loadCliConfig with admin.mcp.config', () => {
       },
     };
     const settings = createTestMergedSettings({
+      mcpServers: localMcpServers,
       admin: {
         ...baseSettings.admin,
         mcp: { enabled: true, config: adminAllowlist },
@@ -1513,6 +1515,7 @@ describe('loadCliConfig with admin.mcp.config', () => {
       },
     };
     const settings = createTestMergedSettings({
+      mcpServers: localMcpServers,
       admin: {
         ...baseSettings.admin,
         mcp: { enabled: true, config: adminAllowlist },
@@ -1546,6 +1549,7 @@ describe('loadCliConfig with admin.mcp.config', () => {
       },
     };
     const settings = createTestMergedSettings({
+      mcpServers: localMcpServers,
       admin: {
         ...baseSettings.admin,
         mcp: { enabled: true, config: adminAllowlist },

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -17,6 +17,7 @@ import {
   type ExtensionLoader,
   debugLogger,
   ApprovalMode,
+  type MCPServerConfig,
 } from '@google/gemini-cli-core';
 import { loadCliConfig, parseArguments, type CliArgs } from './config.js';
 import { type Settings, createTestMergedSettings } from './settings.js';
@@ -1428,6 +1429,198 @@ describe('loadCliConfig with allowed-mcp-server-names', () => {
     const config = await loadCliConfig(settings, 'test-session', argv);
     expect(config.getAllowedMcpServers()).toEqual(['server2', 'server3']);
     expect(config.getBlockedMcpServers()).toEqual([]);
+  });
+});
+
+describe('loadCliConfig with admin.mcp.config', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
+    vi.stubEnv('GEMINI_API_KEY', 'test-api-key');
+    vi.spyOn(ExtensionManager.prototype, 'getExtensions').mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  const localMcpServers: Record<string, MCPServerConfig> = {
+    serverA: {
+      command: 'npx',
+      args: ['-y', '@mcp/server-a'],
+      env: { KEY: 'VALUE' },
+      cwd: '/local/cwd',
+      trust: false,
+    },
+    serverB: {
+      command: 'npx',
+      args: ['-y', '@mcp/server-b'],
+      trust: false,
+    },
+  };
+
+  const baseSettings = createTestMergedSettings({
+    mcp: { serverCommand: 'npx -y @mcp/default-server' },
+    mcpServers: localMcpServers,
+  });
+
+  it('should use local configuration if admin allowlist is empty', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments(createTestMergedSettings());
+    const settings = createTestMergedSettings({
+      admin: {
+        ...baseSettings.admin,
+        mcp: { enabled: true, config: {} },
+      },
+    });
+    const config = await loadCliConfig(settings, 'test-session', argv);
+    expect(config.getMcpServers()).toEqual(localMcpServers);
+    expect(config.getMcpServerCommand()).toBe('npx -y @mcp/default-server');
+  });
+
+  it('should ignore locally configured servers not present in the allowlist', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments(createTestMergedSettings());
+    const adminAllowlist: Record<string, MCPServerConfig> = {
+      serverA: {
+        type: 'sse',
+        url: 'https://admin-server-a.com/sse',
+        trust: true,
+      },
+    };
+    const settings = createTestMergedSettings({
+      admin: {
+        ...baseSettings.admin,
+        mcp: { enabled: true, config: adminAllowlist },
+      },
+    });
+    const config = await loadCliConfig(settings, 'test-session', argv);
+
+    const mergedServers = config.getMcpServers();
+    expect(mergedServers).toHaveProperty('serverA');
+    expect(mergedServers).not.toHaveProperty('serverB');
+  });
+
+  it('should clear command, args, env, and cwd for present servers', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments(createTestMergedSettings());
+    const adminAllowlist: Record<string, MCPServerConfig> = {
+      serverA: {
+        type: 'sse',
+        url: 'https://admin-server-a.com/sse',
+        trust: true,
+      },
+    };
+    const settings = createTestMergedSettings({
+      admin: {
+        ...baseSettings.admin,
+        mcp: { enabled: true, config: adminAllowlist },
+      },
+    });
+    const config = await loadCliConfig(settings, 'test-session', argv);
+
+    const serverA = config.getMcpServers()?.['serverA'];
+    expect(serverA).toEqual({
+      ...localMcpServers['serverA'],
+      type: 'sse',
+      url: 'https://admin-server-a.com/sse',
+      trust: true,
+      command: undefined,
+      args: undefined,
+      env: undefined,
+      cwd: undefined,
+    });
+  });
+
+  it('should not initialize a server if it is in allowlist but missing locally', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments(createTestMergedSettings());
+    const adminAllowlist: Record<string, MCPServerConfig> = {
+      serverC: {
+        type: 'sse',
+        url: 'https://admin-server-c.com/sse',
+        trust: true,
+      },
+    };
+    const settings = createTestMergedSettings({
+      admin: {
+        ...baseSettings.admin,
+        mcp: { enabled: true, config: adminAllowlist },
+      },
+    });
+    const config = await loadCliConfig(settings, 'test-session', argv);
+
+    const mergedServers = config.getMcpServers();
+    expect(mergedServers).not.toHaveProperty('serverC');
+    expect(Object.keys(mergedServers || {})).toHaveLength(0);
+  });
+
+  it('should merge local fields and prefer admin tool filters', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments(createTestMergedSettings());
+    const adminAllowlist: Record<string, MCPServerConfig> = {
+      serverA: {
+        type: 'sse',
+        url: 'https://admin-server-a.com/sse',
+        trust: true,
+        includeTools: ['admin_tool'],
+      },
+    };
+    const localMcpServersWithTools: Record<string, MCPServerConfig> = {
+      serverA: {
+        ...localMcpServers['serverA'],
+        includeTools: ['local_tool'],
+        timeout: 1234,
+      },
+    };
+    const settings = createTestMergedSettings({
+      mcpServers: localMcpServersWithTools,
+      admin: {
+        ...baseSettings.admin,
+        mcp: { enabled: true, config: adminAllowlist },
+      },
+    });
+    const config = await loadCliConfig(settings, 'test-session', argv);
+
+    const serverA = config.getMcpServers()?.['serverA'];
+    expect(serverA).toMatchObject({
+      timeout: 1234,
+      includeTools: ['admin_tool'],
+      type: 'sse',
+      url: 'https://admin-server-a.com/sse',
+      trust: true,
+    });
+    expect(serverA?.command).toBeUndefined();
+  });
+
+  it('should use local tool filters when admin does not define them', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments(createTestMergedSettings());
+    const adminAllowlist: Record<string, MCPServerConfig> = {
+      serverA: {
+        type: 'sse',
+        url: 'https://admin-server-a.com/sse',
+        trust: true,
+      },
+    };
+    const localMcpServersWithTools: Record<string, MCPServerConfig> = {
+      serverA: {
+        ...localMcpServers['serverA'],
+        includeTools: ['local_tool'],
+      },
+    };
+    const settings = createTestMergedSettings({
+      mcpServers: localMcpServersWithTools,
+      admin: {
+        ...baseSettings.admin,
+        mcp: { enabled: true, config: adminAllowlist },
+      },
+    });
+    const config = await loadCliConfig(settings, 'test-session', argv);
+
+    const serverA = config.getMcpServers()?.['serverA'];
+    expect(serverA?.includeTools).toEqual(['local_tool']);
   });
 });
 

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1599,7 +1599,12 @@ describe('loadCliConfig with admin.mcp.config', () => {
       url: 'https://admin-server-a.com/sse',
       trust: true,
     });
-    expect(serverA?.command).toBeUndefined();
+    expect(serverA).not.toHaveProperty('command');
+    expect(serverA).not.toHaveProperty('args');
+    expect(serverA).not.toHaveProperty('env');
+    expect(serverA).not.toHaveProperty('cwd');
+    expect(serverA).not.toHaveProperty('httpUrl');
+    expect(serverA).not.toHaveProperty('tcp');
   });
 
   it('should use local tool filters when admin does not define them', async () => {

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1530,6 +1530,8 @@ describe('loadCliConfig with admin.mcp.config', () => {
       args: undefined,
       env: undefined,
       cwd: undefined,
+      httpUrl: undefined,
+      tcp: undefined,
     });
   });
 

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1469,6 +1469,7 @@ describe('loadCliConfig with admin.mcp.config', () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments(createTestMergedSettings());
     const settings = createTestMergedSettings({
+      mcp: baseSettings.mcp,
       mcpServers: localMcpServers,
       admin: {
         ...baseSettings.admin,
@@ -1491,6 +1492,7 @@ describe('loadCliConfig with admin.mcp.config', () => {
       },
     };
     const settings = createTestMergedSettings({
+      mcp: baseSettings.mcp,
       mcpServers: localMcpServers,
       admin: {
         ...baseSettings.admin,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -699,13 +699,15 @@ export async function loadCliConfig(
           url: adminConfig.url,
           type: adminConfig.type,
           trust: adminConfig.trust,
-          command: undefined,
-          args: undefined,
-          env: undefined,
-          cwd: undefined,
-          httpUrl: undefined,
-          tcp: undefined,
         };
+
+        // Remove local connection details
+        delete mergedConfig.command;
+        delete mergedConfig.args;
+        delete mergedConfig.env;
+        delete mergedConfig.cwd;
+        delete mergedConfig.httpUrl;
+        delete mergedConfig.tcp;
 
         if (
           (adminConfig.includeTools && adminConfig.includeTools.length > 0) ||

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -39,7 +39,7 @@ import type {
   type OutputFormat,
   coreEvents,
   GEMINI_MODEL_ALIAS_AUTO,
-  getAdminErrorMessage
+  getAdminErrorMessage,
 } from '@google/gemini-cli-core';
 import {
   type Settings,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -701,6 +701,8 @@ export async function loadCliConfig(
           args: undefined,
           env: undefined,
           cwd: undefined,
+          httpUrl: undefined,
+          tcp: undefined,
         };
 
         if (

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -35,10 +35,10 @@ import {
   coreEvents,
   GEMINI_MODEL_ALIAS_AUTO,
   getAdminErrorMessage,
+  Config,
 } from '@google/gemini-cli-core';
 import type {
   MCPServerConfig,
-  Config,
   HookDefinition,
   HookEventName,
   OutputFormat,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -11,9 +11,7 @@ import { mcpCommand } from '../commands/mcp.js';
 import { extensionsCommand } from '../commands/extensions.js';
 import { skillsCommand } from '../commands/skills.js';
 import { hooksCommand } from '../commands/hooks.js';
-import type {
-  MCPServerConfig,
-  Config,
+import {
   setGeminiMdFilename as setServerGeminiMdFilename,
   getCurrentGeminiMdFilename,
   ApprovalMode,
@@ -34,12 +32,16 @@ import type {
   WEB_FETCH_TOOL_NAME,
   getVersion,
   PREVIEW_GEMINI_MODEL_AUTO,
-  type HookDefinition,
-  type HookEventName,
-  type OutputFormat,
   coreEvents,
   GEMINI_MODEL_ALIAS_AUTO,
   getAdminErrorMessage,
+} from '@google/gemini-cli-core';
+import type {
+  MCPServerConfig,
+  Config,
+  HookDefinition,
+  HookEventName,
+  OutputFormat,
 } from '@google/gemini-cli-core';
 import {
   type Settings,

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -75,7 +75,11 @@ import {
   SettingScope,
   LoadedSettings,
 } from './settings.js';
-import { FatalConfigError, GEMINI_DIR } from '@google/gemini-cli-core';
+import {
+  FatalConfigError,
+  GEMINI_DIR,
+  type MCPServerConfig,
+} from '@google/gemini-cli-core';
 import { updateSettingsFilePreservingFormat } from '../utils/commentJson.js';
 import {
   getSettingsSchema,
@@ -2304,6 +2308,28 @@ describe('Settings Loading and Merging', () => {
       expect(loadedSettings.merged.admin?.secureModeEnabled).toBe(false);
       expect(loadedSettings.merged.admin?.mcp?.enabled).toBe(true);
       expect(loadedSettings.merged.admin?.extensions?.enabled).toBe(true);
+    });
+
+    it('should un-nest MCP configuration from remote settings', () => {
+      const loadedSettings = loadSettings(MOCK_WORKSPACE_DIR);
+      const mcpServers: Record<string, MCPServerConfig> = {
+        'admin-server': {
+          url: 'http://admin-mcp.com',
+          type: 'sse',
+          trust: true,
+        },
+      };
+
+      loadedSettings.setRemoteAdminSettings({
+        mcpSetting: {
+          mcpEnabled: true,
+          mcpConfig: {
+            mcpServers,
+          },
+        },
+      });
+
+      expect(loadedSettings.merged.admin?.mcp?.config).toEqual(mcpServers);
     });
 
     it('should set skills based on unmanagedCapabilitiesEnabled', () => {

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -360,7 +360,10 @@ export class LoadedSettings {
     }
 
     admin.secureModeEnabled = !strictModeDisabled;
-    admin.mcp = { enabled: mcpSetting?.mcpEnabled };
+    admin.mcp = {
+      enabled: mcpSetting?.mcpEnabled,
+      config: mcpSetting?.mcpConfig?.mcpServers,
+    };
     admin.extensions = {
       enabled: cliFeatureSetting?.extensionsSetting?.extensionsEnabled,
     };

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1867,6 +1867,20 @@ const SETTINGS_SCHEMA = {
             showInDialog: false,
             mergeStrategy: MergeStrategy.REPLACE,
           },
+          config: {
+            type: 'object',
+            label: 'MCP Config',
+            category: 'Admin',
+            requiresRestart: false,
+            default: {} as Record<string, MCPServerConfig>,
+            description: 'Admin-configured MCP servers.',
+            showInDialog: false,
+            mergeStrategy: MergeStrategy.REPLACE,
+            additionalProperties: {
+              type: 'object',
+              ref: 'MCPServerConfig',
+            },
+          },
         },
       },
       skills: {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1712,6 +1712,16 @@
               "markdownDescription": "If false, disallows MCP servers from being used.\n\n- Category: `Admin`\n- Requires restart: `no`\n- Default: `true`",
               "default": true,
               "type": "boolean"
+            },
+            "config": {
+              "title": "MCP Config",
+              "description": "Admin-configured MCP servers.",
+              "markdownDescription": "Admin-configured MCP servers.\n\n- Category: `Admin`\n- Requires restart: `no`\n- Default: `{}`",
+              "default": {},
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/MCPServerConfig"
+              }
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
## Summary

This PR introduces admin allowlist mechanism for MCP  server configurations. When `admin.mcp.config` is enabled and configured, the CLI will filter locally defined MCP servers, only allowing those present in the admin allowlist. For allowed servers, local `command`, `args`, `env`, and `cwd` fields will be cleared for security, and admin-defined tool filters will take precedence.

## Details

- If `admin.mcp.config` is set, only servers explicitly listed in this configuration will be considered.
- For servers present in both local and admin configurations, admin settings for `url`, `type`, and `trust` will be applied, while local executable-related fields (`command`, `args`, `env`, `cwd`) will be nullified to prevent local overrides of secure admin configurations.
- Admin-defined `includeTools` and `excludeTools` will override local settings for tool filtering, ensuring consistent tool exposure. If admin does not define tool filters, local tool filters will still be used.

## Related Issues
https://github.com/google-gemini/maintainers-gemini-cli/issues/1178