### PR TITLE
fix(cli): prevent crash when stdin lacks .on method

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -111,7 +111,7 @@ export async function runNonInteractive({
 
     const setupStdinCancellation = () => {
       // Only setup if stdin is a TTY (user can interact)
-      if (!process.stdin.isTTY) {
+      if (!process.stdin.isTTY || typeof process.stdin.on !== 'function') {
         return;
       }
 

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -811,9 +811,18 @@ export function KeypressProvider({
       };
     }
 
-    stdin.on('data', dataListener);
+    if (typeof stdin.on === 'function') {
+      stdin.on('data', dataListener);
+    } else {
+      debugLogger.warn(
+        'stdin.on is not a function in KeypressContext. Input handling may be impaired.',
+      );
+    }
+
     return () => {
-      stdin.removeListener('data', dataListener);
+      if (typeof stdin.removeListener === 'function') {
+        stdin.removeListener('data', dataListener);
+      }
       if (wasRaw === false) {
         setRawMode(false);
       }


### PR DESCRIPTION
## Summary

Fixes a crash `API Error. input.on is not a function` that occurs in environments where `process.stdin` does not implement the standard `.on()` method, even if `isTTY` is true.

## Details

In some environments (like certain test runners, CI environments, or web-based terminals), `process.stdin` may be mocked or follow a different stream implementation that lacks the standard EventEmitter `.on()` method. This PR adds defensive checks to ensure `.on()` exists before attempting to attach event listeners in both interactive (`KeypressContext`) and non-interactive (`nonInteractiveCli`) modes.

## Related Issues

None.

## How to Validate

1. Run the CLI in an environment where `stdin` is non-standard.
2. Verify that the CLI no longer crashes with `input.on is not a function`.
3. Verify that normal input handling still works in a standard TTY.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) - N/A
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
  - [ ] Windows
  - [x] Linux
    - [x] npm run
