### PR TITLE
docs: require pr-creator skill for PR generation

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -55,6 +55,8 @@ powerful tool for developers.
 - **Contributions:** Follow the process outlined in `CONTRIBUTING.md`. Requires
   signing the Google CLA.
 - **Pull Requests:** Keep PRs small, focused, and linked to an existing issue.
+  Always activate the `pr-creator` skill for PR generation, even when using the
+  `gh` CLI.
 - **Commit Messages:** Follow the
   [Conventional Commits](https://www.conventionalcommits.org/) standard.
 - **Coding Style:** Adhere to existing patterns in `packages/cli` (React/Ink)


### PR DESCRIPTION
## Summary

Updated GEMINI.md to require the use of the pr-creator skill for all PR generations. This ensures that PRs consistently follow the repository's templates and standards.

## Details

- Added instruction to the "Development Conventions" section in GEMINI.md.

## Related Issues

N/A

## How to Validate

N/A (documentation change)

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
