### PR TITLE
feat: prompt users to run /terminal-setup in supported terminals

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -143,6 +143,7 @@ import { isWorkspaceTrusted } from '../config/trustedFolders.js';
 import { useAlternateBuffer } from './hooks/useAlternateBuffer.js';
 import { useSettings } from './contexts/SettingsContext.js';
 import { terminalCapabilityManager } from './utils/terminalCapabilityManager.js';
+import { useTerminalSetupPrompt } from './utils/terminalSetup.js';
 import { useInputHistoryStore } from './hooks/useInputHistoryStore.js';
 import { useBanner } from './hooks/useBanner.js';
 import { useHookDisplayState } from './hooks/useHookDisplayState.js';
@@ -550,6 +551,9 @@ export const AppContainer = (props: AppContainerProps) => {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     initializeFromLogger(logger);
   }, [logger, initializeFromLogger]);
+
+  // Prompt user to run /terminal-setup if applicable (one-time)
+  useTerminalSetupPrompt(addConfirmUpdateExtensionRequest, historyManager);
 
   const refreshStatic = useCallback(() => {
     if (!isAlternateBuffer) {

--- a/packages/cli/src/utils/persistentState.ts
+++ b/packages/cli/src/utils/persistentState.ts
@@ -15,6 +15,7 @@ interface PersistentStateData {
   tipsShown?: number;
   hasSeenScreenReaderNudge?: boolean;
   focusUiEnabled?: boolean;
+  terminalSetupPromptShown?: boolean;
   // Add other persistent state keys here as needed
 }
 


### PR DESCRIPTION
## Summary

One-time prompt asking users if they'd like to run `/terminal-setup` when running inside a supported terminal (VS Code, Cursor, Windsurf, Antigravity) that doesn't have multiline keybindings configured. This is a fresh implementation addressing all feedback from the closed PR #16235.

Closes #16005

## Details

- **`useTerminalSetupPrompt` hook** in `terminalSetup.ts` — encapsulates all prompt logic, keeping `AppContainer.tsx` minimal (2 lines: import + call)
- **`shouldPromptForTerminalSetup()`** — checks kitty protocol, terminal detection, and existing keybindings to determine if prompting is useful
- **`TERMINAL_DATA` map + `getSupportedTerminalData()`** — replaces switch statements, shared between `shouldPromptForTerminalSetup()` and `terminalSetup()`
- **`hasOurBinding()` helper** — DRY shared function for checking shift+enter/ctrl+enter keybinding presence
- **`useRef` for cancelled flag** — fixes the critical bug from #16235 where `useEffect` cleanup ran on re-render, cancelling the async flow before the user could respond "yes"
- **`persistentState('terminalSetupPromptShown')`** — ensures the prompt is only shown once per user
- **`debugLogger.debug()`** in all catch blocks instead of silently swallowing errors
- 8 new tests for `shouldPromptForTerminalSetup`

## Related Issues

Closes #16005
Supersedes #16235

## How to Validate

1. Run tests: `npx vitest run packages/cli/src/ui/utils/terminalSetup.test.ts` (18 tests pass)
2. Build: `npm run build --workspace=packages/cli`
3. Manual test in VS Code terminal without existing keybindings:
   - Run `gemini` — should see a Y/N prompt asking to configure terminal
   - Select "Yes" — keybindings should be written
   - Run `gemini` again — prompt should NOT appear (persistent state)
4. Manual test in a terminal with keybindings already configured — prompt should NOT appear
5. Manual test outside VS Code/Cursor/Windsurf/Antigravity — prompt should NOT appear

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker