### PR TITLE
Fix cli_help output to return only answer field  [issue: #19463]

### DIFF
--- a/packages/core/src/agents/cli-help-agent.test.ts
+++ b/packages/core/src/agents/cli-help-agent.test.ts
@@ -55,12 +55,12 @@ describe('CliHelpAgent', () => {
     expect(query).toContain('${question}');
   });
 
-  it('should process output to a formatted JSON string', () => {
+  it('should process output to return only the answer field', () => {
     const mockOutput = {
       answer: 'This is the answer.',
       sources: ['file1.md', 'file2.md'],
     };
     const processed = localAgent.processOutput?.(mockOutput);
-    expect(processed).toBe(JSON.stringify(mockOutput, null, 2));
+    expect(processed).toBe('This is the answer.');
   });
 });

--- a/packages/core/src/agents/cli-help-agent.ts
+++ b/packages/core/src/agents/cli-help-agent.ts
@@ -49,7 +49,7 @@ export const CliHelpAgent = (
     schema: CliHelpReportSchema,
   },
 
-  processOutput: (output) => JSON.stringify(output, null, 2),
+  processOutput: (output) => output.answer,
 
   modelConfig: {
     model: GEMINI_MODEL_ALIAS_FLASH,


### PR DESCRIPTION
Summary
Fixes CLI output formatting when delegating to the cli_help subagent. Previously, the CLI would output the full JSON object including internal metadata like sources. Now it only outputs the actual answer text to users, eliminating confusing internal reasoning text.

Details
The cli_help agent was using processOutput: (output) => JSON.stringify(output, null, 2) which returned the complete response object. Changed to processOutput: (output) => output.answer to return only the user-facing answer. This affects only the final display output - internal agent logic and schema validation remain unchanged.

Updated the corresponding unit test to expect only the answer field instead of the full JSON string.

Related Issues
Fixes #19463 - CLI prints internal reasoning text when delegating to cli_help subagent instead of only showing the answer.
<img width="1919" height="1019" alt="Screenshot 2026-02-20 120333" src="https://github.com/user-attachments/assets/248d10e4-e861-4243-bfa7-5058e476ec89" />


Fixed this as you can see in the screenshot above


NOTE:-
Not validated on MacOS/Linux (Windows only).



## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [✓] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [✓] Windows
    - [✓] npm run
    - [✓] npx
    - [✓] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
