### PR TITLE
fix: use discoverOAuthFromWWWAuthenticate for reactive OAuth flow (#18760)

### DIFF
--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -666,18 +666,25 @@ async function handleAutomaticOAuth(
   try {
     debugLogger.log(`🔐 '${mcpServerName}' requires OAuth authentication`);
 
-    // Always try to parse the resource metadata URI from the www-authenticate header
-    let oauthConfig;
-    const resourceMetadataUri =
-      OAuthUtils.parseWWWAuthenticateHeader(wwwAuthenticate);
-    if (resourceMetadataUri) {
-      oauthConfig = await OAuthUtils.discoverOAuthConfig(resourceMetadataUri);
-    } else if (hasNetworkTransport(mcpServerConfig)) {
+    // Use the actual server URL for OAuth discovery and resource validation
+    const serverUrl = mcpServerConfig.httpUrl || mcpServerConfig.url;
+
+    // Try to discover OAuth config from the WWW-Authenticate header first.
+    // discoverOAuthFromWWWAuthenticate() directly fetches the resource_metadata URI
+    // from the header and validates the resource parameter against the server URL,
+    // avoiding the double .well-known path issue that occurs when passing a
+    // resource_metadata URI to discoverOAuthConfig() (which expects a server URL).
+    let oauthConfig = await OAuthUtils.discoverOAuthFromWWWAuthenticate(
+      wwwAuthenticate,
+      serverUrl,
+    );
+
+    if (!oauthConfig && hasNetworkTransport(mcpServerConfig)) {
       // Fallback: try to discover OAuth config from the base URL
-      const serverUrl = new URL(
+      const serverUrlObj = new URL(
         mcpServerConfig.httpUrl || mcpServerConfig.url!,
       );
-      const baseUrl = `${serverUrl.protocol}//${serverUrl.host}`;
+      const baseUrl = `${serverUrlObj.protocol}//${serverUrlObj.host}`;
       oauthConfig = await OAuthUtils.discoverOAuthConfig(baseUrl);
     }
 
@@ -701,7 +708,6 @@ async function handleAutomaticOAuth(
 
     // Perform OAuth authentication
     // Pass the server URL for proper discovery
-    const serverUrl = mcpServerConfig.httpUrl || mcpServerConfig.url;
     debugLogger.log(
       `Starting OAuth authentication for server '${mcpServerName}'...`,
     );


### PR DESCRIPTION
## Problem

`handleAutomaticOAuth()` passes the `resource_metadata` URI (already a `.well-known` URL extracted from the `WWW-Authenticate` header) to `discoverOAuthConfig()`, which expects a **server URL** and internally constructs `.well-known` paths from it. This causes:

1. **Double-nested `.well-known` paths** → 404 on resource metadata fetch
2. **Fallback to base URL** → fetches metadata without path context
3. **`ResourceMismatchError`** → the resource parameter from fallback metadata doesn't match the path-based server URL

This affects all OAuth-protected MCP servers that serve resources under paths (gateways, multi-tenant setups).

## Root Cause

```typescript
// BEFORE (broken): resourceMetadataUri is already a .well-known URL
const resourceMetadataUri = OAuthUtils.parseWWWAuthenticateHeader(wwwAuthenticate);
if (resourceMetadataUri) {
  // discoverOAuthConfig() will try to build .well-known URLs from this,
  // resulting in double-nested paths like:
  // /.well-known/oauth-protected-resource/.well-known/oauth-protected-resource/path
  oauthConfig = await OAuthUtils.discoverOAuthConfig(resourceMetadataUri);
}
```

## Fix

Use the existing `discoverOAuthFromWWWAuthenticate()` utility which correctly:
1. Parses the `resource_metadata` URI from the `WWW-Authenticate` header
2. Directly fetches the resource metadata (no double `.well-known` construction)
3. Validates the `resource` parameter against the actual server URL (RFC 9728 §7.3)
4. Discovers the authorization server from the metadata

```typescript
// AFTER (fixed): use the correct utility that handles the full flow
const serverUrl = mcpServerConfig.httpUrl || mcpServerConfig.url;
let oauthConfig = await OAuthUtils.discoverOAuthFromWWWAuthenticate(
  wwwAuthenticate,
  serverUrl,
);
```

Fallback to base URL discovery via `discoverOAuthConfig()` is preserved for servers that don't include `resource_metadata` in the `WWW-Authenticate` header.

Fixes #18760