### PR TITLE
feat(cli): support git submodules in extension installation

### DIFF
--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -75,6 +75,7 @@ describe('github.ts', () => {
       checkout: ReturnType<typeof vi.fn>;
       listRemote: ReturnType<typeof vi.fn>;
       revparse: ReturnType<typeof vi.fn>;
+      submoduleUpdate: ReturnType<typeof vi.fn>;
     };
 
     beforeEach(() => {
@@ -85,6 +86,7 @@ describe('github.ts', () => {
         checkout: vi.fn(),
         listRemote: vi.fn(),
         revparse: vi.fn(),
+        submoduleUpdate: vi.fn(),
       };
       vi.mocked(simpleGit).mockReturnValue(mockGit as unknown as SimpleGit);
     });
@@ -108,6 +110,10 @@ describe('github.ts', () => {
       );
       expect(mockGit.fetch).toHaveBeenCalledWith('origin', 'v1.0.0');
       expect(mockGit.checkout).toHaveBeenCalledWith('FETCH_HEAD');
+      expect(mockGit.submoduleUpdate).toHaveBeenCalledWith([
+        '--init',
+        '--recursive',
+      ]);
     });
 
     it('should throw if no remotes found', async () => {

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -69,6 +69,9 @@ export async function cloneFromGit(
     // After fetching, checkout FETCH_HEAD to get the content of the fetched ref.
     // This results in a detached HEAD state, which is fine for this purpose.
     await git.checkout('FETCH_HEAD');
+
+    // Initialize and update submodules recursively.
+    await git.submoduleUpdate(['--init', '--recursive']);
   } catch (error) {
     throw new Error(
       `Failed to clone Git repository from ${installMetadata.source} ${getErrorMessage(error)}`,


### PR DESCRIPTION
## Summary
Supports recursive cloning and initialization of Git submodules when installing extensions. This ensures that extensions relying on submodules (e.g., for shared libraries or assets) are fully functional immediately after installation.

## Details
- Modified `packages/cli/src/config/extensions/github.ts` to initialize submodules after checkout.
- Added verification test in `packages/cli/src/config/extensions/github.test.ts`.

## Related Issues
Closes #18385 

## How to Validate
1. Run `npm run build`
2. Run `npm test -w @google/gemini-cli -- src/config/extensions/github.test.ts`
3. Install an extension with submodules (e.g., creating a test repo with one) and verify contents.

## Pre-Merge Checklist
- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run