### PR TITLE
fix(core): clarify DNS resolution failures in API errors

### DIFF
--- a/packages/core/src/utils/errorParsing.test.ts
+++ b/packages/core/src/utils/errorParsing.test.ts
@@ -114,4 +114,29 @@ describe('parseAndFormatApiError', () => {
     const expected = '[API Error: An unknown error occurred.]';
     expect(parseAndFormatApiError(error)).toBe(expected);
   });
+
+  it('should append a DNS hint for ENOTFOUND errors', () => {
+    const errorMessage =
+      'request to https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent failed, reason: getaddrinfo ENOTFOUND cloudcode-pa.googleapis.com';
+    const result = parseAndFormatApiError(errorMessage);
+    expect(result).toContain(`[API Error: ${errorMessage}]`);
+    expect(result).toContain(
+      'Network error: DNS resolution failed for cloudcode-pa.googleapis.com.',
+    );
+  });
+
+  it('should append a DNS hint for EAI_AGAIN errors in structured errors', () => {
+    const error: StructuredError = {
+      message:
+        'request failed, reason: getaddrinfo EAI_AGAIN cloudcode-pa.googleapis.com',
+      status: 503,
+    };
+    const result = parseAndFormatApiError(error);
+    expect(result).toContain(
+      '[API Error: request failed, reason: getaddrinfo EAI_AGAIN cloudcode-pa.googleapis.com]',
+    );
+    expect(result).toContain(
+      'Network error: DNS resolution failed for cloudcode-pa.googleapis.com.',
+    );
+  });
 });


### PR DESCRIPTION
## Summary
Improve API error messaging for DNS lookup failures so users get actionable guidance when requests fail with ENOTFOUND / EAI_AGAIN.

## Details
- Updated parseAndFormatApiError() in packages/core/src/utils/errorParsing.ts to append a DNS troubleshooting hint when error messages include:
  - ENOTFOUND
  - EAI_AGAIN
- Extracts hostname from messages like getaddrinfo ENOTFOUND <host> and includes it in the hint when available.
- Applies this for:
  - structured errors
  - plain string errors
  - JSON-wrapped API errors
- Added tests in packages/core/src/utils/errorParsing.test.ts for:
  - plain string ENOTFOUND case
  - structured EAI_AGAIN case

## Related Issues
Fixes #19908

## How to Validate
`ash
cd packages/core
npx -y node@22 ../../node_modules/vitest/vitest.mjs run src/utils/errorParsing.test.ts
npx -y node@22 ../../node_modules/eslint/bin/eslint.js src/utils/errorParsing.ts src/utils/errorParsing.test.ts
`

## Pre-Merge Checklist
- [x] Added/updated tests
- [x] No breaking changes
