### PR TITLE
feat(cli): respect ui.showShortcutsHint setting in ShortcutsHint comp…

### DIFF
--- a/packages/cli/src/ui/components/ShortcutsHint.tsx
+++ b/packages/cli/src/ui/components/ShortcutsHint.tsx
@@ -8,9 +8,17 @@ import type React from 'react';
 import { Text } from 'ink';
 import { theme } from '../semantic-colors.js';
 import { useUIState } from '../contexts/UIStateContext.js';
+import { useSettingsStore } from '../contexts/SettingsContext.js';
 
 export const ShortcutsHint: React.FC = () => {
   const { cleanUiDetailsVisible, shortcutsHelpVisible } = useUIState();
+  const { settings } = useSettingsStore();
+
+  // ✅ NEW FEATURE (Issue #18535)
+  // Hide "? for shortcuts" when disabled in config
+  const showHint = settings.merged.ui?.showShortcutsHint ?? true;
+
+  if (!showHint) return null;
 
   if (!cleanUiDetailsVisible) {
     return <Text color={theme.text.secondary}> press tab twice for more </Text>;


### PR DESCRIPTION
## Summary
Adds support for the `ui.showShortcutsHint` configuration flag to control the visibility of the "? for shortcuts" hint in the CLI UI.

When disabled, the inline hint is hidden while the actual "?" help functionality remains unchanged.

## Details
- Uses `useSettingsStore` to read merged settings.
- Conditionally renders the `ShortcutsHint` component based on `ui.showShortcutsHint`.
- Default behavior remains unchanged (hint visible by default).

This helps users keep a cleaner UI without removing access to the shortcuts menu.

## Related Issues
Related to #18535

## How to Validate
1. Run the CLI:
   npm start
2. Open settings:
   /settings
3. Disable **Show Shortcuts Hint**
4. Verify:
   - "? for shortcuts" text disappears
   - Typing `?` still opens the help menu

## Pre-Merge Checklist
- [x] No breaking changes
- [x] Lint passed
- [x] Typecheck passed
- [x] Preflight checks passed
- [x] Feature tested locally