### PR TITLE
Disable failing eval test

### DIFF
--- a/evals/hierarchical_memory.eval.ts
+++ b/evals/hierarchical_memory.eval.ts
@@ -6,14 +6,9 @@
 
 import { describe, expect } from 'vitest';
 import { evalTest } from './test-helper.js';
-import {
-  assertModelHasOutput,
-  checkModelOutputContent,
-} from '../integration-tests/test-helper.js';
+import { assertModelHasOutput } from '../integration-tests/test-helper.js';
 
-describe('Hierarchical Memory', () => {
-  const TEST_PREFIX = 'Hierarchical memory test: ';
-
+describe.skip('Hierarchical Memory', () => {
   const conflictResolutionTest =
     'Agent follows hierarchy for contradictory instructions';
   evalTest('ALWAYS_PASSES', {

--- a/evals/hierarchical_memory.eval.ts
+++ b/evals/hierarchical_memory.eval.ts
@@ -8,10 +8,10 @@ import { describe, expect } from 'vitest';
 import { evalTest } from './test-helper.js';
 import { assertModelHasOutput } from '../integration-tests/test-helper.js';
 
-describe.skip('Hierarchical Memory', () => {
+describe('Hierarchical Memory', () => {
   const conflictResolutionTest =
     'Agent follows hierarchy for contradictory instructions';
-  evalTest('ALWAYS_PASSES', {
+  evalTest('USUALLY_PASSES', {
     name: conflictResolutionTest,
     params: {
       settings: {
@@ -47,7 +47,7 @@ What is my favorite fruit? Tell me just the name of the fruit.`,
   });
 
   const provenanceAwarenessTest = 'Agent is aware of memory provenance';
-  evalTest('ALWAYS_PASSES', {
+  evalTest('USUALLY_PASSES', {
     name: provenanceAwarenessTest,
     params: {
       settings: {
@@ -86,7 +86,7 @@ Provide the answer as an XML block like this:
   });
 
   const extensionVsGlobalTest = 'Extension memory wins over Global memory';
-  evalTest('ALWAYS_PASSES', {
+  evalTest('USUALLY_PASSES', {
     name: extensionVsGlobalTest,
     params: {
       settings: {


### PR DESCRIPTION
## Summary

This is failing in multiple places and blocking merges of critical PRs because it's exceeding the timeout because of model overloaded errors

Temporarily disabling it to unblock folks

Example: https://github.com/google-gemini/gemini-cli/actions/runs/22149067171/job/64045531463

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
