### PR TITLE
fix(core): allow any preview model in quota access check

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -2116,6 +2116,21 @@ describe('Config Quota & Preview Model Access', () => {
       expect(config.getHasAccessToPreviewModel()).toBe(true);
     });
 
+    it('should update hasAccessToPreviewModel to true if quota includes Gemini 3.1 preview model', async () => {
+      mockCodeAssistServer.retrieveUserQuota.mockResolvedValue({
+        buckets: [
+          {
+            modelId: 'gemini-3.1-pro-preview',
+            remainingAmount: '100',
+            remainingFraction: 1.0,
+          },
+        ],
+      });
+
+      await config.refreshUserQuota();
+      expect(config.getHasAccessToPreviewModel()).toBe(true);
+    });
+
     it('should update hasAccessToPreviewModel to false if quota does not include preview model', async () => {
       mockCodeAssistServer.retrieveUserQuota.mockResolvedValue({
         buckets: [

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1500,7 +1500,8 @@ export class Config {
       }
 
       const hasAccess =
-        quota.buckets?.some((b) => b.modelId === PREVIEW_GEMINI_MODEL) ?? false;
+        quota.buckets?.some((b) => b.modelId && isPreviewModel(b.modelId)) ??
+        false;
       this.setHasAccessToPreviewModel(hasAccess);
       return quota;
     } catch (e) {

--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -36,6 +36,7 @@ describe('isPreviewModel', () => {
   it('should return true for preview models', () => {
     expect(isPreviewModel(PREVIEW_GEMINI_MODEL)).toBe(true);
     expect(isPreviewModel(PREVIEW_GEMINI_3_1_MODEL)).toBe(true);
+    expect(isPreviewModel(PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL)).toBe(true);
     expect(isPreviewModel(PREVIEW_GEMINI_FLASH_MODEL)).toBe(true);
     expect(isPreviewModel(PREVIEW_GEMINI_MODEL_AUTO)).toBe(true);
   });

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -134,6 +134,7 @@ export function isPreviewModel(model: string): boolean {
   return (
     model === PREVIEW_GEMINI_MODEL ||
     model === PREVIEW_GEMINI_3_1_MODEL ||
+    model === PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL ||
     model === PREVIEW_GEMINI_FLASH_MODEL ||
     model === PREVIEW_GEMINI_MODEL_AUTO
   );


### PR DESCRIPTION
## Summary

Fixes a bug where users with access only to Gemini 3.1 preview models are incorrectly downgraded to Gemini 2.5 because the CLI's access check specifically looks for the legacy Gemini 3.0 preview model ID (`gemini-3-pro-preview`) instead of any valid preview model.

## Details

The `refreshUserQuota()` method in `packages/core/src/config/config.ts` was hardcoded to check for `PREVIEW_GEMINI_MODEL` ('gemini-3-pro-preview'). With the launch of Gemini 3.1, users who have been transitioned to 3.1 may no longer have the 3.0 bucket in their quota.

### Changes:
- Updated `refreshUserQuota` to use the `isPreviewModel()` helper, which correctly identifies both 3.0 and 3.1 models.
- Updated `isPreviewModel()` in `packages/core/src/config/models.ts` to include `PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL` ('gemini-3.1-pro-preview-customtools'), ensuring full coverage for all 3.1 preview variants.
- Added regression tests in `packages/core/src/config/config.test.ts` and `packages/core/src/config/models.test.ts`.

## Related Issues

Fixes reported issue where users transitioned to Gemini 3.1 are unable to access Gemini 3 models.

## How to Validate

- Run the new test case in `packages/core/src/config/config.test.ts`: `npm test -w @google/gemini-cli-core -- src/config/config.test.ts`
- Run the updated tests in `packages/core/src/config/models.test.ts`: `npm test -w @google/gemini-cli-core -- src/config/models.test.ts`
- Confirm that both Gemini 3.1 Pro Preview and the custom tools variant are correctly identified as preview models.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
