### PR TITLE
fix(plan): exclude EnterPlanMode tool from YOLO mode

### DIFF
--- a/docs/cli/plan-mode.md
+++ b/docs/cli/plan-mode.md
@@ -70,6 +70,8 @@ You can enter Plan Mode in three ways:
 3.  **Natural Language:** Ask the agent to "start a plan for...". The agent will
     then call the [`enter_plan_mode`] tool to switch modes.
 
+> **Note:** Plan Mode is not available when the CLI is in YOLO mode.
+
 ### The Planning Workflow
 
 1.  **Requirements:** The agent clarifies goals using [`ask_user`].

--- a/docs/cli/plan-mode.md
+++ b/docs/cli/plan-mode.md
@@ -69,8 +69,7 @@ You can enter Plan Mode in three ways:
 2.  **Command:** Type `/plan` in the input box.
 3.  **Natural Language:** Ask the agent to "start a plan for...". The agent will
     then call the [`enter_plan_mode`] tool to switch modes.
-
-> **Note:** Plan Mode is not available when the CLI is in YOLO mode.
+    - **Note:** This tool is not available when the CLI is in YOLO mode.
 
 ### The Planning Workflow
 

--- a/docs/tools/planning.md
+++ b/docs/tools/planning.md
@@ -11,6 +11,8 @@ by the agent when you ask it to "start a plan" using natural language. In this
 mode, the agent is restricted to read-only tools to allow for safe exploration
 and planning.
 
+> **Note:** This tool is not available when the CLI is in YOLO mode.
+
 - **Tool name:** `enter_plan_mode`
 - **Display name:** Enter Plan Mode
 - **File:** `enter-plan-mode.ts`

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1356,7 +1356,22 @@ describe('setApprovalMode with folder trust', () => {
     expect(updateSpy).toHaveBeenCalled();
   });
 
-  it('should not update system instruction when switching between non-Plan modes', () => {
+  it('should update system instruction when entering YOLO mode', () => {
+    const config = new Config(baseParams);
+    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+    vi.spyOn(config, 'getToolRegistry').mockReturnValue({
+      getTool: vi.fn().mockReturnValue(undefined),
+      unregisterTool: vi.fn(),
+      registerTool: vi.fn(),
+    } as Partial<ToolRegistry> as ToolRegistry);
+    const updateSpy = vi.spyOn(config, 'updateSystemInstructionIfInitialized');
+
+    config.setApprovalMode(ApprovalMode.YOLO);
+
+    expect(updateSpy).toHaveBeenCalled();
+  });
+
+  it('should not update system instruction when switching between non-Plan/non-YOLO modes', () => {
     const config = new Config(baseParams);
     vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
     const updateSpy = vi.spyOn(config, 'updateSystemInstructionIfInitialized');
@@ -2597,6 +2612,27 @@ describe('syncPlanModeTools', () => {
       ...baseParams,
       approvalMode: ApprovalMode.DEFAULT,
       plan: false,
+    });
+    const registry = new ToolRegistry(config, config.getMessageBus());
+    vi.spyOn(config, 'getToolRegistry').mockReturnValue(registry);
+
+    const registerSpy = vi.spyOn(registry, 'registerTool');
+    vi.spyOn(registry, 'getTool').mockReturnValue(undefined);
+
+    config.syncPlanModeTools();
+
+    const { EnterPlanModeTool } = await import('../tools/enter-plan-mode.js');
+    const registeredTool = registerSpy.mock.calls.find(
+      (call) => call[0] instanceof EnterPlanModeTool,
+    );
+    expect(registeredTool).toBeUndefined();
+  });
+
+  it('should NOT register EnterPlanModeTool when in YOLO mode, even if plan is enabled', async () => {
+    const config = new Config({
+      ...baseParams,
+      approvalMode: ApprovalMode.YOLO,
+      plan: true,
     });
     const registry = new ToolRegistry(config, config.getMessageBus());
     vi.spyOn(config, 'getToolRegistry').mockReturnValue(registry);

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1737,7 +1737,11 @@ export class Config {
     const isPlanModeTransition =
       currentMode !== mode &&
       (currentMode === ApprovalMode.PLAN || mode === ApprovalMode.PLAN);
-    if (isPlanModeTransition) {
+    const isYoloModeTransition =
+      currentMode !== mode &&
+      (currentMode === ApprovalMode.YOLO || mode === ApprovalMode.YOLO);
+
+    if (isPlanModeTransition || isYoloModeTransition) {
       this.syncPlanModeTools();
       this.updateSystemInstructionIfInitialized();
     }
@@ -1747,8 +1751,13 @@ export class Config {
    * Synchronizes enter/exit plan mode tools based on current mode.
    */
   syncPlanModeTools(): void {
-    const isPlanMode = this.getApprovalMode() === ApprovalMode.PLAN;
     const registry = this.getToolRegistry();
+    if (!registry) {
+      return;
+    }
+    const approvalMode = this.getApprovalMode();
+    const isPlanMode = approvalMode === ApprovalMode.PLAN;
+    const isYoloMode = approvalMode === ApprovalMode.YOLO;
 
     if (isPlanMode) {
       if (registry.getTool(ENTER_PLAN_MODE_TOOL_NAME)) {
@@ -1761,7 +1770,7 @@ export class Config {
       if (registry.getTool(EXIT_PLAN_MODE_TOOL_NAME)) {
         registry.unregisterTool(EXIT_PLAN_MODE_TOOL_NAME);
       }
-      if (this.planEnabled) {
+      if (this.planEnabled && !isYoloMode) {
         if (!registry.getTool(ENTER_PLAN_MODE_TOOL_NAME)) {
           registry.registerTool(new EnterPlanModeTool(this, this.messageBus));
         }


### PR DESCRIPTION
## Summary

Exclude `EnterPlanMode` tool from YOLO mode to prevent it from becoming too interactive, which defeats the purpose of YOLO mode.

## Details

- Modified `Config.setApprovalMode` to trigger system instruction updates and tool synchronization when transitioning to/from YOLO mode.
- Updated `Config.syncPlanModeTools` to avoid registering `EnterPlanModeTool` if the current mode is YOLO.
- Updated documentation in `docs/cli/plan-mode.md` and `docs/tools/planning.md` to reflect this restriction.
- Added unit tests in `packages/core/src/config/config.test.ts` to verify that the tool is not registered in YOLO mode and that system instructions are updated correctly.

## Related Issues

Closes #19569

## How to Validate

- Run unit tests: `npm test -w @google/gemini-cli-core -- src/config/config.test.ts`
- Manually verify that when in YOLO mode, the `enter_plan_mode` tool is not available in the tool registry.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
