### PR TITLE
fix(core): improve headless mode detection for flags and query args

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -445,7 +445,11 @@ export async function loadCliConfig(
     process.env['VITEST'] === 'true'
       ? false
       : (settings.security?.folderTrust?.enabled ?? false);
-  const trustedFolder = isWorkspaceTrusted(settings, cwd)?.isTrusted ?? false;
+  const trustedFolder =
+    isWorkspaceTrusted(settings, cwd, undefined, {
+      prompt: argv.prompt,
+      query: argv.query,
+    })?.isTrusted ?? false;
 
   // Set the context filename in the server's memoryTool module BEFORE loading memory
   // TODO(b/343434939): This is a bit of a hack. The contextFileName should ideally be passed
@@ -602,8 +606,7 @@ export async function loadCliConfig(
   const interactive =
     !!argv.promptInteractive ||
     !!argv.experimentalAcp ||
-    (!isHeadlessMode({ prompt: argv.prompt }) &&
-      !argv.query &&
+    (!isHeadlessMode({ prompt: argv.prompt, query: argv.query }) &&
       !argv.isCommand);
 
   const allowedTools = argv.allowedTools || settings.tools?.allowed || [];

--- a/packages/cli/src/config/trustedFolders.test.ts
+++ b/packages/cli/src/config/trustedFolders.test.ts
@@ -449,6 +449,14 @@ describe('Trusted Folders', () => {
         false,
       );
     });
+
+    it('should return true for isPathTrusted when isHeadlessMode is true', async () => {
+      const geminiCore = await import('@google/gemini-cli-core');
+      vi.spyOn(geminiCore, 'isHeadlessMode').mockReturnValue(true);
+
+      const folders = loadTrustedFolders();
+      expect(folders.isPathTrusted('/any-untrusted-path')).toBe(true);
+    });
   });
 
   describe('Trusted Folders Caching', () => {

--- a/packages/core/src/utils/headless.ts
+++ b/packages/core/src/utils/headless.ts
@@ -28,34 +28,24 @@ export interface HeadlessModeOptions {
  * @returns true if the environment is considered headless.
  */
 export function isHeadlessMode(options?: HeadlessModeOptions): boolean {
-  if (process.env['GEMINI_CLI_INTEGRATION_TEST'] === 'true') {
-    if (
-      !!options?.prompt ||
-      !!options?.query ||
-      (!!process.stdin && !process.stdin.isTTY) ||
-      (!!process.stdout && !process.stdout.isTTY)
-    ) {
+  if (process.env['GEMINI_CLI_INTEGRATION_TEST'] !== 'true') {
+    const isCI =
+      process.env['CI'] === 'true' || process.env['GITHUB_ACTIONS'] === 'true';
+    if (isCI) {
       return true;
     }
-    return process.argv.some(
-      (arg) =>
-        arg === '-p' || arg === '--prompt' || arg === '-y' || arg === '--yolo',
-    );
   }
 
-  const isCI =
-    process.env['CI'] === 'true' || process.env['GITHUB_ACTIONS'] === 'true';
   const isNotTTY =
     (!!process.stdin && !process.stdin.isTTY) ||
     (!!process.stdout && !process.stdout.isTTY);
 
-  if (isCI || isNotTTY || !!options?.prompt || !!options?.query) {
+  if (isNotTTY || !!options?.prompt || !!options?.query) {
     return true;
   }
 
   // Fallback: check process.argv for flags that imply headless or auto-approve mode.
-  const argv = process.argv;
-  return argv.some(
+  return process.argv.some(
     (arg) =>
       arg === '-p' || arg === '--prompt' || arg === '-y' || arg === '--yolo',
   );

--- a/packages/core/src/utils/headless.ts
+++ b/packages/core/src/utils/headless.ts
@@ -29,17 +29,34 @@ export interface HeadlessModeOptions {
  */
 export function isHeadlessMode(options?: HeadlessModeOptions): boolean {
   if (process.env['GEMINI_CLI_INTEGRATION_TEST'] === 'true') {
-    return (
+    if (
       !!options?.prompt ||
+      !!options?.query ||
       (!!process.stdin && !process.stdin.isTTY) ||
       (!!process.stdout && !process.stdout.isTTY)
+    ) {
+      return true;
+    }
+    return process.argv.some(
+      (arg) =>
+        arg === '-p' || arg === '--prompt' || arg === '-y' || arg === '--yolo',
     );
   }
-  return (
-    process.env['CI'] === 'true' ||
-    process.env['GITHUB_ACTIONS'] === 'true' ||
-    !!options?.prompt ||
+
+  const isCI =
+    process.env['CI'] === 'true' || process.env['GITHUB_ACTIONS'] === 'true';
+  const isNotTTY =
     (!!process.stdin && !process.stdin.isTTY) ||
-    (!!process.stdout && !process.stdout.isTTY)
+    (!!process.stdout && !process.stdout.isTTY);
+
+  if (isCI || isNotTTY || !!options?.prompt || !!options?.query) {
+    return true;
+  }
+
+  // Fallback: check process.argv for flags that imply headless or auto-approve mode.
+  const argv = process.argv;
+  return argv.some(
+    (arg) =>
+      arg === '-p' || arg === '--prompt' || arg === '-y' || arg === '--yolo',
   );
 }


### PR DESCRIPTION
## Summary

Improve headless mode detection to correctly trust workspaces when using flags like `-p`, `--prompt`, `-y`, and `--yolo`, or when providing query positional arguments. This ensures that non-interactive commands correctly bypass folder trust prompts.

## Details

- Updated `isHeadlessMode` in `packages/core` to detect query arguments and fallback to `process.argv` for common headless/auto-approve flags.
- Updated `isWorkspaceTrusted` in `packages/cli` to accept and pass headless options, ensuring trust is granted when headless mode is active.
- Refined interactivity logic in `loadCliConfig` to stay consistent with the improved headless detection.
- Fixed TypeScript errors in tests by using canonical `Object.defineProperty` for system streams instead of `delete`.

## Related Issues

Fixes the issue where `npm start -- -y -p "hi"` would still trigger folder trust errors.

## How to Validate

1. Run `npm start -- -y -p "hi"` in an untrusted folder.
2. Observe that it no longer prompts for folder trust and proceeds with the prompt.
3. Run `npm run test -w @google/gemini-cli-core -- src/utils/headless.test.ts` to verify detection logic.
4. Run `npm run build` to ensure no regressions in types or linting.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [x] Seatbelt
