### PR TITLE
perf(cli): skip redundant GEMINI.md loading during auth bootstrap

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -436,6 +436,7 @@ export function isDebugMode(argv: CliArgs): boolean {
 
 export interface LoadCliConfigOptions {
   cwd?: string;
+  skipMemoryLoad?: boolean;
   projectHooks?: { [K in HookEventName]?: HookDefinition[] } & {
     disabled?: string[];
   };
@@ -517,7 +518,7 @@ export async function loadCliConfig(
   let fileCount = 0;
   let filePaths: string[] = [];
 
-  if (!experimentalJitContext) {
+  if (!experimentalJitContext && !options.skipMemoryLoad) {
     // Call the (now wrapper) loadHierarchicalGeminiMemory which calls the server's version
     const result = await loadServerHierarchicalMemory(
       cwd,

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -437,8 +437,9 @@ export async function main() {
     }
   }
 
-  const partialConfig = await loadCliConfig(settings.merged, sessionId, argv, {
+  let partialConfig = await loadCliConfig(settings.merged, sessionId, argv, {
     projectHooks: settings.workspace.settings.hooks,
+    skipMemoryLoad: true,
   });
   adminControlsListner.setConfig(partialConfig);
 
@@ -506,6 +507,11 @@ export async function main() {
     // We intentionally omit the list of extensions here because extensions
     // should not impact auth or setting up the sandbox.
     // TODO(jacobr): refactor loadCliConfig so there is a minimal version
+    // that only initializes enough config to enable refreshAuth or find another way
+    // to decouple refreshAuth from requiring a config.
+    partialConfig = await loadCliConfig(settings.merged, sessionId, argv, {
+      skipMemoryLoad: true,
+    });
     // that only initializes enough config to enable refreshAuth or find
     // another way to decouple refreshAuth from requiring a config.
 


### PR DESCRIPTION
Fixes #17637 by adding a `skipMemoryLoad` option to `loadCliConfig()` to prevent redundant file discovery when generating partial configs. This is part of GSoC 2026 Project #3 (Startup Performance Optimization).