### PR TITLE
fix: Use `PREVIEW_GEMINI_FLASH_MODEL` for numerical classification to prevent routing recursion.

### DIFF
--- a/packages/core/src/routing/strategies/numericalClassifierStrategy.test.ts
+++ b/packages/core/src/routing/strategies/numericalClassifierStrategy.test.ts
@@ -15,7 +15,6 @@ import {
   PREVIEW_GEMINI_MODEL_AUTO,
   DEFAULT_GEMINI_MODEL_AUTO,
   DEFAULT_GEMINI_MODEL,
-  PREVIEW_GEMINI_FLASH_MODEL,
 } from '../../config/models.js';
 import { promptIdContext } from '../../utils/promptIdContext.js';
 import type { Content } from '@google/genai';

--- a/packages/core/src/routing/strategies/numericalClassifierStrategy.test.ts
+++ b/packages/core/src/routing/strategies/numericalClassifierStrategy.test.ts
@@ -15,6 +15,7 @@ import {
   PREVIEW_GEMINI_MODEL_AUTO,
   DEFAULT_GEMINI_MODEL_AUTO,
   DEFAULT_GEMINI_MODEL,
+  PREVIEW_GEMINI_FLASH_MODEL,
 } from '../../config/models.js';
 import { promptIdContext } from '../../utils/promptIdContext.js';
 import type { Content } from '@google/genai';
@@ -118,7 +119,7 @@ describe('NumericalClassifierStrategy', () => {
       .calls[0][0];
 
     expect(generateJsonCall).toMatchObject({
-      modelConfigKey: { model: mockResolvedConfig.model },
+      modelConfigKey: { model: PREVIEW_GEMINI_FLASH_MODEL },
       promptId: 'test-prompt-id',
     });
 

--- a/packages/core/src/routing/strategies/numericalClassifierStrategy.ts
+++ b/packages/core/src/routing/strategies/numericalClassifierStrategy.ts
@@ -12,7 +12,11 @@ import type {
   RoutingDecision,
   RoutingStrategy,
 } from '../routingStrategy.js';
-import { resolveClassifierModel, isGemini3Model } from '../../config/models.js';
+import {
+  PREVIEW_GEMINI_FLASH_MODEL,
+  resolveClassifierModel,
+  isGemini3Model,
+} from '../../config/models.js';
 import { createUserContent, Type } from '@google/genai';
 import type { Config } from '../../config/config.js';
 import { debugLogger } from '../../utils/debugLogger.js';
@@ -163,7 +167,8 @@ export class NumericalClassifierStrategy implements RoutingStrategy {
       });
 
       const jsonResponse = await baseLlmClient.generateJson({
-        modelConfigKey: { model: 'classifier' },
+        // Use a concrete Flash model for classification to avoid routing recursion.
+        modelConfigKey: { model: PREVIEW_GEMINI_FLASH_MODEL },
         contents: [...finalHistory, createUserContent(sanitizedRequest)],
         schema: RESPONSE_SCHEMA,
         systemInstruction: CLASSIFIER_SYSTEM_PROMPT,


### PR DESCRIPTION

## Summary for #18518 

Fixes a critical bug where the **auto model routing** could enter an **infinite recursion loop**, causing it to fail and always fall back to `gemini-flash`.

This change explicitly forces the `NumericalClassifierStrategy` to use a **concrete Flash model** for its internal classification step, preventing self-referential routing and ensuring correct model upgrades.

---

## Details

The `NumericalClassifierStrategy` determines whether to route a user request to a **high-intelligence model (Pro)** or a **fast model (Flash)** by asking an LLM to score the request's complexity.

Previously, this internal classification step requested a model using the alias **`classifier`**. If the configuration or an experiment resolved `classifier` to `auto` (the router itself), the system would enter an infinite feedback loop:

```
Auto
  -> NumericalClassifier
    -> llm.generate('classifier')
      -> Auto
        -> NumericalClassifier
          -> ...
```

This PR updates:

```
packages/core/src/routing/strategies/numericalClassifierStrategy.ts
```

to explicitly use **`GEMINI_3_FLASH`** (or an equivalent concrete lightweight model) for the complexity-scoring step.

This breaks the recursion loop and ensures that:

* Auto routing works correctly
* Complex tasks can successfully upgrade to `gemini-pro`

---

## Related Issues

* Fixes #18518

---

## How to Validate

### 1. Configure CLI to Use Auto Routing

Ensure your configuration uses auto routing:

```yaml
model: auto
```

(e.g. in `~/.gemini/config.yaml` or equivalent settings)

---

### 2. Run a Simple Command

```bash
gemini "fix this typo in README.md"
```

**Expected Result**

* Router assigns a low score (< threshold)
* Request is routed to **Flash**
* Command completes successfully

---

### 3. Run a Complex Command

```bash
gemini "Refactor the authentication logic in packages/cli/src/core/auth.ts to use the Strategy pattern and update all tests."
```

**Expected Result**

* Router assigns a high score (≥ threshold)
* Request is routed to **Pro**

---

### 4. Verify Routing Behavior

Run with debug enabled:

```bash
gemini --debug "..."
```

Confirm that:

* `NumericalClassifierStrategy` selects **Pro**
* No recursion or routing errors occur

---

## Pre-Merge Checklist

* [x] Updated relevant documentation / README (if needed)
* [x] Added or updated tests (regression coverage for classifier model selection)
* [ ] Noted breaking changes (none)
* [x] Validated on required platforms:

  * [x] macOS
  * [x] `npm run`
  * [x] `npx`
  * [ ] Windows
  * [ ] Linux
