### PR TITLE
feat(ui): add theme incompatibility message clarification

### DIFF
--- a/packages/cli/src/utils/terminalTheme.ts
+++ b/packages/cli/src/utils/terminalTheme.ts
@@ -63,7 +63,7 @@ export async function setupTerminalAndTheme(
       if (backgroundType && currentTheme.type !== backgroundType) {
         coreEvents.emitFeedback(
           'warning',
-          `Theme '${currentTheme.name}' (${currentTheme.type}) might look incorrect on your ${backgroundType} terminal background. Type /theme to change theme.`,
+          `Theme '${currentTheme.name}' (${currentTheme.type}) might look incorrect on your ${backgroundType} terminal background. Type /theme to change theme.\nThis message is not visible if the color palette is wrong.`,
         );
       }
     }


### PR DESCRIPTION
## Summary

Add an additional line to the theme incompatibility warning message explaining that the message itself might not be visible if the color palette is incorrect.

## Details

The existing warning message about theme incompatibility was not clear about its own visibility. This change adds a self-referential message to inform users that if they cannot see the warning, it's likely due to the color palette being incorrect.

## Related Issues

N/A

## How to Validate

1. Run the CLI in a terminal with a dark background and a light theme selected (or vice-versa) such that the theme is incompatible.
2. Observe the theme incompatibility warning message.
3. Verify that the new line "This message is not visible if the color palette is wrong." is present below the original warning.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
