### PR TITLE
feat: enable plan mode experiment in settings

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -2,6 +2,7 @@
   "experimental": {
     "toolOutputMasking": {
       "enabled": true
-    }
+    },
+    "plan": true
   }
 }


### PR DESCRIPTION
This change enables the experimental 'Plan Mode' feature by adding 'plan: true' to the .gemini/settings.json file. This is intended to facilitate teamfooding and gather feedback on the new planning capabilities directly within the repository workflow.

Related to https://github.com/google-gemini/gemini-cli/issues/17571