### PR TITLE
fix(cli): restore YOLO mode after exiting Plan mode

### DIFF
--- a/.gemini/skills/pr-address-comments/scripts/fetch-pr-info.js
+++ b/.gemini/skills/pr-address-comments/scripts/fetch-pr-info.js
@@ -20,7 +20,8 @@ async function run(cmd) {
       stdio: ['pipe', 'pipe', 'ignore'],
     });
     return stdout.trim();
-  } catch (_e) { // eslint-disable-line @typescript-eslint/no-unused-vars
+  } catch (_e) {
+    // eslint-disable-line @typescript-eslint/no-unused-vars
     return null;
   }
 }


### PR DESCRIPTION
Fixes #19592

### Problem
When starting with `gemini --yolo`, entering Plan mode (Shift+Tab) and then exiting with Shift+Tab always returned to Default/Manual instead of YOLO. Tool execution then required confirmation instead of staying auto-approved.

### Solution
- **Initial mode at startup:** On first run, the hook records the current approval mode (YOLO when started with `--yolo`, otherwise DEFAULT). This is used when leaving Plan so we restore the right mode.
- **Exiting Plan:** When leaving Plan via Shift+Tab, we restore the mode that was active at CLI open (YOLO or DEFAULT) instead of always restoring DEFAULT.
- **Cycle behavior:**
  - **YOLO sequence** (started with `--yolo`): YOLO → DEFAULT → AUTO_EDIT → PLAN → YOLO (repeat).
  - **Default sequence:** DEFAULT → PLAN → AUTO_EDIT → DEFAULT (repeat).
- From YOLO, Shift+Tab goes to DEFAULT so the full cycle (including Plan) is still available.

### Changes
- `packages/cli/src/ui/hooks/useApprovalModeIndicator.ts`: Added `initialModeRef` to capture mode at CLI open; cycle logic uses it so Plan exit restores YOLO or DEFAULT and the two sequences above are correct.
- `packages/cli/src/ui/hooks/useApprovalModeIndicator.test.ts`: Tests for YOLO restore after Plan, default sequence (DEFAULT → PLAN → AUTO_EDIT → DEFAULT), and updated expectations for initial `getApprovalMode` call count and cycle behavior.

### Testing
- `npm run preflight` (or `npm run test` in `packages/cli`) — all tests pass.
- Manual: Start with `gemini --yolo`, press Shift+Tab until Plan, then Shift+Tab again → returns to YOLO.

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [x] Docker
