### PR TITLE
fix: merge duplicate imports in packages/core

### DIFF
--- a/packages/core/src/agents/a2a-client-manager.test.ts
+++ b/packages/core/src/agents/a2a-client-manager.test.ts
@@ -10,13 +10,15 @@ import {
   type SendMessageResult,
 } from './a2a-client-manager.js';
 import type { AgentCard, Task } from '@a2a-js/sdk';
-import type { AuthenticationHandler, Client } from '@a2a-js/sdk/client';
-import { ClientFactory, DefaultAgentCardResolver } from '@a2a-js/sdk/client';
-import { debugLogger } from '../utils/debugLogger.js';
 import {
+  type AuthenticationHandler,
+  type Client,
+  ClientFactory,
+  DefaultAgentCardResolver,
   createAuthenticatingFetchWithRetry,
   ClientFactoryOptions,
 } from '@a2a-js/sdk/client';
+import { debugLogger } from '../utils/debugLogger.js';
 
 vi.mock('../utils/debugLogger.js', () => ({
   debugLogger: {

--- a/packages/core/src/agents/agentLoader.test.ts
+++ b/packages/core/src/agents/agentLoader.test.ts
@@ -15,8 +15,11 @@ import {
   AgentLoadError,
 } from './agentLoader.js';
 import { GEMINI_MODEL_ALIAS_PRO } from '../config/models.js';
-import type { LocalAgentDefinition } from './types.js';
-import { DEFAULT_MAX_TIME_MINUTES, DEFAULT_MAX_TURNS } from './types.js';
+import {
+  type LocalAgentDefinition,
+  DEFAULT_MAX_TIME_MINUTES,
+  DEFAULT_MAX_TURNS,
+} from './types.js';
 
 describe('loader', () => {
   let tempDir: string;

--- a/packages/core/src/agents/local-executor.test.ts
+++ b/packages/core/src/agents/local-executor.test.ts
@@ -47,19 +47,19 @@ import {
   logAgentFinish,
   logRecoveryAttempt,
 } from '../telemetry/loggers.js';
-import { LlmRole } from '../telemetry/types.js';
 import {
+  LlmRole,
   AgentStartEvent,
   AgentFinishEvent,
   RecoveryAttemptEvent,
 } from '../telemetry/types.js';
-import type {
-  AgentInputs,
-  LocalAgentDefinition,
-  SubagentActivityEvent,
-  OutputConfig,
+import {
+  type AgentInputs,
+  type LocalAgentDefinition,
+  type SubagentActivityEvent,
+  type OutputConfig,
+  AgentTerminateMode,
 } from './types.js';
-import { AgentTerminateMode } from './types.js';
 import type { AnyDeclarativeTool, AnyToolInvocation } from '../tools/tools.js';
 import type { ToolCallRequestInfo } from '../scheduler/types.js';
 import { CompressionStatus } from '../core/turn.js';
@@ -68,8 +68,7 @@ import type {
   ModelConfigKey,
   ResolvedModelConfig,
 } from '../services/modelConfigService.js';
-import type { AgentRegistry } from './registry.js';
-import { getModelConfigAlias } from './registry.js';
+import { type AgentRegistry, getModelConfigAlias } from './registry.js';
 import type { ModelRouterService } from '../routing/modelRouterService.js';
 
 const {

--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -7,13 +7,13 @@
 import type { Config } from '../config/config.js';
 import { reportError } from '../utils/errorReporting.js';
 import { GeminiChat, StreamEventType } from '../core/geminiChat.js';
-import { Type } from '@google/genai';
-import type {
-  Content,
-  Part,
-  FunctionCall,
-  FunctionDeclaration,
-  Schema,
+import {
+  Type,
+  type Content,
+  type Part,
+  type FunctionCall,
+  type FunctionDeclaration,
+  type Schema,
 } from '@google/genai';
 import { ToolRegistry } from '../tools/tool-registry.js';
 import {
@@ -36,13 +36,11 @@ import {
   RecoveryAttemptEvent,
   LlmRole,
 } from '../telemetry/types.js';
-import type {
-  LocalAgentDefinition,
-  AgentInputs,
-  OutputObject,
-  SubagentActivityEvent,
-} from './types.js';
 import {
+  type LocalAgentDefinition,
+  type AgentInputs,
+  type OutputObject,
+  type SubagentActivityEvent,
   AgentTerminateMode,
   DEFAULT_QUERY_STRING,
   DEFAULT_MAX_TURNS,

--- a/packages/core/src/agents/local-invocation.test.ts
+++ b/packages/core/src/agents/local-invocation.test.ts
@@ -5,11 +5,14 @@
  */
 
 import { describe, it, expect, vi, beforeEach, type Mocked } from 'vitest';
-import type { LocalAgentDefinition } from './types.js';
+import {
+  type LocalAgentDefinition,
+  type SubagentActivityEvent,
+  type AgentInputs,
+  AgentTerminateMode,
+} from './types.js';
 import { LocalSubagentInvocation } from './local-invocation.js';
 import { LocalAgentExecutor } from './local-executor.js';
-import type { SubagentActivityEvent, AgentInputs } from './types.js';
-import { AgentTerminateMode } from './types.js';
 import { makeFakeConfig } from '../test-utils/config.js';
 import { ToolErrorType } from '../tools/tool-error.js';
 import type { Config } from '../config/config.js';

--- a/packages/core/src/agents/registry.test.ts
+++ b/packages/core/src/agents/registry.test.ts
@@ -8,7 +8,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AgentRegistry, getModelConfigAlias } from './registry.js';
 import { makeFakeConfig } from '../test-utils/config.js';
 import type { AgentDefinition, LocalAgentDefinition } from './types.js';
-import type { Config, GeminiCLIExtension } from '../config/config.js';
+import type {
+  Config,
+  GeminiCLIExtension,
+  ConfigParameters,
+} from '../config/config.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { coreEvents, CoreEvent } from '../utils/events.js';
 import { A2AClientManager } from './a2a-client-manager.js';
@@ -22,7 +26,6 @@ import {
 } from '../config/models.js';
 import * as tomlLoader from './agentLoader.js';
 import { SimpleExtensionLoader } from '../utils/extensionLoader.js';
-import type { ConfigParameters } from '../config/config.js';
 import type { ToolRegistry } from '../tools/tool-registry.js';
 import { ThinkingLevel } from '@google/genai';
 import type { AcknowledgedAgentsService } from './acknowledgedAgents.js';

--- a/packages/core/src/agents/remote-invocation.ts
+++ b/packages/core/src/agents/remote-invocation.ts
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ToolConfirmationOutcome } from '../tools/tools.js';
 import {
   BaseToolInvocation,
+  type ToolConfirmationOutcome,
   type ToolResult,
   type ToolCallConfirmationDetails,
 } from '../tools/tools.js';
-import { DEFAULT_QUERY_STRING } from './types.js';
-import type {
-  RemoteAgentInputs,
-  RemoteAgentDefinition,
-  AgentInputs,
+import {
+  DEFAULT_QUERY_STRING,
+  type RemoteAgentInputs,
+  type RemoteAgentDefinition,
+  type AgentInputs,
 } from './types.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { A2AClientManager } from './a2a-client-manager.js';

--- a/packages/core/src/code_assist/codeAssist.ts
+++ b/packages/core/src/code_assist/codeAssist.ts
@@ -4,12 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ContentGenerator } from '../core/contentGenerator.js';
-import { AuthType } from '../core/contentGenerator.js';
+import { type ContentGenerator, AuthType } from '../core/contentGenerator.js';
 import { getOauthClient } from './oauth2.js';
 import { setupUser } from './setup.js';
-import type { HttpOptions } from './server.js';
-import { CodeAssistServer } from './server.js';
+import { type HttpOptions, CodeAssistServer } from './server.js';
 import type { Config } from '../config/config.js';
 import { LoggingContentGenerator } from '../core/loggingContentGenerator.js';
 

--- a/packages/core/src/code_assist/converter.test.ts
+++ b/packages/core/src/code_assist/converter.test.ts
@@ -5,20 +5,18 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { CaGenerateContentResponse } from './converter.js';
 import {
+  type CaGenerateContentResponse,
   toGenerateContentRequest,
   fromGenerateContentResponse,
   toContents,
 } from './converter.js';
-import type {
-  ContentListUnion,
-  GenerateContentParameters,
-} from '@google/genai';
 import {
   GenerateContentResponse,
   FinishReason,
   BlockedReason,
+  type ContentListUnion,
+  type GenerateContentParameters,
   type Part,
 } from '@google/genai';
 

--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -4,29 +4,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  Content,
-  ContentListUnion,
-  ContentUnion,
-  GenerateContentConfig,
-  GenerateContentParameters,
-  CountTokensParameters,
-  CountTokensResponse,
-  GenerationConfigRoutingConfig,
-  MediaResolution,
-  Candidate,
-  ModelSelectionConfig,
-  GenerateContentResponsePromptFeedback,
-  GenerateContentResponseUsageMetadata,
-  Part,
-  SafetySetting,
-  PartUnion,
-  SpeechConfigUnion,
-  ThinkingConfig,
-  ToolListUnion,
-  ToolConfig,
+import {
+  type Content,
+  type ContentListUnion,
+  type ContentUnion,
+  type GenerateContentConfig,
+  type GenerateContentParameters,
+  type CountTokensParameters,
+  type CountTokensResponse,
+  type GenerationConfigRoutingConfig,
+  type MediaResolution,
+  type Candidate,
+  type ModelSelectionConfig,
+  type GenerateContentResponsePromptFeedback,
+  type GenerateContentResponseUsageMetadata,
+  type Part,
+  type SafetySetting,
+  type PartUnion,
+  type SpeechConfigUnion,
+  type ThinkingConfig,
+  type ToolListUnion,
+  type ToolConfig,
+  GenerateContentResponse,
 } from '@google/genai';
-import { GenerateContentResponse } from '@google/genai';
 
 export interface CAGenerateContentRequest {
   model: string;

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -4,9 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Credentials } from 'google-auth-library';
-import type { Mock } from 'vitest';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  type Credentials,
+  OAuth2Client,
+  Compute,
+  GoogleAuth,
+} from 'google-auth-library';
+import {
+  type Mock,
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from 'vitest';
 import {
   getOauthClient,
   resetOauthClientForTesting,
@@ -15,7 +27,6 @@ import {
   authEvents,
 } from './oauth2.js';
 import { UserAccountManager } from '../utils/userAccountManager.js';
-import { OAuth2Client, Compute, GoogleAuth } from 'google-auth-library';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import http from 'node:http';

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Credentials, AuthClient, JWTInput } from 'google-auth-library';
 import {
+  type Credentials,
+  type AuthClient,
+  type JWTInput,
   OAuth2Client,
   Compute,
   CodeChallengeMethod,

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -5,22 +5,23 @@
  */
 
 import type { AuthClient } from 'google-auth-library';
-import type {
-  CodeAssistGlobalUserSettingResponse,
-  LoadCodeAssistRequest,
-  LoadCodeAssistResponse,
-  LongRunningOperationResponse,
-  OnboardUserRequest,
-  SetCodeAssistGlobalUserSettingRequest,
-  ClientMetadata,
-  RetrieveUserQuotaRequest,
-  RetrieveUserQuotaResponse,
-  FetchAdminControlsRequest,
-  FetchAdminControlsResponse,
-  ConversationOffered,
-  ConversationInteraction,
-  StreamingLatency,
-  RecordCodeAssistMetricsRequest,
+import {
+  type CodeAssistGlobalUserSettingResponse,
+  type LoadCodeAssistRequest,
+  type LoadCodeAssistResponse,
+  type LongRunningOperationResponse,
+  type OnboardUserRequest,
+  type SetCodeAssistGlobalUserSettingRequest,
+  type ClientMetadata,
+  type RetrieveUserQuotaRequest,
+  type RetrieveUserQuotaResponse,
+  type FetchAdminControlsRequest,
+  type FetchAdminControlsResponse,
+  type ConversationOffered,
+  type ConversationInteraction,
+  type StreamingLatency,
+  type RecordCodeAssistMetricsRequest,
+  UserTierId,
 } from './types.js';
 import type {
   ListExperimentsRequest,
@@ -37,12 +38,9 @@ import type {
 import * as readline from 'node:readline';
 import { Readable } from 'node:stream';
 import type { ContentGenerator } from '../core/contentGenerator.js';
-import { UserTierId } from './types.js';
-import type {
-  CaCountTokenResponse,
-  CaGenerateContentResponse,
-} from './converter.js';
 import {
+  type CaCountTokenResponse,
+  type CaGenerateContentResponse,
   fromCountTokenResponse,
   fromGenerateContentResponse,
   toCountTokenRequest,

--- a/packages/core/src/code_assist/setup.test.ts
+++ b/packages/core/src/code_assist/setup.test.ts
@@ -14,8 +14,7 @@ import { ValidationRequiredError } from '../utils/googleQuotaErrors.js';
 import { ChangeAuthRequestedError } from '../utils/errors.js';
 import { CodeAssistServer } from '../code_assist/server.js';
 import type { OAuth2Client } from 'google-auth-library';
-import type { GeminiUserTier } from './types.js';
-import { UserTierId } from './types.js';
+import { type GeminiUserTier, UserTierId } from './types.js';
 
 vi.mock('../code_assist/server.js');
 

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  ClientMetadata,
-  GeminiUserTier,
-  IneligibleTier,
-  LoadCodeAssistResponse,
-  OnboardUserRequest,
+import {
+  type ClientMetadata,
+  type GeminiUserTier,
+  type IneligibleTier,
+  type LoadCodeAssistResponse,
+  type OnboardUserRequest,
+  UserTierId,
+  IneligibleTierReasonCode,
 } from './types.js';
-import { UserTierId, IneligibleTierReasonCode } from './types.js';
-import type { HttpOptions } from './server.js';
-import { CodeAssistServer } from './server.js';
+import { type HttpOptions, CodeAssistServer } from './server.js';
 import type { AuthClient } from 'google-auth-library';
 import type { ValidationHandler } from '../fallback/types.js';
 import { ChangeAuthRequestedError } from '../utils/errors.js';

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -4,15 +4,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { Mock } from 'vitest';
-import type { ConfigParameters, SandboxConfig } from './config.js';
-import { Config, DEFAULT_FILE_FILTERING_OPTIONS } from './config.js';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
+import {
+  type ConfigParameters,
+  type SandboxConfig,
+  Config,
+  DEFAULT_FILE_FILTERING_OPTIONS,
+} from './config.js';
 import { ExperimentFlags } from '../code_assist/experiments/flagNames.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { ApprovalMode } from '../policy/types.js';
-import type { HookDefinition } from '../hooks/types.js';
-import { HookType, HookEventName } from '../hooks/types.js';
+import {
+  type HookDefinition,
+  HookType,
+  HookEventName,
+} from '../hooks/types.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
@@ -20,12 +34,13 @@ import { setGeminiMdFilename as mockSetGeminiMdFilename } from '../tools/memoryT
 import {
   DEFAULT_TELEMETRY_TARGET,
   DEFAULT_OTLP_ENDPOINT,
+  uiTelemetryService,
 } from '../telemetry/index.js';
-import type { ContentGeneratorConfig } from '../core/contentGenerator.js';
 import {
   AuthType,
   createContentGenerator,
   createContentGeneratorConfig,
+  type ContentGeneratorConfig,
 } from '../core/contentGenerator.js';
 import { GeminiClient } from '../core/client.js';
 import { GitService } from '../services/gitService.js';
@@ -201,14 +216,15 @@ vi.mock('../services/contextManager.js', () => ({
 
 import { BaseLlmClient } from '../core/baseLlmClient.js';
 import { tokenLimit } from '../core/tokenLimits.js';
-import { uiTelemetryService } from '../telemetry/index.js';
 import { getCodeAssistServer } from '../code_assist/codeAssist.js';
 import { getExperiments } from '../code_assist/experiments/experiments.js';
 import type { CodeAssistServer } from '../code_assist/server.js';
 import { ContextManager } from '../services/contextManager.js';
 import { UserTierId } from '../code_assist/types.js';
-import type { ModelConfigService } from '../services/modelConfigService.js';
-import type { ModelConfigServiceConfig } from '../services/modelConfigService.js';
+import type {
+  ModelConfigService,
+  ModelConfigServiceConfig,
+} from '../services/modelConfigService.js';
 import { ExitPlanModeTool } from '../tools/exit-plan-mode.js';
 import { EnterPlanModeTool } from '../tools/enter-plan-mode.js';
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -9,14 +9,12 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { inspect } from 'node:util';
 import process from 'node:process';
-import type {
-  ContentGenerator,
-  ContentGeneratorConfig,
-} from '../core/contentGenerator.js';
 import {
   AuthType,
   createContentGenerator,
   createContentGeneratorConfig,
+  type ContentGenerator,
+  type ContentGeneratorConfig,
 } from '../core/contentGenerator.js';
 import { PromptRegistry } from '../prompts/prompt-registry.js';
 import { ResourceRegistry } from '../resources/resource-registry.js';
@@ -41,12 +39,12 @@ import { BaseLlmClient } from '../core/baseLlmClient.js';
 import type { HookDefinition, HookEventName } from '../hooks/types.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { GitService } from '../services/gitService.js';
-import type { TelemetryTarget } from '../telemetry/index.js';
 import {
   initializeTelemetry,
   DEFAULT_TELEMETRY_TARGET,
   DEFAULT_OTLP_ENDPOINT,
   uiTelemetryService,
+  type TelemetryTarget,
 } from '../telemetry/index.js';
 import { coreEvents, CoreEvent } from '../utils/events.js';
 import { tokenLimit } from '../core/tokenLimits.js';
@@ -66,9 +64,16 @@ import { shouldAttemptBrowserLaunch } from '../utils/browser.js';
 import type { MCPOAuthConfig } from '../mcp/oauth-provider.js';
 import { ideContextStore } from '../ide/ideContext.js';
 import { WriteTodosTool } from '../tools/write-todos.js';
-import type { FileSystemService } from '../services/fileSystemService.js';
-import { StandardFileSystemService } from '../services/fileSystemService.js';
-import { logRipgrepFallback, logFlashFallback } from '../telemetry/loggers.js';
+import {
+  StandardFileSystemService,
+  type FileSystemService,
+} from '../services/fileSystemService.js';
+import {
+  logRipgrepFallback,
+  logFlashFallback,
+  logApprovalModeSwitch,
+  logApprovalModeDuration,
+} from '../telemetry/loggers.js';
 import {
   RipgrepFallbackEvent,
   FlashFallbackEvent,
@@ -82,11 +87,11 @@ import type {
 import { ModelAvailabilityService } from '../availability/modelAvailabilityService.js';
 import { ModelRouterService } from '../routing/modelRouterService.js';
 import { OutputFormat } from '../output/types.js';
-import type {
-  ModelConfig,
-  ModelConfigServiceConfig,
+import {
+  ModelConfigService,
+  type ModelConfig,
+  type ModelConfigServiceConfig,
 } from '../services/modelConfigService.js';
-import { ModelConfigService } from '../services/modelConfigService.js';
 import { DEFAULT_MODEL_CONFIGS } from './defaultModelConfigs.js';
 import { ContextManager } from '../services/contextManager.js';
 import type { GenerateContentParameters } from '@google/genai';
@@ -103,26 +108,26 @@ import type { EventEmitter } from 'node:events';
 import { PolicyEngine } from '../policy/policy-engine.js';
 import { ApprovalMode, type PolicyEngineConfig } from '../policy/types.js';
 import { HookSystem } from '../hooks/index.js';
-import type { UserTierId } from '../code_assist/types.js';
-import type { RetrieveUserQuotaResponse } from '../code_assist/types.js';
-import type { AdminControlsSettings } from '../code_assist/types.js';
+import type {
+  UserTierId,
+  RetrieveUserQuotaResponse,
+  AdminControlsSettings,
+} from '../code_assist/types.js';
 import type { HierarchicalMemory } from './memory.js';
 import { getCodeAssistServer } from '../code_assist/codeAssist.js';
-import type { Experiments } from '../code_assist/experiments/experiments.js';
+import {
+  getExperiments,
+  type Experiments,
+} from '../code_assist/experiments/experiments.js';
 import { AgentRegistry } from '../agents/registry.js';
 import { AcknowledgedAgentsService } from '../agents/acknowledgedAgents.js';
 import { setGlobalProxy } from '../utils/fetch.js';
 import { SubagentTool } from '../agents/subagent-tool.js';
-import { getExperiments } from '../code_assist/experiments/experiments.js';
 import { ExperimentFlags } from '../code_assist/experiments/flagNames.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { SkillManager, type SkillDefinition } from '../skills/skillManager.js';
 import { startupProfiler } from '../telemetry/startupProfiler.js';
 import type { AgentDefinition } from '../agents/types.js';
-import {
-  logApprovalModeSwitch,
-  logApprovalModeDuration,
-} from '../telemetry/loggers.js';
 import { fetchAdminControls } from '../code_assist/admin/admin_controls.js';
 import { isSubpath } from '../utils/paths.js';
 import { UserHintService } from './userHintService.js';
@@ -288,10 +293,10 @@ export interface ExtensionInstallMetadata {
   allowPreRelease?: boolean;
 }
 
-import type { FileFilteringOptions } from './constants.js';
 import {
   DEFAULT_FILE_FILTERING_OPTIONS,
   DEFAULT_MEMORY_FILE_FILTERING_OPTIONS,
+  type FileFilteringOptions,
 } from './constants.js';
 import {
   DEFAULT_TOOL_PROTECTION_THRESHOLD,

--- a/packages/core/src/core/baseLlmClient.test.ts
+++ b/packages/core/src/core/baseLlmClient.test.ts
@@ -15,22 +15,23 @@ import {
   type Mock,
 } from 'vitest';
 
-import { BaseLlmClient, type GenerateJsonOptions } from './baseLlmClient.js';
-import type { ContentGenerator } from './contentGenerator.js';
+import {
+  BaseLlmClient,
+  type GenerateContentOptions,
+  type GenerateJsonOptions,
+} from './baseLlmClient.js';
+import { AuthType, type ContentGenerator } from './contentGenerator.js';
 import type { ModelAvailabilityService } from '../availability/modelAvailabilityService.js';
 import { createAvailabilityServiceMock } from '../availability/testUtils.js';
-import type { GenerateContentOptions } from './baseLlmClient.js';
 import type { GenerateContentResponse } from '@google/genai';
 import type { Config } from '../config/config.js';
-import { AuthType } from './contentGenerator.js';
 import { reportError } from '../utils/errorReporting.js';
 import { logMalformedJsonResponse } from '../telemetry/loggers.js';
 import { retryWithBackoff } from '../utils/retry.js';
-import { MalformedJsonResponseEvent } from '../telemetry/types.js';
+import { MalformedJsonResponseEvent, LlmRole } from '../telemetry/types.js';
 import { getErrorMessage } from '../utils/errors.js';
 import type { ModelConfigService } from '../services/modelConfigService.js';
 import { makeResolvedModelConfig } from '../services/modelConfigServiceTestUtils.js';
-import { LlmRole } from '../telemetry/types.js';
 
 vi.mock('../utils/errorReporting.js');
 vi.mock('../telemetry/loggers.js');

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -4,27 +4,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  GenerateContentConfig,
-  PartListUnion,
-  Content,
-  Tool,
-  GenerateContentResponse,
+import {
+  type GenerateContentConfig,
+  type PartListUnion,
+  type Content,
+  type Tool,
+  type GenerateContentResponse,
+  createUserContent,
 } from '@google/genai';
-import { createUserContent } from '@google/genai';
 import {
   getDirectoryContextString,
   getInitialChatHistory,
 } from '../utils/environmentContext.js';
-import type { ServerGeminiStreamEvent, ChatCompressionInfo } from './turn.js';
-import { CompressionStatus } from './turn.js';
-import { Turn, GeminiEventType } from './turn.js';
+import {
+  type ServerGeminiStreamEvent,
+  type ChatCompressionInfo,
+  CompressionStatus,
+  Turn,
+  GeminiEventType,
+} from './turn.js';
 import type { Config } from '../config/config.js';
 import { getCoreSystemPrompt } from './prompts.js';
 import { checkNextSpeaker } from '../utils/nextSpeakerChecker.js';
 import { reportError } from '../utils/errorReporting.js';
 import { GeminiChat } from './geminiChat.js';
-import { retryWithBackoff } from '../utils/retry.js';
+import {
+  retryWithBackoff,
+  type RetryAvailabilityContext,
+} from '../utils/retry.js';
 import type { ValidationRequiredError } from '../utils/googleQuotaErrors.js';
 import { getErrorMessage } from '../utils/errors.js';
 import { tokenLimit } from './tokenLimits.js';
@@ -47,6 +54,7 @@ import type {
 import {
   ContentRetryFailureEvent,
   NextSpeakerCheckEvent,
+  type LlmRole,
 } from '../telemetry/types.js';
 import { uiTelemetryService } from '../telemetry/uiTelemetry.js';
 import type { IdeContext, File } from '../ide/types.js';
@@ -61,10 +69,8 @@ import {
   createAvailabilityContextProvider,
 } from '../availability/policyHelpers.js';
 import { resolveModel } from '../config/models.js';
-import type { RetryAvailabilityContext } from '../utils/retry.js';
 import { partToString } from '../utils/partUtils.js';
 import { coreEvents, CoreEvent } from '../utils/events.js';
-import type { LlmRole } from '../telemetry/types.js';
 
 const MAX_TURNS = 100;
 

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -5,8 +5,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { ContentGenerator } from './contentGenerator.js';
 import {
+  type ContentGenerator,
   createContentGenerator,
   AuthType,
   createContentGeneratorConfig,

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  CountTokensResponse,
-  GenerateContentResponse,
-  GenerateContentParameters,
-  CountTokensParameters,
-  EmbedContentResponse,
-  EmbedContentParameters,
+import {
+  type CountTokensResponse,
+  type GenerateContentResponse,
+  type GenerateContentParameters,
+  type CountTokensParameters,
+  type EmbedContentResponse,
+  type EmbedContentParameters,
+  GoogleGenAI,
 } from '@google/genai';
-import { GoogleGenAI } from '@google/genai';
 import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
 import type { Config } from '../config/config.js';
 import { loadApiKey } from './apiKeyCredentialStorage.js';

--- a/packages/core/src/core/coreToolHookTriggers.ts
+++ b/packages/core/src/core/coreToolHookTriggers.ts
@@ -6,11 +6,14 @@
 
 import { type McpToolContext, BeforeToolHookOutput } from '../hooks/types.js';
 import type { Config } from '../config/config.js';
-import type { ToolResult, AnyDeclarativeTool } from '../tools/tools.js';
+import type {
+  ToolResult,
+  AnyDeclarativeTool,
+  AnyToolInvocation,
+} from '../tools/tools.js';
 import { ToolErrorType } from '../tools/tool-error.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import type { AnsiOutput, ShellExecutionConfig } from '../index.js';
-import type { AnyToolInvocation } from '../tools/tools.js';
 import { ShellToolInvocation } from '../tools/shell.js';
 import { DiscoveredMCPToolInvocation } from '../tools/mcp-tool.js';
 

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import type { Mock } from 'vitest';
+import { describe, it, expect, vi, type Mock } from 'vitest';
 import type { CallableTool } from '@google/genai';
 import { CoreToolScheduler } from './coreToolScheduler.js';
 import {
@@ -14,16 +13,14 @@ import {
   type ErroredToolCall,
   CoreToolCallStatus,
 } from '../scheduler/types.js';
-import type {
-  ToolCallConfirmationDetails,
-  ToolConfirmationPayload,
-  ToolInvocation,
-  ToolResult,
-  Config,
-  ToolRegistry,
-  MessageBus,
-} from '../index.js';
 import {
+  type ToolCallConfirmationDetails,
+  type ToolConfirmationPayload,
+  type ToolInvocation,
+  type ToolResult,
+  type Config,
+  type ToolRegistry,
+  type MessageBus,
   DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
   BaseDeclarativeTool,
   BaseToolInvocation,

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -21,8 +21,10 @@ import { ToolCallEvent } from '../telemetry/types.js';
 import { runInDevTraceSpan } from '../telemetry/trace.js';
 import { ToolModificationHandler } from '../scheduler/tool-modifier.js';
 import { getToolSuggestion } from '../utils/tool-utils.js';
-import type { ToolConfirmationRequest } from '../confirmation-bus/types.js';
-import { MessageBusType } from '../confirmation-bus/types.js';
+import {
+  type ToolConfirmationRequest,
+  MessageBusType,
+} from '../confirmation-bus/types.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import {
   type ToolCall,
@@ -41,8 +43,8 @@ import {
   type ToolCallsUpdateHandler,
   type ToolCallRequestInfo,
   type ToolCallResponseInfo,
+  CoreToolCallStatus,
 } from '../scheduler/types.js';
-import { CoreToolCallStatus } from '../scheduler/types.js';
 import { ToolExecutor } from '../scheduler/tool-executor.js';
 import { DiscoveredMCPTool } from '../tools/mcp-tool.js';
 import { getPolicyDenialError } from '../scheduler/policy.js';

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -5,8 +5,12 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { Content, GenerateContentResponse } from '@google/genai';
-import { ApiError, ThinkingLevel } from '@google/genai';
+import {
+  type Content,
+  type GenerateContentResponse,
+  ApiError,
+  ThinkingLevel,
+} from '@google/genai';
 import type { ContentGenerator } from '../core/contentGenerator.js';
 import {
   GeminiChat,

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -7,17 +7,18 @@
 // DISCLAIMER: This is a copied version of https://github.com/googleapis/js-genai/blob/main/src/chats.ts with the intention of working around a key bug
 // where function responses are not treated as "valid" responses: https://b.corp.google.com/issues/420354090
 
-import type {
-  GenerateContentResponse,
-  Content,
-  Part,
-  Tool,
-  PartListUnion,
-  GenerateContentConfig,
-  GenerateContentParameters,
+import {
+  type GenerateContentResponse,
+  type Content,
+  type Part,
+  type Tool,
+  type PartListUnion,
+  type GenerateContentConfig,
+  type GenerateContentParameters,
+  createUserContent,
+  FinishReason,
 } from '@google/genai';
 import { toParts } from '../code_assist/converter.js';
-import { createUserContent, FinishReason } from '@google/genai';
 import {
   retryWithBackoff,
   isRetryableError,
@@ -44,6 +45,7 @@ import {
 import {
   ContentRetryEvent,
   ContentRetryFailureEvent,
+  type LlmRole,
 } from '../telemetry/types.js';
 import { handleFallback } from '../fallback/handler.js';
 import { isFunctionResponse } from '../utils/messageInspectors.js';
@@ -55,7 +57,6 @@ import {
   createAvailabilityContextProvider,
 } from '../availability/policyHelpers.js';
 import { coreEvents } from '../utils/events.js';
-import type { LlmRole } from '../telemetry/types.js';
 
 export enum StreamEventType {
   /** A regular content chunk from the API. */

--- a/packages/core/src/core/geminiChat_network_retry.test.ts
+++ b/packages/core/src/core/geminiChat_network_retry.test.ts
@@ -5,8 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { GenerateContentResponse } from '@google/genai';
-import { ApiError } from '@google/genai';
+import { type GenerateContentResponse, ApiError } from '@google/genai';
 import type { ContentGenerator } from '../core/contentGenerator.js';
 import { GeminiChat, StreamEventType, type StreamEvent } from './geminiChat.js';
 import type { Config } from '../config/config.js';

--- a/packages/core/src/core/logger.test.ts
+++ b/packages/core/src/core/logger.test.ts
@@ -13,8 +13,8 @@ import {
   afterEach,
   afterAll,
 } from 'vitest';
-import type { LogEntry } from './logger.js';
 import {
+  type LogEntry,
   Logger,
   MessageSenderType,
   encodeTagName,

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -16,8 +16,8 @@ import type {
   GenerateContentResponseUsageMetadata,
   GenerateContentResponse,
 } from '@google/genai';
-import type { ServerDetails } from '../telemetry/types.js';
 import {
+  type ServerDetails,
   ApiRequestEvent,
   ApiResponseEvent,
   ApiErrorEvent,

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -5,15 +5,19 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type {
-  ServerGeminiToolCallRequestEvent,
-  ServerGeminiErrorEvent,
+import {
+  type ServerGeminiToolCallRequestEvent,
+  type ServerGeminiErrorEvent,
+  Turn,
+  GeminiEventType,
 } from './turn.js';
-import { Turn, GeminiEventType } from './turn.js';
 import type { GenerateContentResponse, Part, Content } from '@google/genai';
 import { reportError } from '../utils/errorReporting.js';
-import type { GeminiChat } from './geminiChat.js';
-import { InvalidStreamError, StreamEventType } from './geminiChat.js';
+import {
+  type GeminiChat,
+  InvalidStreamError,
+  StreamEventType,
+} from './geminiChat.js';
 import { LlmRole } from '../telemetry/types.js';
 
 const mockSendMessageStream = vi.fn();

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  PartListUnion,
-  GenerateContentResponse,
-  FunctionCall,
-  FunctionDeclaration,
-  FinishReason,
-  GenerateContentResponseUsageMetadata,
+import {
+  type PartListUnion,
+  type GenerateContentResponse,
+  type FunctionCall,
+  type FunctionDeclaration,
+  type FinishReason,
+  type GenerateContentResponseUsageMetadata,
+  createUserContent,
 } from '@google/genai';
 import type {
   ToolCallConfirmationDetails,
@@ -23,10 +24,8 @@ import {
   UnauthorizedError,
   toFriendlyError,
 } from '../utils/errors.js';
-import type { GeminiChat } from './geminiChat.js';
-import { InvalidStreamError } from './geminiChat.js';
+import { type GeminiChat, InvalidStreamError } from './geminiChat.js';
 import { parseThought, type ThoughtSummary } from '../utils/thoughtUtils.js';
-import { createUserContent } from '@google/genai';
 import type { ModelConfigKey } from '../services/modelConfigService.js';
 import { getCitations } from '../utils/generateContentResponseUtilities.js';
 import { LlmRole } from '../telemetry/types.js';

--- a/packages/core/src/hooks/hookAggregator.test.ts
+++ b/packages/core/src/hooks/hookAggregator.test.ts
@@ -6,13 +6,14 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { HookAggregator } from './hookAggregator.js';
-import type {
-  HookExecutionResult,
-  BeforeToolSelectionOutput,
-  BeforeModelOutput,
-  HookOutput,
+import {
+  type HookExecutionResult,
+  type BeforeToolSelectionOutput,
+  type BeforeModelOutput,
+  type HookOutput,
+  HookType,
+  HookEventName,
 } from './types.js';
-import { HookType, HookEventName } from './types.js';
 
 // Helper function to create proper HookExecutionResult objects
 function createHookExecutionResult(

--- a/packages/core/src/hooks/hookAggregator.ts
+++ b/packages/core/src/hooks/hookAggregator.ts
@@ -5,20 +5,18 @@
  */
 
 import { FunctionCallingConfigMode } from '@google/genai';
-import type {
-  HookOutput,
-  HookExecutionResult,
-  BeforeToolSelectionOutput,
-} from './types.js';
 import {
+  type HookOutput,
+  type HookExecutionResult,
+  type BeforeToolSelectionOutput,
   DefaultHookOutput,
   BeforeToolHookOutput,
   BeforeModelHookOutput,
   BeforeToolSelectionHookOutput,
   AfterModelHookOutput,
   AfterAgentHookOutput,
+  HookEventName,
 } from './types.js';
-import { HookEventName } from './types.js';
 
 /**
  * Aggregated hook result

--- a/packages/core/src/hooks/hookEventHandler.test.ts
+++ b/packages/core/src/hooks/hookEventHandler.test.ts
@@ -11,16 +11,17 @@ import type {
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { HookEventHandler } from './hookEventHandler.js';
 import type { Config } from '../config/config.js';
-import type { HookConfig } from './types.js';
+import {
+  HookEventName,
+  HookType,
+  NotificationType,
+  SessionStartSource,
+  type HookConfig,
+  type HookExecutionResult,
+} from './types.js';
 import type { HookPlanner } from './hookPlanner.js';
 import type { HookRunner } from './hookRunner.js';
 import type { HookAggregator } from './hookAggregator.js';
-import { HookEventName, HookType } from './types.js';
-import {
-  NotificationType,
-  SessionStartSource,
-  type HookExecutionResult,
-} from './types.js';
 
 // Mock debugLogger
 const mockDebugLogger = vi.hoisted(() => ({

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -8,27 +8,27 @@ import type { Config } from '../config/config.js';
 import type { HookPlanner, HookEventContext } from './hookPlanner.js';
 import type { HookRunner } from './hookRunner.js';
 import type { HookAggregator, AggregatedHookResult } from './hookAggregator.js';
-import { HookEventName } from './types.js';
-import type {
-  HookConfig,
-  HookInput,
-  BeforeToolInput,
-  AfterToolInput,
-  BeforeAgentInput,
-  NotificationInput,
-  AfterAgentInput,
-  SessionStartInput,
-  SessionEndInput,
-  PreCompressInput,
-  BeforeModelInput,
-  AfterModelInput,
-  BeforeToolSelectionInput,
-  NotificationType,
-  SessionStartSource,
-  SessionEndReason,
-  PreCompressTrigger,
-  HookExecutionResult,
-  McpToolContext,
+import {
+  HookEventName,
+  type HookConfig,
+  type HookInput,
+  type BeforeToolInput,
+  type AfterToolInput,
+  type BeforeAgentInput,
+  type NotificationInput,
+  type AfterAgentInput,
+  type SessionStartInput,
+  type SessionEndInput,
+  type PreCompressInput,
+  type BeforeModelInput,
+  type AfterModelInput,
+  type BeforeToolSelectionInput,
+  type NotificationType,
+  type SessionStartSource,
+  type SessionEndReason,
+  type PreCompressTrigger,
+  type HookExecutionResult,
+  type McpToolContext,
 } from './types.js';
 import { defaultHookTranslator } from './hookTranslator.js';
 import type {

--- a/packages/core/src/hooks/hookPlanner.ts
+++ b/packages/core/src/hooks/hookPlanner.ts
@@ -5,8 +5,11 @@
  */
 
 import type { HookRegistry, HookRegistryEntry } from './hookRegistry.js';
-import type { HookExecutionPlan } from './types.js';
-import { getHookKey, type HookEventName } from './types.js';
+import {
+  getHookKey,
+  type HookExecutionPlan,
+  type HookEventName,
+} from './types.js';
 import { debugLogger } from '../utils/debugLogger.js';
 
 /**

--- a/packages/core/src/hooks/hookRegistry.test.ts
+++ b/packages/core/src/hooks/hookRegistry.test.ts
@@ -13,9 +13,9 @@ import {
   HookEventName,
   HookType,
   HOOKS_CONFIG_FIELDS,
+  type HookDefinition,
 } from './types.js';
 import type { Config } from '../config/config.js';
-import type { HookDefinition } from './types.js';
 
 // Mock fs
 vi.mock('fs', () => ({

--- a/packages/core/src/hooks/hookRegistry.ts
+++ b/packages/core/src/hooks/hookRegistry.ts
@@ -5,8 +5,13 @@
  */
 
 import type { Config } from '../config/config.js';
-import type { HookDefinition, HookConfig } from './types.js';
-import { HookEventName, ConfigSource, HOOKS_CONFIG_FIELDS } from './types.js';
+import {
+  type HookDefinition,
+  type HookConfig,
+  HookEventName,
+  ConfigSource,
+  HOOKS_CONFIG_FIELDS,
+} from './types.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { TrustedHooksManager } from './trustedHooks.js';
 import { coreEvents } from '../utils/events.js';

--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -7,9 +7,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { HookRunner } from './hookRunner.js';
-import { HookEventName, HookType, ConfigSource } from './types.js';
-import type { HookConfig } from './types.js';
-import type { HookInput } from './types.js';
+import {
+  HookEventName,
+  HookType,
+  ConfigSource,
+  type HookConfig,
+  type HookInput,
+} from './types.js';
 import type { Readable, Writable } from 'node:stream';
 import type { Config } from '../config/config.js';
 

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -5,17 +5,18 @@
  */
 
 import { spawn } from 'node:child_process';
-import type {
-  HookConfig,
-  HookInput,
-  HookOutput,
-  HookExecutionResult,
-  BeforeAgentInput,
-  BeforeModelInput,
-  BeforeModelOutput,
-  BeforeToolInput,
+import {
+  type HookConfig,
+  type HookInput,
+  type HookOutput,
+  type HookExecutionResult,
+  type BeforeAgentInput,
+  type BeforeModelInput,
+  type BeforeModelOutput,
+  type BeforeToolInput,
+  HookEventName,
+  ConfigSource,
 } from './types.js';
-import { HookEventName, ConfigSource } from './types.js';
 import type { Config } from '../config/config.js';
 import type { LLMRequest } from './hookTranslator.js';
 import { debugLogger } from '../utils/debugLogger.js';

--- a/packages/core/src/hooks/hookSystem.test.ts
+++ b/packages/core/src/hooks/hookSystem.test.ts
@@ -8,11 +8,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { HookSystem } from './hookSystem.js';
 import { Config } from '../config/config.js';
 import { HookType } from './types.js';
-import { spawn } from 'node:child_process';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import type { ChildProcessWithoutNullStreams } from 'node:child_process';
 import type { Readable, Writable } from 'node:stream';
 
 // Mock type for the child_process spawn

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -5,25 +5,23 @@
  */
 
 import type { Config } from '../config/config.js';
-import { HookRegistry } from './hookRegistry.js';
+import { HookRegistry, type HookRegistryEntry } from './hookRegistry.js';
 import { HookRunner } from './hookRunner.js';
-import { HookAggregator } from './hookAggregator.js';
+import { HookAggregator, type AggregatedHookResult } from './hookAggregator.js';
 import { HookPlanner } from './hookPlanner.js';
 import { HookEventHandler } from './hookEventHandler.js';
-import type { HookRegistryEntry } from './hookRegistry.js';
 import { debugLogger } from '../utils/debugLogger.js';
-import type {
-  SessionStartSource,
-  SessionEndReason,
-  PreCompressTrigger,
-  DefaultHookOutput,
-  BeforeModelHookOutput,
-  AfterModelHookOutput,
-  BeforeToolSelectionHookOutput,
-  McpToolContext,
+import {
+  type SessionStartSource,
+  type SessionEndReason,
+  type PreCompressTrigger,
+  type DefaultHookOutput,
+  type BeforeModelHookOutput,
+  type AfterModelHookOutput,
+  type BeforeToolSelectionHookOutput,
+  type McpToolContext,
+  NotificationType,
 } from './types.js';
-import { NotificationType } from './types.js';
-import type { AggregatedHookResult } from './hookAggregator.js';
 import type {
   GenerateContentParameters,
   GenerateContentResponse,

--- a/packages/core/src/hooks/types.test.ts
+++ b/packages/core/src/hooks/types.test.ts
@@ -14,15 +14,18 @@ import {
   HookEventName,
   HookType,
   BeforeToolHookOutput,
+  type HookDecision,
 } from './types.js';
-import { defaultHookTranslator } from './hookTranslator.js';
+import {
+  defaultHookTranslator,
+  type LLMRequest,
+  type LLMResponse,
+} from './hookTranslator.js';
 import type {
   GenerateContentParameters,
   GenerateContentResponse,
   ToolConfig,
 } from '@google/genai';
-import type { LLMRequest, LLMResponse } from './hookTranslator.js';
-import type { HookDecision } from './types.js';
 
 vi.mock('./hookTranslator.js', () => ({
   defaultHookTranslator: {

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -10,12 +10,12 @@ import type {
   ToolConfig as GenAIToolConfig,
   ToolListUnion,
 } from '@google/genai';
-import type {
-  LLMRequest,
-  LLMResponse,
-  HookToolConfig,
+import {
+  type LLMRequest,
+  type LLMResponse,
+  type HookToolConfig,
+  defaultHookTranslator,
 } from './hookTranslator.js';
-import { defaultHookTranslator } from './hookTranslator.js';
 
 /**
  * Configuration source levels in precedence order (highest to lowest)

--- a/packages/core/src/ide/ide-installer.test.ts
+++ b/packages/core/src/ide/ide-installer.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal();
@@ -23,8 +23,6 @@ vi.mock('../utils/paths.js', async (importOriginal) => {
     homedir: vi.fn(),
   };
 });
-
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { getIdeInstaller } from './ide-installer.js';
 import * as child_process from 'node:child_process';
 import * as fs from 'node:fs';

--- a/packages/core/src/mcp/google-auth-provider.test.ts
+++ b/packages/core/src/mcp/google-auth-provider.test.ts
@@ -6,8 +6,7 @@
 
 import { GoogleAuth } from 'google-auth-library';
 import { GoogleCredentialProvider } from './google-auth-provider.js';
-import type { Mock } from 'vitest';
-import { vi, describe, beforeEach, it, expect } from 'vitest';
+import { type Mock, vi, describe, beforeEach, it, expect } from 'vitest';
 import type { MCPServerConfig } from '../config/config.js';
 
 vi.mock('google-auth-library');

--- a/packages/core/src/mcp/oauth-provider.test.ts
+++ b/packages/core/src/mcp/oauth-provider.test.ts
@@ -56,12 +56,12 @@ vi.mock('node:readline', () => ({
 
 import * as http from 'node:http';
 import * as crypto from 'node:crypto';
-import type {
-  MCPOAuthConfig,
-  OAuthTokenResponse,
-  OAuthClientRegistrationResponse,
+import {
+  type MCPOAuthConfig,
+  type OAuthTokenResponse,
+  type OAuthClientRegistrationResponse,
+  MCPOAuthProvider,
 } from './oauth-provider.js';
-import { MCPOAuthProvider } from './oauth-provider.js';
 import { getConsentForOauth } from '../utils/authConsent.js';
 import type { OAuthToken } from './token-storage/types.js';
 import { MCPOAuthTokenStorage } from './oauth-token-storage.js';

--- a/packages/core/src/mcp/oauth-utils.test.ts
+++ b/packages/core/src/mcp/oauth-utils.test.ts
@@ -5,11 +5,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type {
-  OAuthAuthorizationServerMetadata,
-  OAuthProtectedResourceMetadata,
+import {
+  type OAuthAuthorizationServerMetadata,
+  type OAuthProtectedResourceMetadata,
+  OAuthUtils,
 } from './oauth-utils.js';
-import { OAuthUtils } from './oauth-utils.js';
 
 // Mock fetch globally
 const mockFetch = vi.fn();

--- a/packages/core/src/mcp/token-storage/hybrid-token-storage.ts
+++ b/packages/core/src/mcp/token-storage/hybrid-token-storage.ts
@@ -6,8 +6,11 @@
 
 import { BaseTokenStorage } from './base-token-storage.js';
 import { FileTokenStorage } from './file-token-storage.js';
-import type { TokenStorage, OAuthCredentials } from './types.js';
-import { TokenStorageType } from './types.js';
+import {
+  TokenStorageType,
+  type TokenStorage,
+  type OAuthCredentials,
+} from './types.js';
 import { coreEvents } from '../../utils/events.js';
 import { TokenStorageInitializationEvent } from '../../telemetry/types.js';
 

--- a/packages/core/src/output/stream-json-formatter.test.ts
+++ b/packages/core/src/output/stream-json-formatter.test.ts
@@ -6,14 +6,14 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { StreamJsonFormatter } from './stream-json-formatter.js';
-import { JsonStreamEventType } from './types.js';
-import type {
-  InitEvent,
-  MessageEvent,
-  ToolUseEvent,
-  ToolResultEvent,
-  ErrorEvent,
-  ResultEvent,
+import {
+  JsonStreamEventType,
+  type InitEvent,
+  type MessageEvent,
+  type ToolUseEvent,
+  type ToolResultEvent,
+  type ErrorEvent,
+  type ResultEvent,
 } from './types.js';
 import type { SessionMetrics } from '../telemetry/uiTelemetry.js';
 import { ToolCallDecision } from '../telemetry/tool-call-decision.js';

--- a/packages/core/src/policy/config.test.ts
+++ b/packages/core/src/policy/config.test.ts
@@ -8,8 +8,12 @@ import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 
 import nodePath from 'node:path';
 
-import type { PolicySettings } from './types.js';
-import { ApprovalMode, PolicyDecision, InProcessCheckerType } from './types.js';
+import {
+  type PolicySettings,
+  ApprovalMode,
+  PolicyDecision,
+  InProcessCheckerType,
+} from './types.js';
 import { isDirectorySecure } from '../utils/security.js';
 
 vi.unmock('../config/storage.js');

--- a/packages/core/src/policy/toml-loader.test.ts
+++ b/packages/core/src/policy/toml-loader.test.ts
@@ -14,8 +14,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { loadPoliciesFromToml } from './toml-loader.js';
-import type { PolicyLoadResult } from './toml-loader.js';
+import { loadPoliciesFromToml, type PolicyLoadResult } from './toml-loader.js';
 import { PolicyEngine } from './policy-engine.js';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/packages/core/src/safety/built-in.test.ts
+++ b/packages/core/src/safety/built-in.test.ts
@@ -9,8 +9,7 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { AllowedPathChecker } from './built-in.js';
-import type { SafetyCheckInput } from './protocol.js';
-import { SafetyCheckDecision } from './protocol.js';
+import { type SafetyCheckInput, SafetyCheckDecision } from './protocol.js';
 import type { FunctionCall } from '@google/genai';
 
 describe('AllowedPathChecker', () => {

--- a/packages/core/src/safety/built-in.ts
+++ b/packages/core/src/safety/built-in.ts
@@ -6,8 +6,11 @@
 
 import * as path from 'node:path';
 import * as fs from 'node:fs';
-import type { SafetyCheckInput, SafetyCheckResult } from './protocol.js';
-import { SafetyCheckDecision } from './protocol.js';
+import {
+  type SafetyCheckInput,
+  type SafetyCheckResult,
+  SafetyCheckDecision,
+} from './protocol.js';
 import type { AllowedPathConfig } from '../policy/types.js';
 
 /**

--- a/packages/core/src/safety/checker-runner.test.ts
+++ b/packages/core/src/safety/checker-runner.test.ts
@@ -13,8 +13,7 @@ import {
   type InProcessCheckerConfig,
   InProcessCheckerType,
 } from '../policy/types.js';
-import type { SafetyCheckResult } from './protocol.js';
-import { SafetyCheckDecision } from './protocol.js';
+import { type SafetyCheckResult, SafetyCheckDecision } from './protocol.js';
 import type { Config } from '../config/config.js';
 
 // Mock dependencies

--- a/packages/core/src/safety/checker-runner.ts
+++ b/packages/core/src/safety/checker-runner.ts
@@ -11,8 +11,11 @@ import type {
   InProcessCheckerConfig,
   ExternalCheckerConfig,
 } from '../policy/types.js';
-import type { SafetyCheckInput, SafetyCheckResult } from './protocol.js';
-import { SafetyCheckDecision } from './protocol.js';
+import {
+  type SafetyCheckInput,
+  type SafetyCheckResult,
+  SafetyCheckDecision,
+} from './protocol.js';
 import type { CheckerRegistry } from './registry.js';
 import type { ContextBuilder } from './context-builder.js';
 import { z } from 'zod';

--- a/packages/core/src/scheduler/confirmation.test.ts
+++ b/packages/core/src/scheduler/confirmation.test.ts
@@ -28,8 +28,11 @@ import {
 } from '../tools/tools.js';
 import type { SchedulerStateManager } from './state-manager.js';
 import type { ToolModificationHandler } from './tool-modifier.js';
-import type { ValidatingToolCall, WaitingToolCall } from './types.js';
-import { ROOT_SCHEDULER_ID } from './types.js';
+import {
+  type ValidatingToolCall,
+  type WaitingToolCall,
+  ROOT_SCHEDULER_ID,
+} from './types.js';
 import type { Config } from '../config/config.js';
 import { type EditorType } from '../utils/editor.js';
 import { randomUUID } from 'node:crypto';

--- a/packages/core/src/scheduler/policy.test.ts
+++ b/packages/core/src/scheduler/policy.test.ts
@@ -25,16 +25,16 @@ import {
   type ToolExecuteConfirmationDetails,
   type AnyToolInvocation,
 } from '../tools/tools.js';
-import type {
-  ValidatingToolCall,
-  ToolCallRequestInfo,
-  CompletedToolCall,
+import {
+  type ValidatingToolCall,
+  type ToolCallRequestInfo,
+  type CompletedToolCall,
+  ROOT_SCHEDULER_ID,
 } from './types.js';
 import type { PolicyEngine } from '../policy/policy-engine.js';
 import { DiscoveredMCPTool } from '../tools/mcp-tool.js';
 import { CoreToolScheduler } from '../core/coreToolScheduler.js';
 import { Scheduler } from './scheduler.js';
-import { ROOT_SCHEDULER_ID } from './types.js';
 import { ToolErrorType } from '../tools/tool-error.js';
 import type { ToolRegistry } from '../tools/tool-registry.js';
 

--- a/packages/core/src/scheduler/scheduler.test.ts
+++ b/packages/core/src/scheduler/scheduler.test.ts
@@ -67,18 +67,19 @@ import {
   type AnyDeclarativeTool,
   type AnyToolInvocation,
 } from '../tools/tools.js';
-import type {
-  ToolCallRequestInfo,
-  ValidatingToolCall,
-  SuccessfulToolCall,
-  ErroredToolCall,
-  CancelledToolCall,
-  CompletedToolCall,
-  ToolCallResponseInfo,
-  Status,
-  ToolCall,
+import {
+  type ToolCallRequestInfo,
+  type ValidatingToolCall,
+  type SuccessfulToolCall,
+  type ErroredToolCall,
+  type CancelledToolCall,
+  type CompletedToolCall,
+  type ToolCallResponseInfo,
+  type Status,
+  type ToolCall,
+  CoreToolCallStatus,
+  ROOT_SCHEDULER_ID,
 } from './types.js';
-import { CoreToolCallStatus, ROOT_SCHEDULER_ID } from './types.js';
 import { ToolErrorType } from '../tools/tool-error.js';
 import * as ToolUtils from '../utils/tool-utils.js';
 import type { EditorType } from '../utils/editor.js';

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -23,8 +23,7 @@ import {
   type ScheduledToolCall,
 } from './types.js';
 import { ToolErrorType } from '../tools/tool-error.js';
-import type { ApprovalMode } from '../policy/types.js';
-import { PolicyDecision } from '../policy/types.js';
+import { type ApprovalMode, PolicyDecision } from '../policy/types.js';
 import {
   ToolConfirmationOutcome,
   type AnyDeclarativeTool,

--- a/packages/core/src/scheduler/scheduler_parallel.test.ts
+++ b/packages/core/src/scheduler/scheduler_parallel.test.ts
@@ -63,14 +63,14 @@ import {
   type AnyDeclarativeTool,
   type AnyToolInvocation,
 } from '../tools/tools.js';
-import type {
-  ToolCallRequestInfo,
-  CompletedToolCall,
-  SuccessfulToolCall,
-  Status,
-  ToolCall,
+import {
+  type ToolCallRequestInfo,
+  type CompletedToolCall,
+  type SuccessfulToolCall,
+  type Status,
+  type ToolCall,
+  ROOT_SCHEDULER_ID,
 } from './types.js';
-import { ROOT_SCHEDULER_ID } from './types.js';
 import type { EditorType } from '../utils/editor.js';
 
 describe('Scheduler Parallel Execution', () => {

--- a/packages/core/src/scheduler/state-manager.test.ts
+++ b/packages/core/src/scheduler/state-manager.test.ts
@@ -6,17 +6,18 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SchedulerStateManager } from './state-manager.js';
-import type {
-  ValidatingToolCall,
-  WaitingToolCall,
-  SuccessfulToolCall,
-  ErroredToolCall,
-  CancelledToolCall,
-  ExecutingToolCall,
-  ToolCallRequestInfo,
-  ToolCallResponseInfo,
+import {
+  type ValidatingToolCall,
+  type WaitingToolCall,
+  type SuccessfulToolCall,
+  type ErroredToolCall,
+  type CancelledToolCall,
+  type ExecutingToolCall,
+  type ToolCallRequestInfo,
+  type ToolCallResponseInfo,
+  CoreToolCallStatus,
+  ROOT_SCHEDULER_ID,
 } from './types.js';
-import { CoreToolCallStatus, ROOT_SCHEDULER_ID } from './types.js';
 import {
   ToolConfirmationOutcome,
   type AnyDeclarativeTool,

--- a/packages/core/src/scheduler/state-manager.ts
+++ b/packages/core/src/scheduler/state-manager.ts
@@ -4,21 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  ToolCall,
-  Status,
-  WaitingToolCall,
-  CompletedToolCall,
-  SuccessfulToolCall,
-  ErroredToolCall,
-  CancelledToolCall,
-  ScheduledToolCall,
-  ValidatingToolCall,
-  ExecutingToolCall,
-  ToolCallResponseInfo,
+import {
+  type ToolCall,
+  type Status,
+  type WaitingToolCall,
+  type CompletedToolCall,
+  type SuccessfulToolCall,
+  type ErroredToolCall,
+  type CancelledToolCall,
+  type ScheduledToolCall,
+  type ValidatingToolCall,
+  type ExecutingToolCall,
+  type ToolCallResponseInfo,
+  CoreToolCallStatus,
+  ROOT_SCHEDULER_ID,
 } from './types.js';
-import { CoreToolCallStatus } from './types.js';
-import { ROOT_SCHEDULER_ID } from './types.js';
 import type {
   ToolConfirmationOutcome,
   ToolResultDisplay,

--- a/packages/core/src/scheduler/tool-executor.test.ts
+++ b/packages/core/src/scheduler/tool-executor.test.ts
@@ -6,13 +6,11 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ToolExecutor } from './tool-executor.js';
-import type { Config } from '../index.js';
+import type { Config, AnyToolInvocation } from '../index.js';
 import type { ToolResult } from '../tools/tools.js';
 import { makeFakeConfig } from '../test-utils/config.js';
 import { MockTool } from '../test-utils/mock-tool.js';
-import type { ScheduledToolCall } from './types.js';
-import { CoreToolCallStatus } from './types.js';
-import type { AnyToolInvocation } from '../index.js';
+import { type ScheduledToolCall, CoreToolCallStatus } from './types.js';
 import { SHELL_TOOL_NAME } from '../tools/tool-names.js';
 import * as fileUtils from '../utils/fileUtils.js';
 import * as coreToolHookTriggers from '../core/coreToolHookTriggers.js';

--- a/packages/core/src/scheduler/tool-executor.ts
+++ b/packages/core/src/scheduler/tool-executor.ts
@@ -4,14 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  ToolCallRequestInfo,
-  ToolCallResponseInfo,
-  ToolResult,
-  Config,
-  AnsiOutput,
-} from '../index.js';
 import {
+  type ToolCallRequestInfo,
+  type ToolCallResponseInfo,
+  type ToolResult,
+  type Config,
+  type AnsiOutput,
   ToolErrorType,
   ToolOutputTruncatedEvent,
   logToolOutputTruncated,
@@ -25,15 +23,15 @@ import {
   formatTruncatedToolOutput,
 } from '../utils/fileUtils.js';
 import { convertToFunctionResponse } from '../utils/generateContentResponseUtilities.js';
-import type {
-  CompletedToolCall,
-  ToolCall,
-  ExecutingToolCall,
-  ErroredToolCall,
-  SuccessfulToolCall,
-  CancelledToolCall,
+import {
+  type CompletedToolCall,
+  type ToolCall,
+  type ExecutingToolCall,
+  type ErroredToolCall,
+  type SuccessfulToolCall,
+  type CancelledToolCall,
+  CoreToolCallStatus,
 } from './types.js';
-import { CoreToolCallStatus } from './types.js';
 
 export interface ToolExecutionContext {
   call: ToolCall;

--- a/packages/core/src/scheduler/tool-modifier.test.ts
+++ b/packages/core/src/scheduler/tool-modifier.test.ts
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { ToolModificationHandler } from './tool-modifier.js';
-import type { WaitingToolCall, ToolCallRequestInfo } from './types.js';
-import { CoreToolCallStatus } from './types.js';
+import {
+  type WaitingToolCall,
+  type ToolCallRequestInfo,
+  CoreToolCallStatus,
+} from './types.js';
 import * as modifiableToolModule from '../tools/modifiable-tool.js';
 import * as Diff from 'diff';
 import { MockModifiableTool, MockTool } from '../test-utils/mock-tool.js';
@@ -17,7 +20,6 @@ import type {
   ToolConfirmationPayload,
 } from '../tools/tools.js';
 import type { ModifyContext } from '../tools/modifiable-tool.js';
-import type { Mock } from 'vitest';
 
 // Mock the modules that export functions we need to control
 vi.mock('diff', () => ({

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -12,7 +12,7 @@ import { tokenLimit } from '../core/tokenLimits.js';
 import { getCompressionPrompt } from '../core/prompts.js';
 import { getResponseText } from '../utils/partUtils.js';
 import { logChatCompression } from '../telemetry/loggers.js';
-import { makeChatCompressionEvent } from '../telemetry/types.js';
+import { makeChatCompressionEvent, LlmRole } from '../telemetry/types.js';
 import {
   saveTruncatedToolOutput,
   formatTruncatedToolOutput,
@@ -32,7 +32,6 @@ import {
   PREVIEW_GEMINI_3_1_MODEL,
 } from '../config/models.js';
 import { PreCompressTrigger } from '../hooks/types.js';
-import { LlmRole } from '../telemetry/types.js';
 
 /**
  * Default threshold for compression token count as a fraction of the model's

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -8,14 +8,14 @@ import { expect, it, describe, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import type {
-  ConversationRecord,
-  ToolCallRecord,
-  MessageRecord,
+import {
+  type ConversationRecord,
+  type ToolCallRecord,
+  type MessageRecord,
+  ChatRecordingService,
 } from './chatRecordingService.js';
 import { CoreToolCallStatus } from '../scheduler/types.js';
 import type { Content, Part } from '@google/genai';
-import { ChatRecordingService } from './chatRecordingService.js';
 import type { Config } from '../config/config.js';
 import { getProjectHash } from '../utils/paths.js';
 

--- a/packages/core/src/services/fileDiscoveryService.ts
+++ b/packages/core/src/services/fileDiscoveryService.ts
@@ -4,10 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { GitIgnoreFilter } from '../utils/gitIgnoreParser.js';
-import type { IgnoreFileFilter } from '../utils/ignoreFileParser.js';
-import { GitIgnoreParser } from '../utils/gitIgnoreParser.js';
-import { IgnoreFileParser } from '../utils/ignoreFileParser.js';
+import {
+  type GitIgnoreFilter,
+  GitIgnoreParser,
+} from '../utils/gitIgnoreParser.js';
+import {
+  type IgnoreFileFilter,
+  IgnoreFileParser,
+} from '../utils/ignoreFileParser.js';
 import { isGitRepository } from '../utils/gitUtils.js';
 import { GEMINI_IGNORE_FILE_NAME } from '../config/constants.js';
 import fs from 'node:fs';

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -8,8 +8,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { isNodeError } from '../utils/errors.js';
 import { spawnAsync } from '../utils/shell-utils.js';
-import type { SimpleGit } from 'simple-git';
-import { simpleGit, CheckRepoActions } from 'simple-git';
+import { type SimpleGit, simpleGit, CheckRepoActions } from 'simple-git';
 import type { Storage } from '../config/storage.js';
 import { debugLogger } from '../utils/debugLogger.js';
 

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -9,12 +9,12 @@ import type { Content } from '@google/genai';
 import type { Config } from '../config/config.js';
 import type { GeminiClient } from '../core/client.js';
 import type { BaseLlmClient } from '../core/baseLlmClient.js';
-import type {
-  ServerGeminiContentEvent,
-  ServerGeminiStreamEvent,
-  ServerGeminiToolCallRequestEvent,
+import {
+  type ServerGeminiContentEvent,
+  type ServerGeminiStreamEvent,
+  type ServerGeminiToolCallRequestEvent,
+  GeminiEventType,
 } from '../core/turn.js';
-import { GeminiEventType } from '../core/turn.js';
 import * as loggers from '../telemetry/loggers.js';
 import { LoopType } from '../telemetry/types.js';
 import { LoopDetectionService } from './loopDetectionService.js';

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -6,8 +6,7 @@
 
 import type { Content } from '@google/genai';
 import { createHash } from 'node:crypto';
-import type { ServerGeminiStreamEvent } from '../core/turn.js';
-import { GeminiEventType } from '../core/turn.js';
+import { type ServerGeminiStreamEvent, GeminiEventType } from '../core/turn.js';
 import {
   logLoopDetected,
   logLoopDetectionDisabled,
@@ -18,6 +17,7 @@ import {
   LoopDetectionDisabledEvent,
   LoopType,
   LlmLoopCheckEvent,
+  LlmRole,
 } from '../telemetry/types.js';
 import type { Config } from '../config/config.js';
 import {
@@ -25,7 +25,6 @@ import {
   isFunctionResponse,
 } from '../utils/messageInspectors.js';
 import { debugLogger } from '../utils/debugLogger.js';
-import { LlmRole } from '../telemetry/types.js';
 
 const TOOL_CALL_LOOP_THRESHOLD = 5;
 const CONTENT_LOOP_THRESHOLD = 10;

--- a/packages/core/src/services/modelConfig.integration.test.ts
+++ b/packages/core/src/services/modelConfig.integration.test.ts
@@ -5,8 +5,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { ModelConfigService } from './modelConfigService.js';
-import type { ModelConfigServiceConfig } from './modelConfigService.js';
+import {
+  ModelConfigService,
+  type ModelConfigServiceConfig,
+} from './modelConfigService.js';
 
 // This test suite is designed to validate the end-to-end logic of the
 // ModelConfigService with a complex, realistic configuration.

--- a/packages/core/src/services/modelConfigService.test.ts
+++ b/packages/core/src/services/modelConfigService.test.ts
@@ -5,11 +5,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type {
-  ModelConfigAlias,
-  ModelConfigServiceConfig,
+import {
+  type ModelConfigAlias,
+  type ModelConfigServiceConfig,
+  ModelConfigService,
 } from './modelConfigService.js';
-import { ModelConfigService } from './modelConfigService.js';
 
 describe('ModelConfigService', () => {
   it('should resolve a basic alias to its model and settings', () => {

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -16,11 +16,11 @@ import {
 import EventEmitter from 'node:events';
 import type { Readable } from 'node:stream';
 import { type ChildProcess } from 'node:child_process';
-import type {
-  ShellOutputEvent,
-  ShellExecutionConfig,
+import {
+  type ShellOutputEvent,
+  type ShellExecutionConfig,
+  ShellExecutionService,
 } from './shellExecutionService.js';
-import { ShellExecutionService } from './shellExecutionService.js';
 import type { AnsiOutput, AnsiToken } from '../utils/terminalSerializer.js';
 
 // Hoisted Mocks

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -5,8 +5,7 @@
  */
 
 import stripAnsi from 'strip-ansi';
-import type { PtyImplementation } from '../utils/getPty.js';
-import { getPty } from '../utils/getPty.js';
+import { type PtyImplementation, getPty } from '../utils/getPty.js';
 import { spawn as cpSpawn, type ChildProcess } from 'node:child_process';
 import { TextDecoder } from 'node:util';
 import os from 'node:os';

--- a/packages/core/src/telemetry/activity-monitor.test.ts
+++ b/packages/core/src/telemetry/activity-monitor.test.ts
@@ -13,9 +13,9 @@ import {
   recordGlobalActivity,
   startGlobalActivityMonitoring,
   stopGlobalActivityMonitoring,
+  type ActivityEvent,
 } from './activity-monitor.js';
 import { ActivityType } from './activity-types.js';
-import type { ActivityEvent } from './activity-monitor.js';
 import type { Config } from '../config/config.js';
 import { debugLogger } from '../utils/debugLogger.js';
 

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'vitest';
 import {
   vi,
   describe,
@@ -15,10 +14,17 @@ import {
   afterAll,
   beforeEach,
 } from 'vitest';
-import type { LogEvent, LogEventEntry } from './clearcut-logger.js';
-import { ClearcutLogger, EventNames, TEST_ONLY } from './clearcut-logger.js';
-import type { ContentGeneratorConfig } from '../../core/contentGenerator.js';
-import { AuthType } from '../../core/contentGenerator.js';
+import {
+  type LogEvent,
+  type LogEventEntry,
+  ClearcutLogger,
+  EventNames,
+  TEST_ONLY,
+} from './clearcut-logger.js';
+import {
+  type ContentGeneratorConfig,
+  AuthType,
+} from '../../core/contentGenerator.js';
 import type { SuccessfulToolCall } from '../../core/coreToolScheduler.js';
 import type { ConfigParameters } from '../../config/config.js';
 import { EventMetadataKey } from './event-metadata-key.js';
@@ -41,8 +47,7 @@ import { GIT_COMMIT_INFO, CLI_VERSION } from '../../generated/git-commit.js';
 import { UserAccountManager } from '../../utils/userAccountManager.js';
 import { InstallationManager } from '../../utils/installationManager.js';
 
-import si from 'systeminformation';
-import type { Systeminformation } from 'systeminformation';
+import si, { type Systeminformation } from 'systeminformation';
 import * as os from 'node:os';
 
 interface CustomMatchers<R = unknown> {

--- a/packages/core/src/telemetry/file-exporters.test.ts
+++ b/packages/core/src/telemetry/file-exporters.test.ts
@@ -13,8 +13,10 @@ import {
 import { ExportResultCode } from '@opentelemetry/core';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import type { ReadableLogRecord } from '@opentelemetry/sdk-logs';
-import type { ResourceMetrics } from '@opentelemetry/sdk-metrics';
-import { AggregationTemporality } from '@opentelemetry/sdk-metrics';
+import {
+  type ResourceMetrics,
+  AggregationTemporality,
+} from '@opentelemetry/sdk-metrics';
 import * as fs from 'node:fs';
 
 function createMockWriteStream(): {

--- a/packages/core/src/telemetry/file-exporters.ts
+++ b/packages/core/src/telemetry/file-exporters.ts
@@ -5,18 +5,17 @@
  */
 
 import * as fs from 'node:fs';
-import type { ExportResult } from '@opentelemetry/core';
-import { ExportResultCode } from '@opentelemetry/core';
+import { type ExportResult, ExportResultCode } from '@opentelemetry/core';
 import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
 import type {
   ReadableLogRecord,
   LogRecordExporter,
 } from '@opentelemetry/sdk-logs';
-import type {
-  ResourceMetrics,
-  PushMetricExporter,
+import {
+  type ResourceMetrics,
+  type PushMetricExporter,
+  AggregationTemporality,
 } from '@opentelemetry/sdk-metrics';
-import { AggregationTemporality } from '@opentelemetry/sdk-metrics';
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 
 class FileExporter {

--- a/packages/core/src/telemetry/gcp-exporters.ts
+++ b/packages/core/src/telemetry/gcp-exporters.ts
@@ -7,11 +7,12 @@
 import { type JWTInput } from 'google-auth-library';
 import { TraceExporter } from '@google-cloud/opentelemetry-cloud-trace-exporter';
 import { MetricExporter } from '@google-cloud/opentelemetry-cloud-monitoring-exporter';
-import { Logging } from '@google-cloud/logging';
-import type { Log } from '@google-cloud/logging';
-import { hrTimeToMilliseconds } from '@opentelemetry/core';
-import type { ExportResult } from '@opentelemetry/core';
-import { ExportResultCode } from '@opentelemetry/core';
+import { Logging, type Log } from '@google-cloud/logging';
+import {
+  hrTimeToMilliseconds,
+  ExportResultCode,
+  type ExportResult,
+} from '@opentelemetry/core';
 import type {
   ReadableLogRecord,
   LogRecordExporter,

--- a/packages/core/src/telemetry/loggers.test.circular.ts
+++ b/packages/core/src/telemetry/loggers.test.circular.ts
@@ -16,8 +16,8 @@ import type { CompletedToolCall } from '../core/coreToolScheduler.js';
 import {
   type ToolCallRequestInfo,
   type ToolCallResponseInfo,
+  CoreToolCallStatus,
 } from '../scheduler/types.js';
-import { CoreToolCallStatus } from '../scheduler/types.js';
 import { MockTool } from '../test-utils/mock-tool.js';
 
 describe('Circular Reference Handling', () => {

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  AnyDeclarativeTool,
-  AnyToolInvocation,
-  CompletedToolCall,
-  ContentGeneratorConfig,
-  ErroredToolCall,
-} from '../index.js';
 import {
   CoreToolCallStatus,
   AuthType,
@@ -19,11 +12,16 @@ import {
   ToolConfirmationOutcome,
   ToolErrorType,
   ToolRegistry,
+  type AnyDeclarativeTool,
+  type AnyToolInvocation,
+  type CompletedToolCall,
+  type ContentGeneratorConfig,
+  type ErroredToolCall,
   type MessageBus,
 } from '../index.js';
 import { OutputFormat } from '../output/types.js';
 import { logs } from '@opentelemetry/api-logs';
-import type { Config } from '../config/config.js';
+import type { Config, GeminiCLIExtension } from '../config/config.js';
 import {
   logApiError,
   logApiRequest,
@@ -100,7 +98,6 @@ import { FileOperation } from './metrics.js';
 import * as sdk from './sdk.js';
 import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 import { vi, describe, beforeEach, it, expect, afterEach } from 'vitest';
-import { type GeminiCLIExtension } from '../config/config.js';
 import {
   FinishReason,
   type CallableTool,

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { LogRecord } from '@opentelemetry/api-logs';
-import { logs } from '@opentelemetry/api-logs';
+import { type LogRecord, logs } from '@opentelemetry/api-logs';
 import type { Config } from '../config/config.js';
 import { SERVICE_NAME } from './constants.js';
 import {
@@ -13,51 +12,49 @@ import {
   EVENT_API_RESPONSE,
   EVENT_TOOL_CALL,
   EVENT_REWIND,
-} from './types.js';
-import type {
-  ApiErrorEvent,
-  ApiRequestEvent,
-  ApiResponseEvent,
-  FileOperationEvent,
-  IdeConnectionEvent,
-  StartSessionEvent,
-  ToolCallEvent,
-  UserPromptEvent,
-  FlashFallbackEvent,
-  NextSpeakerCheckEvent,
-  LoopDetectedEvent,
-  LoopDetectionDisabledEvent,
-  SlashCommandEvent,
-  RewindEvent,
-  ConversationFinishedEvent,
-  ChatCompressionEvent,
-  MalformedJsonResponseEvent,
-  ContentRetryEvent,
-  ContentRetryFailureEvent,
-  RipgrepFallbackEvent,
-  ToolOutputTruncatedEvent,
-  ModelRoutingEvent,
-  ExtensionDisableEvent,
-  ExtensionEnableEvent,
-  ExtensionUninstallEvent,
-  ExtensionInstallEvent,
-  ModelSlashCommandEvent,
-  EditStrategyEvent,
-  EditCorrectionEvent,
-  AgentStartEvent,
-  AgentFinishEvent,
-  RecoveryAttemptEvent,
-  WebFetchFallbackAttemptEvent,
-  ExtensionUpdateEvent,
-  ApprovalModeSwitchEvent,
-  ApprovalModeDurationEvent,
-  HookCallEvent,
-  StartupStatsEvent,
-  LlmLoopCheckEvent,
-  PlanExecutionEvent,
-  ToolOutputMaskingEvent,
-  KeychainAvailabilityEvent,
-  TokenStorageInitializationEvent,
+  type ApiErrorEvent,
+  type ApiRequestEvent,
+  type ApiResponseEvent,
+  type FileOperationEvent,
+  type IdeConnectionEvent,
+  type StartSessionEvent,
+  type ToolCallEvent,
+  type UserPromptEvent,
+  type FlashFallbackEvent,
+  type NextSpeakerCheckEvent,
+  type LoopDetectedEvent,
+  type LoopDetectionDisabledEvent,
+  type SlashCommandEvent,
+  type RewindEvent,
+  type ConversationFinishedEvent,
+  type ChatCompressionEvent,
+  type MalformedJsonResponseEvent,
+  type ContentRetryEvent,
+  type ContentRetryFailureEvent,
+  type RipgrepFallbackEvent,
+  type ToolOutputTruncatedEvent,
+  type ModelRoutingEvent,
+  type ExtensionDisableEvent,
+  type ExtensionEnableEvent,
+  type ExtensionUninstallEvent,
+  type ExtensionInstallEvent,
+  type ModelSlashCommandEvent,
+  type EditStrategyEvent,
+  type EditCorrectionEvent,
+  type AgentStartEvent,
+  type AgentFinishEvent,
+  type RecoveryAttemptEvent,
+  type WebFetchFallbackAttemptEvent,
+  type ExtensionUpdateEvent,
+  type ApprovalModeSwitchEvent,
+  type ApprovalModeDurationEvent,
+  type HookCallEvent,
+  type StartupStatsEvent,
+  type LlmLoopCheckEvent,
+  type PlanExecutionEvent,
+  type ToolOutputMaskingEvent,
+  type KeychainAvailabilityEvent,
+  type TokenStorageInitializationEvent,
 } from './types.js';
 import {
   recordApiErrorMetrics,
@@ -80,8 +77,7 @@ import {
   recordTokenStorageInitialization,
 } from './metrics.js';
 import { bufferTelemetryEvent } from './sdk.js';
-import type { UiEvent } from './uiTelemetry.js';
-import { uiTelemetryService } from './uiTelemetry.js';
+import { type UiEvent, uiTelemetryService } from './uiTelemetry.js';
 import { ClearcutLogger } from './clearcut-logger/clearcut-logger.js';
 import { debugLogger } from '../utils/debugLogger.js';
 

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -4,8 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Attributes, Meter, Counter, Histogram } from '@opentelemetry/api';
-import { diag, metrics, ValueType } from '@opentelemetry/api';
+import {
+  type Attributes,
+  type Meter,
+  type Counter,
+  type Histogram,
+  diag,
+  metrics,
+  ValueType,
+} from '@opentelemetry/api';
 import { SERVICE_NAME } from './constants.js';
 import type { Config } from '../config/config.js';
 import type {

--- a/packages/core/src/telemetry/semantic.ts
+++ b/packages/core/src/telemetry/semantic.ts
@@ -11,13 +11,13 @@
  * @see https://github.com/open-telemetry/semantic-conventions/blob/8b4f210f43136e57c1f6f47292eb6d38e3bf30bb/docs/gen-ai/gen-ai-events.md
  */
 
-import { FinishReason } from '@google/genai';
-import type {
-  Candidate,
-  Content,
-  ContentUnion,
-  Part,
-  PartUnion,
+import {
+  FinishReason,
+  type Candidate,
+  type Content,
+  type ContentUnion,
+  type Part,
+  type PartUnion,
 } from '@google/genai';
 import { truncateString } from '../utils/textUtils.js';
 

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -31,8 +31,8 @@ import type { AgentTerminateMode } from '../agents/types.js';
 import { getCommonAttributes } from './telemetryAttributes.js';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
-import type { OTelFinishReason } from './semantic.js';
 import {
+  type OTelFinishReason,
   toInputMessages,
   toOutputMessages,
   toFinishReasons,

--- a/packages/core/src/telemetry/uiTelemetry.test.ts
+++ b/packages/core/src/telemetry/uiTelemetry.test.ts
@@ -7,12 +7,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { UiTelemetryService } from './uiTelemetry.js';
 import { ToolCallDecision } from './tool-call-decision.js';
-import type { ApiErrorEvent, ApiResponseEvent } from './types.js';
-import { ToolCallEvent } from './types.js';
 import {
+  ToolCallEvent,
   EVENT_API_ERROR,
   EVENT_API_RESPONSE,
   EVENT_TOOL_CALL,
+  type ApiErrorEvent,
+  type ApiResponseEvent,
 } from './types.js';
 import type {
   CompletedToolCall,

--- a/packages/core/src/telemetry/uiTelemetry.ts
+++ b/packages/core/src/telemetry/uiTelemetry.ts
@@ -9,16 +9,13 @@ import {
   EVENT_API_ERROR,
   EVENT_API_RESPONSE,
   EVENT_TOOL_CALL,
+  type ApiErrorEvent,
+  type ApiResponseEvent,
+  type ToolCallEvent,
+  type LlmRole,
 } from './types.js';
 
 import { ToolCallDecision } from './tool-call-decision.js';
-import type {
-  ApiErrorEvent,
-  ApiResponseEvent,
-  ToolCallEvent,
-} from './types.js';
-
-import type { LlmRole } from './types.js';
 
 export type UiEvent =
   | (ApiResponseEvent & { 'event.name': typeof EVENT_API_RESPONSE })

--- a/packages/core/src/test-utils/config.ts
+++ b/packages/core/src/test-utils/config.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ConfigParameters } from '../config/config.js';
-import { Config } from '../config/config.js';
+import { Config, type ConfigParameters } from '../config/config.js';
 
 /**
  * Default parameters used for {@link FAKE_CONFIG}

--- a/packages/core/src/test-utils/mock-tool.ts
+++ b/packages/core/src/test-utils/mock-tool.ts
@@ -8,15 +8,13 @@ import type {
   ModifiableDeclarativeTool,
   ModifyContext,
 } from '../tools/modifiable-tool.js';
-import type {
-  ToolCallConfirmationDetails,
-  ToolInvocation,
-  ToolResult,
-} from '../tools/tools.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
   Kind,
+  type ToolCallConfirmationDetails,
+  type ToolInvocation,
+  type ToolResult,
 } from '../tools/tools.js';
 import { createMockMessageBus } from './mock-message-bus.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';

--- a/packages/core/src/tools/activate-skill.ts
+++ b/packages/core/src/tools/activate-skill.ts
@@ -7,13 +7,15 @@
 import * as path from 'node:path';
 import { getFolderStructure } from '../utils/getFolderStructure.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
-import type {
-  ToolResult,
-  ToolCallConfirmationDetails,
-  ToolInvocation,
-  ToolConfirmationOutcome,
+import {
+  type ToolResult,
+  type ToolCallConfirmationDetails,
+  type ToolInvocation,
+  type ToolConfirmationOutcome,
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  Kind,
 } from './tools.js';
-import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
 import type { Config } from '../config/config.js';
 import { ACTIVATE_SKILL_TOOL_NAME } from './tool-names.js';
 import { ToolErrorType } from './tool-error.js';

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -38,10 +38,11 @@ import {
 import { IdeClient } from '../ide/ide-client.js';
 import { FixLLMEditWithInstruction } from '../utils/llm-edit-fixer.js';
 import { safeLiteralReplace, detectLineEnding } from '../utils/textUtils.js';
-import { EditStrategyEvent } from '../telemetry/types.js';
-import { logEditStrategy } from '../telemetry/loggers.js';
-import { EditCorrectionEvent } from '../telemetry/types.js';
-import { logEditCorrectionEvent } from '../telemetry/loggers.js';
+import { EditStrategyEvent, EditCorrectionEvent } from '../telemetry/types.js';
+import {
+  logEditStrategy,
+  logEditCorrectionEvent,
+} from '../telemetry/loggers.js';
 
 import { correctPath } from '../utils/pathCorrector.js';
 import {

--- a/packages/core/src/tools/glob.test.ts
+++ b/packages/core/src/tools/glob.test.ts
@@ -4,8 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { GlobToolParams, GlobPath } from './glob.js';
-import { GlobTool, sortFileEntries } from './glob.js';
+import {
+  type GlobToolParams,
+  type GlobPath,
+  GlobTool,
+  sortFileEntries,
+} from './glob.js';
 import { partListUnionToString } from '../core/geminiRequest.js';
 import path from 'node:path';
 import { isSubpath } from '../utils/paths.js';

--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -8,8 +8,13 @@ import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import { glob, escape } from 'glob';
-import type { ToolInvocation, ToolResult } from './tools.js';
-import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
+import {
+  type ToolInvocation,
+  type ToolResult,
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  Kind,
+} from './tools.js';
 import { shortenPath, makeRelative } from '../utils/paths.js';
 import { type Config } from '../config/config.js';
 import { DEFAULT_FILE_FILTERING_OPTIONS } from '../config/constants.js';

--- a/packages/core/src/tools/grep.test.ts
+++ b/packages/core/src/tools/grep.test.ts
@@ -5,8 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import type { GrepToolParams } from './grep.js';
-import { GrepTool } from './grep.js';
+import { type GrepToolParams, GrepTool } from './grep.js';
 import type { ToolResult } from './tools.js';
 import path from 'node:path';
 import { isSubpath } from '../utils/paths.js';

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -10,13 +10,18 @@ import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { globStream } from 'glob';
-import type { ToolInvocation, ToolResult } from './tools.js';
+import {
+  type ToolInvocation,
+  type ToolResult,
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  Kind,
+} from './tools.js';
 import { execStreaming } from '../utils/shell-utils.js';
 import {
   DEFAULT_TOTAL_MAX_MATCHES,
   DEFAULT_SEARCH_TIMEOUT_MS,
 } from './constants.js';
-import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
 import { makeRelative, shortenPath } from '../utils/paths.js';
 import { getErrorMessage, isNodeError } from '../utils/errors.js';
 import { isGitRepository } from '../utils/gitUtils.js';

--- a/packages/core/src/tools/ls.ts
+++ b/packages/core/src/tools/ls.ts
@@ -7,8 +7,13 @@
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import type { ToolInvocation, ToolResult } from './tools.js';
-import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
+import {
+  type ToolInvocation,
+  type ToolResult,
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  Kind,
+} from './tools.js';
 import { makeRelative, shortenPath } from '../utils/paths.js';
 import type { Config } from '../config/config.js';
 import { DEFAULT_FILE_FILTERING_OPTIONS } from '../config/constants.js';

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -11,19 +11,16 @@ import type {
   JsonSchemaType,
   JsonSchemaValidator,
 } from '@modelcontextprotocol/sdk/validation/types.js';
-import type { SSEClientTransportOptions } from '@modelcontextprotocol/sdk/client/sse.js';
-import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import {
+  type SSEClientTransportOptions,
+  SSEClientTransport,
+} from '@modelcontextprotocol/sdk/client/sse.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import type { StreamableHTTPClientTransportOptions } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {
+  type StreamableHTTPClientTransportOptions,
+  StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
-import type {
-  GetPromptResult,
-  Prompt,
-  ReadResourceResult,
-  Resource,
-  Tool as McpTool,
-} from '@modelcontextprotocol/sdk/types.js';
 import {
   ListResourcesResultSchema,
   ListRootsRequestSchema,
@@ -32,11 +29,19 @@ import {
   ToolListChangedNotificationSchema,
   PromptListChangedNotificationSchema,
   ProgressNotificationSchema,
+  type Tool as McpTool,
+  type GetPromptResult,
+  type Prompt,
+  type ReadResourceResult,
+  type Resource,
 } from '@modelcontextprotocol/sdk/types.js';
 import { ApprovalMode, PolicyDecision } from '../policy/types.js';
 import { parse } from 'shell-quote';
-import type { Config, MCPServerConfig } from '../config/config.js';
-import { AuthProviderType } from '../config/config.js';
+import {
+  type Config,
+  type MCPServerConfig,
+  AuthProviderType,
+} from '../config/config.js';
 import { GoogleCredentialProvider } from '../mcp/google-auth-provider.js';
 import { ServiceAccountImpersonationProvider } from '../mcp/sa-impersonation-provider.js';
 import { DiscoveredMCPTool } from './mcp-tool.js';

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -5,17 +5,15 @@
  */
 
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
-import type {
-  ToolCallConfirmationDetails,
-  ToolInvocation,
-  ToolMcpConfirmationDetails,
-  ToolResult,
-} from './tools.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
   Kind,
   ToolConfirmationOutcome,
+  type ToolCallConfirmationDetails,
+  type ToolInvocation,
+  type ToolMcpConfirmationDetails,
+  type ToolResult,
   type PolicyUpdateOptions,
 } from './tools.js';
 import type { CallableTool, FunctionCall, Part } from '@google/genai';

--- a/packages/core/src/tools/memoryTool.test.ts
+++ b/packages/core/src/tools/memoryTool.test.ts
@@ -4,8 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Mock } from 'vitest';
-import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  type Mock,
+  vi,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from 'vitest';
 import {
   MemoryTool,
   setGeminiMdFilename,

--- a/packages/core/src/tools/memoryTool.ts
+++ b/packages/core/src/tools/memoryTool.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ToolEditConfirmationDetails, ToolResult } from './tools.js';
 import {
+  type ToolEditConfirmationDetails,
+  type ToolResult,
   BaseDeclarativeTool,
   BaseToolInvocation,
   Kind,

--- a/packages/core/src/tools/modifiable-tool.test.ts
+++ b/packages/core/src/tools/modifiable-tool.test.ts
@@ -5,11 +5,9 @@
  */
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import type {
-  ModifyContext,
-  ModifiableDeclarativeTool,
-} from './modifiable-tool.js';
 import {
+  type ModifyContext,
+  type ModifiableDeclarativeTool,
   modifyWithEditor,
   isModifiableDeclarativeTool,
 } from './modifiable-tool.js';

--- a/packages/core/src/tools/modifiable-tool.ts
+++ b/packages/core/src/tools/modifiable-tool.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { EditorType } from '../utils/editor.js';
-import { openDiff } from '../utils/editor.js';
+import { type EditorType, openDiff } from '../utils/editor.js';
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';

--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -5,8 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import type { ReadFileToolParams } from './read-file.js';
-import { ReadFileTool } from './read-file.js';
+import { type ReadFileToolParams, ReadFileTool } from './read-file.js';
 import { ToolErrorType } from './tool-error.js';
 import path from 'node:path';
 import { isSubpath } from '../utils/paths.js';

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -7,8 +7,14 @@
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import path from 'node:path';
 import { makeRelative, shortenPath } from '../utils/paths.js';
-import type { ToolInvocation, ToolLocation, ToolResult } from './tools.js';
-import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
+import {
+  type ToolInvocation,
+  type ToolLocation,
+  type ToolResult,
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  Kind,
+} from './tools.js';
 import { ToolErrorType } from './tool-error.js';
 
 import type { PartUnion } from '@google/genai';

--- a/packages/core/src/tools/read-many-files.test.ts
+++ b/packages/core/src/tools/read-many-files.test.ts
@@ -4,8 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import type { Mock } from 'vitest';
+import {
+  vi,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
 import { mockControl } from '../__mocks__/fs/promises.js';
 import { ReadManyFilesTool } from './read-many-files.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';

--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -5,14 +5,19 @@
  */
 
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
-import type { ToolInvocation, ToolResult } from './tools.js';
-import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
+import {
+  type ToolInvocation,
+  type ToolResult,
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  Kind,
+} from './tools.js';
 import { getErrorMessage } from '../utils/errors.js';
 import * as fsPromises from 'node:fs/promises';
 import * as path from 'node:path';
 import { glob, escape } from 'glob';
-import type { ProcessedFileReadResult } from '../utils/fileUtils.js';
 import {
+  type ProcessedFileReadResult,
   detectFileType,
   processSingleFileContent,
   DEFAULT_ENCODING,

--- a/packages/core/src/tools/ripGrep.test.ts
+++ b/packages/core/src/tools/ripGrep.test.ts
@@ -13,8 +13,12 @@ import {
   afterAll,
   vi,
 } from 'vitest';
-import type { RipGrepToolParams } from './ripGrep.js';
-import { canUseRipgrep, RipGrepTool, ensureRgPath } from './ripGrep.js';
+import {
+  type RipGrepToolParams,
+  canUseRipgrep,
+  RipGrepTool,
+  ensureRgPath,
+} from './ripGrep.js';
 import path from 'node:path';
 import { isSubpath } from '../utils/paths.js';
 import fs from 'node:fs/promises';
@@ -23,8 +27,7 @@ import type { Config } from '../config/config.js';
 import { Storage } from '../config/storage.js';
 import { GEMINI_IGNORE_FILE_NAME } from '../config/constants.js';
 import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.js';
-import type { ChildProcess } from 'node:child_process';
-import { spawn } from 'node:child_process';
+import { type ChildProcess, spawn } from 'node:child_process';
 import { PassThrough, Readable } from 'node:stream';
 import EventEmitter from 'node:events';
 import { downloadRipGrep } from '@joshua.litt/get-ripgrep';

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -9,8 +9,13 @@ import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import { downloadRipGrep } from '@joshua.litt/get-ripgrep';
-import type { ToolInvocation, ToolResult } from './tools.js';
-import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
+import {
+  type ToolInvocation,
+  type ToolResult,
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  Kind,
+} from './tools.js';
 import { ToolErrorType } from './tool-error.js';
 import { makeRelative, shortenPath } from '../utils/paths.js';
 import { getErrorMessage, isNodeError } from '../utils/errors.js';

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -42,7 +42,7 @@ vi.mock('crypto');
 vi.mock('../utils/summarizer.js');
 
 import { initializeShellParsers } from '../utils/shell-utils.js';
-import { ShellTool } from './shell.js';
+import { ShellTool, OUTPUT_UPDATE_INTERVAL_MS } from './shell.js';
 import { debugLogger } from '../index.js';
 import { type Config } from '../config/config.js';
 import {
@@ -58,7 +58,6 @@ import * as crypto from 'node:crypto';
 import * as summarizer from '../utils/summarizer.js';
 import { ToolErrorType } from './tool-error.js';
 import { ToolConfirmationOutcome } from './tools.js';
-import { OUTPUT_UPDATE_INTERVAL_MS } from './shell.js';
 import { SHELL_TOOL_NAME } from './tool-names.js';
 import { WorkspaceContext } from '../utils/workspaceContext.js';
 import {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -11,27 +11,25 @@ import crypto from 'node:crypto';
 import type { Config } from '../config/config.js';
 import { debugLogger } from '../index.js';
 import { ToolErrorType } from './tool-error.js';
-import type {
-  ToolInvocation,
-  ToolResult,
-  ToolCallConfirmationDetails,
-  ToolExecuteConfirmationDetails,
-} from './tools.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
   ToolConfirmationOutcome,
   Kind,
+  type ToolInvocation,
+  type ToolResult,
+  type ToolCallConfirmationDetails,
+  type ToolExecuteConfirmationDetails,
   type PolicyUpdateOptions,
 } from './tools.js';
 
 import { getErrorMessage } from '../utils/errors.js';
 import { summarizeToolOutput } from '../utils/summarizer.js';
-import type {
-  ShellExecutionConfig,
-  ShellOutputEvent,
+import {
+  type ShellExecutionConfig,
+  type ShellOutputEvent,
+  ShellExecutionService,
 } from '../services/shellExecutionService.js';
-import { ShellExecutionService } from '../services/shellExecutionService.js';
 import { formatBytes } from '../utils/formatters.js';
 import type { AnsiOutput } from '../utils/terminalSerializer.js';
 import {

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -7,15 +7,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Mocked, MockInstance } from 'vitest';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { ConfigParameters } from '../config/config.js';
-import { Config } from '../config/config.js';
+import { type ConfigParameters, Config } from '../config/config.js';
 import { ApprovalMode } from '../policy/types.js';
 
 import { ToolRegistry, DiscoveredTool } from './tool-registry.js';
 import { DISCOVERED_TOOL_PREFIX } from './tool-names.js';
 import { DiscoveredMCPTool, MCP_QUALIFIED_NAME_SEPARATOR } from './mcp-tool.js';
-import type { FunctionDeclaration, CallableTool } from '@google/genai';
-import { mcpToTool } from '@google/genai';
+import {
+  type FunctionDeclaration,
+  type CallableTool,
+  mcpToTool,
+} from '@google/genai';
 import { spawn } from 'node:child_process';
 
 import fs from 'node:fs';

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -5,12 +5,14 @@
  */
 
 import type { FunctionDeclaration } from '@google/genai';
-import type {
-  AnyDeclarativeTool,
-  ToolResult,
-  ToolInvocation,
+import {
+  type AnyDeclarativeTool,
+  type ToolResult,
+  type ToolInvocation,
+  Kind,
+  BaseDeclarativeTool,
+  BaseToolInvocation,
 } from './tools.js';
-import { Kind, BaseDeclarativeTool, BaseToolInvocation } from './tools.js';
 import type { Config } from '../config/config.js';
 import { ApprovalMode } from '../policy/types.js';
 import { spawn } from 'node:child_process';

--- a/packages/core/src/tools/tools.test.ts
+++ b/packages/core/src/tools/tools.test.ts
@@ -5,8 +5,13 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import type { ToolInvocation, ToolResult } from './tools.js';
-import { DeclarativeTool, hasCycleInSchema, Kind } from './tools.js';
+import {
+  type ToolInvocation,
+  type ToolResult,
+  DeclarativeTool,
+  hasCycleInSchema,
+  Kind,
+} from './tools.js';
 import { ToolErrorType } from './tool-error.js';
 import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 import { ReadFileTool } from './read-file.js';

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -4,15 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  ToolCallConfirmationDetails,
-  ToolInvocation,
-  ToolResult,
-} from './tools.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
   Kind,
+  type ToolCallConfirmationDetails,
+  type ToolInvocation,
+  type ToolResult,
   type ToolConfirmationOutcome,
 } from './tools.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';

--- a/packages/core/src/tools/web-search.test.ts
+++ b/packages/core/src/tools/web-search.test.ts
@@ -4,10 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Mock } from 'vitest';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { WebSearchToolParams } from './web-search.js';
-import { WebSearchTool } from './web-search.js';
+import {
+  type Mock,
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from 'vitest';
+import { type WebSearchToolParams, WebSearchTool } from './web-search.js';
 import type { Config } from '../config/config.js';
 import { GeminiClient } from '../core/client.js';
 import { ToolErrorType } from './tool-error.js';

--- a/packages/core/src/tools/web-search.ts
+++ b/packages/core/src/tools/web-search.ts
@@ -7,8 +7,13 @@
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { WEB_SEARCH_TOOL_NAME } from './tool-names.js';
 import type { GroundingMetadata } from '@google/genai';
-import type { ToolInvocation, ToolResult } from './tools.js';
-import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
+import {
+  type ToolInvocation,
+  type ToolResult,
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  Kind,
+} from './tools.js';
 import { ToolErrorType } from './tool-error.js';
 
 import { getErrorMessage } from '../utils/errors.js';

--- a/packages/core/src/tools/write-file.test.ts
+++ b/packages/core/src/tools/write-file.test.ts
@@ -13,16 +13,19 @@ import {
   vi,
   type Mocked,
 } from 'vitest';
-import type { WriteFileToolParams } from './write-file.js';
-import { getCorrectedFileContent, WriteFileTool } from './write-file.js';
+import {
+  type WriteFileToolParams,
+  getCorrectedFileContent,
+  WriteFileTool,
+} from './write-file.js';
 import { ToolErrorType } from './tool-error.js';
-import type {
-  FileDiff,
-  ToolEditConfirmationDetails,
-  ToolInvocation,
-  ToolResult,
+import {
+  type FileDiff,
+  type ToolEditConfirmationDetails,
+  type ToolInvocation,
+  type ToolResult,
+  ToolConfirmationOutcome,
 } from './tools.js';
-import { ToolConfirmationOutcome } from './tools.js';
 import { type EditToolParams } from './edit.js';
 import type { Config } from '../config/config.js';
 import { ApprovalMode } from '../policy/types.js';
@@ -33,14 +36,13 @@ import fs from 'node:fs';
 import os from 'node:os';
 import { GeminiClient } from '../core/client.js';
 import type { BaseLlmClient } from '../core/baseLlmClient.js';
-import type { CorrectedEditResult } from '../utils/editCorrector.js';
 import {
+  type CorrectedEditResult,
   ensureCorrectEdit,
   ensureCorrectFileContent,
 } from '../utils/editCorrector.js';
 import { StandardFileSystemService } from '../services/fileSystemService.js';
-import type { DiffUpdateResult } from '../ide/ide-client.js';
-import { IdeClient } from '../ide/ide-client.js';
+import { type DiffUpdateResult, IdeClient } from '../ide/ide-client.js';
 import { WorkspaceContext } from '../utils/workspaceContext.js';
 import {
   createMockMessageBus,

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -13,18 +13,16 @@ import { WRITE_FILE_TOOL_NAME, WRITE_FILE_DISPLAY_NAME } from './tool-names.js';
 import type { Config } from '../config/config.js';
 import { ApprovalMode } from '../policy/types.js';
 
-import type {
-  FileDiff,
-  ToolCallConfirmationDetails,
-  ToolEditConfirmationDetails,
-  ToolInvocation,
-  ToolLocation,
-  ToolResult,
-} from './tools.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
   Kind,
+  type FileDiff,
+  type ToolCallConfirmationDetails,
+  type ToolEditConfirmationDetails,
+  type ToolInvocation,
+  type ToolLocation,
+  type ToolResult,
   type ToolConfirmationOutcome,
 } from './tools.js';
 import { ToolErrorType } from './tool-error.js';

--- a/packages/core/src/tools/write-todos.ts
+++ b/packages/core/src/tools/write-todos.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ToolInvocation } from './tools.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
   Kind,
+  type ToolInvocation,
   type Todo,
   type ToolResult,
 } from './tools.js';

--- a/packages/core/src/utils/apiConversionUtils.test.ts
+++ b/packages/core/src/utils/apiConversionUtils.test.ts
@@ -6,8 +6,8 @@
 
 import { describe, it, expect } from 'vitest';
 import { convertToRestPayload } from './apiConversionUtils.js';
-import type { GenerateContentParameters } from '@google/genai';
 import {
+  type GenerateContentParameters,
   FunctionCallingConfigMode,
   HarmCategory,
   HarmBlockThreshold,

--- a/packages/core/src/utils/authConsent.test.ts
+++ b/packages/core/src/utils/authConsent.test.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import readline from 'node:readline';
 import process from 'node:process';
 import { coreEvents } from './events.js';

--- a/packages/core/src/utils/editCorrector.test.ts
+++ b/packages/core/src/utils/editCorrector.test.ts
@@ -5,8 +5,15 @@
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { Mock } from 'vitest';
-import { vi, describe, it, expect, beforeEach, type Mocked } from 'vitest';
+import {
+  vi,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  type Mock,
+  type Mocked,
+} from 'vitest';
 import * as fs from 'node:fs';
 import { EDIT_TOOL_NAME } from '../tools/tool-names.js';
 import type { BaseLlmClient } from '../core/baseLlmClient.js';

--- a/packages/core/src/utils/filesearch/crawler.test.ts
+++ b/packages/core/src/utils/filesearch/crawler.test.ts
@@ -10,8 +10,7 @@ import * as path from 'node:path';
 import * as cache from './crawlCache.js';
 import { crawl } from './crawler.js';
 import { createTmpDir, cleanupTmpDir } from '@google/gemini-cli-test-utils';
-import type { Ignore } from './ignore.js';
-import { loadIgnoreRules } from './ignore.js';
+import { type Ignore, loadIgnoreRules } from './ignore.js';
 import { GEMINI_IGNORE_FILE_NAME } from '../../config/constants.js';
 import { FileDiscoveryService } from '../../services/fileDiscoveryService.js';
 

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -6,12 +6,10 @@
 
 import path from 'node:path';
 import picomatch from 'picomatch';
-import type { Ignore } from './ignore.js';
-import { loadIgnoreRules } from './ignore.js';
+import { type Ignore, loadIgnoreRules } from './ignore.js';
 import { ResultCache } from './result-cache.js';
 import { crawl } from './crawler.js';
-import type { FzfResultItem } from 'fzf';
-import { AsyncFzf } from 'fzf';
+import { type FzfResultItem, AsyncFzf } from 'fzf';
 import { unescapePath } from '../paths.js';
 import type { FileDiscoveryService } from '../../services/fileDiscoveryService.js';
 

--- a/packages/core/src/utils/generateContentResponseUtilities.test.ts
+++ b/packages/core/src/utils/generateContentResponseUtilities.test.ts
@@ -16,14 +16,14 @@ import {
   getCitations,
   convertToFunctionResponse,
 } from './generateContentResponseUtilities.js';
-import type {
-  GenerateContentResponse,
-  Part,
-  SafetyRating,
-  CitationMetadata,
-  PartListUnion,
+import {
+  type GenerateContentResponse,
+  type Part,
+  type SafetyRating,
+  type CitationMetadata,
+  type PartListUnion,
+  FinishReason,
 } from '@google/genai';
-import { FinishReason } from '@google/genai';
 import {
   DEFAULT_GEMINI_MODEL,
   PREVIEW_GEMINI_MODEL,

--- a/packages/core/src/utils/getFolderStructure.test.ts
+++ b/packages/core/src/utils/getFolderStructure.test.ts
@@ -10,7 +10,6 @@ import * as nodePath from 'node:path';
 import * as os from 'node:os';
 import { getFolderStructure } from './getFolderStructure.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
-import * as path from 'node:path';
 import { GEMINI_DIR } from './paths.js';
 import { GEMINI_IGNORE_FILE_NAME } from 'src/config/constants.js';
 
@@ -18,20 +17,20 @@ describe('getFolderStructure', () => {
   let testRootDir: string;
 
   async function createEmptyDir(...pathSegments: string[]) {
-    const fullPath = path.join(testRootDir, ...pathSegments);
+    const fullPath = nodePath.join(testRootDir, ...pathSegments);
     await fsPromises.mkdir(fullPath, { recursive: true });
   }
 
   async function createTestFile(...pathSegments: string[]) {
-    const fullPath = path.join(testRootDir, ...pathSegments);
-    await fsPromises.mkdir(path.dirname(fullPath), { recursive: true });
+    const fullPath = nodePath.join(testRootDir, ...pathSegments);
+    await fsPromises.mkdir(nodePath.dirname(fullPath), { recursive: true });
     await fsPromises.writeFile(fullPath, '');
     return fullPath;
   }
 
   beforeEach(async () => {
     testRootDir = await fsPromises.mkdtemp(
-      path.join(os.tmpdir(), 'folder-structure-test-'),
+      nodePath.join(os.tmpdir(), 'folder-structure-test-'),
     );
   });
 
@@ -49,10 +48,10 @@ describe('getFolderStructure', () => {
       `
 Showing up to 200 items (files + folders).
 
-${testRootDir}${path.sep}
+${testRootDir}${nodePath.sep}
 ├───fileA1.ts
 ├───fileA2.js
-└───subfolderB${path.sep}
+└───subfolderB${nodePath.sep}
     └───fileB1.md
 `.trim(),
     );
@@ -64,7 +63,7 @@ ${testRootDir}${path.sep}
       `
 Showing up to 200 items (files + folders).
 
-${testRootDir}${path.sep}
+${testRootDir}${nodePath.sep}
 `
         .trim()
         .trim(),
@@ -85,15 +84,15 @@ ${testRootDir}${path.sep}
       `
 Showing up to 200 items (files + folders). Folders or files indicated with ... contain more items not shown, were ignored, or the display limit (200 items) was reached.
 
-${testRootDir}${path.sep}
+${testRootDir}${nodePath.sep}
 ├───.hiddenfile
 ├───file1.txt
-├───emptyFolder${path.sep}
-├───node_modules${path.sep}...
-└───subfolderA${path.sep}
+├───emptyFolder${nodePath.sep}
+├───node_modules${nodePath.sep}...
+└───subfolderA${nodePath.sep}
     ├───fileA1.ts
     ├───fileA2.js
-    └───subfolderB${path.sep}
+    └───subfolderB${nodePath.sep}
         └───fileB1.md
 `.trim(),
     );
@@ -112,12 +111,12 @@ ${testRootDir}${path.sep}
     const expected = `
 Showing up to 200 items (files + folders). Folders or files indicated with ... contain more items not shown, were ignored, or the display limit (200 items) was reached.
 
-${testRootDir}${path.sep}
+${testRootDir}${nodePath.sep}
 ├───.hiddenfile
 ├───file1.txt
-├───emptyFolder${path.sep}
-├───node_modules${path.sep}...
-└───subfolderA${path.sep}...
+├───emptyFolder${nodePath.sep}
+├───node_modules${nodePath.sep}...
+└───subfolderA${nodePath.sep}...
 `.trim();
     expect(structure.trim()).toBe(expected);
   });
@@ -133,9 +132,9 @@ ${testRootDir}${path.sep}
     const expected = `
 Showing up to 200 items (files + folders).
 
-${testRootDir}${path.sep}
+${testRootDir}${nodePath.sep}
 ├───fileA1.ts
-└───subfolderB${path.sep}
+└───subfolderB${nodePath.sep}
 `.trim();
     expect(structure.trim()).toBe(expected);
   });
@@ -151,10 +150,10 @@ ${testRootDir}${path.sep}
     const expected = `
 Showing up to 3 items (files + folders).
 
-${testRootDir}${path.sep}
+${testRootDir}${nodePath.sep}
 ├───fileA1.ts
 ├───fileA2.js
-└───subfolderB${path.sep}
+└───subfolderB${nodePath.sep}
 `.trim();
     expect(structure.trim()).toBe(expected);
   });
@@ -170,11 +169,11 @@ ${testRootDir}${path.sep}
     const expectedRevised = `
 Showing up to 4 items (files + folders). Folders or files indicated with ... contain more items not shown, were ignored, or the display limit (4 items) was reached.
 
-${testRootDir}${path.sep}
-├───folder-0${path.sep}
-├───folder-1${path.sep}
-├───folder-2${path.sep}
-├───folder-3${path.sep}
+${testRootDir}${nodePath.sep}
+├───folder-0${nodePath.sep}
+├───folder-1${nodePath.sep}
+├───folder-2${nodePath.sep}
+├───folder-3${nodePath.sep}
 └───...
 `.trim();
     expect(structure.trim()).toBe(expectedRevised);
@@ -191,7 +190,7 @@ ${testRootDir}${path.sep}
     const expected = `
 Showing up to 1 items (files + folders). Folders or files indicated with ... contain more items not shown, were ignored, or the display limit (1 items) was reached.
 
-${testRootDir}${path.sep}
+${testRootDir}${nodePath.sep}
 ├───fileA1.ts
 ├───...
 └───...
@@ -200,7 +199,7 @@ ${testRootDir}${path.sep}
   });
 
   it('should handle non-existent directory', async () => {
-    const nonExistentPath = path.join(testRootDir, 'non-existent');
+    const nonExistentPath = nodePath.join(testRootDir, 'non-existent');
     const structure = await getFolderStructure(nonExistentPath);
     expect(structure).toContain(
       `Error: Could not read directory "${nonExistentPath}". Check path and permissions.`,
@@ -216,10 +215,10 @@ ${testRootDir}${path.sep}
     const expected = `
 Showing up to 10 items (files + folders).
 
-${testRootDir}${path.sep}
-└───level1${path.sep}
-    └───level2${path.sep}
-        └───level3${path.sep}
+${testRootDir}${nodePath.sep}
+└───level1${nodePath.sep}
+    └───level2${nodePath.sep}
+        └───level3${nodePath.sep}
             └───file.txt
 `.trim();
     expect(structure.trim()).toBe(expected);
@@ -234,17 +233,17 @@ ${testRootDir}${path.sep}
     const expected = `
 Showing up to 3 items (files + folders).
 
-${testRootDir}${path.sep}
-└───level1${path.sep}
-    └───level2${path.sep}
-        └───level3${path.sep}
+${testRootDir}${nodePath.sep}
+└───level1${nodePath.sep}
+    └───level2${nodePath.sep}
+        └───level3${nodePath.sep}
 `.trim();
     expect(structure.trim()).toBe(expected);
   });
 
   describe('with gitignore', () => {
     beforeEach(async () => {
-      await fsPromises.mkdir(path.join(testRootDir, '.git'), {
+      await fsPromises.mkdir(nodePath.join(testRootDir, '.git'), {
         recursive: true,
       });
     });
@@ -266,7 +265,7 @@ ${testRootDir}${path.sep}
       });
 
       expect(structure).not.toContain('ignored.txt');
-      expect(structure).toContain(`node_modules${path.sep}...`);
+      expect(structure).toContain(`node_modules${nodePath.sep}...`);
       expect(structure).not.toContain('logs.json');
       expect(structure).toContain('config.yaml');
       expect(structure).toContain('file1.txt');
@@ -312,7 +311,7 @@ ${testRootDir}${path.sep}
         fileService,
       });
       expect(structure).not.toContain('ignored.txt');
-      expect(structure).toContain(`node_modules${path.sep}...`);
+      expect(structure).toContain(`node_modules${nodePath.sep}...`);
       expect(structure).not.toContain('logs.json');
     });
 
@@ -338,7 +337,7 @@ ${testRootDir}${path.sep}
       });
       expect(structure).toContain('ignored.txt');
       // node_modules is still ignored by default
-      expect(structure).toContain(`node_modules${path.sep}...`);
+      expect(structure).toContain(`node_modules${nodePath.sep}...`);
     });
   });
 });

--- a/packages/core/src/utils/getFolderStructure.ts
+++ b/packages/core/src/utils/getFolderStructure.ts
@@ -12,8 +12,10 @@ import type {
   FileDiscoveryService,
   FilterFilesOptions,
 } from '../services/fileDiscoveryService.js';
-import type { FileFilteringOptions } from '../config/constants.js';
-import { DEFAULT_FILE_FILTERING_OPTIONS } from '../config/constants.js';
+import {
+  type FileFilteringOptions,
+  DEFAULT_FILE_FILTERING_OPTIONS,
+} from '../config/constants.js';
 import { debugLogger } from './debugLogger.js';
 
 const MAX_ITEMS = 200;

--- a/packages/core/src/utils/googleErrors.test.ts
+++ b/packages/core/src/utils/googleErrors.test.ts
@@ -5,8 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { parseGoogleApiError } from './googleErrors.js';
-import type { QuotaFailure } from './googleErrors.js';
+import { parseGoogleApiError, type QuotaFailure } from './googleErrors.js';
 
 describe('parseGoogleApiError', () => {
   it('should return null for non-gaxios errors', () => {

--- a/packages/core/src/utils/googleQuotaErrors.ts
+++ b/packages/core/src/utils/googleQuotaErrors.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  ErrorInfo,
-  GoogleApiError,
-  Help,
-  QuotaFailure,
-  RetryInfo,
+import {
+  type ErrorInfo,
+  type GoogleApiError,
+  type Help,
+  type QuotaFailure,
+  type RetryInfo,
+  parseGoogleApiError,
 } from './googleErrors.js';
-import { parseGoogleApiError } from './googleErrors.js';
 import { getErrorStatus, ModelNotFoundError } from './httpErrors.js';
 
 /**

--- a/packages/core/src/utils/installationManager.test.ts
+++ b/packages/core/src/utils/installationManager.test.ts
@@ -4,8 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Mock } from 'vitest';
-import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  type Mock,
+  vi,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from 'vitest';
 import { InstallationManager } from './installationManager.js';
 import * as fs from 'node:fs';
 import * as os from 'node:os';

--- a/packages/core/src/utils/memoryDiscovery.test.ts
+++ b/packages/core/src/utils/memoryDiscovery.test.ts
@@ -20,10 +20,9 @@ import {
   setGeminiMdFilename,
   DEFAULT_CONTEXT_FILENAME,
 } from '../tools/memoryTool.js';
-import { flattenMemory } from '../config/memory.js';
+import { flattenMemory, type HierarchicalMemory } from '../config/memory.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
-import { GEMINI_DIR, normalizePath } from './paths.js';
-import type { HierarchicalMemory } from '../config/memory.js';
+import { GEMINI_DIR, normalizePath, homedir as pathsHomedir } from './paths.js';
 
 function flattenResult(result: {
   memoryContent: HierarchicalMemory;
@@ -61,8 +60,6 @@ vi.mock('../utils/paths.js', async (importOriginal) => {
     homedir: vi.fn(),
   };
 });
-
-import { homedir as pathsHomedir } from './paths.js';
 
 describe('memoryDiscovery', () => {
   const DEFAULT_FOLDER_TRUST = true;

--- a/packages/core/src/utils/memoryDiscovery.ts
+++ b/packages/core/src/utils/memoryDiscovery.ts
@@ -11,8 +11,10 @@ import { bfsFileSearch } from './bfsFileSearch.js';
 import { getAllGeminiMdFilenames } from '../tools/memoryTool.js';
 import type { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { processImports } from './memoryImportProcessor.js';
-import type { FileFilteringOptions } from '../config/constants.js';
-import { DEFAULT_MEMORY_FILE_FILTERING_OPTIONS } from '../config/constants.js';
+import {
+  type FileFilteringOptions,
+  DEFAULT_MEMORY_FILE_FILTERING_OPTIONS,
+} from '../config/constants.js';
 import { GEMINI_DIR, homedir, normalizePath } from './paths.js';
 import type { ExtensionLoader } from './extensionLoader.js';
 import { debugLogger } from './debugLogger.js';

--- a/packages/core/src/utils/nextSpeakerChecker.test.ts
+++ b/packages/core/src/utils/nextSpeakerChecker.test.ts
@@ -4,14 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Mock } from 'vitest';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  type Mock,
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from 'vitest';
 import type { Content } from '@google/genai';
 import { BaseLlmClient } from '../core/baseLlmClient.js';
 import type { ContentGenerator } from '../core/contentGenerator.js';
 import type { Config } from '../config/config.js';
-import type { NextSpeakerResponse } from './nextSpeakerChecker.js';
-import { checkNextSpeaker } from './nextSpeakerChecker.js';
+import {
+  type NextSpeakerResponse,
+  checkNextSpeaker,
+} from './nextSpeakerChecker.js';
 import { GeminiChat } from '../core/geminiChat.js';
 
 // Mock fs module to prevent actual file system operations during tests

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { GenerateContentResponse } from '@google/genai';
-import { ApiError } from '@google/genai';
+import { type GenerateContentResponse, ApiError } from '@google/genai';
 import {
   TerminalQuotaError,
   RetryableQuotaError,

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -14,8 +14,7 @@ import {
   type SpawnOptionsWithoutStdio,
 } from 'node:child_process';
 import * as readline from 'node:readline';
-import type { Node, Tree } from 'web-tree-sitter';
-import { Language, Parser, Query } from 'web-tree-sitter';
+import { type Node, type Tree, Language, Parser, Query } from 'web-tree-sitter';
 import { loadWasmBinary } from './fileUtils.js';
 import { debugLogger } from './debugLogger.js';
 

--- a/packages/core/src/utils/summarizer.test.ts
+++ b/packages/core/src/utils/summarizer.test.ts
@@ -4,8 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Mock } from 'vitest';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  type Mock,
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from 'vitest';
 import { GeminiClient } from '../core/client.js';
 import { Config } from '../config/config.js';
 import {

--- a/packages/core/src/utils/tool-utils.test.ts
+++ b/packages/core/src/utils/tool-utils.test.ts
@@ -10,8 +10,9 @@ import {
   getToolSuggestion,
   shouldHideToolCall,
 } from './tool-utils.js';
-import type { AnyToolInvocation, Config } from '../index.js';
 import {
+  type AnyToolInvocation,
+  type Config,
   ReadFileTool,
   ApprovalMode,
   CoreToolCallStatus,

--- a/packages/core/src/utils/tool-utils.ts
+++ b/packages/core/src/utils/tool-utils.ts
@@ -4,8 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { AnyDeclarativeTool, AnyToolInvocation } from '../index.js';
-import { isTool } from '../index.js';
+import {
+  type AnyDeclarativeTool,
+  type AnyToolInvocation,
+  isTool,
+} from '../index.js';
 import { SHELL_TOOL_NAMES } from './shell-utils.js';
 import levenshtein from 'fast-levenshtein';
 import { ApprovalMode } from '../policy/types.js';

--- a/packages/core/src/utils/userAccountManager.test.ts
+++ b/packages/core/src/utils/userAccountManager.test.ts
@@ -4,8 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Mock } from 'vitest';
-import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  type Mock,
+  vi,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from 'vitest';
 import { UserAccountManager } from './userAccountManager.js';
 import * as fs from 'node:fs';
 import * as os from 'node:os';


### PR DESCRIPTION
## Summary
- Merged duplicate import statements across all files in `packages/core` (130+ files)
- Combined type and value imports from the same module using inline `type` syntax
- Fixed import ordering to comply with `import/no-duplicates` ESLint rule

## Changes
- Used ESLint's `--fix` with `import/no-duplicates` rule to automatically merge most duplicates
- Manually fixed edge cases where ESLint's autofix created malformed imports
- Ensured proper separation of value imports and type imports
- Fixed `getFolderStructure.test.ts` to use correct namespace import references

## Testing
- ✅ All 265 test suites pass (4998 tests)
- ✅ TypeScript compilation successful
- ✅ ESLint passes with only 2 pre-existing warnings (unrelated to this PR)

## Related
Part of #19753 - PR 3 of 4 (packages/core)

Previous PRs:
- PR 1: #19777 (packages/sdk + packages/test-utils)
- PR 2: #19781 (packages/a2a-server)