### PR TITLE
fix(cli): reload skills and agents on extension restart

### DIFF
--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -129,6 +129,8 @@ describe('extensionsCommand', () => {
   let mockContext: CommandContext;
   const mockDispatchExtensionState = vi.fn();
   let mockExtensionLoader: unknown;
+  let mockReloadSkills: MockedFunction<() => Promise<void>>;
+  let mockReloadAgents: MockedFunction<() => Promise<void>>;
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -148,7 +150,8 @@ describe('extensionsCommand', () => {
 
     mockGetExtensions.mockReturnValue([inactiveExt, activeExt, allExt]);
     vi.mocked(open).mockClear();
-    const mockReloadAgents = vi.fn().mockResolvedValue(undefined);
+    mockReloadAgents = vi.fn().mockResolvedValue(undefined);
+    mockReloadSkills = vi.fn().mockResolvedValue(undefined);
 
     mockContext = createMockCommandContext({
       services: {
@@ -156,7 +159,7 @@ describe('extensionsCommand', () => {
           getExtensions: mockGetExtensions,
           getExtensionLoader: vi.fn().mockReturnValue(mockExtensionLoader),
           getWorkingDir: () => '/test/dir',
-          reloadSkills: vi.fn().mockResolvedValue(undefined),
+          reloadSkills: mockReloadSkills,
           getAgentRegistry: vi.fn().mockReturnValue({
             reload: mockReloadAgents,
           }),
@@ -898,6 +901,27 @@ describe('extensionsCommand', () => {
         type: 'RESTARTED',
         payload: { name: 'ext2' },
       });
+      expect(mockReloadSkills).toHaveBeenCalled();
+      expect(mockReloadAgents).toHaveBeenCalled();
+    });
+
+    it('handles errors during skill or agent reload', async () => {
+      const mockExtensions = [
+        { name: 'ext1', isActive: true },
+      ] as GeminiCLIExtension[];
+      mockGetExtensions.mockReturnValue(mockExtensions);
+      mockReloadSkills.mockRejectedValue(new Error('Failed to reload skills'));
+
+      await restartAction!(mockContext, '--all');
+
+      expect(mockRestartExtension).toHaveBeenCalledWith(mockExtensions[0]);
+      expect(mockReloadSkills).toHaveBeenCalled();
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.ERROR,
+          text: 'Failed to reload skills or agents: Failed to reload skills',
+        }),
+      );
     });
 
     it('restarts only specified active extensions', async () => {

--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -148,12 +148,18 @@ describe('extensionsCommand', () => {
 
     mockGetExtensions.mockReturnValue([inactiveExt, activeExt, allExt]);
     vi.mocked(open).mockClear();
+    const mockReloadAgents = vi.fn().mockResolvedValue(undefined);
+
     mockContext = createMockCommandContext({
       services: {
         config: {
           getExtensions: mockGetExtensions,
           getExtensionLoader: vi.fn().mockReturnValue(mockExtensionLoader),
           getWorkingDir: () => '/test/dir',
+          reloadSkills: vi.fn().mockResolvedValue(undefined),
+          getAgentRegistry: vi.fn().mockReturnValue({
+            reload: mockReloadAgents,
+          }),
         },
       },
       ui: {

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -231,6 +231,11 @@ async function restartAction(
     (result): result is PromiseRejectedResult => result.status === 'rejected',
   );
 
+  if (failures.length < extensionsToRestart.length) {
+    await context.services.config?.reloadSkills();
+    await context.services.config?.getAgentRegistry()?.reload();
+  }
+
   if (failures.length > 0) {
     const errorMessages = failures
       .map((failure, index) => {

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -232,8 +232,15 @@ async function restartAction(
   );
 
   if (failures.length < extensionsToRestart.length) {
-    await context.services.config?.reloadSkills();
-    await context.services.config?.getAgentRegistry()?.reload();
+    try {
+      await context.services.config?.reloadSkills();
+      await context.services.config?.getAgentRegistry()?.reload();
+    } catch (error) {
+      context.ui.addItem({
+        type: MessageType.ERROR,
+        text: `Failed to reload skills or agents: ${getErrorMessage(error)}`,
+      });
+    }
   }
 
   if (failures.length > 0) {


### PR DESCRIPTION
This PR ensures that when extensions are restarted via `/extensions restart`, any associated skills and agents are automatically reloaded. Previously, users had to manually run `/skills reload` and `/agents refresh` for changes to take effect.