### PR TITLE
refactor(config): remove enablePromptCompletion from settings

### DIFF
--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -22,17 +22,16 @@ they appear in the UI.
 
 ### General
 
-| UI Label                 | Setting                            | Description                                                                                                                                                                    | Default     |
-| ------------------------ | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
-| Vim Mode                 | `general.vimMode`                  | Enable Vim keybindings                                                                                                                                                         | `false`     |
-| Default Approval Mode    | `general.defaultApprovalMode`      | The default approval mode for tool execution. 'default' prompts for approval, 'auto_edit' auto-approves edit tools, and 'plan' is read-only mode. 'yolo' is not supported yet. | `"default"` |
-| Enable Auto Update       | `general.enableAutoUpdate`         | Enable automatic updates.                                                                                                                                                      | `true`      |
-| Enable Notifications     | `general.enableNotifications`      | Enable run-event notifications for action-required prompts and session completion. Currently macOS only.                                                                       | `false`     |
-| Plan Directory           | `general.plan.directory`           | The directory where planning artifacts are stored. If not specified, defaults to the system temporary directory.                                                               | `undefined` |
-| Enable Prompt Completion | `general.enablePromptCompletion`   | Enable AI-powered prompt completion suggestions while typing.                                                                                                                  | `false`     |
-| Debug Keystroke Logging  | `general.debugKeystrokeLogging`    | Enable debug logging of keystrokes to the console.                                                                                                                             | `false`     |
-| Enable Session Cleanup   | `general.sessionRetention.enabled` | Enable automatic session cleanup                                                                                                                                               | `false`     |
-| Keep chat history        | `general.sessionRetention.maxAge`  | Automatically delete chats older than this time period (e.g., "30d", "7d", "24h", "1w")                                                                                        | `undefined` |
+| UI Label                | Setting                            | Description                                                                                                                                                                    | Default     |
+| ----------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
+| Vim Mode                | `general.vimMode`                  | Enable Vim keybindings                                                                                                                                                         | `false`     |
+| Default Approval Mode   | `general.defaultApprovalMode`      | The default approval mode for tool execution. 'default' prompts for approval, 'auto_edit' auto-approves edit tools, and 'plan' is read-only mode. 'yolo' is not supported yet. | `"default"` |
+| Enable Auto Update      | `general.enableAutoUpdate`         | Enable automatic updates.                                                                                                                                                      | `true`      |
+| Enable Notifications    | `general.enableNotifications`      | Enable run-event notifications for action-required prompts and session completion. Currently macOS only.                                                                       | `false`     |
+| Plan Directory          | `general.plan.directory`           | The directory where planning artifacts are stored. If not specified, defaults to the system temporary directory.                                                               | `undefined` |
+| Debug Keystroke Logging | `general.debugKeystrokeLogging`    | Enable debug logging of keystrokes to the console.                                                                                                                             | `false`     |
+| Enable Session Cleanup  | `general.sessionRetention.enabled` | Enable automatic session cleanup                                                                                                                                               | `false`     |
+| Keep chat history       | `general.sessionRetention.maxAge`  | Automatically delete chats older than this time period (e.g., "30d", "7d", "24h", "1w")                                                                                        | `undefined` |
 
 ### Output
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -137,12 +137,6 @@ their corresponding top-level category object in your `settings.json` file.
   - **Default:** `undefined`
   - **Requires restart:** Yes
 
-- **`general.enablePromptCompletion`** (boolean):
-  - **Description:** Enable AI-powered prompt completion suggestions while
-    typing.
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
 - **`general.retryFetchErrors`** (boolean):
   - **Description:** Retry on "exception TypeError: fetch failed sending
     request" errors.

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -848,7 +848,6 @@ export async function loadCliConfig(
     enableShellOutputEfficiency:
       settings.tools?.shell?.enableShellOutputEfficiency ?? true,
     skipNextSpeakerCheck: settings.model?.skipNextSpeakerCheck,
-    enablePromptCompletion: settings.general?.enablePromptCompletion,
     truncateToolOutputThreshold: settings.tools?.truncateToolOutputThreshold,
     eventEmitter: coreEvents,
     useWriteTodos: argv.useWriteTodos ?? settings.useWriteTodos,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -287,16 +287,6 @@ const SETTINGS_SCHEMA = {
           },
         },
       },
-      enablePromptCompletion: {
-        type: 'boolean',
-        label: 'Enable Prompt Completion',
-        category: 'General',
-        requiresRestart: true,
-        default: false,
-        description:
-          'Enable AI-powered prompt completion suggestions while typing.',
-        showInDialog: true,
-      },
       retryFetchErrors: {
         type: 'boolean',
         label: 'Retry Fetch Errors',

--- a/packages/cli/src/config/settings_repro.test.ts
+++ b/packages/cli/src/config/settings_repro.test.ts
@@ -131,7 +131,6 @@ describe('Settings Repro', () => {
       },
       general: {
         debugKeystrokeLogging: false,
-        enablePromptCompletion: false,
         preferredEditor: 'vim',
         vimMode: false,
       },

--- a/packages/cli/src/test-utils/mockConfig.ts
+++ b/packages/cli/src/test-utils/mockConfig.ts
@@ -128,7 +128,6 @@ export const createMockConfig = (overrides: Partial<Config> = {}): Config =>
     getShellToolInactivityTimeout: vi.fn().mockReturnValue(300000),
     getShellExecutionConfig: vi.fn().mockReturnValue({}),
     setShellExecutionConfig: vi.fn(),
-    getEnablePromptCompletion: vi.fn().mockReturnValue(false),
     getEnableToolOutputTruncation: vi.fn().mockReturnValue(true),
     getTruncateToolOutputThreshold: vi.fn().mockReturnValue(1000),
     getTruncateToolOutputLines: vi.fn().mockReturnValue(100),

--- a/packages/cli/src/ui/components/SettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.test.tsx
@@ -1620,7 +1620,6 @@ describe('SettingsDialog', () => {
             vimMode: true,
             enableAutoUpdate: false,
             debugKeystrokeLogging: true,
-            enablePromptCompletion: true,
           },
           ui: {
             hideWindowTitle: true,
@@ -1766,7 +1765,6 @@ describe('SettingsDialog', () => {
             vimMode: false,
             enableAutoUpdate: true,
             debugKeystrokeLogging: false,
-            enablePromptCompletion: false,
           },
           ui: {
             hideWindowTitle: false,

--- a/packages/cli/src/ui/components/__snapshots__/SettingsDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/SettingsDialog.test.tsx.snap
@@ -25,14 +25,14 @@ exports[`SettingsDialog > Initial Rendering > should render settings list with v
 │    Plan Directory                                                                     undefined  │
 │    The directory where planning artifacts are stored. If not specified, defaults t…              │
 │                                                                                                  │
-│    Enable Prompt Completion                                                               false  │
-│    Enable AI-powered prompt completion suggestions while typing.                                 │
-│                                                                                                  │
 │    Debug Keystroke Logging                                                                false  │
 │    Enable debug logging of keystrokes to the console.                                            │
 │                                                                                                  │
 │    Enable Session Cleanup                                                                 false  │
 │    Enable automatic session cleanup                                                              │
+│                                                                                                  │
+│    Keep chat history                                                                  undefined  │
+│    Automatically delete chats older than this time period (e.g., "30d", "7d", "24h…              │
 │                                                                                                  │
 │  ▼                                                                                               │
 │                                                                                                  │
@@ -72,14 +72,14 @@ exports[`SettingsDialog > Snapshot Tests > should render 'accessibility settings
 │    Plan Directory                                                                     undefined  │
 │    The directory where planning artifacts are stored. If not specified, defaults t…              │
 │                                                                                                  │
-│    Enable Prompt Completion                                                               false  │
-│    Enable AI-powered prompt completion suggestions while typing.                                 │
-│                                                                                                  │
 │    Debug Keystroke Logging                                                                false  │
 │    Enable debug logging of keystrokes to the console.                                            │
 │                                                                                                  │
 │    Enable Session Cleanup                                                                 false  │
 │    Enable automatic session cleanup                                                              │
+│                                                                                                  │
+│    Keep chat history                                                                  undefined  │
+│    Automatically delete chats older than this time period (e.g., "30d", "7d", "24h…              │
 │                                                                                                  │
 │  ▼                                                                                               │
 │                                                                                                  │
@@ -119,14 +119,14 @@ exports[`SettingsDialog > Snapshot Tests > should render 'all boolean settings d
 │    Plan Directory                                                                     undefined  │
 │    The directory where planning artifacts are stored. If not specified, defaults t…              │
 │                                                                                                  │
-│    Enable Prompt Completion                                                              false*  │
-│    Enable AI-powered prompt completion suggestions while typing.                                 │
-│                                                                                                  │
 │    Debug Keystroke Logging                                                               false*  │
 │    Enable debug logging of keystrokes to the console.                                            │
 │                                                                                                  │
 │    Enable Session Cleanup                                                                 false  │
 │    Enable automatic session cleanup                                                              │
+│                                                                                                  │
+│    Keep chat history                                                                  undefined  │
+│    Automatically delete chats older than this time period (e.g., "30d", "7d", "24h…              │
 │                                                                                                  │
 │  ▼                                                                                               │
 │                                                                                                  │
@@ -166,14 +166,14 @@ exports[`SettingsDialog > Snapshot Tests > should render 'default state' correct
 │    Plan Directory                                                                     undefined  │
 │    The directory where planning artifacts are stored. If not specified, defaults t…              │
 │                                                                                                  │
-│    Enable Prompt Completion                                                               false  │
-│    Enable AI-powered prompt completion suggestions while typing.                                 │
-│                                                                                                  │
 │    Debug Keystroke Logging                                                                false  │
 │    Enable debug logging of keystrokes to the console.                                            │
 │                                                                                                  │
 │    Enable Session Cleanup                                                                 false  │
 │    Enable automatic session cleanup                                                              │
+│                                                                                                  │
+│    Keep chat history                                                                  undefined  │
+│    Automatically delete chats older than this time period (e.g., "30d", "7d", "24h…              │
 │                                                                                                  │
 │  ▼                                                                                               │
 │                                                                                                  │
@@ -213,14 +213,14 @@ exports[`SettingsDialog > Snapshot Tests > should render 'file filtering setting
 │    Plan Directory                                                                     undefined  │
 │    The directory where planning artifacts are stored. If not specified, defaults t…              │
 │                                                                                                  │
-│    Enable Prompt Completion                                                               false  │
-│    Enable AI-powered prompt completion suggestions while typing.                                 │
-│                                                                                                  │
 │    Debug Keystroke Logging                                                                false  │
 │    Enable debug logging of keystrokes to the console.                                            │
 │                                                                                                  │
 │    Enable Session Cleanup                                                                 false  │
 │    Enable automatic session cleanup                                                              │
+│                                                                                                  │
+│    Keep chat history                                                                  undefined  │
+│    Automatically delete chats older than this time period (e.g., "30d", "7d", "24h…              │
 │                                                                                                  │
 │  ▼                                                                                               │
 │                                                                                                  │
@@ -260,14 +260,14 @@ exports[`SettingsDialog > Snapshot Tests > should render 'focused on scope selec
 │    Plan Directory                                                                     undefined  │
 │    The directory where planning artifacts are stored. If not specified, defaults t…              │
 │                                                                                                  │
-│    Enable Prompt Completion                                                               false  │
-│    Enable AI-powered prompt completion suggestions while typing.                                 │
-│                                                                                                  │
 │    Debug Keystroke Logging                                                                false  │
 │    Enable debug logging of keystrokes to the console.                                            │
 │                                                                                                  │
 │    Enable Session Cleanup                                                                 false  │
 │    Enable automatic session cleanup                                                              │
+│                                                                                                  │
+│    Keep chat history                                                                  undefined  │
+│    Automatically delete chats older than this time period (e.g., "30d", "7d", "24h…              │
 │                                                                                                  │
 │  ▼                                                                                               │
 │                                                                                                  │
@@ -307,14 +307,14 @@ exports[`SettingsDialog > Snapshot Tests > should render 'mixed boolean and numb
 │    Plan Directory                                                                     undefined  │
 │    The directory where planning artifacts are stored. If not specified, defaults t…              │
 │                                                                                                  │
-│    Enable Prompt Completion                                                               false  │
-│    Enable AI-powered prompt completion suggestions while typing.                                 │
-│                                                                                                  │
 │    Debug Keystroke Logging                                                                false  │
 │    Enable debug logging of keystrokes to the console.                                            │
 │                                                                                                  │
 │    Enable Session Cleanup                                                                 false  │
 │    Enable automatic session cleanup                                                              │
+│                                                                                                  │
+│    Keep chat history                                                                  undefined  │
+│    Automatically delete chats older than this time period (e.g., "30d", "7d", "24h…              │
 │                                                                                                  │
 │  ▼                                                                                               │
 │                                                                                                  │
@@ -354,14 +354,14 @@ exports[`SettingsDialog > Snapshot Tests > should render 'tools and security set
 │    Plan Directory                                                                     undefined  │
 │    The directory where planning artifacts are stored. If not specified, defaults t…              │
 │                                                                                                  │
-│    Enable Prompt Completion                                                               false  │
-│    Enable AI-powered prompt completion suggestions while typing.                                 │
-│                                                                                                  │
 │    Debug Keystroke Logging                                                                false  │
 │    Enable debug logging of keystrokes to the console.                                            │
 │                                                                                                  │
 │    Enable Session Cleanup                                                                 false  │
 │    Enable automatic session cleanup                                                              │
+│                                                                                                  │
+│    Keep chat history                                                                  undefined  │
+│    Automatically delete chats older than this time period (e.g., "30d", "7d", "24h…              │
 │                                                                                                  │
 │  ▼                                                                                               │
 │                                                                                                  │
@@ -401,14 +401,14 @@ exports[`SettingsDialog > Snapshot Tests > should render 'various boolean settin
 │    Plan Directory                                                                     undefined  │
 │    The directory where planning artifacts are stored. If not specified, defaults t…              │
 │                                                                                                  │
-│    Enable Prompt Completion                                                               true*  │
-│    Enable AI-powered prompt completion suggestions while typing.                                 │
-│                                                                                                  │
 │    Debug Keystroke Logging                                                                true*  │
 │    Enable debug logging of keystrokes to the console.                                            │
 │                                                                                                  │
 │    Enable Session Cleanup                                                                 false  │
 │    Enable automatic session cleanup                                                              │
+│                                                                                                  │
+│    Keep chat history                                                                  undefined  │
+│    Automatically delete chats older than this time period (e.g., "30d", "7d", "24h…              │
 │                                                                                                  │
 │  ▼                                                                                               │
 │                                                                                                  │

--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
@@ -94,7 +94,6 @@ const setupMocks = ({
 describe('useCommandCompletion', () => {
   const mockCommandContext = {} as CommandContext;
   const mockConfig = {
-    getEnablePromptCompletion: () => false,
     getGeminiClient: vi.fn(),
   } as unknown as Config;
   const testRootDir = '/';
@@ -499,7 +498,6 @@ describe('useCommandCompletion', () => {
   describe('prompt completion filtering', () => {
     it('should not trigger prompt completion for line comments', async () => {
       const mockConfig = {
-        getEnablePromptCompletion: () => true,
         getGeminiClient: vi.fn(),
       } as unknown as Config;
 
@@ -532,7 +530,6 @@ describe('useCommandCompletion', () => {
 
     it('should not trigger prompt completion for block comments', async () => {
       const mockConfig = {
-        getEnablePromptCompletion: () => true,
         getGeminiClient: vi.fn(),
       } as unknown as Config;
 
@@ -567,7 +564,6 @@ describe('useCommandCompletion', () => {
 
     it('should trigger prompt completion for regular text when enabled', async () => {
       const mockConfig = {
-        getEnablePromptCompletion: () => true,
         getGeminiClient: vi.fn(),
       } as unknown as Config;
 

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -156,9 +156,7 @@ export function useCommandCompletion({
 
       // Check for prompt completion - only if enabled
       const trimmedText = buffer.text.trim();
-      const isPromptCompletionEnabled =
-        config?.getEnablePromptCompletion() ?? false;
-
+      const isPromptCompletionEnabled = false;
       if (
         isPromptCompletionEnabled &&
         trimmedText.length >= PROMPT_COMPLETION_MIN_LENGTH &&
@@ -179,7 +177,7 @@ export function useCommandCompletion({
         completionStart: -1,
         completionEnd: -1,
       };
-    }, [cursorRow, cursorCol, buffer.lines, buffer.text, config]);
+    }, [cursorRow, cursorCol, buffer.lines, buffer.text]);
 
   useAtCompletion({
     enabled: active && completionMode === CompletionMode.AT,
@@ -204,7 +202,6 @@ export function useCommandCompletion({
   const promptCompletion = usePromptCompletion({
     buffer,
     config,
-    enabled: active && completionMode === CompletionMode.PROMPT,
   });
 
   useEffect(() => {

--- a/packages/cli/src/ui/hooks/usePromptCompletion.ts
+++ b/packages/cli/src/ui/hooks/usePromptCompletion.ts
@@ -26,13 +26,11 @@ export interface PromptCompletion {
 export interface UsePromptCompletionOptions {
   buffer: TextBuffer;
   config?: Config;
-  enabled: boolean;
 }
 
 export function usePromptCompletion({
   buffer,
   config,
-  enabled,
 }: UsePromptCompletionOptions): PromptCompletion {
   const [ghostText, setGhostText] = useState<string>('');
   const [isLoadingGhostText, setIsLoadingGhostText] = useState<boolean>(false);
@@ -42,8 +40,7 @@ export function usePromptCompletion({
   const lastSelectedTextRef = useRef<string>('');
   const lastRequestedTextRef = useRef<string>('');
 
-  const isPromptCompletionEnabled =
-    enabled && (config?.getEnablePromptCompletion() ?? false);
+  const isPromptCompletionEnabled = false;
 
   const clearGhostText = useCallback(() => {
     setGhostText('');

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -466,7 +466,6 @@ export interface ConfigParameters {
   skipNextSpeakerCheck?: boolean;
   shellExecutionConfig?: ShellExecutionConfig;
   extensionManagement?: boolean;
-  enablePromptCompletion?: boolean;
   truncateToolOutputThreshold?: number;
   eventEmitter?: EventEmitter;
   useWriteTodos?: boolean;
@@ -639,7 +638,6 @@ export class Config {
   private readonly useBackgroundColor: boolean;
   private shellExecutionConfig: ShellExecutionConfig;
   private readonly extensionManagement: boolean = true;
-  private readonly enablePromptCompletion: boolean = false;
   private readonly truncateToolOutputThreshold: number;
   private compressionTruncationCounter = 0;
   private initialized = false;
@@ -861,7 +859,6 @@ export class Config {
 
     this.fakeResponses = params.fakeResponses;
     this.recordResponses = params.recordResponses;
-    this.enablePromptCompletion = params.enablePromptCompletion ?? false;
     this.fileExclusions = new FileExclusions(this);
     this.eventEmitter = params.eventEmitter;
     this.policyEngine = new PolicyEngine({
@@ -2436,10 +2433,6 @@ export class Config {
   }
   getScreenReader(): boolean {
     return this.accessibility.screenReader ?? false;
-  }
-
-  getEnablePromptCompletion(): boolean {
-    return this.enablePromptCompletion;
   }
 
   getTruncateToolOutputThreshold(): number {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -121,13 +121,6 @@
           },
           "additionalProperties": false
         },
-        "enablePromptCompletion": {
-          "title": "Enable Prompt Completion",
-          "description": "Enable AI-powered prompt completion suggestions while typing.",
-          "markdownDescription": "Enable AI-powered prompt completion suggestions while typing.\n\n- Category: `General`\n- Requires restart: `yes`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
         "retryFetchErrors": {
           "title": "Retry Fetch Errors",
           "description": "Retry on \"exception TypeError: fetch failed sending request\" errors.",


### PR DESCRIPTION
## Summary

This PR removes the `enablePromptCompletion` option from the CLI configuration and settings dialog. The feature has been disabled by default as it's consuming a huge flash lite quota and will revisit this.

## Details

- Removed `enablePromptCompletion` from `ConfigParameters` and `Config` class in `packages/core`.
- Removed mapping in `packages/cli`'s config builder.
- Removed the setting from `settingsSchema.ts` and `schemas/settings.schema.json`.
- Updated `useCommandCompletion` and `usePromptCompletion` hooks to forcefully disable prompt completion and removed dependencies on the old configuration getter.
- Removed references to the setting in configuration and cli documentation (`docs/reference/configuration.md`, `docs/cli/settings.md`).
- Removed mention from the changelog to avoid confusion for users consulting past features.
- Updated `SettingsDialog` snapshots and corresponding tests to remove the boolean setting.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/19975

## How to Validate

1. Run `npm test` to ensure all tests pass (particularly `SettingsDialog.test.tsx` and core configuration tests).
2. Run `npm run build` to verify the codebase compiles successfully.
3. Verify that `enablePromptCompletion` is no longer present in `~/.gemini/settings.json` schemas.
4. Launch the CLI and verify the "Enable Prompt Completion" setting is no longer displayed in the Settings dialog (accessed via `/settings`).

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker