### PR TITLE
fix(cli): enable multi-arch docker builds for sandbox

### DIFF
--- a/.github/actions/push-sandbox/action.yml
+++ b/.github/actions/push-sandbox/action.yml
@@ -71,6 +71,8 @@ runs:
       env:
         INPUTS_GITHUB_REF_NAME: '${{ inputs.github-ref-name }}'
         INPUTS_GITHUB_SHA: '${{ inputs.github-sha }}'
+    # We build amd64 just so we can verify it.
+    # We build and push both amd64 and arm64 in the publish step.
     - name: 'build'
       id: 'docker_build'
       shell: 'bash'

--- a/.github/actions/push-sandbox/action.yml
+++ b/.github/actions/push-sandbox/action.yml
@@ -44,6 +44,8 @@ runs:
     - name: 'npm build'
       shell: 'bash'
       run: 'npm run build'
+    - name: 'Set up QEMU'
+      uses: 'docker/setup-qemu-action@v3'
     - name: 'Set up Docker Buildx'
       uses: 'docker/setup-buildx-action@v3'
     - name: 'Log in to GitHub Container Registry'
@@ -69,12 +71,13 @@ runs:
       env:
         INPUTS_GITHUB_REF_NAME: '${{ inputs.github-ref-name }}'
         INPUTS_GITHUB_SHA: '${{ inputs.github-sha }}'
-    - name: 'build'
+    - name: 'build and publish'
       id: 'docker_build'
       shell: 'bash'
       env:
         GEMINI_SANDBOX_IMAGE_TAG: '${{ steps.image_tag.outputs.FINAL_TAG }}'
         GEMINI_SANDBOX: 'docker'
+        BUILD_SANDBOX_FLAGS: "${{ inputs.dry-run != 'true' && '--platform linux/amd64,linux/arm64 --push' || '--platform linux/amd64 --load' }}"
         STEPS_IMAGE_TAG_OUTPUTS_FINAL_TAG: '${{ steps.image_tag.outputs.FINAL_TAG }}'
       run: |-
         npm run build:sandbox -- \
@@ -83,19 +86,13 @@ runs:
         echo "uri=$(cat final_image_uri.txt)" >> $GITHUB_OUTPUT
     - name: 'verify'
       shell: 'bash'
+      if: "${{ inputs.dry-run == 'true' }}"
       run: |-
         docker run --rm --entrypoint sh "${{ steps.docker_build.outputs.uri }}" -lc '
           set -e
           node -e "const fs=require(\"node:fs\"); JSON.parse(fs.readFileSync(\"/usr/local/share/npm-global/lib/node_modules/@google/gemini-cli/package.json\",\"utf8\")); JSON.parse(fs.readFileSync(\"/usr/local/share/npm-global/lib/node_modules/@google/gemini-cli-core/package.json\",\"utf8\"));"
           /usr/local/share/npm-global/bin/gemini --version >/dev/null
         '
-    - name: 'publish'
-      shell: 'bash'
-      if: "${{ inputs.dry-run != 'true' }}"
-      run: |-
-        docker push "${STEPS_DOCKER_BUILD_OUTPUTS_URI}"
-      env:
-        STEPS_DOCKER_BUILD_OUTPUTS_URI: '${{ steps.docker_build.outputs.uri }}'
     - name: 'Create issue on failure'
       if: |-
         ${{ failure() }}

--- a/.github/actions/push-sandbox/action.yml
+++ b/.github/actions/push-sandbox/action.yml
@@ -81,7 +81,7 @@ runs:
         STEPS_IMAGE_TAG_OUTPUTS_FINAL_TAG: '${{ steps.image_tag.outputs.FINAL_TAG }}'
       run: |-
         npm run build:sandbox -- \
-          --image google/gemini-cli-sandbox:${STEPS_IMAGE_TAG_OUTPUTS_FINAL_TAG} \
+          --image "google/gemini-cli-sandbox:${STEPS_IMAGE_TAG_OUTPUTS_FINAL_TAG}" \
           --output-file final_image_uri.txt
         echo "uri=$(cat final_image_uri.txt)" >> $GITHUB_OUTPUT
     - name: 'verify'
@@ -102,7 +102,7 @@ runs:
         STEPS_IMAGE_TAG_OUTPUTS_FINAL_TAG: '${{ steps.image_tag.outputs.FINAL_TAG }}'
       run: |-
         npm run build:sandbox -- \
-          --image google/gemini-cli-sandbox:${STEPS_IMAGE_TAG_OUTPUTS_FINAL_TAG}
+          --image "google/gemini-cli-sandbox:${STEPS_IMAGE_TAG_OUTPUTS_FINAL_TAG}"
     - name: 'Create issue on failure'
       if: |-
         ${{ failure() }}

--- a/.github/actions/push-sandbox/action.yml
+++ b/.github/actions/push-sandbox/action.yml
@@ -71,13 +71,13 @@ runs:
       env:
         INPUTS_GITHUB_REF_NAME: '${{ inputs.github-ref-name }}'
         INPUTS_GITHUB_SHA: '${{ inputs.github-sha }}'
-    - name: 'build and publish'
+    - name: 'build'
       id: 'docker_build'
       shell: 'bash'
       env:
         GEMINI_SANDBOX_IMAGE_TAG: '${{ steps.image_tag.outputs.FINAL_TAG }}'
         GEMINI_SANDBOX: 'docker'
-        BUILD_SANDBOX_FLAGS: "${{ inputs.dry-run != 'true' && '--platform linux/amd64,linux/arm64 --push' || '--platform linux/amd64 --load' }}"
+        BUILD_SANDBOX_FLAGS: '--platform linux/amd64 --load'
         STEPS_IMAGE_TAG_OUTPUTS_FINAL_TAG: '${{ steps.image_tag.outputs.FINAL_TAG }}'
       run: |-
         npm run build:sandbox -- \
@@ -86,13 +86,23 @@ runs:
         echo "uri=$(cat final_image_uri.txt)" >> $GITHUB_OUTPUT
     - name: 'verify'
       shell: 'bash'
-      if: "${{ inputs.dry-run == 'true' }}"
       run: |-
         docker run --rm --entrypoint sh "${{ steps.docker_build.outputs.uri }}" -lc '
           set -e
           node -e "const fs=require(\"node:fs\"); JSON.parse(fs.readFileSync(\"/usr/local/share/npm-global/lib/node_modules/@google/gemini-cli/package.json\",\"utf8\")); JSON.parse(fs.readFileSync(\"/usr/local/share/npm-global/lib/node_modules/@google/gemini-cli-core/package.json\",\"utf8\"));"
           /usr/local/share/npm-global/bin/gemini --version >/dev/null
         '
+    - name: 'publish'
+      shell: 'bash'
+      if: "${{ inputs.dry-run != 'true' }}"
+      env:
+        GEMINI_SANDBOX_IMAGE_TAG: '${{ steps.image_tag.outputs.FINAL_TAG }}'
+        GEMINI_SANDBOX: 'docker'
+        BUILD_SANDBOX_FLAGS: '--platform linux/amd64,linux/arm64 --push'
+        STEPS_IMAGE_TAG_OUTPUTS_FINAL_TAG: '${{ steps.image_tag.outputs.FINAL_TAG }}'
+      run: |-
+        npm run build:sandbox -- \
+          --image google/gemini-cli-sandbox:${STEPS_IMAGE_TAG_OUTPUTS_FINAL_TAG}
     - name: 'Create issue on failure'
       if: |-
         ${{ failure() }}


### PR DESCRIPTION
## Summary

Fixes the `exec format error` and `failed to map segment from shared object` crashes that occur when running the sandbox on ARM64 hosts (like the Raspberry Pi 5). This enables multi-architecture Docker builds in the sandbox release pipeline.

## Details

The GitHub Actions workflow building the sandbox image currently defaults to only `linux/amd64`. When an `arm64` host pulls the image, Docker attempts to run it using QEMU emulation, resulting in low-level memory mapping failures (specifically when executing `groupadd`).

This change passes `--platform linux/amd64,linux/arm64` and `--push` to the buildx executor within the Actions pipeline. Docker automatically publishes the multi-arch manifest.

## Related Issues

Fixes #15778

## How to Validate

1. Trigger the Github Actions `Release Sandbox` workflow (or wait for the nightly).
2. Note the build process correctly building both architecture variants using `docker buildx`.
3. Test locally on an ARM64 host (e.g., Raspberry Pi 5):
   - Re-run `gemini -s`.
   - The native image will be pulled, and the sandbox will start successfully without emulation crashing.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
  - [ ] Windows
  - [x] Linux
