### PR TITLE
fix(core): remove no-unsafe-type-assertion suppressions in JSON & Con…

### DIFF
--- a/packages/core/src/utils/safeJsonStringify.ts
+++ b/packages/core/src/utils/safeJsonStringify.ts
@@ -11,8 +11,6 @@
  * @param space - Optional space parameter for formatting (defaults to no formatting)
  * @returns JSON string with circular references replaced by [Circular]
  */
-import type { Config } from '../config/config.js';
-
 export function safeJsonStringify(
   obj: unknown,
   space?: string | number,
@@ -58,8 +56,7 @@ function removeEmptyObjects(data: any): object {
 export function safeJsonStringifyBooleanValuesOnly(obj: any): string {
   let configSeen = false;
   return JSON.stringify(removeEmptyObjects(obj), (key, value) => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    if ((value as Config) !== null && !configSeen) {
+    if (value !== null && !configSeen) {
       configSeen = true;
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return value;


### PR DESCRIPTION
## Summary

Fixes #19710. Removes `@typescript-eslint/no-unsafe-type-assertion` suppressions in `packages/core/src/utils/` by replacing `as Type` casts with runtime validation (Zod, type guards, and safe property narrowing).

## Details

- **safeJsonStringify.ts**: Removed the pointless `(value as Config) !== null` cast — the null check works identically without it. Removed the unused `Config` type import. Removed one eslint-disable comment.

- **schemaValidator.ts**:
  - **ESM/CJS interop**: Replaced `(AjvPkg as any).default || AjvPkg` pattern with type-guarded resolution helpers (`createAjvFromModule`, `resolveFormatsPlugin`) that validate resolved exports via `typeof val === 'function'` checks at runtime. Removed three eslint-disable comments (covering both `no-unsafe-type-assertion` and `no-explicit-any`).
  - **Schema logging**: Replaced `(schema as Record<string, unknown>)?.['$schema']` with a `getSchemaUri()` helper that uses the `in` operator for safe property narrowing. Removed two eslint-disable comments.

- **userAccountManager.ts**: Replaced `parsed as Partial<UserAccounts>` with a Zod schema (`UserAccountsSchema`) and `safeParse()` for runtime-validated JSON parsing, consistent with existing codebase patterns (e.g., `checkpointUtils.ts`). Removed one eslint-disable comment.

## How to Validate

```bash
# Type-check (no new errors)
npx tsc --noEmit --project packages/core/tsconfig.json

# Lint (no errors on changed files)
node node_modules/.bin/eslint packages/core/src/utils/safeJsonStringify.ts packages/core/src/utils/schemaValidator.ts packages/core/src/utils/userAccountManager.ts

# Unit tests (43 tests, all pass)
npx vitest run packages/core/src/utils/safeJsonStringify.test.ts packages/core/src/utils/schemaValidator.test.ts packages/core/src/utils/userAccountManager.test.ts

# Verify no suppressions remain
grep -rn "no-unsafe-type-assertion" packages/core/src/utils/safeJsonStringify.ts packages/core/src/utils/schemaValidator.ts packages/core/src/utils/userAccountManager.ts

```

## Pre-Merge Checklist

- Updated relevant documentation and README (if needed)
- Added/updated tests (if needed)
- Noted breaking changes (if any)
- Validated on required platforms/methods:
  - MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker