### PR TITLE
fix(auth): prevent GOOGLE_CLOUD_PROJECT from overriding OAuth sessions

### DIFF
--- a/packages/cli/src/ui/commands/aboutCommand.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.ts
@@ -9,9 +9,11 @@ import { CommandKind } from './types.js';
 import process from 'node:process';
 import { MessageType, type HistoryItemAbout } from '../types.js';
 import {
+  AuthType,
   IdeClient,
   UserAccountManager,
   debugLogger,
+  getCodeAssistServer,
   getVersion,
 } from '@google/gemini-cli-core';
 
@@ -34,7 +36,14 @@ export const aboutCommand: SlashCommand = {
     const cliVersion = await getVersion();
     const selectedAuthType =
       context.services.settings.merged.security.auth.selectedType || '';
-    const gcpProject = process.env['GOOGLE_CLOUD_PROJECT'] || '';
+    const gcpProject =
+      selectedAuthType === AuthType.USE_VERTEX_AI
+        ? process.env['GOOGLE_CLOUD_PROJECT'] ||
+          process.env['GOOGLE_CLOUD_PROJECT_ID'] ||
+          ''
+        : context.services.config
+          ? (getCodeAssistServer(context.services.config)?.projectId ?? '')
+          : '';
     const ideClient = await getIdeClientName(context);
 
     const userAccountManager = new UserAccountManager();

--- a/packages/core/src/code_assist/codeAssist.test.ts
+++ b/packages/core/src/code_assist/codeAssist.test.ts
@@ -65,6 +65,7 @@ describe('codeAssist', () => {
         mockAuthClient,
         mockValidationHandler,
         httpOptions,
+        { preferEnvProjectId: false },
       );
       expect(MockedCodeAssistServer).toHaveBeenCalledWith(
         mockAuthClient,
@@ -95,6 +96,7 @@ describe('codeAssist', () => {
         mockAuthClient,
         mockValidationHandler,
         httpOptions,
+        { preferEnvProjectId: true },
       );
       expect(MockedCodeAssistServer).toHaveBeenCalledWith(
         mockAuthClient,

--- a/packages/core/src/code_assist/codeAssist.ts
+++ b/packages/core/src/code_assist/codeAssist.ts
@@ -28,6 +28,11 @@ export async function createCodeAssistContentGenerator(
       authClient,
       config.getValidationHandler(),
       httpOptions,
+      {
+        // For Google OAuth, do not force host GOOGLE_CLOUD_PROJECT unless
+        // Code Assist explicitly requires a user-provided project.
+        preferEnvProjectId: authType === AuthType.COMPUTE_ADC,
+      },
     );
     return new CodeAssistServer(
       authClient,


### PR DESCRIPTION
## Summary

Fixes an auth-selection bug where `GOOGLE_CLOUD_PROJECT` from the host environment could incorrectly force Google OAuth (personal/Workspace) sessions into a GCP project context, causing `403 PERMISSION_DENIED` / `CONSUMER_INVALID` failures.

This PR makes Google OAuth default to Code Assist-managed project resolution first, and only falls back to env project when a project is explicitly required. It also updates `/about` so project display reflects active auth/runtime context rather than leaking host env context in OAuth flows.

## Details

- Added `SetupUserOptions` in `packages/core/src/code_assist/setup.ts` with `preferEnvProjectId`.
- Refactored setup flow:
  - `setupUserWithProjectId(...)` handles load/onboard lifecycle.
  - `setupUser(...)` now supports a two-pass strategy:
    - Pass 1: optional no-env-project mode.
    - Pass 2: retry with env project only when initial attempt fails with `ProjectIdRequiredError`.
- Updated `createCodeAssistContentGenerator(...)` in `packages/core/src/code_assist/codeAssist.ts`:
  - `AuthType.LOGIN_WITH_GOOGLE` -> `preferEnvProjectId: false`
  - `AuthType.COMPUTE_ADC` -> `preferEnvProjectId: true` (preserves existing env-first behavior for compute/ADC scenarios).
- Updated `/about` in `packages/cli/src/ui/commands/aboutCommand.ts`:
  - For `vertex-ai`, show env project (`GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_PROJECT_ID`).
  - For OAuth/Code Assist, show active project from `getCodeAssistServer(...).projectId`.
- Added/updated tests:
  - `packages/core/src/code_assist/setup.test.ts`
    - ignores env project on first pass when configured.
    - retries with env project when project is required.
  - `packages/core/src/code_assist/codeAssist.test.ts`
    - verifies auth-type-specific `setupUser` options.
  - `packages/cli/src/ui/commands/aboutCommand.test.ts`
    - verifies auth-mode-specific project display behavior.

## Related Issues

Closes #19865

## How to Validate

1. Run focused tests:
   ```bash
   npm run test --workspace @google/gemini-cli-core -- packages/core/src/code_assist/setup.test.ts packages/core/src/code_assist/codeAssist.test.ts
   npm run test --workspace @google/gemini-cli -- packages/cli/src/ui/commands/aboutCommand.test.ts
   ```
   Expected:
   - All tests pass, including new setup fallback tests and `/about` auth-mode project display test.

2. Reproduce original bug scenario (manual):
   ```bash
   export GOOGLE_CLOUD_PROJECT=TEST
   ```
   - Use Google OAuth login (personal/Workspace, non-Vertex flow).
   - Start CLI and run a normal prompt.
   Expected:
   - CLI should not immediately force requests through `TEST` project.
   - No `PERMISSION_DENIED` / `CONSUMER_INVALID` solely from host env project leakage.

3. Verify fallback behavior when project is actually required:
   - Use an account flow requiring a user project.
   - Keep `GOOGLE_CLOUD_PROJECT` set to a valid project.
   Expected:
   - Setup retries with env project and proceeds instead of failing on first pass.

4. Verify `/about` output:
   - In OAuth mode: project should reflect active Code Assist server project, not raw env by default.
   - In Vertex mode: project should reflect env project values.

5. Optional build sanity:
   ```bash
   npm run build --workspace @google/gemini-cli-core
   npm run build --workspace @google/gemini-cli
   ```
   Expected:
   - `core` build succeeds.
   - `cli` build status may include unrelated pre-existing repo issues; this PR does not introduce new build errors in touched files.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
