### PR TITLE
fix(core): prevent agent continuation loop after interrupt

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1135,6 +1135,10 @@ export const useGeminiStream = (
       let geminiMessageBuffer = '';
       const toolCallRequests: ToolCallRequestInfo[] = [];
       for await (const event of stream) {
+        // Check for abort mid-stream to break out immediately
+        if (signal.aborted || turnCancelledRef.current) {
+          return StreamProcessingStatus.UserCancelled;
+        }
         if (
           event.type !== ServerGeminiEventType.Thought &&
           thoughtRef.current !== null
@@ -1339,6 +1343,10 @@ export const useGeminiStream = (
               );
 
               if (processingStatus === StreamProcessingStatus.UserCancelled) {
+                if (pendingHistoryItemRef.current) {
+                  addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+                  setPendingHistoryItem(null);
+                }
                 return;
               }
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -736,6 +736,10 @@ export class GeminiClient {
           );
           return turn;
         }
+        // Check if abort was triggered before continuing
+        if (signal?.aborted) {
+          return turn;
+        }
         const nextRequest = [{ text: 'System: Please continue.' }];
         // Recursive call - update turn with result
         turn = yield* this.sendMessageStream(
@@ -769,6 +773,10 @@ export class GeminiClient {
             nextSpeakerCheck?.next_speaker || '',
           ),
         );
+        // Re-check abort signal after async checkNextSpeaker call
+        if (signal?.aborted) {
+          return turn;
+        }
         if (nextSpeakerCheck?.next_speaker === 'model') {
           const nextRequest = [{ text: 'Please continue.' }];
           turn = yield* this.sendMessageStream(


### PR DESCRIPTION
When a user interrupts the agent with Ctrl+C during streaming, the agent would continue "explaining itself" instead of stopping. The interrupt would trigger the abort signal, but race conditions between async operations and the recursive continuation logic allowed the model to keep generating responses.

This fix adds explicit abort signal checks before recursive `sendMessageStream` calls, ensuring the agent stops immediately after an interrupt in both the invalid stream retry path and the next speaker continuation path.

## Root Cause

In `packages/core/src/core/client.ts`, the continuation logic after `checkNextSpeaker()` did not re-verify the abort signal after the async call completed:

```typescript
// Before (broken):
const nextSpeakerCheck = await checkNextSpeaker(
  this.getChat(),
  this.config.getBaseLlmClient(),
  signal,
  prompt_id,
);
if (nextSpeakerCheck?.next_speaker === 'model') {
  const nextRequest = [{ text: 'Please continue.' }];
  turn = yield* this.sendMessageStream(
    nextRequest,
    signal,
    prompt_id,
    boundedTurns - 1,
    false,
    displayContent,
  );
}
```

When `checkNextSpeaker()` returned `'model'` due to an "incomplete" response (which happens after an interrupt mid-stream), the system would automatically send "Please continue." to the model, causing it to explain itself. The same issue existed in the invalid stream retry path.

Additionally, in `packages/cli/src/ui/hooks/useGeminiStream.ts`, the stream event processing loop did not check for abort mid-iteration, allowing events to continue processing even after cancellation.

## Fix

Applied three abort signal checks:

**1. Invalid stream retry path (`client.ts`):**
```typescript
// After (fixed):
if (signal?.aborted) {
  return turn;
}
const nextRequest = [{ text: 'System: Please continue.' }];
```

**2. Next speaker continuation path (`client.ts`):**
```typescript
// After (fixed):
const nextSpeakerCheck = await checkNextSpeaker(...);
// Re-check abort signal after async checkNextSpeaker call
if (signal?.aborted) {
  return turn;
}
if (nextSpeakerCheck?.next_speaker === 'model') {
```

**3. Stream event processing loop (`useGeminiStream.ts`):**
```typescript
// After (fixed):
for await (const event of stream) {
  // Check for abort mid-stream to break out immediately
  if (signal.aborted || turnCancelledRef.current) {
    return StreamProcessingStatus.UserCancelled;
  }
  // ... rest of event processing
}
```

## Tests

All existing tests continue to pass:
- `client.test.ts`: 71 passed (1 skipped)
- `useGeminiStream.test.tsx`: 68 passed

No new tests were added as the fix addresses race conditions in async abort handling that are difficult to reproduce reliably in unit tests.

Fixes #19880
````
