### PR TITLE
Fix for silent failures in non-interactive mode

### DIFF
--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -13,6 +13,7 @@ import {
   getAllMCPServerStatuses,
   MCPServerStatus,
   isNodeError,
+  getErrorMessage,
   parseAndFormatApiError,
   safeLiteralReplace,
   DEFAULT_GUI_EDITOR,
@@ -727,16 +728,17 @@ export class Task {
         // Block scope for lexical declaration
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         const errorEvent = event as ServerGeminiErrorEvent; // Type assertion
-        const errorMessage =
-          errorEvent.value?.error.message ?? 'Unknown error from LLM stream';
+        const errorMessage = errorEvent.value?.error
+          ? getErrorMessage(errorEvent.value.error)
+          : 'Unknown error from LLM stream';
         logger.error(
           '[Task] Received error event from LLM stream:',
           errorMessage,
         );
 
         let errMessage = `Unknown error from LLM stream: ${JSON.stringify(event)}`;
-        if (errorEvent.value) {
-          errMessage = parseAndFormatApiError(errorEvent.value);
+        if (errorEvent.value?.error) {
+          errMessage = parseAndFormatApiError(errorEvent.value.error);
         }
         this.cancelPendingTools(`LLM stream error: ${errorMessage}`);
         this.setTaskStateAndPublishUpdate(

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -41,7 +41,6 @@ main().catch(async (error) => {
     writeToStderr('Cleanup timed out, forcing exit...\n');
     process.exit(1);
   }, 5000);
-  cleanupTimeout.unref(); // Don't keep the process alive just for the timeout
 
   try {
     await runExitCleanup();

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -65,12 +65,7 @@ main().catch(async (error) => {
   if (error instanceof Error) {
     writeToStderr(error.stack + '\n');
   } else {
-    // If it's not an Error instance, try to stringify it nicely
-    try {
-      writeToStderr(JSON.stringify(error, null, 2) + '\n');
-    } catch {
-      writeToStderr(String(error) + '\n');
-    }
+    writeToStderr(String(error) + '\n');
   }
   process.exit(1);
 });

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -261,7 +261,10 @@ describe('Turn', () => {
       const errorEvent = events[0] as ServerGeminiErrorEvent;
       expect(errorEvent.type).toBe(GeminiEventType.Error);
       expect(errorEvent.value).toEqual({
-        error,
+        error: {
+          message: 'API Error',
+          status: undefined,
+        },
       });
       expect(turn.getDebugResponses().length).toBe(0);
       expect(reportError).toHaveBeenCalledWith(

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -261,7 +261,7 @@ describe('Turn', () => {
       const errorEvent = events[0] as ServerGeminiErrorEvent;
       expect(errorEvent.type).toBe(GeminiEventType.Error);
       expect(errorEvent.value).toEqual({
-        error: { message: 'API Error', status: undefined },
+        error,
       });
       expect(turn.getDebugResponses().length).toBe(0);
       expect(reportError).toHaveBeenCalledWith(

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -116,7 +116,7 @@ export interface StructuredError {
 }
 
 export interface GeminiErrorEventValue {
-  error: StructuredError;
+  error: unknown;
 }
 
 export interface GeminiFinishedEventValue {
@@ -398,7 +398,7 @@ export class Turn {
         status,
       };
       await this.chat.maybeIncludeSchemaDepthContext(structuredError);
-      yield { type: GeminiEventType.Error, value: { error: structuredError } };
+      yield { type: GeminiEventType.Error, value: { error } };
       return;
     }
   }

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -398,7 +398,7 @@ export class Turn {
         status,
       };
       await this.chat.maybeIncludeSchemaDepthContext(structuredError);
-      yield { type: GeminiEventType.Error, value: { error } };
+      yield { type: GeminiEventType.Error, value: { error: structuredError } };
       return;
     }
   }


### PR DESCRIPTION
## Summary

Non-interactive mode outputs exit code 0 during evals when we hit multiple api errors (429, etc.) and run out of retries. This makes it harder for the eval framework to distinguish infra-related failures from actual task failures.

## Details

GCLI summary of a debugging looking into a suspiciously low-scoring eval run:

I have investigated the cause of the low pass rate (26%) for run benchhub-eval-68275684. My analysis confirms your suspicion: the majority
  of the FAILED instances were caused by errors outside of the agent's control.

  Core Cause: Systemic Quota Exhaustion (429 Errors)
  The primary reason for the low pass rate is a Vertex AI API quota limit that was hit because 500 instances were running simultaneously.


  Key Evidence:
   * Widespread 429 Errors: I sampled several instances reported as FAILED (e.g., sympy__sympy-20154, django__django-13033,
     sympy__sympy-16450) and found that their agent logs (gemini-cli.txt) all show:
      Resource exhausted. Please try again later. ... status: RESOURCE_EXHAUSTED.
   * Silent Agent Crashes: When the agent (gemini-cli) hits the maximum number of retries for these 429 errors, it crashes. However, it
     incorrectly exits with a return code of 0 instead of a non-zero error code.
   * Invalid Verification: Because the agent returned code 0, the harbor framework assumed it had finished its work. It then proceeded to run
     the verifier on the original, unmodified code. Since the code was never fixed, the tests failed (reward 0.0), and the result was recorded
     as a "Failure" rather than an "Error."
   * Comparison with True Errors: The only instance marked as ERROR (scikit-learn__scikit-learn-14710) was a VerifierTimeoutError, which is
     explicitly caught by the framework. The agent-level 429 crashes were missed because of the incorrect exit code.


  Summary Breakdown of `instance_error` and "False Fails"

  ┌─────────────────┬───────┬──────────────────────────────────────────────────────────────────────────────────────┐
  │ Reported Status │ Count │ Actual Cause                                                                         │
  ├─────────────────┼───────┼──────────────────────────────────────────────────────────────────────────────────────┤
  │ PASSED      │ 130   │ Agent successfully fixed the issue.                                                  │
  │ FAILED      │ 369   │ Mostly False Fails. Agent crashed due to 429 quota errors before applying fixes. │
  │ ERROR       │ 1     │ VerifierTimeoutError (Tests took > 50 minutes).                                    │
  └─────────────────┴───────┴──────────────────────────────────────────────────────────────────────────────────────┘


## Related Issues

Fixes #19906

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
