### PR TITLE
fix(cli): gracefully handle extension update failures

### DIFF
--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -309,7 +309,7 @@ Would you like to attempt to install via "git clone" instead?`,
         ).getExtensionDir();
 
         // Create Backup
-        const backupPath = `${destinationPath}_backup`;
+        const backupPath = `${destinationPath}_backup_${randomUUID()}`;
         let backupCreated = false;
 
         if (isUpdate) {
@@ -398,12 +398,19 @@ Would you like to attempt to install via "git clone" instead?`,
           }
         } catch (loadError) {
           if (backupCreated) {
-            await fs.promises.rm(destinationPath, {
-              recursive: true,
-              force: true,
-            });
-            await fs.promises.rename(backupPath, destinationPath);
-            extension = await this.loadExtension(destinationPath);
+            try {
+              await fs.promises.rm(destinationPath, {
+                recursive: true,
+                force: true,
+              });
+              await fs.promises.rename(backupPath, destinationPath);
+              await this.loadExtension(destinationPath);
+            } catch (restoreError) {
+              debugLogger.error(
+                'Failed to restore extension from backup after update failure:',
+                restoreError,
+              );
+            }
           }
           throw loadError;
         } finally {

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -307,6 +307,28 @@ Would you like to attempt to install via "git clone" instead?`,
         const destinationPath = new ExtensionStorage(
           newExtensionName,
         ).getExtensionDir();
+
+        // Create Backup
+        const backupPath = `${destinationPath}_backup`;
+        let backupCreated = false;
+
+        if (isUpdate) {
+          try {
+            const destExists = await fs.promises
+              .stat(destinationPath)
+              .then(() => true)
+              .catch(() => false);
+            if (destExists) {
+              await fs.promises.cp(destinationPath, backupPath, {
+                recursive: true,
+              });
+              backupCreated = true;
+            }
+          } catch (backupError) {
+            debugLogger.warn('Could not create extension backup:', backupError);
+          }
+        }
+
         let previousSettings: Record<string, string> | undefined;
         if (isUpdate) {
           previousSettings = await getEnvContents(
@@ -368,11 +390,28 @@ Would you like to attempt to install via "git clone" instead?`,
         );
         await fs.promises.writeFile(metadataPath, metadataString);
 
-        // TODO: Gracefully handle this call failing, we should back up the old
-        // extension prior to overwriting it and then restore and restart it.
-        extension = await this.loadExtension(destinationPath);
-        if (!extension) {
-          throw new Error(`Extension not found`);
+        // Restore Backup on Failure
+        try {
+          extension = await this.loadExtension(destinationPath);
+          if (!extension) {
+            throw new Error(`Extension not found`);
+          }
+        } catch (loadError) {
+          if (backupCreated) {
+            await fs.promises.rm(destinationPath, {
+              recursive: true,
+              force: true,
+            });
+            await fs.promises.rename(backupPath, destinationPath);
+            extension = await this.loadExtension(destinationPath);
+          }
+          throw loadError;
+        } finally {
+          if (backupCreated) {
+            await fs.promises
+              .rm(backupPath, { recursive: true, force: true })
+              .catch(() => {});
+          }
         }
         if (isUpdate) {
           await logExtensionUpdateEvent(


### PR DESCRIPTION
## Summary

Resolves a `TODO` in `extension-manager.ts` by adding a backup and restore fallback during extension updates to prevent broken states if the update fails.

## Details

Before: If `loadExtension` failed during an update, the old extension was already uninstalled and permanently lost.
After: Creates a `_backup` directory before uninstalling. If the new extension fails to load, the `catch` block successfully restores the backup directory.

## Related Issues

Fixes #19950

## How to Validate

1. Run `npm start` and install any working local extension.
2. Attempt to update it using a path to an intentionally broken extension (e.g., missing or invalid configuration).
3. Verify the CLI catches the error and the original extension directory is fully restored and functional.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker