### PR TITLE
feat(config): make API retry settings configurable

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -859,6 +859,7 @@ export async function loadCliConfig(
     fakeResponses: argv.fakeResponses,
     recordResponses: argv.recordResponses,
     retryFetchErrors: settings.general?.retryFetchErrors,
+    highDemandRetry: settings.general?.highDemandRetry,
     ptyInfo: ptyInfo?.name,
     disableLLMCorrection: settings.tools?.disableLLMCorrection,
     rawOutput: argv.rawOutput,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -307,6 +307,44 @@ const SETTINGS_SCHEMA = {
           'Retry on "exception TypeError: fetch failed sending request" errors.',
         showInDialog: false,
       },
+      highDemandRetry: {
+        type: 'object',
+        label: 'High Demand Retry',
+        category: 'General',
+        requiresRestart: false,
+        default: {},
+        description:
+          'Controls retry behavior for transient API failures including 503 High Demand, other 5xx errors, and network errors.',
+        properties: {
+          maxAttempts: {
+            type: 'number',
+            label: 'Max Attempts',
+            category: 'General',
+            requiresRestart: false,
+            default: 3,
+            description:
+              'Maximum number of retry attempts for transient API failures (503 High Demand, 5xx, network errors).',
+          },
+          initialDelayMs: {
+            type: 'number',
+            label: 'Initial Delay (ms)',
+            category: 'General',
+            requiresRestart: false,
+            default: 5000,
+            description:
+              'Initial backoff delay in milliseconds before the first retry attempt for transient API failures.',
+          },
+          maxDelayMs: {
+            type: 'number',
+            label: 'Max Delay (ms)',
+            category: 'General',
+            requiresRestart: false,
+            default: 30000,
+            description:
+              'Maximum backoff delay cap in milliseconds between retry attempts for transient API failures.',
+          },
+        },
+      },
       debugKeystrokeLogging: {
         type: 'boolean',
         label: 'Debug Keystroke Logging',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -390,7 +390,14 @@ export interface PolicyUpdateConfirmationRequest {
   policyDir: string;
   newHash: string;
 }
-
+export interface HighDemandRetrySettings {
+  /** Total retry attempts for 503 High Demand errors. */
+  maxAttempts?: number;
+  /** Base backoff delay in ms (default: 5000) */
+  initialDelayMs?: number;
+  /** Max backoff delay cap in ms (default: 30000) */
+  maxDelayMs?: number;
+}
 export interface ConfigParameters {
   sessionId: string;
   clientVersion?: string;
@@ -476,6 +483,7 @@ export interface ConfigParameters {
   disableModelRouterForAuth?: AuthType[];
   continueOnFailedApiCall?: boolean;
   retryFetchErrors?: boolean;
+  highDemandRetry?: HighDemandRetrySettings;
   enableShellOutputEfficiency?: boolean;
   shellToolInactivityTimeout?: number;
   fakeResponses?: string;
@@ -532,6 +540,7 @@ export class Config {
   private contentGeneratorConfig!: ContentGeneratorConfig;
   private contentGenerator!: ContentGenerator;
   readonly modelConfigService: ModelConfigService;
+  private readonly highDemandRetry: HighDemandRetrySettings;
   private readonly embeddingModel: string;
   private readonly sandbox: SandboxConfig | undefined;
   private readonly targetDir: string;
@@ -583,7 +592,6 @@ export class Config {
   private readonly noBrowser: boolean;
   private readonly folderTrust: boolean;
   private ideMode: boolean;
-
   private _activeModel: string;
   private readonly maxSessionTurns: number;
   private readonly listSessions: boolean;
@@ -704,6 +712,7 @@ export class Config {
   private approvedPlanPath: string | undefined;
 
   constructor(params: ConfigParameters) {
+    this.highDemandRetry = params.highDemandRetry ?? {};
     this.sessionId = params.sessionId;
     this.clientVersion = params.clientVersion ?? 'unknown';
     this.approvedPlanPath = undefined;
@@ -1177,7 +1186,9 @@ export class Config {
   getSessionId(): string {
     return this.sessionId;
   }
-
+  getHighDemandRetry(): HighDemandRetrySettings {
+    return this.highDemandRetry;
+  }
   setSessionId(sessionId: string): void {
     this.sessionId = sessionId;
   }

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -645,8 +645,8 @@ export class GeminiChat {
         coreEvents.emitRetryAttempt({
           attempt,
           maxAttempts:
-            this.config.getHighDemandRetry()?.maxAttempts ??
             availabilityMaxAttempts ??
+            this.config.getHighDemandRetry()?.maxAttempts ??
             DEFAULT_MAX_ATTEMPTS,
           delayMs,
           error: error instanceof Error ? error.message : String(error),

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -638,8 +638,8 @@ export class GeminiChat {
       initialDelayMs: this.config.getHighDemandRetry()?.initialDelayMs,
       maxDelayMs: this.config.getHighDemandRetry()?.maxDelayMs,
       maxAttempts:
-        this.config.getHighDemandRetry()?.maxAttempts ??
-        availabilityMaxAttempts,
+        availabilityMaxAttempts ??
+        this.config.getHighDemandRetry()?.maxAttempts,
       getAvailabilityContext,
       onRetry: (attempt, error, delayMs) => {
         coreEvents.emitRetryAttempt({

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -635,12 +635,19 @@ export class GeminiChat {
       authType: this.config.getContentGeneratorConfig()?.authType,
       retryFetchErrors: this.config.getRetryFetchErrors(),
       signal: abortSignal,
-      maxAttempts: availabilityMaxAttempts,
+      initialDelayMs: this.config.getHighDemandRetry()?.initialDelayMs,
+      maxDelayMs: this.config.getHighDemandRetry()?.maxDelayMs,
+      maxAttempts:
+        this.config.getHighDemandRetry()?.maxAttempts ??
+        availabilityMaxAttempts,
       getAvailabilityContext,
       onRetry: (attempt, error, delayMs) => {
         coreEvents.emitRetryAttempt({
           attempt,
-          maxAttempts: availabilityMaxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+          maxAttempts:
+            this.config.getHighDemandRetry()?.maxAttempts ??
+            availabilityMaxAttempts ??
+            DEFAULT_MAX_ATTEMPTS,
           delayMs,
           error: error instanceof Error ? error.message : String(error),
           model: lastModelToUse,


### PR DESCRIPTION
## Summary
Adds general.highDemandRetry to settings.json so users can tune retry behavior for 503 High Demand and other transient API failures (5xx, network errors) without patching the source. Previously these were hardcoded to 3 attempts, 5s initial backoff, 30s max backoff.

## Details
Three new sub-settings under general.highDemandRetry:

maxAttempts (default: 3) — total retry attempts
initialDelayMs (default: 5000) — base exponential backoff delay
maxDelayMs (default: 30000) — max backoff cap

Default values match existing DEFAULT_RETRY_OPTIONS so behaviour is unchanged when the setting is not configured.

## Related Issues
closes #19927

## How to Validate

1. Add to ~/.gemini/settings.json:
` '{ "general": { "highDemandRetry": { "maxAttempts": 5, "initialDelayMs": 1000, "maxDelayMs": 10000 } } }`

4. Run gemini and trigger a request; observe retry log lines respect the configured count and delays.
5. Remove the setting entirely — confirm behaviour is identical to before (3 attempts, 5s/30s backoff).
6. Run npm run typecheck — exits 0.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
