### PR TITLE
fix(cli): guard setRawMode in signal handlers to prevent EIO crash

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -603,11 +603,24 @@ export async function main() {
       }
 
       // This cleanup isn't strictly needed but may help in certain situations.
+      // Guard against EIO errors when TTY is disconnected (common on Node 24+)
       process.on('SIGTERM', () => {
-        process.stdin.setRawMode(wasRaw);
+        try {
+          if (process.stdin.isTTY) {
+            process.stdin.setRawMode(wasRaw);
+          }
+        } catch {
+          // TTY may be disconnected, ignore
+        }
       });
       process.on('SIGINT', () => {
-        process.stdin.setRawMode(wasRaw);
+        try {
+          if (process.stdin.isTTY) {
+            process.stdin.setRawMode(wasRaw);
+          }
+        } catch {
+          // TTY may be disconnected, ignore
+        }
       });
     }
 


### PR DESCRIPTION
## Summary

On Node.js 24+, calling `setRawMode()` on a disconnected TTY throws an `EIO` error. This can happen when SIGTERM/SIGINT fires after the terminal has already been closed.

This PR adds an `isTTY` check and try-catch wrapper to gracefully handle this edge case in the signal handlers.

## Problem

```
Error: setRawMode EIO
    at ReadStream.setRawMode (node:tty:81:24)
    at process.<anonymous> (gemini.js:381:31)
    at process.emit (node:events:520:35)
```

This occurs when:
- Parent process terminates
- Terminal emulator closes
- SSH session drops
- Process is backgrounded then terminal closes

## Solution

Guard the `setRawMode` calls with:
1. `process.stdin.isTTY` check
2. try-catch to swallow any remaining edge cases

Similar to the fix in #15410 for `readStdin.ts`, but for the signal handlers in `gemini.tsx`.

## Test Plan

- [x] Tested on Node.js 24.13.0 - no longer crashes on signal
- [x] Tested on Node.js 22.22.0 - continues to work as before