### PR TITLE
feat(core): fallback to chat-base when using unrecognized models for chat

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -892,7 +892,7 @@ ${JSON.stringify(
       // Assert
       expect(ideContextStore.get).toHaveBeenCalled();
       expect(mockTurnRunFn).toHaveBeenCalledWith(
-        { model: 'default-routed-model' },
+        { model: 'default-routed-model', isChatModel: true },
         initialRequest,
         expect.any(AbortSignal),
         undefined,
@@ -1722,7 +1722,7 @@ ${JSON.stringify(
         expect(mockConfig.getModelRouterService).toHaveBeenCalled();
         expect(mockRouterService.route).toHaveBeenCalled();
         expect(mockTurnRunFn).toHaveBeenCalledWith(
-          { model: 'routed-model' },
+          { model: 'routed-model', isChatModel: true },
           [{ text: 'Hi' }],
           expect.any(AbortSignal),
           undefined,
@@ -1740,7 +1740,7 @@ ${JSON.stringify(
 
         expect(mockRouterService.route).toHaveBeenCalledTimes(1);
         expect(mockTurnRunFn).toHaveBeenCalledWith(
-          { model: 'routed-model' },
+          { model: 'routed-model', isChatModel: true },
           [{ text: 'Hi' }],
           expect.any(AbortSignal),
           undefined,
@@ -1758,7 +1758,7 @@ ${JSON.stringify(
         expect(mockRouterService.route).toHaveBeenCalledTimes(1);
         // Should stick to the first model
         expect(mockTurnRunFn).toHaveBeenCalledWith(
-          { model: 'routed-model' },
+          { model: 'routed-model', isChatModel: true },
           [{ text: 'Continue' }],
           expect.any(AbortSignal),
           undefined,
@@ -1776,7 +1776,7 @@ ${JSON.stringify(
 
         expect(mockRouterService.route).toHaveBeenCalledTimes(1);
         expect(mockTurnRunFn).toHaveBeenCalledWith(
-          { model: 'routed-model' },
+          { model: 'routed-model', isChatModel: true },
           [{ text: 'Hi' }],
           expect.any(AbortSignal),
           undefined,
@@ -1798,7 +1798,7 @@ ${JSON.stringify(
         expect(mockRouterService.route).toHaveBeenCalledTimes(2);
         // Should use the newly routed model
         expect(mockTurnRunFn).toHaveBeenCalledWith(
-          { model: 'new-routed-model' },
+          { model: 'new-routed-model', isChatModel: true },
           [{ text: 'A new topic' }],
           expect.any(AbortSignal),
           undefined,
@@ -1826,7 +1826,7 @@ ${JSON.stringify(
         expect(mockRouterService.route).toHaveBeenCalledTimes(1);
         expect(mockTurnRunFn).toHaveBeenNthCalledWith(
           1,
-          { model: 'original-model' },
+          { model: 'original-model', isChatModel: true },
           [{ text: 'Hi' }],
           expect.any(AbortSignal),
           undefined,
@@ -1849,7 +1849,7 @@ ${JSON.stringify(
         expect(mockRouterService.route).toHaveBeenCalledTimes(2);
         expect(mockTurnRunFn).toHaveBeenNthCalledWith(
           2,
-          { model: 'fallback-model' },
+          { model: 'fallback-model', isChatModel: true },
           [{ text: 'Continue' }],
           expect.any(AbortSignal),
           undefined,
@@ -1935,7 +1935,7 @@ ${JSON.stringify(
       // First call with original request
       expect(mockTurnRunFn).toHaveBeenNthCalledWith(
         1,
-        { model: 'default-routed-model' },
+        { model: 'default-routed-model', isChatModel: true },
         initialRequest,
         expect.any(AbortSignal),
         undefined,
@@ -1944,7 +1944,7 @@ ${JSON.stringify(
       // Second call with "Please continue."
       expect(mockTurnRunFn).toHaveBeenNthCalledWith(
         2,
-        { model: 'default-routed-model' },
+        { model: 'default-routed-model', isChatModel: true },
         [{ text: 'System: Please continue.' }],
         expect.any(AbortSignal),
         undefined,

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -656,7 +656,10 @@ export class GeminiClient {
     }
 
     // availability logic
-    const modelConfigKey: ModelConfigKey = { model: modelToUse };
+    const modelConfigKey: ModelConfigKey = {
+      model: modelToUse,
+      isChatModel: true,
+    };
     const { model: finalModel } = applyModelSelection(
       this.config,
       modelConfigKey,

--- a/packages/core/src/services/modelConfigService.test.ts
+++ b/packages/core/src/services/modelConfigService.test.ts
@@ -729,6 +729,71 @@ describe('ModelConfigService', () => {
     });
   });
 
+  describe('fallback behavior', () => {
+    it('should fallback to chat-base if the requested model is completely unknown', () => {
+      const config: ModelConfigServiceConfig = {
+        aliases: {
+          'chat-base': {
+            modelConfig: {
+              model: 'default-fallback-model',
+              generateContentConfig: {
+                temperature: 0.99,
+              },
+            },
+          },
+        },
+      };
+      const service = new ModelConfigService(config);
+      const resolved = service.getResolvedConfig({
+        model: 'my-custom-model',
+        isChatModel: true,
+      });
+
+      // It preserves the requested model name, but inherits the config from chat-base
+      expect(resolved.model).toBe('my-custom-model');
+      expect(resolved.generateContentConfig).toEqual({
+        temperature: 0.99,
+      });
+    });
+
+    it('should return empty config if requested model is unknown and chat-base is not defined', () => {
+      const config: ModelConfigServiceConfig = {
+        aliases: {},
+      };
+      const service = new ModelConfigService(config);
+      const resolved = service.getResolvedConfig({
+        model: 'my-custom-model',
+        isChatModel: true,
+      });
+
+      expect(resolved.model).toBe('my-custom-model');
+      expect(resolved.generateContentConfig).toEqual({});
+    });
+
+    it('should NOT fallback to chat-base if the requested model is completely unknown but isChatModel is false', () => {
+      const config: ModelConfigServiceConfig = {
+        aliases: {
+          'chat-base': {
+            modelConfig: {
+              model: 'default-fallback-model',
+              generateContentConfig: {
+                temperature: 0.99,
+              },
+            },
+          },
+        },
+      };
+      const service = new ModelConfigService(config);
+      const resolved = service.getResolvedConfig({
+        model: 'my-custom-model',
+        isChatModel: false,
+      });
+
+      expect(resolved.model).toBe('my-custom-model');
+      expect(resolved.generateContentConfig).toEqual({});
+    });
+  });
+
   describe('unrecognized models', () => {
     it('should apply overrides to unrecognized model names', () => {
       const unregisteredModelName = 'my-unregistered-model-v1';


### PR DESCRIPTION
## Summary

This PR updates the Model Config Service so that when an unrecognized model is requested via the CLI (e.g., `-m my-custom-model`), it automatically inherits the `chat-base` generation configuration.

Previously, using an unknown model resulted in an empty configuration, stripping away standard interactive chat defaults like `temperature: 1`, `topP: 0.95` and `topK: 64`.

## Details

This change adds an `isChatModel` property to the `ModelConfigKey` interface to signify when a configuration request originates from the primary interactive chat session. The `resolveAliasChain` method has been updated to conditionally apply the `chat-base` fallback only when `isChatModel` is true. This ensures that internal background models (e.g., the summarizer) are not inadvertently affected and continue to receive an empty fallback config when encountering unrecognized aliases.

## Related Issues

#18007

## How to Validate

1. Run the CLI with an unknown model: `npm start -- -m my-custom-model`.
2. Observe that the chat session inherits the default hyperparameter configurations as defined in `chat-base` (e.g., it shouldn't feel restricted to default 0 temperature, etc.).
3. Try running another command requiring a background tool/summary and verify it executes properly without the `chat-base` overrides.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
