### PR TITLE
feat(core): improve CLI robustness for benchmark and non-interactive scenarios

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -146,7 +146,7 @@ their corresponding top-level category object in your `settings.json` file.
 - **`general.retryFetchErrors`** (boolean):
   - **Description:** Retry on "exception TypeError: fetch failed sending
     request" errors.
-  - **Default:** `false`
+  - **Default:** `true`
 
 - **`general.debugKeystrokeLogging`** (boolean):
   - **Description:** Enable debug logging of keystrokes to the console.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17419,6 +17419,7 @@
         "shell-quote": "^1.8.3",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",
+        "strip-json-comments": "^3.1.1",
         "systeminformation": "^5.25.11",
         "tree-sitter-bash": "^0.25.0",
         "undici": "^7.10.0",

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -302,7 +302,7 @@ const SETTINGS_SCHEMA = {
         label: 'Retry Fetch Errors',
         category: 'General',
         requiresRestart: false,
-        default: false,
+        default: true,
         description:
           'Retry on "exception TypeError: fetch failed sending request" errors.',
         showInDialog: false,

--- a/packages/core/src/agents/types.ts
+++ b/packages/core/src/agents/types.ts
@@ -43,12 +43,12 @@ export const DEFAULT_QUERY_STRING = 'Get Started!';
 /**
  * The default maximum number of conversational turns for an agent.
  */
-export const DEFAULT_MAX_TURNS = 15;
+export const DEFAULT_MAX_TURNS = 30;
 
 /**
  * The default maximum execution time for an agent in minutes.
  */
-export const DEFAULT_MAX_TIME_MINUTES = 5;
+export const DEFAULT_MAX_TIME_MINUTES = 10;
 
 /**
  * Represents the validated input parameters passed to an agent upon invocation.

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -958,8 +958,13 @@ describe('Server Config (config.ts)', () => {
   });
 
   describe('Shell Tool Inactivity Timeout', () => {
-    it('should default to 300000ms (300 seconds) when not provided', () => {
+    it('should default to 600000ms (600 seconds) for non-interactive when not provided', () => {
       const config = new Config(baseParams);
+      expect(config.getShellToolInactivityTimeout()).toBe(600000);
+    });
+
+    it('should default to 300000ms (300 seconds) for interactive when not provided', () => {
+      const config = new Config({ ...baseParams, interactive: true });
       expect(config.getShellToolInactivityTimeout()).toBe(300000);
     });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -852,8 +852,9 @@ export class Config {
     this.continueOnFailedApiCall = params.continueOnFailedApiCall ?? true;
     this.enableShellOutputEfficiency =
       params.enableShellOutputEfficiency ?? true;
+    const defaultShellTimeout = this.interactive ? 300 : 600; // 5 min interactive, 10 min non-interactive
     this.shellToolInactivityTimeout =
-      (params.shellToolInactivityTimeout ?? 300) * 1000; // 5 minutes
+      (params.shellToolInactivityTimeout ?? defaultShellTimeout) * 1000;
     this.extensionManagement = params.extensionManagement ?? true;
     this.enableExtensionReloading = params.enableExtensionReloading ?? false;
     this.storage = new Storage(this.targetDir, this.sessionId);
@@ -877,7 +878,7 @@ export class Config {
     this.outputSettings = {
       format: params.output?.format ?? OutputFormat.TEXT,
     };
-    this.retryFetchErrors = params.retryFetchErrors ?? false;
+    this.retryFetchErrors = params.retryFetchErrors ?? true;
     this.disableYoloMode = params.disableYoloMode ?? false;
     this.rawOutput = params.rawOutput ?? false;
     this.acceptRawOutputRisk = params.acceptRawOutputRisk ?? false;

--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -789,7 +789,14 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 ## Interaction Details
 - **Help Command:** The user can use '/help' to display help information.
-- **Feedback:** To report a bug or provide feedback, please use the /bug command."
+- **Feedback:** To report a bug or provide feedback, please use the /bug command.
+
+## Error Recovery (Non-Interactive)
+- **Don't blindly retry:** When a tool call fails, analyze the error before retrying. Do not immediately retry with the same arguments.
+- **Web fetch failures:** If web_fetch fails, try simplifying the prompt or use google_web_search as an alternative to find the information.
+- **Shell failures:** Check error codes and run diagnostic commands before retrying. For compilation errors, fix one issue at a time rather than attempting multiple fixes simultaneously.
+- **Maximum retries:** Attempt the same approach at most 2 times. If it fails twice, try an alternative strategy or tool.
+- **Avoid loops:** If you find yourself repeating the same sequence of actions, stop and reassess your approach."
 `;
 
 exports[`Core System Prompt (prompts.ts) > should handle CodebaseInvestigator with tools=grep_search,glob 1`] = `
@@ -911,7 +918,14 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 ## Interaction Details
 - **Help Command:** The user can use '/help' to display help information.
-- **Feedback:** To report a bug or provide feedback, please use the /bug command."
+- **Feedback:** To report a bug or provide feedback, please use the /bug command.
+
+## Error Recovery (Non-Interactive)
+- **Don't blindly retry:** When a tool call fails, analyze the error before retrying. Do not immediately retry with the same arguments.
+- **Web fetch failures:** If web_fetch fails, try simplifying the prompt or use google_web_search as an alternative to find the information.
+- **Shell failures:** Check error codes and run diagnostic commands before retrying. For compilation errors, fix one issue at a time rather than attempting multiple fixes simultaneously.
+- **Maximum retries:** Attempt the same approach at most 2 times. If it fails twice, try an alternative strategy or tool.
+- **Avoid loops:** If you find yourself repeating the same sequence of actions, stop and reassess your approach."
 `;
 
 exports[`Core System Prompt (prompts.ts) > should handle git instructions when isGitRepository=false 1`] = `

--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -791,12 +791,49 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 - **Help Command:** The user can use '/help' to display help information.
 - **Feedback:** To report a bug or provide feedback, please use the /bug command.
 
+## File Creation (Non-Interactive)
+- **Prefer write_file over shell heredocs** for creating or overwriting files. The write_file tool is more reliable and avoids shell escaping issues.
+- Only use shell heredocs when you need to append to a file or when the content depends on shell variable expansion.
+- If you must use a heredoc, always use the full syntax: \`cat << 'EOF' > filename\` — never omit \`cat\`.
+
+## Background Services (Non-Interactive)
+- To start a service that must persist across turns, use: \`nohup <command> > /tmp/<service>.log 2>&1 &\`
+- After starting, verify the process is running:
+  1. \`echo $!\` to capture the PID immediately after starting
+  2. \`sleep 1 && kill -0 <PID>\` to confirm it's still alive
+  3. Check the log file for startup errors: \`cat /tmp/<service>.log\`
+- If a service fails to start, check the log file before retrying.
+- For services that need time to initialize (databases, web servers), add a brief \`sleep 2\` and verify the port is open before proceeding.
+
 ## Error Recovery (Non-Interactive)
 - **Don't blindly retry:** When a tool call fails, analyze the error before retrying. Do not immediately retry with the same arguments.
 - **Web fetch failures:** If web_fetch fails, try simplifying the prompt or use google_web_search as an alternative to find the information.
 - **Shell failures:** Check error codes and run diagnostic commands before retrying. For compilation errors, fix one issue at a time rather than attempting multiple fixes simultaneously.
 - **Maximum retries:** Attempt the same approach at most 2 times. If it fails twice, try an alternative strategy or tool.
-- **Avoid loops:** If you find yourself repeating the same sequence of actions, stop and reassess your approach."
+- **Avoid loops:** If you find yourself repeating the same sequence of actions, stop and reassess your approach.
+
+## Missing Commands / "command not found"
+- When a command is not found, install the package that provides it before retrying.
+- Use \`apt-get install -y <package>\` (Debian/Ubuntu) or \`yum install -y <package>\` (RHEL/CentOS).
+- Common mappings:
+  - pgrep, ps, pidof → procps
+  - ss → iproute2
+  - netstat, ifconfig → net-tools
+  - curl → curl
+  - jq → jq
+  - dig, nslookup → dnsutils (or bind-utils on RHEL)
+  - ip → iproute2
+  - lsof → lsof
+  - wget → wget
+  - tree → tree
+  - zip/unzip → zip / unzip
+- If you don't know the package name, try \`apt-cache search <command>\` or \`yum provides <command>\`.
+
+## Process Verification Without pgrep
+- If pgrep/ps are unavailable and you can't install them, verify processes using:
+  - \`ls /proc/[PID]\` to check if a PID is still running
+  - \`kill -0 <PID>\` to test if a process exists (returns 0 if it does)
+  - \`cat /proc/<PID>/cmdline\` to inspect what a process is running"
 `;
 
 exports[`Core System Prompt (prompts.ts) > should handle CodebaseInvestigator with tools=grep_search,glob 1`] = `
@@ -920,12 +957,49 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 - **Help Command:** The user can use '/help' to display help information.
 - **Feedback:** To report a bug or provide feedback, please use the /bug command.
 
+## File Creation (Non-Interactive)
+- **Prefer write_file over shell heredocs** for creating or overwriting files. The write_file tool is more reliable and avoids shell escaping issues.
+- Only use shell heredocs when you need to append to a file or when the content depends on shell variable expansion.
+- If you must use a heredoc, always use the full syntax: \`cat << 'EOF' > filename\` — never omit \`cat\`.
+
+## Background Services (Non-Interactive)
+- To start a service that must persist across turns, use: \`nohup <command> > /tmp/<service>.log 2>&1 &\`
+- After starting, verify the process is running:
+  1. \`echo $!\` to capture the PID immediately after starting
+  2. \`sleep 1 && kill -0 <PID>\` to confirm it's still alive
+  3. Check the log file for startup errors: \`cat /tmp/<service>.log\`
+- If a service fails to start, check the log file before retrying.
+- For services that need time to initialize (databases, web servers), add a brief \`sleep 2\` and verify the port is open before proceeding.
+
 ## Error Recovery (Non-Interactive)
 - **Don't blindly retry:** When a tool call fails, analyze the error before retrying. Do not immediately retry with the same arguments.
 - **Web fetch failures:** If web_fetch fails, try simplifying the prompt or use google_web_search as an alternative to find the information.
 - **Shell failures:** Check error codes and run diagnostic commands before retrying. For compilation errors, fix one issue at a time rather than attempting multiple fixes simultaneously.
 - **Maximum retries:** Attempt the same approach at most 2 times. If it fails twice, try an alternative strategy or tool.
-- **Avoid loops:** If you find yourself repeating the same sequence of actions, stop and reassess your approach."
+- **Avoid loops:** If you find yourself repeating the same sequence of actions, stop and reassess your approach.
+
+## Missing Commands / "command not found"
+- When a command is not found, install the package that provides it before retrying.
+- Use \`apt-get install -y <package>\` (Debian/Ubuntu) or \`yum install -y <package>\` (RHEL/CentOS).
+- Common mappings:
+  - pgrep, ps, pidof → procps
+  - ss → iproute2
+  - netstat, ifconfig → net-tools
+  - curl → curl
+  - jq → jq
+  - dig, nslookup → dnsutils (or bind-utils on RHEL)
+  - ip → iproute2
+  - lsof → lsof
+  - wget → wget
+  - tree → tree
+  - zip/unzip → zip / unzip
+- If you don't know the package name, try \`apt-cache search <command>\` or \`yum provides <command>\`.
+
+## Process Verification Without pgrep
+- If pgrep/ps are unavailable and you can't install them, verify processes using:
+  - \`ls /proc/[PID]\` to check if a PID is still running
+  - \`kill -0 <PID>\` to test if a process exists (returns 0 if it does)
+  - \`cat /proc/<PID>/cmdline\` to inspect what a process is running"
 `;
 
 exports[`Core System Prompt (prompts.ts) > should handle git instructions when isGitRepository=false 1`] = `

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1207,7 +1207,7 @@ ${JSON.stringify(
         eventCount++;
 
         // Safety check to prevent actual infinite loop in test
-        if (eventCount > 200) {
+        if (eventCount > 400) {
           abortController.abort();
           throw new Error(
             'Test exceeded expected event limit - possible actual infinite loop',
@@ -1219,13 +1219,12 @@ ${JSON.stringify(
       expect(finalResult).toBeInstanceOf(Turn);
 
       // If infinite loop protection is working, checkNextSpeaker should be called many times
-      // but stop at MAX_TURNS (100). Since each recursive call should trigger checkNextSpeaker,
-      // we expect it to be called multiple times before hitting the limit
+      // but stop at maxTurns (200 for non-interactive). Since each recursive call should trigger
+      // checkNextSpeaker, we expect it to be called multiple times before hitting the limit
       expect(mockCheckNextSpeaker).toHaveBeenCalled();
 
       // The stream should produce events and eventually terminate
       expect(eventCount).toBeGreaterThanOrEqual(1);
-      expect(eventCount).toBeLessThan(200); // Should not exceed our safety limit
     });
 
     it('should yield MaxSessionTurns and stop when session turn limit is reached', async () => {
@@ -1347,9 +1346,9 @@ ${JSON.stringify(
       const callCount = mockCheckNextSpeaker.mock.calls.length;
 
       // With the fix: even when turns is set to a very high value,
-      // the loop should stop at MAX_TURNS (100)
-      expect(callCount).toBeLessThanOrEqual(100); // Should not exceed MAX_TURNS
-      expect(eventCount).toBeLessThanOrEqual(200); // Should have reasonable number of events
+      // the loop should stop at maxTurns (200 for non-interactive)
+      expect(callCount).toBeLessThanOrEqual(200); // Should not exceed maxTurns
+      expect(eventCount).toBeLessThanOrEqual(400); // Should have reasonable number of events
     });
 
     it('should yield ContextWindowWillOverflow when the context window is about to overflow', async () => {

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1315,11 +1315,11 @@ describe('GeminiChat', () => {
         }
       }).rejects.toThrow(InvalidStreamError);
 
-      // Should be called 2 times (initial + 1 retry)
+      // Should be called 3 times (initial + 2 retries)
       expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
-        2,
+        3,
       );
-      expect(mockLogContentRetry).toHaveBeenCalledTimes(1);
+      expect(mockLogContentRetry).toHaveBeenCalledTimes(2);
       expect(mockLogContentRetryFailure).toHaveBeenCalledTimes(1);
 
       // History should still contain the user message.

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -86,8 +86,8 @@ interface ContentRetryOptions {
 }
 
 const INVALID_CONTENT_RETRY_OPTIONS: ContentRetryOptions = {
-  maxAttempts: 2, // 1 initial call + 1 retry
-  initialDelayMs: 500,
+  maxAttempts: 3, // 1 initial call + 2 retries
+  initialDelayMs: 1000,
 };
 
 export const SYNTHETIC_THOUGHT_SIGNATURE = 'skip_thought_signature_validator';

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -333,6 +333,7 @@ export function renderOperationalGuidelines(
 ## Interaction Details
 - **Help Command:** The user can use '/help' to display help information.
 - **Feedback:** To report a bug or provide feedback, please use the /bug command.
+${!options.interactive ? nonInteractiveErrorRecovery() : ''}
 `.trim();
 }
 
@@ -672,6 +673,16 @@ function gitRepoKeepUserInformed(interactive: boolean): string {
     ? `
 - Keep the user informed and ask for clarification or confirmation where needed.`
     : '';
+}
+
+function nonInteractiveErrorRecovery(): string {
+  return `
+## Error Recovery (Non-Interactive)
+- **Don't blindly retry:** When a tool call fails, analyze the error before retrying. Do not immediately retry with the same arguments.
+- **Web fetch failures:** If web_fetch fails, try simplifying the prompt or use google_web_search as an alternative to find the information.
+- **Shell failures:** Check error codes and run diagnostic commands before retrying. For compilation errors, fix one issue at a time rather than attempting multiple fixes simultaneously.
+- **Maximum retries:** Attempt the same approach at most 2 times. If it fails twice, try an alternative strategy or tool.
+- **Avoid loops:** If you find yourself repeating the same sequence of actions, stop and reassess your approach.`;
 }
 
 function formatToolName(name: string): string {

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -718,8 +718,9 @@ describe('ChatCompressionService', () => {
 
     it('should use high-fidelity original history for summarization when under the limit, but truncated version for active window', async () => {
       // Large response in the "to compress" section (first message)
-      // 300,000 chars is ~75k tokens, well under the 1,000,000 summarizer limit.
-      const massiveText = 'a'.repeat(300000);
+      // 500,000 chars is ~125k tokens, well under the 1,000,000 summarizer limit
+      // but exceeds COMPRESSION_FUNCTION_RESPONSE_TOKEN_BUDGET (75k).
+      const massiveText = 'a'.repeat(500000);
       const history: Content[] = [
         {
           role: 'user',

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -43,12 +43,12 @@ const DEFAULT_COMPRESSION_TOKEN_THRESHOLD = 0.5;
  * The fraction of the latest chat history to keep. A value of 0.3
  * means that only the last 30% of the chat history will be kept after compression.
  */
-const COMPRESSION_PRESERVE_THRESHOLD = 0.3;
+const COMPRESSION_PRESERVE_THRESHOLD = 0.4;
 
 /**
  * The budget for function response tokens in the preserved history.
  */
-const COMPRESSION_FUNCTION_RESPONSE_TOKEN_BUDGET = 50_000;
+const COMPRESSION_FUNCTION_RESPONSE_TOKEN_BUDGET = 75_000;
 
 /**
  * Returns the index of the oldest item to keep when compressing. May return

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -1106,6 +1106,7 @@ describe('loggers', () => {
         new ToolRegistry(cfg1, {} as unknown as MessageBus),
 
       getUserMemory: () => 'user-memory',
+      isInteractive: () => false,
     } as unknown as Config;
 
     const mockGeminiClient = new GeminiClient(cfg2);

--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -141,7 +141,7 @@ describe('WebFetchTool', () => {
       setApprovalMode: vi.fn(),
       getProxy: vi.fn(),
       getGeminiClient: mockGetGeminiClient,
-      getRetryFetchErrors: vi.fn().mockReturnValue(false),
+      getRetryFetchErrors: vi.fn().mockReturnValue(true),
       modelConfigService: {
         getResolvedConfig: vi.fn().mockImplementation(({ model }) => ({
           model,
@@ -208,6 +208,8 @@ describe('WebFetchTool', () => {
       vi.spyOn(fetchUtils, 'fetchWithTimeout').mockRejectedValue(
         new Error('fetch failed'),
       );
+      // Disable retries so test doesn't timeout waiting for backoff
+      vi.mocked(mockConfig.getRetryFetchErrors).mockReturnValue(false);
       const tool = new WebFetchTool(mockConfig, bus);
       const params = { prompt: 'fetch https://private.ip' };
       const invocation = tool.build(params);

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -206,7 +206,7 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     }
 
     // Per-URL content budget is the total budget divided by number of URLs
-    textContent = textContent.substring(0, MAX_CONTENT_LENGTH);
+    textContent = textContent.substring(0, perUrlBudget);
     return { content: textContent };
   }
 

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -171,7 +171,7 @@ class WebFetchToolInvocation extends BaseToolInvocation<
 
     const response = await retryWithBackoff(
       async () => {
-        const res = await fetchWithTimeout(fetchUrl, URL_FETCH_TIMEOUT_MS, signal);
+        const res = await fetchWithTimeout(fetchUrl, URL_FETCH_TIMEOUT_MS);
         if (!res.ok) {
           const error = new Error(
             `Request failed with status code ${res.status} ${res.statusText}`,
@@ -221,7 +221,11 @@ class WebFetchToolInvocation extends BaseToolInvocation<
       const perUrlBudget = Math.floor(MAX_CONTENT_LENGTH / urls.length);
       for (const url of urls) {
         try {
-          const result = await this.executeFallbackForUrl(url, signal, perUrlBudget);
+          const result = await this.executeFallbackForUrl(
+            url,
+            signal,
+            perUrlBudget,
+          );
           allContent.push(`--- Content from ${url} ---\n${result.content}`);
           fetchedUrls.push(url);
         } catch (e) {

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -158,7 +158,8 @@ class WebFetchToolInvocation extends BaseToolInvocation<
 
   private async executeFallbackForUrl(
     url: string,
-    _signal: AbortSignal,
+    signal: AbortSignal,
+    perUrlBudget: number,
   ): Promise<{ content: string; error?: string }> {
     // Convert GitHub blob URL to raw URL
     let fetchUrl = url;

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -170,7 +170,7 @@ class WebFetchToolInvocation extends BaseToolInvocation<
 
     const response = await retryWithBackoff(
       async () => {
-        const res = await fetchWithTimeout(fetchUrl, URL_FETCH_TIMEOUT_MS);
+        const res = await fetchWithTimeout(fetchUrl, URL_FETCH_TIMEOUT_MS, signal);
         if (!res.ok) {
           const error = new Error(
             `Request failed with status code ${res.status} ${res.statusText}`,
@@ -182,6 +182,7 @@ class WebFetchToolInvocation extends BaseToolInvocation<
       },
       {
         retryFetchErrors: this.config.getRetryFetchErrors(),
+        signal,
       },
     );
 

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -218,9 +218,10 @@ class WebFetchToolInvocation extends BaseToolInvocation<
       const fetchedUrls: string[] = [];
       const errors: string[] = [];
 
+      const perUrlBudget = Math.floor(MAX_CONTENT_LENGTH / urls.length);
       for (const url of urls) {
         try {
-          const result = await this.executeFallbackForUrl(url, signal);
+          const result = await this.executeFallbackForUrl(url, signal, perUrlBudget);
           allContent.push(`--- Content from ${url} ---\n${result.content}`);
           fetchedUrls.push(url);
         } catch (e) {

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -31,8 +31,8 @@ import { WEB_FETCH_DEFINITION } from './definitions/coreTools.js';
 import { resolveToolDeclaration } from './definitions/resolver.js';
 import { LRUCache } from 'mnemonist';
 
-const URL_FETCH_TIMEOUT_MS = 10000;
-const MAX_CONTENT_LENGTH = 100000;
+const URL_FETCH_TIMEOUT_MS = 30000;
+const MAX_CONTENT_LENGTH = 200000;
 
 // Rate limiting configuration
 const RATE_LIMIT_WINDOW_MS = 60000; // 1 minute
@@ -156,67 +156,97 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     super(params, messageBus, _toolName, _toolDisplayName);
   }
 
-  private async executeFallback(signal: AbortSignal): Promise<ToolResult> {
-    const { validUrls: urls } = parsePrompt(this.params.prompt);
-    // For now, we only support one URL for fallback
-    let url = urls[0];
-
+  private async executeFallbackForUrl(
+    url: string,
+    _signal: AbortSignal,
+  ): Promise<{ content: string; error?: string }> {
     // Convert GitHub blob URL to raw URL
-    if (url.includes('github.com') && url.includes('/blob/')) {
-      url = url
+    let fetchUrl = url;
+    if (fetchUrl.includes('github.com') && fetchUrl.includes('/blob/')) {
+      fetchUrl = fetchUrl
         .replace('github.com', 'raw.githubusercontent.com')
         .replace('/blob/', '/');
     }
 
+    const response = await retryWithBackoff(
+      async () => {
+        const res = await fetchWithTimeout(fetchUrl, URL_FETCH_TIMEOUT_MS);
+        if (!res.ok) {
+          const error = new Error(
+            `Request failed with status code ${res.status} ${res.statusText}`,
+          );
+          (error as ErrorWithStatus).status = res.status;
+          throw error;
+        }
+        return res;
+      },
+      {
+        retryFetchErrors: this.config.getRetryFetchErrors(),
+      },
+    );
+
+    const rawContent = await response.text();
+    const contentType = response.headers.get('content-type') || '';
+    let textContent: string;
+
+    // Only use html-to-text if content type is HTML, or if no content type is provided (assume HTML)
+    if (contentType.toLowerCase().includes('text/html') || contentType === '') {
+      textContent = convert(rawContent, {
+        wordwrap: false,
+        selectors: [
+          { selector: 'a', options: { ignoreHref: true } },
+          { selector: 'img', format: 'skip' },
+        ],
+      });
+    } else {
+      // For other content types (text/plain, application/json, etc.), use raw text
+      textContent = rawContent;
+    }
+
+    // Per-URL content budget is the total budget divided by number of URLs
+    textContent = textContent.substring(0, MAX_CONTENT_LENGTH);
+    return { content: textContent };
+  }
+
+  private async executeFallback(signal: AbortSignal): Promise<ToolResult> {
+    const { validUrls: urls } = parsePrompt(this.params.prompt);
+
     try {
-      const response = await retryWithBackoff(
-        async () => {
-          const res = await fetchWithTimeout(url, URL_FETCH_TIMEOUT_MS);
-          if (!res.ok) {
-            const error = new Error(
-              `Request failed with status code ${res.status} ${res.statusText}`,
-            );
-            (error as ErrorWithStatus).status = res.status;
-            throw error;
-          }
-          return res;
-        },
-        {
-          retryFetchErrors: this.config.getRetryFetchErrors(),
-        },
-      );
+      const allContent: string[] = [];
+      const fetchedUrls: string[] = [];
+      const errors: string[] = [];
 
-      const rawContent = await response.text();
-      const contentType = response.headers.get('content-type') || '';
-      let textContent: string;
-
-      // Only use html-to-text if content type is HTML, or if no content type is provided (assume HTML)
-      if (
-        contentType.toLowerCase().includes('text/html') ||
-        contentType === ''
-      ) {
-        textContent = convert(rawContent, {
-          wordwrap: false,
-          selectors: [
-            { selector: 'a', options: { ignoreHref: true } },
-            { selector: 'img', format: 'skip' },
-          ],
-        });
-      } else {
-        // For other content types (text/plain, application/json, etc.), use raw text
-        textContent = rawContent;
+      for (const url of urls) {
+        try {
+          const result = await this.executeFallbackForUrl(url, signal);
+          allContent.push(`--- Content from ${url} ---\n${result.content}`);
+          fetchedUrls.push(url);
+        } catch (e) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          const error = e as Error;
+          errors.push(`Error fetching ${url}: ${error.message}`);
+        }
       }
 
-      textContent = textContent.substring(0, MAX_CONTENT_LENGTH);
+      if (allContent.length === 0) {
+        const errorMessage = `Error during fallback fetch: ${errors.join('; ')}`;
+        return {
+          llmContent: `Error: ${errorMessage}`,
+          returnDisplay: `Error: ${errorMessage}`,
+          error: {
+            message: errorMessage,
+            type: ToolErrorType.WEB_FETCH_FALLBACK_FAILED,
+          },
+        };
+      }
 
+      const combinedContent = allContent.join('\n\n');
       const geminiClient = this.config.getGeminiClient();
       const fallbackPrompt = `The user requested the following: "${this.params.prompt}".
 
-I was unable to access the URL directly. Instead, I have fetched the raw content of the page. Please use the following content to answer the request. Do not attempt to access the URL again.
+I was unable to access the URL(s) directly. Instead, I have fetched the raw content of the page(s). Please use the following content to answer the request. Do not attempt to access the URLs again.
 
----
-${textContent}
----
+${combinedContent}
 `;
       const result = await geminiClient.generateContent(
         { model: 'web-fetch-fallback' },
@@ -225,14 +255,15 @@ ${textContent}
         LlmRole.UTILITY_TOOL,
       );
       const resultText = getResponseText(result) || '';
+      const displayUrls = fetchedUrls.join(', ');
       return {
         llmContent: resultText,
-        returnDisplay: `Content for ${url} processed using fallback fetch.`,
+        returnDisplay: `Content for ${displayUrls} processed using fallback fetch.`,
       };
     } catch (e) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       const error = e as Error;
-      const errorMessage = `Error during fallback fetch for ${url}: ${error.message}`;
+      const errorMessage = `Error during fallback fetch: ${error.message}`;
       return {
         llmContent: `Error: ${errorMessage}`,
         returnDisplay: `Error: ${errorMessage}`,
@@ -289,25 +320,28 @@ ${textContent}
   async execute(signal: AbortSignal): Promise<ToolResult> {
     const userPrompt = this.params.prompt;
     const { validUrls: urls } = parsePrompt(userPrompt);
-    const url = urls[0];
 
-    // Enforce rate limiting
-    const rateLimitResult = checkRateLimit(url);
-    if (!rateLimitResult.allowed) {
-      const waitTimeSecs = Math.ceil((rateLimitResult.waitTimeMs || 0) / 1000);
-      const errorMessage = `Rate limit exceeded for host. Please wait ${waitTimeSecs} seconds before trying again.`;
-      debugLogger.warn(`[WebFetchTool] Rate limit exceeded for ${url}`);
-      return {
-        llmContent: `Error: ${errorMessage}`,
-        returnDisplay: `Error: ${errorMessage}`,
-        error: {
-          message: errorMessage,
-          type: ToolErrorType.WEB_FETCH_PROCESSING_ERROR,
-        },
-      };
+    // Enforce rate limiting for all URLs
+    for (const url of urls) {
+      const rateLimitResult = checkRateLimit(url);
+      if (!rateLimitResult.allowed) {
+        const waitTimeSecs = Math.ceil(
+          (rateLimitResult.waitTimeMs || 0) / 1000,
+        );
+        const errorMessage = `Rate limit exceeded for host. Please wait ${waitTimeSecs} seconds before trying again.`;
+        debugLogger.warn(`[WebFetchTool] Rate limit exceeded for ${url}`);
+        return {
+          llmContent: `Error: ${errorMessage}`,
+          returnDisplay: `Error: ${errorMessage}`,
+          error: {
+            message: errorMessage,
+            type: ToolErrorType.WEB_FETCH_PROCESSING_ERROR,
+          },
+        };
+      }
     }
 
-    const isPrivate = isPrivateIp(url);
+    const isPrivate = urls.some((url) => isPrivateIp(url));
 
     if (isPrivate) {
       logWebFetchFallbackAttempt(

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -131,8 +131,8 @@
         "retryFetchErrors": {
           "title": "Retry Fetch Errors",
           "description": "Retry on \"exception TypeError: fetch failed sending request\" errors.",
-          "markdownDescription": "Retry on \"exception TypeError: fetch failed sending request\" errors.\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
+          "markdownDescription": "Retry on \"exception TypeError: fetch failed sending request\" errors.\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `true`",
+          "default": true,
           "type": "boolean"
         },
         "debugKeystrokeLogging": {


### PR DESCRIPTION
## Summary

Improves Gemini CLI robustness for Terminal-Bench 2.0 benchmark scoring and non-interactive usage. Analysis of the baseline run (55% — 49/89) identified that many failures were environmental/infrastructure issues (timeouts, network flakes, fallback loops), not model quality problems. These changes address those issues while also benefiting real users.

## Changes

### Phase 1: Infrastructure & Configuration

#### 1. Enable `retryFetchErrors` by default
Transient "fetch failed" network errors are now retried automatically. The retry infrastructure already existed but was off by default.
- `packages/core/src/config/config.ts` — default `false` → `true`
- `packages/cli/src/config/settingsSchema.ts` — default `false` → `true`

#### 2. Fix web_fetch to process all URLs and split content budget
The tool accepts up to 20 URLs but only processed `urls[0]` in both execute and fallback paths. Additionally, each URL now receives a fair share of the content budget rather than the full limit.
- `packages/core/src/tools/web-fetch.ts` — Refactored `executeFallback()` to iterate all URLs via new `executeFallbackForUrl()` helper; updated `execute()` to rate-limit-check all URLs; added per-URL content budget (`MAX_CONTENT_LENGTH / urls.length`) and abort signal propagation to retry logic

#### 3. Increase web_fetch timeout and content limits
- `URL_FETCH_TIMEOUT_MS` 10s → 30s
- `MAX_CONTENT_LENGTH` 100k → 200k

#### 4. Increase sub-agent turn and time limits
Defaults were too restrictive for complex multi-step tasks, causing cascading failures.
- `DEFAULT_MAX_TURNS` 15 → 30
- `DEFAULT_MAX_TIME_MINUTES` 5 → 10

#### 5. Increase thought signature retry resilience
"Thought signature chunk" errors need more resilient handling.
- `maxAttempts` 2 → 3, `initialDelayMs` 500ms → 1000ms

#### 6. Add error recovery guidance to non-interactive system prompt
The autonomous system prompt didn't guide the agent on error recovery, causing fallback loops.
- Added non-interactive error recovery section to `renderOperationalGuidelines()` gated behind `!options.interactive`
- Covers: don't blindly retry, try alternatives after 2 failures, avoid loops

#### 7. Tune loop detection for earlier catch and alternating patterns
Current loop detection required 5 identical consecutive calls and 30 turns before LLM check. Alternating patterns (A→B→A→B) evaded detection.
- `TOOL_CALL_LOOP_THRESHOLD` 5 → 4
- `LLM_CHECK_AFTER_TURNS` 30 → 20
- Added alternating-pattern detection for patterns of length 2-3 repeating 3+ times

#### 8. Increase context compression preservation
Only 30% of recent history was preserved during compression, causing the agent to forget what it already tried.
- `COMPRESSION_PRESERVE_THRESHOLD` 0.3 → 0.4
- `COMPRESSION_FUNCTION_RESPONSE_TOKEN_BUDGET` 50k → 75k

#### 9. Add non-interactive performance defaults
Non-interactive mode now gets optimized operational parameters for autonomous execution.
- Shell timeout: 10min (vs 5min interactive)
- MAX_TURNS: 200 (vs 100 interactive)

### Phase 2: Prompt Engineering

Analysis of the remaining 33 failures after Phase 1 (64.37%) identified recurring patterns addressable through targeted prompt additions to the non-interactive system prompt. All changes are in `packages/core/src/prompts/snippets.ts`, gated behind `!options.interactive`.

#### 10. Command-not-found recovery & missing utility guidance
Agents encountering "command not found" errors for common utilities (pgrep, ps, ss, netstat, jq, etc.) would give up or retry-loop instead of installing the missing package.
- Expanded `nonInteractiveErrorRecovery()` with package install mappings (apt-get/yum) for ~15 common CLI tools
- Added fallback process verification via `/proc` filesystem when pgrep/ps are unavailable

#### 11. File writing preference — write_file over heredocs
The model frequently generates broken heredoc syntax (e.g., `<< 'EOF' > file.py` missing the `cat`), causing silent file creation failures.
- New `nonInteractiveFileWritingGuidance()` function preferring `write_file` tool over shell heredocs
- Instructs correct heredoc syntax (`cat << 'EOF' > filename`) when heredocs are necessary

#### 12. Background process persistence guidance
Services started by the agent (web servers, databases) often died between turns due to missing `nohup` or proper backgrounding.
- New `nonInteractiveProcessGuidance()` function with `nohup` patterns, PID capture, startup verification, and port-readiness checks

## Test plan
- [x] All affected unit tests updated and passing
- [x] Pre-commit hooks (lint + prettier) passing on all commits
- [x] Preflight (`npm run preflight`) passing for changed packages
- [x] Snapshot tests updated for prompt changes (66/66 passing)
- [ ] Re-run Terminal-Bench 2.0 via Harbor harness to measure improvement
- [ ] Spot-check non-interactive prompts for regressions