### PR TITLE
fix(core): prevent state corruption in McpClientManager during collis

### DIFF
--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -177,7 +177,10 @@ export class McpClientManager {
     config: MCPServerConfig,
   ): Promise<void> {
     const existing = this.clients.get(name);
-    if (existing && existing.getServerConfig().extension !== config.extension) {
+    if (
+      existing &&
+      existing.getServerConfig().extension?.id !== config.extension?.id
+    ) {
       const extensionText = config.extension
         ? ` from extension "${config.extension.name}"`
         : '';

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -176,6 +176,17 @@ export class McpClientManager {
     name: string,
     config: MCPServerConfig,
   ): Promise<void> {
+    const existing = this.clients.get(name);
+    if (existing && existing.getServerConfig().extension !== config.extension) {
+      const extensionText = config.extension
+        ? ` from extension "${config.extension.name}"`
+        : '';
+      debugLogger.warn(
+        `Skipping MCP config for server with name "${name}"${extensionText} as it already exists.`,
+      );
+      return;
+    }
+
     // Always track server config for UI display
     this.allServerConfigs.set(name, config);
 
@@ -191,7 +202,6 @@ export class McpClientManager {
     }
     // User-disabled servers: disconnect if running, don't start
     if (await this.isDisabledByUser(name)) {
-      const existing = this.clients.get(name);
       if (existing) {
         await this.disconnectClient(name);
       }
@@ -201,16 +211,6 @@ export class McpClientManager {
       return;
     }
     if (config.extension && !config.extension.isActive) {
-      return;
-    }
-    const existing = this.clients.get(name);
-    if (existing && existing.getServerConfig().extension !== config.extension) {
-      const extensionText = config.extension
-        ? ` from extension "${config.extension.name}"`
-        : '';
-      debugLogger.warn(
-        `Skipping MCP config for server with name "${name}"${extensionText} as it already exists.`,
-      );
       return;
     }
 


### PR DESCRIPTION
## Summary

Moves the connection interference check up in `McpClientManager.maybeDiscoverMcpServer` to evaluate conditions before the server is assigned an entry in `allServerConfigs`. This fixes a bug where active connections are corrupted by name collisions from new tool discovery.

## Details

Previously, `this.allServerConfigs.set(name, config)` was being updated before collision conditions were met, leading to invalid states: 
- An existing server’s config got lost and disconnecting an extension might mistakenly drop a user’s server.
- The new connection would later abort, becoming an orphaned client.
Now, the check guarantees safe state transitions.

## Related Issues

Fixes #19660

## How to Validate

1. Register an existing user server.
2. Load an extension that configures a conflicting server name.
3. Validate that the original user server operates smoothly without errors or drop-out when disabling the extension.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
