### PR TITLE
chore(lint): fix lint errors seen when running npm run lint

### DIFF
--- a/packages/a2a-server/src/agent/task.test.ts
+++ b/packages/a2a-server/src/agent/task.test.ts
@@ -14,19 +14,21 @@ import {
   type Mock,
 } from 'vitest';
 import { Task } from './task.js';
+import type {
+  ToolCall,
+  Config,
+  ToolCallRequestInfo,
+  GitService,
+  CompletedToolCall,
+} from '@google/gemini-cli-core';
 import {
   GeminiEventType,
-  type Config,
-  type ToolCallRequestInfo,
-  type GitService,
-  type CompletedToolCall,
   ApprovalMode,
   ToolConfirmationOutcome,
 } from '@google/gemini-cli-core';
 import { createMockConfig } from '../utils/testing_utils.js';
 import type { ExecutionEventBus, RequestContext } from '@a2a-js/sdk/server';
 import { CoderAgentEvent } from '../types.js';
-import type { ToolCall } from '@google/gemini-cli-core';
 
 const mockProcessRestorableToolCalls = vi.hoisted(() => vi.fn());
 

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -30,8 +30,7 @@ import {
   EDIT_TOOL_NAMES,
   processRestorableToolCalls,
 } from '@google/gemini-cli-core';
-import type { RequestContext } from '@a2a-js/sdk/server';
-import { type ExecutionEventBus } from '@a2a-js/sdk/server';
+import type { RequestContext, ExecutionEventBus } from '@a2a-js/sdk/server';
 import type {
   TaskStatusUpdateEvent,
   TaskArtifactUpdateEvent,

--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -8,17 +8,19 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as dotenv from 'dotenv';
 
-import type { TelemetryTarget } from '@google/gemini-cli-core';
+import type {
+  TelemetryTarget,
+  ConfigParameters,
+  ExtensionLoader,
+} from '@google/gemini-cli-core';
 import {
   AuthType,
   Config,
-  type ConfigParameters,
   FileDiscoveryService,
   ApprovalMode,
   loadServerHierarchicalMemory,
   GEMINI_DIR,
   DEFAULT_GEMINI_EMBEDDING_MODEL,
-  type ExtensionLoader,
   startupProfiler,
   PREVIEW_GEMINI_MODEL,
   homedir,

--- a/packages/a2a-server/src/http/app.test.ts
+++ b/packages/a2a-server/src/http/app.test.ts
@@ -4,12 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Config } from '@google/gemini-cli-core';
-import {
-  GeminiEventType,
-  ApprovalMode,
-  type ToolCallConfirmationDetails,
+import type {
+  Config,
+  ToolCallConfirmationDetails,
 } from '@google/gemini-cli-core';
+import { GeminiEventType, ApprovalMode } from '@google/gemini-cli-core';
 import type {
   TaskStatusUpdateEvent,
   SendStreamingMessageSuccessResponse,

--- a/packages/core/src/agents/a2a-client-manager.test.ts
+++ b/packages/core/src/agents/a2a-client-manager.test.ts
@@ -11,12 +11,13 @@ import {
 } from './a2a-client-manager.js';
 import type { AgentCard, Task } from '@a2a-js/sdk';
 import type { AuthenticationHandler, Client } from '@a2a-js/sdk/client';
-import { ClientFactory, DefaultAgentCardResolver } from '@a2a-js/sdk/client';
-import { debugLogger } from '../utils/debugLogger.js';
 import {
+  ClientFactory,
+  DefaultAgentCardResolver,
   createAuthenticatingFetchWithRetry,
   ClientFactoryOptions,
 } from '@a2a-js/sdk/client';
+import { debugLogger } from '../utils/debugLogger.js';
 
 vi.mock('../utils/debugLogger.js', () => ({
   debugLogger: {

--- a/packages/core/src/agents/agentLoader.ts
+++ b/packages/core/src/agents/agentLoader.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import yaml from 'js-yaml';
+import { load } from 'js-yaml';
 import * as fs from 'node:fs/promises';
 import { type Dirent } from 'node:fs';
 import * as path from 'node:path';
@@ -262,7 +262,7 @@ export async function parseAgentMarkdown(
 
   let rawFrontmatter: unknown;
   try {
-    rawFrontmatter = yaml.load(frontmatterStr);
+    rawFrontmatter = load(frontmatterStr);
   } catch (error) {
     throw new AgentLoadError(
       filePath,

--- a/packages/core/src/agents/local-invocation.test.ts
+++ b/packages/core/src/agents/local-invocation.test.ts
@@ -5,10 +5,13 @@
  */
 
 import { describe, it, expect, vi, beforeEach, type Mocked } from 'vitest';
-import type { LocalAgentDefinition } from './types.js';
+import type {
+  LocalAgentDefinition,
+  SubagentActivityEvent,
+  AgentInputs,
+} from './types.js';
 import { LocalSubagentInvocation } from './local-invocation.js';
 import { LocalAgentExecutor } from './local-executor.js';
-import type { SubagentActivityEvent, AgentInputs } from './types.js';
 import { AgentTerminateMode } from './types.js';
 import { makeFakeConfig } from '../test-utils/config.js';
 import { ToolErrorType } from '../tools/tool-error.js';

--- a/packages/core/src/agents/registry.test.ts
+++ b/packages/core/src/agents/registry.test.ts
@@ -8,7 +8,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AgentRegistry, getModelConfigAlias } from './registry.js';
 import { makeFakeConfig } from '../test-utils/config.js';
 import type { AgentDefinition, LocalAgentDefinition } from './types.js';
-import type { Config, GeminiCLIExtension } from '../config/config.js';
+import type {
+  Config,
+  GeminiCLIExtension,
+  ConfigParameters,
+} from '../config/config.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { coreEvents, CoreEvent } from '../utils/events.js';
 import { A2AClientManager } from './a2a-client-manager.js';
@@ -22,7 +26,6 @@ import {
 } from '../config/models.js';
 import * as tomlLoader from './agentLoader.js';
 import { SimpleExtensionLoader } from '../utils/extensionLoader.js';
-import type { ConfigParameters } from '../config/config.js';
 import type { ToolRegistry } from '../tools/tool-registry.js';
 import { ThinkingLevel } from '@google/genai';
 import type { AcknowledgedAgentsService } from './acknowledgedAgents.js';

--- a/packages/core/src/agents/remote-invocation.ts
+++ b/packages/core/src/agents/remote-invocation.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ToolConfirmationOutcome } from '../tools/tools.js';
-import {
-  BaseToolInvocation,
-  type ToolResult,
-  type ToolCallConfirmationDetails,
+import type {
+  ToolConfirmationOutcome,
+  ToolResult,
+  ToolCallConfirmationDetails,
 } from '../tools/tools.js';
+import { BaseToolInvocation } from '../tools/tools.js';
 import { DEFAULT_QUERY_STRING } from './types.js';
 import type {
   RemoteAgentInputs,

--- a/packages/core/src/code_assist/converter.test.ts
+++ b/packages/core/src/code_assist/converter.test.ts
@@ -14,12 +14,12 @@ import {
 import type {
   ContentListUnion,
   GenerateContentParameters,
+  Part,
 } from '@google/genai';
 import {
   GenerateContentResponse,
   FinishReason,
   BlockedReason,
-  type Part,
 } from '@google/genai';
 
 describe('converter', () => {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -20,6 +20,7 @@ import { setGeminiMdFilename as mockSetGeminiMdFilename } from '../tools/memoryT
 import {
   DEFAULT_TELEMETRY_TARGET,
   DEFAULT_OTLP_ENDPOINT,
+  uiTelemetryService,
 } from '../telemetry/index.js';
 import type { ContentGeneratorConfig } from '../core/contentGenerator.js';
 import {
@@ -201,14 +202,15 @@ vi.mock('../services/contextManager.js', () => ({
 
 import { BaseLlmClient } from '../core/baseLlmClient.js';
 import { tokenLimit } from '../core/tokenLimits.js';
-import { uiTelemetryService } from '../telemetry/index.js';
 import { getCodeAssistServer } from '../code_assist/codeAssist.js';
 import { getExperiments } from '../code_assist/experiments/experiments.js';
 import type { CodeAssistServer } from '../code_assist/server.js';
 import { ContextManager } from '../services/contextManager.js';
 import { UserTierId } from '../code_assist/types.js';
-import type { ModelConfigService } from '../services/modelConfigService.js';
-import type { ModelConfigServiceConfig } from '../services/modelConfigService.js';
+import type {
+  ModelConfigService,
+  ModelConfigServiceConfig,
+} from '../services/modelConfigService.js';
 import { ExitPlanModeTool } from '../tools/exit-plan-mode.js';
 import { EnterPlanModeTool } from '../tools/enter-plan-mode.js';
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -68,7 +68,12 @@ import { ideContextStore } from '../ide/ideContext.js';
 import { WriteTodosTool } from '../tools/write-todos.js';
 import type { FileSystemService } from '../services/fileSystemService.js';
 import { StandardFileSystemService } from '../services/fileSystemService.js';
-import { logRipgrepFallback, logFlashFallback } from '../telemetry/loggers.js';
+import {
+  logRipgrepFallback,
+  logFlashFallback,
+  logApprovalModeSwitch,
+  logApprovalModeDuration,
+} from '../telemetry/loggers.js';
 import {
   RipgrepFallbackEvent,
   FlashFallbackEvent,
@@ -103,9 +108,11 @@ import type { EventEmitter } from 'node:events';
 import { PolicyEngine } from '../policy/policy-engine.js';
 import { ApprovalMode, type PolicyEngineConfig } from '../policy/types.js';
 import { HookSystem } from '../hooks/index.js';
-import type { UserTierId } from '../code_assist/types.js';
-import type { RetrieveUserQuotaResponse } from '../code_assist/types.js';
-import type { AdminControlsSettings } from '../code_assist/types.js';
+import type {
+  UserTierId,
+  RetrieveUserQuotaResponse,
+  AdminControlsSettings,
+} from '../code_assist/types.js';
 import type { HierarchicalMemory } from './memory.js';
 import { getCodeAssistServer } from '../code_assist/codeAssist.js';
 import type { Experiments } from '../code_assist/experiments/experiments.js';
@@ -119,10 +126,6 @@ import { debugLogger } from '../utils/debugLogger.js';
 import { SkillManager, type SkillDefinition } from '../skills/skillManager.js';
 import { startupProfiler } from '../telemetry/startupProfiler.js';
 import type { AgentDefinition } from '../agents/types.js';
-import {
-  logApprovalModeSwitch,
-  logApprovalModeDuration,
-} from '../telemetry/loggers.js';
 import { fetchAdminControls } from '../code_assist/admin/admin_controls.js';
 import { isSubpath } from '../utils/paths.js';
 import { UserHintService } from './userHintService.js';

--- a/packages/core/src/core/baseLlmClient.test.ts
+++ b/packages/core/src/core/baseLlmClient.test.ts
@@ -15,22 +15,24 @@ import {
   type Mock,
 } from 'vitest';
 
-import { BaseLlmClient, type GenerateJsonOptions } from './baseLlmClient.js';
+import type {
+  GenerateContentOptions,
+  GenerateJsonOptions,
+} from './baseLlmClient.js';
+import { BaseLlmClient } from './baseLlmClient.js';
 import type { ContentGenerator } from './contentGenerator.js';
 import type { ModelAvailabilityService } from '../availability/modelAvailabilityService.js';
 import { createAvailabilityServiceMock } from '../availability/testUtils.js';
-import type { GenerateContentOptions } from './baseLlmClient.js';
 import type { GenerateContentResponse } from '@google/genai';
 import type { Config } from '../config/config.js';
 import { AuthType } from './contentGenerator.js';
 import { reportError } from '../utils/errorReporting.js';
 import { logMalformedJsonResponse } from '../telemetry/loggers.js';
 import { retryWithBackoff } from '../utils/retry.js';
-import { MalformedJsonResponseEvent } from '../telemetry/types.js';
+import { MalformedJsonResponseEvent, LlmRole } from '../telemetry/types.js';
 import { getErrorMessage } from '../utils/errors.js';
 import type { ModelConfigService } from '../services/modelConfigService.js';
 import { makeResolvedModelConfig } from '../services/modelConfigServiceTestUtils.js';
-import { LlmRole } from '../telemetry/types.js';
 
 vi.mock('../utils/errorReporting.js');
 vi.mock('../telemetry/loggers.js');

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -17,8 +17,7 @@ import {
   getInitialChatHistory,
 } from '../utils/environmentContext.js';
 import type { ServerGeminiStreamEvent, ChatCompressionInfo } from './turn.js';
-import { CompressionStatus } from './turn.js';
-import { Turn, GeminiEventType } from './turn.js';
+import { CompressionStatus, Turn, GeminiEventType } from './turn.js';
 import type { Config } from '../config/config.js';
 import { getCoreSystemPrompt } from './prompts.js';
 import { checkNextSpeaker } from '../utils/nextSpeakerChecker.js';

--- a/packages/core/src/core/coreToolHookTriggers.ts
+++ b/packages/core/src/core/coreToolHookTriggers.ts
@@ -6,11 +6,14 @@
 
 import { type McpToolContext, BeforeToolHookOutput } from '../hooks/types.js';
 import type { Config } from '../config/config.js';
-import type { ToolResult, AnyDeclarativeTool } from '../tools/tools.js';
+import type {
+  ToolResult,
+  AnyDeclarativeTool,
+  AnyToolInvocation,
+} from '../tools/tools.js';
 import { ToolErrorType } from '../tools/tool-error.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import type { AnsiOutput, ShellExecutionConfig } from '../index.js';
-import type { AnyToolInvocation } from '../tools/tools.js';
 import { ShellToolInvocation } from '../tools/shell.js';
 import { DiscoveredMCPToolInvocation } from '../tools/mcp-tool.js';
 

--- a/packages/core/src/hooks/hookAggregator.ts
+++ b/packages/core/src/hooks/hookAggregator.ts
@@ -17,8 +17,8 @@ import {
   BeforeToolSelectionHookOutput,
   AfterModelHookOutput,
   AfterAgentHookOutput,
+  HookEventName,
 } from './types.js';
-import { HookEventName } from './types.js';
 
 /**
  * Aggregated hook result

--- a/packages/core/src/hooks/hookEventHandler.test.ts
+++ b/packages/core/src/hooks/hookEventHandler.test.ts
@@ -11,16 +11,16 @@ import type {
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { HookEventHandler } from './hookEventHandler.js';
 import type { Config } from '../config/config.js';
-import type { HookConfig } from './types.js';
-import type { HookPlanner } from './hookPlanner.js';
-import type { HookRunner } from './hookRunner.js';
-import type { HookAggregator } from './hookAggregator.js';
-import { HookEventName, HookType } from './types.js';
+import type { HookConfig, HookExecutionResult } from './types.js';
 import {
   NotificationType,
   SessionStartSource,
-  type HookExecutionResult,
+  HookEventName,
+  HookType,
 } from './types.js';
+import type { HookPlanner } from './hookPlanner.js';
+import type { HookRunner } from './hookRunner.js';
+import type { HookAggregator } from './hookAggregator.js';
 
 // Mock debugLogger
 const mockDebugLogger = vi.hoisted(() => ({

--- a/packages/core/src/hooks/hookPlanner.ts
+++ b/packages/core/src/hooks/hookPlanner.ts
@@ -5,8 +5,8 @@
  */
 
 import type { HookRegistry, HookRegistryEntry } from './hookRegistry.js';
-import type { HookExecutionPlan } from './types.js';
-import { getHookKey, type HookEventName } from './types.js';
+import type { HookExecutionPlan, HookEventName } from './types.js';
+import { getHookKey } from './types.js';
 import { debugLogger } from '../utils/debugLogger.js';
 
 /**

--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -8,8 +8,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { HookRunner } from './hookRunner.js';
 import { HookEventName, HookType, ConfigSource } from './types.js';
-import type { HookConfig } from './types.js';
-import type { HookInput } from './types.js';
+import type { HookConfig, HookInput } from './types.js';
 import type { Readable, Writable } from 'node:stream';
 import type { Config } from '../config/config.js';
 

--- a/packages/core/src/ide/ide-installer.test.ts
+++ b/packages/core/src/ide/ide-installer.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal();
@@ -24,7 +24,6 @@ vi.mock('../utils/paths.js', async (importOriginal) => {
   };
 });
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { getIdeInstaller } from './ide-installer.js';
 import * as child_process from 'node:child_process';
 import * as fs from 'node:fs';

--- a/packages/core/src/scheduler/state-manager.ts
+++ b/packages/core/src/scheduler/state-manager.ts
@@ -17,8 +17,7 @@ import type {
   ExecutingToolCall,
   ToolCallResponseInfo,
 } from './types.js';
-import { CoreToolCallStatus } from './types.js';
-import { ROOT_SCHEDULER_ID } from './types.js';
+import { CoreToolCallStatus, ROOT_SCHEDULER_ID } from './types.js';
 import type {
   ToolConfirmationOutcome,
   ToolResultDisplay,

--- a/packages/core/src/scheduler/tool-executor.test.ts
+++ b/packages/core/src/scheduler/tool-executor.test.ts
@@ -6,13 +6,12 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ToolExecutor } from './tool-executor.js';
-import type { Config } from '../index.js';
+import type { Config, AnyToolInvocation } from '../index.js';
 import type { ToolResult } from '../tools/tools.js';
 import { makeFakeConfig } from '../test-utils/config.js';
 import { MockTool } from '../test-utils/mock-tool.js';
 import type { ScheduledToolCall } from './types.js';
 import { CoreToolCallStatus } from './types.js';
-import type { AnyToolInvocation } from '../index.js';
 import { SHELL_TOOL_NAME } from '../tools/tool-names.js';
 import * as fileUtils from '../utils/fileUtils.js';
 import * as coreToolHookTriggers from '../core/coreToolHookTriggers.js';

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -12,7 +12,7 @@ import { tokenLimit } from '../core/tokenLimits.js';
 import { getCompressionPrompt } from '../core/prompts.js';
 import { getResponseText } from '../utils/partUtils.js';
 import { logChatCompression } from '../telemetry/loggers.js';
-import { makeChatCompressionEvent } from '../telemetry/types.js';
+import { makeChatCompressionEvent, LlmRole } from '../telemetry/types.js';
 import {
   saveTruncatedToolOutput,
   formatTruncatedToolOutput,
@@ -32,7 +32,6 @@ import {
   PREVIEW_GEMINI_3_1_MODEL,
 } from '../config/models.js';
 import { PreCompressTrigger } from '../hooks/types.js';
-import { LlmRole } from '../telemetry/types.js';
 
 /**
  * Default threshold for compression token count as a fraction of the model's

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -18,6 +18,7 @@ import {
   LoopDetectionDisabledEvent,
   LoopType,
   LlmLoopCheckEvent,
+  LlmRole,
 } from '../telemetry/types.js';
 import type { Config } from '../config/config.js';
 import {
@@ -25,7 +26,6 @@ import {
   isFunctionResponse,
 } from '../utils/messageInspectors.js';
 import { debugLogger } from '../utils/debugLogger.js';
-import { LlmRole } from '../telemetry/types.js';
 
 const TOOL_CALL_LOOP_THRESHOLD = 5;
 const CONTENT_LOOP_THRESHOLD = 10;

--- a/packages/core/src/skills/skillLoader.ts
+++ b/packages/core/src/skills/skillLoader.ts
@@ -7,7 +7,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { glob } from 'glob';
-import yaml from 'js-yaml';
+import { load } from 'js-yaml';
 import { debugLogger } from '../utils/debugLogger.js';
 import { coreEvents } from '../utils/events.js';
 
@@ -40,7 +40,7 @@ function parseFrontmatter(
   content: string,
 ): { name: string; description: string } | null {
   try {
-    const parsed = yaml.load(content);
+    const parsed = load(content);
     if (parsed && typeof parsed === 'object') {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       const { name, description } = parsed as Record<string, unknown>;

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'vitest';
 import {
   vi,
   describe,

--- a/packages/core/src/telemetry/gcp-exporters.ts
+++ b/packages/core/src/telemetry/gcp-exporters.ts
@@ -9,9 +9,8 @@ import { TraceExporter } from '@google-cloud/opentelemetry-cloud-trace-exporter'
 import { MetricExporter } from '@google-cloud/opentelemetry-cloud-monitoring-exporter';
 import { Logging } from '@google-cloud/logging';
 import type { Log } from '@google-cloud/logging';
-import { hrTimeToMilliseconds } from '@opentelemetry/core';
+import { hrTimeToMilliseconds, ExportResultCode } from '@opentelemetry/core';
 import type { ExportResult } from '@opentelemetry/core';
-import { ExportResultCode } from '@opentelemetry/core';
 import type {
   ReadableLogRecord,
   LogRecordExporter,

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -10,6 +10,7 @@ import type {
   CompletedToolCall,
   ContentGeneratorConfig,
   ErroredToolCall,
+  MessageBus,
 } from '../index.js';
 import {
   CoreToolCallStatus,
@@ -19,11 +20,10 @@ import {
   ToolConfirmationOutcome,
   ToolErrorType,
   ToolRegistry,
-  type MessageBus,
 } from '../index.js';
 import { OutputFormat } from '../output/types.js';
 import { logs } from '@opentelemetry/api-logs';
-import type { Config } from '../config/config.js';
+import type { Config, GeminiCLIExtension } from '../config/config.js';
 import {
   logApiError,
   logApiRequest,
@@ -100,7 +100,6 @@ import { FileOperation } from './metrics.js';
 import * as sdk from './sdk.js';
 import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 import { vi, describe, beforeEach, it, expect, afterEach } from 'vitest';
-import { type GeminiCLIExtension } from '../config/config.js';
 import {
   FinishReason,
   type CallableTool,

--- a/packages/core/src/telemetry/uiTelemetry.test.ts
+++ b/packages/core/src/telemetry/uiTelemetry.test.ts
@@ -8,8 +8,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { UiTelemetryService } from './uiTelemetry.js';
 import { ToolCallDecision } from './tool-call-decision.js';
 import type { ApiErrorEvent, ApiResponseEvent } from './types.js';
-import { ToolCallEvent } from './types.js';
 import {
+  ToolCallEvent,
   EVENT_API_ERROR,
   EVENT_API_RESPONSE,
   EVENT_TOOL_CALL,

--- a/packages/core/src/telemetry/uiTelemetry.ts
+++ b/packages/core/src/telemetry/uiTelemetry.ts
@@ -16,9 +16,8 @@ import type {
   ApiErrorEvent,
   ApiResponseEvent,
   ToolCallEvent,
+  LlmRole,
 } from './types.js';
-
-import type { LlmRole } from './types.js';
 
 export type UiEvent =
   | (ApiResponseEvent & { 'event.name': typeof EVENT_API_RESPONSE })

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -38,10 +38,11 @@ import {
 import { IdeClient } from '../ide/ide-client.js';
 import { FixLLMEditWithInstruction } from '../utils/llm-edit-fixer.js';
 import { safeLiteralReplace, detectLineEnding } from '../utils/textUtils.js';
-import { EditStrategyEvent } from '../telemetry/types.js';
-import { logEditStrategy } from '../telemetry/loggers.js';
-import { EditCorrectionEvent } from '../telemetry/types.js';
-import { logEditCorrectionEvent } from '../telemetry/loggers.js';
+import { EditStrategyEvent, EditCorrectionEvent } from '../telemetry/types.js';
+import {
+  logEditStrategy,
+  logEditCorrectionEvent,
+} from '../telemetry/loggers.js';
 
 import { correctPath } from '../utils/pathCorrector.js';
 import {

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -10,13 +10,13 @@ import type {
   ToolInvocation,
   ToolMcpConfirmationDetails,
   ToolResult,
+  PolicyUpdateOptions,
 } from './tools.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
   Kind,
   ToolConfirmationOutcome,
-  type PolicyUpdateOptions,
 } from './tools.js';
 import type { CallableTool, FunctionCall, Part } from '@google/genai';
 import { ToolErrorType } from './tool-error.js';

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -42,7 +42,7 @@ vi.mock('crypto');
 vi.mock('../utils/summarizer.js');
 
 import { initializeShellParsers } from '../utils/shell-utils.js';
-import { ShellTool } from './shell.js';
+import { ShellTool, OUTPUT_UPDATE_INTERVAL_MS } from './shell.js';
 import { debugLogger } from '../index.js';
 import { type Config } from '../config/config.js';
 import {
@@ -58,7 +58,6 @@ import * as crypto from 'node:crypto';
 import * as summarizer from '../utils/summarizer.js';
 import { ToolErrorType } from './tool-error.js';
 import { ToolConfirmationOutcome } from './tools.js';
-import { OUTPUT_UPDATE_INTERVAL_MS } from './shell.js';
 import { SHELL_TOOL_NAME } from './tool-names.js';
 import { WorkspaceContext } from '../utils/workspaceContext.js';
 import {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -16,13 +16,13 @@ import type {
   ToolResult,
   ToolCallConfirmationDetails,
   ToolExecuteConfirmationDetails,
+  PolicyUpdateOptions,
 } from './tools.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
   ToolConfirmationOutcome,
   Kind,
-  type PolicyUpdateOptions,
 } from './tools.js';
 
 import { getErrorMessage } from '../utils/errors.js';

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -8,13 +8,9 @@ import type {
   ToolCallConfirmationDetails,
   ToolInvocation,
   ToolResult,
+  ToolConfirmationOutcome,
 } from './tools.js';
-import {
-  BaseDeclarativeTool,
-  BaseToolInvocation,
-  Kind,
-  type ToolConfirmationOutcome,
-} from './tools.js';
+import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { ToolErrorType } from './tool-error.js';
 import { getErrorMessage } from '../utils/errors.js';

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -20,13 +20,9 @@ import type {
   ToolInvocation,
   ToolLocation,
   ToolResult,
+  ToolConfirmationOutcome,
 } from './tools.js';
-import {
-  BaseDeclarativeTool,
-  BaseToolInvocation,
-  Kind,
-  type ToolConfirmationOutcome,
-} from './tools.js';
+import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
 import { ToolErrorType } from './tool-error.js';
 import { makeRelative, shortenPath } from '../utils/paths.js';
 import { getErrorMessage, isNodeError } from '../utils/errors.js';

--- a/packages/core/src/tools/write-todos.ts
+++ b/packages/core/src/tools/write-todos.ts
@@ -4,14 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ToolInvocation } from './tools.js';
-import {
-  BaseDeclarativeTool,
-  BaseToolInvocation,
-  Kind,
-  type Todo,
-  type ToolResult,
-} from './tools.js';
+import type { ToolInvocation, Todo, ToolResult } from './tools.js';
+import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { WRITE_TODOS_TOOL_NAME } from './tool-names.js';
 import { WRITE_TODOS_DEFINITION } from './definitions/coreTools.js';

--- a/packages/core/src/utils/editCorrector.test.ts
+++ b/packages/core/src/utils/editCorrector.test.ts
@@ -5,8 +5,8 @@
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { Mock } from 'vitest';
-import { vi, describe, it, expect, beforeEach, type Mocked } from 'vitest';
+import type { Mock, Mocked } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import * as fs from 'node:fs';
 import { EDIT_TOOL_NAME } from '../tools/tool-names.js';
 import type { BaseLlmClient } from '../core/baseLlmClient.js';

--- a/packages/core/src/utils/getFolderStructure.test.ts
+++ b/packages/core/src/utils/getFolderStructure.test.ts
@@ -6,7 +6,6 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fsPromises from 'node:fs/promises';
-import * as nodePath from 'node:path';
 import * as os from 'node:os';
 import { getFolderStructure } from './getFolderStructure.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
@@ -251,7 +250,7 @@ ${testRootDir}${path.sep}
 
     it('should ignore files and folders specified in .gitignore', async () => {
       await fsPromises.writeFile(
-        nodePath.join(testRootDir, '.gitignore'),
+        path.join(testRootDir, '.gitignore'),
         'ignored.txt\nnode_modules/\n.gemini/*\n!/.gemini/config.yaml',
       );
       await createTestFile('file1.txt');
@@ -274,7 +273,7 @@ ${testRootDir}${path.sep}
 
     it('should not ignore files if respectGitIgnore is false', async () => {
       await fsPromises.writeFile(
-        nodePath.join(testRootDir, '.gitignore'),
+        path.join(testRootDir, '.gitignore'),
         'ignored.txt',
       );
       await createTestFile('file1.txt');
@@ -298,7 +297,7 @@ ${testRootDir}${path.sep}
   describe('with geminiignore', () => {
     it('should ignore geminiignore files by default', async () => {
       await fsPromises.writeFile(
-        nodePath.join(testRootDir, GEMINI_IGNORE_FILE_NAME),
+        path.join(testRootDir, GEMINI_IGNORE_FILE_NAME),
         'ignored.txt\nnode_modules/\n.gemini/\n!/.gemini/config.yaml',
       );
       await createTestFile('file1.txt');
@@ -318,7 +317,7 @@ ${testRootDir}${path.sep}
 
     it('should not ignore files if respectGeminiIgnore is false', async () => {
       await fsPromises.writeFile(
-        nodePath.join(testRootDir, GEMINI_IGNORE_FILE_NAME),
+        path.join(testRootDir, GEMINI_IGNORE_FILE_NAME),
         'ignored.txt\nnode_modules/\n.gemini/\n!/.gemini/config.yaml',
       );
       await createTestFile('file1.txt');

--- a/packages/core/src/utils/memoryDiscovery.test.ts
+++ b/packages/core/src/utils/memoryDiscovery.test.ts
@@ -22,7 +22,7 @@ import {
 } from '../tools/memoryTool.js';
 import { flattenMemory } from '../config/memory.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
-import { GEMINI_DIR, normalizePath } from './paths.js';
+import { GEMINI_DIR, normalizePath, homedir as pathsHomedir } from './paths.js';
 import type { HierarchicalMemory } from '../config/memory.js';
 
 function flattenResult(result: {
@@ -61,8 +61,6 @@ vi.mock('../utils/paths.js', async (importOriginal) => {
     homedir: vi.fn(),
   };
 });
-
-import { homedir as pathsHomedir } from './paths.js';
 
 describe('memoryDiscovery', () => {
   const DEFAULT_FOLDER_TRUST = true;


### PR DESCRIPTION
## Summary

This PR addresses and fixes various lint errors reported when running `npm run lint` across `packages/a2a-server` and `packages/core`.

## Details

The changes include:
- Reordering and consolidating imports (combining type-only and value imports) to adhere to project standards.
- Updating `js-yaml` usage from `yaml.load` to `load` to comply with the latest API.
- Removing unused imports and fixing minor stylistic inconsistencies in test files.
These fixes ensure that the codebase remains clean and passes CI linting checks.

## Related Issues

None.

## How to Validate

1. Run `npm run lint` from the project root.
2. Confirm that no linting errors are reported for the modified packages.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
