### PR TITLE
refactor(code-assist): add @deprecated annotation to secureModeEnabled (#20329)

### DIFF
--- a/packages/core/src/code_assist/types.ts
+++ b/packages/core/src/code_assist/types.ts
@@ -351,7 +351,7 @@ export const AdminControlsSettingsSchema = z.object({
 export type AdminControlsSettings = z.infer<typeof AdminControlsSettingsSchema>;
 
 export const FetchAdminControlsResponseSchema = z.object({
-  // TODO: deprecate once backend stops sending this field
+  /** @deprecated This field will be removed once the backend stops sending it. Use `strictModeDisabled` instead. */
   secureModeEnabled: z.boolean().optional(),
   strictModeDisabled: z.boolean().optional(),
   mcpSetting: McpSettingSchema.optional(),


### PR DESCRIPTION
## Summary

Adds a `@deprecated` JSDoc annotation to the `secureModeEnabled` field in `FetchAdminControlsResponseSchema`, replacing the TODO comment. This surfaces IDE deprecation warnings and guides consumers to use `strictModeDisabled` instead.

## Details

The field had a `// TODO: deprecate once backend stops sending this field` comment. This change converts it to a proper `@deprecated` JSDoc tag so TypeScript-aware editors display deprecation strikethroughs and warnings. No runtime behavior changes.

## Related Issues

Fixes #20329

## How to Validate

1. Verify the annotation is correct:
   ```bash
   grep -A1 "@deprecated" packages/core/src/code_assist/types.ts
   ```
   Should show: `/** @deprecated This field will be removed once the backend stops sending it. Use strictModeDisabled instead. */`

2. Run tests:
   ```bash
   npm test -w @google/gemini-cli-core -- src/code_assist
   ```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
