### PR TITLE
feat: handle multiple dynamic context filenames in system prompt

### DIFF
--- a/packages/core/src/prompts/promptProvider.test.ts
+++ b/packages/core/src/prompts/promptProvider.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/core/src/prompts/promptProvider.test.ts
+++ b/packages/core/src/prompts/promptProvider.test.ts
@@ -7,7 +7,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PromptProvider } from './promptProvider.js';
 import type { Config } from '../config/config.js';
-import { getAllGeminiMdFilenames } from '../tools/memoryTool.js';
+import {
+  getAllGeminiMdFilenames,
+  DEFAULT_CONTEXT_FILENAME,
+} from '../tools/memoryTool.js';
 import { PREVIEW_GEMINI_MODEL } from '../config/models.js';
 
 vi.mock('../tools/memoryTool.js', async (importOriginal) => {
@@ -55,7 +58,7 @@ describe('PromptProvider', () => {
 
   it('should handle multiple context filenames in the system prompt', () => {
     vi.mocked(getAllGeminiMdFilenames).mockReturnValue([
-      'GEMINI.md',
+      DEFAULT_CONTEXT_FILENAME,
       'CUSTOM.md',
       'ANOTHER.md',
     ]);
@@ -65,13 +68,13 @@ describe('PromptProvider', () => {
 
     // Verify renderCoreMandates usage
     expect(prompt).toContain(
-      'Instructions found in `GEMINI.md`, `CUSTOM.md` or `ANOTHER.md` files are foundational mandates.',
+      `Instructions found in \`${DEFAULT_CONTEXT_FILENAME}\`, \`CUSTOM.md\` or \`ANOTHER.md\` files are foundational mandates.`,
     );
   });
 
   it('should handle multiple context filenames in user memory section', () => {
     vi.mocked(getAllGeminiMdFilenames).mockReturnValue([
-      'GEMINI.md',
+      DEFAULT_CONTEXT_FILENAME,
       'CUSTOM.md',
     ]);
 
@@ -83,7 +86,7 @@ describe('PromptProvider', () => {
 
     // Verify renderUserMemory usage
     expect(prompt).toContain(
-      '# Contextual Instructions (GEMINI.md, CUSTOM.md)',
+      `# Contextual Instructions (${DEFAULT_CONTEXT_FILENAME}, CUSTOM.md)`,
     );
   });
 });

--- a/packages/core/src/prompts/promptProvider.test.ts
+++ b/packages/core/src/prompts/promptProvider.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PromptProvider } from './promptProvider.js';
+import type { Config } from '../config/config.js';
+import { getAllGeminiMdFilenames } from '../tools/memoryTool.js';
+import { PREVIEW_GEMINI_MODEL } from '../config/models.js';
+
+vi.mock('../tools/memoryTool.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    getAllGeminiMdFilenames: vi.fn(),
+  };
+});
+
+vi.mock('../utils/gitUtils', () => ({
+  isGitRepository: vi.fn().mockReturnValue(false),
+}));
+
+describe('PromptProvider', () => {
+  let mockConfig: Config;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockConfig = {
+      getToolRegistry: vi.fn().mockReturnValue({
+        getAllToolNames: vi.fn().mockReturnValue([]),
+        getAllTools: vi.fn().mockReturnValue([]),
+      }),
+      getEnableShellOutputEfficiency: vi.fn().mockReturnValue(true),
+      storage: {
+        getProjectTempDir: vi.fn().mockReturnValue('/tmp/project-temp'),
+        getProjectTempPlansDir: vi
+          .fn()
+          .mockReturnValue('/tmp/project-temp/plans'),
+      },
+      isInteractive: vi.fn().mockReturnValue(true),
+      isInteractiveShellEnabled: vi.fn().mockReturnValue(true),
+      getSkillManager: vi.fn().mockReturnValue({
+        getSkills: vi.fn().mockReturnValue([]),
+      }),
+      getActiveModel: vi.fn().mockReturnValue(PREVIEW_GEMINI_MODEL),
+      getAgentRegistry: vi.fn().mockReturnValue({
+        getAllDefinitions: vi.fn().mockReturnValue([]),
+      }),
+      getApprovedPlanPath: vi.fn().mockReturnValue(undefined),
+      getApprovalMode: vi.fn(),
+    } as unknown as Config;
+  });
+
+  it('should handle multiple context filenames in the system prompt', () => {
+    vi.mocked(getAllGeminiMdFilenames).mockReturnValue([
+      'GEMINI.md',
+      'CUSTOM.md',
+      'ANOTHER.md',
+    ]);
+
+    const provider = new PromptProvider();
+    const prompt = provider.getCoreSystemPrompt(mockConfig);
+
+    // Verify renderCoreMandates usage
+    expect(prompt).toContain(
+      'Instructions found in `GEMINI.md`, `CUSTOM.md` or `ANOTHER.md` files are foundational mandates.',
+    );
+  });
+
+  it('should handle multiple context filenames in user memory section', () => {
+    vi.mocked(getAllGeminiMdFilenames).mockReturnValue([
+      'GEMINI.md',
+      'CUSTOM.md',
+    ]);
+
+    const provider = new PromptProvider();
+    const prompt = provider.getCoreSystemPrompt(
+      mockConfig,
+      'Some memory content',
+    );
+
+    // Verify renderUserMemory usage
+    expect(prompt).toContain(
+      '# Contextual Instructions (GEMINI.md, CUSTOM.md)',
+    );
+  });
+});

--- a/packages/core/src/prompts/promptProvider.ts
+++ b/packages/core/src/prompts/promptProvider.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/core/src/prompts/promptProvider.ts
+++ b/packages/core/src/prompts/promptProvider.ts
@@ -184,7 +184,6 @@ export class PromptProvider {
           : this.withSection('finalReminder', () => ({
               readFileToolName: READ_FILE_TOOL_NAME,
             })),
-        contextFilenames,
       } as snippets.SystemPromptOptions;
 
       basePrompt = (

--- a/packages/core/src/prompts/promptProvider.ts
+++ b/packages/core/src/prompts/promptProvider.ts
@@ -28,6 +28,7 @@ import {
 } from '../tools/tool-names.js';
 import { resolveModel, isPreviewModel } from '../config/models.js';
 import { DiscoveredMCPTool } from '../tools/mcp-tool.js';
+import { getAllGeminiMdFilenames } from '../tools/memoryTool.js';
 
 /**
  * Orchestrates prompt generation by gathering context and building options.
@@ -56,6 +57,7 @@ export class PromptProvider {
     const desiredModel = resolveModel(config.getActiveModel());
     const isGemini3 = isPreviewModel(desiredModel);
     const activeSnippets = isGemini3 ? snippets : legacySnippets;
+    const contextFilenames = getAllGeminiMdFilenames();
 
     // --- Context Gathering ---
     let planModeToolsList = PLAN_MODE_TOOLS.filter((t) =>
@@ -114,6 +116,7 @@ export class PromptProvider {
           interactive: interactiveMode,
           isGemini3,
           hasSkills: skills.length > 0,
+          contextFilenames,
         })),
         subAgents: this.withSection('agentContexts', () =>
           config
@@ -181,6 +184,7 @@ export class PromptProvider {
           : this.withSection('finalReminder', () => ({
               readFileToolName: READ_FILE_TOOL_NAME,
             })),
+        contextFilenames,
       } as snippets.SystemPromptOptions;
 
       basePrompt = (
@@ -191,7 +195,11 @@ export class PromptProvider {
     }
 
     // --- Finalization (Shell) ---
-    const finalPrompt = activeSnippets.renderFinalShell(basePrompt, userMemory);
+    const finalPrompt = activeSnippets.renderFinalShell(
+      basePrompt,
+      userMemory,
+      contextFilenames,
+    );
 
     // Sanitize erratic newlines from composition
     const sanitizedPrompt = finalPrompt.replace(/\n{3,}/g, '\n\n');

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -32,6 +32,7 @@ export interface SystemPromptOptions {
   operationalGuidelines?: OperationalGuidelinesOptions;
   sandbox?: SandboxMode;
   gitRepo?: GitRepoOptions;
+  contextFilenames?: string[];
 }
 
 export interface PreambleOptions {
@@ -42,6 +43,7 @@ export interface CoreMandatesOptions {
   interactive: boolean;
   isGemini3: boolean;
   hasSkills: boolean;
+  contextFilenames?: string[];
 }
 
 export interface PrimaryWorkflowsOptions {
@@ -120,11 +122,12 @@ ${renderGitRepo(options.gitRepo)}
 export function renderFinalShell(
   basePrompt: string,
   userMemory?: string,
+  contextFilenames?: string[],
 ): string {
   return `
 ${basePrompt.trim()}
 
-${renderUserMemory(userMemory)}
+${renderUserMemory(userMemory, contextFilenames)}
 `.trim();
 }
 
@@ -139,6 +142,15 @@ export function renderPreamble(options?: PreambleOptions): string {
 
 export function renderCoreMandates(options?: CoreMandatesOptions): string {
   if (!options) return '';
+  const filenames = options.contextFilenames ?? ['GEMINI.md'];
+  const formattedFilenames =
+    filenames.length > 1
+      ? filenames
+          .slice(0, -1)
+          .map((f) => `\`${f}\``)
+          .join(', ') + ` or \`${filenames[filenames.length - 1]}\``
+      : `\`${filenames[0]}\``;
+
   return `
 # Core Mandates
 
@@ -148,7 +160,7 @@ export function renderCoreMandates(options?: CoreMandatesOptions): string {
 - **Protocol:** Do not ask for permission to use tools; the system handles confirmation. Your responsibility is to justify the action, not to seek authorization.
 
 ## Engineering Standards
-- **Contextual Precedence:** Instructions found in \`GEMINI.md\` files are foundational mandates. They take absolute precedence over the general workflows and tool defaults described in this system prompt.
+- **Contextual Precedence:** Instructions found in ${formattedFilenames} files are foundational mandates. They take absolute precedence over the general workflows and tool defaults described in this system prompt.
 - **Conventions & Style:** Rigorously adhere to existing workspace conventions, architectural patterns, and style (naming, formatting, typing, commenting). During the research phase, analyze surrounding files, tests, and configuration to ensure your changes are seamless, idiomatic, and consistent with the local context. Never compromise idiomatic quality or completeness (e.g., proper declarations, type safety, documentation) to minimize tool calls; all supporting changes required by local conventions are part of a surgical update.
 - **Libraries/Frameworks:** NEVER assume a library/framework is available. Verify its established usage within the project (check imports, configuration files like 'package.json', 'Cargo.toml', 'requirements.txt', etc.) before employing it.
 - **Technical Integrity:** You are responsible for the entire lifecycle: implementation, testing, and validation. Within the scope of your changes, prioritize readability and long-term maintainability by consolidating logic into clean abstractions rather than threading state across unrelated layers. Align strictly with the requested architectural direction, ensuring the final implementation is focused and free of redundant "just-in-case" alternatives. Validation is not merely running tests; it is the exhaustive process of ensuring that every aspect of your change—behavioral, structural, and stylistic—is correct and fully compatible with the broader project. For bug fixes, you must empirically reproduce the failure with a new test case or reproduction script before applying the fix.
@@ -328,10 +340,15 @@ export function renderGitRepo(options?: GitRepoOptions): string {
 - Never push changes to a remote repository without being asked explicitly by the user.`.trim();
 }
 
-export function renderUserMemory(memory?: string): string {
+export function renderUserMemory(
+  memory?: string,
+  contextFilenames?: string[],
+): string {
   if (!memory || memory.trim().length === 0) return '';
+  const filenames = contextFilenames ?? ['GEMINI.md'];
+  const formattedHeader = filenames.join(', ');
   return `
-# Contextual Instructions (GEMINI.md)
+# Contextual Instructions (${formattedHeader})
 The following content is loaded from local and global configuration files.
 **Context Precedence:**
 - **Global (~/.gemini/):** foundational user preferences. Apply these broadly.
@@ -540,7 +557,7 @@ function toolUsageInteractive(
 ): string {
   if (interactive) {
     const ctrlF = interactiveShellEnabled
-      ? ' If you choose to execute an interactive command consider letting the user know they can press `ctrl + f` to focus into the shell to provide input.'
+      ? ' If you choose to execute an interactive command consider letting the user know they can press \`ctrl + f\` to focus into the shell to provide input.'
       : '';
     return `
 - **Background Processes:** To run a command in the background, set the \`is_background\` parameter to true. If unsure, ask the user.

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -18,6 +18,7 @@ import {
   WRITE_FILE_TOOL_NAME,
   WRITE_TODOS_TOOL_NAME,
 } from '../tools/tool-names.js';
+import { DEFAULT_CONTEXT_FILENAME } from '../tools/memoryTool.js';
 
 // --- Options Structs ---
 
@@ -32,7 +33,6 @@ export interface SystemPromptOptions {
   operationalGuidelines?: OperationalGuidelinesOptions;
   sandbox?: SandboxMode;
   gitRepo?: GitRepoOptions;
-  contextFilenames?: string[];
 }
 
 export interface PreambleOptions {
@@ -142,7 +142,7 @@ export function renderPreamble(options?: PreambleOptions): string {
 
 export function renderCoreMandates(options?: CoreMandatesOptions): string {
   if (!options) return '';
-  const filenames = options.contextFilenames ?? ['GEMINI.md'];
+  const filenames = options.contextFilenames ?? [DEFAULT_CONTEXT_FILENAME];
   const formattedFilenames =
     filenames.length > 1
       ? filenames
@@ -345,7 +345,7 @@ export function renderUserMemory(
   contextFilenames?: string[],
 ): string {
   if (!memory || memory.trim().length === 0) return '';
-  const filenames = contextFilenames ?? ['GEMINI.md'];
+  const filenames = contextFilenames ?? [DEFAULT_CONTEXT_FILENAME];
   const formattedHeader = filenames.join(', ');
   return `
 # Contextual Instructions (${formattedHeader})
@@ -557,7 +557,7 @@ function toolUsageInteractive(
 ): string {
   if (interactive) {
     const ctrlF = interactiveShellEnabled
-      ? ' If you choose to execute an interactive command consider letting the user know they can press \`ctrl + f\` to focus into the shell to provide input.'
+      ? ' If you choose to execute an interactive command consider letting the user know they can press `ctrl + f` to focus into the shell to provide input.'
       : '';
     return `
 - **Background Processes:** To run a command in the background, set the \`is_background\` parameter to true. If unsure, ask the user.


### PR DESCRIPTION
## Summary

This PR updates the system prompt to dynamically reflect the configured context filename(s). It replaces the hardcoded `GEMINI.md` string with the actual filename(s) from the configuration, supporting both single strings and arrays of filenames.

## Details

- Modified `packages/core/src/prompts/snippets.ts` to support `contextFilenames` as an array of strings in `SystemPromptOptions` and `CoreMandatesOptions`.
- Updated `renderCoreMandates` to format multiple filenames as a natural language list (e.g., "`GEMINI.md`, `CUSTOM.md` or `ANOTHER.md`").
- Updated `renderUserMemory` and `renderFinalShell` to propagate and display multiple filenames in the contextual instructions header.
- Updated `packages/core/src/prompts/promptProvider.ts` to retrieve all configured filenames using `getAllGeminiMdFilenames()` and pass them to the rendering functions.
- Removed an unused import `getCurrentGeminiMdFilename` in `promptProvider.ts` that was causing build failures.
- Added comprehensive unit tests in `packages/core/src/prompts/promptProvider.test.ts` to verify prompt generation with multiple context filenames.

## Related Issues

None.

## How to Validate

1. Run the new prompt provider tests:
   ```bash
   npm test -w @google/gemini-cli-core -- src/prompts/promptProvider.test.ts
   ```
2. Run existing core prompt tests:
   ```bash
   npm test -w @google/gemini-cli-core -- src/core/prompts.test.ts
   ```
3. (Optional) Manually verify by setting a custom context filename in `config.yaml` and checking the generated system prompt via `GEMINI_WRITE_SYSTEM_MD=true`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
