### PR TITLE
fix(core): improve WSL shell execution routing and shell loop detection normalization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17419,6 +17419,7 @@
         "shell-quote": "^1.8.3",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",
+        "strip-json-comments": "^3.1.1",
         "systeminformation": "^5.25.11",
         "tree-sitter-bash": "^0.25.0",
         "undici": "^7.10.0",

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -172,6 +172,23 @@ describe('LoopDetectionService', () => {
       }
       expect(loggers.logLoopDetected).not.toHaveBeenCalled();
     });
+
+    it('should detect shell tool loops even when wrapper and description vary', () => {
+      let isLoop = false;
+
+      for (let i = 0; i < TOOL_CALL_LOOP_THRESHOLD; i++) {
+        const command = i % 2 === 0 ? 'bash -c "echo    hello"' : 'echo hello';
+        const event = createToolCallRequestEvent('run_shell_command', {
+          command,
+          description: `attempt-${i}`,
+          is_background: false,
+        });
+        isLoop = service.addAndCheck(event);
+      }
+
+      expect(isLoop).toBe(true);
+      expect(loggers.logLoopDetected).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('Content Loop Detection', () => {


### PR DESCRIPTION
## Summary

This PR improves shell execution reliability in Windows + WSL environments and strengthens loop-detection guardrails for shell tool retries.
Impact is functional: commands run from WSL UNC paths are routed safely, and semantically repeated shell retries are detected more reliably.

## Details

- Updated shell execution planning to detect WSL UNC paths (for example `\\wsl.localhost\Ubuntu\...`) and route execution via `wsl.exe` with the correct distro/path context.
- Added robust UNC parsing logic for WSL path handling.
- Normalized shell tool-call arguments in loop detection by stripping shell wrappers and normalizing whitespace before keying.
- Added regression tests for:
  - WSL UNC shell execution routing behavior.
  - Loop detection across wrapper/description variations.

## Related Issues

Related to #19879 

## How to Validate

1. Build core package:
   - `npm run build -w @google/gemini-cli-core`
   - Expected: successful TypeScript build with no errors.
2. Lint changed core files:
   - `npm run lint -w @google/gemini-cli-core -- src/services/shellExecutionService.ts src/services/loopDetectionService.ts src/services/shellExecutionService.test.ts src/services/loopDetectionService.test.ts`
   - Expected: no lint errors.
3. Run targeted regression tests:
   - `npm run test -w @google/gemini-cli-core -- src/services/shellExecutionService.test.ts src/services/loopDetectionService.test.ts`
   - Expected: both test files pass (104 tests total).
4. WSL environment check:
   - Run from WSL shell (or through `wsl.exe -d Ubuntu -- bash -lc ...`) to avoid Windows UNC `cmd.exe` fallback issues.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker

Notes:
- No breaking changes.
- Documentation updates were not required for this internal behavior fix.
