### PR TITLE
fix(a2a-server): use parametersJsonSchema in task metadata

### DIFF
--- a/docs/reference/tools-api.md
+++ b/docs/reference/tools-api.md
@@ -13,9 +13,9 @@ content, and perform various actions beyond simple text generation.
   - `displayName`: A user-friendly name.
   - `description`: A clear explanation of what the tool does, which is provided
     to the Gemini model.
-  - `parameterSchema`: A JSON schema defining the parameters that the tool
-    accepts. This is crucial for the Gemini model to understand how to call the
-    tool correctly.
+  - `schema.parametersJsonSchema`: A JSON schema defining the parameters that
+    the tool accepts. This is crucial for the Gemini model to understand how to
+    call the tool correctly.
   - `validateToolParams()`: A method to validate incoming parameters.
   - `getDescription()`: A method to provide a human-readable description of what
     the tool will do with specific parameters before execution.

--- a/packages/a2a-server/src/agent/task.test.ts
+++ b/packages/a2a-server/src/agent/task.test.ts
@@ -266,7 +266,9 @@ describe('Task', () => {
       expect(metadata.mcpServers[0].tools[0].parameterSchema).toEqual(
         expectedSchema,
       );
-      expect(metadata.availableTools[0].parameterSchema).toEqual(expectedSchema);
+      expect(metadata.availableTools[0].parameterSchema).toEqual(
+        expectedSchema,
+      );
     });
 
     it('should fall back to schema.parameters when parametersJsonSchema is missing', async () => {
@@ -311,7 +313,9 @@ describe('Task', () => {
       expect(metadata.mcpServers[0].tools[0].parameterSchema).toEqual(
         expectedSchema,
       );
-      expect(metadata.availableTools[0].parameterSchema).toEqual(expectedSchema);
+      expect(metadata.availableTools[0].parameterSchema).toEqual(
+        expectedSchema,
+      );
     });
   });
 

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -127,7 +127,7 @@ export class Task {
     const serverStatuses = getAllMCPServerStatuses();
     const getToolParameterSchema = (
       tool: Pick<AnyDeclarativeTool, 'schema'>,
-    ): unknown => tool.schema.parametersJsonSchema ?? tool.schema.parameters;
+    ): unknown => tool.schema?.parametersJsonSchema ?? tool.schema?.parameters;
     const servers = Object.keys(mcpServers).map((serverName) => ({
       name: serverName,
       status: serverStatuses.get(serverName) || MCPServerStatus.DISCONNECTED,

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -125,20 +125,23 @@ export class Task {
     const toolRegistry = this.config.getToolRegistry();
     const mcpServers = this.config.getMcpClientManager()?.getMcpServers() || {};
     const serverStatuses = getAllMCPServerStatuses();
+    const getToolParameterSchema = (
+      tool: Pick<AnyDeclarativeTool, 'schema'>,
+    ): unknown => tool.schema.parametersJsonSchema ?? tool.schema.parameters;
     const servers = Object.keys(mcpServers).map((serverName) => ({
       name: serverName,
       status: serverStatuses.get(serverName) || MCPServerStatus.DISCONNECTED,
       tools: toolRegistry.getToolsByServer(serverName).map((tool) => ({
         name: tool.name,
         description: tool.description,
-        parameterSchema: tool.schema.parameters,
+        parameterSchema: getToolParameterSchema(tool),
       })),
     }));
 
     const availableTools = toolRegistry.getAllTools().map((tool) => ({
       name: tool.name,
       description: tool.description,
-      parameterSchema: tool.schema.parameters,
+      parameterSchema: getToolParameterSchema(tool),
     }));
 
     const metadata: TaskMetadata = {


### PR DESCRIPTION
## Summary

Fix documentation drift in the Tools API docs and align A2A task metadata schema extraction with the core tool declaration shape.

## Details

- Updated `docs/reference/tools-api.md` to reference `schema.parametersJsonSchema` (instead of `parameterSchema`) in the core tool contract description.
- Fixed `Task.getMetadata()` in `packages/a2a-server/src/agent/task.ts` to read tool schemas from `tool.schema.parametersJsonSchema`.
- Added a compatibility fallback to `tool.schema.parameters` for legacy/alternate tool schema shapes.
- Added a guard for missing schemas to avoid runtime errors (`tool.schema?.parametersJsonSchema ?? tool.schema?.parameters`).
- Added regression tests in `packages/a2a-server/src/agent/task.test.ts` to cover:
  - `parametersJsonSchema` path
  - fallback `parameters` path
  - missing `schema` path

## Related Issues

Fixes #19934

## How to Validate

1. Run the A2A task tests:
   - `cd packages/a2a-server`
   - `npx -y node@22 ../../node_modules/vitest/vitest.mjs run src/agent/task.test.ts`
2. Confirm all tests pass (`20 passed`).
3. Review docs update in `docs/reference/tools-api.md` and verify the property name is `schema.parametersJsonSchema`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
  - No breaking changes.
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [ ] npm run
    - [x] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
