### PR TITLE
feat(cli): add experimental.useOSC52Copy setting

### DIFF
--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -128,12 +128,13 @@ they appear in the UI.
 
 ### Experimental
 
-| UI Label                   | Setting                                  | Description                                                                         | Default |
-| -------------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------- | ------- |
-| Enable Tool Output Masking | `experimental.toolOutputMasking.enabled` | Enables tool output masking to save tokens.                                         | `true`  |
-| Use OSC 52 Paste           | `experimental.useOSC52Paste`             | Use OSC 52 sequence for pasting instead of clipboardy (useful for remote sessions). | `false` |
-| Plan                       | `experimental.plan`                      | Enable planning features (Plan Mode and tools).                                     | `false` |
-| Model Steering             | `experimental.modelSteering`             | Enable model steering (user hints) to guide the model during tool execution.        | `false` |
+| UI Label                   | Setting                                  | Description                                                                                                                                               | Default |
+| -------------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| Enable Tool Output Masking | `experimental.toolOutputMasking.enabled` | Enables tool output masking to save tokens.                                                                                                               | `true`  |
+| Use OSC 52 Paste           | `experimental.useOSC52Paste`             | Use OSC 52 for pasting. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it). | `false` |
+| Use OSC 52 Copy            | `experimental.useOSC52Copy`              | Use OSC 52 for copying. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it). | `false` |
+| Plan                       | `experimental.plan`                      | Enable planning features (Plan Mode and tools).                                                                                                           | `false` |
+| Model Steering             | `experimental.modelSteering`             | Enable model steering (user hints) to guide the model during tool execution.                                                                              | `false` |
 
 ### Skills
 

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -941,8 +941,15 @@ their corresponding top-level category object in your `settings.json` file.
   - **Requires restart:** Yes
 
 - **`experimental.useOSC52Paste`** (boolean):
-  - **Description:** Use OSC 52 sequence for pasting instead of clipboardy
-    (useful for remote sessions).
+  - **Description:** Use OSC 52 for pasting. This may be more robust than the
+    default system when using remote terminal sessions (if your terminal is
+    configured to allow it).
+  - **Default:** `false`
+
+- **`experimental.useOSC52Copy`** (boolean):
+  - **Description:** Use OSC 52 for copying. This may be more robust than the
+    default system when using remote terminal sessions (if your terminal is
+    configured to allow it).
   - **Default:** `false`
 
 - **`experimental.plan`** (boolean):

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1632,7 +1632,17 @@ const SETTINGS_SCHEMA = {
         requiresRestart: false,
         default: false,
         description:
-          'Use OSC 52 sequence for pasting instead of clipboardy (useful for remote sessions).',
+          'Use OSC 52 for pasting. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it).',
+        showInDialog: true,
+      },
+      useOSC52Copy: {
+        type: 'boolean',
+        label: 'Use OSC 52 Copy',
+        category: 'Experimental',
+        requiresRestart: false,
+        default: false,
+        description:
+          'Use OSC 52 for copying. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it).',
         showInDialog: true,
       },
       plan: {

--- a/packages/cli/src/ui/commands/copyCommand.test.ts
+++ b/packages/cli/src/ui/commands/copyCommand.test.ts
@@ -125,6 +125,7 @@ describe('copyCommand', () => {
 
     expect(mockCopyToClipboard).toHaveBeenCalledWith(
       'Hi there! How can I help you?',
+      expect.anything(),
     );
   });
 
@@ -143,7 +144,10 @@ describe('copyCommand', () => {
 
     const result = await copyCommand.action(mockContext, '');
 
-    expect(mockCopyToClipboard).toHaveBeenCalledWith('Part 1: Part 2: Part 3');
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      'Part 1: Part 2: Part 3',
+      expect.anything(),
+    );
     expect(result).toEqual({
       type: 'message',
       messageType: 'info',
@@ -170,7 +174,10 @@ describe('copyCommand', () => {
 
     const result = await copyCommand.action(mockContext, '');
 
-    expect(mockCopyToClipboard).toHaveBeenCalledWith('Text part more text');
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      'Text part more text',
+      expect.anything(),
+    );
     expect(result).toEqual({
       type: 'message',
       messageType: 'info',
@@ -201,7 +208,10 @@ describe('copyCommand', () => {
 
     const result = await copyCommand.action(mockContext, '');
 
-    expect(mockCopyToClipboard).toHaveBeenCalledWith('Second AI response');
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      'Second AI response',
+      expect.anything(),
+    );
     expect(result).toEqual({
       type: 'message',
       messageType: 'info',
@@ -230,6 +240,11 @@ describe('copyCommand', () => {
       messageType: 'error',
       content: `Failed to copy to the clipboard. ${clipboardError.message}`,
     });
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      'AI response',
+      expect.anything(),
+    );
   });
 
   it('should handle non-Error clipboard errors', async () => {
@@ -253,6 +268,11 @@ describe('copyCommand', () => {
       messageType: 'error',
       content: `Failed to copy to the clipboard. ${rejectedValue}`,
     });
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      'AI response',
+      expect.anything(),
+    );
   });
 
   it('should return info message when no text parts found in AI message', async () => {

--- a/packages/cli/src/ui/commands/copyCommand.ts
+++ b/packages/cli/src/ui/commands/copyCommand.ts
@@ -38,7 +38,8 @@ export const copyCommand: SlashCommand = {
 
     if (lastAiOutput) {
       try {
-        await copyToClipboard(lastAiOutput);
+        const settings = context.services.settings.merged;
+        await copyToClipboard(lastAiOutput, settings);
 
         return {
           type: 'message',

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1587,8 +1587,15 @@
         },
         "useOSC52Paste": {
           "title": "Use OSC 52 Paste",
-          "description": "Use OSC 52 sequence for pasting instead of clipboardy (useful for remote sessions).",
-          "markdownDescription": "Use OSC 52 sequence for pasting instead of clipboardy (useful for remote sessions).\n\n- Category: `Experimental`\n- Requires restart: `no`\n- Default: `false`",
+          "description": "Use OSC 52 for pasting. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it).",
+          "markdownDescription": "Use OSC 52 for pasting. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it).\n\n- Category: `Experimental`\n- Requires restart: `no`\n- Default: `false`",
+          "default": false,
+          "type": "boolean"
+        },
+        "useOSC52Copy": {
+          "title": "Use OSC 52 Copy",
+          "description": "Use OSC 52 for copying. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it).",
+          "markdownDescription": "Use OSC 52 for copying. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it).\n\n- Category: `Experimental`\n- Requires restart: `no`\n- Default: `false`",
           "default": false,
           "type": "boolean"
         },


### PR DESCRIPTION
## Summary

Adds an experimental setting `experimental.useOSC52Copy` to allow users to force the use of OSC 52 escape sequences for copying to the clipboard, bypassing `clipboardy`.

## Details

- Added `useOSC52Copy` to `settingsSchema.ts` and `settings.schema.json`.
- Updated `copyToClipboard` in `commandUtils.ts` to respect this setting, bypassing the standard SSH/WSL heuristics if enabled.
- Updated `copyCommand.ts` to pass the settings to `copyToClipboard`.
- Added tests to verify the new behavior.
- Updated documentation.

## Related Issues

Fixes #19086

## How to Validate

1.  Set `"experimental": { "useOSC52Copy": true }` in your `config.json`.
2.  Run a command that generates output.
3.  Run `/copy`.
4.  Verify the content is in your system clipboard.
5.  (Optional) Verify in an environment where standard clipboard tools fail (e.g., Emacs `eat` terminal).

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
