### PR TITLE
feat(cli): add tools.trusted to bypass tool confirmation

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -749,6 +749,12 @@ their corresponding top-level category object in your `settings.json` file.
   - **Default:** `undefined`
   - **Requires restart:** Yes
 
+- **`tools.trusted`** (array):
+  - **Description:** Tool names that bypass the confirmation dialog. Use this
+    for trusted workflows (for example ["save_memory"]).
+  - **Default:** `undefined`
+  - **Requires restart:** Yes
+
 - **`tools.exclude`** (array):
   - **Description:** Tool names to exclude from discovery.
   - **Default:** `undefined`

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -3201,10 +3201,10 @@ describe('Policy Engine Integration in loadCliConfig', () => {
     vi.restoreAllMocks();
   });
 
-  it('should pass merged allowed tools from CLI and settings to createPolicyEngineConfig', async () => {
+  it('should pass merged allowed tools from CLI, tools.allowed, and tools.trusted to createPolicyEngineConfig', async () => {
     process.argv = ['node', 'script.js', '--allowed-tools', 'cli-tool'];
     const settings = createTestMergedSettings({
-      tools: { allowed: ['settings-tool'] },
+      tools: { allowed: ['settings-tool'], trusted: ['save_memory'] },
     });
     const argv = await parseArguments(createTestMergedSettings());
 
@@ -3213,7 +3213,7 @@ describe('Policy Engine Integration in loadCliConfig', () => {
     expect(ServerConfig.createPolicyEngineConfig).toHaveBeenCalledWith(
       expect.objectContaining({
         tools: expect.objectContaining({
-          allowed: expect.arrayContaining(['cli-tool']),
+          allowed: expect.arrayContaining(['cli-tool', 'save_memory']),
         }),
       }),
       expect.anything(),

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -632,7 +632,12 @@ export async function loadCliConfig(
     (!isHeadlessMode({ prompt: argv.prompt, query: argv.query }) &&
       !argv.isCommand);
 
-  const allowedTools = argv.allowedTools || settings.tools?.allowed || [];
+  const deprecatedAllowedTools =
+    argv.allowedTools || settings.tools?.allowed || [];
+  const trustedTools = settings.tools?.trusted || [];
+  const allowedTools = [
+    ...new Set([...deprecatedAllowedTools, ...trustedTools]),
+  ];
   const allowedToolsSet = new Set(allowedTools);
 
   // In non-interactive mode, exclude tools that require a prompt.

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1217,6 +1217,19 @@ const SETTINGS_SCHEMA = {
         showInDialog: false,
         items: { type: 'string' },
       },
+      trusted: {
+        type: 'array',
+        label: 'Trusted Tools',
+        category: 'Tools',
+        requiresRestart: true,
+        default: undefined as string[] | undefined,
+        description: oneLine`
+          Tool names that bypass the confirmation dialog.
+          Use this for trusted workflows (for example ["save_memory"]).
+        `,
+        showInDialog: false,
+        items: { type: 'string' },
+      },
       exclude: {
         type: 'array',
         label: 'Exclude Tools',

--- a/packages/core/src/services/FolderTrustDiscoveryService.test.ts
+++ b/packages/core/src/services/FolderTrustDiscoveryService.test.ts
@@ -76,7 +76,7 @@ describe('FolderTrustDiscoveryService', () => {
 
     const settings = {
       tools: {
-        allowed: ['git'],
+        trusted: ['save_memory'],
         sandbox: false,
       },
       experimental: {
@@ -96,7 +96,7 @@ describe('FolderTrustDiscoveryService', () => {
     const results = await FolderTrustDiscoveryService.discover(tempDir);
 
     expect(results.securityWarnings).toContain(
-      'This project auto-approves certain tools (tools.allowed).',
+      'This project auto-approves certain tools (tools.allowed/tools.trusted).',
     );
     expect(results.securityWarnings).toContain(
       'This project enables autonomous agents (enableAgents).',

--- a/packages/core/src/services/FolderTrustDiscoveryService.ts
+++ b/packages/core/src/services/FolderTrustDiscoveryService.ts
@@ -169,11 +169,15 @@ export class FolderTrustDiscoveryService {
         : undefined;
 
     const allowedTools = tools?.['allowed'];
+    const trustedTools = tools?.['trusted'];
 
     const checks = [
       {
-        condition: Array.isArray(allowedTools) && allowedTools.length > 0,
-        message: 'This project auto-approves certain tools (tools.allowed).',
+        condition:
+          (Array.isArray(allowedTools) && allowedTools.length > 0) ||
+          (Array.isArray(trustedTools) && trustedTools.length > 0),
+        message:
+          'This project auto-approves certain tools (tools.allowed/tools.trusted).',
       },
       {
         condition: experimental?.['enableAgents'] === true,

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1267,6 +1267,15 @@
             "type": "string"
           }
         },
+        "trusted": {
+          "title": "Trusted Tools",
+          "description": "Tool names that bypass the confirmation dialog. Use this for trusted workflows (for example [\"save_memory\"]).",
+          "markdownDescription": "Tool names that bypass the confirmation dialog. Use this for trusted workflows (for example [\"save_memory\"]).\n\n- Category: `Tools`\n- Requires restart: `yes`",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "exclude": {
           "title": "Exclude Tools",
           "description": "Tool names to exclude from discovery.",


### PR DESCRIPTION
## Summary

This PR adds a new `tools.trusted` configuration to allow explicitly listed tools to run without interactive confirmation, addressing the save-memory confirmation workflow issue.  
It keeps backward compatibility with existing `tools.allowed` usage while improving clarity of intent and aligning behavior with policy wiring and trust warnings.

## Details

- Added support for `tools.trusted` in settings/schema/docs and merged it into the effective auto-approved tool set at config load time.
- Kept compatibility with deprecated `tools.allowed` so existing user configs continue to work.
- Updated folder-trust discovery security warnings to treat `tools.trusted` the same way as other auto-approval paths.
- Updated tests for config/policy and folder-trust discovery to cover the new setting.
- Regenerated settings schema and configuration reference docs to keep generated artifacts in sync.

## Related Issues

Fixes #19967

## How to Validate

1. Install dependencies (if needed):
   - `npm ci`

2. Run targeted tests for changed behavior:
   - `npm run test -- packages/cli/src/config/config.test.ts`
   - `npm run test -- packages/core/src/services/FolderTrustDiscoveryService.test.ts`

3. Run broader validation/preflight:
   - `NODE_OPTIONS=--max-old-space-size=8192 npm run preflight`

4. Manual behavior check:
   - Add this in `settings.json`:
     - `"tools": { "trusted": ["save_memory"] }`
   - Start CLI and trigger `save_memory`.
   - Expected: no extra confirmation prompt for trusted tool.
   - Remove from trusted list and retry.
   - Expected: confirmation prompt appears again.

5. Security warning check:
   - With `tools.trusted` configured, verify folder trust discovery includes warning about auto-approved tools.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) — None
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
