### PR TITLE
feat(core): complete migration of subagents and internal tools to Gemini 3

### DIFF
--- a/packages/core/src/agents/cli-help-agent.test.ts
+++ b/packages/core/src/agents/cli-help-agent.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import { CliHelpAgent } from './cli-help-agent.js';
 import { GET_INTERNAL_DOCS_TOOL_NAME } from '../tools/tool-names.js';
-import { GEMINI_MODEL_ALIAS_FLASH } from '../config/models.js';
+import { PREVIEW_GEMINI_FLASH_MODEL } from '../config/models.js';
 import type { LocalAgentDefinition } from './types.js';
 import type { Config } from '../config/config.js';
 
@@ -36,7 +36,7 @@ describe('CliHelpAgent', () => {
   });
 
   it('should use the correct model and tools', () => {
-    expect(localAgent.modelConfig?.model).toBe(GEMINI_MODEL_ALIAS_FLASH);
+    expect(localAgent.modelConfig?.model).toBe(PREVIEW_GEMINI_FLASH_MODEL);
 
     const tools = localAgent.toolConfig?.tools || [];
     const hasInternalDocsTool = tools.some(

--- a/packages/core/src/agents/cli-help-agent.ts
+++ b/packages/core/src/agents/cli-help-agent.ts
@@ -5,7 +5,7 @@
  */
 
 import type { AgentDefinition } from './types.js';
-import { GEMINI_MODEL_ALIAS_FLASH } from '../config/models.js';
+import { PREVIEW_GEMINI_FLASH_MODEL } from '../config/models.js';
 import { z } from 'zod';
 import type { Config } from '../config/config.js';
 import { GetInternalDocsTool } from '../tools/get-internal-docs.js';
@@ -52,7 +52,7 @@ export const CliHelpAgent = (
   processOutput: (output) => JSON.stringify(output, null, 2),
 
   modelConfig: {
-    model: GEMINI_MODEL_ALIAS_FLASH,
+    model: PREVIEW_GEMINI_FLASH_MODEL,
     generateContentConfig: {
       temperature: 0.1,
       topP: 0.95,

--- a/packages/core/src/agents/codebase-investigator.test.ts
+++ b/packages/core/src/agents/codebase-investigator.test.ts
@@ -12,7 +12,7 @@ import {
   LS_TOOL_NAME,
   READ_FILE_TOOL_NAME,
 } from '../tools/tool-names.js';
-import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
+import { PREVIEW_GEMINI_FLASH_MODEL } from '../config/models.js';
 import { makeFakeConfig } from '../test-utils/config.js';
 
 describe('CodebaseInvestigatorAgent', () => {
@@ -44,7 +44,7 @@ describe('CodebaseInvestigatorAgent', () => {
     expect(inputSchema.properties['objective']).toBeDefined();
     expect(inputSchema.required).toContain('objective');
     expect(agent.outputConfig?.outputName).toBe('report');
-    expect(agent.modelConfig?.model).toBe(DEFAULT_GEMINI_MODEL);
+    expect(agent.modelConfig?.model).toBe(PREVIEW_GEMINI_FLASH_MODEL);
     expect(agent.toolConfig?.tools).toEqual([
       LS_TOOL_NAME,
       READ_FILE_TOOL_NAME,

--- a/packages/core/src/agents/codebase-investigator.ts
+++ b/packages/core/src/agents/codebase-investigator.ts
@@ -13,7 +13,6 @@ import {
 } from '../tools/tool-names.js';
 import {
   DEFAULT_THINKING_MODE,
-  DEFAULT_GEMINI_MODEL,
   PREVIEW_GEMINI_FLASH_MODEL,
   isPreviewModel,
 } from '../config/models.js';
@@ -49,13 +48,10 @@ const CodebaseInvestigationReportSchema = z.object({
  * dependencies, and technologies.
  */
 export const CodebaseInvestigatorAgent = (
-  config: Config,
+  _config: Config,
 ): LocalAgentDefinition<typeof CodebaseInvestigationReportSchema> => {
-  // Use Preview Flash model if the main model is any of the preview models.
-  // If the main model is not a preview model, use the default pro model.
-  const model = isPreviewModel(config.getModel())
-    ? PREVIEW_GEMINI_FLASH_MODEL
-    : DEFAULT_GEMINI_MODEL;
+  // Use Gemini 3 Flash model for subagent tasks to balance performance and latency.
+  const model = PREVIEW_GEMINI_FLASH_MODEL;
 
   const listCommand =
     process.platform === 'win32'

--- a/packages/core/src/tools/write-todos.ts
+++ b/packages/core/src/tools/write-todos.ts
@@ -53,13 +53,13 @@ DO NOT use this tool for simple tasks that can be completed in less than 2 steps
 ## Examples of When to Use the Todo List
 
 <example>
-User request: Create a website with a React for creating fancy logos using gemini-2.5-flash-image
+User request: Create a website with a React for creating fancy logos using gemini-3-flash-preview
 
 ToDo list created by the agent:
 1. Initialize a new React project environment (e.g., using Vite).
 2. Design and build the core UI components: a text input (prompt field) for the logo description, selection controls for style parameters (if the API supports them), and an image preview area.
 3. Implement state management (e.g., React Context or Zustand) to manage the user's input prompt, the API loading status (pending, success, error), and the resulting image data.
-4. Create an API service module within the React app (using "fetch" or "axios") to securely format and send the prompt data via an HTTP POST request to the specified "gemini-2.5-flash-image" (Gemini model) endpoint.
+4. Create an API service module within the React app (using "fetch" or "axios") to securely format and send the prompt data via an HTTP POST request to the specified "gemini-3-flash-preview" (Gemini model) endpoint.
 5. Implement asynchronous logic to handle the API call: show a loading indicator while the request is pending, retrieve the generated image (e.g., as a URL or base64 string) upon success, and display any errors.
 6. Display the returned "fancy logo" from the API response in the preview area component.
 7. Add functionality (e.g., a "Download" button) to allow the user to save the generated image file.


### PR DESCRIPTION
## TLDR

This PR completes the migration of subagents and internal tools to Gemini 3, resolving remaining hardcoded Gemini 2.5 references. It specifically updates the Codebase Investigator and CLI Help agents, and cleans up legacy model references in the `write-todos` tool description.

## Dive Deeper

- **Codebase Investigator**: Now consistently uses `PREVIEW_GEMINI_FLASH_MODEL` (Gemini 3 Flash) instead of conditionally falling back to Gemini 2.5 Pro. This improves performance and ensures the agent leverages the latest model architecture.
- **CLI Help Agent**: Explicitly switched to `PREVIEW_GEMINI_FLASH_MODEL` for internal consistency with other subagents.
- **Write-Todos Cleanup**: Updated example documentation in `write-todos.ts` to replace legacy `gemini-2.5-flash-image` references with `gemini-3-flash-preview`.
- **Test Alignment**: Updated unit tests for both subagents to reflect the model changes.

## Reviewer Test Plan

Reviewers should verify that the subagents (`cli_help` and `codebase_investigator`) correctly resolve to Gemini 3 Flash. This can be checked by inspecting the `modelConfig` in the respective agent files or by running the agents in a debug session.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to google-gemini/maintainers-gemini-cli#1284