### PR TITLE
docs(skills): add string-reviewer skill for UX writing

### DIFF
--- a/.gemini/skills/string-reviewer/SKILL.md
+++ b/.gemini/skills/string-reviewer/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: string-reviewer
+description: >
+  Help contributors adhere to project UX writing standards for strings. Use 
+  when creating components, reviewing pull requests, or when explicitly 
+  asked to review text.
+---
+
+# String Reviewer
+
+## Instructions
+
+Look for user-facing strings that are too long, unclear, or inconsistent. This
+includes inline text, error messages, and other user-facing text.
+
+Do NOT automatically change strings without user approval, as the context may be  
+important. You must only suggest changes and do not attempt to rewrite them
+directly unless the user explicitly asks you to do so.
+
+### Step 1: Determine if the text adheres to good UX writing principles
+
+Use these basic principles of good UX writing as a guide for your suggestions. 
+These principles include clarity, usefulness, brevity, and style:
+
+#### Clarity
+
+- Text is easy to understand
+- Text is easy to follow
+- 60 or higher readability score based on the Flesch-Kincaid model
+- No errors or typos
+
+#### Usefulness
+
+- Users get the info they need, when they need it
+- Use plain, familiar language
+- Concepts are explained; value props are user-focused
+
+#### Brevity
+
+- Language is precise
+- Short, simple sentences; active voice
+- Text is broken up; scannable
+
+#### Style
+
+- Friendly, helpful, positive, and humble tone
+- Sentence-style capitalization
+- Solitary sentences aren't punctuated
+- Speaks to the user ("you")
+
+### Step 2: Ensure that error messages are actionable by the end user
+
+If the text is an error message, ensure that it provides actionable information 
+to the end user. Review the reference at [error message guidelines](./references/error-messages.md) 
+for more details.
+
+### Step 3: Ensure consistent use of keyboard shortcuts
+
+Our preferred style is `Modifier+Key`. Modifiers should be capitalized, and the
+key should be uppercase. There should be no additional spaces.
+
+- **"Escape"** should be written as `Esc` for brevity.
+- If there are space constraints, it is acceptable to use Unicode symbols for
+  modifiers, for example `⇧+K` for `Shift+K`, or `⏎` for `Enter`. 
+  
+#### Examples
+
+* `Ctrl+C`
+* `Esc`
+* `Shift+Tab`
+
+### Step 4: Enforce general style guidelines
+
+1. Don't use a period after a single sentence. When a sentence appears by itself
+   on its own line, do not end it with a period. Use a period if the sentence is
+   particularly long or complex.
+2. Use contractions. However, don't make a sentence harder to understand just to
+   follow this rule. For example, "do not" can give more emphasis than "don't"
+   when needed. 
+3. Use abbreviations with care. It’s okay to abbreviate commonly understood
+   terms, such as "VM", but be consistent. Try to avoid mixing and matching
+   abbreviations and non-abbreviations in the same flow.
+4. Use ampersands instead of “and” sparingly. Don't use "+" instead of "&".
+5. Only capitalize the first word in titles and headings.
+6. Use a serial/Oxford comma to separate items in a list.
+7. Avoid pleasantries like “sorry”. Instead, be clear about the issue and
+   promote a positive solution.
+
+### Step 5: Use consistent terminology
+
+Finally, review the text for consistent use of terminology. A full list of
+preferred terminology can be found in the [terminology reference](./references/terminology.md).

--- a/.gemini/skills/string-reviewer/references/error-messages.md
+++ b/.gemini/skills/string-reviewer/references/error-messages.md
@@ -1,0 +1,44 @@
+# Writing helpful error messages
+
+Bad error messages frustrate users. Good error messages provide critical
+information when things are not working as expected. Error messages are often
+the main way developers interact with users when problems occur. Some error
+messages are caused by invalid user inputs or misuse of certain features and
+some are caused by product defects; all error messages require users to figure
+out what to do next.
+
+Great error messages answer two questions as clearly and concisely as possible: 
+
+1. What went wrong? 
+2. How can I fix it?
+
+## Principles
+
+- Write concise error messages. Emphasize what's important. Cut unnecessary
+  text.
+- Avoid double negatives. Readers find double negatives hard to parse. 
+- Converting from passive voice to active voice often makes sentences conciser
+  and easier to understand.
+- Use terminology consistently for all error messages within a single feature.
+
+## Be positive
+
+- Instead of telling the user what they did wrong, tell the user how to get it
+  right.
+- While maintaining positivity, avoid the words "sorry" or "please." Focus
+  instead on clearly describing the problem and solution.
+
+## Avoid humor
+
+Don't attempt to make error messages humorous. Humor in error messages can fail
+for the following reasons:
+
+- Errors frustrate users. Angry users are generally not receptive to humor.
+- Users can misinterpret humor. (Jokes don't always cross borders well.)
+- Humor can detract from the goal of the error message.
+
+## Don't blame the user
+
+If possible, focus the error message on what went wrong rather than assigning
+blame.
+

--- a/.gemini/skills/string-reviewer/references/terminology.md
+++ b/.gemini/skills/string-reviewer/references/terminology.md
@@ -1,0 +1,59 @@
+### Preferred
+
+- Use **"create"** when a user is creating or setting up something.
+- Use **"allow"** instead of **"may"** to indicate that permission has been granted 
+  to perform some action.
+- Use **"canceled"**, not **"cancelled"**.
+- Use **"configure"** to refer to the process of changing the attributes of a 
+  feature, even if that includes turning on or off the feature.
+- Use **"delete"**   when the action being performed is destructive.
+- Use **"enable"** for binary operations that turn a feature or API on. Use "turn 
+  on" and "turn off" instead of "enable" and "disable" for other situations.
+- Use **"key combination"** to refer to pressing multiple keys simultaneously.
+- Use **"key sequence"** to refer to pressing multiple keys separately in order.
+- Use **"modify"** to refer to something that has changed vs obtaining the
+  latest version of something.
+- Use **"remove"** when the action being performed takes an item out of a larger
+  whole, but doesn't destroy the item itself.
+- Use **"set up"** as a verb. Use **"setup"** as a noun or adjective.
+- Use **"show"**. In general, use paired with **"hide"**.
+- Use **"sign in"**, **"sign out"** as a verb. Use **"sign-in"** or 
+  **"sign-out"** as a noun or adjective.
+- Use **"update"** when you mean to obtain the latest version of something.
+- Use **"want"** instead of **"like"** or **"would like"**.
+
+#### Don't use
+
+- Don't use **"etc."** It's redundant. To convey that a series is incomplete,
+  introduce it with "such as" instead.
+- Don't use **"hostname"**, use "host name" instead.
+- Don't use **"in order to"**. It's too formal. "Before you can" is usually better 
+  in UI text.
+- Don't use **"one or more"**. Specify the quantity where possible. Use "at
+  least one" when the quantity is 1+ but you can't be sure of the number.
+  Likewise, use "at least one" when the user must choose a quantity of 1+.
+- Don't use the terms **"log in"**, **"log on"**, **"login"**, **"logout"** or
+  **"log out"**.
+- Don't use **"like"** or **"would you like"**. Use **"want"** instead. Better yet, 
+  rephrase so that it's not referring to the user's emotional state, but rather
+  what is required.
+
+#### Use with caution
+
+- Avoid using **"leverage"**, especially as a verb. "Leverage" is considered a 
+  buzzword largely devoid of meaning apart from the simpler "use".
+- Avoid using **"once"** as a synonym for "after". Typically, when "once" is used 
+  in this way, it is followed by a verb in the perfect tense. 
+- Don't use **"e.g."** Use "example", "such as", "like", or "for example". The
+  phrase is always followed by a comma.
+- Don't use **"i.e."** unless absolutely essential to make text fit. 
+  Use "that is" instead.
+- Use **"disable"** for binary operations that turn a feature or API off. Use 
+  "turn on" and "turn off" instead of "enable" and "disable" for other 
+  situations. For UI elements that are not available, use "dimmed" instead
+  of "disabled".
+- Use **"please"** only when you're asking the user to do something
+  inconvenient, not just following the instructions in a typical flow.
+- Use **"really"** sparingly in such constructions as "Do you really want to..." 
+  Because of the weight it puts on the decision, it should be used to confirm 
+  actions that the user is extremely unlikely to make.


### PR DESCRIPTION
## Summary

Adds a new `string-reviewer` skill to help contributors adhere to standardized UX writing principles for user-facing strings.

## Details

This PR introduces the `string-reviewer` skill, which provides:
-   **Guidelines:** A comprehensive set of rules for clarity, usefulness, brevity, and style (`SKILL.md`).
-   **References:** Detailed guides for error messages (`references/error-messages.md`) and terminology (`references/terminology.md`).
-   **Workflow:** Instructions for reviewing strings in components, PRs, or on request.

The skill is designed to ensure consistent and high-quality copy across the CLI.

## Related Issues

N/A

## How to Validate

1.  Checkout this branch.
2.  Ask the agent to activate the skill (e.g., "Use the string-reviewer skill").
3.  Verify the skill instructions are loaded and displayed correctly.
4.  (Optional) Ask the agent to review a string using the skill to test its application.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
