### PR TITLE
Fix number of lines being reported in rewind confirmation dialog

### DIFF
--- a/packages/cli/src/ui/utils/rewindFileOps.test.ts
+++ b/packages/cli/src/ui/utils/rewindFileOps.test.ts
@@ -41,7 +41,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
       debug: vi.fn(),
     },
     getFileDiffFromResultDisplay: vi.fn(),
-    computeAddedAndRemovedLines: vi.fn(),
+    computeModelAddedAndRemovedLines: vi.fn(),
   };
 });
 
@@ -68,7 +68,7 @@ describe('rewindFileOps', () => {
     });
 
     it('calculates stats for single turn correctly', async () => {
-      const { getFileDiffFromResultDisplay, computeAddedAndRemovedLines } =
+      const { getFileDiffFromResultDisplay, computeModelAddedAndRemovedLines } =
         await import('@google/gemini-cli-core');
       vi.mocked(getFileDiffFromResultDisplay).mockReturnValue({
         filePath: 'test.ts',
@@ -88,7 +88,7 @@ describe('rewindFileOps', () => {
         },
         fileDiff: 'diff',
       });
-      vi.mocked(computeAddedAndRemovedLines).mockReturnValue({
+      vi.mocked(computeModelAddedAndRemovedLines).mockReturnValue({
         addedLines: 3,
         removedLines: 3,
       });
@@ -124,7 +124,7 @@ describe('rewindFileOps', () => {
 
   describe('calculateRewindImpact', () => {
     it('calculates cumulative stats across multiple turns', async () => {
-      const { getFileDiffFromResultDisplay, computeAddedAndRemovedLines } =
+      const { getFileDiffFromResultDisplay, computeModelAddedAndRemovedLines } =
         await import('@google/gemini-cli-core');
       vi.mocked(getFileDiffFromResultDisplay)
         .mockReturnValueOnce({
@@ -164,7 +164,7 @@ describe('rewindFileOps', () => {
           fileDiff: 'diff2',
         });
 
-      vi.mocked(computeAddedAndRemovedLines)
+      vi.mocked(computeModelAddedAndRemovedLines)
         .mockReturnValueOnce({ addedLines: 5, removedLines: 3 })
         .mockReturnValueOnce({ addedLines: 4, removedLines: 0 });
 

--- a/packages/cli/src/ui/utils/rewindFileOps.ts
+++ b/packages/cli/src/ui/utils/rewindFileOps.ts
@@ -14,7 +14,7 @@ import {
   coreEvents,
   debugLogger,
   getFileDiffFromResultDisplay,
-  computeAddedAndRemovedLines,
+  computeModelAddedAndRemovedLines,
 } from '@google/gemini-cli-core';
 
 export interface FileChangeDetail {
@@ -61,7 +61,7 @@ export function calculateTurnStats(
         if (fileDiff) {
           hasEdits = true;
           const stats = fileDiff.diffStat;
-          const calculations = computeAddedAndRemovedLines(stats);
+          const calculations = computeModelAddedAndRemovedLines(stats);
           addedLines += calculations.addedLines;
           removedLines += calculations.removedLines;
 
@@ -112,7 +112,7 @@ export function calculateRewindImpact(
         if (fileDiff) {
           hasEdits = true;
           const stats = fileDiff.diffStat;
-          const calculations = computeAddedAndRemovedLines(stats);
+          const calculations = computeModelAddedAndRemovedLines(stats);
           addedLines += calculations.addedLines;
           removedLines += calculations.removedLines;
           files.add(fileDiff.fileName);

--- a/packages/core/src/utils/fileDiffUtils.test.ts
+++ b/packages/core/src/utils/fileDiffUtils.test.ts
@@ -77,8 +77,8 @@ describe('fileDiffUtils', () => {
 
       const result = computeAddedAndRemovedLines(stats);
       expect(result).toEqual({
-        addedLines: 12, // 10 + 2
-        removedLines: 6, // 5 + 1
+        addedLines: 10,
+        removedLines: 5,
       });
     });
 

--- a/packages/core/src/utils/fileDiffUtils.test.ts
+++ b/packages/core/src/utils/fileDiffUtils.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   getFileDiffFromResultDisplay,
-  computeAddedAndRemovedLines,
+  computeModelAddedAndRemovedLines,
 } from './fileDiffUtils.js';
 import type { FileDiff, ToolResultDisplay } from '../tools/tools.js';
 
@@ -57,7 +57,7 @@ describe('fileDiffUtils', () => {
 
   describe('computeAddedAndRemovedLines', () => {
     it('returns 0 added and 0 removed if stats is undefined', () => {
-      expect(computeAddedAndRemovedLines(undefined)).toEqual({
+      expect(computeModelAddedAndRemovedLines(undefined)).toEqual({
         addedLines: 0,
         removedLines: 0,
       });
@@ -75,7 +75,7 @@ describe('fileDiffUtils', () => {
         user_removed_chars: 10,
       };
 
-      const result = computeAddedAndRemovedLines(stats);
+      const result = computeModelAddedAndRemovedLines(stats);
       expect(result).toEqual({
         addedLines: 10,
         removedLines: 5,
@@ -94,7 +94,7 @@ describe('fileDiffUtils', () => {
         user_removed_chars: 0,
       };
 
-      const result = computeAddedAndRemovedLines(stats);
+      const result = computeModelAddedAndRemovedLines(stats);
       expect(result).toEqual({
         addedLines: 0,
         removedLines: 0,

--- a/packages/core/src/utils/fileDiffUtils.ts
+++ b/packages/core/src/utils/fileDiffUtils.ts
@@ -44,7 +44,7 @@ export function computeAddedAndRemovedLines(
     };
   }
   return {
-    addedLines: stats.model_added_lines + stats.user_added_lines,
-    removedLines: stats.model_removed_lines + stats.user_removed_lines,
+    addedLines: stats.model_added_lines,
+    removedLines: stats.model_removed_lines,
   };
 }

--- a/packages/core/src/utils/fileDiffUtils.ts
+++ b/packages/core/src/utils/fileDiffUtils.ts
@@ -31,7 +31,7 @@ export function getFileDiffFromResultDisplay(
   return undefined;
 }
 
-export function computeAddedAndRemovedLines(
+export function computeModelAddedAndRemovedLines(
   stats: FileDiff['diffStat'] | undefined,
 ): {
   addedLines: number;


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Exclude `user_added_lines` and `user_removed_lines` from rewind viewer and rewind confirmation dialog. A large number of lines were being reported as removed and `user_removed_lines` was the culprit.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues
Fixes #18674 
<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate
Run a session in auto-edit mode with many edit and write tools called, there shouldn't be a large number of lines added or removed and should match with `git diff --numstat main`
<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
