### PR TITLE
fix(core): fallback to child_process for WSL Windows binaries to prevent hang

### DIFF
--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -17,6 +17,7 @@ import { getCachedEncodingForBuffer } from '../utils/systemEncoding.js';
 import {
   getShellConfiguration,
   resolveExecutable,
+  getCommandRoots,
   type ShellType,
 } from '../utils/shell-utils.js';
 import { isBinary } from '../utils/textUtils.js';
@@ -283,7 +284,10 @@ export class ShellExecutionService {
       config: shellExecutionConfig,
     });
 
-    if (shouldUseNodePty) {
+    if (
+      shouldUseNodePty &&
+      !(await this.isWslWindowsBinary(commandToExecute))
+    ) {
       const ptyInfo = await getPty();
       if (ptyInfo) {
         try {
@@ -310,6 +314,51 @@ export class ShellExecutionService {
       shellExecutionConfig.sanitizationConfig,
       shouldUseNodePty,
     );
+  }
+
+  private static async isWslWindowsBinary(
+    commandToExecute: string,
+  ): Promise<boolean> {
+    if (os.platform() !== 'linux') return false;
+
+    const roots = getCommandRoots(commandToExecute);
+
+    for (const root of roots) {
+      const executablePath = await resolveExecutable(root).catch(
+        () => undefined,
+      );
+      if (!executablePath) continue;
+
+      const canonicalPath = await fs.promises
+        .realpath(executablePath)
+        .catch(() => undefined);
+      if (!canonicalPath) continue;
+
+      if (await this.hasWindowsMagicBytes(canonicalPath)) {
+        debugLogger.debug(
+          `WSL Windows binary detected in pipeline: "${root}" (${canonicalPath}), disabling PTY`,
+        );
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private static async hasWindowsMagicBytes(
+    filePath: string,
+  ): Promise<boolean> {
+    const fd = await fs.promises.open(filePath, 'r').catch(() => undefined);
+    if (!fd) return false;
+
+    try {
+      const { bytesRead, buffer } = await fd.read(Buffer.alloc(2), 0, 2, 0);
+      return bytesRead === 2 && buffer.toString() === 'MZ';
+    } catch {
+      return false;
+    } finally {
+      await fd.close();
+    }
   }
 
   private static appendAndTruncate(


### PR DESCRIPTION
## Summary

Fixes a critical deadlock where running Windows binaries (like `pwsh.exe`) via WSL in a PTY causes an indefinite hang due to unanswered Cursor Position Requests (`\u001b[6n`).

## Details

Detects if a command resolves to a Windows path (e.g., `/mnt/c/...`) on Linux and forces a fallback to `child_process` (standard pipes) instead of using `node-pty`. This ensures that interactive-only escape sequences are not triggered or expected.

## Related Issues

Fixes #15233

## How to Validate

Run `gemini -p "pwsh --version"` in a WSL environment.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
