### PR TITLE
fix(a2a-server): pass allowedTools settings to core Config

### DIFF
--- a/packages/a2a-server/src/config/config.test.ts
+++ b/packages/a2a-server/src/config/config.test.ts
@@ -267,4 +267,47 @@ describe('loadConfig', () => {
       customIgnoreFilePaths: [testPath],
     });
   });
+
+  describe('tool configuration', () => {
+    it('should pass V1 allowedTools to Config properly', async () => {
+      const settings: Settings = {
+        allowedTools: ['shell', 'edit'],
+      };
+      await loadConfig(settings, mockExtensionLoader, taskId);
+      expect(Config).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowedTools: ['shell', 'edit'],
+        }),
+      );
+    });
+
+    it('should pass V2 tools.allowed to Config properly', async () => {
+      const settings: Settings = {
+        tools: {
+          allowed: ['shell', 'fetch'],
+        },
+      };
+      await loadConfig(settings, mockExtensionLoader, taskId);
+      expect(Config).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowedTools: ['shell', 'fetch'],
+        }),
+      );
+    });
+
+    it('should prefer V1 allowedTools over V2 tools.allowed if both present', async () => {
+      const settings: Settings = {
+        allowedTools: ['v1-tool'],
+        tools: {
+          allowed: ['v2-tool'],
+        },
+      };
+      await loadConfig(settings, mockExtensionLoader, taskId);
+      expect(Config).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowedTools: ['v1-tool'],
+        }),
+      );
+    });
+  });
 });

--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -68,8 +68,9 @@ export async function loadConfig(
     debugMode: process.env['DEBUG'] === 'true' || false,
     question: '', // Not used in server mode directly like CLI
 
-    coreTools: settings.coreTools || undefined,
-    excludeTools: settings.excludeTools || undefined,
+    coreTools: settings.coreTools || settings.tools?.core || undefined,
+    excludeTools: settings.excludeTools || settings.tools?.exclude || undefined,
+    allowedTools: settings.allowedTools || settings.tools?.allowed || undefined,
     showMemoryUsage: settings.showMemoryUsage || false,
     approvalMode:
       process.env['GEMINI_YOLO_MODE'] === 'true'

--- a/packages/a2a-server/src/config/settings.ts
+++ b/packages/a2a-server/src/config/settings.ts
@@ -27,6 +27,12 @@ export interface Settings {
   mcpServers?: Record<string, MCPServerConfig>;
   coreTools?: string[];
   excludeTools?: string[];
+  allowedTools?: string[];
+  tools?: {
+    allowed?: string[];
+    exclude?: string[];
+    core?: string[];
+  };
   telemetry?: TelemetrySettings;
   showMemoryUsage?: boolean;
   checkpointing?: CheckpointingSettings;


### PR DESCRIPTION
Fixes #16393

**What this solves:**
When using Gemini CLI via the VS Code extension (`a2a-server`), the `allowedTools` configuration in `settings.json` is not respected. This is because the property was entirely omitted from the server's `ConfigParameters` object, causing `a2a-server` to ignore the user's explicit tools approvals and halting the agent unexpectedly.

**What the fix does:**
Updated `packages/a2a-server/src/config/settings.ts` and `packages/a2a-server/src/config/config.ts` to properly extract the `allowedTools` array from the user's settings. Since the CLI recently transitioned to a nested `tools.allowed` schema (V2) from the flat `allowedTools` schema (V1), this fix bridges the gap by checking and passing both structures explicitly to the core `Config` object.

**Testing:**
- Added unit tests to `a2a-server/src/config/config.test.ts` to verify that both V1 and V2 `allowedTools` settings correctly instantiate the `Config` instance.
- Verified that `npm run preflight` passes entirely, including `test:ci` and formatting validations.

### Checklist

- [x] I have linked to an existing issue.
- [x] My PR is small and focused.
- [x] I have ensured `npm run preflight` passes.
- [x] I have written a clear PR description following Conventional Commits.
