### PR TITLE
docs: fix inconsistent commandRegex example in policy engine

### DIFF
--- a/docs/core/policy-engine.md
+++ b/docs/core/policy-engine.md
@@ -208,9 +208,11 @@ commandPrefix = "git "
 
 # (Optional) A regex to match against the entire shell command.
 # This is also syntactic sugar for `toolName = "run_shell_command"`.
-# Note: This pattern is tested against the JSON representation of the arguments (e.g., `{"command":"<your_command>"}`), so anchors like `^` or `$` will apply to the full JSON string, not just the command text.
+# Note: This pattern is tested against the JSON representation of the arguments (e.g., `{"command":"<your_command>"}`).
+# Because it prepends `"command":"`, it effectively matches from the start of the command.
+# Anchors like `^` or `$` apply to the full JSON string, so `^` should usually be avoided here.
 # You cannot use commandPrefix and commandRegex in the same rule.
-commandRegex = "^git (commit|push)"
+commandRegex = "git (commit|push)"
 
 # The decision to take. Must be "allow", "deny", or "ask_user".
 decision = "ask_user"

--- a/packages/core/src/policy/toml-loader.test.ts
+++ b/packages/core/src/policy/toml-loader.test.ts
@@ -111,6 +111,24 @@ priority = 100
       expect(result.errors).toHaveLength(0);
     });
 
+    it('should NOT match if ^ is used in commandRegex because it matches against full JSON', async () => {
+      const result = await runLoadPoliciesFromToml(`
+[[rule]]
+toolName = "run_shell_command"
+commandRegex = "^git status"
+decision = "allow"
+priority = 100
+`);
+
+      expect(result.rules).toHaveLength(1);
+      // The generated pattern is "command":"^git status
+      // This will NOT match '{"command":"git status"}' because of the '{"' at the start.
+      expect(
+        result.rules[0].argsPattern?.test('{"command":"git status"}'),
+      ).toBe(false);
+      expect(result.errors).toHaveLength(0);
+    });
+
     it('should expand toolName array', async () => {
       const result = await runLoadPoliciesFromToml(`
 [[rule]]


### PR DESCRIPTION
## Summary

Fix inconsistent `commandRegex` documentation and example. The example incorrectly used a `^` anchor which would never match because the pattern is tested against stringified JSON arguments.

## Details

- Updated `docs/core/policy-engine.md` to remove `^` from the `commandRegex` example.
- Added a note explaining that `commandRegex` prepends `\"command\":\"` to the pattern.
- Added a regression test in `packages/core/src/policy/toml-loader.test.ts` to verify that `^` in `commandRegex` causes a mismatch.

## Related Issues

Fixes https://chat.google.com/room/AAQApBm33UQ/zJmZJPS5j1s/zJmZJPS5j1s?cls=10

## How to Validate

1. Run the new test: `npm test -w @google/gemini-cli-core -- src/policy/toml-loader.test.ts`
2. Verify the test `should NOT match if ^ is used in commandRegex because it matches against full JSON` passes.
3. Review the updated `docs/core/policy-engine.md`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
