### PR TITLE
test(cli): fix AppContainer act() warnings and improve waitFor resilience

### DIFF
--- a/packages/cli/src/test-utils/async.ts
+++ b/packages/cli/src/test-utils/async.ts
@@ -5,6 +5,7 @@
  */
 
 import { act } from 'react';
+import { vi } from 'vitest';
 
 // The waitFor from vitest doesn't properly wrap in act(), so we have to
 // implement our own like the one in @testing-library/react
@@ -13,7 +14,7 @@ import { act } from 'react';
 // for React state updates.
 export async function waitFor(
   assertion: () => void,
-  { timeout = 1000, interval = 50 } = {},
+  { timeout = 2000, interval = 50 } = {},
 ): Promise<void> {
   const startTime = Date.now();
 
@@ -27,7 +28,11 @@ export async function waitFor(
       }
 
       await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, interval));
+        if (vi.isFakeTimers()) {
+          await vi.advanceTimersByTimeAsync(interval);
+        } else {
+          await new Promise((resolve) => setTimeout(resolve, interval));
+        }
       });
     }
   }

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -146,12 +146,28 @@ vi.mock('./components/shared/text-buffer.js');
 vi.mock('./hooks/useLogger.js');
 vi.mock('./hooks/useInputHistoryStore.js');
 vi.mock('./hooks/useHookDisplayState.js');
+vi.mock('./hooks/useBanner.js', () => ({
+  useBanner: vi.fn((bannerData) => ({
+    bannerText: (
+      bannerData.warningText ||
+      bannerData.defaultText ||
+      ''
+    ).replace(/\\n/g, '\n'),
+  })),
+}));
+vi.mock('./hooks/useShellInactivityStatus.js', () => ({
+  useShellInactivityStatus: vi.fn(() => ({
+    shouldShowFocusHint: false,
+    inactivityStatus: 'none',
+  })),
+}));
 vi.mock('./hooks/useTerminalTheme.js', () => ({
   useTerminalTheme: vi.fn(),
 }));
 
 import { useHookDisplayState } from './hooks/useHookDisplayState.js';
 import { useTerminalTheme } from './hooks/useTerminalTheme.js';
+import { useShellInactivityStatus } from './hooks/useShellInactivityStatus.js';
 
 // Mock external utilities
 vi.mock('../utils/events.js');
@@ -255,6 +271,7 @@ describe('AppContainer State Management', () => {
   const mockedUseInputHistoryStore = useInputHistoryStore as Mock;
   const mockedUseHookDisplayState = useHookDisplayState as Mock;
   const mockedUseTerminalTheme = useTerminalTheme as Mock;
+  const mockedUseShellInactivityStatus = useShellInactivityStatus as Mock;
 
   const DEFAULT_GEMINI_STREAM_MOCK = {
     streamingState: 'idle',
@@ -384,6 +401,10 @@ describe('AppContainer State Management', () => {
     });
     mockedUseHookDisplayState.mockReturnValue([]);
     mockedUseTerminalTheme.mockReturnValue(undefined);
+    mockedUseShellInactivityStatus.mockReturnValue({
+      shouldShowFocusHint: false,
+      inactivityStatus: 'none',
+    });
 
     // Mock Config
     mockConfig = makeFakeConfig();
@@ -1246,8 +1267,15 @@ describe('AppContainer State Management', () => {
     });
 
     describe('Shell Focus Action Required', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         vi.useFakeTimers();
+        // Use real implementation for these tests to verify title updates
+        const actual = await vi.importActual<
+          typeof import('./hooks/useShellInactivityStatus.js')
+        >('./hooks/useShellInactivityStatus.js');
+        mockedUseShellInactivityStatus.mockImplementation(
+          actual.useShellInactivityStatus,
+        );
       });
 
       afterEach(() => {


### PR DESCRIPTION
## Summary

Fixes flaky and failing tests in `AppContainer.test.tsx` by addressing React `act()` warnings and improving the `waitFor` utility's resilience when using fake timers.

## Details

- **Mocked `useBanner` and `useShellInactivityStatus`**: These hooks were triggering background state updates during rendering, leading to "not wrapped in act()" warnings. Mocking them by default stabilizes the test environment.
- **Improved `waitFor` Utility**: Enhanced `packages/cli/src/test-utils/async.ts` to automatically advance timers using `vi.advanceTimersByTimeAsync` if `vi.isFakeTimers()` is true. This ensures that assertions dependent on time (like inactivity status) resolve correctly without manual timer manipulation in every `waitFor` block.
- **CI Resilience**: Increased the default `waitFor` timeout to 2000ms to reduce flakiness in slower environments like Windows CI.
- **Test Refactoring**: Updated `AppContainer.test.tsx` to use `vi.importActual` for terminal title tests that specifically require the real `useShellInactivityStatus` logic, while keeping the rest of the suite isolated.

## Related Issues

N/A (Discovered via CI failure in https://github.com/google-gemini/gemini-cli/actions/runs/21820047149/job/62950816295)

## How to Validate

Run the unit tests for the CLI package:
```bash
npm test -w @google/gemini-cli -- src/ui/AppContainer.test.tsx
```
Verify that all 78 tests pass without `act()` warnings.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
