### PR TITLE
Add headless auto mode for interactive runs

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -18,6 +18,7 @@ import {
   getAdminErrorMessage,
 } from '@google/gemini-cli-core';
 import { aboutCommand } from '../ui/commands/aboutCommand.js';
+import { autoCommand } from '../ui/commands/autoCommand.js';
 import { agentsCommand } from '../ui/commands/agentsCommand.js';
 import { authCommand } from '../ui/commands/authCommand.js';
 import { bugCommand } from '../ui/commands/bugCommand.js';
@@ -80,6 +81,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
 
     const allDefinitions: Array<SlashCommand | null> = [
       aboutCommand,
+      autoCommand,
       ...(this.config?.isAgentsEnabled() ? [agentsCommand] : []),
       authCommand,
       bugCommand,

--- a/packages/cli/src/ui/commands/autoCommand.test.ts
+++ b/packages/cli/src/ui/commands/autoCommand.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { autoCommand } from './autoCommand.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import type { CommandContext } from './types.js';
+
+describe('autoCommand', () => {
+  let mockContext: CommandContext;
+
+  beforeEach(() => {
+    mockContext = createMockCommandContext({
+      services: {
+        config: {
+          enterHeadlessMode: vi.fn(),
+        },
+      },
+      ui: {
+        addItem: vi.fn(),
+      },
+    } as unknown as CommandContext);
+  });
+
+  it('should return an error when config is not available', async () => {
+    const context = createMockCommandContext({
+      services: { config: null },
+    } as unknown as CommandContext);
+
+    if (!autoCommand.action) throw new Error('Action missing');
+    const result = await autoCommand.action(context, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Configuration not available.',
+    });
+  });
+
+  it('should enable headless mode and submit args', async () => {
+    if (!autoCommand.action) throw new Error('Action missing');
+    const result = await autoCommand.action(mockContext, 'do the thing');
+
+    expect(mockContext.services.config!.enterHeadlessMode).toHaveBeenCalled();
+    expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+      {
+        type: 'info',
+        text: 'Headless mode enabled for this run; approvals will be auto-rejected.',
+      },
+      expect.any(Number),
+    );
+    expect(result).toEqual({
+      type: 'submit_prompt',
+      content: 'do the thing',
+    });
+  });
+
+  it('should default to "continue" when no args are provided', async () => {
+    if (!autoCommand.action) throw new Error('Action missing');
+    const result = await autoCommand.action(mockContext, '   ');
+
+    expect(result).toEqual({
+      type: 'submit_prompt',
+      content: 'continue',
+    });
+  });
+});

--- a/packages/cli/src/ui/commands/autoCommand.ts
+++ b/packages/cli/src/ui/commands/autoCommand.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  CommandContext,
+  SlashCommand,
+  SlashCommandActionReturn,
+} from './types.js';
+import { CommandKind } from './types.js';
+
+const DEFAULT_PROMPT = 'continue';
+
+export const autoCommand: SlashCommand = {
+  name: 'auto',
+  altNames: ['headless'],
+  description:
+    'Run the agent headlessly for one run (auto-rejecting confirmations)',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: async (
+    context: CommandContext,
+    args: string,
+  ): Promise<SlashCommandActionReturn> => {
+    const config = context.services.config;
+    if (!config) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'Configuration not available.',
+      };
+    }
+
+    config.enterHeadlessMode();
+
+    context.ui.addItem(
+      {
+        type: 'info',
+        text: 'Headless mode enabled for this run; approvals will be auto-rejected.',
+      },
+      Date.now(),
+    );
+
+    const trimmedArgs = args.trim();
+    return {
+      type: 'submit_prompt',
+      content: trimmedArgs.length > 0 ? trimmedArgs : DEFAULT_PROMPT,
+    };
+  },
+};

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -26,6 +26,7 @@ import { ShowMoreLines } from './ShowMoreLines.js';
 import { QueuedMessageDisplay } from './QueuedMessageDisplay.js';
 import { ContextUsageDisplay } from './ContextUsageDisplay.js';
 import { HorizontalLine } from './shared/HorizontalLine.js';
+import { TrajectorySummaryDisplay } from './TrajectorySummaryDisplay.js';
 import { OverflowProvider } from '../contexts/OverflowContext.js';
 import { isNarrowWidth } from '../utils/isNarrowWidth.js';
 import { useUIState } from '../contexts/UIStateContext.js';
@@ -318,6 +319,7 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
         )}
         {showShortcutsHelp && <ShortcutsHelp />}
         {showUiDetails && <HorizontalLine />}
+        {showUiDetails && <TrajectorySummaryDisplay />}
         {showUiDetails && (
           <Box
             justifyContent={

--- a/packages/cli/src/ui/components/TrajectorySummaryDisplay.test.tsx
+++ b/packages/cli/src/ui/components/TrajectorySummaryDisplay.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render } from '../../test-utils/render.js';
+import { describe, it, expect } from 'vitest';
+import { TrajectorySummaryDisplay } from './TrajectorySummaryDisplay.js';
+import { UIStateContext, type UIState } from '../contexts/UIStateContext.js';
+
+const renderWithHistory = async (history: UIState['history']) => {
+  const uiState = { history } as Partial<UIState> as UIState;
+  const result = render(
+    <UIStateContext.Provider value={uiState}>
+      <TrajectorySummaryDisplay />
+    </UIStateContext.Provider>,
+  );
+  await result.waitUntilReady();
+  return result;
+};
+
+describe('<TrajectorySummaryDisplay />', () => {
+  it('renders the goal from the first user message', async () => {
+    const { lastFrame } = await renderWithHistory([
+      { id: 1, type: 'user', text: 'Add dark mode to the app' },
+    ]);
+    expect(lastFrame()).toContain('Goal: Add dark mode to the app');
+  });
+
+  it('extracts the goal from slash command arguments', async () => {
+    const { lastFrame } = await renderWithHistory([
+      { id: 1, type: 'user', text: '/plan Add support for evals' },
+    ]);
+    expect(lastFrame()).toContain('Goal: Add support for evals');
+  });
+});

--- a/packages/cli/src/ui/components/TrajectorySummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/TrajectorySummaryDisplay.tsx
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box, Text } from 'ink';
+import { useMemo } from 'react';
+import { theme } from '../semantic-colors.js';
+import { useUIState } from '../contexts/UIStateContext.js';
+
+const MAX_SUMMARY_LENGTH = 80;
+
+function normalizeSummary(text: string): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  if (!collapsed) {
+    return '';
+  }
+
+  const sentenceMatch = collapsed.match(/^(.+?[.!?])(\s|$)/);
+  const sentence = sentenceMatch ? sentenceMatch[1] : collapsed;
+
+  if (sentence.length <= MAX_SUMMARY_LENGTH) {
+    return sentence;
+  }
+
+  return sentence.slice(0, Math.max(0, MAX_SUMMARY_LENGTH - 3)) + '...';
+}
+
+function deriveGoalSummary(history: Array<{ type: string; text?: string }>) {
+  for (const item of history) {
+    if (item.type !== 'user') {
+      continue;
+    }
+    const trimmed = item.text?.trim();
+    if (!trimmed) {
+      continue;
+    }
+    if (trimmed.startsWith('/')) {
+      const withoutCommand = trimmed.replace(/^\/\S+\s+/, '').trim();
+      if (!withoutCommand) {
+        continue; // Skip slash commands like /help or /plan with no args
+      }
+      return normalizeSummary(withoutCommand);
+    }
+    return normalizeSummary(trimmed);
+  }
+  return '';
+}
+
+export const TrajectorySummaryDisplay: React.FC = () => {
+  const { history } = useUIState();
+  const summary = useMemo(() => deriveGoalSummary(history), [history]);
+
+  if (!summary) {
+    return null;
+  }
+
+  return (
+    <Box paddingX={1}>
+      <Text wrap="truncate-end">
+        <Text color={theme.text.secondary}>Goal: </Text>
+        <Text color={theme.text.primary} bold>
+          {summary}
+        </Text>
+      </Text>
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/TrajectorySummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/TrajectorySummaryDisplay.tsx
@@ -21,11 +21,14 @@ function normalizeSummary(text: string): string {
   const sentenceMatch = collapsed.match(/^(.+?[.!?])(\s|$)/);
   const sentence = sentenceMatch ? sentenceMatch[1] : collapsed;
 
-  if (sentence.length <= MAX_SUMMARY_LENGTH) {
+  const segments = Array.from(sentence);
+  if (segments.length <= MAX_SUMMARY_LENGTH) {
     return sentence;
   }
 
-  return sentence.slice(0, Math.max(0, MAX_SUMMARY_LENGTH - 3)) + '...';
+  return (
+    segments.slice(0, Math.max(0, MAX_SUMMARY_LENGTH - 3)).join('') + '...'
+  );
 }
 
 function deriveGoalSummary(history: Array<{ type: string; text?: string }>) {
@@ -38,7 +41,7 @@ function deriveGoalSummary(history: Array<{ type: string; text?: string }>) {
       continue;
     }
     if (trimmed.startsWith('/')) {
-      const withoutCommand = trimmed.replace(/^\/\S+\s+/, '').trim();
+      const withoutCommand = trimmed.replace(/^\/\S+\s*/, '').trim();
       if (!withoutCommand) {
         continue; // Skip slash commands like /help or /plan with no args
       }

--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -312,6 +312,28 @@ describe('PolicyEngine', () => {
       ).toBe(PolicyDecision.DENY);
     });
 
+    it('should toggle non-interactive behavior at runtime', async () => {
+      const rules: PolicyRule[] = [
+        { toolName: 'interactive-tool', decision: PolicyDecision.ASK_USER },
+      ];
+
+      engine = new PolicyEngine({ rules, nonInteractive: false });
+
+      expect(
+        (await engine.check({ name: 'interactive-tool' }, undefined)).decision,
+      ).toBe(PolicyDecision.ASK_USER);
+
+      engine.setNonInteractive(true);
+      expect(
+        (await engine.check({ name: 'interactive-tool' }, undefined)).decision,
+      ).toBe(PolicyDecision.DENY);
+
+      engine.setNonInteractive(false);
+      expect(
+        (await engine.check({ name: 'interactive-tool' }, undefined)).decision,
+      ).toBe(PolicyDecision.ASK_USER);
+    });
+
     it('should dynamically switch between modes and respect rule modes', async () => {
       const rules: PolicyRule[] = [
         {

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -100,7 +100,7 @@ export class PolicyEngine {
   private checkers: SafetyCheckerRule[];
   private hookCheckers: HookCheckerRule[];
   private readonly defaultDecision: PolicyDecision;
-  private readonly nonInteractive: boolean;
+  private nonInteractive: boolean;
   private readonly checkerRunner?: CheckerRunner;
   private approvalMode: ApprovalMode;
 
@@ -132,6 +132,20 @@ export class PolicyEngine {
    */
   getApprovalMode(): ApprovalMode {
     return this.approvalMode;
+  }
+
+  /**
+   * Update whether the engine should treat ASK_USER as DENY.
+   */
+  setNonInteractive(enabled: boolean): void {
+    this.nonInteractive = enabled;
+  }
+
+  /**
+   * Returns true when ASK_USER should be treated as DENY.
+   */
+  isNonInteractive(): boolean {
+    return this.nonInteractive;
   }
 
   private shouldDowngradeForRedirection(

--- a/packages/core/src/prompts/promptProvider.test.ts
+++ b/packages/core/src/prompts/promptProvider.test.ts
@@ -51,6 +51,7 @@ describe('PromptProvider', () => {
       }),
       getApprovedPlanPath: vi.fn().mockReturnValue(undefined),
       getApprovalMode: vi.fn(),
+      getInteractiveOverride: vi.fn(),
     } as unknown as Config;
   });
 
@@ -86,5 +87,18 @@ describe('PromptProvider', () => {
     expect(prompt).toContain(
       `# Contextual Instructions (${DEFAULT_CONTEXT_FILENAME}, CUSTOM.md)`,
     );
+  });
+
+  it('should respect interactive override for headless mode', () => {
+    vi.mocked(getAllGeminiMdFilenames).mockReturnValue([
+      DEFAULT_CONTEXT_FILENAME,
+    ]);
+    vi.mocked(mockConfig.getInteractiveOverride).mockReturnValue(false);
+    vi.mocked(mockConfig.isInteractive).mockReturnValue(true);
+
+    const provider = new PromptProvider();
+    const prompt = provider.getCoreSystemPrompt(mockConfig);
+
+    expect(prompt).toContain('autonomous CLI agent');
   });
 });

--- a/packages/core/src/prompts/promptProvider.ts
+++ b/packages/core/src/prompts/promptProvider.ts
@@ -49,7 +49,10 @@ export class PromptProvider {
       process.env['GEMINI_SYSTEM_MD'],
     );
 
-    const interactiveMode = interactiveOverride ?? config.isInteractive();
+    const interactiveMode =
+      interactiveOverride ??
+      config.getInteractiveOverride?.() ??
+      config.isInteractive();
     const approvalMode = config.getApprovalMode?.() ?? ApprovalMode.DEFAULT;
     const isPlanMode = approvalMode === ApprovalMode.PLAN;
     const isYoloMode = approvalMode === ApprovalMode.YOLO;


### PR DESCRIPTION
## Summary

- Add `/auto` (alias `/headless`) to run one headless turn from interactive sessions.
- Add runtime headless toggles in policy/config and prompt override to non-interactive guidance.
- Auto-cancel pending confirmations and auto-exit headless mode when a run completes.

## Details

- Headless mode snapshots prior interactive/non-interactive state and restores after completion.
- Pending approvals are auto-cancelled (ASK_USER -> DENY) to avoid blocking.
- Includes tests for policy toggle, prompt override, command behavior, and headless UI flow.

## Related Issues

closes #19776

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
