### PR TITLE
feat(core): support custom reasoning models by default

### DIFF
--- a/packages/core/src/agents/codebase-investigator.ts
+++ b/packages/core/src/agents/codebase-investigator.ts
@@ -15,7 +15,7 @@ import {
   DEFAULT_THINKING_MODE,
   DEFAULT_GEMINI_MODEL,
   PREVIEW_GEMINI_FLASH_MODEL,
-  isPreviewModel,
+  supportsModernFeatures,
 } from '../config/models.js';
 import { z } from 'zod';
 import type { Config } from '../config/config.js';
@@ -51,9 +51,9 @@ const CodebaseInvestigationReportSchema = z.object({
 export const CodebaseInvestigatorAgent = (
   config: Config,
 ): LocalAgentDefinition<typeof CodebaseInvestigationReportSchema> => {
-  // Use Preview Flash model if the main model is any of the preview models.
-  // If the main model is not a preview model, use the default pro model.
-  const model = isPreviewModel(config.getModel())
+  // Use Preview Flash model if the main model supports modern features.
+  // If the main model is not a modern model, use the default pro model.
+  const model = supportsModernFeatures(config.getModel())
     ? PREVIEW_GEMINI_FLASH_MODEL
     : DEFAULT_GEMINI_MODEL;
 
@@ -96,7 +96,7 @@ export const CodebaseInvestigatorAgent = (
       generateContentConfig: {
         temperature: 0.1,
         topP: 0.95,
-        thinkingConfig: isPreviewModel(model)
+        thinkingConfig: supportsModernFeatures(model)
           ? {
               includeThoughts: true,
               thinkingLevel: ThinkingLevel.HIGH,

--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -10,6 +10,8 @@ import {
   resolveClassifierModel,
   isGemini3Model,
   isGemini2Model,
+  isCustomModel,
+  supportsModernFeatures,
   isAutoModel,
   getDisplayString,
   DEFAULT_GEMINI_MODEL,
@@ -24,6 +26,50 @@ import {
   PREVIEW_GEMINI_MODEL_AUTO,
   DEFAULT_GEMINI_MODEL_AUTO,
 } from './models.js';
+
+describe('isCustomModel', () => {
+  it('should return true for models not starting with gemini-', () => {
+    expect(isCustomModel('testing')).toBe(true);
+    expect(isCustomModel('gpt-4')).toBe(true);
+    expect(isCustomModel('claude-3')).toBe(true);
+  });
+
+  it('should return false for Gemini models', () => {
+    expect(isCustomModel('gemini-1.5-pro')).toBe(false);
+    expect(isCustomModel('gemini-2.0-flash')).toBe(false);
+    expect(isCustomModel('gemini-3-pro-preview')).toBe(false);
+  });
+
+  it('should return false for aliases that resolve to Gemini models', () => {
+    expect(isCustomModel(GEMINI_MODEL_ALIAS_AUTO)).toBe(false);
+    expect(isCustomModel(GEMINI_MODEL_ALIAS_PRO)).toBe(false);
+  });
+});
+
+describe('supportsModernFeatures', () => {
+  it('should return true for Gemini 3 models', () => {
+    expect(supportsModernFeatures('gemini-3-pro-preview')).toBe(true);
+    expect(supportsModernFeatures('gemini-3-flash-preview')).toBe(true);
+  });
+
+  it('should return true for custom models', () => {
+    expect(supportsModernFeatures('testing')).toBe(true);
+    expect(supportsModernFeatures('some-custom-model')).toBe(true);
+  });
+
+  it('should return false for older Gemini models', () => {
+    expect(supportsModernFeatures('gemini-2.5-pro')).toBe(false);
+    expect(supportsModernFeatures('gemini-2.5-flash')).toBe(false);
+    expect(supportsModernFeatures('gemini-2.0-flash')).toBe(false);
+    expect(supportsModernFeatures('gemini-1.5-pro')).toBe(false);
+    expect(supportsModernFeatures('gemini-1.0-pro')).toBe(false);
+  });
+
+  it('should return true for modern aliases', () => {
+    expect(supportsModernFeatures(GEMINI_MODEL_ALIAS_PRO)).toBe(true);
+    expect(supportsModernFeatures(GEMINI_MODEL_ALIAS_AUTO)).toBe(true);
+  });
+});
 
 describe('isGemini3Model', () => {
   it('should return true for gemini-3 models', () => {

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -142,6 +142,29 @@ export function isGemini2Model(model: string): boolean {
 }
 
 /**
+ * Checks if the model is a "custom" model (not Gemini branded).
+ *
+ * @param model The model name to check.
+ * @returns True if the model is not a Gemini branded model.
+ */
+export function isCustomModel(model: string): boolean {
+  const resolved = resolveModel(model);
+  return !resolved.startsWith('gemini-');
+}
+
+/**
+ * Checks if the model should be treated as a modern model.
+ * This includes Gemini 3 models and any custom models.
+ *
+ * @param model The model name to check.
+ * @returns True if the model supports modern features like thoughts.
+ */
+export function supportsModernFeatures(model: string): boolean {
+  if (isGemini3Model(model)) return true;
+  return isCustomModel(model);
+}
+
+/**
  * Checks if the model is an auto model.
  *
  * @param model The model name to check.

--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -534,7 +534,6 @@ exports[`Core System Prompt (prompts.ts) > should append userMemory with separat
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If the user implies a change (e.g., reports a bug) without explicitly asking for a fix, **ask for confirmation first**. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
-
 - **Explain Before Acting:** Never call tools in silence. You MUST provide a concise, one-sentence explanation of your intent or strategy immediately before executing tool calls. This is essential for transparency, especially when confirming a request or answering a question. Silence is only acceptable for repetitive, low-level discovery operations (e.g., sequential file reads) where narration would be noisy.
 
 # Available Sub-Agents
@@ -664,7 +663,6 @@ exports[`Core System Prompt (prompts.ts) > should handle CodebaseInvestigator wi
 - **Handle Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request. If the user implies a change (e.g., reports a bug) without explicitly asking for a fix, do not perform it automatically.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
-
 - **Explain Before Acting:** Never call tools in silence. You MUST provide a concise, one-sentence explanation of your intent or strategy immediately before executing tool calls. This is essential for transparency, especially when confirming a request or answering a question. Silence is only acceptable for repetitive, low-level discovery operations (e.g., sequential file reads) where narration would be noisy.
   - **Continue the work** You are not to interact with the user. Do your best to complete the task at hand, using your best judgement and avoid asking user for any additional information.
 
@@ -760,7 +758,6 @@ exports[`Core System Prompt (prompts.ts) > should handle CodebaseInvestigator wi
 - **Handle Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request. If the user implies a change (e.g., reports a bug) without explicitly asking for a fix, do not perform it automatically.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
-
 - **Explain Before Acting:** Never call tools in silence. You MUST provide a concise, one-sentence explanation of your intent or strategy immediately before executing tool calls. This is essential for transparency, especially when confirming a request or answering a question. Silence is only acceptable for repetitive, low-level discovery operations (e.g., sequential file reads) where narration would be noisy.
   - **Continue the work** You are not to interact with the user. Do your best to complete the task at hand, using your best judgement and avoid asking user for any additional information.
 
@@ -1326,7 +1323,6 @@ exports[`Core System Prompt (prompts.ts) > should include available_skills with 
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
 - **Skill Guidance:** Once a skill is activated via \`activate_skill\`, its instructions and resources are returned wrapped in \`<activated_skill>\` tags. You MUST treat the content within \`<instructions>\` as expert procedural guidance, prioritizing these specialized rules and workflows over your general defaults for the duration of the task. You may utilize any listed \`<available_resources>\` as needed. Follow this expert guidance strictly while continuing to uphold your core safety and security standards.
-
 - **Explain Before Acting:** Never call tools in silence. You MUST provide a concise, one-sentence explanation of your intent or strategy immediately before executing tool calls. This is essential for transparency, especially when confirming a request or answering a question. Silence is only acceptable for repetitive, low-level discovery operations (e.g., sequential file reads) where narration would be noisy.
 
 # Available Sub-Agents
@@ -1451,7 +1447,6 @@ exports[`Core System Prompt (prompts.ts) > should include correct sandbox instru
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If the user implies a change (e.g., reports a bug) without explicitly asking for a fix, **ask for confirmation first**. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
-
 - **Explain Before Acting:** Never call tools in silence. You MUST provide a concise, one-sentence explanation of your intent or strategy immediately before executing tool calls. This is essential for transparency, especially when confirming a request or answering a question. Silence is only acceptable for repetitive, low-level discovery operations (e.g., sequential file reads) where narration would be noisy.
 
 # Available Sub-Agents
@@ -1568,7 +1563,6 @@ exports[`Core System Prompt (prompts.ts) > should include correct sandbox instru
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If the user implies a change (e.g., reports a bug) without explicitly asking for a fix, **ask for confirmation first**. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
-
 - **Explain Before Acting:** Never call tools in silence. You MUST provide a concise, one-sentence explanation of your intent or strategy immediately before executing tool calls. This is essential for transparency, especially when confirming a request or answering a question. Silence is only acceptable for repetitive, low-level discovery operations (e.g., sequential file reads) where narration would be noisy.
 
 # Available Sub-Agents
@@ -1685,7 +1679,6 @@ exports[`Core System Prompt (prompts.ts) > should include correct sandbox instru
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If the user implies a change (e.g., reports a bug) without explicitly asking for a fix, **ask for confirmation first**. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
-
 - **Explain Before Acting:** Never call tools in silence. You MUST provide a concise, one-sentence explanation of your intent or strategy immediately before executing tool calls. This is essential for transparency, especially when confirming a request or answering a question. Silence is only acceptable for repetitive, low-level discovery operations (e.g., sequential file reads) where narration would be noisy.
 
 # Available Sub-Agents
@@ -1798,7 +1791,6 @@ exports[`Core System Prompt (prompts.ts) > should include planning phase suggest
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If the user implies a change (e.g., reports a bug) without explicitly asking for a fix, **ask for confirmation first**. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
-
 - **Explain Before Acting:** Never call tools in silence. You MUST provide a concise, one-sentence explanation of your intent or strategy immediately before executing tool calls. This is essential for transparency, especially when confirming a request or answering a question. Silence is only acceptable for repetitive, low-level discovery operations (e.g., sequential file reads) where narration would be noisy.
 
 # Available Sub-Agents
@@ -1910,7 +1902,6 @@ exports[`Core System Prompt (prompts.ts) > should include sub-agents in XML for 
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If the user implies a change (e.g., reports a bug) without explicitly asking for a fix, **ask for confirmation first**. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
-
 - **Explain Before Acting:** Never call tools in silence. You MUST provide a concise, one-sentence explanation of your intent or strategy immediately before executing tool calls. This is essential for transparency, especially when confirming a request or answering a question. Silence is only acceptable for repetitive, low-level discovery operations (e.g., sequential file reads) where narration would be noisy.
 
 # Available Sub-Agents
@@ -2262,7 +2253,6 @@ exports[`Core System Prompt (prompts.ts) > should return the base prompt when us
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If the user implies a change (e.g., reports a bug) without explicitly asking for a fix, **ask for confirmation first**. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
-
 - **Explain Before Acting:** Never call tools in silence. You MUST provide a concise, one-sentence explanation of your intent or strategy immediately before executing tool calls. This is essential for transparency, especially when confirming a request or answering a question. Silence is only acceptable for repetitive, low-level discovery operations (e.g., sequential file reads) where narration would be noisy.
 
 # Available Sub-Agents
@@ -2375,7 +2365,6 @@ exports[`Core System Prompt (prompts.ts) > should return the base prompt when us
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If the user implies a change (e.g., reports a bug) without explicitly asking for a fix, **ask for confirmation first**. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
-
 - **Explain Before Acting:** Never call tools in silence. You MUST provide a concise, one-sentence explanation of your intent or strategy immediately before executing tool calls. This is essential for transparency, especially when confirming a request or answering a question. Silence is only acceptable for repetitive, low-level discovery operations (e.g., sequential file reads) where narration would be noisy.
 
 # Available Sub-Agents
@@ -2599,7 +2588,6 @@ exports[`Core System Prompt (prompts.ts) > should use chatty system prompt for p
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If the user implies a change (e.g., reports a bug) without explicitly asking for a fix, **ask for confirmation first**. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
-
 - **Explain Before Acting:** Never call tools in silence. You MUST provide a concise, one-sentence explanation of your intent or strategy immediately before executing tool calls. This is essential for transparency, especially when confirming a request or answering a question. Silence is only acceptable for repetitive, low-level discovery operations (e.g., sequential file reads) where narration would be noisy.
 
 # Available Sub-Agents
@@ -2712,7 +2700,6 @@ exports[`Core System Prompt (prompts.ts) > should use chatty system prompt for p
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If the user implies a change (e.g., reports a bug) without explicitly asking for a fix, **ask for confirmation first**. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
-
 - **Explain Before Acting:** Never call tools in silence. You MUST provide a concise, one-sentence explanation of your intent or strategy immediately before executing tool calls. This is essential for transparency, especially when confirming a request or answering a question. Silence is only acceptable for repetitive, low-level discovery operations (e.g., sequential file reads) where narration would be noisy.
 
 # Available Sub-Agents

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -28,7 +28,7 @@ import type { Config } from '../config/config.js';
 import {
   resolveModel,
   isGemini2Model,
-  isPreviewModel,
+  supportsModernFeatures,
 } from '../config/models.js';
 import { hasCycleInSchema } from '../tools/tools.js';
 import type { StructuredError } from './turn.js';
@@ -520,7 +520,7 @@ export class GeminiChat {
         abortSignal,
       };
 
-      let contentsToUse = isPreviewModel(modelToUse)
+      let contentsToUse = supportsModernFeatures(modelToUse)
         ? contentsForPreviewModel
         : requestContents;
 

--- a/packages/core/src/prompts/promptProvider.ts
+++ b/packages/core/src/prompts/promptProvider.ts
@@ -29,7 +29,7 @@ import {
   GLOB_TOOL_NAME,
   GREP_TOOL_NAME,
 } from '../tools/tool-names.js';
-import { resolveModel, isPreviewModel } from '../config/models.js';
+import { resolveModel, supportsModernFeatures } from '../config/models.js';
 import { DiscoveredMCPTool } from '../tools/mcp-tool.js';
 import { getAllGeminiMdFilenames } from '../tools/memoryTool.js';
 
@@ -59,8 +59,8 @@ export class PromptProvider {
     const approvedPlanPath = config.getApprovedPlanPath();
 
     const desiredModel = resolveModel(config.getActiveModel());
-    const isGemini3 = isPreviewModel(desiredModel);
-    const activeSnippets = isGemini3 ? snippets : legacySnippets;
+    const isModernModel = supportsModernFeatures(desiredModel);
+    const activeSnippets = isModernModel ? snippets : legacySnippets;
     const contextFilenames = getAllGeminiMdFilenames();
 
     // --- Context Gathering ---
@@ -108,7 +108,7 @@ export class PromptProvider {
         basePrompt,
         config,
         skillsPrompt,
-        isGemini3,
+        isModernModel,
       );
     } else {
       // --- Standard Composition ---
@@ -125,7 +125,6 @@ export class PromptProvider {
         })),
         coreMandates: this.withSection('coreMandates', () => ({
           interactive: interactiveMode,
-          isGemini3,
           hasSkills: skills.length > 0,
           hasHierarchicalMemory,
           contextFilenames,
@@ -182,7 +181,6 @@ export class PromptProvider {
           'operationalGuidelines',
           () => ({
             interactive: interactiveMode,
-            isGemini3,
             enableShellEfficiency: config.getEnableShellOutputEfficiency(),
             interactiveShellEnabled: config.isInteractiveShellEnabled(),
           }),
@@ -198,7 +196,7 @@ export class PromptProvider {
           () => ({ interactive: interactiveMode }),
           isGitRepository(process.cwd()) ? true : false,
         ),
-        finalReminder: isGemini3
+        finalReminder: isModernModel
           ? undefined
           : this.withSection('finalReminder', () => ({
               readFileToolName: READ_FILE_TOOL_NAME,
@@ -234,8 +232,8 @@ export class PromptProvider {
 
   getCompressionPrompt(config: Config): string {
     const desiredModel = resolveModel(config.getActiveModel());
-    const isGemini3 = isPreviewModel(desiredModel);
-    const activeSnippets = isGemini3 ? snippets : legacySnippets;
+    const isModernModel = supportsModernFeatures(desiredModel);
+    const activeSnippets = isModernModel ? snippets : legacySnippets;
     return activeSnippets.getCompressionPrompt();
   }
 

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -43,7 +43,6 @@ export interface PreambleOptions {
 
 export interface CoreMandatesOptions {
   interactive: boolean;
-  isGemini3: boolean;
   hasSkills: boolean;
   hasHierarchicalMemory: boolean;
   contextFilenames?: string[];
@@ -61,7 +60,6 @@ export interface PrimaryWorkflowsOptions {
 
 export interface OperationalGuidelinesOptions {
   interactive: boolean;
-  isGemini3: boolean;
   interactiveShellEnabled: boolean;
 }
 
@@ -179,7 +177,7 @@ export function renderCoreMandates(options?: CoreMandatesOptions): string {
 - ${mandateConfirm(options.interactive)}
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.${mandateSkillGuidance(options.hasSkills)}
-${mandateExplainBeforeActing(options.isGemini3)}${mandateContinueWork(options.interactive)}
+- **Explain Before Acting:** Never call tools in silence. You MUST provide a concise, one-sentence explanation of your intent or strategy immediately before executing tool calls. This is essential for transparency, especially when confirming a request or answering a question. Silence is only acceptable for repetitive, low-level discovery operations (e.g., sequential file reads) where narration would be noisy.${mandateContinueWork(options.interactive)}
 `.trim();
 }
 
@@ -282,7 +280,8 @@ export function renderOperationalGuidelines(
 - **Role:** A senior software engineer and collaborative peer programmer.
 - **High-Signal Output:** Focus exclusively on **intent** and **technical rationale**. Avoid conversational filler, apologies, and mechanical tool-use narration (e.g., "I will now call...").
 - **Concise & Direct:** Adopt a professional, direct, and concise tone suitable for a CLI environment.
-- **Minimal Output:** Aim for fewer than 3 lines of text output (excluding tool use/code generation) per response whenever practical.${toneAndStyleNoChitchat(options.isGemini3)}
+- **Minimal Output:** Aim for fewer than 3 lines of text output (excluding tool use/code generation) per response whenever practical.
+- **No Chitchat:** Avoid conversational filler, preambles ("Okay, I will now..."), or postambles ("I have finished the changes...") unless they serve to explain intent as required by the 'Explain Before Acting' mandate.
 - **No Repetition:** Once you have provided a final synthesis of your work, do not repeat yourself or provide additional summaries. For simple or direct requests, prioritize extreme brevity.
 - **Formatting:** Use GitHub-flavored Markdown. Responses will be rendered in monospace.
 - **Tools vs. Text:** Use tools for actions, text output *only* for communication. Do not add explanatory comments within tool calls.
@@ -483,12 +482,6 @@ function mandateConflictResolution(hasHierarchicalMemory: boolean): string {
   return '\n- **Conflict Resolution:** Instructions are provided in hierarchical context tags: `<global_context>`, `<extension_context>`, and `<project_context>`. In case of contradictory instructions, follow this priority: `<project_context>` (highest) > `<extension_context>` > `<global_context>` (lowest).';
 }
 
-function mandateExplainBeforeActing(isGemini3: boolean): string {
-  if (!isGemini3) return '';
-  return `
-- **Explain Before Acting:** Never call tools in silence. You MUST provide a concise, one-sentence explanation of your intent or strategy immediately before executing tool calls. This is essential for transparency, especially when confirming a request or answering a question. Silence is only acceptable for repetitive, low-level discovery operations (e.g., sequential file reads) where narration would be noisy.`;
-}
-
 function mandateContinueWork(interactive: boolean): string {
   if (interactive) return '';
   return `
@@ -605,14 +598,6 @@ function newApplicationSteps(options: PrimaryWorkflowsOptions): string {
      - **CLIs:** Python or Go.
 3. **Implementation:** Autonomously implement each feature per the approved plan. When starting, scaffold the application using ${formatToolName(SHELL_TOOL_NAME)}. For interactive scaffolding tools (like create-react-app, create-vite, or npm create), you MUST use the corresponding non-interactive flag (e.g. '--yes', '-y', or specific template flags) to prevent the environment from hanging waiting for user input. For visual assets, utilize **platform-native primitives** (e.g., stylized shapes, gradients, icons). Never link to external services or assume local paths for assets that have not been created.
 4. **Verify:** Review work against the original request. Fix bugs and deviations. **Build the application and ensure there are no compile errors.**`.trim();
-}
-
-function toneAndStyleNoChitchat(isGemini3: boolean): string {
-  return isGemini3
-    ? `
-- **No Chitchat:** Avoid conversational filler, preambles ("Okay, I will now..."), or postambles ("I have finished the changes...") unless they serve to explain intent as required by the 'Explain Before Acting' mandate.`
-    : `
-- **No Chitchat:** Avoid conversational filler, preambles ("Okay, I will now..."), or postambles ("I have finished the changes..."). Get straight to the action or answer.`;
 }
 
 function toolUsageInteractive(


### PR DESCRIPTION
## Summary

Refactor model feature gating to support custom/unknown reasoning models by default. Non-Gemini branded models are now treated as "modern" to enable features like thoughts and modern system prompts without hardcoding names.

## Details

- Added `supportsModernFeatures` and `isCustomModel` to identify non-Gemini branded models.
- Updated `PromptProvider`, `GeminiChat`, and agents to use capability-based checks instead of hardcoded model lists.
- Simplified `snippets.ts` by assuming modern capabilities when invoked.
- Maintained legacy behavior for Gemini 2.x models.

## Related Issues

N/A

## How to Validate

1. Run with a custom model name: `gemini --model custom-model "Hello"`
2. Run unit tests: `npm test -w @google/gemini-cli-core -- src/config/models.test.ts src/core/geminiChat.test.ts src/core/prompts.test.ts`

## Pre-Merge Checklist

- [x] Added/updated tests
- [x] Validated on MacOS
