### PR TITLE
fix(cli): disable auto-completion on Shift+Tab to preserve mode cycling

### DIFF
--- a/docs/cli/keyboard-shortcuts.md
+++ b/docs/cli/keyboard-shortcuts.md
@@ -61,7 +61,7 @@ available combinations.
 | Show the next entry in history.              | `Ctrl + N (no Shift)` |
 | Start reverse search through history.        | `Ctrl + R`            |
 | Submit the selected reverse-search match.    | `Enter (no Ctrl)`     |
-| Accept a suggestion while reverse searching. | `Tab`                 |
+| Accept a suggestion while reverse searching. | `Tab (no Shift)`      |
 | Browse and rewind previous interactions.     | `Double Esc`          |
 
 #### Navigation
@@ -79,7 +79,7 @@ available combinations.
 
 | Action                                  | Keys                                               |
 | --------------------------------------- | -------------------------------------------------- |
-| Accept the inline suggestion.           | `Tab`<br />`Enter (no Ctrl)`                       |
+| Accept the inline suggestion.           | `Tab (no Shift)`<br />`Enter (no Ctrl)`            |
 | Move to the previous completion option. | `Up Arrow (no Shift)`<br />`Ctrl + P (no Shift)`   |
 | Move to the next completion option.     | `Down Arrow (no Shift)`<br />`Ctrl + N (no Shift)` |
 | Expand an inline suggestion.            | `Right Arrow`                                      |

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -212,7 +212,7 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.REVERSE_SEARCH]: [{ key: 'r', ctrl: true }],
   [Command.REWIND]: [{ key: 'double escape' }],
   [Command.SUBMIT_REVERSE_SEARCH]: [{ key: 'return', ctrl: false }],
-  [Command.ACCEPT_SUGGESTION_REVERSE_SEARCH]: [{ key: 'tab' }],
+  [Command.ACCEPT_SUGGESTION_REVERSE_SEARCH]: [{ key: 'tab', shift: false }],
 
   // Navigation
   [Command.NAVIGATION_UP]: [{ key: 'up', shift: false }],
@@ -231,7 +231,10 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.DIALOG_PREV]: [{ key: 'tab', shift: true }],
 
   // Suggestions & Completions
-  [Command.ACCEPT_SUGGESTION]: [{ key: 'tab' }, { key: 'return', ctrl: false }],
+  [Command.ACCEPT_SUGGESTION]: [
+    { key: 'tab', shift: false },
+    { key: 'return', ctrl: false },
+  ],
   [Command.COMPLETION_UP]: [
     { key: 'up', shift: false },
     { key: 'p', shift: false, ctrl: true },

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -974,6 +974,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       // Handle Tab key for ghost text acceptance
       if (
         key.name === 'tab' &&
+        !key.shift &&
         !completion.showSuggestions &&
         completion.promptCompletion.text
       ) {


### PR DESCRIPTION
## Summary

Disables auto-completion when Shift+Tab is pressed. Shift+Tab is used to cycle approval modes (Default, Auto-Edit, Plan), and triggering auto-completion simultaneously was disruptive and unintended.

## Details

- Updated `defaultKeyBindings` for `ACCEPT_SUGGESTION` and `ACCEPT_SUGGESTION_REVERSE_SEARCH` to explicitly require `shift: false`.
- Updated `InputPrompt.tsx` ghost text acceptance logic to check `!key.shift` before accepting.
- Added comprehensive unit tests in `InputPrompt.test.tsx` for all completion modes (standard, reverse search, and ghost text) to ensure Shift+Tab is ignored.
- Regenerated keybindings documentation to reflect the updated default bindings.

## Related Issues

Related to the reported bug where Shift+Tab triggers unwanted auto-completion.

## How to Validate

1. Start Gemini CLI.
2. Type a partial command (e.g., `/h`).
3. Press `Shift+Tab`.
4. Observe that it cycles the approval mode (e.g., to "Accepting edits") instead of auto-completing to `/help`.
5. Run tests: `npm test -w @google/gemini-cli -- src/ui/components/InputPrompt.test.tsx`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
