### PR TITLE
chore: cleanup unused and add unlisted dependencies in packages/a2a-server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4234,6 +4234,27 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/tar": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.13.tgz",
+      "integrity": "sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "minipass": "^4.0.0"
+      }
+    },
+    "node_modules/@types/tar/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@types/tinycolor2": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.6.tgz",
@@ -17243,6 +17264,7 @@
         "@types/express": "^5.0.3",
         "@types/fs-extra": "^11.0.4",
         "@types/supertest": "^6.0.3",
+        "@types/tar": "^6.1.13",
         "dotenv": "^16.4.5",
         "supertest": "^7.1.4",
         "typescript": "^5.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4234,27 +4234,6 @@
         "@types/superagent": "^8.1.0"
       }
     },
-    "node_modules/@types/tar": {
-      "version": "6.1.13",
-      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.13.tgz",
-      "integrity": "sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "minipass": "^4.0.0"
-      }
-    },
-    "node_modules/@types/tar/node_modules/minipass": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@types/tinycolor2": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.6.tgz",
@@ -17251,6 +17230,7 @@
         "@google/gemini-cli-core": "file:../core",
         "express": "^5.1.0",
         "fs-extra": "^11.3.0",
+        "strip-json-comments": "^3.1.1",
         "tar": "^7.5.2",
         "uuid": "^13.0.0",
         "winston": "^3.17.0"
@@ -17259,10 +17239,10 @@
         "gemini-cli-a2a-server": "dist/a2a-server.mjs"
       },
       "devDependencies": {
+        "@google/genai": "^1.30.0",
         "@types/express": "^5.0.3",
         "@types/fs-extra": "^11.0.4",
         "@types/supertest": "^6.0.3",
-        "@types/tar": "^6.1.13",
         "dotenv": "^16.4.5",
         "supertest": "^7.1.4",
         "typescript": "^5.3.3",

--- a/packages/a2a-server/package.json
+++ b/packages/a2a-server/package.json
@@ -40,6 +40,7 @@
     "@types/express": "^5.0.3",
     "@types/fs-extra": "^11.0.4",
     "@types/supertest": "^6.0.3",
+    "@types/tar": "^6.1.13",
     "dotenv": "^16.4.5",
     "supertest": "^7.1.4",
     "typescript": "^5.3.3",

--- a/packages/a2a-server/package.json
+++ b/packages/a2a-server/package.json
@@ -30,15 +30,16 @@
     "@google/gemini-cli-core": "file:../core",
     "express": "^5.1.0",
     "fs-extra": "^11.3.0",
+    "strip-json-comments": "^3.1.1",
     "tar": "^7.5.2",
     "uuid": "^13.0.0",
     "winston": "^3.17.0"
   },
   "devDependencies": {
+    "@google/genai": "^1.30.0",
     "@types/express": "^5.0.3",
     "@types/fs-extra": "^11.0.4",
     "@types/supertest": "^6.0.3",
-    "@types/tar": "^6.1.13",
     "dotenv": "^16.4.5",
     "supertest": "^7.1.4",
     "typescript": "^5.3.3",


### PR DESCRIPTION
### Description
This PR cleans up the dependencies in `packages/a2a-server` based on `knip` analysis.

### Changes
- **Added missing dependency**: `strip-json-comments`.
- **Added missing devDependency**: `@google/genai` (used for types in `src/agent/task.ts`).
- Updated `package-lock.json` to reflect these changes.

Verification: Builds successfully and all tests pass.

Relates to https://github.com/google-gemini/gemini-cli/issues/18199