### PR TITLE
fix(core): prevent omission placeholder deletions in replace/write_file

### DIFF
--- a/packages/core/src/tools/definitions/__snapshots__/coreToolsModelSnapshots.test.ts.snap
+++ b/packages/core/src/tools/definitions/__snapshots__/coreToolsModelSnapshots.test.ts.snap
@@ -547,7 +547,7 @@ A good instruction should concisely answer:
         "type": "string",
       },
       "new_string": {
-        "description": "The exact literal text to replace \`old_string\` with, preferably unescaped. Provide the EXACT text. Ensure the resulting code is correct and idiomatic.",
+        "description": "The exact literal text to replace \`old_string\` with, preferably unescaped. Provide the EXACT text. Ensure the resulting code is correct and idiomatic. Do not use omission placeholders like '(rest of methods ...)', '...', or 'unchanged code'; provide exact literal code.",
         "type": "string",
       },
       "old_string": {
@@ -665,7 +665,7 @@ exports[`coreTools snapshots for specific models > Model: gemini-2.5-pro > snaps
   "parametersJsonSchema": {
     "properties": {
       "content": {
-        "description": "The content to write to the file.",
+        "description": "The content to write to the file. Do not use omission placeholders like '(rest of methods ...)', '...', or 'unchanged code'; provide complete literal content.",
         "type": "string",
       },
       "file_path": {
@@ -1312,7 +1312,7 @@ The user has the ability to modify the \`new_string\` content. If modified, this
         "type": "string",
       },
       "new_string": {
-        "description": "The exact literal text to replace \`old_string\` with, unescaped. Provide the EXACT text. Ensure the resulting code is correct and idiomatic.",
+        "description": "The exact literal text to replace \`old_string\` with, unescaped. Provide the EXACT text. Ensure the resulting code is correct and idiomatic. Do not use omission placeholders like '(rest of methods ...)', '...', or 'unchanged code'; provide exact literal code.",
         "type": "string",
       },
       "old_string": {
@@ -1429,7 +1429,7 @@ The user has the ability to modify \`content\`. If modified, this will be stated
   "parametersJsonSchema": {
     "properties": {
       "content": {
-        "description": "The content to write to the file.",
+        "description": "The content to write to the file. Do not use omission placeholders like '(rest of methods ...)', '...', or 'unchanged code'; provide complete literal content.",
         "type": "string",
       },
       "file_path": {

--- a/packages/core/src/tools/definitions/model-family-sets/default-legacy.ts
+++ b/packages/core/src/tools/definitions/model-family-sets/default-legacy.ts
@@ -71,7 +71,8 @@ export const DEFAULT_LEGACY_SET: CoreToolSet = {
           type: 'string',
         },
         content: {
-          description: 'The content to write to the file.',
+          description:
+            "The content to write to the file. Do not use omission placeholders like '(rest of methods ...)', '...', or 'unchanged code'; provide complete literal content.",
           type: 'string',
         },
       },
@@ -332,7 +333,7 @@ A good instruction should concisely answer:
         },
         new_string: {
           description:
-            'The exact literal text to replace `old_string` with, preferably unescaped. Provide the EXACT text. Ensure the resulting code is correct and idiomatic.',
+            "The exact literal text to replace `old_string` with, preferably unescaped. Provide the EXACT text. Ensure the resulting code is correct and idiomatic. Do not use omission placeholders like '(rest of methods ...)', '...', or 'unchanged code'; provide exact literal code.",
           type: 'string',
         },
         expected_replacements: {

--- a/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts
+++ b/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts
@@ -73,7 +73,8 @@ The user has the ability to modify \`content\`. If modified, this will be stated
           type: 'string',
         },
         content: {
-          description: 'The content to write to the file.',
+          description:
+            "The content to write to the file. Do not use omission placeholders like '(rest of methods ...)', '...', or 'unchanged code'; provide complete literal content.",
           type: 'string',
         },
       },
@@ -310,7 +311,7 @@ The user has the ability to modify the \`new_string\` content. If modified, this
         },
         new_string: {
           description:
-            'The exact literal text to replace `old_string` with, unescaped. Provide the EXACT text. Ensure the resulting code is correct and idiomatic.',
+            "The exact literal text to replace `old_string` with, unescaped. Provide the EXACT text. Ensure the resulting code is correct and idiomatic. Do not use omission placeholders like '(rest of methods ...)', '...', or 'unchanged code'; provide exact literal code.",
           type: 'string',
         },
         expected_replacements: {

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -54,7 +54,7 @@ import { debugLogger } from '../utils/debugLogger.js';
 import levenshtein from 'fast-levenshtein';
 import { EDIT_DEFINITION } from './definitions/coreTools.js';
 import { resolveToolDeclaration } from './definitions/resolver.js';
-import { detectOmissionPlaceholder } from './omissionPlaceholderDetector.js';
+import { detectOmissionPlaceholders } from './omissionPlaceholderDetector.js';
 
 const ENABLE_FUZZY_MATCH_RECOVERY = true;
 const FUZZY_MATCH_THRESHOLD = 0.1; // Allow up to 10% weighted difference
@@ -974,21 +974,16 @@ export class EditTool
     }
     params.file_path = filePath;
 
-    const newPlaceholderMatch = detectOmissionPlaceholder(params.new_string);
-    if (newPlaceholderMatch.found) {
-      const oldPlaceholderMatch = detectOmissionPlaceholder(params.old_string);
-      const normalizedNewPlaceholder = newPlaceholderMatch.match
-        ?.trim()
-        .toLowerCase();
-      const normalizedOldPlaceholder = oldPlaceholderMatch.match
-        ?.trim()
-        .toLowerCase();
+    const newPlaceholders = detectOmissionPlaceholders(params.new_string);
+    if (newPlaceholders.length > 0) {
+      const oldPlaceholders = new Set(
+        detectOmissionPlaceholders(params.old_string),
+      );
 
-      if (
-        !oldPlaceholderMatch.found ||
-        normalizedOldPlaceholder !== normalizedNewPlaceholder
-      ) {
-        return "`new_string` contains an omission placeholder (for example 'rest of methods ...'). Provide exact literal replacement text.";
+      for (const placeholder of newPlaceholders) {
+        if (!oldPlaceholders.has(placeholder)) {
+          return "`new_string` contains an omission placeholder (for example 'rest of methods ...'). Provide exact literal replacement text.";
+        }
       }
     }
 

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -54,6 +54,7 @@ import { debugLogger } from '../utils/debugLogger.js';
 import levenshtein from 'fast-levenshtein';
 import { EDIT_DEFINITION } from './definitions/coreTools.js';
 import { resolveToolDeclaration } from './definitions/resolver.js';
+import { detectOmissionPlaceholder } from './omissionPlaceholderDetector.js';
 
 const ENABLE_FUZZY_MATCH_RECOVERY = true;
 const FUZZY_MATCH_THRESHOLD = 0.1; // Allow up to 10% weighted difference
@@ -972,6 +973,24 @@ export class EditTool
       filePath = result.correctedPath;
     }
     params.file_path = filePath;
+
+    const newPlaceholderMatch = detectOmissionPlaceholder(params.new_string);
+    if (newPlaceholderMatch.found) {
+      const oldPlaceholderMatch = detectOmissionPlaceholder(params.old_string);
+      const normalizedNewPlaceholder = newPlaceholderMatch.match
+        ?.trim()
+        .toLowerCase();
+      const normalizedOldPlaceholder = oldPlaceholderMatch.match
+        ?.trim()
+        .toLowerCase();
+
+      if (
+        !oldPlaceholderMatch.found ||
+        normalizedOldPlaceholder !== normalizedNewPlaceholder
+      ) {
+        return "`new_string` contains an omission placeholder (for example 'rest of methods ...'). Provide exact literal replacement text.";
+      }
+    }
 
     return this.config.validatePathAccess(params.file_path);
   }

--- a/packages/core/src/tools/omissionPlaceholderDetector.test.ts
+++ b/packages/core/src/tools/omissionPlaceholderDetector.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { detectOmissionPlaceholder } from './omissionPlaceholderDetector.js';
+
+describe('detectOmissionPlaceholder', () => {
+  it('detects standalone placeholder lines', () => {
+    expect(detectOmissionPlaceholder('(rest of methods ...)')).toEqual({
+      found: true,
+      match: '(rest of methods ...)',
+    });
+    expect(detectOmissionPlaceholder('(rest of code ...)')).toEqual({
+      found: true,
+      match: '(rest of code ...)',
+    });
+    expect(detectOmissionPlaceholder('(unchanged code ...)')).toEqual({
+      found: true,
+      match: '(unchanged code ...)',
+    });
+    expect(detectOmissionPlaceholder('// rest of methods ...')).toEqual({
+      found: true,
+      match: '// rest of methods ...',
+    });
+  });
+
+  it('detects case-insensitive placeholders', () => {
+    expect(detectOmissionPlaceholder('(Rest Of Methods ...)')).toEqual({
+      found: true,
+      match: '(Rest Of Methods ...)',
+    });
+  });
+
+  it('detects placeholder lines inside larger multiline text', () => {
+    const text = `class Example {\n  methodA() {}\n  (rest of methods ...)\n}`;
+    expect(detectOmissionPlaceholder(text)).toEqual({
+      found: true,
+      match: '(rest of methods ...)',
+    });
+  });
+
+  it('does not detect placeholders embedded in normal code', () => {
+    expect(
+      detectOmissionPlaceholder(
+        'const note = "(rest of methods ...)";\nconsole.log(note);',
+      ),
+    ).toEqual({
+      found: false,
+    });
+  });
+
+  it('does not detect text without ellipsis marker', () => {
+    expect(detectOmissionPlaceholder('(rest of methods)')).toEqual({
+      found: false,
+    });
+  });
+
+  it('does not detect unrelated ellipsis text', () => {
+    expect(detectOmissionPlaceholder('const message = "loading...";')).toEqual({
+      found: false,
+    });
+  });
+
+  it('does not detect omission phrase when it is inline code/comment context', () => {
+    expect(
+      detectOmissionPlaceholder('return value; // rest of methods ...'),
+    ).toEqual({
+      found: false,
+    });
+  });
+});

--- a/packages/core/src/tools/omissionPlaceholderDetector.test.ts
+++ b/packages/core/src/tools/omissionPlaceholderDetector.test.ts
@@ -5,70 +5,59 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { detectOmissionPlaceholder } from './omissionPlaceholderDetector.js';
+import { detectOmissionPlaceholders } from './omissionPlaceholderDetector.js';
 
-describe('detectOmissionPlaceholder', () => {
+describe('detectOmissionPlaceholders', () => {
   it('detects standalone placeholder lines', () => {
-    expect(detectOmissionPlaceholder('(rest of methods ...)')).toEqual({
-      found: true,
-      match: '(rest of methods ...)',
-    });
-    expect(detectOmissionPlaceholder('(rest of code ...)')).toEqual({
-      found: true,
-      match: '(rest of code ...)',
-    });
-    expect(detectOmissionPlaceholder('(unchanged code ...)')).toEqual({
-      found: true,
-      match: '(unchanged code ...)',
-    });
-    expect(detectOmissionPlaceholder('// rest of methods ...')).toEqual({
-      found: true,
-      match: '// rest of methods ...',
-    });
+    expect(detectOmissionPlaceholders('(rest of methods ...)')).toEqual([
+      'rest of methods ...',
+    ]);
+    expect(detectOmissionPlaceholders('(rest of code ...)')).toEqual([
+      'rest of code ...',
+    ]);
+    expect(detectOmissionPlaceholders('(unchanged code ...)')).toEqual([
+      'unchanged code ...',
+    ]);
+    expect(detectOmissionPlaceholders('// rest of methods ...')).toEqual([
+      'rest of methods ...',
+    ]);
   });
 
   it('detects case-insensitive placeholders', () => {
-    expect(detectOmissionPlaceholder('(Rest Of Methods ...)')).toEqual({
-      found: true,
-      match: '(Rest Of Methods ...)',
-    });
+    expect(detectOmissionPlaceholders('(Rest Of Methods ...)')).toEqual([
+      'rest of methods ...',
+    ]);
   });
 
-  it('detects placeholder lines inside larger multiline text', () => {
-    const text = `class Example {\n  methodA() {}\n  (rest of methods ...)\n}`;
-    expect(detectOmissionPlaceholder(text)).toEqual({
-      found: true,
-      match: '(rest of methods ...)',
-    });
+  it('detects multiple placeholder lines in one input', () => {
+    const text = `class Example {
+  run() {}
+  (rest of methods ...)
+  (unchanged code ...)
+}`;
+    expect(detectOmissionPlaceholders(text)).toEqual([
+      'rest of methods ...',
+      'unchanged code ...',
+    ]);
   });
 
   it('does not detect placeholders embedded in normal code', () => {
     expect(
-      detectOmissionPlaceholder(
+      detectOmissionPlaceholders(
         'const note = "(rest of methods ...)";\nconsole.log(note);',
       ),
-    ).toEqual({
-      found: false,
-    });
+    ).toEqual([]);
   });
 
-  it('does not detect text without ellipsis marker', () => {
-    expect(detectOmissionPlaceholder('(rest of methods)')).toEqual({
-      found: false,
-    });
+  it('does not detect omission phrase when inline in a comment', () => {
+    expect(
+      detectOmissionPlaceholders('return value; // rest of methods ...'),
+    ).toEqual([]);
   });
 
   it('does not detect unrelated ellipsis text', () => {
-    expect(detectOmissionPlaceholder('const message = "loading...";')).toEqual({
-      found: false,
-    });
-  });
-
-  it('does not detect omission phrase when it is inline code/comment context', () => {
-    expect(
-      detectOmissionPlaceholder('return value; // rest of methods ...'),
-    ).toEqual({
-      found: false,
-    });
+    expect(detectOmissionPlaceholders('const message = "loading...";')).toEqual(
+      [],
+    );
   });
 });

--- a/packages/core/src/tools/omissionPlaceholderDetector.ts
+++ b/packages/core/src/tools/omissionPlaceholderDetector.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface OmissionPlaceholderDetectionResult {
+  found: boolean;
+  match?: string;
+}
+
+const STANDALONE_OMISSION_LINE_PATTERN =
+  /^(?:\/\/\s*)?\(?\s*(?:rest\s+of(?:\s+(?:methods?|code))?|unchanged\s+(?:code|methods?))\s*\.{3,}\s*\)?$/i;
+
+/**
+ * Detects shorthand omission placeholders such as:
+ * - (rest of methods ...)
+ * - (rest of code ...)
+ * - (unchanged code ...)
+ * - // rest of methods ...
+ */
+export function detectOmissionPlaceholder(
+  text: string,
+): OmissionPlaceholderDetectionResult {
+  const lines = text.split(/\r?\n/);
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+
+    if (!line.includes('...')) {
+      continue;
+    }
+
+    if (
+      !/rest\s+of/i.test(line) &&
+      !/unchanged\s+(?:code|methods?)/i.test(line)
+    ) {
+      continue;
+    }
+
+    if (STANDALONE_OMISSION_LINE_PATTERN.test(line)) {
+      return { found: true, match: line };
+    }
+  }
+
+  return { found: false };
+}

--- a/packages/core/src/tools/write-file.test.ts
+++ b/packages/core/src/tools/write-file.test.ts
@@ -310,6 +310,42 @@ describe('WriteFileTool', () => {
       };
       expect(() => tool.build(params)).toThrow(`Missing or empty "file_path"`);
     });
+
+    it('should throw an error if content includes an omission placeholder', () => {
+      const params = {
+        file_path: path.join(rootDir, 'placeholder.txt'),
+        content: '(rest of methods ...)',
+      };
+      expect(() => tool.build(params)).toThrow(
+        "`content` contains an omission placeholder (for example 'rest of methods ...'). Provide complete file content.",
+      );
+    });
+
+    it('should allow content with ellipsis in a normal string literal', () => {
+      const params = {
+        file_path: path.join(rootDir, 'valid-content.ts'),
+        content: 'const note = "(rest of methods ...)";',
+      };
+      const invocation = tool.build(params);
+      expect(invocation).toBeDefined();
+      expect(invocation.params).toEqual(params);
+    });
+
+    it('should reject omission placeholder within multiline file content (regression #19858)', () => {
+      const params = {
+        file_path: path.join(rootDir, 'service.ts'),
+        content: `class Service {
+  execute() {
+    return "run";
+  }
+
+  // rest of methods ...
+}`,
+      };
+      expect(() => tool.build(params)).toThrow(
+        "`content` contains an omission placeholder (for example 'rest of methods ...'). Provide complete file content.",
+      );
+    });
   });
 
   describe('getCorrectedFileContent', () => {

--- a/packages/core/src/tools/write-file.test.ts
+++ b/packages/core/src/tools/write-file.test.ts
@@ -321,17 +321,7 @@ describe('WriteFileTool', () => {
       );
     });
 
-    it('should allow content with ellipsis in a normal string literal', () => {
-      const params = {
-        file_path: path.join(rootDir, 'valid-content.ts'),
-        content: 'const note = "(rest of methods ...)";',
-      };
-      const invocation = tool.build(params);
-      expect(invocation).toBeDefined();
-      expect(invocation.params).toEqual(params);
-    });
-
-    it('should reject omission placeholder within multiline file content (regression #19858)', () => {
+    it('should throw an error when multiline content includes omission placeholders', () => {
       const params = {
         file_path: path.join(rootDir, 'service.ts'),
         content: `class Service {
@@ -345,6 +335,16 @@ describe('WriteFileTool', () => {
       expect(() => tool.build(params)).toThrow(
         "`content` contains an omission placeholder (for example 'rest of methods ...'). Provide complete file content.",
       );
+    });
+
+    it('should allow content with placeholder text in a normal string literal', () => {
+      const params = {
+        file_path: path.join(rootDir, 'valid-content.ts'),
+        content: 'const note = "(rest of methods ...)";',
+      };
+      const invocation = tool.build(params);
+      expect(invocation).toBeDefined();
+      expect(invocation.params).toEqual(params);
     });
   });
 

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -47,7 +47,7 @@ import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { WRITE_FILE_DEFINITION } from './definitions/coreTools.js';
 import { resolveToolDeclaration } from './definitions/resolver.js';
-import { detectOmissionPlaceholder } from './omissionPlaceholderDetector.js';
+import { detectOmissionPlaceholders } from './omissionPlaceholderDetector.js';
 
 /**
  * Parameters for the WriteFile tool
@@ -487,8 +487,8 @@ export class WriteFileTool
       }`;
     }
 
-    const omissionPlaceholderMatch = detectOmissionPlaceholder(params.content);
-    if (omissionPlaceholderMatch.found) {
+    const omissionPlaceholders = detectOmissionPlaceholders(params.content);
+    if (omissionPlaceholders.length > 0) {
       return "`content` contains an omission placeholder (for example 'rest of methods ...'). Provide complete file content.";
     }
 

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -47,6 +47,7 @@ import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { WRITE_FILE_DEFINITION } from './definitions/coreTools.js';
 import { resolveToolDeclaration } from './definitions/resolver.js';
+import { detectOmissionPlaceholder } from './omissionPlaceholderDetector.js';
 
 /**
  * Parameters for the WriteFile tool
@@ -484,6 +485,11 @@ export class WriteFileTool
       return `Error accessing path properties for validation: ${resolvedPath}. Reason: ${
         statError instanceof Error ? statError.message : String(statError)
       }`;
+    }
+
+    const omissionPlaceholderMatch = detectOmissionPlaceholder(params.content);
+    if (omissionPlaceholderMatch.found) {
+      return "`content` contains an omission placeholder (for example 'rest of methods ...'). Provide complete file content.";
     }
 
     return null;


### PR DESCRIPTION
## Summary

Prevents a reported failure mode where edit/write proposals replace unchanged code with omission placeholders like `(rest of methods ...)`, which shows up as large unintended deletions in diffs.

This PR adds validation guardrails in `replace` and `write_file`, strengthens model-facing tool descriptions to forbid omission placeholders, and adds regression coverage for the issue pattern.

## Details

The issue described model edits that replace unchanged code with placeholder lines like [(rest of methods ...)](app://-/index.html#), causing large red deletions in diffs. This fix now blocks those payloads at tool validation time in both:

```
replace (new_string)
write_file (content)
```

So those placeholder-based edits no longer execute, which prevents that class of misleading diff/deletion.

It’s targeted to standalone omission-placeholder lines (the problematic pattern), not arbitrary ... inside normal code/string literals.

- Added a new detector utility:
  - `packages/core/src/tools/omissionPlaceholderDetector.ts`
  - Detects standalone omission placeholders (case-insensitive), including:
    - `(rest of methods ...)`
    - `(rest of code ...)`
    - `(unchanged code ...)`
    - `// rest of methods ...`
- Enforced detector in tool validation:
  - `packages/core/src/tools/edit.ts`
    - Rejects `new_string` omission placeholders unless the same placeholder is already present in `old_string`.
  - `packages/core/src/tools/write-file.ts`
    - Rejects omission placeholders in `content`.
- Updated tool-definition descriptions to explicitly prohibit omission placeholders:
  - `packages/core/src/tools/definitions/model-family-sets/gemini-3.ts`
  - `packages/core/src/tools/definitions/model-family-sets/default-legacy.ts`
- Added/updated tests:
  - `packages/core/src/tools/omissionPlaceholderDetector.test.ts`
  - `packages/core/src/tools/edit.test.ts`
  - `packages/core/src/tools/write-file.test.ts`
- Updated snapshots for tool definitions:
  - `packages/core/src/tools/definitions/__snapshots__/coreToolsModelSnapshots.test.ts.snap`

Regression proof:
- In a detached temp worktree at the pre-change commit, newly added regression assertions failed:
  - `EditTool.validateToolParams` returned `null` (no rejection) for placeholder-containing `new_string`.
  - `WriteFileTool.build` did not throw for placeholder-containing `content`.
- After this change, those scenarios pass in the updated test suites.

## Related Issues

Fixes #19858

## How to Validate

1. Run detector tests:
   - `npm run test --workspace @google/gemini-cli-core -- src/tools/omissionPlaceholderDetector.test.ts`
   - Expected: all tests pass.

2. Run edit tool tests:
   - `npm run test --workspace @google/gemini-cli-core -- src/tools/edit.test.ts`
   - Expected: all tests pass, including regression test rejecting multiline omission placeholders.

3. Run write-file tool tests:
   - `npm run test --workspace @google/gemini-cli-core -- src/tools/write-file.test.ts`
   - Expected: all tests pass, including regression test rejecting multiline omission placeholders.

4. Run tool-definition snapshot test:
   - `npm run test --workspace @google/gemini-cli-core -- src/tools/definitions/coreToolsModelSnapshots.test.ts`
   - Expected: passes with updated snapshots.

Edge cases covered by tests:
- Placeholder text inside normal code/string literal is not flagged.
- Placeholder rejection triggers for standalone omission-style lines.
- `replace` allows pass-through only when the same placeholder is already in `old_string`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

Breaking changes:
- None in public CLI API/commands.
- Behavioral tightening: `replace`/`write_file` now reject omission-placeholder payloads during validation.