### PR TITLE
fix(core): enable model fallback for API key users on quota errors

### DIFF
--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -5,7 +5,6 @@
  */
 
 import {
-  AuthType,
   type Config,
   type FallbackModelHandler,
   type FallbackIntent,
@@ -55,15 +54,6 @@ export function useQuotaAndFallback({
       fallbackModel,
       error,
     ): Promise<FallbackIntent | null> => {
-      // Fallbacks are currently only handled for OAuth users.
-      const contentGeneratorConfig = config.getContentGeneratorConfig();
-      if (
-        !contentGeneratorConfig ||
-        contentGeneratorConfig.authType !== AuthType.LOGIN_WITH_GOOGLE
-      ) {
-        return null;
-      }
-
       let message: string;
       let isTerminalQuotaError = false;
       let isModelNotFoundError = false;

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -128,14 +128,15 @@ describe('handleFallback', () => {
       );
     });
 
-    it('should return null immediately if authType is not OAuth', async () => {
+    it('should proceed with fallback for API key users', async () => {
+      policyHandler.mockResolvedValue('retry_always');
       const result = await handleFallback(
         policyConfig,
         MOCK_PRO_MODEL,
         AUTH_API_KEY,
       );
-      expect(result).toBeNull();
-      expect(policyHandler).not.toHaveBeenCalled();
+      expect(result).toBe(true);
+      expect(policyHandler).toHaveBeenCalled();
     });
 
     it('uses availability selection with correct candidates when enabled', async () => {

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -5,7 +5,6 @@
  */
 
 import type { Config } from '../config/config.js';
-import { AuthType } from '../core/contentGenerator.js';
 import { openBrowserSecurely } from '../utils/secure-browser-launcher.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { getErrorMessage } from '../utils/errors.js';
@@ -26,10 +25,6 @@ export async function handleFallback(
   authType?: string,
   error?: unknown,
 ): Promise<string | boolean | null> {
-  if (authType !== AuthType.LOGIN_WITH_GOOGLE) {
-    return null;
-  }
-
   const chain = resolvePolicyChain(config);
   const { failedPolicy, candidates } = buildFallbackPolicyContext(
     chain,


### PR DESCRIPTION
## Summary

API key users hitting `RESOURCE_EXHAUSTED` (429) errors on Pro models get no fallback dialog — only a raw error. This PR removes two OAuth-only guards that blocked API key users from the fallback flow, enabling the same model-switch UI that OAuth users already have.

## Details

Two guards in the codebase explicitly restricted the fallback mechanism to OAuth (`LOGIN_WITH_GOOGLE`) users only:

1. **`packages/core/src/fallback/handler.ts`** — Early return `null` when `authType !== AuthType.LOGIN_WITH_GOOGLE`
2. **`packages/cli/src/ui/hooks/useQuotaAndFallback.ts`** — Same guard inside the `fallbackHandler` callback

Both guards (and their now-unused `AuthType` imports) are removed. When an API key user hits a quota error on a Pro model, they now see the same interactive dialog offering to switch to a Flash model.

Tests updated accordingly — the previous assertions that API key users get `null` (no fallback) now verify that fallback proceeds correctly.

## Related Issues

Fixes #19700

## How to Validate

1. Run the targeted tests:
   ```bash
   npx vitest run packages/core/src/fallback/handler.test.ts
   npx vitest run packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
   ```
2. Both test suites pass (14/14 and 21/21 respectively).
3. Use an API key auth method, trigger a quota error on a Pro model, and verify the fallback dialog appears.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [x] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker