### PR TITLE
fix(cli): enable symlink tests on Windows using junctions

### DIFF
--- a/packages/cli/src/config/trustedFolders.test.ts
+++ b/packages/cli/src/config/trustedFolders.test.ts
@@ -500,7 +500,7 @@ describe('Trusted Folders', () => {
       const realDir = path.join(tempDir, 'real');
       const symlinkDir = path.join(tempDir, 'symlink');
       fs.mkdirSync(realDir);
-      fs.symlinkSync(realDir, symlinkDir, 'junction');
+      fs.symlinkSync(realDir, symlinkDir, process.platform === 'win32' ? 'junction' : 'dir');
 
       // Rule uses realpath
       const config = { [realDir]: TrustLevel.TRUST_FOLDER };

--- a/packages/cli/src/config/trustedFolders.test.ts
+++ b/packages/cli/src/config/trustedFolders.test.ts
@@ -490,33 +490,25 @@ describe('Trusted Folders', () => {
     });
   });
 
-  const itif = (condition: boolean) => (condition ? it : it.skip);
-
   describe('Symlinks Support', () => {
     const mockSettings: Settings = {
       security: { folderTrust: { enabled: true } },
     };
 
-    // TODO: issue 19387 - Enable symlink tests on Windows
-    itif(process.platform !== 'win32')(
-      'should trust a folder if the rule matches the realpath',
-      () => {
-        // Create a real directory and a symlink
-        const realDir = path.join(tempDir, 'real');
-        const symlinkDir = path.join(tempDir, 'symlink');
-        fs.mkdirSync(realDir);
-        fs.symlinkSync(realDir, symlinkDir, 'dir');
+    it('should trust a folder if the rule matches the realpath', () => {
+      // Create a real directory and a symlink
+      const realDir = path.join(tempDir, 'real');
+      const symlinkDir = path.join(tempDir, 'symlink');
+      fs.mkdirSync(realDir);
+      fs.symlinkSync(realDir, symlinkDir, 'junction');
 
-        // Rule uses realpath
-        const config = { [realDir]: TrustLevel.TRUST_FOLDER };
-        fs.writeFileSync(trustedFoldersPath, JSON.stringify(config), 'utf-8');
+      // Rule uses realpath
+      const config = { [realDir]: TrustLevel.TRUST_FOLDER };
+      fs.writeFileSync(trustedFoldersPath, JSON.stringify(config), 'utf-8');
 
-        // Check against symlink path
-        expect(isWorkspaceTrusted(mockSettings, symlinkDir).isTrusted).toBe(
-          true,
-        );
-      },
-    );
+      // Check against symlink path
+      expect(isWorkspaceTrusted(mockSettings, symlinkDir).isTrusted).toBe(true);
+    });
   });
 
   describe('Verification: Auth and Trust Interaction', () => {

--- a/packages/cli/src/utils/skillUtils.test.ts
+++ b/packages/cli/src/utils/skillUtils.test.ts
@@ -10,6 +10,8 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { installSkill, linkSkill, uninstallSkill } from './skillUtils.js';
 
+const itif = (condition: boolean) => (condition ? it : it.skip);
+
 describe('skillUtils', () => {
   let tempDir: string;
   const projectRoot = path.resolve(__dirname, '../../../../../');
@@ -26,66 +28,49 @@ describe('skillUtils', () => {
     vi.unstubAllEnvs();
   });
 
-  const itif = (condition: boolean) => (condition ? it : it.skip);
-
   describe('linkSkill', () => {
-    // TODO: issue 19388 - Enable linkSkill tests on Windows
-    itif(process.platform !== 'win32')(
-      'should successfully link from a local directory',
-      async () => {
-        // Create a mock skill directory
-        const mockSkillSourceDir = path.join(tempDir, 'mock-skill-source');
-        const skillSubDir = path.join(mockSkillSourceDir, 'test-skill');
-        await fs.mkdir(skillSubDir, { recursive: true });
-        await fs.writeFile(
-          path.join(skillSubDir, 'SKILL.md'),
-          '---\nname: test-skill\ndescription: test\n---\nbody',
-        );
+    it('should successfully link from a local directory', async () => {
+      // Create a mock skill directory
+      const mockSkillSourceDir = path.join(tempDir, 'mock-skill-source');
+      const skillSubDir = path.join(mockSkillSourceDir, 'test-skill');
+      await fs.mkdir(skillSubDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillSubDir, 'SKILL.md'),
+        '---\nname: test-skill\ndescription: test\n---\nbody',
+      );
 
-        const skills = await linkSkill(
-          mockSkillSourceDir,
-          'workspace',
-          () => {},
-        );
-        expect(skills.length).toBe(1);
-        expect(skills[0].name).toBe('test-skill');
+      const skills = await linkSkill(mockSkillSourceDir, 'workspace', () => {});
+      expect(skills.length).toBe(1);
+      expect(skills[0].name).toBe('test-skill');
 
-        const linkedPath = path.join(tempDir, '.gemini/skills', 'test-skill');
-        const stats = await fs.lstat(linkedPath);
-        expect(stats.isSymbolicLink()).toBe(true);
+      const linkedPath = path.join(tempDir, '.gemini/skills', 'test-skill');
+      const stats = await fs.lstat(linkedPath);
+      expect(stats.isSymbolicLink()).toBe(true);
 
-        const linkTarget = await fs.readlink(linkedPath);
-        expect(path.resolve(linkTarget)).toBe(path.resolve(skillSubDir));
-      },
-    );
+      const linkTarget = await fs.readlink(linkedPath);
+      expect(path.resolve(linkTarget)).toBe(path.resolve(skillSubDir));
+    });
 
-    itif(process.platform !== 'win32')(
-      'should overwrite existing skill at destination',
-      async () => {
-        const mockSkillSourceDir = path.join(tempDir, 'mock-skill-source');
-        const skillSubDir = path.join(mockSkillSourceDir, 'test-skill');
-        await fs.mkdir(skillSubDir, { recursive: true });
-        await fs.writeFile(
-          path.join(skillSubDir, 'SKILL.md'),
-          '---\nname: test-skill\ndescription: test\n---\nbody',
-        );
+    it('should overwrite existing skill at destination', async () => {
+      const mockSkillSourceDir = path.join(tempDir, 'mock-skill-source');
+      const skillSubDir = path.join(mockSkillSourceDir, 'test-skill');
+      await fs.mkdir(skillSubDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillSubDir, 'SKILL.md'),
+        '---\nname: test-skill\ndescription: test\n---\nbody',
+      );
 
-        const targetDir = path.join(tempDir, '.gemini/skills');
-        await fs.mkdir(targetDir, { recursive: true });
-        const existingPath = path.join(targetDir, 'test-skill');
-        await fs.mkdir(existingPath);
+      const targetDir = path.join(tempDir, '.gemini/skills');
+      await fs.mkdir(targetDir, { recursive: true });
+      const existingPath = path.join(targetDir, 'test-skill');
+      await fs.mkdir(existingPath);
 
-        const skills = await linkSkill(
-          mockSkillSourceDir,
-          'workspace',
-          () => {},
-        );
-        expect(skills.length).toBe(1);
+      const skills = await linkSkill(mockSkillSourceDir, 'workspace', () => {});
+      expect(skills.length).toBe(1);
 
-        const stats = await fs.lstat(existingPath);
-        expect(stats.isSymbolicLink()).toBe(true);
-      },
-    );
+      const stats = await fs.lstat(existingPath);
+      expect(stats.isSymbolicLink()).toBe(true);
+    });
 
     it('should abort linking if consent is rejected', async () => {
       const mockSkillSourceDir = path.join(tempDir, 'mock-skill-source');

--- a/packages/cli/src/utils/skillUtils.ts
+++ b/packages/cli/src/utils/skillUtils.ts
@@ -248,7 +248,8 @@ export async function linkSkill(
       await fs.rm(destPath, { recursive: true, force: true });
     }
 
-    await fs.symlink(skillSourceDir, destPath, 'dir');
+    const symlinkType = process.platform === 'win32' ? 'junction' : 'dir';
+    await fs.symlink(skillSourceDir, destPath, symlinkType);
     linkedSkills.push({ name: skillName, location: destPath });
   }
 


### PR DESCRIPTION
## Summary
On Windows, `fs.symlink` with type `'dir'` requires admin privileges, which caused symlink-related tests to be skipped. This PR uses `'junction'` instead, which works for standard (non-admin) Windows users.

## Details
- **`skillUtils.ts`**: Use `'junction'` on `win32` instead of `'dir'` natively in code.
- **`skillUtils.test.ts`**: Unskip 2 `linkSkill` tests gated behind `win32` check.
- **`trustedFolders.test.ts`**: Unskip symlink trust test, use `'junction'` for the directory symlink during testing.

## Related Issues
Fixes #19387
Fixes #19388

## How to Validate
Run the test suites natively on a Windows device (without Administrator permissions):
1. `npx vitest run src/config/trustedFolders.test.ts` (Should pass 32 tests)
2. `npx vitest run src/utils/skillUtils.test.ts` (Should pass 7 tests)

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
  - [x] Windows
    - [x] npm run
  - [ ] Linux
