### PR TITLE
Stop showing an error message in `/plan`

### DIFF
--- a/packages/cli/src/ui/commands/planCommand.test.ts
+++ b/packages/cli/src/ui/commands/planCommand.test.ts
@@ -92,21 +92,6 @@ describe('planCommand', () => {
     );
   });
 
-  it('should show "No approved plan found" if no approved plan path in config', async () => {
-    vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(true);
-    vi.mocked(mockContext.services.config!.getApprovedPlanPath).mockReturnValue(
-      undefined,
-    );
-
-    if (!planCommand.action) throw new Error('Action missing');
-    await planCommand.action(mockContext, '');
-
-    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
-      'error',
-      'No approved plan found. Please create and approve a plan first.',
-    );
-  });
-
   it('should display the approved plan from config', async () => {
     const mockPlanPath = '/mock/plans/dir/approved-plan.md';
     vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(true);

--- a/packages/cli/src/ui/commands/planCommand.ts
+++ b/packages/cli/src/ui/commands/planCommand.ts
@@ -37,10 +37,6 @@ export const planCommand: SlashCommand = {
     const approvedPlanPath = config.getApprovedPlanPath();
 
     if (!approvedPlanPath) {
-      coreEvents.emitFeedback(
-        'error',
-        'No approved plan found. Please create and approve a plan first.',
-      );
       return;
     }
 


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
As title suggests
## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Related to #17686, this is a follow up fix.

## How to Validate
When in plan mode, it should show the approved plan if it exists. Otherwise nothing happens.

When not in plan mode and we run `/plan` we should switch into plan mode.


https://github.com/user-attachments/assets/f6d8839b-70e8-4fc3-a500-b849d9dee33a



<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
