### PR TITLE
fix(core): improve error type extraction for telemetry

### DIFF
--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -36,6 +36,7 @@ import { toContents } from '../code_assist/converter.js';
 import { isStructuredError } from '../utils/quotaErrorDetection.js';
 import { runInDevTraceSpan, type SpanMetadata } from '../telemetry/trace.js';
 import { debugLogger } from '../utils/debugLogger.js';
+import { getErrorType } from '../utils/errors.js';
 
 interface StructuredError {
   status: number;
@@ -167,7 +168,7 @@ export class LoggingContentGenerator implements ContentGenerator {
     serverDetails?: ServerDetails,
   ): void {
     const errorMessage = error instanceof Error ? error.message : String(error);
-    const errorType = error instanceof Error ? error.name : 'unknown';
+    const errorType = getErrorType(error);
 
     logApiError(
       this.config,

--- a/packages/core/src/utils/errors.test.ts
+++ b/packages/core/src/utils/errors.test.ts
@@ -12,6 +12,14 @@ import {
   BadRequestError,
   ForbiddenError,
   getErrorMessage,
+  getErrorType,
+  FatalAuthenticationError,
+  FatalCancellationError,
+  FatalInputError,
+  FatalSandboxError,
+  FatalConfigError,
+  FatalTurnLimitedError,
+  FatalToolExecutionError,
 } from './errors.js';
 
 describe('getErrorMessage', () => {
@@ -199,5 +207,46 @@ describe('toFriendlyError', () => {
   it('should return original error if not a Gaxios error object', () => {
     const error = new Error('Regular Error');
     expect(toFriendlyError(error)).toBe(error);
+  });
+});
+
+describe('getErrorType', () => {
+  it('should return error name for standard errors', () => {
+    expect(getErrorType(new Error('test'))).toBe('Error');
+    expect(getErrorType(new TypeError('test'))).toBe('TypeError');
+    expect(getErrorType(new SyntaxError('test'))).toBe('SyntaxError');
+  });
+
+  it('should return constructor name for custom errors', () => {
+    expect(getErrorType(new FatalAuthenticationError('test'))).toBe(
+      'FatalAuthenticationError',
+    );
+    expect(getErrorType(new FatalInputError('test'))).toBe('FatalInputError');
+    expect(getErrorType(new FatalSandboxError('test'))).toBe(
+      'FatalSandboxError',
+    );
+    expect(getErrorType(new FatalConfigError('test'))).toBe('FatalConfigError');
+    expect(getErrorType(new FatalTurnLimitedError('test'))).toBe(
+      'FatalTurnLimitedError',
+    );
+    expect(getErrorType(new FatalToolExecutionError('test'))).toBe(
+      'FatalToolExecutionError',
+    );
+    expect(getErrorType(new FatalCancellationError('test'))).toBe(
+      'FatalCancellationError',
+    );
+    expect(getErrorType(new ForbiddenError('test'))).toBe('ForbiddenError');
+    expect(getErrorType(new UnauthorizedError('test'))).toBe(
+      'UnauthorizedError',
+    );
+    expect(getErrorType(new BadRequestError('test'))).toBe('BadRequestError');
+  });
+
+  it('should return "unknown" for non-Error objects', () => {
+    expect(getErrorType('string error')).toBe('unknown');
+    expect(getErrorType(123)).toBe('unknown');
+    expect(getErrorType({})).toBe('unknown');
+    expect(getErrorType(null)).toBe('unknown');
+    expect(getErrorType(undefined)).toBe('unknown');
   });
 });

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -26,6 +26,15 @@ export function getErrorMessage(error: unknown): string {
   }
 }
 
+export function getErrorType(error: unknown): string {
+  if (!(error instanceof Error)) return 'unknown';
+
+  // Return constructor name if the generic 'Error' name is used (for custom errors)
+  return error.name === 'Error'
+    ? (error.constructor?.name ?? 'Error')
+    : error.name;
+}
+
 export class FatalError extends Error {
   constructor(
     message: string,


### PR DESCRIPTION
## Summary

Improve error type extraction for telemetry logging for API errors.
Currently 93% of the errors are just being logged as generic "Error".
<img width="290" height="314" alt="5vCyvxsdxeJuAYN (1)" src="https://github.com/user-attachments/assets/0abe7c65-7fc6-4314-ad79-66b98b49d648" />


## Details
- Updated `_logApiError` to use the granular error type name. Previously, all custom errors like "UnauthorizedError" or "FatalAuthenticationError" were being logged as generic "Error".

## Related Issues

Fixes #19481

## How to Validate

1. Run unit tests: `npm test packages/core/src/utils/errors.test.ts` and `npm test packages/core/src/core/loggingContentGenerator.test.ts`
2. Manually verify telemetry logs (if possible) or rely on the updated unit tests which mock the logging.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
