### PR TITLE
perf(cli): reduce startup imports and defer pre-parse work

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -310,6 +310,10 @@ export async function main() {
     coreEvents.emitFeedback('warning', error.message);
   });
 
+  const parseArgsHandle = startupProfiler.start('parse_arguments');
+  const argv = await parseArguments(settings.merged);
+  parseArgsHandle?.end();
+
   const trustedFolders = loadTrustedFolders();
   trustedFolders.errors.forEach((error: TrustedFoldersError) => {
     coreEvents.emitFeedback(
@@ -319,10 +323,6 @@ export async function main() {
   });
 
   await cleanupCheckpoints();
-
-  const parseArgsHandle = startupProfiler.start('parse_arguments');
-  const argv = await parseArguments(settings.merged);
-  parseArgsHandle?.end();
 
   // Check for invalid input combinations early to prevent crashes
   if (argv.promptInteractive && !process.stdin.isTTY) {

--- a/packages/core/src/agents/delegate-to-agent-tool.test.ts
+++ b/packages/core/src/agents/delegate-to-agent-tool.test.ts
@@ -121,6 +121,31 @@ describe('DelegateToAgentTool', () => {
     );
   });
 
+  it('should return INVALID_TOOL_PARAMS when agent_name is missing', async () => {
+    const invocation = tool.build({} as DelegateParams);
+
+    const result = await invocation.execute(new AbortController().signal);
+    expect(result.error?.type).toBe('invalid_tool_params');
+    expect(result.error?.message).toContain(
+      "Missing required parameter 'agent_name'",
+    );
+  });
+
+  it.each(['undefined', 'UNDEFINED', 'null', 'NULL'])(
+    'should return INVALID_TOOL_PARAMS when agent_name is sentinel %s',
+    async (agentName) => {
+      const invocation = tool.build({
+        agent_name: agentName,
+      } as DelegateParams);
+
+      const result = await invocation.execute(new AbortController().signal);
+      expect(result.error?.type).toBe('invalid_tool_params');
+      expect(result.error?.message).toContain(
+        "Missing required parameter 'agent_name'",
+      );
+    },
+  );
+
   it('should throw helpful error when agent_name does not exist', async () => {
     // We allow validation to pass now, checking happens in execute.
     const invocation = tool.build({


### PR DESCRIPTION
## Summary\n- lazy-load command modules in parseArguments to avoid eager startup imports\n- lazy-load heavy loadCliConfig dependencies\n- parse CLI args before trusted-folders/checkpoint cleanup in main startup path\n\n## Validation\n- vitest run src/config/config.test.ts src/config/skills-backward-compatibility.test.ts src/gemini_cleanup.test.tsx