### PR TITLE
docs: add legacy snippets convention to GEMINI.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -52,6 +52,10 @@ powerful tool for developers.
 
 ## Development Conventions
 
+- **Legacy Snippets:** `packages/core/src/prompts/snippets.legacy.ts` is a
+  snapshot of an older system prompt. Avoid changing the prompting verbiage to
+  preserve its historical behavior; however, structural changes to ensure
+  compilation or simplify the code are permitted.
 - **Contributions:** Follow the process outlined in `CONTRIBUTING.md`. Requires
   signing the Google CLA.
 - **Pull Requests:** Keep PRs small, focused, and linked to an existing issue.


### PR DESCRIPTION
## Summary

Add a development convention to `GEMINI.md` regarding `packages/core/src/prompts/snippets.legacy.ts`.

## Details

This update clarifies that `snippets.legacy.ts` is a snapshot of an older system prompt and its prompting verbiage should be preserved to maintain historical behavior. Structural changes for compilation or simplicity are still allowed.

## Related Issues

N/A

## How to Validate

Verify the content of `GEMINI.md`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
