### PR TITLE
Fix newline insertion bug in replace tool

### DIFF
--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -167,7 +167,7 @@ async function calculateFlexibleReplacement(
     if (isMatch) {
       flexibleOccurrences++;
       const firstLineInMatch = window[0];
-      const indentationMatch = firstLineInMatch.match(/^(\s*)/);
+      const indentationMatch = firstLineInMatch.match(/^([ \t]*)/);
       const indentation = indentationMatch ? indentationMatch[1] : '';
       const newBlockWithIndent = replaceLines.map(
         (line: string) => `${indentation}${line}`,
@@ -229,7 +229,7 @@ async function calculateRegexReplacement(
 
   // The final pattern captures leading whitespace (indentation) and then matches the token pattern.
   // 'm' flag enables multi-line mode, so '^' matches the start of any line.
-  const finalPattern = `^(\\s*)${pattern}`;
+  const finalPattern = `^([ \t]*)${pattern}`;
   const flexibleRegex = new RegExp(finalPattern, 'm');
 
   const match = flexibleRegex.exec(currentContent);


### PR DESCRIPTION
Fix issue where Gemini would sometimes "pad" blocks of code by adding newlines between every line.

## Summary

Restrict indentation capture to horizontal whitespace in calculateRegexReplacement and calculateFlexibleReplacement to prevent extra newlines from being inserted when the target block is preceded by blank lines.


## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

Fixes #18591 

## How to Validate

Give Gemini the following instructions:

>    1. Setup: Create a file named repro.py with exactly one leading blank line followed by a two-line function. Run this command:
>      printf "\ndef foo():\n    print(\"hello\")\n" > repro.py
>   2. Trigger: Use the replace tool with an old_string that contains an intentional whitespace error (two spaces after def) to force a flexible/regex match. It must be a multi-line replacement to see the bug:
>       * old_string: "def  foo():\n    print(\"hello\")"
>       * new_string: "def bar():\n    print(\"hello\")"
>   3. Verify: Read the file back.
>       * Fixed behavior: The file should contain exactly one blank line at the top, followed by the two lines of the function.
>       * Buggy behavior: An extra blank line will appear between def bar(): and print("hello") because the tool incorrectly includes the leading \n in its indentation capture.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
