### PR TITLE
feat(cli): update approval mode labels and shortcuts per latest UX spec

### DIFF
--- a/packages/cli/src/ui/components/ApprovalModeIndicator.test.tsx
+++ b/packages/cli/src/ui/components/ApprovalModeIndicator.test.tsx
@@ -15,8 +15,8 @@ describe('ApprovalModeIndicator', () => {
       <ApprovalModeIndicator approvalMode={ApprovalMode.AUTO_EDIT} />,
     );
     const output = lastFrame();
-    expect(output).toContain('auto-edit');
-    expect(output).toContain('shift + tab to enter default mode');
+    expect(output).toContain('auto-accept edits');
+    expect(output).toContain('shift+tab to manual');
   });
 
   it('renders correctly for AUTO_EDIT mode with plan enabled', () => {
@@ -27,8 +27,8 @@ describe('ApprovalModeIndicator', () => {
       />,
     );
     const output = lastFrame();
-    expect(output).toContain('auto-edit');
-    expect(output).toContain('shift + tab to enter default mode');
+    expect(output).toContain('auto-accept edits');
+    expect(output).toContain('shift+tab to manual');
   });
 
   it('renders correctly for PLAN mode', () => {
@@ -37,7 +37,7 @@ describe('ApprovalModeIndicator', () => {
     );
     const output = lastFrame();
     expect(output).toContain('plan');
-    expect(output).toContain('shift + tab to enter auto-edit mode');
+    expect(output).toContain('shift+tab to accept edits');
   });
 
   it('renders correctly for YOLO mode', () => {
@@ -46,7 +46,7 @@ describe('ApprovalModeIndicator', () => {
     );
     const output = lastFrame();
     expect(output).toContain('YOLO');
-    expect(output).toContain('shift + tab to enter auto-edit mode');
+    expect(output).toContain('ctrl+y');
   });
 
   it('renders correctly for DEFAULT mode', () => {
@@ -54,7 +54,7 @@ describe('ApprovalModeIndicator', () => {
       <ApprovalModeIndicator approvalMode={ApprovalMode.DEFAULT} />,
     );
     const output = lastFrame();
-    expect(output).toContain('shift + tab to enter auto-edit mode');
+    expect(output).toContain('shift+tab to accept edits');
   });
 
   it('renders correctly for DEFAULT mode with plan enabled', () => {
@@ -65,6 +65,6 @@ describe('ApprovalModeIndicator', () => {
       />,
     );
     const output = lastFrame();
-    expect(output).toContain('shift + tab to enter plan mode');
+    expect(output).toContain('shift+tab to plan');
   });
 });

--- a/packages/cli/src/ui/components/ApprovalModeIndicator.tsx
+++ b/packages/cli/src/ui/components/ApprovalModeIndicator.tsx
@@ -25,26 +25,26 @@ export const ApprovalModeIndicator: React.FC<ApprovalModeIndicatorProps> = ({
   switch (approvalMode) {
     case ApprovalMode.AUTO_EDIT:
       textColor = theme.status.warning;
-      textContent = 'auto-edit';
-      subText = 'shift + tab to enter default mode';
+      textContent = 'auto-accept edits';
+      subText = 'shift+tab to manual';
       break;
     case ApprovalMode.PLAN:
       textColor = theme.status.success;
       textContent = 'plan';
-      subText = 'shift + tab to enter auto-edit mode';
+      subText = 'shift+tab to accept edits';
       break;
     case ApprovalMode.YOLO:
       textColor = theme.status.error;
       textContent = 'YOLO';
-      subText = 'shift + tab to enter auto-edit mode';
+      subText = 'ctrl+y';
       break;
     case ApprovalMode.DEFAULT:
     default:
       textColor = theme.text.accent;
       textContent = '';
       subText = isPlanEnabled
-        ? 'shift + tab to enter plan mode'
-        : 'shift + tab to enter auto-edit mode';
+        ? 'shift+tab to plan'
+        : 'shift+tab to accept edits';
       break;
   }
 


### PR DESCRIPTION
Related to https://github.com/google-gemini/gemini-cli/issues/18473
Follow up to https://github.com/google-gemini/gemini-cli/pull/18476

<img width="876" height="154" alt="image" src="https://github.com/user-attachments/assets/24b0c26e-59c8-4e2a-bab7-acb61a37364e" />

<img width="926" height="144" alt="image" src="https://github.com/user-attachments/assets/fa9ab36f-c9d1-4d5c-83c3-219d3b7ce12a" />

<img width="954" height="154" alt="image" src="https://github.com/user-attachments/assets/5a3c598e-624c-4a0c-acba-faf009a88adf" />

<img width="908" height="158" alt="image" src="https://github.com/user-attachments/assets/e54fc95b-3049-4390-b4b2-79a61b5872e8" />
