### PR TITLE
chore(release): automate release verification on all release workflows

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -122,6 +122,17 @@ jobs:
           core-package-name: '${{ vars.CORE_PACKAGE_NAME }}'
           a2a-package-name: '${{ vars.A2A_PACKAGE_NAME }}'
 
+      - name: 'Verify Release'
+        if: '${{ github.event.inputs.dry_run == false }}'
+        uses: './.github/actions/verify-release'
+        with:
+          npm-package: '${{ vars.CLI_PACKAGE_NAME }}@${{ github.event.inputs.npm_channel }}'
+          expected-version: '${{ steps.release_info.outputs.RELEASE_VERSION }}'
+          npm-registry-url: '${{ vars.NPM_REGISTRY_URL }}'
+          npm-registry-scope: '${{ vars.NPM_REGISTRY_SCOPE }}'
+          gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
       - name: 'Create Issue on Failure'
         if: '${{ failure() && github.event.inputs.dry_run == false }}'
         env:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -137,6 +137,17 @@ jobs:
           core-package-name: '${{ vars.CORE_PACKAGE_NAME }}'
           a2a-package-name: '${{ vars.A2A_PACKAGE_NAME }}'
 
+      - name: 'Verify Release'
+        if: "${{ steps.vars.outputs.is_dry_run != 'true' }}"
+        uses: './.github/actions/verify-release'
+        with:
+          npm-package: '${{ vars.CLI_PACKAGE_NAME }}@${{ steps.nightly_version.outputs.NPM_TAG }}'
+          expected-version: '${{ steps.nightly_version.outputs.RELEASE_VERSION }}'
+          npm-registry-url: '${{ vars.NPM_REGISTRY_URL }}'
+          npm-registry-scope: '${{ vars.NPM_REGISTRY_SCOPE }}'
+          gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
       - name: 'Create and Merge Pull Request'
         if: "github.event.inputs.environment != 'dev'"
         uses: './.github/actions/create-pull-request'

--- a/.github/workflows/release-patch-3-release.yml
+++ b/.github/workflows/release-patch-3-release.yml
@@ -195,6 +195,17 @@ jobs:
           a2a-package-name: '${{ vars.A2A_PACKAGE_NAME }}'
           working-directory: './release'
 
+      - name: 'Verify Release'
+        if: '${{ github.event.inputs.dry_run == false }}'
+        uses: './.github/actions/verify-release'
+        with:
+          npm-package: '${{ vars.CLI_PACKAGE_NAME }}@${{ steps.patch_version.outputs.NPM_TAG }}'
+          expected-version: '${{ steps.patch_version.outputs.RELEASE_VERSION }}'
+          npm-registry-url: '${{ vars.NPM_REGISTRY_URL }}'
+          npm-registry-scope: '${{ vars.NPM_REGISTRY_SCOPE }}'
+          gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
       - name: 'Create Issue on Failure'
         if: '${{ failure() && github.event.inputs.dry_run == false }}'
         env:

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -251,6 +251,17 @@ jobs:
           core-package-name: '${{ vars.CORE_PACKAGE_NAME }}'
           a2a-package-name: '${{ vars.A2A_PACKAGE_NAME }}'
 
+      - name: 'Verify Release'
+        if: '${{ github.event.inputs.dry_run == false }}'
+        uses: './.github/actions/verify-release'
+        with:
+          npm-package: '${{ vars.CLI_PACKAGE_NAME }}@preview'
+          expected-version: '${{ needs.calculate-versions.outputs.PREVIEW_VERSION }}'
+          npm-registry-url: '${{ vars.NPM_REGISTRY_URL }}'
+          npm-registry-scope: '${{ vars.NPM_REGISTRY_SCOPE }}'
+          gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
       - name: 'Create Issue on Failure'
         if: '${{ failure() && github.event.inputs.dry_run == false }}'
         env:
@@ -316,6 +327,17 @@ jobs:
           cli-package-name: '${{ vars.CLI_PACKAGE_NAME }}'
           core-package-name: '${{ vars.CORE_PACKAGE_NAME }}'
           a2a-package-name: '${{ vars.A2A_PACKAGE_NAME }}'
+
+      - name: 'Verify Release'
+        if: '${{ github.event.inputs.dry_run == false }}'
+        uses: './.github/actions/verify-release'
+        with:
+          npm-package: '${{ vars.CLI_PACKAGE_NAME }}@latest'
+          expected-version: '${{ needs.calculate-versions.outputs.STABLE_VERSION }}'
+          npm-registry-url: '${{ vars.NPM_REGISTRY_URL }}'
+          npm-registry-scope: '${{ vars.NPM_REGISTRY_SCOPE }}'
+          gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
 
       - name: 'Create Issue on Failure'
         if: '${{ failure() && github.event.inputs.dry_run == false }}'

--- a/docs/release-confidence.md
+++ b/docs/release-confidence.md
@@ -39,14 +39,22 @@ All workflows in `.github/workflows/chained_e2e.yml` must pass.
 - **Sandboxing:** Tests must pass with both `sandbox:none` and `sandbox:docker`
   on Linux.
 
-### 3. Post-deployment smoke tests
+### 3. Post-deployment verification
 
-After a release is published to npm, the `smoke-test.yml` workflow runs. This
-must pass to confirm the package is installable and the binary is executable.
+After a release is successfully published to NPM, an automated verification step
+immediately runs as part of the release workflow. This step confirms the package
+is correctly distributed and functional in a clean environment.
 
-- **Command:** `npx -y @google/gemini-cli@<tag> --version` must return the
-  correct version without error.
-- **Platform:** Currently runs on `ubuntu-latest`.
+- **Check:**
+  1.  Installs the package globally from the live NPM registry.
+  2.  Verifies the binary executes and reports the correct version:
+      `gemini --version`
+  3.  Executes the full suite of integration tests against the installed binary
+      to catch packaging regressions.
+- **Platforms:** Currently validated on **Linux, macOS, and Windows** (via
+  `.github/actions/verify-release`).
+- **Failure Handling:** If verification fails, the release workflow terminates
+  with an error, and a high-priority GitHub issue is automatically created.
 
 ## Level 2: Manual verification and dogfooding
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -369,20 +369,32 @@ the main release file once service account permissions are sorted out.
 
 ## Release validation
 
-After pushing a new release smoke testing should be performed to ensure that the
-packages are working as expected. This can be done by installing the packages
-locally and running a set of tests to ensure that they are functioning
-correctly.
+Every release is automatically validated immediately after publication to NPM.
+This automated gate ensures that the artifacts available to users are functional
+and contain all required files.
+
+### Automated verification
+
+The release workflows (`nightly`, `promote`, `patch`, and `manual`) include a
+mandatory verification step that runs after a successful publish. This step:
+
+1.  **Installs from NPM:** Downloads and installs the newly published version
+    from the NPM registry.
+2.  **Smoke tests:** Verifies the `gemini --version` command returns the correct
+    version string for both global installs and `npx` execution.
+3.  **Integration tests:** Runs the complete integration test suite against the
+    installed binary to detect packaging issues (for example, missing assets or
+    dependency conflicts).
+
+### Manual smoke testing
+
+While the core logic is automated, we still recommend a quick manual check to
+verify the UX "feel."
 
 - `npx -y @google/gemini-cli@latest --version` to validate the push worked as
-  expected if you were not doing a rc or dev tag
-- `npx -y @google/gemini-cli@<release tag> --version` to validate the tag pushed
-  appropriately
-- _This is destructive locally_
-  `npm uninstall @google/gemini-cli && npm uninstall -g @google/gemini-cli && npm cache clean --force &&  npm install @google/gemini-cli@<version>`
-- Smoke testing a basic run through of exercising a few llm commands and tools
-  is recommended to ensure that the packages are working as expected. We'll
-  codify this more in the future.
+  expected.
+- Execute a few basic commands and tools to ensure interactive elements (like
+  spinners and colors) look correct in your specific terminal environment.
 
 ## Local testing and validation: Changes to the packaging and publishing process
 


### PR DESCRIPTION
## Summary

This PR automates the critical "verify release" step by integrating the `verify-release` action directly into our release workflows. This ensures that every nightly, preview, stable, and patch release is immediately installed and smoke-tested against the live NPM registry after publication.

## Details

Currently, release verification is a manual step or relies on a separate `verify-release` workflow that must be triggered by hand. This PR adds a `Verify Release` job to the following workflows:

- **Release: Nightly** (`release-nightly.yml`): Verifies the nightly build immediately after publishing.
- **Release: Promote** (`release-promote.yml`): Verifies both the `preview` and `stable` releases during the promotion process.
- **Release: Patch (3) Release** (`release-patch-3-release.yml`): Verifies hotfix releases to ensure critical fixes are deployable.
- **Release: Manual** (`release-manual.yml`): Verifies manually triggered releases.

The verification step:
1.  Installs the newly published package globally from NPM.
2.  Verifies the installed version matches the expected version.
3.  Runs the full integration test suite against the installed binary to catch packaging regressions (e.g., missing assets in `dist/`).

## Related Issues

Fixes #18140

## How to Validate

Since this modifies release workflows, it cannot be fully tested without performing a release. However, you can validate the configuration by:

1.  Reviewing the workflow YAML changes to ensure the inputs to `verify-release` are correct (package name, version, API keys).
2.  Verifying that the condition `if: ${{ github.event.inputs.dry_run == false }}` (or equivalent) is correctly applied so verification doesn't run during dry runs.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README
- [x] Added/updated tests (The change *is* adding tests)
- [x] Noted breaking changes (None)
- [x] Validated on required platforms/methods:
  - [x] Linux (CI environment)
