### PR TITLE
feat(ui): align `AskUser` color scheme with UX spec

### DIFF
--- a/packages/cli/src/ui/components/ToolConfirmationQueue.tsx
+++ b/packages/cli/src/ui/components/ToolConfirmationQueue.tsx
@@ -70,10 +70,11 @@ export const ToolConfirmationQueue: React.FC<ToolConfirmationQueueProps> = ({
       ? Math.max(maxHeight - 6, 4)
       : undefined;
 
-  const borderColor = theme.status.warning;
-  const hideToolIdentity =
+  const isRoutine =
     tool.confirmationDetails?.type === 'ask_user' ||
     tool.confirmationDetails?.type === 'exit_plan_mode';
+  const borderColor = isRoutine ? theme.status.success : theme.status.warning;
+  const hideToolIdentity = isRoutine;
 
   return (
     <OverflowProvider>
@@ -90,7 +91,7 @@ export const ToolConfirmationQueue: React.FC<ToolConfirmationQueueProps> = ({
               marginBottom={hideToolIdentity ? 0 : 1}
               justifyContent="space-between"
             >
-              <Text color={theme.status.warning} bold>
+              <Text color={borderColor} bold>
                 {getConfirmationHeader(tool.confirmationDetails)}
               </Text>
               {total > 1 && (

--- a/packages/cli/src/ui/components/__snapshots__/ToolConfirmationQueue.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ToolConfirmationQueue.test.tsx.snap
@@ -40,6 +40,33 @@ exports[`ToolConfirmationQueue > does not render expansion hint when constrainHe
 ╰──────────────────────────────────────────────────────────────────────────────╯"
 `;
 
+exports[`ToolConfirmationQueue > renders AskUser tool confirmation with Success color 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────╮
+│ Answer Questions                                                             │
+│                                                                              │
+│ Review your answers:                                                         │
+│                                                                              │
+│                                                                              │
+│ Enter to submit · Tab/Shift+Tab to edit answers · Esc to cancel              │
+╰──────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+exports[`ToolConfirmationQueue > renders ExitPlanMode tool confirmation with Success color 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────╮
+│ Ready to start implementation?                                               │
+│                                                                              │
+│ Plan content goes here                                                       │
+│                                                                              │
+│ ● 1.  Yes, automatically accept edits                                        │
+│       Approves plan and allows tools to run automatically                    │
+│   2.  Yes, manually accept edits                                             │
+│       Approves plan but requires confirmation for each tool                  │
+│   3.  Type your feedback...                                                  │
+│                                                                              │
+│ Enter to select · ↑/↓ to navigate · Esc to cancel                            │
+╰──────────────────────────────────────────────────────────────────────────────╯"
+`;
+
 exports[`ToolConfirmationQueue > renders expansion hint when content is long and constrained 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────╮
 │ Action Required                                                              │


### PR DESCRIPTION
Update the border and header of AskUser and ExitPlanMode tool confirmations to use a green color scheme (theme.status.success), aligning with the active state color used within the dialog.

Closes #18325

<img width="3430" height="648" alt="image" src="https://github.com/user-attachments/assets/aefe368d-aaee-4e9c-bad6-4ef22268c42f" />

<img width="3440" height="956" alt="image" src="https://github.com/user-attachments/assets/dae72805-926c-484d-b27c-6403e83d7d31" />
