### PR TITLE
fix(cli): always show API key input dialog when user selects Gemini API Key auth

### DIFF
--- a/packages/cli/src/ui/auth/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.test.tsx
@@ -244,7 +244,7 @@ describe('AuthDialog', () => {
       expect(props.setAuthContext).toHaveBeenCalledWith({});
     });
 
-    it('skips API key dialog on initial setup if env var is present', async () => {
+    it('shows API key dialog on initial setup even when env var is present', async () => {
       mockedValidateAuthMethod.mockReturnValue(null);
       vi.stubEnv('GEMINI_API_KEY', 'test-key-from-env');
       // props.settings.merged.security.auth.selectedType is undefined here, simulating initial setup
@@ -255,11 +255,11 @@ describe('AuthDialog', () => {
       await handleAuthSelect(AuthType.USE_GEMINI);
 
       expect(props.setAuthState).toHaveBeenCalledWith(
-        AuthState.Unauthenticated,
+        AuthState.AwaitingApiKeyInput,
       );
     });
 
-    it('skips API key dialog if env var is present but empty', async () => {
+    it('shows API key dialog even when env var is empty string', async () => {
       mockedValidateAuthMethod.mockReturnValue(null);
       vi.stubEnv('GEMINI_API_KEY', ''); // Empty string
       // props.settings.merged.security.auth.selectedType is undefined here
@@ -270,7 +270,7 @@ describe('AuthDialog', () => {
       await handleAuthSelect(AuthType.USE_GEMINI);
 
       expect(props.setAuthState).toHaveBeenCalledWith(
-        AuthState.Unauthenticated,
+        AuthState.AwaitingApiKeyInput,
       );
     });
 
@@ -289,7 +289,7 @@ describe('AuthDialog', () => {
       );
     });
 
-    it('skips API key dialog on re-auth if env var is present (cannot edit)', async () => {
+    it('shows API key dialog on re-auth even when env var is present', async () => {
       mockedValidateAuthMethod.mockReturnValue(null);
       vi.stubEnv('GEMINI_API_KEY', 'test-key-from-env');
       // Simulate that the user has already authenticated once
@@ -302,7 +302,7 @@ describe('AuthDialog', () => {
       await handleAuthSelect(AuthType.USE_GEMINI);
 
       expect(props.setAuthState).toHaveBeenCalledWith(
-        AuthState.Unauthenticated,
+        AuthState.AwaitingApiKeyInput,
       );
     });
 

--- a/packages/cli/src/ui/auth/AuthDialog.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.tsx
@@ -139,13 +139,8 @@ export function AuthDialog({
         }
 
         if (authType === AuthType.USE_GEMINI) {
-          if (process.env['GEMINI_API_KEY'] !== undefined) {
-            setAuthState(AuthState.Unauthenticated);
-            return;
-          } else {
-            setAuthState(AuthState.AwaitingApiKeyInput);
-            return;
-          }
+          setAuthState(AuthState.AwaitingApiKeyInput);
+          return;
         }
       }
       setAuthState(AuthState.Unauthenticated);


### PR DESCRIPTION
## Summary

When a user explicitly selects "Use Gemini API Key" from the `/auth` dialog, the API key input should always be shown. Previously, if `GEMINI_API_KEY` was already set as an environment variable, the dialog was skipped entirely - the user had no way to change or override their key through the UI.

- Removed the `process.env['GEMINI_API_KEY']` check in the `onSelect` callback
- Always transitions to `AuthState.AwaitingApiKeyInput` when user selects API key auth
- The existing `useAuth` hook already handles pre-filling the dialog with the env var value if present
- Updated 3 tests to match the new behavior

## Test plan

- [x] All 24 AuthDialog tests pass
- [ ] Set `GEMINI_API_KEY` env var, run `/auth`, select "Use Gemini API Key" - should show input dialog
- [ ] Without env var, run `/auth`, select "Use Gemini API Key" - should show input dialog
- [ ] Verify dialog is pre-filled with env var value when present

Fixes #15605