### PR TITLE
fix(core): replace deprecated punycode built-in with userland alternative

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -23,6 +23,19 @@ const __dirname = path.dirname(__filename);
 const require = createRequire(import.meta.url);
 const pkg = require(path.resolve(__dirname, 'package.json'));
 
+const punycodePath = path.resolve(
+  __dirname,
+  'node_modules/punycode/punycode.js',
+);
+const punycodePlugin = {
+  name: 'punycode-userland',
+  setup(build) {
+    build.onResolve({ filter: /^punycode$/ }, () => ({
+      path: punycodePath,
+    }));
+  },
+};
+
 function createWasmPlugins() {
   const wasmBinaryPlugin = {
     name: 'wasm-binary',
@@ -85,7 +98,7 @@ const cliConfig = {
   define: {
     'process.env.CLI_VERSION': JSON.stringify(pkg.version),
   },
-  plugins: createWasmPlugins(),
+  plugins: [punycodePlugin, ...createWasmPlugins()],
   alias: {
     'is-in-ci': path.resolve(__dirname, 'packages/cli/src/patches/is-in-ci.ts'),
   },
@@ -102,7 +115,7 @@ const a2aServerConfig = {
   define: {
     'process.env.CLI_VERSION': JSON.stringify(pkg.version),
   },
-  plugins: createWasmPlugins(),
+  plugins: [punycodePlugin, ...createWasmPlugins()],
 };
 
 Promise.allSettled([


### PR DESCRIPTION


Redirects the deprecated Node.js built-in `punycode` module to its userland counterpart via a custom esbuild plugin. Applies to both the CLI and A2A server build configs to suppress deprecation warnings.

## Summary

Node.js has deprecated its built-in punycode module and emits a DeprecationWarning: The punycode module is deprecated at runtime. This PR adds a lightweight esbuild plugin (punycode-userland) that intercepts the punycode bare specifier and resolves it to the userland punycode package already present in node_modules, eliminating the warning for both the CLI and A2A server bundles.

## Details

A punycodePlugin is defined in esbuild.config.js using build.onResolve to intercept any import matching /^punycode$/ and redirect it to node_modules/punycode/punycode.js. The plugin is prepended to the plugins array in both cliConfig and a2aServerConfig so it runs before other resolvers. No changes to package.json or production dependencies are required — the punycode npm package is already a transitive dependency.

## Related Issues

Related to the Node.js deprecation of the built-in punycode module (deprecated since Node.js v21 per DEP0040).

## How to Validate

- Build the project:
   npm run build
- Start the CLI:
   npm start
- Confirm no DeprecationWarning: The \punycode\ module is deprecated appears in stderr output.
- Run the preflight suite to ensure nothing regressed:
   npm run prefligh

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x ] Updated relevant documentation and README (if needed)
- [ x] Added/updated tests (if needed)
- [ x ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
