### PR TITLE
fix(auth): make validateAuthMethod async to fix keychain startup error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17419,6 +17419,7 @@
         "shell-quote": "^1.8.3",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",
+        "strip-json-comments": "^3.1.1",
         "systeminformation": "^5.25.11",
         "tree-sitter-bash": "^0.25.0",
         "undici": "^7.10.0",

--- a/packages/cli/src/config/auth.test.ts
+++ b/packages/cli/src/config/auth.test.ts
@@ -8,6 +8,15 @@ import { AuthType } from '@google/gemini-cli-core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { validateAuthMethod } from './auth.js';
 
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    loadApiKey: vi.fn().mockResolvedValue(null),
+  };
+});
+
 vi.mock('./settings.js', () => ({
   loadEnvironment: vi.fn(),
   loadSettings: vi.fn().mockReturnValue({
@@ -90,10 +99,10 @@ describe('validateAuthMethod', () => {
       envs: {},
       expected: 'Invalid auth method selected.',
     },
-  ])('$description', ({ authType, envs, expected }) => {
+  ])('$description', async ({ authType, envs, expected }) => {
     for (const [key, value] of Object.entries(envs)) {
       vi.stubEnv(key, value as string);
     }
-    expect(validateAuthMethod(authType)).toBe(expected);
+    expect(await validateAuthMethod(authType)).toBe(expected);
   });
 });

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -4,10 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AuthType } from '@google/gemini-cli-core';
+import { AuthType, loadApiKey } from '@google/gemini-cli-core';
 import { loadEnvironment, loadSettings } from './settings.js';
 
-export function validateAuthMethod(authMethod: string): string | null {
+export async function validateAuthMethod(
+  authMethod: string,
+): Promise<string | null> {
   loadEnvironment(loadSettings().merged, process.cwd());
   if (
     authMethod === AuthType.LOGIN_WITH_GOOGLE ||
@@ -17,7 +19,8 @@ export function validateAuthMethod(authMethod: string): string | null {
   }
 
   if (authMethod === AuthType.USE_GEMINI) {
-    if (!process.env['GEMINI_API_KEY']) {
+    const hasKey = process.env['GEMINI_API_KEY'] || (await loadApiKey());
+    if (!hasKey) {
       return (
         'When using Gemini API, you must specify the GEMINI_API_KEY environment variable.\n' +
         'Update your environment and try again (no reload needed if using .env)!'

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -452,7 +452,7 @@ export async function main() {
         partialConfig.isInteractive() &&
         settings.merged.security.auth.selectedType
       ) {
-        const err = validateAuthMethod(
+        const err = await validateAuthMethod(
           settings.merged.security.auth.selectedType,
         );
         if (err) {

--- a/packages/cli/src/test-utils/AppRig.tsx
+++ b/packages/cli/src/test-utils/AppRig.tsx
@@ -64,7 +64,7 @@ vi.mock('../ui/auth/useAuth.js', () => ({
     apiKeyDefaultValue: 'test-api-key',
     reloadApiKey: vi.fn().mockResolvedValue('test-api-key'),
   }),
-  validateAuthMethodWithSettings: () => null,
+  validateAuthMethodWithSettings: async () => null,
 }));
 
 // A minimal mock ExtensionManager to satisfy AppContainer's forceful cast

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -837,19 +837,15 @@ Logging in with Google... Restarting Gemini CLI to continue.
       settings.merged.security.auth.selectedType &&
       !settings.merged.security.auth.useExternal
     ) {
-      // We skip validation for Gemini API key here because it might be stored
-      // in the keychain, which we can't check synchronously.
-      // The useAuth hook handles validation for this case.
-      if (settings.merged.security.auth.selectedType === AuthType.USE_GEMINI) {
-        return;
-      }
-
-      const error = validateAuthMethod(
-        settings.merged.security.auth.selectedType,
-      );
-      if (error) {
-        onAuthError(error);
-      }
+      const checkAuth = async () => {
+        const error = await validateAuthMethod(
+          settings.merged.security.auth.selectedType!,
+        );
+        if (error) {
+          onAuthError(error);
+        }
+      };
+      void checkAuth();
     }
   }, [
     settings.merged.security.auth.selectedType,

--- a/packages/cli/src/ui/auth/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.test.tsx
@@ -225,14 +225,14 @@ describe('AuthDialog', () => {
 
   describe('handleAuthSelect', () => {
     it('calls onAuthError if validation fails', async () => {
-      mockedValidateAuthMethod.mockReturnValue('Invalid method');
+      mockedValidateAuthMethod.mockResolvedValue('Invalid method');
       const { waitUntilReady, unmount } = renderWithProviders(
         <AuthDialog {...props} />,
       );
       await waitUntilReady();
       const { onSelect: handleAuthSelect } =
         mockedRadioButtonSelect.mock.calls[0][0];
-      handleAuthSelect(AuthType.USE_GEMINI);
+      await handleAuthSelect(AuthType.USE_GEMINI);
 
       expect(mockedValidateAuthMethod).toHaveBeenCalledWith(
         AuthType.USE_GEMINI,

--- a/packages/cli/src/ui/auth/AuthDialog.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.tsx
@@ -155,8 +155,8 @@ export function AuthDialog({
     [settings, config, setAuthState, exiting, setAuthContext],
   );
 
-  const handleAuthSelect = (authMethod: AuthType) => {
-    const error = validateAuthMethodWithSettings(authMethod, settings);
+  const handleAuthSelect = async (authMethod: AuthType) => {
+    const error = await validateAuthMethodWithSettings(authMethod, settings);
     if (error) {
       onAuthError(error);
     } else {

--- a/packages/cli/src/ui/auth/useAuth.test.tsx
+++ b/packages/cli/src/ui/auth/useAuth.test.tsx
@@ -49,7 +49,7 @@ describe('useAuth', () => {
   });
 
   describe('validateAuthMethodWithSettings', () => {
-    it('should return error if auth type is enforced and does not match', () => {
+    it('should return error if auth type is enforced and does not match', async () => {
       const settings = {
         merged: {
           security: {
@@ -60,14 +60,14 @@ describe('useAuth', () => {
         },
       } as LoadedSettings;
 
-      const error = validateAuthMethodWithSettings(
+      const error = await validateAuthMethodWithSettings(
         AuthType.USE_GEMINI,
         settings,
       );
       expect(error).toContain('Authentication is enforced to be oauth');
     });
 
-    it('should return null if useExternal is true', () => {
+    it('should return null if useExternal is true', async () => {
       const settings = {
         merged: {
           security: {
@@ -78,14 +78,14 @@ describe('useAuth', () => {
         },
       } as LoadedSettings;
 
-      const error = validateAuthMethodWithSettings(
+      const error = await validateAuthMethodWithSettings(
         AuthType.LOGIN_WITH_GOOGLE,
         settings,
       );
       expect(error).toBeNull();
     });
 
-    it('should return null if authType is USE_GEMINI', () => {
+    it('should return null if authType is USE_GEMINI', async () => {
       const settings = {
         merged: {
           security: {
@@ -94,14 +94,15 @@ describe('useAuth', () => {
         },
       } as LoadedSettings;
 
-      const error = validateAuthMethodWithSettings(
+      mockValidateAuthMethod.mockReturnValue(null);
+      const error = await validateAuthMethodWithSettings(
         AuthType.USE_GEMINI,
         settings,
       );
       expect(error).toBeNull();
     });
 
-    it('should call validateAuthMethod for other auth types', () => {
+    it('should call validateAuthMethod for other auth types', async () => {
       const settings = {
         merged: {
           security: {
@@ -111,7 +112,7 @@ describe('useAuth', () => {
       } as LoadedSettings;
 
       mockValidateAuthMethod.mockReturnValue('Validation Error');
-      const error = validateAuthMethodWithSettings(
+      const error = await validateAuthMethodWithSettings(
         AuthType.LOGIN_WITH_GOOGLE,
         settings,
       );

--- a/packages/cli/src/ui/auth/useAuth.ts
+++ b/packages/cli/src/ui/auth/useAuth.ts
@@ -16,10 +16,10 @@ import { getErrorMessage } from '@google/gemini-cli-core';
 import { AuthState } from '../types.js';
 import { validateAuthMethod } from '../../config/auth.js';
 
-export function validateAuthMethodWithSettings(
+export async function validateAuthMethodWithSettings(
   authType: AuthType,
   settings: LoadedSettings,
-): string | null {
+): Promise<string | null> {
   const enforcedType = settings.merged.security.auth.enforcedType;
   if (enforcedType && enforcedType !== authType) {
     return `Authentication is enforced to be ${enforcedType}, but you are currently using ${authType}.`;
@@ -27,10 +27,7 @@ export function validateAuthMethodWithSettings(
   if (settings.merged.security.auth.useExternal) {
     return null;
   }
-  // If using Gemini API key, we don't validate it here as we might need to prompt for it.
-  if (authType === AuthType.USE_GEMINI) {
-    return null;
-  }
+
   return validateAuthMethod(authType);
 }
 
@@ -104,7 +101,7 @@ export const useAuthCommand = (
         }
       }
 
-      const error = validateAuthMethodWithSettings(authType, settings);
+      const error = await validateAuthMethodWithSettings(authType, settings);
       if (error) {
         onAuthError(error);
         return;

--- a/packages/cli/src/validateNonInterActiveAuth.test.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.test.ts
@@ -59,7 +59,7 @@ describe('validateNonInterActiveAuth', () => {
       .mockImplementation((code?: string | number | null | undefined) => {
         throw new Error(`process.exit(${code}) called`);
       });
-    vi.spyOn(auth, 'validateAuthMethod').mockReturnValue(null);
+    vi.spyOn(auth, 'validateAuthMethod').mockResolvedValue(null);
     mockSettings = {
       system: { path: '', settings: {} },
       systemDefaults: { path: '', settings: {} },
@@ -247,7 +247,7 @@ describe('validateNonInterActiveAuth', () => {
 
   it('exits if validateAuthMethod returns error', async () => {
     // Mock validateAuthMethod to return error
-    vi.spyOn(auth, 'validateAuthMethod').mockReturnValue('Auth error!');
+    vi.spyOn(auth, 'validateAuthMethod').mockResolvedValue('Auth error!');
     const nonInteractiveConfig = createLocalMockConfig({
       getOutputFormat: vi.fn().mockReturnValue(OutputFormat.TEXT),
       getContentGeneratorConfig: vi
@@ -277,7 +277,7 @@ describe('validateNonInterActiveAuth', () => {
     // Mock validateAuthMethod to return error to ensure it's not being called
     const validateAuthMethodSpy = vi
       .spyOn(auth, 'validateAuthMethod')
-      .mockReturnValue('Auth error!');
+      .mockResolvedValue('Auth error!');
     const nonInteractiveConfig = createLocalMockConfig({});
     // Even with an invalid auth type, it should not exit
     // because validation is skipped.
@@ -432,7 +432,7 @@ describe('validateNonInterActiveAuth', () => {
     });
 
     it(`prints JSON error when validateAuthMethod fails and exits with code ${ExitCodes.FATAL_AUTHENTICATION_ERROR}`, async () => {
-      vi.spyOn(auth, 'validateAuthMethod').mockReturnValue('Auth error!');
+      vi.spyOn(auth, 'validateAuthMethod').mockResolvedValue('Auth error!');
       process.env['GEMINI_API_KEY'] = 'fake-key';
 
       const nonInteractiveConfig = createLocalMockConfig({

--- a/packages/cli/src/validateNonInterActiveAuth.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.ts
@@ -42,7 +42,7 @@ export async function validateNonInteractiveAuth(
     const authType: AuthType = effectiveAuthType;
 
     if (!useExternalAuth) {
-      const err = validateAuthMethod(String(authType));
+      const err = await validateAuthMethod(String(authType));
       if (err != null) {
         throw new Error(err);
       }


### PR DESCRIPTION
## Summary

This PR fixes a bug that causes the Gemini CLI to crash on startup with an "Authentication error" when the Gemini API key is stored securely in the system keychain rather than directly in `process.env['GEMINI_API_KEY']`. 

## Details

The issue was introduced in commit `d74bf9ef`, which added an unconditional validation check for the selected authentication method (`validateNonInteractiveAuth`) upon application startup. However, the validation method (`validateAuthMethod`) was entirely synchronous and could not fetch the API key from the asynchronous `HybridTokenStorage`. Therefore, if the key was stored in the keychain, the validation immediately failed.

This PR:
- Refactors `validateAuthMethod` in `auth.ts` to be an `async` function and awaits `loadApiKey()`.
- Updates all callers (like `validateNonInteractiveAuth.ts`, `gemini.tsx`, and `useAuth.ts`) to properly `await` the validation check.
- Updates tests to use `mockResolvedValue` and `await` where necessary.

## Related Issues

Fixes #17225

## How to Validate

1. Store an API key in the credential storage by authenticating interactively (`gemini auth`).
2. Remove any local `.env` containing `GEMINI_API_KEY`.
3. Unset `GEMINI_API_KEY` from the shell.
4. Run `npm run start` (or standard `gemini` if packaged) to launch the CLI.
5. The CLI should load without complaining about the missing `GEMINI_API_KEY`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker