### PR TITLE
feat(cli): add setting to hide '?' shortcuts hint

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -471,6 +471,15 @@ const SETTINGS_SCHEMA = {
         description: 'Hide the application banner',
         showInDialog: true,
       },
+      hideShortcutsHint: {
+        type: 'boolean',
+        label: 'Hide Shortcuts Hint',
+        category: 'UI',
+        requiresRestart: false,
+        default: false,
+        description: 'Hide the "? for shortcuts" hint above the input.',
+        showInDialog: true,
+      },
       hideContextSummary: {
         type: 'boolean',
         label: 'Hide Context Summary',

--- a/packages/cli/src/ui/components/Composer.test.tsx
+++ b/packages/cli/src/ui/components/Composer.test.tsx
@@ -672,5 +672,27 @@ describe('Composer', () => {
 
       expect(lastFrame()).toContain('ShortcutsHint');
     });
+
+    it('hides shortcuts hint when hideShortcutsHint setting is true', () => {
+      const uiState = createMockUIState();
+      const settings = createMockSettings({
+        ui: { hideShortcutsHint: true },
+      });
+
+      const { lastFrame } = renderComposer(uiState, settings);
+
+      expect(lastFrame()).not.toContain('ShortcutsHint');
+    });
+
+    it('shows shortcuts hint when hideShortcutsHint setting is false', () => {
+      const uiState = createMockUIState();
+      const settings = createMockSettings({
+        ui: { hideShortcutsHint: false },
+      });
+
+      const { lastFrame } = renderComposer(uiState, settings);
+
+      expect(lastFrame()).toContain('ShortcutsHint');
+    });
   });
 });

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -133,7 +133,8 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
             flexDirection="column"
             alignItems={isNarrow ? 'flex-start' : 'flex-end'}
           >
-            {!hasPendingActionRequired && <ShortcutsHint />}
+            {!hasPendingActionRequired &&
+              !settings.merged.ui.hideShortcutsHint && <ShortcutsHint />}
           </Box>
         </Box>
         {uiState.shortcutsHelpVisible && <ShortcutsHelp />}


### PR DESCRIPTION
## Summary

Adds a `hideShortcutsHint` boolean UI setting that allows users to hide the persistent `? for shortcuts` label above the input. Typing `?` at an empty prompt still opens the shortcuts panel — this only removes the visual hint.

Closes #18535

## Changes

| File | Change |
|------|--------|
| `settingsSchema.ts` | Added `hideShortcutsHint` boolean to `ui.properties` (default: `false`, `showInDialog: true`) |
| `Composer.tsx` | Gated `<ShortcutsHint />` rendering on the new setting |
| `Composer.test.tsx` | Added 2 test cases for the new setting |

## Testing

- All 33 Composer tests pass (including 2 new)
- TypeScript compilation clean (`tsc --noEmit`)

## Design Decisions

- Follows the exact same pattern as existing `hideTips`, `hideBanner`, `hideFooter` settings
- Named `hideShortcutsHint` (not `hideShortcutsMenu`) to be clear this only hides the hint label, not the `?` functionality itself
- No restart required (`requiresRestart: false`) — takes effect immediately