### PR TITLE
fix- windows: add shell: true for spawnSync to fix EINVAL with .cmd editors

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -3087,6 +3087,7 @@ export function useTextBuffer({
       setRawMode?.(false);
       const { status, error } = spawnSync(command, args, {
         stdio: 'inherit',
+        shell: process.platform === 'win32',
       });
       if (error) throw error;
       if (typeof status === 'number' && status !== 0)


### PR DESCRIPTION
… files

## Summary

Fix EINVAL error when spawning .cmd files (e.g. code.cmd) on Windows for external editor vscode.

Adds `shell: process.platform === 'win32'` to `spawnSync` options in `openInExternalEditor`, so batch files execute correctly without Node.js security restrictions.

## Details

Node.js (v18+) blocks direct execution of .cmd/.bat files via spawnSync without shell: true due to security changes.

This patch simply applies `shell: true` only on Windows,.
Locally tested on win 11 with vscode as preferred editor and now ctrl+x opens editor without crashing.

## Related Issues

Fixes #17376

## How to Validate

1. set preferred editor to vscode
2. gemini
3. press crtl+x
4. yahtzee

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
