### PR TITLE
chore: un-export internal types and functions in cli package

### DIFF
--- a/packages/cli/src/config/config.integration.test.ts
+++ b/packages/cli/src/config/config.integration.test.ts
@@ -27,7 +27,7 @@ import { http, HttpResponse } from 'msw';
 
 import { setupServer } from 'msw/node';
 
-export const server = setupServer();
+const server = setupServer();
 
 // TODO(richieforeman): Consider moving this to test setup globally.
 beforeAll(() => {

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -1105,7 +1105,7 @@ export async function inferInstallMetadata(
   }
 }
 
-export function getExtensionId(
+function getExtensionId(
   config: ExtensionConfig,
   installMetadata?: ExtensionInstallMetadata,
 ): string {

--- a/packages/cli/src/utils/deepMerge.ts
+++ b/packages/cli/src/utils/deepMerge.ts
@@ -6,7 +6,7 @@
 
 import { MergeStrategy } from '../config/settingsSchema.js';
 
-export type Mergeable =
+type Mergeable =
   | string
   | number
   | boolean
@@ -15,7 +15,7 @@ export type Mergeable =
   | object
   | Mergeable[];
 
-export type MergeableObject = Record<string, Mergeable>;
+type MergeableObject = Record<string, Mergeable>;
 
 function isPlainObject(item: unknown): item is MergeableObject {
   return !!item && typeof item === 'object' && !Array.isArray(item);

--- a/packages/cli/src/utils/settingsUtils.ts
+++ b/packages/cli/src/utils/settingsUtils.ts
@@ -41,7 +41,7 @@ function flattenSchema(schema: SettingsSchema, prefix = ''): FlattenedSchema {
 let _FLATTENED_SCHEMA: FlattenedSchema | undefined;
 
 /** Returns a flattened schema, the first call is memoized for future requests. */
-export function getFlattenedSchema() {
+function getFlattenedSchema() {
   return (
     _FLATTENED_SCHEMA ??
     (_FLATTENED_SCHEMA = flattenSchema(getSettingsSchema()))
@@ -132,10 +132,7 @@ export function getRestartRequiredSettings(): string[] {
 /**
  * Recursively gets a value from a nested object using a key path array.
  */
-export function getNestedValue(
-  obj: Record<string, unknown>,
-  path: string[],
-): unknown {
+function getNestedValue(obj: Record<string, unknown>, path: string[]): unknown {
   const [first, ...rest] = path;
   if (!first || !(first in obj)) {
     return undefined;


### PR DESCRIPTION
## Summary

This PR un-exports several internal types and functions in the `cli` package that were identified as unused outside their respective modules by `ts-prune`.

## Details

The following symbols have been un-exported:
- `Mergeable` and `MergeableObject` in `packages/cli/src/utils/deepMerge.ts`
- `getFlattenedSchema` and `getNestedValue` in `packages/cli/src/utils/settingsUtils.ts`
- `getExtensionId` in `packages/cli/src/config/extension-manager.ts`
- `server` (MSW mock server) in `packages/cli/src/config/config.integration.test.ts`

Reducing the public surface area of internal modules improves maintainability and makes it clearer which symbols are intended for cross-module use.

## Related Issues

Related to #18007

## How to Validate

1. Run `npm run typecheck` to ensure no external dependencies were broken.
2. Run `npm run build` to ensure the project still builds.
3. Run `npm run test` in the `cli` package to ensure tests still pass.

## Pre-Merge Checklist

- [x] Validated on MacOS (`npm run preflight` passed locally)