### PR TITLE
Update Ink version to 6.4.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "ink": "npm:@jrichman/ink@6.4.8",
+        "ink": "npm:@jrichman/ink@6.4.9",
         "latest-version": "^9.0.0",
         "simple-git": "^3.28.0"
       },
@@ -10548,9 +10548,9 @@
     },
     "node_modules/ink": {
       "name": "@jrichman/ink",
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.4.8.tgz",
-      "integrity": "sha512-v0thcXIKl9hqF/1w4HqA6MKxIcMoWSP3YtEZIAA+eeJngXpN5lGnMkb6rllB7FnOdwyEyYaFTcu1ZVr4/JZpWQ==",
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.4.9.tgz",
+      "integrity": "sha512-UwsR8HWPb4ZCBttgbP0Tc8BoB45CT4++UrPL9YYdjzOj0RZOys0yZqBUldGUpkoACSwwXGtEthYPh5EjT7Z1ig==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -18097,7 +18097,7 @@
         "fzf": "^0.5.2",
         "glob": "^12.0.0",
         "highlight.js": "^11.11.1",
-        "ink": "npm:@jrichman/ink@6.4.8",
+        "ink": "npm:@jrichman/ink@6.4.9",
         "ink-gradient": "^3.0.0",
         "ink-spinner": "^5.0.0",
         "latest-version": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "pre-commit": "node scripts/pre-commit.js"
   },
   "overrides": {
-    "ink": "npm:@jrichman/ink@6.4.8",
+    "ink": "npm:@jrichman/ink@6.4.9",
     "wrap-ansi": "9.0.2",
     "cliui": {
       "wrap-ansi": "7.0.0"
@@ -124,7 +124,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "ink": "npm:@jrichman/ink@6.4.8",
+    "ink": "npm:@jrichman/ink@6.4.9",
     "latest-version": "^9.0.0",
     "simple-git": "^3.28.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,7 +46,7 @@
     "fzf": "^0.5.2",
     "glob": "^12.0.0",
     "highlight.js": "^11.11.1",
-    "ink": "npm:@jrichman/ink@6.4.8",
+    "ink": "npm:@jrichman/ink@6.4.9",
     "ink-gradient": "^3.0.0",
     "ink-spinner": "^5.0.0",
     "latest-version": "^9.0.0",


### PR DESCRIPTION
## Summary

New version has an IME fix and exports APIs to make it easier to perform text wrapping for markdown tables.
