### PR TITLE
fix(cli): show MCP tool arguments in the approval dialog

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.test.tsx
@@ -148,6 +148,7 @@ describe('ToolConfirmationMessage', () => {
       serverName: 'test-server',
       toolName: 'test-tool',
       toolDisplayName: 'Test Tool',
+      args: { query: 'hello world', limit: 10 },
     };
 
     describe.each([

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -16,6 +16,7 @@ import {
   ToolConfirmationOutcome,
   hasRedirection,
   debugLogger,
+  safeJsonStringify,
 } from '@google/gemini-cli-core';
 import type { RadioSelectItem } from '../shared/RadioButtonSelect.js';
 import { useToolActions } from '../../contexts/ToolActionsContext.js';
@@ -446,11 +447,23 @@ export const ToolConfirmationMessage: React.FC<
     } else if (confirmationDetails.type === 'mcp') {
       // mcp tool confirmation
       const mcpProps = confirmationDetails;
+      const hasArgs =
+        mcpProps.args !== undefined && Object.keys(mcpProps.args).length > 0;
 
       bodyContent = (
         <Box flexDirection="column">
           <Text color={theme.text.link}>MCP Server: {mcpProps.serverName}</Text>
           <Text color={theme.text.link}>Tool: {mcpProps.toolName}</Text>
+          {hasArgs && (
+            <MaxSizedBox
+              maxHeight={availableBodyContentHeight()}
+              maxWidth={Math.max(terminalWidth, 1)}
+            >
+              <Text color={theme.text.secondary}>
+                {safeJsonStringify(mcpProps.args, 2)}
+              </Text>
+            </MaxSizedBox>
+          )}
         </Box>
       );
     }

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolConfirmationMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolConfirmationMessage.test.tsx.snap
@@ -105,6 +105,10 @@ Do you want to proceed?
 exports[`ToolConfirmationMessage > with folder trust > 'for mcp confirmations' > should NOT show "allow always" when folder is untrusted 1`] = `
 "MCP Server: test-server
 Tool: test-tool
+{
+  "query": "hello world",
+  "limit": 10
+}
 Allow execution of MCP tool "test-tool" from server "test-server"?
 
 ● 1. Allow once
@@ -115,6 +119,10 @@ Allow execution of MCP tool "test-tool" from server "test-server"?
 exports[`ToolConfirmationMessage > with folder trust > 'for mcp confirmations' > should show "allow always" when folder is trusted 1`] = `
 "MCP Server: test-server
 Tool: test-tool
+{
+  "query": "hello world",
+  "limit": 10
+}
 Allow execution of MCP tool "test-tool" from server "test-server"?
 
 ● 1. Allow once

--- a/packages/core/src/confirmation-bus/types.ts
+++ b/packages/core/src/confirmation-bus/types.ts
@@ -95,6 +95,8 @@ export type SerializableConfirmationDetails =
       serverName: string;
       toolName: string;
       toolDisplayName: string;
+      /** The arguments the model passed to the tool, shown in the approval dialog. */
+      args?: Record<string, unknown>;
     }
   | {
       type: 'ask_user';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -107,6 +107,7 @@ export * from './utils/secure-browser-launcher.js';
 export * from './utils/apiConversionUtils.js';
 export * from './utils/channel.js';
 export * from './utils/constants.js';
+export { safeJsonStringify } from './utils/safeJsonStringify.js';
 
 // Export services
 export * from './services/fileDiscoveryService.js';

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -5,13 +5,11 @@
  */
 
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
-import type {
-  ToolCallConfirmationDetails,
-  ToolInvocation,
-  ToolMcpConfirmationDetails,
-  ToolResult,
-} from './tools.js';
 import {
+  type ToolCallConfirmationDetails,
+  type ToolInvocation,
+  type ToolMcpConfirmationDetails,
+  type ToolResult,
   BaseDeclarativeTool,
   BaseToolInvocation,
   Kind,
@@ -123,6 +121,7 @@ export class DiscoveredMCPToolInvocation extends BaseToolInvocation<
       serverName: this.serverName,
       toolName: this.serverToolName, // Display original tool name in confirmation
       toolDisplayName: this.displayName, // Display global registry name exposed to model and user
+      args: Object.keys(this.params).length > 0 ? this.params : undefined,
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         if (outcome === ToolConfirmationOutcome.ProceedAlwaysServer) {
           DiscoveredMCPToolInvocation.allowlist.add(serverAllowListKey);

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -757,6 +757,8 @@ export interface ToolMcpConfirmationDetails {
   serverName: string;
   toolName: string;
   toolDisplayName: string;
+  /** The arguments the model passed to the tool, shown in the approval dialog. */
+  args?: Record<string, unknown>;
   onConfirm: (outcome: ToolConfirmationOutcome) => Promise<void>;
 }
 


### PR DESCRIPTION
## Summary

MCP tool approval dialog only showed the server name and tool name,
hiding the actual arguments the model was about to execute. Users had
no way to review the full payload before approving, which is a
security and UX concern. This PR surfaces those arguments in the
confirmation dialog as pretty-printed JSON.

## Details

Four files changed across `core` and `cli`:

- **`packages/core/src/tools/tools.ts`** — added optional
  `args?: Record<string, unknown>` field to `ToolMcpConfirmationDetails`.
- **`packages/core/src/confirmation-bus/types.ts`** — added the same
  `args` field to the serializable `mcp` bus type so the data flows
  through to the UI layer.
- **`packages/core/src/tools/mcp-tool.ts`** — populated `args` from
  `this.params` in `getConfirmationDetails()`; set to `undefined` when
  the params object is empty to avoid rendering an empty block.
- **`packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx`**
  — rendered `args` as pretty-printed JSON inside a `MaxSizedBox`
  (respects available terminal height) beneath the tool name when present.

The `args` field is optional and defaults to `undefined`, so all
existing behaviour for tools with no parameters is fully preserved.

## Related Issues

Fixes #19168

## How to Validate

1. Configure an MCP server in `~/.gemini/settings.json`.
2. Run `npm start` and send a prompt that causes the model to invoke an
   MCP tool with arguments (e.g. a search or query tool).
3. When the approval dialog appears:
   - **Before this PR:** only `MCP Server: <name>` and `Tool: <name>`
     are shown.
   - **After this PR:** the arguments are also shown as formatted JSON:
     ```json
     {
       "query": "hello world",
       "limit": 10
     }
     ```
4. Confirm that approving / denying the dialog still works as expected.
5. Trigger an MCP tool that takes **no arguments** and confirm no empty
   block is rendered.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [x] Docker
