### PR TITLE
fix(core): complete MCP discovery when configured servers are skipped

### DIFF
--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -103,6 +103,43 @@ describe('McpClientManager', () => {
     expect(manager.getDiscoveryState()).toBe(MCPDiscoveryState.COMPLETED);
   });
 
+  it('should mark discovery completed when all configured servers are user-disabled', async () => {
+    mockConfig.getMcpServers.mockReturnValue({
+      'test-server': {},
+    });
+    mockConfig.getMcpEnablementCallbacks.mockReturnValue({
+      isSessionDisabled: vi.fn().mockReturnValue(false),
+      isFileEnabled: vi.fn().mockResolvedValue(false),
+    });
+
+    const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
+    const promise = manager.startConfiguredMcpServers();
+    expect(manager.getDiscoveryState()).toBe(MCPDiscoveryState.IN_PROGRESS);
+    await promise;
+
+    expect(manager.getDiscoveryState()).toBe(MCPDiscoveryState.COMPLETED);
+    expect(manager.getMcpServerCount()).toBe(0);
+    expect(mockedMcpClient.connect).not.toHaveBeenCalled();
+    expect(mockedMcpClient.discover).not.toHaveBeenCalled();
+  });
+
+  it('should mark discovery completed when all configured servers are blocked', async () => {
+    mockConfig.getMcpServers.mockReturnValue({
+      'test-server': {},
+    });
+    mockConfig.getBlockedMcpServers.mockReturnValue(['test-server']);
+
+    const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
+    const promise = manager.startConfiguredMcpServers();
+    expect(manager.getDiscoveryState()).toBe(MCPDiscoveryState.IN_PROGRESS);
+    await promise;
+
+    expect(manager.getDiscoveryState()).toBe(MCPDiscoveryState.COMPLETED);
+    expect(manager.getMcpServerCount()).toBe(0);
+    expect(mockedMcpClient.connect).not.toHaveBeenCalled();
+    expect(mockedMcpClient.discover).not.toHaveBeenCalled();
+  });
+
   it('should not discover tools if folder is not trusted', async () => {
     mockConfig.getMcpServers.mockReturnValue({
       'test-server': {},

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -337,6 +337,15 @@ export class McpClientManager {
         this.maybeDiscoverMcpServer(name, config),
       ),
     );
+
+    // If every configured server was skipped (for example because all are
+    // disabled by user settings), no discovery promise is created. In that
+    // case we must still mark discovery complete or the UI will wait forever.
+    if (!this.discoveryPromise) {
+      this.discoveryState = MCPDiscoveryState.COMPLETED;
+      this.eventEmitter?.emit('mcp-client-update', this.clients);
+    }
+
     await this.cliConfig.refreshMcpContext();
   }
 

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -341,7 +341,7 @@ export class McpClientManager {
     // If every configured server was skipped (for example because all are
     // disabled by user settings), no discovery promise is created. In that
     // case we must still mark discovery complete or the UI will wait forever.
-    if (!this.discoveryPromise) {
+    if (this.discoveryState === MCPDiscoveryState.IN_PROGRESS) {
       this.discoveryState = MCPDiscoveryState.COMPLETED;
       this.eventEmitter?.emit('mcp-client-update', this.clients);
     }


### PR DESCRIPTION
## Summary

Fixes an MCP readiness edge case that could block normal prompt execution indefinitely.

When configured MCP servers are all skipped during startup (for example, user-disabled or blocked), discovery could remain in `IN_PROGRESS` forever. The UI then kept queueing prompts behind "Waiting for MCP servers to initialize...".

## Details

- Update `startConfiguredMcpServers()` in `packages/core/src/tools/mcp-client-manager.ts`:
  - after startup attempts complete, if no discovery promise exists, mark discovery as `COMPLETED` and emit `mcp-client-update`.
- Add regression coverage in `packages/core/src/tools/mcp-client-manager.test.ts`:
  - `should mark discovery completed when all configured servers are user-disabled`
  - `should mark discovery completed when all configured servers are blocked`

Behavioral flow:

```text
before: configured servers -> IN_PROGRESS -> all skipped -> no discovery promise -> stuck IN_PROGRESS
after:  configured servers -> IN_PROGRESS -> all skipped -> no discovery promise -> COMPLETE + update event
```

## Related Issues

Fixes #18585

## How to Validate

1. Run focused MCP manager tests:
   - `npm run test --workspace @google/gemini-cli-core -- src/tools/mcp-client-manager.test.ts`
2. Run MCP-related core tests:
   - `npm run test --workspace @google/gemini-cli-core -- src/tools/mcp-client.test.ts src/tools/mcp-tool.test.ts src/prompts/mcp-prompts.test.ts src/tools/xcode-mcp-fix-transport.test.ts src/code_assist/admin/mcpUtils.test.ts`
3. Run CLI MCP readiness queue tests:
   - `npm run test --workspace @google/gemini-cli -- src/ui/hooks/useMcpStatus.test.tsx src/ui/hooks/useMessageQueue.test.tsx`
4. Run full core suite:
   - `npm run test --workspace @google/gemini-cli-core`

Expected result: all listed suites pass; when all configured MCP servers are skipped, discovery transitions to `COMPLETED` and prompts are not permanently queued.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
