### PR TITLE
feat(cli): add --session-id flag to allow custom session UUID

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -97,6 +97,7 @@ export interface CliArgs {
   rawOutput: boolean | undefined;
   acceptRawOutputRisk: boolean | undefined;
   isCommand: boolean | undefined;
+  sessionId: string | undefined;
 }
 
 export async function parseArguments(
@@ -238,6 +239,12 @@ export async function parseArguments(
             }
             return value;
           },
+        })
+        .option('session-id', {
+          type: 'string',
+          nargs: 1,
+          description:
+            'Use a specific session ID instead of a randomly generated one.',
         })
         .option('list-sessions', {
           type: 'boolean',

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -496,6 +496,7 @@ describe('gemini.tsx main function kitty protocol', () => {
       rawOutput: undefined,
       acceptRawOutputRisk: undefined,
       isCommand: undefined,
+      sessionId: undefined,
     });
 
     await act(async () => {

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -431,9 +431,14 @@ export async function main() {
     }
   }
 
-  const partialConfig = await loadCliConfig(settings.merged, sessionId, argv, {
-    projectHooks: settings.workspace.settings.hooks,
-  });
+  const partialConfig = await loadCliConfig(
+    settings.merged,
+    argv.sessionId ?? sessionId,
+    argv,
+    {
+      projectHooks: settings.workspace.settings.hooks,
+    },
+  );
   adminControlsListner.setConfig(partialConfig);
 
   // Refresh auth to fetch remote admin settings from CCPA and before entering
@@ -555,9 +560,14 @@ export async function main() {
   // may have side effects.
   {
     const loadConfigHandle = startupProfiler.start('load_cli_config');
-    const config = await loadCliConfig(settings.merged, sessionId, argv, {
-      projectHooks: settings.workspace.settings.hooks,
-    });
+    const config = await loadCliConfig(
+      settings.merged,
+      argv.sessionId ?? sessionId,
+      argv,
+      {
+        projectHooks: settings.workspace.settings.hooks,
+      },
+    );
     loadConfigHandle?.end();
 
     // Initialize storage immediately after loading config to ensure that


### PR DESCRIPTION
Allows automation tools to pre-seed a session ID before launching, enabling path pre-computation without a post-launch capture step.

Fixes #19602

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
