### PR TITLE
fix(core): ensure user rejections update tool outcome for telemetry

### DIFF
--- a/packages/core/src/scheduler/scheduler.test.ts
+++ b/packages/core/src/scheduler/scheduler.test.ts
@@ -973,6 +973,10 @@ describe('Scheduler (Orchestrator)', () => {
         CoreToolCallStatus.Cancelled,
         'User denied execution.',
       );
+      expect(mockStateManager.setOutcome).toHaveBeenCalledWith(
+        'call-1',
+        ToolConfirmationOutcome.Cancel,
+      );
       expect(mockStateManager.cancelAllQueued).toHaveBeenCalledWith(
         'User cancelled operation',
       );

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -487,15 +487,17 @@ export class Scheduler {
       });
       outcome = result.outcome;
       lastDetails = result.lastDetails;
-    } else {
-      this.state.setOutcome(callId, ToolConfirmationOutcome.ProceedOnce);
     }
 
+    this.state.setOutcome(callId, outcome);
+
     // Handle Policy Updates
-    await updatePolicy(toolCall.tool, outcome, lastDetails, {
-      config: this.config,
-      messageBus: this.messageBus,
-    });
+    if (decision === PolicyDecision.ASK_USER && outcome) {
+      await updatePolicy(toolCall.tool, outcome, lastDetails, {
+        config: this.config,
+        messageBus: this.messageBus,
+      });
+    }
 
     // Handle cancellation (cascades to entire batch)
     if (outcome === ToolConfirmationOutcome.Cancel) {


### PR DESCRIPTION
## Summary
This PR fixes a bug where the "User Agreement" (`agreementRate`) telemetry metric always reported 100%, even when users rejected tool call confirmations. 

## Details
The core issue was that user rejection outcomes were not being set in the scheduler's state, causing these events to be missed by the telemetry system.

The `_processToolCall` method in `packages/core/src/scheduler/scheduler.ts` only called `this.state.setOutcome()` when a tool was auto-allowed. This PR ensures `this.state.setOutcome()` is called unconditionally with the `outcome` derived from `resolveConfirmation()`, correctly capturing user decisions like `ToolConfirmationOutcome.Cancel`. This allows the `ToolCallEvent` to be created with the correct `ToolCallDecision.REJECT`, so it's properly logged.

Because `outcome` is now properly set for all code paths, this check ensures the policy engine is only invoked when the user actively made a choice, preventing unintended side-effects from sending default outcomes for auto-allowed tools.

## Related Issues
Fixes https://github.com/google-gemini/gemini-cli/issues/19035 (mirror of b/484240481)

## Testing
- Run the core tests: `npm test -w @google/gemini-cli-core`. All tests should pass, including the new assertion in `scheduler.test.ts` specifically checking for the `setOutcome` call on cancel.

## How to Validate

- Run `npm run start`
- Trigger a tool call that requires user confirmation (e.g., ask it to condense the README into half)
- When prompted by Gemini CLI, use the down arrow key and enter key to select "4. No, suggest changes (esc)"
- Ask it to try again
- This time, choose "1. Allow Once"
- Run /stats (or simply exit out of the CLI)

**Previous Behavior (Bug):**
In stats, the User Agreement is (pre-fix)

```
User Agreement:             100.0% (1 reviewed)
```

**Fixed Behavior:**
In stats, the User Agreement is now (post-fix)

```
User Agreement:             50.0% (2 reviewed)
```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
