### PR TITLE
fix(core): enforce coreTools restrictions for sub-agents and skills

### DIFF
--- a/packages/core/src/agents/codebase-investigator.test.ts
+++ b/packages/core/src/agents/codebase-investigator.test.ts
@@ -11,6 +11,7 @@ import {
   GREP_TOOL_NAME,
   LS_TOOL_NAME,
   READ_FILE_TOOL_NAME,
+  WEB_FETCH_TOOL_NAME,
 } from '../tools/tool-names.js';
 import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
 import { makeFakeConfig } from '../test-utils/config.js';
@@ -50,6 +51,7 @@ describe('CodebaseInvestigatorAgent', () => {
       READ_FILE_TOOL_NAME,
       GLOB_TOOL_NAME,
       GREP_TOOL_NAME,
+      WEB_FETCH_TOOL_NAME,
     ]);
   });
 

--- a/packages/core/src/agents/codebase-investigator.ts
+++ b/packages/core/src/agents/codebase-investigator.ts
@@ -10,6 +10,7 @@ import {
   GREP_TOOL_NAME,
   LS_TOOL_NAME,
   READ_FILE_TOOL_NAME,
+  WEB_FETCH_TOOL_NAME,
 } from '../tools/tool-names.js';
 import {
   DEFAULT_THINKING_MODE,
@@ -120,6 +121,7 @@ export const CodebaseInvestigatorAgent = (
         READ_FILE_TOOL_NAME,
         GLOB_TOOL_NAME,
         GREP_TOOL_NAME,
+        WEB_FETCH_TOOL_NAME,
       ],
     },
 


### PR DESCRIPTION
### Summary
This PR fixes a bug where sub-agent tools (like `codebase_investigator`) and the `activate_skill` tool were being registered even when they were explicitly excluded via the `coreTools` configuration.

### Underlying Issues
- Sub-agents were registered based only on `allowedTools`, ignoring the more restrictive `coreTools` list.
- `ActivateSkillTool` was being re-registered during skill discovery/refresh without checking if it was allowed by `coreTools`.
- These registration leaks caused behavioral evaluation failures (e.g., `save_memory`) because the agent (especially Gemini 3 / `auto` model) would try to use these tools, which would then fail due to missing dependencies in the restricted registry.
- `CodebaseInvestigatorAgent` was missing `web_fetch` in its `toolConfig`, despite its system prompt allowing it.

### Changes
- Introduced `isToolEnabledByCore` helper in `config.ts` to centralize tool enablement logic.
- Updated `registerSubAgentTools`, `initialize`, and `reloadSkills` to use this helper.
- Added `web_fetch` to `CodebaseInvestigatorAgent`.

### Validation
Verified 100% pass rate for `save_memory` evals with `GEMINI_MODEL=auto` locally.