### PR TITLE
fix(cli): fix history navigation regression after prompt autocomplete

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -281,6 +281,11 @@ describe('InputPrompt', () => {
       navigateDown: vi.fn(),
       handleSubmit: vi.fn(),
     };
+    // The updated mock implementation for useInputHistory is a critical improvement for test reliability.
+    // By explicitly calling onSubmit(val) within mockInputHistory.handleSubmit, the mock now accurately
+    // simulates the real hook's behavior. This ensures that tests correctly verify the propagation of
+    // submitted values, preventing potential false positives where the component might appear to work
+    // correctly without actually triggering the necessary onSubmit callback for history management.
     mockedUseInputHistory.mockImplementation(({ onSubmit }) => {
       mockInputHistory.handleSubmit = vi.fn((val) => onSubmit(val));
       return mockInputHistory;
@@ -4096,6 +4101,11 @@ describe('InputPrompt', () => {
     beforeEach(() => {
       props.userMessages = ['first message', 'second message'];
       // Mock useInputHistory to actually call onChange
+      // Including onSubmit in the destructuring of the mockImplementation for useInputHistory is essential here.
+      // This change correctly sets up the mock to allow handleSubmit to call the onSubmit callback, which is
+      // crucial for accurately testing the interaction with the history hook. Without this, the mock's
+      // handleSubmit would not be able to correctly trigger the onSubmit logic, potentially leading to
+      // incomplete test coverage for the history navigation fix.
       mockedUseInputHistory.mockImplementation(({ onChange, onSubmit }) => ({
         navigateUp: () => {
           onChange('second message', 'start');
@@ -4105,6 +4115,10 @@ describe('InputPrompt', () => {
           onChange('first message', 'end');
           return true;
         },
+        // This update to the handleSubmit mock within the beforeEach block is vital.
+        // By ensuring mockInputHistory.handleSubmit calls onSubmit(val), the test accurately reflects
+        // the component's dependency on the useInputHistory hook to process submissions. This directly
+        // supports the fix for the history navigation regression by verifying that the correct submission path is taken.
         handleSubmit: vi.fn((val) => onSubmit(val)),
       }));
     });

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -281,7 +281,10 @@ describe('InputPrompt', () => {
       navigateDown: vi.fn(),
       handleSubmit: vi.fn(),
     };
-    mockedUseInputHistory.mockReturnValue(mockInputHistory);
+    mockedUseInputHistory.mockImplementation(({ onSubmit }) => {
+      mockInputHistory.handleSubmit = vi.fn((val) => onSubmit(val));
+      return mockInputHistory;
+    });
 
     mockReverseSearchCompletion = {
       suggestions: [],
@@ -4093,7 +4096,7 @@ describe('InputPrompt', () => {
     beforeEach(() => {
       props.userMessages = ['first message', 'second message'];
       // Mock useInputHistory to actually call onChange
-      mockedUseInputHistory.mockImplementation(({ onChange }) => ({
+      mockedUseInputHistory.mockImplementation(({ onChange, onSubmit }) => ({
         navigateUp: () => {
           onChange('second message', 'start');
           return true;
@@ -4102,7 +4105,7 @@ describe('InputPrompt', () => {
           onChange('first message', 'end');
           return true;
         },
-        handleSubmit: vi.fn(),
+        handleSubmit: vi.fn((val) => onSubmit(val)),
       }));
     });
 

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -281,11 +281,6 @@ describe('InputPrompt', () => {
       navigateDown: vi.fn(),
       handleSubmit: vi.fn(),
     };
-    // The updated mock implementation for useInputHistory is a critical improvement for test reliability.
-    // By explicitly calling onSubmit(val) within mockInputHistory.handleSubmit, the mock now accurately
-    // simulates the real hook's behavior. This ensures that tests correctly verify the propagation of
-    // submitted values, preventing potential false positives where the component might appear to work
-    // correctly without actually triggering the necessary onSubmit callback for history management.
     mockedUseInputHistory.mockImplementation(({ onSubmit }) => {
       mockInputHistory.handleSubmit = vi.fn((val) => onSubmit(val));
       return mockInputHistory;
@@ -4101,11 +4096,6 @@ describe('InputPrompt', () => {
     beforeEach(() => {
       props.userMessages = ['first message', 'second message'];
       // Mock useInputHistory to actually call onChange
-      // Including onSubmit in the destructuring of the mockImplementation for useInputHistory is essential here.
-      // This change correctly sets up the mock to allow handleSubmit to call the onSubmit callback, which is
-      // crucial for accurately testing the interaction with the history hook. Without this, the mock's
-      // handleSubmit would not be able to correctly trigger the onSubmit logic, potentially leading to
-      // incomplete test coverage for the history navigation fix.
       mockedUseInputHistory.mockImplementation(({ onChange, onSubmit }) => ({
         navigateUp: () => {
           onChange('second message', 'start');
@@ -4115,10 +4105,6 @@ describe('InputPrompt', () => {
           onChange('first message', 'end');
           return true;
         },
-        // This update to the handleSubmit mock within the beforeEach block is vital.
-        // By ensuring mockInputHistory.handleSubmit calls onSubmit(val), the test accurately reflects
-        // the component's dependency on the useInputHistory hook to process submissions. This directly
-        // supports the fix for the history navigation regression by verifying that the correct submission path is taken.
         handleSubmit: vi.fn((val) => onSubmit(val)),
       }));
     });

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -334,31 +334,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     ],
   );
 
-  const handleSubmit = useCallback(
-    (submittedValue: string) => {
-      const trimmedMessage = submittedValue.trim();
-      const isSlash = isSlashCommand(trimmedMessage);
-
-      const isShell = shellModeActive;
-      if (
-        (isSlash || isShell) &&
-        streamingState === StreamingState.Responding
-      ) {
-        setQueueErrorMessage(
-          `${isShell ? 'Shell' : 'Slash'} commands cannot be queued`,
-        );
-        return;
-      }
-      handleSubmitAndClear(trimmedMessage);
-    },
-    [
-      handleSubmitAndClear,
-      shellModeActive,
-      streamingState,
-      setQueueErrorMessage,
-    ],
-  );
-
   const customSetTextAndResetCompletionSignal = useCallback(
     (newText: string, cursorPosition?: 'start' | 'end' | number) => {
       buffer.setText(newText, cursorPosition);
@@ -377,6 +352,26 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     currentCursorOffset: buffer.getOffset(),
     onChange: customSetTextAndResetCompletionSignal,
   });
+
+  const handleSubmit = useCallback(
+    (submittedValue: string) => {
+      const trimmedMessage = submittedValue.trim();
+      const isSlash = isSlashCommand(trimmedMessage);
+
+      const isShell = shellModeActive;
+      if (
+        (isSlash || isShell) &&
+        streamingState === StreamingState.Responding
+      ) {
+        setQueueErrorMessage(
+          `${isShell ? 'Shell' : 'Slash'} commands cannot be queued`,
+        );
+        return;
+      }
+      inputHistory.handleSubmit(trimmedMessage);
+    },
+    [inputHistory, shellModeActive, streamingState, setQueueErrorMessage],
+  );
 
   // Effect to reset completion if history navigation just occurred and set the text
   useEffect(() => {
@@ -855,7 +850,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             showSuggestions && activeSuggestionIndex > -1
               ? suggestions[activeSuggestionIndex].value
               : buffer.text;
-          handleSubmitAndClear(textToSubmit);
+          inputHistory.handleSubmit(textToSubmit);
           resetState();
           setActive(false);
           return true;
@@ -1152,7 +1147,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       setShellModeActive,
       onClearScreen,
       inputHistory,
-      handleSubmitAndClear,
       handleSubmit,
       shellHistory,
       reverseSearchCompletion,

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -850,7 +850,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             showSuggestions && activeSuggestionIndex > -1
               ? suggestions[activeSuggestionIndex].value
               : buffer.text;
-          inputHistory.handleSubmit(textToSubmit);
+          handleSubmit(textToSubmit);
           resetState();
           setActive(false);
           return true;


### PR DESCRIPTION
## Summary

Fixes a regression in history navigation where the Up Arrow key would skip the most recently submitted command. This was introduced by the autocomplete polish (#18181).

## Details

The autocomplete PR refactored `InputPrompt.tsx` to call a local `handleSubmitAndClear` directly on submission. This bypassed the `useInputHistory` hook's `handleSubmit` method, which is responsible for resetting the internal `historyIndex`. As a result, if a user submitted a command while at a specific history index, that index persisted, causing the next Up Arrow press to navigate from the wrong starting point.

This fix refactors `InputPrompt.tsx` to:
1. Reorder the `handleSubmit` definition to appear after the `inputHistory` hook initialization.
2. Update `handleSubmit` to call `inputHistory.handleSubmit(trimmedMessage)`.
3. Update the `SUBMIT_REVERSE_SEARCH` handler to call `inputHistory.handleSubmit(textToSubmit)`.
4. Update the `useInputHistory` mock in tests to ensure it correctly invokes the `onSubmit` callback.

## Related Issues

Fixes #18754.
Related to #18181.

## How to Validate

1. Open Gemini CLI.
2. Enter a command and submit it.
3. Press Up Arrow. The command just entered should appear.
4. Enter another command, cancel it (Ctrl+C), then re-submit it.
5. Press Up Arrow. The re-submitted command should appear.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt