### PR TITLE
fix(vscode-ide-companion): append truncation suffix when selected text exceeds 16KB

### DIFF
--- a/docs/ide-integration/ide-companion-spec.md
+++ b/docs/ide-integration/ide-companion-spec.md
@@ -151,10 +151,15 @@ and truncation steps before sending the information to the model.
   on setting `isActive: true` and providing cursor/selection details only for
   the currently focused file.
 - **Truncation:** To manage token limits, the CLI truncates both the file list
-  (to 10 files) and the `selectedText` (to 16KB).
+  (to 10 files) and the `selectedText` (to 16KB). When truncating
+  `selectedText`, the CLI appends the suffix `... [TRUNCATED]` so the model
+  knows the selection was cut. Plugins that truncate before sending should do
+  the same.
 
 While the CLI handles the final truncation, it is highly recommended that your
-plugin also limits the amount of context it sends.
+plugin also limits the amount of context it sends and, when truncating
+`selectedText`, appends a truncation suffix (e.g. `... [TRUNCATED]`) for
+consistency.
 
 ## III. The diffing interface
 

--- a/docs/ide-integration/index.md
+++ b/docs/ide-integration/index.md
@@ -15,8 +15,8 @@ support VS Code extensions. To build support for other editors, see the
   to provide more relevant and accurate responses. This context includes:
   - The **10 most recently accessed files** in your workspace.
   - Your active cursor position.
-  - Any text you have selected (up to a 16KB limit; longer selections will be
-    truncated).
+  - Any text you have selected (up to a 16KB limit; longer selections are
+    truncated and indicated with a `... [TRUNCATED]` suffix).
 
 - **Native diffing:** When Gemini suggests code modifications, you can view the
   changes directly within your IDE's native diff viewer. This allows you to

--- a/packages/vscode-ide-companion/README.md
+++ b/packages/vscode-ide-companion/README.md
@@ -11,8 +11,9 @@ compatible with both VS Code and VS Code forks.
   project's structure and content.
 
 - Selection Context: Gemini CLI can easily access your cursor's position and
-  selected text within the editor, giving it valuable context directly from your
-  current work.
+  selected text within the editor (up to 16KB; longer selections are truncated
+  with a `... [TRUNCATED]` indicator), giving it valuable context directly from
+  your current work.
 
 - Native Diffing: Seamlessly view, modify, and accept code changes suggested by
   Gemini CLI directly within the editor.

--- a/packages/vscode-ide-companion/src/open-files-manager.test.ts
+++ b/packages/vscode-ide-companion/src/open-files-manager.test.ts
@@ -355,7 +355,9 @@ describe('OpenFilesManager', () => {
     const manager = new OpenFilesManager(context);
     const uri = getUri('/test/file1.txt');
     const longText = 'a'.repeat(20000);
-    const truncatedText = longText.substring(0, 16384);
+    const suffix = '... [TRUNCATED]';
+    const maxContentLength = 16384 - suffix.length;
+    const truncatedText = longText.substring(0, maxContentLength) + suffix;
 
     const selection = {
       active: { line: 10, character: 20 },
@@ -382,6 +384,8 @@ describe('OpenFilesManager', () => {
 
     const file = manager.state.workspaceState!.openFiles![0];
     expect(file.selectedText).toBe(truncatedText);
+    expect(file.selectedText).toHaveLength(16384);
+    expect(file.selectedText!.endsWith(suffix)).toBe(true);
   });
 
   it('deactivates the previously active file', async () => {

--- a/packages/vscode-ide-companion/src/open-files-manager.ts
+++ b/packages/vscode-ide-companion/src/open-files-manager.ts
@@ -12,6 +12,8 @@ import type {
 
 export const MAX_FILES = 10;
 const MAX_SELECTED_TEXT_LENGTH = 16384; // 16 KiB limit
+/** Suffix appended when selected text is truncated; must stay in sync with core ideContext. */
+const TRUNCATION_SUFFIX = '... [TRUNCATED]';
 
 /**
  * Keeps track of the workspace state, including open files, cursor position, and selected text.
@@ -156,7 +158,10 @@ export class OpenFilesManager {
     let selectedText: string | undefined =
       editor.document.getText(editor.selection) || undefined;
     if (selectedText && selectedText.length > MAX_SELECTED_TEXT_LENGTH) {
-      selectedText = selectedText.substring(0, MAX_SELECTED_TEXT_LENGTH);
+      const maxContentLength =
+        MAX_SELECTED_TEXT_LENGTH - TRUNCATION_SUFFIX.length;
+      selectedText =
+        selectedText.substring(0, maxContentLength) + TRUNCATION_SUFFIX;
     }
     file.selectedText = selectedText;
   }


### PR DESCRIPTION
## Summary
When the VS Code extension truncates the user's selected text to the 16KB limit, it now appends the same suffix the core uses (`... [TRUNCATED]`) so the model and tooling know the selection was truncated.

## Changes
- **`packages/vscode-ide-companion/src/open-files-manager.ts`**: Added `TRUNCATION_SUFFIX` and, when selection length exceeds 16KB, truncate to `MAX_SELECTED_TEXT_LENGTH - suffix.length` and append the suffix so total length stays within the limit. Aligns with `packages/core/src/ide/ideContext.ts` and `textUtils.truncateString`.
- **`packages/vscode-ide-companion/src/open-files-manager.test.ts`**: Updated the "truncates long selected text" test to expect the new truncated string with suffix and to assert length and `endsWith(suffix)`.

## Why
Previously, truncated selection was sent as exactly 16384 characters with no indication it was cut. The core only adds the suffix when it truncates; if the extension sent exactly 16384 chars, the model never saw that the selection was truncated. Appending the suffix in the extension makes behavior consistent and gives the model explicit truncation feedback.

## Testing
- `npm run test --workspace gemini-cli-vscode-ide-companion -- src/open-files-manager.test.ts` — 17 tests pass.

When the extension truncates selected text to 16KB, append '... [TRUNCATED]' so the model receives a clear signal that the selection was cut. Aligns with core ideContext truncation behavior and avoids silent truncation.


## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
