### PR TITLE
feat(cli): suppress punycode deprecation warnings

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// important to keep this as the very first import
+import './src/utils/suppressPunycodeWarnings.js';
 import { main } from './src/gemini.js';
 import { FatalError, writeToStderr } from '@google/gemini-cli-core';
 import { runExitCleanup } from './src/utils/cleanup.js';

--- a/packages/cli/src/utils/suppressPunycodeWarnings.ts
+++ b/packages/cli/src/utils/suppressPunycodeWarnings.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Suppress punycode deprecation warning (DEP0040)
+// This is required because several dependencies (e.g., node-fetch -> tr46) still use the deprecated punycode module.
+// We monkey patch process.emitWarning because it's called during module evaluation, often before a standard 'warning' listener can be registered.
+
+const originalEmitWarning = process.emitWarning;
+type EmitWarningParameters = Parameters<typeof process.emitWarning>;
+
+process.emitWarning = function (...args: EmitWarningParameters) {
+  // We check all arguments because the identifying code ('DEP0040') can be passed
+  // positionally (as the 3rd argument) or inside an options object (as the 2nd argument)
+  // depending on which process.emitWarning overload is called.
+  if (args.some(isPunycodeWarning)) return;
+
+  return originalEmitWarning.apply(process, args);
+} as typeof process.emitWarning;
+
+function isPunycodeWarning(warning: unknown): boolean {
+  if (typeof warning === 'string') {
+    return warning.includes('punycode') || warning === 'DEP0040';
+  }
+  if (warning !== null && typeof warning === 'object') {
+    return 'code' in warning && warning.code === 'DEP0040';
+  }
+  return false;
+}


### PR DESCRIPTION
#### Description
This PR silences the Node.js `punycode` deprecation warning (`DEP0040`) triggered by dependencies during CLI startup.

Fixes #18342.
Addresses part of #14422.

#### Changes
- Added `packages/cli/src/utils/suppressPunycodeWarnings.ts` which implements a type-safe override of `process.emitWarning` to filter out `punycode` related messages.
- Updated `packages/cli/index.ts` to import this utility at the absolute top of the file, ensuring it catches warnings during the evaluation of all other modules.

#### Verification Results
Confirmed the warning no longer appears when running:
- `gemini --help`
- `gemini --version`