### PR TITLE
fix(cli): allow closing debug console after auto-open via flicker

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1520,28 +1520,14 @@ Logging in with Google... Restarting Gemini CLI to continue.
       if (keyMatchers[Command.SHOW_ERROR_DETAILS](key)) {
         if (settings.merged.general.devtools) {
           void (async () => {
-            try {
-              const { startDevToolsServer } = await import(
-                '../utils/devtoolsService.js'
-              );
-              const { openBrowserSecurely, shouldLaunchBrowser } = await import(
-                '@google/gemini-cli-core'
-              );
-              const url = await startDevToolsServer(config);
-              if (shouldLaunchBrowser()) {
-                try {
-                  await openBrowserSecurely(url);
-                } catch (e) {
-                  setShowErrorDetails((prev) => !prev);
-                  debugLogger.warn('Failed to open browser securely:', e);
-                }
-              } else {
-                setShowErrorDetails((prev) => !prev);
-              }
-            } catch (e) {
-              setShowErrorDetails(true);
-              debugLogger.error('Failed to start DevTools server:', e);
-            }
+            const { toggleDevToolsPanel } = await import(
+              '../utils/devtoolsService.js'
+            );
+            await toggleDevToolsPanel(
+              config,
+              () => setShowErrorDetails((prev) => !prev),
+              () => setShowErrorDetails(true),
+            );
           })();
         } else {
           setShowErrorDetails((prev) => !prev);

--- a/packages/cli/src/utils/devtoolsService.ts
+++ b/packages/cli/src/utils/devtoolsService.ts
@@ -210,6 +210,35 @@ async function startDevToolsServerImpl(config: Config): Promise<string> {
   return url;
 }
 
+/**
+ * Handles the F12 key toggle for the DevTools panel.
+ * Starts the DevTools server, attempts to open the browser,
+ * and always calls the toggle callback regardless of the outcome.
+ */
+export async function toggleDevToolsPanel(
+  config: Config,
+  toggle: () => void,
+  setOpen: () => void,
+): Promise<void> {
+  try {
+    const { openBrowserSecurely, shouldLaunchBrowser } = await import(
+      '@google/gemini-cli-core'
+    );
+    const url = await startDevToolsServer(config);
+    if (shouldLaunchBrowser()) {
+      try {
+        await openBrowserSecurely(url);
+      } catch (e) {
+        debugLogger.warn('Failed to open browser securely:', e);
+      }
+    }
+    toggle();
+  } catch (e) {
+    setOpen();
+    debugLogger.error('Failed to start DevTools server:', e);
+  }
+}
+
 /** Reset module-level state — test only. */
 export function resetForTesting() {
   promotionAttempts = 0;


### PR DESCRIPTION
## Summary

- After f5b1245, pressing F12 with devtools enabled would start the DevTools server and open the browser, but **not toggle `showErrorDetails`** on the success path — so the debug console couldn't be closed once flicker auto-opened it.
- Extracts the F12 async handler logic into a testable `toggleDevToolsPanel()` function in `devtoolsService.ts` and ensures **all** code paths call the toggle/setOpen callback.

## Details

The original inline handler in `AppContainer.tsx` had three branches when `devtools` was enabled:
1. Browser opens successfully → **no toggle** (bug)
2. Browser fails to open → toggle
3. `shouldLaunchBrowser()` is false → toggle

Now all three paths correctly invoke the callback. The logic is extracted into `toggleDevToolsPanel()` with full test coverage.

## Related Issues

Closes the regression introduced by f5b1245f5158c85558bb6ee456df6ccace65d9c2 (#18695).

## How to Validate

1. Enable `devtools: true` in settings
2. Trigger flicker (or an unhandled rejection) so the debug console auto-opens
3. Press F12 → the debug console should close
4. Run `npx vitest run packages/cli/src/utils/devtoolsService.test.ts` — all 18 tests pass including the 4 new `toggleDevToolsPanel` tests

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker