### PR TITLE
fix(bundling): copy devtools package to bundle for runtime resolution

### DIFF
--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -73,4 +73,26 @@ if (existsSync(builtinSkillsSrc)) {
   console.log('Copied built-in skills to bundle/builtin/');
 }
 
+// 5. Copy DevTools package so the external dynamic import resolves at runtime
+const devtoolsSrc = join(root, 'packages/devtools');
+const devtoolsDest = join(
+  bundleDir,
+  'node_modules',
+  '@google',
+  'gemini-cli-devtools',
+);
+const devtoolsDistSrc = join(devtoolsSrc, 'dist');
+if (existsSync(devtoolsDistSrc)) {
+  mkdirSync(devtoolsDest, { recursive: true });
+  cpSync(devtoolsDistSrc, join(devtoolsDest, 'dist'), {
+    recursive: true,
+    dereference: true,
+  });
+  copyFileSync(
+    join(devtoolsSrc, 'package.json'),
+    join(devtoolsDest, 'package.json'),
+  );
+  console.log('Copied devtools package to bundle/node_modules/');
+}
+
 console.log('Assets copied to bundle/');


### PR DESCRIPTION
## Summary

This PR adds a step to `scripts/copy_bundle_assets.js` to copy the `@google/gemini-cli-devtools` package (its `dist` and `package.json`) into the `bundle/node_modules` directory.

## Details

When the CLI is bundled, dynamic imports for the devtools package fail if the package is not available in the expected `node_modules` structure relative to the bundle. This change ensures the devtools package is included in the bundle, allowing it to be resolved correctly at runtime.

## Related Issues

#18007

## How to Validate

1. Run the bundling process (e.g., `npm run build` or the relevant script that calls `scripts/copy_bundle_assets.js`).
2. Check the `bundle/` directory.
3. Verify that `bundle/node_modules/@google/gemini-cli-devtools/` exists and contains the `dist` folder and `package.json`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
