### PR TITLE
fix(settings): show descriptive error when saving system settings wit…

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -1048,12 +1048,23 @@ export function saveSettings(settingsFile: SettingsFile): void {
       settingsFile.path,
       settingsToSave as Record<string, unknown>,
     );
-  } catch (error) {
-    coreEvents.emitFeedback(
-      'error',
-      'There was an error saving your latest settings changes.',
-      error,
-    );
+  } catch (error: unknown) {
+    if (
+      error instanceof Error &&
+      (error as NodeJS.ErrnoException).code === 'EACCES'
+    ) {
+      coreEvents.emitFeedback(
+        'error',
+        `Permission denied: Cannot write to ${settingsFile.path}. Try running with sudo.`,
+        error,
+      );
+    } else {
+      coreEvents.emitFeedback(
+        'error',
+        'There was an error saving your latest settings changes.',
+        error,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #18052

## Summary
Improve error handling when saving system settings without sufficient permissions.

Previously, when attempting to save system settings without root privileges on Linux, the CLI displayed a generic error message. This change ensures that permission-related errors are reported clearly to the user.

## Details
When a filesystem operation fails with an EACCES error while saving system settings, the CLI now detects this condition and emits a descriptive error message instead of a generic failure message.

This improves user experience by clearly indicating that elevated permissions may be required.

## Related Issues
Fixes #18052

## How to Validate
1. Run the CLI on Linux without root privileges.
2. Attempt to save system settings.
3. Confirm that a descriptive "Permission denied" message is shown instead of a generic error message.

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
  - [x] Windows
  - [ ] Linux
