### PR TITLE
fix: make build scripts idempotent by cleaning dest dirs before cpSync

### DIFF
--- a/scripts/build_package.js
+++ b/scripts/build_package.js
@@ -18,7 +18,7 @@
 // limitations under the License.
 
 import { execSync } from 'node:child_process';
-import { writeFileSync, existsSync, cpSync } from 'node:fs';
+import { writeFileSync, existsSync, cpSync, rmSync } from 'node:fs';
 import { join, basename } from 'node:path';
 
 if (!process.cwd().includes('packages')) {
@@ -39,6 +39,9 @@ if (packageName === 'core') {
   const docsSource = join(process.cwd(), '..', '..', 'docs');
   const docsTarget = join(process.cwd(), 'dist', 'docs');
   if (existsSync(docsSource)) {
+    if (existsSync(docsTarget)) {
+      rmSync(docsTarget, { recursive: true });
+    }
     cpSync(docsSource, docsTarget, { recursive: true, dereference: true });
     console.log('Copied documentation to dist/docs');
   }

--- a/scripts/build_package.js
+++ b/scripts/build_package.js
@@ -39,9 +39,7 @@ if (packageName === 'core') {
   const docsSource = join(process.cwd(), '..', '..', 'docs');
   const docsTarget = join(process.cwd(), 'dist', 'docs');
   if (existsSync(docsSource)) {
-    if (existsSync(docsTarget)) {
-      rmSync(docsTarget, { recursive: true });
-    }
+    rmSync(docsTarget, { recursive: true, force: true });
     cpSync(docsSource, docsTarget, { recursive: true, dereference: true });
     console.log('Copied documentation to dist/docs');
   }

--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -58,9 +58,7 @@ console.log(`Copied ${policyFiles.length} policy files to bundle/policies/`);
 const docsSrc = join(root, 'docs');
 const docsDest = join(bundleDir, 'docs');
 if (existsSync(docsSrc)) {
-  if (existsSync(docsDest)) {
-    rmSync(docsDest, { recursive: true });
-  }
+  rmSync(docsDest, { recursive: true, force: true });
   cpSync(docsSrc, docsDest, { recursive: true, dereference: true });
   console.log('Copied docs to bundle/docs/');
 }
@@ -69,9 +67,7 @@ if (existsSync(docsSrc)) {
 const builtinSkillsSrc = join(root, 'packages/core/src/skills/builtin');
 const builtinSkillsDest = join(bundleDir, 'builtin');
 if (existsSync(builtinSkillsSrc)) {
-  if (existsSync(builtinSkillsDest)) {
-    rmSync(builtinSkillsDest, { recursive: true });
-  }
+  rmSync(builtinSkillsDest, { recursive: true, force: true });
   cpSync(builtinSkillsSrc, builtinSkillsDest, {
     recursive: true,
     dereference: true,

--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -17,7 +17,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { copyFileSync, existsSync, mkdirSync, cpSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, cpSync, rmSync } from 'node:fs';
 import { dirname, join, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { glob } from 'glob';
@@ -58,6 +58,9 @@ console.log(`Copied ${policyFiles.length} policy files to bundle/policies/`);
 const docsSrc = join(root, 'docs');
 const docsDest = join(bundleDir, 'docs');
 if (existsSync(docsSrc)) {
+  if (existsSync(docsDest)) {
+    rmSync(docsDest, { recursive: true });
+  }
   cpSync(docsSrc, docsDest, { recursive: true, dereference: true });
   console.log('Copied docs to bundle/docs/');
 }
@@ -66,6 +69,9 @@ if (existsSync(docsSrc)) {
 const builtinSkillsSrc = join(root, 'packages/core/src/skills/builtin');
 const builtinSkillsDest = join(bundleDir, 'builtin');
 if (existsSync(builtinSkillsSrc)) {
+  if (existsSync(builtinSkillsDest)) {
+    rmSync(builtinSkillsDest, { recursive: true });
+  }
   cpSync(builtinSkillsSrc, builtinSkillsDest, {
     recursive: true,
     dereference: true,


### PR DESCRIPTION
## Summary

Fix repeat builds failing due to `cpSync` with `dereference: true` throwing when the destination directory already exists and contains a resolved symlink (`docs/CONTRIBUTING.md` → `../CONTRIBUTING.md`). This causes `npm run build`, `npm run build:all`, and `npm install` (via the `prepare` hook) to fail on any run after the first successful build.

## Details

`docs/CONTRIBUTING.md` is a symlink tracked in git. Both `copy_bundle_assets.js` and `build_package.js` use `cpSync(..., { dereference: true })` to copy the `docs/` directory into build output directories (`bundle/docs/`, `packages/core/dist/docs/`).

On the first build this works fine. On subsequent builds, `cpSync` detects that the dereferenced source and existing destination resolve to the same underlying file and throws:
- `ERR_FS_CP_EINVAL` ("src and dest cannot be the same") on Node 20
- `EEXIST` ("File exists") on Node 25

The fix removes the existing destination directory before calling `cpSync` in both scripts, making builds idempotent. The same treatment is applied to the `bundle/builtin/` copy for consistency.

## Related Issues

Fixes #19929

## How to Validate

1. Check out this branch and run `npm install`
2. Run `npm run build` — should succeed
3. Run `npm run build` again — should succeed (previously failed here)
4. Run `npm run build:all` — should succeed
5. Run `npm run build:all` again — should succeed (previously failed here)
6. Verify `bundle/docs/`, `bundle/builtin/`, and `packages/core/dist/docs/` contain expected files after each build

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker