### PR TITLE
Support verbose mode for subagents

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -965,7 +965,7 @@ const SETTINGS_SCHEMA = {
         label: 'Subagent Verbose Mode',
         category: 'Advanced',
         requiresRestart: false,
-        default: true,
+        default: false,
         description:
           'When true, stream subagent thinking and action logs (thoughts, tool calls, errors) into the conversation for debugging. When false, only minimal output is shown.',
         showInDialog: false,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -960,6 +960,16 @@ const SETTINGS_SCHEMA = {
     description: 'Settings for subagents.',
     showInDialog: false,
     properties: {
+      verbose: {
+        type: 'boolean',
+        label: 'Subagent Verbose Mode',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: true,
+        description:
+          'When true, stream subagent thinking and action logs (thoughts, tool calls, errors) into the conversation for debugging. When false, only minimal output is shown.',
+        showInDialog: false,
+      },
       overrides: {
         type: 'object',
         label: 'Agent Overrides',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -201,6 +201,7 @@ export interface AgentOverride {
 
 export interface AgentSettings {
   overrides?: Record<string, AgentOverride>;
+  verbose?: boolean;
 }
 
 export interface CustomTheme {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1084,6 +1084,13 @@
       "default": {},
       "type": "object",
       "properties": {
+        "verbose": {
+          "title": "Subagent Verbose Mode",
+          "description": "When true, stream subagent thinking and action logs (thoughts, tool calls, errors) into the conversation for debugging. When false, only minimal output is shown.",
+          "markdownDescription": "When true, stream subagent thinking and action logs (thoughts, tool calls, errors) into the conversation for debugging. When false, only minimal output is shown.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `true`",
+          "default": true,
+          "type": "boolean"
+        },
         "overrides": {
           "title": "Agent Overrides",
           "description": "Override settings for specific agents, e.g. to disable the agent, set a custom model config, or run config.",


### PR DESCRIPTION
## Summary

Adds a configurable **verbose mode** for subagents so their thinking, tool calls, and errors are streamed into the conversation history (like the main agent). When verbose is off, only minimal output is shown. This addresses poor debuggability when subagents fail.

## Details

- **New setting:** `agents.verbose` (boolean, default `true`). When `true`, subagent activity (thoughts, TOOL_CALL_START, TOOL_CALL_END, ERROR) is streamed to the tool output; when `false`, only thought chunks are streamed (previous behavior).
- **Implementation:** `LocalSubagentInvocation` reads `config.getAgentsSettings()?.verbose` and forwards all `SubagentActivityEvent` types to `updateOutput` when verbose is on, with clear prefixes.
- **Config/schema:** `AgentSettings` and `schemas/settings.schema.json` plus CLI `settingsSchema.ts` now include the `verbose` option.
- **Tests:** New/updated tests in `local-invocation.test.ts` for default verbose (all activities streamed) and for `verbose: false` (only initial message).

Issue: #19666

## How to Validate

1. **Enable subagents:** In settings, set `experimental.enableAgents` to `true` (and optionally `agents.verbose` to `true`; it’s the default).
2. **Run a task that uses a subagent** (e.g. one that triggers the codebase investigator or another built-in subagent).
3. **With verbose on (default):** In the conversation, confirm you see subagent thoughts.
4. **With verbose off:** Set `agents.verbose` to `false`, run again, and confirm only “Subagent starting…” and the final result appear (no tool/error lines).
5. **Unit tests:** From repo root, run:  
   `npm run test -- packages/core/src/agents/local-invocation.test.ts`  
   (or equivalent test command for this project). All tests should pass.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) — schema/settings only; no separate doc added
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any) — **None.** Default is verbose on; existing users get more output, not less.
- [ ] Validated on required platforms/methods:
  - [ ] MacOS — (npm run / npx / Docker / Podman / Seatbelt as required)
  - [ ] Windows — (npm run / npx / Docker as required)
  - [ ] Linux — (npm run / npx / Docker as required)