### PR TITLE
feat(cli): add DevTools integration with gemini-cli-devtools

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -3,5 +3,8 @@
     "toolOutputMasking": {
       "enabled": true
     }
+  },
+  "general": {
+    "devtools": true
   }
 }

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -106,6 +106,10 @@ their corresponding top-level category object in your `settings.json` file.
   - **Description:** Enable Vim keybindings
   - **Default:** `false`
 
+- **`general.devtools`** (boolean):
+  - **Description:** Enable DevTools inspector on launch.
+  - **Default:** `false`
+
 - **`general.enableAutoUpdate`** (boolean):
   - **Description:** Enable automatic updates.
   - **Default:** `true`

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -63,6 +63,7 @@ const external = [
   '@lydell/node-pty-win32-arm64',
   '@lydell/node-pty-win32-x64',
   'keytar',
+  'gemini-cli-devtools',
 ];
 
 const baseConfig = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "@lydell/node-pty-linux-x64": "1.1.0",
         "@lydell/node-pty-win32-arm64": "1.1.0",
         "@lydell/node-pty-win32-x64": "1.1.0",
+        "gemini-cli-devtools": "^0.2.1",
         "keytar": "^7.9.0",
         "node-pty": "^1.0.0"
       }
@@ -9603,6 +9604,18 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/gemini-cli-devtools": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/gemini-cli-devtools/-/gemini-cli-devtools-0.2.1.tgz",
+      "integrity": "sha512-PcqPL9ZZjgjsp3oYhcXnUc6yNeLvdZuU/UQp0aT+DA8pt3BZzPzXthlOmIrRRqHBdLjMLPwN5GD29zR5bASXtQ==",
+      "optional": true,
+      "dependencies": {
+        "ws": "^8.16.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/gemini-cli-vscode-ide-companion": {

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "@lydell/node-pty-linux-x64": "1.1.0",
     "@lydell/node-pty-win32-arm64": "1.1.0",
     "@lydell/node-pty-win32-x64": "1.1.0",
+    "gemini-cli-devtools": "^0.2.1",
     "keytar": "^7.9.0",
     "node-pty": "^1.0.0"
   },

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -179,6 +179,15 @@ const SETTINGS_SCHEMA = {
         description: 'Enable Vim keybindings',
         showInDialog: true,
       },
+      devtools: {
+        type: 'boolean',
+        label: 'DevTools',
+        category: 'General',
+        requiresRestart: false,
+        default: false,
+        description: 'Enable DevTools inspector on launch.',
+        showInDialog: false,
+      },
       enableAutoUpdate: {
         type: 'boolean',
         label: 'Enable Auto Update',

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -531,8 +531,9 @@ export async function main() {
       for (const log of earlyConsoleLogs) {
         capture.logConsole(log);
       }
-      earlyConsoleLogs.length = 0;
     }
+    // Always clear early logs to avoid unbounded memory growth
+    earlyConsoleLogs.length = 0;
 
     // Register config for telemetry shutdown
     // This ensures telemetry (including SessionEnd hooks) is properly flushed on exit

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -39,7 +39,7 @@ import type { LoadedSettings } from './config/settings.js';
 vi.mock('./ui/hooks/atCommandProcessor.js');
 
 const mockRegisterActivityLogger = vi.hoisted(() => vi.fn());
-vi.mock('./utils/activityLogger.js', () => ({
+vi.mock('./utils/devtoolsService.js', () => ({
   registerActivityLogger: mockRegisterActivityLogger,
 }));
 

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -73,9 +73,9 @@ export async function runNonInteractive({
 
     if (process.env['GEMINI_CLI_ACTIVITY_LOG_TARGET']) {
       const { registerActivityLogger } = await import(
-        './utils/activityLogger.js'
+        './utils/devtoolsService.js'
       );
-      registerActivityLogger(config);
+      await registerActivityLogger(config);
     }
 
     const { stdout: workingStdout } = createWorkingStdio();

--- a/packages/cli/src/ui/utils/ConsolePatcher.ts
+++ b/packages/cli/src/ui/utils/ConsolePatcher.ts
@@ -49,18 +49,16 @@ export class ConsolePatcher {
   private patchConsoleMethod =
     (type: 'log' | 'warn' | 'error' | 'debug' | 'info') =>
     (...args: unknown[]) => {
+      if (type === 'debug' && !this.params.debugMode) return;
+
       if (this.params.stderr) {
-        if (type !== 'debug' || this.params.debugMode) {
-          this.originalConsoleError(this.formatArgs(args));
-        }
-      } else {
-        if (type !== 'debug' || this.params.debugMode) {
-          this.params.onNewMessage?.({
-            type,
-            content: this.formatArgs(args),
-            count: 1,
-          });
-        }
+        this.originalConsoleError(this.formatArgs(args));
       }
+
+      this.params.onNewMessage?.({
+        type,
+        content: this.formatArgs(args),
+        count: 1,
+      });
     };
 }

--- a/packages/cli/src/ui/utils/ConsolePatcher.ts
+++ b/packages/cli/src/ui/utils/ConsolePatcher.ts
@@ -49,16 +49,18 @@ export class ConsolePatcher {
   private patchConsoleMethod =
     (type: 'log' | 'warn' | 'error' | 'debug' | 'info') =>
     (...args: unknown[]) => {
-      if (type === 'debug' && !this.params.debugMode) return;
-
       if (this.params.stderr) {
-        this.originalConsoleError(this.formatArgs(args));
+        if (type !== 'debug' || this.params.debugMode) {
+          this.originalConsoleError(this.formatArgs(args));
+        }
+      } else {
+        if (type !== 'debug' || this.params.debugMode) {
+          this.params.onNewMessage?.({
+            type,
+            content: this.formatArgs(args),
+            count: 1,
+          });
+        }
       }
-
-      this.params.onNewMessage?.({
-        type,
-        content: this.formatArgs(args),
-        count: 1,
-      });
     };
 }

--- a/packages/cli/src/utils/devtoolsService.test.ts
+++ b/packages/cli/src/utils/devtoolsService.test.ts
@@ -1,0 +1,303 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { Config } from '@google/gemini-cli-core';
+
+// --- Mocks (hoisted) ---
+
+const mockInitActivityLogger = vi.hoisted(() => vi.fn());
+const mockAddNetworkTransport = vi.hoisted(() => vi.fn());
+
+type Listener = (...args: unknown[]) => void;
+
+const { MockWebSocket } = vi.hoisted(() => {
+  class MockWebSocket {
+    close = vi.fn();
+    url: string;
+    static instances: MockWebSocket[] = [];
+    private listeners = new Map<string, Listener[]>();
+
+    constructor(url: string) {
+      this.url = url;
+      MockWebSocket.instances.push(this);
+    }
+
+    on(event: string, fn: Listener) {
+      const fns = this.listeners.get(event) || [];
+      fns.push(fn);
+      this.listeners.set(event, fns);
+      return this;
+    }
+
+    emit(event: string, ...args: unknown[]) {
+      for (const fn of this.listeners.get(event) || []) {
+        fn(...args);
+      }
+    }
+
+    simulateOpen() {
+      this.emit('open');
+    }
+
+    simulateError() {
+      this.emit('error', new Error('ECONNREFUSED'));
+    }
+  }
+  return { MockWebSocket };
+});
+
+const mockDevToolsInstance = vi.hoisted(() => ({
+  start: vi.fn(),
+  stop: vi.fn(),
+  getPort: vi.fn(),
+}));
+
+vi.mock('./activityLogger.js', () => ({
+  initActivityLogger: mockInitActivityLogger,
+  addNetworkTransport: mockAddNetworkTransport,
+}));
+
+vi.mock('@google/gemini-cli-core', () => ({
+  debugLogger: {
+    log: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('ws', () => ({
+  default: MockWebSocket,
+}));
+
+vi.mock('gemini-cli-devtools', () => ({
+  DevTools: {
+    getInstance: () => mockDevToolsInstance,
+  },
+}));
+
+// --- Import under test (after mocks) ---
+import { registerActivityLogger, resetForTesting } from './devtoolsService.js';
+
+function createMockConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    isInteractive: vi.fn().mockReturnValue(true),
+    getSessionId: vi.fn().mockReturnValue('test-session'),
+    getDebugMode: vi.fn().mockReturnValue(false),
+    storage: { getProjectTempLogsDir: vi.fn().mockReturnValue('/tmp/logs') },
+    ...overrides,
+  } as unknown as Config;
+}
+
+describe('devtoolsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    MockWebSocket.instances = [];
+    resetForTesting();
+    delete process.env['GEMINI_CLI_ACTIVITY_LOG_TARGET'];
+  });
+
+  describe('registerActivityLogger', () => {
+    it('connects to existing DevTools server when probe succeeds', async () => {
+      const config = createMockConfig();
+
+      // The probe WebSocket will succeed
+      const promise = registerActivityLogger(config);
+
+      // Wait for WebSocket to be created
+      await vi.waitFor(() => {
+        expect(MockWebSocket.instances.length).toBe(1);
+      });
+
+      // Simulate probe success
+      MockWebSocket.instances[0].simulateOpen();
+
+      await promise;
+
+      expect(mockInitActivityLogger).toHaveBeenCalledWith(config, {
+        mode: 'network',
+        host: '127.0.0.1',
+        port: 25417,
+        onReconnectFailed: expect.any(Function),
+      });
+    });
+
+    it('starts new DevTools server when probe fails', async () => {
+      const config = createMockConfig();
+      mockDevToolsInstance.start.mockResolvedValue('http://127.0.0.1:25417');
+      mockDevToolsInstance.getPort.mockReturnValue(25417);
+
+      const promise = registerActivityLogger(config);
+
+      // Wait for probe WebSocket
+      await vi.waitFor(() => {
+        expect(MockWebSocket.instances.length).toBe(1);
+      });
+
+      // Simulate probe failure
+      MockWebSocket.instances[0].simulateError();
+
+      await promise;
+
+      expect(mockDevToolsInstance.start).toHaveBeenCalled();
+      expect(mockInitActivityLogger).toHaveBeenCalledWith(config, {
+        mode: 'network',
+        host: '127.0.0.1',
+        port: 25417,
+        onReconnectFailed: expect.any(Function),
+      });
+    });
+
+    it('falls back to file mode when target env var is set', async () => {
+      process.env['GEMINI_CLI_ACTIVITY_LOG_TARGET'] = '/tmp/test.jsonl';
+      const config = createMockConfig();
+
+      await registerActivityLogger(config);
+
+      expect(mockInitActivityLogger).toHaveBeenCalledWith(config, {
+        mode: 'file',
+        filePath: '/tmp/test.jsonl',
+      });
+    });
+
+    it('does nothing in file mode when config.storage is missing', async () => {
+      process.env['GEMINI_CLI_ACTIVITY_LOG_TARGET'] = '/tmp/test.jsonl';
+      const config = createMockConfig({ storage: undefined });
+
+      await registerActivityLogger(config);
+
+      expect(mockInitActivityLogger).not.toHaveBeenCalled();
+    });
+
+    it('falls back to file logging when DevTools start fails', async () => {
+      const config = createMockConfig();
+      mockDevToolsInstance.start.mockRejectedValue(
+        new Error('MODULE_NOT_FOUND'),
+      );
+
+      const promise = registerActivityLogger(config);
+
+      // Wait for probe WebSocket
+      await vi.waitFor(() => {
+        expect(MockWebSocket.instances.length).toBe(1);
+      });
+
+      // Probe fails → tries to start server → server start fails → file fallback
+      MockWebSocket.instances[0].simulateError();
+
+      await promise;
+
+      expect(mockInitActivityLogger).toHaveBeenCalledWith(config, {
+        mode: 'file',
+        filePath: undefined,
+      });
+    });
+  });
+
+  describe('startOrJoinDevTools (via registerActivityLogger)', () => {
+    it('stops own server and connects to existing when losing port race', async () => {
+      const config = createMockConfig();
+
+      // Server starts on a different port (lost the race)
+      mockDevToolsInstance.start.mockResolvedValue('http://127.0.0.1:25418');
+      mockDevToolsInstance.getPort.mockReturnValue(25418);
+
+      const promise = registerActivityLogger(config);
+
+      // First: probe for existing server (fails)
+      await vi.waitFor(() => {
+        expect(MockWebSocket.instances.length).toBe(1);
+      });
+      MockWebSocket.instances[0].simulateError();
+
+      // Second: after starting, probes the default port winner
+      await vi.waitFor(() => {
+        expect(MockWebSocket.instances.length).toBe(2);
+      });
+      // Winner is alive
+      MockWebSocket.instances[1].simulateOpen();
+
+      await promise;
+
+      expect(mockDevToolsInstance.stop).toHaveBeenCalled();
+      expect(mockInitActivityLogger).toHaveBeenCalledWith(
+        config,
+        expect.objectContaining({
+          mode: 'network',
+          host: '127.0.0.1',
+          port: 25417, // connected to winner's port
+        }),
+      );
+    });
+
+    it('keeps own server when winner is not responding', async () => {
+      const config = createMockConfig();
+
+      mockDevToolsInstance.start.mockResolvedValue('http://127.0.0.1:25418');
+      mockDevToolsInstance.getPort.mockReturnValue(25418);
+
+      const promise = registerActivityLogger(config);
+
+      // Probe for existing (fails)
+      await vi.waitFor(() => {
+        expect(MockWebSocket.instances.length).toBe(1);
+      });
+      MockWebSocket.instances[0].simulateError();
+
+      // Probe the winner (also fails)
+      await vi.waitFor(() => {
+        expect(MockWebSocket.instances.length).toBe(2);
+      });
+      MockWebSocket.instances[1].simulateError();
+
+      await promise;
+
+      expect(mockDevToolsInstance.stop).not.toHaveBeenCalled();
+      expect(mockInitActivityLogger).toHaveBeenCalledWith(
+        config,
+        expect.objectContaining({
+          mode: 'network',
+          port: 25418, // kept own port
+        }),
+      );
+    });
+  });
+
+  describe('handlePromotion (via onReconnectFailed)', () => {
+    it('caps promotion attempts at MAX_PROMOTION_ATTEMPTS', async () => {
+      const config = createMockConfig();
+      mockDevToolsInstance.start.mockResolvedValue('http://127.0.0.1:25417');
+      mockDevToolsInstance.getPort.mockReturnValue(25417);
+
+      // First: set up the logger so we can grab onReconnectFailed
+      const promise = registerActivityLogger(config);
+
+      await vi.waitFor(() => {
+        expect(MockWebSocket.instances.length).toBe(1);
+      });
+      MockWebSocket.instances[0].simulateError();
+
+      await promise;
+
+      // Extract onReconnectFailed callback
+      const initCall = mockInitActivityLogger.mock.calls[0];
+      const onReconnectFailed = initCall[1].onReconnectFailed;
+      expect(onReconnectFailed).toBeDefined();
+
+      // Trigger promotion MAX_PROMOTION_ATTEMPTS + 1 times
+      // Each call should succeed (addNetworkTransport called) until cap is hit
+      mockAddNetworkTransport.mockClear();
+
+      await onReconnectFailed(); // attempt 1
+      await onReconnectFailed(); // attempt 2
+      await onReconnectFailed(); // attempt 3
+      await onReconnectFailed(); // attempt 4 — should be capped
+
+      // Only 3 calls to addNetworkTransport (capped at MAX_PROMOTION_ATTEMPTS)
+      expect(mockAddNetworkTransport).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/packages/cli/src/utils/devtoolsService.ts
+++ b/packages/cli/src/utils/devtoolsService.ts
@@ -1,0 +1,163 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { debugLogger } from '@google/gemini-cli-core';
+import type { Config } from '@google/gemini-cli-core';
+import WebSocket from 'ws';
+import { initActivityLogger, addNetworkTransport } from './activityLogger.js';
+
+interface IDevTools {
+  start(): Promise<string>;
+  stop(): Promise<void>;
+  getPort(): number;
+}
+
+const DEVTOOLS_PKG = 'gemini-cli-devtools';
+const DEFAULT_DEVTOOLS_PORT = 25417;
+const DEFAULT_DEVTOOLS_HOST = '127.0.0.1';
+
+/**
+ * Probe whether a DevTools server is already listening on the given host:port.
+ * Returns true if a WebSocket handshake succeeds within a short timeout.
+ */
+function probeDevTools(host: string, port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const ws = new WebSocket(`ws://${host}:${port}/ws`);
+    const timer = setTimeout(() => {
+      ws.close();
+      resolve(false);
+    }, 500);
+
+    ws.on('open', () => {
+      clearTimeout(timer);
+      ws.close();
+      resolve(true);
+    });
+
+    ws.on('error', () => {
+      clearTimeout(timer);
+      resolve(false);
+    });
+  });
+}
+
+/**
+ * Start a DevTools server, then check if we won the default port.
+ * If another instance grabbed it first (race), stop ours and connect as client.
+ * Returns { host, port } of the DevTools to connect to.
+ */
+async function startOrJoinDevTools(
+  defaultHost: string,
+  defaultPort: number,
+): Promise<{ host: string; port: number }> {
+  const mod = await import(DEVTOOLS_PKG);
+  const devtools: IDevTools = mod.DevTools.getInstance();
+  const url = await devtools.start();
+  const actualPort = devtools.getPort();
+
+  if (actualPort === defaultPort) {
+    // We won the port — we are the server
+    debugLogger.log(`DevTools available at: ${url}`);
+    return { host: defaultHost, port: actualPort };
+  }
+
+  // Lost the race — someone else has the default port.
+  // Verify the winner is actually alive, then stop ours and connect to theirs.
+  const winnerAlive = await probeDevTools(defaultHost, defaultPort);
+  if (winnerAlive) {
+    await devtools.stop();
+    debugLogger.log(
+      `DevTools (existing) at: http://${defaultHost}:${defaultPort}`,
+    );
+    return { host: defaultHost, port: defaultPort };
+  }
+
+  // Winner isn't responding (maybe also racing and failed) — keep ours
+  debugLogger.log(`DevTools available at: ${url}`);
+  return { host: defaultHost, port: actualPort };
+}
+
+/**
+ * Handle promotion: when reconnect fails, start or join a DevTools server
+ * and add a new network transport for the logger.
+ */
+async function handlePromotion(config: Config) {
+  try {
+    const result = await startOrJoinDevTools(
+      DEFAULT_DEVTOOLS_HOST,
+      DEFAULT_DEVTOOLS_PORT,
+    );
+    addNetworkTransport(config, result.host, result.port, () =>
+      handlePromotion(config),
+    );
+  } catch (err) {
+    debugLogger.debug('Failed to promote to DevTools server:', err);
+  }
+}
+
+/**
+ * Registers the activity logger.
+ * Captures network and console logs via DevTools WebSocket or to a file.
+ *
+ * Environment variable GEMINI_CLI_ACTIVITY_LOG_TARGET controls the output:
+ * - file path (e.g., "/tmp/logs.jsonl") → file mode
+ * - not set → auto-start DevTools (reuses existing instance if already running)
+ *
+ * @param config The CLI configuration
+ */
+export async function registerActivityLogger(config: Config) {
+  const target = process.env['GEMINI_CLI_ACTIVITY_LOG_TARGET'];
+
+  if (!target) {
+    // No explicit target: try connecting to existing DevTools, then start new one
+    const onReconnectFailed = () => handlePromotion(config);
+
+    // Probe for an existing DevTools server
+    const existing = await probeDevTools(
+      DEFAULT_DEVTOOLS_HOST,
+      DEFAULT_DEVTOOLS_PORT,
+    );
+    if (existing) {
+      debugLogger.log(
+        `DevTools (existing) at: http://${DEFAULT_DEVTOOLS_HOST}:${DEFAULT_DEVTOOLS_PORT}`,
+      );
+      initActivityLogger(config, {
+        mode: 'network',
+        host: DEFAULT_DEVTOOLS_HOST,
+        port: DEFAULT_DEVTOOLS_PORT,
+        onReconnectFailed,
+      });
+      return;
+    }
+
+    // No existing server — start (or join if we lose the race)
+    try {
+      const result = await startOrJoinDevTools(
+        DEFAULT_DEVTOOLS_HOST,
+        DEFAULT_DEVTOOLS_PORT,
+      );
+      initActivityLogger(config, {
+        mode: 'network',
+        host: result.host,
+        port: result.port,
+        onReconnectFailed,
+      });
+      return;
+    } catch (err) {
+      debugLogger.debug(
+        'Failed to start DevTools, falling back to file logging:',
+        err,
+      );
+    }
+  }
+
+  // File mode fallback
+  if (!config.storage) {
+    return;
+  }
+
+  initActivityLogger(config, { mode: 'file', filePath: target });
+}

--- a/packages/cli/src/utils/devtoolsService.ts
+++ b/packages/cli/src/utils/devtoolsService.ts
@@ -41,6 +41,7 @@ function probeDevTools(host: string, port: number): Promise<boolean> {
 
     ws.on('error', () => {
       clearTimeout(timer);
+      ws.close();
       resolve(false);
     });
   });

--- a/packages/cli/src/utils/devtoolsService.ts
+++ b/packages/cli/src/utils/devtoolsService.ts
@@ -18,6 +18,8 @@ interface IDevTools {
 const DEVTOOLS_PKG = 'gemini-cli-devtools';
 const DEFAULT_DEVTOOLS_PORT = 25417;
 const DEFAULT_DEVTOOLS_HOST = '127.0.0.1';
+const MAX_PROMOTION_ATTEMPTS = 3;
+let promotionAttempts = 0;
 
 /**
  * Probe whether a DevTools server is already listening on the given host:port.
@@ -85,6 +87,14 @@ async function startOrJoinDevTools(
  * and add a new network transport for the logger.
  */
 async function handlePromotion(config: Config) {
+  promotionAttempts++;
+  if (promotionAttempts > MAX_PROMOTION_ATTEMPTS) {
+    debugLogger.debug(
+      `Giving up on DevTools promotion after ${MAX_PROMOTION_ATTEMPTS} attempts`,
+    );
+    return;
+  }
+
   try {
     const result = await startOrJoinDevTools(
       DEFAULT_DEVTOOLS_HOST,
@@ -160,4 +170,9 @@ export async function registerActivityLogger(config: Config) {
   }
 
   initActivityLogger(config, { mode: 'file', filePath: target });
+}
+
+/** Reset module-level state — test only. */
+export function resetForTesting() {
+  promotionAttempts = 0;
 }

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -42,6 +42,13 @@
           "default": false,
           "type": "boolean"
         },
+        "devtools": {
+          "title": "DevTools",
+          "description": "Enable DevTools inspector on launch.",
+          "markdownDescription": "Enable DevTools inspector on launch.\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `false`",
+          "default": false,
+          "type": "boolean"
+        },
         "enableAutoUpdate": {
           "title": "Enable Auto Update",
           "description": "Enable automatic updates.",


### PR DESCRIPTION
## Summary

Add a DevTools web inspector for Gemini CLI sessions. When enabled via `general.devtools`, the CLI streams network requests and console logs to a local DevTools web UI in real time.

## Details

- **`devtoolsService.ts`**: Manages DevTools server lifecycle — probes for existing instance, starts/joins with race handling, auto-promotes on reconnect failure
- **`activityLogger.ts`**: Adds WebSocket transport mode for streaming network/console logs to DevTools server, with auto-reconnect logic
- **`gemini.tsx`**: Initializes DevTools when `general.devtools` is enabled, replays early console logs
- Uses [`gemini-cli-devtools`](https://www.npmjs.com/package/gemini-cli-devtools) from npm as an external dynamic import (not bundled into `gemini.js`)
- `.gemini/settings.json` enables devtools by default for developers of this repo

## Related Issues

https://github.com/google-gemini/gemini-cli/issues/18494

## How to Validate

1. `npm install && npm run build`
2. `node bundle/gemini.js` — should print `DevTools available at: http://127.0.0.1:25417`
3. Open the URL in browser — Console and Network tabs should appear
4. Send a message in the CLI — network requests appear in DevTools
5. Verify copy/download JSON buttons work on request/response bodies
6. Disable with `"general": { "devtools": false }` in settings — CLI should start without DevTools

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run