### PR TITLE
feat: increase `ask_user` label limit to 16 characters

### DIFF
--- a/packages/core/src/tools/ask-user.test.ts
+++ b/packages/core/src/tools/ask-user.test.ts
@@ -71,7 +71,7 @@ describe('AskUserTool', () => {
       const result = tool.validateToolParams({
         questions: [{ question: 'Test?', header: 'This is way too long' }],
       });
-      expect(result).toContain('must NOT have more than 12 characters');
+      expect(result).toContain('must NOT have more than 16 characters');
     });
 
     it('should return error if options has fewer than 2 items', () => {

--- a/packages/core/src/tools/ask-user.ts
+++ b/packages/core/src/tools/ask-user.ts
@@ -50,9 +50,9 @@ export class AskUserTool extends BaseDeclarativeTool<
                 },
                 header: {
                   type: 'string',
-                  maxLength: 12,
+                  maxLength: 16,
                   description:
-                    'Very short label displayed as a chip/tag (max 12 chars). Examples: "Auth method", "Library", "Approach".',
+                    'Very short label displayed as a chip/tag (max 16 chars). Examples: "Auth method", "Library", "Approach".',
                 },
                 type: {
                   type: 'string',


### PR DESCRIPTION
## Summary

   Increase the maximum character length for `ask_user` tool labels (headers) from 12 to 16 characters.

## Details

   The previous limit of 12 characters was found to be too restrictive for certain descriptive labels. This PR updates:
   - The JSON schema in `AskUserTool` to allow `maxLength: 16`.
   - The internal description to reflect the new limit.
   - The corresponding test expectations in `ask-user.test.ts`.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Closes #18319

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

Ask for a question with a 14 or 15 char label.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
