### PR TITLE
docs: remove TOC marker from Plan Mode header

### DIFF
--- a/docs/cli/plan-mode.md
+++ b/docs/cli/plan-mode.md
@@ -1,4 +1,4 @@
-# Plan Mode (experimental) <!-- omit in toc -->
+# Plan Mode (experimental)
 
 Plan Mode is a safe, read-only mode for researching and designing complex
 changes. It prevents modifications while you research, design and plan an


### PR DESCRIPTION
Related to https://github.com/google-gemini/gemini-cli/issues/16871

Website doesn't handle comments in headers: 
<img width="2142" height="970" alt="image" src="https://github.com/user-attachments/assets/14691f3f-5572-45c5-9568-b0bdc81b28e5" />
