### PR TITLE
feat(telemetry): add onboarding start and end metrics for login with google

### DIFF
--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -32,6 +32,7 @@ Learn how to enable and setup OpenTelemetry for Gemini CLI.
     - [Metrics](#metrics)
       - [Custom](#custom)
         - [Sessions](#sessions-1)
+        - [Authentication](#authentication)
         - [Tools](#tools-1)
         - [API](#api-1)
         - [Token usage](#token-usage)
@@ -649,6 +650,16 @@ Metrics are numerical measurements of behavior over time.
 Counts CLI sessions at startup.
 
 - `gemini_cli.session.count` (Counter, Int): Incremented once per CLI startup.
+
+##### Authentication
+
+Tracks "Login with Google" OAuth flow initiation and completion.
+
+- `gemini_cli.google_auth.start` (Counter, Int): Incremented when the "Login
+  with Google" OAuth flow begins.
+
+- `gemini_cli.google_auth.end` (Counter, Int): Incremented when the "Login with
+  Google" OAuth flow completes successfully.
 
 ##### Tools
 

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -26,10 +26,7 @@ import {
   clearOauthClientCache,
   authEvents,
 } from './oauth2.js';
-import {
-  recordGoogleAuthStart,
-  recordGoogleAuthEnd,
-} from '../telemetry/metrics.js';
+import { logGoogleAuthStart, logGoogleAuthEnd } from '../telemetry/loggers.js';
 import { UserAccountManager } from '../utils/userAccountManager.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -109,9 +106,9 @@ vi.mock('../mcp/token-storage/hybrid-token-storage.js', () => ({
   })),
 }));
 
-vi.mock('../telemetry/metrics.js', () => ({
-  recordGoogleAuthStart: vi.fn(),
-  recordGoogleAuthEnd: vi.fn(),
+vi.mock('../telemetry/loggers.js', () => ({
+  logGoogleAuthStart: vi.fn(),
+  logGoogleAuthEnd: vi.fn(),
 }));
 
 const mockConfig = {
@@ -1415,8 +1412,14 @@ describe('oauth2', () => {
 
         await getOauthClient(AuthType.LOGIN_WITH_GOOGLE, mockConfig);
 
-        expect(recordGoogleAuthStart).toHaveBeenCalledWith(mockConfig);
-        expect(recordGoogleAuthEnd).toHaveBeenCalledWith(mockConfig);
+        expect(logGoogleAuthStart).toHaveBeenCalledWith(
+          mockConfig,
+          expect.any(Object),
+        );
+        expect(logGoogleAuthEnd).toHaveBeenCalledWith(
+          mockConfig,
+          expect.any(Object),
+        );
       });
 
       it('should NOT record google auth events for non-LOGIN_WITH_GOOGLE auth types', async () => {

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -1420,21 +1420,18 @@ describe('oauth2', () => {
       });
 
       it('should NOT record onboarding events for other auth types', async () => {
-        // Mock getOauthClient behavior for other auth types if needed, 
-        // or just rely on the fact that existing tests cover them. 
+        // Mock getOauthClient behavior for other auth types if needed,
+        // or just rely on the fact that existing tests cover them.
         // But here we want to explicitly verify the absence of calls.
         // For simplicity, let's reuse the cached creds scenario but with a different AuthType if possible,
         // or mock the flow to succeed without LOGIN_WITH_GOOGLE.
-        
-        // However, getOauthClient logic is specific to AuthType. 
+        // However, getOauthClient logic is specific to AuthType.
         // Let's test with AuthType.USE_GEMINI which might have a different flow.
         // Actually, initOauthClient is what we modified.
         // Let's just verify that standard calls don't trigger it if we can.
-        
-        // Since we modified initOauthClient, we can check that function directly if exposed, 
+        // Since we modified initOauthClient, we can check that function directly if exposed,
         // but it is not.
-        
-        // Let's just stick to the positive case for now as negative cases would require 
+        // Let's just stick to the positive case for now as negative cases would require
         // setting up different valid auth flows which might be complex.
       });
     });

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -26,6 +26,10 @@ import {
   clearOauthClientCache,
   authEvents,
 } from './oauth2.js';
+import {
+  recordOnboardingStart,
+  recordOnboardingEnd,
+} from '../telemetry/metrics.js';
 import { UserAccountManager } from '../utils/userAccountManager.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -103,6 +107,11 @@ vi.mock('../mcp/token-storage/hybrid-token-storage.js', () => ({
     setCredentials: vi.fn(),
     deleteCredentials: vi.fn(),
   })),
+}));
+
+vi.mock('../telemetry/metrics.js', () => ({
+  recordOnboardingStart: vi.fn(),
+  recordOnboardingEnd: vi.fn(),
 }));
 
 const mockConfig = {
@@ -1382,6 +1391,51 @@ describe('oauth2', () => {
         await expect(
           getOauthClient(AuthType.LOGIN_WITH_GOOGLE, mockConfig),
         ).rejects.toThrow(FatalCancellationError);
+      });
+    });
+
+    describe('onboarding telemetry', () => {
+      it('should record onboarding start and end events for LOGIN_WITH_GOOGLE', async () => {
+        const mockOAuth2Client = {
+          setCredentials: vi.fn(),
+          getAccessToken: vi.fn().mockResolvedValue({ token: 'mock-token' }),
+          getTokenInfo: vi.fn().mockResolvedValue({}),
+          on: vi.fn(),
+        } as unknown as OAuth2Client;
+        vi.mocked(OAuth2Client).mockImplementation(() => mockOAuth2Client);
+
+        const cachedCreds = { refresh_token: 'test-token' };
+        const credsPath = path.join(
+          tempHomeDir,
+          GEMINI_DIR,
+          'oauth_creds.json',
+        );
+        await fs.promises.mkdir(path.dirname(credsPath), { recursive: true });
+        await fs.promises.writeFile(credsPath, JSON.stringify(cachedCreds));
+
+        await getOauthClient(AuthType.LOGIN_WITH_GOOGLE, mockConfig);
+
+        expect(recordOnboardingStart).toHaveBeenCalledWith(mockConfig);
+        expect(recordOnboardingEnd).toHaveBeenCalledWith(mockConfig);
+      });
+
+      it('should NOT record onboarding events for other auth types', async () => {
+        // Mock getOauthClient behavior for other auth types if needed, 
+        // or just rely on the fact that existing tests cover them. 
+        // But here we want to explicitly verify the absence of calls.
+        // For simplicity, let's reuse the cached creds scenario but with a different AuthType if possible,
+        // or mock the flow to succeed without LOGIN_WITH_GOOGLE.
+        
+        // However, getOauthClient logic is specific to AuthType. 
+        // Let's test with AuthType.USE_GEMINI which might have a different flow.
+        // Actually, initOauthClient is what we modified.
+        // Let's just verify that standard calls don't trigger it if we can.
+        
+        // Since we modified initOauthClient, we can check that function directly if exposed, 
+        // but it is not.
+        
+        // Let's just stick to the positive case for now as negative cases would require 
+        // setting up different valid auth flows which might be complex.
       });
     });
 

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -27,8 +27,8 @@ import {
   authEvents,
 } from './oauth2.js';
 import {
-  recordOnboardingStart,
-  recordOnboardingEnd,
+  recordGoogleAuthStart,
+  recordGoogleAuthEnd,
 } from '../telemetry/metrics.js';
 import { UserAccountManager } from '../utils/userAccountManager.js';
 import * as fs from 'node:fs';
@@ -110,8 +110,8 @@ vi.mock('../mcp/token-storage/hybrid-token-storage.js', () => ({
 }));
 
 vi.mock('../telemetry/metrics.js', () => ({
-  recordOnboardingStart: vi.fn(),
-  recordOnboardingEnd: vi.fn(),
+  recordGoogleAuthStart: vi.fn(),
+  recordGoogleAuthEnd: vi.fn(),
 }));
 
 const mockConfig = {
@@ -1415,8 +1415,8 @@ describe('oauth2', () => {
 
         await getOauthClient(AuthType.LOGIN_WITH_GOOGLE, mockConfig);
 
-        expect(recordOnboardingStart).toHaveBeenCalledWith(mockConfig);
-        expect(recordOnboardingEnd).toHaveBeenCalledWith(mockConfig);
+        expect(recordGoogleAuthStart).toHaveBeenCalledWith(mockConfig);
+        expect(recordGoogleAuthEnd).toHaveBeenCalledWith(mockConfig);
       });
 
       it('should NOT record onboarding events for other auth types', async () => {

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -1419,20 +1419,28 @@ describe('oauth2', () => {
         expect(recordGoogleAuthEnd).toHaveBeenCalledWith(mockConfig);
       });
 
-      it('should NOT record onboarding events for other auth types', async () => {
-        // Mock getOauthClient behavior for other auth types if needed,
-        // or just rely on the fact that existing tests cover them.
-        // But here we want to explicitly verify the absence of calls.
-        // For simplicity, let's reuse the cached creds scenario but with a different AuthType if possible,
-        // or mock the flow to succeed without LOGIN_WITH_GOOGLE.
-        // However, getOauthClient logic is specific to AuthType.
-        // Let's test with AuthType.USE_GEMINI which might have a different flow.
-        // Actually, initOauthClient is what we modified.
-        // Let's just verify that standard calls don't trigger it if we can.
-        // Since we modified initOauthClient, we can check that function directly if exposed,
-        // but it is not.
-        // Let's just stick to the positive case for now as negative cases would require
-        // setting up different valid auth flows which might be complex.
+      it('should NOT record google auth events for non-LOGIN_WITH_GOOGLE auth types', async () => {
+        const mockOAuth2Client = {
+          setCredentials: vi.fn(),
+          getAccessToken: vi.fn().mockResolvedValue({ token: 'mock-token' }),
+          getTokenInfo: vi.fn().mockResolvedValue({}),
+          on: vi.fn(),
+        } as unknown as OAuth2Client;
+        vi.mocked(OAuth2Client).mockImplementation(() => mockOAuth2Client);
+
+        const cachedCreds = { refresh_token: 'test-token' };
+        const credsPath = path.join(
+          tempHomeDir,
+          GEMINI_DIR,
+          'oauth_creds.json',
+        );
+        await fs.promises.mkdir(path.dirname(credsPath), { recursive: true });
+        await fs.promises.writeFile(credsPath, JSON.stringify(cachedCreds));
+
+        await getOauthClient(AuthType.COMPUTE_ADC, mockConfig);
+
+        expect(recordGoogleAuthStart).not.toHaveBeenCalled();
+        expect(recordGoogleAuthEnd).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -117,6 +117,12 @@ async function initOauthClient(
   authType: AuthType,
   config: Config,
 ): Promise<AuthClient> {
+  const recordOnboardingEndIfApplicable = () => {
+    if (authType === AuthType.LOGIN_WITH_GOOGLE) {
+      recordOnboardingEnd(config);
+    }
+  };
+
   const credentials = await fetchCachedCredentials();
 
   if (
@@ -172,10 +178,6 @@ async function initOauthClient(
     }
 
     await triggerPostAuthCallbacks(tokens);
-
-    if (authType === AuthType.LOGIN_WITH_GOOGLE) {
-      recordOnboardingEnd(config);
-    }
   });
 
   if (credentials) {
@@ -200,10 +202,6 @@ async function initOauthClient(
         }
         debugLogger.log('Loaded cached credentials.');
         await triggerPostAuthCallbacks(credentials as Credentials);
-
-        if (authType === AuthType.LOGIN_WITH_GOOGLE) {
-          recordOnboardingEnd(config);
-        }
 
         return client;
       }
@@ -296,9 +294,7 @@ async function initOauthClient(
     }
 
     await triggerPostAuthCallbacks(client.credentials);
-    if (authType === AuthType.LOGIN_WITH_GOOGLE) {
-      recordOnboardingEnd(config);
-    }
+    recordOnboardingEndIfApplicable();
   } else {
     // In ACP mode, we skip the interactive consent and directly open the browser
     if (!config.getAcpMode()) {
@@ -405,9 +401,7 @@ async function initOauthClient(
     });
 
     await triggerPostAuthCallbacks(client.credentials);
-    if (authType === AuthType.LOGIN_WITH_GOOGLE) {
-      recordOnboardingEnd(config);
-    }
+    recordOnboardingEndIfApplicable();
   }
 
   return client;

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -21,10 +21,11 @@ import { EventEmitter } from 'node:events';
 import open from 'open';
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
+import { logGoogleAuthStart, logGoogleAuthEnd } from '../telemetry/loggers.js';
 import {
-  recordGoogleAuthStart,
-  recordGoogleAuthEnd,
-} from '../telemetry/metrics.js';
+  GoogleAuthStartEvent,
+  GoogleAuthEndEvent,
+} from '../telemetry/types.js';
 import type { Config } from '../config/config.js';
 import {
   getErrorMessage,
@@ -117,6 +118,12 @@ async function initOauthClient(
   authType: AuthType,
   config: Config,
 ): Promise<AuthClient> {
+  const logGoogleAuthEndIfApplicable = () => {
+    if (authType === AuthType.LOGIN_WITH_GOOGLE) {
+      logGoogleAuthEnd(config, new GoogleAuthEndEvent());
+    }
+  };
+
   const credentials = await fetchCachedCredentials();
 
   if (
@@ -148,7 +155,7 @@ async function initOauthClient(
   });
 
   if (authType === AuthType.LOGIN_WITH_GOOGLE) {
-    recordGoogleAuthStart(config);
+    logGoogleAuthStart(config, new GoogleAuthStartEvent());
   }
 
   const useEncryptedStorage = getUseEncryptedStorageFlag();
@@ -200,9 +207,7 @@ async function initOauthClient(
         debugLogger.log('Loaded cached credentials.');
         await triggerPostAuthCallbacks(credentials as Credentials);
 
-        if (authType === AuthType.LOGIN_WITH_GOOGLE) {
-          recordGoogleAuthEnd(config);
-        }
+        logGoogleAuthEndIfApplicable();
         return client;
       }
     } catch (error) {
@@ -294,9 +299,7 @@ async function initOauthClient(
     }
 
     await triggerPostAuthCallbacks(client.credentials);
-    if (authType === AuthType.LOGIN_WITH_GOOGLE) {
-      recordGoogleAuthEnd(config);
-    }
+    logGoogleAuthEndIfApplicable();
   } else {
     // In ACP mode, we skip the interactive consent and directly open the browser
     if (!config.getAcpMode()) {
@@ -403,9 +406,7 @@ async function initOauthClient(
     });
 
     await triggerPostAuthCallbacks(client.credentials);
-    if (authType === AuthType.LOGIN_WITH_GOOGLE) {
-      recordGoogleAuthEnd(config);
-    }
+    logGoogleAuthEndIfApplicable();
   }
 
   return client;

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -117,12 +117,6 @@ async function initOauthClient(
   authType: AuthType,
   config: Config,
 ): Promise<AuthClient> {
-  const recordGoogleAuthEndIfApplicable = () => {
-    if (authType === AuthType.LOGIN_WITH_GOOGLE) {
-      recordGoogleAuthEnd(config);
-    }
-  };
-
   const credentials = await fetchCachedCredentials();
 
   if (
@@ -167,6 +161,9 @@ async function initOauthClient(
       access_token: process.env['GOOGLE_CLOUD_ACCESS_TOKEN'],
     });
     await fetchAndCacheUserInfo(client);
+    if (authType === AuthType.LOGIN_WITH_GOOGLE) {
+      recordGoogleAuthEnd(config);
+    }
     return client;
   }
 
@@ -203,7 +200,9 @@ async function initOauthClient(
         debugLogger.log('Loaded cached credentials.');
         await triggerPostAuthCallbacks(credentials as Credentials);
 
-        recordGoogleAuthEndIfApplicable();
+        if (authType === AuthType.LOGIN_WITH_GOOGLE) {
+          recordGoogleAuthEnd(config);
+        }
         return client;
       }
     } catch (error) {
@@ -295,7 +294,9 @@ async function initOauthClient(
     }
 
     await triggerPostAuthCallbacks(client.credentials);
-    recordGoogleAuthEndIfApplicable();
+    if (authType === AuthType.LOGIN_WITH_GOOGLE) {
+      recordGoogleAuthEnd(config);
+    }
   } else {
     // In ACP mode, we skip the interactive consent and directly open the browser
     if (!config.getAcpMode()) {
@@ -402,7 +403,9 @@ async function initOauthClient(
     });
 
     await triggerPostAuthCallbacks(client.credentials);
-    recordGoogleAuthEndIfApplicable();
+    if (authType === AuthType.LOGIN_WITH_GOOGLE) {
+      recordGoogleAuthEnd(config);
+    }
   }
 
   return client;

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -167,6 +167,7 @@ async function initOauthClient(
       access_token: process.env['GOOGLE_CLOUD_ACCESS_TOKEN'],
     });
     await fetchAndCacheUserInfo(client);
+    recordOnboardingEndIfApplicable();
     return client;
   }
 
@@ -203,6 +204,7 @@ async function initOauthClient(
         debugLogger.log('Loaded cached credentials.');
         await triggerPostAuthCallbacks(credentials as Credentials);
 
+        recordOnboardingEndIfApplicable();
         return client;
       }
     } catch (error) {

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -21,6 +21,10 @@ import { EventEmitter } from 'node:events';
 import open from 'open';
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
+import {
+  recordOnboardingStart,
+  recordOnboardingEnd,
+} from '../telemetry/metrics.js';
 import type { Config } from '../config/config.js';
 import {
   getErrorMessage,
@@ -142,6 +146,11 @@ async function initOauthClient(
       proxy: config.getProxy(),
     },
   });
+
+  if (authType === AuthType.LOGIN_WITH_GOOGLE) {
+    recordOnboardingStart(config);
+  }
+
   const useEncryptedStorage = getUseEncryptedStorageFlag();
 
   if (
@@ -163,6 +172,10 @@ async function initOauthClient(
     }
 
     await triggerPostAuthCallbacks(tokens);
+
+    if (authType === AuthType.LOGIN_WITH_GOOGLE) {
+      recordOnboardingEnd(config);
+    }
   });
 
   if (credentials) {
@@ -187,6 +200,10 @@ async function initOauthClient(
         }
         debugLogger.log('Loaded cached credentials.');
         await triggerPostAuthCallbacks(credentials as Credentials);
+
+        if (authType === AuthType.LOGIN_WITH_GOOGLE) {
+          recordOnboardingEnd(config);
+        }
 
         return client;
       }
@@ -279,6 +296,9 @@ async function initOauthClient(
     }
 
     await triggerPostAuthCallbacks(client.credentials);
+    if (authType === AuthType.LOGIN_WITH_GOOGLE) {
+      recordOnboardingEnd(config);
+    }
   } else {
     // In ACP mode, we skip the interactive consent and directly open the browser
     if (!config.getAcpMode()) {
@@ -385,6 +405,9 @@ async function initOauthClient(
     });
 
     await triggerPostAuthCallbacks(client.credentials);
+    if (authType === AuthType.LOGIN_WITH_GOOGLE) {
+      recordOnboardingEnd(config);
+    }
   }
 
   return client;

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -22,8 +22,8 @@ import open from 'open';
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
 import {
-  recordOnboardingStart,
-  recordOnboardingEnd,
+  recordGoogleAuthStart,
+  recordGoogleAuthEnd,
 } from '../telemetry/metrics.js';
 import type { Config } from '../config/config.js';
 import {
@@ -117,9 +117,9 @@ async function initOauthClient(
   authType: AuthType,
   config: Config,
 ): Promise<AuthClient> {
-  const recordOnboardingEndIfApplicable = () => {
+  const recordGoogleAuthEndIfApplicable = () => {
     if (authType === AuthType.LOGIN_WITH_GOOGLE) {
-      recordOnboardingEnd(config);
+      recordGoogleAuthEnd(config);
     }
   };
 
@@ -154,7 +154,7 @@ async function initOauthClient(
   });
 
   if (authType === AuthType.LOGIN_WITH_GOOGLE) {
-    recordOnboardingStart(config);
+    recordGoogleAuthStart(config);
   }
 
   const useEncryptedStorage = getUseEncryptedStorageFlag();
@@ -167,7 +167,6 @@ async function initOauthClient(
       access_token: process.env['GOOGLE_CLOUD_ACCESS_TOKEN'],
     });
     await fetchAndCacheUserInfo(client);
-    recordOnboardingEndIfApplicable();
     return client;
   }
 
@@ -204,7 +203,7 @@ async function initOauthClient(
         debugLogger.log('Loaded cached credentials.');
         await triggerPostAuthCallbacks(credentials as Credentials);
 
-        recordOnboardingEndIfApplicable();
+        recordGoogleAuthEndIfApplicable();
         return client;
       }
     } catch (error) {
@@ -296,7 +295,7 @@ async function initOauthClient(
     }
 
     await triggerPostAuthCallbacks(client.credentials);
-    recordOnboardingEndIfApplicable();
+    recordGoogleAuthEndIfApplicable();
   } else {
     // In ACP mode, we skip the interactive consent and directly open the browser
     if (!config.getAcpMode()) {
@@ -403,7 +402,7 @@ async function initOauthClient(
     });
 
     await triggerPostAuthCallbacks(client.credentials);
-    recordOnboardingEndIfApplicable();
+    recordGoogleAuthEndIfApplicable();
   }
 
   return client;

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -50,6 +50,8 @@ import type {
   KeychainAvailabilityEvent,
   TokenStorageInitializationEvent,
   StartupStatsEvent,
+  GoogleAuthStartEvent,
+  GoogleAuthEndEvent,
 } from '../types.js';
 import { EventMetadataKey } from './event-metadata-key.js';
 import type { Config } from '../../config/config.js';
@@ -116,6 +118,8 @@ export enum EventNames {
   TOOL_OUTPUT_MASKING = 'tool_output_masking',
   KEYCHAIN_AVAILABILITY = 'keychain_availability',
   TOKEN_STORAGE_INITIALIZATION = 'token_storage_initialization',
+  GOOGLE_AUTH_START = 'google_auth_start',
+  GOOGLE_AUTH_END = 'google_auth_end',
   CONSECA_POLICY_GENERATION = 'conseca_policy_generation',
   CONSECA_VERDICT = 'conseca_verdict',
   STARTUP_STATS = 'startup_stats',
@@ -1690,6 +1694,16 @@ export class ClearcutLogger {
     this.enqueueLogEvent(
       this.createLogEvent(EventNames.TOKEN_STORAGE_INITIALIZATION, data),
     );
+    this.flushIfNeeded();
+  }
+
+  logGoogleAuthStartEvent(_event: GoogleAuthStartEvent): void {
+    this.enqueueLogEvent(this.createLogEvent(EventNames.GOOGLE_AUTH_START, []));
+    this.flushIfNeeded();
+  }
+
+  logGoogleAuthEndEvent(_event: GoogleAuthEndEvent): void {
+    this.enqueueLogEvent(this.createLogEvent(EventNames.GOOGLE_AUTH_END, []));
     this.flushIfNeeded();
   }
 

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -56,6 +56,8 @@ import {
   type ToolOutputMaskingEvent,
   type KeychainAvailabilityEvent,
   type TokenStorageInitializationEvent,
+  type GoogleAuthStartEvent,
+  type GoogleAuthEndEvent,
 } from './types.js';
 import {
   recordApiErrorMetrics,
@@ -77,6 +79,8 @@ import {
   recordKeychainAvailability,
   recordTokenStorageInitialization,
   recordInvalidChunk,
+  recordGoogleAuthStart,
+  recordGoogleAuthEnd,
 } from './metrics.js';
 import { bufferTelemetryEvent } from './sdk.js';
 import { uiTelemetryService, type UiEvent } from './uiTelemetry.js';
@@ -841,6 +845,40 @@ export function logTokenStorageInitialization(
     logger.emit(logRecord);
 
     recordTokenStorageInitialization(config, event);
+  });
+}
+
+export function logGoogleAuthStart(
+  config: Config,
+  event: GoogleAuthStartEvent,
+): void {
+  ClearcutLogger.getInstance(config)?.logGoogleAuthStartEvent(event);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+
+    recordGoogleAuthStart(config);
+  });
+}
+
+export function logGoogleAuthEnd(
+  config: Config,
+  event: GoogleAuthEndEvent,
+): void {
+  ClearcutLogger.getInstance(config)?.logGoogleAuthEndEvent(event);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+
+    recordGoogleAuthEnd(config);
   });
 }
 

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -50,6 +50,8 @@ const KEYCHAIN_AVAILABILITY_COUNT = 'gemini_cli.keychain.availability.count';
 const TOKEN_STORAGE_TYPE_COUNT = 'gemini_cli.token_storage.type.count';
 const OVERAGE_OPTION_COUNT = 'gemini_cli.overage_option.count';
 const CREDIT_PURCHASE_COUNT = 'gemini_cli.credit_purchase.count';
+const EVENT_ONBOARDING_START = 'gemini_cli.onboarding.start';
+const EVENT_ONBOARDING_END = 'gemini_cli.onboarding.end';
 
 // Agent Metrics
 const AGENT_RUN_COUNT = 'gemini_cli.agent.run.count';
@@ -264,7 +266,6 @@ const COUNTER_DEFINITIONS = {
     assign: (c: Counter) => (tokenStorageTypeCounter = c),
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     attributes: {} as {
-      type: string;
       forced: boolean;
     },
   },
@@ -287,6 +288,18 @@ const COUNTER_DEFINITIONS = {
       source: string;
       model: string;
     },
+  },
+  [EVENT_ONBOARDING_START]: {
+    description: 'Counts onboarding start events.',
+    valueType: ValueType.INT,
+    assign: (c: Counter) => (onboardingStartCounter = c),
+    attributes: {} as Record<string, never>,
+  },
+  [EVENT_ONBOARDING_END]: {
+    description: 'Counts onboarding end events.',
+    valueType: ValueType.INT,
+    assign: (c: Counter) => (onboardingEndCounter = c),
+    attributes: {} as Record<string, never>,
   },
 } as const;
 
@@ -536,7 +549,7 @@ const PERFORMANCE_HISTOGRAM_DEFINITIONS = {
   },
 } as const;
 
-type AllMetricDefs = typeof COUNTER_DEFINITIONS &
+export type AllMetricDefs = typeof COUNTER_DEFINITIONS &
   typeof HISTOGRAM_DEFINITIONS &
   typeof PERFORMANCE_COUNTER_DEFINITIONS &
   typeof PERFORMANCE_HISTOGRAM_DEFINITIONS;
@@ -628,6 +641,8 @@ let keychainAvailabilityCounter: Counter | undefined;
 let tokenStorageTypeCounter: Counter | undefined;
 let overageOptionCounter: Counter | undefined;
 let creditPurchaseCounter: Counter | undefined;
+let onboardingStartCounter: Counter | undefined;
+let onboardingEndCounter: Counter | undefined;
 
 // OpenTelemetry GenAI Semantic Convention Metrics
 let genAiClientTokenUsageHistogram: Histogram | undefined;
@@ -799,6 +814,25 @@ export function recordLinesChanged(
 }
 
 // --- New Metric Recording Functions ---
+
+/**
+ * Records a metric for when the onboarding process starts.
+ */
+export function recordOnboardingStart(config: Config): void {
+  if (!onboardingStartCounter || !isMetricsInitialized) return;
+  onboardingStartCounter.add(
+    1,
+    baseMetricDefinition.getCommonAttributes(config),
+  );
+}
+
+/**
+ * Records a metric for when the onboarding process ends successfully.
+ */
+export function recordOnboardingEnd(config: Config): void {
+  if (!onboardingEndCounter || !isMetricsInitialized) return;
+  onboardingEndCounter.add(1, baseMetricDefinition.getCommonAttributes(config));
+}
 
 /**
  * Records a metric for when a UI frame flickers.
@@ -1361,7 +1395,6 @@ export function recordTokenStorageInitialization(
   if (!tokenStorageTypeCounter || !isMetricsInitialized) return;
   tokenStorageTypeCounter.add(1, {
     ...baseMetricDefinition.getCommonAttributes(config),
-    type: event.type,
     forced: event.forced,
   });
 }

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -266,6 +266,7 @@ const COUNTER_DEFINITIONS = {
     assign: (c: Counter) => (tokenStorageTypeCounter = c),
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     attributes: {} as {
+      type: string;
       forced: boolean;
     },
   },

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -1396,6 +1396,7 @@ export function recordTokenStorageInitialization(
   if (!tokenStorageTypeCounter || !isMetricsInitialized) return;
   tokenStorageTypeCounter.add(1, {
     ...baseMetricDefinition.getCommonAttributes(config),
+    type: event.type,
     forced: event.forced,
   });
 }

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -1398,6 +1398,7 @@ export function recordTokenStorageInitialization(
     ...baseMetricDefinition.getCommonAttributes(config),
     type: event.type,
     forced: event.forced,
+    type: event.type,
   });
 }
 

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -50,8 +50,8 @@ const KEYCHAIN_AVAILABILITY_COUNT = 'gemini_cli.keychain.availability.count';
 const TOKEN_STORAGE_TYPE_COUNT = 'gemini_cli.token_storage.type.count';
 const OVERAGE_OPTION_COUNT = 'gemini_cli.overage_option.count';
 const CREDIT_PURCHASE_COUNT = 'gemini_cli.credit_purchase.count';
-const EVENT_ONBOARDING_START = 'gemini_cli.onboarding.start';
-const EVENT_ONBOARDING_END = 'gemini_cli.onboarding.end';
+const EVENT_GOOGLE_AUTH_START = 'gemini_cli.google_auth.start';
+const EVENT_GOOGLE_AUTH_END = 'gemini_cli.google_auth.end';
 
 // Agent Metrics
 const AGENT_RUN_COUNT = 'gemini_cli.agent.run.count';
@@ -290,16 +290,16 @@ const COUNTER_DEFINITIONS = {
       model: string;
     },
   },
-  [EVENT_ONBOARDING_START]: {
-    description: 'Counts onboarding start events.',
+  [EVENT_GOOGLE_AUTH_START]: {
+    description: 'Counts auth "Login with Google" started.',
     valueType: ValueType.INT,
-    assign: (c: Counter) => (onboardingStartCounter = c),
+    assign: (c: Counter) => (googleAuthStartCounter = c),
     attributes: {} as Record<string, never>,
   },
-  [EVENT_ONBOARDING_END]: {
-    description: 'Counts onboarding end events.',
+  [EVENT_GOOGLE_AUTH_END]: {
+    description: 'Counts auth "Login with Google" succeeded.',
     valueType: ValueType.INT,
-    assign: (c: Counter) => (onboardingEndCounter = c),
+    assign: (c: Counter) => (googleAuthEndCounter = c),
     attributes: {} as Record<string, never>,
   },
 } as const;
@@ -642,8 +642,8 @@ let keychainAvailabilityCounter: Counter | undefined;
 let tokenStorageTypeCounter: Counter | undefined;
 let overageOptionCounter: Counter | undefined;
 let creditPurchaseCounter: Counter | undefined;
-let onboardingStartCounter: Counter | undefined;
-let onboardingEndCounter: Counter | undefined;
+let googleAuthStartCounter: Counter | undefined;
+let googleAuthEndCounter: Counter | undefined;
 
 // OpenTelemetry GenAI Semantic Convention Metrics
 let genAiClientTokenUsageHistogram: Histogram | undefined;
@@ -817,22 +817,22 @@ export function recordLinesChanged(
 // --- New Metric Recording Functions ---
 
 /**
- * Records a metric for when the onboarding process starts.
+ * Records a metric for when the Google auth process starts.
  */
-export function recordOnboardingStart(config: Config): void {
-  if (!onboardingStartCounter || !isMetricsInitialized) return;
-  onboardingStartCounter.add(
+export function recordGoogleAuthStart(config: Config): void {
+  if (!googleAuthStartCounter || !isMetricsInitialized) return;
+  googleAuthStartCounter.add(
     1,
     baseMetricDefinition.getCommonAttributes(config),
   );
 }
 
 /**
- * Records a metric for when the onboarding process ends successfully.
+ * Records a metric for when the Google auth process ends successfully.
  */
-export function recordOnboardingEnd(config: Config): void {
-  if (!onboardingEndCounter || !isMetricsInitialized) return;
-  onboardingEndCounter.add(1, baseMetricDefinition.getCommonAttributes(config));
+export function recordGoogleAuthEnd(config: Config): void {
+  if (!googleAuthEndCounter || !isMetricsInitialized) return;
+  googleAuthEndCounter.add(1, baseMetricDefinition.getCommonAttributes(config));
 }
 
 /**

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -2307,6 +2307,52 @@ export class KeychainAvailabilityEvent implements BaseTelemetryEvent {
   }
 }
 
+export const EVENT_GOOGLE_AUTH_START = 'gemini_cli.google_auth.start';
+export class GoogleAuthStartEvent implements BaseTelemetryEvent {
+  'event.name': 'google_auth_start';
+  'event.timestamp': string;
+
+  constructor() {
+    this['event.name'] = 'google_auth_start';
+    this['event.timestamp'] = new Date().toISOString();
+  }
+
+  toOpenTelemetryAttributes(config: Config): LogAttributes {
+    return {
+      ...getCommonAttributes(config),
+      'event.name': EVENT_GOOGLE_AUTH_START,
+      'event.timestamp': this['event.timestamp'],
+    };
+  }
+
+  toLogBody(): string {
+    return 'Google auth started.';
+  }
+}
+
+export const EVENT_GOOGLE_AUTH_END = 'gemini_cli.google_auth.end';
+export class GoogleAuthEndEvent implements BaseTelemetryEvent {
+  'event.name': 'google_auth_end';
+  'event.timestamp': string;
+
+  constructor() {
+    this['event.name'] = 'google_auth_end';
+    this['event.timestamp'] = new Date().toISOString();
+  }
+
+  toOpenTelemetryAttributes(config: Config): LogAttributes {
+    return {
+      ...getCommonAttributes(config),
+      'event.name': EVENT_GOOGLE_AUTH_END,
+      'event.timestamp': this['event.timestamp'],
+    };
+  }
+
+  toLogBody(): string {
+    return 'Google auth succeeded.';
+  }
+}
+
 export const EVENT_TOKEN_STORAGE_INITIALIZATION =
   'gemini_cli.token_storage.initialization';
 export class TokenStorageInitializationEvent implements BaseTelemetryEvent {


### PR DESCRIPTION
## Summary

This PR adds telemetry for the onboarding process when using "Login with Google". It records a `gemini_cli.onboarding.start` event when the OAuth flow begins and a `gemini_cli.onboarding.end` event when the flow completes successfully (either via cached credentials or a full browser-based login).

## Details

- Modified `packages/core/src/telemetry/metrics.ts` to define the new counters and recording functions `recordOnboardingStart` and `recordOnboardingEnd`.
- Modified `packages/core/src/code_assist/oauth2.ts` to trigger these recording functions at the beginning and end of the `initOauthClient` process when `AuthType.LOGIN_WITH_GOOGLE` is used.
- Added unit tests in `packages/core/src/code_assist/oauth2.test.ts` to ensure metrics are correctly recorded during the OAuth flow.

## Related Issues

Fixes #20194

## How to Validate

1. Run unit tests: `npm test -w @google/gemini-cli-core -- src/code_assist/oauth2.test.ts`
2. Verify that the new tests pass, confirming the telemetry events are triggered as expected.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
