### PR TITLE
Shortcuts: Move SectionHeader title below top line and refine styling

### DIFF
--- a/packages/cli/src/test-utils/render.tsx
+++ b/packages/cli/src/test-utils/render.tsx
@@ -393,9 +393,11 @@ export const render = (
       exitOnCtrlC: false,
       patchConsole: false,
       onRender: (metrics: RenderMetrics) => {
-        if (isInkRenderMetrics(metrics)) {
-          stdout.onRender(metrics.staticOutput ?? '', metrics.output);
-        }
+        const output = isInkRenderMetrics(metrics) ? metrics.output : '...';
+        const staticOutput = isInkRenderMetrics(metrics)
+          ? (metrics.staticOutput ?? '')
+          : '';
+        stdout.onRender(staticOutput, output);
       },
     });
   });

--- a/packages/cli/src/ui/components/ShortcutsHelp.tsx
+++ b/packages/cli/src/ui/components/ShortcutsHelp.tsx
@@ -67,7 +67,7 @@ export const ShortcutsHelp: React.FC = () => {
 
   return (
     <Box flexDirection="column" width="100%">
-      <SectionHeader title="Shortcuts (for more, see /help)" />
+      <SectionHeader title=" Shortcuts" subtitle="See /help for more" />
       <Box flexDirection="row" flexWrap="wrap" paddingLeft={1} paddingRight={2}>
         {itemsForDisplay.map((item, index) => (
           <Box

--- a/packages/cli/src/ui/components/ShortcutsHelp.tsx
+++ b/packages/cli/src/ui/components/ShortcutsHelp.tsx
@@ -67,7 +67,7 @@ export const ShortcutsHelp: React.FC = () => {
 
   return (
     <Box flexDirection="column" width="100%">
-      <SectionHeader title=" Shortcuts" subtitle="See /help for more" />
+      <SectionHeader title=" Shortcuts" subtitle=" See /help for more" />
       <Box flexDirection="row" flexWrap="wrap" paddingLeft={1} paddingRight={2}>
         {itemsForDisplay.map((item, index) => (
           <Box

--- a/packages/cli/src/ui/components/__snapshots__/ShortcutsHelp.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ShortcutsHelp.test.tsx.snap
@@ -1,7 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ShortcutsHelp > renders correctly in 'narrow' mode on 'linux' 1`] = `
-"── Shortcuts (for more, see /help) ─────
+"────────────────────────────────────────
+ Shortcuts See /help for more
  ! shell mode
  @ select file or folder
  Esc Esc clear & rewind
@@ -16,7 +17,8 @@ exports[`ShortcutsHelp > renders correctly in 'narrow' mode on 'linux' 1`] = `
 `;
 
 exports[`ShortcutsHelp > renders correctly in 'narrow' mode on 'mac' 1`] = `
-"── Shortcuts (for more, see /help) ─────
+"────────────────────────────────────────
+ Shortcuts See /help for more
  ! shell mode
  @ select file or folder
  Esc Esc clear & rewind
@@ -31,7 +33,8 @@ exports[`ShortcutsHelp > renders correctly in 'narrow' mode on 'mac' 1`] = `
 `;
 
 exports[`ShortcutsHelp > renders correctly in 'wide' mode on 'linux' 1`] = `
-"── Shortcuts (for more, see /help) ─────────────────────────────────────────────────────────────────
+"────────────────────────────────────────────────────────────────────────────────────────────────────
+ Shortcuts See /help for more
  ! shell mode                    Shift+Tab cycle mode            Ctrl+V paste images
  @ select file or folder         Ctrl+Y YOLO mode                Alt+M raw markdown mode
  Esc Esc clear & rewind          Ctrl+R reverse-search history   Ctrl+X open external editor
@@ -40,7 +43,8 @@ exports[`ShortcutsHelp > renders correctly in 'wide' mode on 'linux' 1`] = `
 `;
 
 exports[`ShortcutsHelp > renders correctly in 'wide' mode on 'mac' 1`] = `
-"── Shortcuts (for more, see /help) ─────────────────────────────────────────────────────────────────
+"────────────────────────────────────────────────────────────────────────────────────────────────────
+ Shortcuts See /help for more
  ! shell mode                    Shift+Tab cycle mode            Ctrl+V paste images
  @ select file or folder         Ctrl+Y YOLO mode                Option+M raw markdown mode
  Esc Esc clear & rewind          Ctrl+R reverse-search history   Ctrl+X open external editor

--- a/packages/cli/src/ui/components/shared/SectionHeader.test.tsx
+++ b/packages/cli/src/ui/components/shared/SectionHeader.test.tsx
@@ -33,7 +33,7 @@ describe('<SectionHeader />', () => {
     {
       description: 'renders correctly with a subtitle',
       title: 'Shortcuts',
-      subtitle: 'See /help for more',
+      subtitle: ' See /help for more',
       width: 40,
     },
   ])('$description', async ({ title, subtitle, width }) => {

--- a/packages/cli/src/ui/components/shared/SectionHeader.test.tsx
+++ b/packages/cli/src/ui/components/shared/SectionHeader.test.tsx
@@ -30,9 +30,15 @@ describe('<SectionHeader />', () => {
       title: 'Narrow Container',
       width: 25,
     },
-  ])('$description', async ({ title, width }) => {
+    {
+      description: 'renders correctly with a subtitle',
+      title: 'Shortcuts',
+      subtitle: 'See /help for more',
+      width: 40,
+    },
+  ])('$description', async ({ title, subtitle, width }) => {
     const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-      <SectionHeader title={title} />,
+      <SectionHeader title={title} subtitle={subtitle} />,
       { width },
     );
     await waitUntilReady();

--- a/packages/cli/src/ui/components/shared/SectionHeader.tsx
+++ b/packages/cli/src/ui/components/shared/SectionHeader.tsx
@@ -23,7 +23,7 @@ export const SectionHeader: React.FC<{ title: string; subtitle?: string }> = ({
       borderColor={theme.text.secondary}
     />
     <Box flexDirection="row">
-      <Text color="white" bold wrap="truncate-end">
+      <Text color={theme.text.primary} bold wrap="truncate-end">
         {title}
       </Text>
       {subtitle && <Text color={theme.text.secondary}> {subtitle}</Text>}

--- a/packages/cli/src/ui/components/shared/SectionHeader.tsx
+++ b/packages/cli/src/ui/components/shared/SectionHeader.tsx
@@ -8,16 +8,13 @@ import type React from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../../semantic-colors.js';
 
-export const SectionHeader: React.FC<{ title: string }> = ({ title }) => (
-  <Box width="100%" flexDirection="row" overflow="hidden">
-    <Text color={theme.text.secondary} wrap="truncate-end">
-      {`── ${title}`}
-    </Text>
+export const SectionHeader: React.FC<{ title: string; subtitle?: string }> = ({
+  title,
+  subtitle,
+}) => (
+  <Box width="100%" flexDirection="column" overflow="hidden">
     <Box
-      flexGrow={1}
-      flexShrink={0}
-      minWidth={2}
-      marginLeft={1}
+      width="100%"
       borderStyle="single"
       borderTop
       borderBottom={false}
@@ -25,5 +22,11 @@ export const SectionHeader: React.FC<{ title: string }> = ({ title }) => (
       borderRight={false}
       borderColor={theme.text.secondary}
     />
+    <Box flexDirection="row">
+      <Text color="white" bold wrap="truncate-end">
+        {title}
+      </Text>
+      {subtitle && <Text color={theme.text.secondary}> {subtitle}</Text>}
+    </Box>
   </Box>
 );

--- a/packages/cli/src/ui/components/shared/SectionHeader.tsx
+++ b/packages/cli/src/ui/components/shared/SectionHeader.tsx
@@ -26,7 +26,11 @@ export const SectionHeader: React.FC<{ title: string; subtitle?: string }> = ({
       <Text color={theme.text.primary} bold wrap="truncate-end">
         {title}
       </Text>
-      {subtitle && <Text color={theme.text.secondary}> {subtitle}</Text>}
+      {subtitle && (
+        <Text color={theme.text.secondary} wrap="truncate-end">
+          {subtitle}
+        </Text>
+      )}
     </Box>
   </Box>
 );

--- a/packages/cli/src/ui/components/shared/__snapshots__/SectionHeader.test.tsx.snap
+++ b/packages/cli/src/ui/components/shared/__snapshots__/SectionHeader.test.tsx.snap
@@ -14,3 +14,8 @@ exports[`<SectionHeader /> > 'renders correctly with a standard tit…' 1`] = `
 "────────────────────────────────────────
 My Header"
 `;
+
+exports[`<SectionHeader /> > 'renders correctly with a subtitle' 1`] = `
+"────────────────────────────────────────
+Shortcuts See /help for more"
+`;

--- a/packages/cli/src/ui/components/shared/__snapshots__/SectionHeader.test.tsx.snap
+++ b/packages/cli/src/ui/components/shared/__snapshots__/SectionHeader.test.tsx.snap
@@ -2,20 +2,24 @@
 
 exports[`<SectionHeader /> > 'renders correctly in a narrow contain…' 1`] = `
 "─────────────────────────
-Narrow Container"
+Narrow Container
+"
 `;
 
 exports[`<SectionHeader /> > 'renders correctly when title is trunc…' 1`] = `
 "────────────────────
-Very Long Header Ti…"
+Very Long Header Ti…
+"
 `;
 
 exports[`<SectionHeader /> > 'renders correctly with a standard tit…' 1`] = `
 "────────────────────────────────────────
-My Header"
+My Header
+"
 `;
 
 exports[`<SectionHeader /> > 'renders correctly with a subtitle' 1`] = `
 "────────────────────────────────────────
-Shortcuts See /help for more"
+Shortcuts See /help for more
+"
 `;

--- a/packages/cli/src/ui/components/shared/__snapshots__/SectionHeader.test.tsx.snap
+++ b/packages/cli/src/ui/components/shared/__snapshots__/SectionHeader.test.tsx.snap
@@ -1,16 +1,16 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`<SectionHeader /> > 'renders correctly in a narrow contain…' 1`] = `
-"── Narrow Container ─────
-"
+"─────────────────────────
+Narrow Container"
 `;
 
 exports[`<SectionHeader /> > 'renders correctly when title is trunc…' 1`] = `
-"── Very Long Hea… ──
-"
+"────────────────────
+Very Long Header Ti…"
 `;
 
 exports[`<SectionHeader /> > 'renders correctly with a standard tit…' 1`] = `
-"── My Header ───────────────────────────
-"
+"────────────────────────────────────────
+My Header"
 `;


### PR DESCRIPTION
## Summary

Refine the `SectionHeader` component design as requested for the Shortcuts help panel. Moves the title below the top horizontal line and updates the styling to bold white for the title and secondary gray for the subtitle.

## Details

- Changed `SectionHeader` from `flexDirection: row` to `column` to stack the title below the line.
- Added support for an optional `subtitle` prop in `SectionHeader`.
- Styled the title with `bold` and `white` color.
- Updated `ShortcutsHelp` to use the new title/subtitle structure: " Shortcuts" (bold white) and "See /help for more" (secondary gray).
- Updated snapshots for `SectionHeader` and `ShortcutsHelp`.

<img width="512" height="143" alt="image" src="https://github.com/user-attachments/assets/24ba4901-4657-4f94-9744-03f50f680150" />


## Related Issues

Fixes #18717
Related to #18532

## How to Validate

1. Start the CLI: `npm run start`
2. Press `?` to open the shortcuts help.
3. Verify the header:
   - Top line is full width.
   - " Shortcuts" is bold white on the next line.
   - "See /help for more" is gray next to it.
4. Run tests: `npm test -w @google/gemini-cli -- src/ui/components/shared/SectionHeader.test.tsx src/ui/components/ShortcutsHelp.test.tsx`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
