### PR TITLE
docs: add risk assessment for Lunar New Year release window

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -79,3 +79,15 @@ powerful tool for developers.
 - Documentation is located in the `docs/` directory.
 - Suggest documentation updates when code changes render existing documentation
   obsolete or incomplete.
+
+## Risk Assessment & Release Planning
+
+- **Lunar New Year Window (Feb 15 - Feb 22, 2026):** A significant portion of
+  the active developer and contributor base will be offline during this period.
+  Given the current architectural shift towards a more complex, IDE-like engine
+  (e.g., event-driven scheduler, XML sub-agents, and interactive UI refactors),
+  pushing a stable release around Feb 15 (Lunar New Year Eve) carries high risk.
+  Infrastructure instability or critical UX regressions (like ESC/Mouse
+  deadlocks) discovered during this window may experience delayed resolution. It
+  is recommended to implement a release freeze or prioritize stability over new
+  features during this period.


### PR DESCRIPTION
## Summary

Add a formal risk assessment to `GEMINI.md` regarding the upcoming Lunar New Year release window (Feb 15 - Feb 22, 2026).

## Details

The Gemini CLI is currently undergoing a significant architectural transition towards an event-driven, IDE-like engine (XML sub-agents, reactive UI refactors, etc.). A large portion of the active developer and contributor base will be offline during the Lunar New Year period. 

Pushing a stable release (e.g., v0.28.0 or v0.29.0) around February 15th poses a high risk, as any critical regressions or infrastructure failures discovered during this time may face delayed resolution. This PR documents this risk and recommends a release freeze or a focus on stability over new features during this window.

## Related Issues

Related to #18164 (Interactive stability concerns).

## How to Validate

Read the updated `GEMINI.md` file.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Linux (Termux/Android)
