### PR TITLE
fix(cli): watch .git/HEAD in addition to .git/logs/HEAD for branch updates

### DIFF
--- a/packages/cli/src/ui/hooks/useGitBranchName.test.tsx
+++ b/packages/cli/src/ui/hooks/useGitBranchName.test.tsx
@@ -171,6 +171,11 @@ describe('useGitBranchName', () => {
     // Simulate file change event on .git/logs/HEAD
     await act(async () => {
       fs.writeFileSync(GIT_LOGS_HEAD_PATH, 'ref: refs/heads/develop');
+      // Trigger the watcher callback manually as memfs might not trigger it in all environments
+      const onFileChange = watchSpy.mock.calls.find(
+        (call) => call[0] === GIT_LOGS_HEAD_PATH,
+      )?.[1] as (eventType: string) => void;
+      if (onFileChange) onFileChange('change');
       rerender();
     });
 
@@ -208,6 +213,11 @@ describe('useGitBranchName', () => {
     // Simulate file change event on .git/HEAD (branch switch)
     await act(async () => {
       fs.writeFileSync(GIT_HEAD_PATH, 'ref: refs/heads/feature-branch');
+      // Trigger the watcher callback manually
+      const onFileChange = watchSpy.mock.calls.find(
+        (call) => call[0] === GIT_HEAD_PATH,
+      )?.[1] as (eventType: string) => void;
+      if (onFileChange) onFileChange('change');
       rerender();
     });
 

--- a/packages/cli/src/ui/hooks/useGitBranchName.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.ts
@@ -40,36 +40,46 @@ export function useGitBranchName(cwd: string): string | undefined {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fetchBranchName(); // Initial fetch
 
+    const gitHeadPath = path.join(cwd, '.git', 'HEAD');
     const gitLogsHeadPath = path.join(cwd, '.git', 'logs', 'HEAD');
-    let watcher: fs.FSWatcher | undefined;
+    const watchers: fs.FSWatcher[] = [];
     let cancelled = false;
 
-    const setupWatcher = async () => {
-      try {
-        // Check if .git/logs/HEAD exists, as it might not in a new repo or orphaned head
-        await fsPromises.access(gitLogsHeadPath, fs.constants.F_OK);
-        if (cancelled) return;
-        watcher = fs.watch(gitLogsHeadPath, (eventType: string) => {
-          // Changes to .git/logs/HEAD (appends) indicate HEAD has likely changed
-          if (eventType === 'change' || eventType === 'rename') {
-            // Handle rename just in case
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            fetchBranchName();
-          }
-        });
-      } catch (_watchError) {
-        // Silently ignore watcher errors (e.g. permissions or file not existing),
-        // similar to how exec errors are handled.
-        // The branch name will simply not update automatically.
+    const onFileChange = (eventType: string) => {
+      if (eventType === 'change' || eventType === 'rename') {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        fetchBranchName();
       }
     };
 
+    const watchFile = async (filePath: string) => {
+      try {
+        await fsPromises.access(filePath, fs.constants.F_OK);
+        if (cancelled) return;
+        const watcher = fs.watch(filePath, onFileChange);
+        watchers.push(watcher);
+      } catch {
+        // Silently ignore if the file doesn't exist or can't be watched.
+      }
+    };
+
+    const setupWatchers = async () => {
+      // Watch .git/HEAD — the canonical source for the current branch ref.
+      // This file is always updated on branch switches (git checkout, git switch).
+      await watchFile(gitHeadPath);
+      // Also watch .git/logs/HEAD for reflog-based updates, which covers
+      // additional operations like commits and resets.
+      await watchFile(gitLogsHeadPath);
+    };
+
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    setupWatcher();
+    setupWatchers();
 
     return () => {
       cancelled = true;
-      watcher?.close();
+      for (const watcher of watchers) {
+        watcher.close();
+      }
     };
   }, [cwd, fetchBranchName]);
 


### PR DESCRIPTION
When users switch branches via the ! shell command (e.g. !git checkout),
the branch name in the UI footer did not update because the hook only
watched .git/logs/HEAD. On some platforms and git operations, only
.git/HEAD is updated reliably.

This change watches both .git/HEAD (the canonical branch reference) and
.git/logs/HEAD (the reflog) to ensure the UI always reflects branch
switches.

Fixes #19271
