### PR TITLE
fix(sandbox): harden image packaging integrity checks

### DIFF
--- a/.github/actions/push-sandbox/action.yml
+++ b/.github/actions/push-sandbox/action.yml
@@ -77,6 +77,14 @@ runs:
           --image google/gemini-cli-sandbox:${{ steps.image_tag.outputs.FINAL_TAG }} \
           --output-file final_image_uri.txt
         echo "uri=$(cat final_image_uri.txt)" >> $GITHUB_OUTPUT
+    - name: 'verify'
+      shell: 'bash'
+      run: |-
+        docker run --rm --entrypoint sh "${{ steps.docker_build.outputs.uri }}" -lc '
+          set -e
+          node -e "const fs=require(\"node:fs\"); JSON.parse(fs.readFileSync(\"/usr/local/share/npm-global/lib/node_modules/@google/gemini-cli/package.json\",\"utf8\")); JSON.parse(fs.readFileSync(\"/usr/local/share/npm-global/lib/node_modules/@google/gemini-cli-core/package.json\",\"utf8\"));"
+          /usr/local/share/npm-global/bin/gemini --version >/dev/null
+        '
     - name: 'publish'
       shell: 'bash'
       if: "${{ inputs.dry-run != 'true' }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,10 @@ USER node
 # install gemini-cli and clean up
 COPY packages/cli/dist/google-gemini-cli-*.tgz /tmp/gemini-cli.tgz
 COPY packages/core/dist/google-gemini-cli-core-*.tgz /tmp/gemini-core.tgz
-RUN npm install -g /tmp/gemini-cli.tgz /tmp/gemini-core.tgz \
+RUN npm install -g /tmp/gemini-core.tgz \
+  && npm install -g /tmp/gemini-cli.tgz \
+  && node -e "const fs=require('node:fs'); JSON.parse(fs.readFileSync('/usr/local/share/npm-global/lib/node_modules/@google/gemini-cli/package.json','utf8')); JSON.parse(fs.readFileSync('/usr/local/share/npm-global/lib/node_modules/@google/gemini-cli-core/package.json','utf8'));" \
+  && gemini --version > /dev/null \
   && npm cache clean --force \
   && rm -f /tmp/gemini-{cli,core}.tgz
 


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

This PR fixes a `--sandbox` startup regression where published sandbox images could contain an invalid/corrupted `@google/gemini-cli-core/package.json`, causing Gemini CLI to crash with `ERR_INVALID_PACKAGE_CONFIG` (issue #19085).

The fix hardens sandbox image packaging and release verification so corrupted package metadata is caught before publish and blocked from release.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

- Updated `/Users/aviralgarg/Everything/gemini-cli/Dockerfile`:
  - installs `@google/gemini-cli-core` first, then `@google/gemini-cli` (sequential global installs instead of one combined install)
  - adds explicit in-image JSON integrity checks for:
    - `/usr/local/share/npm-global/lib/node_modules/@google/gemini-cli/package.json`
    - `/usr/local/share/npm-global/lib/node_modules/@google/gemini-cli-core/package.json`
  - adds a CLI sanity check (`gemini --version`) during image build

- Updated `/Users/aviralgarg/Everything/gemini-cli/.github/actions/push-sandbox/action.yml`:
  - adds a post-build `verify` step before publish that:
    - parses both installed package manifests inside the built image
    - runs `/usr/local/share/npm-global/bin/gemini --version`
  - prevents publishing a broken sandbox image even if build appears successful

Design intent:
- Fail fast at image build time if package install output is invalid.
- Add a release-gate verification step so CI blocks broken images from being pushed.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

Fixes #19085

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

1. Build workspace packages:
```bash
npm run build --workspaces
```
Expected: all workspace builds succeed.

2. Build sandbox image:
```bash
npm run build:sandbox -- --image google/gemini-cli-sandbox:local-test --output-file final_image_uri.txt
```
Expected: image builds successfully and writes `final_image_uri.txt`.

3. Run in-container integrity checks:
```bash
docker run --rm --entrypoint sh "$(cat final_image_uri.txt)" -lc '
  set -e
  node -e "const fs=require(\"node:fs\"); JSON.parse(fs.readFileSync(\"/usr/local/share/npm-global/lib/node_modules/@google/gemini-cli/package.json\",\"utf8\")); JSON.parse(fs.readFileSync(\"/usr/local/share/npm-global/lib/node_modules/@google/gemini-cli-core/package.json\",\"utf8\"));"
  /usr/local/share/npm-global/bin/gemini --version >/dev/null
'
```
Expected: exits 0 with no JSON parse errors and CLI version command succeeds.

4. Run repository checks:
```bash
npm run lint:all
npm run test:scripts
```
Expected: both commands pass.

5. Edge-case check (manual):
- Corrupt either installed package manifest inside a test container and rerun step 3.
Expected: JSON parse command fails non-zero, demonstrating the release gate blocks publish.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [x] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
