### PR TITLE
fix(cli): add equality guard to useTerminalTheme to prevent redundant flicker

### DIFF
--- a/packages/cli/src/ui/hooks/useTerminalTheme.ts
+++ b/packages/cli/src/ui/hooks/useTerminalTheme.ts
@@ -56,6 +56,12 @@ export function useTerminalTheme(
       if (!match) return;
 
       const hexColor = parseColor(match[1], match[2], match[3]);
+
+      // Avoid unnecessary re-renders (flicker) if the background hasn't changed
+      if (hexColor === config.getTerminalBackground()) {
+        return;
+      }
+
       const luminance = getLuminance(hexColor);
       config.setTerminalBackground(hexColor);
       themeManager.setTerminalBackground(hexColor);


### PR DESCRIPTION
## Summary

Fixes a UI flicker regression where the screen was redrawn on every terminal background poll event (every 60s by default) even if the background color had not changed.

## Details

Added a strict equality check between the new parsed `hexColor` and the current terminal background from the config. If they match, we return early instead of triggering `refreshStatic()`. This significantly improves visual stability in environments like VS Code and WSL where these redraws are most noticeable.

## Related Issues

Relates to #19040

## How to Validate

Run the CLI in VS Code/WSL and observe that the screen remains stable after the 60s polling interval triggers.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
