### PR TITLE
Release note generator fix

### DIFF
--- a/.gemini/skills/docs-changelog/SKILL.md
+++ b/.gemini/skills/docs-changelog/SKILL.md
@@ -23,6 +23,8 @@ To standardize the process of updating changelog files (`latest.md`,
 ## Guidelines for `latest.md` and `preview.md` Highlights
 
 - Aim for **3-5 key highlight points**.
+- Each highlight point must start with a bold-typed title that summarizes the
+  change (e.g., `**New Feature:** A brief description...`).
 - **Prioritize** summarizing new features over other changes like bug fixes or
   chores.
 - **Avoid** mentioning features that are "experimental" or "in preview" in
@@ -65,6 +67,8 @@ detailed **highlights** section for the release-specific page.
 
 1.  **Create the Announcement for `index.md`**:
     -   Generate a concise announcement summarizing the most important changes.
+        Each announcement entry must start with a bold-typed title that
+        summarizes the change.
     -   **Important**: The format for this announcement is unique. You **must**
         use the existing announcements in `docs/changelogs/index.md` and the
         example within

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           # The user-level skills need to be available to the workflow
           fetch-depth: 0
-          ref: main
+          ref: 'main'
 
       - name: 'Set up Node.js'
         uses: 'actions/setup-node@v4'

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -42,7 +42,6 @@ jobs:
         id: 'release_info'
         run: |
           VERSION="${{ github.event.inputs.version || github.event.release.tag_name }}"
-          BODY="${{ github.event.inputs.body || github.event.release.body }}"
           TIME="${{ github.event.inputs.time || github.event.release.created_at }}"
 
           echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
@@ -50,10 +49,11 @@ jobs:
 
           # Use a heredoc to preserve multiline release body
           echo 'RAW_CHANGELOG<<EOF' >> "$GITHUB_OUTPUT"
-          printf "%s\n" "${BODY}" >> "$GITHUB_OUTPUT"
+          printf "%s\n" "$BODY" >> "$GITHUB_OUTPUT"
           echo 'EOF' >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: '${{ secrets.GEMINI_CLI_ROBOT_GITHUB_PAT }}'
+          BODY: '${{ github.event.inputs.body || github.event.release.body }}'
 
       - name: 'Generate Changelog with Gemini'
         uses: 'google-github-actions/run-gemini-cli@a3bf79042542528e91937b3a3a6fbc4967ee3c31' # ratchet:google-github-actions/run-gemini-cli@v0

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           # The user-level skills need to be available to the workflow
           fetch-depth: 0
+          ref: main
 
       - name: 'Set up Node.js'
         uses: 'actions/setup-node@v4'


### PR DESCRIPTION
## Summary

Release note generator fixes:

1. Don't echo incoming release body as it causes errors.
2. Checkout main instead of the release's reference, so we always get the latest version of this workflow.

Related to #18505 