### PR TITLE
feat(hooks): add NotificationType.ShellInteraction for interactive shell (#19527)

### DIFF
--- a/docs/hooks/reference.md
+++ b/docs/hooks/reference.md
@@ -263,14 +263,18 @@ telemetry.
 
 ### `Notification`
 
-Fires when the CLI emits a system alert (e.g., Tool Permissions). Used for
-external logging or cross-platform alerts.
+Fires when the CLI emits a system alert (e.g., Tool Permissions, interactive
+shell waiting for input). Used for external logging or cross-platform alerts.
 
 - **Input Fields**:
-  - `notification_type`: (`"ToolPermission"`)
+  - `notification_type`: (`"ToolPermission"` | `"ShellInteraction"`)
+    - `ToolPermission`: Tool permission/confirmation prompt is being shown.
+    - `ShellInteraction`: An interactive shell session is active and waiting for
+      user input (e.g. vim, htop). Use matcher `"ShellInteraction"` to receive
+      only these notifications.
   - `message`: Summary of the alert.
   - `details`: JSON object with alert-specific metadata (e.g., tool name, file
-    path).
+    path; for `ShellInteraction`, `pid` and `source: "interactive_shell"`).
 - **Relevant Output Fields**:
   - `systemMessage`: Displayed alongside the system alert.
 - **Observability Only**: This hook **cannot** block alerts or grant permissions

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -420,12 +420,14 @@ export const useShellCommandProcessor = (
           if (pid) {
             dispatch({ type: 'SET_ACTIVE_PTY', pid });
             // Notify hooks when interactive shell is waiting for user input (Fixes #19527)
-            void config
-              .getHookSystem()
-              ?.fireShellInteractionNotificationEvent(
-                'Interactive shell waiting for user input',
-                { pid },
-              );
+            if (config.getEnableInteractiveShell()) {
+              void config
+                .getHookSystem()
+                ?.fireShellInteractionNotificationEvent(
+                  'Interactive shell waiting for user input',
+                  { pid },
+                );
+            }
             setPendingHistoryItem((prevItem) => {
               if (prevItem?.type === 'tool_group') {
                 return {

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -419,6 +419,13 @@ export const useShellCommandProcessor = (
           executionPid = pid;
           if (pid) {
             dispatch({ type: 'SET_ACTIVE_PTY', pid });
+            // Notify hooks when interactive shell is waiting for user input (Fixes #19527)
+            void config
+              .getHookSystem()
+              ?.fireShellInteractionNotificationEvent(
+                'Interactive shell waiting for user input',
+                { pid },
+              );
             setPendingHistoryItem((prevItem) => {
               if (prevItem?.type === 'tool_group') {
                 return {

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -138,7 +138,8 @@ export class HookEventHandler {
       details,
     };
 
-    return this.executeHooks(HookEventName.Notification, input);
+    const context: HookEventContext = { trigger: type };
+    return this.executeHooks(HookEventName.Notification, input, context);
   }
 
   /**

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -425,4 +425,24 @@ export class HookSystem {
       );
     }
   }
+
+  /**
+   * Fire a Notification hook when an interactive shell is waiting for user input.
+   * Use matcher "ShellInteraction" in Notification hook config to receive this.
+   * @see https://github.com/google-gemini/gemini-cli/issues/19527
+   */
+  async fireShellInteractionNotificationEvent(
+    message: string = 'Interactive shell waiting for user input',
+    details: Record<string, unknown> = {},
+  ): Promise<void> {
+    try {
+      await this.hookEventHandler.fireNotificationEvent(
+        NotificationType.ShellInteraction,
+        message,
+        { ...details, source: 'interactive_shell' },
+      );
+    } catch (error) {
+      debugLogger.debug('ShellInteraction NotificationEvent failed:', error);
+    }
+  }
 }

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -484,6 +484,8 @@ export interface BeforeAgentOutput extends HookOutput {
  */
 export enum NotificationType {
   ToolPermission = 'ToolPermission',
+  /** Fires when an interactive shell session is active and waiting for user input. */
+  ShellInteraction = 'ShellInteraction',
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds **NotificationType: `ShellInteraction`** so Notification hooks can run when an interactive shell is waiting for user input (e.g. vim, htop, `git rebase -i`). Users can get desktop or other notifications when the CLI is blocked on shell input.

Fixes #19527

## Changes

- **Core:** Added `ShellInteraction` to `NotificationType` enum; `fireNotificationEvent` now passes `context.trigger` so matcher filters by type.
- **Core:** New `fireShellInteractionNotificationEvent()` on HookSystem.
- **CLI:** Fires the notification when an interactive shell gets a PTY (waiting for input).
- **Docs:** Updated hooks reference for `ShellInteraction` and matcher usage.
- **Tests:** Unit test for ShellInteraction notification and context.

## Example

```json
{
  "hooks": {
    "Notification": [{
      "matcher": "ShellInteraction",
      "hooks": [{ "type": "command", "command": "notify-send 'Gemini' 'Interactive shell waiting'", "timeout": 5000 }]
    }]
  }
}
```