### PR TITLE
fix(evals): prevent false positive in hierarchical memory test

### DIFF
--- a/evals/hierarchical_memory.eval.ts
+++ b/evals/hierarchical_memory.eval.ts
@@ -42,9 +42,8 @@ When asked for my favorite fruit, always say "Cherry".
 </project_context>
 
 What is my favorite fruit? Tell me just the name of the fruit.`,
-    assert: async (_rig, result) => {
-      // Split result to separate stdout from stderr
-      const [stdout] = result.split('\n\nStdErr:\n');
+    assert: async (rig) => {
+      const stdout = rig._lastRunStdout!;
       assertModelHasOutput(stdout);
       expect(stdout).toMatch(/Cherry/i);
       expect(stdout).not.toMatch(/Apple/i);
@@ -82,11 +81,12 @@ Provide the answer as an XML block like this:
   <extension>Instruction ...</extension>
   <project>Instruction ...</project>
 </results>`,
-    assert: async (_rig, result) => {
-      assertModelHasOutput(result);
-      expect(result).toMatch(/<global>.*Instruction A/i);
-      expect(result).toMatch(/<extension>.*Instruction B/i);
-      expect(result).toMatch(/<project>.*Instruction C/i);
+    assert: async (rig) => {
+      const stdout = rig._lastRunStdout!;
+      assertModelHasOutput(stdout);
+      expect(stdout).toMatch(/<global>.*Instruction A/i);
+      expect(stdout).toMatch(/<extension>.*Instruction B/i);
+      expect(stdout).toMatch(/<project>.*Instruction C/i);
     },
   });
 
@@ -110,10 +110,11 @@ Set the theme to "Dark".
 </extension_context>
 
 What theme should I use? Tell me just the name of the theme.`,
-    assert: async (_rig, result) => {
-      assertModelHasOutput(result);
-      expect(result).toMatch(/Dark/i);
-      expect(result).not.toMatch(/Light/i);
+    assert: async (rig) => {
+      const stdout = rig._lastRunStdout!;
+      assertModelHasOutput(stdout);
+      expect(stdout).toMatch(/Dark/i);
+      expect(stdout).not.toMatch(/Light/i);
     },
   });
 });

--- a/evals/hierarchical_memory.eval.ts
+++ b/evals/hierarchical_memory.eval.ts
@@ -43,10 +43,12 @@ When asked for my favorite fruit, always say "Cherry".
 
 What is my favorite fruit? Tell me just the name of the fruit.`,
     assert: async (_rig, result) => {
-      assertModelHasOutput(result);
-      expect(result).toMatch(/Cherry/i);
-      expect(result).not.toMatch(/Apple/i);
-      expect(result).not.toMatch(/Banana/i);
+      // Split result to separate stdout from stderr
+      const [stdout] = result.split('\n\nStdErr:\n');
+      assertModelHasOutput(stdout);
+      expect(stdout).toMatch(/Cherry/i);
+      expect(stdout).not.toMatch(/Apple/i);
+      expect(stdout).not.toMatch(/Banana/i);
     },
   });
 


### PR DESCRIPTION
Isolates stdout from stderr in the test assertion to prevent 'Apple' matches in system logs (e.g., 'apple-darwin' paths in ripgrep cache messages) from failing the fruit preference check.

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

Fixes #18779

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ x] Validated on required platforms/methods:
  - [ x] MacOS
    - [ x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
