### PR TITLE
fix(core): ensure `enter_plan_mode` tool registration respects `experimental.plan`

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -2333,10 +2333,11 @@ describe('syncPlanModeTools', () => {
     expect(registeredTool).toBeInstanceOf(ExitPlanModeTool);
   });
 
-  it('should register EnterPlanModeTool and unregister ExitPlanModeTool when NOT in PLAN mode', async () => {
+  it('should register EnterPlanModeTool and unregister ExitPlanModeTool when NOT in PLAN mode and experimental.plan is enabled', async () => {
     const config = new Config({
       ...baseParams,
       approvalMode: ApprovalMode.DEFAULT,
+      plan: true,
     });
     const registry = new ToolRegistry(config, config.getMessageBus());
     vi.spyOn(config, 'getToolRegistry').mockReturnValue(registry);
@@ -2358,6 +2359,27 @@ describe('syncPlanModeTools', () => {
     const registeredTool = registerSpy.mock.calls[0][0];
     const { EnterPlanModeTool } = await import('../tools/enter-plan-mode.js');
     expect(registeredTool).toBeInstanceOf(EnterPlanModeTool);
+  });
+
+  it('should NOT register EnterPlanModeTool when experimental.plan is disabled', async () => {
+    const config = new Config({
+      ...baseParams,
+      approvalMode: ApprovalMode.DEFAULT,
+      plan: false,
+    });
+    const registry = new ToolRegistry(config, config.getMessageBus());
+    vi.spyOn(config, 'getToolRegistry').mockReturnValue(registry);
+
+    const registerSpy = vi.spyOn(registry, 'registerTool');
+    vi.spyOn(registry, 'getTool').mockReturnValue(undefined);
+
+    config.syncPlanModeTools();
+
+    const { EnterPlanModeTool } = await import('../tools/enter-plan-mode.js');
+    const registeredTool = registerSpy.mock.calls.find(
+      (call) => call[0] instanceof EnterPlanModeTool,
+    );
+    expect(registeredTool).toBeUndefined();
   });
 
   it('should call geminiClient.setTools if initialized', async () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1540,8 +1540,14 @@ export class Config {
       if (registry.getTool(EXIT_PLAN_MODE_TOOL_NAME)) {
         registry.unregisterTool(EXIT_PLAN_MODE_TOOL_NAME);
       }
-      if (!registry.getTool(ENTER_PLAN_MODE_TOOL_NAME)) {
-        registry.registerTool(new EnterPlanModeTool(this, this.messageBus));
+      if (this.planEnabled) {
+        if (!registry.getTool(ENTER_PLAN_MODE_TOOL_NAME)) {
+          registry.registerTool(new EnterPlanModeTool(this, this.messageBus));
+        }
+      } else {
+        if (registry.getTool(ENTER_PLAN_MODE_TOOL_NAME)) {
+          registry.unregisterTool(ENTER_PLAN_MODE_TOOL_NAME);
+        }
       }
     }
 


### PR DESCRIPTION
The `enter_plan_mode` tool was being registered unconditionally when not in plan mode. This change updates `syncPlanModeTools` to only register the tool if `experimental.plan` is enabled. Follow up to https://github.com/google-gemini/gemini-cli/pull/18352 where `syncPlanModeTools` was introduced. Added regression tests to verify that the tool is correctly registered or unregistered based on the `experimental.plan` setting.

Related to https://github.com/google-gemini/gemini-cli/issues/18334.
