### PR TITLE
fix(evals): update save_memory evals and simplify tool description

### DIFF
--- a/packages/core/src/tools/memoryTool.test.ts
+++ b/packages/core/src/tools/memoryTool.test.ts
@@ -102,7 +102,7 @@ describe('MemoryTool', () => {
       expect(memoryTool.name).toBe('save_memory');
       expect(memoryTool.displayName).toBe('SaveMemory');
       expect(memoryTool.description).toContain(
-        'Saves a specific piece of information',
+        'Saves concise global user context',
       );
       expect(memoryTool.schema).toBeDefined();
       expect(memoryTool.schema.name).toBe('save_memory');


### PR DESCRIPTION
## Summary

This PR fixes the failing `save_memory` behavioral evaluations by aligning them with the tool's core mandate: storing global user context, not workspace-local facts.

## Details

The original evaluations were 'testing for failure' by asking the agent to store project-specific details (DB schemas, entry points) in long-term global memory. This caused significant regressions, especially with Gemini 3 Pro, which correctly identified these as project-local facts and refused to call the tool.

Key changes:
- **Eval Updates**: Converted project-specific memory tests into negative evaluations that assert `save_memory` is **NOT** called.
- **Term Standardization**: Replaced 'project' with 'workspace' to clarify that context local to the current environment (including sub-folders) should remain local.
- **Tool Description**: Simplified and strengthened the `save_memory` description to explicitly forbid workspace-local facts while minimizing token usage.
- **Environment Stability**: Added standard file tools to evaluations to prevent hallucinations when models try to verify workspace context.

Verified stable passage across both Gemini 2.5 Pro and Gemini 3 Pro.

## Related Issues

Part of the ongoing behavioral evaluation stabilization effort.
