### PR TITLE
Enforce import/no-duplicates as error

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -69,7 +69,8 @@ export default tseslint.config(
       ...importPlugin.configs.recommended.rules,
       ...importPlugin.configs.typescript.rules,
       'import/no-default-export': 'warn',
-      'import/no-unresolved': 'off', // Disable for now, can be noisy with monorepos/paths
+      'import/no-unresolved': 'off',
+      'import/no-duplicates': 'error',
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,27 +55,8 @@ export default tseslint.config(
     },
   },
   {
-    // Import specific config
-    files: ['packages/*/src/**/*.{ts,tsx}'], // Target all TS/TSX in the packages
-    plugins: {
-      import: importPlugin,
-    },
-    settings: {
-      'import/resolver': {
-        node: true,
-      },
-    },
-    rules: {
-      ...importPlugin.configs.recommended.rules,
-      ...importPlugin.configs.typescript.rules,
-      'import/no-default-export': 'warn',
-      'import/no-unresolved': 'off',
-      'import/no-duplicates': 'error',
-    },
-  },
-  {
-    // General overrides and rules for the project (TS/TSX files)
-    files: ['packages/*/src/**/*.{ts,tsx}'], // Target only TS/TSX in the cli package
+    // Rules for packages/*/src (TS/TSX)
+    files: ['packages/*/src/**/*.{ts,tsx}'],
     plugins: {
       import: importPlugin,
     },
@@ -96,6 +77,11 @@ export default tseslint.config(
       },
     },
     rules: {
+      ...importPlugin.configs.recommended.rules,
+      ...importPlugin.configs.typescript.rules,
+      'import/no-default-export': 'warn',
+      'import/no-unresolved': 'off',
+      'import/no-duplicates': 'error',
       // General Best Practice Rules (subset adapted for flat config)
       '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
       'arrow-body-style': ['error', 'as-needed'],


### PR DESCRIPTION
## Summary

Upgrades `import/no-duplicates` from warning to error to prevent new violations.

Duplicate imports were already cleaned up in #19753 (PRs #19777, #19781, #19791, #19795). This PR enforces the rule going forward.

## Changes

- Set `import/no-duplicates` to `error` in `eslint.config.js`

Closes #19752