### PR TITLE
add package @google/gemini-cli-devtools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17310,7 +17310,6 @@
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.12.0",
         "@google/gemini-cli-core": "file:../core",
-        "@google/gemini-cli-devtools": "file:../devtools",
         "@google/genai": "1.30.0",
         "@iarna/toml": "^2.2.5",
         "@modelcontextprotocol/sdk": "^1.23.0",
@@ -17354,6 +17353,7 @@
         "gemini": "dist/index.js"
       },
       "devDependencies": {
+        "@google/gemini-cli-devtools": "file:../devtools",
         "@google/gemini-cli-test-utils": "file:../test-utils",
         "@types/command-exists": "^1.2.3",
         "@types/hast": "^3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17310,6 +17310,7 @@
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.12.0",
         "@google/gemini-cli-core": "file:../core",
+        "@google/gemini-cli-devtools": "file:../devtools",
         "@google/genai": "1.30.0",
         "@iarna/toml": "^2.2.5",
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.12.0",
     "@google/gemini-cli-core": "file:../core",
+    "@google/gemini-cli-devtools": "file:../devtools",
     "@google/genai": "1.30.0",
     "@iarna/toml": "^2.2.5",
     "@modelcontextprotocol/sdk": "^1.23.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.12.0",
     "@google/gemini-cli-core": "file:../core",
-    "@google/gemini-cli-devtools": "file:../devtools",
     "@google/genai": "1.30.0",
     "@iarna/toml": "^2.2.5",
     "@modelcontextprotocol/sdk": "^1.23.0",
@@ -72,6 +71,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@google/gemini-cli-devtools": "file:../devtools",
     "@google/gemini-cli-test-utils": "file:../test-utils",
     "@types/command-exists": "^1.2.3",
     "@types/hast": "^3.0.4",


### PR DESCRIPTION
## Summary

The current build is failing without cache.

## Details

`@google/gemini-cli-devtools` is imported in `packages/cli/src/utils/devtoolsService.ts` but is missing from `packages/cli/package.json`.

## Related Issues

none

## How to Validate

Nothing is failing anymore.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [X] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
