### PR TITLE
test(integration): fix windows integration issues for hook tests

### DIFF
--- a/integration-tests/hooks-agent-flow.test.ts
+++ b/integration-tests/hooks-agent-flow.test.ts
@@ -7,7 +7,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TestRig } from './test-helper.js';
 import { join } from 'node:path';
-import { writeFileSync } from 'node:fs';
 
 describe('Hooks Agent Flow', () => {
   let rig: TestRig;
@@ -49,11 +48,10 @@ describe('Hooks Agent Flow', () => {
       console.error('DEBUG: BeforeAgent hook executed');
       `;
 
-      const scriptPath = join(rig.testDir!, 'before_agent_context.cjs').replace(
-        /\\/g,
-        '/',
+      const scriptPath = rig.createHookScript(
+        'before_agent_context.cjs',
+        hookScript,
       );
-      writeFileSync(scriptPath, hookScript);
 
       await rig.configure({
         settings: {
@@ -118,11 +116,10 @@ describe('Hooks Agent Flow', () => {
       }
       `;
 
-      const scriptPath = join(rig.testDir!, 'after_agent_verify.cjs').replace(
-        /\\/g,
-        '/',
+      const scriptPath = rig.createHookScript(
+        'after_agent_verify.cjs',
+        hookScript,
       );
-      writeFileSync(scriptPath, hookScript);
 
       await rig.configure({
         settings: {
@@ -182,11 +179,10 @@ describe('Hooks Agent Flow', () => {
         fs.writeFileSync('${messageCountFile}', JSON.stringify(counts));
         console.log(JSON.stringify({ decision: 'allow' }));
       `;
-      const beforeModelScriptPath = join(
-        rig.testDir!,
+      const beforeModelScriptPath = rig.createHookScript(
         'before_model_counter.cjs',
-      ).replace(/\\/g, '/');
-      writeFileSync(beforeModelScriptPath, beforeModelScript);
+        beforeModelScript,
+      );
 
       const afterAgentScript = `
         console.log(JSON.stringify({
@@ -198,11 +194,10 @@ describe('Hooks Agent Flow', () => {
           }
         }));
       `;
-      const afterAgentScriptPath = join(
-        rig.testDir!,
+      const afterAgentScriptPath = rig.createHookScript(
         'after_agent_clear.cjs',
-      ).replace(/\\/g, '/');
-      writeFileSync(afterAgentScriptPath, afterAgentScript);
+        afterAgentScript,
+      );
 
       await rig.configure({
         fakeResponsesPath: join(
@@ -270,18 +265,16 @@ describe('Hooks Agent Flow', () => {
       );
 
       const beforeAgentScript = "console.log('BeforeAgent Fired')";
-      const beforeAgentScriptPath = join(
-        rig.testDir!,
+      const beforeAgentScriptPath = rig.createHookScript(
         'before_agent_loop.cjs',
-      ).replace(/\\/g, '/');
-      writeFileSync(beforeAgentScriptPath, beforeAgentScript);
+        beforeAgentScript,
+      );
 
       const afterAgentScript = "console.log('AfterAgent Fired')";
-      const afterAgentScriptPath = join(
-        rig.testDir!,
+      const afterAgentScriptPath = rig.createHookScript(
         'after_agent_loop.cjs',
-      ).replace(/\\/g, '/');
-      writeFileSync(afterAgentScriptPath, afterAgentScript);
+        afterAgentScript,
+      );
 
       await rig.configure({
         fakeResponsesPath: join(

--- a/integration-tests/hooks-agent-flow.test.ts
+++ b/integration-tests/hooks-agent-flow.test.ts
@@ -24,7 +24,8 @@ describe('Hooks Agent Flow', () => {
 
   describe('BeforeAgent Hooks', () => {
     it('should inject additional context via BeforeAgent hook', async () => {
-      await rig.setup('should inject additional context via BeforeAgent hook', {
+      await rig.setup('should inject additional context via BeforeAgent hook');
+      await rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-agent-flow.responses',
@@ -54,7 +55,7 @@ describe('Hooks Agent Flow', () => {
       );
       writeFileSync(scriptPath, hookScript);
 
-      await rig.setup('should inject additional context via BeforeAgent hook', {
+      await rig.configure({
         settings: {
           hooksConfig: {
             enabled: true,
@@ -97,7 +98,8 @@ describe('Hooks Agent Flow', () => {
 
   describe('AfterAgent Hooks', () => {
     it('should receive prompt and response in AfterAgent hook', async () => {
-      await rig.setup('should receive prompt and response in AfterAgent hook', {
+      await rig.setup('should receive prompt and response in AfterAgent hook');
+      await rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-agent-flow.responses',
@@ -122,7 +124,7 @@ describe('Hooks Agent Flow', () => {
       );
       writeFileSync(scriptPath, hookScript);
 
-      await rig.setup('should receive prompt and response in AfterAgent hook', {
+      await rig.configure({
         settings: {
           hooksConfig: {
             enabled: true,

--- a/integration-tests/hooks-agent-flow.test.ts
+++ b/integration-tests/hooks-agent-flow.test.ts
@@ -163,12 +163,7 @@ describe('Hooks Agent Flow', () => {
     });
 
     it('should process clearContext in AfterAgent hook output', async () => {
-      await rig.setup('should process clearContext in AfterAgent hook output', {
-        fakeResponsesPath: join(
-          import.meta.dirname,
-          'hooks-system.after-agent.responses',
-        ),
-      });
+      await rig.setup('should process clearContext in AfterAgent hook output');
 
       // BeforeModel hook to track message counts across LLM calls
       const messageCountFile = join(
@@ -207,7 +202,11 @@ describe('Hooks Agent Flow', () => {
       ).replace(/\\/g, '/');
       writeFileSync(afterAgentScriptPath, afterAgentScript);
 
-      await rig.setup('should process clearContext in AfterAgent hook output', {
+      await rig.configure({
+        fakeResponsesPath: join(
+          import.meta.dirname,
+          'hooks-system.after-agent.responses',
+        ),
         settings: {
           hooksConfig: {
             enabled: true,
@@ -282,44 +281,41 @@ describe('Hooks Agent Flow', () => {
       ).replace(/\\/g, '/');
       writeFileSync(afterAgentScriptPath, afterAgentScript);
 
-      await rig.setup(
-        'should fire BeforeAgent and AfterAgent exactly once per turn despite tool calls',
-        {
-          fakeResponsesPath: join(
-            import.meta.dirname,
-            'hooks-agent-flow-multistep.responses',
-          ),
-          settings: {
-            hooksConfig: {
-              enabled: true,
-            },
-            hooks: {
-              BeforeAgent: [
-                {
-                  hooks: [
-                    {
-                      type: 'command',
-                      command: `node "${beforeAgentScriptPath}"`,
-                      timeout: 5000,
-                    },
-                  ],
-                },
-              ],
-              AfterAgent: [
-                {
-                  hooks: [
-                    {
-                      type: 'command',
-                      command: `node "${afterAgentScriptPath}"`,
-                      timeout: 5000,
-                    },
-                  ],
-                },
-              ],
-            },
+      await rig.configure({
+        fakeResponsesPath: join(
+          import.meta.dirname,
+          'hooks-agent-flow-multistep.responses',
+        ),
+        settings: {
+          hooksConfig: {
+            enabled: true,
+          },
+          hooks: {
+            BeforeAgent: [
+              {
+                hooks: [
+                  {
+                    type: 'command',
+                    command: `node "${beforeAgentScriptPath}"`,
+                    timeout: 5000,
+                  },
+                ],
+              },
+            ],
+            AfterAgent: [
+              {
+                hooks: [
+                  {
+                    type: 'command',
+                    command: `node "${afterAgentScriptPath}"`,
+                    timeout: 5000,
+                  },
+                ],
+              },
+            ],
           },
         },
-      );
+      });
 
       await rig.run({ args: 'Do a multi-step task' });
 

--- a/integration-tests/hooks-system.test.ts
+++ b/integration-tests/hooks-system.test.ts
@@ -31,35 +31,32 @@ describe('Hooks System Integration', () => {
         "console.log(JSON.stringify({decision: 'block', reason: 'File writing blocked by security policy'}))",
       );
 
-      rig.setup(
-        'should block tool execution when hook returns block decision',
-        {
-          fakeResponsesPath: join(
-            import.meta.dirname,
-            'hooks-system.block-tool.responses',
-          ),
-          settings: {
-            hooksConfig: {
-              enabled: true,
-            },
-            hooks: {
-              BeforeTool: [
-                {
-                  matcher: 'write_file',
-                  sequential: true,
-                  hooks: [
-                    {
-                      type: 'command',
-                      command: `node "${scriptPath}"`,
-                      timeout: 5000,
-                    },
-                  ],
-                },
-              ],
-            },
+      rig.configure({
+        fakeResponsesPath: join(
+          import.meta.dirname,
+          'hooks-system.block-tool.responses',
+        ),
+        settings: {
+          hooksConfig: {
+            enabled: true,
+          },
+          hooks: {
+            BeforeTool: [
+              {
+                matcher: 'write_file',
+                sequential: true,
+                hooks: [
+                  {
+                    type: 'command',
+                    command: `node "${scriptPath}"`,
+                    timeout: 5000,
+                  },
+                ],
+              },
+            ],
           },
         },
-      );
+      });
 
       const result = await rig.run({
         args: 'Create a file called test.txt with content "Hello World"',
@@ -93,35 +90,32 @@ describe('Hooks System Integration', () => {
         "process.stderr.write('File writing blocked by security policy'); process.exit(2)",
       );
 
-      rig.setup(
-        'should block tool execution and use stderr as reason when hook exits with code 2',
-        {
-          fakeResponsesPath: join(
-            import.meta.dirname,
-            'hooks-system.block-tool.responses',
-          ),
-          settings: {
-            hooksConfig: {
-              enabled: true,
-            },
-            hooks: {
-              BeforeTool: [
-                {
-                  matcher: 'write_file',
-                  hooks: [
-                    {
-                      type: 'command',
-                      // Exit with code 2 and write reason to stderr
-                      command: `node "${scriptPath}"`,
-                      timeout: 5000,
-                    },
-                  ],
-                },
-              ],
-            },
+      rig.configure({
+        fakeResponsesPath: join(
+          import.meta.dirname,
+          'hooks-system.block-tool.responses',
+        ),
+        settings: {
+          hooksConfig: {
+            enabled: true,
+          },
+          hooks: {
+            BeforeTool: [
+              {
+                matcher: 'write_file',
+                hooks: [
+                  {
+                    type: 'command',
+                    // Exit with code 2 and write reason to stderr
+                    command: `node "${scriptPath}"`,
+                    timeout: 5000,
+                  },
+                ],
+              },
+            ],
           },
         },
-      );
+      });
 
       const result = await rig.run({
         args: 'Create a file called test.txt with content "Hello World"',
@@ -158,34 +152,31 @@ describe('Hooks System Integration', () => {
         "console.log(JSON.stringify({decision: 'allow', reason: 'File writing approved'}))",
       );
 
-      rig.setup(
-        'should allow tool execution when hook returns allow decision',
-        {
-          fakeResponsesPath: join(
-            import.meta.dirname,
-            'hooks-system.allow-tool.responses',
-          ),
-          settings: {
-            hooksConfig: {
-              enabled: true,
-            },
-            hooks: {
-              BeforeTool: [
-                {
-                  matcher: 'write_file',
-                  hooks: [
-                    {
-                      type: 'command',
-                      command: `node "${scriptPath}"`,
-                      timeout: 5000,
-                    },
-                  ],
-                },
-              ],
-            },
+      rig.configure({
+        fakeResponsesPath: join(
+          import.meta.dirname,
+          'hooks-system.allow-tool.responses',
+        ),
+        settings: {
+          hooksConfig: {
+            enabled: true,
+          },
+          hooks: {
+            BeforeTool: [
+              {
+                matcher: 'write_file',
+                hooks: [
+                  {
+                    type: 'command',
+                    command: `node "${scriptPath}"`,
+                    timeout: 5000,
+                  },
+                ],
+              },
+            ],
           },
         },
-      );
+      });
 
       await rig.run({
         args: 'Create a file called approved.txt with content "Approved content"',
@@ -214,7 +205,7 @@ describe('Hooks System Integration', () => {
         "console.log(JSON.stringify({hookSpecificOutput: {hookEventName: 'AfterTool', additionalContext: 'Security scan: File content appears safe'}}))",
       );
       const command = `node "${scriptPath}"`;
-      rig.setup('should add additional context from AfterTool hooks', {
+      rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-system.after-tool-context.responses',
@@ -634,7 +625,7 @@ console.log(JSON.stringify({
       );
       const hookCommand = `node "${scriptPath.replace(/\\/g, '/')}"`;
 
-      rig.setup('should handle notification hooks for tool permissions', {
+      rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-system.notification.responses',
@@ -742,7 +733,7 @@ console.log(JSON.stringify({
       const hook1Command = `node "${script1Path.replace(/\\/g, '/')}"`;
       const hook2Command = `node "${script2Path.replace(/\\/g, '/')}"`;
 
-      rig.setup('should execute hooks sequentially when configured', {
+      rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-system.sequential-execution.responses',
@@ -876,36 +867,33 @@ try {
         "console.log('Pollution'); console.log(JSON.stringify({decision: 'deny', reason: 'Should be ignored'}))",
       );
 
-      rig.setup(
-        'should treat mixed stdout (text + JSON) as system message and allow execution when exit code is 0',
-        {
-          fakeResponsesPath: join(
-            import.meta.dirname,
-            'hooks-system.allow-tool.responses',
-          ),
-          settings: {
-            hooksConfig: {
-              enabled: true,
-            },
-            hooks: {
-              BeforeTool: [
-                {
-                  matcher: 'write_file',
-                  hooks: [
-                    {
-                      type: 'command',
-                      // Output plain text then JSON.
-                      // This breaks JSON parsing, so it falls back to 'allow' with the whole stdout as systemMessage.
-                      command: `node "${scriptPath}"`,
-                      timeout: 5000,
-                    },
-                  ],
-                },
-              ],
-            },
+      rig.configure({
+        fakeResponsesPath: join(
+          import.meta.dirname,
+          'hooks-system.allow-tool.responses',
+        ),
+        settings: {
+          hooksConfig: {
+            enabled: true,
+          },
+          hooks: {
+            BeforeTool: [
+              {
+                matcher: 'write_file',
+                hooks: [
+                  {
+                    type: 'command',
+                    // Output plain text then JSON.
+                    // This breaks JSON parsing, so it falls back to 'allow' with the whole stdout as systemMessage.
+                    command: `node "${scriptPath}"`,
+                    timeout: 5000,
+                  },
+                ],
+              },
+            ],
           },
         },
-      );
+      });
 
       const result = await rig.run({
         args: 'Create a file called approved.txt with content "Approved content"',
@@ -945,7 +933,7 @@ try {
       const afterToolCommand = `node "${afterToolScript.replace(/\\/g, '/')}"`;
       const beforeAgentCommand = `node "${beforeAgentScript.replace(/\\/g, '/')}"`;
 
-      rig.setup('should handle hooks for all major event types', {
+      rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-system.multiple-events.responses',
@@ -1062,7 +1050,7 @@ try {
       const failingCommand = `node "${failingScript.replace(/\\/g, '/')}"`;
       const workingCommand = `node "${workingScript.replace(/\\/g, '/')}"`;
 
-      rig.setup('should handle hook failures gracefully', {
+      rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-system.error-handling.responses',
@@ -1120,7 +1108,7 @@ try {
       );
       const hookCommand = `node "${scriptPath.replace(/\\/g, '/')}"`;
 
-      rig.setup('should generate telemetry events for hook executions', {
+      rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-system.telemetry.responses',
@@ -1167,7 +1155,7 @@ try {
       );
       const sessionStartCommand = `node "${scriptPath.replace(/\\/g, '/')}"`;
 
-      rig.setup('should fire SessionStart hook on app startup', {
+      rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-system.session-startup.responses',
@@ -1405,46 +1393,43 @@ console.log(JSON.stringify({
       const sessionEndCommand = `node "${endScriptPath.replace(/\\/g, '/')}"`;
       const sessionStartCommand = `node "${startScriptPath.replace(/\\/g, '/')}"`;
 
-      rig.setup(
-        'should fire SessionEnd and SessionStart hooks on /clear command',
-        {
-          fakeResponsesPath: join(
-            import.meta.dirname,
-            'hooks-system.session-clear.responses',
-          ),
-          settings: {
-            hooksConfig: {
-              enabled: true,
-            },
-            hooks: {
-              SessionEnd: [
-                {
-                  matcher: '*',
-                  hooks: [
-                    {
-                      type: 'command',
-                      command: sessionEndCommand,
-                      timeout: 5000,
-                    },
-                  ],
-                },
-              ],
-              SessionStart: [
-                {
-                  matcher: '*',
-                  hooks: [
-                    {
-                      type: 'command',
-                      command: sessionStartCommand,
-                      timeout: 5000,
-                    },
-                  ],
-                },
-              ],
-            },
+      rig.configure({
+        fakeResponsesPath: join(
+          import.meta.dirname,
+          'hooks-system.session-clear.responses',
+        ),
+        settings: {
+          hooksConfig: {
+            enabled: true,
+          },
+          hooks: {
+            SessionEnd: [
+              {
+                matcher: '*',
+                hooks: [
+                  {
+                    type: 'command',
+                    command: sessionEndCommand,
+                    timeout: 5000,
+                  },
+                ],
+              },
+            ],
+            SessionStart: [
+              {
+                matcher: '*',
+                hooks: [
+                  {
+                    type: 'command',
+                    command: sessionStartCommand,
+                    timeout: 5000,
+                  },
+                ],
+              },
+            ],
           },
         },
-      );
+      });
 
       const run = await rig.runInteractive();
 
@@ -1585,7 +1570,7 @@ console.log(JSON.stringify({
       );
       const preCompressCommand = `node "${scriptPath.replace(/\\/g, '/')}"`;
 
-      rig.setup('should fire PreCompress hook on automatic compression', {
+      rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-system.compress-auto.responses',
@@ -1659,7 +1644,7 @@ console.log(JSON.stringify({
       );
       const sessionEndCommand = `node "${scriptPath.replace(/\\/g, '/')}"`;
 
-      rig.setup('should fire SessionEnd hook on graceful exit', {
+      rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-system.session-startup.responses',

--- a/integration-tests/hooks-system.test.ts
+++ b/integration-tests/hooks-system.test.ts
@@ -46,7 +46,7 @@ describe('Hooks System Integration', () => {
                 hooks: [
                   {
                     type: 'command',
-                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
+                    command: `node "${scriptPath}"`,
                     timeout: 5000,
                   },
                 ],
@@ -104,7 +104,7 @@ describe('Hooks System Integration', () => {
                   {
                     type: 'command',
                     // Exit with code 2 and write reason to stderr
-                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
+                    command: `node "${scriptPath}"`,
                     timeout: 5000,
                   },
                 ],
@@ -164,7 +164,7 @@ describe('Hooks System Integration', () => {
                 hooks: [
                   {
                     type: 'command',
-                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
+                    command: `node "${scriptPath}"`,
                     timeout: 5000,
                   },
                 ],
@@ -889,7 +889,7 @@ try {
                     type: 'command',
                     // Output plain text then JSON.
                     // This breaks JSON parsing, so it falls back to 'allow' with the whole stdout as systemMessage.
-                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
+                    command: `node "${scriptPath}"`,
                     timeout: 5000,
                   },
                 ],

--- a/integration-tests/hooks-system.test.ts
+++ b/integration-tests/hooks-system.test.ts
@@ -7,7 +7,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TestRig, poll } from './test-helper.js';
 import { join } from 'node:path';
-import { writeFileSync } from 'node:fs';
 
 describe('Hooks System Integration', () => {
   let rig: TestRig;
@@ -25,9 +24,8 @@ describe('Hooks System Integration', () => {
   describe('Command Hooks - Blocking Behavior', () => {
     it('should block tool execution when hook returns block decision', async () => {
       rig.setup('should block tool execution when hook returns block decision');
-      const scriptPath = join(rig.testDir!, 'block_tool.cjs');
-      writeFileSync(
-        scriptPath,
+      const scriptPath = rig.createHookScript(
+        'block_tool.cjs',
         "console.log(JSON.stringify({decision: 'block', reason: 'File writing blocked by security policy'}))",
       );
 
@@ -84,9 +82,8 @@ describe('Hooks System Integration', () => {
       rig.setup(
         'should block tool execution and use stderr as reason when hook exits with code 2',
       );
-      const scriptPath = join(rig.testDir!, 'block_tool_stderr.cjs');
-      writeFileSync(
-        scriptPath,
+      const scriptPath = rig.createHookScript(
+        'block_tool_stderr.cjs',
         "process.stderr.write('File writing blocked by security policy'); process.exit(2)",
       );
 
@@ -146,9 +143,8 @@ describe('Hooks System Integration', () => {
 
     it('should allow tool execution when hook returns allow decision', async () => {
       rig.setup('should allow tool execution when hook returns allow decision');
-      const scriptPath = join(rig.testDir!, 'allow_tool.cjs');
-      writeFileSync(
-        scriptPath,
+      const scriptPath = rig.createHookScript(
+        'allow_tool.cjs',
         "console.log(JSON.stringify({decision: 'allow', reason: 'File writing approved'}))",
       );
 
@@ -199,12 +195,11 @@ describe('Hooks System Integration', () => {
   describe('Command Hooks - Additional Context', () => {
     it('should add additional context from AfterTool hooks', async () => {
       rig.setup('should add additional context from AfterTool hooks');
-      const scriptPath = join(rig.testDir!, 'after_tool_context.cjs');
-      writeFileSync(
-        scriptPath,
+      const scriptPath = rig.createHookScript(
+        'after_tool_context.cjs',
         "console.log(JSON.stringify({hookSpecificOutput: {hookEventName: 'AfterTool', additionalContext: 'Security scan: File content appears safe'}}))",
       );
-      const command = `node "${scriptPath.replace(/\\/g, '/')}"`;
+      const command = `node "${scriptPath}"`;
       rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
@@ -282,8 +277,10 @@ console.log(JSON.stringify({
   }
 }));`;
 
-      const scriptPath = join(rig.testDir!, 'before_model_hook.cjs');
-      writeFileSync(scriptPath, hookScript);
+      const scriptPath = rig.createHookScript(
+        'before_model_hook.cjs',
+        hookScript,
+      );
 
       rig.configure({
         settings: {
@@ -296,7 +293,7 @@ console.log(JSON.stringify({
                 hooks: [
                   {
                     type: 'command',
-                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
+                    command: `node "${scriptPath}"`,
                     timeout: 5000,
                   },
                 ],
@@ -341,8 +338,10 @@ console.log(JSON.stringify({
   decision: "deny",
   reason: "Model execution blocked by security policy"
 }));`;
-      const scriptPath = join(rig.testDir!, 'before_model_deny_hook.cjs');
-      writeFileSync(scriptPath, hookScript);
+      const scriptPath = rig.createHookScript(
+        'before_model_deny_hook.cjs',
+        hookScript,
+      );
 
       rig.configure({
         settings: {
@@ -355,7 +354,7 @@ console.log(JSON.stringify({
                 hooks: [
                   {
                     type: 'command',
-                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
+                    command: `node "${scriptPath}"`,
                     timeout: 5000,
                   },
                 ],
@@ -383,8 +382,10 @@ console.log(JSON.stringify({
   decision: "block",
   reason: "Model execution blocked by security policy"
 }));`;
-      const scriptPath = join(rig.testDir!, 'before_model_block_hook.cjs');
-      writeFileSync(scriptPath, hookScript);
+      const scriptPath = rig.createHookScript(
+        'before_model_block_hook.cjs',
+        hookScript,
+      );
 
       rig.configure({
         settings: {
@@ -397,7 +398,7 @@ console.log(JSON.stringify({
                 hooks: [
                   {
                     type: 'command',
-                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
+                    command: `node "${scriptPath}"`,
                     timeout: 5000,
                   },
                 ],
@@ -450,8 +451,10 @@ console.log(JSON.stringify({
   }
 }));`;
 
-        const scriptPath = join(rig.testDir!, 'after_model_hook.cjs');
-        writeFileSync(scriptPath, hookScript);
+        const scriptPath = rig.createHookScript(
+          'after_model_hook.cjs',
+          hookScript,
+        );
 
         rig.configure({
           settings: {
@@ -464,7 +467,7 @@ console.log(JSON.stringify({
                   hooks: [
                     {
                       type: 'command',
-                      command: `node "${scriptPath.replace(/\\/g, '/')}"`,
+                      command: `node "${scriptPath}"`,
                       timeout: 5000,
                     },
                   ],
@@ -508,8 +511,10 @@ console.log(JSON.stringify({
     }
   }
 }));`;
-      const scriptPath = join(rig.testDir!, 'before_tool_selection_hook.cjs');
-      writeFileSync(scriptPath, hookScript);
+      const scriptPath = rig.createHookScript(
+        'before_tool_selection_hook.cjs',
+        hookScript,
+      );
 
       rig.configure({
         settings: {
@@ -523,7 +528,7 @@ console.log(JSON.stringify({
                 hooks: [
                   {
                     type: 'command',
-                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
+                    command: `node "${scriptPath}"`,
                     timeout: 5000,
                   },
                 ],
@@ -577,8 +582,10 @@ console.log(JSON.stringify({
   }
 }));`;
 
-      const scriptPath = join(rig.testDir!, 'before_agent_hook.cjs');
-      writeFileSync(scriptPath, hookScript);
+      const scriptPath = rig.createHookScript(
+        'before_agent_hook.cjs',
+        hookScript,
+      );
 
       rig.configure({
         settings: {
@@ -591,7 +598,7 @@ console.log(JSON.stringify({
                 hooks: [
                   {
                     type: 'command',
-                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
+                    command: `node "${scriptPath}"`,
                     timeout: 5000,
                   },
                 ],
@@ -616,12 +623,11 @@ console.log(JSON.stringify({
     it('should handle notification hooks for tool permissions', async () => {
       rig.setup('should handle notification hooks for tool permissions');
       // Create script for hook (works on both Unix and Windows)
-      const scriptPath = join(rig.testDir!, 'notification_hook.cjs');
-      writeFileSync(
-        scriptPath,
+      const scriptPath = rig.createHookScript(
+        'notification_hook.cjs',
         "console.log(JSON.stringify({suppressOutput: false, systemMessage: 'Permission request logged by security hook'}))",
       );
-      const hookCommand = `node "${scriptPath.replace(/\\/g, '/')}"`;
+      const hookCommand = `node "${scriptPath}"`;
 
       rig.configure({
         fakeResponsesPath: join(
@@ -717,19 +723,17 @@ console.log(JSON.stringify({
     it('should execute hooks sequentially when configured', async () => {
       rig.setup('should execute hooks sequentially when configured');
       // Create script for hooks (works on both Unix and Windows)
-      const script1Path = join(rig.testDir!, 'hook1.cjs');
-      writeFileSync(
-        script1Path,
+      const script1Path = rig.createHookScript(
+        'hook1.cjs',
         "console.log(JSON.stringify({decision: 'allow', hookSpecificOutput: {hookEventName: 'BeforeAgent', additionalContext: 'Step 1: Initial validation passed.'}}))",
       );
-      const script2Path = join(rig.testDir!, 'hook2.cjs');
-      writeFileSync(
-        script2Path,
+      const script2Path = rig.createHookScript(
+        'hook2.cjs',
         "console.log(JSON.stringify({decision: 'allow', hookSpecificOutput: {hookEventName: 'BeforeAgent', additionalContext: 'Step 2: Security check completed.'}}))",
       );
 
-      const hook1Command = `node "${script1Path.replace(/\\/g, '/')}"`;
-      const hook2Command = `node "${script2Path.replace(/\\/g, '/')}"`;
+      const hook1Command = `node "${script1Path}"`;
+      const hook2Command = `node "${script2Path}"`;
 
       rig.configure({
         fakeResponsesPath: join(
@@ -815,8 +819,10 @@ try {
   console.log(JSON.stringify({decision: "block", reason: "Invalid JSON"}));
 }`;
 
-      const scriptPath = join(rig.testDir!, 'input_validation_hook.cjs');
-      writeFileSync(scriptPath, hookScript);
+      const scriptPath = rig.createHookScript(
+        'input_validation_hook.cjs',
+        hookScript,
+      );
 
       rig.configure({
         settings: {
@@ -829,7 +835,7 @@ try {
                 hooks: [
                   {
                     type: 'command',
-                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
+                    command: `node "${scriptPath}"`,
                     timeout: 5000,
                   },
                 ],
@@ -860,9 +866,8 @@ try {
       rig.setup(
         'should treat mixed stdout (text + JSON) as system message and allow execution when exit code is 0',
       );
-      const scriptPath = join(rig.testDir!, 'mixed_stdout.cjs');
-      writeFileSync(
-        scriptPath,
+      const scriptPath = rig.createHookScript(
+        'mixed_stdout.cjs',
         "console.log('Pollution'); console.log(JSON.stringify({decision: 'deny', reason: 'Should be ignored'}))",
       );
 
@@ -912,25 +917,22 @@ try {
     it('should handle hooks for all major event types', async () => {
       rig.setup('should handle hooks for all major event types');
       // Create scripts for hooks (works on both Unix and Windows)
-      const beforeToolScript = join(rig.testDir!, 'before_tool_all.cjs');
-      writeFileSync(
-        beforeToolScript,
+      const beforeToolScript = rig.createHookScript(
+        'before_tool_all.cjs',
         "console.log(JSON.stringify({decision: 'allow', systemMessage: 'BeforeTool: File operation logged'}))",
       );
-      const afterToolScript = join(rig.testDir!, 'after_tool_all.cjs');
-      writeFileSync(
-        afterToolScript,
+      const afterToolScript = rig.createHookScript(
+        'after_tool_all.cjs',
         "console.log(JSON.stringify({hookSpecificOutput: {hookEventName: 'AfterTool', additionalContext: 'AfterTool: Operation completed successfully'}}))",
       );
-      const beforeAgentScript = join(rig.testDir!, 'before_agent_all.cjs');
-      writeFileSync(
-        beforeAgentScript,
+      const beforeAgentScript = rig.createHookScript(
+        'before_agent_all.cjs',
         "console.log(JSON.stringify({decision: 'allow', hookSpecificOutput: {hookEventName: 'BeforeAgent', additionalContext: 'BeforeAgent: User request processed'}}))",
       );
 
-      const beforeToolCommand = `node "${beforeToolScript.replace(/\\/g, '/')}"`;
-      const afterToolCommand = `node "${afterToolScript.replace(/\\/g, '/')}"`;
-      const beforeAgentCommand = `node "${beforeAgentScript.replace(/\\/g, '/')}"`;
+      const beforeToolCommand = `node "${beforeToolScript}"`;
+      const afterToolCommand = `node "${afterToolScript}"`;
+      const beforeAgentCommand = `node "${beforeAgentScript}"`;
 
       rig.configure({
         fakeResponsesPath: join(
@@ -1038,16 +1040,17 @@ try {
   describe('Hook Error Handling', () => {
     it('should handle hook failures gracefully', async () => {
       rig.setup('should handle hook failures gracefully');
-      const failingScript = join(rig.testDir!, 'failing_hook.cjs');
-      writeFileSync(failingScript, 'process.exit(1)');
-      const workingScript = join(rig.testDir!, 'working_hook.cjs');
-      writeFileSync(
-        workingScript,
+      const failingScript = rig.createHookScript(
+        'failing_hook.cjs',
+        'process.exit(1)',
+      );
+      const workingScript = rig.createHookScript(
+        'working_hook.cjs',
         "console.log(JSON.stringify({decision: 'allow', reason: 'Working hook succeeded'}))",
       );
 
-      const failingCommand = `node "${failingScript.replace(/\\/g, '/')}"`;
-      const workingCommand = `node "${workingScript.replace(/\\/g, '/')}"`;
+      const failingCommand = `node "${failingScript}"`;
+      const workingCommand = `node "${workingScript}"`;
 
       rig.configure({
         fakeResponsesPath: join(
@@ -1100,12 +1103,11 @@ try {
   describe('Hook Telemetry and Observability', () => {
     it('should generate telemetry events for hook executions', async () => {
       rig.setup('should generate telemetry events for hook executions');
-      const scriptPath = join(rig.testDir!, 'telemetry_hook.cjs');
-      writeFileSync(
-        scriptPath,
+      const scriptPath = rig.createHookScript(
+        'telemetry_hook.cjs',
         "console.log(JSON.stringify({decision: 'allow', reason: 'Telemetry test hook'}))",
       );
-      const hookCommand = `node "${scriptPath.replace(/\\/g, '/')}"`;
+      const hookCommand = `node "${scriptPath}"`;
 
       rig.configure({
         fakeResponsesPath: join(
@@ -1147,12 +1149,11 @@ try {
   describe('Session Lifecycle Hooks', () => {
     it('should fire SessionStart hook on app startup', async () => {
       rig.setup('should fire SessionStart hook on app startup');
-      const scriptPath = join(rig.testDir!, 'session_start.cjs');
-      writeFileSync(
-        scriptPath,
+      const scriptPath = rig.createHookScript(
+        'session_start.cjs',
         "console.log(JSON.stringify({decision: 'allow', systemMessage: 'Session starting on startup'}))",
       );
-      const sessionStartCommand = `node "${scriptPath.replace(/\\/g, '/')}"`;
+      const sessionStartCommand = `node "${scriptPath}"`;
 
       rig.configure({
         fakeResponsesPath: join(
@@ -1229,8 +1230,10 @@ console.log(JSON.stringify({
         ),
       });
 
-      const scriptPath = join(rig.testDir!, 'session_start_context_hook.cjs');
-      writeFileSync(scriptPath, hookScript);
+      const scriptPath = rig.createHookScript(
+        'session_start_context_hook.cjs',
+        hookScript,
+      );
 
       rig.configure({
         settings: {
@@ -1244,7 +1247,7 @@ console.log(JSON.stringify({
                 hooks: [
                   {
                     type: 'command',
-                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
+                    command: `node "${scriptPath}"`,
                     timeout: 5000,
                   },
                 ],
@@ -1309,11 +1312,10 @@ console.log(JSON.stringify({
         ),
       });
 
-      const scriptPath = join(
-        rig.testDir!,
+      const scriptPath = rig.createHookScript(
         'session_start_interactive_hook.cjs',
+        hookScript,
       );
-      writeFileSync(scriptPath, hookScript);
 
       rig.configure({
         settings: {
@@ -1327,7 +1329,7 @@ console.log(JSON.stringify({
                 hooks: [
                   {
                     type: 'command',
-                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
+                    command: `node "${scriptPath}"`,
                     timeout: 5000,
                   },
                 ],
@@ -1376,19 +1378,17 @@ console.log(JSON.stringify({
         'should fire SessionEnd and SessionStart hooks on /clear command',
       );
       // Create script for hooks (works on both Unix and Windows)
-      const endScriptPath = join(rig.testDir!, 'session_end_clear.cjs');
-      writeFileSync(
-        endScriptPath,
+      const endScriptPath = rig.createHookScript(
+        'session_end_clear.cjs',
         "console.log(JSON.stringify({decision: 'allow', systemMessage: 'Session ending due to clear'}))",
       );
-      const startScriptPath = join(rig.testDir!, 'session_start_clear.cjs');
-      writeFileSync(
-        startScriptPath,
+      const startScriptPath = rig.createHookScript(
+        'session_start_clear.cjs',
         "console.log(JSON.stringify({decision: 'allow', systemMessage: 'Session starting after clear'}))",
       );
 
-      const sessionEndCommand = `node "${endScriptPath.replace(/\\/g, '/')}"`;
-      const sessionStartCommand = `node "${startScriptPath.replace(/\\/g, '/')}"`;
+      const sessionEndCommand = `node "${endScriptPath}"`;
+      const sessionStartCommand = `node "${startScriptPath}"`;
 
       rig.configure({
         fakeResponsesPath: join(
@@ -1560,12 +1560,11 @@ console.log(JSON.stringify({
   describe('Compression Hooks', () => {
     it('should fire PreCompress hook on automatic compression', async () => {
       rig.setup('should fire PreCompress hook on automatic compression');
-      const scriptPath = join(rig.testDir!, 'pre_compress.cjs');
-      writeFileSync(
-        scriptPath,
+      const scriptPath = rig.createHookScript(
+        'pre_compress.cjs',
         "console.log(JSON.stringify({decision: 'allow', systemMessage: 'PreCompress hook executed for automatic compression'}))",
       );
-      const preCompressCommand = `node "${scriptPath.replace(/\\/g, '/')}"`;
+      const preCompressCommand = `node "${scriptPath}"`;
 
       rig.configure({
         fakeResponsesPath: join(
@@ -1634,12 +1633,11 @@ console.log(JSON.stringify({
       rig.setup(
         'should fire SessionEnd hook on graceful exit in non-interactive mode',
       );
-      const scriptPath = join(rig.testDir!, 'session_end_exit.cjs');
-      writeFileSync(
-        scriptPath,
+      const scriptPath = rig.createHookScript(
+        'session_end_exit.cjs',
         "console.log(JSON.stringify({decision: 'allow', systemMessage: 'SessionEnd hook executed on exit'}))",
       );
-      const sessionEndCommand = `node "${scriptPath.replace(/\\/g, '/')}"`;
+      const sessionEndCommand = `node "${scriptPath}"`;
 
       rig.configure({
         fakeResponsesPath: join(
@@ -1740,17 +1738,14 @@ console.log(JSON.stringify({decision: "allow", systemMessage: "Enabled hook exec
       const disabledHookScript = `const fs = require('fs');
 console.log(JSON.stringify({decision: "block", systemMessage: "Disabled hook should not execute", reason: "This hook should be disabled"}));`;
 
-      const enabledPath = join(rig.testDir!, 'enabled_hook.cjs').replace(
-        /\\/g,
-        '/',
+      const enabledPath = rig.createHookScript(
+        'enabled_hook.cjs',
+        enabledHookScript,
       );
-      const disabledPath = join(rig.testDir!, 'disabled_hook.cjs').replace(
-        /\\/g,
-        '/',
+      const disabledPath = rig.createHookScript(
+        'disabled_hook.cjs',
+        disabledHookScript,
       );
-
-      writeFileSync(enabledPath, enabledHookScript);
-      writeFileSync(disabledPath, disabledHookScript);
 
       rig.configure({
         settings: {
@@ -1824,17 +1819,14 @@ console.log(JSON.stringify({decision: "allow", systemMessage: "Active hook execu
       const disabledHookScript = `const fs = require('fs');
 console.log(JSON.stringify({decision: "block", systemMessage: "Disabled hook should not execute", reason: "This hook is disabled"}));`;
 
-      const activePath = join(rig.testDir!, 'active_hook.cjs').replace(
-        /\\/g,
-        '/',
+      const activePath = rig.createHookScript(
+        'active_hook.cjs',
+        activeHookScript,
       );
-      const disabledPath = join(rig.testDir!, 'disabled_hook.cjs').replace(
-        /\\/g,
-        '/',
+      const disabledPath = rig.createHookScript(
+        'disabled_hook.cjs',
+        disabledHookScript,
       );
-
-      writeFileSync(activePath, activeHookScript);
-      writeFileSync(disabledPath, disabledHookScript);
 
       rig.configure({
         settings: {
@@ -1930,13 +1922,10 @@ console.log(JSON.stringify({decision: "block", systemMessage: "Disabled hook sho
         hookOutput,
       )}));`;
 
-      const scriptPath = join(rig.testDir!, 'input_override_hook.js');
-      writeFileSync(scriptPath, hookScript);
-
-      // Ensure path is properly escaped for command line usage on all platforms
-      // On Windows, backslashes in the command string need to be handled carefully
-      // Using forward slashes works well with Node.js on all platforms
-      const commandPath = scriptPath.replace(/\\/g, '/');
+      const commandPath = rig.createHookScript(
+        'input_override_hook.cjs',
+        hookScript,
+      );
 
       // 2. Full setup with settings and fake responses
       rig.configure({
@@ -1990,9 +1979,9 @@ console.log(JSON.stringify({decision: "block", systemMessage: "Disabled hook sho
       expect(hookTelemetryFound).toBeTruthy();
 
       const hookLogs = rig.readHookLogs();
-      expect(hookLogs.length).toBe(1);
+      expect(hookLogs.length).toBeGreaterThanOrEqual(1);
       expect(hookLogs[0].hookCall.hook_name).toContain(
-        'input_override_hook.js',
+        'input_override_hook.cjs',
       );
 
       // 4. Verify that the agent didn't try to work-around the hook input change
@@ -2021,9 +2010,10 @@ console.log(JSON.stringify({decision: "block", systemMessage: "Disabled hook sho
       )}));`;
 
       rig.setup('should stop agent execution via BeforeTool hook');
-      const scriptPath = join(rig.testDir!, 'before_tool_stop_hook.js');
-      writeFileSync(scriptPath, hookScript);
-      const commandPath = scriptPath.replace(/\\/g, '/');
+      const commandPath = rig.createHookScript(
+        'before_tool_stop_hook.cjs',
+        hookScript,
+      );
 
       rig.configure({
         fakeResponsesPath: join(

--- a/integration-tests/hooks-system.test.ts
+++ b/integration-tests/hooks-system.test.ts
@@ -48,7 +48,7 @@ describe('Hooks System Integration', () => {
                 hooks: [
                   {
                     type: 'command',
-                    command: `node "${scriptPath}"`,
+                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
                     timeout: 5000,
                   },
                 ],
@@ -107,7 +107,7 @@ describe('Hooks System Integration', () => {
                   {
                     type: 'command',
                     // Exit with code 2 and write reason to stderr
-                    command: `node "${scriptPath}"`,
+                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
                     timeout: 5000,
                   },
                 ],
@@ -168,7 +168,7 @@ describe('Hooks System Integration', () => {
                 hooks: [
                   {
                     type: 'command',
-                    command: `node "${scriptPath}"`,
+                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
                     timeout: 5000,
                   },
                 ],
@@ -204,7 +204,7 @@ describe('Hooks System Integration', () => {
         scriptPath,
         "console.log(JSON.stringify({hookSpecificOutput: {hookEventName: 'AfterTool', additionalContext: 'Security scan: File content appears safe'}}))",
       );
-      const command = `node "${scriptPath}"`;
+      const command = `node "${scriptPath.replace(/\\/g, '/')}"`;
       rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
@@ -259,7 +259,8 @@ describe('Hooks System Integration', () => {
     it('should modify LLM requests with BeforeModel hooks', async () => {
       // Create a hook script that replaces the LLM request with a modified version
       // Note: Providing messages in the hook output REPLACES the entire conversation
-      rig.setup('should modify LLM requests with BeforeModel hooks', {
+      rig.setup('should modify LLM requests with BeforeModel hooks');
+      rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-system.before-model.responses',
@@ -284,7 +285,7 @@ console.log(JSON.stringify({
       const scriptPath = join(rig.testDir!, 'before_model_hook.cjs');
       writeFileSync(scriptPath, hookScript);
 
-      rig.setup('should modify LLM requests with BeforeModel hooks', {
+      rig.configure({
         settings: {
           hooksConfig: {
             enabled: true,
@@ -343,29 +344,26 @@ console.log(JSON.stringify({
       const scriptPath = join(rig.testDir!, 'before_model_deny_hook.cjs');
       writeFileSync(scriptPath, hookScript);
 
-      rig.setup(
-        'should block model execution when BeforeModel hook returns deny decision',
-        {
-          settings: {
-            hooksConfig: {
-              enabled: true,
-            },
-            hooks: {
-              BeforeModel: [
-                {
-                  hooks: [
-                    {
-                      type: 'command',
-                      command: `node "${scriptPath}"`,
-                      timeout: 5000,
-                    },
-                  ],
-                },
-              ],
-            },
+      rig.configure({
+        settings: {
+          hooksConfig: {
+            enabled: true,
+          },
+          hooks: {
+            BeforeModel: [
+              {
+                hooks: [
+                  {
+                    type: 'command',
+                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
+                    timeout: 5000,
+                  },
+                ],
+              },
+            ],
           },
         },
-      );
+      });
 
       const result = await rig.run({ args: 'Hello' });
 
@@ -388,29 +386,26 @@ console.log(JSON.stringify({
       const scriptPath = join(rig.testDir!, 'before_model_block_hook.cjs');
       writeFileSync(scriptPath, hookScript);
 
-      rig.setup(
-        'should block model execution when BeforeModel hook returns block decision',
-        {
-          settings: {
-            hooksConfig: {
-              enabled: true,
-            },
-            hooks: {
-              BeforeModel: [
-                {
-                  hooks: [
-                    {
-                      type: 'command',
-                      command: `node "${scriptPath}"`,
-                      timeout: 5000,
-                    },
-                  ],
-                },
-              ],
-            },
+      rig.configure({
+        settings: {
+          hooksConfig: {
+            enabled: true,
+          },
+          hooks: {
+            BeforeModel: [
+              {
+                hooks: [
+                  {
+                    type: 'command',
+                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
+                    timeout: 5000,
+                  },
+                ],
+              },
+            ],
           },
         },
-      );
+      });
 
       const result = await rig.run({ args: 'Hello' });
 
@@ -427,7 +422,8 @@ console.log(JSON.stringify({
     it.skipIf(process.platform === 'win32')(
       'should modify LLM responses with AfterModel hooks',
       async () => {
-        rig.setup('should modify LLM responses with AfterModel hooks', {
+        rig.setup('should modify LLM responses with AfterModel hooks');
+        rig.configure({
           fakeResponsesPath: join(
             import.meta.dirname,
             'hooks-system.after-model.responses',
@@ -457,7 +453,7 @@ console.log(JSON.stringify({
         const scriptPath = join(rig.testDir!, 'after_model_hook.cjs');
         writeFileSync(scriptPath, hookScript);
 
-        rig.setup('should modify LLM responses with AfterModel hooks', {
+        rig.configure({
           settings: {
             hooksConfig: {
               enabled: true,
@@ -468,7 +464,7 @@ console.log(JSON.stringify({
                   hooks: [
                     {
                       type: 'command',
-                      command: `node "${scriptPath}"`,
+                      command: `node "${scriptPath.replace(/\\/g, '/')}"`,
                       timeout: 5000,
                     },
                   ],
@@ -494,7 +490,8 @@ console.log(JSON.stringify({
 
   describe('BeforeToolSelection Hooks - Tool Configuration', () => {
     it('should modify tool selection with BeforeToolSelection hooks', async () => {
-      rig.setup('should modify tool selection with BeforeToolSelection hooks', {
+      rig.setup('should modify tool selection with BeforeToolSelection hooks');
+      rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-system.before-tool-selection.responses',
@@ -514,7 +511,7 @@ console.log(JSON.stringify({
       const scriptPath = join(rig.testDir!, 'before_tool_selection_hook.cjs');
       writeFileSync(scriptPath, hookScript);
 
-      rig.setup('should modify tool selection with BeforeToolSelection hooks', {
+      rig.configure({
         settings: {
           debugMode: true,
           hooksConfig: {
@@ -563,7 +560,8 @@ console.log(JSON.stringify({
 
   describe('BeforeAgent Hooks - Prompt Augmentation', () => {
     it('should augment prompts with BeforeAgent hooks', async () => {
-      rig.setup('should augment prompts with BeforeAgent hooks', {
+      rig.setup('should augment prompts with BeforeAgent hooks');
+      rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-system.before-agent.responses',
@@ -582,7 +580,7 @@ console.log(JSON.stringify({
       const scriptPath = join(rig.testDir!, 'before_agent_hook.cjs');
       writeFileSync(scriptPath, hookScript);
 
-      rig.setup('should augment prompts with BeforeAgent hooks', {
+      rig.configure({
         settings: {
           hooksConfig: {
             enabled: true,
@@ -795,7 +793,8 @@ console.log(JSON.stringify({
 
   describe('Hook Input/Output Validation', () => {
     it('should provide correct input format to hooks', async () => {
-      rig.setup('should provide correct input format to hooks', {
+      rig.setup('should provide correct input format to hooks');
+      rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-system.input-validation.responses',
@@ -819,7 +818,7 @@ try {
       const scriptPath = join(rig.testDir!, 'input_validation_hook.cjs');
       writeFileSync(scriptPath, hookScript);
 
-      rig.setup('should provide correct input format to hooks', {
+      rig.configure({
         settings: {
           hooksConfig: {
             enabled: true,
@@ -885,7 +884,7 @@ try {
                     type: 'command',
                     // Output plain text then JSON.
                     // This breaks JSON parsing, so it falls back to 'allow' with the whole stdout as systemMessage.
-                    command: `node "${scriptPath}"`,
+                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
                     timeout: 5000,
                   },
                 ],
@@ -1222,7 +1221,8 @@ console.log(JSON.stringify({
   }
 }));`;
 
-      rig.setup('should fire SessionStart hook and inject context', {
+      rig.setup('should fire SessionStart hook and inject context');
+      rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-system.session-startup.responses',
@@ -1232,7 +1232,7 @@ console.log(JSON.stringify({
       const scriptPath = join(rig.testDir!, 'session_start_context_hook.cjs');
       writeFileSync(scriptPath, hookScript);
 
-      rig.setup('should fire SessionStart hook and inject context', {
+      rig.configure({
         settings: {
           hooksConfig: {
             enabled: true,
@@ -1301,13 +1301,13 @@ console.log(JSON.stringify({
 
       rig.setup(
         'should fire SessionStart hook and display systemMessage in interactive mode',
-        {
-          fakeResponsesPath: join(
-            import.meta.dirname,
-            'hooks-system.session-startup.responses',
-          ),
-        },
       );
+      rig.configure({
+        fakeResponsesPath: join(
+          import.meta.dirname,
+          'hooks-system.session-startup.responses',
+        ),
+      });
 
       const scriptPath = join(
         rig.testDir!,
@@ -1315,30 +1315,27 @@ console.log(JSON.stringify({
       );
       writeFileSync(scriptPath, hookScript);
 
-      rig.setup(
-        'should fire SessionStart hook and display systemMessage in interactive mode',
-        {
-          settings: {
-            hooksConfig: {
-              enabled: true,
-            },
-            hooks: {
-              SessionStart: [
-                {
-                  matcher: 'startup',
-                  hooks: [
-                    {
-                      type: 'command',
-                      command: `node "${scriptPath}"`,
-                      timeout: 5000,
-                    },
-                  ],
-                },
-              ],
-            },
+      rig.configure({
+        settings: {
+          hooksConfig: {
+            enabled: true,
+          },
+          hooks: {
+            SessionStart: [
+              {
+                matcher: 'startup',
+                hooks: [
+                  {
+                    type: 'command',
+                    command: `node "${scriptPath.replace(/\\/g, '/')}"`,
+                    timeout: 5000,
+                  },
+                ],
+              },
+            ],
           },
         },
-      );
+      });
 
       const run = await rig.runInteractive();
 
@@ -1728,7 +1725,8 @@ console.log(JSON.stringify({
 
   describe('Hook Disabling', () => {
     it('should not execute hooks disabled in settings file', async () => {
-      rig.setup('should not execute hooks disabled in settings file', {
+      rig.setup('should not execute hooks disabled in settings file');
+      rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-system.disabled-via-settings.responses',
@@ -1742,13 +1740,19 @@ console.log(JSON.stringify({decision: "allow", systemMessage: "Enabled hook exec
       const disabledHookScript = `const fs = require('fs');
 console.log(JSON.stringify({decision: "block", systemMessage: "Disabled hook should not execute", reason: "This hook should be disabled"}));`;
 
-      const enabledPath = join(rig.testDir!, 'enabled_hook.cjs');
-      const disabledPath = join(rig.testDir!, 'disabled_hook.cjs');
+      const enabledPath = join(rig.testDir!, 'enabled_hook.cjs').replace(
+        /\\/g,
+        '/',
+      );
+      const disabledPath = join(rig.testDir!, 'disabled_hook.cjs').replace(
+        /\\/g,
+        '/',
+      );
 
       writeFileSync(enabledPath, enabledHookScript);
       writeFileSync(disabledPath, disabledHookScript);
 
-      rig.setup('should not execute hooks disabled in settings file', {
+      rig.configure({
         settings: {
           hooksConfig: {
             enabled: true,
@@ -1805,7 +1809,8 @@ console.log(JSON.stringify({decision: "block", systemMessage: "Disabled hook sho
     });
 
     it('should respect disabled hooks across multiple operations', async () => {
-      rig.setup('should respect disabled hooks across multiple operations', {
+      rig.setup('should respect disabled hooks across multiple operations');
+      rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-system.disabled-via-command.responses',
@@ -1819,13 +1824,19 @@ console.log(JSON.stringify({decision: "allow", systemMessage: "Active hook execu
       const disabledHookScript = `const fs = require('fs');
 console.log(JSON.stringify({decision: "block", systemMessage: "Disabled hook should not execute", reason: "This hook is disabled"}));`;
 
-      const activePath = join(rig.testDir!, 'active_hook.cjs');
-      const disabledPath = join(rig.testDir!, 'disabled_hook.cjs');
+      const activePath = join(rig.testDir!, 'active_hook.cjs').replace(
+        /\\/g,
+        '/',
+      );
+      const disabledPath = join(rig.testDir!, 'disabled_hook.cjs').replace(
+        /\\/g,
+        '/',
+      );
 
       writeFileSync(activePath, activeHookScript);
       writeFileSync(disabledPath, disabledHookScript);
 
-      rig.setup('should respect disabled hooks across multiple operations', {
+      rig.configure({
         settings: {
           hooksConfig: {
             enabled: true,
@@ -1928,7 +1939,7 @@ console.log(JSON.stringify({decision: "block", systemMessage: "Disabled hook sho
       const commandPath = scriptPath.replace(/\\/g, '/');
 
       // 2. Full setup with settings and fake responses
-      rig.setup('should override tool input parameters via BeforeTool hook', {
+      rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-system.input-modification.responses',
@@ -2014,7 +2025,7 @@ console.log(JSON.stringify({decision: "block", systemMessage: "Disabled hook sho
       writeFileSync(scriptPath, hookScript);
       const commandPath = scriptPath.replace(/\\/g, '/');
 
-      rig.setup('should stop agent execution via BeforeTool hook', {
+      rig.configure({
         fakeResponsesPath: join(
           import.meta.dirname,
           'hooks-system.before-tool-stop.responses',

--- a/packages/test-utils/src/test-rig.ts
+++ b/packages/test-utils/src/test-rig.ts
@@ -387,6 +387,19 @@ export class TestRig {
     this._createSettingsFile(options.settings);
   }
 
+  /**
+   * Creates a hook script file and returns a normalized path suitable for cross-platform execution.
+   */
+  createHookScript(fileName: string, content: string): string {
+    if (!this.testDir) {
+      throw new Error('TestRig must be setup before calling createHookScript');
+    }
+    const scriptPath = join(this.testDir, fileName);
+    writeFileSync(scriptPath, content);
+    // Return a path normalized for use in shell commands across platforms.
+    return scriptPath.replace(/\\/g, '/');
+  }
+
   private _createSettingsFile(overrideSettings?: Record<string, unknown>) {
     const projectGeminiDir = join(this.testDir!, GEMINI_DIR);
     mkdirSync(projectGeminiDir, { recursive: true });

--- a/packages/test-utils/src/test-rig.ts
+++ b/packages/test-utils/src/test-rig.ts
@@ -361,6 +361,20 @@ export class TestRig {
     this.homeDir = join(testFileDir, sanitizedName + '-home');
     mkdirSync(this.testDir, { recursive: true });
     mkdirSync(this.homeDir, { recursive: true });
+
+    if (options.settings || options.fakeResponsesPath) {
+      this.configure(options);
+    }
+  }
+
+  configure(options: {
+    settings?: Record<string, unknown>;
+    fakeResponsesPath?: string;
+  }) {
+    if (!this.testDir || !this.homeDir) {
+      throw new Error('TestRig must be setup before calling configure');
+    }
+
     if (options.fakeResponsesPath) {
       this.fakeResponsesPath = join(this.testDir, 'fake-responses.json');
       this.originalFakeResponsesPath = options.fakeResponsesPath;


### PR DESCRIPTION
## Summary

Fixes integration tests (`hooks-agent-flow.test.ts` and `hooks-system.test.ts`) that were failing on Windows due to platform-specific path and shell handling differences.

## Details

The fixes address the following root causes:
- **Shell Quoting/Escaping**: Replaced brittle inline `node -e` commands with external `.cjs` script files to avoid PowerShell quoting issues that caused hangs and timeouts.
- **Path Escaping**: Normalized all paths injected into commands/scripts to forward slashes to prevent backslashes from being interpreted as escape characters (e.g., `	`, `
`) by Node.js.
- **Initialization Race Conditions**: Ensured `rig.setup()` is called before accessing `rig.testDir` or performing file operations to correctly initialize the test directory.
- **Settings Schema Compliance**: Corrected the `hooks` settings structure by moving the `enabled` flag to `hooksConfig`.

## Related Issues

Related to #123

## How to Validate

Run the integration tests in a Windows environment (or macOS/Linux to ensure no regressions):
```bash
npm run bundle
npm run test:e2e hooks-agent-flow.test.ts hooks-system.test.ts
```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
