### PR TITLE
chore: un-export internal core symbols and types

### DIFF
--- a/packages/cli/src/config/config.integration.test.ts
+++ b/packages/cli/src/config/config.integration.test.ts
@@ -27,7 +27,7 @@ import { http, HttpResponse } from 'msw';
 
 import { setupServer } from 'msw/node';
 
-export const server = setupServer();
+const server = setupServer();
 
 // TODO(richieforeman): Consider moving this to test setup globally.
 beforeAll(() => {

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -1105,7 +1105,7 @@ export async function inferInstallMetadata(
   }
 }
 
-export function getExtensionId(
+function getExtensionId(
   config: ExtensionConfig,
   installMetadata?: ExtensionInstallMetadata,
 ): string {

--- a/packages/cli/src/utils/deepMerge.ts
+++ b/packages/cli/src/utils/deepMerge.ts
@@ -6,7 +6,7 @@
 
 import { MergeStrategy } from '../config/settingsSchema.js';
 
-export type Mergeable =
+type Mergeable =
   | string
   | number
   | boolean
@@ -15,7 +15,7 @@ export type Mergeable =
   | object
   | Mergeable[];
 
-export type MergeableObject = Record<string, Mergeable>;
+type MergeableObject = Record<string, Mergeable>;
 
 function isPlainObject(item: unknown): item is MergeableObject {
   return !!item && typeof item === 'object' && !Array.isArray(item);

--- a/packages/cli/src/utils/settingsUtils.ts
+++ b/packages/cli/src/utils/settingsUtils.ts
@@ -41,7 +41,7 @@ function flattenSchema(schema: SettingsSchema, prefix = ''): FlattenedSchema {
 let _FLATTENED_SCHEMA: FlattenedSchema | undefined;
 
 /** Returns a flattened schema, the first call is memoized for future requests. */
-export function getFlattenedSchema() {
+function getFlattenedSchema() {
   return (
     _FLATTENED_SCHEMA ??
     (_FLATTENED_SCHEMA = flattenSchema(getSettingsSchema()))
@@ -132,10 +132,7 @@ export function getRestartRequiredSettings(): string[] {
 /**
  * Recursively gets a value from a nested object using a key path array.
  */
-export function getNestedValue(
-  obj: Record<string, unknown>,
-  path: string[],
-): unknown {
+function getNestedValue(obj: Record<string, unknown>, path: string[]): unknown {
   const [first, ...rest] = path;
   if (!first || !(first in obj)) {
     return undefined;

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -13,12 +13,6 @@ export {
   DEFAULT_GEMINI_FLASH_LITE_MODEL,
   DEFAULT_GEMINI_EMBEDDING_MODEL,
 } from './src/config/models.js';
-export {
-  serializeTerminalToObject,
-  type AnsiOutput,
-  type AnsiLine,
-  type AnsiToken,
-} from './src/utils/terminalSerializer.js';
 export { DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD } from './src/config/config.js';
 export { detectIdeFromEnv } from './src/ide/detect-ide.js';
 export {

--- a/packages/core/src/agents/a2aUtils.ts
+++ b/packages/core/src/agents/a2aUtils.ts
@@ -28,7 +28,7 @@ export function extractMessageText(message: Message | undefined): string {
 /**
  * Extracts text from a single Part.
  */
-export function extractPartText(part: Part): string {
+function extractPartText(part: Part): string {
   if (isTextPart(part)) {
     return part.text;
   }

--- a/packages/core/src/agents/acknowledgedAgents.ts
+++ b/packages/core/src/agents/acknowledgedAgents.ts
@@ -10,7 +10,7 @@ import { Storage } from '../config/storage.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { getErrorMessage, isNodeError } from '../utils/errors.js';
 
-export interface AcknowledgedAgentsMap {
+interface AcknowledgedAgentsMap {
   // Project Path -> Agent Name -> Agent Hash
   [projectPath: string]: {
     [agentName: string]: string;

--- a/packages/core/src/agents/agent-scheduler.ts
+++ b/packages/core/src/agents/agent-scheduler.ts
@@ -16,7 +16,7 @@ import type { EditorType } from '../utils/editor.js';
 /**
  * Options for scheduling agent tools.
  */
-export interface AgentSchedulingOptions {
+interface AgentSchedulingOptions {
   /** The unique ID for this agent's scheduler. */
   schedulerId: string;
   /** The ID of the tool call that invoked this agent. */

--- a/packages/core/src/availability/modelAvailabilityService.ts
+++ b/packages/core/src/availability/modelAvailabilityService.ts
@@ -7,9 +7,9 @@
 export type ModelId = string;
 
 type TerminalUnavailabilityReason = 'quota' | 'capacity';
-export type TurnUnavailabilityReason = 'retry_once_per_turn';
+type TurnUnavailabilityReason = 'retry_once_per_turn';
 
-export type UnavailabilityReason =
+type UnavailabilityReason =
   | TerminalUnavailabilityReason
   | TurnUnavailabilityReason
   | 'unknown';
@@ -24,7 +24,7 @@ type HealthState =
       consumed: boolean;
     };
 
-export interface ModelAvailabilitySnapshot {
+interface ModelAvailabilitySnapshot {
   available: boolean;
   reason?: UnavailabilityReason;
 }

--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -28,7 +28,7 @@ import type {
 } from '@google/genai';
 import { GenerateContentResponse } from '@google/genai';
 
-export interface CAGenerateContentRequest {
+interface CAGenerateContentRequest {
   model: string;
   project?: string;
   user_prompt_id?: string;
@@ -84,7 +84,7 @@ interface VertexGenerateContentResponse {
   modelVersion?: string;
 }
 
-export interface CaCountTokenRequest {
+interface CaCountTokenRequest {
   request: VertexCountTokenRequest;
 }
 

--- a/packages/core/src/config/projectRegistry.ts
+++ b/packages/core/src/config/projectRegistry.ts
@@ -10,7 +10,7 @@ import * as os from 'node:os';
 import { lock } from 'proper-lockfile';
 import { debugLogger } from '../utils/debugLogger.js';
 
-export interface RegistryData {
+interface RegistryData {
   projects: Record<string, string>;
 }
 

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -38,7 +38,7 @@ import type { ToolCallConfirmationDetails } from '../tools/tools.js';
  * Main hook system that coordinates all hook-related functionality
  */
 
-export interface BeforeModelHookResult {
+interface BeforeModelHookResult {
   /** Whether the model call was blocked */
   blocked: boolean;
   /** Whether the execution should be stopped entirely */
@@ -56,7 +56,7 @@ export interface BeforeModelHookResult {
 /**
  * Result from firing the BeforeToolSelection hook.
  */
-export interface BeforeToolSelectionHookResult {
+interface BeforeToolSelectionHookResult {
   /** Modified tool config */
   toolConfig?: ToolConfig;
   /** Modified tools */
@@ -67,7 +67,7 @@ export interface BeforeToolSelectionHookResult {
  * Result from firing the AfterModel hook.
  * Contains either a modified response or indicates to use the original chunk.
  */
-export interface AfterModelHookResult {
+interface AfterModelHookResult {
   /** The response to yield (either modified or original) */
   response: GenerateContentResponse;
   /** Whether the execution should be stopped entirely */

--- a/packages/core/src/hooks/hookTranslator.ts
+++ b/packages/core/src/hooks/hookTranslator.ts
@@ -73,7 +73,7 @@ export interface HookToolConfig {
 /**
  * Base class for hook translators - handles version-specific translation logic
  */
-export abstract class HookTranslator {
+abstract class HookTranslator {
   abstract toHookLLMRequest(sdkRequest: GenerateContentParameters): LLMRequest;
   abstract fromHookLLMRequest(
     hookRequest: LLMRequest,

--- a/packages/core/src/ide/detect-ide.ts
+++ b/packages/core/src/ide/detect-ide.ts
@@ -38,7 +38,7 @@ export function isCloudShell(): boolean {
   return !!(process.env['EDITOR_IN_CLOUD_SHELL'] || process.env['CLOUD_SHELL']);
 }
 
-export function isJetBrains(): boolean {
+function isJetBrains(): boolean {
   return !!process.env['TERMINAL_EMULATOR']
     ?.toLowerCase()
     .includes('jetbrains');

--- a/packages/core/src/ide/ide-connection-utils.ts
+++ b/packages/core/src/ide/ide-connection-utils.ts
@@ -26,7 +26,7 @@ export type StdioConfig = {
   args: string[];
 };
 
-export type ConnectionConfig = {
+type ConnectionConfig = {
   port?: string;
   authToken?: string;
   stdio?: StdioConfig;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,7 +56,6 @@ export * from './core/apiKeyCredentialStorage.js';
 
 // Export utilities
 export * from './utils/fetch.js';
-export { homedir, tmpdir } from './utils/paths.js';
 export * from './utils/paths.js';
 export * from './utils/checks.js';
 export * from './utils/schemaValidator.js';

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -17,8 +17,6 @@ import { coreEvents } from '../utils/events.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { getConsentForOauth } from '../utils/authConsent.js';
 
-export const OAUTH_DISPLAY_MESSAGE_EVENT = 'oauth-display-message' as const;
-
 /**
  * OAuth configuration for an MCP server.
  */
@@ -38,7 +36,7 @@ export interface MCPOAuthConfig {
 /**
  * OAuth authorization response.
  */
-export interface OAuthAuthorizationResponse {
+interface OAuthAuthorizationResponse {
   code: string;
   state: string;
 }
@@ -57,7 +55,7 @@ export interface OAuthTokenResponse {
 /**
  * Dynamic client registration request (RFC 7591).
  */
-export interface OAuthClientRegistrationRequest {
+interface OAuthClientRegistrationRequest {
   client_name: string;
   redirect_uris: string[];
   grant_types: string[];

--- a/packages/core/src/safety/checker-runner.ts
+++ b/packages/core/src/safety/checker-runner.ts
@@ -36,7 +36,7 @@ const SafetyCheckResultSchema: z.ZodType<SafetyCheckResult> =
 /**
  * Configuration for the checker runner.
  */
-export interface CheckerRunnerConfig {
+interface CheckerRunnerConfig {
   /**
    * Maximum time (in milliseconds) to wait for a checker to complete.
    * Default: 5000 (5 seconds)

--- a/packages/core/src/scheduler/confirmation.ts
+++ b/packages/core/src/scheduler/confirmation.ts
@@ -30,7 +30,7 @@ import type { DiffUpdateResult } from '../ide/ide-client.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { coreEvents } from '../utils/events.js';
 
-export interface ConfirmationResult {
+interface ConfirmationResult {
   outcome: ToolConfirmationOutcome;
   payload?: ToolConfirmationPayload;
 }
@@ -38,7 +38,7 @@ export interface ConfirmationResult {
 /**
  * Result of the full confirmation flow, including any user modifications.
  */
-export interface ResolutionResult {
+interface ResolutionResult {
   outcome: ToolConfirmationOutcome;
   lastDetails?: SerializableConfirmationDetails;
 }

--- a/packages/core/src/scheduler/tool-modifier.ts
+++ b/packages/core/src/scheduler/tool-modifier.ts
@@ -14,7 +14,7 @@ import {
 import type { ToolConfirmationPayload } from '../tools/tools.js';
 import type { WaitingToolCall } from './types.js';
 
-export interface ModificationResult {
+interface ModificationResult {
   updatedParams: Record<string, unknown>;
   updatedDiff?: string;
 }

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -36,18 +36,18 @@ import { PreCompressTrigger } from '../hooks/types.js';
  * Default threshold for compression token count as a fraction of the model's
  * token limit. If the chat history exceeds this threshold, it will be compressed.
  */
-export const DEFAULT_COMPRESSION_TOKEN_THRESHOLD = 0.5;
+const DEFAULT_COMPRESSION_TOKEN_THRESHOLD = 0.5;
 
 /**
  * The fraction of the latest chat history to keep. A value of 0.3
  * means that only the last 30% of the chat history will be kept after compression.
  */
-export const COMPRESSION_PRESERVE_THRESHOLD = 0.3;
+const COMPRESSION_PRESERVE_THRESHOLD = 0.3;
 
 /**
  * The budget for function response tokens in the preserved history.
  */
-export const COMPRESSION_FUNCTION_RESPONSE_TOKEN_BUDGET = 50_000;
+const COMPRESSION_FUNCTION_RESPONSE_TOKEN_BUDGET = 50_000;
 
 /**
  * Returns the index of the oldest item to keep when compressing. May return

--- a/packages/core/src/services/modelConfigService.ts
+++ b/packages/core/src/services/modelConfigService.ts
@@ -60,7 +60,7 @@ export type ResolvedModelConfig = _ResolvedModelConfig & {
   readonly _brand: unique symbol;
 };
 
-export interface _ResolvedModelConfig {
+interface _ResolvedModelConfig {
   model: string; // The actual, resolved model name
   generateContentConfig: GenerateContentConfig;
 }

--- a/packages/core/src/services/toolOutputMaskingService.ts
+++ b/packages/core/src/services/toolOutputMaskingService.ts
@@ -42,7 +42,7 @@ const EXEMPT_TOOLS = new Set([
   EXIT_PLAN_MODE_TOOL_NAME,
 ]);
 
-export interface MaskingResult {
+interface MaskingResult {
   newHistory: Content[];
   maskedCount: number;
   tokensSaved: number;

--- a/packages/core/src/telemetry/activity-monitor.ts
+++ b/packages/core/src/telemetry/activity-monitor.ts
@@ -37,7 +37,7 @@ export interface ActivityMonitorConfig {
 /**
  * Activity listener callback function
  */
-export type ActivityListener = (event: ActivityEvent) => void;
+type ActivityListener = (event: ActivityEvent) => void;
 
 /**
  * Default configuration for activity monitoring

--- a/packages/core/src/telemetry/semantic.ts
+++ b/packages/core/src/telemetry/semantic.ts
@@ -276,14 +276,14 @@ export function toOTelPart(part: Part): AnyPart {
   return new GenericPart('unknown', { ...part });
 }
 
-export enum OTelRole {
+enum OTelRole {
   SYSTEM = 'system',
   USER = 'user',
   ASSISTANT = 'assistant',
   TOOL = 'tool',
 }
 
-export function toOTelRole(role?: string): OTelRole {
+function toOTelRole(role?: string): OTelRole {
   switch (role?.toLowerCase()) {
     case 'system':
       return OTelRole.SYSTEM;
@@ -301,7 +301,7 @@ export function toOTelRole(role?: string): OTelRole {
   }
 }
 
-export type InputMessages = ChatMessage[];
+type InputMessages = ChatMessage[];
 
 export enum OTelOutputType {
   IMAGE = 'image',
@@ -318,7 +318,7 @@ export enum OTelFinishReason {
   ERROR = 'error',
 }
 
-export function toOTelFinishReason(finishReason?: string): OTelFinishReason {
+function toOTelFinishReason(finishReason?: string): OTelFinishReason {
   switch (finishReason) {
     // we have significantly more finish reasons than the spec
     case FinishReason.FINISH_REASON_UNSPECIFIED:
@@ -352,27 +352,27 @@ export function toOTelFinishReason(finishReason?: string): OTelFinishReason {
   }
 }
 
-export interface OutputMessage extends ChatMessage {
+interface OutputMessage extends ChatMessage {
   finish_reason: FinishReason | string;
 }
 
-export type OutputMessages = OutputMessage[];
+type OutputMessages = OutputMessage[];
 
-export type AnyPart =
+type AnyPart =
   | TextPart
   | ToolCallRequestPart
   | ToolCallResponsePart
   | ReasoningPart
   | GenericPart;
 
-export type SystemInstruction = AnyPart[];
+type SystemInstruction = AnyPart[];
 
-export interface ChatMessage {
+interface ChatMessage {
   role: string | undefined;
   parts: AnyPart[];
 }
 
-export class TextPart {
+class TextPart {
   readonly type = 'text';
   content: string;
 
@@ -381,7 +381,7 @@ export class TextPart {
   }
 }
 
-export class ToolCallRequestPart {
+class ToolCallRequestPart {
   readonly type = 'tool_call';
   name?: string;
   id?: string;
@@ -394,7 +394,7 @@ export class ToolCallRequestPart {
   }
 }
 
-export class ToolCallResponsePart {
+class ToolCallResponsePart {
   readonly type = 'tool_call_response';
   response?: string;
   id?: string;
@@ -405,7 +405,7 @@ export class ToolCallResponsePart {
   }
 }
 
-export class ReasoningPart {
+class ReasoningPart {
   readonly type = 'reasoning';
   content: string;
 
@@ -414,7 +414,7 @@ export class ReasoningPart {
   }
 }
 
-export class GenericPart {
+class GenericPart {
   type: string;
   [key: string]: unknown;
 

--- a/packages/core/src/telemetry/startupProfiler.ts
+++ b/packages/core/src/telemetry/startupProfiler.ts
@@ -24,7 +24,7 @@ interface StartupPhase {
 /**
  * Handle returned by start() that allows ending the phase without repeating the phase name.
  */
-export interface StartupPhaseHandle {
+interface StartupPhaseHandle {
   end(details?: Record<string, string | number | boolean>): void;
 }
 

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -41,7 +41,7 @@ import {
 import { sanitizeHookName } from './sanitize.js';
 import { getFileDiffFromResultDisplay } from '../utils/fileDiffUtils.js';
 
-export interface BaseTelemetryEvent {
+interface BaseTelemetryEvent {
   'event.name': string;
   /** Current timestamp in ISO 8601 format */
   'event.timestamp': string;
@@ -522,19 +522,19 @@ export interface ServerDetails {
   port: number;
 }
 
-export interface GenAIPromptDetails {
+interface GenAIPromptDetails {
   prompt_id: string;
   contents: Content[];
   generate_content_config?: GenerateContentConfig;
   server?: ServerDetails;
 }
 
-export interface GenAIResponseDetails {
+interface GenAIResponseDetails {
   response_id?: string;
   candidates?: Candidate[];
 }
 
-export interface GenAIUsageDetails {
+interface GenAIUsageDetails {
   input_token_count: number;
   output_token_count: number;
   cached_content_token_count: number;

--- a/packages/core/src/utils/editCorrector.ts
+++ b/packages/core/src/utils/editCorrector.ts
@@ -402,7 +402,7 @@ const OLD_STRING_CORRECTION_SCHEMA: Record<string, unknown> = {
   required: ['corrected_target_snippet'],
 };
 
-export async function correctOldStringMismatch(
+async function correctOldStringMismatch(
   baseLlmClient: BaseLlmClient,
   fileContent: string,
   problematicSnippet: string,
@@ -480,7 +480,7 @@ const NEW_STRING_CORRECTION_SCHEMA: Record<string, unknown> = {
 /**
  * Adjusts the new_string to align with a corrected old_string, maintaining the original intent.
  */
-export async function correctNewString(
+async function correctNewString(
   baseLlmClient: BaseLlmClient,
   originalOldString: string,
   correctedOldString: string,
@@ -561,7 +561,7 @@ const CORRECT_NEW_STRING_ESCAPING_SCHEMA: Record<string, unknown> = {
   required: ['corrected_new_string_escaping'],
 };
 
-export async function correctNewStringEscaping(
+async function correctNewStringEscaping(
   baseLlmClient: BaseLlmClient,
   oldString: string,
   potentiallyProblematicNewString: string,
@@ -634,7 +634,7 @@ const CORRECT_STRING_ESCAPING_SCHEMA: Record<string, unknown> = {
   required: ['corrected_string_escaping'],
 };
 
-export async function correctStringEscaping(
+async function correctStringEscaping(
   potentiallyProblematicString: string,
   baseLlmClient: BaseLlmClient,
   abortSignal: AbortSignal,


### PR DESCRIPTION
## Summary

This PR un-exports a substantial batch of internal interfaces, types, and functions in the `core` package that are not intended for public use.

## Details

The following changes have been made:
- **Terminal Serializer**: Un-exported `serializeTerminalToObject`, `AnsiOutput`, `AnsiLine`, and `AnsiToken` from the public API (`packages/core/index.ts`). They remain exported from their module for use by the `cli` package via internal re-exports.
- **OTel Semantic Mapping**: Un-exported numerous internal OTel mapping structures in `src/telemetry/semantic.ts`.
- **Internal Utilities**: Un-exported several internal interfaces and functions across various modules (e.g., `editCorrector.ts`, `modelAvailabilityService.ts`, `hookSystem.ts`) that are only used within the `core` package.
- **Dead Code**: Deleted the unused constant `OAUTH_DISPLAY_MESSAGE_EVENT` in `src/mcp/oauth-provider.ts`.

Reducing the public API surface area improves maintainability and clearly distinguishes between public contracts and internal implementation details.

## Related Issues

Related to #18007

## How to Validate

1. Run `npm run build` to ensure no cross-module dependencies were broken.
2. Run `npm run typecheck` to verify type safety.
3. Run `npm test` in `packages/core` to ensure tests still pass.

## Pre-Merge Checklist

- [x] Validated on MacOS (`npm run preflight` passed locally)