### PR TITLE
fix(core): expand excludeTools with legacy aliases for renamed tools

### DIFF
--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -84,11 +84,24 @@ vi.mock('@google/genai', async () => {
 // Mock tool-names to provide a consistent alias for testing
 vi.mock('./tool-names.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./tool-names.js')>();
+  const mockedAliases: Record<string, string> = {
+    ...actual.TOOL_LEGACY_ALIASES,
+    legacy_test_tool: 'current_test_tool',
+  };
   return {
     ...actual,
-    TOOL_LEGACY_ALIASES: {
-      ...actual.TOOL_LEGACY_ALIASES,
-      legacy_test_tool: 'current_test_tool',
+    TOOL_LEGACY_ALIASES: mockedAliases,
+    // Override getToolAliases to use the mocked aliases map
+    getToolAliases: (name: string): string[] => {
+      const aliases = new Set<string>([name]);
+      const canonicalName = mockedAliases[name] ?? name;
+      aliases.add(canonicalName);
+      for (const [legacyName, currentName] of Object.entries(mockedAliases)) {
+        if (currentName === canonicalName) {
+          aliases.add(legacyName);
+        }
+      }
+      return Array.from(aliases);
     },
   };
 });
@@ -289,6 +302,26 @@ describe('ToolRegistry', () => {
         name: 'should match class names',
         tools: [excludedTool],
         excludedTools: ['ExcludedMockTool'],
+      },
+      {
+        name: 'should exclude a tool when its legacy alias is in excludeTools',
+        tools: [
+          new MockTool({
+            name: 'current_test_tool',
+            displayName: 'Current Test Tool',
+          }),
+        ],
+        excludedTools: ['legacy_test_tool'],
+      },
+      {
+        name: 'should exclude a tool when its current name is in excludeTools and tool is registered under current name',
+        tools: [
+          new MockTool({
+            name: 'current_test_tool',
+            displayName: 'Current Test Tool',
+          }),
+        ],
+        excludedTools: ['current_test_tool'],
       },
     ])('$name', ({ tools, excludedTools }) => {
       toolRegistry.registerTool(allowedTool);


### PR DESCRIPTION
## Summary

`excludeTools` did not respect legacy tool aliases, so excluding a tool by its old name (e.g. `search_file_content`) failed to exclude the renamed tool (`grep_search`).

## Details

The alias system from #17974 was integrated into `getTool()` and the policy engine, but not into the `excludeTools` filtering in `ToolRegistry`. Added `expandExcludeToolsWithAliases()` that expands each entry in the exclude set via `getToolAliases()`, applied in both `getActiveTools()` and the `isActiveTool()` fallback path.

## Related Issues

Follows up on #17974 and #18003.

## How to Validate

1. Add `{"tools": {"exclude": ["search_file_content"]}}` to `.gemini/settings.json`
2. Start gemini — the `grep_search` tool should be excluded
3. Run existing tests: `npx vitest run packages/core/src/tools/tool-registry.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker