### PR TITLE
Feature/track deleted corrupted sessions

### DIFF
--- a/packages/cli/src/utils/sessionCleanup.test.ts
+++ b/packages/cli/src/utils/sessionCleanup.test.ts
@@ -1695,5 +1695,61 @@ describe('Session Cleanup', () => {
       expect(result.disabled).toBe(false);
       expect(result.failed).toBe(1);
     });
+
+    it('should track corrupted sessions in deleted-corrupted.json', async () => {
+      const config = createMockConfig();
+      const settings: Settings = {
+        general: {
+          sessionRetention: {
+            enabled: true,
+            maxAge: '30d',
+          },
+        },
+      };
+
+      const corruptedSessionId1 = 'corrupt1-1234-5678-90ab-cdef12345678';
+      const corruptedSessionId2 = 'corrupt2-abcd-efgh-ijkl-mnop12345678';
+
+      // Mock the corrupted session file content with sessionIds
+      mockFs.readFile.mockImplementation(async (filePath) => {
+        const filePathStr = filePath.toString();
+        if (filePathStr.includes('corrupt1')) {
+          return `{"sessionId":"${corruptedSessionId1}","messages":[{"role":"user"`;
+        }
+        if (filePathStr.includes('corrupt2')) {
+          return `{"sessionId":"${corruptedSessionId2}","messages":[{"role":"user"`;
+        }
+        return '[]';
+      });
+
+      // Mock getAllSessionFiles to return corrupted files
+      mockGetAllSessionFiles.mockResolvedValue([
+        {
+          fileName: `${SESSION_FILE_PREFIX}2025-01-02T10-00-00-corrupt1.json`,
+          sessionInfo: null,
+        },
+        {
+          fileName: `${SESSION_FILE_PREFIX}2025-01-03T10-00-00-corrupt2.json`,
+          sessionInfo: null,
+        },
+      ]);
+
+      mockFs.unlink.mockResolvedValue(undefined);
+      mockFs.writeFile.mockResolvedValue(undefined);
+
+      const result = await cleanupExpiredSessions(config, settings);
+
+      expect(result.deleted).toBe(2);
+
+      // Verify that tracking file was written with the corrupted sessionIds
+      const writeFileCalls = mockFs.writeFile.mock.calls;
+      const trackingFileCall = writeFileCalls.find((call) =>
+        call[0].toString().includes('deleted-corrupted.json'),
+      );
+
+      expect(trackingFileCall).toBeDefined();
+      expect(trackingFileCall![1]).toContain(corruptedSessionId1);
+      expect(trackingFileCall![1]).toContain(corruptedSessionId2);
+    });
   });
 });

--- a/packages/cli/src/utils/sessionCleanup.ts
+++ b/packages/cli/src/utils/sessionCleanup.ts
@@ -16,6 +16,10 @@ import {
 import type { Settings, SessionRetentionSettings } from '../config/settings.js';
 import { getAllSessionFiles, type SessionFileEntry } from './sessionUtils.js';
 
+// Constants for deleted corrupted sessions tracking
+const DELETED_CORRUPTED_FILE = 'deleted-corrupted.json';
+const MAX_DELETED_TRACKING = 100;
+
 // Constants
 export const DEFAULT_MIN_RETENTION = '1d' as string;
 const MIN_MAX_COUNT = 1;
@@ -72,6 +76,13 @@ export async function cleanupExpiredSessions(
       return { ...result, disabled: true };
     }
 
+    // Also clean up old entries from deleted-corrupted tracking file
+    try {
+      await cleanupOldDeletedTracking(config.storage.getProjectTempDir());
+    } catch {
+      // Ignore errors in cleanup of tracking file
+    }
+
     // Get all session files (including corrupted ones) for this project
     const allFiles = await getAllSessionFiles(chatsDir, config.getSessionId());
     result.scanned = allFiles.length;
@@ -86,10 +97,32 @@ export async function cleanupExpiredSessions(
       retentionConfig,
     );
 
+    // Track corrupted sessions being deleted
+    const corruptedSessionIds: string[] = [];
+
     // Delete all sessions that need to be deleted
     for (const sessionToDelete of sessionsToDelete) {
       try {
         const sessionPath = path.join(chatsDir, sessionToDelete.fileName);
+
+        // Track corrupted session deletion BEFORE deleting the file
+        if (sessionToDelete.sessionInfo === null) {
+          try {
+            const content = await fs.readFile(sessionPath, 'utf-8');
+            const idMatch = content.match(/"sessionId"\s*:\s*"([^"]+)"/);
+            if (idMatch && idMatch[1]) {
+              corruptedSessionIds.push(idMatch[1]);
+            }
+          } catch {
+            const uuidMatch = sessionToDelete.fileName.match(
+              /([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/i,
+            );
+            if (uuidMatch) {
+              corruptedSessionIds.push(uuidMatch[1]);
+            }
+          }
+        }
+
         await fs.unlink(sessionPath);
 
         // ALSO cleanup Activity logs in the project logs directory
@@ -165,6 +198,22 @@ export async function cleanupExpiredSessions(
     }
 
     result.skipped = result.scanned - result.deleted - result.failed;
+
+    // Record deleted corrupted sessions
+    if (corruptedSessionIds.length > 0) {
+      try {
+        await recordDeletedCorruptedSessions(
+          config.storage.getProjectTempDir(),
+          corruptedSessionIds,
+        );
+      } catch (error) {
+        if (config.getDebugMode()) {
+          debugLogger.debug(
+            `Failed to record deleted corrupted sessions: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          );
+        }
+      }
+    }
 
     if (config.getDebugMode() && result.deleted > 0) {
       debugLogger.debug(
@@ -530,4 +579,87 @@ export async function cleanupToolOutputFiles(
   }
 
   return result;
+}
+
+/**
+ * Records deleted corrupted session IDs to a tracking file.
+ * Keeps only the most recent MAX_DELETED_TRACKING entries.
+ */
+async function recordDeletedCorruptedSessions(
+  projectTempDir: string,
+  newSessionIds: string[],
+): Promise<void> {
+  const trackingPath = path.join(projectTempDir, DELETED_CORRUPTED_FILE);
+
+  let existingIds: string[] = [];
+  try {
+    const content = await fs.readFile(trackingPath, 'utf8');
+    const data = JSON.parse(content);
+    if (Array.isArray(data)) {
+      existingIds = data;
+    }
+  } catch {
+    // Ignore if file doesn't exist or is invalid
+  }
+
+  const combined = [...newSessionIds, ...existingIds];
+
+  const unique = Array.from(new Set(combined));
+
+  const trimmed = unique.slice(0, MAX_DELETED_TRACKING);
+
+  await fs.writeFile(trackingPath, JSON.stringify(trimmed, null, 2), 'utf8');
+}
+
+/**
+ * Checks if a session ID was deleted as corrupted.
+ */
+export async function wasSessionDeletedAsCorrupted(
+  projectTempDir: string,
+  sessionId: string,
+): Promise<boolean> {
+  const trackingPath = path.join(projectTempDir, DELETED_CORRUPTED_FILE);
+
+  try {
+    const content = await fs.readFile(trackingPath, 'utf8');
+    const data = JSON.parse(content);
+    if (Array.isArray(data)) {
+      const shortId = sessionId.slice(0, 8);
+      return data.some(
+        (id) =>
+          id === sessionId ||
+          id.startsWith(shortId) ||
+          sessionId.startsWith(id),
+      );
+    }
+  } catch {
+    // Ignore if file doesn't exist or is invalid
+  }
+
+  return false;
+}
+
+/**
+ * Cleans up old entries from the deleted tracking file.
+ * Called during cleanup to prevent unbounded growth.
+ */
+async function cleanupOldDeletedTracking(
+  projectTempDir: string,
+): Promise<void> {
+  const trackingPath = path.join(projectTempDir, DELETED_CORRUPTED_FILE);
+
+  try {
+    const content = await fs.readFile(trackingPath, 'utf8');
+    const data = JSON.parse(content);
+    if (Array.isArray(data) && data.length > MAX_DELETED_TRACKING) {
+      const trimmed = data.slice(0, MAX_DELETED_TRACKING);
+      await fs.writeFile(
+        trackingPath,
+        JSON.stringify(trimmed, null, 2),
+        'utf8',
+      );
+    }
+  } catch {
+    // Ignore errors during cleanup of tracking file
+  }
 }

--- a/packages/cli/src/utils/sessionCleanup.ts
+++ b/packages/cli/src/utils/sessionCleanup.ts
@@ -76,13 +76,6 @@ export async function cleanupExpiredSessions(
       return { ...result, disabled: true };
     }
 
-    // Also clean up old entries from deleted-corrupted tracking file
-    try {
-      await cleanupOldDeletedTracking(config.storage.getProjectTempDir());
-    } catch {
-      // Ignore errors in cleanup of tracking file
-    }
-
     // Get all session files (including corrupted ones) for this project
     const allFiles = await getAllSessionFiles(chatsDir, config.getSessionId());
     result.scanned = allFiles.length;
@@ -114,11 +107,12 @@ export async function cleanupExpiredSessions(
               corruptedSessionIds.push(idMatch[1]);
             }
           } catch {
-            const uuidMatch = sessionToDelete.fileName.match(
-              /([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/i,
+            // If we can't read the file, try to extract short ID from filename
+            const match = sessionToDelete.fileName.match(
+              /-([a-f0-9]{8,})\.json$/i,
             );
-            if (uuidMatch) {
-              corruptedSessionIds.push(uuidMatch[1]);
+            if (match) {
+              corruptedSessionIds.push(match[1]);
             }
           }
         }
@@ -624,12 +618,11 @@ export async function wasSessionDeletedAsCorrupted(
     const content = await fs.readFile(trackingPath, 'utf8');
     const data = JSON.parse(content);
     if (Array.isArray(data)) {
-      const shortId = sessionId.slice(0, 8);
       return data.some(
         (id) =>
           id === sessionId ||
-          id.startsWith(shortId) ||
-          sessionId.startsWith(id),
+          (sessionId.length >= 8 && id.startsWith(sessionId)) ||
+          (id.length >= 8 && sessionId.startsWith(id)),
       );
     }
   } catch {
@@ -637,29 +630,4 @@ export async function wasSessionDeletedAsCorrupted(
   }
 
   return false;
-}
-
-/**
- * Cleans up old entries from the deleted tracking file.
- * Called during cleanup to prevent unbounded growth.
- */
-async function cleanupOldDeletedTracking(
-  projectTempDir: string,
-): Promise<void> {
-  const trackingPath = path.join(projectTempDir, DELETED_CORRUPTED_FILE);
-
-  try {
-    const content = await fs.readFile(trackingPath, 'utf8');
-    const data = JSON.parse(content);
-    if (Array.isArray(data) && data.length > MAX_DELETED_TRACKING) {
-      const trimmed = data.slice(0, MAX_DELETED_TRACKING);
-      await fs.writeFile(
-        trackingPath,
-        JSON.stringify(trimmed, null, 2),
-        'utf8',
-      );
-    }
-  } catch {
-    // Ignore errors during cleanup of tracking file
-  }
 }

--- a/packages/cli/src/utils/sessionUtils.test.ts
+++ b/packages/cli/src/utils/sessionUtils.test.ts
@@ -364,6 +364,56 @@ describe('SessionSelector', () => {
     );
   });
 
+  it('should show specific error for sessions deleted as corrupted', async () => {
+    const sessionId1 = randomUUID();
+    const deletedSessionId = randomUUID();
+
+    // Create test session files
+    const chatsDir = path.join(tmpDir, 'chats');
+    await fs.mkdir(chatsDir, { recursive: true });
+
+    const session1 = {
+      sessionId: sessionId1,
+      projectHash: 'test-hash',
+      startTime: '2024-01-01T10:00:00.000Z',
+      lastUpdated: '2024-01-01T10:30:00.000Z',
+      messages: [
+        {
+          type: 'user',
+          content: 'Test message 1',
+          id: 'msg1',
+          timestamp: '2024-01-01T10:00:00.000Z',
+        },
+      ],
+    };
+
+    await fs.writeFile(
+      path.join(
+        chatsDir,
+        `${SESSION_FILE_PREFIX}2024-01-01T10-00-${sessionId1.slice(0, 8)}.json`,
+      ),
+      JSON.stringify(session1, null, 2),
+    );
+
+    // Create a deleted-corrupted.json file with the deleted session ID
+    await fs.writeFile(
+      path.join(tmpDir, 'deleted-corrupted.json'),
+      JSON.stringify([deletedSessionId]),
+    );
+
+    const sessionSelector = new SessionSelector(config);
+
+    // Try to resolve the deleted session - should get specific error
+    await expect(
+      sessionSelector.resolveSession(deletedSessionId),
+    ).rejects.toThrow('was previously deleted because it was corrupted');
+
+    // Try to resolve a session that never existed - should get generic error
+    await expect(
+      sessionSelector.resolveSession('never-existed-uuid'),
+    ).rejects.toThrow('Invalid session identifier');
+  });
+
   it('should not list sessions with only system messages', async () => {
     const sessionIdWithUser = randomUUID();
     const sessionIdSystemOnly = randomUUID();

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -447,6 +447,22 @@ export class SessionSelector {
       return sortedSessions[index - 1];
     }
 
+    // Check if this session was deleted as corrupted
+    const { wasSessionDeletedAsCorrupted } = await import(
+      './sessionCleanup.js'
+    );
+    const wasDeleted = await wasSessionDeletedAsCorrupted(
+      this.config.storage.getProjectTempDir(),
+      identifier,
+    );
+
+    if (wasDeleted) {
+      throw new SessionError(
+        'INVALID_SESSION_IDENTIFIER',
+        `Session "${identifier}" was previously deleted because it was corrupted.\n  Use --list-sessions to see available sessions.`,
+      );
+    }
+
     throw SessionError.invalidSessionIdentifier(identifier);
   }
 


### PR DESCRIPTION
## Summary

Improves session resumption error messages by tracking deleted corrupted sessions. When users try to resume a session that was automatically deleted due to corruption, they now receive a specific error message explaining what happened, instead of a generic "invalid session identifier" error.

## Details

### Problem
When session files become corrupted (invalid JSON, missing fields, etc.), the cleanup process automatically deletes them without any record. If users try to resume these sessions, they receive a generic "Invalid session identifier" error that doesn't explain the session was previously valid but got corrupted and deleted.

### Solution
Implemented a tracking system that records sessionIds of deleted corrupted sessions:

1. **Tracking File**: `~/.gemini/tmp/<project>/deleted-corrupted.json` stores up to 100 most recent deleted corrupted session IDs
2. **SessionId Extraction**: Before deleting corrupted files, extract the sessionId from file content 
3. **Improved Error Messages**: When `--resume` fails, check tracking file and show specific error: `"Session '<uuid>' was previously deleted because it was corrupted."`


## Related Issues

Fixes #18593

## How to Validate

### 1. Create a corrupted session file
```bash
cd ~/.gemini/tmp/gemini-cli/chats/
echo '{"sessionId":"test-aaaa-bbbb-cccc-dddddddddddd","messages":[{"role":"user","content":"test"}],"config":{' > session-test-corrupt.json
```

### 2. Trigger cleanup (lists sessions, deletes corrupted file)
```bash
npm start -- --list-sessions
```

### 3. Verify file was deleted
```bash
ls ~/.gemini/tmp/gemini-cli/chats/ | grep test-corrupt
# Should return nothing
```

### 4. Verify sessionId was tracked
```bash
cat ~/.gemini/tmp/gemini-cli/deleted-corrupted.json
# Should contain "test-aaaa-bbbb-cccc-dddddddddddd"
```

### 5. Verify improved error message
```bash
npm start -- --resume test-aaaa-bbbb-cccc-dddddddddddd --prompt "test"
# Should show: "Session 'test-aaaa-...' was previously deleted because it was corrupted."
```

### 6. Verify generic error still works
```bash
npm start -- --resume never-existed-uuid --prompt "test"
# Should show: "Invalid session identifier 'never-existed-uuid'."
```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
