### PR TITLE
feat(cli): improve quota display in /stats command and footer

### DIFF
--- a/packages/cli/src/ui/components/ModelStatsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/ModelStatsDisplay.test.tsx
@@ -4,12 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { render } from '../../test-utils/render.js';
+import { renderWithProviders } from '../../test-utils/render.js';
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import { ModelStatsDisplay } from './ModelStatsDisplay.js';
 import * as SessionContext from '../contexts/SessionContext.js';
-import * as SettingsContext from '../contexts/SettingsContext.js';
-import type { LoadedSettings } from '../../config/settings.js';
 import type { SessionMetrics } from '../contexts/SessionContext.js';
 import { ToolCallDecision, LlmRole } from '@google/gemini-cli-core';
 
@@ -22,16 +20,7 @@ vi.mock('../contexts/SessionContext.js', async (importOriginal) => {
   };
 });
 
-vi.mock('../contexts/SettingsContext.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof SettingsContext>();
-  return {
-    ...actual,
-    useSettings: vi.fn(),
-  };
-});
-
 const useSessionStatsMock = vi.mocked(SessionContext.useSessionStats);
-const useSettingsMock = vi.mocked(SettingsContext.useSettings);
 
 const renderWithMockedStats = async (
   metrics: SessionMetrics,
@@ -51,17 +40,9 @@ const renderWithMockedStats = async (
     startNewPrompt: vi.fn(),
   });
 
-  useSettingsMock.mockReturnValue({
-    merged: {
-      ui: {
-        showUserIdentity: true,
-      },
-    },
-  } as unknown as LoadedSettings);
-
-  const result = render(
+  const result = renderWithProviders(
     <ModelStatsDisplay currentModel={currentModel} />,
-    width,
+    { width },
   );
   await result.waitUntilReady();
   return result;
@@ -474,14 +455,6 @@ describe('<ModelStatsDisplay />', () => {
   });
 
   it('should render user identity information when provided', async () => {
-    useSettingsMock.mockReturnValue({
-      merged: {
-        ui: {
-          showUserIdentity: true,
-        },
-      },
-    } as unknown as LoadedSettings);
-
     useSessionStatsMock.mockReturnValue({
       stats: {
         sessionId: 'test-session',
@@ -528,7 +501,7 @@ describe('<ModelStatsDisplay />', () => {
       startNewPrompt: vi.fn(),
     });
 
-    const { lastFrame, waitUntilReady, unmount } = render(
+    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
       <ModelStatsDisplay
         selectedAuthType="oauth"
         userEmail="test@example.com"

--- a/packages/cli/src/ui/components/ModelStatsDisplay.tsx
+++ b/packages/cli/src/ui/components/ModelStatsDisplay.tsx
@@ -65,21 +65,6 @@ export const ModelStatsDisplay: React.FC<ModelStatsDisplayProps> = ({
     ([, metrics]) => metrics.api.totalRequests > 0,
   );
 
-  if (activeModels.length === 0) {
-    return (
-      <Box
-        borderStyle="round"
-        borderColor={theme.border.default}
-        paddingTop={1}
-        paddingX={2}
-      >
-        <Text color={theme.text.primary}>
-          No API calls have been made in this session.
-        </Text>
-      </Box>
-    );
-  }
-
   const modelNames = activeModels.map(([name]) => name);
 
   const hasThoughts = activeModels.some(
@@ -354,19 +339,20 @@ export const ModelStatsDisplay: React.FC<ModelStatsDisplayProps> = ({
           <Text color={theme.text.primary}>{tier}</Text>
         </Box>
       )}
-      {isAuto &&
-        pooledRemaining !== undefined &&
-        pooledLimit !== undefined &&
-        pooledLimit > 0 && (
-          <QuotaStatsInfo
-            remaining={pooledRemaining}
-            limit={pooledLimit}
-            resetTime={pooledResetTime}
-          />
-        )}
+      <QuotaStatsInfo
+        remaining={pooledRemaining}
+        limit={pooledLimit}
+        resetTime={pooledResetTime}
+      />
       {(showUserIdentity || isAuto) && <Box height={1} />}
 
-      <Table data={rows} columns={columns} />
+      {activeModels.length === 0 ? (
+        <Text color={theme.text.primary}>
+          No API calls have been made in this session.
+        </Text>
+      ) : (
+        <Table data={rows} columns={columns} />
+      )}
     </Box>
   );
 };

--- a/packages/cli/src/ui/components/ModelStatsDisplay.tsx
+++ b/packages/cli/src/ui/components/ModelStatsDisplay.tsx
@@ -23,9 +23,12 @@ import {
   getDisplayString,
   isAutoModel,
   LlmRole,
+  AuthType,
+  type RetrieveUserQuotaResponse,
 } from '@google/gemini-cli-core';
 import type { QuotaStats } from '../types.js';
 import { QuotaStatsInfo } from './QuotaStatsInfo.js';
+import { useConfig } from '../contexts/ConfigContext.js';
 
 interface StatRowData {
   metric: string;
@@ -43,6 +46,7 @@ interface ModelStatsDisplayProps {
   tier?: string;
   currentModel?: string;
   quotaStats?: QuotaStats;
+  quotas?: RetrieveUserQuotaResponse;
 }
 
 export const ModelStatsDisplay: React.FC<ModelStatsDisplayProps> = ({
@@ -51,8 +55,14 @@ export const ModelStatsDisplay: React.FC<ModelStatsDisplayProps> = ({
   tier,
   currentModel,
   quotaStats,
+  quotas,
 }) => {
   const { stats } = useSessionStats();
+  const config = useConfig();
+  const useGemini3_1 = config.getGemini31LaunchedSync?.() ?? false;
+  const useCustomToolModel =
+    useGemini3_1 &&
+    config.getContentGeneratorConfig().authType === AuthType.USE_GEMINI;
 
   const pooledRemaining = quotaStats?.remaining;
   const pooledLimit = quotaStats?.limit;
@@ -343,6 +353,9 @@ export const ModelStatsDisplay: React.FC<ModelStatsDisplayProps> = ({
         remaining={pooledRemaining}
         limit={pooledLimit}
         resetTime={pooledResetTime}
+        quotas={quotas}
+        useGemini3_1={useGemini3_1}
+        useCustomToolModel={useCustomToolModel}
       />
       {(showUserIdentity || isAuto) && <Box height={1} />}
 

--- a/packages/cli/src/ui/components/QuotaDisplay.tsx
+++ b/packages/cli/src/ui/components/QuotaDisplay.tsx
@@ -42,7 +42,16 @@ export const QuotaDisplay: React.FC<QuotaDisplayProps> = ({
   });
 
   const resetInfo =
-    !terse && resetTime ? `, ${formatResetTime(resetTime)}` : '';
+    !terse && resetTime
+      ? (function (t) {
+          const formatted = formatResetTime(t);
+          const info =
+            formatted === 'Resetting...' || formatted === '< 1m'
+              ? formatted
+              : `resets in ${formatted}`;
+          return `, ${info}`;
+        })(resetTime)
+      : '';
 
   if (remaining === 0) {
     return (

--- a/packages/cli/src/ui/components/QuotaStatsInfo.tsx
+++ b/packages/cli/src/ui/components/QuotaStatsInfo.tsx
@@ -27,37 +27,59 @@ export const QuotaStatsInfo: React.FC<QuotaStatsInfoProps> = ({
   resetTime,
   showDetails = true,
 }) => {
-  if (remaining === undefined || limit === undefined || limit === 0) {
+  const hasData =
+    (remaining !== undefined && remaining !== null) ||
+    (limit !== undefined && limit !== null && limit > 0);
+
+  if (!hasData && !showDetails) {
     return null;
   }
 
-  const percentage = (remaining / limit) * 100;
-  const color = getStatusColor(percentage, {
-    green: QUOTA_THRESHOLD_HIGH,
-    yellow: QUOTA_THRESHOLD_MEDIUM,
-  });
+  const percentage =
+    limit && limit > 0 && remaining !== undefined && remaining !== null
+      ? (remaining / limit) * 100
+      : undefined;
+
+  const color =
+    percentage !== undefined
+      ? getStatusColor(percentage, {
+          green: QUOTA_THRESHOLD_HIGH,
+          yellow: QUOTA_THRESHOLD_MEDIUM,
+        })
+      : theme.text.primary;
 
   return (
     <Box flexDirection="column" marginTop={0} marginBottom={0}>
-      <Text color={color}>
-        {remaining === 0
-          ? `Limit reached`
-          : `${percentage.toFixed(0)}% usage remaining`}
-        {resetTime && `, ${formatResetTime(resetTime)}`}
-      </Text>
+      {hasData && (
+        <Text color={color}>
+          <Text bold>
+            {remaining === 0
+              ? `Limit reached`
+              : percentage !== undefined
+                ? `${percentage.toFixed(0)}%`
+                : remaining !== undefined && remaining !== null
+                  ? `${remaining.toLocaleString()}`
+                  : 'Limit reached'}
+          </Text>
+          {remaining !== 0 && (
+            <Text>
+              {percentage !== undefined ||
+              (remaining !== undefined && remaining !== null)
+                ? ' usage remaining'
+                : ''}
+            </Text>
+          )}
+          {resetTime && `, ${formatResetTime(resetTime)}`}
+        </Text>
+      )}
       {showDetails && (
         <>
           <Text color={theme.text.primary}>
-            Usage limit: {limit.toLocaleString()}
-          </Text>
-          <Text color={theme.text.primary}>
             Usage limits span all sessions and reset daily.
           </Text>
-          {remaining === 0 && (
-            <Text color={theme.text.primary}>
-              Please /auth to upgrade or switch to an API key to continue.
-            </Text>
-          )}
+          <Text color={theme.text.primary}>
+            /auth to upgrade or switch to API key.
+          </Text>
         </>
       )}
     </Box>

--- a/packages/cli/src/ui/components/QuotaStatsInfo.tsx
+++ b/packages/cli/src/ui/components/QuotaStatsInfo.tsx
@@ -69,7 +69,13 @@ export const QuotaStatsInfo: React.FC<QuotaStatsInfoProps> = ({
                 : ''}
             </Text>
           )}
-          {resetTime && `, ${formatResetTime(resetTime)}`}
+          {resetTime &&
+            `, ${(function (t) {
+              const formatted = formatResetTime(t);
+              return formatted === 'Resetting...' || formatted === '< 1m'
+                ? formatted
+                : `resets in ${formatted}`;
+            })(resetTime)}`}
         </Text>
       )}
       {showDetails && (

--- a/packages/cli/src/ui/components/QuotaStatsInfo.tsx
+++ b/packages/cli/src/ui/components/QuotaStatsInfo.tsx
@@ -57,18 +57,9 @@ export const QuotaStatsInfo: React.FC<QuotaStatsInfoProps> = ({
               ? `Limit reached`
               : percentage !== undefined
                 ? `${percentage.toFixed(0)}%`
-                : remaining !== undefined && remaining !== null
-                  ? `${remaining.toLocaleString()}`
-                  : 'Limit reached'}
+                : 'Limit reached'}
           </Text>
-          {remaining !== 0 && (
-            <Text>
-              {percentage !== undefined ||
-              (remaining !== undefined && remaining !== null)
-                ? ' usage remaining'
-                : ''}
-            </Text>
-          )}
+          {remaining !== 0 && <Text> usage remaining</Text>}
           {resetTime &&
             `, ${(function (t) {
               const formatted = formatResetTime(t);

--- a/packages/cli/src/ui/components/QuotaStatsInfo.tsx
+++ b/packages/cli/src/ui/components/QuotaStatsInfo.tsx
@@ -85,13 +85,7 @@ export const QuotaStatsInfo: React.FC<QuotaStatsInfoProps> = ({
               : `${displayPercentage.toFixed(0)}%`}
           </Text>
           {displayPercentage !== 0 && <Text> usage remaining</Text>}
-          {displayResetTime &&
-            `, ${(function (t) {
-              const formatted = formatResetTime(t);
-              return formatted === 'Resetting...' || formatted === '< 1m'
-                ? formatted
-                : `resets in ${formatted}`;
-            })(displayResetTime)}`}
+          {displayResetTime && `, ${formatResetTime(displayResetTime)}`}
         </Text>
       )}
       {showDetails && (

--- a/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -278,7 +278,13 @@ const ModelUsageTable: React.FC<{
                   </Text>
                 </Box>
                 <Box width={tokenColumnWidth} justifyContent="flex-end">
-                  <Text color={theme.text.secondary}>{row.cachedTokens}</Text>
+                  <Text
+                    color={
+                      row.isActive ? theme.text.primary : theme.text.secondary
+                    }
+                  >
+                    {row.cachedTokens}
+                  </Text>
                 </Box>
                 <Box width={tokenColumnWidth} justifyContent="flex-end">
                   <Text
@@ -294,19 +300,19 @@ const ModelUsageTable: React.FC<{
             {showQuotaColumn && (
               <Box flexGrow={1} justifyContent="flex-end">
                 {row.bucket && row.bucket.remainingFraction != null && (
-                  <Text color={theme.text.secondary}>
+                  <Text
+                    color={
+                      row.isActive ? theme.text.primary : theme.text.secondary
+                    }
+                  >
                     {(row.bucket.remainingFraction * 100).toFixed(1)}%
                     {row.bucket.resetTime && (
                       <Text color={theme.text.secondary}>
                         {' '}
                         (
-                        {(function (t) {
-                          const formatted = formatResetTime(t);
-                          return formatted === 'Resetting...' ||
-                            formatted === '< 1m'
-                            ? formatted
-                            : `Resets in ${formatted}`;
-                        })(row.bucket.resetTime)}
+                        {formatResetTime(row.bucket.resetTime, {
+                          capitalize: true,
+                        })}
                         )
                       </Text>
                     )}

--- a/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -365,10 +365,13 @@ const ModelUsageTable: React.FC<{
                       <Text color={theme.text.secondary}>
                         {' '}
                         (
-                        {formatResetTime(row.bucket.resetTime).replace(
-                          'resets in',
-                          'Resets in',
-                        )}
+                        {(function (t) {
+                          const formatted = formatResetTime(t);
+                          return formatted === 'Resetting...' ||
+                            formatted === '< 1m'
+                            ? formatted
+                            : `Resets in ${formatted}`;
+                        })(row.bucket.resetTime)}
                         )
                       </Text>
                     )}

--- a/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -157,18 +157,27 @@ const ModelUsageTable: React.FC<{
 }) => {
   const rows = buildModelRows(models, quotas, useGemini3_1, useCustomToolModel);
 
-  if (rows.length === 0) {
+  const isAuto = currentModel && isAutoModel(currentModel);
+  const modelUsageTitle = isAuto
+    ? `${getDisplayString(currentModel)} Usage`
+    : `Model Usage`;
+
+  const hasPooledQuota =
+    (pooledRemaining !== undefined && pooledRemaining !== null) ||
+    (pooledLimit !== undefined && pooledLimit !== null && pooledLimit > 0);
+
+  if (rows.length === 0 && !hasPooledQuota && !isAuto) {
     return null;
   }
 
   const showQuotaColumn = !!quotas && rows.some((row) => !!row.bucket);
 
-  const nameWidth = 25;
+  const nameWidth = 22;
   const requestsWidth = 7;
   const uncachedWidth = 15;
   const cachedWidth = 14;
   const outputTokensWidth = 15;
-  const usageLimitWidth = showQuotaColumn ? 28 : 0;
+  const usageLimitWidth = showQuotaColumn ? 40 : 0;
 
   const cacheEfficiencyColor = getStatusColor(cacheEfficiency, {
     green: CACHE_EFFICIENCY_HIGH,
@@ -182,11 +191,6 @@ const ModelUsageTable: React.FC<{
       ? usageLimitWidth
       : uncachedWidth + cachedWidth + outputTokensWidth);
 
-  const isAuto = currentModel && isAutoModel(currentModel);
-  const modelUsageTitle = isAuto
-    ? `${getDisplayString(currentModel)} Usage`
-    : `Model Usage`;
-
   return (
     <Box flexDirection="column" marginBottom={1}>
       {/* Header */}
@@ -198,178 +202,185 @@ const ModelUsageTable: React.FC<{
         </Box>
       </Box>
 
-      {isAuto &&
-        showQuotaColumn &&
-        pooledRemaining !== undefined &&
-        pooledLimit !== undefined &&
-        pooledLimit > 0 && (
-          <Box flexDirection="column" marginTop={0} marginBottom={1}>
-            <QuotaStatsInfo
-              remaining={pooledRemaining}
-              limit={pooledLimit}
-              resetTime={pooledResetTime}
-            />
+      {(hasPooledQuota || isAuto) && (
+        <Box flexDirection="column" marginTop={0} marginBottom={1}>
+          <QuotaStatsInfo
+            remaining={pooledRemaining}
+            limit={pooledLimit}
+            resetTime={pooledResetTime}
+            showDetails={true}
+          />
+          {isAuto && (
             <Text color={theme.text.primary}>
               For a full token breakdown, run `/stats model`.
             </Text>
-          </Box>
-        )}
-
-      <Box alignItems="flex-end">
-        <Box width={nameWidth}>
-          <Text bold color={theme.text.primary}>
-            Model
-          </Text>
-        </Box>
-        <Box
-          width={requestsWidth}
-          flexDirection="column"
-          alignItems="flex-end"
-          flexShrink={0}
-        >
-          <Text bold color={theme.text.primary}>
-            Reqs
-          </Text>
-        </Box>
-
-        {!showQuotaColumn && (
-          <>
-            <Box
-              width={uncachedWidth}
-              flexDirection="column"
-              alignItems="flex-end"
-              flexShrink={0}
-            >
-              <Text bold color={theme.text.primary}>
-                Input Tokens
-              </Text>
-            </Box>
-            <Box
-              width={cachedWidth}
-              flexDirection="column"
-              alignItems="flex-end"
-              flexShrink={0}
-            >
-              <Text bold color={theme.text.primary}>
-                Cache Reads
-              </Text>
-            </Box>
-            <Box
-              width={outputTokensWidth}
-              flexDirection="column"
-              alignItems="flex-end"
-              flexShrink={0}
-            >
-              <Text bold color={theme.text.primary}>
-                Output Tokens
-              </Text>
-            </Box>
-          </>
-        )}
-        {showQuotaColumn && (
-          <Box
-            width={usageLimitWidth}
-            flexDirection="column"
-            alignItems="flex-end"
-          >
-            <Text bold color={theme.text.primary}>
-              Usage remaining
-            </Text>
-          </Box>
-        )}
-      </Box>
-
-      {/* Divider */}
-      <Box
-        borderStyle="round"
-        borderBottom={true}
-        borderTop={false}
-        borderLeft={false}
-        borderRight={false}
-        borderColor={theme.border.default}
-        width={totalWidth}
-      ></Box>
-
-      {rows.map((row) => (
-        <Box key={row.key}>
-          <Box width={nameWidth}>
-            <Text
-              color={row.isActive ? theme.text.primary : theme.text.secondary}
-              wrap="truncate-end"
-            >
-              {row.modelName}
-            </Text>
-          </Box>
-          <Box
-            width={requestsWidth}
-            flexDirection="column"
-            alignItems="flex-end"
-            flexShrink={0}
-          >
-            <Text
-              color={row.isActive ? theme.text.primary : theme.text.secondary}
-            >
-              {row.requests}
-            </Text>
-          </Box>
-          {!showQuotaColumn && (
-            <>
-              <Box
-                width={uncachedWidth}
-                flexDirection="column"
-                alignItems="flex-end"
-                flexShrink={0}
-              >
-                <Text
-                  color={
-                    row.isActive ? theme.text.primary : theme.text.secondary
-                  }
-                >
-                  {row.inputTokens}
-                </Text>
-              </Box>
-              <Box
-                width={cachedWidth}
-                flexDirection="column"
-                alignItems="flex-end"
-                flexShrink={0}
-              >
-                <Text color={theme.text.secondary}>{row.cachedTokens}</Text>
-              </Box>
-              <Box
-                width={outputTokensWidth}
-                flexDirection="column"
-                alignItems="flex-end"
-                flexShrink={0}
-              >
-                <Text
-                  color={
-                    row.isActive ? theme.text.primary : theme.text.secondary
-                  }
-                >
-                  {row.outputTokens}
-                </Text>
-              </Box>
-            </>
           )}
-          <Box
-            width={usageLimitWidth}
-            flexDirection="column"
-            alignItems="flex-end"
-          >
-            {row.bucket &&
-              row.bucket.remainingFraction != null &&
-              row.bucket.resetTime && (
-                <Text color={theme.text.secondary} wrap="truncate-end">
-                  {(row.bucket.remainingFraction * 100).toFixed(1)}%{' '}
-                  {formatResetTime(row.bucket.resetTime)}
-                </Text>
-              )}
-          </Box>
         </Box>
-      ))}
+      )}
 
-      {cacheEfficiency > 0 && !showQuotaColumn && (
+      {rows.length > 0 && (
+        <>
+          <Box alignItems="flex-end">
+            <Box width={nameWidth}>
+              <Text bold color={theme.text.primary}>
+                Model
+              </Text>
+            </Box>
+            <Box
+              width={requestsWidth}
+              flexDirection="column"
+              alignItems="flex-end"
+              flexShrink={0}
+            >
+              <Text bold color={theme.text.primary}>
+                Reqs
+              </Text>
+            </Box>
+
+            {!showQuotaColumn && (
+              <>
+                <Box
+                  width={uncachedWidth}
+                  flexDirection="column"
+                  alignItems="flex-end"
+                  flexShrink={0}
+                >
+                  <Text bold color={theme.text.primary}>
+                    Input Tokens
+                  </Text>
+                </Box>
+                <Box
+                  width={cachedWidth}
+                  flexDirection="column"
+                  alignItems="flex-end"
+                  flexShrink={0}
+                >
+                  <Text bold color={theme.text.primary}>
+                    Cache Reads
+                  </Text>
+                </Box>
+                <Box
+                  width={outputTokensWidth}
+                  flexDirection="column"
+                  alignItems="flex-end"
+                  flexShrink={0}
+                >
+                  <Text bold color={theme.text.primary}>
+                    Output Tokens
+                  </Text>
+                </Box>
+              </>
+            )}
+            {showQuotaColumn && (
+              <Box width={usageLimitWidth} justifyContent="flex-end">
+                <Text bold color={theme.text.primary}>
+                  Usage left
+                </Text>
+              </Box>
+            )}
+          </Box>
+
+          {/* Divider */}
+          <Box
+            borderStyle="round"
+            borderBottom={true}
+            borderTop={false}
+            borderLeft={false}
+            borderRight={false}
+            borderColor={theme.border.default}
+            width={totalWidth}
+          ></Box>
+
+          {rows.map((row) => (
+            <Box key={row.key}>
+              <Box width={nameWidth}>
+                <Text
+                  color={
+                    row.isActive ? theme.text.primary : theme.text.secondary
+                  }
+                  wrap="truncate-end"
+                >
+                  {row.modelName}
+                </Text>
+              </Box>
+              <Box
+                width={requestsWidth}
+                flexDirection="column"
+                alignItems="flex-end"
+                flexShrink={0}
+              >
+                <Text
+                  color={
+                    row.isActive ? theme.text.primary : theme.text.secondary
+                  }
+                >
+                  {row.requests}
+                </Text>
+              </Box>
+              {!showQuotaColumn && (
+                <>
+                  <Box
+                    width={uncachedWidth}
+                    flexDirection="column"
+                    alignItems="flex-end"
+                    flexShrink={0}
+                  >
+                    <Text
+                      color={
+                        row.isActive ? theme.text.primary : theme.text.secondary
+                      }
+                    >
+                      {row.inputTokens}
+                    </Text>
+                  </Box>
+                  <Box
+                    width={cachedWidth}
+                    flexDirection="column"
+                    alignItems="flex-end"
+                    flexShrink={0}
+                  >
+                    <Text color={theme.text.secondary}>{row.cachedTokens}</Text>
+                  </Box>
+                  <Box
+                    width={outputTokensWidth}
+                    flexDirection="column"
+                    alignItems="flex-end"
+                    flexShrink={0}
+                  >
+                    <Text
+                      color={
+                        row.isActive ? theme.text.primary : theme.text.secondary
+                      }
+                    >
+                      {row.outputTokens}
+                    </Text>
+                  </Box>
+                </>
+              )}
+              <Box width={usageLimitWidth} justifyContent="flex-end">
+                {row.bucket && row.bucket.remainingFraction != null && (
+                  <Text color={theme.text.secondary}>
+                    {(row.bucket.remainingFraction * 100).toFixed(1)}%
+                    {row.bucket.resetTime && (
+                      <Text color={theme.text.secondary}>
+                        {' '}
+                        (
+                        {formatResetTime(row.bucket.resetTime).replace(
+                          'resets in',
+                          'Resets in',
+                        )}
+                        )
+                      </Text>
+                    )}
+                  </Text>
+                )}
+              </Box>
+            </Box>
+          ))}
+        </>
+      )}
+
+      {cacheEfficiency > 0 && !showQuotaColumn && rows.length > 0 && (
         <Box flexDirection="column" marginTop={1}>
           <Text color={theme.text.primary}>
             <Text color={theme.status.success}>Savings Highlight:</Text>{' '}

--- a/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -162,15 +162,7 @@ const ModelUsageTable: React.FC<{
     ? `${getDisplayString(currentModel)} Usage`
     : `Model Usage`;
 
-  const hasPooledQuota =
-    (pooledRemaining !== undefined && pooledRemaining !== null) ||
-    (pooledLimit !== undefined && pooledLimit !== null && pooledLimit > 0);
-
-  if (rows.length === 0 && !hasPooledQuota && !isAuto) {
-    return null;
-  }
-
-  const showQuotaColumn = !!quotas && rows.some((row) => !!row.bucket);
+  const showQuotaColumn = !!quotas;
 
   const nameWidth = 22;
   const requestsWidth = 7;
@@ -202,28 +194,100 @@ const ModelUsageTable: React.FC<{
         </Box>
       </Box>
 
-      {(hasPooledQuota || isAuto) && (
-        <Box flexDirection="column" marginTop={0} marginBottom={1}>
-          <QuotaStatsInfo
-            remaining={pooledRemaining}
-            limit={pooledLimit}
-            resetTime={pooledResetTime}
-            showDetails={true}
-          />
-          {isAuto && (
-            <Text color={theme.text.primary}>
-              For a full token breakdown, run `/stats model`.
-            </Text>
-          )}
-        </Box>
-      )}
+      <Box flexDirection="column" marginTop={0} marginBottom={1}>
+        <QuotaStatsInfo
+          remaining={pooledRemaining}
+          limit={pooledLimit}
+          resetTime={pooledResetTime}
+          showDetails={true}
+        />
+        {isAuto && (
+          <Text color={theme.text.primary}>
+            For a full token breakdown, run `/stats model`.
+          </Text>
+        )}
+      </Box>
 
-      {rows.length > 0 && (
-        <>
-          <Box alignItems="flex-end">
-            <Box width={nameWidth}>
+      <Box alignItems="flex-end">
+        <Box width={nameWidth}>
+          <Text bold color={theme.text.primary}>
+            Model
+          </Text>
+        </Box>
+        <Box
+          width={requestsWidth}
+          flexDirection="column"
+          alignItems="flex-end"
+          flexShrink={0}
+        >
+          <Text bold color={theme.text.primary}>
+            Reqs
+          </Text>
+        </Box>
+
+        {!showQuotaColumn && (
+          <>
+            <Box
+              width={uncachedWidth}
+              flexDirection="column"
+              alignItems="flex-end"
+              flexShrink={0}
+            >
               <Text bold color={theme.text.primary}>
-                Model
+                Input Tokens
+              </Text>
+            </Box>
+            <Box
+              width={cachedWidth}
+              flexDirection="column"
+              alignItems="flex-end"
+              flexShrink={0}
+            >
+              <Text bold color={theme.text.primary}>
+                Cache Reads
+              </Text>
+            </Box>
+            <Box
+              width={outputTokensWidth}
+              flexDirection="column"
+              alignItems="flex-end"
+              flexShrink={0}
+            >
+              <Text bold color={theme.text.primary}>
+                Output Tokens
+              </Text>
+            </Box>
+          </>
+        )}
+        {showQuotaColumn && (
+          <Box width={usageLimitWidth} justifyContent="flex-end">
+            <Text bold color={theme.text.primary}>
+              Usage left
+            </Text>
+          </Box>
+        )}
+      </Box>
+
+      {/* Divider */}
+      <Box
+        borderStyle="round"
+        borderBottom={true}
+        borderTop={false}
+        borderLeft={false}
+        borderRight={false}
+        borderColor={theme.border.default}
+        width={totalWidth}
+      ></Box>
+
+      {rows.length > 0 ? (
+        rows.map((row) => (
+          <Box key={row.key}>
+            <Box width={nameWidth}>
+              <Text
+                color={row.isActive ? theme.text.primary : theme.text.secondary}
+                wrap="truncate-end"
+              >
+                {row.modelName}
               </Text>
             </Box>
             <Box
@@ -232,11 +296,12 @@ const ModelUsageTable: React.FC<{
               alignItems="flex-end"
               flexShrink={0}
             >
-              <Text bold color={theme.text.primary}>
-                Reqs
+              <Text
+                color={row.isActive ? theme.text.primary : theme.text.secondary}
+              >
+                {row.requests}
               </Text>
             </Box>
-
             {!showQuotaColumn && (
               <>
                 <Box
@@ -245,8 +310,12 @@ const ModelUsageTable: React.FC<{
                   alignItems="flex-end"
                   flexShrink={0}
                 >
-                  <Text bold color={theme.text.primary}>
-                    Input Tokens
+                  <Text
+                    color={
+                      row.isActive ? theme.text.primary : theme.text.secondary
+                    }
+                  >
+                    {row.inputTokens}
                   </Text>
                 </Box>
                 <Box
@@ -255,9 +324,7 @@ const ModelUsageTable: React.FC<{
                   alignItems="flex-end"
                   flexShrink={0}
                 >
-                  <Text bold color={theme.text.primary}>
-                    Cache Reads
-                  </Text>
+                  <Text color={theme.text.secondary}>{row.cachedTokens}</Text>
                 </Box>
                 <Box
                   width={outputTokensWidth}
@@ -265,122 +332,43 @@ const ModelUsageTable: React.FC<{
                   alignItems="flex-end"
                   flexShrink={0}
                 >
-                  <Text bold color={theme.text.primary}>
-                    Output Tokens
+                  <Text
+                    color={
+                      row.isActive ? theme.text.primary : theme.text.secondary
+                    }
+                  >
+                    {row.outputTokens}
                   </Text>
                 </Box>
               </>
             )}
-            {showQuotaColumn && (
-              <Box width={usageLimitWidth} justifyContent="flex-end">
-                <Text bold color={theme.text.primary}>
-                  Usage left
-                </Text>
-              </Box>
-            )}
-          </Box>
-
-          {/* Divider */}
-          <Box
-            borderStyle="round"
-            borderBottom={true}
-            borderTop={false}
-            borderLeft={false}
-            borderRight={false}
-            borderColor={theme.border.default}
-            width={totalWidth}
-          ></Box>
-
-          {rows.map((row) => (
-            <Box key={row.key}>
-              <Box width={nameWidth}>
-                <Text
-                  color={
-                    row.isActive ? theme.text.primary : theme.text.secondary
-                  }
-                  wrap="truncate-end"
-                >
-                  {row.modelName}
-                </Text>
-              </Box>
-              <Box
-                width={requestsWidth}
-                flexDirection="column"
-                alignItems="flex-end"
-                flexShrink={0}
-              >
-                <Text
-                  color={
-                    row.isActive ? theme.text.primary : theme.text.secondary
-                  }
-                >
-                  {row.requests}
-                </Text>
-              </Box>
-              {!showQuotaColumn && (
-                <>
-                  <Box
-                    width={uncachedWidth}
-                    flexDirection="column"
-                    alignItems="flex-end"
-                    flexShrink={0}
-                  >
-                    <Text
-                      color={
-                        row.isActive ? theme.text.primary : theme.text.secondary
-                      }
-                    >
-                      {row.inputTokens}
+            <Box width={usageLimitWidth} justifyContent="flex-end">
+              {row.bucket && row.bucket.remainingFraction != null && (
+                <Text color={theme.text.secondary}>
+                  {(row.bucket.remainingFraction * 100).toFixed(1)}%
+                  {row.bucket.resetTime && (
+                    <Text color={theme.text.secondary}>
+                      {' '}
+                      (
+                      {(function (t) {
+                        const formatted = formatResetTime(t);
+                        return formatted === 'Resetting...' ||
+                          formatted === '< 1m'
+                          ? formatted
+                          : `Resets in ${formatted}`;
+                      })(row.bucket.resetTime)}
+                      )
                     </Text>
-                  </Box>
-                  <Box
-                    width={cachedWidth}
-                    flexDirection="column"
-                    alignItems="flex-end"
-                    flexShrink={0}
-                  >
-                    <Text color={theme.text.secondary}>{row.cachedTokens}</Text>
-                  </Box>
-                  <Box
-                    width={outputTokensWidth}
-                    flexDirection="column"
-                    alignItems="flex-end"
-                    flexShrink={0}
-                  >
-                    <Text
-                      color={
-                        row.isActive ? theme.text.primary : theme.text.secondary
-                      }
-                    >
-                      {row.outputTokens}
-                    </Text>
-                  </Box>
-                </>
+                  )}
+                </Text>
               )}
-              <Box width={usageLimitWidth} justifyContent="flex-end">
-                {row.bucket && row.bucket.remainingFraction != null && (
-                  <Text color={theme.text.secondary}>
-                    {(row.bucket.remainingFraction * 100).toFixed(1)}%
-                    {row.bucket.resetTime && (
-                      <Text color={theme.text.secondary}>
-                        {' '}
-                        (
-                        {(function (t) {
-                          const formatted = formatResetTime(t);
-                          return formatted === 'Resetting...' ||
-                            formatted === '< 1m'
-                            ? formatted
-                            : `Resets in ${formatted}`;
-                        })(row.bucket.resetTime)}
-                        )
-                      </Text>
-                    )}
-                  </Text>
-                )}
-              </Box>
             </Box>
-          ))}
-        </>
+          </Box>
+        ))
+      ) : (
+        <Box>
+          <Text color={theme.text.secondary}>No model usage recorded.</Text>
+        </Box>
       )}
 
       {cacheEfficiency > 0 && !showQuotaColumn && rows.length > 0 && (

--- a/packages/cli/src/ui/components/__snapshots__/ModelStatsDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ModelStatsDisplay.test.tsx.snap
@@ -5,6 +5,8 @@ exports[`<ModelStatsDisplay /> > should display a single model correctly 1`] = `
 │                                                                                                  │
 │  Model Stats For Nerds                                                                           │
 │                                                                                                  │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
 │  Metric                      gemini-2.5-pro                                                      │
 │  ──────────────────────────────────────────────────────────────────────────────────────────────  │
@@ -28,6 +30,8 @@ exports[`<ModelStatsDisplay /> > should display conditional rows if at least one
 │                                                                                                  │
 │  Model Stats For Nerds                                                                           │
 │                                                                                                  │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
 │  Metric                      gemini-2.5-pro                   gemini-2.5-flash                   │
 │  ──────────────────────────────────────────────────────────────────────────────────────────────  │
@@ -51,6 +55,8 @@ exports[`<ModelStatsDisplay /> > should display role breakdown correctly 1`] = `
 │                                                                                                  │
 │  Model Stats For Nerds                                                                           │
 │                                                                                                  │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
 │  Metric                      gemini-2.5-pro                                                      │
 │  ──────────────────────────────────────────────────────────────────────────────────────────────  │
@@ -78,6 +84,8 @@ exports[`<ModelStatsDisplay /> > should display stats for multiple models correc
 │                                                                                                  │
 │  Model Stats For Nerds                                                                           │
 │                                                                                                  │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
 │  Metric                      gemini-2.5-pro                   gemini-2.5-flash                   │
 │  ──────────────────────────────────────────────────────────────────────────────────────────────  │
@@ -101,6 +109,8 @@ exports[`<ModelStatsDisplay /> > should filter out invalid role names 1`] = `
 │                                                                                                  │
 │  Model Stats For Nerds                                                                           │
 │                                                                                                  │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
 │  Metric                      gemini-2.5-pro                                                      │
 │  ──────────────────────────────────────────────────────────────────────────────────────────────  │
@@ -121,6 +131,8 @@ exports[`<ModelStatsDisplay /> > should handle large values without wrapping or 
 │                                                                                                  │
 │  Model Stats For Nerds                                                                           │
 │                                                                                                  │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
 │  Metric                      gemini-2.5-pro                                                      │
 │  ──────────────────────────────────────────────────────────────────────────────────────────────  │
@@ -144,6 +156,8 @@ exports[`<ModelStatsDisplay /> > should handle long role name layout 1`] = `
 │                                                                                                  │
 │  Model Stats For Nerds                                                                           │
 │                                                                                                  │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
 │  Metric                      gemini-2.5-pro                                                      │
 │  ──────────────────────────────────────────────────────────────────────────────────────────────  │
@@ -170,6 +184,8 @@ exports[`<ModelStatsDisplay /> > should not display conditional rows if no model
 │                                                                                                  │
 │  Model Stats For Nerds                                                                           │
 │                                                                                                  │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
 │  Metric                      gemini-2.5-pro                                                      │
 │  ──────────────────────────────────────────────────────────────────────────────────────────────  │
@@ -187,6 +203,11 @@ exports[`<ModelStatsDisplay /> > should not display conditional rows if no model
 
 exports[`<ModelStatsDisplay /> > should render "no API calls" message when there are no active models 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                  │
+│  Model Stats For Nerds                                                                           │
+│                                                                                                  │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
 │  No API calls have been made in this session.                                                    │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
@@ -21,8 +21,8 @@ exports[`<StatsDisplay /> > Code Changes Display > displays Code Changes when li
 │  Usage limits span all sessions and reset daily.                                                 │
 │  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
-│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
-│  ─────────────────────────────────────────────────────────────────────────                       │
+│  Model                             Reqs   Input Tokens    Cache Reads  Output Tokens             │
+│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
 │  No model usage recorded.                                                                        │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -49,8 +49,8 @@ exports[`<StatsDisplay /> > Code Changes Display > hides Code Changes when no li
 │  Usage limits span all sessions and reset daily.                                                 │
 │  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
-│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
-│  ─────────────────────────────────────────────────────────────────────────                       │
+│  Model                             Reqs   Input Tokens    Cache Reads  Output Tokens             │
+│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
 │  No model usage recorded.                                                                        │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -77,8 +77,8 @@ exports[`<StatsDisplay /> > Conditional Color Tests > renders success rate in gr
 │  Usage limits span all sessions and reset daily.                                                 │
 │  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
-│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
-│  ─────────────────────────────────────────────────────────────────────────                       │
+│  Model                             Reqs   Input Tokens    Cache Reads  Output Tokens             │
+│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
 │  No model usage recorded.                                                                        │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -105,8 +105,8 @@ exports[`<StatsDisplay /> > Conditional Color Tests > renders success rate in re
 │  Usage limits span all sessions and reset daily.                                                 │
 │  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
-│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
-│  ─────────────────────────────────────────────────────────────────────────                       │
+│  Model                             Reqs   Input Tokens    Cache Reads  Output Tokens             │
+│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
 │  No model usage recorded.                                                                        │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -133,8 +133,8 @@ exports[`<StatsDisplay /> > Conditional Color Tests > renders success rate in ye
 │  Usage limits span all sessions and reset daily.                                                 │
 │  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
-│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
-│  ─────────────────────────────────────────────────────────────────────────                       │
+│  Model                             Reqs   Input Tokens    Cache Reads  Output Tokens             │
+│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
 │  No model usage recorded.                                                                        │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -161,9 +161,9 @@ exports[`<StatsDisplay /> > Conditional Rendering Tests > hides Efficiency secti
 │  Usage limits span all sessions and reset daily.                                                 │
 │  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
-│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
-│  ─────────────────────────────────────────────────────────────────────────                       │
-│  gemini-2.5-pro              1            100             0            100                       │
+│  Model                             Reqs   Input Tokens    Cache Reads  Output Tokens             │
+│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
+│  gemini-2.5-pro                       1            100              0            100             │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -189,8 +189,8 @@ exports[`<StatsDisplay /> > Conditional Rendering Tests > hides User Agreement w
 │  Usage limits span all sessions and reset daily.                                                 │
 │  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
-│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
-│  ─────────────────────────────────────────────────────────────────────────                       │
+│  Model                             Reqs   Input Tokens    Cache Reads  Output Tokens             │
+│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
 │  No model usage recorded.                                                                        │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -214,12 +214,13 @@ exports[`<StatsDisplay /> > Quota Display > renders model table quota percentage
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │  Model Usage                                                                                     │
+│  50% usage remaining                                                                             │
 │  Usage limits span all sessions and reset daily.                                                 │
 │  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
-│  Model                    Reqs                              Usage left                           │
-│  ─────────────────────────────────────────────────────────────────────                           │
-│  gemini-2.5-flash            -                                   50.0%                           │
+│  Model                             Reqs                                              Usage left  │
+│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
+│  gemini-2.5-flash                     -                                                   50.0%  │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -247,8 +248,8 @@ exports[`<StatsDisplay /> > Quota Display > renders pooled quota even when no mo
 │  /auth to upgrade or switch to API key.                                                          │
 │  For a full token breakdown, run \`/stats model\`.                                                 │
 │                                                                                                  │
-│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
-│  ─────────────────────────────────────────────────────────────────────────                       │
+│  Model                             Reqs   Input Tokens    Cache Reads  Output Tokens             │
+│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
 │  No model usage recorded.                                                                        │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -277,10 +278,10 @@ exports[`<StatsDisplay /> > Quota Display > renders pooled quota information for
 │  /auth to upgrade or switch to API key.                                                          │
 │  For a full token breakdown, run \`/stats model\`.                                                 │
 │                                                                                                  │
-│  Model                    Reqs                              Usage left                           │
-│  ─────────────────────────────────────────────────────────────────────                           │
-│  gemini-2.5-pro              -                                   10.0%                           │
-│  gemini-2.5-flash            -                                   70.0%                           │
+│  Model                             Reqs                                              Usage left  │
+│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
+│  gemini-2.5-pro                       -                                                   10.0%  │
+│  gemini-2.5-flash                     -                                                   70.0%  │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -303,12 +304,13 @@ exports[`<StatsDisplay /> > Quota Display > renders quota information for unused
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │  Model Usage                                                                                     │
+│  50% usage remaining, resets in 2h                                                               │
 │  Usage limits span all sessions and reset daily.                                                 │
 │  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
-│  Model                    Reqs                              Usage left                           │
-│  ─────────────────────────────────────────────────────────────────────                           │
-│  gemini-2.5-flash            -                    50.0% (Resets in 2h)                           │
+│  Model                             Reqs                                              Usage left  │
+│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
+│  gemini-2.5-flash                     -                                    50.0% (Resets in 2h)  │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -331,12 +333,13 @@ exports[`<StatsDisplay /> > Quota Display > renders quota information when quota
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │  Model Usage                                                                                     │
+│  75% usage remaining, resets in 1h 30m                                                           │
 │  Usage limits span all sessions and reset daily.                                                 │
 │  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
-│  Model                    Reqs                              Usage left                           │
-│  ─────────────────────────────────────────────────────────────────────                           │
-│  gemini-2.5-pro              1                75.0% (Resets in 1h 30m)                           │
+│  Model                             Reqs                                              Usage left  │
+│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
+│  gemini-2.5-pro                       1                                75.0% (Resets in 1h 30m)  │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -362,8 +365,8 @@ exports[`<StatsDisplay /> > Title Rendering > renders the custom title when a ti
 │  Usage limits span all sessions and reset daily.                                                 │
 │  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
-│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
-│  ─────────────────────────────────────────────────────────────────────────                       │
+│  Model                             Reqs   Input Tokens    Cache Reads  Output Tokens             │
+│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
 │  No model usage recorded.                                                                        │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -390,8 +393,8 @@ exports[`<StatsDisplay /> > Title Rendering > renders the default title when no 
 │  Usage limits span all sessions and reset daily.                                                 │
 │  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
-│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
-│  ─────────────────────────────────────────────────────────────────────────                       │
+│  Model                             Reqs   Input Tokens    Cache Reads  Output Tokens             │
+│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
 │  No model usage recorded.                                                                        │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -418,10 +421,10 @@ exports[`<StatsDisplay /> > renders a table with two models correctly 1`] = `
 │  Usage limits span all sessions and reset daily.                                                 │
 │  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
-│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
-│  ─────────────────────────────────────────────────────────────────────────                       │
-│  gemini-2.5-pro              3            500           500          2,000                       │
-│  gemini-2.5-flash            5         15,000        10,000         15,000                       │
+│  Model                             Reqs   Input Tokens    Cache Reads  Output Tokens             │
+│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
+│  gemini-2.5-pro                       3            500            500          2,000             │
+│  gemini-2.5-flash                     5         15,000         10,000         15,000             │
 │                                                                                                  │
 │  Savings Highlight: 10,500 (40.4%) of input tokens were served from the cache, reducing costs.   │
 │                                                                                                  │
@@ -450,9 +453,9 @@ exports[`<StatsDisplay /> > renders all sections when all data is present 1`] = 
 │  Usage limits span all sessions and reset daily.                                                 │
 │  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
-│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
-│  ─────────────────────────────────────────────────────────────────────────                       │
-│  gemini-2.5-pro              1             50            50            100                       │
+│  Model                             Reqs   Input Tokens    Cache Reads  Output Tokens             │
+│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
+│  gemini-2.5-pro                       1             50             50            100             │
 │                                                                                                  │
 │  Savings Highlight: 50 (50.0%) of input tokens were served from the cache, reducing costs.       │
 │                                                                                                  │
@@ -480,8 +483,8 @@ exports[`<StatsDisplay /> > renders only the Performance section in its zero sta
 │  Usage limits span all sessions and reset daily.                                                 │
 │  /auth to upgrade or switch to API key.                                                          │
 │                                                                                                  │
-│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
-│  ─────────────────────────────────────────────────────────────────────────                       │
+│  Model                             Reqs   Input Tokens    Cache Reads  Output Tokens             │
+│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
 │  No model usage recorded.                                                                        │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
@@ -118,9 +118,9 @@ exports[`<StatsDisplay /> > Conditional Rendering Tests > hides Efficiency secti
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │  Model Usage                                                                                     │
-│  Model                       Reqs   Input Tokens   Cache Reads  Output Tokens                    │
-│  ────────────────────────────────────────────────────────────────────────────                    │
-│  gemini-2.5-pro                 1            100             0            100                    │
+│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
+│  ─────────────────────────────────────────────────────────────────────────                       │
+│  gemini-2.5-pro              1            100             0            100                       │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -146,6 +146,58 @@ exports[`<StatsDisplay /> > Conditional Rendering Tests > hides User Agreement w
 "
 `;
 
+exports[`<StatsDisplay /> > Quota Display > renders model table quota percentage even when resetTime is missing 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                  │
+│  Session Stats                                                                                   │
+│                                                                                                  │
+│  Interaction Summary                                                                             │
+│  Session ID:                 test-session-id                                                     │
+│  Tool Calls:                 0 ( ✓ 0 x 0 )                                                       │
+│  Success Rate:               0.0%                                                                │
+│                                                                                                  │
+│  Performance                                                                                     │
+│  Wall Time:                  1s                                                                  │
+│  Agent Active:               0s                                                                  │
+│    » API Time:               0s (0.0%)                                                           │
+│    » Tool Time:              0s (0.0%)                                                           │
+│                                                                                                  │
+│  Model Usage                                                                                     │
+│  Model                    Reqs                              Usage left                           │
+│  ─────────────────────────────────────────────────────────────────────                           │
+│  gemini-2.5-flash            -                                   50.0%                           │
+│                                                                                                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+"
+`;
+
+exports[`<StatsDisplay /> > Quota Display > renders pooled quota even when no models have been used and no individual quotas are available 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                  │
+│  Session Stats                                                                                   │
+│                                                                                                  │
+│  Interaction Summary                                                                             │
+│  Session ID:                 test-session-id                                                     │
+│  Tool Calls:                 0 ( ✓ 0 x 0 )                                                       │
+│  Success Rate:               0.0%                                                                │
+│                                                                                                  │
+│  Performance                                                                                     │
+│  Wall Time:                  1s                                                                  │
+│  Agent Active:               0s                                                                  │
+│    » API Time:               0s (0.0%)                                                           │
+│    » Tool Time:              0s (0.0%)                                                           │
+│                                                                                                  │
+│  Auto (Gemini 3) Usage                                                                           │
+│  50% usage remaining                                                                             │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│  For a full token breakdown, run \`/stats model\`.                                                 │
+│                                                                                                  │
+│                                                                                                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+"
+`;
+
 exports[`<StatsDisplay /> > Quota Display > renders pooled quota information for auto mode 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
 │                                                                                                  │
@@ -164,14 +216,14 @@ exports[`<StatsDisplay /> > Quota Display > renders pooled quota information for
 │                                                                                                  │
 │  auto Usage                                                                                      │
 │  65% usage remaining                                                                             │
-│  Usage limit: 1,100                                                                              │
 │  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
 │  For a full token breakdown, run \`/stats model\`.                                                 │
 │                                                                                                  │
-│  Model                       Reqs             Usage remaining                                    │
-│  ────────────────────────────────────────────────────────────                                    │
-│  gemini-2.5-pro                 -                                                                │
-│  gemini-2.5-flash               -                                                                │
+│  Model                    Reqs                              Usage left                           │
+│  ─────────────────────────────────────────────────────────────────────                           │
+│  gemini-2.5-pro              -                                   10.0%                           │
+│  gemini-2.5-flash            -                                   70.0%                           │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -194,9 +246,9 @@ exports[`<StatsDisplay /> > Quota Display > renders quota information for unused
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │  Model Usage                                                                                     │
-│  Model                       Reqs             Usage remaining                                    │
-│  ────────────────────────────────────────────────────────────                                    │
-│  gemini-2.5-flash               -          50.0% resets in 2h                                    │
+│  Model                    Reqs                              Usage left                           │
+│  ─────────────────────────────────────────────────────────────────────                           │
+│  gemini-2.5-flash            -                    50.0% (Resets in 2h)                           │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -219,9 +271,9 @@ exports[`<StatsDisplay /> > Quota Display > renders quota information when quota
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │  Model Usage                                                                                     │
-│  Model                       Reqs             Usage remaining                                    │
-│  ────────────────────────────────────────────────────────────                                    │
-│  gemini-2.5-pro                 1      75.0% resets in 1h 30m                                    │
+│  Model                    Reqs                              Usage left                           │
+│  ─────────────────────────────────────────────────────────────────────                           │
+│  gemini-2.5-pro              1                75.0% (Resets in 1h 30m)                           │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -284,10 +336,10 @@ exports[`<StatsDisplay /> > renders a table with two models correctly 1`] = `
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │  Model Usage                                                                                     │
-│  Model                       Reqs   Input Tokens   Cache Reads  Output Tokens                    │
-│  ────────────────────────────────────────────────────────────────────────────                    │
-│  gemini-2.5-pro                 3            500           500          2,000                    │
-│  gemini-2.5-flash               5         15,000        10,000         15,000                    │
+│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
+│  ─────────────────────────────────────────────────────────────────────────                       │
+│  gemini-2.5-pro              3            500           500          2,000                       │
+│  gemini-2.5-flash            5         15,000        10,000         15,000                       │
 │                                                                                                  │
 │  Savings Highlight: 10,500 (40.4%) of input tokens were served from the cache, reducing costs.   │
 │                                                                                                  │
@@ -313,9 +365,9 @@ exports[`<StatsDisplay /> > renders all sections when all data is present 1`] = 
 │    » Tool Time:              123ms (55.2%)                                                       │
 │                                                                                                  │
 │  Model Usage                                                                                     │
-│  Model                       Reqs   Input Tokens   Cache Reads  Output Tokens                    │
-│  ────────────────────────────────────────────────────────────────────────────                    │
-│  gemini-2.5-pro                 1             50            50            100                    │
+│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
+│  ─────────────────────────────────────────────────────────────────────────                       │
+│  gemini-2.5-pro              1             50            50            100                       │
 │                                                                                                  │
 │  Savings Highlight: 50 (50.0%) of input tokens were served from the cache, reducing costs.       │
 │                                                                                                  │

--- a/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
@@ -17,6 +17,14 @@ exports[`<StatsDisplay /> > Code Changes Display > displays Code Changes when li
 │    » API Time:               0s (0.0%)                                                           │
 │    » Tool Time:              100ms (100.0%)                                                      │
 │                                                                                                  │
+│  Model Usage                                                                                     │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
+│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
+│  ─────────────────────────────────────────────────────────────────────────                       │
+│  No model usage recorded.                                                                        │
+│                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
 `;
@@ -36,6 +44,14 @@ exports[`<StatsDisplay /> > Code Changes Display > hides Code Changes when no li
 │  Agent Active:               100ms                                                               │
 │    » API Time:               0s (0.0%)                                                           │
 │    » Tool Time:              100ms (100.0%)                                                      │
+│                                                                                                  │
+│  Model Usage                                                                                     │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
+│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
+│  ─────────────────────────────────────────────────────────────────────────                       │
+│  No model usage recorded.                                                                        │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -57,6 +73,14 @@ exports[`<StatsDisplay /> > Conditional Color Tests > renders success rate in gr
 │    » API Time:               0s (0.0%)                                                           │
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
+│  Model Usage                                                                                     │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
+│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
+│  ─────────────────────────────────────────────────────────────────────────                       │
+│  No model usage recorded.                                                                        │
+│                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
 `;
@@ -77,6 +101,14 @@ exports[`<StatsDisplay /> > Conditional Color Tests > renders success rate in re
 │    » API Time:               0s (0.0%)                                                           │
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
+│  Model Usage                                                                                     │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
+│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
+│  ─────────────────────────────────────────────────────────────────────────                       │
+│  No model usage recorded.                                                                        │
+│                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
 `;
@@ -96,6 +128,14 @@ exports[`<StatsDisplay /> > Conditional Color Tests > renders success rate in ye
 │  Agent Active:               0s                                                                  │
 │    » API Time:               0s (0.0%)                                                           │
 │    » Tool Time:              0s (0.0%)                                                           │
+│                                                                                                  │
+│  Model Usage                                                                                     │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
+│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
+│  ─────────────────────────────────────────────────────────────────────────                       │
+│  No model usage recorded.                                                                        │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -118,6 +158,9 @@ exports[`<StatsDisplay /> > Conditional Rendering Tests > hides Efficiency secti
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │  Model Usage                                                                                     │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
 │  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
 │  ─────────────────────────────────────────────────────────────────────────                       │
 │  gemini-2.5-pro              1            100             0            100                       │
@@ -142,6 +185,14 @@ exports[`<StatsDisplay /> > Conditional Rendering Tests > hides User Agreement w
 │    » API Time:               0s (0.0%)                                                           │
 │    » Tool Time:              123ms (100.0%)                                                      │
 │                                                                                                  │
+│  Model Usage                                                                                     │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
+│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
+│  ─────────────────────────────────────────────────────────────────────────                       │
+│  No model usage recorded.                                                                        │
+│                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
 `;
@@ -163,6 +214,9 @@ exports[`<StatsDisplay /> > Quota Display > renders model table quota percentage
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │  Model Usage                                                                                     │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
 │  Model                    Reqs                              Usage left                           │
 │  ─────────────────────────────────────────────────────────────────────                           │
 │  gemini-2.5-flash            -                                   50.0%                           │
@@ -193,6 +247,9 @@ exports[`<StatsDisplay /> > Quota Display > renders pooled quota even when no mo
 │  /auth to upgrade or switch to API key.                                                          │
 │  For a full token breakdown, run \`/stats model\`.                                                 │
 │                                                                                                  │
+│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
+│  ─────────────────────────────────────────────────────────────────────────                       │
+│  No model usage recorded.                                                                        │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -246,6 +303,9 @@ exports[`<StatsDisplay /> > Quota Display > renders quota information for unused
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │  Model Usage                                                                                     │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
 │  Model                    Reqs                              Usage left                           │
 │  ─────────────────────────────────────────────────────────────────────                           │
 │  gemini-2.5-flash            -                    50.0% (Resets in 2h)                           │
@@ -271,6 +331,9 @@ exports[`<StatsDisplay /> > Quota Display > renders quota information when quota
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │  Model Usage                                                                                     │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
 │  Model                    Reqs                              Usage left                           │
 │  ─────────────────────────────────────────────────────────────────────                           │
 │  gemini-2.5-pro              1                75.0% (Resets in 1h 30m)                           │
@@ -295,6 +358,14 @@ exports[`<StatsDisplay /> > Title Rendering > renders the custom title when a ti
 │    » API Time:               0s (0.0%)                                                           │
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
+│  Model Usage                                                                                     │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
+│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
+│  ─────────────────────────────────────────────────────────────────────────                       │
+│  No model usage recorded.                                                                        │
+│                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
 `;
@@ -314,6 +385,14 @@ exports[`<StatsDisplay /> > Title Rendering > renders the default title when no 
 │  Agent Active:               0s                                                                  │
 │    » API Time:               0s (0.0%)                                                           │
 │    » Tool Time:              0s (0.0%)                                                           │
+│                                                                                                  │
+│  Model Usage                                                                                     │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
+│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
+│  ─────────────────────────────────────────────────────────────────────────                       │
+│  No model usage recorded.                                                                        │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -336,6 +415,9 @@ exports[`<StatsDisplay /> > renders a table with two models correctly 1`] = `
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │  Model Usage                                                                                     │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
 │  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
 │  ─────────────────────────────────────────────────────────────────────────                       │
 │  gemini-2.5-pro              3            500           500          2,000                       │
@@ -365,6 +447,9 @@ exports[`<StatsDisplay /> > renders all sections when all data is present 1`] = 
 │    » Tool Time:              123ms (55.2%)                                                       │
 │                                                                                                  │
 │  Model Usage                                                                                     │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
 │  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
 │  ─────────────────────────────────────────────────────────────────────────                       │
 │  gemini-2.5-pro              1             50            50            100                       │
@@ -390,6 +475,14 @@ exports[`<StatsDisplay /> > renders only the Performance section in its zero sta
 │  Agent Active:               0s                                                                  │
 │    » API Time:               0s (0.0%)                                                           │
 │    » Tool Time:              0s (0.0%)                                                           │
+│                                                                                                  │
+│  Model Usage                                                                                     │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
+│  Model                    Reqs   Input Tokens   Cache Reads  Output Tokens                       │
+│  ─────────────────────────────────────────────────────────────────────────                       │
+│  No model usage recorded.                                                                        │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "

--- a/packages/cli/src/ui/utils/displayUtils.ts
+++ b/packages/cli/src/ui/utils/displayUtils.ts
@@ -16,8 +16,8 @@ export const USER_AGREEMENT_RATE_MEDIUM = 45;
 export const CACHE_EFFICIENCY_HIGH = 40;
 export const CACHE_EFFICIENCY_MEDIUM = 15;
 
-export const QUOTA_THRESHOLD_HIGH = 20;
-export const QUOTA_THRESHOLD_MEDIUM = 5;
+export const QUOTA_THRESHOLD_HIGH = 50;
+export const QUOTA_THRESHOLD_MEDIUM = 20;
 
 // --- Color Logic ---
 export const getStatusColor = (

--- a/packages/cli/src/ui/utils/displayUtils.ts
+++ b/packages/cli/src/ui/utils/displayUtils.ts
@@ -16,8 +16,8 @@ export const USER_AGREEMENT_RATE_MEDIUM = 45;
 export const CACHE_EFFICIENCY_HIGH = 40;
 export const CACHE_EFFICIENCY_MEDIUM = 15;
 
-export const QUOTA_THRESHOLD_HIGH = 50;
-export const QUOTA_THRESHOLD_MEDIUM = 20;
+export const QUOTA_THRESHOLD_HIGH = 20;
+export const QUOTA_THRESHOLD_MEDIUM = 5;
 
 // --- Color Logic ---
 export const getStatusColor = (

--- a/packages/cli/src/ui/utils/formatters.ts
+++ b/packages/cli/src/ui/utils/formatters.ts
@@ -105,7 +105,8 @@ export const formatResetTime = (resetTime: string): string => {
   if (isNaN(date.getTime())) {
     const timestamp = parseInt(resetTime, 10);
     if (!isNaN(timestamp)) {
-      // Could be seconds or milliseconds. If < 10^12, likely seconds.
+      // Heuristic: If the timestamp is less than 10^12, it is likely in seconds
+      // (as 10^12 ms is year 2001, while 10^12 s is far in the future).
       date = new Date(timestamp < 10000000000 ? timestamp * 1000 : timestamp);
     }
   }

--- a/packages/cli/src/ui/utils/formatters.ts
+++ b/packages/cli/src/ui/utils/formatters.ts
@@ -125,23 +125,16 @@ export const formatResetTime = (
   const diff = date.getTime() - Date.now();
   if (diff <= 0) return 'Resetting...';
 
-  const totalMinutes = Math.ceil(diff / (1000 * 60));
+  const totalMinutes = Math.floor(diff / (1000 * 60));
   const hours = Math.floor(totalMinutes / 60);
   const minutes = totalMinutes % 60;
 
   const fmt = (val: number, unit: 'hour' | 'minute') =>
-    new Intl.RelativeTimeFormat('en', {
-      style: 'narrow',
-      numeric: 'always',
-    })
-      .formatToParts(val, unit)
-      .filter(
-        (p) =>
-          p.type !== 'literal' || (p.value !== 'in ' && p.value !== ' ago'),
-      )
-      .map((p) => p.value)
-      .join('')
-      .trim();
+    new Intl.NumberFormat('en', {
+      style: 'unit',
+      unit,
+      unitDisplay: 'narrow',
+    }).format(val);
 
   let timeStr = '';
   if (hours > 0 && minutes > 0) {

--- a/packages/cli/src/ui/utils/formatters.ts
+++ b/packages/cli/src/ui/utils/formatters.ts
@@ -115,7 +115,7 @@ export const formatResetTime = (resetTime: string): string => {
   }
 
   const diff = date.getTime() - Date.now();
-  if (diff <= 0) return '(Resetting...)';
+  if (diff <= 0) return 'Resetting...';
 
   const totalMinutes = Math.ceil(diff / (1000 * 60));
   const hours = Math.floor(totalMinutes / 60);
@@ -128,16 +128,13 @@ export const formatResetTime = (resetTime: string): string => {
       unitDisplay: 'narrow',
     }).format(val);
 
-  let timeStr = '';
   if (hours > 0 && minutes > 0) {
-    timeStr = `${fmt(hours, 'hour')} ${fmt(minutes, 'minute')}`;
+    return `${fmt(hours, 'hour')} ${fmt(minutes, 'minute')}`;
   } else if (hours > 0) {
-    timeStr = fmt(hours, 'hour');
+    return fmt(hours, 'hour');
   } else if (minutes > 0) {
-    timeStr = fmt(minutes, 'minute');
+    return fmt(minutes, 'minute');
   } else {
-    timeStr = '< 1m';
+    return '< 1m';
   }
-
-  return `resets in ${timeStr}`;
 };

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1338,7 +1338,9 @@ export class Config {
       // For reset time, take the one that is nearest in the future (soonest reset)
       const resetTime = [proQuota?.resetTime, flashQuota?.resetTime]
         .filter((t): t is string => !!t)
-        .sort()[0];
+        .map((t) => new Date(t))
+        .sort((a, b) => a.getTime() - b.getTime())[0]
+        ?.toISOString();
 
       return {
         remaining: (proQuota?.remaining ?? 0) + (flashQuota?.remaining ?? 0),

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -68,7 +68,10 @@ import { ideContextStore } from '../ide/ideContext.js';
 import { WriteTodosTool } from '../tools/write-todos.js';
 import type { FileSystemService } from '../services/fileSystemService.js';
 import { StandardFileSystemService } from '../services/fileSystemService.js';
-import { logRipgrepFallback, logFlashFallback } from '../telemetry/loggers.js';
+import { logRipgrepFallback, logFlashFallback ,
+  logApprovalModeSwitch,
+  logApprovalModeDuration,
+} from '../telemetry/loggers.js';
 import {
   RipgrepFallbackEvent,
   FlashFallbackEvent,
@@ -103,9 +106,7 @@ import type { EventEmitter } from 'node:events';
 import { PolicyEngine } from '../policy/policy-engine.js';
 import { ApprovalMode, type PolicyEngineConfig } from '../policy/types.js';
 import { HookSystem } from '../hooks/index.js';
-import type { UserTierId } from '../code_assist/types.js';
-import type { RetrieveUserQuotaResponse } from '../code_assist/types.js';
-import type { AdminControlsSettings } from '../code_assist/types.js';
+import type { UserTierId , RetrieveUserQuotaResponse , AdminControlsSettings } from '../code_assist/types.js';
 import type { HierarchicalMemory } from './memory.js';
 import { getCodeAssistServer } from '../code_assist/codeAssist.js';
 import type { Experiments } from '../code_assist/experiments/experiments.js';
@@ -119,10 +120,6 @@ import { debugLogger } from '../utils/debugLogger.js';
 import { SkillManager, type SkillDefinition } from '../skills/skillManager.js';
 import { startupProfiler } from '../telemetry/startupProfiler.js';
 import type { AgentDefinition } from '../agents/types.js';
-import {
-  logApprovalModeSwitch,
-  logApprovalModeDuration,
-} from '../telemetry/loggers.js';
 import { fetchAdminControls } from '../code_assist/admin/admin_controls.js';
 import { isSubpath } from '../utils/paths.js';
 import { UserHintService } from './userHintService.js';
@@ -1335,12 +1332,11 @@ export class Config {
     const flashQuota = this.modelQuotas.get(flashModel);
 
     if (proQuota || flashQuota) {
-      // For reset time, take the one that is nearest in the future (soonest reset)
+      // For reset time, take the one that is furthest in the future (most conservative)
       const resetTime = [proQuota?.resetTime, flashQuota?.resetTime]
         .filter((t): t is string => !!t)
-        .map((t) => new Date(t))
-        .sort((a, b) => a.getTime() - b.getTime())[0]
-        ?.toISOString();
+        .sort()
+        .reverse()[0];
 
       return {
         remaining: (proQuota?.remaining ?? 0) + (flashQuota?.remaining ?? 0),

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -68,7 +68,9 @@ import { ideContextStore } from '../ide/ideContext.js';
 import { WriteTodosTool } from '../tools/write-todos.js';
 import type { FileSystemService } from '../services/fileSystemService.js';
 import { StandardFileSystemService } from '../services/fileSystemService.js';
-import { logRipgrepFallback, logFlashFallback ,
+import {
+  logRipgrepFallback,
+  logFlashFallback,
   logApprovalModeSwitch,
   logApprovalModeDuration,
 } from '../telemetry/loggers.js';
@@ -106,7 +108,11 @@ import type { EventEmitter } from 'node:events';
 import { PolicyEngine } from '../policy/policy-engine.js';
 import { ApprovalMode, type PolicyEngineConfig } from '../policy/types.js';
 import { HookSystem } from '../hooks/index.js';
-import type { UserTierId , RetrieveUserQuotaResponse , AdminControlsSettings } from '../code_assist/types.js';
+import type {
+  UserTierId,
+  RetrieveUserQuotaResponse,
+  AdminControlsSettings,
+} from '../code_assist/types.js';
 import type { HierarchicalMemory } from './memory.js';
 import { getCodeAssistServer } from '../code_assist/codeAssist.js';
 import type { Experiments } from '../code_assist/experiments/experiments.js';
@@ -1335,8 +1341,8 @@ export class Config {
       // For reset time, take the one that is furthest in the future (most conservative)
       const resetTime = [proQuota?.resetTime, flashQuota?.resetTime]
         .filter((t): t is string => !!t)
-        .sort()
-        .reverse()[0];
+        .map((t) => ({ original: t, date: new Date(t) }))
+        .sort((a, b) => b.date.getTime() - a.date.getTime())[0]?.original;
 
       return {
         remaining: (proQuota?.remaining ?? 0) + (flashQuota?.remaining ?? 0),

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1335,11 +1335,10 @@ export class Config {
     const flashQuota = this.modelQuotas.get(flashModel);
 
     if (proQuota || flashQuota) {
-      // For reset time, take the one that is furthest in the future (most conservative)
+      // For reset time, take the one that is nearest in the future (soonest reset)
       const resetTime = [proQuota?.resetTime, flashQuota?.resetTime]
         .filter((t): t is string => !!t)
-        .sort()
-        .reverse()[0];
+        .sort()[0];
 
       return {
         remaining: (proQuota?.remaining ?? 0) + (flashQuota?.remaining ?? 0),


### PR DESCRIPTION
## Summary

Improve the visual styling and data visibility of API quota information in the `/stats` command and the CLI footer.
<img width="449" height="510" alt="Screenshot 2026-02-20 173418" src="https://github.com/user-attachments/assets/26cca9f0-da2e-4786-80a2-396887959171" />

## Details

- **Consistent Visibility:** Updated `/stats` and `/stats session` to show available pooled quota summary even if no models have been used in the current session.
- **Design Alignment:** Refined `QuotaStatsInfo` styling to match the requested design:
  - Bolder usage percentages for better readability.
  - Added commas before reset times.
  - Updated the `/auth` message to a more concise format.
- **Improved Formatting:**
  - Standardized the "Usage left" column in the model usage table.
  - Wrapped reset info in parentheses with capitalized "Resets in" (e.g., `(Resets in 1h 43m)`).
  - Improved `formatResetTime` to be more resilient to different date formats and handle cases where the reset is imminent (showing `< 1m`) or in the past (showing `Resetting...`).
- **Layout Robustness:** Adjusted column widths and removed truncation in `StatsDisplay` to ensure reset time information is always fully visible.
- **Resilient Rendering:** Ensured informational quota text ("Usage limits span all sessions...") renders consistently for auto-models even when specific numeric data is missing.

## Related Issues

N/A

## How to Validate

1. Run `/stats` or `/stats session` in an authenticated session.
2. Verify the quota summary block appears with bold percentages and ", resets in" formatting.
3. Verify the "Usage left" column in the model table shows percentages and `(Resets in ...)` info.
4. Run tests: `npm test packages/cli/src/ui/components/StatsDisplay.test.tsx`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
  - [ ] Windows
  - [x] Linux
    - [x] npm run

Fixes #19584