### PR TITLE
feat(cli): tri-state '?' toggle for shortcuts input (#18547)

### DIFF
--- a/docs/cli/keyboard-shortcuts.md
+++ b/docs/cli/keyboard-shortcuts.md
@@ -128,9 +128,10 @@ available combinations.
 - `Option+B/F/M` (macOS only): Are interpreted as `Cmd+B/F/M` even if your
   terminal isn't configured to send Meta with Option.
 - `!` on an empty prompt: Enter or exit shell mode.
-- `?` on an empty prompt: Toggle the shortcuts panel above the input. Press
-  `Esc`, `Backspace`, or any printable key to close it. Press `?` again to close
-  the panel and insert a `?` into the prompt.
+- `?` on an empty prompt: First press opens the shortcuts panel, second press
+  closes it without inserting text, and third press inserts a literal `?`.
+  Pressing `Esc` or `Backspace` closes the panel. Pressing any other printable
+  key closes the panel and inserts that key.
 - `\` (at end of a line) + `Enter`: Insert a newline without leaving single-line
   mode.
 - `Esc` pressed twice quickly: Clear the input prompt if it is not empty,


### PR DESCRIPTION
## Summary

Implement tri-state input handling for `?` on an empty prompt so users can:
1. Open shortcuts help on first press,
2. Close help on second press (without inserting text),
3. Insert a literal `?` on third press.

## Details

- Added a dedicated tri-state tracker in `InputPrompt` for empty-prompt `?` behavior.
- Updated input handling so:
  - first `?` opens shortcuts help,
  - second `?` closes shortcuts help,
  - third `?` inserts literal `?`.
- Preserved existing close behavior for shortcuts help on `Esc`, `Backspace`, paste, and other printable keys.
- Added focused tests for the tri-state flow and for closing-on-other-printable-key behavior.
- Updated keyboard shortcuts docs to reflect the new sequence.

## Related Issues

Fixes #18547
Related to #18532

## How to Validate

1. Run targeted tests:
   - `npm run test --workspace @google/gemini-cli -- src/ui/components/InputPrompt.test.tsx`
   - Expected: test suite passes.
2. Run build:
   - `npm run build --workspace @google/gemini-cli`
   - Expected: build completes successfully.
3. Manual behavior check in CLI with empty input:
   - Press `?` once: shortcuts panel opens, input stays empty.
   - Press `?` again: panel closes, input stays empty.
   - Press `?` third time: literal `?` appears in input.
   - Open panel with `?`, then press `a`: panel closes and `a` is inserted.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
