### PR TITLE
fix(cli): pass session ID from config to SessionStatsProvider

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -240,7 +240,10 @@ export async function startInteractiveUI(
             <TerminalProvider>
               <ScrollProvider>
                 <OverflowProvider>
-                  <SessionStatsProvider>
+                  <SessionStatsProvider
+                    key={config.getSessionId()}
+                    initialSessionId={config.getSessionId()}
+                  >
                     <VimModeProvider settings={settings}>
                       <AppContainer
                         config={config}

--- a/packages/cli/src/test-utils/render.tsx
+++ b/packages/cli/src/test-utils/render.tsx
@@ -695,7 +695,7 @@ export const renderWithProviders = (
           <UIStateContext.Provider value={finalUiState}>
             <VimModeProvider settings={finalSettings}>
               <ShellFocusContext.Provider value={shellFocus}>
-                <SessionStatsProvider>
+                <SessionStatsProvider initialSessionId="test-session-id">
                   <StreamingContext.Provider
                     value={finalUiState.streamingState}
                   >

--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -126,7 +126,7 @@ describe('<HistoryItemDisplay />', () => {
       duration: '1s',
     };
     const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-      <SessionStatsProvider>
+      <SessionStatsProvider initialSessionId="test-session-id">
         <HistoryItemDisplay {...baseItem} item={item} />
       </SessionStatsProvider>,
     );
@@ -161,7 +161,7 @@ describe('<HistoryItemDisplay />', () => {
       type: 'model_stats',
     };
     const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-      <SessionStatsProvider>
+      <SessionStatsProvider initialSessionId="test-session-id">
         <HistoryItemDisplay {...baseItem} item={item} />
       </SessionStatsProvider>,
     );
@@ -178,7 +178,7 @@ describe('<HistoryItemDisplay />', () => {
       type: 'tool_stats',
     };
     const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-      <SessionStatsProvider>
+      <SessionStatsProvider initialSessionId="test-session-id">
         <HistoryItemDisplay {...baseItem} item={item} />
       </SessionStatsProvider>,
     );
@@ -196,7 +196,7 @@ describe('<HistoryItemDisplay />', () => {
       duration: '1s',
     };
     const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-      <SessionStatsProvider>
+      <SessionStatsProvider initialSessionId="test-session-id">
         <HistoryItemDisplay {...baseItem} item={item} />
       </SessionStatsProvider>,
     );

--- a/packages/cli/src/ui/contexts/SessionContext.test.tsx
+++ b/packages/cli/src/ui/contexts/SessionContext.test.tsx
@@ -59,7 +59,7 @@ describe('SessionStatsContext', () => {
     > = { current: undefined };
 
     const { unmount } = render(
-      <SessionStatsProvider>
+      <SessionStatsProvider initialSessionId="test-session-id">
         <TestHarness contextRef={contextRef} />
       </SessionStatsProvider>,
     );
@@ -78,7 +78,7 @@ describe('SessionStatsContext', () => {
     > = { current: undefined };
 
     const { unmount } = render(
-      <SessionStatsProvider>
+      <SessionStatsProvider initialSessionId="test-session-id">
         <TestHarness contextRef={contextRef} />
       </SessionStatsProvider>,
     );
@@ -161,7 +161,7 @@ describe('SessionStatsContext', () => {
     };
 
     const { unmount } = render(
-      <SessionStatsProvider>
+      <SessionStatsProvider initialSessionId="test-session-id">
         <CountingTestHarness />
       </SessionStatsProvider>,
     );


### PR DESCRIPTION
## Summary
Fixes #18369

`/stats session` displayed a different Session ID than the one in the session file, because `SessionStatsProvider` imported a module-level `randomUUID()` constant from `@google/gemini-cli-core` instead of reading from the `Config` object.

## Changes
- **SessionContext.tsx**: Removed `sessionId` import from `@google/gemini-cli-core`. Added `initialSessionId` prop to `SessionStatsProvider`.
- **gemini.tsx**: Pass `config.getSessionId()` as `initialSessionId`, which correctly reflects the resumed session's ID.
- **Test files**: Updated all `SessionStatsProvider` usages to pass the new required prop.

## Root Cause
`packages/core/src/utils/session.ts` exports `const sessionId = randomUUID()` — frozen once at module load. The ESM module graph can create separate instances, so the UUID used by `SessionStatsProvider` differed from the one used by `chatRecordingService` (which writes the session file). After `--resume`, `config.setSessionId()` was called correctly, but `SessionStatsProvider` never read from it.

## Testing
- All 44 related tests pass (SessionContext, StatsDisplay, HistoryItemDisplay)
- Full build passes (exit code 0)
- Pre-existing failures in `vim-buffer-actions.test.ts` confirmed on unmodified main