### PR TITLE
fix(core): propagate User-Agent header to setup-phase CodeAssist API calls

### DIFF
--- a/packages/core/src/code_assist/codeAssist.test.ts
+++ b/packages/core/src/code_assist/codeAssist.test.ts
@@ -64,6 +64,7 @@ describe('codeAssist', () => {
       expect(setupUser).toHaveBeenCalledWith(
         mockAuthClient,
         mockValidationHandler,
+        httpOptions,
       );
       expect(MockedCodeAssistServer).toHaveBeenCalledWith(
         mockAuthClient,
@@ -93,6 +94,7 @@ describe('codeAssist', () => {
       expect(setupUser).toHaveBeenCalledWith(
         mockAuthClient,
         mockValidationHandler,
+        httpOptions,
       );
       expect(MockedCodeAssistServer).toHaveBeenCalledWith(
         mockAuthClient,

--- a/packages/core/src/code_assist/codeAssist.ts
+++ b/packages/core/src/code_assist/codeAssist.ts
@@ -24,7 +24,11 @@ export async function createCodeAssistContentGenerator(
     authType === AuthType.COMPUTE_ADC
   ) {
     const authClient = await getOauthClient(authType, config);
-    const userData = await setupUser(authClient, config.getValidationHandler());
+    const userData = await setupUser(
+      authClient,
+      config.getValidationHandler(),
+      httpOptions,
+    );
     return new CodeAssistServer(
       authClient,
       userData.projectId,

--- a/packages/core/src/code_assist/setup.test.ts
+++ b/packages/core/src/code_assist/setup.test.ts
@@ -77,6 +77,27 @@ describe('setupUser for existing user', () => {
     );
   });
 
+  it('should pass httpOptions to CodeAssistServer when provided', async () => {
+    vi.stubEnv('GOOGLE_CLOUD_PROJECT', 'test-project');
+    mockLoad.mockResolvedValue({
+      currentTier: mockPaidTier,
+    });
+    const httpOptions = {
+      headers: {
+        'User-Agent': 'GeminiCLI/1.0.0/gemini-2.0-flash (darwin; arm64)',
+      },
+    };
+    await setupUser({} as OAuth2Client, undefined, httpOptions);
+    expect(CodeAssistServer).toHaveBeenCalledWith(
+      {},
+      'test-project',
+      httpOptions,
+      '',
+      undefined,
+      undefined,
+    );
+  });
+
   it('should ignore GOOGLE_CLOUD_PROJECT when project from server is set', async () => {
     vi.stubEnv('GOOGLE_CLOUD_PROJECT', 'test-project');
     mockLoad.mockResolvedValue({

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -12,6 +12,7 @@ import type {
   OnboardUserRequest,
 } from './types.js';
 import { UserTierId, IneligibleTierReasonCode } from './types.js';
+import type { HttpOptions } from './server.js';
 import { CodeAssistServer } from './server.js';
 import type { AuthClient } from 'google-auth-library';
 import type { ValidationHandler } from '../fallback/types.js';
@@ -77,6 +78,7 @@ export interface UserData {
 export async function setupUser(
   client: AuthClient,
   validationHandler?: ValidationHandler,
+  httpOptions: HttpOptions = {},
 ): Promise<UserData> {
   const projectId =
     process.env['GOOGLE_CLOUD_PROJECT'] ||
@@ -85,7 +87,7 @@ export async function setupUser(
   const caServer = new CodeAssistServer(
     client,
     projectId,
-    {},
+    httpOptions,
     '',
     undefined,
     undefined,


### PR DESCRIPTION
## Summary

Propagate `User-Agent` header to setup-phase CodeAssist API calls.

## Details

During the setup phase of CodeAssist, certain API calls (`loadCodeAssist`, `onboardUser`) were being made without the `User-Agent` header. This occurred because `setupUser` was instantiating `CodeAssistServer` with an empty `httpOptions` object. This PR updates `setupUser` to accept `httpOptions` and pass them when instantiating `CodeAssistServer`, and ensures `createCodeAssistContentGenerator` passes its `httpOptions` to `setupUser`.

## Related Issues

Fixes #19181

## How to Validate

Check sherlog traces for missing `user-agent` header now available. Sample:

   - LoadCodeAssist: http://sherlog/_3k8RehIozL
   - ListExperiments: http://sherlog/_1doFTQsghv

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
