### PR TITLE
chore(ui): remove outdated tip about model routing

### DIFF
--- a/packages/cli/src/ui/constants/tips.ts
+++ b/packages/cli/src/ui/constants/tips.ts
@@ -76,7 +76,6 @@ export const INFORMATIVE_TIPS = [
   'Set the number of lines to keep when truncating outputs (/settings)…',
   'Enable policy-based tool confirmation via message bus (/settings)…',
   'Enable write_todos_list tool to generate task lists (/settings)…',
-  'Enable model routing based on complexity (/settings)…',
   'Enable experimental subagents for task delegation (/settings)…',
   'Enable extension management features (settings.json)…',
   'Enable extension reloading within the CLI session (settings.json)…',


### PR DESCRIPTION
## Summary
This PR removes the outdated tip about "Enable model routing based on complexity" from the CLI tips list.

## Details
The model routing is no longer configurable from /settings, but is automatically applied if one uses Auto mode.

## Related Issues
Related to https://github.com/google-gemini/gemini-cli/issues/19225

## How to Validate
1. Run `npm test -w packages/cli` to ensure no tests are broken.
2. Verify that the tip no longer appears in the list of informative tips.

## Pre-Merge Checklist
- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed) - Verified existing tests pass.
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run

