### PR TITLE
fix(cli): prevent UI reset and destructive clearing on terminal resize

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -266,14 +266,10 @@ export async function startInteractiveUI(
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
 
+  const app = <AppWrapper key="gemini-root" />;
+
   const instance = render(
-    process.env['DEBUG'] ? (
-      <React.StrictMode>
-        <AppWrapper key="gemini-root" />
-      </React.StrictMode>
-    ) : (
-      <AppWrapper key="gemini-root" />
-    ),
+    process.env['DEBUG'] ? <React.StrictMode>{app}</React.StrictMode> : app,
     {
       stdout: inkStdout,
       stderr: inkStderr,

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -269,10 +269,10 @@ export async function startInteractiveUI(
   const instance = render(
     process.env['DEBUG'] ? (
       <React.StrictMode>
-        <AppWrapper key={isAndroid ? 'android-root' : undefined} />
+        <AppWrapper key="gemini-root" />
       </React.StrictMode>
     ) : (
-      <AppWrapper key={isAndroid ? 'android-root' : undefined} />
+      <AppWrapper key="gemini-root" />
     ),
     {
       stdout: inkStdout,

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -14,6 +14,7 @@ import { basename } from 'node:path';
 import v8 from 'node:v8';
 import os from 'node:os';
 import dns from 'node:dns';
+import { isAndroid } from './utils/platform.js';
 import { start_sandbox } from './utils/sandbox.js';
 import type { DnsResolutionOrder, LoadedSettings } from './config/settings.js';
 import {
@@ -268,10 +269,10 @@ export async function startInteractiveUI(
   const instance = render(
     process.env['DEBUG'] ? (
       <React.StrictMode>
-        <AppWrapper key={os.platform() === 'android' ? 'android-root' : undefined} />
+        <AppWrapper key={isAndroid ? 'android-root' : undefined} />
       </React.StrictMode>
     ) : (
-      <AppWrapper key={os.platform() === 'android' ? 'android-root' : undefined} />
+      <AppWrapper key={isAndroid ? 'android-root' : undefined} />
     ),
     {
       stdout: inkStdout,

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -268,10 +268,10 @@ export async function startInteractiveUI(
   const instance = render(
     process.env['DEBUG'] ? (
       <React.StrictMode>
-        <AppWrapper />
+        <AppWrapper key={os.platform() === 'android' ? 'android-root' : undefined} />
       </React.StrictMode>
     ) : (
-      <AppWrapper />
+      <AppWrapper key={os.platform() === 'android' ? 'android-root' : undefined} />
     ),
     {
       stdout: inkStdout,

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1502,6 +1502,10 @@ Logging in with Google... Restarting Gemini CLI to continue.
       return;
     }
 
+    if (!isAlternateBuffer) {
+      return;
+    }
+
     const handler = setTimeout(() => {
       refreshStatic();
     }, 300);
@@ -1509,7 +1513,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     return () => {
       clearTimeout(handler);
     };
-  }, [terminalWidth, refreshStatic]);
+  }, [terminalWidth, terminalHeight, isAlternateBuffer, refreshStatic]);
 
   useEffect(() => {
     const unsubscribe = ideContextStore.subscribe(setIdeContextState);

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -212,7 +212,6 @@ export const AppContainer = (props: AppContainerProps) => {
   useMemoryMonitor(historyManager);
   const isAlternateBuffer = useAlternateBuffer();
   const [corgiMode, setCorgiMode] = useState(false);
-  const [forceRerenderKey, setForceRerenderKey] = useState(0);
   const [debugMessage, setDebugMessage] = useState<string>('');
   const [quittingMessages, setQuittingMessages] = useState<
     HistoryItem[] | null
@@ -1474,7 +1473,6 @@ Logging in with Google... Restarting Gemini CLI to continue.
     handleWarning,
     setRawMode,
     refreshStatic,
-    setForceRerenderKey,
     shouldUseAlternateScreen,
   });
 
@@ -2401,7 +2399,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
           >
             <ToolActionsProvider config={config} toolCalls={allToolCalls}>
               <ShellFocusContext.Provider value={isFocused}>
-                <App key={`app-${forceRerenderKey}`} />
+                <App />
               </ShellFocusContext.Provider>
             </ToolActionsProvider>
           </AppContext.Provider>

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1472,7 +1472,6 @@ Logging in with Google... Restarting Gemini CLI to continue.
   const { handleSuspend } = useSuspend({
     handleWarning,
     setRawMode,
-    refreshStatic,
     shouldUseAlternateScreen,
   });
 

--- a/packages/cli/src/ui/hooks/useSuspend.test.ts
+++ b/packages/cli/src/ui/hooks/useSuspend.test.ts
@@ -81,7 +81,6 @@ describe('useSuspend', () => {
   it('cleans terminal state on suspend and restores/repaints on resume in alternate screen mode', () => {
     const handleWarning = vi.fn();
     const setRawMode = vi.fn();
-    const refreshStatic = vi.fn();
     const enableSupportedModes =
       terminalCapabilityManager.enableSupportedModes as unknown as Mock;
 
@@ -89,7 +88,6 @@ describe('useSuspend', () => {
       useSuspend({
         handleWarning,
         setRawMode,
-        refreshStatic,
         shouldUseAlternateScreen: true,
       }),
     );
@@ -123,7 +121,6 @@ describe('useSuspend', () => {
     expect(enableSupportedModes).toHaveBeenCalledTimes(1);
     expect(enableMouseEvents).toHaveBeenCalledTimes(1);
     expect(setRawMode).toHaveBeenCalledWith(true);
-    expect(refreshStatic).toHaveBeenCalledTimes(1);
 
     unmount();
   });
@@ -131,13 +128,11 @@ describe('useSuspend', () => {
   it('does not toggle alternate screen or mouse restore when alternate screen mode is disabled', () => {
     const handleWarning = vi.fn();
     const setRawMode = vi.fn();
-    const refreshStatic = vi.fn();
 
     const { result, unmount } = renderHook(() =>
       useSuspend({
         handleWarning,
         setRawMode,
-        refreshStatic,
         shouldUseAlternateScreen: false,
       }),
     );
@@ -163,13 +158,11 @@ describe('useSuspend', () => {
 
     const handleWarning = vi.fn();
     const setRawMode = vi.fn();
-    const refreshStatic = vi.fn();
 
     const { result, unmount } = renderHook(() =>
       useSuspend({
         handleWarning,
         setRawMode,
-        refreshStatic,
         shouldUseAlternateScreen: true,
       }),
     );

--- a/packages/cli/src/ui/hooks/useSuspend.test.ts
+++ b/packages/cli/src/ui/hooks/useSuspend.test.ts
@@ -82,7 +82,6 @@ describe('useSuspend', () => {
     const handleWarning = vi.fn();
     const setRawMode = vi.fn();
     const refreshStatic = vi.fn();
-    const setForceRerenderKey = vi.fn();
     const enableSupportedModes =
       terminalCapabilityManager.enableSupportedModes as unknown as Mock;
 
@@ -91,7 +90,6 @@ describe('useSuspend', () => {
         handleWarning,
         setRawMode,
         refreshStatic,
-        setForceRerenderKey,
         shouldUseAlternateScreen: true,
       }),
     );
@@ -126,7 +124,6 @@ describe('useSuspend', () => {
     expect(enableMouseEvents).toHaveBeenCalledTimes(1);
     expect(setRawMode).toHaveBeenCalledWith(true);
     expect(refreshStatic).toHaveBeenCalledTimes(1);
-    expect(setForceRerenderKey).toHaveBeenCalledTimes(1);
 
     unmount();
   });
@@ -135,14 +132,12 @@ describe('useSuspend', () => {
     const handleWarning = vi.fn();
     const setRawMode = vi.fn();
     const refreshStatic = vi.fn();
-    const setForceRerenderKey = vi.fn();
 
     const { result, unmount } = renderHook(() =>
       useSuspend({
         handleWarning,
         setRawMode,
         refreshStatic,
-        setForceRerenderKey,
         shouldUseAlternateScreen: false,
       }),
     );
@@ -169,14 +164,12 @@ describe('useSuspend', () => {
     const handleWarning = vi.fn();
     const setRawMode = vi.fn();
     const refreshStatic = vi.fn();
-    const setForceRerenderKey = vi.fn();
 
     const { result, unmount } = renderHook(() =>
       useSuspend({
         handleWarning,
         setRawMode,
         refreshStatic,
-        setForceRerenderKey,
         shouldUseAlternateScreen: true,
       }),
     );

--- a/packages/cli/src/ui/hooks/useSuspend.ts
+++ b/packages/cli/src/ui/hooks/useSuspend.ts
@@ -25,14 +25,12 @@ import { WARNING_PROMPT_DURATION_MS } from '../constants.js';
 interface UseSuspendProps {
   handleWarning: (message: string) => void;
   setRawMode: (mode: boolean) => void;
-  refreshStatic: () => void;
   shouldUseAlternateScreen: boolean;
 }
 
 export function useSuspend({
   handleWarning,
   setRawMode,
-  refreshStatic,
   shouldUseAlternateScreen,
 }: UseSuspendProps) {
   const [ctrlZPressCount, setCtrlZPressCount] = useState(0);
@@ -107,11 +105,6 @@ export function useSuspend({
           // Force Ink to do a complete repaint by emitting a resize event.
           // We avoid remounting the entire App component to preserve local state.
           process.stdout.emit('resize');
-
-          // Give a tick for resize to process
-          setImmediate(() => {
-            refreshStatic();
-          });
         } finally {
           if (onResumeHandlerRef.current === onResume) {
             onResumeHandlerRef.current = null;

--- a/packages/cli/src/ui/hooks/useSuspend.ts
+++ b/packages/cli/src/ui/hooks/useSuspend.ts
@@ -113,7 +113,9 @@ export function useSuspend({
           // Give a tick for resize to process, then trigger remount
           setImmediate(() => {
             refreshStatic();
-            setForceRerenderKey((prev) => prev + 1);
+            if (process.platform !== 'android') {
+              setForceRerenderKey((prev) => prev + 1);
+            }
           });
         } finally {
           if (onResumeHandlerRef.current === onResume) {

--- a/packages/cli/src/ui/hooks/useSuspend.ts
+++ b/packages/cli/src/ui/hooks/useSuspend.ts
@@ -19,6 +19,7 @@ import {
   cleanupTerminalOnExit,
   terminalCapabilityManager,
 } from '../utils/terminalCapabilityManager.js';
+import { isAndroid } from '../../utils/platform.js';
 import { WARNING_PROMPT_DURATION_MS } from '../constants.js';
 
 interface UseSuspendProps {
@@ -113,7 +114,7 @@ export function useSuspend({
           // Give a tick for resize to process, then trigger remount
           setImmediate(() => {
             refreshStatic();
-            if (process.platform !== 'android') {
+            if (!isAndroid) {
               setForceRerenderKey((prev) => prev + 1);
             }
           });

--- a/packages/cli/src/ui/hooks/useSuspend.ts
+++ b/packages/cli/src/ui/hooks/useSuspend.ts
@@ -26,7 +26,6 @@ interface UseSuspendProps {
   handleWarning: (message: string) => void;
   setRawMode: (mode: boolean) => void;
   refreshStatic: () => void;
-  setForceRerenderKey: (updater: (prev: number) => number) => void;
   shouldUseAlternateScreen: boolean;
 }
 
@@ -34,7 +33,6 @@ export function useSuspend({
   handleWarning,
   setRawMode,
   refreshStatic,
-  setForceRerenderKey,
   shouldUseAlternateScreen,
 }: UseSuspendProps) {
   const [ctrlZPressCount, setCtrlZPressCount] = useState(0);
@@ -106,17 +104,13 @@ export function useSuspend({
             enableMouseEvents();
           }
 
-          // Force Ink to do a complete repaint by:
-          // 1. Emitting a resize event (tricks Ink into full redraw)
-          // 2. Remounting components via state changes
+          // Force Ink to do a complete repaint by emitting a resize event.
+          // We avoid remounting the entire App component to preserve local state.
           process.stdout.emit('resize');
 
-          // Give a tick for resize to process, then trigger remount
+          // Give a tick for resize to process
           setImmediate(() => {
             refreshStatic();
-            if (!isAndroid) {
-              setForceRerenderKey((prev) => prev + 1);
-            }
           });
         } finally {
           if (onResumeHandlerRef.current === onResume) {

--- a/packages/cli/src/ui/hooks/useSuspend.ts
+++ b/packages/cli/src/ui/hooks/useSuspend.ts
@@ -132,8 +132,6 @@ export function useSuspend({
     ctrlZPressCount,
     handleWarning,
     setRawMode,
-    refreshStatic,
-    setForceRerenderKey,
     shouldUseAlternateScreen,
   ]);
 

--- a/packages/cli/src/utils/platform.ts
+++ b/packages/cli/src/utils/platform.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import os from 'node:os';
+
+/**
+ * Whether the current platform is Android (Termux).
+ */
+export const isAndroid = os.platform() === 'android';

--- a/packages/cli/src/utils/relaunch.ts
+++ b/packages/cli/src/utils/relaunch.ts
@@ -5,6 +5,7 @@
  */
 
 import { spawn } from 'node:child_process';
+import os from 'node:os';
 import { RELAUNCH_EXIT_CODE } from './processUtils.js';
 import {
   writeToStderr,
@@ -12,6 +13,11 @@ import {
 } from '@google/gemini-cli-core';
 
 export async function relaunchOnExitCode(runner: () => Promise<number>) {
+  if (os.platform() === 'android') {
+    const exitCode = await runner();
+    process.exit(exitCode);
+  }
+
   while (true) {
     try {
       const exitCode = await runner();

--- a/packages/cli/src/utils/relaunch.ts
+++ b/packages/cli/src/utils/relaunch.ts
@@ -6,6 +6,7 @@
 
 import { spawn } from 'node:child_process';
 import os from 'node:os';
+import { isAndroid } from './platform.js';
 import { RELAUNCH_EXIT_CODE } from './processUtils.js';
 import {
   writeToStderr,
@@ -17,7 +18,7 @@ export async function relaunchOnExitCode(runner: () => Promise<number>) {
     try {
       const exitCode = await runner();
 
-      if (os.platform() === 'android' || exitCode !== RELAUNCH_EXIT_CODE) {
+      if (isAndroid || exitCode !== RELAUNCH_EXIT_CODE) {
         process.exit(exitCode);
       }
     } catch (error) {

--- a/packages/cli/src/utils/relaunch.ts
+++ b/packages/cli/src/utils/relaunch.ts
@@ -13,16 +13,11 @@ import {
 } from '@google/gemini-cli-core';
 
 export async function relaunchOnExitCode(runner: () => Promise<number>) {
-  if (os.platform() === 'android') {
-    const exitCode = await runner();
-    process.exit(exitCode);
-  }
-
   while (true) {
     try {
       const exitCode = await runner();
 
-      if (exitCode !== RELAUNCH_EXIT_CODE) {
+      if (os.platform() === 'android' || exitCode !== RELAUNCH_EXIT_CODE) {
         process.exit(exitCode);
       }
     } catch (error) {


### PR DESCRIPTION
## Summary

Fixes UI reset issues when resizing the terminal or moving the application to the background. This addresses both Android/Termux specific issues and a general bug where terminal width changes caused destructive screen clearing.

## Details

1. **General UI Stability**:
   - Resizing the terminal (width change) previously triggered a destructive `refreshStatic()` call which cleared the terminal screen and remounted the history. This behavior is now disabled when not in alternate buffer mode, as clearing the terminal is undesirable and breaks scrollback.
   - Added a stable `key` to `AppWrapper` globally to prevent React component remounting during terminal resize events.
   - Included `terminalHeight` in the redraw trigger for alternate buffer mode to ensure the UI responds to vertical resizes.

2. **Android/Termux Specifics**:
   - **Relauncher Loop**: Disabled the relauncher for the 'android' platform to prevent duplicate UI elements and repeated auth prompts when Android kills background processes.
   - **Suspension Stability**: Prevented forced rerender on resume for Android to preserve input state.

## Related Issues

Fixes #18914

## How to Validate

1. Run the CLI in any terminal.
2. Resize the terminal window. The UI should adjust without clearing the entire screen or resetting scrollback (unless in alternate buffer mode).
3. On Termux, toggle the virtual keyboard. The UI should remain stable.
4. Move the app to the background and return. The state should be preserved.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Termux (Android)
  - [x] Ubuntu (Linux)
