### PR TITLE
feat(cli): deprecate --allowed-tools and excludeTools in favor of policy engine

### DIFF
--- a/docs/cli/cli-reference.md
+++ b/docs/cli/cli-reference.md
@@ -27,29 +27,29 @@ and parameters.
 
 ## CLI Options
 
-| Option                           | Alias | Type    | Default   | Description                                                                                                |
-| -------------------------------- | ----- | ------- | --------- | ---------------------------------------------------------------------------------------------------------- |
-| `--debug`                        | `-d`  | boolean | `false`   | Run in debug mode with verbose logging                                                                     |
-| `--version`                      | `-v`  | -       | -         | Show CLI version number and exit                                                                           |
-| `--help`                         | `-h`  | -       | -         | Show help information                                                                                      |
-| `--model`                        | `-m`  | string  | `auto`    | Model to use. See [Model Selection](#model-selection) for available values.                                |
-| `--prompt`                       | `-p`  | string  | -         | Prompt text. Appended to stdin input if provided. **Deprecated:** Use positional arguments instead.        |
-| `--prompt-interactive`           | `-i`  | string  | -         | Execute prompt and continue in interactive mode                                                            |
-| `--sandbox`                      | `-s`  | boolean | `false`   | Run in a sandboxed environment for safer execution                                                         |
-| `--approval-mode`                | -     | string  | `default` | Approval mode for tool execution. Choices: `default`, `auto_edit`, `yolo`                                  |
-| `--yolo`                         | `-y`  | boolean | `false`   | **Deprecated.** Auto-approve all actions. Use `--approval-mode=yolo` instead.                              |
-| `--experimental-acp`             | -     | boolean | -         | Start in ACP (Agent Code Pilot) mode. **Experimental feature.**                                            |
-| `--experimental-zed-integration` | -     | boolean | -         | Run in Zed editor integration mode. **Experimental feature.**                                              |
-| `--allowed-mcp-server-names`     | -     | array   | -         | Allowed MCP server names (comma-separated or multiple flags)                                               |
-| `--allowed-tools`                | -     | array   | -         | Tools that are allowed to run without confirmation (comma-separated or multiple flags)                     |
-| `--extensions`                   | `-e`  | array   | -         | List of extensions to use. If not provided, all extensions are enabled (comma-separated or multiple flags) |
-| `--list-extensions`              | `-l`  | boolean | -         | List all available extensions and exit                                                                     |
-| `--resume`                       | `-r`  | string  | -         | Resume a previous session. Use `"latest"` for most recent or index number (e.g. `--resume 5`)              |
-| `--list-sessions`                | -     | boolean | -         | List available sessions for the current project and exit                                                   |
-| `--delete-session`               | -     | string  | -         | Delete a session by index number (use `--list-sessions` to see available sessions)                         |
-| `--include-directories`          | -     | array   | -         | Additional directories to include in the workspace (comma-separated or multiple flags)                     |
-| `--screen-reader`                | -     | boolean | -         | Enable screen reader mode for accessibility                                                                |
-| `--output-format`                | `-o`  | string  | `text`    | The format of the CLI output. Choices: `text`, `json`, `stream-json`                                       |
+| Option                           | Alias | Type    | Default   | Description                                                                                                                                                       |
+| -------------------------------- | ----- | ------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--debug`                        | `-d`  | boolean | `false`   | Run in debug mode with verbose logging                                                                                                                            |
+| `--version`                      | `-v`  | -       | -         | Show CLI version number and exit                                                                                                                                  |
+| `--help`                         | `-h`  | -       | -         | Show help information                                                                                                                                             |
+| `--model`                        | `-m`  | string  | `auto`    | Model to use. See [Model Selection](#model-selection) for available values.                                                                                       |
+| `--prompt`                       | `-p`  | string  | -         | Prompt text. Appended to stdin input if provided. **Deprecated:** Use positional arguments instead.                                                               |
+| `--prompt-interactive`           | `-i`  | string  | -         | Execute prompt and continue in interactive mode                                                                                                                   |
+| `--sandbox`                      | `-s`  | boolean | `false`   | Run in a sandboxed environment for safer execution                                                                                                                |
+| `--approval-mode`                | -     | string  | `default` | Approval mode for tool execution. Choices: `default`, `auto_edit`, `yolo`                                                                                         |
+| `--yolo`                         | `-y`  | boolean | `false`   | **Deprecated.** Auto-approve all actions. Use `--approval-mode=yolo` instead.                                                                                     |
+| `--experimental-acp`             | -     | boolean | -         | Start in ACP (Agent Code Pilot) mode. **Experimental feature.**                                                                                                   |
+| `--experimental-zed-integration` | -     | boolean | -         | Run in Zed editor integration mode. **Experimental feature.**                                                                                                     |
+| `--allowed-mcp-server-names`     | -     | array   | -         | Allowed MCP server names (comma-separated or multiple flags)                                                                                                      |
+| `--allowed-tools`                | -     | array   | -         | **Deprecated.** Use the [Policy Engine](../core/policy-engine.md) instead. Tools that are allowed to run without confirmation (comma-separated or multiple flags) |
+| `--extensions`                   | `-e`  | array   | -         | List of extensions to use. If not provided, all extensions are enabled (comma-separated or multiple flags)                                                        |
+| `--list-extensions`              | `-l`  | boolean | -         | List all available extensions and exit                                                                                                                            |
+| `--resume`                       | `-r`  | string  | -         | Resume a previous session. Use `"latest"` for most recent or index number (e.g. `--resume 5`)                                                                     |
+| `--list-sessions`                | -     | boolean | -         | List available sessions for the current project and exit                                                                                                          |
+| `--delete-session`               | -     | string  | -         | Delete a session by index number (use `--list-sessions` to see available sessions)                                                                                |
+| `--include-directories`          | -     | array   | -         | Additional directories to include in the workspace (comma-separated or multiple flags)                                                                            |
+| `--screen-reader`                | -     | boolean | -         | Enable screen reader mode for accessibility                                                                                                                       |
+| `--output-format`                | `-o`  | string  | `text`    | The format of the CLI output. Choices: `text`, `json`, `stream-json`                                                                                              |
 
 ## Model selection
 

--- a/docs/cli/enterprise.md
+++ b/docs/cli/enterprise.md
@@ -223,9 +223,9 @@ gemini
 ## Restricting tool access
 
 You can significantly enhance security by controlling which tools the Gemini
-model can use. This is achieved through the `tools.core` and `tools.exclude`
-settings. For a list of available tools, see the
-[Tools documentation](../tools/index.md).
+model can use. This is achieved through the `tools.core` setting and the
+[Policy Engine](../core/policy-engine.md). For a list of available tools, see
+the [Tools documentation](../tools/index.md).
 
 ### Allowlisting with `coreTools`
 
@@ -243,7 +243,10 @@ on the approved list.
 }
 ```
 
-### Blocklisting with `excludeTools`
+### Blocklisting with `excludeTools` (Deprecated)
+
+> **Deprecated:** Use the [Policy Engine](../core/policy-engine.md) for more
+> robust control.
 
 Alternatively, you can add specific tools that are considered dangerous in your
 environment to a blocklist.

--- a/docs/get-started/configuration-v1.md
+++ b/docs/get-started/configuration-v1.md
@@ -166,19 +166,21 @@ a few things you can try in order of recommendation:
   - **Default:** All tools available for use by the Gemini model.
   - **Example:** `"coreTools": ["ReadFileTool", "GlobTool", "ShellTool(ls)"]`.
 
-- **`allowedTools`** (array of strings):
+- **`allowedTools`** (array of strings) [DEPRECATED]:
   - **Default:** `undefined`
   - **Description:** A list of tool names that will bypass the confirmation
     dialog. This is useful for tools that you trust and use frequently. The
-    match semantics are the same as `coreTools`.
+    match semantics are the same as `coreTools`. **Deprecated**: Use the
+    [Policy Engine](../core/policy-engine.md) instead.
   - **Example:** `"allowedTools": ["ShellTool(git status)"]`.
 
-- **`excludeTools`** (array of strings):
+- **`excludeTools`** (array of strings) [DEPRECATED]:
   - **Description:** Allows you to specify a list of core tool names that should
     be excluded from the model. A tool listed in both `excludeTools` and
     `coreTools` is excluded. You can also specify command-specific restrictions
     for tools that support it, like the `ShellTool`. For example,
     `"excludeTools": ["ShellTool(rm -rf)"]` will block the `rm -rf` command.
+    **Deprecated**: Use the [Policy Engine](../core/policy-engine.md) instead.
   - **Default**: No tools excluded.
   - **Example:** `"excludeTools": ["run_shell_command", "findFiles"]`.
   - **Security Note:** Command-specific restrictions in `excludeTools` for

--- a/docs/tools/shell.md
+++ b/docs/tools/shell.md
@@ -167,10 +167,11 @@ configuration file.
   `"tools": {"core": ["run_shell_command(git)"]}` will only allow `git`
   commands. Including the generic `run_shell_command` acts as a wildcard,
   allowing any command not explicitly blocked.
-- `tools.exclude`: To block specific commands, add entries to the `exclude` list
-  under the `tools` category in the format `run_shell_command(<command>)`. For
-  example, `"tools": {"exclude": ["run_shell_command(rm)"]}` will block `rm`
-  commands.
+- `tools.exclude` [DEPRECATED]: To block specific commands, use the
+  [Policy Engine](../core/policy-engine.md). Historically, this setting allowed
+  adding entries to the `exclude` list under the `tools` category in the format
+  `run_shell_command(<command>)`. For example,
+  `"tools": {"exclude": ["run_shell_command(rm)"]}` will block `rm` commands.
 
 The validation logic is designed to be secure and flexible:
 

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -3183,10 +3183,12 @@ describe('Policy Engine Integration in loadCliConfig', () => {
     await loadCliConfig(settings, 'test-session', argv);
 
     // In non-interactive mode, ShellTool, etc. are excluded
+    // But we don't pass them to createPolicyEngineConfig anymore,
+    // as they are aggregated in Config.getExcludeTools()
     expect(ServerConfig.createPolicyEngineConfig).toHaveBeenCalledWith(
       expect.objectContaining({
         tools: expect.objectContaining({
-          exclude: expect.arrayContaining([SHELL_TOOL_NAME]),
+          exclude: [],
         }),
       }),
       expect.anything(),

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -3183,12 +3183,10 @@ describe('Policy Engine Integration in loadCliConfig', () => {
     await loadCliConfig(settings, 'test-session', argv);
 
     // In non-interactive mode, ShellTool, etc. are excluded
-    // But we don't pass them to createPolicyEngineConfig anymore,
-    // as they are aggregated in Config.getExcludeTools()
     expect(ServerConfig.createPolicyEngineConfig).toHaveBeenCalledWith(
       expect.objectContaining({
         tools: expect.objectContaining({
-          exclude: [],
+          exclude: expect.arrayContaining([SHELL_TOOL_NAME]),
         }),
       }),
       expect.anything(),

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -661,10 +661,7 @@ export async function loadCliConfig(
     tools: {
       ...settings.tools,
       allowed: allowedTools,
-      // Exclude is intentionally empty for PolicyEngine configuration to
-      // avoid generating redundant DENY rules. The full set of tool
-      // exclusions is aggregated centrally in Config.getExcludeTools().
-      exclude: [],
+      exclude: excludeTools,
     },
     mcp: {
       ...settings.mcp,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -660,7 +660,10 @@ export async function loadCliConfig(
     tools: {
       ...settings.tools,
       allowed: allowedTools,
-      exclude: excludeTools,
+      // Exclude is intentionally empty for PolicyEngine configuration to
+      // avoid generating redundant DENY rules. The full set of tool
+      // exclusions is aggregated centrally in Config.getExcludeTools().
+      exclude: [],
     },
     mcp: {
       ...settings.mcp,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -177,7 +177,8 @@ export async function parseArguments(
           type: 'array',
           string: true,
           nargs: 1,
-          description: 'Tools that are allowed to run without confirmation',
+          description:
+            '[DEPRECATED: Use Policy Engine instead See https://geminicli.com/docs/core/policy-engine] Tools that are allowed to run without confirmation',
           coerce: (tools: string[]) =>
             // Handle comma-separated values
             tools.flatMap((tool) => tool.split(',').map((t) => t.trim())),

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -362,6 +362,16 @@ export async function main() {
   parseArgsHandle?.end();
 
   if (
+    (argv.allowedTools && argv.allowedTools.length > 0) ||
+    (settings.merged.tools?.allowed && settings.merged.tools.allowed.length > 0)
+  ) {
+    coreEvents.emitFeedback(
+      'warning',
+      'Warning: --allowed-tools cli argument and tools.allowed in settings.json are deprecated and will be removed in 1.0: Migrate to Policy Engine: https://geminicli.com/docs/core/policy-engine/',
+    );
+  }
+
+  if (
     settings.merged.tools?.exclude &&
     settings.merged.tools.exclude.length > 0
   ) {

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -361,6 +361,16 @@ export async function main() {
   const argv = await parseArguments(settings.merged);
   parseArgsHandle?.end();
 
+  if (
+    settings.merged.tools?.exclude &&
+    settings.merged.tools.exclude.length > 0
+  ) {
+    coreEvents.emitFeedback(
+      'warning',
+      'Warning: tools.exclude in settings.json is deprecated and will be removed in 1.0. Migrate to Policy Engine: https://geminicli.com/docs/core/policy-engine/',
+    );
+  }
+
   if (argv.startupMessages) {
     argv.startupMessages.forEach((msg) => {
       coreEvents.emitFeedback('info', msg);

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -383,6 +383,7 @@ export interface ConfigParameters {
   question?: string;
 
   coreTools?: string[];
+  /** @deprecated Use Policy Engine instead */
   allowedTools?: string[];
   /** @deprecated Use Policy Engine instead */
   excludeTools?: string[];
@@ -517,6 +518,7 @@ export class Config {
   private readonly question: string | undefined;
 
   private readonly coreTools: string[] | undefined;
+  /** @deprecated Use Policy Engine instead */
   private readonly allowedTools: string[] | undefined;
   /** @deprecated Use Policy Engine instead */
   private readonly excludeTools: string[] | undefined;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -384,6 +384,7 @@ export interface ConfigParameters {
 
   coreTools?: string[];
   allowedTools?: string[];
+  /** @deprecated Use Policy Engine instead */
   excludeTools?: string[];
   toolDiscoveryCommand?: string;
   toolCallCommand?: string;
@@ -517,6 +518,7 @@ export class Config {
 
   private readonly coreTools: string[] | undefined;
   private readonly allowedTools: string[] | undefined;
+  /** @deprecated Use Policy Engine instead */
   private readonly excludeTools: string[] | undefined;
   private readonly toolDiscoveryCommand: string | undefined;
   private readonly toolCallCommand: string | undefined;
@@ -1487,11 +1489,12 @@ export class Config {
 
   /**
    * All the excluded tools from static configuration, loaded extensions, or
-   * other sources.
+   * other sources (like the Policy Engine).
    *
    * May change over time.
    */
   getExcludeTools(): Set<string> | undefined {
+    // Right now this is present for backward compatibility with settings.json exclude
     const excludeToolsSet = new Set([...(this.excludeTools ?? [])]);
     for (const extension of this.getExtensionLoader().getExtensions()) {
       if (!extension.isActive) {
@@ -1501,6 +1504,12 @@ export class Config {
         excludeToolsSet.add(tool);
       }
     }
+
+    const policyExclusions = this.policyEngine.getExcludedTools();
+    for (const tool of policyExclusions) {
+      excludeToolsSet.add(tool);
+    }
+
     return excludeToolsSet;
   }
 

--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -2096,6 +2096,37 @@ describe('PolicyEngine', () => {
       const excluded = engine.getExcludedTools();
       expect(excluded.has('tool1')).toBe(false);
     });
+
+    it('should respect approval mode', () => {
+      const rules: PolicyRule[] = [
+        {
+          toolName: 'tool1',
+          decision: PolicyDecision.DENY,
+          modes: [ApprovalMode.PLAN],
+        },
+      ];
+
+      // Default mode (not PLAN)
+      engine = new PolicyEngine({
+        rules,
+        approvalMode: ApprovalMode.DEFAULT,
+      });
+      let excluded = engine.getExcludedTools();
+      expect(excluded.has('tool1')).toBe(false);
+
+      // PLAN mode
+      engine = new PolicyEngine({
+        rules,
+        approvalMode: ApprovalMode.PLAN,
+      });
+      excluded = engine.getExcludedTools();
+      expect(excluded.has('tool1')).toBe(true);
+
+      // Switch mode dynamically
+      engine.setApprovalMode(ApprovalMode.DEFAULT);
+      excluded = engine.getExcludedTools();
+      expect(excluded.has('tool1')).toBe(false);
+    });
   });
 
   describe('YOLO mode with ask_user tool', () => {

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -530,6 +530,13 @@ export class PolicyEngine {
         continue;
       }
 
+      // Check if rule applies to current approval mode
+      if (rule.modes && rule.modes.length > 0) {
+        if (!rule.modes.includes(this.approvalMode)) {
+          continue;
+        }
+      }
+
       // If we've already processed this tool (found a higher priority rule), skip
       if (processedTools.has(rule.toolName)) {
         continue;


### PR DESCRIPTION
## Summary

Deprecates the `--allowed-tools` CLI flag, `tools.allowed`, and `tools.exclude` configuration options in favor of the Policy Engine, unifying tool exclusion logic.

## Details

This PR implements a two-phase deprecation plan for legacy tool permission flags, guiding users toward the Policy Engine.

### 1. Deprecate `--allowed-tools` / `tools.allowed`
- **CLI**: Updated help description for `--allowed-tools` to indicate deprecation.
- **Runtime**: Added a warning in `gemini.tsx` if `allowedTools` is used via CLI args or settings.
- **Core**: Added `@deprecated` tags to `allowedTools` in `Config` properties.

### 2. Deprecate `tools.exclude` & Unify Exclusion Logic
- **Policy Engine**: Implemented `PolicyEngine.getExcludedTools()` to expose effectively denied tools.
- **Config**: Updated `Config.getExcludeTools()` to centrally aggregate exclusions from:
    - System defaults
    - Extensions
    - The Policy Engine
- **Runtime**: Added a startup warning for `tools.exclude` usage in `settings.json`.
- **Core**: Marked `excludeTools` as deprecated in `Config` parameters and class.
- **Compatibility**: Maintained legacy exclude processing in Core's `createPolicyEngineConfig` while refactoring CLI usage to avoid redundancy.

## Related Issues

Partial solution for #11302 as this only deprecates.

## How to Validate

1.  **Allowed Tools Warning**:
    - Run `gemini --allowed-tools="ShellTool"`.
    - Observe the warning: "The allowed-tools cli argument and tools.allowed setting are deprecated..."
2.  **Exclude Tools Warning**:
    - Add `"tools": { "exclude": ["some_tool"] }` to `settings.json`.
    - Run `gemini`.
    - Observe the warning about `tools.exclude` deprecation.
3.  **Clean Run**:
    - Run `gemini` without these flags/settings.
    - Observe no warnings.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
