### PR TITLE
feat: add `extensionsExplore` setting to enable extensions explore UI.

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -855,6 +855,11 @@ their corresponding top-level category object in your `settings.json` file.
   - **Default:** `true`
   - **Requires restart:** Yes
 
+- **`experimental.extensionRegistry`** (boolean):
+  - **Description:** Enable extension registry explore UI.
+  - **Default:** `false`
+  - **Requires restart:** Yes
+
 - **`experimental.extensionReloading`** (boolean):
   - **Description:** Enables extension loading/unloading within the CLI session.
   - **Default:** `false`

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1514,6 +1514,15 @@ const SETTINGS_SCHEMA = {
         description: 'Enable requesting and fetching of extension settings.',
         showInDialog: false,
       },
+      extensionRegistry: {
+        type: 'boolean',
+        label: 'Extension Registry Explore UI',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: false,
+        description: 'Enable extension registry explore UI.',
+        showInDialog: false,
+      },
       extensionReloading: {
         type: 'boolean',
         label: 'Extension Reloading',

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1466,6 +1466,13 @@
           "default": true,
           "type": "boolean"
         },
+        "extensionRegistry": {
+          "title": "Extension Registry Explore UI",
+          "description": "Enable extension registry explore UI.",
+          "markdownDescription": "Enable extension registry explore UI.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
+          "default": false,
+          "type": "boolean"
+        },
         "extensionReloading": {
           "title": "Extension Reloading",
           "description": "Enables extension loading/unloading within the CLI session.",


### PR DESCRIPTION
## Summary

add `extensionsRegistry` setting to enable extensions explore UI.
Run `npm run schema:settings` to update the json.

## Related Issues

https://github.com/google-gemini/maintainers-gemini-cli/issues/1322

## How to Validate

Built the plugin: `npm run build:all`
Checked types: `tsc --noEmit locally via npm run typecheck`
Verified tests: `npm run test:ci -w @google/gemini-cli`
Ran full validation: `npm run preflight`

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ N/A ] Updated relevant documentation and README (if needed)
- [ N/A ] Added/updated tests (if needed)
- [ N/A ] Noted breaking changes (if any)
- [ N/A  ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker