### PR TITLE
feat(core): remove unnecessary login verbiage from Code Assist auth

### DIFF
--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -271,7 +271,7 @@ async function initOauthClient(
 
     await triggerPostAuthCallbacks(client.credentials);
   } else {
-    const userConsent = await getConsentForOauth('Code Assist login required.');
+    const userConsent = await getConsentForOauth('');
     if (!userConsent) {
       throw new FatalCancellationError('Authentication cancelled by user.');
     }
@@ -281,8 +281,7 @@ async function initOauthClient(
     coreEvents.emit(CoreEvent.UserFeedback, {
       severity: 'info',
       message:
-        `\n\nCode Assist login required.\n` +
-        `Attempting to open authentication page in your browser.\n` +
+        `\n\nAttempting to open authentication page in your browser.\n` +
         `Otherwise navigate to:\n\n${webLogin.authUrl}\n\n\n`,
     });
     try {

--- a/packages/core/src/utils/authConsent.test.ts
+++ b/packages/core/src/utils/authConsent.test.ts
@@ -56,6 +56,25 @@ describe('getConsentForOauth', () => {
       );
     });
 
+    it('should handle empty prompt correctly', async () => {
+      const mockEmitConsentRequest = vi.spyOn(coreEvents, 'emitConsentRequest');
+      vi.spyOn(coreEvents, 'listenerCount').mockReturnValue(1);
+
+      mockEmitConsentRequest.mockImplementation((payload) => {
+        payload.onConfirm(true);
+      });
+
+      await getConsentForOauth('');
+
+      expect(mockEmitConsentRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: expect.stringMatching(
+            /^Opening authentication page in your browser\./,
+          ),
+        }),
+      );
+    });
+
     it('should return false when user declines via UI', async () => {
       const mockEmitConsentRequest = vi.spyOn(coreEvents, 'emitConsentRequest');
       vi.spyOn(coreEvents, 'listenerCount').mockReturnValue(1);

--- a/packages/core/src/utils/authConsent.ts
+++ b/packages/core/src/utils/authConsent.ts
@@ -15,7 +15,9 @@ import { isHeadlessMode } from './headless.js';
  * Handles both interactive and non-interactive (headless) modes.
  */
 export async function getConsentForOauth(prompt: string): Promise<boolean> {
-  const finalPrompt = prompt + ' Opening authentication page in your browser. ';
+  const finalPrompt =
+    (prompt ? prompt + ' ' : '') +
+    'Opening authentication page in your browser. ';
 
   if (isHeadlessMode()) {
     return getOauthConsentNonInteractive(finalPrompt);


### PR DESCRIPTION
## Summary

Removes the unnecessary "Code Assist Login required" verbiage from the login dialog and OAuth flow.

## Details

- Modified `packages/core/src/code_assist/oauth2.ts` to remove redundant login required messages.
- Updated `packages/core/src/utils/authConsent.ts` to handle empty prompts gracefully (preventing leading spaces).
- Added a unit test in `packages/core/src/utils/authConsent.test.ts` to verify empty prompt handling.

## Related Issues

Related to internal request for UI simplification.

## How to Validate

1. Run the unit tests: `npm test -w @google/gemini-cli-core -- src/utils/authConsent.test.ts src/code_assist/oauth2.test.ts`
2. Manually trigger a login flow (e.g., by clearing credentials or using a new environment) and observe the consent prompt and browser message.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
