### PR TITLE
fix(hooks): remove unnecessary logging for hook registration

### DIFF
--- a/packages/core/src/hooks/hookRegistry.test.ts
+++ b/packages/core/src/hooks/hookRegistry.test.ts
@@ -90,7 +90,7 @@ describe('HookRegistry', () => {
       await hookRegistry.initialize();
 
       expect(hookRegistry.getAllHooks()).toHaveLength(0);
-      expect(mockDebugLogger.log).toHaveBeenCalledWith(
+      expect(mockDebugLogger.debug).toHaveBeenCalledWith(
         'Hook registry initialized with 0 hook entries',
       );
     });

--- a/packages/core/src/hooks/hookRegistry.ts
+++ b/packages/core/src/hooks/hookRegistry.ts
@@ -41,7 +41,7 @@ export class HookRegistry {
     this.entries = [];
     this.processHooksFromConfig();
 
-    debugLogger.log(
+    debugLogger.debug(
       `Hook registry initialized with ${this.entries.length} hook entries`,
     );
   }


### PR DESCRIPTION
removes unneeded hook logging for initial hooks that are registered since this is noisy for non-interactive mode