### PR TITLE
fix(cli): extensions dialog UX polish

### DIFF
--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -39,8 +39,8 @@ import {
 } from '../../config/settingsSchema.js';
 import { coreEvents, debugLogger } from '@google/gemini-cli-core';
 import type { Config } from '@google/gemini-cli-core';
-import { useUIState } from '../contexts/UIStateContext.js';
-import { useTextBuffer } from './shared/text-buffer.js';
+
+import { useSearchBuffer } from '../hooks/useSearchBuffer.js';
 import {
   BaseSettingsDialog,
   type SettingsDialogItem,
@@ -207,20 +207,10 @@ export function SettingsDialog({
     return max;
   }, [selectedScope, settings]);
 
-  // Get mainAreaWidth for search buffer viewport
-  const { mainAreaWidth } = useUIState();
-  const viewportWidth = mainAreaWidth - 8;
-
   // Search input buffer
-  const searchBuffer = useTextBuffer({
+  const searchBuffer = useSearchBuffer({
     initialText: '',
-    initialCursorOffset: 0,
-    viewport: {
-      width: viewportWidth,
-      height: 1,
-    },
-    singleLine: true,
-    onChange: (text) => setSearchQuery(text),
+    onChange: setSearchQuery,
   });
 
   // Generate items for BaseSettingsDialog

--- a/packages/cli/src/ui/components/shared/SearchableList.test.tsx
+++ b/packages/cli/src/ui/components/shared/SearchableList.test.tsx
@@ -131,7 +131,7 @@ describe('SearchableList', () => {
 
     await waitFor(() => {
       const frame = lastFrame();
-      expect(frame).toContain('> Item Two');
+      expect(frame).toContain('● Item Two');
     });
 
     await React.act(async () => {
@@ -152,8 +152,8 @@ describe('SearchableList', () => {
     await waitFor(() => {
       const frame = lastFrame();
       expect(frame).toContain('Item Two');
-      expect(frame).toContain('> Item One');
-      expect(frame).not.toContain('> Item Two');
+      expect(frame).toContain('● Item One');
+      expect(frame).not.toContain('● Item Two');
     });
   });
 

--- a/packages/cli/src/ui/components/shared/SearchableList.test.tsx
+++ b/packages/cli/src/ui/components/shared/SearchableList.test.tsx
@@ -133,6 +133,7 @@ describe('SearchableList', () => {
       const frame = lastFrame();
       expect(frame).toContain('● Item Two');
     });
+    expect(lastFrame()).toMatchSnapshot();
 
     await React.act(async () => {
       stdin.write('One');
@@ -143,6 +144,7 @@ describe('SearchableList', () => {
       expect(frame).toContain('Item One');
       expect(frame).not.toContain('Item Two');
     });
+    expect(lastFrame()).toMatchSnapshot();
 
     await React.act(async () => {
       // Backspace "One" (3 chars)
@@ -155,6 +157,7 @@ describe('SearchableList', () => {
       expect(frame).toContain('● Item One');
       expect(frame).not.toContain('● Item Two');
     });
+    expect(lastFrame()).toMatchSnapshot();
   });
 
   it('should filter items based on search query', async () => {

--- a/packages/cli/src/ui/components/shared/SearchableList.tsx
+++ b/packages/cli/src/ui/components/shared/SearchableList.tsx
@@ -112,13 +112,38 @@ export function SearchableList<T extends GenericListItem>({
     isFocused: true,
     showNumbers: false,
     wrapAround: true,
+    priority: true,
   });
+
+  const [scrollOffsetState, setScrollOffsetState] = React.useState(0);
+
+  // Compute effective scroll offset during render to avoid visual flicker
+  let scrollOffset = scrollOffsetState;
+
+  if (activeIndex < scrollOffset) {
+    scrollOffset = activeIndex;
+  } else if (activeIndex >= scrollOffset + maxItemsToShow) {
+    scrollOffset = activeIndex - maxItemsToShow + 1;
+  }
+
+  const maxScroll = Math.max(0, filteredItems.length - maxItemsToShow);
+  if (scrollOffset > maxScroll) {
+    scrollOffset = maxScroll;
+  }
+
+  // Update state to match derived value if it changed
+  React.useLayoutEffect(() => {
+    if (scrollOffsetState !== scrollOffset) {
+      setScrollOffsetState(scrollOffset);
+    }
+  }, [scrollOffset, scrollOffsetState]);
 
   // Reset selection to top when items change if requested
   const prevItemsRef = React.useRef(filteredItems);
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (resetSelectionOnItemsChange && filteredItems !== prevItemsRef.current) {
       setActiveIndex(0);
+      setScrollOffsetState(0);
     }
     prevItemsRef.current = filteredItems;
   }, [filteredItems, setActiveIndex, resetSelectionOnItemsChange]);
@@ -135,14 +160,6 @@ export function SearchableList<T extends GenericListItem>({
     { isActive: true },
   );
 
-  const scrollOffset = Math.max(
-    0,
-    Math.min(
-      activeIndex - Math.floor(maxItemsToShow / 2),
-      Math.max(0, filteredItems.length - maxItemsToShow),
-    ),
-  );
-
   const visibleItems = filteredItems.slice(
     scrollOffset,
     scrollOffset + maxItemsToShow,
@@ -153,21 +170,22 @@ export function SearchableList<T extends GenericListItem>({
     isActive: boolean,
     labelWidth: number,
   ) => (
-    <Box flexDirection="column">
-      <Text
-        color={isActive ? theme.status.success : theme.text.primary}
-        bold={isActive}
-      >
-        {isActive ? '> ' : '  '}
-        {item.label.padEnd(labelWidth)}
-      </Text>
-      {item.description && (
-        <Box marginLeft={2}>
+    <Box flexDirection="row" alignItems="flex-start">
+      <Box minWidth={2} flexShrink={0}>
+        <Text color={isActive ? theme.status.success : theme.text.secondary}>
+          {isActive ? '●' : ''}
+        </Text>
+      </Box>
+      <Box flexDirection="column" flexGrow={1} minWidth={0}>
+        <Text color={isActive ? theme.status.success : theme.text.primary}>
+          {item.label.padEnd(labelWidth)}
+        </Text>
+        {item.description && (
           <Text color={theme.text.secondary} wrap="truncate-end">
             {item.description}
           </Text>
-        </Box>
-      )}
+        )}
+      </Box>
     </Box>
   );
 
@@ -204,16 +222,28 @@ export function SearchableList<T extends GenericListItem>({
             <Text color={theme.text.secondary}>No items found.</Text>
           </Box>
         ) : (
-          visibleItems.map((item, index) => {
-            const isSelected = activeIndex === scrollOffset + index;
-            return (
-              <Box key={item.key} marginBottom={1}>
-                {renderItem
-                  ? renderItem(item, isSelected, maxLabelWidth)
-                  : defaultRenderItem(item, isSelected, maxLabelWidth)}
+          <>
+            {filteredItems.length > maxItemsToShow && (
+              <Box marginX={1}>
+                <Text color={theme.text.secondary}>▲</Text>
               </Box>
-            );
-          })
+            )}
+            {visibleItems.map((item, index) => {
+              const isSelected = activeIndex === scrollOffset + index;
+              return (
+                <Box key={item.key} marginBottom={1} marginX={1}>
+                  {renderItem
+                    ? renderItem(item, isSelected, maxLabelWidth)
+                    : defaultRenderItem(item, isSelected, maxLabelWidth)}
+                </Box>
+              );
+            })}
+            {filteredItems.length > maxItemsToShow && (
+              <Box marginX={1}>
+                <Text color={theme.text.secondary}>▼</Text>
+              </Box>
+            )}
+          </>
         )}
       </Box>
 

--- a/packages/cli/src/ui/components/shared/SearchableList.tsx
+++ b/packages/cli/src/ui/components/shared/SearchableList.tsx
@@ -132,11 +132,9 @@ export function SearchableList<T extends GenericListItem>({
   }
 
   // Update state to match derived value if it changed
-  React.useLayoutEffect(() => {
-    if (scrollOffsetState !== scrollOffset) {
-      setScrollOffsetState(scrollOffset);
-    }
-  }, [scrollOffset, scrollOffsetState]);
+  if (scrollOffsetState !== scrollOffset) {
+    setScrollOffsetState(scrollOffset);
+  }
 
   // Reset selection to top when items change if requested
   const prevItemsRef = React.useRef(filteredItems);

--- a/packages/cli/src/ui/components/shared/__snapshots__/SearchableList.test.tsx.snap
+++ b/packages/cli/src/ui/components/shared/__snapshots__/SearchableList.test.tsx.snap
@@ -7,13 +7,13 @@ exports[`SearchableList > should match snapshot 1`] = `
  │ Search...                                                                                      │
  ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 
- > Item One
-   Description for item one
+  ● Item One
+    Description for item one
 
-   Item Two
-   Description for item two
+    Item Two
+    Description for item two
 
-   Item Three
-   Description for item three
+    Item Three
+    Description for item three
 "
 `;

--- a/packages/cli/src/ui/components/shared/__snapshots__/SearchableList.test.tsx.snap
+++ b/packages/cli/src/ui/components/shared/__snapshots__/SearchableList.test.tsx.snap
@@ -17,3 +17,51 @@ exports[`SearchableList > should match snapshot 1`] = `
     Description for item three
 "
 `;
+
+exports[`SearchableList > should reset selection to top when items change if resetSelectionOnItemsChange is true 1`] = `
+" Test List
+
+ ╭────────────────────────────────────────────────────────────────────────────────────────────────╮
+ │ Search...                                                                                      │
+ ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+    Item One
+    Description for item one
+
+  ● Item Two
+    Description for item two
+
+    Item Three
+    Description for item three
+"
+`;
+
+exports[`SearchableList > should reset selection to top when items change if resetSelectionOnItemsChange is true 2`] = `
+" Test List
+
+ ╭────────────────────────────────────────────────────────────────────────────────────────────────╮
+ │ One                                                                                            │
+ ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+  ● Item One
+    Description for item one
+"
+`;
+
+exports[`SearchableList > should reset selection to top when items change if resetSelectionOnItemsChange is true 3`] = `
+" Test List
+
+ ╭────────────────────────────────────────────────────────────────────────────────────────────────╮
+ │ Search...                                                                                      │
+ ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+  ● Item One
+    Description for item one
+
+    Item Two
+    Description for item two
+
+    Item Three
+    Description for item three
+"
+`;

--- a/packages/cli/src/ui/components/views/ExtensionRegistryView.test.tsx
+++ b/packages/cli/src/ui/components/views/ExtensionRegistryView.test.tsx
@@ -126,6 +126,8 @@ describe('ExtensionRegistryView', () => {
 
     vi.mocked(useUIState).mockReturnValue({
       mainAreaWidth: 100,
+      terminalHeight: 40,
+      staticExtraHeight: 5,
     } as unknown as ReturnType<typeof useUIState>);
 
     vi.mocked(useConfig).mockReturnValue({

--- a/packages/cli/src/ui/hooks/useRegistrySearch.ts
+++ b/packages/cli/src/ui/hooks/useRegistrySearch.ts
@@ -4,16 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useEffect } from 'react';
-import {
-  useTextBuffer,
-  type TextBuffer,
-} from '../components/shared/text-buffer.js';
-import { useUIState } from '../contexts/UIStateContext.js';
+import { useState, useEffect, useRef } from 'react';
+import type { TextBuffer } from '../components/shared/text-buffer.js';
 import type { GenericListItem } from '../components/shared/SearchableList.js';
-
-const MIN_VIEWPORT_WIDTH = 20;
-const VIEWPORT_WIDTH_OFFSET = 8;
+import { useSearchBuffer } from './useSearchBuffer.js';
 
 export interface UseRegistrySearchResult<T extends GenericListItem> {
   filteredItems: T[];
@@ -31,26 +25,19 @@ export function useRegistrySearch<T extends GenericListItem>(props: {
   const { items, initialQuery = '', onSearch } = props;
 
   const [searchQuery, setSearchQuery] = useState(initialQuery);
+  const isFirstRender = useRef(true);
 
   useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
     onSearch?.(searchQuery);
   }, [searchQuery, onSearch]);
 
-  const { mainAreaWidth } = useUIState();
-  const viewportWidth = Math.max(
-    MIN_VIEWPORT_WIDTH,
-    mainAreaWidth - VIEWPORT_WIDTH_OFFSET,
-  );
-
-  const searchBuffer = useTextBuffer({
+  const searchBuffer = useSearchBuffer({
     initialText: searchQuery,
-    initialCursorOffset: searchQuery.length,
-    viewport: {
-      width: viewportWidth,
-      height: 1,
-    },
-    singleLine: true,
-    onChange: (text) => setSearchQuery(text),
+    onChange: setSearchQuery,
   });
 
   const maxLabelWidth = 0;

--- a/packages/cli/src/ui/hooks/useRegistrySearch.ts
+++ b/packages/cli/src/ui/hooks/useRegistrySearch.ts
@@ -26,14 +26,17 @@ export function useRegistrySearch<T extends GenericListItem>(props: {
 
   const [searchQuery, setSearchQuery] = useState(initialQuery);
   const isFirstRender = useRef(true);
+  const onSearchRef = useRef(onSearch);
+
+  onSearchRef.current = onSearch;
 
   useEffect(() => {
     if (isFirstRender.current) {
       isFirstRender.current = false;
       return;
     }
-    onSearch?.(searchQuery);
-  }, [searchQuery, onSearch]);
+    onSearchRef.current?.(searchQuery);
+  }, [searchQuery]);
 
   const searchBuffer = useSearchBuffer({
     initialText: searchQuery,

--- a/packages/cli/src/ui/hooks/useSearchBuffer.ts
+++ b/packages/cli/src/ui/hooks/useSearchBuffer.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  useTextBuffer,
+  type TextBuffer,
+} from '../components/shared/text-buffer.js';
+import { useUIState } from '../contexts/UIStateContext.js';
+
+const MIN_VIEWPORT_WIDTH = 20;
+const VIEWPORT_WIDTH_OFFSET = 8;
+
+export interface UseSearchBufferProps {
+  initialText?: string;
+  onChange: (text: string) => void;
+}
+
+export function useSearchBuffer({
+  initialText = '',
+  onChange,
+}: UseSearchBufferProps): TextBuffer {
+  const { mainAreaWidth } = useUIState();
+  const viewportWidth = Math.max(
+    MIN_VIEWPORT_WIDTH,
+    mainAreaWidth - VIEWPORT_WIDTH_OFFSET,
+  );
+
+  return useTextBuffer({
+    initialText,
+    initialCursorOffset: initialText.length,
+    viewport: {
+      width: viewportWidth,
+      height: 1,
+    },
+    singleLine: true,
+    onChange,
+  });
+}


### PR DESCRIPTION
## Summary

This PR introduces several UX improvements to the settings dialog, specifically focusing on the `SearchableList` component. It includes better scrolling, clearer visual indicators, and refactoring search input logic into a reusable `useSearchBuffer` hook.

<img width="963" height="500" alt="image" src="https://github.com/user-attachments/assets/1efdb714-9039-43f9-88cc-ac33489c0a76" />

Demo:
https://screencast.googleplex.com/cast/NjY1MjA1NzMxNzUzOTg0MHxhYjgxYWExNS1lMg

## Details

- **Visual Indicators:** Updated selection cursor in `SearchableList` to use a `●` character with proper styling instead of `>`.
- **Scrolling Enhancements:** Improved scroll offset calculation directly during render for `SearchableList` to prevent visual flicker.
- **Refactoring:** Abstracted the search buffer logic out of `SettingsDialog` and `useRegistrySearch` into a new `useSearchBuffer` hook for better code organization and reusability.
- **Dynamic Sizing:** `ExtensionRegistryView` now calculates `maxItemsToShow` dynamically based on available terminal height from `useUIState()`.
- **Bug Fix:** Fixed an issue in `useRegistrySearch` where an unstable `onSearch` prop could cause performance degradation via `useEffect`.

## Related Issues

Fixes #19697 

## How to Validate

- Open the extensions dialog using the CLI.
- Navigate up and down using arrow keys; the selection indicator (`●`) should follow. 
  You should now be able to navigate with consistent behavior to the settings dialog (e.g. the list scrolls when you are at the top or bottom rather than odd behavior keeping a line in the middle selected).
- Open the Extension Registry view and verify that the number of extensions displayed adjusts dynamically to your terminal size.
