### PR TITLE
Allow ask headers longer than 16 chars

### DIFF
--- a/packages/cli/src/ui/components/shared/TabHeader.test.tsx
+++ b/packages/cli/src/ui/components/shared/TabHeader.test.tsx
@@ -173,6 +173,28 @@ describe('TabHeader', () => {
       unmount();
     });
 
+    it('truncates long headers when not selected', async () => {
+      const longTabs: Tab[] = [
+        { key: '0', header: 'ThisIsAVeryLongHeaderThatShouldBeTruncated' },
+        { key: '1', header: 'AnotherVeryLongHeader' },
+      ];
+      const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
+        <TabHeader tabs={longTabs} currentIndex={0} />,
+      );
+      await waitUntilReady();
+      const frame = lastFrame();
+
+      // Current tab (index 0) should NOT be truncated
+      expect(frame).toContain('ThisIsAVeryLongHeaderThatShouldBeTruncated');
+
+      // Inactive tab (index 1) SHOULD be truncated to 16 chars (15 chars + …)
+      const expectedTruncated = 'AnotherVeryLong…';
+      expect(frame).toContain(expectedTruncated);
+      expect(frame).not.toContain('AnotherVeryLongHeader');
+
+      unmount();
+    });
+
     it('falls back to default when renderStatusIcon returns undefined', async () => {
       const renderStatusIcon = () => undefined;
       const { lastFrame, waitUntilReady, unmount } = renderWithProviders(

--- a/packages/cli/src/ui/components/shared/TabHeader.tsx
+++ b/packages/cli/src/ui/components/shared/TabHeader.tsx
@@ -94,16 +94,19 @@ export function TabHeader({
           {showStatusIcons && (
             <Text color={theme.text.secondary}>{getStatusIcon(tab, i)} </Text>
           )}
-          <Text
-            color={
-              i === currentIndex ? theme.status.success : theme.text.secondary
-            }
-            bold={i === currentIndex}
-            underline={i === currentIndex}
-            aria-current={i === currentIndex ? 'step' : undefined}
-          >
-            {tab.header}
-          </Text>
+          <Box maxWidth={i !== currentIndex ? 16 : 100}>
+            <Text
+              color={
+                i === currentIndex ? theme.status.success : theme.text.secondary
+              }
+              bold={i === currentIndex}
+              underline={i === currentIndex}
+              aria-current={i === currentIndex ? 'step' : undefined}
+              wrap="truncate"
+            >
+              {tab.header}
+            </Text>
+          </Box>
         </React.Fragment>
       ))}
       {showArrows && <Text color={theme.text.secondary}>{' →'}</Text>}

--- a/packages/core/src/tools/ask-user.test.ts
+++ b/packages/core/src/tools/ask-user.test.ts
@@ -103,19 +103,6 @@ describe('AskUserTool', () => {
       expect(result).toContain("must have required property 'header'");
     });
 
-    it('should return error if header exceeds max length', () => {
-      const result = tool.validateToolParams({
-        questions: [
-          {
-            question: 'Test?',
-            header: 'This is way too long',
-            type: QuestionType.CHOICE,
-          },
-        ],
-      });
-      expect(result).toContain('must NOT have more than 16 characters');
-    });
-
     it('should return error if options has fewer than 2 items', () => {
       const result = tool.validateToolParams({
         questions: [
@@ -276,13 +263,7 @@ describe('AskUserTool', () => {
   describe('validateBuildAndExecute', () => {
     it('should hide validation errors from returnDisplay', async () => {
       const params = {
-        questions: [
-          {
-            question: 'Test?',
-            header: 'This is way too long',
-            type: QuestionType.TEXT,
-          },
-        ],
+        questions: [],
       };
 
       const result = await tool.validateBuildAndExecute(

--- a/packages/core/src/tools/definitions/__snapshots__/coreToolsModelSnapshots.test.ts.snap
+++ b/packages/core/src/tools/definitions/__snapshots__/coreToolsModelSnapshots.test.ts.snap
@@ -80,8 +80,7 @@ exports[`coreTools snapshots for specific models > Model: gemini-2.5-pro > snaps
         "items": {
           "properties": {
             "header": {
-              "description": "MUST be 16 characters or fewer or the call will fail. Very short label displayed as a chip/tag. Use abbreviations: "Auth" not "Authentication", "Config" not "Configuration". Examples: "Auth method", "Library", "Approach", "Database".",
-              "maxLength": 16,
+              "description": "Very short label displayed as a chip/tag. Use abbreviations: "Auth" not "Authentication", "Config" not "Configuration". Examples: "Auth method", "Library", "Approach", "Database".",
               "type": "string",
             },
             "multiSelect": {
@@ -869,8 +868,7 @@ exports[`coreTools snapshots for specific models > Model: gemini-3-pro-preview >
         "items": {
           "properties": {
             "header": {
-              "description": "MUST be 16 characters or fewer or the call will fail. Very short label displayed as a chip/tag. Use abbreviations: "Auth" not "Authentication", "Config" not "Configuration". Examples: "Auth method", "Library", "Approach", "Database".",
-              "maxLength": 16,
+              "description": "Very short label displayed as a chip/tag. Use abbreviations: "Auth" not "Authentication", "Config" not "Configuration". Examples: "Auth method", "Library", "Approach", "Database".",
               "type": "string",
             },
             "multiSelect": {

--- a/packages/core/src/tools/definitions/model-family-sets/default-legacy.ts
+++ b/packages/core/src/tools/definitions/model-family-sets/default-legacy.ts
@@ -609,9 +609,8 @@ The agent did not use the todo list because this task could be completed by a ti
               },
               header: {
                 type: 'string',
-                maxLength: 16,
                 description:
-                  'MUST be 16 characters or fewer or the call will fail. Very short label displayed as a chip/tag. Use abbreviations: "Auth" not "Authentication", "Config" not "Configuration". Examples: "Auth method", "Library", "Approach", "Database".',
+                  'Very short label displayed as a chip/tag. Use abbreviations: "Auth" not "Authentication", "Config" not "Configuration". Examples: "Auth method", "Library", "Approach", "Database".',
               },
               type: {
                 type: 'string',

--- a/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts
+++ b/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts
@@ -587,9 +587,8 @@ The agent did not use the todo list because this task could be completed by a ti
               },
               header: {
                 type: 'string',
-                maxLength: 16,
                 description:
-                  'MUST be 16 characters or fewer or the call will fail. Very short label displayed as a chip/tag. Use abbreviations: "Auth" not "Authentication", "Config" not "Configuration". Examples: "Auth method", "Library", "Approach", "Database".',
+                  'Very short label displayed as a chip/tag. Use abbreviations: "Auth" not "Authentication", "Config" not "Configuration". Examples: "Auth method", "Library", "Approach", "Database".',
               },
               type: {
                 type: 'string',


### PR DESCRIPTION
## Summary

Allow ask headers longer than 16 chars

## Details

To save space, we truncate inactive headers if they are longer than 16 characters.

<img width="940" height="389" alt="Screenshot 2026-02-23 at 9 31 27 AM" src="https://github.com/user-attachments/assets/b83cd420-c63f-4bd0-99cd-0ec5b3aa762c" />

## Related Issues

Fixes #19233

## How to Validate

Ask Gemini to ask you questions with long headers

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
