### PR TITLE
fix(core): treat 503 Service Unavailable as retryable quota error

### DIFF
--- a/.gemini/skills/pr-address-comments/scripts/fetch-pr-info.js
+++ b/.gemini/skills/pr-address-comments/scripts/fetch-pr-info.js
@@ -20,7 +20,8 @@ async function run(cmd) {
       stdio: ['pipe', 'pipe', 'ignore'],
     });
     return stdout.trim();
-  } catch (_e) { // eslint-disable-line @typescript-eslint/no-unused-vars
+  } catch (_e) {
+    // eslint-disable-line @typescript-eslint/no-unused-vars
     return null;
   }
 }

--- a/packages/core/src/utils/googleQuotaErrors.test.ts
+++ b/packages/core/src/utils/googleQuotaErrors.test.ts
@@ -65,7 +65,23 @@ describe('classifyGoogleError', () => {
     expect((result as RetryableQuotaError).message).toBe(rawError.message);
   });
 
-  it('should return original error if code is not 429', () => {
+  it('should return RetryableQuotaError for 503 Service Unavailable', () => {
+    const apiError: GoogleApiError = {
+      code: 503,
+      message: 'Service Unavailable',
+      details: [],
+    };
+    vi.spyOn(errorParser, 'parseGoogleApiError').mockReturnValue(apiError);
+    const originalError = new Error('Service Unavailable');
+    const result = classifyGoogleError(originalError);
+    expect(result).toBeInstanceOf(RetryableQuotaError);
+    if (result instanceof RetryableQuotaError) {
+      expect(result.cause).toBe(apiError);
+      expect(result.message).toBe('Service Unavailable');
+    }
+  });
+
+  it('should return original error if code is not 429 or 503', () => {
     const apiError: GoogleApiError = {
       code: 500,
       message: 'Server error',

--- a/packages/core/src/utils/googleQuotaErrors.ts
+++ b/packages/core/src/utils/googleQuotaErrors.ts
@@ -202,6 +202,21 @@ export function classifyGoogleError(error: unknown): unknown {
     }
   }
 
+  // Check for 503 Service Unavailable errors
+  if (status === 503) {
+    const errorMessage =
+      googleApiError?.message ||
+      (error instanceof Error ? error.message : String(error));
+    return new RetryableQuotaError(
+      errorMessage,
+      googleApiError ?? {
+        code: 503,
+        message: errorMessage,
+        details: [],
+      },
+    );
+  }
+
   if (
     !googleApiError ||
     googleApiError.code !== 429 ||


### PR DESCRIPTION
## Summary

Treat 503 Service Unavailable as a retryable quota error in `classifyGoogleError`. This ensures that temporary service interruptions are handled similarly to rate limits, allowing the system to retry the operation instead of failing immediately.

## Details

- Updated `classifyGoogleError` in `packages/core/src/utils/googleQuotaErrors.ts` to check for status code 503.
- If status is 503, it returns a `RetryableQuotaError`.
- Added a corresponding unit test in `packages/core/src/utils/googleQuotaErrors.test.ts`.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/19656

## How to Validate

Run `npm test -w @google/gemini-cli-core -- src/utils/googleQuotaErrors.test.ts` to verify the new test case.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
