### PR TITLE
feat(core): add policy chain support for Gemini 3.1

### DIFF
--- a/packages/core/src/availability/policyCatalog.test.ts
+++ b/packages/core/src/availability/policyCatalog.test.ts
@@ -12,6 +12,8 @@ import {
 } from './policyCatalog.js';
 import {
   DEFAULT_GEMINI_MODEL,
+  PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL,
+  PREVIEW_GEMINI_3_1_MODEL,
   PREVIEW_GEMINI_MODEL,
 } from '../config/models.js';
 
@@ -20,6 +22,27 @@ describe('policyCatalog', () => {
     const chain = getModelPolicyChain({ previewEnabled: true });
     expect(chain[0]?.model).toBe(PREVIEW_GEMINI_MODEL);
     expect(chain).toHaveLength(2);
+  });
+
+  it('returns Gemini 3.1 chain when useGemini31 is true', () => {
+    const chain = getModelPolicyChain({
+      previewEnabled: true,
+      useGemini31: true,
+    });
+    expect(chain[0]?.model).toBe(PREVIEW_GEMINI_3_1_MODEL);
+    expect(chain).toHaveLength(2);
+    expect(chain[1]?.model).toBe('gemini-3-flash-preview');
+  });
+
+  it('returns Gemini 3.1 Custom Tools chain when useGemini31 and useCustomToolModel are true', () => {
+    const chain = getModelPolicyChain({
+      previewEnabled: true,
+      useGemini31: true,
+      useCustomToolModel: true,
+    });
+    expect(chain[0]?.model).toBe(PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL);
+    expect(chain).toHaveLength(2);
+    expect(chain[1]?.model).toBe('gemini-3-flash-preview');
   });
 
   it('returns default chain when preview disabled', () => {


### PR DESCRIPTION
## Summary

This PR adds explicit support for `PREVIEW_GEMINI_3_1_MODEL` and `PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL` in the model policy chain. It ensures that these models correctly fallback to `PREVIEW_GEMINI_FLASH_MODEL` when availability or quota issues occur.

## Details

- **Dynamic Resolution**: Updated `getModelPolicyChain` in `policyCatalog.ts` to use `resolveModel`. This allows the preview chain to start with the specific 3.1 model requested (either standard or custom tools) while still maintaining the fallback to Flash.
- **Context Propagation**: Updated `resolvePolicyChain` in `policyHelpers.ts` to correctly identify when Gemini 3.1 or Custom Tool models should be used based on the user's authentication type and experiment flags.
- **Comprehensive Testing**: Added unit tests to `policyCatalog.test.ts` and `policyHelpers.test.ts` to verify the new resolution logic and fallback behavior.

## Related Issues

Fixes #19988

## How to Validate

Run the updated unit tests to verify the chain resolution logic:
```bash
npm test -w @google/gemini-cli-core -- src/availability/policyCatalog.test.ts src/availability/policyHelpers.test.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
