### PR TITLE
feat(policy): repurpose "Always Allow" persistence to workspace level

### DIFF
--- a/packages/cli/src/config/policy.ts
+++ b/packages/cli/src/config/policy.ts
@@ -41,8 +41,9 @@ export async function createPolicyEngineConfig(
 export function createPolicyUpdater(
   policyEngine: PolicyEngine,
   messageBus: MessageBus,
+  storage: Storage,
 ) {
-  return createCorePolicyUpdater(policyEngine, messageBus);
+  return createCorePolicyUpdater(policyEngine, messageBus, storage);
 }
 
 export interface WorkspacePolicyState {

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -583,7 +583,7 @@ export async function main() {
 
     const policyEngine = config.getPolicyEngine();
     const messageBus = config.getMessageBus();
-    createPolicyUpdater(policyEngine, messageBus);
+    createPolicyUpdater(policyEngine, messageBus, config.storage);
 
     // Register SessionEnd hook to fire on graceful exit
     // This runs before telemetry shutdown in runExitCleanup()

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -23,6 +23,8 @@ const TMP_DIR_NAME = 'tmp';
 const BIN_DIR_NAME = 'bin';
 const AGENTS_DIR_NAME = '.agents';
 
+export const AUTO_SAVED_POLICY_FILENAME = 'auto-saved.toml';
+
 export class Storage {
   private readonly targetDir: string;
   private readonly sessionId: string | undefined;
@@ -152,6 +154,13 @@ export class Storage {
 
   getWorkspacePoliciesDir(): string {
     return path.join(this.getGeminiDir(), 'policies');
+  }
+
+  getAutoSavedPolicyPath(): string {
+    return path.join(
+      this.getWorkspacePoliciesDir(),
+      AUTO_SAVED_POLICY_FILENAME,
+    );
   }
 
   ensureProjectTempDirExists(): void {

--- a/packages/core/src/policy/config.ts
+++ b/packages/core/src/policy/config.ts
@@ -57,8 +57,6 @@ export const ALLOWED_TOOLS_FLAG_PRIORITY = USER_POLICY_TIER + 0.3;
 export const TRUSTED_MCP_SERVER_PRIORITY = USER_POLICY_TIER + 0.2;
 export const ALLOWED_MCP_SERVER_PRIORITY = USER_POLICY_TIER + 0.1;
 
-export const AUTO_SAVED_POLICY_FILENAME = 'auto-saved.toml';
-
 /**
  * Gets the list of directories to search for policy files, in order of increasing priority
  * (Default -> User -> Project -> Admin).
@@ -451,10 +449,7 @@ export function createPolicyUpdater(
           try {
             const workspacePoliciesDir = storage.getWorkspacePoliciesDir();
             await fs.mkdir(workspacePoliciesDir, { recursive: true });
-            const policyFile = path.join(
-              workspacePoliciesDir,
-              AUTO_SAVED_POLICY_FILENAME,
-            );
+            const policyFile = storage.getAutoSavedPolicyPath();
 
             // Read existing file
             let existingData: { rule?: TomlRule[] } = {};

--- a/packages/core/src/policy/config.ts
+++ b/packages/core/src/policy/config.ts
@@ -43,6 +43,22 @@ export const WORKSPACE_POLICY_TIER = 2;
 export const USER_POLICY_TIER = 3;
 export const ADMIN_POLICY_TIER = 4;
 
+// Specific priority offsets and derived priorities for dynamic/settings rules.
+// These are added to the tier base (e.g., USER_POLICY_TIER).
+
+// Workspace tier (2) + high priority (950/1000) = ALWAYS_ALLOW_PRIORITY
+// This ensures user "always allow" selections are high priority
+// within the workspace tier but still lose to user/admin policies.
+export const ALWAYS_ALLOW_PRIORITY = WORKSPACE_POLICY_TIER + 0.95;
+
+export const MCP_EXCLUDED_PRIORITY = USER_POLICY_TIER + 0.9;
+export const EXCLUDE_TOOLS_FLAG_PRIORITY = USER_POLICY_TIER + 0.4;
+export const ALLOWED_TOOLS_FLAG_PRIORITY = USER_POLICY_TIER + 0.3;
+export const TRUSTED_MCP_SERVER_PRIORITY = USER_POLICY_TIER + 0.2;
+export const ALLOWED_MCP_SERVER_PRIORITY = USER_POLICY_TIER + 0.1;
+
+export const AUTO_SAVED_POLICY_FILENAME = 'auto-saved.toml';
+
 /**
  * Gets the list of directories to search for policy files, in order of increasing priority
  * (Default -> User -> Project -> Admin).
@@ -233,13 +249,14 @@ export async function createPolicyEngineConfig(
   // This ensures Admin > User > Workspace > Default hierarchy is always preserved,
   // while allowing user-specified priorities to work within each tier.
   //
-  // Settings-based and dynamic rules (all in user tier 3.x):
-  //   3.95: Tools that the user has selected as "Always Allow" in the interactive UI
-  //   3.9:  MCP servers excluded list (security: persistent server blocks)
-  //   3.4:  Command line flag --exclude-tools (explicit temporary blocks)
-  //   3.3:  Command line flag --allowed-tools (explicit temporary allows)
-  //   3.2:  MCP servers with trust=true (persistent trusted servers)
-  //   3.1:  MCP servers allowed list (persistent general server allows)
+  // Settings-based and dynamic rules (mixed tiers):
+  //   MCP_EXCLUDED_PRIORITY:        MCP servers excluded list (security: persistent server blocks)
+  //   EXCLUDE_TOOLS_FLAG_PRIORITY:  Command line flag --exclude-tools (explicit temporary blocks)
+  //   ALLOWED_TOOLS_FLAG_PRIORITY:  Command line flag --allowed-tools (explicit temporary allows)
+  //   TRUSTED_MCP_SERVER_PRIORITY:  MCP servers with trust=true (persistent trusted servers)
+  //   ALLOWED_MCP_SERVER_PRIORITY:  MCP servers allowed list (persistent general server allows)
+  //   ALWAYS_ALLOW_PRIORITY:        Tools that the user has selected as "Always Allow" in the interactive UI
+  //                                 (Workspace tier 2.x - scoped to the project)
   //
   // TOML policy priorities (before transformation):
   //   10: Write tools default to ASK_USER (becomes 1.010 in default tier)
@@ -250,33 +267,33 @@ export async function createPolicyEngineConfig(
   //   999: YOLO mode allow-all (becomes 1.999 in default tier)
 
   // MCP servers that are explicitly excluded in settings.mcp.excluded
-  // Priority: 3.9 (highest in user tier for security - persistent server blocks)
+  // Priority: MCP_EXCLUDED_PRIORITY (highest in user tier for security - persistent server blocks)
   if (settings.mcp?.excluded) {
     for (const serverName of settings.mcp.excluded) {
       rules.push({
         toolName: `${serverName}__*`,
         decision: PolicyDecision.DENY,
-        priority: 3.9,
+        priority: MCP_EXCLUDED_PRIORITY,
         source: 'Settings (MCP Excluded)',
       });
     }
   }
 
   // Tools that are explicitly excluded in the settings.
-  // Priority: 3.4 (user tier - explicit temporary blocks)
+  // Priority: EXCLUDE_TOOLS_FLAG_PRIORITY (user tier - explicit temporary blocks)
   if (settings.tools?.exclude) {
     for (const tool of settings.tools.exclude) {
       rules.push({
         toolName: tool,
         decision: PolicyDecision.DENY,
-        priority: 3.4,
+        priority: EXCLUDE_TOOLS_FLAG_PRIORITY,
         source: 'Settings (Tools Excluded)',
       });
     }
   }
 
   // Tools that are explicitly allowed in the settings.
-  // Priority: 3.3 (user tier - explicit temporary allows)
+  // Priority: ALLOWED_TOOLS_FLAG_PRIORITY (user tier - explicit temporary allows)
   if (settings.tools?.allowed) {
     for (const tool of settings.tools.allowed) {
       // Check for legacy format: toolName(args)
@@ -296,7 +313,7 @@ export async function createPolicyEngineConfig(
               rules.push({
                 toolName,
                 decision: PolicyDecision.ALLOW,
-                priority: 3.3,
+                priority: ALLOWED_TOOLS_FLAG_PRIORITY,
                 argsPattern: new RegExp(pattern),
                 source: 'Settings (Tools Allowed)',
               });
@@ -308,7 +325,7 @@ export async function createPolicyEngineConfig(
           rules.push({
             toolName,
             decision: PolicyDecision.ALLOW,
-            priority: 3.3,
+            priority: ALLOWED_TOOLS_FLAG_PRIORITY,
             source: 'Settings (Tools Allowed)',
           });
         }
@@ -320,7 +337,7 @@ export async function createPolicyEngineConfig(
         rules.push({
           toolName,
           decision: PolicyDecision.ALLOW,
-          priority: 3.3,
+          priority: ALLOWED_TOOLS_FLAG_PRIORITY,
           source: 'Settings (Tools Allowed)',
         });
       }
@@ -328,7 +345,7 @@ export async function createPolicyEngineConfig(
   }
 
   // MCP servers that are trusted in the settings.
-  // Priority: 3.2 (user tier - persistent trusted servers)
+  // Priority: TRUSTED_MCP_SERVER_PRIORITY (user tier - persistent trusted servers)
   if (settings.mcpServers) {
     for (const [serverName, serverConfig] of Object.entries(
       settings.mcpServers,
@@ -339,7 +356,7 @@ export async function createPolicyEngineConfig(
         rules.push({
           toolName: `${serverName}__*`,
           decision: PolicyDecision.ALLOW,
-          priority: 3.2,
+          priority: TRUSTED_MCP_SERVER_PRIORITY,
           source: 'Settings (MCP Trusted)',
         });
       }
@@ -347,13 +364,13 @@ export async function createPolicyEngineConfig(
   }
 
   // MCP servers that are explicitly allowed in settings.mcp.allowed
-  // Priority: 3.1 (user tier - persistent general server allows)
+  // Priority: ALLOWED_MCP_SERVER_PRIORITY (user tier - persistent general server allows)
   if (settings.mcp?.allowed) {
     for (const serverName of settings.mcp.allowed) {
       rules.push({
         toolName: `${serverName}__*`,
         decision: PolicyDecision.ALLOW,
-        priority: 3.1,
+        priority: ALLOWED_MCP_SERVER_PRIORITY,
         source: 'Settings (MCP Allowed)',
       });
     }
@@ -381,6 +398,7 @@ interface TomlRule {
 export function createPolicyUpdater(
   policyEngine: PolicyEngine,
   messageBus: MessageBus,
+  storage: Storage,
 ) {
   // Use a sequential queue for persistence to avoid lost updates from concurrent events.
   let persistenceQueue = Promise.resolve();
@@ -400,10 +418,7 @@ export function createPolicyUpdater(
             policyEngine.addRule({
               toolName,
               decision: PolicyDecision.ALLOW,
-              // User tier (3) + high priority (950/1000) = 3.95
-              // This ensures user "always allow" selections are high priority
-              // but still lose to admin policies (4.xxx) and settings excludes (300)
-              priority: 3.95,
+              priority: ALWAYS_ALLOW_PRIORITY,
               argsPattern: new RegExp(pattern),
               source: 'Dynamic (Confirmed)',
             });
@@ -425,10 +440,7 @@ export function createPolicyUpdater(
         policyEngine.addRule({
           toolName,
           decision: PolicyDecision.ALLOW,
-          // User tier (3) + high priority (950/1000) = 3.95
-          // This ensures user "always allow" selections are high priority
-          // but still lose to admin policies (4.xxx) and settings excludes (300)
-          priority: 3.95,
+          priority: ALWAYS_ALLOW_PRIORITY,
           argsPattern,
           source: 'Dynamic (Confirmed)',
         });
@@ -437,9 +449,12 @@ export function createPolicyUpdater(
       if (message.persist) {
         persistenceQueue = persistenceQueue.then(async () => {
           try {
-            const userPoliciesDir = Storage.getUserPoliciesDir();
-            await fs.mkdir(userPoliciesDir, { recursive: true });
-            const policyFile = path.join(userPoliciesDir, 'auto-saved.toml');
+            const workspacePoliciesDir = storage.getWorkspacePoliciesDir();
+            await fs.mkdir(workspacePoliciesDir, { recursive: true });
+            const policyFile = path.join(
+              workspacePoliciesDir,
+              AUTO_SAVED_POLICY_FILENAME,
+            );
 
             // Read existing file
             let existingData: { rule?: TomlRule[] } = {};

--- a/packages/core/src/policy/persistence.test.ts
+++ b/packages/core/src/policy/persistence.test.ts
@@ -15,15 +15,11 @@ import {
 } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import {
-  createPolicyUpdater,
-  ALWAYS_ALLOW_PRIORITY,
-  AUTO_SAVED_POLICY_FILENAME,
-} from './config.js';
+import { createPolicyUpdater, ALWAYS_ALLOW_PRIORITY } from './config.js';
 import { PolicyEngine } from './policy-engine.js';
 import { MessageBus } from '../confirmation-bus/message-bus.js';
 import { MessageBusType } from '../confirmation-bus/types.js';
-import { Storage } from '../config/storage.js';
+import { Storage, AUTO_SAVED_POLICY_FILENAME } from '../config/storage.js';
 import { ApprovalMode } from './types.js';
 
 vi.mock('node:fs/promises');
@@ -53,9 +49,14 @@ describe('createPolicyUpdater', () => {
     createPolicyUpdater(policyEngine, messageBus, mockStorage);
 
     const workspacePoliciesDir = '/mock/project/.gemini/policies';
+    const policyFile = path.join(
+      workspacePoliciesDir,
+      AUTO_SAVED_POLICY_FILENAME,
+    );
     vi.spyOn(mockStorage, 'getWorkspacePoliciesDir').mockReturnValue(
       workspacePoliciesDir,
     );
+    vi.spyOn(mockStorage, 'getAutoSavedPolicyPath').mockReturnValue(policyFile);
     (fs.mkdir as unknown as Mock).mockResolvedValue(undefined);
     (fs.readFile as unknown as Mock).mockRejectedValue(
       new Error('File not found'),
@@ -93,7 +94,7 @@ describe('createPolicyUpdater', () => {
     );
     expect(fs.rename).toHaveBeenCalledWith(
       expect.stringMatching(/\.tmp$/),
-      path.join(workspacePoliciesDir, AUTO_SAVED_POLICY_FILENAME),
+      policyFile,
     );
   });
 
@@ -115,9 +116,14 @@ describe('createPolicyUpdater', () => {
     createPolicyUpdater(policyEngine, messageBus, mockStorage);
 
     const workspacePoliciesDir = '/mock/project/.gemini/policies';
+    const policyFile = path.join(
+      workspacePoliciesDir,
+      AUTO_SAVED_POLICY_FILENAME,
+    );
     vi.spyOn(mockStorage, 'getWorkspacePoliciesDir').mockReturnValue(
       workspacePoliciesDir,
     );
+    vi.spyOn(mockStorage, 'getAutoSavedPolicyPath').mockReturnValue(policyFile);
     (fs.mkdir as unknown as Mock).mockResolvedValue(undefined);
     (fs.readFile as unknown as Mock).mockRejectedValue(
       new Error('File not found'),
@@ -163,9 +169,14 @@ describe('createPolicyUpdater', () => {
     createPolicyUpdater(policyEngine, messageBus, mockStorage);
 
     const workspacePoliciesDir = '/mock/project/.gemini/policies';
+    const policyFile = path.join(
+      workspacePoliciesDir,
+      AUTO_SAVED_POLICY_FILENAME,
+    );
     vi.spyOn(mockStorage, 'getWorkspacePoliciesDir').mockReturnValue(
       workspacePoliciesDir,
     );
+    vi.spyOn(mockStorage, 'getAutoSavedPolicyPath').mockReturnValue(policyFile);
     (fs.mkdir as unknown as Mock).mockResolvedValue(undefined);
     (fs.readFile as unknown as Mock).mockRejectedValue(
       new Error('File not found'),
@@ -204,9 +215,14 @@ describe('createPolicyUpdater', () => {
     createPolicyUpdater(policyEngine, messageBus, mockStorage);
 
     const workspacePoliciesDir = '/mock/project/.gemini/policies';
+    const policyFile = path.join(
+      workspacePoliciesDir,
+      AUTO_SAVED_POLICY_FILENAME,
+    );
     vi.spyOn(mockStorage, 'getWorkspacePoliciesDir').mockReturnValue(
       workspacePoliciesDir,
     );
+    vi.spyOn(mockStorage, 'getAutoSavedPolicyPath').mockReturnValue(policyFile);
     (fs.mkdir as unknown as Mock).mockResolvedValue(undefined);
     (fs.readFile as unknown as Mock).mockRejectedValue(
       new Error('File not found'),


### PR DESCRIPTION
## Summary

Repurposes the "Allow for all future sessions" (policy persistence) functionality from the user level to the workspace level. This ensures that tool and MCP server permissions granted by the user are scoped to the specific project/workspace rather than being applied globally.

## Details

- **Scoping**: Updated `createPolicyUpdater` in `packages/core/src/policy/config.ts` to accept a `Storage` instance and use `storage.getWorkspacePoliciesDir()` for persisting rules to `.gemini/policies/auto-saved.toml`.
- **Priority Tier**: Moved dynamic "Always Allow" rules from the User Tier (3.95) to the Workspace Tier (2.95) using a new `ALWAYS_ALLOW_PRIORITY` constant.
- **Refactoring**: Introduced static constants for all policy priority levels to eliminate hardcoded numbers and improved comment clarity.
- **Integration**: Updated CLI orchestration in `gemini.tsx` and the policy wrapper in `packages/cli/src/config/policy.ts` to pass the `Storage` instance correctly.

## Related Issues

Fixes #19704

## How to Validate

1. Run Gemini CLI in a project directory.
2. Trigger a tool that requires confirmation.
3. Select "Allow for all future sessions".
4. Verify that `.gemini/policies/auto-saved.toml` is created in the current directory.
5. Verify that the rule is NOT applied when running Gemini CLI in a different directory.
6. Run core tests: `npm test -w @google/gemini-cli-core -- src/policy/policy-updater.test.ts src/policy/persistence.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
