### PR TITLE
fix(cli): prevent vim escape from cancelling stream in insert mode

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -559,6 +559,13 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         (streamingState === StreamingState.Responding ||
           streamingState === StreamingState.WaitingForConfirmation)
       ) {
+        // If Vim mode is enabled, let it handle the escape key first (e.g., to
+        // switch from INSERT to NORMAL mode). If it handles it, we stop
+        // propagation. Otherwise, we return false to let the cancellation logic
+        // in useGeminiStream handle it.
+        if (vimHandleInput && vimHandleInput(key)) {
+          return true;
+        }
         return false;
       }
 

--- a/packages/cli/src/ui/contexts/VimModeContext.tsx
+++ b/packages/cli/src/ui/contexts/VimModeContext.tsx
@@ -40,10 +40,20 @@ export const VimModeProvider = ({
   useEffect(() => {
     // Initialize vimEnabled from settings on mount
     const enabled = settings.merged.general.vimMode;
-    setVimEnabled(enabled);
+    setVimEnabled((prev) => {
+      if (prev !== enabled) {
+        return enabled;
+      }
+      return prev;
+    });
     // When vim mode is enabled, start in INSERT mode
     if (enabled) {
-      setVimMode('INSERT');
+      setVimMode((prev) => {
+        if (prev !== 'INSERT') {
+          return 'INSERT';
+        }
+        return prev;
+      });
     }
   }, [settings.merged.general.vimMode]);
 
@@ -68,7 +78,7 @@ export const VimModeProvider = ({
       toggleVimEnabled,
       setVimMode,
     }),
-    [vimEnabled, vimMode, toggleVimEnabled],
+    [vimEnabled, vimMode, toggleVimEnabled, setVimMode],
   );
 
   return (

--- a/packages/cli/src/ui/contexts/VimModeContext.tsx
+++ b/packages/cli/src/ui/contexts/VimModeContext.tsx
@@ -9,6 +9,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from 'react';
 import type { LoadedSettings } from '../../config/settings.js';
@@ -57,12 +58,18 @@ export const VimModeProvider = ({
     return newValue;
   }, [vimEnabled, settings]);
 
-  const value = {
-    vimEnabled,
-    vimMode,
-    toggleVimEnabled,
-    setVimMode,
-  };
+  // Memoize the context value to prevent unnecessary re-renders of consumers
+  // (like useGeminiStream) which could otherwise trigger infinite loop warnings
+  // when re-subscribing to events.
+  const value = useMemo(
+    () => ({
+      vimEnabled,
+      vimMode,
+      toggleVimEnabled,
+      setVimMode,
+    }),
+    [vimEnabled, vimMode, toggleVimEnabled],
+  );
 
   return (
     <VimModeContext.Provider value={value}>{children}</VimModeContext.Provider>


### PR DESCRIPTION
## Summary

This PR fixes an issue where pressing `Escape` while in Vim INSERT mode would
incorrectly cancel the active Gemini request. The expected behavior is for
`Escape` to switch the editor to NORMAL mode without interrupting the stream,
unless already in NORMAL mode.

## Details

- Modified `InputPrompt.tsx` to allow `vimHandleInput` to process keys during
  streaming states.
- Updated `useGeminiStream.ts` to explicitly guard against cancellation in Vim
  INSERT mode.
- Optimized `VimModeContext.tsx` with `useMemo` to ensure stability and prevent
  re-render loops.

## Related Issues

Fixes #13503

## How to Validate

1.  Enable Vim mode.
2.  Send a prompt that generates a long response.
3.  You will be in INSERT mode after hitting Enter.
4.  Press `Escape`.
    - **Expected:** The editor switches to NORMAL mode (cursor changes/block
      cursor), and the stream **continues**.
5.  Press `Escape` again (while in NORMAL mode).
    - **Expected:** The request is cancelled.

https://github.com/user-attachments/assets/198e6812-2939-48b3-8942-d4fe22f758c3



## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
