### PR TITLE
Add support for numpad keys

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -37,7 +37,7 @@ export enum KeypressPriority {
 // Parse the key itself
 const KEY_INFO_MAP: Record<
   string,
-  { name: string; shift?: boolean; ctrl?: boolean }
+  { name: string; sequence?: string; shift?: boolean; ctrl?: boolean }
 > = {
   '[200~': { name: 'paste-start' },
   '[201~': { name: 'paste-end' },
@@ -120,6 +120,21 @@ const KEY_INFO_MAP: Record<
   '[6^': { name: 'pagedown', ctrl: true },
   '[7^': { name: 'home', ctrl: true },
   '[8^': { name: 'end', ctrl: true },
+  Oj: { name: '*', sequence: '*' },
+  Ok: { name: '+', sequence: '+' },
+  Om: { name: '-', sequence: '-' },
+  Oo: { name: '/', sequence: '/' },
+  Op: { name: '0', sequence: '0' },
+  Oq: { name: '1', sequence: '1' },
+  Or: { name: '2', sequence: '2' },
+  Os: { name: '3', sequence: '3' },
+  Ot: { name: '4', sequence: '4' },
+  Ou: { name: '5', sequence: '5' },
+  Ov: { name: '6', sequence: '6' },
+  Ow: { name: '7', sequence: '7' },
+  Ox: { name: '8', sequence: '8' },
+  Oy: { name: '9', sequence: '9' },
+  On: { name: '.', sequence: '.' },
 };
 
 const kUTF16SurrogateThreshold = 0x10000; // 2 ** 16
@@ -527,6 +542,10 @@ function* emitKeys(
       const keyInfo = KEY_INFO_MAP[code];
       if (keyInfo) {
         name = keyInfo.name;
+        if (keyInfo.sequence) {
+          sequence = keyInfo.sequence;
+          insertable = true;
+        }
         if (keyInfo.shift) {
           shift = true;
         }


### PR DESCRIPTION
## Summary

Add escape sequences for numpad keys in KEY_INFO_MAP to prevent numpad key from being ignored

## Related Issues

Closes #12288 #19469 

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

@scidomino please have a look