### PR TITLE
fix(core): skip telemetry logging for AbortError exceptions

### DIFF
--- a/packages/core/src/core/loggingContentGenerator.test.ts
+++ b/packages/core/src/core/loggingContentGenerator.test.ts
@@ -315,6 +315,27 @@ describe('LoggingContentGenerator', () => {
         });
       });
     });
+
+    it('should NOT log error on AbortError (user cancellation)', async () => {
+      const req = {
+        contents: [{ role: 'user', parts: [{ text: 'hello' }] }],
+        model: 'gemini-pro',
+      };
+      const userPromptId = 'prompt-123';
+      const abortError = new Error('Aborted');
+      abortError.name = 'AbortError';
+      vi.mocked(wrapped.generateContent).mockRejectedValue(abortError);
+
+      await expect(
+        loggingContentGenerator.generateContent(
+          req,
+          userPromptId,
+          LlmRole.MAIN,
+        ),
+      ).rejects.toThrow(abortError);
+
+      expect(logApiError).not.toHaveBeenCalled();
+    });
   });
 
   describe('generateContentStream', () => {
@@ -460,6 +481,67 @@ describe('LoggingContentGenerator', () => {
       );
       const errorEvent = vi.mocked(logApiError).mock.calls[0][1];
       expect(errorEvent.duration_ms).toBe(1000);
+    });
+
+    it('should NOT log error on AbortError during connection phase', async () => {
+      const req = {
+        contents: [{ role: 'user', parts: [{ text: 'hello' }] }],
+        model: 'gemini-pro',
+      };
+      const userPromptId = 'prompt-123';
+      const abortError = new Error('Aborted');
+      abortError.name = 'AbortError';
+      vi.mocked(wrapped.generateContentStream).mockRejectedValue(abortError);
+
+      await expect(
+        loggingContentGenerator.generateContentStream(
+          req,
+          userPromptId,
+          LlmRole.MAIN,
+        ),
+      ).rejects.toThrow(abortError);
+
+      expect(logApiError).not.toHaveBeenCalled();
+    });
+
+    it('should NOT log error on AbortError during stream iteration', async () => {
+      const req = {
+        contents: [{ role: 'user', parts: [{ text: 'hello' }] }],
+        model: 'gemini-pro',
+      };
+      const userPromptId = 'prompt-123';
+      const abortError = new Error('Aborted');
+      abortError.name = 'AbortError';
+
+      async function* createAbortingGenerator() {
+        yield {
+          candidates: [],
+          text: undefined,
+          functionCalls: undefined,
+          executableCode: undefined,
+          codeExecutionResult: undefined,
+          data: undefined,
+        } as unknown as GenerateContentResponse;
+        throw abortError;
+      }
+
+      vi.mocked(wrapped.generateContentStream).mockResolvedValue(
+        createAbortingGenerator(),
+      );
+
+      const stream = await loggingContentGenerator.generateContentStream(
+        req,
+        userPromptId,
+        LlmRole.MAIN,
+      );
+
+      await expect(async () => {
+        for await (const _ of stream) {
+          // consume stream
+        }
+      }).rejects.toThrow(abortError);
+
+      expect(logApiError).not.toHaveBeenCalled();
     });
 
     it('should set latest API request in config for main agent requests', async () => {

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -36,7 +36,7 @@ import { toContents } from '../code_assist/converter.js';
 import { isStructuredError } from '../utils/quotaErrorDetection.js';
 import { runInDevTraceSpan, type SpanMetadata } from '../telemetry/trace.js';
 import { debugLogger } from '../utils/debugLogger.js';
-import { getErrorType } from '../utils/errors.js';
+import { isAbortError, getErrorType } from '../utils/errors.js';
 import {
   GeminiCliOperation,
   GEN_AI_PROMPT_NAME,
@@ -310,6 +310,10 @@ export class LoggingContentGenerator implements ContentGenerator {
     generationConfig?: GenerateContentConfig,
     serverDetails?: ServerDetails,
   ): void {
+    if (isAbortError(error)) {
+      // Don't log aborted requests (e.g., user cancellation, internal timeouts) as API errors.
+      return;
+    }
     const errorMessage = error instanceof Error ? error.message : String(error);
     const errorType = getErrorType(error);
 

--- a/packages/core/src/utils/errors.test.ts
+++ b/packages/core/src/utils/errors.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   isAuthenticationError,
+  isAbortError,
   UnauthorizedError,
   toFriendlyError,
   BadRequestError,
@@ -45,6 +46,29 @@ describe('getErrorMessage', () => {
       },
     };
     expect(getErrorMessage(error)).toBe('Bad Request Message');
+  });
+});
+
+describe('isAbortError', () => {
+  it('should return true for AbortError', () => {
+    const error = new Error('Aborted');
+    error.name = 'AbortError';
+    expect(isAbortError(error)).toBe(true);
+  });
+
+  it('should return true for DOMException AbortError', () => {
+    const error = new DOMException('Aborted', 'AbortError');
+    expect(isAbortError(error)).toBe(true);
+  });
+
+  it('should return false for other errors', () => {
+    expect(isAbortError(new Error('Other error'))).toBe(false);
+  });
+
+  it('should return false for non-error objects', () => {
+    expect(isAbortError({ name: 'AbortError' })).toBe(false);
+    expect(isAbortError(null)).toBe(false);
+    expect(isAbortError('AbortError')).toBe(false);
   });
 });
 

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -26,6 +26,13 @@ export function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && 'code' in error;
 }
 
+/**
+ * Checks if an error is an AbortError.
+ */
+export function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
 export function getErrorMessage(error: unknown): string {
   const friendlyError = toFriendlyError(error);
   if (friendlyError instanceof Error) {


### PR DESCRIPTION
## Summary

Skip logging API errors when a request is aborted by the user or encounters an internal timeout (i.e., `AbortError`).

## Details

When a user cancels a request or leaves a session, the Gemini API client throws an `AbortError`. Previously, this was logged as a generic API error in the `LoggingContentGenerator`, which skewed telemetry and error reporting for model usage.

This PR adds a centralized `isAbortError` utility to `packages/core/src/utils/errors.ts` and uses it to add explicit checks for `AbortError` in both streaming and non-streaming request paths in `LoggingContentGenerator`. This ensures these user-initiated cancellations or timeouts are not tracked as system or API errors.

## Related Issues

Fixes #17328

## How to Validate

1. Run the CLI and initiate a model request.
2. Abort the request (e.g., via Ctrl+C or by triggering an abort signal during a long generation).
3. Verify that `logApiError` is NOT triggered in the telemetry/logs.
4. Review and run the new unit tests in `packages/core/src/core/loggingContentGenerator.test.ts` and `packages/core/src/utils/errors.test.ts`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
