### PR TITLE
fix(core): deduplicate command names in shell confirmation

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -42,7 +42,7 @@ vi.mock('crypto');
 vi.mock('../utils/summarizer.js');
 
 import { initializeShellParsers } from '../utils/shell-utils.js';
-import { ShellTool } from './shell.js';
+import { ShellTool, OUTPUT_UPDATE_INTERVAL_MS } from './shell.js';
 import { debugLogger } from '../index.js';
 import { type Config } from '../config/config.js';
 import {
@@ -58,7 +58,6 @@ import * as crypto from 'node:crypto';
 import * as summarizer from '../utils/summarizer.js';
 import { ToolErrorType } from './tool-error.js';
 import { ToolConfirmationOutcome } from './tools.js';
-import { OUTPUT_UPDATE_INTERVAL_MS } from './shell.js';
 import { SHELL_TOOL_NAME } from './tool-names.js';
 import { WorkspaceContext } from '../utils/workspaceContext.js';
 import {
@@ -775,6 +774,22 @@ describe('ShellTool', () => {
   });
 
   describe('getConfirmationDetails', () => {
+    it('should deduplicate root commands in confirmation details', async () => {
+      const shellTool = new ShellTool(mockConfig, createMockMessageBus());
+      const command = 'git status && git diff && git log';
+      const invocation = shellTool.build({ command });
+
+      // @ts-expect-error - getConfirmationDetails is protected
+      const details = await invocation.getConfirmationDetails(
+        new AbortController().signal,
+      );
+
+      expect(details).not.toBe(false);
+      if (details && details.type === 'exec') {
+        expect(details.rootCommand).toBe('git');
+      }
+    });
+
     it('should annotate sub-commands with redirection correctly', async () => {
       const shellTool = new ShellTool(mockConfig, createMockMessageBus());
       const command = 'mkdir -p baz && echo "hello" > baz/test.md && ls';

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -16,13 +16,13 @@ import type {
   ToolResult,
   ToolCallConfirmationDetails,
   ToolExecuteConfirmationDetails,
+  PolicyUpdateOptions,
 } from './tools.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
   ToolConfirmationOutcome,
   Kind,
-  type PolicyUpdateOptions,
 } from './tools.js';
 
 import { getErrorMessage } from '../utils/errors.js';
@@ -124,9 +124,9 @@ export class ShellToolInvocation extends BaseToolInvocation<
         rootCommandDisplay += ', redirection';
       }
     } else {
-      rootCommandDisplay = parsed.details
-        .map((detail) => detail.name)
-        .join(', ');
+      rootCommandDisplay = [
+        ...new Set(parsed.details.map((detail) => detail.name)),
+      ].join(', ');
     }
 
     const rootCommands = [...new Set(getCommandRoots(command))];


### PR DESCRIPTION
## Summary

This PR deduplicates the root command names displayed in the "Action Required" confirmation prompt for the shell tool.

## Details

Previously, when a user executed a chained command like `git status && git diff && git log`, the confirmation prompt would ask `Allow execution of: 'git, git, git'?`. This PR uses a `Set` to filter out duplicate root commands, resulting in a cleaner prompt: `Allow execution of: 'git'?`. 

## Related Issues

Fixes #19768

## How to Validate

1. Start the CLI and run a command that invokes multiple subcommands with the same root, e.g., `run "echo 1 && echo 2 && echo 3"`.
2. Observe the Action Required confirmation prompt. It should display `Allow execution of: 'echo'?` instead of `Allow execution of: 'echo, echo, echo'?`.
3. Existing tests, including the newly added deduplication unit test (`should deduplicate root commands in confirmation details` in `shell.test.ts`), pass successfully.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker