### PR TITLE
docs(core): fix parameter property name in tools-api reference

### DIFF
--- a/docs/reference/tools-api.md
+++ b/docs/reference/tools-api.md
@@ -13,7 +13,7 @@ content, and perform various actions beyond simple text generation.
   - `displayName`: A user-friendly name.
   - `description`: A clear explanation of what the tool does, which is provided
     to the Gemini model.
-  - `parameterSchema`: A JSON schema defining the parameters that the tool
+  - `parametersJsonSchema`: A JSON schema defining the parameters that the tool
     accepts. This is crucial for the Gemini model to understand how to call the
     tool correctly.
   - `validateToolParams()`: A method to validate incoming parameters.


### PR DESCRIPTION
## Summary

Fixes the incorrect property name for tool parameter schemas in the
documentation to match the actual implementation.

## Details

The documentation at `docs/reference/tools-api.md` incorrectly referred to the
property as `parameterSchema`. The implementation in `packages/core/src/tools/`
(specifically in `BaseDeclarativeTool` and the core tool definitions) expects
`parametersJsonSchema`. This discrepancy causes confusion for developers
implementing custom tools or sub-agents.

Note: During investigation, a related mismatch was found in
`packages/a2a-server/src/agent/task.ts` (accessing `.parameters` instead of
`.parametersJsonSchema`), which should be addressed in a follow-up PR as it was
out of scope for this documentation fix.

## Related Issues

Fixes #19934

## How to Validate

1. Open `docs/reference/tools-api.md`.
2. Verify that the property name under "Core concepts" -> "Tool" is now
   `parametersJsonSchema`.
3. Confirm this matches the property name used in
   `packages/core/src/tools/tools.ts`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
