### PR TITLE
refactor(core): adopt `CoreToolCallStatus` enum for type safety

### DIFF
--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -50,6 +50,7 @@ import {
   coreEvents,
   applyAdminAllowlist,
   getAdminBlockedMcpServersMessage,
+  CoreToolCallStatus,
 } from '@google/gemini-cli-core';
 import { maybeRequestConsentOrFail } from './extensions/consent.js';
 import { resolveEnvVarsInObject } from '../utils/envVarResolver.js';
@@ -383,7 +384,7 @@ Would you like to attempt to install via "git clone" instead?`,
               newExtensionConfig.version,
               previousExtensionConfig.version,
               installMetadata.type,
-              'success',
+              CoreToolCallStatus.Success,
             ),
           );
         } else {
@@ -395,7 +396,7 @@ Would you like to attempt to install via "git clone" instead?`,
               getExtensionId(newExtensionConfig, installMetadata),
               newExtensionConfig.version,
               installMetadata.type,
-              'success',
+              CoreToolCallStatus.Success,
             ),
           );
           await this.enableExtension(
@@ -433,7 +434,7 @@ Would you like to attempt to install via "git clone" instead?`,
             newExtensionConfig?.version ?? '',
             previousExtensionConfig.version,
             installMetadata.type,
-            'error',
+            CoreToolCallStatus.Error,
           ),
         );
       } else {
@@ -445,7 +446,7 @@ Would you like to attempt to install via "git clone" instead?`,
             extensionId ?? '',
             newExtensionConfig?.version ?? '',
             installMetadata.type,
-            'error',
+            CoreToolCallStatus.Error,
           ),
         );
       }
@@ -491,7 +492,7 @@ Would you like to attempt to install via "git clone" instead?`,
         extension.name,
         hashValue(extension.name),
         extension.id,
-        'success',
+        CoreToolCallStatus.Success,
       ),
     );
   }

--- a/packages/cli/src/ui/hooks/toolMapping.test.ts
+++ b/packages/cli/src/ui/hooks/toolMapping.test.ts
@@ -18,6 +18,7 @@ import {
   type ExecutingToolCall,
   type WaitingToolCall,
   type CancelledToolCall,
+  CoreToolCallStatus,
 } from '@google/gemini-cli-core';
 import { ToolCallStatus } from '../types.js';
 
@@ -28,13 +29,13 @@ describe('toolMapping', () => {
 
   describe('mapCoreStatusToDisplayStatus', () => {
     it.each([
-      ['validating', ToolCallStatus.Pending],
-      ['awaiting_approval', ToolCallStatus.Confirming],
-      ['executing', ToolCallStatus.Executing],
-      ['success', ToolCallStatus.Success],
-      ['cancelled', ToolCallStatus.Canceled],
-      ['error', ToolCallStatus.Error],
-      ['scheduled', ToolCallStatus.Pending],
+      [CoreToolCallStatus.Validating, ToolCallStatus.Pending],
+      [CoreToolCallStatus.AwaitingApproval, ToolCallStatus.Confirming],
+      [CoreToolCallStatus.Executing, ToolCallStatus.Executing],
+      [CoreToolCallStatus.Success, ToolCallStatus.Success],
+      [CoreToolCallStatus.Cancelled, ToolCallStatus.Canceled],
+      [CoreToolCallStatus.Error, ToolCallStatus.Error],
+      [CoreToolCallStatus.Scheduled, ToolCallStatus.Pending],
     ] as const)('maps %s to %s', (coreStatus, expectedDisplayStatus) => {
       expect(mapCoreStatusToDisplayStatus(coreStatus)).toBe(
         expectedDisplayStatus,
@@ -77,7 +78,7 @@ describe('toolMapping', () => {
 
     it('handles a single tool call input', () => {
       const toolCall: ScheduledToolCall = {
-        status: 'scheduled',
+        status: CoreToolCallStatus.Scheduled,
         request: mockRequest,
         tool: mockTool,
         invocation: mockInvocation,
@@ -91,13 +92,13 @@ describe('toolMapping', () => {
 
     it('handles an array of tool calls', () => {
       const toolCall1: ScheduledToolCall = {
-        status: 'scheduled',
+        status: CoreToolCallStatus.Scheduled,
         request: mockRequest,
         tool: mockTool,
         invocation: mockInvocation,
       };
       const toolCall2: ScheduledToolCall = {
-        status: 'scheduled',
+        status: CoreToolCallStatus.Scheduled,
         request: { ...mockRequest, callId: 'call-2' },
         tool: mockTool,
         invocation: mockInvocation,
@@ -111,7 +112,7 @@ describe('toolMapping', () => {
 
     it('maps successful tool call properties correctly', () => {
       const toolCall: SuccessfulToolCall = {
-        status: 'success',
+        status: CoreToolCallStatus.Success,
         request: mockRequest,
         tool: mockTool,
         invocation: mockInvocation,
@@ -139,7 +140,7 @@ describe('toolMapping', () => {
 
     it('maps executing tool call properties correctly with live output and ptyId', () => {
       const toolCall: ExecutingToolCall = {
-        status: 'executing',
+        status: CoreToolCallStatus.Executing,
         request: mockRequest,
         tool: mockTool,
         invocation: mockInvocation,
@@ -166,7 +167,7 @@ describe('toolMapping', () => {
       };
 
       const toolCall: WaitingToolCall = {
-        status: 'awaiting_approval',
+        status: CoreToolCallStatus.AwaitingApproval,
         request: mockRequest,
         tool: mockTool,
         invocation: mockInvocation,
@@ -193,7 +194,7 @@ describe('toolMapping', () => {
       };
 
       const toolCall: WaitingToolCall = {
-        status: 'awaiting_approval',
+        status: CoreToolCallStatus.AwaitingApproval,
         request: mockRequest,
         tool: mockTool,
         invocation: mockInvocation,
@@ -211,7 +212,7 @@ describe('toolMapping', () => {
     it('maps error tool call missing tool definition', () => {
       // e.g. "TOOL_NOT_REGISTERED" errors
       const toolCall: ToolCall = {
-        status: 'error',
+        status: CoreToolCallStatus.Error,
         request: mockRequest, // name: 'test_tool'
         response: { ...mockResponse, resultDisplay: 'Tool not found' },
         // notice: no `tool` or `invocation` defined here
@@ -229,7 +230,7 @@ describe('toolMapping', () => {
 
     it('maps cancelled tool call properties correctly', () => {
       const toolCall: CancelledToolCall = {
-        status: 'cancelled',
+        status: CoreToolCallStatus.Cancelled,
         request: mockRequest,
         tool: mockTool,
         invocation: mockInvocation,
@@ -248,7 +249,7 @@ describe('toolMapping', () => {
 
     it('propagates borderTop and borderBottom options correctly', () => {
       const toolCall: ScheduledToolCall = {
-        status: 'scheduled',
+        status: CoreToolCallStatus.Scheduled,
         request: mockRequest,
         tool: mockTool,
         invocation: mockInvocation,
@@ -264,7 +265,7 @@ describe('toolMapping', () => {
 
     it('sets resultDisplay to undefined for pre-execution statuses', () => {
       const toolCall: ScheduledToolCall = {
-        status: 'scheduled',
+        status: CoreToolCallStatus.Scheduled,
         request: mockRequest,
         tool: mockTool,
         invocation: mockInvocation,

--- a/packages/cli/src/ui/hooks/toolMapping.ts
+++ b/packages/cli/src/ui/hooks/toolMapping.ts
@@ -10,6 +10,8 @@ import {
   type SerializableConfirmationDetails,
   type ToolResultDisplay,
   debugLogger,
+  CoreToolCallStatus,
+  checkExhaustive,
 } from '@google/gemini-cli-core';
 import {
   ToolCallStatus,
@@ -17,25 +19,23 @@ import {
   type IndividualToolCallDisplay,
 } from '../types.js';
 
-import { checkExhaustive } from '@google/gemini-cli-core';
-
 export function mapCoreStatusToDisplayStatus(
   coreStatus: CoreStatus,
 ): ToolCallStatus {
   switch (coreStatus) {
-    case 'validating':
+    case CoreToolCallStatus.Validating:
       return ToolCallStatus.Pending;
-    case 'awaiting_approval':
+    case CoreToolCallStatus.AwaitingApproval:
       return ToolCallStatus.Confirming;
-    case 'executing':
+    case CoreToolCallStatus.Executing:
       return ToolCallStatus.Executing;
-    case 'success':
+    case CoreToolCallStatus.Success:
       return ToolCallStatus.Success;
-    case 'cancelled':
+    case CoreToolCallStatus.Cancelled:
       return ToolCallStatus.Canceled;
-    case 'error':
+    case CoreToolCallStatus.Error:
       return ToolCallStatus.Error;
-    case 'scheduled':
+    case CoreToolCallStatus.Scheduled:
       return ToolCallStatus.Pending;
     default:
       return checkExhaustive(coreStatus);
@@ -60,7 +60,7 @@ export function mapToDisplay(
 
     const displayName = call.tool?.displayName ?? call.request.name;
 
-    if (call.status === 'error') {
+    if (call.status === CoreToolCallStatus.Error) {
       description = JSON.stringify(call.request.args);
     } else {
       description = call.invocation.getDescription();
@@ -82,25 +82,25 @@ export function mapToDisplay(
     let correlationId: string | undefined = undefined;
 
     switch (call.status) {
-      case 'success':
+      case CoreToolCallStatus.Success:
         resultDisplay = call.response.resultDisplay;
         outputFile = call.response.outputFile;
         break;
-      case 'error':
-      case 'cancelled':
+      case CoreToolCallStatus.Error:
+      case CoreToolCallStatus.Cancelled:
         resultDisplay = call.response.resultDisplay;
         break;
-      case 'awaiting_approval':
+      case CoreToolCallStatus.AwaitingApproval:
         correlationId = call.correlationId;
         // Pass through details. Context handles dispatch (callback vs bus).
         confirmationDetails = call.confirmationDetails;
         break;
-      case 'executing':
+      case CoreToolCallStatus.Executing:
         resultDisplay = call.liveOutput;
         ptyId = call.pid;
         break;
-      case 'scheduled':
-      case 'validating':
+      case CoreToolCallStatus.Scheduled:
+      case CoreToolCallStatus.Validating:
         break;
       default: {
         const exhaustiveCheck: never = call;

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -13,6 +13,7 @@ import type {
   ConversationRecord,
 } from '@google/gemini-cli-core';
 import {
+  CoreToolCallStatus,
   AuthType,
   logToolCall,
   convertToFunctionResponse,
@@ -451,7 +452,10 @@ export class Session {
             await this.sendUpdate({
               sessionUpdate: 'tool_call',
               toolCallId: toolCall.id,
-              status: toolCall.status === 'success' ? 'completed' : 'failed',
+              status:
+                toolCall.status === CoreToolCallStatus.Success
+                  ? 'completed'
+                  : 'failed',
               title: toolCall.displayName || toolCall.name,
               content: toolCallContent,
               kind: tool ? toAcpToolKind(tool.kind) : 'other',
@@ -477,7 +481,7 @@ export class Session {
     while (nextMessage !== null) {
       if (pendingSend.signal.aborted) {
         chat.addHistory(nextMessage);
-        return { stopReason: 'cancelled' };
+        return { stopReason: CoreToolCallStatus.Cancelled };
       }
 
       const functionCalls: FunctionCall[] = [];
@@ -494,7 +498,7 @@ export class Session {
 
         for await (const resp of responseStream) {
           if (pendingSend.signal.aborted) {
-            return { stopReason: 'cancelled' };
+            return { stopReason: CoreToolCallStatus.Cancelled };
           }
 
           if (
@@ -529,7 +533,7 @@ export class Session {
         }
 
         if (pendingSend.signal.aborted) {
-          return { stopReason: 'cancelled' };
+          return { stopReason: CoreToolCallStatus.Cancelled };
         }
       } catch (error) {
         if (getErrorStatus(error) === 429) {
@@ -543,7 +547,7 @@ export class Session {
           pendingSend.signal.aborted ||
           (error instanceof Error && error.name === 'AbortError')
         ) {
-          return { stopReason: 'cancelled' };
+          return { stopReason: CoreToolCallStatus.Cancelled };
         }
 
         throw new acp.RequestError(
@@ -663,7 +667,7 @@ export class Session {
 
         const output = await this.connection.requestPermission(params);
         const outcome =
-          output.outcome.outcome === 'cancelled'
+          output.outcome.outcome === CoreToolCallStatus.Cancelled
             ? ToolConfirmationOutcome.Cancel
             : z
                 .nativeEnum(ToolConfirmationOutcome)
@@ -728,7 +732,7 @@ export class Session {
 
       this.chat.recordCompletedToolCalls(this.config.getActiveModel(), [
         {
-          status: 'success',
+          status: CoreToolCallStatus.Success,
           request: {
             callId,
             name: fc.name,
@@ -773,7 +777,7 @@ export class Session {
 
       this.chat.recordCompletedToolCalls(this.config.getActiveModel(), [
         {
-          status: 'error',
+          status: CoreToolCallStatus.Error,
           request: {
             callId,
             name: fc.name,

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -42,6 +42,7 @@ import {
   type ToolCallRequestInfo,
   type ToolCallResponseInfo,
 } from '../scheduler/types.js';
+import { CoreToolCallStatus } from '../scheduler/types.js';
 import { ToolExecutor } from '../scheduler/tool-executor.js';
 import { DiscoveredMCPTool } from '../tools/mcp-tool.js';
 import { getPolicyDenialError } from '../scheduler/policy.js';
@@ -164,31 +165,34 @@ export class CoreToolScheduler {
 
   private setStatusInternal(
     targetCallId: string,
-    status: 'success',
+    status: CoreToolCallStatus.Success,
     signal: AbortSignal,
     response: ToolCallResponseInfo,
   ): void;
   private setStatusInternal(
     targetCallId: string,
-    status: 'awaiting_approval',
+    status: CoreToolCallStatus.AwaitingApproval,
     signal: AbortSignal,
     confirmationDetails: ToolCallConfirmationDetails,
   ): void;
   private setStatusInternal(
     targetCallId: string,
-    status: 'error',
+    status: CoreToolCallStatus.Error,
     signal: AbortSignal,
     response: ToolCallResponseInfo,
   ): void;
   private setStatusInternal(
     targetCallId: string,
-    status: 'cancelled',
+    status: CoreToolCallStatus.Cancelled,
     signal: AbortSignal,
     reason: string,
   ): void;
   private setStatusInternal(
     targetCallId: string,
-    status: 'executing' | 'scheduled' | 'validating',
+    status:
+      | CoreToolCallStatus.Executing
+      | CoreToolCallStatus.Scheduled
+      | CoreToolCallStatus.Validating,
     signal: AbortSignal,
   ): void;
   private setStatusInternal(
@@ -200,9 +204,9 @@ export class CoreToolScheduler {
     this.toolCalls = this.toolCalls.map((currentCall) => {
       if (
         currentCall.request.callId !== targetCallId ||
-        currentCall.status === 'success' ||
-        currentCall.status === 'error' ||
-        currentCall.status === 'cancelled'
+        currentCall.status === CoreToolCallStatus.Success ||
+        currentCall.status === CoreToolCallStatus.Error ||
+        currentCall.status === CoreToolCallStatus.Cancelled
       ) {
         return currentCall;
       }
@@ -215,7 +219,7 @@ export class CoreToolScheduler {
       const outcome = currentCall.outcome;
 
       switch (newStatus) {
-        case 'success': {
+        case CoreToolCallStatus.Success: {
           const durationMs = existingStartTime
             ? Date.now() - existingStartTime
             : undefined;
@@ -223,20 +227,20 @@ export class CoreToolScheduler {
             request: currentCall.request,
             tool: toolInstance,
             invocation,
-            status: 'success',
+            status: CoreToolCallStatus.Success,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
             response: auxiliaryData as ToolCallResponseInfo,
             durationMs,
             outcome,
           } as SuccessfulToolCall;
         }
-        case 'error': {
+        case CoreToolCallStatus.Error: {
           const durationMs = existingStartTime
             ? Date.now() - existingStartTime
             : undefined;
           return {
             request: currentCall.request,
-            status: 'error',
+            status: CoreToolCallStatus.Error,
             tool: toolInstance,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
             response: auxiliaryData as ToolCallResponseInfo,
@@ -244,34 +248,35 @@ export class CoreToolScheduler {
             outcome,
           } as ErroredToolCall;
         }
-        case 'awaiting_approval':
+        case CoreToolCallStatus.AwaitingApproval:
           return {
             request: currentCall.request,
             tool: toolInstance,
-            status: 'awaiting_approval',
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-            confirmationDetails: auxiliaryData as ToolCallConfirmationDetails,
+            status: CoreToolCallStatus.AwaitingApproval,
+            confirmationDetails:
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+              auxiliaryData as ToolCallConfirmationDetails,
             startTime: existingStartTime,
             outcome,
             invocation,
           } as WaitingToolCall;
-        case 'scheduled':
+        case CoreToolCallStatus.Scheduled:
           return {
             request: currentCall.request,
             tool: toolInstance,
-            status: 'scheduled',
+            status: CoreToolCallStatus.Scheduled,
             startTime: existingStartTime,
             outcome,
             invocation,
           } as ScheduledToolCall;
-        case 'cancelled': {
+        case CoreToolCallStatus.Cancelled: {
           const durationMs = existingStartTime
             ? Date.now() - existingStartTime
             : undefined;
 
           // Preserve diff for cancelled edit operations
           let resultDisplay: ToolResultDisplay | undefined = undefined;
-          if (currentCall.status === 'awaiting_approval') {
+          if (currentCall.status === CoreToolCallStatus.AwaitingApproval) {
             const waitingCall = currentCall;
             if (waitingCall.confirmationDetails.type === 'edit') {
               resultDisplay = {
@@ -290,7 +295,7 @@ export class CoreToolScheduler {
             request: currentCall.request,
             tool: toolInstance,
             invocation,
-            status: 'cancelled',
+            status: CoreToolCallStatus.Cancelled,
             response: {
               callId: currentCall.request.callId,
               responseParts: [
@@ -313,20 +318,20 @@ export class CoreToolScheduler {
             outcome,
           } as CancelledToolCall;
         }
-        case 'validating':
+        case CoreToolCallStatus.Validating:
           return {
             request: currentCall.request,
             tool: toolInstance,
-            status: 'validating',
+            status: CoreToolCallStatus.Validating,
             startTime: existingStartTime,
             outcome,
             invocation,
           } as ValidatingToolCall;
-        case 'executing':
+        case CoreToolCallStatus.Executing:
           return {
             request: currentCall.request,
             tool: toolInstance,
-            status: 'executing',
+            status: CoreToolCallStatus.Executing,
             startTime: existingStartTime,
             outcome,
             invocation,
@@ -344,7 +349,10 @@ export class CoreToolScheduler {
     this.toolCalls = this.toolCalls.map((call) => {
       // We should never be asked to set args on an ErroredToolCall, but
       // we guard for the case anyways.
-      if (call.request.callId !== targetCallId || call.status === 'error') {
+      if (
+        call.request.callId !== targetCallId ||
+        call.status === CoreToolCallStatus.Error
+      ) {
         return call;
       }
 
@@ -362,7 +370,7 @@ export class CoreToolScheduler {
         return {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
           request: { ...call.request, args: args as Record<string, unknown> },
-          status: 'error',
+          status: CoreToolCallStatus.Error,
           tool: call.tool,
           response,
         } as ErroredToolCall;
@@ -382,7 +390,8 @@ export class CoreToolScheduler {
       this.isFinalizingToolCalls ||
       this.toolCalls.some(
         (call) =>
-          call.status === 'executing' || call.status === 'awaiting_approval',
+          call.status === CoreToolCallStatus.Executing ||
+          call.status === CoreToolCallStatus.AwaitingApproval,
       )
     );
   }
@@ -453,14 +462,14 @@ export class CoreToolScheduler {
       const activeCall = this.toolCalls[0];
       // Only cancel if it's in a cancellable state.
       if (
-        activeCall.status === 'awaiting_approval' ||
-        activeCall.status === 'executing' ||
-        activeCall.status === 'scheduled' ||
-        activeCall.status === 'validating'
+        activeCall.status === CoreToolCallStatus.AwaitingApproval ||
+        activeCall.status === CoreToolCallStatus.Executing ||
+        activeCall.status === CoreToolCallStatus.Scheduled ||
+        activeCall.status === CoreToolCallStatus.Validating
       ) {
         this.setStatusInternal(
           activeCall.request.callId,
-          'cancelled',
+          CoreToolCallStatus.Cancelled,
           signal,
           'User cancelled the operation.',
         );
@@ -501,7 +510,7 @@ export class CoreToolScheduler {
             );
             const errorMessage = `Tool "${reqInfo.name}" not found in registry. Tools must use the exact names that are registered.${suggestion}`;
             return {
-              status: 'error',
+              status: CoreToolCallStatus.Error,
               request: reqInfo,
               response: createErrorResponse(
                 reqInfo,
@@ -518,7 +527,7 @@ export class CoreToolScheduler {
           );
           if (invocationOrError instanceof Error) {
             return {
-              status: 'error',
+              status: CoreToolCallStatus.Error,
               request: reqInfo,
               tool: toolInstance,
               response: createErrorResponse(
@@ -531,7 +540,7 @@ export class CoreToolScheduler {
           }
 
           return {
-            status: 'validating',
+            status: CoreToolCallStatus.Validating,
             request: reqInfo,
             tool: toolInstance,
             invocation: invocationOrError,
@@ -568,7 +577,7 @@ export class CoreToolScheduler {
     this.notifyToolCallsUpdate();
 
     // Handle tools that were already errored during creation.
-    if (toolCall.status === 'error') {
+    if (toolCall.status === CoreToolCallStatus.Error) {
       // An error during validation means this "active" tool is already complete.
       // We need to check for batch completion to either finish or process the next in queue.
       await this.checkAndNotifyCompletion(signal);
@@ -576,14 +585,14 @@ export class CoreToolScheduler {
     }
 
     // This logic is moved from the old `for` loop in `_schedule`.
-    if (toolCall.status === 'validating') {
+    if (toolCall.status === CoreToolCallStatus.Validating) {
       const { request: reqInfo, invocation } = toolCall;
 
       try {
         if (signal.aborted) {
           this.setStatusInternal(
             reqInfo.callId,
-            'cancelled',
+            CoreToolCallStatus.Cancelled,
             signal,
             'Tool call cancelled by user.',
           );
@@ -614,7 +623,7 @@ export class CoreToolScheduler {
           );
           this.setStatusInternal(
             reqInfo.callId,
-            'error',
+            CoreToolCallStatus.Error,
             signal,
             createErrorResponse(reqInfo, new Error(errorMessage), errorType),
           );
@@ -627,7 +636,11 @@ export class CoreToolScheduler {
             reqInfo.callId,
             ToolConfirmationOutcome.ProceedAlways,
           );
-          this.setStatusInternal(reqInfo.callId, 'scheduled', signal);
+          this.setStatusInternal(
+            reqInfo.callId,
+            CoreToolCallStatus.Scheduled,
+            signal,
+          );
         } else {
           // PolicyDecision.ASK_USER
 
@@ -640,7 +653,11 @@ export class CoreToolScheduler {
               reqInfo.callId,
               ToolConfirmationOutcome.ProceedAlways,
             );
-            this.setStatusInternal(reqInfo.callId, 'scheduled', signal);
+            this.setStatusInternal(
+              reqInfo.callId,
+              CoreToolCallStatus.Scheduled,
+              signal,
+            );
           } else {
             if (!this.config.isInteractive()) {
               throw new Error(
@@ -700,7 +717,7 @@ export class CoreToolScheduler {
             };
             this.setStatusInternal(
               reqInfo.callId,
-              'awaiting_approval',
+              CoreToolCallStatus.AwaitingApproval,
               signal,
               wrappedConfirmationDetails,
             );
@@ -710,7 +727,7 @@ export class CoreToolScheduler {
         if (signal.aborted) {
           this.setStatusInternal(
             reqInfo.callId,
-            'cancelled',
+            CoreToolCallStatus.Cancelled,
             signal,
             'Tool call cancelled by user.',
           );
@@ -718,7 +735,7 @@ export class CoreToolScheduler {
         } else {
           this.setStatusInternal(
             reqInfo.callId,
-            'error',
+            CoreToolCallStatus.Error,
             signal,
             createErrorResponse(
               reqInfo,
@@ -741,10 +758,12 @@ export class CoreToolScheduler {
     payload?: ToolConfirmationPayload,
   ): Promise<void> {
     const toolCall = this.toolCalls.find(
-      (c) => c.request.callId === callId && c.status === 'awaiting_approval',
+      (c) =>
+        c.request.callId === callId &&
+        c.status === CoreToolCallStatus.AwaitingApproval,
     );
 
-    if (toolCall && toolCall.status === 'awaiting_approval') {
+    if (toolCall && toolCall.status === CoreToolCallStatus.AwaitingApproval) {
       await originalOnConfirm(outcome);
     }
 
@@ -763,11 +782,17 @@ export class CoreToolScheduler {
         return;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      this.setStatusInternal(callId, 'awaiting_approval', signal, {
-        ...waitingToolCall.confirmationDetails,
-        isModifying: true,
-      } as ToolCallConfirmationDetails);
+      /* eslint-disable @typescript-eslint/no-unsafe-type-assertion */
+      this.setStatusInternal(
+        callId,
+        CoreToolCallStatus.AwaitingApproval,
+        signal,
+        {
+          ...waitingToolCall.confirmationDetails,
+          isModifying: true,
+        } as ToolCallConfirmationDetails,
+      );
+      /* eslint-enable @typescript-eslint/no-unsafe-type-assertion */
 
       const result = await this.toolModifier.handleModifyWithEditor(
         waitingToolCall,
@@ -778,18 +803,30 @@ export class CoreToolScheduler {
       // Restore status (isModifying: false) and update diff if result exists
       if (result) {
         this.setArgsInternal(callId, result.updatedParams);
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        this.setStatusInternal(callId, 'awaiting_approval', signal, {
-          ...waitingToolCall.confirmationDetails,
-          fileDiff: result.updatedDiff,
-          isModifying: false,
-        } as ToolCallConfirmationDetails);
+        /* eslint-disable @typescript-eslint/no-unsafe-type-assertion */
+        this.setStatusInternal(
+          callId,
+          CoreToolCallStatus.AwaitingApproval,
+          signal,
+          {
+            ...waitingToolCall.confirmationDetails,
+            fileDiff: result.updatedDiff,
+            isModifying: false,
+          } as ToolCallConfirmationDetails,
+        );
+        /* eslint-enable @typescript-eslint/no-unsafe-type-assertion */
       } else {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        this.setStatusInternal(callId, 'awaiting_approval', signal, {
-          ...waitingToolCall.confirmationDetails,
-          isModifying: false,
-        } as ToolCallConfirmationDetails);
+        /* eslint-disable @typescript-eslint/no-unsafe-type-assertion */
+        this.setStatusInternal(
+          callId,
+          CoreToolCallStatus.AwaitingApproval,
+          signal,
+          {
+            ...waitingToolCall.confirmationDetails,
+            isModifying: false,
+          } as ToolCallConfirmationDetails,
+        );
+        /* eslint-enable @typescript-eslint/no-unsafe-type-assertion */
       }
     } else {
       // If the client provided new content, apply it and wait for
@@ -803,17 +840,22 @@ export class CoreToolScheduler {
         );
         if (result) {
           this.setArgsInternal(callId, result.updatedParams);
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          this.setStatusInternal(callId, 'awaiting_approval', signal, {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-            ...(toolCall as WaitingToolCall).confirmationDetails,
-            fileDiff: result.updatedDiff,
-          } as ToolCallConfirmationDetails);
+          /* eslint-disable @typescript-eslint/no-unsafe-type-assertion */
+          this.setStatusInternal(
+            callId,
+            CoreToolCallStatus.AwaitingApproval,
+            signal,
+            {
+              ...(toolCall as WaitingToolCall).confirmationDetails,
+              fileDiff: result.updatedDiff,
+            } as ToolCallConfirmationDetails,
+          );
+          /* eslint-enable @typescript-eslint/no-unsafe-type-assertion */
           // After an inline modification, wait for another user confirmation.
           return;
         }
       }
-      this.setStatusInternal(callId, 'scheduled', signal);
+      this.setStatusInternal(callId, CoreToolCallStatus.Scheduled, signal);
     }
     await this.attemptExecutionOfScheduledCalls(signal);
   }
@@ -823,21 +865,25 @@ export class CoreToolScheduler {
   ): Promise<void> {
     const allCallsFinalOrScheduled = this.toolCalls.every(
       (call) =>
-        call.status === 'scheduled' ||
-        call.status === 'cancelled' ||
-        call.status === 'success' ||
-        call.status === 'error',
+        call.status === CoreToolCallStatus.Scheduled ||
+        call.status === CoreToolCallStatus.Cancelled ||
+        call.status === CoreToolCallStatus.Success ||
+        call.status === CoreToolCallStatus.Error,
     );
 
     if (allCallsFinalOrScheduled) {
       const callsToExecute = this.toolCalls.filter(
-        (call) => call.status === 'scheduled',
+        (call) => call.status === CoreToolCallStatus.Scheduled,
       );
 
       for (const toolCall of callsToExecute) {
-        if (toolCall.status !== 'scheduled') continue;
+        if (toolCall.status !== CoreToolCallStatus.Scheduled) continue;
 
-        this.setStatusInternal(toolCall.request.callId, 'executing', signal);
+        this.setStatusInternal(
+          toolCall.request.callId,
+          CoreToolCallStatus.Executing,
+          signal,
+        );
         const executingCall = this.toolCalls.find(
           (c) => c.request.callId === toolCall.request.callId,
         );
@@ -855,7 +901,8 @@ export class CoreToolScheduler {
               this.outputUpdateHandler(callId, output);
             }
             this.toolCalls = this.toolCalls.map((tc) =>
-              tc.request.callId === callId && tc.status === 'executing'
+              tc.request.callId === callId &&
+              tc.status === CoreToolCallStatus.Executing
                 ? { ...tc, liveOutput: output }
                 : tc,
             );
@@ -893,11 +940,11 @@ export class CoreToolScheduler {
     } else {
       const activeCall = this.toolCalls[0];
       const isTerminal =
-        activeCall.status === 'success' ||
-        activeCall.status === 'error' ||
-        activeCall.status === 'cancelled';
+        activeCall.status === CoreToolCallStatus.Success ||
+        activeCall.status === CoreToolCallStatus.Error ||
+        activeCall.status === CoreToolCallStatus.Cancelled;
 
-      // If the active tool is not in a terminal state (e.g., it's 'executing' or 'awaiting_approval'),
+      // If the active tool is not in a terminal state (e.g., it's CoreToolCallStatus.Executing or CoreToolCallStatus.AwaitingApproval),
       // then the scheduler is still busy or paused. We should not proceed.
       if (!isTerminal) {
         return;
@@ -967,7 +1014,7 @@ export class CoreToolScheduler {
     while (this.toolCallQueue.length > 0) {
       const queuedCall = this.toolCallQueue.shift()!;
       // Don't cancel tools that already errored during validation.
-      if (queuedCall.status === 'error') {
+      if (queuedCall.status === CoreToolCallStatus.Error) {
         this.completedToolCallsForBatch.push(queuedCall);
         continue;
       }
@@ -981,7 +1028,7 @@ export class CoreToolScheduler {
         request: queuedCall.request,
         tool: queuedCall.tool,
         invocation: queuedCall.invocation,
-        status: 'cancelled',
+        status: CoreToolCallStatus.Cancelled,
         response: {
           callId: queuedCall.request.callId,
           responseParts: [

--- a/packages/core/src/scheduler/confirmation.ts
+++ b/packages/core/src/scheduler/confirmation.ts
@@ -17,7 +17,11 @@ import {
   type ToolConfirmationPayload,
   type ToolCallConfirmationDetails,
 } from '../tools/tools.js';
-import type { ValidatingToolCall, WaitingToolCall } from './types.js';
+import {
+  type ValidatingToolCall,
+  type WaitingToolCall,
+  CoreToolCallStatus,
+} from './types.js';
 import type { Config } from '../config/config.js';
 import type { SchedulerStateManager } from './state-manager.js';
 import type { ToolModificationHandler } from './tool-modifier.js';
@@ -145,7 +149,7 @@ export async function resolveConfirmation(
     const ideConfirmation =
       'ideConfirmation' in details ? details.ideConfirmation : undefined;
 
-    state.updateStatus(callId, 'awaiting_approval', {
+    state.updateStatus(callId, CoreToolCallStatus.AwaitingApproval, {
       confirmationDetails: serializableDetails,
       correlationId,
     });

--- a/packages/core/src/scheduler/tool-executor.test.ts
+++ b/packages/core/src/scheduler/tool-executor.test.ts
@@ -11,6 +11,7 @@ import type { ToolResult } from '../tools/tools.js';
 import { makeFakeConfig } from '../test-utils/config.js';
 import { MockTool } from '../test-utils/mock-tool.js';
 import type { ScheduledToolCall } from './types.js';
+import { CoreToolCallStatus } from './types.js';
 import type { AnyToolInvocation } from '../index.js';
 import { SHELL_TOOL_NAME } from '../tools/tool-names.js';
 import * as fileUtils from '../utils/fileUtils.js';
@@ -71,7 +72,7 @@ describe('ToolExecutor', () => {
     } as ToolResult);
 
     const scheduledCall: ScheduledToolCall = {
-      status: 'scheduled',
+      status: CoreToolCallStatus.Scheduled,
       request: {
         callId: 'call-1',
         name: 'testTool',
@@ -91,8 +92,8 @@ describe('ToolExecutor', () => {
       onUpdateToolCall,
     });
 
-    expect(result.status).toBe('success');
-    if (result.status === 'success') {
+    expect(result.status).toBe(CoreToolCallStatus.Success);
+    if (result.status === CoreToolCallStatus.Success) {
       const response = result.response.responseParts[0]?.functionResponse
         ?.response as Record<string, unknown>;
       expect(response).toEqual({ output: 'Tool output' });
@@ -111,7 +112,7 @@ describe('ToolExecutor', () => {
     );
 
     const scheduledCall: ScheduledToolCall = {
-      status: 'scheduled',
+      status: CoreToolCallStatus.Scheduled,
       request: {
         callId: 'call-2',
         name: 'failTool',
@@ -130,8 +131,8 @@ describe('ToolExecutor', () => {
       onUpdateToolCall: vi.fn(),
     });
 
-    expect(result.status).toBe('error');
-    if (result.status === 'error') {
+    expect(result.status).toBe(CoreToolCallStatus.Error);
+    if (result.status === CoreToolCallStatus.Error) {
       expect(result.response.error?.message).toBe('Tool Failed');
     }
   });
@@ -151,7 +152,7 @@ describe('ToolExecutor', () => {
     );
 
     const scheduledCall: ScheduledToolCall = {
-      status: 'scheduled',
+      status: CoreToolCallStatus.Scheduled,
       request: {
         callId: 'call-3',
         name: 'slowTool',
@@ -174,7 +175,7 @@ describe('ToolExecutor', () => {
     controller.abort();
     const result = await promise;
 
-    expect(result.status).toBe('cancelled');
+    expect(result.status).toBe(CoreToolCallStatus.Cancelled);
   });
 
   it('should truncate large shell output', async () => {
@@ -193,7 +194,7 @@ describe('ToolExecutor', () => {
     });
 
     const scheduledCall: ScheduledToolCall = {
-      status: 'scheduled',
+      status: CoreToolCallStatus.Scheduled,
       request: {
         callId: 'call-trunc',
         name: SHELL_TOOL_NAME,
@@ -228,8 +229,8 @@ describe('ToolExecutor', () => {
       10, // threshold (maxChars)
     );
 
-    expect(result.status).toBe('success');
-    if (result.status === 'success') {
+    expect(result.status).toBe(CoreToolCallStatus.Success);
+    if (result.status === CoreToolCallStatus.Success) {
       const response = result.response.responseParts[0]?.functionResponse
         ?.response as Record<string, unknown>;
       // The content should be the *truncated* version returned by the mock formatTruncatedToolOutput
@@ -262,7 +263,7 @@ describe('ToolExecutor', () => {
     );
 
     const scheduledCall: ScheduledToolCall = {
-      status: 'scheduled',
+      status: CoreToolCallStatus.Scheduled,
       request: {
         callId: 'call-pid',
         name: SHELL_TOOL_NAME,
@@ -287,7 +288,7 @@ describe('ToolExecutor', () => {
     // 4. Verify PID was reported
     expect(onUpdateToolCall).toHaveBeenCalledWith(
       expect.objectContaining({
-        status: 'executing',
+        status: CoreToolCallStatus.Executing,
         pid: testPid,
       }),
     );

--- a/packages/core/src/scheduler/tool-executor.ts
+++ b/packages/core/src/scheduler/tool-executor.ts
@@ -33,6 +33,7 @@ import type {
   SuccessfulToolCall,
   CancelledToolCall,
 } from './types.js';
+import { CoreToolCallStatus } from './types.js';
 
 export interface ToolExecutionContext {
   call: ToolCall;
@@ -81,7 +82,7 @@ export class ToolExecutor {
             const setPidCallback = (pid: number) => {
               const executingCall: ExecutingToolCall = {
                 ...call,
-                status: 'executing',
+                status: CoreToolCallStatus.Executing,
                 tool,
                 invocation,
                 pid,
@@ -170,7 +171,7 @@ export class ToolExecutor {
     }
 
     return {
-      status: 'cancelled',
+      status: CoreToolCallStatus.Cancelled,
       request: call.request,
       response: {
         callId: call.request.callId,
@@ -256,7 +257,7 @@ export class ToolExecutor {
     }
 
     return {
-      status: 'success',
+      status: CoreToolCallStatus.Success,
       request: call.request,
       tool: call.tool,
       response: successResponse,
@@ -281,7 +282,7 @@ export class ToolExecutor {
     const startTime = 'startTime' in call ? call.startTime : undefined;
 
     return {
-      status: 'error',
+      status: CoreToolCallStatus.Error,
       request: call.request,
       response,
       tool: call.tool,

--- a/packages/core/src/scheduler/tool-modifier.test.ts
+++ b/packages/core/src/scheduler/tool-modifier.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ToolModificationHandler } from './tool-modifier.js';
 import type { WaitingToolCall, ToolCallRequestInfo } from './types.js';
+import { CoreToolCallStatus } from './types.js';
 import * as modifiableToolModule from '../tools/modifiable-tool.js';
 import * as Diff from 'diff';
 import { MockModifiableTool, MockTool } from '../test-utils/mock-tool.js';
@@ -37,7 +38,7 @@ function createMockWaitingToolCall(
   overrides: Partial<WaitingToolCall> = {},
 ): WaitingToolCall {
   return {
-    status: 'awaiting_approval',
+    status: CoreToolCallStatus.AwaitingApproval,
     request: {
       callId: 'test-call-id',
       name: 'test-tool',

--- a/packages/core/src/scheduler/types.ts
+++ b/packages/core/src/scheduler/types.ts
@@ -18,6 +18,19 @@ import type { SerializableConfirmationDetails } from '../confirmation-bus/types.
 
 export const ROOT_SCHEDULER_ID = 'root';
 
+/**
+ * Internal core statuses for the tool call state machine.
+ */
+export enum CoreToolCallStatus {
+  Validating = 'validating',
+  Scheduled = 'scheduled',
+  Error = 'error',
+  Success = 'success',
+  Executing = 'executing',
+  Cancelled = 'cancelled',
+  AwaitingApproval = 'awaiting_approval',
+}
+
 export interface ToolCallRequestInfo {
   callId: string;
   name: string;
@@ -45,7 +58,7 @@ export interface ToolCallResponseInfo {
 }
 
 export type ValidatingToolCall = {
-  status: 'validating';
+  status: CoreToolCallStatus.Validating;
   request: ToolCallRequestInfo;
   tool: AnyDeclarativeTool;
   invocation: AnyToolInvocation;
@@ -55,7 +68,7 @@ export type ValidatingToolCall = {
 };
 
 export type ScheduledToolCall = {
-  status: 'scheduled';
+  status: CoreToolCallStatus.Scheduled;
   request: ToolCallRequestInfo;
   tool: AnyDeclarativeTool;
   invocation: AnyToolInvocation;
@@ -65,7 +78,7 @@ export type ScheduledToolCall = {
 };
 
 export type ErroredToolCall = {
-  status: 'error';
+  status: CoreToolCallStatus.Error;
   request: ToolCallRequestInfo;
   response: ToolCallResponseInfo;
   tool?: AnyDeclarativeTool;
@@ -75,7 +88,7 @@ export type ErroredToolCall = {
 };
 
 export type SuccessfulToolCall = {
-  status: 'success';
+  status: CoreToolCallStatus.Success;
   request: ToolCallRequestInfo;
   tool: AnyDeclarativeTool;
   response: ToolCallResponseInfo;
@@ -86,7 +99,7 @@ export type SuccessfulToolCall = {
 };
 
 export type ExecutingToolCall = {
-  status: 'executing';
+  status: CoreToolCallStatus.Executing;
   request: ToolCallRequestInfo;
   tool: AnyDeclarativeTool;
   invocation: AnyToolInvocation;
@@ -98,7 +111,7 @@ export type ExecutingToolCall = {
 };
 
 export type CancelledToolCall = {
-  status: 'cancelled';
+  status: CoreToolCallStatus.Cancelled;
   request: ToolCallRequestInfo;
   response: ToolCallResponseInfo;
   tool: AnyDeclarativeTool;
@@ -109,7 +122,7 @@ export type CancelledToolCall = {
 };
 
 export type WaitingToolCall = {
-  status: 'awaiting_approval';
+  status: CoreToolCallStatus.AwaitingApproval;
   request: ToolCallRequestInfo;
   tool: AnyDeclarativeTool;
   invocation: AnyToolInvocation;

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -13,6 +13,7 @@ import type {
   ToolCallRecord,
   MessageRecord,
 } from './chatRecordingService.js';
+import { CoreToolCallStatus } from '../scheduler/types.js';
 import type { Content, Part } from '@google/genai';
 import { ChatRecordingService } from './chatRecordingService.js';
 import type { Config } from '../config/config.js';
@@ -247,7 +248,7 @@ describe('ChatRecordingService', () => {
         id: 'tool-1',
         name: 'testTool',
         args: {},
-        status: 'awaiting_approval',
+        status: CoreToolCallStatus.AwaitingApproval,
         timestamp: new Date().toISOString(),
       };
       chatRecordingService.recordToolCalls('gemini-pro', [toolCall]);
@@ -274,7 +275,7 @@ describe('ChatRecordingService', () => {
         id: 'tool-1',
         name: 'testTool',
         args: {},
-        status: 'awaiting_approval',
+        status: CoreToolCallStatus.AwaitingApproval,
         timestamp: new Date().toISOString(),
       };
       chatRecordingService.recordToolCalls('gemini-pro', [toolCall]);
@@ -571,7 +572,7 @@ describe('ChatRecordingService', () => {
           name: 'list_files',
           args: { path: '.' },
           result: originalResult,
-          status: 'success',
+          status: CoreToolCallStatus.Success,
           timestamp: new Date().toISOString(),
         },
       ]);
@@ -650,7 +651,7 @@ describe('ChatRecordingService', () => {
           name: 'read_file',
           args: { path: 'image.png' },
           result: originalResult,
-          status: 'success',
+          status: CoreToolCallStatus.Success,
           timestamp: new Date().toISOString(),
         },
       ]);
@@ -707,7 +708,7 @@ describe('ChatRecordingService', () => {
           name: 'read_file',
           args: { path: 'test.txt' },
           result: [],
-          status: 'success',
+          status: CoreToolCallStatus.Success,
           timestamp: new Date().toISOString(),
         },
       ]);

--- a/packages/core/src/telemetry/loggers.test.circular.ts
+++ b/packages/core/src/telemetry/loggers.test.circular.ts
@@ -17,6 +17,7 @@ import {
   type ToolCallRequestInfo,
   type ToolCallResponseInfo,
 } from '../scheduler/types.js';
+import { CoreToolCallStatus } from '../scheduler/types.js';
 import { MockTool } from '../test-utils/mock-tool.js';
 
 describe('Circular Reference Handling', () => {
@@ -62,7 +63,7 @@ describe('Circular Reference Handling', () => {
 
     const tool = new MockTool({ name: 'mock-tool' });
     const mockCompletedToolCall: CompletedToolCall = {
-      status: 'success',
+      status: CoreToolCallStatus.Success,
       request: mockRequest,
       response: mockResponse,
       tool,
@@ -112,7 +113,7 @@ describe('Circular Reference Handling', () => {
 
     const tool = new MockTool({ name: 'mock-tool' });
     const mockCompletedToolCall: CompletedToolCall = {
-      status: 'success',
+      status: CoreToolCallStatus.Success,
       request: mockRequest,
       response: mockResponse,
       tool,

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -12,6 +12,7 @@ import type {
   ErroredToolCall,
 } from '../index.js';
 import {
+  CoreToolCallStatus,
   AuthType,
   EditTool,
   GeminiClient,
@@ -1070,7 +1071,7 @@ describe('loggers', () => {
     it('should log a tool call with all fields', () => {
       const tool = new EditTool(mockConfig, createMockMessageBus());
       const call: CompletedToolCall = {
-        status: 'success',
+        status: CoreToolCallStatus.Success,
         request: {
           name: 'test-function',
           args: {
@@ -1188,7 +1189,7 @@ describe('loggers', () => {
 
     it('should merge data from response into metadata', () => {
       const call: CompletedToolCall = {
-        status: 'success',
+        status: CoreToolCallStatus.Success,
         request: {
           name: 'ask_user',
           args: { questions: [] },
@@ -1234,7 +1235,7 @@ describe('loggers', () => {
 
     it('should log a tool call with a reject decision', () => {
       const call: ErroredToolCall = {
-        status: 'error',
+        status: CoreToolCallStatus.Error,
         request: {
           name: 'test-function',
           args: {
@@ -1312,7 +1313,7 @@ describe('loggers', () => {
 
     it('should log a tool call with a modify decision', () => {
       const call: CompletedToolCall = {
-        status: 'success',
+        status: CoreToolCallStatus.Success,
         request: {
           name: 'test-function',
           args: {
@@ -1392,7 +1393,7 @@ describe('loggers', () => {
 
     it('should log a tool call without a decision', () => {
       const call: CompletedToolCall = {
-        status: 'success',
+        status: CoreToolCallStatus.Success,
         request: {
           name: 'test-function',
           args: {
@@ -1472,7 +1473,7 @@ describe('loggers', () => {
     it('should log a failed tool call with an error', () => {
       const errorMessage = 'test-error';
       const call: ErroredToolCall = {
-        status: 'error',
+        status: CoreToolCallStatus.Error,
         request: {
           name: 'test-function',
           args: {
@@ -1573,7 +1574,7 @@ describe('loggers', () => {
       );
 
       const call: CompletedToolCall = {
-        status: 'success',
+        status: CoreToolCallStatus.Success,
         request: {
           name: 'mock_mcp_tool',
           args: { arg1: 'value1', arg2: 2 },
@@ -1890,7 +1891,7 @@ describe('loggers', () => {
         'testing-id',
         '0.1.0',
         'git',
-        'success',
+        CoreToolCallStatus.Success,
       );
 
       await logExtensionInstallEvent(mockConfig, event);
@@ -1911,7 +1912,7 @@ describe('loggers', () => {
           extension_name: 'testing',
           extension_version: '0.1.0',
           extension_source: 'git',
-          status: 'success',
+          status: CoreToolCallStatus.Success,
         },
       });
     });
@@ -1943,7 +1944,7 @@ describe('loggers', () => {
         '0.1.0',
         '0.1.1',
         'git',
-        'success',
+        CoreToolCallStatus.Success,
       );
 
       await logExtensionUpdateEvent(mockConfig, event);
@@ -1965,7 +1966,7 @@ describe('loggers', () => {
           extension_version: '0.1.0',
           extension_previous_version: '0.1.1',
           extension_source: 'git',
-          status: 'success',
+          status: CoreToolCallStatus.Success,
         },
       });
     });
@@ -1993,7 +1994,7 @@ describe('loggers', () => {
         'testing',
         'testing-hash',
         'testing-id',
-        'success',
+        CoreToolCallStatus.Success,
       );
 
       await logExtensionUninstall(mockConfig, event);
@@ -2012,7 +2013,7 @@ describe('loggers', () => {
           'event.timestamp': '2025-01-01T00:00:00.000Z',
           interactive: false,
           extension_name: 'testing',
-          status: 'success',
+          status: CoreToolCallStatus.Success,
         },
       });
     });

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -27,6 +27,7 @@ import { makeRelative, shortenPath } from '../utils/paths.js';
 import { isNodeError } from '../utils/errors.js';
 import type { Config } from '../config/config.js';
 import { ApprovalMode } from '../policy/types.js';
+import { CoreToolCallStatus } from '../scheduler/types.js';
 
 import { DEFAULT_DIFF_OPTIONS, getDiffStat } from './diffOptions.js';
 import {
@@ -505,7 +506,7 @@ class EditToolInvocation
       };
     }
 
-    const event = new EditCorrectionEvent('success');
+    const event = new EditCorrectionEvent(CoreToolCallStatus.Success);
     logEditCorrectionEvent(this.config, event);
 
     return {

--- a/packages/core/src/utils/tool-utils.test.ts
+++ b/packages/core/src/utils/tool-utils.test.ts
@@ -7,7 +7,7 @@
 import { expect, describe, it } from 'vitest';
 import { doesToolInvocationMatch, getToolSuggestion } from './tool-utils.js';
 import type { AnyToolInvocation, Config } from '../index.js';
-import { ReadFileTool } from '../tools/read-file.js';
+import { ReadFileTool } from '../index.js';
 import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 
 describe('getToolSuggestion', () => {


### PR DESCRIPTION
This change replaces hardcoded tool call status strings ('validating', 'scheduled', 'executing', 'success', 'error', 'cancelled') with a centralized 'CoreToolCallStatus' enum in the core package.

Benefits:
- Type Safety: Prevents runtime errors and logic bugs caused by typos in status strings across the core and cli packages.
- Maintainability: Provides a single source of truth for all possible tool call states, making it easier to track and update state transitions.
- Developer Experience: Enables IDE autocomplete and better discoverability of tool call statuses.
- Code Quality: Resolves several unsafe type assertions and clarifies state handling in the Scheduler and CoreToolScheduler.

This refactor establishes a more robust foundation for tool execution tracking and UI mapping.

Related to https://github.com/google-gemini/gemini-cli/issues/18918.
