### PR TITLE
feat(cli): handle invalid model names in useQuotaAndFallback

### DIFF
--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -83,16 +83,21 @@ export function useQuotaAndFallback({
           `/auth to switch to API key.`,
         ].filter(Boolean);
         message = messageLines.join('\n');
-      } else if (
-        error instanceof ModelNotFoundError &&
-        VALID_GEMINI_MODELS.has(failedModel)
-      ) {
+      } else if (error instanceof ModelNotFoundError) {
         isModelNotFoundError = true;
-        const messageLines = [
-          `It seems like you don't have access to ${failedModel}.`,
-          `Your admin might have disabled the access. Contact them to enable the Preview Release Channel.`,
-        ];
-        message = messageLines.join('\n');
+        if (VALID_GEMINI_MODELS.has(failedModel)) {
+          const messageLines = [
+            `It seems like you don't have access to ${failedModel}.`,
+            `Your admin might have disabled the access. Contact them to enable the Preview Release Channel.`,
+          ];
+          message = messageLines.join('\n');
+        } else {
+          const messageLines = [
+            `Model "${failedModel}" was not found or is invalid.`,
+            `/model to switch models.`,
+          ];
+          message = messageLines.join('\n');
+        }
       } else {
         const messageLines = [
           `We are currently experiencing high demand.`,


### PR DESCRIPTION
## Summary

Handles cases where a model is not found or is invalid in `useQuotaAndFallback`. This provides a clearer error message to the user, suggesting they use `/model` to switch models instead of showing a blank or generic error.

## Details

- Updated `packages/cli/src/ui/hooks/useQuotaAndFallback.ts` to handle `ModelNotFoundError` properly by providing a descriptive message when the failed model is not in the list of valid Gemini models.
- Added a test case in `packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts` to verify the new error message for invalid model names.

## Related Issues

Closes #19220

## How to Validate

1.  Mock a `ModelNotFoundError` with an invalid model name in `useQuotaAndFallback`.
2.  Observe the error message displayed in the UI. It should state: 'Model "[invalid_model_name]" was not found or is invalid. /model to switch models.'
3.  Run unit tests: `npm test -w @google/gemini-cli -- src/ui/hooks/useQuotaAndFallback.test.ts`

## Pre-Merge Checklist

- [x] Added/updated tests
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
