### PR TITLE
fix(cli): re-enable CLI banner

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -2078,8 +2078,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
 
     const fetchBannerTexts = async () => {
       const [defaultBanner, warningBanner] = await Promise.all([
-        // TODO: temporarily disabling the banner, it will be re-added.
-        '',
+        config.getBannerTextNoCapacityIssues(),
         config.getBannerTextCapacityIssues(),
       ]);
 


### PR DESCRIPTION
## Summary

Re-enables the CLI banner text for standard cases (no capacity issues) in the UI.

## Details

The dummy empty string that temporarily disabled the banner in `AppContainer.tsx` has been removed, restoring `config.getBannerTextNoCapacityIssues()`. 

## Related Issues

Fixes #19737

## How to Validate

1. Start the CLI using `npm start`
2. Ensure you see the banner text during initialization.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker