### PR TITLE
feat(core): add replace arg to init command to regenerate gemini.md file

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -149,6 +149,9 @@ Slash commands provide meta-level control over the CLI itself.
     command analyzes the current directory and generates a tailored context
     file, making it simpler for them to provide project-specific instructions to
     the Gemini agent.
+  - **Usage:**
+    - `/init`: Creates a `GEMINI.md` file if it doesn't exist.
+    - `/init replace`: Overwrites the existing `GEMINI.md` file with a new one.
 
 - **`/introspect`**
   - **Description:** Provide debugging information about the current Gemini CLI

--- a/packages/a2a-server/src/commands/init.test.ts
+++ b/packages/a2a-server/src/commands/init.test.ts
@@ -141,6 +141,7 @@ describe('InitCommand', () => {
 
     describe('when handling submit_prompt', () => {
       beforeEach(() => {
+        vi.mocked(fs.existsSync).mockReturnValue(true);
         vi.mocked(performInit).mockReturnValue({
           type: 'submit_prompt',
           content: 'Create a new GEMINI.md file.',
@@ -180,6 +181,29 @@ describe('InitCommand', () => {
           }),
           eventBus,
         );
+      });
+
+      it('passes true for replace when "replace" is the only argument', async () => {
+        vi.mocked(performInit).mockReturnValue({
+          type: 'submit_prompt',
+          content: 'Create a new GEMINI.md file.',
+        } as CommandActionReturn);
+
+        await command.execute(context, ['replace']);
+        expect(performInit).toHaveBeenCalledWith(expect.any(Boolean), true);
+      });
+
+      it('passes false for replace when explicit "replace" argument is missing or mixed', async () => {
+        vi.mocked(performInit).mockReturnValue({
+          type: 'submit_prompt',
+          content: 'Create a new GEMINI.md file.',
+        } as CommandActionReturn);
+
+        await command.execute(context, []);
+        expect(performInit).toHaveBeenCalledWith(expect.any(Boolean), false);
+
+        await command.execute(context, ['replace', 'extra']);
+        expect(performInit).toHaveBeenCalledWith(expect.any(Boolean), false);
       });
     });
   });

--- a/packages/a2a-server/src/commands/init.ts
+++ b/packages/a2a-server/src/commands/init.ts
@@ -138,7 +138,7 @@ export class InitCommand implements Command {
       process.env['CODER_AGENT_WORKSPACE_PATH']!,
       'GEMINI.md',
     );
-    const replace = _args.includes('replace');
+    const replace = _args.length === 1 && _args[0] === 'replace';
     const result = performInit(fs.existsSync(geminiMdPath), replace);
 
     const taskId = uuidv4();

--- a/packages/a2a-server/src/commands/init.ts
+++ b/packages/a2a-server/src/commands/init.ts
@@ -138,7 +138,8 @@ export class InitCommand implements Command {
       process.env['CODER_AGENT_WORKSPACE_PATH']!,
       'GEMINI.md',
     );
-    const result = performInit(fs.existsSync(geminiMdPath));
+    const replace = _args.includes('replace');
+    const result = performInit(fs.existsSync(geminiMdPath), replace);
 
     const taskId = uuidv4();
     const contextId = uuidv4();

--- a/packages/cli/src/ui/commands/initCommand.test.ts
+++ b/packages/cli/src/ui/commands/initCommand.test.ts
@@ -55,7 +55,7 @@ describe('initCommand', () => {
       type: 'message',
       messageType: 'info',
       content:
-        'A GEMINI.md file already exists in this directory. No changes were made.',
+        'A GEMINI.md file already exists in this directory. No changes were made. Use "init replace" to overwrite it.',
     });
     // Assert: Ensure no file was written
     expect(fs.writeFileSync).not.toHaveBeenCalled();

--- a/packages/cli/src/ui/commands/initCommand.test.ts
+++ b/packages/cli/src/ui/commands/initCommand.test.ts
@@ -90,6 +90,41 @@ describe('initCommand', () => {
     );
   });
 
+  it('should pass true for replace when argument is exactly "replace"', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const result = await initCommand.action!(mockContext, 'replace');
+
+    // Should NOT show the "already exists" message because replace=true
+    expect(result).not.toEqual(
+      expect.objectContaining({
+        type: 'message',
+        messageType: 'info',
+      }),
+    );
+    // Should proceed to create file (submit_prompt)
+    expect(fs.writeFileSync).toHaveBeenCalled();
+  });
+
+  it('should pass false for replace when argument is "replace me" or other mismatch', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+
+    // Case: "replace me"
+    let result = await initCommand.action!(mockContext, 'replace me');
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: expect.stringContaining('already exists'),
+    });
+
+    // Case: "init" (empty args - usually empty string)
+    result = await initCommand.action!(mockContext, '');
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: expect.stringContaining('already exists'),
+    });
+  });
+
   it('should return an error if config is not available', async () => {
     // Arrange: Create a context without config
     const noConfigContext = createMockCommandContext();

--- a/packages/cli/src/ui/commands/initCommand.ts
+++ b/packages/cli/src/ui/commands/initCommand.ts
@@ -33,7 +33,8 @@ export const initCommand: SlashCommand = {
     const targetDir = context.services.config.getTargetDir();
     const geminiMdPath = path.join(targetDir, 'GEMINI.md');
 
-    const result = performInit(fs.existsSync(geminiMdPath));
+    const replace = _args?.trim() === 'replace';
+    const result = performInit(fs.existsSync(geminiMdPath), replace);
 
     if (result.type === 'submit_prompt') {
       // Create an empty GEMINI.md file

--- a/packages/core/src/commands/init.test.ts
+++ b/packages/core/src/commands/init.test.ts
@@ -26,4 +26,13 @@ describe('performInit', () => {
       expect(result.content).toContain('You are an AI agent');
     }
   });
+
+  it('returns submit_prompt if GEMINI.md exists but replace is true', () => {
+    const result = performInit(true, true);
+    expect(result.type).toBe('submit_prompt');
+
+    if (result.type === 'submit_prompt') {
+      expect(result.content).toContain('You are an AI agent');
+    }
+  });
 });

--- a/packages/core/src/commands/init.ts
+++ b/packages/core/src/commands/init.ts
@@ -6,13 +6,16 @@
 
 import type { CommandActionReturn } from './types.js';
 
-export function performInit(doesGeminiMdExist: boolean): CommandActionReturn {
-  if (doesGeminiMdExist) {
+export function performInit(
+  doesGeminiMdExist: boolean,
+  replace = false,
+): CommandActionReturn {
+  if (doesGeminiMdExist && !replace) {
     return {
       type: 'message',
       messageType: 'info',
       content:
-        'A GEMINI.md file already exists in this directory. No changes were made.',
+        'A GEMINI.md file already exists in this directory. No changes were made. Use "init replace" to overwrite it.',
     };
   }
 


### PR DESCRIPTION
## Summary

Adds a `replace` argument to the `/init` command to allow overwriting an existing `GEMINI.md` file.

## Details

- **Core (`packages/core`)**: Updated `performInit` to accept a `replace` boolean. It now returns a "submit_prompt" action even if `GEMINI.md` exists, provided `replace` is true.
- **CLI (`packages/cli`)**: Updated `initCommand` to parse the `replace` argument from the input string (e.g., `/init replace`) and pass it to the core logic.
- **A2A Server (`packages/a2a-server`)**: Updated `InitCommand` to check for the `replace` flag in the arguments array.
- **Tests**: Added unit tests in Core and CLI packages to verify the new behavior and ensuring the correct informational message is shown when `replace` is omitted.

## Related Issues

Closes #17635

## How to Validate

1.  **Build the project**:
    ```bash
    npm run build
    ```
2.  **Create a dummy `GEMINI.md`**:
    ```bash
    touch GEMINI.md
    ```
3.  **Run `init` (should fail/warn)**:
    ```bash
    node packages/cli/dist/index.js --prompt "/init"
    # Expected output: Info message saying GEMINI.md exists and suggesting "init replace"
    ```
4.  **Run `init replace` (should succeed)**:
    ```bash
    # Ensure GEMINI_API_KEY is set
    export GEMINI_API_KEY="..."
    node packages/cli/dist/index.js --prompt "/init replace"
    # Expected result: GEMINI.md is regenerated/overwritten.
    ```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
  - [ ] Windows
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker