### PR TITLE
feat(docs): Add list of available Gemini CLI tools to policy engine documentation

### DIFF
--- a/docs/reference/policy-engine.md
+++ b/docs/reference/policy-engine.md
@@ -76,8 +76,11 @@ The `toolName` in the rule must match the name of the tool being called.
 - **Codebase Investigator Agent** (`codebase_investigator`)
 - **Edit** (`replace`)
 - **Enter Plan Mode** (`enter_plan_mode`)
+- **Exit Plan Mode** (`exit_plan_mode`)
 - **FindFiles** (`glob`)
+- **Get Internal Docs** (`get_internal_docs`)
 - **GoogleSearch** (`google_web_search`)
+- **Read Many Files** (`read_many_files`)
 - **ReadFile** (`read_file`)
 - **ReadFolder** (`list_directory`)
 - **SaveMemory** (`save_memory`)
@@ -85,6 +88,7 @@ The `toolName` in the rule must match the name of the tool being called.
 - **Shell** (`run_shell_command`)
 - **WebFetch** (`web_fetch`)
 - **WriteFile** (`write_file`)
+- **Write Todos** (`write_todos`)
 
 #### Arguments pattern
 

--- a/docs/reference/policy-engine.md
+++ b/docs/reference/policy-engine.md
@@ -68,6 +68,24 @@ The `toolName` in the rule must match the name of the tool being called.
   wildcard. A `toolName` of `my-server__*` will match any tool from the
   `my-server` MCP.
 
+#### Available Gemini CLI Tools
+
+- **Activate Skill** (`activate_skill`)
+- **Ask User** (`ask_user`)
+- **CLI Help Agent** (`cli_help`)
+- **Codebase Investigator Agent** (`codebase_investigator`)
+- **Edit** (`replace`)
+- **Enter Plan Mode** (`enter_plan_mode`)
+- **FindFiles** (`glob`)
+- **GoogleSearch** (`google_web_search`)
+- **ReadFile** (`read_file`)
+- **ReadFolder** (`list_directory`)
+- **SaveMemory** (`save_memory`)
+- **SearchText** (`grep_search`)
+- **Shell** (`run_shell_command`)
+- **WebFetch** (`web_fetch`)
+- **WriteFile** (`write_file`)
+
 #### Arguments pattern
 
 If `argsPattern` is specified, the tool's arguments are converted to a stable

--- a/docs/reference/policy-engine.md
+++ b/docs/reference/policy-engine.md
@@ -68,25 +68,22 @@ The `toolName` in the rule must match the name of the tool being called.
   wildcard. A `toolName` of `my-server__*` will match any tool from the
   `my-server` MCP.
 
-#### Available Gemini CLI Tools
-
 - **Activate Skill** (`activate_skill`)
 - **Ask User** (`ask_user`)
-- **CLI Help Agent** (`cli_help`)
 - **Codebase Investigator Agent** (`codebase_investigator`)
 - **Edit** (`replace`)
 - **Enter Plan Mode** (`enter_plan_mode`)
 - **Exit Plan Mode** (`exit_plan_mode`)
 - **FindFiles** (`glob`)
 - **Get Internal Docs** (`get_internal_docs`)
-- **GoogleSearch** (`google_web_search`)
+- **Google Search** (`google_web_search`)
+- **List Directory** (`list_directory`)
 - **Read Many Files** (`read_many_files`)
 - **ReadFile** (`read_file`)
-- **ReadFolder** (`list_directory`)
-- **SaveMemory** (`save_memory`)
-- **SearchText** (`grep_search`)
-- **Shell** (`run_shell_command`)
-- **WebFetch** (`web_fetch`)
+- **Run Shell Command** (`run_shell_command`)
+- **Save Memory** (`save_memory`)
+- **Search Text** (`grep_search`)
+- **Web Fetch** (`web_fetch`)
 - **WriteFile** (`write_file`)
 - **Write Todos** (`write_todos`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17419,6 +17419,7 @@
         "shell-quote": "^1.8.3",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",
+        "strip-json-comments": "^3.1.1",
         "systeminformation": "^5.25.11",
         "tree-sitter-bash": "^0.25.0",
         "undici": "^7.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17419,7 +17419,6 @@
         "shell-quote": "^1.8.3",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",
-        "strip-json-comments": "^3.1.1",
         "systeminformation": "^5.25.11",
         "tree-sitter-bash": "^0.25.0",
         "undici": "^7.10.0",


### PR DESCRIPTION
## Summary

 Adds a new “Available Gemini CLI Tools” section to the Policy Engine documentation.
 Fixes #18750 


## Related Issues

N/A

## How to Validate

1) Navigate to the https://geminicli.com/docs/reference/policy-engine/ link in web browser.
2) Scroll to the Conditions section.
3) Verify that new “Available Gemini CLI Tools” section is present.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
