### PR TITLE
fix(cli): color extension link success message green

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,6 +36,7 @@
     "@modelcontextprotocol/sdk": "^1.23.0",
     "@types/update-notifier": "^6.0.8",
     "ansi-regex": "^6.2.2",
+    "chalk": "^5.4.1",
     "clipboardy": "^5.0.0",
     "color-convert": "^2.0.1",
     "command-exists": "^1.2.9",

--- a/packages/cli/src/commands/extensions/link.ts
+++ b/packages/cli/src/commands/extensions/link.ts
@@ -5,6 +5,7 @@
  */
 
 import type { CommandModule } from 'yargs';
+import chalk from 'chalk';
 import {
   debugLogger,
   type ExtensionInstallMetadata,
@@ -49,7 +50,9 @@ export async function handleLink(args: InstallArgs) {
     const extension =
       await extensionManager.installOrUpdateExtension(installMetadata);
     debugLogger.log(
-      `Extension "${extension.name}" linked successfully and enabled.`,
+      chalk.green(
+        `Extension "${extension.name}" linked successfully and enabled.`,
+      ),
     );
   } catch (error) {
     debugLogger.error(getErrorMessage(error));


### PR DESCRIPTION
## Summary

Colors the success message for `gemini extensions link` green in the debug console.

## Details

Uses `chalk.green()` to explicitly set the color of the "linked successfully" message. Previously, this was appearing in red (the default error color) because it was logged via `debugLogger.log()` without explicit coloring.

## Related Issues

N/A

## How to Validate

1. Link a local extension: `npm start -- extensions link ./path/to/extension --consent`
2. Open the debug console (F12).
3. Confirm the success message is green.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
  - [ ] Windows
  - [x] Linux
    - [x] npm run
<img width="661" height="29" alt="Screenshot 2026-02-05 at 10 20 04 AM" src="https://github.com/user-attachments/assets/44d46d1c-b667-4c88-88f2-dcd8ce3df981" />

