### PR TITLE
Add witty phrase about locating seahorse emoji

### DIFF
--- a/packages/cli/src/ui/constants/wittyPhrases.ts
+++ b/packages/cli/src/ui/constants/wittyPhrases.ts
@@ -110,6 +110,7 @@ export const WITTY_LOADING_PHRASES = [
   'Communing with the machine spirit…',
   'Letting the thoughts marinate…',
   'Just remembered where I put my keys…',
+  'Locating seahorse emoji…',
   'Pondering the orb…',
   "I've seen things you people wouldn't believe… like a user who reads loading messages.",
   'Initiating thoughtful gaze…',


### PR DESCRIPTION
## Summary

Adds witty phrase, reference to when people found out LLMs couldn't find a [non-existance seahorse emoji](https://www.reddit.com/r/de_EDV/comments/1o6taqk/wieso_hat_chatgpt_einen_anfall_wenn_man_nach/?tl=en)

Addresses #10568 