### PR TITLE
docs: document expected_replacements in replace tool

### DIFF
--- a/docs/tools/file-system.md
+++ b/docs/tools/file-system.md
@@ -119,10 +119,10 @@ context around the `old_string` to ensure it modifies the correct location.
   - `expected_replacements` (number, optional): Expected number of replacements.
     Defaults to 1.
 - **Behavior:**
-  - If the number of occurrences of `old_string` found in the file exceeds
-    `expected_replacements`, the replacement fails to prevent accidental
-    cascading replacements, and the language model is instructed to either
-    provide more specific context in `old_string` or explicitly increase
+  - If the number of occurrences of `old_string` found in the file does not match
+    `expected_replacements`, the replacement fails. This prevents both accidental
+    cascading replacements and incomplete changes. The language model is then
+    instructed to either provide a more specific `old_string` or to update
     `expected_replacements`.
 - **Confirmation:** Requires manual user approval.
 

--- a/docs/tools/file-system.md
+++ b/docs/tools/file-system.md
@@ -116,6 +116,14 @@ context around the `old_string` to ensure it modifies the correct location.
   - `instruction` (string, required): Semantic description of the change.
   - `old_string` (string, required): Exact literal text to find.
   - `new_string` (string, required): Exact literal text to replace with.
+  - `expected_replacements` (number, optional): Expected number of replacements.
+    Defaults to 1.
+- **Behavior:**
+  - If the number of occurrences of `old_string` found in the file exceeds
+    `expected_replacements`, the replacement fails to prevent accidental
+    cascading replacements, and the language model is instructed to either
+    provide more specific context in `old_string` or explicitly increase
+    `expected_replacements`.
 - **Confirmation:** Requires manual user approval.
 
 ## Next steps


### PR DESCRIPTION
This PR updates the file-system tools documentation to reflect the recent addition of the `expected_replacements` parameter in the edit/replace tool, detailing its uniqueness guard behavior. Related to #18917.