### PR TITLE
fix(core): Prevent loop detection false positives on lists with long shared prefixes

### DIFF
--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -210,6 +210,25 @@ describe('LoopDetectionService', () => {
       expect(loggers.logLoopDetected).toHaveBeenCalledTimes(1);
     });
 
+    it('should not detect a loop for a list with a long shared prefix', () => {
+      service.reset('');
+      let isLoop = false;
+      const longPrefix =
+        'projects/my-google-cloud-project-12345/locations/us-central1/services/';
+
+      let listContent = '';
+      for (let i = 0; i < 15; i++) {
+        listContent += `- ${longPrefix}${i}\n`;
+      }
+
+      // Simulate receiving the list in a single large chunk or a few chunks
+      // This is the specific case where the issue occurs, as list boundaries might not reset tracking properly
+      isLoop = service.addAndCheck(createContentEvent(listContent));
+
+      expect(isLoop).toBe(false);
+      expect(loggers.logLoopDetected).not.toHaveBeenCalled();
+    });
+
     it('should not detect a loop if repetitions are very far apart', () => {
       service.reset('');
       const repeatedContent = createRepetitiveContent(1, CONTENT_CHUNK_SIZE);

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -379,7 +379,30 @@ export class LoopDetectionService {
     const averageDistance = totalDistance / (CONTENT_LOOP_THRESHOLD - 1);
     const maxAllowedDistance = CONTENT_CHUNK_SIZE * 5;
 
-    return averageDistance <= maxAllowedDistance;
+    if (averageDistance > maxAllowedDistance) {
+      return false;
+    }
+
+    // Verify that the sequence is actually repeating, not just sharing a common prefix.
+    // For a true loop, the text between occurrences of the chunk (the period) should be highly repetitive.
+    const periods = new Set<string>();
+    for (let i = 0; i < recentIndices.length - 1; i++) {
+      periods.add(
+        this.streamContentHistory.substring(
+          recentIndices[i],
+          recentIndices[i + 1],
+        ),
+      );
+    }
+
+    // If the periods are mostly unique, it's a list of distinct items with a shared prefix.
+    // A true loop will have a small number of unique periods (usually 1, sometimes 2 or 3).
+    // We use Math.floor(CONTENT_LOOP_THRESHOLD / 2) as a safe threshold.
+    if (periods.size > Math.floor(CONTENT_LOOP_THRESHOLD / 2)) {
+      return false;
+    }
+
+    return true;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes an issue where loop detection was over-triggering on lists containing long, shared prefixes (e.g., lists of external service names). The `LoopDetectionService` now verifies that the sequence is actually repeating in its entirety and not just sharing a common prefix.

## Details

The algorithm previously hashed 50-character chunks of streaming text and triggered when a chunk repeated 10 times in close proximity. This meant any sequence sharing a 50+ character prefix (like a list of Google Cloud service names) would trigger a false loop detection.
By analyzing the sequences of text ("periods") between each identical chunk occurrence, the logic now differentiates between true chanting/looping (where the periods are highly repetitive or few in unique number) and valid lists with shared prefixes (where the text trailing the prefix is highly variable).

## Related Issues
#18007 

## How to Validate

You can validate this change by prompting the AI to output a long list of items sharing a very long prefix (e.g., "List 20 Google Cloud resource names in the format 'projects/my-google-cloud-project-12345/locations/us-central1/services/...'"). The model should stream the full list without halting with a loop detection error.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
