### PR TITLE
fix(plan): allow safe fallback when experiment setting for plan is not enabled but approval mode at startup is plan

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1344,6 +1344,36 @@ describe('Approval mode tool exclusion logic', () => {
       'Invalid approval mode: invalid_mode. Valid values are: yolo, auto_edit, plan, default',
     );
   });
+
+  it('should fall back to default approval mode if plan mode is requested but not enabled', async () => {
+    process.argv = ['node', 'script.js'];
+    const settings = createTestMergedSettings({
+      general: {
+        defaultApprovalMode: 'plan',
+      },
+      experimental: {
+        plan: false,
+      },
+    });
+    const argv = await parseArguments(settings);
+    const config = await loadCliConfig(settings, 'test-session', argv);
+    expect(config.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
+  });
+
+  it('should allow plan approval mode if experimental plan is enabled', async () => {
+    process.argv = ['node', 'script.js'];
+    const settings = createTestMergedSettings({
+      general: {
+        defaultApprovalMode: 'plan',
+      },
+      experimental: {
+        plan: true,
+      },
+    });
+    const argv = await parseArguments(settings);
+    const config = await loadCliConfig(settings, 'test-session', argv);
+    expect(config.getApprovalMode()).toBe(ApprovalMode.PLAN);
+  });
 });
 
 describe('loadCliConfig with allowed-mcp-server-names', () => {
@@ -2556,9 +2586,8 @@ describe('loadCliConfig approval mode', () => {
       },
     });
 
-    await expect(loadCliConfig(settings, 'test-session', argv)).rejects.toThrow(
-      'Approval mode "plan" is only available when experimental.plan is enabled.',
-    );
+    const config = await loadCliConfig(settings, 'test-session', argv);
+    expect(config.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
   });
 
   it('should throw error when --approval-mode=plan is used but experimental.plan setting is missing', async () => {
@@ -2566,9 +2595,8 @@ describe('loadCliConfig approval mode', () => {
     const argv = await parseArguments(createTestMergedSettings());
     const settings = createTestMergedSettings({});
 
-    await expect(loadCliConfig(settings, 'test-session', argv)).rejects.toThrow(
-      'Approval mode "plan" is only available when experimental.plan is enabled.',
-    );
+    const config = await loadCliConfig(settings, 'test-session', argv);
+    expect(config.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
   });
 
   // --- Untrusted Folder Scenarios ---
@@ -2678,11 +2706,8 @@ describe('loadCliConfig approval mode', () => {
         experimental: { plan: false },
       });
       const argv = await parseArguments(settings);
-      await expect(
-        loadCliConfig(settings, 'test-session', argv),
-      ).rejects.toThrow(
-        'Approval mode "plan" is only available when experimental.plan is enabled.',
-      );
+      const config = await loadCliConfig(settings, 'test-session', argv);
+      expect(config.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
     });
   });
 });

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -555,11 +555,13 @@ export async function loadCliConfig(
         break;
       case 'plan':
         if (!(settings.experimental?.plan ?? false)) {
-          throw new Error(
-            'Approval mode "plan" is only available when experimental.plan is enabled.',
+          debugLogger.warn(
+            'Approval mode "plan" is only available when experimental.plan is enabled. Falling back to "default".',
           );
+          approvalMode = ApprovalMode.DEFAULT;
+        } else {
+          approvalMode = ApprovalMode.PLAN;
         }
-        approvalMode = ApprovalMode.PLAN;
         break;
       case 'default':
         approvalMode = ApprovalMode.DEFAULT;


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
This PR fixes a startup crash that occurred when the plan approval mode was requested (via settings or command-line flags) while the experimental plan feature was disabled. Instead of throwing a terminal error, the CLI now gracefully falls back to the default approval mode and logs a warning, ensuring the tool remains usable even with configuration mismatches.
## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
   - Graceful Fallback: Updated loadCliConfig in packages/cli/src/config/config.ts to intercept cases where plan mode is selected without the experimental.plan setting being enabled. It now issues a warning via debugLogger and defaults to ApprovalMode.DEFAULT.
   - Improved Robustness: This change prevents the CLI from becoming unresponsive due to stale or incorrect configuration settings related to experimental features.
## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes https://github.com/google-gemini/gemini-cli/issues/19272
## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
Turn off plan mode in all settings (user, project, and systems). If default approval mode is set as plan mode in any setting, startup should not crash and should fallback to default mode.


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
