### PR TITLE
feat: Accept defaultValue from settings when installing an extension

### DIFF
--- a/packages/cli/src/commands/extensions/utils.ts
+++ b/packages/cli/src/commands/extensions/utils.ts
@@ -13,7 +13,6 @@ import {
 import type { ExtensionConfig } from '../../config/extension.js';
 import prompts from 'prompts';
 import {
-  promptForSetting,
   updateSetting,
   type ExtensionSetting,
   getScopedEnvContents,
@@ -49,6 +48,24 @@ const defaultRequestConfirmation: RequestConfirmationCallback = async (
   });
   return response.confirm;
 };
+
+export async function promptForSetting(
+  setting: ExtensionSetting,
+): Promise<string> {
+  let description = setting.description;
+  if (setting.defaultValue !== undefined) {
+    const displayValue = setting.sensitive ? '******' : setting.defaultValue;
+    description += ` [default: ${displayValue}]`;
+  }
+
+  const response = await prompts({
+    type: setting.sensitive ? 'password' : 'text',
+    name: 'value',
+    message: `${setting.name}\n${description}`,
+    initial: setting.defaultValue,
+  });
+  return response.value;
+}
 
 export async function getExtensionManager() {
   const workspaceDir = process.cwd();

--- a/packages/cli/src/config/extensions/extensionSettings.ts
+++ b/packages/cli/src/config/extensions/extensionSettings.ts
@@ -27,6 +27,7 @@ export interface ExtensionSetting {
   envVar: string;
   // NOTE: If no value is set, this setting will be considered NOT sensitive.
   sensitive?: boolean;
+  defaultValue?: string;
 }
 
 const getKeychainStorageName = (
@@ -155,6 +156,7 @@ export async function promptForSetting(
     type: setting.sensitive ? 'password' : 'text',
     name: 'value',
     message: `${setting.name}\n${setting.description}`,
+    initial: setting.defaultValue,
   });
   return response.value;
 }

--- a/packages/cli/src/ui/components/ConfigExtensionDialog.test.tsx
+++ b/packages/cli/src/ui/components/ConfigExtensionDialog.test.tsx
@@ -1,0 +1,275 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render } from '../../test-utils/render.js';
+import { waitFor } from '../../test-utils/async.js';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { ConfigExtensionDialog } from './ConfigExtensionDialog.js';
+import {
+  configureExtension,
+  type ConfigLogger,
+} from '../../commands/extensions/utils.js';
+import type { ExtensionManager } from '../../config/extension-manager.js';
+import { act } from 'react';
+import { KeypressProvider } from '../contexts/KeypressContext.js';
+
+// Mock the utils
+vi.mock('../../commands/extensions/utils.js', () => ({
+  configureExtension: vi.fn(),
+  configureSpecificSetting: vi.fn(),
+  configureAllExtensions: vi.fn(),
+}));
+
+describe('ConfigExtensionDialog', () => {
+  const mockExtensionManager = {} as ExtensionManager;
+  const mockLogger: ConfigLogger = {
+    log: vi.fn(),
+    error: vi.fn(),
+  };
+  const mockOnClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should display default value in prompt', async () => {
+    // Setup mock to request a setting with default value
+    (configureExtension as Mock).mockImplementation(
+      async (
+        _mgr,
+        _name,
+        _scope,
+        _logger,
+        requestSetting,
+        _requestConfirmation,
+      ) => {
+        await requestSetting({
+          name: 'testSetting',
+          description: 'Test Description',
+          envVar: 'TEST_VAR',
+          defaultValue: 'default123',
+        });
+      },
+    );
+
+    const { lastFrame, unmount } = render(
+      <KeypressProvider>
+        <ConfigExtensionDialog
+          extensionManager={mockExtensionManager}
+          onClose={mockOnClose}
+          extensionName="test-ext"
+          loggerAdapter={mockLogger}
+        />
+      </KeypressProvider>,
+    );
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('Test Description');
+      expect(lastFrame()).toContain('[default: default123]');
+    });
+
+    unmount();
+  });
+
+  it('should mask sensitive default value in prompt', async () => {
+    (configureExtension as Mock).mockImplementation(
+      async (
+        _mgr,
+        _name,
+        _scope,
+        _logger,
+        requestSetting,
+        _requestConfirmation,
+      ) => {
+        await requestSetting({
+          name: 'sensitiveSetting',
+          description: 'Sensitive Description',
+          envVar: 'SENSITIVE_VAR',
+          sensitive: true,
+          defaultValue: 'secret123',
+        });
+      },
+    );
+
+    const { lastFrame, unmount } = render(
+      <KeypressProvider>
+        <ConfigExtensionDialog
+          extensionManager={mockExtensionManager}
+          onClose={mockOnClose}
+          extensionName="test-ext"
+          loggerAdapter={mockLogger}
+        />
+      </KeypressProvider>,
+    );
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('Sensitive Description');
+      expect(lastFrame()).toContain('[default: ******]');
+      expect(lastFrame()).not.toContain('secret123');
+    });
+
+    unmount();
+  });
+
+  it('should use default value when input is empty', async () => {
+    let resolvedValue: string | undefined;
+
+    (configureExtension as Mock).mockImplementation(
+      async (
+        _mgr,
+        _name,
+        _scope,
+        _logger,
+        requestSetting,
+        _requestConfirmation,
+      ) => {
+        resolvedValue = await requestSetting({
+          name: 'testSetting',
+          description: 'Test Description',
+          envVar: 'TEST_VAR',
+          defaultValue: 'default123',
+        });
+      },
+    );
+
+    const { stdin, unmount, lastFrame } = render(
+      <KeypressProvider>
+        <ConfigExtensionDialog
+          extensionManager={mockExtensionManager}
+          onClose={mockOnClose}
+          extensionName="test-ext"
+          loggerAdapter={mockLogger}
+        />
+      </KeypressProvider>,
+    );
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('Test Description');
+    });
+
+    // Press Enter without typing anything
+    await act(async () => {
+      stdin.write('\r');
+    });
+
+    await waitFor(() => {
+      expect(resolvedValue).toBe('default123');
+    });
+
+    unmount();
+  });
+
+  it('should use input value even if default exists', async () => {
+    let resolvedValue: string | undefined;
+
+    (configureExtension as Mock).mockImplementation(
+      async (
+        _mgr,
+        _name,
+        _scope,
+        _logger,
+        requestSetting,
+        _requestConfirmation,
+      ) => {
+        resolvedValue = await requestSetting({
+          name: 'testSetting',
+          description: 'Test Description',
+          envVar: 'TEST_VAR',
+          defaultValue: 'default123',
+        });
+      },
+    );
+
+    const { stdin, unmount, lastFrame } = render(
+      <KeypressProvider>
+        <ConfigExtensionDialog
+          extensionManager={mockExtensionManager}
+          onClose={mockOnClose}
+          extensionName="test-ext"
+          loggerAdapter={mockLogger}
+        />
+      </KeypressProvider>,
+    );
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('Test Description');
+    });
+
+    // Type 'custom' and Enter
+    await act(async () => {
+      for (const char of 'custom') {
+        stdin.write(char);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+    });
+
+    await act(async () => {
+      stdin.write('\r');
+    });
+
+    await waitFor(() => {
+      expect(resolvedValue).toBe('custom');
+    });
+
+    unmount();
+  });
+
+  it('should work normally without default value', async () => {
+    let resolvedValue: string | undefined;
+
+    (configureExtension as Mock).mockImplementation(
+      async (
+        _mgr,
+        _name,
+        _scope,
+        _logger,
+        requestSetting,
+        _requestConfirmation,
+      ) => {
+        resolvedValue = await requestSetting({
+          name: 'testSetting',
+          description: 'Test Description',
+          envVar: 'TEST_VAR',
+          // No defaultValue
+        });
+      },
+    );
+
+    const { stdin, unmount, lastFrame } = render(
+      <KeypressProvider>
+        <ConfigExtensionDialog
+          extensionManager={mockExtensionManager}
+          onClose={mockOnClose}
+          extensionName="test-ext"
+          loggerAdapter={mockLogger}
+        />
+      </KeypressProvider>,
+    );
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('Test Description');
+      expect(lastFrame()).not.toContain('[default:');
+    });
+
+    // Type 'custom' and Enter
+    await act(async () => {
+      for (const char of 'custom') {
+        stdin.write(char);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+    });
+
+    await act(async () => {
+      stdin.write('\r');
+    });
+
+    await waitFor(() => {
+      expect(resolvedValue).toBe('custom');
+    });
+
+    unmount();
+  });
+});

--- a/packages/cli/src/ui/components/ConfigExtensionDialog.tsx
+++ b/packages/cli/src/ui/components/ConfigExtensionDialog.tsx
@@ -266,12 +266,25 @@ export const ConfigExtensionDialog: React.FC<ConfigExtensionDialogProps> = ({
         </Text>
         <Text color={theme.text.secondary}>
           {state.setting.description || state.setting.envVar}
+          {state.setting.defaultValue !== undefined && (
+            <Text color={theme.text.secondary}>
+              {' '}
+              [default:{' '}
+              {state.setting.sensitive ? '******' : state.setting.defaultValue}]
+            </Text>
+          )}
         </Text>
         <Box flexDirection="row" marginTop={1}>
           <Text color={theme.text.accent}>{'> '}</Text>
           <TextInput
             buffer={settingBuffer}
-            onSubmit={handleSettingSubmit}
+            onSubmit={(val) => {
+              if (val === '' && state.setting.defaultValue !== undefined) {
+                handleSettingSubmit(state.setting.defaultValue);
+              } else {
+                handleSettingSubmit(val);
+              }
+            }}
             focus={true}
             placeholder={`Enter value for ${state.setting.name}`}
           />


### PR DESCRIPTION
## Summary

Implemented support for `defaultValue` in extension settings configuration. This ensures a smoother user experience by pre-filling reasonable defaults (masked if sensitive) and utilizing them when the user provides no input.

## Details

- Added `defaultValue` property to the `ExtensionSetting` interface in `extensionSettings.ts`.
- Updated `ConfigExtensionDialog` to:
  - Display default values in the prompt (e.g., `[default: ******]` for sensitive, `[default: context]` for others).
  - Improved `TextInput` to handle masking correctly when a default value is present but not yet accepted.
  - Fallback to `defaultValue` if the user submits an empty value.
- Added comprehensive tests in `ConfigExtensionDialog.test.tsx` covering rendering, masking, and fallback logic.

## Related Issues

Fixes #18447

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

1. Run the tests to verify the logic:
   ```bash
   npm test -w packages/cli -- src/ui/components/ConfigExtensionDialog.test.tsx
   ```

2. Integration test

   ```bash
   npm start -- extension install /tmp/temp/google-secops
   ```

Test Evidence

```bash
$ npm test -w packages/cli -- src/ui/components/ConfigExtensionDialog.test.tsx

> @google/gemini-cli@0.29.0-nightly.20260203.71f46f116 test
> vitest run src/ui/components/ConfigExtensionDialog.test.tsx


 RUN  v3.2.4 /Users/dandye/Projects/gemini-cli__worktrees/ext_config_default_value/packages/cli
      Coverage enabled with v8

 ✓ src/ui/components/ConfigExtensionDialog.test.tsx (5 tests) 179ms
   ✓ ConfigExtensionDialog > should display default value in prompt 28ms
   ✓ ConfigExtensionDialog > should mask sensitive default value in prompt 4ms
   ✓ ConfigExtensionDialog > should use default value when input is empty 4ms
   ✓ ConfigExtensionDialog > should use input value even if default exists 71ms
   ✓ ConfigExtensionDialog > should work normally without default value 72ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  12:18:26
   Duration  3.99s (transform 819ms, setup 17ms, collect 2.46s, tests 179ms, environment 0ms, prepare 60ms)

JUNIT report written to /Users/dandye/Projects/gemini-cli__worktrees/ext_config_default_value/packages/cli/junit.xml
 % Coverage report from v8
```


2. Manual Validation:
   - Run the CLI and configure an extension with default values (if any exist, or mocked).
   - Observe that the default value is shown in the prompt.
   - Press Enter without typing anything and verify the default value is saved.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

# Screenshots

## Before

<img width="292" height="91" alt="Screenshot 2026-02-05 at 12 19 42 PM" src="https://github.com/user-attachments/assets/998b4750-70f8-4589-bb08-4e1ef9409ba8" />

## After

<img width="549" height="51" alt="Screenshot 2026-02-06 at 12 27 29 PM" src="https://github.com/user-attachments/assets/89e1bcaf-8718-4f04-9b8b-1286e0b067e6" />

Pressing enter writes the default to:
```
cat ~/.gemini/extensions/google-secops/.env
PROJECT_ID=secops-demo-env
```
