### PR TITLE
Add extension registry client

### DIFF
--- a/packages/cli/src/config/extensionRegistryClient.test.ts
+++ b/packages/cli/src/config/extensionRegistryClient.test.ts
@@ -1,0 +1,205 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
+import {
+  ExtensionRegistryClient,
+  type RegistryExtension,
+} from './extensionRegistryClient.js';
+
+const mockExtensions: RegistryExtension[] = [
+  {
+    id: 'ext1',
+    rank: 1,
+    url: 'https://github.com/test/ext1',
+    fullName: 'test/ext1',
+    repoDescription: 'Test extension 1',
+    stars: 100,
+    lastUpdated: '2025-01-01T00:00:00Z',
+    extensionName: 'extension-one',
+    extensionVersion: '1.0.0',
+    extensionDescription: 'First test extension',
+    avatarUrl: 'https://example.com/avatar1.png',
+    hasMCP: true,
+    hasContext: false,
+    isGoogleOwned: false,
+    licenseKey: 'mit',
+    hasHooks: false,
+    hasCustomCommands: false,
+    hasSkills: false,
+  },
+  {
+    id: 'ext2',
+    rank: 2,
+    url: 'https://github.com/test/ext2',
+    fullName: 'test/ext2',
+    repoDescription: 'Test extension 2',
+    stars: 50,
+    lastUpdated: '2025-01-02T00:00:00Z',
+    extensionName: 'extension-two',
+    extensionVersion: '0.5.0',
+    extensionDescription: 'Second test extension',
+    avatarUrl: 'https://example.com/avatar2.png',
+    hasMCP: false,
+    hasContext: true,
+    isGoogleOwned: true,
+    licenseKey: 'apache-2.0',
+    hasHooks: false,
+    hasCustomCommands: false,
+    hasSkills: false,
+  },
+  {
+    id: 'ext3',
+    rank: 3,
+    url: 'https://github.com/test/ext3',
+    fullName: 'test/ext3',
+    repoDescription: 'Test extension 3',
+    stars: 10,
+    lastUpdated: '2025-01-03T00:00:00Z',
+    extensionName: 'extension-three',
+    extensionVersion: '0.1.0',
+    extensionDescription: 'Third test extension',
+    avatarUrl: 'https://example.com/avatar3.png',
+    hasMCP: true,
+    hasContext: true,
+    isGoogleOwned: false,
+    licenseKey: 'gpl-3.0',
+    hasHooks: false,
+    hasCustomCommands: false,
+    hasSkills: false,
+  },
+];
+
+describe('ExtensionRegistryClient', () => {
+  let client: ExtensionRegistryClient;
+  let fetchMock: Mock;
+
+  beforeEach(() => {
+    client = new ExtensionRegistryClient();
+    fetchMock = vi.fn();
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should fetch and return extensions with pagination (default ranking)', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => mockExtensions,
+    });
+
+    const result = await client.getExtensions(1, 2);
+    expect(result.extensions).toHaveLength(2);
+    expect(result.extensions[0].id).toBe('ext1'); // rank 1
+    expect(result.extensions[1].id).toBe('ext2'); // rank 2
+    expect(result.total).toBe(3);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://geminicli.com/extensions.json',
+    );
+  });
+
+  it('should return extensions sorted alphabetically', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => mockExtensions,
+    });
+
+    const result = await client.getExtensions(1, 3, 'alphabetical');
+    expect(result.extensions).toHaveLength(3);
+    expect(result.extensions[0].id).toBe('ext1');
+    expect(result.extensions[1].id).toBe('ext3');
+    expect(result.extensions[2].id).toBe('ext2');
+  });
+
+  it('should return the second page of extensions', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => mockExtensions,
+    });
+
+    const result = await client.getExtensions(2, 2);
+    expect(result.extensions).toHaveLength(1);
+    expect(result.extensions[0].id).toBe('ext3');
+    expect(result.total).toBe(3);
+  });
+
+  it('should search extensions by name', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => mockExtensions,
+    });
+
+    const results = await client.searchExtensions('one');
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe('ext1');
+  });
+
+  it('should search extensions by description', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => mockExtensions,
+    });
+
+    const results = await client.searchExtensions('Second');
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe('ext2');
+  });
+
+  it('should get an extension by ID', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => mockExtensions,
+    });
+
+    const result = await client.getExtension('ext2');
+    expect(result).toBeDefined();
+    expect(result?.id).toBe('ext2');
+  });
+
+  it('should return undefined if extension not found', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => mockExtensions,
+    });
+
+    const result = await client.getExtension('non-existent');
+    expect(result).toBeUndefined();
+  });
+
+  it('should cache the fetch result', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => mockExtensions,
+    });
+
+    await client.getExtensions();
+    await client.getExtensions();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throw an error if fetch fails', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      statusText: 'Not Found',
+    });
+
+    await expect(client.getExtensions()).rejects.toThrow(
+      'Failed to fetch extensions: Not Found',
+    );
+  });
+});

--- a/packages/cli/src/config/extensionRegistryClient.ts
+++ b/packages/cli/src/config/extensionRegistryClient.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface RegistryExtension {
+  id: string;
+  rank: number;
+  url: string;
+  fullName: string;
+  repoDescription: string;
+  stars: number;
+  lastUpdated: string;
+  extensionName: string;
+  extensionVersion: string;
+  extensionDescription: string;
+  avatarUrl: string;
+  hasMCP: boolean;
+  hasContext: boolean;
+  hasHooks: boolean;
+  hasSkills: boolean;
+  hasCustomCommands: boolean;
+  isGoogleOwned: boolean;
+  licenseKey: string;
+}
+
+export class ExtensionRegistryClient {
+  private static readonly REGISTRY_URL =
+    'https://geminicli.com/extensions.json';
+  private cache: RegistryExtension[] | null = null;
+
+  async getExtensions(
+    page: number = 1,
+    limit: number = 10,
+    orderBy: 'ranking' | 'alphabetical' = 'ranking',
+  ): Promise<{ extensions: RegistryExtension[]; total: number }> {
+    const allExtensions = [...(await this.fetchAllExtensions())];
+
+    switch (orderBy) {
+      case 'ranking':
+        allExtensions.sort((a, b) => a.rank - b.rank);
+        break;
+      case 'alphabetical':
+        allExtensions.sort((a, b) =>
+          a.extensionName.localeCompare(b.extensionName),
+        );
+        break;
+      default:
+        break;
+    }
+
+    const startIndex = (page - 1) * limit;
+    const endIndex = startIndex + limit;
+    return {
+      extensions: allExtensions.slice(startIndex, endIndex),
+      total: allExtensions.length,
+    };
+  }
+
+  async searchExtensions(query: string): Promise<RegistryExtension[]> {
+    const allExtensions = await this.fetchAllExtensions();
+    const lowerQuery = query.toLowerCase();
+    return allExtensions.filter(
+      (ext) =>
+        ext.extensionName.toLowerCase().includes(lowerQuery) ||
+        ext.extensionDescription.toLowerCase().includes(lowerQuery) ||
+        ext.fullName.toLowerCase().includes(lowerQuery),
+    );
+  }
+
+  async getExtension(id: string): Promise<RegistryExtension | undefined> {
+    const allExtensions = await this.fetchAllExtensions();
+    return allExtensions.find((ext) => ext.id === id);
+  }
+
+  private async fetchAllExtensions(): Promise<RegistryExtension[]> {
+    if (this.cache) {
+      return this.cache;
+    }
+
+    const response = await fetch(ExtensionRegistryClient.REGISTRY_URL);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch extensions: ${response.statusText}`);
+    }
+
+    this.cache = (await response.json()) as RegistryExtension[];
+    return this.cache;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,7 @@ export * from './code_assist/admin/admin_controls.js';
 export * from './core/apiKeyCredentialStorage.js';
 
 // Export utilities
+export * from './utils/fetch.js';
 export { homedir, tmpdir } from './utils/paths.js';
 export * from './utils/paths.js';
 export * from './utils/checks.js';


### PR DESCRIPTION
## Summary

Add a client to be used to fetch extensions from geminicli.com/extensions.json

## Details

This may change in the future, but should unblock UI work at the moment.

## Related Issues

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/1321


## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
