### PR TITLE
fix(vscode): resolve unsafe assignment lint errors

### DIFF
--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -151,6 +151,30 @@ describe('activate', () => {
       vi.mocked(context.globalState.get).mockReturnValue(true);
     });
 
+    it('should not fetch marketplace when packageJSON version is missing', async () => {
+      const contextWithBadPackageJson = {
+        ...context,
+        extension: { packageJSON: {} },
+      } as unknown as vscode.ExtensionContext;
+      const fetchSpy = vi
+        .spyOn(global, 'fetch')
+        .mockResolvedValue({} as Response);
+      await activate(contextWithBadPackageJson);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not show notification when marketplace response has unexpected shape', async () => {
+      const showInformationMessageMock = vi.mocked(
+        vscode.window.showInformationMessage,
+      );
+      vi.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        json: async () => ({ results: 'invalid result' }),
+      } as Response);
+      await activate(context);
+      expect(showInformationMessageMock).not.toHaveBeenCalled();
+    });
+
     it('should show an update notification if a newer version is available', async () => {
       vi.spyOn(global, 'fetch').mockResolvedValue({
         ok: true,

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -34,7 +34,9 @@ let logger: vscode.OutputChannel;
 let log: (message: string) => void = () => {};
 
 const VscodePackageJsonSchema = z.object({
-  version: z.string(),
+  version: z.string().refine((v) => semver.valid(v) !== null, {
+    message: 'version must be a valid semver string',
+  }),
 });
 
 const MarketplaceResponseSchema = z.object({


### PR DESCRIPTION
## Summary
Disallow and remove unsafe assignment in VS Code companion package.
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details
- Removed now-unused `eslint-disable-next-line @typescript-eslint/no-unsafe-assignment`.
- Introduced `VscodePackageJsonSchema` and `MarketplaceResponseSchema` zod validation schemas to validate current extension version and marketplace API response respectively.
- Used Optional chaining with possibly empty arrays only.
- This is part of Phase 4.2 of the systemic type safety cleanup.
<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues
Fixes #19717
<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

Run the following commands in the package directory:
```bash
npm run lint -w packages/vscode-ide-companion
npm run check-types -w packages/vscode-ide-companion
```
<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
