### PR TITLE
fix(core): ensure --yolo does not force headless mode

### DIFF
--- a/packages/core/src/utils/headless.test.ts
+++ b/packages/core/src/utils/headless.test.ts
@@ -120,18 +120,18 @@ describe('isHeadlessMode', () => {
     }
   });
 
-  it('should return true if -y or --yolo is in process.argv as a fallback', () => {
+  it('should return false if -y or --yolo is in process.argv as a fallback', () => {
     const originalArgv = process.argv;
     process.argv = ['node', 'index.js', '-y'];
     try {
-      expect(isHeadlessMode()).toBe(true);
+      expect(isHeadlessMode()).toBe(false);
     } finally {
       process.argv = originalArgv;
     }
 
     process.argv = ['node', 'index.js', '--yolo'];
     try {
-      expect(isHeadlessMode()).toBe(true);
+      expect(isHeadlessMode()).toBe(false);
     } finally {
       process.argv = originalArgv;
     }

--- a/packages/core/src/utils/headless.ts
+++ b/packages/core/src/utils/headless.ts
@@ -44,9 +44,6 @@ export function isHeadlessMode(options?: HeadlessModeOptions): boolean {
     return true;
   }
 
-  // Fallback: check process.argv for flags that imply headless or auto-approve mode.
-  return process.argv.some(
-    (arg) =>
-      arg === '-p' || arg === '--prompt' || arg === '-y' || arg === '--yolo',
-  );
+  // Fallback: check process.argv for flags that imply headless mode.
+  return process.argv.some((arg) => arg === '-p' || arg === '--prompt');
 }


### PR DESCRIPTION
## Summary

Fixes a regression where `gemini --yolo` would incorrectly boot into headless mode instead of the interactive REPL.

## Details

PR #18855 added `-y` and `--yolo` to the `isHeadlessMode` detection logic. This caused the CLI to believe it was in a non-interactive environment whenever the YOLO flag was present, even if running in a TTY. This PR removes those flags from the detection logic as YOLO is an approval mode, not an environment indicator.

## Related Issues

Fixes a regression introduced in #18855.

## How to Validate

1. Run `gemini --yolo` in a terminal.
2. Verify it enters the interactive REPL instead of immediately exiting or running in headless mode.
3. Run `npm test -w @google/gemini-cli-core -- src/utils/headless.test.ts` to verify all headless detection tests pass.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
