### PR TITLE
feat(config): add setting to make directory tree context configurable

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -633,6 +633,11 @@ their corresponding top-level category object in your `settings.json` file.
   - **Description:** The format to use when importing memory.
   - **Default:** `undefined`
 
+- **`context.includeDirectoryTree`** (boolean):
+  - **Description:** Whether to include the directory tree of the current
+    working directory in the initial request to the model.
+  - **Default:** `true`
+
 - **`context.discoveryMaxDirs`** (number):
   - **Description:** Maximum number of directories to search for memory.
   - **Default:** `200`

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -454,6 +454,7 @@ export async function loadCliConfig(
   }
 
   const memoryImportFormat = settings.context?.importFormat || 'tree';
+  const includeDirectoryTree = settings.context?.includeDirectoryTree ?? true;
 
   const ideMode = settings.ide?.enabled ?? false;
 
@@ -745,6 +746,7 @@ export async function loadCliConfig(
     embeddingModel: DEFAULT_GEMINI_EMBEDDING_MODEL,
     sandbox: sandboxConfig,
     targetDir: cwd,
+    includeDirectoryTree,
     includeDirectories,
     loadMemoryFromIncludeDirectories:
       settings.context?.loadMemoryFromIncludeDirectories || false,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -949,6 +949,16 @@ const SETTINGS_SCHEMA = {
         description: 'The format to use when importing memory.',
         showInDialog: false,
       },
+      includeDirectoryTree: {
+        type: 'boolean',
+        label: 'Include Directory Tree',
+        category: 'Context',
+        requiresRestart: false,
+        default: true,
+        description:
+          'Whether to include the directory tree of the current working directory in the initial request to the model.',
+        showInDialog: false,
+      },
       discoveryMaxDirs: {
         type: 'number',
         label: 'Memory Discovery Max Dirs',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -436,6 +436,7 @@ export interface ConfigParameters {
   folderTrust?: boolean;
   ideMode?: boolean;
   loadMemoryFromIncludeDirectories?: boolean;
+  includeDirectoryTree?: boolean;
   importFormat?: 'tree' | 'flat';
   discoveryMaxDirs?: number;
   compressionThreshold?: number;
@@ -603,6 +604,7 @@ export class Config {
     | undefined;
   private readonly experimentalZedIntegration: boolean = false;
   private readonly loadMemoryFromIncludeDirectories: boolean = false;
+  private readonly includeDirectoryTree: boolean = true;
   private readonly importFormat: 'tree' | 'flat';
   private readonly discoveryMaxDirs: number;
   private readonly compressionThreshold: number | undefined;
@@ -786,6 +788,7 @@ export class Config {
     this.summarizeToolOutput = params.summarizeToolOutput;
     this.folderTrust = params.folderTrust ?? false;
     this.ideMode = params.ideMode ?? false;
+    this.includeDirectoryTree = params.includeDirectoryTree ?? true;
     this.loadMemoryFromIncludeDirectories =
       params.loadMemoryFromIncludeDirectories ?? false;
     this.importFormat = params.importFormat ?? 'tree';
@@ -1159,6 +1162,10 @@ export class Config {
 
   shouldLoadMemoryFromIncludeDirectories(): boolean {
     return this.loadMemoryFromIncludeDirectories;
+  }
+
+  getIncludeDirectoryTree(): boolean {
+    return this.includeDirectoryTree;
   }
 
   getImportFormat(): 'tree' | 'flat' {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -243,6 +243,7 @@ describe('Gemini Client (client.ts)', () => {
       getShowModelInfoInChat: vi.fn().mockReturnValue(false),
       getContinueOnFailedApiCall: vi.fn(),
       getProjectRoot: vi.fn().mockReturnValue('/test/project/root'),
+      getIncludeDirectoryTree: vi.fn().mockReturnValue(true),
       storage: {
         getProjectTempDir: vi.fn().mockReturnValue('/test/temp'),
       },

--- a/packages/core/src/utils/environmentContext.test.ts
+++ b/packages/core/src/utils/environmentContext.test.ts
@@ -88,6 +88,7 @@ describe('getEnvironmentContext', () => {
         getDirectories: vi.fn().mockReturnValue(['/test/dir']),
       }),
       getFileService: vi.fn(),
+      getIncludeDirectoryTree: vi.fn().mockReturnValue(true),
       getEnvironmentMemory: vi.fn().mockReturnValue('Mock Environment Memory'),
 
       getToolRegistry: vi.fn().mockReturnValue(mockToolRegistry),
@@ -144,6 +145,24 @@ describe('getEnvironmentContext', () => {
     );
     expect(context).toContain('</session_context>');
     expect(getFolderStructure).toHaveBeenCalledTimes(2);
+  });
+
+  it('should omit directory structure when getIncludeDirectoryTree is false', async () => {
+    (vi.mocked(mockConfig.getIncludeDirectoryTree!) as Mock).mockReturnValue(
+      false,
+    );
+
+    const parts = await getEnvironmentContext(mockConfig as Config);
+
+    expect(parts.length).toBe(1);
+    const context = parts[0].text;
+
+    expect(context).toContain('<session_context>');
+    expect(context).not.toContain('Directory Structure:');
+    expect(context).not.toContain('Mock Folder Structure');
+    expect(context).toContain('Mock Environment Memory');
+    expect(context).toContain('</session_context>');
+    expect(getFolderStructure).not.toHaveBeenCalled();
   });
 
   it('should handle read_many_files returning no content', async () => {

--- a/packages/core/src/utils/environmentContext.ts
+++ b/packages/core/src/utils/environmentContext.ts
@@ -65,7 +65,7 @@ This is the Gemini CLI. We are setting up the context for our chat.
 Today's date is ${today} (formatted according to the user's locale).
 My operating system is: ${platform}
 The project's temporary directory is: ${tempDir}
-${directoryContext ? directoryContext + '\n' : ''}
+${directoryContext}
 
 ${environmentMemory}
 </session_context>`.trim();

--- a/packages/core/src/utils/environmentContext.ts
+++ b/packages/core/src/utils/environmentContext.ts
@@ -53,7 +53,9 @@ export async function getEnvironmentContext(config: Config): Promise<Part[]> {
     day: 'numeric',
   });
   const platform = process.platform;
-  const directoryContext = await getDirectoryContextString(config);
+  const directoryContext = config.getIncludeDirectoryTree()
+    ? await getDirectoryContextString(config)
+    : '';
   const tempDir = config.storage.getProjectTempDir();
   const environmentMemory = config.getEnvironmentMemory();
 
@@ -63,7 +65,7 @@ This is the Gemini CLI. We are setting up the context for our chat.
 Today's date is ${today} (formatted according to the user's locale).
 My operating system is: ${platform}
 The project's temporary directory is: ${tempDir}
-${directoryContext}
+${directoryContext ? directoryContext + '\n' : ''}
 
 ${environmentMemory}
 </session_context>`.trim();

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1052,6 +1052,13 @@
           "markdownDescription": "The format to use when importing memory.\n\n- Category: `Context`\n- Requires restart: `no`",
           "type": "string"
         },
+        "includeDirectoryTree": {
+          "title": "Include Directory Tree",
+          "description": "Whether to include the directory tree of the current working directory in the initial request to the model.",
+          "markdownDescription": "Whether to include the directory tree of the current working directory in the initial request to the model.\n\n- Category: `Context`\n- Requires restart: `no`\n- Default: `true`",
+          "default": true,
+          "type": "boolean"
+        },
         "discoveryMaxDirs": {
           "title": "Memory Discovery Max Dirs",
           "description": "Maximum number of directories to search for memory.",


### PR DESCRIPTION
## Summary

Adds a new advanced setting `context.includeDirectoryTree` to control whether the workspace directory tree is included in the initial session context sent to the model. This allows users with very large workspaces or specific context window concerns to opt out of sending the full directory structure by default.

## Details

- Added the `includeDirectoryTree` boolean setting (default: `true`) to [settingsSchema.ts](cci:7://file:///usr/local/google/home/kevinramdass/github/gemini-cli/packages/cli/src/config/settingsSchema.ts:0:0-0:0) under the `context` category.
- Set `showInDialog: false` so it acts as an advanced configuration and does not clutter the settings UI.
- Plumbed the setting through [loadCliConfig](cci:1://file:///usr/local/google/home/kevinramdass/github/gemini-cli/packages/cli/src/config/config.ts:440:0-865:1) in the `cli` package down to the [Config](cci:2://file:///usr/local/google/home/kevinramdass/github/gemini-cli/packages/core/src/config/config.ts:494:0-2611:1) class in the `core` package.
- Updated the [getEnvironmentContext](cci:1://file:///usr/local/google/home/kevinramdass/github/gemini-cli/packages/core/src/utils/environmentContext.ts:40:0-75:1) utility to conditionally omit the directory structure and workspace list when the flag is set to `false`.
- Added unit test coverage in [environmentContext.test.ts](cci:7://file:///usr/local/google/home/kevinramdass/github/gemini-cli/packages/core/src/utils/environmentContext.test.ts:0:0-0:0) to verify the exclusion logic.
- Generated the updated `settings.md` documentation.

## Related Issues

Related to #15328 

## How to Validate

1. Run the test suite: `npm run test`
2. Add the following to your `~/.gemini/settings.json`:
   ```json
   "context": {
     "includeDirectoryTree": false
   }
3. Run `npm run start` in the workspace.
4. Run /chat debug to dump the current session's initial context request.
5. Inspect the generated gcli-request-*.json file.
6. Verify that the <session_context> block no longer contains the - **Workspace Directories:** and - **Directory Structure:** sections.
