### PR TITLE
fix: remove extra padding in Composer

### DIFF
--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -191,7 +191,7 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
 
       {showUiDetails && <TodoTray />}
 
-      <Box marginTop={1} width="100%" flexDirection="column">
+      <Box width="100%" flexDirection="column">
         <Box
           width="100%"
           flexDirection={isNarrow ? 'column' : 'row'}

--- a/packages/cli/src/ui/components/__snapshots__/Composer.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/Composer.test.tsx.snap
@@ -1,8 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Composer > Snapshots > matches snapshot in idle state 1`] = `
-"
-                                                                                       ShortcutsHint
+"                                                                                       ShortcutsHint
 ────────────────────────────────────────────────────────────────────────────────────────────────────
  ApprovalModeIndicator                                                                 StatusDisplay
 InputPrompt:   Type your message or @path/to/file
@@ -11,22 +10,19 @@ Footer
 `;
 
 exports[`Composer > Snapshots > matches snapshot in minimal UI mode 1`] = `
-"
-                                                                                       ShortcutsHint
+"                                                                                       ShortcutsHint
 InputPrompt:   Type your message or @path/to/file
 "
 `;
 
 exports[`Composer > Snapshots > matches snapshot in minimal UI mode while loading 1`] = `
-"
- LoadingIndicator
+" LoadingIndicator
 InputPrompt:   Type your message or @path/to/file
 "
 `;
 
 exports[`Composer > Snapshots > matches snapshot in narrow view 1`] = `
 "
-
 ShortcutsHint
 ────────────────────────────────────────
  ApprovalModeIndicator
@@ -39,8 +35,7 @@ Footer
 `;
 
 exports[`Composer > Snapshots > matches snapshot while streaming 1`] = `
-"
- LoadingIndicator: Thinking                                                            ShortcutsHint
+" LoadingIndicator: Thinking                                                            ShortcutsHint
 ────────────────────────────────────────────────────────────────────────────────────────────────────
  ApprovalModeIndicator
 InputPrompt:   Type your message or @path/to/file


### PR DESCRIPTION
## Summary

Remove padding above shortcuts and loading phrase line.

<img width="2552" height="975" alt="image" src="https://github.com/user-attachments/assets/bd89f96a-a512-454f-bf8b-cc33df76218a" />

## Details

The shortcuts and loading phrase line has a padding above it, this is taking up valuable space in the terminal. It also is minimizing the scroll space in alternate buffer mode.

### Before
<img width="2420" height="458" alt="image" src="https://github.com/user-attachments/assets/aab206b9-bf4e-4b59-833f-cd545926db53" />

<img width="1697" height="519" alt="image" src="https://github.com/user-attachments/assets/e4fb432c-4115-428b-b6fa-a2a69dc9747b" />


### After

<img width="2437" height="464" alt="image" src="https://github.com/user-attachments/assets/f2517902-6b65-4c57-983c-885e9f7c1271" />

<img width="1697" height="439" alt="image" src="https://github.com/user-attachments/assets/5e4f6930-e0b9-4369-ab0f-db221c9c4015" />



## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
