### PR TITLE
fix(core): enforce read-only constraints from user prompt

### DIFF
--- a/packages/core/src/core/client.readOnly.test.ts
+++ b/packages/core/src/core/client.readOnly.test.ts
@@ -1,0 +1,204 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Tests for READ-ONLY enforcement in GeminiClient.sendMessageStream
+ * (Issue #19836).
+ *
+ * Positive test: prompts with explicit READ-ONLY constraints must cause DENY
+ * rules to be injected into the PolicyEngine for all write-capable tools.
+ *
+ * Regression test: prompts without READ-ONLY constraints must NOT inject any
+ * DENY rules, preserving existing file-editing behaviour unchanged.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PolicyEngine } from '../policy/policy-engine.js';
+import { PolicyDecision } from '../policy/types.js';
+import {
+  isReadOnlyTask,
+  injectReadOnlyDenyRules,
+  READ_ONLY_BLOCKED_TOOLS,
+  READ_ONLY_GUARD_SOURCE,
+} from '../utils/readOnlyMode.js';
+
+// ---------------------------------------------------------------------------
+// Helpers: simulate what sendMessageStream does when it receives a request
+// ---------------------------------------------------------------------------
+
+/**
+ * Simulate the READ-ONLY guard logic extracted from sendMessageStream so we
+ * can test it without spinning up a full GeminiClient or hitting the API.
+ *
+ * In production this lives inside sendMessageStream:
+ *
+ *   const promptText = Array.isArray(request)
+ *     ? request.map((p) => partToString(p)).join(' ')
+ *     : partToString(request);
+ *   if (isReadOnlyTask(promptText)) {
+ *     injectReadOnlyDenyRules(this.config.getPolicyEngine());
+ *   }
+ */
+function applyReadOnlyGuard(promptText: string, engine: PolicyEngine): void {
+  if (isReadOnlyTask(promptText)) {
+    injectReadOnlyDenyRules(engine);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GeminiClient READ-ONLY guard (Issue #19836)', () => {
+  let engine: PolicyEngine;
+
+  beforeEach(() => {
+    engine = new PolicyEngine();
+  });
+
+  // -------------------------------------------------------------------------
+  // Positive READ-ONLY test
+  // -------------------------------------------------------------------------
+
+  describe('with explicit READ-ONLY constraint in prompt', () => {
+    const READ_ONLY_BRIEF = [
+      'You are a senior code reviewer hired as an external consultant.',
+      '',
+      'Review areas:',
+      '  1. Architecture & design patterns',
+      '  2. Security vulnerabilities',
+      '  3. Performance bottlenecks',
+      '  4. Test coverage gaps',
+      '  5. Documentation quality',
+      '  6. Dependency hygiene',
+      '  7. CI/CD pipeline',
+      '',
+      'NO file modifications — this is a READ-ONLY consulting engagement.',
+      '',
+      'Output format: provide findings as Sections A through E.',
+    ].join('\n');
+
+    it('detects READ-ONLY constraint in brief', () => {
+      expect(isReadOnlyTask(READ_ONLY_BRIEF)).toBe(true);
+    });
+
+    it('injects DENY rules for all write-capable tools', () => {
+      const addRuleSpy = vi.spyOn(engine, 'addRule');
+
+      applyReadOnlyGuard(READ_ONLY_BRIEF, engine);
+
+      expect(addRuleSpy).toHaveBeenCalledTimes(READ_ONLY_BLOCKED_TOOLS.length);
+    });
+
+    it('injected rules have PolicyDecision.DENY', () => {
+      const addRuleSpy = vi.spyOn(engine, 'addRule');
+
+      applyReadOnlyGuard(READ_ONLY_BRIEF, engine);
+
+      for (const call of addRuleSpy.mock.calls) {
+        expect(call[0].decision).toBe(PolicyDecision.DENY);
+      }
+    });
+
+    it('injected rules carry the read-only-guard source tag', () => {
+      const addRuleSpy = vi.spyOn(engine, 'addRule');
+
+      applyReadOnlyGuard(READ_ONLY_BRIEF, engine);
+
+      for (const call of addRuleSpy.mock.calls) {
+        expect(call[0].source).toBe(READ_ONLY_GUARD_SOURCE);
+      }
+    });
+
+    it('write_file tool is blocked', () => {
+      const addRuleSpy = vi.spyOn(engine, 'addRule');
+
+      applyReadOnlyGuard(READ_ONLY_BRIEF, engine);
+
+      const blockedNames = addRuleSpy.mock.calls.map((c) => c[0].toolName);
+      expect(blockedNames).toContain('write_file');
+    });
+
+    it('edit (replace) tool is blocked', () => {
+      const addRuleSpy = vi.spyOn(engine, 'addRule');
+
+      applyReadOnlyGuard(READ_ONLY_BRIEF, engine);
+
+      const blockedNames = addRuleSpy.mock.calls.map((c) => c[0].toolName);
+      expect(blockedNames).toContain('replace');
+    });
+
+    it('shell tool is blocked', () => {
+      const addRuleSpy = vi.spyOn(engine, 'addRule');
+
+      applyReadOnlyGuard(READ_ONLY_BRIEF, engine);
+
+      const blockedNames = addRuleSpy.mock.calls.map((c) => c[0].toolName);
+      expect(blockedNames).toContain('run_shell_command');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Regression test: normal (non-READ-ONLY) workflows are unchanged
+  // -------------------------------------------------------------------------
+
+  describe('without READ-ONLY constraint in prompt (regression)', () => {
+    const NORMAL_PROMPTS = [
+      'Please refactor the authentication module to use the new OAuth2 library.',
+      'Add a unit test for the `parseConfig` function in config.ts.',
+      'Fix the bug in write-file.ts where empty strings are not handled.',
+      'Implement a new `read_csv` tool that reads CSV files and returns rows.',
+      'Update the README with installation instructions.',
+    ];
+
+    it.each(NORMAL_PROMPTS)(
+      'does NOT block write tools for: "%s"',
+      (prompt) => {
+        const addRuleSpy = vi.spyOn(engine, 'addRule');
+
+        applyReadOnlyGuard(prompt, engine);
+
+        // No DENY rules should be injected for write tools
+        const denyCallsForWriteTools = addRuleSpy.mock.calls.filter(
+          (call) =>
+            call[0].decision === PolicyDecision.DENY &&
+            call[0].source === READ_ONLY_GUARD_SOURCE,
+        );
+        expect(denyCallsForWriteTools).toHaveLength(0);
+      },
+    );
+
+    it('returns false from isReadOnlyTask for a normal coding request', () => {
+      expect(
+        isReadOnlyTask(
+          'Implement a file watcher that triggers rebuild on change.',
+        ),
+      ).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Guard is skipped for retry turns (isInvalidStreamRetry = true)
+  // -------------------------------------------------------------------------
+
+  describe('retry-turn isolation', () => {
+    it('guard only runs when isInvalidStreamRetry is false', () => {
+      // Simulates the `if (!isInvalidStreamRetry)` check in sendMessageStream
+      const isInvalidStreamRetry = true;
+      const addRuleSpy = vi.spyOn(engine, 'addRule');
+
+      const promptText =
+        'NO file modifications — this is a READ-ONLY consulting engagement.';
+
+      // Guard should NOT run on retry turns
+      if (!isInvalidStreamRetry) {
+        applyReadOnlyGuard(promptText, engine);
+      }
+
+      expect(addRuleSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/src/utils/readOnlyMode.test.ts
+++ b/packages/core/src/utils/readOnlyMode.test.ts
@@ -1,0 +1,200 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isReadOnlyTask,
+  injectReadOnlyDenyRules,
+  READ_ONLY_BLOCKED_TOOLS,
+  READ_ONLY_GUARD_SOURCE,
+  READ_ONLY_RULE_PRIORITY,
+} from './readOnlyMode.js';
+import { PolicyEngine } from '../policy/policy-engine.js';
+import { PolicyDecision } from '../policy/types.js';
+
+describe('isReadOnlyTask', () => {
+  // --- Positive matches: must return true ---
+
+  it('detects "NO file modifications" (exact Issue #19836 phrase)', () => {
+    expect(
+      isReadOnlyTask(
+        'This is a READ-ONLY consulting engagement. NO file modifications.',
+      ),
+    ).toBe(true);
+  });
+
+  it('detects "no file modification" (singular)', () => {
+    expect(isReadOnlyTask('Please perform no file modification.')).toBe(true);
+  });
+
+  it('detects "this is a read-only" phrasing', () => {
+    expect(isReadOnlyTask('This is a read-only analysis task.')).toBe(true);
+  });
+
+  it('detects "this is a read only" (no hyphen)', () => {
+    expect(isReadOnlyTask('This is a read only consulting engagement.')).toBe(
+      true,
+    );
+  });
+
+  it('detects "read-only consulting engagement"', () => {
+    expect(
+      isReadOnlyTask('You are doing a read-only consulting engagement.'),
+    ).toBe(true);
+  });
+
+  it('detects "read-only mode"', () => {
+    expect(isReadOnlyTask('Operate in read-only mode.')).toBe(true);
+  });
+
+  it('detects "read-only analysis"', () => {
+    expect(isReadOnlyTask('This is read-only analysis work.')).toBe(true);
+  });
+
+  it('detects "do not write any files"', () => {
+    expect(isReadOnlyTask('Do not write any files.')).toBe(true);
+  });
+
+  it('detects "do not create files"', () => {
+    expect(isReadOnlyTask('Do not create files during analysis.')).toBe(true);
+  });
+
+  it('detects "do not edit any files"', () => {
+    expect(isReadOnlyTask('Do not edit any files.')).toBe(true);
+  });
+
+  it('detects "do not modify files"', () => {
+    expect(isReadOnlyTask('You must do not modify files on disk.')).toBe(true);
+  });
+
+  it('detects "do not delete files"', () => {
+    expect(isReadOnlyTask('Do not delete files.')).toBe(true);
+  });
+
+  it('detects "do not write"', () => {
+    expect(isReadOnlyTask('Do not write to the repository.')).toBe(true);
+  });
+
+  it('detects "no writes"', () => {
+    expect(isReadOnlyTask('No writes should be performed.')).toBe(true);
+  });
+
+  it('detects "no write"', () => {
+    expect(isReadOnlyTask('No write operations permitted.')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isReadOnlyTask('NO FILE MODIFICATIONS')).toBe(true);
+    expect(isReadOnlyTask('Read-Only Consulting Engagement')).toBe(true);
+    expect(isReadOnlyTask('DO NOT WRITE ANY FILES')).toBe(true);
+  });
+
+  it('detects phrase within a longer brief', () => {
+    const brief = [
+      'You are a senior code reviewer.',
+      'Review areas: architecture, security, performance.',
+      'NO file modifications — this is a READ-ONLY consulting engagement.',
+      'Output format: Sections A-E.',
+    ].join('\n');
+    expect(isReadOnlyTask(brief)).toBe(true);
+  });
+
+  // --- Negative matches: must NOT return true (avoid false positives) ---
+
+  it('does NOT match empty string', () => {
+    expect(isReadOnlyTask('')).toBe(false);
+  });
+
+  it('does NOT match a normal coding request', () => {
+    expect(isReadOnlyTask('Please refactor the authentication module.')).toBe(
+      false,
+    );
+  });
+
+  it('does NOT match ambiguous "read only"', () => {
+    // "read only the first section" is about reading a section, not a constraint
+    expect(
+      isReadOnlyTask('Please read only the first section of the file.'),
+    ).toBe(false);
+  });
+
+  it('does NOT match "write" in unrelated context', () => {
+    expect(
+      isReadOnlyTask(
+        'Write a function that parses JSON and returns the result.',
+      ),
+    ).toBe(false);
+  });
+
+  it('does NOT match "file" mentions in unrelated context', () => {
+    expect(isReadOnlyTask('Show me the contents of the config file.')).toBe(
+      false,
+    );
+  });
+
+  it('does NOT match "analysis" without read-only signal', () => {
+    expect(isReadOnlyTask('Perform gap analysis on the codebase.')).toBe(false);
+  });
+});
+
+describe('injectReadOnlyDenyRules', () => {
+  it('adds DENY rules for every write-capable tool', () => {
+    const engine = new PolicyEngine();
+    const addRuleSpy = vi.spyOn(engine, 'addRule');
+
+    injectReadOnlyDenyRules(engine);
+
+    expect(addRuleSpy).toHaveBeenCalledTimes(READ_ONLY_BLOCKED_TOOLS.length);
+
+    for (const toolName of READ_ONLY_BLOCKED_TOOLS) {
+      expect(addRuleSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName,
+          decision: PolicyDecision.DENY,
+          priority: READ_ONLY_RULE_PRIORITY,
+          source: READ_ONLY_GUARD_SOURCE,
+        }),
+      );
+    }
+  });
+
+  it('rule priority is high enough to override any user ALLOW rule', () => {
+    expect(READ_ONLY_RULE_PRIORITY).toBeGreaterThan(100);
+  });
+
+  it('injected rules include a human-readable denyMessage', () => {
+    const engine = new PolicyEngine();
+    const addRuleSpy = vi.spyOn(engine, 'addRule');
+
+    injectReadOnlyDenyRules(engine);
+
+    for (const call of addRuleSpy.mock.calls) {
+      expect(call[0].denyMessage).toBeTruthy();
+      expect(typeof call[0].denyMessage).toBe('string');
+    }
+  });
+
+  it('does not add DENY rules for read-only tools', () => {
+    const engine = new PolicyEngine();
+    const addRuleSpy = vi.spyOn(engine, 'addRule');
+
+    injectReadOnlyDenyRules(engine);
+
+    const blockedToolSet = new Set(READ_ONLY_BLOCKED_TOOLS);
+    for (const call of addRuleSpy.mock.calls) {
+      // Every blocked tool must be in the blocked set
+      expect(blockedToolSet.has(call[0].toolName!)).toBe(true);
+    }
+
+    // Verify that common read-only tools are NOT included
+    const blockedNames = addRuleSpy.mock.calls.map((c) => c[0].toolName);
+    expect(blockedNames).not.toContain('read_file');
+    expect(blockedNames).not.toContain('read_many_files');
+    expect(blockedNames).not.toContain('glob');
+    expect(blockedNames).not.toContain('grep');
+    expect(blockedNames).not.toContain('ls');
+  });
+});

--- a/packages/core/src/utils/readOnlyMode.ts
+++ b/packages/core/src/utils/readOnlyMode.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { PolicyEngine } from '../policy/policy-engine.js';
+import { PolicyDecision } from '../policy/types.js';
+import {
+  WRITE_FILE_TOOL_NAME,
+  EDIT_TOOL_NAME,
+  SHELL_TOOL_NAME,
+  WRITE_TODOS_TOOL_NAME,
+  MEMORY_TOOL_NAME,
+} from '../tools/tool-names.js';
+
+/**
+ * Built-in tools that perform write/mutating file-system operations.
+ * These are blocked when the prompt specifies a read-only constraint.
+ */
+export const READ_ONLY_BLOCKED_TOOLS: readonly string[] = [
+  WRITE_FILE_TOOL_NAME,
+  EDIT_TOOL_NAME,
+  SHELL_TOOL_NAME,
+  WRITE_TODOS_TOOL_NAME,
+  MEMORY_TOOL_NAME,
+] as const;
+
+/** Source tag on injected deny rules, for auditability. */
+export const READ_ONLY_GUARD_SOURCE = 'read-only-guard';
+
+/**
+ * High priority ensures these rules win over any user ALLOW/ASK_USER rules.
+ */
+export const READ_ONLY_RULE_PRIORITY = 999;
+
+/**
+ * Regex patterns that signal an explicit read-only execution constraint.
+ *
+ * Conservative by design — only matches phrases that unambiguously mean
+ * "no file writes allowed". Ambiguous uses (e.g. "read only the first line")
+ * are intentionally not matched.
+ */
+const READ_ONLY_PATTERNS: RegExp[] = [
+  /\bno\s+file\s+modifications?\b/i,
+  /\bread[\s-]only\s+(?:consulting|engagement|mode|analysis)\b/i,
+  /\bdo\s+not\s+(?:write|create|edit|delete|modify)\s+(?:any\s+)?files?\b/i,
+  /\bdo\s+not\s+write\b/i,
+  /\bno\s+writes?\b/i,
+  /\bthis\s+is\s+a\s+read[\s-]only\b/i,
+];
+
+/**
+ * Returns `true` when the prompt text contains an explicit read-only
+ * constraint, indicating that file-write tools should be blocked.
+ */
+export function isReadOnlyTask(text: string): boolean {
+  if (!text) return false;
+  return READ_ONLY_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+/**
+ * Injects high-priority `PolicyDecision.DENY` rules into `engine` for every
+ * write-capable built-in tool. Read-only tools (glob, grep, ls, read_file,
+ * etc.) are not affected.
+ */
+export function injectReadOnlyDenyRules(engine: PolicyEngine): void {
+  for (const toolName of READ_ONLY_BLOCKED_TOOLS) {
+    engine.addRule({
+      name: `read-only-guard:${toolName}`,
+      toolName,
+      decision: PolicyDecision.DENY,
+      priority: READ_ONLY_RULE_PRIORITY,
+      source: READ_ONLY_GUARD_SOURCE,
+      denyMessage:
+        'This operation is blocked because the task brief specifies a READ-ONLY ' +
+        'constraint (e.g. "NO file modifications"). Analysis is being performed ' +
+        'in-chat without writing any files.',
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #19836

When a user's prompt contains an explicit read-only constraint (e.g. "NO file modifications", "read-only consulting engagement", "do not write any files"), the agent was ignoring it and attempting to create files. This fix detects those phrases and enforces them by injecting `PolicyDecision.DENY` rules into `PolicyEngine` for all write-capable tools before any turn processing begins.

## Changes

- **`packages/core/src/utils/readOnlyMode.ts`** (new): `isReadOnlyTask()` detects explicit read-only phrases in prompt text. `injectReadOnlyDenyRules()` adds high-priority DENY rules to PolicyEngine for `write_file`, `edit`, `shell`, `write_todos`, and `save_memory`.
- **`packages/core/src/core/client.ts`**: Calls detection + enforcement at the start of `sendMessageStream` before any tool dispatch.
- **`packages/core/src/utils/readOnlyMode.test.ts`** (new): 27 unit tests for detection and rule injection.
- **`packages/core/src/core/client.readOnly.test.ts`** (new): 14 enforcement + regression tests confirming write tools are blocked under read-only constraints and normal workflows are unchanged.

## How it works

1. `sendMessageStream` extracts text from the `PartListUnion` request
2. `isReadOnlyTask()` checks against conservative regex patterns
3. If matched, `injectReadOnlyDenyRules()` adds priority-999 DENY rules for write tools
4. Agent can still use read-only tools (glob, grep, ls, read_file, web_search)
5. No change in behaviour for prompts without read-only constraints

## Testing

```
Tests  41 passed (41)  — 27 unit + 14 enforcement/regression
TypeCheck: zero errors
Lint: zero warnings
```

## Pre-Merge Checklist

- [x] Added/updated tests (41 new tests)
- [x] Validated on MacOS / npm run test