### PR TITLE
feat(cli): Standardize Reload Command Names (#18345)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17737,7 +17737,6 @@
         "shell-quote": "^1.8.3",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",
-        "strip-json-comments": "^3.1.1",
         "systeminformation": "^5.25.11",
         "tree-sitter-bash": "^0.25.0",
         "undici": "^7.10.0",

--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -1116,6 +1116,18 @@ describe('extensionsCommand', () => {
       const suggestions = completeExtensions(mockContext, 'ext');
       expect(suggestions).toEqual(['ext1']);
     });
+
+    it('should suggest only enabled extension names for the restart command alias', async () => {
+      mockContext.invocation!.name = 'restart';
+      const mockExtensions = [
+        { name: 'ext1', isActive: true },
+        { name: 'ext2', isActive: false },
+      ] as GeminiCLIExtension[];
+      mockGetExtensions.mockReturnValue(mockExtensions);
+
+      const suggestions = completeExtensions(mockContext, 'ext');
+      expect(suggestions).toEqual(['ext1']);
+    });
   });
 
   describe('config', () => {

--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -915,16 +915,16 @@ describe('extensionsCommand', () => {
   });
 
   describe('reload', () => {
-    let restartAction: SlashCommand['action'];
+    let reloadAction: SlashCommand['action'];
     let mockRestartExtension: MockedFunction<
       typeof ExtensionLoader.prototype.restartExtension
     >;
 
     beforeEach(() => {
-      restartAction = extensionsCommand().subCommands?.find(
+      reloadAction = extensionsCommand().subCommands?.find(
         (c) => c.name === 'reload',
       )?.action;
-      expect(restartAction).not.toBeNull();
+      expect(reloadAction).not.toBeNull();
 
       mockRestartExtension = vi.fn();
       mockContext.services.agentContext!.config.getExtensionLoader = vi
@@ -944,7 +944,7 @@ describe('extensionsCommand', () => {
           restartExtension: mockRestartExtension,
         }));
 
-      await restartAction!(mockContext, '--all');
+      await reloadAction!(mockContext, '--all');
 
       expect(mockContext.ui.addItem).toHaveBeenCalledWith({
         type: MessageType.INFO,
@@ -960,7 +960,7 @@ describe('extensionsCommand', () => {
       ] as GeminiCLIExtension[];
       mockGetExtensions.mockReturnValue(mockExtensions);
 
-      await restartAction!(mockContext, '--all');
+      await reloadAction!(mockContext, '--all');
 
       expect(mockRestartExtension).toHaveBeenCalledTimes(2);
       expect(mockRestartExtension).toHaveBeenCalledWith(mockExtensions[0]);
@@ -996,7 +996,7 @@ describe('extensionsCommand', () => {
       mockGetExtensions.mockReturnValue(mockExtensions);
       mockReloadSkills.mockRejectedValue(new Error('Failed to reload skills'));
 
-      await restartAction!(mockContext, '--all');
+      await reloadAction!(mockContext, '--all');
 
       expect(mockRestartExtension).toHaveBeenCalledWith(mockExtensions[0]);
       expect(mockReloadSkills).toHaveBeenCalled();
@@ -1016,7 +1016,7 @@ describe('extensionsCommand', () => {
       ] as GeminiCLIExtension[];
       mockGetExtensions.mockReturnValue(mockExtensions);
 
-      await restartAction!(mockContext, 'ext1 ext3');
+      await reloadAction!(mockContext, 'ext1 ext3');
 
       expect(mockRestartExtension).toHaveBeenCalledTimes(1);
       expect(mockRestartExtension).toHaveBeenCalledWith(mockExtensions[2]);
@@ -1029,7 +1029,7 @@ describe('extensionsCommand', () => {
     it('shows an error if no extension loader is available', async () => {
       mockContext.services.agentContext!.config.getExtensionLoader = vi.fn();
 
-      await restartAction!(mockContext, '--all');
+      await reloadAction!(mockContext, '--all');
 
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1041,7 +1041,7 @@ describe('extensionsCommand', () => {
     });
 
     it('shows usage error for no arguments', async () => {
-      await restartAction!(mockContext, '');
+      await reloadAction!(mockContext, '');
 
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1059,7 +1059,7 @@ describe('extensionsCommand', () => {
       mockGetExtensions.mockReturnValue(mockExtensions);
       mockRestartExtension.mockRejectedValue(new Error('Failed to restart'));
 
-      await restartAction!(mockContext, '--all');
+      await reloadAction!(mockContext, '--all');
 
       expect(mockRestartExtension).toHaveBeenCalledWith(mockExtensions[0]);
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
@@ -1076,7 +1076,7 @@ describe('extensionsCommand', () => {
       ] as GeminiCLIExtension[];
       mockGetExtensions.mockReturnValue(mockExtensions);
 
-      await restartAction!(mockContext, 'ext1 ext2');
+      await reloadAction!(mockContext, 'ext1 ext2');
 
       expect(mockRestartExtension).toHaveBeenCalledTimes(1);
       expect(mockRestartExtension).toHaveBeenCalledWith(mockExtensions[0]);
@@ -1094,7 +1094,7 @@ describe('extensionsCommand', () => {
       ] as GeminiCLIExtension[];
       mockGetExtensions.mockReturnValue(mockExtensions);
 
-      await restartAction!(mockContext, 'ext2 ext3');
+      await reloadAction!(mockContext, 'ext2 ext3');
 
       expect(mockRestartExtension).not.toHaveBeenCalled();
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -754,8 +754,11 @@ export function completeExtensions(
   if (context.invocation?.name === 'enable') {
     extensions = extensions.filter((ext) => !ext.isActive);
   }
+  if (
     context.invocation?.name === 'disable' ||
-    context.invocation?.name === 'reload'
+    context.invocation?.name === 'reload' ||
+    context.invocation?.name === 'restart'
+  ) {
     extensions = extensions.filter((ext) => ext.isActive);
   }
   const extensionNames = extensions.map((ext) => ext.name);

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -754,11 +754,8 @@ export function completeExtensions(
   if (context.invocation?.name === 'enable') {
     extensions = extensions.filter((ext) => !ext.isActive);
   }
-  if (
     context.invocation?.name === 'disable' ||
-    context.invocation?.name === 'restart' ||
     context.invocation?.name === 'reload'
-  ) {
     extensions = extensions.filter((ext) => ext.isActive);
   }
   const extensionNames = extensions.map((ext) => ext.name);

--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -134,7 +134,7 @@ const authCommand: SlashCommand = {
       if (mcpClientManager) {
         context.ui.addItem({
           type: 'info',
-          text: `Restarting MCP server '${serverName}'...`,
+          text: `Reloading MCP server '${serverName}'...`,
         });
         await mcpClientManager.restartServer(serverName);
       }


### PR DESCRIPTION
Fixes #18345. Replaced refresh/restart command structures across `/mcp`, `/memory`, `/agents`, and `/extensions` namespaces with `/reload`, while keeping the old names as `altNames` for backward compatibility.