### PR TITLE
Fix Devtools Websocket Authentication Issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17419,6 +17419,7 @@
         "shell-quote": "^1.8.3",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",
+        "strip-json-comments": "^3.1.1",
         "systeminformation": "^5.25.11",
         "tree-sitter-bash": "^0.25.0",
         "undici": "^7.10.0",

--- a/packages/cli/src/utils/activityLogger.ts
+++ b/packages/cli/src/utils/activityLogger.ts
@@ -617,7 +617,7 @@ function setupNetworkLogging(
   host: string,
   port: number,
   config: Config,
-  token: string,
+  token: string | null,
   onReconnectFailed?: () => void,
 ) {
   const transportBuffer: object[] = [];
@@ -630,7 +630,8 @@ function setupNetworkLogging(
 
   const connect = () => {
     try {
-      ws = new WebSocket(`ws://${host}:${port}/ws?token=${token}`);
+      const query = token ? `?token=${encodeURIComponent(token)}` : '';
+      ws = new WebSocket(`ws://${host}:${port}/ws${query}`);
 
       ws.on('open', () => {
         debugLogger.debug(`WebSocket connected to ${host}:${port}`);
@@ -855,7 +856,7 @@ export function initActivityLogger(
         mode: 'network';
         host: string;
         port: number;
-        token?: string;
+        token?: string | null;
         onReconnectFailed?: () => void;
       }
     | { mode: 'file'; filePath?: string }
@@ -870,7 +871,7 @@ export function initActivityLogger(
       options.host,
       options.port,
       config,
-      options.token || '',
+      options.token ?? null,
       options.onReconnectFailed,
     );
     capture.enableNetworkLogging();
@@ -890,7 +891,7 @@ export function addNetworkTransport(
   config: Config,
   host: string,
   port: number,
-  token: string,
+  token: string | null,
   onReconnectFailed?: () => void,
 ): void {
   const capture = ActivityLogger.getInstance();

--- a/packages/cli/src/utils/activityLogger.ts
+++ b/packages/cli/src/utils/activityLogger.ts
@@ -617,6 +617,7 @@ function setupNetworkLogging(
   host: string,
   port: number,
   config: Config,
+  token: string,
   onReconnectFailed?: () => void,
 ) {
   const transportBuffer: object[] = [];
@@ -629,7 +630,7 @@ function setupNetworkLogging(
 
   const connect = () => {
     try {
-      ws = new WebSocket(`ws://${host}:${port}/ws`);
+      ws = new WebSocket(`ws://${host}:${port}/ws?token=${token}`);
 
       ws.on('open', () => {
         debugLogger.debug(`WebSocket connected to ${host}:${port}`);
@@ -854,6 +855,7 @@ export function initActivityLogger(
         mode: 'network';
         host: string;
         port: number;
+        token?: string;
         onReconnectFailed?: () => void;
       }
     | { mode: 'file'; filePath?: string }
@@ -868,6 +870,7 @@ export function initActivityLogger(
       options.host,
       options.port,
       config,
+      options.token || '',
       options.onReconnectFailed,
     );
     capture.enableNetworkLogging();
@@ -887,8 +890,9 @@ export function addNetworkTransport(
   config: Config,
   host: string,
   port: number,
+  token: string,
   onReconnectFailed?: () => void,
 ): void {
   const capture = ActivityLogger.getInstance();
-  setupNetworkLogging(capture, host, port, config, onReconnectFailed);
+  setupNetworkLogging(capture, host, port, config, token, onReconnectFailed);
 }

--- a/packages/cli/src/utils/devtoolsService.test.ts
+++ b/packages/cli/src/utils/devtoolsService.test.ts
@@ -54,6 +54,7 @@ const mockDevToolsInstance = vi.hoisted(() => ({
   start: vi.fn(),
   stop: vi.fn(),
   getPort: vi.fn(),
+  getToken: vi.fn().mockReturnValue('test-token-abc123'),
 }));
 
 const mockActivityLoggerInstance = vi.hoisted(() => ({
@@ -155,6 +156,7 @@ describe('devtoolsService', () => {
         config,
         '127.0.0.1',
         25417,
+        '', // No token when connecting to existing server
         expect.any(Function),
       );
       expect(
@@ -223,6 +225,7 @@ describe('devtoolsService', () => {
         config,
         '127.0.0.1',
         25417,
+        'test-token-abc123',
         expect.any(Function),
       );
       expect(
@@ -364,6 +367,7 @@ describe('devtoolsService', () => {
         config,
         '127.0.0.1',
         25417,
+        '', // No token when connecting to existing winner
         expect.any(Function),
       );
     });
@@ -396,6 +400,7 @@ describe('devtoolsService', () => {
         config,
         '127.0.0.1',
         25418,
+        'test-token-abc123',
         expect.any(Function),
       );
     });
@@ -419,7 +424,7 @@ describe('devtoolsService', () => {
 
       // Extract onReconnectFailed callback
       const initCall = mockAddNetworkTransport.mock.calls[0];
-      const onReconnectFailed = initCall[3];
+      const onReconnectFailed = initCall[4];
       expect(onReconnectFailed).toBeDefined();
 
       // Trigger promotion MAX_PROMOTION_ATTEMPTS + 1 times

--- a/packages/cli/src/utils/devtoolsService.test.ts
+++ b/packages/cli/src/utils/devtoolsService.test.ts
@@ -156,7 +156,7 @@ describe('devtoolsService', () => {
         config,
         '127.0.0.1',
         25417,
-        '', // No token when connecting to existing server
+        null, // No token when connecting to existing server
         expect.any(Function),
       );
       expect(
@@ -363,11 +363,12 @@ describe('devtoolsService', () => {
 
       expect(mockDevToolsInstance.stop).toHaveBeenCalled();
       expect(url).toBe('http://localhost:25417');
+      // Default is ALLOW — transport is added even without token (token file may not exist in tests)
       expect(mockAddNetworkTransport).toHaveBeenCalledWith(
         config,
         '127.0.0.1',
         25417,
-        '', // No token when connecting to existing winner
+        null, // No token file in tests
         expect.any(Function),
       );
     });

--- a/packages/cli/src/utils/devtoolsService.ts
+++ b/packages/cli/src/utils/devtoolsService.ts
@@ -125,6 +125,8 @@ async function startOrJoinDevTools(
     // We won the port — we are the server.
     // Persist the token so other CLI instances can authenticate.
     writeTokenFile(actualPort, token);
+    // Clean up the token file when the process exits
+    process.on('exit', () => removeTokenFile(actualPort));
     debugLogger.log(`DevTools available at: ${url}`);
     return { host: defaultHost, port: actualPort, token };
   }
@@ -147,6 +149,7 @@ async function startOrJoinDevTools(
 
   // Winner isn’t responding — keep ours.
   writeTokenFile(actualPort, token);
+  process.on('exit', () => removeTokenFile(actualPort));
   debugLogger.log(`DevTools available at: ${url}`);
   return { host: defaultHost, port: actualPort, token };
 }

--- a/packages/devtools/client/index.html
+++ b/packages/devtools/client/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Gemini CLI DevTools</title>
+    <meta name="devtools-auth-token" content="__DEVTOOLS_AUTH_TOKEN__" />
     <style>
       html,
       body,

--- a/packages/devtools/client/src/hooks.ts
+++ b/packages/devtools/client/src/hooks.ts
@@ -20,7 +20,11 @@ export function useDevToolsData() {
   const [connectedSessions, setConnectedSessions] = useState<string[]>([]);
 
   useEffect(() => {
-    const evtSource = new EventSource('/events');
+    const token =
+      document
+        .querySelector('meta[name="devtools-auth-token"]')
+        ?.getAttribute('content') || '';
+    const evtSource = new EventSource(`/events?token=${token}`);
 
     evtSource.onopen = () => setIsConnected(true);
     evtSource.onerror = () => setIsConnected(false);


### PR DESCRIPTION
## Summary
The DevTools server (`packages/devtools/src/index.ts`) accepts WebSocket and SSE connections without any authentication. Any local process can read all Gemini API traffic (user prompts, model responses, console logs) or inject fake logs via curl `http://127.0.0.1:25417/events` or new `WebSocket('ws://127.0.0.1:25417/ws')`. This PR adds shared-secret token authentication to all DevTools endpoints.

## Details
A cryptographically random token (`crypto.randomBytes(32)`) is generated at server startup and required as a `?token=` query parameter on:
- WebSocket `/ws` — invalid token → connection closed with code `4001 Unauthorized`
- SSE `/events` — invalid token → `403 Forbidden`
- Cross-origin HTTP — now fully rejected with 403 (previously only omitted the CORS header but still served the response)

The browser UI continues to work seamlessly because the server injects the token into a <meta> tag in the HTML it serves, and the client reads it automatically. Used query params instead of headers? EventSource (SSE) doesn't support custom headers, and WebSocket only supports cookies or URL params — query params are the only mechanism that works for both.
Files Changed:
- `packages/devtools/src/index.ts` — token generation, WS/SSE/HTTP validation, HTML injection
- `packages/devtools/client/index.html` — <meta> tag placeholder
- `packages/devtools/client/src/hooks.ts` — reads token, passes to EventSource
- `packages/cli/src/utils/devtoolsService.ts` — threads token through lifecycle
- `packages/cli/src/utils/activityLogger.ts` — appends token to WebSocket URL
- `packages/cli/src/utils/devtoolsService.test.ts` — updated mocks and assertions

## Related Issues
Fixes #19899

## How to Validate
1. Build: `npm run build`
2. Run tests: `npm test -w @google/gemini-cli -- src/utils/devtoolsService.test.ts src/utils/activityLogger.test.ts` (25 tests pass)
3. Enable DevTools (`general.devtools: true`) and start the CLI
4. Verify SSE blocked: `curl -N http://127.0.0.1:25417/events` → `403 Forbidden`
5. Verify WS blocked: In any browser console: `new WebSocket('ws://127.0.0.1:25417/ws')` → closed immediately
6. Verify UI still works: Open `http://127.0.0.1:25417` → DevTools loads and displays logs normally

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker