### PR TITLE
Fix #18708: feat: Add /undo command to revert last conversation turn

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -34,6 +34,7 @@ import { extensionsCommand } from '../ui/commands/extensionsCommand.js';
 import { helpCommand } from '../ui/commands/helpCommand.js';
 import { shortcutsCommand } from '../ui/commands/shortcutsCommand.js';
 import { rewindCommand } from '../ui/commands/rewindCommand.js';
+import { undoCommand } from '../ui/commands/undoCommand.js';
 import { hooksCommand } from '../ui/commands/hooksCommand.js';
 import { ideCommand } from '../ui/commands/ideCommand.js';
 import { initCommand } from '../ui/commands/initCommand.js';
@@ -122,6 +123,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       shortcutsCommand,
       ...(this.config?.getEnableHooksUI() ? [hooksCommand] : []),
       rewindCommand,
+      undoCommand,
       await ideCommand(),
       initCommand,
       ...(isNightlyBuild ? [oncallCommand] : []),

--- a/packages/cli/src/ui/commands/rewindCommand.tsx
+++ b/packages/cli/src/ui/commands/rewindCommand.tsx
@@ -36,7 +36,7 @@ import {
  * @param messageId The ID of the message to rewind to.
  * @param newText The new text for the input field after rewinding.
  */
-async function rewindConversation(
+export async function rewindConversation(
   context: CommandContext,
   client: GeminiClient,
   recordingService: ChatRecordingService,

--- a/packages/cli/src/ui/commands/undoCommand.ts
+++ b/packages/cli/src/ui/commands/undoCommand.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CommandKind, type SlashCommand } from './types.js';
+import { rewindConversation } from './rewindCommand.js';
+
+/**
+ * The /undo command removes the last conversation turn (the most recent user
+ * prompt and the model response it triggered) from the context window.
+ */
+export const undoCommand: SlashCommand = {
+  name: 'undo',
+  description: 'Remove the last conversation turn from the context window',
+  kind: CommandKind.BUILT_IN,
+  action: async (context) => {
+    const config = context.services.config;
+    if (!config) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'Config not found',
+      };
+    }
+
+    const client = config.getGeminiClient();
+    if (!client) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'Client not initialized',
+      };
+    }
+
+    const recordingService = client.getChatRecordingService();
+    if (!recordingService) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'Recording service unavailable',
+      };
+    }
+
+    const conversation = recordingService.getConversation();
+    if (!conversation) {
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: 'No conversation found.',
+      };
+    }
+
+    // Find the last user message to rewind to (removing it and everything after)
+    const lastUserMessage = [...conversation.messages]
+      .reverse()
+      .find((msg) => msg.type === 'user');
+
+    if (!lastUserMessage) {
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: 'Nothing to undo.',
+      };
+    }
+
+    await rewindConversation(
+      context,
+      client,
+      recordingService,
+      lastUserMessage.id,
+      '',
+    );
+
+    return {
+      type: 'message',
+      messageType: 'info',
+      content: 'Last conversation turn removed.',
+    };
+  },
+};

--- a/packages/cli/src/ui/commands/undoCommand.ts
+++ b/packages/cli/src/ui/commands/undoCommand.ts
@@ -6,6 +6,7 @@
 
 import { CommandKind, type SlashCommand } from './types.js';
 import { rewindConversation } from './rewindCommand.js';
+import { revertFileChanges } from '../utils/rewindFileOps.js';
 
 /**
  * The /undo command removes the last conversation turn (the most recent user
@@ -65,6 +66,7 @@ export const undoCommand: SlashCommand = {
       };
     }
 
+    await revertFileChanges(conversation, lastUserMessage.id);
     await rewindConversation(
       context,
       client,


### PR DESCRIPTION
Fixes #18708

## Summary
This PR fixes: feat: Add /undo command to revert last conversation turn

## Changes
```
packages/cli/src/services/BuiltinCommandLoader.ts |  2 +
 packages/cli/src/ui/commands/rewindCommand.tsx    |  2 +-
 packages/cli/src/ui/commands/undoCommand.ts       | 82 +++++++++++++++++++++++
 3 files changed, 85 insertions(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).