### PR TITLE
fix: trap SIGHUP in shell execution to prevent WSL2 signal 1 termination

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -247,7 +247,7 @@ describe('ShellExecutionService', () => {
         'bash',
         [
           '-c',
-          'shopt -u promptvars nullglob extglob nocaseglob dotglob; ls -l',
+          "trap '' HUP; shopt -u promptvars nullglob extglob nocaseglob dotglob; ls -l",
         ],
         expect.any(Object),
       );
@@ -746,7 +746,7 @@ describe('ShellExecutionService', () => {
         'bash',
         [
           '-c',
-          'shopt -u promptvars nullglob extglob nocaseglob dotglob; ls "foo bar"',
+          'trap \'\' HUP; shopt -u promptvars nullglob extglob nocaseglob dotglob; ls "foo bar"',
         ],
         expect.any(Object),
       );
@@ -934,7 +934,7 @@ describe('ShellExecutionService child_process fallback', () => {
         'bash',
         [
           '-c',
-          'shopt -u promptvars nullglob extglob nocaseglob dotglob; ls -l',
+          "trap '' HUP; shopt -u promptvars nullglob extglob nocaseglob dotglob; ls -l",
         ],
         expect.objectContaining({ shell: false, detached: true }),
       );
@@ -1267,7 +1267,7 @@ describe('ShellExecutionService child_process fallback', () => {
         'bash',
         [
           '-c',
-          'shopt -u promptvars nullglob extglob nocaseglob dotglob; ls "foo bar"',
+          'trap \'\' HUP; shopt -u promptvars nullglob extglob nocaseglob dotglob; ls "foo bar"',
         ],
         expect.objectContaining({
           shell: false,


### PR DESCRIPTION
## What does this PR do?

Fixes #16248 — All shell commands fail with "Command terminated by signal: 1" on WSL2 environments.

## Root Cause

On WSL2 (especially when running inside VS Code's terminal), the pseudo-terminal (PTY) lifecycle can send spurious `SIGHUP` (signal 1) to child processes. This happens because:

1. WSL2's PTY implementation handles terminal hangup differently than native Linux
2. VS Code's terminal creates nested PTYs — Gemini CLI's PTY runs inside VS Code's PTY
3. When the outer PTY layer closes or resizes, it can propagate `SIGHUP` to the inner process group

This causes every shell command spawned by Gemini CLI to terminate immediately.

## Fix

Added `trap '' HUP` before spawned shell commands in both execution paths:

- **`executeWithPty()`** — the primary PTY-based execution path
- **`childProcessFallback()`** — the fallback child_process-based path

The trap is only applied on Unix platforms (not Windows/PowerShell), since `SIGHUP` is a Unix signal concept.

### Why this is safe

- Gemini CLI already uses explicit `SIGTERM`/`SIGKILL` via `killProcessGroup()` for process cleanup
- `SIGHUP` is only used for terminal hangup detection, which is spurious in WSL2
- User commands can still override the trap in their own subshells if needed
- This is the same technique used by `nohup(1)` internally

## Testing

- All 53 `shellExecutionService.test.ts` tests pass ✅
- All 39 `shell.test.ts` tests pass ✅
- TypeScript compiles with zero errors ✅
- Updated 4 test assertions to expect the `trap '' HUP;` prefix in bash commands
- PowerShell tests remain unchanged (no trap on Windows)