### PR TITLE
fix(ide): use CLI version in MCP client handshake (#3487)

### DIFF
--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -22,6 +22,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { IDE_REQUEST_TIMEOUT_MS } from './constants.js';
 import { debugLogger } from '../utils/debugLogger.js';
+import { getVersion } from '../utils/version.js';
 import {
   getConnectionConfigFromFile,
   getIdeServerHost,
@@ -41,13 +42,13 @@ const logger = {
 
 export type DiffUpdateResult =
   | {
-      status: 'accepted';
-      content?: string;
-    }
+    status: 'accepted';
+    content?: string;
+  }
   | {
-      status: 'rejected';
-      content: undefined;
-    };
+    status: 'rejected';
+    content: undefined;
+  };
 
 export type IDEConnectionState = {
   status: IDEConnectionStatus;
@@ -85,7 +86,7 @@ export class IdeClient {
    */
   private diffMutex = Promise.resolve();
 
-  private constructor() {}
+  private constructor() { }
 
   static getInstance(): Promise<IdeClient> {
     if (!IdeClient.instancePromise) {
@@ -588,8 +589,7 @@ export class IdeClient {
       logger.debug(`Server URL: ${serverUrl}`);
       this.client = new Client({
         name: 'streamable-http-client',
-        // TODO(#3487): use the CLI version here.
-        version: '1.0.0',
+        version: await getVersion(),
       });
       transport = new StreamableHTTPClientTransport(new URL(serverUrl), {
         fetch: await createProxyAwareFetch(ideServerHost),
@@ -623,8 +623,7 @@ export class IdeClient {
       logger.debug('Attempting to connect to IDE via stdio');
       this.client = new Client({
         name: 'stdio-client',
-        // TODO(#3487): use the CLI version here.
-        version: '1.0.0',
+        version: await getVersion(),
       });
 
       transport = new StdioClientTransport({


### PR DESCRIPTION
## Summary

Replaces the hardcoded `version: '1.0.0'` in both MCP client initializations (`StreamableHTTPClientTransport` and `StdioClientTransport`) with a call to `getVersion()` from `utils/version.ts`, so the IDE receives the actual CLI version during the MCP protocol handshake.

## Details

The `Client` constructor in `ide-client.ts` was using a hardcoded `'1.0.0'` string in two places (lines 591 and 626). The existing `getVersion()` utility already resolves the CLI version from `CLI_VERSION` env var or `package.json`, so this change simply imports and uses it. Both call sites are in `async` functions, so `await getVersion()` works directly.

## Related Issues

Fixes #3487

## How to Validate

1. Run the IDE client tests:
   ```bash
   npm test -w @google/gemini-cli-core -- src/ide/ide-client.test.ts
   ```
   All 26 tests should pass.

2. Verify the import and usage:
   ```bash
   grep -n "getVersion" packages/core/src/ide/ide-client.ts
   ```
   Should show the import on line 25 and usage on lines 590 and 624.

3. Run full preflight:
   ```bash
   npm run preflight
   ```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
