### PR TITLE
fix(ui): auto-enable alternate buffer in Cloud Shell to prevent flick…

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -115,7 +115,11 @@ export * from './skills/skillLoader.js';
 export * from './ide/ide-client.js';
 export * from './ide/ideContext.js';
 export * from './ide/ide-installer.js';
-export { IDE_DEFINITIONS, type IdeInfo } from './ide/detect-ide.js';
+export {
+  IDE_DEFINITIONS,
+  isCloudShell,
+  type IdeInfo,
+} from './ide/detect-ide.js';
 export * from './ide/constants.js';
 export * from './ide/types.js';
 


### PR DESCRIPTION
 Summary
Auto-enable alternate screen buffer in Cloud Shell to eliminate UI flickering caused by full-screen repaints on every Ink render frame.

Details
Cloud Shell's web-based terminal redraws slowly compared to native terminals. Without the alternate buffer, Ink clears and repaints the entire screen on every frame, which produces visible strobing/flickering. Enabling the alternate buffer also enables incremental rendering (which only redraws changed lines), eliminating the issue.

The fix modifies isAlternateBufferEnabled() in useAlternateBuffer.ts to return true when isCloudShell() detects a Cloud Shell environment (via CLOUD_SHELL or EDITOR_IN_CLOUD_SHELL env vars). This is the single decision point that controls alternate buffer, incremental rendering, mouse events, and height constraints — so one change cascades correctly through all dependent behavior.

isCloudShell was already implemented in @google/gemini-cli-core but not exported from the package index; this PR adds the export.

Users can still override the behavior by explicitly setting useAlternateBuffer: false in their settings.

Related Issues

Fixes #18079, #18080

How to Validate
  1. Open https://shell.cloud.google.com
  2. Clone the branch and build:
  ```
  git clone https://github.com/ppgranger/gemini-cli.git
  cd gemini-cli
  git checkout fix/cloud-shell-flickering
  npm install
  npm run build
  npm start
```

  5. Verify: UI should render without flickering, the terminal should use the alternate screen buffer (shell history preserved on exit, scroll stays within the app)
  6. Compare with main to observe the flickering difference
  7. To simulate locally: CLOUD_SHELL=true npm start — verify alternate buffer activates

  Pre-Merge Checklist
  - [x] Validated on required platforms/methods:
    - [x] Cloud Shell