### PR TITLE
fix(core): cache CLI version to ensure consistency during sessions

### DIFF
--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -18,6 +18,7 @@ import { LoggingContentGenerator } from './loggingContentGenerator.js';
 import { loadApiKey } from './apiKeyCredentialStorage.js';
 import { FakeContentGenerator } from './fakeContentGenerator.js';
 import { RecordingContentGenerator } from './recordingContentGenerator.js';
+import { resetVersionCache } from '../utils/version.js';
 
 vi.mock('../code_assist/codeAssist.js');
 vi.mock('@google/genai');
@@ -35,6 +36,7 @@ const mockConfig = {
 
 describe('createContentGenerator', () => {
   beforeEach(() => {
+    resetVersionCache();
     vi.clearAllMocks();
   });
 

--- a/packages/core/src/utils/version.test.ts
+++ b/packages/core/src/utils/version.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getVersion } from './version.js';
+import { getVersion, resetVersionCache } from './version.js';
 import { getPackageJson } from './package.js';
 
 vi.mock('./package.js', () => ({
@@ -17,6 +17,8 @@ describe('version', () => {
 
   beforeEach(() => {
     vi.resetModules();
+    vi.clearAllMocks();
+    resetVersionCache();
     process.env = { ...originalEnv };
     vi.mocked(getPackageJson).mockResolvedValue({ version: '1.0.0' });
   });
@@ -42,5 +44,21 @@ describe('version', () => {
     vi.mocked(getPackageJson).mockResolvedValue(undefined);
     const version = await getVersion();
     expect(version).toBe('unknown');
+  });
+
+  it('should cache the version and only call getPackageJson once', async () => {
+    delete process.env['CLI_VERSION'];
+    vi.mocked(getPackageJson).mockResolvedValue({ version: '1.2.3' });
+
+    const version1 = await getVersion();
+    expect(version1).toBe('1.2.3');
+    expect(getPackageJson).toHaveBeenCalledTimes(1);
+
+    // Change the mock value to simulate an update on disk
+    vi.mocked(getPackageJson).mockResolvedValue({ version: '2.0.0' });
+
+    const version2 = await getVersion();
+    expect(version2).toBe('1.2.3'); // Should still be the cached version
+    expect(getPackageJson).toHaveBeenCalledTimes(1); // Should not have been called again
   });
 });

--- a/packages/core/src/utils/version.ts
+++ b/packages/core/src/utils/version.ts
@@ -11,7 +11,20 @@ import path from 'node:path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-export async function getVersion(): Promise<string> {
-  const pkgJson = await getPackageJson(__dirname);
-  return process.env['CLI_VERSION'] || pkgJson?.version || 'unknown';
+let versionPromise: Promise<string> | undefined;
+
+export function getVersion(): Promise<string> {
+  if (versionPromise) {
+    return versionPromise;
+  }
+  versionPromise = (async () => {
+    const pkgJson = await getPackageJson(__dirname);
+    return process.env['CLI_VERSION'] || pkgJson?.version || 'unknown';
+  })();
+  return versionPromise;
+}
+
+/** For testing purposes only */
+export function resetVersionCache(): void {
+  versionPromise = undefined;
 }


### PR DESCRIPTION
## Summary

Caches the CLI version string at startup to ensure consistent reporting throughout a session.

## Details

Previously, `getVersion()` read `package.json` from disk on every call. If an auto-update occurred while a session was active, commands like `/about` would report the new version from disk even though the running process was still the older version. This PR introduces a `cachedVersion` variable to "freeze" the version at startup.

## Related Issues

Fixes #18792

## How to Validate

1. Start CLI: `npm start`
2. Run `/about` -> see version A.
3. Edit `packages/core/package.json` -> set version to B.
4. Run `/about` -> still see version A.
5. Run unit tests: `npm test -w @google/gemini-cli-core -- src/utils/version.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
