### PR TITLE
feat: add `extensionsExplore` setting to enable extensions explore UI.

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1514,6 +1514,15 @@ const SETTINGS_SCHEMA = {
         description: 'Enable requesting and fetching of extension settings.',
         showInDialog: false,
       },
+      extensionsExplore: {
+        type: 'boolean',
+        label: 'Extensions Explore',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: false,
+        description: 'Enable extensions explore UI.',
+        showInDialog: false,
+      },
       extensionReloading: {
         type: 'boolean',
         label: 'Extension Reloading',


### PR DESCRIPTION
## Summary

add `extensionsExplore` setting to enable extensions explore UI.

## Related Issues

https://github.com/google-gemini/maintainers-gemini-cli/issues/1322

## How to Validate

Built the plugin: `npm run build:all`
Checked types: `tsc --noEmit locally via npm run typecheck`
Verified tests: `npm run test:ci -w @google/gemini-cli`
Ran full validation: `npm run preflight`

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ N/A ] Updated relevant documentation and README (if needed)
- [ N/A ] Added/updated tests (if needed)
- [ N/A ] Noted breaking changes (if any)
- [ N/A  ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
