### PR TITLE
fix(oauth): use discoverOAuthFromWWWAuthenticate for 401-triggered OAuth discovery

### DIFF
--- a/packages/core/src/mcp/oauth-utils.test.ts
+++ b/packages/core/src/mcp/oauth-utils.test.ts
@@ -378,12 +378,18 @@ describe('OAuthUtils', () => {
   describe('isPrivateHost', () => {
     it('should detect localhost', () => {
       expect(OAuthUtils.isPrivateHost('localhost')).toBe(true);
-      expect(OAuthUtils.isPrivateHost('127.0.0.1')).toBe(true);
+      expect(OAuthUtils.isPrivateHost('LOCALHOST')).toBe(true);
       expect(OAuthUtils.isPrivateHost('::1')).toBe(true);
     });
 
-    it('should detect cloud metadata endpoint', () => {
+    it('should detect full loopback range', () => {
+      expect(OAuthUtils.isPrivateHost('127.0.0.1')).toBe(true);
+      expect(OAuthUtils.isPrivateHost('127.255.255.255')).toBe(true);
+    });
+
+    it('should detect link-local range', () => {
       expect(OAuthUtils.isPrivateHost('169.254.169.254')).toBe(true);
+      expect(OAuthUtils.isPrivateHost('169.254.0.1')).toBe(true);
     });
 
     it('should detect private IPv4 ranges', () => {
@@ -392,6 +398,12 @@ describe('OAuthUtils', () => {
       expect(OAuthUtils.isPrivateHost('172.31.255.255')).toBe(true);
       expect(OAuthUtils.isPrivateHost('192.168.1.1')).toBe(true);
       expect(OAuthUtils.isPrivateHost('0.0.0.0')).toBe(true);
+    });
+
+    it('should detect IPv6 private ranges', () => {
+      expect(OAuthUtils.isPrivateHost('[fc00::1]')).toBe(true);
+      expect(OAuthUtils.isPrivateHost('[fd12::1]')).toBe(true);
+      expect(OAuthUtils.isPrivateHost('[fe80::1]')).toBe(true);
     });
 
     it('should allow public hosts', () => {

--- a/packages/core/src/mcp/oauth-utils.ts
+++ b/packages/core/src/mcp/oauth-utils.ts
@@ -97,7 +97,12 @@ export class OAuthUtils {
     resourceMetadataUrl: string,
   ): Promise<OAuthProtectedResourceMetadata | null> {
     try {
-      const response = await fetch(resourceMetadataUrl);
+      // Disable redirect following to prevent SSRF via open redirects.
+      // An attacker could provide a URI that passes origin checks but
+      // redirects to internal resources (e.g., 169.254.169.254).
+      const response = await fetch(resourceMetadataUrl, {
+        redirect: 'error',
+      });
       if (!response.ok) {
         return null;
       }

--- a/packages/core/src/mcp/oauth-utils.ts
+++ b/packages/core/src/mcp/oauth-utils.ts
@@ -342,6 +342,20 @@ export class OAuthUtils {
       return null;
     }
 
+    // Verify the resource_metadata URI has the same origin as the MCP server
+    // to prevent SSRF via attacker-controlled WWW-Authenticate headers.
+    if (mcpServerUrl) {
+      try {
+        const metadataOrigin = new URL(resourceMetadataUri).origin;
+        const serverOrigin = new URL(mcpServerUrl).origin;
+        if (metadataOrigin !== serverOrigin) {
+          return null;
+        }
+      } catch {
+        return null;
+      }
+    }
+
     const resourceMetadata =
       await this.fetchProtectedResourceMetadata(resourceMetadataUri);
 


### PR DESCRIPTION
Fixes #18760

## Problem

`handleAutomaticOAuth()` passes the `resource_metadata` URI from the `WWW-Authenticate` header to `discoverOAuthConfig()`, which expects a base server URL. Since `resource_metadata` is already a `.well-known` URL, `discoverOAuthConfig` constructs a double-nested path like:

```
https://example.com/.well-known/oauth-protected-resource/.well-known/oauth-protected-resource
```

This 404s. The root-based fallback then fetches the root metadata but validation fails with `ResourceMismatchError` because it compares the root resource against the `.well-known` URI instead of the actual server URL.

## Fix

Replace `discoverOAuthConfig(resourceMetadataUri)` with `discoverOAuthFromWWWAuthenticate(wwwAuthenticate, serverUrl)`, which already exists in `oauth-utils.ts` and correctly:
1. Fetches the resource metadata directly from the `resource_metadata` URI
2. Validates the `resource` field against the actual MCP server URL (per RFC 9728 §7.3)
3. Discovers the authorization server from the metadata

The base-URL fallback path (`discoverOAuthConfig`) is preserved for 401 responses that don't include a `resource_metadata` in the `WWW-Authenticate` header.

## Testing

Updated existing tests in `mcp-client.test.ts` to mock `discoverOAuthFromWWWAuthenticate` on the primary path and `discoverOAuthConfig` on the fallback path. All 60 tests pass.