### PR TITLE
Fix(core) --no-deprecation flag to the Node.js args i

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17419,6 +17419,7 @@
         "shell-quote": "^1.8.3",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",
+        "strip-json-comments": "^3.1.1",
         "systeminformation": "^5.25.11",
         "tree-sitter-bash": "^0.25.0",
         "undici": "^7.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "latest-version": "^9.0.0",
         "proper-lockfile": "^4.1.2",
         "punycode": "^2.3.1",
-        "simple-git": "^3.28.0"
+        "simple-git": "^3.28.0",
+        "strip-json-comments": "^3.1.1"
       },
       "bin": {
         "gemini": "bundle/gemini.js"

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -32,7 +32,7 @@ execSync('node ./scripts/check-build-status.js', {
   cwd: root,
 });
 
-const nodeArgs = ['--no-deprecation'];
+const nodeArgs = ['--disable-warning=DEP0040'];
 
 let sandboxCommand = undefined;
 try {

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -32,7 +32,8 @@ execSync('node ./scripts/check-build-status.js', {
   cwd: root,
 });
 
-const nodeArgs = [];
+const nodeArgs = ['--no-deprecation'];
+
 let sandboxCommand = undefined;
 try {
   sandboxCommand = execSync('node scripts/sandbox_command.js', {


### PR DESCRIPTION
The punycode deprecation warning comes from a deep dependency chain (eslint → ajv → uri-js → punycode).

## Related Issues
#19818 


- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [.] Validated on required platforms/methods:
  - [.] MacOS
    - [.] npm run
    - [ ] npx
    - [] Docker
    - [ ] Podman
    - [.] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
