### PR TITLE
fix: use discoverOAuthFromWWWAuthenticate for reactive OAuth flow (#18760)

### DIFF
--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -666,18 +666,17 @@ async function handleAutomaticOAuth(
   try {
     debugLogger.log(`🔐 '${mcpServerName}' requires OAuth authentication`);
 
-    // Always try to parse the resource metadata URI from the www-authenticate header
-    let oauthConfig;
-    const resourceMetadataUri =
-      OAuthUtils.parseWWWAuthenticateHeader(wwwAuthenticate);
-    if (resourceMetadataUri) {
-      oauthConfig = await OAuthUtils.discoverOAuthConfig(resourceMetadataUri);
-    } else if (hasNetworkTransport(mcpServerConfig)) {
+    const serverUrl = mcpServerConfig.httpUrl || mcpServerConfig.url;
+
+    // Try to discover OAuth config from the WWW-Authenticate header first
+    let oauthConfig = await OAuthUtils.discoverOAuthFromWWWAuthenticate(
+      wwwAuthenticate,
+      serverUrl,
+    );
+
+    if (!oauthConfig && hasNetworkTransport(mcpServerConfig)) {
       // Fallback: try to discover OAuth config from the base URL
-      const serverUrl = new URL(
-        mcpServerConfig.httpUrl || mcpServerConfig.url!,
-      );
-      const baseUrl = `${serverUrl.protocol}//${serverUrl.host}`;
+      const baseUrl = OAuthUtils.extractBaseUrl(serverUrl!);
       oauthConfig = await OAuthUtils.discoverOAuthConfig(baseUrl);
     }
 
@@ -700,8 +699,6 @@ async function handleAutomaticOAuth(
     };
 
     // Perform OAuth authentication
-    // Pass the server URL for proper discovery
-    const serverUrl = mcpServerConfig.httpUrl || mcpServerConfig.url;
     debugLogger.log(
       `Starting OAuth authentication for server '${mcpServerName}'...`,
     );


### PR DESCRIPTION
## Summary

- Fix `handleAutomaticOAuth()` passing a `resource_metadata` URI (already a `.well-known` URL) to `discoverOAuthConfig()`, which expects a server URL — causing double-nested `.well-known` paths (404) and `ResourceMismatchError` for path-based MCP servers
- Switch to the existing `discoverOAuthFromWWWAuthenticate()` utility which correctly fetches the resource metadata URI directly and validates against the actual server URL
- Use `extractBaseUrl()` in the fallback path instead of inline URL construction

## Root Cause

`discoverOAuthConfig(resourceMetadataUri)` constructs `.well-known` discovery paths from its input. When the input is *already* a `.well-known` URL parsed from the `WWW-Authenticate` header, this produces:

```
https://example.com/.well-known/oauth-protected-resource/.well-known/oauth-protected-resource
```

The 404 triggers a fallback that fetches root metadata, but validation then compares the root `resource` value against the metadata URI (not the server URL), throwing `ResourceMismatchError`.

## Fix

Use `discoverOAuthFromWWWAuthenticate()` (already exists in `oauth-utils.ts`) which:
1. Parses the `resource_metadata` URI from the `WWW-Authenticate` header
2. Fetches it directly (no `.well-known` path construction)
3. Validates the `resource` parameter against the actual server URL (RFC 9728 §7.3)

Fallback to `discoverOAuthConfig()` with the base URL is preserved for servers without `resource_metadata` in the header.

## Test plan

- [x] Existing unit tests pass (93/93 — `mcp-client.test.ts` + `oauth-utils.test.ts`)
- [x] TypeScript typecheck passes with no new errors
- [x] ESLint + Prettier pass
- [ ] Manual test with a path-based OAuth MCP server returning `WWW-Authenticate: Bearer resource_metadata="..."`

Fixes #18760
Supersedes #18798 (stalled on CLA)