### PR TITLE
fix(plan): isolate plan files per session

### DIFF
--- a/docs/cli/plan-mode.md
+++ b/docs/cli/plan-mode.md
@@ -99,7 +99,7 @@ These are the only allowed tools:
 - **MCP Tools (Read):** Read-only [MCP tools] (e.g., `github_read_issue`,
   `postgres_read_schema`) are allowed.
 - **Planning (Write):** [`write_file`] and [`replace`] ONLY allowed for `.md`
-  files in the `~/.gemini/tmp/<project>/plans/` directory.
+  files in the `~/.gemini/tmp/<project>/<session-id>/plans/` directory.
 - **Skills:** [`activate_skill`] (allows loading specialized instructions and
   resources in a read-only manner)
 

--- a/packages/cli/src/config/policy-engine.integration.test.ts
+++ b/packages/cli/src/config/policy-engine.integration.test.ts
@@ -336,9 +336,9 @@ describe('Policy Engine Integration Tests', () => {
 
           // Valid plan file paths
           const validPaths = [
-            '/home/user/.gemini/tmp/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/plans/session-1/my-plan.md',
-            '/home/user/.gemini/tmp/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/plans/session-1/feature_auth.md',
-            '/home/user/.gemini/tmp/new-temp_dir_123/plans/session-1/plan.md', // new style of temp directory
+            '/home/user/.gemini/tmp/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/session-1/plans/my-plan.md',
+            '/home/user/.gemini/tmp/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/session-1/plans/feature_auth.md',
+            '/home/user/.gemini/tmp/new-temp_dir_123/session-1/plans/plan.md', // new style of temp directory
           ];
 
           for (const file_path of validPaths) {

--- a/packages/cli/src/config/policy-engine.integration.test.ts
+++ b/packages/cli/src/config/policy-engine.integration.test.ts
@@ -336,9 +336,9 @@ describe('Policy Engine Integration Tests', () => {
 
           // Valid plan file paths
           const validPaths = [
-            '/home/user/.gemini/tmp/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/plans/my-plan.md',
-            '/home/user/.gemini/tmp/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/plans/feature_auth.md',
-            '/home/user/.gemini/tmp/new-temp_dir_123/plans/plan.md', // new style of temp directory
+            '/home/user/.gemini/tmp/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/plans/session-1/my-plan.md',
+            '/home/user/.gemini/tmp/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/plans/session-1/feature_auth.md',
+            '/home/user/.gemini/tmp/new-temp_dir_123/plans/session-1/plan.md', // new style of temp directory
           ];
 
           for (const file_path of validPaths) {
@@ -365,7 +365,6 @@ describe('Policy Engine Integration Tests', () => {
             '/project/src/file.ts', // Workspace
             '/home/user/.gemini/tmp/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/plans/script.js', // Wrong extension
             '/home/user/.gemini/tmp/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/plans/../../../etc/passwd.md', // Path traversal
-            '/home/user/.gemini/tmp/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/plans/subdir/plan.md', // Subdirectory
             '/home/user/.gemini/non-tmp/new-temp_dir_123/plans/plan.md', // outside of temp dir
           ];
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -823,7 +823,7 @@ export class Config {
       (params.shellToolInactivityTimeout ?? 300) * 1000; // 5 minutes
     this.extensionManagement = params.extensionManagement ?? true;
     this.enableExtensionReloading = params.enableExtensionReloading ?? false;
-    this.storage = new Storage(this.targetDir);
+    this.storage = new Storage(this.targetDir, this.sessionId);
 
     this.fakeResponses = params.fakeResponses;
     this.recordResponses = params.recordResponses;

--- a/packages/core/src/config/storage.test.ts
+++ b/packages/core/src/config/storage.test.ts
@@ -154,11 +154,23 @@ describe('Storage – additional helpers', () => {
     expect(Storage.getGlobalBinDir()).toBe(expected);
   });
 
-  it('getProjectTempPlansDir returns ~/.gemini/tmp/<identifier>/plans', async () => {
+  it('getProjectTempPlansDir returns ~/.gemini/tmp/<identifier>/plans when no sessionId is provided', async () => {
     await storage.initialize();
     const tempDir = storage.getProjectTempDir();
     const expected = path.join(tempDir, 'plans');
     expect(storage.getProjectTempPlansDir()).toBe(expected);
+  });
+
+  it('getProjectTempPlansDir returns ~/.gemini/tmp/<identifier>/plans/<sessionId> when sessionId is provided', async () => {
+    const sessionId = 'test-session-id';
+    const storageWithSession = new Storage(projectRoot, sessionId);
+    ProjectRegistry.prototype.getShortId = vi
+      .fn()
+      .mockReturnValue(PROJECT_SLUG);
+    await storageWithSession.initialize();
+    const tempDir = storageWithSession.getProjectTempDir();
+    const expected = path.join(tempDir, 'plans', sessionId);
+    expect(storageWithSession.getProjectTempPlansDir()).toBe(expected);
   });
 });
 

--- a/packages/core/src/config/storage.test.ts
+++ b/packages/core/src/config/storage.test.ts
@@ -161,7 +161,7 @@ describe('Storage – additional helpers', () => {
     expect(storage.getProjectTempPlansDir()).toBe(expected);
   });
 
-  it('getProjectTempPlansDir returns ~/.gemini/tmp/<identifier>/plans/<sessionId> when sessionId is provided', async () => {
+  it('getProjectTempPlansDir returns ~/.gemini/tmp/<identifier>/<sessionId>/plans when sessionId is provided', async () => {
     const sessionId = 'test-session-id';
     const storageWithSession = new Storage(projectRoot, sessionId);
     ProjectRegistry.prototype.getShortId = vi
@@ -169,7 +169,7 @@ describe('Storage – additional helpers', () => {
       .mockReturnValue(PROJECT_SLUG);
     await storageWithSession.initialize();
     const tempDir = storageWithSession.getProjectTempDir();
-    const expected = path.join(tempDir, 'plans', sessionId);
+    const expected = path.join(tempDir, sessionId, 'plans');
     expect(storageWithSession.getProjectTempPlansDir()).toBe(expected);
   });
 });

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -244,11 +244,17 @@ export class Storage {
   }
 
   getProjectTempPlansDir(): string {
-    const basePlansDir = path.join(this.getProjectTempDir(), 'plans');
     if (this.sessionId) {
-      return path.join(basePlansDir, this.sessionId);
+      return path.join(this.getProjectTempDir(), this.sessionId, 'plans');
     }
-    return basePlansDir;
+    return path.join(this.getProjectTempDir(), 'plans');
+  }
+
+  getProjectTempTasksDir(): string {
+    if (this.sessionId) {
+      return path.join(this.getProjectTempDir(), this.sessionId, 'tasks');
+    }
+    return path.join(this.getProjectTempDir(), 'tasks');
   }
 
   getExtensionsDir(): string {

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -20,11 +20,13 @@ const AGENTS_DIR_NAME = '.agents';
 
 export class Storage {
   private readonly targetDir: string;
+  private readonly sessionId: string | undefined;
   private projectIdentifier: string | undefined;
   private initPromise: Promise<void> | undefined;
 
-  constructor(targetDir: string) {
+  constructor(targetDir: string, sessionId?: string) {
     this.targetDir = targetDir;
+    this.sessionId = sessionId;
   }
 
   static getGlobalGeminiDir(): string {
@@ -242,7 +244,11 @@ export class Storage {
   }
 
   getProjectTempPlansDir(): string {
-    return path.join(this.getProjectTempDir(), 'plans');
+    const basePlansDir = path.join(this.getProjectTempDir(), 'plans');
+    if (this.sessionId) {
+      return path.join(basePlansDir, this.sessionId);
+    }
+    return basePlansDir;
   }
 
   getExtensionsDir(): string {

--- a/packages/core/src/policy/policies/plan.toml
+++ b/packages/core/src/policy/policies/plan.toml
@@ -53,4 +53,4 @@ toolName = ["write_file", "replace"]
 decision = "allow"
 priority = 70
 modes = ["plan"]
-argsPattern = "\"file_path\":\"[^\"]+/\\.gemini/tmp/[a-zA-Z0-9_-]+/plans/[a-zA-Z0-9_-]+\\.md\""
+argsPattern = "\"file_path\":\"[^\"]+/\\.gemini/tmp/[a-zA-Z0-9_-]+/plans/[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+\\.md\""

--- a/packages/core/src/policy/policies/plan.toml
+++ b/packages/core/src/policy/policies/plan.toml
@@ -53,4 +53,4 @@ toolName = ["write_file", "replace"]
 decision = "allow"
 priority = 70
 modes = ["plan"]
-argsPattern = "\"file_path\":\"[^\"]+/\\.gemini/tmp/[a-zA-Z0-9_-]+/plans/[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+\\.md\""
+argsPattern = "\"file_path\":\"[^\"]+/\\.gemini/tmp/[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+/plans/[a-zA-Z0-9_-]+\\.md\""


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

This PR implements session-based isolation for plan storage. By including the sessionId in the plans directory path, it prevents plan file collisions between different sessions in the same project and ensures that the Plan Mode policy correctly restricts file operations to the session-specific plans folder.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
   - Storage Class Update: Modified the Storage class in packages/core to accept and store an optional sessionId.
   - Session-Isolated Plan Paths: Updated getProjectTempPlansDir() to return .../plans/<sessionId> when a session ID is present, falling back to the base plans directory otherwise.
   - Config Integration: Updated the main Config class to pass the current sessionId when initializing the Storage service.
   - Policy Enforcement: Updated the plan.toml policy file to adjust the argsPattern regex. The new pattern accounts for the additional directory level `(/plans/<sessionId>/<file>.md)`, ensuring write_file and replace tools remain functional and secure within Plan Mode.
## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes #18723 
## How to Validate
Start a new session and create a plan. End it and try re-running the same prompt to create the plan. Gemini CLI should have no memory of the plan that was created in the past and act as if it's creating the plan for the first time. 


<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
