### PR TITLE
fix: surface model thinking traces in non-interactive output modes

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -314,7 +314,19 @@ export async function runNonInteractive({
             handleCancellationError(config);
           }
 
-          if (event.type === GeminiEventType.Content) {
+          if (event.type === GeminiEventType.Thought) {
+            if (streamFormatter) {
+              const thought = event.value;
+              const content = thought.subject
+                ? `${thought.subject}: ${thought.description}`
+                : thought.description;
+              streamFormatter.emitEvent({
+                type: JsonStreamEventType.THOUGHT,
+                timestamp: new Date().toISOString(),
+                content,
+              });
+            }
+          } else if (event.type === GeminiEventType.Content) {
             const isRaw =
               config.getRawOutput() || config.getAcceptRawOutputRisk();
             const output = isRaw ? event.value : stripAnsi(event.value);

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -317,9 +317,12 @@ export async function runNonInteractive({
 
           if (event.type === GeminiEventType.Thought) {
             const thought = event.value;
-            const content = thought.subject
+            const rawContent = thought.subject
               ? `${thought.subject}: ${thought.description}`
               : thought.description;
+            const isRawThought =
+              config.getRawOutput() || config.getAcceptRawOutputRisk();
+            const content = isRawThought ? rawContent : stripAnsi(rawContent);
             if (streamFormatter) {
               streamFormatter.emitEvent({
                 type: JsonStreamEventType.THOUGHT,

--- a/packages/core/src/output/json-formatter.test.ts
+++ b/packages/core/src/output/json-formatter.test.ts
@@ -331,4 +331,79 @@ describe('JsonFormatter', () => {
     expect(parsed.error.message).toBe('Error\x07 with\x08 control\x0B chars');
     expect(() => JSON.parse(formatted)).not.toThrow();
   });
+
+  it('should include thoughts when provided', () => {
+    const formatter = new JsonFormatter();
+    const response = 'The answer is 42.';
+    const thoughts = [
+      'Analyzing the question: Considering philosophical implications.',
+      'The user wants a brief answer.',
+    ];
+    const formatted = formatter.format(
+      undefined,
+      response,
+      undefined,
+      undefined,
+      thoughts,
+    );
+    const parsed = JSON.parse(formatted);
+    expect(parsed).toEqual({
+      response,
+      thoughts,
+    });
+  });
+
+  it('should omit thoughts when array is empty', () => {
+    const formatter = new JsonFormatter();
+    const response = 'Simple response.';
+    const formatted = formatter.format(
+      undefined,
+      response,
+      undefined,
+      undefined,
+      [],
+    );
+    const parsed = JSON.parse(formatted);
+    expect(parsed).toEqual({ response });
+    expect(parsed.thoughts).toBeUndefined();
+  });
+
+  it('should include thoughts with response, stats, and session ID', () => {
+    const formatter = new JsonFormatter();
+    const response = 'Full response.';
+    const sessionId = 'test-session';
+    const stats: SessionMetrics = {
+      models: {},
+      tools: {
+        totalCalls: 0,
+        totalSuccess: 0,
+        totalFail: 0,
+        totalDurationMs: 0,
+        totalDecisions: {
+          accept: 0,
+          reject: 0,
+          modify: 0,
+          auto_accept: 0,
+        },
+        byName: {},
+      },
+      files: {
+        totalLinesAdded: 0,
+        totalLinesRemoved: 0,
+      },
+    };
+    const thoughts = ['Planning the response.'];
+    const formatted = formatter.format(
+      sessionId,
+      response,
+      stats,
+      undefined,
+      thoughts,
+    );
+    const parsed = JSON.parse(formatted);
+    expect(parsed.session_id).toBe(sessionId);
+    expect(parsed.response).toBe(response);
+    expect(parsed.thoughts).toEqual(thoughts);
+    expect(parsed.stats).toEqual(stats);
+  });
 });

--- a/packages/core/src/output/json-formatter.ts
+++ b/packages/core/src/output/json-formatter.ts
@@ -14,6 +14,7 @@ export class JsonFormatter {
     response?: string,
     stats?: SessionMetrics,
     error?: JsonError,
+    thoughts?: string[],
   ): string {
     const output: JsonOutput = {};
 
@@ -23,6 +24,10 @@ export class JsonFormatter {
 
     if (response !== undefined) {
       output.response = stripAnsi(response);
+    }
+
+    if (thoughts && thoughts.length > 0) {
+      output.thoughts = thoughts;
     }
 
     if (stats) {

--- a/packages/core/src/output/stream-json-formatter.test.ts
+++ b/packages/core/src/output/stream-json-formatter.test.ts
@@ -13,6 +13,7 @@ import type {
   ToolUseEvent,
   ToolResultEvent,
   ErrorEvent,
+  ThoughtEvent,
   ResultEvent,
 } from './types.js';
 import type { SessionMetrics } from '../telemetry/uiTelemetry.js';
@@ -181,6 +182,19 @@ describe('StreamJsonFormatter', () => {
           duration_ms: 1200,
           tool_calls: 0,
         },
+      };
+
+      const result = formatter.formatEvent(event);
+
+      expect(result).toBe(JSON.stringify(event) + '\n');
+      expect(JSON.parse(result.trim())).toEqual(event);
+    });
+
+    it('should format thought event', () => {
+      const event: ThoughtEvent = {
+        type: JsonStreamEventType.THOUGHT,
+        timestamp: '2025-10-10T12:00:00.000Z',
+        content: 'Planning: Considering the best approach.',
       };
 
       const result = formatter.formatEvent(event);

--- a/packages/core/src/output/types.ts
+++ b/packages/core/src/output/types.ts
@@ -21,6 +21,7 @@ export interface JsonError {
 export interface JsonOutput {
   session_id?: string;
   response?: string;
+  thoughts?: string[];
   stats?: SessionMetrics;
   error?: JsonError;
 }

--- a/packages/core/src/output/types.ts
+++ b/packages/core/src/output/types.ts
@@ -33,6 +33,7 @@ export enum JsonStreamEventType {
   TOOL_RESULT = 'tool_result',
   ERROR = 'error',
   RESULT = 'result',
+  THOUGHT = 'thought',
 }
 
 export interface BaseJsonStreamEvent {
@@ -88,6 +89,11 @@ export interface StreamStats {
   tool_calls: number;
 }
 
+export interface ThoughtEvent extends BaseJsonStreamEvent {
+  type: JsonStreamEventType.THOUGHT;
+  content: string;
+}
+
 export interface ResultEvent extends BaseJsonStreamEvent {
   type: JsonStreamEventType.RESULT;
   status: 'success' | 'error';
@@ -104,4 +110,5 @@ export type JsonStreamEvent =
   | ToolUseEvent
   | ToolResultEvent
   | ErrorEvent
+  | ThoughtEvent
   | ResultEvent;


### PR DESCRIPTION
Fixes: #20120

## Summary

Model thinking/reasoning events (`GeminiEventType.Thought`) are already emitted by the core turn loop and displayed in the interactive TUI, but silently dropped in all three non-interactive output modes. These traces are useful/interesting for e.g. building interactive harnesses around the Gemini CLI. This PR surfaces them:

- **stream-json**: new `{"type":"thought","content":"..."}` JSONL event
- **json**: new `"thoughts": [...]` array in output object
- **text**: `Thinking: ...` lines written to stderr

## Details

The Gemini API returns thought content via `part.thought` in streamed responses. The core already parses these into `ThoughtSummary` objects (subject + description) and yields `GeminiEventType.Thought` events. The interactive TUI consumes them via `setThought()` in `useGeminiStream`, but `nonInteractiveCli.ts` had no handler for the event type.

Design decisions:
- Text mode writes to **stderr** (thoughts are metadata, not the response itself)
- JSON mode **omits** the `thoughts` key entirely when no thoughts occur (no empty arrays in output)
- Thought content is formatted as `"Subject: Description"` when a subject exists, or just the description when it doesn't (matching how `parseThought` structures it)

## Related Issues

N/A

## How to Validate

Added tests.

```bash
# Stream-json mode — look for {"type":"thought"} events
gemini -p "What is 2+2? Think step by step." -o stream-json 2>/dev/null | jq -r 'select(.type=="thought") | .content'

# JSON mode — look for "thoughts" array in output
gemini -p "Explain recursion briefly." -o json 2>/dev/null | jq '.thoughts'
# Text mode — thoughts appear on stderr, response on stdout
gemini -p "What is the capital of France?" 2>thoughts.txt
cat thoughts.txt  # should contain "Thinking: ..." lines

# No thoughts — verify clean output when model doesn't think
# (short factual queries may not trigger thinking)
gemini -p "Say hello." -o json 2>/dev/null | jq 'has("thoughts")'
# expected: false
```

## Pre-Merge Checklist

- [x] Added/updated tests (if needed)
- [x] Validated on required platforms/methods:
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
