### PR TITLE
docs: clarify preflight instructions in GEMINI.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -47,7 +47,13 @@ powerful tool for developers.
     be relative to the workspace root, e.g.,
     `-w @google/gemini-cli-core -- src/routing/modelRouterService.test.ts`)
 - **Full Validation:** `npm run preflight` (Heaviest check; runs clean, install,
-  build, lint, type check, and tests. Recommended before submitting PRs.)
+  build, lint, type check, and tests. Recommended before submitting PRs. Due to
+  its long runtime, only run this at the very end of a code implementation task.
+  If it fails, use faster, targeted commands (e.g., `npm run test`,
+  `npm run lint`, or workspace-specific tests) to iterate on fixes before
+  re-running `preflight`. For simple, non-code changes like documentation or
+  prompting updates, skip `preflight` at the end of the task and wait for PR
+  validation.)
 - **Individual Checks:** `npm run lint` / `npm run format` / `npm run typecheck`
 
 ## Development Conventions


### PR DESCRIPTION
## Summary

Clarifies the preflight instructions in `GEMINI.md` to be more nuanced about when to run `npm run preflight`.

## Details

Because `npm run preflight` takes a significantly long time to execute, the updated guidance recommends:
1. Running it only at the very end of code implementation tasks.
2. Using faster, targeted commands like `npm run test` or `npm run lint` when iterating on fixes.
3. Skipping the full preflight suite completely for simple, non-code changes like prompting and documentation.

## Related Issues

None.

## How to Validate

Review the updated text in `GEMINI.md` for clarity and correctness.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker