### PR TITLE
fix(cli): update F12 behavior to only open drawer if browser fails

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1525,6 +1525,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
             );
             await toggleDevToolsPanel(
               config,
+              showErrorDetails,
               () => setShowErrorDetails((prev) => !prev),
               () => setShowErrorDetails(true),
             );
@@ -1665,6 +1666,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       tabFocusTimeoutRef,
       showTransientMessage,
       settings.merged.general.devtools,
+      showErrorDetails,
     ],
   );
 

--- a/packages/cli/src/utils/devtoolsService.test.ts
+++ b/packages/cli/src/utils/devtoolsService.test.ts
@@ -437,7 +437,19 @@ describe('devtoolsService', () => {
   });
 
   describe('toggleDevToolsPanel', () => {
-    it('calls toggle when browser opens successfully', async () => {
+    it('calls toggle (to close) when already open', async () => {
+      const config = createMockConfig();
+      const toggle = vi.fn();
+      const setOpen = vi.fn();
+
+      const promise = toggleDevToolsPanel(config, true, toggle, setOpen);
+      await promise;
+
+      expect(toggle).toHaveBeenCalledTimes(1);
+      expect(setOpen).not.toHaveBeenCalled();
+    });
+
+    it('does NOT call toggle or setOpen when browser opens successfully', async () => {
       const config = createMockConfig();
       const toggle = vi.fn();
       const setOpen = vi.fn();
@@ -447,18 +459,18 @@ describe('devtoolsService', () => {
       mockDevToolsInstance.start.mockResolvedValue('http://127.0.0.1:25417');
       mockDevToolsInstance.getPort.mockReturnValue(25417);
 
-      const promise = toggleDevToolsPanel(config, toggle, setOpen);
+      const promise = toggleDevToolsPanel(config, false, toggle, setOpen);
 
       await vi.waitFor(() => expect(MockWebSocket.instances.length).toBe(1));
       MockWebSocket.instances[0].simulateError();
 
       await promise;
 
-      expect(toggle).toHaveBeenCalledTimes(1);
+      expect(toggle).not.toHaveBeenCalled();
       expect(setOpen).not.toHaveBeenCalled();
     });
 
-    it('calls toggle when browser fails to open', async () => {
+    it('calls setOpen when browser fails to open', async () => {
       const config = createMockConfig();
       const toggle = vi.fn();
       const setOpen = vi.fn();
@@ -468,18 +480,18 @@ describe('devtoolsService', () => {
       mockDevToolsInstance.start.mockResolvedValue('http://127.0.0.1:25417');
       mockDevToolsInstance.getPort.mockReturnValue(25417);
 
-      const promise = toggleDevToolsPanel(config, toggle, setOpen);
+      const promise = toggleDevToolsPanel(config, false, toggle, setOpen);
 
       await vi.waitFor(() => expect(MockWebSocket.instances.length).toBe(1));
       MockWebSocket.instances[0].simulateError();
 
       await promise;
 
-      expect(toggle).toHaveBeenCalledTimes(1);
-      expect(setOpen).not.toHaveBeenCalled();
+      expect(toggle).not.toHaveBeenCalled();
+      expect(setOpen).toHaveBeenCalledTimes(1);
     });
 
-    it('calls toggle when shouldLaunchBrowser returns false', async () => {
+    it('calls setOpen when shouldLaunchBrowser returns false', async () => {
       const config = createMockConfig();
       const toggle = vi.fn();
       const setOpen = vi.fn();
@@ -488,15 +500,15 @@ describe('devtoolsService', () => {
       mockDevToolsInstance.start.mockResolvedValue('http://127.0.0.1:25417');
       mockDevToolsInstance.getPort.mockReturnValue(25417);
 
-      const promise = toggleDevToolsPanel(config, toggle, setOpen);
+      const promise = toggleDevToolsPanel(config, false, toggle, setOpen);
 
       await vi.waitFor(() => expect(MockWebSocket.instances.length).toBe(1));
       MockWebSocket.instances[0].simulateError();
 
       await promise;
 
-      expect(toggle).toHaveBeenCalledTimes(1);
-      expect(setOpen).not.toHaveBeenCalled();
+      expect(toggle).not.toHaveBeenCalled();
+      expect(setOpen).toHaveBeenCalledTimes(1);
     });
 
     it('calls setOpen when DevTools server fails to start', async () => {
@@ -506,7 +518,7 @@ describe('devtoolsService', () => {
 
       mockDevToolsInstance.start.mockRejectedValue(new Error('fail'));
 
-      const promise = toggleDevToolsPanel(config, toggle, setOpen);
+      const promise = toggleDevToolsPanel(config, false, toggle, setOpen);
 
       await vi.waitFor(() => expect(MockWebSocket.instances.length).toBe(1));
       MockWebSocket.instances[0].simulateError();


### PR DESCRIPTION
## TLDR

Updated the F12 key behavior for DevTools. Now, if the drawer is closed, pressing F12 will attempt to open the DevTools in the browser. The drawer will only open if the browser cannot be launched or fails to open. If the drawer is already open, pressing F12 will close it.

## Dive Deeper

This change improves the UX by prioritizing the browser-based DevTools over the built-in debug drawer when possible. It also ensures that F12 acts as a consistent toggle for the drawer's visibility.

Key changes:
-  now takes an  boolean.
- It returns early after a successful browser launch if the drawer was closed.
-  passes the current  state.
- Updated unit tests to reflect and verify these state transitions.

## Reviewer Test Plan

1. Enable devtools in settings.
2. Press F12 when the drawer is closed:
   - It should attempt to open your browser.
   - If the browser opens, the CLI drawer should remain closed.
3. Press F12 when the drawer is open:
   - The drawer should close.
4. (Optional) Simulate a browser launch failure or disable browser launching to verify the drawer still opens as a fallback.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #18795