### PR TITLE
Fix issue where Gemini CLI fails on unknown SSE type and converts Code Assist client to use Zod.

### DIFF
--- a/packages/core/src/code_assist/converter.test.ts
+++ b/packages/core/src/code_assist/converter.test.ts
@@ -331,16 +331,6 @@ describe('converter', () => {
       const genaiRes = fromGenerateContentResponse(codeAssistRes);
       expect(genaiRes.responseId).toBeUndefined();
     });
-
-    it('should handle missing response property gracefully', () => {
-      const invalidRes = {
-        traceId: 'some-trace-id',
-      } as unknown as CaGenerateContentResponse;
-
-      const genaiRes = fromGenerateContentResponse(invalidRes);
-      expect(genaiRes.responseId).toEqual('some-trace-id');
-      expect(genaiRes.candidates).toEqual([]);
-    });
   });
 
   describe('toContents', () => {

--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -137,18 +137,14 @@ export function toGenerateContentRequest(
 export function fromGenerateContentResponse(
   res: CaGenerateContentResponse,
 ): GenerateContentResponse {
-  const out = new GenerateContentResponse();
-  out.responseId = res.traceId;
   const inres = res.response;
-  if (!inres) {
-    out.candidates = [];
-    return out;
-  }
-  out.candidates = inres.candidates ?? [];
+  const out = new GenerateContentResponse();
+  out.candidates = inres.candidates;
   out.automaticFunctionCallingHistory = inres.automaticFunctionCallingHistory;
   out.promptFeedback = inres.promptFeedback;
   out.usageMetadata = inres.usageMetadata;
   out.modelVersion = inres.modelVersion;
+  out.responseId = res.traceId;
   return out;
 }
 

--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -14,10 +14,7 @@ import type {
   CountTokensResponse,
   GenerationConfigRoutingConfig,
   MediaResolution,
-  Candidate,
   ModelSelectionConfig,
-  GenerateContentResponsePromptFeedback,
-  GenerateContentResponseUsageMetadata,
   Part,
   SafetySetting,
   PartUnion,
@@ -27,6 +24,7 @@ import type {
   ToolConfig,
 } from '@google/genai';
 import { GenerateContentResponse } from '@google/genai';
+import { z } from 'zod';
 
 export interface CAGenerateContentRequest {
   model: string;
@@ -71,18 +69,22 @@ interface VertexGenerationConfig {
   thinkingConfig?: ThinkingConfig;
 }
 
-export interface CaGenerateContentResponse {
-  response: VertexGenerateContentResponse;
-  traceId?: string;
-}
+const AnySchema = z.any();
 
-interface VertexGenerateContentResponse {
-  candidates: Candidate[];
-  automaticFunctionCallingHistory?: Content[];
-  promptFeedback?: GenerateContentResponsePromptFeedback;
-  usageMetadata?: GenerateContentResponseUsageMetadata;
-  modelVersion?: string;
-}
+export const CaGenerateContentResponseSchema = z.object({
+  response: z.object({
+    candidates: z.array(AnySchema),
+    automaticFunctionCallingHistory: z.array(AnySchema).optional(),
+    promptFeedback: AnySchema.optional(),
+    usageMetadata: AnySchema.optional(),
+    modelVersion: z.string().optional(),
+  }),
+  traceId: z.string().optional(),
+});
+
+export type CaGenerateContentResponse = z.infer<
+  typeof CaGenerateContentResponseSchema
+>;
 
 export interface CaCountTokenRequest {
   request: VertexCountTokenRequest;
@@ -93,9 +95,11 @@ interface VertexCountTokenRequest {
   contents: Content[];
 }
 
-export interface CaCountTokenResponse {
-  totalTokens: number;
-}
+export const CaCountTokenResponseSchema = z.object({
+  totalTokens: z.number(),
+});
+
+export type CaCountTokenResponse = z.infer<typeof CaCountTokenResponseSchema>;
 
 export function toCountTokenRequest(
   req: CountTokensParameters,

--- a/packages/core/src/code_assist/experiments/types.ts
+++ b/packages/core/src/code_assist/experiments/types.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { z } from 'zod';
 import type { ClientMetadata } from '../types.js';
 
 export interface ListExperimentsRequest {
@@ -11,32 +12,39 @@ export interface ListExperimentsRequest {
   metadata?: ClientMetadata;
 }
 
-export interface ListExperimentsResponse {
-  experimentIds?: number[];
-  flags?: Flag[];
-  filteredFlags?: FilteredFlag[];
-  debugString?: string;
-}
+export const Int32ListSchema = z.object({
+  values: z.array(z.number()).optional(),
+});
+export type Int32List = z.infer<typeof Int32ListSchema>;
 
-export interface Flag {
-  flagId?: number;
-  boolValue?: boolean;
-  floatValue?: number;
-  intValue?: string; // int64
-  stringValue?: string;
-  int32ListValue?: Int32List;
-  stringListValue?: StringList;
-}
+export const StringListSchema = z.object({
+  values: z.array(z.string()).optional(),
+});
+export type StringList = z.infer<typeof StringListSchema>;
 
-export interface Int32List {
-  values?: number[];
-}
+export const FlagSchema = z.object({
+  flagId: z.number().optional(),
+  boolValue: z.boolean().optional(),
+  floatValue: z.number().optional(),
+  intValue: z.string().optional(),
+  stringValue: z.string().optional(),
+  int32ListValue: Int32ListSchema.optional(),
+  stringListValue: StringListSchema.optional(),
+});
+export type Flag = z.infer<typeof FlagSchema>;
 
-export interface StringList {
-  values?: string[];
-}
+export const FilteredFlagSchema = z.object({
+  name: z.string().optional(),
+  reason: z.string().optional(),
+});
+export type FilteredFlag = z.infer<typeof FilteredFlagSchema>;
 
-export interface FilteredFlag {
-  name?: string;
-  reason?: string;
-}
+export const ListExperimentsResponseSchema = z.object({
+  experimentIds: z.array(z.number()).optional(),
+  flags: z.array(FlagSchema).optional(),
+  filteredFlags: z.array(FilteredFlagSchema).optional(),
+  debugString: z.string().optional(),
+});
+export type ListExperimentsResponse = z.infer<
+  typeof ListExperimentsResponseSchema
+>;

--- a/packages/core/src/code_assist/schema.test.ts
+++ b/packages/core/src/code_assist/schema.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { LoadCodeAssistResponseSchema } from './types.js';
+
+describe('LoadCodeAssistResponseSchema', () => {
+  it('should allow missing showNotice in privacyNotice and default to false', () => {
+    const data = {
+      currentTier: {
+        id: 'standard-tier',
+        privacyNotice: {
+          noticeText: 'Some notice',
+        },
+      },
+      allowedTiers: [
+        {
+          id: 'free-tier',
+          privacyNotice: {},
+        },
+        {
+          id: 'standard-tier',
+          privacyNotice: {
+            showNotice: true,
+          },
+        },
+      ],
+    };
+
+    const parsed = LoadCodeAssistResponseSchema.parse(data);
+
+    expect(parsed.currentTier?.privacyNotice?.showNotice).toBe(false);
+    expect(parsed.allowedTiers?.[0].privacyNotice?.showNotice).toBe(false);
+    expect(parsed.allowedTiers?.[1].privacyNotice?.showNotice).toBe(true);
+  });
+
+  it('should allow missing privacyNotice altogether', () => {
+    const data = {
+      currentTier: {
+        id: 'standard-tier',
+      },
+    };
+
+    const parsed = LoadCodeAssistResponseSchema.parse(data);
+
+    expect(parsed.currentTier?.privacyNotice).toBeUndefined();
+  });
+});

--- a/packages/core/src/code_assist/server.test.ts
+++ b/packages/core/src/code_assist/server.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { beforeEach, describe, it, expect, vi, afterEach } from 'vitest';
+import { z } from 'zod';
 import { CodeAssistServer } from './server.js';
 import { OAuth2Client } from 'google-auth-library';
 import { UserTierId, ActionStatus } from './types.js';
@@ -412,7 +413,7 @@ describe('CodeAssistServer', () => {
 
     mockRequest.mockResolvedValue({ data: mockStream });
 
-    const stream = await server.requestStreamingPost('testStream', {});
+    const stream = await server.requestStreamingPost('testStream', {}, z.any());
 
     setTimeout(() => {
       mockStream.push('this is a malformed line\n');
@@ -444,6 +445,7 @@ describe('CodeAssistServer', () => {
     expect(server.requestPost).toHaveBeenCalledWith(
       'onboardUser',
       expect.any(Object),
+      expect.anything(),
     );
     expect(response.name).toBe('operations/123');
   });
@@ -494,6 +496,7 @@ describe('CodeAssistServer', () => {
     expect(server.requestPost).toHaveBeenCalledWith(
       'loadCodeAssist',
       expect.any(Object),
+      expect.anything(),
     );
     expect(response).toEqual(mockResponse);
   });
@@ -546,6 +549,7 @@ describe('CodeAssistServer', () => {
     expect(server.requestPost).toHaveBeenCalledWith(
       'loadCodeAssist',
       expect.any(Object),
+      expect.anything(),
     );
     expect(response).toEqual({
       currentTier: { id: UserTierId.STANDARD },
@@ -564,6 +568,7 @@ describe('CodeAssistServer', () => {
     expect(server.requestPost).toHaveBeenCalledWith(
       'loadCodeAssist',
       expect.any(Object),
+      expect.anything(),
     );
   });
 
@@ -579,10 +584,14 @@ describe('CodeAssistServer', () => {
     };
     const response = await server.listExperiments(metadata);
 
-    expect(server.requestPost).toHaveBeenCalledWith('listExperiments', {
-      project: 'test-project',
-      metadata: { ideVersion: 'v0.1.0', duetProject: 'test-project' },
-    });
+    expect(server.requestPost).toHaveBeenCalledWith(
+      'listExperiments',
+      {
+        project: 'test-project',
+        metadata: { ideVersion: 'v0.1.0', duetProject: 'test-project' },
+      },
+      expect.anything(),
+    );
     expect(response).toEqual(mockResponse);
   });
 
@@ -609,7 +618,11 @@ describe('CodeAssistServer', () => {
 
     const response = await server.retrieveUserQuota(req);
 
-    expect(requestPostSpy).toHaveBeenCalledWith('retrieveUserQuota', req);
+    expect(requestPostSpy).toHaveBeenCalledWith(
+      'retrieveUserQuota',
+      req,
+      expect.anything(),
+    );
     expect(response).toEqual(mockResponse);
   });
 });

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -65,7 +65,7 @@ import {
   recordConversationOffered,
 } from './telemetry.js';
 import { getClientMetadata } from './experiments/client_metadata.js';
-import { debugLogger } from 'src/utils/debugLogger.js';
+import { debugLogger } from '../utils/debugLogger.js';
 /** HTTP options to be used in each of the requests. */
 export interface HttpOptions {
   /** Additional HTTP headers to be sent with the request. */

--- a/packages/core/src/code_assist/types.ts
+++ b/packages/core/src/code_assist/types.ts
@@ -63,7 +63,7 @@ export type UserTierId = (typeof UserTierId)[keyof typeof UserTierId] | string;
  * privacy notice.
  */
 export const PrivacyNoticeSchema = z.object({
-  showNotice: z.boolean(),
+  showNotice: z.boolean().optional().default(false),
   noticeText: z.string().optional(),
 });
 export type PrivacyNotice = z.infer<typeof PrivacyNoticeSchema>;


### PR DESCRIPTION
## Summary

Makes Gemini CLI tolerant of the behaviors that caused #18621 today.
- Adds Zod validation for all Code Assist server response contracts.
- If those notifications fail to parse in generateContentStream(), we log a debug log message, and continue without failure.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
