### PR TITLE
fix(routing): lower auto-model complexity thresholds for PRO selection

### DIFF
--- a/packages/core/src/routing/strategies/numericalClassifierStrategy.test.ts
+++ b/packages/core/src/routing/strategies/numericalClassifierStrategy.test.ts
@@ -102,11 +102,11 @@ describe('NumericalClassifierStrategy', () => {
   });
 
   describe('A/B Testing Logic (Deterministic)', () => {
-    it('Control Group (SessionID "control-group-id" -> Threshold 50): Score 40 -> FLASH', async () => {
+    it('Control Group (SessionID "control-group-id" -> Threshold 30): Score 20 -> FLASH', async () => {
       vi.mocked(mockConfig.getSessionId).mockReturnValue('control-group-id'); // Hash 71 -> Control
       const mockApiResponse = {
-        complexity_reasoning: 'Standard task',
-        complexity_score: 40,
+        complexity_reasoning: 'Trivial task',
+        complexity_score: 20,
       };
       vi.mocked(mockBaseLlmClient.generateJson).mockResolvedValue(
         mockApiResponse,
@@ -123,16 +123,16 @@ describe('NumericalClassifierStrategy', () => {
         metadata: {
           source: 'NumericalClassifier (Control)',
           latencyMs: expect.any(Number),
-          reasoning: expect.stringContaining('Score: 40 / Threshold: 50'),
+          reasoning: expect.stringContaining('Score: 20 / Threshold: 30'),
         },
       });
     });
 
-    it('Control Group (SessionID "control-group-id" -> Threshold 50): Score 60 -> PRO', async () => {
+    it('Control Group (SessionID "control-group-id" -> Threshold 30): Score 40 -> PRO', async () => {
       vi.mocked(mockConfig.getSessionId).mockReturnValue('control-group-id');
       const mockApiResponse = {
-        complexity_reasoning: 'Complex task',
-        complexity_score: 60,
+        complexity_reasoning: 'Standard task',
+        complexity_score: 40,
       };
       vi.mocked(mockBaseLlmClient.generateJson).mockResolvedValue(
         mockApiResponse,
@@ -149,16 +149,16 @@ describe('NumericalClassifierStrategy', () => {
         metadata: {
           source: 'NumericalClassifier (Control)',
           latencyMs: expect.any(Number),
-          reasoning: expect.stringContaining('Score: 60 / Threshold: 50'),
+          reasoning: expect.stringContaining('Score: 40 / Threshold: 30'),
         },
       });
     });
 
-    it('Strict Group (SessionID "test-session-1" -> Threshold 80): Score 60 -> FLASH', async () => {
+    it('Strict Group (SessionID "test-session-1" -> Threshold 60): Score 50 -> FLASH', async () => {
       vi.mocked(mockConfig.getSessionId).mockReturnValue('test-session-1'); // FNV Normalized 18 < 50 -> Strict
       const mockApiResponse = {
-        complexity_reasoning: 'Complex task',
-        complexity_score: 60,
+        complexity_reasoning: 'Standard task',
+        complexity_score: 50,
       };
       vi.mocked(mockBaseLlmClient.generateJson).mockResolvedValue(
         mockApiResponse,
@@ -171,20 +171,20 @@ describe('NumericalClassifierStrategy', () => {
       );
 
       expect(decision).toEqual({
-        model: DEFAULT_GEMINI_FLASH_MODEL, // Routed to Flash because 60 < 80
+        model: DEFAULT_GEMINI_FLASH_MODEL, // Routed to Flash because 50 < 60
         metadata: {
           source: 'NumericalClassifier (Strict)',
           latencyMs: expect.any(Number),
-          reasoning: expect.stringContaining('Score: 60 / Threshold: 80'),
+          reasoning: expect.stringContaining('Score: 50 / Threshold: 60'),
         },
       });
     });
 
-    it('Strict Group (SessionID "test-session-1" -> Threshold 80): Score 90 -> PRO', async () => {
+    it('Strict Group (SessionID "test-session-1" -> Threshold 60): Score 70 -> PRO', async () => {
       vi.mocked(mockConfig.getSessionId).mockReturnValue('test-session-1');
       const mockApiResponse = {
-        complexity_reasoning: 'Extreme task',
-        complexity_score: 90,
+        complexity_reasoning: 'Complex task',
+        complexity_score: 70,
       };
       vi.mocked(mockBaseLlmClient.generateJson).mockResolvedValue(
         mockApiResponse,
@@ -201,7 +201,7 @@ describe('NumericalClassifierStrategy', () => {
         metadata: {
           source: 'NumericalClassifier (Strict)',
           latencyMs: expect.any(Number),
-          reasoning: expect.stringContaining('Score: 90 / Threshold: 80'),
+          reasoning: expect.stringContaining('Score: 70 / Threshold: 60'),
         },
       });
     });
@@ -289,10 +289,10 @@ describe('NumericalClassifierStrategy', () => {
     it('should fall back to A/B testing if CLASSIFIER_THRESHOLD is not present in experiments', async () => {
       // Mock getClassifierThreshold to return undefined
       vi.mocked(mockConfig.getClassifierThreshold).mockResolvedValue(undefined);
-      vi.mocked(mockConfig.getSessionId).mockReturnValue('control-group-id'); // Should resolve to Control (50)
+      vi.mocked(mockConfig.getSessionId).mockReturnValue('control-group-id'); // Should resolve to Control (30)
       const mockApiResponse = {
         complexity_reasoning: 'Test task',
-        complexity_score: 40,
+        complexity_score: 20,
       };
       vi.mocked(mockBaseLlmClient.generateJson).mockResolvedValue(
         mockApiResponse,
@@ -305,11 +305,11 @@ describe('NumericalClassifierStrategy', () => {
       );
 
       expect(decision).toEqual({
-        model: DEFAULT_GEMINI_FLASH_MODEL, // Score 40 < Default A/B Threshold 50
+        model: DEFAULT_GEMINI_FLASH_MODEL, // Score 20 < Default A/B Threshold 30
         metadata: {
           source: 'NumericalClassifier (Control)',
           latencyMs: expect.any(Number),
-          reasoning: expect.stringContaining('Score: 40 / Threshold: 50'),
+          reasoning: expect.stringContaining('Score: 20 / Threshold: 30'),
         },
       });
     });
@@ -319,7 +319,7 @@ describe('NumericalClassifierStrategy', () => {
       vi.mocked(mockConfig.getSessionId).mockReturnValue('control-group-id');
       const mockApiResponse = {
         complexity_reasoning: 'Test task',
-        complexity_score: 40,
+        complexity_score: 20,
       };
       vi.mocked(mockBaseLlmClient.generateJson).mockResolvedValue(
         mockApiResponse,
@@ -336,7 +336,7 @@ describe('NumericalClassifierStrategy', () => {
         metadata: {
           source: 'NumericalClassifier (Control)',
           latencyMs: expect.any(Number),
-          reasoning: expect.stringContaining('Score: 40 / Threshold: 50'),
+          reasoning: expect.stringContaining('Score: 20 / Threshold: 30'),
         },
       });
     });
@@ -346,7 +346,7 @@ describe('NumericalClassifierStrategy', () => {
       vi.mocked(mockConfig.getSessionId).mockReturnValue('control-group-id');
       const mockApiResponse = {
         complexity_reasoning: 'Test task',
-        complexity_score: 60,
+        complexity_score: 40,
       };
       vi.mocked(mockBaseLlmClient.generateJson).mockResolvedValue(
         mockApiResponse,
@@ -363,7 +363,7 @@ describe('NumericalClassifierStrategy', () => {
         metadata: {
           source: 'NumericalClassifier (Control)',
           latencyMs: expect.any(Number),
-          reasoning: expect.stringContaining('Score: 60 / Threshold: 50'),
+          reasoning: expect.stringContaining('Score: 40 / Threshold: 30'),
         },
       });
     });

--- a/packages/core/src/routing/strategies/numericalClassifierStrategy.ts
+++ b/packages/core/src/routing/strategies/numericalClassifierStrategy.ts
@@ -121,7 +121,7 @@ function getComplexityThreshold(sessionId: string): number {
   // 50% split:
   // 0-49: Strict (80)
   // 50-99: Control (50)
-  return normalized < 50 ? 80 : 50;
+  return normalized < 50 ? 60 : 30;
 }
 
 export class NumericalClassifierStrategy implements RoutingStrategy {
@@ -222,7 +222,7 @@ export class NumericalClassifierStrategy implements RoutingStrategy {
     } else {
       // Fallback to deterministic A/B test
       threshold = getComplexityThreshold(sessionId);
-      groupLabel = threshold === 80 ? 'Strict' : 'Control';
+      groupLabel = threshold === 60 ? 'Strict' : 'Control';
     }
 
     const modelAlias = score >= threshold ? PRO_MODEL : FLASH_MODEL;


### PR DESCRIPTION
## Summary

Fixes #18576

When using `auto-gemini-3`, the PRO model (`gemini-3-pro-preview`) is selected for only ~1 out of hundreds of requests. The root cause is that the complexity thresholds in the `NumericalClassifierStrategy` A/B test are too high relative to the scoring rubric:

- **Before:** Control group threshold = 50, Strict group threshold = 80
- **After:** Control group threshold = 30, Strict group threshold = 60

### Why the old thresholds were too high

The complexity rubric scores most typical CLI tasks in the 21-50 range ("Standard" category: single-file edits, simple refactors, fixing clear errors). With the old thresholds:
- **Control group (50):** Standard tasks (score 21-49) never qualified for PRO
- **Strict group (80):** Even High Complexity tasks (score 51-79) didn't qualify for PRO

With the new thresholds:
- **Control group (30):** Mid-range Standard+ tasks route to PRO
- **Strict group (60):** High Complexity+ tasks route to PRO

### Additional finding: Remote `CLASSIFIER_THRESHOLD` override

During testing, I observed that the server pushes a remote `CLASSIFIER_THRESHOLD` of **90** via experiment flags (`flagId: 45750527`, `intValue: '90'`). When present, this remote value overrides the local A/B thresholds entirely, requiring a complexity score ≥ 90 (essentially "Extreme" tasks only) for PRO selection. This remote threshold is likely the primary cause for users currently experiencing the issue. The local threshold fix in this PR serves as the correct fallback default, but the remote threshold may also need adjustment server-side.

## Changes

- `packages/core/src/routing/strategies/numericalClassifierStrategy.ts`:
  - `getComplexityThreshold()`: Changed thresholds from 80/50 to 60/30
  - `getRoutingDecision()`: Updated group label check from `=== 80` to `=== 60`
- `packages/core/src/routing/strategies/numericalClassifierStrategy.test.ts`:
  - Updated all A/B test cases and fallback test cases to reflect new thresholds

## Test plan

- [x] All 51 routing unit tests pass (`npx vitest run packages/core/src/routing/`)
- [x] Pre-commit hooks pass (prettier, eslint)
- [x] Verified routing behavior with `DEBUG=1 npm start` — confirmed remote threshold override behavior
- [ ] Maintainers to review if remote `CLASSIFIER_THRESHOLD` (currently 90) should also be lowered