### PR TITLE
docs(CONTRIBUTING): update React DevTools version to 6

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -372,8 +372,7 @@ specific debug settings.
 
 ### React DevTools
 
-To debug the CLI's React-based UI, you can use React DevTools. Ink, the library
-used for the CLI's interface, is compatible with React DevTools version 4.x.
+To debug the CLI's React-based UI, you can use React DevTools.
 
 1.  **Start the Gemini CLI in development mode:**
 
@@ -381,20 +380,20 @@ used for the CLI's interface, is compatible with React DevTools version 4.x.
     DEV=true npm start
     ```
 
-2.  **Install and run React DevTools version 4.28.5 (or the latest compatible
-    4.x version):**
+2.  **Install and run React DevTools version 6 (which matches the CLI's
+    `react-devtools-core`):**
 
     You can either install it globally:
 
     ```bash
-    npm install -g react-devtools@4.28.5
+    npm install -g react-devtools@6
     react-devtools
     ```
 
     Or run it directly using npx:
 
     ```bash
-    npx react-devtools@4.28.5
+    npx react-devtools@6
     ```
 
     Your running CLI application should then connect to React DevTools.


### PR DESCRIPTION
## Summary

Updates the documentation in `CONTRIBUTING.md` to indicate that React DevTools version 6 is the compatible and recommended version for debugging the CLI's React-based UI, matching the CLI's `react-devtools-core` version.

## Details

Replaced references to version 4.28.5 (and the 4.x line) with version 6. This ensures contributors install the correct version to inspect the CLI

## Related Issues

Fixes #20013

## How to Validate

N/A - Documentation only update

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
