### PR TITLE
feat(vim): implement d0, c0, d^, c^ and d$, c$

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -1655,6 +1655,10 @@ export type TextBufferAction =
   | { type: 'vim_change_line'; payload: { count: number } }
   | { type: 'vim_delete_to_end_of_line' }
   | { type: 'vim_change_to_end_of_line' }
+  | { type: 'vim_delete_to_line_start' }
+  | { type: 'vim_change_to_line_start' }
+  | { type: 'vim_delete_to_first_non_whitespace' }
+  | { type: 'vim_change_to_first_non_whitespace' }
   | {
       type: 'vim_change_movement';
       payload: { movement: 'h' | 'j' | 'k' | 'l'; count: number };
@@ -2458,6 +2462,10 @@ function textBufferReducerLogic(
     case 'vim_move_to_first_line':
     case 'vim_move_to_last_line':
     case 'vim_move_to_line':
+    case 'vim_delete_to_line_start':
+    case 'vim_change_to_line_start':
+    case 'vim_delete_to_first_non_whitespace':
+    case 'vim_change_to_first_non_whitespace':
     case 'vim_escape_insert_mode':
       return handleVimAction(state, action as VimAction);
 
@@ -2946,6 +2954,22 @@ export function useTextBuffer({
 
   const vimChangeToEndOfLine = useCallback((): void => {
     dispatch({ type: 'vim_change_to_end_of_line' });
+  }, []);
+
+  const vimDeleteToLineStart = useCallback((): void => {
+    dispatch({ type: 'vim_delete_to_line_start' });
+  }, []);
+
+  const vimChangeToLineStart = useCallback((): void => {
+    dispatch({ type: 'vim_change_to_line_start' });
+  }, []);
+
+  const vimDeleteToFirstNonWhitespace = useCallback((): void => {
+    dispatch({ type: 'vim_delete_to_first_non_whitespace' });
+  }, []);
+
+  const vimChangeToFirstNonWhitespace = useCallback((): void => {
+    dispatch({ type: 'vim_change_to_first_non_whitespace' });
   }, []);
 
   const vimChangeMovement = useCallback(
@@ -3506,6 +3530,10 @@ export function useTextBuffer({
       vimChangeLine,
       vimDeleteToEndOfLine,
       vimChangeToEndOfLine,
+      vimDeleteToLineStart,
+      vimChangeToLineStart,
+      vimDeleteToFirstNonWhitespace,
+      vimChangeToFirstNonWhitespace,
       vimChangeMovement,
       vimMoveLeft,
       vimMoveRight,
@@ -3588,6 +3616,10 @@ export function useTextBuffer({
       vimChangeLine,
       vimDeleteToEndOfLine,
       vimChangeToEndOfLine,
+      vimDeleteToLineStart,
+      vimChangeToLineStart,
+      vimDeleteToFirstNonWhitespace,
+      vimChangeToFirstNonWhitespace,
       vimChangeMovement,
       vimMoveLeft,
       vimMoveRight,
@@ -3833,6 +3865,22 @@ export interface TextBuffer {
    * Change from cursor to end of line (vim 'C' command)
    */
   vimChangeToEndOfLine: () => void;
+  /**
+   * Delete from cursor to start of line (vim 'd0' command)
+   */
+  vimDeleteToLineStart: () => void;
+  /**
+   * Change from cursor to start of line (vim 'c0' command)
+   */
+  vimChangeToLineStart: () => void;
+  /**
+   * Delete from cursor to first non-whitespace character (vim 'd^' command)
+   */
+  vimDeleteToFirstNonWhitespace: () => void;
+  /**
+   * Change from cursor to first non-whitespace character (vim 'c^' command)
+   */
+  vimChangeToFirstNonWhitespace: () => void;
   /**
    * Change movement operations (vim 'ch', 'cj', 'ck', 'cl' commands)
    */

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -57,6 +57,16 @@ export const isWordCharStrict = (char: string): boolean =>
 
 export const isWhitespace = (char: string): boolean => /\s/.test(char);
 
+// Find first non-whitespace character in a line
+export const findFirstNonWhitespace = (line: string): number => {
+  let col = 0;
+  const lineCodePoints = toCodePoints(line);
+  while (col < lineCodePoints.length && /\s/.test(lineCodePoints[col])) {
+    col++;
+  }
+  return col;
+};
+
 // Check if a character is a combining mark (only diacritics for now)
 export const isCombiningMark = (char: string): boolean => /\p{M}/u.test(char);
 

--- a/packages/cli/src/ui/components/shared/vim-buffer-actions.test.ts
+++ b/packages/cli/src/ui/components/shared/vim-buffer-actions.test.ts
@@ -855,6 +855,124 @@ describe('vim-buffer-actions', () => {
     });
   });
 
+  describe('Line Boundary Commands', () => {
+    describe('vim_delete_to_line_start', () => {
+      it('should delete from cursor to start of line', () => {
+        const state = createTestState(['hello world'], 0, 5);
+        const action = {
+          type: 'vim_delete_to_line_start' as const,
+        }; // Cast to any until types are added
+
+        const result = handleVimAction(state, action);
+        expect(result).toHaveOnlyValidCharacters();
+        expect(result.lines[0]).toBe(' world');
+        expect(result.cursorCol).toBe(0);
+      });
+
+      it('should do nothing if already at start of line', () => {
+        const state = createTestState(['hello world'], 0, 0);
+        const action = {
+          type: 'vim_delete_to_line_start' as const,
+        };
+
+        const result = handleVimAction(state, action);
+        expect(result).toHaveOnlyValidCharacters();
+        expect(result.lines[0]).toBe('hello world');
+        expect(result.cursorCol).toBe(0);
+      });
+    });
+
+    describe('vim_change_to_line_start', () => {
+      it('should delete from cursor to start of line', () => {
+        const state = createTestState(['hello world'], 0, 5);
+        const action = {
+          type: 'vim_change_to_line_start' as const,
+        };
+
+        const result = handleVimAction(state, action);
+        expect(result).toHaveOnlyValidCharacters();
+        expect(result.lines[0]).toBe(' world');
+        expect(result.cursorCol).toBe(0);
+      });
+    });
+
+    describe('vim_delete_to_first_non_whitespace', () => {
+      it('should delete backwards to first non-whitespace', () => {
+        const state = createTestState(['   hello world'], 0, 5); // on 'e', 'h' is at 3
+        const action = {
+          type: 'vim_delete_to_first_non_whitespace' as const,
+        };
+
+        const result = handleVimAction(state, action);
+        expect(result).toHaveOnlyValidCharacters();
+        // Range [3, 5). 3='h', 4='e'. 'he' deleted.
+        expect(result.lines[0]).toBe('   llo world');
+        expect(result.cursorCol).toBe(3);
+      });
+
+      it('should delete forwards to first non-whitespace', () => {
+        const state = createTestState(['   hello world'], 0, 0);
+        const action = {
+          type: 'vim_delete_to_first_non_whitespace' as const,
+        };
+
+        const result = handleVimAction(state, action);
+        expect(result).toHaveOnlyValidCharacters();
+        // Range [0, 3). '   ' deleted.
+        expect(result.lines[0]).toBe('hello world');
+        expect(result.cursorCol).toBe(0);
+      });
+
+      it('should do nothing if on first non-whitespace', () => {
+        const state = createTestState(['   hello world'], 0, 3);
+        const action = {
+          type: 'vim_delete_to_first_non_whitespace' as const,
+        };
+
+        const result = handleVimAction(state, action);
+        expect(result).toHaveOnlyValidCharacters();
+        expect(result.lines[0]).toBe('   hello world');
+        expect(result.cursorCol).toBe(3);
+      });
+
+      it('should handle line with only whitespace', () => {
+        const state = createTestState(['     '], 0, 2);
+        const action = {
+          type: 'vim_delete_to_first_non_whitespace' as const,
+        };
+
+        const result = handleVimAction(state, action);
+        expect(result).toHaveOnlyValidCharacters();
+        expect(result.lines[0]).toBe('  ');
+      });
+
+      it('should delete entire line content if line is all whitespace and cursor is at start', () => {
+        const state = createTestState(['     '], 0, 0);
+        const action = {
+          type: 'vim_delete_to_first_non_whitespace' as const,
+        };
+
+        const result = handleVimAction(state, action);
+        expect(result).toHaveOnlyValidCharacters();
+        expect(result.lines[0]).toBe('');
+      });
+    });
+
+    describe('vim_change_to_first_non_whitespace', () => {
+      it('should delete to first non-whitespace (backward)', () => {
+        const state = createTestState(['   hello world'], 0, 5);
+        const action = {
+          type: 'vim_change_to_first_non_whitespace' as const,
+        };
+
+        const result = handleVimAction(state, action);
+        expect(result).toHaveOnlyValidCharacters();
+        expect(result.lines[0]).toBe('   llo world');
+        expect(result.cursorCol).toBe(3);
+      });
+    });
+  });
+
   describe('Change commands', () => {
     describe('vim_change_word_forward', () => {
       it('should delete from cursor to next word start', () => {

--- a/packages/cli/src/ui/components/shared/vim-buffer-actions.test.ts
+++ b/packages/cli/src/ui/components/shared/vim-buffer-actions.test.ts
@@ -943,10 +943,10 @@ describe('vim-buffer-actions', () => {
 
         const result = handleVimAction(state, action);
         expect(result).toHaveOnlyValidCharacters();
-        expect(result.lines[0]).toBe('  ');
+        expect(result.lines[0]).toBe('   ');
       });
 
-      it('should delete entire line content if line is all whitespace and cursor is at start', () => {
+      it('should delete from start to last character on whitespace-only line if cursor is at start', () => {
         const state = createTestState(['     '], 0, 0);
         const action = {
           type: 'vim_delete_to_first_non_whitespace' as const,
@@ -954,7 +954,26 @@ describe('vim-buffer-actions', () => {
 
         const result = handleVimAction(state, action);
         expect(result).toHaveOnlyValidCharacters();
-        expect(result.lines[0]).toBe('');
+        // Cursor at 0. Target 4. Range [0, 4).
+        // Deletes 0, 1, 2, 3.
+        // Leaves index 4 (1 space).
+        expect(result.lines[0]).toBe(' ');
+      });
+
+      it('should delete forward to last character on whitespace-only line', () => {
+        // Line with 5 spaces. Cursor at position 3 (1-based), so index 2.
+        const state = createTestState(['     '], 0, 2);
+        const action = {
+          type: 'vim_delete_to_first_non_whitespace' as const,
+        };
+
+        const result = handleVimAction(state, action);
+        expect(result).toHaveOnlyValidCharacters();
+        // Logic: Deletes from 2 up to 4 (last char index). Range [2, 4).
+        // Original: 0 1 2 3 4 (5 spaces)
+        // Deleted: 2, 3
+        // Result: 0 1 4 (3 spaces)
+        expect(result.lines[0]).toBe('   ');
       });
     });
 

--- a/packages/cli/src/ui/components/shared/vim-buffer-actions.ts
+++ b/packages/cli/src/ui/components/shared/vim-buffer-actions.ts
@@ -409,11 +409,15 @@ export function handleVimAction(
     case 'vim_delete_to_first_non_whitespace':
     case 'vim_change_to_first_non_whitespace': {
       const currentLine = lines[cursorRow] || '';
-      const firstNonWhitespaceCol = findFirstNonWhitespace(currentLine);
+      let firstNonWhitespaceCol = findFirstNonWhitespace(currentLine);
 
       // If line is all whitespace, firstNonWhitespaceCol equals line length.
-      // This results in deleting/changing from cursor to end of line,
-      // which is consistent with vim's d^ behavior on whitespace-only lines.
+      // In this case, vim's d^ deletes up to the last character (exclusive of end of line, inclusive of start if forward).
+      // Effectively it targets the last character position.
+      if (firstNonWhitespaceCol === cpLen(currentLine)) {
+        firstNonWhitespaceCol = Math.max(0, cpLen(currentLine) - 1);
+      }
+
       const startCol = Math.min(cursorCol, firstNonWhitespaceCol);
       const endCol = Math.max(cursorCol, firstNonWhitespaceCol);
 

--- a/packages/cli/src/ui/components/shared/vim-buffer-actions.ts
+++ b/packages/cli/src/ui/components/shared/vim-buffer-actions.ts
@@ -18,6 +18,7 @@ import {
   findPrevBigWordAcrossLines,
   findWordEndInLine,
   findBigWordEndInLine,
+  findFirstNonWhitespace,
 } from './text-buffer.js';
 import { cpLen, toCodePoints } from '../../utils/textUtils.js';
 import { assumeExhaustive } from '@google/gemini-cli-core';
@@ -408,14 +409,7 @@ export function handleVimAction(
     case 'vim_delete_to_first_non_whitespace':
     case 'vim_change_to_first_non_whitespace': {
       const currentLine = lines[cursorRow] || '';
-      let firstNonWhitespaceCol = 0;
-      const lineCodePoints = toCodePoints(currentLine);
-      while (
-        firstNonWhitespaceCol < lineCodePoints.length &&
-        /\s/.test(lineCodePoints[firstNonWhitespaceCol])
-      ) {
-        firstNonWhitespaceCol++;
-      }
+      const firstNonWhitespaceCol = findFirstNonWhitespace(currentLine);
 
       // If line is all whitespace, firstNonWhitespaceCol equals line length.
       // This results in deleting/changing from cursor to end of line,
@@ -917,13 +911,7 @@ export function handleVimAction(
     case 'vim_insert_at_line_start': {
       const { cursorRow, lines } = state;
       const currentLine = lines[cursorRow] || '';
-      let col = 0;
-
-      // Find first non-whitespace character using proper Unicode handling
-      const lineCodePoints = toCodePoints(currentLine);
-      while (col < lineCodePoints.length && /\s/.test(lineCodePoints[col])) {
-        col++;
-      }
+      const col = findFirstNonWhitespace(currentLine);
 
       return {
         ...state,
@@ -954,13 +942,7 @@ export function handleVimAction(
     case 'vim_move_to_first_nonwhitespace': {
       const { cursorRow, lines } = state;
       const currentLine = lines[cursorRow] || '';
-      let col = 0;
-
-      // Find first non-whitespace character using proper Unicode handling
-      const lineCodePoints = toCodePoints(currentLine);
-      while (col < lineCodePoints.length && /\s/.test(lineCodePoints[col])) {
-        col++;
-      }
+      const col = findFirstNonWhitespace(currentLine);
 
       return {
         ...state,

--- a/packages/cli/src/ui/hooks/vim.test.tsx
+++ b/packages/cli/src/ui/hooks/vim.test.tsx
@@ -967,10 +967,6 @@ describe('useVim hook', () => {
       // We expect vimDeleteToLineStart to be called.
       // Since it's a mock, it won't actually modify the buffer unless we implement logic.
       // But we just want to verify the hook dispatches to it.
-      // The implementation of createMockBuffer has vi.fn() for this.
-      // However, TypeScript doesn't know about it on 'testBuffer' unless we cast it or update types.
-      // Since we updated createMockBuffer, the runtime object has it.
-      // We can check calls.
       expect(testBuffer.vimDeleteToLineStart).toHaveBeenCalled();
     });
 

--- a/packages/cli/src/ui/hooks/vim.test.tsx
+++ b/packages/cli/src/ui/hooks/vim.test.tsx
@@ -191,6 +191,10 @@ describe('useVim hook', () => {
           cursorState.pos = [row, col - 1];
         }
       }),
+      vimDeleteToLineStart: vi.fn(),
+      vimChangeToLineStart: vi.fn(),
+      vimDeleteToFirstNonWhitespace: vi.fn(),
+      vimChangeToFirstNonWhitespace: vi.fn(),
       // Additional properties for transformations
       transformedToLogicalMaps: lines.map(() => []),
       visualToTransformedMap: [],
@@ -944,6 +948,110 @@ describe('useVim hook', () => {
       });
 
       expect(testBuffer.vimMoveWordForward).toHaveBeenCalledWith(3);
+    });
+  });
+
+  describe('Line Boundary Operations', () => {
+    it('should handle d0 (delete to line start)', () => {
+      const testBuffer = createMockBuffer('hello world', [0, 5]);
+      const { result } = renderVimHook(testBuffer);
+      exitInsertMode(result);
+
+      act(() => {
+        result.current.handleInput(createKey({ sequence: 'd' }));
+      });
+      act(() => {
+        result.current.handleInput(createKey({ sequence: '0' }));
+      });
+
+      // We expect vimDeleteToLineStart to be called.
+      // Since it's a mock, it won't actually modify the buffer unless we implement logic.
+      // But we just want to verify the hook dispatches to it.
+      // The implementation of createMockBuffer has vi.fn() for this.
+      // However, TypeScript doesn't know about it on 'testBuffer' unless we cast it or update types.
+      // Since we updated createMockBuffer, the runtime object has it.
+      // We can check calls.
+      expect(testBuffer.vimDeleteToLineStart).toHaveBeenCalled();
+    });
+
+    it('should handle c0 (change to line start)', () => {
+      const testBuffer = createMockBuffer('hello world', [0, 5]);
+      const { result } = renderVimHook(testBuffer);
+      exitInsertMode(result);
+
+      act(() => {
+        result.current.handleInput(createKey({ sequence: 'c' }));
+      });
+      act(() => {
+        result.current.handleInput(createKey({ sequence: '0' }));
+      });
+
+      expect(testBuffer.vimChangeToLineStart).toHaveBeenCalled();
+      expect(result.current.mode).toBe('INSERT');
+    });
+
+    it('should handle d^ (delete to first non-whitespace)', () => {
+      const testBuffer = createMockBuffer('   hello world', [0, 5]);
+      const { result } = renderVimHook(testBuffer);
+      exitInsertMode(result);
+
+      act(() => {
+        result.current.handleInput(createKey({ sequence: 'd' }));
+      });
+      act(() => {
+        result.current.handleInput(createKey({ sequence: '^' }));
+      });
+
+      expect(testBuffer.vimDeleteToFirstNonWhitespace).toHaveBeenCalled();
+    });
+
+    it('should handle c^ (change to first non-whitespace)', () => {
+      const testBuffer = createMockBuffer('   hello world', [0, 5]);
+      const { result } = renderVimHook(testBuffer);
+      exitInsertMode(result);
+
+      act(() => {
+        result.current.handleInput(createKey({ sequence: 'c' }));
+      });
+      act(() => {
+        result.current.handleInput(createKey({ sequence: '^' }));
+      });
+
+      expect(testBuffer.vimChangeToFirstNonWhitespace).toHaveBeenCalled();
+      expect(result.current.mode).toBe('INSERT');
+    });
+
+    it('should handle d$ (delete to line end)', () => {
+      const testBuffer = createMockBuffer('hello world', [0, 0]);
+      const { result } = renderVimHook(testBuffer);
+      exitInsertMode(result);
+
+      act(() => {
+        result.current.handleInput(createKey({ sequence: 'd' }));
+      });
+      act(() => {
+        result.current.handleInput(createKey({ sequence: '$' }));
+      });
+
+      // Should call vimDeleteToEndOfLine (same as D)
+      expect(testBuffer.vimDeleteToEndOfLine).toHaveBeenCalled();
+    });
+
+    it('should handle c$ (change to line end)', () => {
+      const testBuffer = createMockBuffer('hello world', [0, 0]);
+      const { result } = renderVimHook(testBuffer);
+      exitInsertMode(result);
+
+      act(() => {
+        result.current.handleInput(createKey({ sequence: 'c' }));
+      });
+      act(() => {
+        result.current.handleInput(createKey({ sequence: '$' }));
+      });
+
+      // Should call vimChangeToEndOfLine (same as C)
+      expect(testBuffer.vimChangeToEndOfLine).toHaveBeenCalled();
+      expect(result.current.mode).toBe('INSERT');
     });
   });
 

--- a/packages/cli/src/ui/hooks/vim.ts
+++ b/packages/cli/src/ui/hooks/vim.ts
@@ -38,6 +38,10 @@ const CMD_TYPES = {
   CHANGE_LINE: 'cc',
   DELETE_TO_EOL: 'D',
   CHANGE_TO_EOL: 'C',
+  DELETE_TO_LINE_START: 'd0',
+  CHANGE_TO_LINE_START: 'c0',
+  DELETE_TO_FIRST_NON_WHITESPACE: 'd^',
+  CHANGE_TO_FIRST_NON_WHITESPACE: 'c^',
   CHANGE_MOVEMENT: {
     LEFT: 'ch',
     DOWN: 'cj',
@@ -285,6 +289,28 @@ export function useVim(buffer: TextBuffer, onSubmit?: (value: string) => void) {
 
         case CMD_TYPES.CHANGE_TO_EOL: {
           buffer.vimChangeToEndOfLine();
+          updateMode('INSERT');
+          break;
+        }
+
+        case CMD_TYPES.DELETE_TO_LINE_START: {
+          buffer.vimDeleteToLineStart();
+          break;
+        }
+
+        case CMD_TYPES.CHANGE_TO_LINE_START: {
+          buffer.vimChangeToLineStart();
+          updateMode('INSERT');
+          break;
+        }
+
+        case CMD_TYPES.DELETE_TO_FIRST_NON_WHITESPACE: {
+          buffer.vimDeleteToFirstNonWhitespace();
+          break;
+        }
+
+        case CMD_TYPES.CHANGE_TO_FIRST_NON_WHITESPACE: {
+          buffer.vimChangeToFirstNonWhitespace();
           updateMode('INSERT');
           break;
         }
@@ -691,22 +717,76 @@ export function useVim(buffer: TextBuffer, onSubmit?: (value: string) => void) {
           }
 
           case '0': {
-            // Move to start of line
-            buffer.vimMoveToLineStart();
+            if (state.pendingOperator === 'd') {
+              executeCommand(CMD_TYPES.DELETE_TO_LINE_START, 1);
+              dispatch({
+                type: 'SET_LAST_COMMAND',
+                command: { type: CMD_TYPES.DELETE_TO_LINE_START, count: 1 },
+              });
+              dispatch({ type: 'SET_PENDING_OPERATOR', operator: null });
+            } else if (state.pendingOperator === 'c') {
+              executeCommand(CMD_TYPES.CHANGE_TO_LINE_START, 1);
+              dispatch({
+                type: 'SET_LAST_COMMAND',
+                command: { type: CMD_TYPES.CHANGE_TO_LINE_START, count: 1 },
+              });
+              dispatch({ type: 'SET_PENDING_OPERATOR', operator: null });
+            } else {
+              // Move to start of line
+              buffer.vimMoveToLineStart();
+            }
             dispatch({ type: 'CLEAR_COUNT' });
             return true;
           }
 
           case '$': {
-            // Move to end of line
-            buffer.vimMoveToLineEnd();
+            if (state.pendingOperator === 'd') {
+              executeCommand(CMD_TYPES.DELETE_TO_EOL, 1);
+              dispatch({
+                type: 'SET_LAST_COMMAND',
+                command: { type: CMD_TYPES.DELETE_TO_EOL, count: 1 },
+              });
+              dispatch({ type: 'SET_PENDING_OPERATOR', operator: null });
+            } else if (state.pendingOperator === 'c') {
+              executeCommand(CMD_TYPES.CHANGE_TO_EOL, 1);
+              dispatch({
+                type: 'SET_LAST_COMMAND',
+                command: { type: CMD_TYPES.CHANGE_TO_EOL, count: 1 },
+              });
+              dispatch({ type: 'SET_PENDING_OPERATOR', operator: null });
+            } else {
+              // Move to end of line
+              buffer.vimMoveToLineEnd();
+            }
             dispatch({ type: 'CLEAR_COUNT' });
             return true;
           }
 
           case '^': {
-            // Move to first non-whitespace character
-            buffer.vimMoveToFirstNonWhitespace();
+            if (state.pendingOperator === 'd') {
+              executeCommand(CMD_TYPES.DELETE_TO_FIRST_NON_WHITESPACE, 1);
+              dispatch({
+                type: 'SET_LAST_COMMAND',
+                command: {
+                  type: CMD_TYPES.DELETE_TO_FIRST_NON_WHITESPACE,
+                  count: 1,
+                },
+              });
+              dispatch({ type: 'SET_PENDING_OPERATOR', operator: null });
+            } else if (state.pendingOperator === 'c') {
+              executeCommand(CMD_TYPES.CHANGE_TO_FIRST_NON_WHITESPACE, 1);
+              dispatch({
+                type: 'SET_LAST_COMMAND',
+                command: {
+                  type: CMD_TYPES.CHANGE_TO_FIRST_NON_WHITESPACE,
+                  count: 1,
+                },
+              });
+              dispatch({ type: 'SET_PENDING_OPERATOR', operator: null });
+            } else {
+              // Move to first non-whitespace character
+              buffer.vimMoveToFirstNonWhitespace();
+            }
             dispatch({ type: 'CLEAR_COUNT' });
             return true;
           }


### PR DESCRIPTION
## Summary

This implements the Vim mode delete and change operations to the beginning and of line - `d0`, `d^`, `d$`, and their `c` equivalents.

It does not implement `dg_`/`cg_`, which delete/change to the last non-blank character of the line.

## Related Issues

Mostly implements #15988. `dg_` and `cg_` (end-of-line equivalents to `d0` and `c0`) are not specifically referenced in that bug, but should be implemented as part of this functionality. I will do that in a subsequent pull request.

## How to Validate

Build this change and start the Gemini CLI. Test the functionality. `d0` should delete to the start of the line. `d^` should delete to the first non-blank character of the line. `d$` should delete to the end of the line (same as `D`).

The `c` equivalents should function the same, but also enter insert mode after deleting.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [X] Updated relevant documentation and README (if needed)
- [X] Added/updated tests (if needed)
- [X] Noted breaking changes (if any)
- [X] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [X] Linux
    - [X] npm run
    - [ ] npx
    - [ ] Docker
