### PR TITLE
fix(cli): pass proxy environment variables to sandbox-exec

### DIFF
--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -193,6 +193,7 @@ export async function start_sandbox(
       process.stdin.pause();
       sandboxProcess = spawn(config.command, args, {
         stdio: 'inherit',
+        env: sandboxEnv,
       });
       return await new Promise((resolve, reject) => {
         sandboxProcess?.on('error', reject);


### PR DESCRIPTION
## Summary

Fixes an issue where proxy environment variables were not passed to the `sandbox-exec` process, causing proxy configurations to be ignored in the sandbox.

## Details

- Modified `packages/cli/src/utils/sandbox.ts` to explicitly pass the constructed `sandboxEnv` (which is constructed with proxy variables and yet goes unused) to the `spawn` command for the sandbox process.
- Added a regression test in `packages/cli/src/utils/sandbox.test.ts` to verify that `HTTPS_PROXY` is correctly passed to the spawned process.

## Related Issues

Fixes #19187

## How to Validate

1. Run the regression test:
   `npm test -w packages/cli -- src/utils/sandbox.test.ts`
2. Verify that the test `should pass proxy environment variables to sandbox-exec` passes.

Alternatively, try the example proxy:
https://geminicli.com/docs/examples/proxy-script/

1. Run with the proxy:
     `GEMINI_SANDBOX_PROXY_COMMAND=./test-proxy.js SEATBELT_PROFILE=permissive-proxied gemini --sandbox`
2. Enter shell mode (`!`) and run a command like `curl https://example.com`

Before: curl fails
After: curl succeeds

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [x] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
