### PR TITLE
fix(cli): resolve missing file-based slash commands in npm package

### DIFF
--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -74,3 +74,14 @@ if (existsSync(builtinSkillsSrc)) {
 }
 
 console.log('Assets copied to bundle/');
+
+// 5. Copy Built-in Slash Commands (.gemini/commands)
+const commandsSrc = join(root, '.gemini/commands');
+const commandsDest = join(bundleDir, 'commands');
+if (existsSync(commandsSrc)) {
+  cpSync(commandsSrc, commandsDest, {
+    recursive: true,
+    dereference: true,
+  });
+  console.log('Copied built-in commands to bundle/commands/');
+}


### PR DESCRIPTION
Fixes #19009
### What does this PR do?
Fixes an issue where file-based slash commands (like `/prompt-suggest` and `/review-and-fix`) are available during local development but completely missing when the CLI is installed globally via npm.

### The Root Cause
The bug occurs due to a discrepancy between the local workspace and the published npm bundle:
1. **Packaging:** The `.gemini/commands` folder was not being copied into the final `bundle/` directory during the build process, meaning the `.toml` files were never actually published to the npm registry.
2. **Path Resolution:** When installed globally, `FileCommandLoader` only checked the user's current working directory and home directory for project commands, completely missing its own built-in commands. 

### The Fix
1. Updated `FileCommandLoader.ts` to explicitly check its own `__dirname/commands` path (which resolves to `bundle/commands` in production) as a baseline for built-in commands.
2. **Note on `scripts/` modification:** I read the contributing guidelines regarding only modifying the `packages/` directory! However, because this is fundamentally a packaging/bundling bug, I had to add a few lines to `scripts/copy_bundle_assets.js` to ensure the `.gemini/commands` directory actually gets copied into the `bundle/` output during `npm run bundle`. 

### Testing Done
- Ran `npm run preflight` successfully.
- Verified local development (`npm start`) still correctly loads commands.
- Simulated production (`npm run bundle`, `npm pack`, `npm install -g`) and verified the TUI successfully loads `/prompt-suggest` when run outside of the repository.