### PR TITLE
docs: fix broken link for Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ gemini
 
 ### Core Features
 
-- [**Commands Reference**](./docs/cli/commands.md) - All slash commands
+- [**Commands Reference**](./docs/reference/commands.md) - All slash commands
   (`/help`, `/chat`, etc).
 - [**Custom Commands**](./docs/cli/custom-commands.md) - Create your own
   reusable commands.


### PR DESCRIPTION
## Summary

Corrected the broken Commands Reference link in the README. The previous link pointed to a non-existent path.

## Details

Updated the link from `./docs/cli/commands.md` to `./docs/reference/commands.md` to match the actual file structure.

## Related Issues

Related to #20125 

## How to Validate

1. Navigate to the README.md in the file browser.
2. Click the "Commands Reference" link.
3. Verify it leads to the correct documentation page in the `docs/reference/` directory.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
