### PR TITLE
fix(cli): correct 'esc to cancel' position and restore duration display

### DIFF
--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useState } from 'react';
-import { Box, Text, useIsScreenReaderEnabled } from 'ink';
+import { Box, useIsScreenReaderEnabled } from 'ink';
 import { LoadingIndicator } from './LoadingIndicator.js';
 import { StatusDisplay } from './StatusDisplay.js';
 import { ApprovalModeIndicator } from './ApprovalModeIndicator.js';
@@ -30,7 +30,6 @@ import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
 import { StreamingState, ToolCallStatus } from '../types.js';
 import { ConfigInitDisplay } from '../components/ConfigInitDisplay.js';
 import { TodoTray } from './messages/Todo.js';
-import { theme } from '../semantic-colors.js';
 
 export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
   const config = useConfig();
@@ -69,9 +68,6 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
     !hasPendingActionRequired;
   const showApprovalIndicator = !uiState.shellModeActive;
   const showRawMarkdownIndicator = !uiState.renderMarkdown;
-  const showEscToCancelHint =
-    showLoadingIndicator &&
-    uiState.streamingState !== StreamingState.WaitingForConfirmation;
 
   return (
     <Box
@@ -93,11 +89,6 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
       <TodoTray />
 
       <Box marginTop={1} width="100%" flexDirection="column">
-        {showEscToCancelHint && (
-          <Box marginLeft={3}>
-            <Text color={theme.text.secondary}>esc to cancel</Text>
-          </Box>
-        )}
         <Box
           width="100%"
           flexDirection={isNarrow ? 'column' : 'row'}
@@ -127,7 +118,6 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
                     : uiState.currentLoadingPhrase
                 }
                 elapsedTime={uiState.elapsedTime}
-                showCancelAndTimer={false}
               />
             )}
           </Box>


### PR DESCRIPTION
## Summary

Corrected the position of the "esc to cancel" hint and restored the duration display in the CLI UI. This fixes a regression where the cancel hint appeared above the thinking subject and the elapsed time was hidden.

## Details

- Regression introduced in PR #18035.
- Refactored `Composer.tsx` to remove manual rendering of "esc to cancel" which was causing alignment issues.
- Re-enabled `showCancelAndTimer` in `LoadingIndicator` to use its native, correctly aligned display for cancel hints and elapsed time.
- Cleaned up unused `Text` and `theme` imports in `Composer.tsx`.

## Related Issues

N/A (User reported)

## How to Validate

1. Run `npm run start`.
2. Enter a prompt that takes time to respond.
3. Observe that "esc to cancel" and the duration (e.g., "5s") appear on the same line as the loading phrase/thought subject.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
