### PR TITLE
Disallow and suppress unsafe assignment

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -200,6 +200,7 @@ export default tseslint.config(
     ignores: ['**/*.test.ts', '**/*.test.tsx'],
     rules: {
       '@typescript-eslint/no-unsafe-type-assertion': 'error',
+      '@typescript-eslint/no-unsafe-assignment': 'error',
     },
   },
   {

--- a/packages/a2a-server/src/commands/restore.ts
+++ b/packages/a2a-server/src/commands/restore.ts
@@ -69,6 +69,7 @@ export class RestoreCommand implements Command {
         throw error;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const toolCallData = JSON.parse(data);
       const ToolCallDataSchema = getToolCallDataSchema();
       const parseResult = ToolCallDataSchema.safeParse(toolCallData);

--- a/packages/a2a-server/src/config/settings.ts
+++ b/packages/a2a-server/src/config/settings.ts
@@ -7,8 +7,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import type {
-  MCPServerConfig,
+import {
+  type MCPServerConfig,
   debugLogger,
   GEMINI_DIR,
   getErrorMessage,

--- a/packages/a2a-server/src/config/settings.ts
+++ b/packages/a2a-server/src/config/settings.ts
@@ -7,7 +7,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import type { MCPServerConfig ,
+import type {
+  MCPServerConfig,
   debugLogger,
   GEMINI_DIR,
   getErrorMessage,

--- a/packages/a2a-server/src/config/settings.ts
+++ b/packages/a2a-server/src/config/settings.ts
@@ -7,8 +7,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import type { MCPServerConfig } from '@google/gemini-cli-core';
-import {
+import type { MCPServerConfig ,
   debugLogger,
   GEMINI_DIR,
   getErrorMessage,
@@ -122,6 +121,7 @@ export function loadSettings(workspaceDir: string): Settings {
 function resolveEnvVarsInString(value: string): string {
   const envVarRegex = /\$(?:(\w+)|{([^}]+)})/g; // Find $VAR_NAME or ${VAR_NAME}
   return value.replace(envVarRegex, (match, varName1, varName2) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const varName = varName1 || varName2;
     if (process && process.env && typeof process.env[varName] === 'string') {
       return process.env[varName];

--- a/packages/a2a-server/src/http/app.ts
+++ b/packages/a2a-server/src/http/app.ts
@@ -7,8 +7,8 @@
 import express from 'express';
 
 import type { AgentCard, Message } from '@a2a-js/sdk';
-import type {
-  TaskStore,
+import {
+  type TaskStore,
   DefaultRequestHandler,
   InMemoryTaskStore,
   DefaultExecutionEventBus,

--- a/packages/a2a-server/src/http/app.ts
+++ b/packages/a2a-server/src/http/app.ts
@@ -7,7 +7,8 @@
 import express from 'express';
 
 import type { AgentCard, Message } from '@a2a-js/sdk';
-import type { TaskStore ,
+import type {
+  TaskStore,
   DefaultRequestHandler,
   InMemoryTaskStore,
   DefaultExecutionEventBus,
@@ -24,7 +25,11 @@ import { loadConfig, loadEnvironment, setTargetDir } from '../config/config.js';
 import { loadSettings } from '../config/settings.js';
 import { loadExtensions } from '../config/extension.js';
 import { commandRegistry } from '../commands/command-registry.js';
-import { debugLogger, SimpleExtensionLoader , GitService } from '@google/gemini-cli-core';
+import {
+  debugLogger,
+  SimpleExtensionLoader,
+  GitService,
+} from '@google/gemini-cli-core';
 import type { Command, CommandArgument } from '../commands/types.js';
 
 type CommandResponse = {

--- a/packages/a2a-server/src/http/app.ts
+++ b/packages/a2a-server/src/http/app.ts
@@ -7,8 +7,7 @@
 import express from 'express';
 
 import type { AgentCard, Message } from '@a2a-js/sdk';
-import type { TaskStore } from '@a2a-js/sdk/server';
-import {
+import type { TaskStore ,
   DefaultRequestHandler,
   InMemoryTaskStore,
   DefaultExecutionEventBus,
@@ -25,9 +24,8 @@ import { loadConfig, loadEnvironment, setTargetDir } from '../config/config.js';
 import { loadSettings } from '../config/settings.js';
 import { loadExtensions } from '../config/extension.js';
 import { commandRegistry } from '../commands/command-registry.js';
-import { debugLogger, SimpleExtensionLoader } from '@google/gemini-cli-core';
+import { debugLogger, SimpleExtensionLoader , GitService } from '@google/gemini-cli-core';
 import type { Command, CommandArgument } from '../commands/types.js';
-import { GitService } from '@google/gemini-cli-core';
 
 type CommandResponse = {
   name: string;
@@ -88,6 +86,7 @@ async function handleExecuteCommand(
   },
 ) {
   logger.info('[CoreAgent] Received /executeCommand request: ', req.body);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const { command, args } = req.body;
   try {
     if (typeof command !== 'string') {
@@ -211,6 +210,7 @@ export async function createApp() {
         const agentSettings = req.body.agentSettings as
           | AgentSettings
           | undefined;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const contextId = req.body.contextId || uuidv4();
         const wrapper = await agentExecutor.createTask(
           taskId,

--- a/packages/a2a-server/src/persistence/gcs.ts
+++ b/packages/a2a-server/src/persistence/gcs.ts
@@ -246,6 +246,7 @@ export class GCSTaskStore implements TaskStore {
       }
       const [compressedMetadata] = await metadataFile.download();
       const jsonData = gunzipSync(compressedMetadata).toString();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const loadedMetadata = JSON.parse(jsonData);
       logger.info(`Task ${taskId} metadata loaded from GCS.`);
 
@@ -282,12 +283,14 @@ export class GCSTaskStore implements TaskStore {
 
       return {
         id: taskId,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         contextId: loadedMetadata._contextId || uuidv4(),
         kind: 'task',
         status: {
           state: persistedState._taskState,
           timestamp: new Date().toISOString(),
         },
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         metadata: loadedMetadata,
         history: [],
         artifacts: [],

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -866,6 +866,7 @@ Would you like to attempt to install via "git clone" instead?`,
 
     try {
       const hooksContent = await fs.promises.readFile(hooksFilePath, 'utf-8');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const rawHooks = JSON.parse(hooksContent);
 
       if (

--- a/packages/cli/src/config/extensionRegistryClient.ts
+++ b/packages/cli/src/config/extensionRegistryClient.ts
@@ -81,6 +81,7 @@ export class ExtensionRegistryClient {
         `${ext.extensionName} ${ext.extensionDescription} ${ext.fullName}`,
       fuzzy: true,
     });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const results = await fzf.find(query);
     return results.map((r: { item: RegistryExtension }) => r.item);
   }

--- a/packages/cli/src/test-utils/AppRig.tsx
+++ b/packages/cli/src/test-utils/AppRig.tsx
@@ -217,13 +217,14 @@ export class AppRig {
   }
 
   private stubRefreshAuth() {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
     const gcConfig = this.config as any;
     gcConfig.refreshAuth = async (authMethod: AuthType) => {
       gcConfig.modelAvailabilityService.reset();
 
       const newContentGeneratorConfig = {
         authType: authMethod,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         proxy: gcConfig.getProxy(),
         apiKey: process.env['GEMINI_API_KEY'] || 'test-api-key',
       };

--- a/packages/cli/src/test-utils/customMatchers.ts
+++ b/packages/cli/src/test-utils/customMatchers.ts
@@ -21,7 +21,7 @@ import type { TextBuffer } from '../ui/components/shared/text-buffer.js';
 const invalidCharsRegex = /[\b\x1b]/;
 
 function toHaveOnlyValidCharacters(this: Assertion, buffer: TextBuffer) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-assignment
   const { isNot } = this as any;
   let pass = true;
   const invalidLines: Array<{ line: number; content: string }> = [];

--- a/packages/cli/src/test-utils/mockCommandContext.ts
+++ b/packages/cli/src/test-utils/mockCommandContext.ts
@@ -45,7 +45,7 @@ export const createMockCommandContext = (
         forScope: vi.fn().mockReturnValue({ settings: {} }),
       } as unknown as LoadedSettings,
       git: undefined as GitService | undefined,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-assignment
       logger: {
         log: vi.fn(),
         logMessage: vi.fn(),
@@ -54,7 +54,7 @@ export const createMockCommandContext = (
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any, // Cast because Logger is a class.
     },
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-assignment
     ui: {
       addItem: vi.fn(),
       clear: vi.fn(),
@@ -94,11 +94,14 @@ export const createMockCommandContext = (
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const merge = (target: any, source: any): any => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const output = { ...target };
 
     for (const key in source) {
       if (Object.prototype.hasOwnProperty.call(source, key)) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const sourceValue = source[key];
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const targetValue = output[key];
 
         if (
@@ -106,9 +109,11 @@ export const createMockCommandContext = (
           Object.prototype.toString.call(sourceValue) === '[object Object]' &&
           Object.prototype.toString.call(targetValue) === '[object Object]'
         ) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           output[key] = merge(targetValue, sourceValue);
         } else {
           // If not, we do a direct assignment. This preserves Date objects and others.
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           output[key] = sourceValue;
         }
       }

--- a/packages/cli/src/test-utils/settings.ts
+++ b/packages/cli/src/test-utils/settings.ts
@@ -46,6 +46,7 @@ export const createMockSettings = (
     workspace,
     isTrusted,
     errors,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     merged: mergedOverride,
     ...settingsOverrides
   } = overrides;
@@ -75,7 +76,7 @@ export const createMockSettings = (
   // Assign any function overrides (e.g., vi.fn() for methods)
   for (const key in overrides) {
     if (typeof overrides[key] === 'function') {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-assignment
       (loaded as any)[key] = overrides[key];
     }
   }

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -115,6 +115,7 @@ export function SettingsDialog({
     }
 
     const doSearch = async () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const results = await fzfInstance.find(searchQuery);
 
       if (!active) return;

--- a/packages/cli/src/ui/components/triage/TriageDuplicates.tsx
+++ b/packages/cli/src/ui/components/triage/TriageDuplicates.tsx
@@ -451,6 +451,7 @@ Return a JSON object with:
         '--limit',
         String(limit),
       ]);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const issues: Issue[] = JSON.parse(stdout);
       if (issues.length === 0) {
         setState((s) => ({

--- a/packages/cli/src/ui/components/triage/TriageIssues.tsx
+++ b/packages/cli/src/ui/components/triage/TriageIssues.tsx
@@ -137,6 +137,7 @@ export const TriageIssues = ({
           '--limit',
           String(limit),
         ]);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const issues: Issue[] = JSON.parse(stdout);
         if (issues.length === 0) {
           setState((s) => ({

--- a/packages/cli/src/ui/hooks/useAtCompletion.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.ts
@@ -166,6 +166,7 @@ async function searchResourceCandidates(
   const fzf = new AsyncFzf(candidates, {
     selector: (candidate: ResourceSuggestionCandidate) => candidate.searchKey,
   });
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const results = await fzf.find(normalizedPattern, {
     limit: MAX_SUGGESTIONS_TO_SHOW * 3,
   });
@@ -188,6 +189,7 @@ async function searchAgentCandidates(
   const fzf = new AsyncFzf(candidates, {
     selector: (s: Suggestion) => s.label,
   });
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const results = await fzf.find(normalizedPattern, {
     limit: MAX_SUGGESTIONS_TO_SHOW,
   });

--- a/packages/cli/src/ui/hooks/useSessionBrowser.ts
+++ b/packages/cli/src/ui/hooks/useSessionBrowser.ts
@@ -57,6 +57,7 @@ export const useSessionBrowser = (
           const originalFilePath = path.join(chatsDir, fileName);
 
           // Load up the conversation.
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           const conversation: ConversationRecord = JSON.parse(
             await fs.readFile(originalFilePath, 'utf8'),
           );

--- a/packages/cli/src/ui/hooks/useSlashCompletion.ts
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.ts
@@ -271,6 +271,7 @@ function useCommandSuggestions(
           const fzfInstance = getFzfForCommands(commandsToSearch);
           if (fzfInstance) {
             try {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               const fzfResults = await fzfInstance.fzf.find(partial);
               if (signal.aborted) return;
               const uniqueCommands = new Set<SlashCommand>();

--- a/packages/cli/src/ui/hooks/useStateAndRef.ts
+++ b/packages/cli/src/ui/hooks/useStateAndRef.ts
@@ -22,6 +22,7 @@ export const useStateAndRef = <
     (newStateOrCallback) => {
       let newValue: T;
       if (typeof newStateOrCallback === 'function') {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         newValue = newStateOrCallback(ref.current);
       } else {
         newValue = newStateOrCallback;

--- a/packages/cli/src/ui/utils/TableRenderer.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.tsx
@@ -243,6 +243,7 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
     isHeader = false,
   ): React.ReactNode => {
     const renderedCells = cells.map((cell, index) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const width = adjustedWidths[index] || 0;
       return renderCell(cell, width, isHeader);
     });

--- a/packages/cli/src/ui/utils/terminalSetup.ts
+++ b/packages/cli/src/ui/utils/terminalSetup.ts
@@ -179,6 +179,7 @@ async function configureVSCodeStyle(
       await backupFile(keybindingsFile);
       try {
         const cleanContent = stripJsonComments(content);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const parsedContent = JSON.parse(cleanContent);
         if (!Array.isArray(parsedContent)) {
           return {

--- a/packages/cli/src/ui/utils/textUtils.ts
+++ b/packages/cli/src/ui/utils/textUtils.ts
@@ -233,7 +233,9 @@ export function escapeAnsiCtrlCodes<T>(obj: T): T {
     let newArr: unknown[] | null = null;
 
     for (let i = 0; i < obj.length; i++) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const value = obj[i];
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const escapedValue = escapeAnsiCtrlCodes(value);
       if (escapedValue !== value) {
         if (newArr === null) {

--- a/packages/cli/src/utils/envVarResolver.ts
+++ b/packages/cli/src/utils/envVarResolver.ts
@@ -23,6 +23,7 @@ export function resolveEnvVarsInString(
 ): string {
   const envVarRegex = /\$(?:(\w+)|{([^}]+)})/g; // Find $VAR_NAME or ${VAR_NAME}
   return value.replace(envVarRegex, (match, varName1, varName2) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const varName = varName1 || varName2;
     if (customEnv && typeof customEnv[varName] === 'string') {
       return customEnv[varName];

--- a/packages/cli/src/utils/gitUtils.ts
+++ b/packages/cli/src/utils/gitUtils.ts
@@ -78,6 +78,7 @@ export const getLatestGitHubRelease = async (
       );
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const releaseTag = (await response.json()).tag_name;
     if (!releaseTag) {
       throw new Error(`Response did not include tag_name field`);

--- a/packages/cli/src/utils/jsonoutput.ts
+++ b/packages/cli/src/utils/jsonoutput.ts
@@ -29,6 +29,7 @@ export function tryParseJSON(input: string): object | null {
   if (!checkInput(input)) return null;
   const trimmed = input.trim();
   try {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const parsed = JSON.parse(trimmed);
     if (parsed === null || typeof parsed !== 'object') {
       return null;

--- a/packages/cli/src/utils/persistentState.ts
+++ b/packages/cli/src/utils/persistentState.ts
@@ -38,6 +38,7 @@ export class PersistentState {
       const filePath = this.getPath();
       if (fs.existsSync(filePath)) {
         const content = fs.readFileSync(filePath, 'utf-8');
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         this.cache = JSON.parse(content);
       } else {
         this.cache = {};

--- a/packages/cli/src/utils/readStdin.ts
+++ b/packages/cli/src/utils/readStdin.ts
@@ -23,6 +23,7 @@ export async function readStdin(): Promise<string> {
 
     const onReadable = () => {
       let chunk;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       while ((chunk = process.stdin.read()) !== null) {
         if (pipedInputTimerId) {
           clearTimeout(pipedInputTimerId);

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -254,6 +254,7 @@ export const getAllSessionFiles = async (
       async (file): Promise<SessionFileEntry> => {
         const filePath = path.join(chatsDir, file);
         try {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           const content: ConversationRecord = JSON.parse(
             await fs.readFile(filePath, 'utf8'),
           );
@@ -498,6 +499,7 @@ export class SessionSelector {
     const sessionPath = path.join(chatsDir, sessionInfo.fileName);
 
     try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const sessionData: ConversationRecord = JSON.parse(
         await fs.readFile(sessionPath, 'utf8'),
       );

--- a/packages/cli/src/utils/settingsUtils.ts
+++ b/packages/cli/src/utils/settingsUtils.ts
@@ -371,6 +371,7 @@ export function setPendingSettingValue(
   pendingSettings: Settings,
 ): Settings {
   const path = key.split('.');
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const newSettings = JSON.parse(JSON.stringify(pendingSettings));
   setNestedValue(newSettings, path, value);
   return newSettings;

--- a/packages/cli/src/zed-integration/acpErrors.ts
+++ b/packages/cli/src/zed-integration/acpErrors.ts
@@ -25,7 +25,9 @@ function extractRecursiveMessage(input: string): string {
     (trimmed.startsWith('[') && trimmed.endsWith(']'))
   ) {
     try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const parsed = JSON.parse(trimmed);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const next =
         parsed?.error?.message ||
         parsed?.[0]?.error?.message ||

--- a/packages/cli/src/zed-integration/fileSystemService.ts
+++ b/packages/cli/src/zed-integration/fileSystemService.ts
@@ -23,6 +23,7 @@ export class AcpFileSystemService implements FileSystemService {
       return this.fallback.readTextFile(filePath);
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const response = await this.connection.readTextFile({
       path: filePath,
       sessionId: this.sessionId,

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -702,6 +702,7 @@ export class Session {
           },
         };
 
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const output = await this.connection.requestPermission(params);
         const outcome =
           output.outcome.outcome === CoreToolCallStatus.Cancelled

--- a/packages/core/src/agents/acknowledgedAgents.ts
+++ b/packages/core/src/agents/acknowledgedAgents.ts
@@ -27,6 +27,7 @@ export class AcknowledgedAgentsService {
     const filePath = Storage.getAcknowledgedAgentsPath();
     try {
       const content = await fs.readFile(filePath, 'utf-8');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       this.acknowledgedAgents = JSON.parse(content);
     } catch (error: unknown) {
       if (!isNodeError(error) || error.code !== 'ENOENT') {

--- a/packages/core/src/agents/agent-scheduler.ts
+++ b/packages/core/src/agents/agent-scheduler.ts
@@ -54,6 +54,7 @@ export async function scheduleAgentTools(
   } = options;
 
   // Create a proxy/override of the config to provide the agent-specific tool registry.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const agentConfig: Config = Object.create(config);
   agentConfig.getToolRegistry = () => toolRegistry;
 

--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -34,7 +34,8 @@ import {
   AgentStartEvent,
   AgentFinishEvent,
   RecoveryAttemptEvent,
- LlmRole } from '../telemetry/types.js';
+  LlmRole,
+} from '../telemetry/types.js';
 import type {
   LocalAgentDefinition,
   AgentInputs,

--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -34,7 +34,7 @@ import {
   AgentStartEvent,
   AgentFinishEvent,
   RecoveryAttemptEvent,
-} from '../telemetry/types.js';
+ LlmRole } from '../telemetry/types.js';
 import type {
   LocalAgentDefinition,
   AgentInputs,
@@ -59,7 +59,6 @@ import { getVersion } from '../utils/version.js';
 import { getToolCallContext } from '../utils/toolCallContext.js';
 import { scheduleAgentTools } from './agent-scheduler.js';
 import { DeadlineTimer } from '../utils/deadlineTimer.js';
-import { LlmRole } from '../telemetry/types.js';
 import { formatUserHintsForModel } from '../utils/fastAckHelper.js';
 
 /** A callback function to report on agent activity. */
@@ -925,6 +924,7 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
               continue;
             }
 
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             const validatedOutput = validationResult.data;
             if (this.definition.processOutput) {
               submittedOutput = this.definition.processOutput(validatedOutput);

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -394,6 +394,7 @@ export class AgentRegistry {
     }
 
     // Use Object.create to preserve lazy getters on the definition object
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const merged: LocalAgentDefinition<TOutput> = Object.create(definition);
 
     if (overrides.runConfig) {

--- a/packages/core/src/code_assist/admin/admin_controls.ts
+++ b/packages/core/src/code_assist/admin/admin_controls.ts
@@ -31,6 +31,7 @@ export function sanitizeAdminSettings(
 
   if (sanitized.mcpSetting?.mcpConfigJson) {
     try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const parsed = JSON.parse(sanitized.mcpSetting.mcpConfigJson);
       const validationResult = McpConfigDefinitionSchema.safeParse(parsed);
 

--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -181,6 +181,15 @@ function maybeToContent(content?: ContentUnion): Content | undefined {
   return toContent(content);
 }
 
+function isPart(c: ContentUnion): c is PartUnion {
+  return (
+    !Array.isArray(c) &&
+    typeof c !== 'string' &&
+    !('parts' in c) &&
+    !('role' in c)
+  );
+}
+
 function toContent(content: ContentUnion): Content {
   if (Array.isArray(content)) {
     // it's a PartsUnion[]
@@ -196,7 +205,7 @@ function toContent(content: ContentUnion): Content {
       parts: [{ text: content }],
     };
   }
-  if ('parts' in content) {
+  if (!isPart(content)) {
     // it's a Content - process parts to handle thought filtering
     return {
       ...content,
@@ -208,8 +217,7 @@ function toContent(content: ContentUnion): Content {
   // it's a Part
   return {
     role: 'user',
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    parts: [toPart(content as Part)],
+    parts: [toPart(content)],
   };
 }
 

--- a/packages/core/src/code_assist/experiments/experiments.ts
+++ b/packages/core/src/code_assist/experiments/experiments.ts
@@ -35,6 +35,7 @@ export async function getExperiments(
         const expPath = process.env['GEMINI_EXP'];
         debugLogger.debug('Reading experiments from', expPath);
         const content = await fs.promises.readFile(expPath, 'utf8');
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const response: ListExperimentsResponse = JSON.parse(content);
         if (
           (response.flags && !Array.isArray(response.flags)) ||

--- a/packages/core/src/code_assist/experiments/experiments.ts
+++ b/packages/core/src/code_assist/experiments/experiments.ts
@@ -35,7 +35,7 @@ export async function getExperiments(
         const expPath = process.env['GEMINI_EXP'];
         debugLogger.debug('Reading experiments from', expPath);
         const content = await fs.promises.readFile(expPath, 'utf8');
-        const response = JSON.parse(content);
+        const response: ListExperimentsResponse = JSON.parse(content);
         if (
           (response.flags && !Array.isArray(response.flags)) ||
           (response.experimentIds && !Array.isArray(response.experimentIds))
@@ -44,8 +44,7 @@ export async function getExperiments(
             'Invalid format for experiments file: `flags` and `experimentIds` must be arrays if present.',
           );
         }
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        return parseExperiments(response as ListExperimentsResponse);
+        return parseExperiments(response);
       } catch (e) {
         debugLogger.debug('Failed to read experiments from GEMINI_EXP', e);
       }

--- a/packages/core/src/code_assist/oauth-credential-storage.ts
+++ b/packages/core/src/code_assist/oauth-credential-storage.ts
@@ -125,6 +125,7 @@ export class OAuthCredentialStorage {
       throw error;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const credentials: Credentials = JSON.parse(credsJson);
 
     // Save to new storage

--- a/packages/core/src/code_assist/oauth-credential-storage.ts
+++ b/packages/core/src/code_assist/oauth-credential-storage.ts
@@ -125,8 +125,7 @@ export class OAuthCredentialStorage {
       throw error;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    const credentials = JSON.parse(credsJson) as Credentials;
+    const credentials: Credentials = JSON.parse(credsJson);
 
     // Save to new storage
     await this.saveCredentials(credentials);

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -115,9 +115,9 @@ async function initOauthClient(
 
   if (
     credentials &&
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    (credentials as { type?: string }).type ===
-      'external_account_authorized_user'
+    typeof credentials === 'object' &&
+    'type' in credentials &&
+    credentials.type === 'external_account_authorized_user'
   ) {
     const auth = new GoogleAuth({
       scopes: OAUTH_SCOPE,
@@ -603,9 +603,10 @@ export function getAvailablePort(): Promise<number> {
       }
       const server = net.createServer();
       server.listen(0, () => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        const address = server.address()! as net.AddressInfo;
-        port = address.port;
+        const address = server.address();
+        if (address && typeof address === 'object') {
+          port = address.port;
+        }
       });
       server.on('listening', () => {
         server.close();

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -695,6 +695,7 @@ async function fetchAndCacheUserInfo(client: OAuth2Client): Promise<void> {
       return;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const userInfo = await response.json();
     await userAccountManager.cacheGoogleAccount(userInfo.email);
   } catch (error) {

--- a/packages/core/src/core/logger.ts
+++ b/packages/core/src/core/logger.ts
@@ -88,6 +88,7 @@ export class Logger {
     }
     try {
       const fileContent = await fs.readFile(this.logFilePath, 'utf-8');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const parsedLogs = JSON.parse(fileContent);
       if (!Array.isArray(parsedLogs)) {
         debugLogger.debug(
@@ -352,6 +353,7 @@ export class Logger {
     const path = await this._getCheckpointPath(tag);
     try {
       const fileContent = await fs.readFile(path, 'utf-8');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const parsedContent = JSON.parse(fileContent);
 
       // Handle legacy format (just an array of Content)

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -5,7 +5,8 @@
  */
 
 import { spawn } from 'node:child_process';
-import type { HookConfig ,
+import type {
+  HookConfig,
   HookInput,
   HookOutput,
   HookExecutionResult,

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -5,10 +5,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import type { HookConfig } from './types.js';
-import { HookEventName, ConfigSource } from './types.js';
-import type { Config } from '../config/config.js';
-import type {
+import type { HookConfig ,
   HookInput,
   HookOutput,
   HookExecutionResult,
@@ -17,6 +14,8 @@ import type {
   BeforeModelOutput,
   BeforeToolInput,
 } from './types.js';
+import { HookEventName, ConfigSource } from './types.js';
+import type { Config } from '../config/config.js';
 import type { LLMRequest } from './hookTranslator.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { sanitizeEnvironment } from '../services/environmentSanitization.js';
@@ -356,8 +355,10 @@ export class HookRunner {
         const textToParse = stdout.trim() || stderr.trim();
         if (textToParse) {
           try {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             let parsed = JSON.parse(textToParse);
             if (typeof parsed === 'string') {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               parsed = JSON.parse(parsed);
             }
             if (parsed && typeof parsed === 'object') {

--- a/packages/core/src/hooks/trustedHooks.ts
+++ b/packages/core/src/hooks/trustedHooks.ts
@@ -34,6 +34,7 @@ export class TrustedHooksManager {
     try {
       if (fs.existsSync(this.configPath)) {
         const content = fs.readFileSync(this.configPath, 'utf-8');
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         this.trustedHooks = JSON.parse(content);
       }
     } catch (error) {

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -16,7 +16,10 @@ import { getIdeProcessInfo } from './process-utils.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { CallToolResultSchema , ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  CallToolResultSchema,
+  ListToolsResultSchema,
+} from '@modelcontextprotocol/sdk/types.js';
 import { IDE_REQUEST_TIMEOUT_MS } from './constants.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import {

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -16,8 +16,7 @@ import { getIdeProcessInfo } from './process-utils.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
-import { ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolResultSchema , ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import { IDE_REQUEST_TIMEOUT_MS } from './constants.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import {
@@ -343,6 +342,7 @@ export class IdeClient {
 
       if (textPart?.text) {
         try {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           const parsedJson = JSON.parse(textPart.text);
           if (parsedJson && typeof parsedJson.content === 'string') {
             return parsedJson.content;

--- a/packages/core/src/ide/ide-connection-utils.ts
+++ b/packages/core/src/ide/ide-connection-utils.ts
@@ -89,8 +89,10 @@ export function getStdioConfigFromEnv(): StdioConfig | undefined {
   let args: string[] = [];
   if (argsStr) {
     try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const parsedArgs = JSON.parse(argsStr);
       if (Array.isArray(parsedArgs)) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         args = parsedArgs;
       } else {
         logger.error(
@@ -188,6 +190,7 @@ export async function getConnectionConfigFromFile(
   }
 
   if (validWorkspaces.length === 1) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const selected = validWorkspaces[0];
     const fileIndex = parsedContents.indexOf(selected);
     if (fileIndex !== -1) {
@@ -202,6 +205,7 @@ export async function getConnectionConfigFromFile(
       (content) => String(content.port) === portFromEnv,
     );
     if (matchingPortIndex !== -1) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const selected = validWorkspaces[matchingPortIndex];
       const fileIndex = parsedContents.indexOf(selected);
       if (fileIndex !== -1) {
@@ -213,6 +217,7 @@ export async function getConnectionConfigFromFile(
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const selected = validWorkspaces[0];
   const fileIndex = parsedContents.indexOf(selected);
   if (fileIndex !== -1) {

--- a/packages/core/src/ide/process-utils.ts
+++ b/packages/core/src/ide/process-utils.ts
@@ -47,6 +47,7 @@ async function getProcessTableWindows(): Promise<Map<number, ProcessInfo>> {
 
     let processes: RawProcessInfo | RawProcessInfo[];
     try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       processes = JSON.parse(stdout);
     } catch (_e) {
       return processMap;

--- a/packages/core/src/mcp/oauth-provider.test.ts
+++ b/packages/core/src/mcp/oauth-provider.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi , describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 // Mock dependencies AT THE TOP
 const mockOpenBrowserSecurely = vi.hoisted(() => vi.fn());

--- a/packages/core/src/mcp/oauth-utils.ts
+++ b/packages/core/src/mcp/oauth-utils.ts
@@ -409,6 +409,7 @@ export class OAuthUtils {
    */
   static parseTokenExpiry(idToken: string): number | undefined {
     try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const payload = JSON.parse(
         Buffer.from(idToken.split('.')[1], 'base64').toString(),
       );

--- a/packages/core/src/mcp/token-storage/keychain-token-storage.ts
+++ b/packages/core/src/mcp/token-storage/keychain-token-storage.ts
@@ -45,7 +45,9 @@ export class KeychainTokenStorage
     try {
       // Try to import keytar without any timeout - let the OS handle it
       const moduleName = 'keytar';
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const module = await import(moduleName);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       this.keytarModule = module.default || module;
     } catch (_) {
       //Keytar is optional so we shouldn't raise an error of log anything.

--- a/packages/core/src/safety/checker-runner.ts
+++ b/packages/core/src/safety/checker-runner.ts
@@ -229,6 +229,7 @@ export class CheckerRunner {
 
         // Try to parse the output
         try {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           const rawResult = JSON.parse(stdout);
           const result = SafetyCheckResultSchema.parse(rawResult);
 

--- a/packages/core/src/services/sessionSummaryUtils.ts
+++ b/packages/core/src/services/sessionSummaryUtils.ts
@@ -26,6 +26,7 @@ async function generateAndSaveSummary(
 ): Promise<void> {
   // Read session file
   const content = await fs.readFile(sessionPath, 'utf-8');
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const conversation: ConversationRecord = JSON.parse(content);
 
   // Skip if summary already exists
@@ -69,6 +70,7 @@ async function generateAndSaveSummary(
 
   // Re-read the file before writing to handle race conditions
   const freshContent = await fs.readFile(sessionPath, 'utf-8');
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const freshConversation: ConversationRecord = JSON.parse(freshContent);
 
   // Check if summary was added by another process
@@ -127,6 +129,7 @@ export async function getPreviousSession(
 
     try {
       const content = await fs.readFile(filePath, 'utf-8');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const conversation: ConversationRecord = JSON.parse(content);
 
       if (conversation.summary) {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -568,6 +568,7 @@ export class ShellExecutionService {
       const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
       const args = [...argsPrefix, guardedCommand];
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const ptyProcess = ptyInfo.module.spawn(executable, args, {
         cwd,
         name: 'xterm-256color',
@@ -598,6 +599,7 @@ export class ShellExecutionService {
         headlessTerminal.scrollToTop();
 
         this.activePtys.set(ptyProcess.pid, {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           ptyProcess,
           headlessTerminal,
           maxSerializedLines: shellExecutionConfig.maxSerializedLines,
@@ -831,6 +833,7 @@ export class ShellExecutionService {
                 signal: signal ?? null,
                 error,
                 aborted: abortSignal.aborted,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                 pid: ptyProcess.pid,
                 executionMethod: ptyInfo?.name ?? 'node-pty',
               });
@@ -862,9 +865,11 @@ export class ShellExecutionService {
         const abortHandler = async () => {
           if (ptyProcess.pid && !exited) {
             await killProcessGroup({
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               pid: ptyProcess.pid,
               escalate: true,
               isExited: () => exited,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               pty: ptyProcess,
             });
           }
@@ -873,6 +878,7 @@ export class ShellExecutionService {
         abortSignal.addEventListener('abort', abortHandler, { once: true });
       });
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       return { pid: ptyProcess.pid, result };
     } catch (e) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -716,6 +716,7 @@ export class ClearcutLogger {
         event.function_name === ASK_USER_TOOL_NAME &&
         event.metadata['ask_user']
       ) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const askUser = event.metadata['ask_user'];
         const askUserMapping: { [key: string]: EventMetadataKey } = {
           question_types: EventMetadataKey.GEMINI_CLI_ASK_USER_QUESTION_TYPES,

--- a/packages/core/src/telemetry/integration.test.circular.ts
+++ b/packages/core/src/telemetry/integration.test.circular.ts
@@ -36,11 +36,13 @@ describe('Circular Reference Integration Test', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const socketLike: any = {
       _httpMessage: {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         agent: proxyAgentLike,
         socket: null,
       },
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     socketLike._httpMessage.socket = socketLike; // Create circular reference
     proxyAgentLike.sockets['cloudcode-pa.googleapis.com:443'] = [socketLike];
 
@@ -49,6 +51,7 @@ describe('Circular Reference Integration Test', () => {
       error: new Error('Network error'),
       function_args: {
         filePath: '/test/file.txt',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         httpAgent: proxyAgentLike, // This would cause the circular reference
       },
     };

--- a/packages/core/src/telemetry/loggers.test.circular.ts
+++ b/packages/core/src/telemetry/loggers.test.circular.ts
@@ -39,8 +39,10 @@ describe('Circular Reference Handling', () => {
       sockets: {},
       agent: null,
     };
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     circularObject.agent = circularObject; // Create circular reference
     circularObject.sockets['test-host'] = [
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       { _httpMessage: { agent: circularObject } },
     ];
 
@@ -48,6 +50,7 @@ describe('Circular Reference Handling', () => {
     const mockRequest: ToolCallRequestInfo = {
       callId: 'test-call-id',
       name: 'ReadFile',
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       args: circularObject, // This would cause the original error
       isClientInitiated: false,
       prompt_id: 'test-prompt-id',

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -145,12 +145,14 @@ export function logToolCall(config: Config, event: ToolCallEvent): void {
     });
 
     if (event.metadata) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const added = event.metadata['model_added_lines'];
       if (typeof added === 'number' && added > 0) {
         recordLinesChanged(config, added, 'added', {
           function_name: event.function_name,
         });
       }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const removed = event.metadata['model_removed_lines'];
       if (typeof removed === 'number' && removed > 0) {
         recordLinesChanged(config, removed, 'removed', {

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -22,8 +22,7 @@ import type {
   Prompt,
   ReadResourceResult,
   Resource,
-} from '@modelcontextprotocol/sdk/types.js';
-import {
+
   ListResourcesResultSchema,
   ListRootsRequestSchema,
   ReadResourceResultSchema,
@@ -31,8 +30,7 @@ import {
   ToolListChangedNotificationSchema,
   PromptListChangedNotificationSchema,
   ProgressNotificationSchema,
-  type Tool as McpTool,
-} from '@modelcontextprotocol/sdk/types.js';
+  type Tool as McpTool} from '@modelcontextprotocol/sdk/types.js';
 import { ApprovalMode, PolicyDecision } from '../policy/types.js';
 import { parse } from 'shell-quote';
 import type { Config, MCPServerConfig } from '../config/config.js';
@@ -1996,6 +1994,7 @@ export async function createTransport(
       // The `XcodeMcpBridgeFixTransport` wrapper hides the underlying `StdioClientTransport`,
       // which exposes `stderr` for debug logging. We need to unwrap it to attach the listener.
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const underlyingTransport =
         transport instanceof XcodeMcpBridgeFixTransport
           ? // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion
@@ -2007,6 +2006,7 @@ export async function createTransport(
         underlyingTransport.stderr
       ) {
         underlyingTransport.stderr.on('data', (data) => {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           const stderrStr = data.toString().trim();
           debugLogger.debug(
             `[DEBUG] [MCP STDERR (${mcpServerName})]: `,

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -481,8 +481,10 @@ class GrepToolInvocation extends BaseToolInvocation<
     basePath: string,
   ): GrepMatch | null {
     try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const json = JSON.parse(line);
       if (json.type === 'match' || json.type === 'context') {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const data = json.data;
         // Defensive check: ensure text properties exist (skips binary/invalid encoding)
         if (data.path?.text && data.lines?.text) {
@@ -500,7 +502,9 @@ class GrepToolInvocation extends BaseToolInvocation<
 
           return {
             filePath: relativeFilePath || path.basename(absoluteFilePath),
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             lineNumber: data.line_number,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             line: data.lines.text.trimEnd(),
             isContext: json.type === 'context',
           };

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -390,6 +390,7 @@ export class ToolRegistry {
 
       // execute discovery command and extract function declarations (w/ or w/o "tool" wrappers)
       const functions: FunctionDeclaration[] = [];
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const discoveredItems = JSON.parse(stdout.trim());
 
       if (!discoveredItems || !Array.isArray(discoveredItems)) {

--- a/packages/core/src/tools/xcode-mcp-fix-transport.ts
+++ b/packages/core/src/tools/xcode-mcp-fix-transport.ts
@@ -75,7 +75,7 @@ export class XcodeMcpBridgeFixTransport
     // We can cast because we verified 'result' is in response,
     // but TS might still be picky if the type is a strict union.
     // Let's treat it safely.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-assignment
     const result = response.result as any;
 
     // Check if we have content but missing structuredContent
@@ -85,12 +85,15 @@ export class XcodeMcpBridgeFixTransport
       result.content.length > 0 &&
       !result.structuredContent
     ) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const firstItem = result.content[0];
       if (firstItem.type === 'text' && typeof firstItem.text === 'string') {
         try {
           // Attempt to parse the text as JSON
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           const parsed = JSON.parse(firstItem.text);
           // If successful, populate structuredContent
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           result.structuredContent = parsed;
         } catch (_) {
           // Ignored: Content is likely plain text, not JSON.

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -145,6 +145,7 @@ class RecursiveFileSearch implements FileSearch {
       if (pattern.includes('*') || !this.fzf) {
         filteredCandidates = await filter(candidates, pattern, options.signal);
       } else {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         filteredCandidates = await this.fzf
           .find(pattern)
           .then((results: Array<FzfResultItem<string>>) =>

--- a/packages/core/src/utils/getPty.ts
+++ b/packages/core/src/utils/getPty.ts
@@ -23,12 +23,16 @@ export const getPty = async (): Promise<PtyImplementation> => {
   }
   try {
     const lydell = '@lydell/node-pty';
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const module = await import(lydell);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     return { module, name: 'lydell-node-pty' };
   } catch (_e) {
     try {
       const nodePty = 'node-pty';
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const module = await import(nodePty);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       return { module, name: 'node-pty' };
     } catch (_e2) {
       return null;

--- a/packages/core/src/utils/googleErrors.ts
+++ b/packages/core/src/utils/googleErrors.ts
@@ -166,10 +166,12 @@ export function parseGoogleApiError(error: unknown): GoogleApiError | null {
     depth < maxDepth
   ) {
     try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const parsedMessage = JSON.parse(
         currentError.message.replace(/\u00A0/g, '').replace(/\n/g, ' '),
       );
       if (parsedMessage.error) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         currentError = parsedMessage.error;
         depth++;
       } else {
@@ -243,6 +245,7 @@ function fromGaxiosError(errorObj: object): ErrorShape | undefined {
 
     if (typeof data === 'string') {
       try {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         data = JSON.parse(data);
       } catch (_) {
         // Not a JSON string, can't parse.
@@ -250,6 +253,7 @@ function fromGaxiosError(errorObj: object): ErrorShape | undefined {
     }
 
     if (Array.isArray(data) && data.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       data = data[0];
     }
 
@@ -288,6 +292,7 @@ function fromApiError(errorObj: object): ErrorShape | undefined {
 
     if (typeof data === 'string') {
       try {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         data = JSON.parse(data);
       } catch (_) {
         // Not a JSON string, can't parse.
@@ -297,6 +302,7 @@ function fromApiError(errorObj: object): ErrorShape | undefined {
           const lastBrace = data.lastIndexOf('}');
           if (firstBrace !== -1 && lastBrace !== -1 && lastBrace > firstBrace) {
             try {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               data = JSON.parse(data.substring(firstBrace, lastBrace + 1));
             } catch (__) {
               // Still failed
@@ -307,6 +313,7 @@ function fromApiError(errorObj: object): ErrorShape | undefined {
     }
 
     if (Array.isArray(data) && data.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       data = data[0];
     }
 

--- a/packages/core/src/utils/memoryDiscovery.ts
+++ b/packages/core/src/utils/memoryDiscovery.ts
@@ -127,6 +127,7 @@ async function getGeminiMdFilePathsInternal(
         result.value.global.forEach((p) => globalPaths.add(p));
         result.value.project.forEach((p) => projectPaths.add(p));
       } else {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const error = result.reason;
         const message = error instanceof Error ? error.message : String(error);
         logger.error(`Error discovering files in directory: ${message}`);
@@ -299,6 +300,7 @@ export async function readGeminiMdFiles(
       } else {
         // This case shouldn't happen since we catch all errors above,
         // but handle it for completeness
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const error = result.reason;
         const message = error instanceof Error ? error.message : String(error);
         logger.error(`Unexpected error processing file: ${message}`);

--- a/packages/core/src/utils/safeJsonStringify.ts
+++ b/packages/core/src/utils/safeJsonStringify.ts
@@ -37,6 +37,7 @@ export function safeJsonStringify(
 function removeEmptyObjects(data: any): object {
   const cleanedObject: { [key: string]: unknown } = {};
   for (const k in data) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const v = data[k];
     if (v !== null && v !== undefined && typeof v === 'boolean') {
       cleanedObject[k] = v;

--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -12,9 +12,9 @@ import * as addFormats from 'ajv-formats';
 import { debugLogger } from './debugLogger.js';
 
 // Ajv's ESM/CJS interop: use 'any' for compatibility as recommended by Ajv docs
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-assignment
 const AjvClass = (AjvPkg as any).default || AjvPkg;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-assignment
 const Ajv2020Class = (Ajv2020Pkg as any).default || Ajv2020Pkg;
 
 const ajvOptions = {
@@ -29,12 +29,14 @@ const ajvOptions = {
 };
 
 // Draft-07 validator (default)
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const ajvDefault: Ajv = new AjvClass(ajvOptions);
 
 // Draft-2020-12 validator for MCP servers using rmcp
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const ajv2020: Ajv = new Ajv2020Class(ajvOptions);
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-assignment
 const addFormatsFunc = (addFormats as any).default || addFormats;
 addFormatsFunc(ajvDefault);
 addFormatsFunc(ajv2020);

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -479,6 +479,7 @@ function parsePowerShellCommandDetails(
       hasRedirection?: boolean;
     } | null = null;
     try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       parsed = JSON.parse(output);
     } catch {
       return { details: [], hasError: true };

--- a/packages/core/src/utils/stdio.ts
+++ b/packages/core/src/utils/stdio.ts
@@ -88,6 +88,7 @@ export function createWorkingStdio() {
       if (prop === 'write') {
         return writeToStdout;
       }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const value = Reflect.get(target, prop, receiver);
       if (typeof value === 'function') {
         return value.bind(target);
@@ -101,6 +102,7 @@ export function createWorkingStdio() {
       if (prop === 'write') {
         return writeToStderr;
       }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const value = Reflect.get(target, prop, receiver);
       if (typeof value === 'function') {
         return value.bind(target);

--- a/packages/core/src/utils/userAccountManager.ts
+++ b/packages/core/src/utils/userAccountManager.ts
@@ -30,6 +30,7 @@ export class UserAccountManager {
       return defaultState;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const parsed = JSON.parse(content);
 
     // Inlined validation logic
@@ -50,7 +51,9 @@ export class UserAccountManager {
     }
 
     return {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       active: parsed.active ?? null,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       old: parsed.old ?? [],
     };
   }

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -260,6 +260,7 @@ export class DevTools extends EventEmitter {
 
       ws.on('message', (data: Buffer) => {
         try {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           const message = JSON.parse(data.toString());
 
           // Handle registration first

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -210,6 +210,7 @@ export class GeminiCliSession {
           const toolCall = event.value;
           let args = toolCall.args;
           if (typeof args === 'string') {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             args = JSON.parse(args);
           }
           toolCallsToSchedule.push({
@@ -238,6 +239,7 @@ export class GeminiCliSession {
       };
 
       const originalRegistry = this.config.getToolRegistry();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const scopedRegistry: ToolRegistry = Object.create(originalRegistry);
       scopedRegistry.getTool = (name: string) => {
         const tool = originalRegistry.getTool(name);

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -38,6 +38,7 @@ async function checkForUpdates(
   isManagedExtensionSurface: boolean,
 ) {
   try {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const currentVersion = context.extension.packageJSON.version;
 
     // Fetch extension details from the VSCode Marketplace.
@@ -75,9 +76,12 @@ async function checkForUpdates(
       return;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const data = await response.json();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const extension = data?.results?.[0]?.extensions?.[0];
     // The versions are sorted by date, so the first one is the latest.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const latestVersion = extension?.versions?.[0]?.version;
 
     if (


### PR DESCRIPTION
## Summary

Disallows unsafe assignments, like assignment of `any` typed expressions. This prevents a common type safety issue where code can be written that is declared as one type, but in practice, is another.

For now, just suppress all instances.

Fixes: https://github.com/google-gemini/gemini-cli/issues/19719https://github.com/google-gemini/gemini-cli/issues/19719

Additional cleanup tracked under: https://github.com/google-gemini/gemini-cli/issues/19731https://github.com/google-gemini/gemini-cli/issues/19731

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
