### PR TITLE
fix(telemetry): omit request_text from logs based on logPrompts setting

### DIFF
--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -396,8 +396,8 @@ export class ApiRequestEvent implements BaseTelemetryEvent {
       prompt_id: this.prompt.prompt_id,
     };
     // user prompts are contained in request text as session conversation histories,
-    // so omit `request_text` from log if `logPrompts` is false.
-    if (config.getTelemetryLogPromptsEnabled() && this.request_text) {
+    // so add `request_text` from log only if `logPrompts` is true.
+    if (config.getTelemetryLogPromptsEnabled()) {
       attributes['request_text'] = this.request_text;
     }
     return { body: `API request to ${this.model}.`, attributes };

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -394,8 +394,12 @@ export class ApiRequestEvent implements BaseTelemetryEvent {
       'event.timestamp': this['event.timestamp'],
       model: this.model,
       prompt_id: this.prompt.prompt_id,
-      request_text: this.request_text,
     };
+    // user prompts are contained in request text as session conversation histories,
+    // so omit `request_text` from log if `logPrompts` is false.
+    if (config.getTelemetryLogPromptsEnabled() && this.request_text) {
+      attributes['request_text'] = this.request_text;
+    }
     return { body: `API request to ${this.model}.`, attributes };
   }
 


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

exclude `request_text` field from `api_request` event log if `logPromts` is false.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

Updated `ApiRequestEvent.toLogRecord` to exclude the `request_text` field when the `logPrompts` configuration is set to false. This ensures that user conversation history is not recorded in the logs unless explicitly enabled.

#### Testing
Verified the behavior by running the gemini command and checking the Cloud Logging entries.

1. With logPrompts: false (Verified: request_text is omitted)
```json
{
  "jsonPayload": {
    "event.name": "gemini_cli.api_request",
    "event.timestamp": "2026-02-16T02:48:08.225Z",
  },
  "receiveTimestamp": "2026-02-16T02:48:11.477108872Z"
}
```

2. With logPrompts: true (Verified: request_text is retained as before)
```json
{
  "jsonPayload": {
    "request_text": "[...... {\"role\":\"user\",\"parts\":[{\"text\":\"hello, are you ready?\"}]}]",
    "event.name": "gemini_cli.api_request",
    "event.timestamp": "2026-02-16T02:12:27.091Z",
  },
  "receiveTimestamp": "2026-02-16T02:12:27.683933053Z"
}
```

(only relevant fields are shown)

## Related Issues

Fixes #18979

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
