### PR TITLE
fix: guard subprocess output against V8 string length overflow (#17193)

### DIFF
--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -6,3 +6,9 @@
 
 export const REFERENCE_CONTENT_START = '--- Content from referenced files ---';
 export const REFERENCE_CONTENT_END = '--- End of content ---';
+
+/**
+ * Maximum size (in bytes) for subprocess output accumulation.
+ * Prevents V8 string length overflow crashes (0x1fffffe8 character limit).
+ */
+export const MAX_SUBPROCESS_OUTPUT_SIZE = 10 * 1024 * 1024; // 10MB


### PR DESCRIPTION
## Summary

Adds 10MB output size guards to prevent CLI crashes from V8's string length limit (`0x1fffffe8`).

## Details

Several subprocess wrappers accumulated stdout/stderr via unbounded `+=` with no cap. This PR adds byte-length tracking and 10MB limits to all unprotected sites:

- `spawnAsync` - throws on overflow (callers expect small outputs)
- `DiscoveredToolInvocation.execute` — caps + kills process
- `executeCheckerProcess` - fail-closed DENY on overflow
- `executeCommandHook` - fail-closed `success: false` on overflow
- `imageExists` / `pullImage` - stops accumulating past cap

All sites use settled/killed flags to prevent double-resolve after kill -> close races.

## Related Issues

Fixes #17193

## How to Validate

```bash
npm test -w @google/gemini-cli-core -- src/tools/tool-registry.test.ts
npm test -w @google/gemini-cli-core -- src/safety/checker-runner.test.ts
npm test -w @google/gemini-cli-core -- src/hooks/hookRunner.test.ts
npm test -w @google/gemini-cli -- src/utils/sandbox.test.ts
```

All 62 existing tests pass.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
