### PR TITLE
feat(core): add gemini-3.1-pro-preview to models list

### DIFF
--- a/docs/cli/model.md
+++ b/docs/cli/model.md
@@ -19,11 +19,11 @@ Use the following command in Gemini CLI:
 
 Running this command will open a dialog with your options:
 
-| Option            | Description                                                    | Models                                                                 |
-| ----------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| Auto (Gemini 3)   | Let the system choose the best Gemini 3 model for your task.   | gemini-3-pro-preview (if enabled), gemini-3-flash-preview (if enabled) |
-| Auto (Gemini 2.5) | Let the system choose the best Gemini 2.5 model for your task. | gemini-2.5-pro, gemini-2.5-flash                                       |
-| Manual            | Select a specific model.                                       | Any available model.                                                   |
+| Option            | Description                                                    | Models                                                                                   |
+| ----------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Auto (Gemini 3)   | Let the system choose the best Gemini 3 model for your task.   | gemini-3-pro-preview (if enabled), gemini-3-flash-preview (if enabled)                   |
+| Auto (Gemini 2.5) | Let the system choose the best Gemini 2.5 model for your task. | gemini-2.5-pro, gemini-2.5-flash                                                         |
+| Manual            | Select a specific model.                                       | Any available model (e.g. gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-2.5-pro). |
 
 We recommend selecting one of the above **Auto** options. However, you can
 select **Manual** to select a specific model from those available.

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -8,6 +8,7 @@ import type React from 'react';
 import { useCallback, useContext, useMemo, useState } from 'react';
 import { Box, Text } from 'ink';
 import {
+  PREVIEW_GEMINI_3_1_PRO_MODEL,
   PREVIEW_GEMINI_MODEL,
   PREVIEW_GEMINI_FLASH_MODEL,
   PREVIEW_GEMINI_MODEL_AUTO,
@@ -44,6 +45,7 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
       DEFAULT_GEMINI_FLASH_MODEL,
       DEFAULT_GEMINI_FLASH_LITE_MODEL,
       PREVIEW_GEMINI_MODEL,
+      PREVIEW_GEMINI_3_1_PRO_MODEL,
       PREVIEW_GEMINI_FLASH_MODEL,
     ];
     if (manualModels.includes(preferredModel)) {
@@ -91,13 +93,21 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
     ];
 
     if (shouldShowPreviewModels) {
-      list.unshift({
-        value: PREVIEW_GEMINI_MODEL_AUTO,
-        title: getDisplayString(PREVIEW_GEMINI_MODEL_AUTO),
-        description:
-          'Let Gemini CLI decide the best model for the task: gemini-3-pro, gemini-3-flash',
-        key: PREVIEW_GEMINI_MODEL_AUTO,
-      });
+      list.unshift(
+        {
+          value: PREVIEW_GEMINI_3_1_PRO_MODEL,
+          title: getDisplayString(PREVIEW_GEMINI_3_1_PRO_MODEL),
+          description: 'Use Gemini 3.1 Pro (preview) directly',
+          key: PREVIEW_GEMINI_3_1_PRO_MODEL,
+        },
+        {
+          value: PREVIEW_GEMINI_MODEL_AUTO,
+          title: getDisplayString(PREVIEW_GEMINI_MODEL_AUTO),
+          description:
+            'Let Gemini CLI decide the best model for the task: gemini-3-pro, gemini-3-flash',
+          key: PREVIEW_GEMINI_MODEL_AUTO,
+        },
+      );
     }
     return list;
   }, [shouldShowPreviewModels, manualModelSelected]);
@@ -123,6 +133,11 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
 
     if (shouldShowPreviewModels) {
       list.unshift(
+        {
+          value: PREVIEW_GEMINI_3_1_PRO_MODEL,
+          title: PREVIEW_GEMINI_3_1_PRO_MODEL,
+          key: PREVIEW_GEMINI_3_1_PRO_MODEL,
+        },
         {
           value: PREVIEW_GEMINI_MODEL,
           title: PREVIEW_GEMINI_MODEL,

--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -71,6 +71,12 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
         model: 'gemini-3-flash-preview',
       },
     },
+    'gemini-3.1-pro-preview': {
+      extends: 'chat-base-3',
+      modelConfig: {
+        model: 'gemini-3.1-pro-preview',
+      },
+    },
     'gemini-2.5-pro': {
       extends: 'chat-base-2.5',
       modelConfig: {
@@ -216,6 +222,11 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
     'chat-compression-3-flash': {
       modelConfig: {
         model: 'gemini-3-flash-preview',
+      },
+    },
+    'chat-compression-3.1-pro': {
+      modelConfig: {
+        model: 'gemini-3.1-pro-preview',
       },
     },
     'chat-compression-2.5-pro': {

--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -16,6 +16,7 @@ import {
   getDisplayString,
   DEFAULT_GEMINI_MODEL,
   PREVIEW_GEMINI_MODEL,
+  PREVIEW_GEMINI_3_1_PRO_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
   DEFAULT_GEMINI_FLASH_LITE_MODEL,
   supportsMultimodalFunctionResponse,
@@ -38,6 +39,7 @@ describe('isCustomModel', () => {
     expect(isCustomModel('gemini-1.5-pro')).toBe(false);
     expect(isCustomModel('gemini-2.0-flash')).toBe(false);
     expect(isCustomModel('gemini-3-pro-preview')).toBe(false);
+    expect(isCustomModel('gemini-3.1-pro-preview')).toBe(false);
   });
 
   it('should return false for aliases that resolve to Gemini models', () => {
@@ -49,6 +51,7 @@ describe('isCustomModel', () => {
 describe('supportsModernFeatures', () => {
   it('should return true for Gemini 3 models', () => {
     expect(supportsModernFeatures('gemini-3-pro-preview')).toBe(true);
+    expect(supportsModernFeatures('gemini-3.1-pro-preview')).toBe(true);
     expect(supportsModernFeatures('gemini-3-flash-preview')).toBe(true);
   });
 
@@ -75,6 +78,7 @@ describe('isGemini3Model', () => {
   it('should return true for gemini-3 models', () => {
     expect(isGemini3Model('gemini-3-pro-preview')).toBe(true);
     expect(isGemini3Model('gemini-3-flash-preview')).toBe(true);
+    expect(isGemini3Model('gemini-3.1-pro-preview')).toBe(true);
   });
 
   it('should return true for aliases that resolve to Gemini 3', () => {
@@ -115,6 +119,12 @@ describe('getDisplayString', () => {
     );
   });
 
+  it('should return Gemini 3.1 Pro (preview) for gemini-3.1-pro-preview', () => {
+    expect(getDisplayString(PREVIEW_GEMINI_3_1_PRO_MODEL)).toBe(
+      'Gemini 3.1 Pro (preview)',
+    );
+  });
+
   it('should return the model name as is for other models', () => {
     expect(getDisplayString('custom-model')).toBe('custom-model');
     expect(getDisplayString(DEFAULT_GEMINI_FLASH_LITE_MODEL)).toBe(
@@ -124,8 +134,11 @@ describe('getDisplayString', () => {
 });
 
 describe('supportsMultimodalFunctionResponse', () => {
-  it('should return true for gemini-3 model', () => {
+  it('should return true for gemini-3 and gemini-3.1 models', () => {
     expect(supportsMultimodalFunctionResponse('gemini-3-pro')).toBe(true);
+    expect(supportsMultimodalFunctionResponse('gemini-3-pro-preview')).toBe(
+      true,
+    );
   });
 
   it('should return false for gemini-2 models', () => {
@@ -226,6 +239,12 @@ describe('resolveClassifierModel', () => {
     expect(
       resolveClassifierModel(
         PREVIEW_GEMINI_MODEL_AUTO,
+        GEMINI_MODEL_ALIAS_FLASH,
+      ),
+    ).toBe(PREVIEW_GEMINI_FLASH_MODEL);
+    expect(
+      resolveClassifierModel(
+        PREVIEW_GEMINI_3_1_PRO_MODEL,
         GEMINI_MODEL_ALIAS_FLASH,
       ),
     ).toBe(PREVIEW_GEMINI_FLASH_MODEL);

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -5,6 +5,7 @@
  */
 
 export const PREVIEW_GEMINI_MODEL = 'gemini-3-pro-preview';
+export const PREVIEW_GEMINI_3_1_PRO_MODEL = 'gemini-3.1-pro-preview';
 export const PREVIEW_GEMINI_FLASH_MODEL = 'gemini-3-flash-preview';
 export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro';
 export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash';
@@ -12,6 +13,7 @@ export const DEFAULT_GEMINI_FLASH_LITE_MODEL = 'gemini-2.5-flash-lite';
 
 export const VALID_GEMINI_MODELS = new Set([
   PREVIEW_GEMINI_MODEL,
+  PREVIEW_GEMINI_3_1_PRO_MODEL,
   PREVIEW_GEMINI_FLASH_MODEL,
   DEFAULT_GEMINI_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
@@ -83,7 +85,8 @@ export function resolveClassifierModel(
     }
     if (
       requestedModel === PREVIEW_GEMINI_MODEL_AUTO ||
-      requestedModel === PREVIEW_GEMINI_MODEL
+      requestedModel === PREVIEW_GEMINI_MODEL ||
+      requestedModel === PREVIEW_GEMINI_3_1_PRO_MODEL
     ) {
       return PREVIEW_GEMINI_FLASH_MODEL;
     }
@@ -101,6 +104,8 @@ export function getDisplayString(model: string) {
       return PREVIEW_GEMINI_MODEL;
     case GEMINI_MODEL_ALIAS_FLASH:
       return PREVIEW_GEMINI_FLASH_MODEL;
+    case PREVIEW_GEMINI_3_1_PRO_MODEL:
+      return 'Gemini 3.1 Pro (preview)';
     default:
       return model;
   }
@@ -115,6 +120,7 @@ export function getDisplayString(model: string) {
 export function isPreviewModel(model: string): boolean {
   return (
     model === PREVIEW_GEMINI_MODEL ||
+    model === PREVIEW_GEMINI_3_1_PRO_MODEL ||
     model === PREVIEW_GEMINI_FLASH_MODEL ||
     model === PREVIEW_GEMINI_MODEL_AUTO
   );
@@ -186,5 +192,6 @@ export function isAutoModel(model: string): boolean {
  * @returns True if the model supports multimodal function responses.
  */
 export function supportsMultimodalFunctionResponse(model: string): boolean {
-  return model.startsWith('gemini-3-');
+  // Gemini 3 and 3.1 (e.g. gemini-3-pro-preview, gemini-3.1-pro-preview)
+  return /^gemini-3(\.|-|$)/.test(model);
 }

--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_GEMINI_FLASH_LITE_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
   DEFAULT_GEMINI_MODEL,
+  PREVIEW_GEMINI_3_1_PRO_MODEL,
   PREVIEW_GEMINI_FLASH_MODEL,
   PREVIEW_GEMINI_MODEL,
 } from '../config/models.js';
@@ -23,6 +24,7 @@ describe('tokenLimit', () => {
 
   it('should return the correct token limit for preview models', () => {
     expect(tokenLimit(PREVIEW_GEMINI_MODEL)).toBe(1_048_576);
+    expect(tokenLimit(PREVIEW_GEMINI_3_1_PRO_MODEL)).toBe(1_048_576);
     expect(tokenLimit(PREVIEW_GEMINI_FLASH_MODEL)).toBe(1_048_576);
   });
 

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_GEMINI_FLASH_LITE_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
   DEFAULT_GEMINI_MODEL,
+  PREVIEW_GEMINI_3_1_PRO_MODEL,
   PREVIEW_GEMINI_FLASH_MODEL,
   PREVIEW_GEMINI_MODEL,
 } from '../config/models.js';
@@ -22,6 +23,7 @@ export function tokenLimit(model: Model): TokenCount {
   // Pulled from https://ai.google.dev/gemini-api/docs/models
   switch (model) {
     case PREVIEW_GEMINI_MODEL:
+    case PREVIEW_GEMINI_3_1_PRO_MODEL:
     case PREVIEW_GEMINI_FLASH_MODEL:
     case DEFAULT_GEMINI_MODEL:
     case DEFAULT_GEMINI_FLASH_MODEL:

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -119,6 +119,9 @@ describe('modelStringToModelConfigAlias', () => {
     expect(modelStringToModelConfigAlias('gemini-3-pro-preview')).toBe(
       'chat-compression-3-pro',
     );
+    expect(modelStringToModelConfigAlias('gemini-3.1-pro-preview')).toBe(
+      'chat-compression-3.1-pro',
+    );
     expect(modelStringToModelConfigAlias('gemini-2.5-pro')).toBe(
       'chat-compression-2.5-pro',
     );

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -27,6 +27,7 @@ import {
   DEFAULT_GEMINI_FLASH_LITE_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
   DEFAULT_GEMINI_MODEL,
+  PREVIEW_GEMINI_3_1_PRO_MODEL,
   PREVIEW_GEMINI_MODEL,
   PREVIEW_GEMINI_FLASH_MODEL,
 } from '../config/models.js';
@@ -102,6 +103,8 @@ export function modelStringToModelConfigAlias(model: string): string {
   switch (model) {
     case PREVIEW_GEMINI_MODEL:
       return 'chat-compression-3-pro';
+    case PREVIEW_GEMINI_3_1_PRO_MODEL:
+      return 'chat-compression-3.1-pro';
     case PREVIEW_GEMINI_FLASH_MODEL:
       return 'chat-compression-3-flash';
     case DEFAULT_GEMINI_MODEL:


### PR DESCRIPTION
## Summary
Adds support for the new **gemini-3.1-pro-preview** model so users can select and use it in Gemini CLI.

Fixes #19532

## Changes
- **Core (models):** Added `PREVIEW_GEMINI_3_1_PRO_MODEL`, included in `VALID_GEMINI_MODELS`, `isPreviewModel`, `getDisplayString`, and `resolveClassifierModel` (for flash alias).
- **Token limits & compression:** Token limit for 3.1; chat compression mapping to `chat-compression-3.1-pro`.
- **Default config:** New aliases `gemini-3.1-pro-preview` and `chat-compression-3.1-pro` in `defaultModelConfigs`.
- **CLI (ModelDialog):** Gemini 3.1 Pro (preview) shown on the main Select Model screen and at the top of the manual model list.
- **Docs:** Updated `docs/cli/model.md` so the Manual option mentions gemini-3.1-pro-preview.
- **Tests:** Coverage in `models.test.ts`, `tokenLimits.test.ts`, and `chatCompressionService.test.ts`.

## Testing
- `npm run preflight` has been run and passes (as confirmed).


## Pre-Merge Checklist


- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [x] Docker

closes #19532 