### PR TITLE
fix(core): resolve crash in ClearcutLogger when os.cpus() is empty

### DIFF
--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -615,14 +615,17 @@ export class ClearcutLogger {
 
     // Add hardware information only to the start session event
     const cpus = os.cpus();
-    data.push(
-      {
+    if (cpus && cpus.length > 0) {
+      data.push({
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_CPU_INFO,
         value: cpus[0].model,
-      },
+      });
+    }
+
+    data.push(
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_CPU_CORES,
-        value: cpus.length.toString(),
+        value: os.availableParallelism().toString(),
       },
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_RAM_TOTAL_GB,


### PR DESCRIPTION
## Summary

This PR fixes a critical crash in `ClearcutLogger.logStartSessionEvent` that occurs on systems where `os.cpus()` returns an empty array.

## Details

On some environments, such as Android/Termux, `os.cpus()` can return an empty array. The previous implementation attempted to access `cpus[0].model` without checking if the array was empty, leading to a `TypeError: Cannot read properties of undefined (reading 'model')`.

This PR adds a safety check for `cpus.length > 0` before accessing `cpus[0]`.

Additionally, as suggested during development, the core count logging has been updated to use `os.availableParallelism()` instead of `os.cpus().length`, which is the modern and more reliable way to determine parallelism in Node.js (available since v18.14.0/v19.4.0, and this project requires >= v20.0.0).

## Related Issues

Fixes #18527 

## How to Validate

Run the updated unit tests in `@google/gemini-cli-core`:
```bash
npm test -w @google/gemini-cli-core -- src/telemetry/clearcut-logger/clearcut-logger.test.ts
```
The new test case `handles empty os.cpus() gracefully` specifically verifies this fix.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
