### PR TITLE
fix(core): add uniqueness guard to edit tool

### DIFF
--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -137,6 +137,17 @@ async function calculateExactReplacement(
   const normalizedReplace = new_string.replace(/\r\n/g, '\n');
 
   const exactOccurrences = normalizedCode.split(normalizedSearch).length - 1;
+  const expectedReplacements = params.expected_replacements ?? 1;
+
+  if (exactOccurrences > expectedReplacements) {
+    return {
+      newContent: currentContent,
+      occurrences: exactOccurrences,
+      finalOldString: normalizedSearch,
+      finalNewString: normalizedReplace,
+    };
+  }
+
   if (exactOccurrences > 0) {
     let modifiedCode = safeLiteralReplace(
       normalizedCode,


### PR DESCRIPTION
Fixes #18917 by adding a check in `calculateExactReplacement` to prevent multiple occurrences from being incorrectly replaced if they exceed 'expectedReplacements'.