### PR TITLE
fix(core): ensure sub-agents are registered regardless of tools.allowed

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2458,26 +2458,16 @@ export class Config {
       agentsOverrides['codebase_investigator']?.enabled !== false ||
       agentsOverrides['cli_help']?.enabled !== false
     ) {
-      const allowedTools = this.getAllowedTools();
       const definitions = this.agentRegistry.getAllDefinitions();
 
       for (const definition of definitions) {
-        const isAllowed =
-          !allowedTools || allowedTools.includes(definition.name);
-
-        if (isAllowed) {
-          try {
-            const tool = new SubagentTool(
-              definition,
-              this,
-              this.getMessageBus(),
-            );
-            registry.registerTool(tool);
-          } catch (e: unknown) {
-            debugLogger.warn(
-              `Failed to register tool for agent ${definition.name}: ${getErrorMessage(e)}`,
-            );
-          }
+        try {
+          const tool = new SubagentTool(definition, this, this.getMessageBus());
+          registry.registerTool(tool);
+        } catch (e: unknown) {
+          debugLogger.warn(
+            `Failed to register tool for agent ${definition.name}: ${getErrorMessage(e)}`,
+          );
         }
       }
     }


### PR DESCRIPTION
## Summary

This PR fixes an issue where sub-agents (e.g., `codebase_investigator`, `cli_help`) were not registered if a user had an explicit `tools.allowed` list in their `settings.json`. Sub-agents are now exempt from this list, ensuring they are always available when enabled in the agents settings.

## Details

- Removed the `allowedTools` check from `registerSubAgentTools` in `packages/core/src/config/config.ts`.
- Sub-agents continue to respect their individual `enabled` overrides (e.g., `agents.overrides.codebase_investigator.enabled`).
- Added a regression test in `packages/core/src/config/config.test.ts` to verify sub-agent registration regardless of `allowedTools` content.

## Related Issues

Related to the reported issue: "when someone tries to invoke a sub agent aka 'codebase_investigator' and settings.json has 'tools.allowed' it won't work."

## How to Validate

1.  Set `tools.allowed` in `settings.json` (e.g., `["read_file"]`) without including `codebase_investigator`.
2.  Enable agents if not already enabled.
3.  Launch the CLI and attempt to use a feature that invokes `codebase_investigator` (e.g., "Investigate the codebase").
4.  Verify that the sub-agent is available and can be invoked.
5.  Run unit tests: `npm test -w @google/gemini-cli-core -- src/config/config.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
