### PR TITLE
refactor: Extract model config merging logic into dedicated function

### DIFF
--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -237,3 +237,28 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
     },
   ],
 };
+
+/**
+ * Merges user-provided model config service configuration with defaults.
+ * This function only fills in missing values from defaults; it does not
+ * merge them. This preserves the original behavior where user-provided
+ * values completely replace defaults.
+ *
+ * @param userConfig - The user-provided configuration (may be partial)
+ * @returns A complete configuration with defaults filled in for missing values
+ */
+export function mergeModelConfigWithDefaults(
+  userConfig: ModelConfigServiceConfig | undefined,
+): ModelConfigServiceConfig {
+  if (!userConfig) {
+    return DEFAULT_MODEL_CONFIGS;
+  }
+
+  return {
+    // Only use default aliases if user didn't provide any
+    aliases: userConfig.aliases ?? DEFAULT_MODEL_CONFIGS.aliases,
+
+    // Only use default overrides if user didn't provide any
+    overrides: userConfig.overrides ?? DEFAULT_MODEL_CONFIGS.overrides,
+  };
+}


### PR DESCRIPTION
This change refactors the inline HACK for merging model configuration with defaults into a clean, reusable function.

**Background:**
The original hack manually merged default aliases and overrides back into user configurations when they were missing. This was necessary because the settings loading logic doesn't merge defaults with user settings.

**Changes:**
- Added `mergeModelConfigWithDefaults()` function to `defaultModelConfigs.ts`
- Function only fills in missing values from defaults (using `??` operator)
- Maintains the original behavior - user-provided values completely replace defaults
- Removed the inline HACK code and TODO comment from `config.ts`

**Benefits:**
- Clear intent: fill in missing values from defaults
- Reusable and testable function
- No breaking changes
- Cleaner code without inline comments explaining workarounds

**Fixes:**
- Resolves TODO in `config.ts` line 889