### PR TITLE
Fixes 'input.on' is not a function error in Gemini CLI

### DIFF
--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -36,6 +36,7 @@ import type {
   GenerateContentResponse,
 } from '@google/genai';
 import * as readline from 'node:readline';
+import { Readable } from 'node:stream';
 import type { ContentGenerator } from '../core/contentGenerator.js';
 import { UserTierId } from './types.js';
 import type {
@@ -341,7 +342,7 @@ export class CodeAssistServer implements ContentGenerator {
     req: object,
     signal?: AbortSignal,
   ): Promise<AsyncGenerator<T>> {
-    const res = await this.client.request({
+    const res = await this.client.request<AsyncIterable<unknown>>({
       url: this.getMethodUrl(method),
       method: 'POST',
       params: {
@@ -358,8 +359,7 @@ export class CodeAssistServer implements ContentGenerator {
 
     return (async function* (): AsyncGenerator<T> {
       const rl = readline.createInterface({
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        input: res.data as NodeJS.ReadableStream,
+        input: Readable.from(res.data),
         crlfDelay: Infinity, // Recognizes '\r\n' and '\n' as line breaks
       });
 


### PR DESCRIPTION
## Summary

Fixes an error that blocks the ability to use Gemini CLI when authenticated with a Google account. User types in a message and is confronted by an unhandled error.

This is another case of the codebase using casts (as keyword) to override the type system, leading to a failure at runtime instead of a compilation error, as code and dependencies change.

I have filed the following item to track eliminating these code smells: https://github.com/google-gemini/gemini-cli/issues/19440

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
