### PR TITLE
test(core): add logging assertions to fallback handler tests

### DIFF
--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -392,7 +392,8 @@ describe('handleFallback', () => {
       expect(policyConfig.activateFallbackMode).toHaveBeenCalledWith(
         FALLBACK_MODEL,
       );
-      // TODO: add logging expect statement
+      expect(debugLogger.error).not.toHaveBeenCalled();
+      expect(debugLogger.warn).not.toHaveBeenCalled();
     });
 
     it('does NOT call activateFallbackMode when handler returns "stop"', async () => {
@@ -406,7 +407,8 @@ describe('handleFallback', () => {
 
       expect(result).toBe(false);
       expect(policyConfig.activateFallbackMode).not.toHaveBeenCalled();
-      // TODO: add logging expect statement
+      expect(debugLogger.error).not.toHaveBeenCalled();
+      expect(debugLogger.warn).not.toHaveBeenCalled();
     });
 
     it('does NOT call activateFallbackMode when handler returns "retry_once"', async () => {


### PR DESCRIPTION
## Summary
Adds missing logging assertions to the fallback handler tests so success paths explicitly verify that no error or warning logs are emitted.

## Details
Two tests in `packages/core/src/fallback/handler.test.ts` had TODOs to add logging expectations.  
This change completes those TODOs by asserting that:
- `debugLogger.error` is not called
- `debugLogger.warn` is not called  
for the successful "retry_always" and "stop" handler paths.

No production code changes. Tests only.

## Related Issues
Fixes #19784

## How to Validate
From `packages/core`:
```bash
npx vitest run src/fallback/handler.test.ts