### PR TITLE
fix(cli): resolve double rendering in shpool and address vscode lint warnings

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -238,18 +238,15 @@ vi.mock('./validateNonInterActiveAuth.js', () => ({
 }));
 
 describe('gemini.tsx main function', () => {
-  let originalEnvGeminiSandbox: string | undefined;
-  let originalEnvSandbox: string | undefined;
   let originalIsTTY: boolean | undefined;
   let initialUnhandledRejectionListeners: NodeJS.UnhandledRejectionListener[] =
     [];
 
   beforeEach(() => {
     // Store and clear sandbox-related env variables to ensure a consistent test environment
-    originalEnvGeminiSandbox = process.env['GEMINI_SANDBOX'];
-    originalEnvSandbox = process.env['SANDBOX'];
-    delete process.env['GEMINI_SANDBOX'];
-    delete process.env['SANDBOX'];
+    vi.stubEnv('GEMINI_SANDBOX', '');
+    vi.stubEnv('SANDBOX', '');
+    vi.stubEnv('SHPOOL_SESSION_NAME', '');
 
     initialUnhandledRejectionListeners =
       process.listeners('unhandledRejection');
@@ -260,18 +257,6 @@ describe('gemini.tsx main function', () => {
   });
 
   afterEach(() => {
-    // Restore original env variables
-    if (originalEnvGeminiSandbox !== undefined) {
-      process.env['GEMINI_SANDBOX'] = originalEnvGeminiSandbox;
-    } else {
-      delete process.env['GEMINI_SANDBOX'];
-    }
-    if (originalEnvSandbox !== undefined) {
-      process.env['SANDBOX'] = originalEnvSandbox;
-    } else {
-      delete process.env['SANDBOX'];
-    }
-
     const currentListeners = process.listeners('unhandledRejection');
     currentListeners.forEach((listener) => {
       if (!initialUnhandledRejectionListeners.includes(listener)) {
@@ -282,6 +267,7 @@ describe('gemini.tsx main function', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (process.stdin as any).isTTY = originalIsTTY;
 
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -1209,7 +1195,12 @@ describe('startInteractiveUI', () => {
     registerTelemetryConfig: vi.fn(),
   }));
 
+  beforeEach(() => {
+    vi.stubEnv('SHPOOL_SESSION_NAME', '');
+  });
+
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -1308,7 +1299,7 @@ describe('startInteractiveUI', () => {
 
     // Verify all startup tasks were called
     expect(getVersion).toHaveBeenCalledTimes(1);
-    expect(registerCleanup).toHaveBeenCalledTimes(3);
+    expect(registerCleanup).toHaveBeenCalledTimes(4);
 
     // Verify cleanup handler is registered with unmount function
     const cleanupFn = vi.mocked(registerCleanup).mock.calls[0][0];

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -363,7 +363,9 @@ export const AppContainer = (props: AppContainerProps) => {
     (async () => {
       // Note: the program will not work if this fails so let errors be
       // handled by the global catch.
-      await config.initialize();
+      if (!config.isInitialized()) {
+        await config.initialize();
+      }
       setConfigInitialized(true);
       startupProfiler.flush(config);
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -905,6 +905,10 @@ export class Config {
     );
   }
 
+  isInitialized(): boolean {
+    return this.initialized;
+  }
+
   /**
    * Must only be called once, throws if called again.
    */


### PR DESCRIPTION
This commit fixes rendering artifacts (specifically double rendering of the footer
and settings menu) when running Gemini CLI within an shpool session.

Key changes for shpool:
- Detected shpool sessions via the SHPOOL_SESSION_NAME environment variable.
- Added a 100ms delay before initial TUI rendering in shpool to allow terminal
  state and size to stabilize.
- Disabled incrementalRendering for shpool sessions, which prevents frame
  replay artifacts common in multiplexed environments.
- Removed redundant manual enterAlternateScreen() and disableLineWrapping()
  calls in the boot sequence, delegating alternate buffer management entirely
  to the ink library.
- Ensured line wrapping is disabled after alternate buffer entry and properly
  restored on exit via registered cleanup functions.

VS Code Companion refactorings:
- Addressed unsafe type assertions in diff-manager.ts and ide-server.ts by
  using proper type guards (instanceof vscode.TabInputTextDiff) and safer
  header extraction logic. This removes the need for eslint-disable directives
  and ensures compliance with root linting rules.

Test updates:
- Updated unit tests to account for additional cleanup registrations and
  ensured consistent environment variable handling.

Fixes #18703
