### PR TITLE
feat(policy): Support MCP Server Wildcards in Policy Engine

### DIFF
--- a/docs/reference/policy-engine.md
+++ b/docs/reference/policy-engine.md
@@ -64,9 +64,11 @@ primary conditions are the tool's name and its arguments.
 
 The `toolName` in the rule must match the name of the tool being called.
 
-- **Wildcards**: For Model-hosting-protocol (MCP) servers, you can use a
-  wildcard. A `toolName` of `my-server__*` will match any tool from the
-  `my-server` MCP.
+- **Wildcards**: You can use wildcards to match multiple tools.
+  - `*`: Matches **any tool** (built-in or MCP).
+  - `server__*`: Matches any tool from a specific MCP server.
+  - `*__toolName`: Matches a specific tool name across **all** MCP servers.
+  - `*__*`: Matches **any tool from any MCP server**.
 
 #### Arguments pattern
 
@@ -144,9 +146,9 @@ A rule matches a tool call if all of its conditions are met:
 
 1.  **Tool name**: The `toolName` in the rule must match the name of the tool
     being called.
-    - **Wildcards**: For Model-hosting-protocol (MCP) servers, you can use a
-      wildcard. A `toolName` of `my-server__*` will match any tool from the
-      `my-server` MCP.
+    - **Wildcards**: You can use wildcards like `*`, `server__*`, or
+      `*__toolName` to match multiple tools. See [Tool Name](#tool-name) for
+      details.
 2.  **Arguments pattern**: If `argsPattern` is specified, the tool's arguments
     are converted to a stable JSON string, which is then tested against the
     provided regular expression. If the arguments don't match the pattern, the
@@ -272,13 +274,12 @@ priority = 100
 
 ### Special syntax for MCP tools
 
-You can create rules that target tools from Model-hosting-protocol (MCP) servers
-using the `mcpName` field or a wildcard pattern.
+You can create rules that target tools from Model Context Protocol (MCP) servers
+using the `mcpName` field or composite wildcard patterns.
 
-**1. Using `mcpName`**
+**1. Targeting a specific tool on a server**
 
-To target a specific tool from a specific server, combine `mcpName` and
-`toolName`.
+Combine `mcpName` and `toolName` to target a single operation.
 
 ```toml
 # Allows the `search` tool on the `my-jira-server` MCP
@@ -289,10 +290,10 @@ decision = "allow"
 priority = 200
 ```
 
-**2. Using a wildcard**
+**2. Targeting all tools on a specific server**
 
-To create a rule that applies to _all_ tools on a specific MCP server, specify
-only the `mcpName`.
+Specify only the `mcpName` to apply a rule to every tool provided by that
+server.
 
 ```toml
 # Denies all tools from the `untrusted-server` MCP
@@ -301,6 +302,33 @@ mcpName = "untrusted-server"
 decision = "deny"
 priority = 500
 deny_message = "This server is not trusted by the admin."
+```
+
+**3. Targeting all MCP servers**
+
+Use `mcpName = "*"` to create a rule that applies to **all** tools from **any**
+registered MCP server. This is useful for setting category-wide defaults.
+
+```toml
+# Ask user for any tool call from any MCP server
+[[rule]]
+mcpName = "*"
+decision = "ask_user"
+priority = 10
+```
+
+**4. Targeting a tool name across all servers**
+
+Use `mcpName = "*"` with a specific `toolName` to target that operation
+regardless of which server provides it.
+
+```toml
+# Allow the `search` tool across all connected MCP servers
+[[rule]]
+mcpName = "*"
+toolName = "search"
+decision = "allow"
+priority = 50
 ```
 
 ## Default policies

--- a/packages/core/src/policy/toml-loader.test.ts
+++ b/packages/core/src/policy/toml-loader.test.ts
@@ -89,6 +89,34 @@ priority = 100
       expect(result.errors).toHaveLength(0);
     });
 
+    it('should transform mcpName = "*" to wildcard toolName', async () => {
+      const result = await runLoadPoliciesFromToml(`
+[[rule]]
+mcpName = "*"
+decision = "ask_user"
+priority = 10
+`);
+
+      expect(result.rules).toHaveLength(1);
+      expect(result.rules[0].toolName).toBe('*__*');
+      expect(result.rules[0].decision).toBe(PolicyDecision.ASK_USER);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should transform mcpName = "*" and specific toolName to wildcard prefix', async () => {
+      const result = await runLoadPoliciesFromToml(`
+[[rule]]
+mcpName = "*"
+toolName = "search"
+decision = "allow"
+priority = 10
+`);
+
+      expect(result.rules).toHaveLength(1);
+      expect(result.rules[0].toolName).toBe('*__search');
+      expect(result.errors).toHaveLength(0);
+    });
+
     it('should transform commandRegex to argsPattern', async () => {
       const result = await runLoadPoliciesFromToml(`
 [[rule]]


### PR DESCRIPTION
Fixes https://github.com/google-gemini/gemini-cli/issues/19653

- Add support for *, *__*, and *__tool wildcard patterns in policy rules.
- Refine matchesWildcard logic to handle broad categories and specific tool names across servers.
- Update TOML loader to map mcpName to internal composite wildcard patterns.
- Add unit and integration tests for new wildcard matching scenarios.


