### PR TITLE
chore: update colors for ask_user dialog

### DIFF
--- a/packages/cli/src/ui/components/shared/TabHeader.tsx
+++ b/packages/cli/src/ui/components/shared/TabHeader.tsx
@@ -96,9 +96,10 @@ export function TabHeader({
           )}
           <Text
             color={
-              i === currentIndex ? theme.text.accent : theme.text.secondary
+              i === currentIndex ? theme.status.success : theme.text.secondary
             }
             bold={i === currentIndex}
+            underline={i === currentIndex}
             aria-current={i === currentIndex ? 'step' : undefined}
           >
             {tab.header}


### PR DESCRIPTION
## Summary

Update the `ask_user` dialog tab headers to improve accessibility and visual consistency. The active tab now uses the green "success" color (matching the selection list) and is underlined to make it stand out more clearly in the terminal.

<img width="600" height="1480" alt="image" src="https://github.com/user-attachments/assets/c0733270-1de1-474a-9df9-40cd3fa814b4" />


## Details

   - Modified the `TabHeader` component to change the active tab color from `theme.text.accent` (purple) to `theme.status.success` (green).
   - Added the `underline` property to the active tab's `Text` component to enhance visibility and accessibility.
   - These changes ensure the active step in multi-question dialogs is more prominent across different terminal themes.

   ## Related Issues

   Fixes #18542

   ## How to Validate


   1. **Manual Verification**: Run the `ask_user` demo to see the visual changes:

      ```bash
      npx tsx packages/cli/examples/ask-user-dialog-demo.tsx
      ```
   2. **Automated Tests**: Run the relevant unit tests to ensure component logic remains sound:

      ```bash
      npm test -w @google/gemini-cli -- src/ui/components/shared/TabHeader.test.tsx src/ui/components/AskUserDialog.test.tsx
      ```

   ## Pre-Merge Checklist

   - [ ] Updated relevant documentation and README (if needed)
   - [x] Added/updated tests (if needed)
   - [ ] Noted breaking changes (if any)
   - [x] Validated on required platforms/methods:
     - [x] MacOS
       - [x] npm run
       - [ ] npx
       - [ ] Docker
       - [ ] Podman
       - [ ] Seatbelt
     - [ ] Windows
       - [ ] npm run
       - [ ] npx
       - [ ] Docker
     - [ ] Linux
       - [ ] npm run
       - [ ] npx
       - [ ] Docker