### PR TITLE
Add a helper for safe JSON parsing.

### DIFF
--- a/integration-tests/extensions-reload.test.ts
+++ b/integration-tests/extensions-reload.test.ts
@@ -9,7 +9,7 @@ import { TestRig } from './test-helper.js';
 import { TestMcpServer } from './test-mcp-server.js';
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { safeJsonStringify } from '@google/gemini-cli-core/src/utils/safeJsonStringify.js';
+import { safeJsonStringify } from '@google/gemini-cli-core/src/utils/safe-json-helpers.js';
 import { env } from 'node:process';
 import { platform } from 'node:os';
 

--- a/packages/a2a-server/src/commands/restore.ts
+++ b/packages/a2a-server/src/commands/restore.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  safeParseJson,
   getCheckpointInfoList,
   getToolCallDataSchema,
   isNodeError,
@@ -69,8 +70,7 @@ export class RestoreCommand implements Command {
         throw error;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const toolCallData = JSON.parse(data);
+      const toolCallData = safeParseJson(data);
       const ToolCallDataSchema = getToolCallDataSchema();
       const parseResult = ToolCallDataSchema.safeParse(toolCallData);
 

--- a/packages/core/src/confirmation-bus/message-bus.ts
+++ b/packages/core/src/confirmation-bus/message-bus.ts
@@ -9,7 +9,7 @@ import { EventEmitter } from 'node:events';
 import type { PolicyEngine } from '../policy/policy-engine.js';
 import { PolicyDecision } from '../policy/types.js';
 import { MessageBusType, type Message } from './types.js';
-import { safeJsonStringify } from '../utils/safeJsonStringify.js';
+import { safeJsonStringify } from '../utils/safe-json-helpers.js';
 import { debugLogger } from '../utils/debugLogger.js';
 
 export class MessageBus extends EventEmitter {

--- a/packages/core/src/core/fakeContentGenerator.ts
+++ b/packages/core/src/core/fakeContentGenerator.ts
@@ -15,7 +15,7 @@ import {
 import { promises } from 'node:fs';
 import type { ContentGenerator } from './contentGenerator.js';
 import type { UserTierId } from '../code_assist/types.js';
-import { safeJsonStringify } from '../utils/safeJsonStringify.js';
+import { safeJsonStringify } from '../utils/safe-json-helpers.js';
 import type { LlmRole } from '../telemetry/types.js';
 
 export type FakeResponse =

--- a/packages/core/src/core/recordingContentGenerator.test.ts
+++ b/packages/core/src/core/recordingContentGenerator.test.ts
@@ -15,7 +15,7 @@ import type {
 } from '@google/genai';
 import { appendFileSync } from 'node:fs';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
-import { safeJsonStringify } from '../utils/safeJsonStringify.js';
+import { safeJsonStringify } from '../utils/safe-json-helpers.js';
 import type { ContentGenerator } from './contentGenerator.js';
 import { RecordingContentGenerator } from './recordingContentGenerator.js';
 import { LlmRole } from '../telemetry/types.js';

--- a/packages/core/src/core/recordingContentGenerator.ts
+++ b/packages/core/src/core/recordingContentGenerator.ts
@@ -16,7 +16,7 @@ import { appendFileSync } from 'node:fs';
 import type { ContentGenerator } from './contentGenerator.js';
 import type { FakeResponse } from './fakeContentGenerator.js';
 import type { UserTierId } from '../code_assist/types.js';
-import { safeJsonStringify } from '../utils/safeJsonStringify.js';
+import { safeJsonStringify } from '../utils/safe-json-helpers.js';
 import type { LlmRole } from '../telemetry/types.js';
 
 // A ContentGenerator that wraps another content generator and records all the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,7 @@ export * from './code_assist/admin/mcpUtils.js';
 export * from './core/apiKeyCredentialStorage.js';
 
 // Export utilities
+export * from './utils/safe-json-helpers.js';
 export * from './utils/fetch.js';
 export { homedir, tmpdir } from './utils/paths.js';
 export * from './utils/paths.js';

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -57,7 +57,7 @@ import { UserAccountManager } from '../../utils/userAccountManager.js';
 import {
   safeJsonStringify,
   safeJsonStringifyBooleanValuesOnly,
-} from '../../utils/safeJsonStringify.js';
+} from '../../utils/safe-json-helpers.js';
 import { ASK_USER_TOOL_NAME } from '../../tools/tool-names.js';
 import { FixedDeque } from 'mnemonist';
 import { GIT_COMMIT_INFO, CLI_VERSION } from '../../generated/git-commit.js';

--- a/packages/core/src/telemetry/file-exporters.ts
+++ b/packages/core/src/telemetry/file-exporters.ts
@@ -17,7 +17,7 @@ import type {
   PushMetricExporter,
 } from '@opentelemetry/sdk-metrics';
 import { AggregationTemporality } from '@opentelemetry/sdk-metrics';
-import { safeJsonStringify } from '../utils/safeJsonStringify.js';
+import { safeJsonStringify } from '../utils/safe-json-helpers.js';
 
 class FileExporter {
   protected writeStream: fs.WriteStream;

--- a/packages/core/src/telemetry/trace.ts
+++ b/packages/core/src/telemetry/trace.ts
@@ -11,7 +11,7 @@ import {
   type AttributeValue,
   type SpanOptions,
 } from '@opentelemetry/api';
-import { safeJsonStringify } from '../utils/safeJsonStringify.js';
+import { safeJsonStringify } from '../utils/safe-json-helpers.js';
 
 const TRACER_NAME = 'gemini-cli';
 const TRACER_VERSION = 'v1';

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -30,7 +30,7 @@ import type { AgentTerminateMode } from '../agents/types.js';
 
 import { getCommonAttributes } from './telemetryAttributes.js';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
-import { safeJsonStringify } from '../utils/safeJsonStringify.js';
+import { safeJsonStringify } from '../utils/safe-json-helpers.js';
 import type { OTelFinishReason } from './semantic.js';
 import {
   toInputMessages,

--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -7,7 +7,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Mocked } from 'vitest';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { safeJsonStringify } from '../utils/safeJsonStringify.js';
+import { safeJsonStringify } from '../utils/safe-json-helpers.js';
 import { DiscoveredMCPTool, generateValidName } from './mcp-tool.js'; // Added getStringifiedResultForDisplay
 import type { ToolResult } from './tools.js';
 import { ToolConfirmationOutcome } from './tools.js'; // Added ToolConfirmationOutcome

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -10,12 +10,14 @@ import type {
   ToolInvocation,
   ToolMcpConfirmationDetails,
   ToolResult,
-
+  PolicyUpdateOptions,
+} from './tools.js';
+import {
   BaseDeclarativeTool,
   BaseToolInvocation,
   Kind,
   ToolConfirmationOutcome,
-  type PolicyUpdateOptions} from './tools.js';
+} from './tools.js';
 import type { CallableTool, FunctionCall, Part } from '@google/genai';
 import { ToolErrorType } from './tool-error.js';
 import type { Config } from '../config/config.js';

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -4,20 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { safeJsonStringify } from '../utils/safeJsonStringify.js';
+import { safeJsonStringify } from '../utils/safe-json-helpers.js';
 import type {
   ToolCallConfirmationDetails,
   ToolInvocation,
   ToolMcpConfirmationDetails,
   ToolResult,
-} from './tools.js';
-import {
+
   BaseDeclarativeTool,
   BaseToolInvocation,
   Kind,
   ToolConfirmationOutcome,
-  type PolicyUpdateOptions,
-} from './tools.js';
+  type PolicyUpdateOptions} from './tools.js';
 import type { CallableTool, FunctionCall, Part } from '@google/genai';
 import { ToolErrorType } from './tool-error.js';
 import type { Config } from '../config/config.js';

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -18,7 +18,7 @@ import { StringDecoder } from 'node:string_decoder';
 import { DiscoveredMCPTool } from './mcp-tool.js';
 import { parse } from 'shell-quote';
 import { ToolErrorType } from './tool-error.js';
-import { safeJsonStringify } from '../utils/safeJsonStringify.js';
+import { safeJsonStringify } from '../utils/safe-json-helpers.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { coreEvents } from '../utils/events.js';

--- a/packages/core/src/utils/safe-json-helpers.test.ts
+++ b/packages/core/src/utils/safe-json-helpers.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { safeJsonStringify } from './safeJsonStringify.js';
+import { safeJsonStringify } from './safe-json-helpers.js';
 
 describe('safeJsonStringify', () => {
   it('should stringify normal objects without issues', () => {

--- a/packages/core/src/utils/safe-json-helpers.ts
+++ b/packages/core/src/utils/safe-json-helpers.ts
@@ -68,3 +68,13 @@ export function safeJsonStringifyBooleanValuesOnly(obj: any): string {
     return '';
   });
 }
+
+/**
+ * Safely parses a JSON string, typed as unknown to force explicit type assertions or validations by the caller.
+ *
+ * @param text - The JSON string to parse
+ * @returns The parsed JSON object of type unknown
+ */
+export function safeParseJson(text: string): unknown {
+  return JSON.parse(text);
+}


### PR DESCRIPTION
## Summary

Adds a helper for parsing JSON that has an `unknown` return type. Unlike the built in JSON.parse(), this function is explicitly an unknown return type and can use type inference without generating a linter error.

Note that this is no different than just using an explicit type to narrow the assignment to an unknown:

```typescript
// ❌ Generates a linter error
const foo = JSON.parse(json);
```

```typescript
// ✅ Does not generate an error
const foo: unknown = JSON.parse(json);
```

```typescript
// ✅ Does not generate an error
const foo = safeParseJson(json);
```

The main argument for a helper is that it does not require you to explicitly annotate a type. It's always typed as `unknown`, which makes it a bit easier to explain to TS newcomers. It also is a bit more natural to use, particularly when inlining the result as a function parameter. My hope is this makes it less likely that folks just suppress the warning when they get a linter error over a JSON.parse() call.