### PR TITLE
feat(cli): add loading state to new agents notification

### DIFF
--- a/packages/cli/src/ui/components/NewAgentsNotification.test.tsx
+++ b/packages/cli/src/ui/components/NewAgentsNotification.test.tsx
@@ -7,6 +7,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { renderWithProviders as render } from '../../test-utils/render.js';
 import { NewAgentsNotification } from './NewAgentsNotification.js';
+import { waitFor } from '../../test-utils/async.js';
+import { act } from 'react';
 
 describe('NewAgentsNotification', () => {
   const mockAgents = [
@@ -52,6 +54,30 @@ describe('NewAgentsNotification', () => {
 
     const frame = lastFrame();
     expect(frame).toMatchSnapshot();
+    unmount();
+  });
+
+  it('shows processing state when an option is selected', async () => {
+    const asyncOnSelect = vi.fn(
+      () =>
+        new Promise<void>(() => {
+          // Never resolve
+        }),
+    );
+
+    const { lastFrame, stdin, unmount } = render(
+      <NewAgentsNotification agents={mockAgents} onSelect={asyncOnSelect} />,
+    );
+
+    // Press Enter to select the first option
+    await act(async () => {
+      stdin.write('\r');
+    });
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('Processing...');
+    });
+
     unmount();
   });
 });

--- a/packages/cli/src/ui/components/NewAgentsNotification.tsx
+++ b/packages/cli/src/ui/components/NewAgentsNotification.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { useState } from 'react';
 import { Box, Text } from 'ink';
 import { type AgentDefinition } from '@google/gemini-cli-core';
 import { theme } from '../semantic-colors.js';
@@ -11,6 +12,7 @@ import {
   RadioButtonSelect,
   type RadioSelectItem,
 } from './shared/RadioButtonSelect.js';
+import { CliSpinner } from './CliSpinner.js';
 
 export enum NewAgentsChoice {
   ACKNOWLEDGE = 'acknowledge',
@@ -19,13 +21,15 @@ export enum NewAgentsChoice {
 
 interface NewAgentsNotificationProps {
   agents: AgentDefinition[];
-  onSelect: (choice: NewAgentsChoice) => void;
+  onSelect: (choice: NewAgentsChoice) => void | Promise<void>;
 }
 
 export const NewAgentsNotification = ({
   agents,
   onSelect,
 }: NewAgentsNotificationProps) => {
+  const [isProcessing, setIsProcessing] = useState(false);
+
   const options: Array<RadioSelectItem<NewAgentsChoice>> = [
     {
       label: 'Acknowledge and Enable',
@@ -38,6 +42,11 @@ export const NewAgentsNotification = ({
       key: 'ignore',
     },
   ];
+
+  const handleSelect = async (choice: NewAgentsChoice) => {
+    setIsProcessing(true);
+    await onSelect(choice);
+  };
 
   // Limit display to 5 agents to avoid overflow, show count for rest
   const MAX_DISPLAYED_AGENTS = 5;
@@ -85,11 +94,18 @@ export const NewAgentsNotification = ({
           </Box>
         </Box>
 
-        <RadioButtonSelect
-          items={options}
-          onSelect={onSelect}
-          isFocused={true}
-        />
+        {isProcessing ? (
+          <Box>
+            <CliSpinner />
+            <Text color={theme.text.primary}> Processing...</Text>
+          </Box>
+        ) : (
+          <RadioButtonSelect
+            items={options}
+            onSelect={handleSelect}
+            isFocused={true}
+          />
+        )}
       </Box>
     </Box>
   );

--- a/packages/cli/src/ui/components/NewAgentsNotification.tsx
+++ b/packages/cli/src/ui/components/NewAgentsNotification.tsx
@@ -45,7 +45,11 @@ export const NewAgentsNotification = ({
 
   const handleSelect = async (choice: NewAgentsChoice) => {
     setIsProcessing(true);
-    await onSelect(choice);
+    try {
+      await onSelect(choice);
+    } finally {
+      setIsProcessing(false);
+    }
   };
 
   // Limit display to 5 agents to avoid overflow, show count for rest


### PR DESCRIPTION
## Summary

This PR adds a loading state to the `NewAgentsNotification` component to provide visual feedback when a user selects an option. Previously, there was a delay while agents were being acknowledged, leading to a perception that nothing was happening.

## Details
<img width="534" height="207" alt="image" src="https://github.com/user-attachments/assets/5f8baafe-fdd6-4bac-ba43-12969bbe96c3" />


- Added `isProcessing` state to `NewAgentsNotification`.
- Integrated `CliSpinner` to show a "Processing..." message upon selection.
- Updated `onSelect` prop type to support `Promise<void>`.
- Added unit tests to verify the processing state is displayed.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/19191

## How to Validate

1. Run the CLI in a project where new agents are discovered.
2. Select "Acknowledge and Enable".
3. Observe the "Processing..." spinner appearing before the dialog closes.
4. Run tests: `npm test -w @google/gemini-cli -t NewAgentsNotification`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
