### PR TITLE
chore: restrict gemini-automted-issue-triage to only allow echo

### DIFF
--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -155,7 +155,10 @@ jobs:
               "telemetry": {
                 "enabled": true,
                 "target": "gcp"
-              }
+              },
+              "coreTools": [
+                "run_shell_command(echo)"
+              ],
             }
           prompt: |-
             ## Role


### PR DESCRIPTION
 restrict gemini-automted-issue-triage to only allow echo