### PR TITLE
Adjust lint rules to avoid unnecessary warning.

### DIFF
--- a/packages/vscode-ide-companion/eslint.config.mjs
+++ b/packages/vscode-ide-companion/eslint.config.mjs
@@ -10,8 +10,6 @@ import tsParser from '@typescript-eslint/parser';
 export default [
   {
     files: ['**/*.ts'],
-  },
-  {
     plugins: {
       '@typescript-eslint': typescriptEslint,
     },
@@ -40,6 +38,13 @@ export default [
       'no-throw-literal': 'warn',
       semi: 'warn',
       '@typescript-eslint/no-floating-promises': ['error'],
+      '@typescript-eslint/no-unsafe-type-assertion': 'error',
+    },
+  },
+  {
+    files: ['**/*.test.ts'],
+    rules: {
+      '@typescript-eslint/no-unsafe-type-assertion': 'off',
     },
   },
 ];


### PR DESCRIPTION
## Summary

Adjust lint rules to avoid unnecessary warning.

## Details

We were previously getting this error when building:
```
/Users/sciortino/src/gemini-cli/packages/vscode-ide-companion/src/diff-manager.ts
  246:9  warning  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-unsafe-type-assertion')

/Users/sciortino/src/gemini-cli/packages/vscode-ide-companion/src/ide-server.ts
  209:9  warning  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-unsafe-type-assertion')
  294:9  warning  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-unsafe-type-assertion')
  342:9  warning  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-unsafe-type-assertion')

✖ 4 problems (0 errors, 4 warnings)
  0 errors and 4 warnings potentially fixable with the `--fix` option.
```

It was due to the vscode-ide-companion having its own eslint file that was out of sync. This fixes it to have the same setting for this warning that the rest of the project does.
