### PR TITLE
bug(cli) fix flicker due to AppContainer continuous initialization

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -89,7 +89,6 @@ import { SessionStatsProvider } from './ui/contexts/SessionContext.js';
 import { VimModeProvider } from './ui/contexts/VimModeContext.js';
 import { KeypressProvider } from './ui/contexts/KeypressContext.js';
 import { useKittyKeyboardProtocol } from './ui/hooks/useKittyKeyboardProtocol.js';
-import { useTerminalSize } from './ui/hooks/useTerminalSize.js';
 import {
   relaunchAppInChildProcess,
   relaunchOnExitCode,
@@ -221,7 +220,6 @@ export async function startInteractiveUI(
   // Create wrapper component to use hooks inside render
   const AppWrapper = () => {
     useKittyKeyboardProtocol();
-    const { columns, rows } = useTerminalSize();
 
     return (
       <SettingsContext.Provider value={settings}>
@@ -240,7 +238,6 @@ export async function startInteractiveUI(
                 <SessionStatsProvider>
                   <VimModeProvider settings={settings}>
                     <AppContainer
-                      key={`${columns}-${rows}`}
                       config={config}
                       startupWarnings={startupWarnings}
                       version={version}


### PR DESCRIPTION
## Summary
- **Remove spuriously added terminal size listener that was causing AppContainer to be repeatedly initialized.**

## Related Issues

Fixes #18956

Will follow up with a regression test but Gemini struggled to create a proper one so reverted what it added as too much was mocked.