### PR TITLE
fix(cli): hide shortcuts hint while model is thinking or the user has typed a prompt + add debounce to avoid flicker

### DIFF
--- a/packages/cli/src/ui/components/Composer.test.tsx
+++ b/packages/cli/src/ui/components/Composer.test.tsx
@@ -6,8 +6,8 @@
 
 import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
 import { render } from '../../test-utils/render.js';
+import { act, useEffect } from 'react';
 import { Box, Text } from 'ink';
-import { useEffect } from 'react';
 import { Composer } from './Composer.js';
 import { UIStateContext, type UIState } from '../contexts/UIStateContext.js';
 import {
@@ -34,6 +34,7 @@ import { StreamingState } from '../types.js';
 import { TransientMessageType } from '../../utils/events.js';
 import type { LoadedSettings } from '../../config/settings.js';
 import type { SessionMetrics } from '../contexts/SessionContext.js';
+import type { TextBuffer } from './shared/text-buffer.js';
 
 const composerTestControls = vi.hoisted(() => ({
   suggestionsVisible: false,
@@ -809,6 +810,47 @@ describe('Composer', () => {
   });
 
   describe('Shortcuts Hint', () => {
+    it('restores shortcuts hint after 200ms debounce when text is cleared', async () => {
+      vi.useFakeTimers();
+
+      const { lastFrame, rerender } = await renderComposer(
+        createMockUIState({
+          buffer: { text: 'hello' } as unknown as TextBuffer,
+        }),
+      );
+
+      expect(lastFrame()).not.toContain('ShortcutsHint');
+
+      rerender(
+        <ConfigContext.Provider value={createMockConfig() as unknown as Config}>
+          <SettingsContext.Provider
+            value={createMockSettings() as unknown as LoadedSettings}
+          >
+            <UIStateContext.Provider
+              value={createMockUIState({
+                buffer: { text: '' } as unknown as TextBuffer,
+              })}
+            >
+              <UIActionsContext.Provider value={createMockUIActions()}>
+                <Composer />
+              </UIActionsContext.Provider>
+            </UIStateContext.Provider>
+          </SettingsContext.Provider>
+        </ConfigContext.Provider>,
+      );
+
+      // Still hidden immediately after clearing text due to debounce
+      expect(lastFrame()).not.toContain('ShortcutsHint');
+
+      // Fast forward past the 200ms debounce
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200);
+      });
+
+      expect(lastFrame()).toContain('ShortcutsHint');
+      vi.useRealTimers();
+    });
+
     it('hides shortcuts hint when showShortcutsHint setting is false', async () => {
       const uiState = createMockUIState();
       const settings = createMockSettings({
@@ -870,8 +912,7 @@ describe('Composer', () => {
 
     it('hides shortcuts hint when text is typed in buffer', async () => {
       const uiState = createMockUIState({
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        buffer: { text: 'hello' } as any,
+        buffer: { text: 'hello' } as unknown as TextBuffer,
       });
 
       const { lastFrame } = await renderComposer(uiState);

--- a/packages/cli/src/ui/components/Composer.test.tsx
+++ b/packages/cli/src/ui/components/Composer.test.tsx
@@ -1018,9 +1018,10 @@ describe('Composer', () => {
         streamingState: StreamingState.Idle,
       });
 
-      const { lastFrame } = await renderComposer(uiState);
+      const { lastFrame, unmount } = await renderComposer(uiState);
 
       expect(lastFrame()).toContain('ShortcutsHelp');
+      unmount();
     });
 
     it('hides shortcuts help while streaming', async () => {
@@ -1029,9 +1030,10 @@ describe('Composer', () => {
         streamingState: StreamingState.Responding,
       });
 
-      const { lastFrame } = await renderComposer(uiState);
+      const { lastFrame, unmount } = await renderComposer(uiState);
 
       expect(lastFrame()).not.toContain('ShortcutsHelp');
+      unmount();
     });
 
     it('hides shortcuts help when action is required', async () => {
@@ -1044,9 +1046,10 @@ describe('Composer', () => {
         ),
       });
 
-      const { lastFrame } = await renderComposer(uiState);
+      const { lastFrame, unmount } = await renderComposer(uiState);
 
       expect(lastFrame()).not.toContain('ShortcutsHelp');
+      unmount();
     });
   });
 

--- a/packages/cli/src/ui/components/Composer.test.tsx
+++ b/packages/cli/src/ui/components/Composer.test.tsx
@@ -277,11 +277,13 @@ const renderComposer = async (
 
 describe('Composer', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     composerTestControls.suggestionsVisible = false;
     composerTestControls.isAlternateBuffer = false;
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -581,17 +583,11 @@ describe('Composer', () => {
 
   describe('Input and Indicators', () => {
     it('hides non-essential UI details in clean mode', async () => {
-      vi.useFakeTimers();
       const uiState = createMockUIState({
         cleanUiDetailsVisible: false,
       });
 
       const { lastFrame } = await renderComposer(uiState);
-
-      // Fast forward past the debounce
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(500);
-      });
 
       const output = lastFrame();
       expect(output).toContain('ShortcutsHint');
@@ -599,7 +595,6 @@ describe('Composer', () => {
       expect(output).not.toContain('Footer');
       expect(output).not.toContain('ApprovalModeIndicator');
       expect(output).not.toContain('ContextSummaryDisplay');
-      vi.useRealTimers();
     });
 
     it('renders InputPrompt when input is active', async () => {
@@ -826,8 +821,6 @@ describe('Composer', () => {
 
   describe('Shortcuts Hint', () => {
     it('restores shortcuts hint after 200ms debounce when buffer is empty', async () => {
-      vi.useFakeTimers();
-
       const { lastFrame } = await renderComposer(
         createMockUIState({
           buffer: { text: '' } as unknown as TextBuffer,
@@ -835,13 +828,7 @@ describe('Composer', () => {
         }),
       );
 
-      // Fast forward past the 200ms debounce (renderComposer already did 250ms, but we'll do more to be safe)
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(500);
-      });
-
       expect(lastFrame({ allowEmpty: true })).toContain('ShortcutsHint');
-      vi.useRealTimers();
     });
 
     it('does not show shortcuts hint immediately when buffer has text', async () => {
@@ -884,37 +871,23 @@ describe('Composer', () => {
     });
 
     it('keeps shortcuts hint visible when no action is required', async () => {
-      vi.useFakeTimers();
       const uiState = createMockUIState({
         cleanUiDetailsVisible: false,
       });
 
       const { lastFrame } = await renderComposer(uiState);
 
-      // Fast forward past the debounce
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(500);
-      });
-
       expect(lastFrame()).toContain('ShortcutsHint');
-      vi.useRealTimers();
     });
 
     it('shows shortcuts hint when full UI details are visible', async () => {
-      vi.useFakeTimers();
       const uiState = createMockUIState({
         cleanUiDetailsVisible: true,
       });
 
       const { lastFrame } = await renderComposer(uiState);
 
-      // Fast forward past the debounce
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(500);
-      });
-
       expect(lastFrame()).toContain('ShortcutsHint');
-      vi.useRealTimers();
     });
 
     it('hides shortcuts hint while loading when full UI details are visible', async () => {
@@ -991,7 +964,6 @@ describe('Composer', () => {
     });
 
     it('keeps shortcuts hint when suggestions are visible below input in regular buffer', async () => {
-      vi.useFakeTimers();
       composerTestControls.isAlternateBuffer = false;
       composerTestControls.suggestionsVisible = true;
 
@@ -1001,13 +973,7 @@ describe('Composer', () => {
 
       const { lastFrame } = await renderComposer(uiState);
 
-      // Fast forward past the debounce
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(500);
-      });
-
       expect(lastFrame()).toContain('ShortcutsHint');
-      vi.useRealTimers();
     });
   });
 

--- a/packages/cli/src/ui/components/Composer.test.tsx
+++ b/packages/cli/src/ui/components/Composer.test.tsx
@@ -857,6 +857,28 @@ describe('Composer', () => {
       expect(lastFrame()).toContain('ShortcutsHint');
     });
 
+    it('hides shortcuts hint while loading when full UI details are visible', async () => {
+      const uiState = createMockUIState({
+        cleanUiDetailsVisible: true,
+        streamingState: StreamingState.Responding,
+      });
+
+      const { lastFrame } = await renderComposer(uiState);
+
+      expect(lastFrame()).not.toContain('ShortcutsHint');
+    });
+
+    it('hides shortcuts hint when text is typed in buffer', async () => {
+      const uiState = createMockUIState({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        buffer: { text: 'hello' } as any,
+      });
+
+      const { lastFrame } = await renderComposer(uiState);
+
+      expect(lastFrame()).not.toContain('ShortcutsHint');
+    });
+
     it('hides shortcuts hint while loading in minimal mode', async () => {
       const uiState = createMockUIState({
         cleanUiDetailsVisible: false,

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -151,11 +151,30 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
         : undefined,
     );
   const hideShortcutsHintForSuggestions = hideUiDetailsForSuggestions;
+  const isModelIdle = uiState.streamingState === StreamingState.Idle;
+  const isBufferEmpty = uiState.buffer.text.length === 0;
+  const canShowShortcutsHint =
+    isModelIdle && isBufferEmpty && !hasPendingActionRequired;
+  const [showShortcutsHintDebounced, setShowShortcutsHintDebounced] =
+    useState(canShowShortcutsHint);
+
+  useEffect(() => {
+    if (!canShowShortcutsHint) {
+      setShowShortcutsHintDebounced(false);
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      setShowShortcutsHintDebounced(true);
+    }, 200);
+
+    return () => clearTimeout(timeout);
+  }, [canShowShortcutsHint]);
+
   const showShortcutsHint =
     settings.merged.ui.showShortcutsHint &&
     !hideShortcutsHintForSuggestions &&
-    !hideMinimalModeHintWhileBusy &&
-    !hasPendingActionRequired;
+    showShortcutsHintDebounced;
   const showMinimalModeBleedThrough =
     !hideUiDetailsForSuggestions && Boolean(minimalModeBleedThrough);
   const showMinimalInlineLoading = !showUiDetails && showLoadingIndicator;

--- a/packages/cli/src/ui/components/__snapshots__/Composer.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/Composer.test.tsx.snap
@@ -35,7 +35,7 @@ Footer
 `;
 
 exports[`Composer > Snapshots > matches snapshot while streaming 1`] = `
-" LoadingIndicator: Thinking                                                            ShortcutsHint
+" LoadingIndicator: Thinking
 ────────────────────────────────────────────────────────────────────────────────────────────────────
  ApprovalModeIndicator
 InputPrompt:   Type your message or @path/to/file


### PR DESCRIPTION
## Summary

New behavior in alternate buffer mode:
https://screencast.googleplex.com/cast/NjYzMDg0OTEwNDU3NjUxMnw2MGQyYjgyNC1kMg

Demo of undesired bounce when not in alternate buffer mode:
https://screencast.googleplex.com/cast/NjczNjYzMzg4MDY0MTUzNnwxYjgwYWQxOS0zNQ

To repro:
Verify the hint now properly goes away when the model is thinking and goes away when the input prompt is not empty.
Verify that there is no flicker of the hint showing up when you press enter when the input prompt is small.
Fixes #19386
