### PR TITLE
feat(cli): add Alt+D for forward word deletion

### DIFF
--- a/docs/cli/keyboard-shortcuts.md
+++ b/docs/cli/keyboard-shortcuts.md
@@ -36,7 +36,7 @@ available combinations.
 | Delete from the cursor to the start of the line. | `Ctrl + U`                                                       |
 | Clear all text in the input field.               | `Ctrl + C`                                                       |
 | Delete the previous word.                        | `Ctrl + Backspace`<br />`Alt + Backspace`<br />`Ctrl + W`        |
-| Delete the next word.                            | `Ctrl + Delete`<br />`Alt + Delete`                              |
+| Delete the next word.                            | `Ctrl + Delete`<br />`Alt + Delete`<br />`Alt + D`               |
 | Delete the character to the left.                | `Backspace`<br />`Ctrl + H`                                      |
 | Delete the character to the right.               | `Delete`<br />`Ctrl + D`                                         |
 | Undo the most recent text edit.                  | `Cmd + Z (no Shift)`<br />`Alt + Z (no Shift)`                   |

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -178,6 +178,7 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.DELETE_WORD_FORWARD]: [
     { key: 'delete', ctrl: true },
     { key: 'delete', alt: true },
+    { key: 'd', alt: true },
   ],
   [Command.DELETE_CHAR_LEFT]: [{ key: 'backspace' }, { key: 'h', ctrl: true }],
   [Command.DELETE_CHAR_RIGHT]: [{ key: 'delete' }, { key: 'd', ctrl: true }],

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -141,6 +141,7 @@ const MAC_ALT_KEY_CHARACTER_MAP: Record<string, string> = {
   '\u00B5': 'm', // "µ" toggle markup view
   '\u03A9': 'z', // "Ω" Option+z
   '\u00B8': 'Z', // "¸" Option+Shift+z
+  '\u2202': 'd', // "∂" delete word forward
 };
 
 function nonKeyboardEventFilter(

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -130,6 +130,7 @@ describe('keyMatchers', () => {
       positive: [
         createKey('delete', { ctrl: true }),
         createKey('delete', { alt: true }),
+        createKey('d', { alt: true }),
       ],
       negative: [createKey('delete'), createKey('backspace', { ctrl: true })],
     },


### PR DESCRIPTION
feat(cli): add Alt+D for forward word deletion

## Summary

Adds `Alt+D` (Meta-D) as a keybinding for `DELETE_WORD_FORWARD`. This aligns with standard Emacs bindings (`kill-word`) and complements the existing `Alt+Backspace` / `Ctrl+W` backward deletion bindings.

## Details

- **File Modified:** `packages/cli/src/config/keyBindings.ts`
  - Added `{ key: 'd', alt: true }` to `Command.DELETE_WORD_FORWARD`.
- **Tests Updated:** `packages/cli/src/ui/keyMatchers.test.ts`
  - Added a positive test case for `Alt+D` triggering `DELETE_WORD_FORWARD`.
- **Docs Updated:** `docs/cli/keyboard-shortcuts.md`
  - Regenerated documentation to include the new shortcut.

## Related Issues

Fixes #19296

## How to Validate

1. **Test Verification:**
   Run the specific test file:
   ```bash
   npm test -w @google/gemini-cli -- src/ui/keyMatchers.test.ts
   ```

2. **Manual Verification:**
   - Launch the CLI.
   - Type some text.
   - Move the cursor to the middle of the text.
   - Press `Alt+D` (or `Option+D` on macOS).
   - Verify that the word following the cursor is deleted.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
