### PR TITLE
build: replace deprecated built-in punycode with userland package

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -75,6 +75,10 @@ const baseConfig = {
   write: true,
 };
 
+const commonAliases = {
+  punycode: 'punycode/',
+};
+
 const cliConfig = {
   ...baseConfig,
   banner: {
@@ -88,7 +92,7 @@ const cliConfig = {
   plugins: createWasmPlugins(),
   alias: {
     'is-in-ci': path.resolve(__dirname, 'packages/cli/src/patches/is-in-ci.ts'),
-    punycode: 'punycode/',
+    ...commonAliases,
   },
   metafile: true,
 };
@@ -104,9 +108,7 @@ const a2aServerConfig = {
     'process.env.CLI_VERSION': JSON.stringify(pkg.version),
   },
   plugins: createWasmPlugins(),
-  alias: {
-    punycode: 'punycode/',
-  },
+  alias: commonAliases,
 };
 
 Promise.allSettled([

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -88,6 +88,7 @@ const cliConfig = {
   plugins: createWasmPlugins(),
   alias: {
     'is-in-ci': path.resolve(__dirname, 'packages/cli/src/patches/is-in-ci.ts'),
+    punycode: 'punycode/',
   },
   metafile: true,
 };
@@ -103,6 +104,9 @@ const a2aServerConfig = {
     'process.env.CLI_VERSION': JSON.stringify(pkg.version),
   },
   plugins: createWasmPlugins(),
+  alias: {
+    punycode: 'punycode/',
+  },
 };
 
 Promise.allSettled([

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "ink": "npm:@jrichman/ink@6.4.11",
         "latest-version": "^9.0.0",
         "proper-lockfile": "^4.1.2",
+        "punycode": "^2.3.1",
         "simple-git": "^3.28.0"
       },
       "bin": {
@@ -13520,7 +13521,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "ink": "npm:@jrichman/ink@6.4.11",
     "latest-version": "^9.0.0",
     "proper-lockfile": "^4.1.2",
+    "punycode": "^2.3.1",
     "simple-git": "^3.28.0"
   },
   "optionalDependencies": {

--- a/packages/vscode-ide-companion/esbuild.js
+++ b/packages/vscode-ide-companion/esbuild.js
@@ -49,6 +49,9 @@ async function main() {
     define: {
       'import.meta.url': 'import_meta.url',
     },
+    alias: {
+      punycode: 'punycode/',
+    },
     plugins: [
       /* add to the end of plugins array */
       esbuildProblemMatcherPlugin,


### PR DESCRIPTION
## Summary

This PR replaces the deprecated built-in `node:punycode` module with the userland `punycode` npm package. This addresses the `DeprecationWarning: The punycode module is deprecated` warning that appears when bundling and running the CLI due to deep transitive dependencies (e.g., `node-fetch`, `whatwg-url`) relying on it.

## Details

1. Added `punycode@^2.3.1` as a root dependency.
2. Updated `esbuild.config.js` to alias `punycode: 'punycode/'` for both `cliConfig` and `a2aServerConfig`.
3. Updated `packages/vscode-ide-companion/esbuild.js` to include the same `punycode: 'punycode/'` alias.

These alias configurations instruct esbuild to bundle the userland package in place of the built-in node module whenever any transitive dependency requests `punycode`, silently fixing the deprecation without needing forks of upstream packages.


This is aligned with the instructions on https://www.npmjs.com/package/punycode

> ⚠️ Note that userland modules don't hide core modules. For example, require('punycode') still imports the deprecated core module even if you executed npm install punycode. Use require('punycode/') to import userland modules rather than core modules.

## Related Issues

Fixes: #18342