### PR TITLE
fix(policy): support regex anchors in commandRegex

### DIFF
--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -1482,6 +1482,58 @@ describe('PolicyEngine', () => {
     });
   });
 
+  describe('commandRegex anchors', () => {
+    it('should ALLOW tmux command with $ anchor', async () => {
+      const patterns = buildArgsPatterns(
+        undefined,
+        undefined,
+        'tmux send-keys -t [a-z0-9:]+ (C-c|Up|Enter|Up Enter)$',
+      );
+      const regex = new RegExp(patterns[0]!);
+
+      engine.addRule({
+        toolName: 'run_shell_command',
+        decision: PolicyDecision.ALLOW,
+        priority: 100,
+        argsPattern: regex,
+      });
+
+      const toolCall = {
+        name: 'run_shell_command',
+        args: {
+          command: 'tmux send-keys -t superpowers:6 C-c',
+        },
+      };
+
+      const result = await engine.check(toolCall, undefined);
+
+      expect(result.decision).toBe(PolicyDecision.ALLOW);
+    });
+
+    it('should ALLOW git status with ^ anchor', async () => {
+      const patterns = buildArgsPatterns(undefined, undefined, '^git status');
+      const regex = new RegExp(patterns[0]!);
+
+      engine.addRule({
+        toolName: 'run_shell_command',
+        decision: PolicyDecision.ALLOW,
+        priority: 100,
+        argsPattern: regex,
+      });
+
+      const toolCall = {
+        name: 'run_shell_command',
+        args: {
+          command: 'git status',
+        },
+      };
+
+      const result = await engine.check(toolCall, undefined);
+
+      expect(result.decision).toBe(PolicyDecision.ALLOW);
+    });
+  });
+
   describe('Plan Mode vs Subagent Priority (Regression)', () => {
     it('should DENY subagents in Plan Mode despite dynamic allow rules', async () => {
       // Plan Mode Deny (1.06) > Subagent Allow (1.05)

--- a/packages/core/src/policy/toml-loader.test.ts
+++ b/packages/core/src/policy/toml-loader.test.ts
@@ -111,7 +111,7 @@ priority = 100
       expect(result.errors).toHaveLength(0);
     });
 
-    it('should NOT match if ^ is used in commandRegex because it matches against full JSON', async () => {
+    it('should match if ^ is used in commandRegex (TDD: currently fails)', async () => {
       const result = await runLoadPoliciesFromToml(`
 [[rule]]
 toolName = "run_shell_command"
@@ -121,11 +121,10 @@ priority = 100
 `);
 
       expect(result.rules).toHaveLength(1);
-      // The generated pattern is "command":"^git status
-      // This will NOT match '{"command":"git status"}' because of the '{"' at the start.
+      // After the fix, this should match correctly
       expect(
         result.rules[0].argsPattern?.test('{"command":"git status"}'),
-      ).toBe(false);
+      ).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
 

--- a/packages/core/src/policy/toml-loader.test.ts
+++ b/packages/core/src/policy/toml-loader.test.ts
@@ -111,7 +111,7 @@ priority = 100
       expect(result.errors).toHaveLength(0);
     });
 
-    it('should match if ^ is used in commandRegex (TDD: currently fails)', async () => {
+    it('should match if ^ is used in commandRegex', async () => {
       const result = await runLoadPoliciesFromToml(`
 [[rule]]
 toolName = "run_shell_command"
@@ -121,7 +121,7 @@ priority = 100
 `);
 
       expect(result.rules).toHaveLength(1);
-      // After the fix, this should match correctly
+      // The generated pattern is "command":"^git status
       expect(
         result.rules[0].argsPattern?.test('{"command":"git status"}'),
       ).toBe(true);

--- a/packages/core/src/policy/utils.test.ts
+++ b/packages/core/src/policy/utils.test.ts
@@ -145,16 +145,15 @@ describe('policy/utils', () => {
     });
 
     describe('commandRegex anchors', () => {
-      it('should transform ^ anchor correctly (TDD: currently failing to match)', () => {
+      it('should transform ^ anchor correctly', () => {
         const patterns = buildArgsPatterns(undefined, undefined, '^git status');
         const regex = new RegExp(patterns[0]!);
         // JSON stringified command: {"command":"git status"}
         const json = '{"command":"git status"}';
-        // This CURRENTLY fails because the pattern is "command":"^git status
         expect(regex.test(json)).toBe(true);
       });
 
-      it('should transform $ anchor correctly (TDD: currently failing to match)', () => {
+      it('should transform $ anchor correctly', () => {
         const patterns = buildArgsPatterns(
           undefined,
           undefined,
@@ -162,11 +161,10 @@ describe('policy/utils', () => {
         );
         const regex = new RegExp(patterns[0]!);
         const json = '{"command":"tmux send-keys -t superpowers:6 C-c"}';
-        // This CURRENTLY fails because $ matches end of JSON string, not end of command value
         expect(regex.test(json)).toBe(true);
       });
 
-      it('should handle $ anchor when other fields follow (TDD: currently failing)', () => {
+      it('should handle $ anchor when other fields follow', () => {
         const patterns = buildArgsPatterns(undefined, undefined, 'git status$');
         const regex = new RegExp(patterns[0]!);
         const json = '{"command":"git status","dir_path":"/tmp"}';


### PR DESCRIPTION
## Summary

Fixed a bug in the policy engine where regex anchors (`^` and `$`) in `commandRegex` failed to match command arguments. This was occurring because the anchors were being matched against the entire JSON-stringified representation of the tool arguments (e.g., `{"command":"git status"}`) instead of just the command value itself.

## Examples

### Before (Failed to match)
These rules would fail to match `git status` because they were matched against the full JSON string `{"command":"git status"}`.

```toml
# Failed because '^' expected the start of the JSON object '{'
commandRegex = "^git status"

# Failed because '$' expected the end of the JSON object '}'
commandRegex = "git status$"

# Failed for both reasons
commandRegex = "^git status$"
```

### After (Matches correctly)
The anchors are now transformed to match the boundaries of the command value within the JSON string.

```toml
# Matches only if command starts with 'git status'
commandRegex = "^git status"

# Matches only if command is exactly 'git status'
commandRegex = "^git status$"

# Matches the tmux send-keys example with complex groups
commandRegex = "tmux send-keys -t [a-z0-9:]+ (C-c|Up|Enter|Up Enter)$"
```

## Details

Modified `buildArgsPatterns` in `packages/core/src/policy/utils.ts` to transform `commandRegex` anchors into JSON-aware patterns:
- **`^` (Start Anchor)**: Removed from the start of the regex as it is implicitly anchored by the prepended `"command":"` prefix.
- **`$` (End Anchor)**: Replaced with `"(?:,|\})` to match the closing double-quote of the command value in the JSON string.
- **Backslash Protection**: Implemented logic to ensure escaped anchors (e.g., `\$`) are preserved as literals.

Added unit tests in `packages/core/src/policy/utils.test.ts` and high-level regression tests in `packages/core/src/policy/policy-engine.test.ts`.

## Related Issues

Closes #19688

## How to Validate

Run the policy engine tests:
```bash
npm test -w @google/gemini-cli-core -- src/policy/utils.test.ts src/policy/toml-loader.test.ts src/policy/policy-engine.test.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
