### PR TITLE
fix(ui): trap physical Home/End keys to prevent terminal scroll

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -573,6 +573,15 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   const handleInput = useCallback(
     (key: Key) => {
+      // Ctrl+A (Home) / Ctrl+E (End)
+      if (key.name === 'home' || keyMatchers[Command.HOME](key)) {
+        buffer.move('home');
+        return true;
+      }
+      if (key.name === 'end' || keyMatchers[Command.END](key)) {
+        buffer.move('end');
+        return true;
+      }
       // Determine if this keypress is a history navigation command
       const isHistoryUp =
         !shellModeActive &&
@@ -616,7 +625,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           isHistoryNav || isCursorMovement || keyMatchers[Command.ESCAPE](key),
         );
       }
-
       // TODO(jacobr): this special case is likely not needed anymore.
       // We should probably stop supporting paste if the InputPrompt is not
       // focused.
@@ -1081,16 +1089,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             handleSubmit(buffer.text);
           }
         }
-        return true;
-      }
-
-      // Ctrl+A (Home) / Ctrl+E (End)
-      if (keyMatchers[Command.HOME](key)) {
-        buffer.move('home');
-        return true;
-      }
-      if (keyMatchers[Command.END](key)) {
-        buffer.move('end');
         return true;
       }
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -574,12 +574,18 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   const handleInput = useCallback(
     (key: Key) => {
       // Ctrl+A (Home) / Ctrl+E (End)
-      if (key.name === 'home' || keyMatchers[Command.HOME](key)) {
-        buffer.move('home');
-        return true;
-      }
-      if (key.name === 'end' || keyMatchers[Command.END](key)) {
-        buffer.move('end');
+      const isHome =
+        key.name === 'home' ||
+        (key.ctrl && key.name === 'a') ||
+        keyMatchers[Command.HOME](key);
+      const isEnd =
+        key.name === 'end' ||
+        (key.ctrl && key.name === 'e') ||
+        keyMatchers[Command.END](key);
+
+      if (isHome || isEnd) {
+        setSuppressCompletion(true);
+        buffer.move(isHome ? 'home' : 'end');
         return true;
       }
       // Determine if this keypress is a history navigation command


### PR DESCRIPTION
## Summary
Pressing the `Home` or `End` keys (or `Ctrl+A`/`Ctrl+E`) caused the terminal emulator window to scroll, rather than moving the cursor within the input prompt buffer.
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details
Previously, the physical `Home` and `End` keystrokes were either falling through to the default buffer handler too late or bubbling up to the terminal emulator. This caused Terminal and VS Code integrated terminals to hijack the event and scroll the window history.

**Changes made in `InputPrompt.tsx`:**
* **Shifted priority:** Moved the existing Home/End handling logic to the very beginning of the `handleInput` callback so it executes before history or suggestions logic can interfere.
* **Explicit key checks:** Added explicit checks for `key.name === 'home'` and `key.name === 'end'` alongside the existing `keyMatchers`. This ensures the physical keystrokes are correctly trapped and consumed (`return true`) before the terminal emulator can scroll the window.
<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues
Closes #13759
<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate
> Note: If testing in VS Code's integrated terminal, ensure the Terminal > Integrated: Allow Chords setting is unchecked, as VS Code may intercept the keystrokes before they reach the shell.
1. Check out this branch and run `npm run build && npm run start`.
2. Hit `Enter` several times (or run a few commands) to fill the terminal window until a vertical scrollbar appears.
3. Type a long sentence into the prompt (do not hit enter).
4. Scroll your terminal window up slightly so the prompt is at the very bottom of your screen.
5. Press the **Home** key (`Fn + Left Arrow` or `Ctrl+A` on macOS).
   * **Expected Behavior:** The cursor jumps to the beginning of the prompt text. The terminal scrollbar/window remains perfectly still.
6. Press the **End** key (`Fn + Right Arrow` or `Ctrl+E`).
   * **Expected Behavior:** The cursor jumps to the end of the prompt text. The window remains perfectly still.
<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
