### PR TITLE
bug(ui) fix flicker refreshing background color

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -609,11 +609,10 @@ export const AppContainer = (props: AppContainerProps) => {
     setThemeError,
     historyManager.addItem,
     initializationResult.themeError,
+    refreshStatic,
   );
-
   // Poll for terminal background color changes to auto-switch theme
   useTerminalTheme(handleThemeSelect, config, refreshStatic);
-
   const {
     authState,
     setAuthState,

--- a/packages/cli/src/ui/components/ThemeDialog.test.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.test.tsx
@@ -79,14 +79,12 @@ describe('ThemeDialog Snapshots', () => {
     });
   });
 
-  it('should call refreshStatic when a theme is selected', async () => {
-    const mockRefreshStatic = vi.fn();
+  it('should call onSelect when a theme is selected', async () => {
     const settings = createMockSettings();
     const { stdin } = renderWithProviders(
       <ThemeDialog {...baseProps} settings={settings} />,
       {
         settings,
-        uiActions: { refreshStatic: mockRefreshStatic },
       },
     );
 
@@ -96,7 +94,6 @@ describe('ThemeDialog Snapshots', () => {
     });
 
     await waitFor(() => {
-      expect(mockRefreshStatic).toHaveBeenCalled();
       expect(baseProps.onSelect).toHaveBeenCalled();
     });
   });

--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -22,7 +22,6 @@ import { getScopeMessageForSetting } from '../../utils/dialogScopeUtils.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
 import { ScopeSelector } from './shared/ScopeSelector.js';
-import { useUIActions } from '../contexts/UIActionsContext.js';
 import { useUIState } from '../contexts/UIStateContext.js';
 
 interface ThemeDialogProps {
@@ -85,7 +84,6 @@ export function ThemeDialog({
   terminalWidth,
 }: ThemeDialogProps): React.JSX.Element {
   const isAlternateBuffer = useAlternateBuffer();
-  const { refreshStatic } = useUIActions();
   const { terminalBackgroundColor } = useUIState();
   const [selectedScope, setSelectedScope] = useState<LoadableSettingScope>(
     SettingScope.User,
@@ -142,9 +140,8 @@ export function ThemeDialog({
   const handleThemeSelect = useCallback(
     async (themeName: string) => {
       await onSelect(themeName, selectedScope);
-      refreshStatic();
     },
-    [onSelect, selectedScope, refreshStatic],
+    [onSelect, selectedScope],
   );
 
   const handleThemeHighlight = (themeName: string) => {
@@ -159,9 +156,8 @@ export function ThemeDialog({
   const handleScopeSelect = useCallback(
     async (scope: LoadableSettingScope) => {
       await onSelect(highlightedThemeName, scope);
-      refreshStatic();
     },
-    [onSelect, highlightedThemeName, refreshStatic],
+    [onSelect, highlightedThemeName],
   );
 
   const [mode, setMode] = useState<'theme' | 'scope'>('theme');

--- a/packages/cli/src/ui/hooks/useTerminalTheme.ts
+++ b/packages/cli/src/ui/hooks/useTerminalTheme.ts
@@ -56,11 +56,18 @@ export function useTerminalTheme(
       if (!match) return;
 
       const hexColor = parseColor(match[1], match[2], match[3]);
-      const luminance = getLuminance(hexColor);
+      if (!hexColor) return;
+
+      const previousColor = config.getTerminalBackground();
+
+      if (previousColor === hexColor) {
+        return;
+      }
+
       config.setTerminalBackground(hexColor);
       themeManager.setTerminalBackground(hexColor);
-      refreshStatic();
 
+      const luminance = getLuminance(hexColor);
       const currentThemeName = settings.merged.ui.theme;
 
       const newTheme = shouldSwitchTheme(
@@ -72,6 +79,11 @@ export function useTerminalTheme(
 
       if (newTheme) {
         void handleThemeSelect(newTheme, SettingScope.User);
+      } else {
+        // The existing theme had its background changed so refresh because
+        // there may be existing static UI rendered that relies on the old
+        // background color.
+        refreshStatic();
       }
     };
 

--- a/packages/cli/src/ui/hooks/useThemeCommand.ts
+++ b/packages/cli/src/ui/hooks/useThemeCommand.ts
@@ -31,6 +31,7 @@ export const useThemeCommand = (
   setThemeError: (error: string | null) => void,
   addItem: UseHistoryManagerReturn['addItem'],
   initialThemeError: string | null,
+  refreshStatic: () => void,
 ): UseThemeCommandReturn => {
   const [isThemeDialogOpen, setIsThemeDialogOpen] =
     useState(!!initialThemeError);
@@ -102,12 +103,13 @@ export const useThemeCommand = (
           themeManager.loadCustomThemes(loadedSettings.merged.ui.customThemes);
         }
         applyTheme(loadedSettings.merged.ui.theme); // Apply the current theme
+        refreshStatic();
         setThemeError(null);
       } finally {
         setIsThemeDialogOpen(false); // Close the dialog
       }
     },
-    [applyTheme, loadedSettings, setThemeError],
+    [applyTheme, loadedSettings, refreshStatic, setThemeError],
   );
 
   return {


### PR DESCRIPTION
## Summary

We accidentally updated the theme and called refresh static even if the background color was unchanged

To test:
Dial "Terminal Background Polling Interval" to 1s and verify you do not see flicker in iterm2 when you have a somewhat long chat conversation.

Verify that after changing the background color of your terminal (the iterm2 appearance tab of the settings dialog makes this easy) that the theme still updates fully in gemini cli after a second has passed.

Verify that the ThemeDialog still successfully fully updates the theme after you change it.

Fixes #19040
