### PR TITLE
feat(cli): update approval modes UI

### DIFF
--- a/packages/cli/src/ui/components/ApprovalModeIndicator.test.tsx
+++ b/packages/cli/src/ui/components/ApprovalModeIndicator.test.tsx
@@ -15,8 +15,20 @@ describe('ApprovalModeIndicator', () => {
       <ApprovalModeIndicator approvalMode={ApprovalMode.AUTO_EDIT} />,
     );
     const output = lastFrame();
-    expect(output).toContain('accept edits');
-    expect(output).toContain('shift+tab');
+    expect(output).toContain('auto-edit');
+    expect(output).toContain('shift + tab to enter default mode');
+  });
+
+  it('renders correctly for AUTO_EDIT mode with plan enabled', () => {
+    const { lastFrame } = render(
+      <ApprovalModeIndicator
+        approvalMode={ApprovalMode.AUTO_EDIT}
+        isPlanEnabled={true}
+      />,
+    );
+    const output = lastFrame();
+    expect(output).toContain('auto-edit');
+    expect(output).toContain('shift + tab to enter default mode');
   });
 
   it('renders correctly for PLAN mode', () => {
@@ -25,7 +37,7 @@ describe('ApprovalModeIndicator', () => {
     );
     const output = lastFrame();
     expect(output).toContain('plan');
-    expect(output).toContain('shift+tab');
+    expect(output).toContain('shift + tab to enter auto-edit mode');
   });
 
   it('renders correctly for YOLO mode', () => {
@@ -34,7 +46,7 @@ describe('ApprovalModeIndicator', () => {
     );
     const output = lastFrame();
     expect(output).toContain('YOLO');
-    expect(output).toContain('shift+tab');
+    expect(output).toContain('shift + tab to enter auto-edit mode');
   });
 
   it('renders correctly for DEFAULT mode', () => {
@@ -42,6 +54,17 @@ describe('ApprovalModeIndicator', () => {
       <ApprovalModeIndicator approvalMode={ApprovalMode.DEFAULT} />,
     );
     const output = lastFrame();
-    expect(output).toContain('shift+tab for modes');
+    expect(output).toContain('shift + tab to enter auto-edit mode');
+  });
+
+  it('renders correctly for DEFAULT mode with plan enabled', () => {
+    const { lastFrame } = render(
+      <ApprovalModeIndicator
+        approvalMode={ApprovalMode.DEFAULT}
+        isPlanEnabled={true}
+      />,
+    );
+    const output = lastFrame();
+    expect(output).toContain('shift + tab to enter plan mode');
   });
 });

--- a/packages/cli/src/ui/components/ApprovalModeIndicator.test.tsx
+++ b/packages/cli/src/ui/components/ApprovalModeIndicator.test.tsx
@@ -15,7 +15,7 @@ describe('ApprovalModeIndicator', () => {
       <ApprovalModeIndicator approvalMode={ApprovalMode.AUTO_EDIT} />,
     );
     const output = lastFrame();
-    expect(output).toContain('Auto');
+    expect(output).toContain('accept edits');
     expect(output).toContain('shift+tab');
   });
 
@@ -24,7 +24,7 @@ describe('ApprovalModeIndicator', () => {
       <ApprovalModeIndicator approvalMode={ApprovalMode.PLAN} />,
     );
     const output = lastFrame();
-    expect(output).toContain('Plan');
+    expect(output).toContain('plan');
     expect(output).toContain('shift+tab');
   });
 
@@ -42,7 +42,6 @@ describe('ApprovalModeIndicator', () => {
       <ApprovalModeIndicator approvalMode={ApprovalMode.DEFAULT} />,
     );
     const output = lastFrame();
-    expect(output).toContain('Build');
-    expect(output).toContain('shift+tab');
+    expect(output).toContain('shift+tab for modes');
   });
 });

--- a/packages/cli/src/ui/components/ApprovalModeIndicator.test.tsx
+++ b/packages/cli/src/ui/components/ApprovalModeIndicator.test.tsx
@@ -15,8 +15,8 @@ describe('ApprovalModeIndicator', () => {
       <ApprovalModeIndicator approvalMode={ApprovalMode.AUTO_EDIT} />,
     );
     const output = lastFrame();
-    expect(output).toContain('accepting edits');
-    expect(output).toContain('(shift + tab to cycle)');
+    expect(output).toContain('Auto');
+    expect(output).toContain('shift+tab');
   });
 
   it('renders correctly for PLAN mode', () => {
@@ -24,8 +24,8 @@ describe('ApprovalModeIndicator', () => {
       <ApprovalModeIndicator approvalMode={ApprovalMode.PLAN} />,
     );
     const output = lastFrame();
-    expect(output).toContain('plan mode');
-    expect(output).toContain('(shift + tab to cycle)');
+    expect(output).toContain('Plan');
+    expect(output).toContain('shift+tab');
   });
 
   it('renders correctly for YOLO mode', () => {
@@ -33,16 +33,16 @@ describe('ApprovalModeIndicator', () => {
       <ApprovalModeIndicator approvalMode={ApprovalMode.YOLO} />,
     );
     const output = lastFrame();
-    expect(output).toContain('YOLO mode');
-    expect(output).toContain('(ctrl + y to toggle)');
+    expect(output).toContain('YOLO');
+    expect(output).toContain('shift+tab');
   });
 
-  it('renders nothing for DEFAULT mode', () => {
+  it('renders correctly for DEFAULT mode', () => {
     const { lastFrame } = render(
       <ApprovalModeIndicator approvalMode={ApprovalMode.DEFAULT} />,
     );
     const output = lastFrame();
-    expect(output).not.toContain('accepting edits');
-    expect(output).not.toContain('YOLO mode');
+    expect(output).toContain('Build');
+    expect(output).toContain('shift+tab');
   });
 });

--- a/packages/cli/src/ui/components/ApprovalModeIndicator.tsx
+++ b/packages/cli/src/ui/components/ApprovalModeIndicator.tsx
@@ -23,21 +23,24 @@ export const ApprovalModeIndicator: React.FC<ApprovalModeIndicatorProps> = ({
   switch (approvalMode) {
     case ApprovalMode.AUTO_EDIT:
       textColor = theme.status.warning;
-      textContent = 'accepting edits';
-      subText = ' (shift + tab to cycle)';
+      textContent = 'Auto';
+      subText = ' shift+tab';
       break;
     case ApprovalMode.PLAN:
       textColor = theme.status.success;
-      textContent = 'plan mode';
-      subText = ' (shift + tab to cycle)';
+      textContent = 'Plan';
+      subText = ' shift+tab';
       break;
     case ApprovalMode.YOLO:
       textColor = theme.status.error;
-      textContent = 'YOLO mode';
-      subText = ' (ctrl + y to toggle)';
+      textContent = 'YOLO';
+      subText = ' shift+tab';
       break;
     case ApprovalMode.DEFAULT:
     default:
+      textColor = theme.text.accent;
+      textContent = 'Build';
+      subText = ' shift+tab';
       break;
   }
 

--- a/packages/cli/src/ui/components/ApprovalModeIndicator.tsx
+++ b/packages/cli/src/ui/components/ApprovalModeIndicator.tsx
@@ -23,24 +23,24 @@ export const ApprovalModeIndicator: React.FC<ApprovalModeIndicatorProps> = ({
   switch (approvalMode) {
     case ApprovalMode.AUTO_EDIT:
       textColor = theme.status.warning;
-      textContent = 'Auto';
-      subText = ' shift+tab';
+      textContent = 'accept edits';
+      subText = 'shift+tab';
       break;
     case ApprovalMode.PLAN:
       textColor = theme.status.success;
-      textContent = 'Plan';
-      subText = ' shift+tab';
+      textContent = 'plan';
+      subText = 'shift+tab';
       break;
     case ApprovalMode.YOLO:
       textColor = theme.status.error;
       textContent = 'YOLO';
-      subText = ' shift+tab';
+      subText = 'shift+tab';
       break;
     case ApprovalMode.DEFAULT:
     default:
       textColor = theme.text.accent;
-      textContent = 'Build';
-      subText = ' shift+tab';
+      textContent = '';
+      subText = 'shift+tab for modes';
       break;
   }
 
@@ -48,6 +48,7 @@ export const ApprovalModeIndicator: React.FC<ApprovalModeIndicatorProps> = ({
     <Box>
       <Text color={textColor}>
         {textContent}
+        {textContent && subText && ' '}
         {subText && <Text color={theme.text.secondary}>{subText}</Text>}
       </Text>
     </Box>

--- a/packages/cli/src/ui/components/ApprovalModeIndicator.tsx
+++ b/packages/cli/src/ui/components/ApprovalModeIndicator.tsx
@@ -11,10 +11,12 @@ import { ApprovalMode } from '@google/gemini-cli-core';
 
 interface ApprovalModeIndicatorProps {
   approvalMode: ApprovalMode;
+  isPlanEnabled?: boolean;
 }
 
 export const ApprovalModeIndicator: React.FC<ApprovalModeIndicatorProps> = ({
   approvalMode,
+  isPlanEnabled,
 }) => {
   let textColor = '';
   let textContent = '';
@@ -23,24 +25,26 @@ export const ApprovalModeIndicator: React.FC<ApprovalModeIndicatorProps> = ({
   switch (approvalMode) {
     case ApprovalMode.AUTO_EDIT:
       textColor = theme.status.warning;
-      textContent = 'accept edits';
-      subText = 'shift+tab';
+      textContent = 'auto-edit';
+      subText = 'shift + tab to enter default mode';
       break;
     case ApprovalMode.PLAN:
       textColor = theme.status.success;
       textContent = 'plan';
-      subText = 'shift+tab';
+      subText = 'shift + tab to enter auto-edit mode';
       break;
     case ApprovalMode.YOLO:
       textColor = theme.status.error;
       textContent = 'YOLO';
-      subText = 'shift+tab';
+      subText = 'shift + tab to enter auto-edit mode';
       break;
     case ApprovalMode.DEFAULT:
     default:
       textColor = theme.text.accent;
       textContent = '';
-      subText = 'shift+tab for modes';
+      subText = isPlanEnabled
+        ? 'shift + tab to enter plan mode'
+        : 'shift + tab to enter auto-edit mode';
       break;
   }
 

--- a/packages/cli/src/ui/components/ApprovalModeIndicator.tsx
+++ b/packages/cli/src/ui/components/ApprovalModeIndicator.tsx
@@ -47,9 +47,13 @@ export const ApprovalModeIndicator: React.FC<ApprovalModeIndicatorProps> = ({
   return (
     <Box>
       <Text color={textColor}>
-        {textContent}
-        {textContent && subText && ' '}
-        {subText && <Text color={theme.text.secondary}>{subText}</Text>}
+        {textContent ? textContent : null}
+        {subText ? (
+          <Text color={theme.text.secondary}>
+            {textContent ? ' ' : ''}
+            {subText}
+          </Text>
+        ) : null}
       </Text>
     </Box>
   );

--- a/packages/cli/src/ui/components/Composer.test.tsx
+++ b/packages/cli/src/ui/components/Composer.test.tsx
@@ -164,6 +164,7 @@ const createMockConfig = (overrides = {}) => ({
   getDebugMode: vi.fn(() => false),
   getAccessibility: vi.fn(() => ({})),
   getMcpServers: vi.fn(() => ({})),
+  isPlanEnabled: vi.fn(() => false),
   getToolRegistry: () => ({
     getTool: vi.fn(),
   }),

--- a/packages/cli/src/ui/components/Composer.test.tsx
+++ b/packages/cli/src/ui/components/Composer.test.tsx
@@ -485,16 +485,24 @@ describe('Composer', () => {
       expect(lastFrame()).not.toContain('InputPrompt');
     });
 
-    it('shows ApprovalModeIndicator when approval mode is not default and shell mode is inactive', () => {
-      const uiState = createMockUIState({
-        showApprovalModeIndicator: ApprovalMode.YOLO,
-        shellModeActive: false,
-      });
+    it.each([
+      [ApprovalMode.DEFAULT],
+      [ApprovalMode.AUTO_EDIT],
+      [ApprovalMode.PLAN],
+      [ApprovalMode.YOLO],
+    ])(
+      'shows ApprovalModeIndicator when approval mode is %s and shell mode is inactive',
+      (mode) => {
+        const uiState = createMockUIState({
+          showApprovalModeIndicator: mode,
+          shellModeActive: false,
+        });
 
-      const { lastFrame } = renderComposer(uiState);
+        const { lastFrame } = renderComposer(uiState);
 
-      expect(lastFrame()).toMatch(/ApprovalModeIndic[\s\S]*ator/);
-    });
+        expect(lastFrame()).toMatch(/ApprovalModeIndic[\s\S]*ator/);
+      },
+    );
 
     it('shows ShellModeIndicator when shell mode is active', () => {
       const uiState = createMockUIState({

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -27,7 +27,6 @@ import { useVimMode } from '../contexts/VimModeContext.js';
 import { useConfig } from '../contexts/ConfigContext.js';
 import { useSettings } from '../contexts/SettingsContext.js';
 import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
-import { ApprovalMode } from '@google/gemini-cli-core';
 import { StreamingState, ToolCallStatus } from '../types.js';
 import { ConfigInitDisplay } from '../components/ConfigInitDisplay.js';
 import { TodoTray } from './messages/Todo.js';
@@ -68,9 +67,7 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
     (!uiState.embeddedShellFocused || uiState.isBackgroundShellVisible) &&
     uiState.streamingState === StreamingState.Responding &&
     !hasPendingActionRequired;
-  const showApprovalIndicator =
-    showApprovalModeIndicator !== ApprovalMode.DEFAULT &&
-    !uiState.shellModeActive;
+  const showApprovalIndicator = !uiState.shellModeActive;
   const showRawMarkdownIndicator = !uiState.renderMarkdown;
   const showEscToCancelHint =
     showLoadingIndicator &&

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -166,6 +166,7 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
                 {showApprovalIndicator && (
                   <ApprovalModeIndicator
                     approvalMode={showApprovalModeIndicator}
+                    isPlanEnabled={config.isPlanEnabled()}
                   />
                 )}
                 {uiState.shellModeActive && (

--- a/packages/cli/src/ui/hooks/useApprovalModeIndicator.test.ts
+++ b/packages/cli/src/ui/hooks/useApprovalModeIndicator.test.ts
@@ -236,7 +236,7 @@ describe('useApprovalModeIndicator', () => {
     expect(result.current).toBe(ApprovalMode.AUTO_EDIT);
   });
 
-  it('should cycle through DEFAULT -> AUTO_EDIT -> PLAN -> DEFAULT when plan is enabled', () => {
+  it('should cycle through DEFAULT -> PLAN -> AUTO_EDIT -> DEFAULT when plan is enabled', () => {
     mockConfigInstance.getApprovalMode.mockReturnValue(ApprovalMode.DEFAULT);
     mockConfigInstance.isPlanEnabled.mockReturnValue(true);
     renderHook(() =>
@@ -246,15 +246,7 @@ describe('useApprovalModeIndicator', () => {
       }),
     );
 
-    // DEFAULT -> AUTO_EDIT
-    act(() => {
-      capturedUseKeypressHandler({ name: 'tab', shift: true } as Key);
-    });
-    expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
-      ApprovalMode.AUTO_EDIT,
-    );
-
-    // AUTO_EDIT -> PLAN
+    // DEFAULT -> PLAN
     act(() => {
       capturedUseKeypressHandler({ name: 'tab', shift: true } as Key);
     });
@@ -262,7 +254,15 @@ describe('useApprovalModeIndicator', () => {
       ApprovalMode.PLAN,
     );
 
-    // PLAN -> DEFAULT
+    // PLAN -> AUTO_EDIT
+    act(() => {
+      capturedUseKeypressHandler({ name: 'tab', shift: true } as Key);
+    });
+    expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
+      ApprovalMode.AUTO_EDIT,
+    );
+
+    // AUTO_EDIT -> DEFAULT
     act(() => {
       capturedUseKeypressHandler({ name: 'tab', shift: true } as Key);
     });

--- a/packages/cli/src/ui/hooks/useApprovalModeIndicator.ts
+++ b/packages/cli/src/ui/hooks/useApprovalModeIndicator.ts
@@ -72,14 +72,14 @@ export function useApprovalModeIndicator({
         const currentMode = config.getApprovalMode();
         switch (currentMode) {
           case ApprovalMode.DEFAULT:
+            nextApprovalMode = config.isPlanEnabled()
+              ? ApprovalMode.PLAN
+              : ApprovalMode.AUTO_EDIT;
+            break;
+          case ApprovalMode.PLAN:
             nextApprovalMode = ApprovalMode.AUTO_EDIT;
             break;
           case ApprovalMode.AUTO_EDIT:
-            nextApprovalMode = config.isPlanEnabled()
-              ? ApprovalMode.PLAN
-              : ApprovalMode.DEFAULT;
-            break;
-          case ApprovalMode.PLAN:
             nextApprovalMode = ApprovalMode.DEFAULT;
             break;
           case ApprovalMode.YOLO:


### PR DESCRIPTION
- Show the approval mode indicator and hints.
- Standardize shortcut hint to 'shift+tab'. Note: shift+tab cycles out of YOLO but not into it.

Closes https://github.com/google-gemini/gemini-cli/issues/18473

---
<img width="842" height="176" alt="image" src="https://github.com/user-attachments/assets/c1459d5b-1245-4f0c-b2ff-c5f40fcc45e3" />

<img width="780" height="176" alt="image" src="https://github.com/user-attachments/assets/200b866e-19a3-4440-a49a-ff346f297221" />

<img width="786" height="168" alt="image" src="https://github.com/user-attachments/assets/34361578-75de-4ca2-9a54-f7522b8b8688" />

<img width="782" height="174" alt="image" src="https://github.com/user-attachments/assets/7d53b75f-da66-4398-b3d1-01d0754d0394" />

