### PR TITLE
chore(evals): update validation_fidelity_pre_existing_errors to USUALLY_PASSES

### DIFF
--- a/evals/validation_fidelity_pre_existing_errors.eval.ts
+++ b/evals/validation_fidelity_pre_existing_errors.eval.ts
@@ -8,7 +8,7 @@ import { describe, expect } from 'vitest';
 import { evalTest } from './test-helper.js';
 
 describe('validation_fidelity_pre_existing_errors', () => {
-  evalTest('ALWAYS_PASSES', {
+  evalTest('USUALLY_PASSES', {
     name: 'should handle pre-existing project errors gracefully during validation',
     files: {
       'src/math.ts': `


### PR DESCRIPTION
## Summary

Update the `validation_fidelity_pre_existing_errors` eval policy from `ALWAYS_PASSES` to `USUALLY_PASSES`.

## Details

The `validation_fidelity_pre_existing_errors` test involves non-deterministic agent behavior and complex tool interaction (specifically around handling pre-existing errors during validation). Downgrading the policy to `USUALLY_PASSES` more accurately reflects its reliability and prevents CI noise while still allowing it to be tracked as a quality metric.

## Related Issues

N/A

## How to Validate

Run the eval manually (requires `RUN_EVALS=true`):
```bash
npm test -w @google/gemini-cli-integration-tests -- evals/validation_fidelity_pre_existing_errors.eval.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
