### PR TITLE
fix(core): handle non-node streams in CodeAssistServer

### DIFF
--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -23,7 +23,8 @@ import { InstallationManager } from '../utils/installationManager.js';
 import { FakeContentGenerator } from './fakeContentGenerator.js';
 import { parseCustomHeaders } from '../utils/customHeaderUtils.js';
 import { RecordingContentGenerator } from './recordingContentGenerator.js';
-import { getVersion, resolveModel } from '../../index.js';
+import { getVersion } from '../utils/version.js';
+import { resolveModel } from '../config/models.js';
 import type { LlmRole } from '../telemetry/llmRole.js';
 
 /**


### PR DESCRIPTION
## Summary

Fix a crash in `CodeAssistServer` related to non-Node stream responses.

## Details

- **Robust Stream Handling**:
    - Improved `CodeAssistServer` to robustly handle stream responses by wrapping async iterables (like Web `ReadableStream`) into Node.js `Readable` streams.
    - Added defensive checks to provide a clear error message if the API returns an unexpected JSON object instead of a stream, fixing the `input.on is not a function` crash.
- **Maintenance**:
    - Fixed a circular dependency in `contentGenerator.ts` by importing from direct files.
    - Added unit tests for robust stream handling in `server.test.ts`.

## Related Issues

Fixes the `input.on is not a function` crash.

## How to Validate

1. Run `npm start`.
2. Use an environment where the API might return non-Node streams (e.g., some proxy configurations or specific Node.js versions).
3. Verify that the application no longer crashes with `input.on is not a function`.
4. Run `npm test -w @google/gemini-cli-core -- src/code_assist/server.test.ts` to verify the new tests pass.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] Linux
    - [x] npm run
