### PR TITLE
perf(cli): 30X speed boost and memory leak prevention reading large files

### DIFF
--- a/integration-tests/run_shell_command_file_stream.test.ts
+++ b/integration-tests/run_shell_command_file_stream.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestRig } from './test-helper.js';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+describe('run_shell_command streaming to file regression', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = new TestRig();
+  });
+
+  afterEach(async () => await rig.cleanup());
+
+  it('should stream large outputs to a file and verify full content presence', async () => {
+    await rig.setup(
+      'should stream large outputs to a file and verify full content presence',
+      {
+        settings: { tools: { core: ['run_shell_command'] } },
+      },
+    );
+
+    const numLines = 20000;
+    const testFileName = 'large_output_test.txt';
+    const testFilePath = path.join(rig.testDir!, testFileName);
+
+    // Create a ~20MB file with unique content at start and end
+    const startMarker = 'START_OF_FILE_MARKER';
+    const endMarker = 'END_OF_FILE_MARKER';
+
+    const stream = fs.createWriteStream(testFilePath);
+    stream.write(startMarker + '\n');
+    for (let i = 0; i < numLines; i++) {
+      stream.write(`Line ${i + 1}: ` + 'A'.repeat(1000) + '\n');
+    }
+    stream.write(endMarker + '\n');
+    await new Promise((resolve) => stream.end(resolve));
+
+    const fileSize = fs.statSync(testFilePath).size;
+    expect(fileSize).toBeGreaterThan(20000000);
+
+    const prompt = `Use run_shell_command to cat ${testFileName} and say 'Done.'`;
+    await rig.run({ args: prompt });
+
+    await rig.waitForToolCall('run_shell_command', 20000);
+
+    let savedFilePath = '';
+    const tmpdir = os.tmpdir();
+    const tmpFiles = fs.readdirSync(tmpdir);
+    for (const file of tmpFiles) {
+      if (file.startsWith('gemini_shell_output_') && file.endsWith('.log')) {
+        const p = path.join(tmpdir, file);
+        const stat = fs.statSync(p);
+        if (Date.now() - stat.mtimeMs < 60000 && stat.size >= 20000000) {
+          savedFilePath = p;
+        }
+      }
+    }
+
+    expect(savedFilePath).toBeTruthy();
+    const savedContent = fs.readFileSync(savedFilePath, 'utf8');
+    expect(savedContent).toContain(startMarker);
+    expect(savedContent).toContain(endMarker);
+    expect(savedContent.length).toBeGreaterThanOrEqual(fileSize);
+
+    fs.unlinkSync(savedFilePath);
+  }, 120000);
+});

--- a/packages/cli/src/ui/components/AnsiOutput.tsx
+++ b/packages/cli/src/ui/components/AnsiOutput.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type React from 'react';
+import React from 'react';
 import { Box, Text } from 'ink';
 import type { AnsiLine, AnsiOutput, AnsiToken } from '@google/gemini-cli-core';
 
@@ -47,23 +47,26 @@ export const AnsiOutputText: React.FC<AnsiOutputProps> = ({
   );
 };
 
-export const AnsiLineText: React.FC<{ line: AnsiLine }> = ({ line }) => (
-  <Text>
-    {line.length > 0
-      ? line.map((token: AnsiToken, tokenIndex: number) => (
-          <Text
-            key={tokenIndex}
-            color={token.fg}
-            backgroundColor={token.bg}
-            inverse={token.inverse}
-            dimColor={token.dim}
-            bold={token.bold}
-            italic={token.italic}
-            underline={token.underline}
-          >
-            {token.text}
-          </Text>
-        ))
-      : null}
-  </Text>
+export const AnsiLineText = React.memo<{ line: AnsiLine }>(
+  ({ line }: { line: AnsiLine }) => (
+    <Text>
+      {line.length > 0
+        ? line.map((token: AnsiToken, tokenIndex: number) => (
+            <Text
+              key={tokenIndex}
+              color={token.fg}
+              backgroundColor={token.bg}
+              inverse={token.inverse}
+              dimColor={token.dim}
+              bold={token.bold}
+              italic={token.italic}
+              underline={token.underline}
+            >
+              {token.text}
+            </Text>
+          ))
+        : null}
+    </Text>
+  ),
 );
+AnsiLineText.displayName = 'AnsiLineText';

--- a/packages/cli/src/ui/components/messages/ToolResultDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/ToolResultDisplay.tsx
@@ -87,7 +87,7 @@ export const ToolResultDisplay: React.FC<ToolResultDisplayProps> = ({
     if (typeof resultDisplay === 'string') {
       let text = resultDisplay;
       if (text.length > MAXIMUM_RESULT_DISPLAY_CHARACTERS) {
-        text = '...' + text.slice(-MAXIMUM_RESULT_DISPLAY_CHARACTERS);
+        text = text.slice(0, MAXIMUM_RESULT_DISPLAY_CHARACTERS) + '...';
       }
       if (maxLines) {
         const hasTrailingNewline = text.endsWith('\n');

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.test.tsx
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.test.tsx
@@ -121,6 +121,14 @@ describe('useShellCommandProcessor', () => {
     mockIsBinary.mockReturnValue(false);
     vi.mocked(fs.existsSync).mockReturnValue(false);
 
+    vi.mocked(fs.createWriteStream).mockReturnValue({
+      write: vi.fn(),
+      end: vi.fn(),
+      destroy: vi.fn(),
+      bytesWritten: 0,
+      closed: false,
+    } as unknown as fs.WriteStream);
+
     mockShellExecutionService.mockImplementation((_cmd, _cwd, callback) => {
       mockShellOutputCallback = callback;
       return Promise.resolve({

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.test.tsx
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.test.tsx
@@ -121,14 +121,6 @@ describe('useShellCommandProcessor', () => {
     mockIsBinary.mockReturnValue(false);
     vi.mocked(fs.existsSync).mockReturnValue(false);
 
-    vi.mocked(fs.createWriteStream).mockReturnValue({
-      write: vi.fn(),
-      end: vi.fn(),
-      destroy: vi.fn(),
-      bytesWritten: 0,
-      closed: false,
-    } as unknown as fs.WriteStream);
-
     mockShellExecutionService.mockImplementation((_cmd, _cwd, callback) => {
       mockShellOutputCallback = callback;
       return Promise.resolve({

--- a/packages/cli/src/ui/hooks/shellReducer.ts
+++ b/packages/cli/src/ui/hooks/shellReducer.ts
@@ -99,6 +99,13 @@ export function shellReducer(
           typeof shell.output === 'string'
             ? shell.output + action.chunk
             : action.chunk;
+        const MAX_BG_OUTPUT_LENGTH = 100000;
+        if (
+          typeof newOutput === 'string' &&
+          newOutput.length > MAX_BG_OUTPUT_LENGTH
+        ) {
+          newOutput = newOutput.slice(-MAX_BG_OUTPUT_LENGTH);
+        }
       } else {
         newOutput = action.chunk;
       }

--- a/packages/core/src/scheduler/tool-executor.ts
+++ b/packages/core/src/scheduler/tool-executor.ts
@@ -210,8 +210,12 @@ export class ToolExecutor {
 
       if (threshold > 0 && content.length > threshold) {
         const originalContentLength = content.length;
+        const fileContent =
+          typeof toolResult.data?.rawOutput === 'string'
+            ? toolResult.data.rawOutput
+            : content;
         const { outputFile: savedPath } = await saveTruncatedToolOutput(
-          content,
+          fileContent,
           toolName,
           callId,
           this.config.storage.getProjectTempDir(),

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -57,6 +57,7 @@ vi.mock('../utils/textUtils.js', () => ({
 vi.mock('node:os', () => ({
   default: {
     platform: mockPlatform,
+    tmpdir: () => '/tmp',
     constants: {
       signals: {
         SIGTERM: 15,
@@ -65,6 +66,7 @@ vi.mock('node:os', () => ({
     },
   },
   platform: mockPlatform,
+  tmpdir: () => '/tmp',
   constants: {
     signals: {
       SIGTERM: 15,
@@ -679,7 +681,9 @@ describe('ShellExecutionService', () => {
         pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
       });
 
-      expect(result.rawOutput).toEqual(Buffer.concat([binaryChunk1]));
+      expect(result.rawOutput).toEqual(
+        Buffer.concat([binaryChunk1, binaryChunk2]),
+      );
       expect(onOutputEventMock).toHaveBeenCalledTimes(4);
       expect(onOutputEventMock.mock.calls[0][0]).toEqual({
         type: 'binary_detected',
@@ -1195,7 +1199,9 @@ describe('ShellExecutionService child_process fallback', () => {
         cp.emit('exit', 0, null);
       });
 
-      expect(result.rawOutput).toEqual(Buffer.concat([binaryChunk1]));
+      expect(result.rawOutput).toEqual(
+        Buffer.concat([binaryChunk1, binaryChunk2]),
+      );
       expect(onOutputEventMock).toHaveBeenCalledTimes(4);
       expect(onOutputEventMock.mock.calls[0][0]).toEqual({
         type: 'binary_detected',

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -679,9 +679,7 @@ describe('ShellExecutionService', () => {
         pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
       });
 
-      expect(result.rawOutput).toEqual(
-        Buffer.concat([binaryChunk1, binaryChunk2]),
-      );
+      expect(result.rawOutput).toEqual(Buffer.concat([binaryChunk1]));
       expect(onOutputEventMock).toHaveBeenCalledTimes(4);
       expect(onOutputEventMock.mock.calls[0][0]).toEqual({
         type: 'binary_detected',
@@ -1197,9 +1195,7 @@ describe('ShellExecutionService child_process fallback', () => {
         cp.emit('exit', 0, null);
       });
 
-      expect(result.rawOutput).toEqual(
-        Buffer.concat([binaryChunk1, binaryChunk2]),
-      );
+      expect(result.rawOutput).toEqual(Buffer.concat([binaryChunk1]));
       expect(onOutputEventMock).toHaveBeenCalledTimes(4);
       expect(onOutputEventMock.mock.calls[0][0]).toEqual({
         type: 'binary_detected',

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -114,6 +114,12 @@ export interface ShellExecutionConfig {
  */
 export type ShellOutputEvent =
   | {
+      /** The event contains a chunk of raw output string before PTY render. */
+      type: 'raw_data';
+      /** The raw string chunk. */
+      chunk: string;
+    }
+  | {
       /** The event contains a chunk of output data. */
       type: 'data';
       /** The decoded string chunk. */
@@ -142,6 +148,7 @@ interface ActivePty {
   ptyProcess: IPty;
   headlessTerminal: pkg.Terminal;
   maxSerializedLines?: number;
+  lastSerializedOutput?: AnsiOutput;
 }
 
 interface ActiveChildProcess {
@@ -149,7 +156,6 @@ interface ActiveChildProcess {
   state: {
     output: string;
     truncated: boolean;
-    outputChunks: Buffer[];
   };
 }
 
@@ -325,7 +331,6 @@ export class ShellExecutionService {
       const state = {
         output: '',
         truncated: false,
-        outputChunks: [] as Buffer[],
       };
 
       if (child.pid) {
@@ -348,6 +353,8 @@ export class ShellExecutionService {
         let isStreamingRawContent = true;
         const MAX_SNIFF_SIZE = 4096;
         let sniffedBytes = 0;
+        const sniffChunks: Buffer[] = [];
+        let totalBytes = 0;
 
         const handleOutput = (data: Buffer, stream: 'stdout' | 'stderr') => {
           if (!stdoutDecoder || !stderrDecoder) {
@@ -361,10 +368,11 @@ export class ShellExecutionService {
             }
           }
 
-          state.outputChunks.push(data);
+          totalBytes += data.length;
 
           if (isStreamingRawContent && sniffedBytes < MAX_SNIFF_SIZE) {
-            const sniffBuffer = Buffer.concat(state.outputChunks.slice(0, 20));
+            sniffChunks.push(data);
+            const sniffBuffer = Buffer.concat(sniffChunks);
             sniffedBytes = sniffBuffer.length;
 
             if (isBinary(sniffBuffer)) {
@@ -390,6 +398,14 @@ export class ShellExecutionService {
             }
 
             if (decodedChunk) {
+              const rawEvent: ShellOutputEvent = {
+                type: 'raw_data',
+                chunk: decodedChunk,
+              };
+              onOutputEvent(rawEvent);
+              if (child.pid)
+                ShellExecutionService.emitEvent(child.pid, rawEvent);
+
               const event: ShellOutputEvent = {
                 type: 'data',
                 chunk: decodedChunk,
@@ -398,10 +414,6 @@ export class ShellExecutionService {
               if (child.pid) ShellExecutionService.emitEvent(child.pid, event);
             }
           } else {
-            const totalBytes = state.outputChunks.reduce(
-              (sum, chunk) => sum + chunk.length,
-              0,
-            );
             const event: ShellOutputEvent = {
               type: 'binary_progress',
               bytesReceived: totalBytes,
@@ -515,7 +527,7 @@ export class ShellExecutionService {
             }
           }
 
-          const finalBuffer = Buffer.concat(state.outputChunks);
+          const finalBuffer = Buffer.concat(sniffChunks);
 
           return { finalBuffer };
         }
@@ -603,10 +615,10 @@ export class ShellExecutionService {
           maxSerializedLines: shellExecutionConfig.maxSerializedLines,
         });
 
-        let processingChain = Promise.resolve();
         let decoder: TextDecoder | null = null;
         let output: string | AnsiOutput | null = null;
-        const outputChunks: Buffer[] = [];
+        const sniffChunks: Buffer[] = [];
+        let totalBytes = 0;
         const error: Error | null = null;
         let exited = false;
 
@@ -659,6 +671,11 @@ export class ShellExecutionService {
                 return token;
               }),
             );
+          }
+
+          const activePty = this.activePtys.get(ptyProcess.pid);
+          if (activePty) {
+            activePty.lastSerializedOutput = newOutput;
           }
 
           let lastNonEmptyLine = -1;
@@ -724,60 +741,68 @@ export class ShellExecutionService {
           }
         });
 
+        let pendingWrites = 0;
+        let exitTrigger: (() => void) | null = null;
+
         const handleOutput = (data: Buffer) => {
-          processingChain = processingChain.then(
-            () =>
-              new Promise<void>((resolve) => {
-                if (!decoder) {
-                  const encoding = getCachedEncodingForBuffer(data);
-                  try {
-                    decoder = new TextDecoder(encoding);
-                  } catch {
-                    decoder = new TextDecoder('utf-8');
-                  }
+          if (!decoder) {
+            const encoding = getCachedEncodingForBuffer(data);
+            try {
+              decoder = new TextDecoder(encoding);
+            } catch {
+              decoder = new TextDecoder('utf-8');
+            }
+          }
+
+          totalBytes += data.length;
+
+          if (isStreamingRawContent && sniffedBytes < MAX_SNIFF_SIZE) {
+            sniffChunks.push(data);
+            const sniffBuffer = Buffer.concat(sniffChunks);
+            sniffedBytes = sniffBuffer.length;
+
+            if (isBinary(sniffBuffer)) {
+              isStreamingRawContent = false;
+              const event: ShellOutputEvent = { type: 'binary_detected' };
+              onOutputEvent(event);
+              ShellExecutionService.emitEvent(ptyProcess.pid, event);
+            }
+          }
+
+          if (isStreamingRawContent) {
+            const decodedChunk = decoder.decode(data, { stream: true });
+            if (decodedChunk.length === 0) {
+              return;
+            }
+            isWriting = true;
+            pendingWrites++;
+
+            // Emit raw_data for file streaming before pty render
+            const rawEvent: ShellOutputEvent = {
+              type: 'raw_data',
+              chunk: decodedChunk,
+            };
+            onOutputEvent(rawEvent);
+            ShellExecutionService.emitEvent(ptyProcess.pid, rawEvent);
+
+            headlessTerminal.write(decodedChunk, () => {
+              pendingWrites--;
+              render();
+              if (pendingWrites === 0) {
+                isWriting = false;
+                if (exited && exitTrigger) {
+                  exitTrigger();
                 }
-
-                outputChunks.push(data);
-
-                if (isStreamingRawContent && sniffedBytes < MAX_SNIFF_SIZE) {
-                  const sniffBuffer = Buffer.concat(outputChunks.slice(0, 20));
-                  sniffedBytes = sniffBuffer.length;
-
-                  if (isBinary(sniffBuffer)) {
-                    isStreamingRawContent = false;
-                    const event: ShellOutputEvent = { type: 'binary_detected' };
-                    onOutputEvent(event);
-                    ShellExecutionService.emitEvent(ptyProcess.pid, event);
-                  }
-                }
-
-                if (isStreamingRawContent) {
-                  const decodedChunk = decoder.decode(data, { stream: true });
-                  if (decodedChunk.length === 0) {
-                    resolve();
-                    return;
-                  }
-                  isWriting = true;
-                  headlessTerminal.write(decodedChunk, () => {
-                    render();
-                    isWriting = false;
-                    resolve();
-                  });
-                } else {
-                  const totalBytes = outputChunks.reduce(
-                    (sum, chunk) => sum + chunk.length,
-                    0,
-                  );
-                  const event: ShellOutputEvent = {
-                    type: 'binary_progress',
-                    bytesReceived: totalBytes,
-                  };
-                  onOutputEvent(event);
-                  ShellExecutionService.emitEvent(ptyProcess.pid, event);
-                  resolve();
-                }
-              }),
-          );
+              }
+            });
+          } else {
+            const event: ShellOutputEvent = {
+              type: 'binary_progress',
+              bytesReceived: totalBytes,
+            };
+            onOutputEvent(event);
+            ShellExecutionService.emitEvent(ptyProcess.pid, event);
+          }
         };
 
         ptyProcess.onData((data: string) => {
@@ -822,7 +847,7 @@ export class ShellExecutionService {
               ShellExecutionService.emitEvent(ptyProcess.pid, event);
               this.activeListeners.delete(ptyProcess.pid);
 
-              const finalBuffer = Buffer.concat(outputChunks);
+              const finalBuffer = Buffer.concat(sniffChunks);
 
               resolve({
                 rawOutput: finalBuffer,
@@ -834,6 +859,8 @@ export class ShellExecutionService {
                 pid: ptyProcess.pid,
                 executionMethod: ptyInfo?.name ?? 'node-pty',
               });
+
+              headlessTerminal.dispose();
             };
 
             if (abortSignal.aborted) {
@@ -841,21 +868,26 @@ export class ShellExecutionService {
               return;
             }
 
-            const processingComplete = processingChain.then(() => 'processed');
-            const abortFired = new Promise<'aborted'>((res) => {
-              if (abortSignal.aborted) {
-                res('aborted');
-                return;
+            let abortListener: (() => void) | undefined;
+            const finalizeWhenReady = () => {
+              if (abortListener) {
+                abortSignal.removeEventListener('abort', abortListener);
               }
-              abortSignal.addEventListener('abort', () => res('aborted'), {
+              finalize();
+            };
+
+            if (pendingWrites === 0) {
+              finalizeWhenReady();
+            } else {
+              exitTrigger = finalizeWhenReady;
+              abortListener = () => {
+                exitTrigger = null;
+                finalizeWhenReady();
+              };
+              abortSignal.addEventListener('abort', abortListener, {
                 once: true,
               });
-            });
-
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            Promise.race([processingComplete, abortFired]).then(() => {
-              finalize();
-            });
+            }
           },
         );
 
@@ -1076,13 +1108,18 @@ export class ShellExecutionService {
       const endLine = activePty.headlessTerminal.buffer.active.length;
       const startLine = Math.max(
         0,
-        endLine - (activePty.maxSerializedLines ?? 2000),
+        endLine -
+          (activePty.maxSerializedLines ??
+            activePty.headlessTerminal.rows + 1000),
       );
       const bufferData = serializeTerminalToObject(
         activePty.headlessTerminal,
         startLine,
         endLine,
       );
+
+      activePty.lastSerializedOutput = bufferData;
+
       if (bufferData && bufferData.length > 0) {
         listener({ type: 'data', chunk: bufferData });
       }
@@ -1143,13 +1180,18 @@ export class ShellExecutionService {
       const endLine = activePty.headlessTerminal.buffer.active.length;
       const startLine = Math.max(
         0,
-        endLine - (activePty.maxSerializedLines ?? 2000),
+        endLine -
+          (activePty.maxSerializedLines ??
+            activePty.headlessTerminal.rows + 1000),
       );
       const bufferData = serializeTerminalToObject(
         activePty.headlessTerminal,
         startLine,
         endLine,
       );
+
+      activePty.lastSerializedOutput = bufferData;
+
       const event: ShellOutputEvent = { type: 'data', chunk: bufferData };
       const listeners = ShellExecutionService.activeListeners.get(pid);
       if (listeners) {


### PR DESCRIPTION
## Summary

Optimize shell output support to avoid memory usage crashes and improve performance by 30X

Before demo on the same file:
https://screencast.googleplex.com/cast/NTE1NTk3NTcyMjk1ODg0OHxkMjE4ODdjNy0xYg
Performance is so slow you may not run out of memory because you will get bored first.

After demo:
You can now read a 5GB file streamed to stdout and not crash. Performance is now generally aligned with VSCode for the same task instead of being 30X slower.
https://screencast.googleplex.com/cast/NjUyMTA1MjIyNTA3NzI0OHw5YTZiMGIwNS1jNg

Fixes #18953

