### PR TITLE
feat(core): exempt high-signal tools from output masking

### DIFF
--- a/packages/core/src/services/toolOutputMaskingService.test.ts
+++ b/packages/core/src/services/toolOutputMaskingService.test.ts
@@ -12,7 +12,11 @@ import {
   ToolOutputMaskingService,
   MASKING_INDICATOR_TAG,
 } from './toolOutputMaskingService.js';
-import { SHELL_TOOL_NAME } from '../tools/tool-names.js';
+import {
+  SHELL_TOOL_NAME,
+  ACTIVATE_SKILL_TOOL_NAME,
+  MEMORY_TOOL_NAME,
+} from '../tools/tool-names.js';
 import { estimateTokenCountSync } from '../utils/tokenCalculation.js';
 import type { Config } from '../config/config.js';
 import type { Content, Part } from '@google/genai';
@@ -510,5 +514,114 @@ describe('ToolOutputMaskingService', () => {
 
     const result = await service.mask(history, mockConfig);
     expect(result.maskedCount).toBe(0); // padding is protected, tiny_tool would increase size
+  });
+
+  it('should never mask exempt tools (like activate_skill) even if they are deep in history', async () => {
+    const history: Content[] = [
+      {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: ACTIVATE_SKILL_TOOL_NAME,
+              response: { output: 'High value instructions for skill' },
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: MEMORY_TOOL_NAME,
+              response: { output: 'Important user preference' },
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: 'bulky_tool',
+              response: { output: 'A'.repeat(60000) },
+            },
+          },
+        ],
+      },
+      // Protection buffer
+      {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: 'padding',
+              response: { output: 'B'.repeat(60000) },
+            },
+          },
+        ],
+      },
+      { role: 'user', parts: [{ text: 'latest' }] },
+    ];
+
+    mockedEstimateTokenCountSync.mockImplementation((parts: Part[]) => {
+      const resp = parts[0].functionResponse?.response as Record<
+        string,
+        unknown
+      >;
+      const content = (resp?.['output'] as string) ?? JSON.stringify(resp);
+      if (content.includes(`<${MASKING_INDICATOR_TAG}`)) return 100;
+
+      const name = parts[0].functionResponse?.name;
+      if (name === ACTIVATE_SKILL_TOOL_NAME) return 1000;
+      if (name === MEMORY_TOOL_NAME) return 500;
+      if (name === 'bulky_tool') return 60000;
+      if (name === 'padding') return 60000;
+      return 10;
+    });
+
+    const result = await service.mask(history, mockConfig);
+
+    // Both 'bulky_tool' and 'padding' should be masked.
+    // 'padding' (Index 3) crosses the 50k protection boundary immediately.
+    // ACTIVATE_SKILL and MEMORY are exempt.
+    expect(result.maskedCount).toBe(2);
+    expect(result.newHistory[0].parts?.[0].functionResponse?.name).toBe(
+      ACTIVATE_SKILL_TOOL_NAME,
+    );
+    expect(
+      (
+        result.newHistory[0].parts?.[0].functionResponse?.response as Record<
+          string,
+          unknown
+        >
+      )['output'],
+    ).toBe('High value instructions for skill');
+
+    expect(result.newHistory[1].parts?.[0].functionResponse?.name).toBe(
+      MEMORY_TOOL_NAME,
+    );
+    expect(
+      (
+        result.newHistory[1].parts?.[0].functionResponse?.response as Record<
+          string,
+          unknown
+        >
+      )['output'],
+    ).toBe('Important user preference');
+
+    expect(result.newHistory[2].parts?.[0].functionResponse?.name).toBe(
+      'bulky_tool',
+    );
+    expect(
+      (
+        result.newHistory[2].parts?.[0].functionResponse?.response as Record<
+          string,
+          unknown
+        >
+      )['output'],
+    ).toContain(MASKING_INDICATOR_TAG);
   });
 });


### PR DESCRIPTION
## Summary

This PR ensures that high-signal tools (skills, memory, user input, and state transitions) are exempt from context window masking. 

Previously, the `ToolOutputMaskingService` would mask any tool output older than the protection window once prunable tokens exceeded the threshold. This was problematic for tools like `activate_skill`, where the model needs the instruction set and resource mappings to function correctly across long-running sessions.

## Details

- Added an `EXEMPT_TOOLS` set containing `activate_skill`, `save_memory`, `ask_user`, `enter_plan_mode`, and `exit_plan_mode`.
- Updated the backward scan in `ToolOutputMaskingService` to skip masking for any `functionResponse` from these tools.
- Exempt tools no longer contribute to the prunable token count, ensuring they are preserved indefinitely.
- Verified that existing shell tool masking and protection window logic remains unaffected.

## Related Issues

N/A

## How to Validate

1. Run the targeted unit tests:
   ```bash
   npm test -w @google/gemini-cli-core -- src/services/toolOutputMaskingService.test.ts
   ```
2. Verify the new test case "should never mask exempt tools (like activate_skill) even if they are deep in history" passes.
3. (Optional) Run `npm run preflight` to verify the entire monorepo.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) - *Handled via code comments*
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
