### PR TITLE
fix(core): allow slug-format tool names in sub-agent validation

### DIFF
--- a/packages/core/src/tools/tool-names.test.ts
+++ b/packages/core/src/tools/tool-names.test.ts
@@ -69,10 +69,17 @@ describe('tool-names', () => {
 
     it('should reject invalid tool names', () => {
       expect(isValidToolName('')).toBe(false);
-      expect(isValidToolName('invalid-name')).toBe(false);
       expect(isValidToolName('server__')).toBe(false);
       expect(isValidToolName('__tool')).toBe(false);
       expect(isValidToolName('server__tool__extra')).toBe(false);
+      expect(isValidToolName('has spaces')).toBe(false);
+      expect(isValidToolName('special!chars')).toBe(false);
+    });
+
+    it('should validate MCP tool short names (slug format)', () => {
+      expect(isValidToolName('read_graph')).toBe(true);
+      expect(isValidToolName('kubectl_get')).toBe(true);
+      expect(isValidToolName('my-tool')).toBe(true);
     });
 
     it('should handle wildcards when allowed', () => {

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -156,6 +156,8 @@ export function isValidToolName(
     return true;
   }
 
+  const slugRegex = /^[a-z0-9_-]+$/i;
+
   // MCP tools (format: server__tool)
   if (name.includes('__')) {
     const parts = name.split('__');
@@ -170,9 +172,12 @@ export function isValidToolName(
       return !!options.allowWildcards;
     }
 
-    // Basic slug validation for server and tool names
-    const slugRegex = /^[a-z0-9-_]+$/i;
     return slugRegex.test(server) && slugRegex.test(tool);
+  }
+
+  // Allow simple slug-format tool names (e.g., MCP tools referenced by short name)
+  if (slugRegex.test(name)) {
+    return true;
   }
 
   return false;


### PR DESCRIPTION
## Summary

Fixes #19599

- `isValidToolName()` rejected simple slug-format MCP tool names (e.g., `read_graph`, `kubectl_get`) because they didn't match any known pattern (built-in, legacy alias, discovered, or `server__tool` format)
- Sub-agents failed to load with `Agent loading error: Validation failed: Agent Definition: tools.X: Invalid tool name` when referencing MCP tools by short name in YAML frontmatter
- Added a slug-format fallback (`/^[a-z0-9_-]+$/i`) before the final `return false` in `isValidToolName()`, consistent with how agent names are already validated in `agentLoader.ts` using the same slug pattern

## Test plan

- [x] `tool-names.test.ts` — 10/10 passed (added new test for MCP short names, updated rejection tests)
- [x] `agentLoader.test.ts` — 26/26 passed
- [x] `local-executor.test.ts` — 40/40 passed (existing MCP qualified name enforcement still works)
- [x] Pre-commit hooks (prettier + eslint) — passed