### PR TITLE
Fix/cyclic tool call loop detection

### DIFF
--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -778,6 +778,7 @@ export class RipgrepFallbackEvent implements BaseTelemetryEvent {
 
 export enum LoopType {
   CONSECUTIVE_IDENTICAL_TOOL_CALLS = 'consecutive_identical_tool_calls',
+  CYCLIC_TOOL_CALLS = 'cyclic_tool_calls',
   CHANTING_IDENTICAL_SENTENCES = 'chanting_identical_sentences',
   LLM_DETECTED_LOOP = 'llm_detected_loop',
 }


### PR DESCRIPTION
## Problem

The loop detector only caught **consecutive** identical tool calls (A,A,A,A,A).
Alternating or rotating patterns like A→B→A→B or A→B→C→A→B→C evaded detection
entirely — the counter reset on every key change, letting the agent burn through
all 100 turns and explaining the 584 MB memory / "tremendous loops" in the report.

## Root cause

`checkToolCallLoop` in `loopDetectionService.ts` resets `toolCallRepetitionCount`
on every key change, so alternating patterns never reach the threshold of 5.
The LLM-based fallback only activates after 30 turns.

## Fix

Adds a sliding-window cyclic detector alongside the existing consecutive check:

| Constant | Value | Meaning |
|---|---|---|
| `TOOL_CALL_HISTORY_WINDOW` | 20 | Ring-buffer of recent call keys |
| `MIN_CYCLE_LENGTH` | 2 | Smallest repeating unit (A→B) |
| `MAX_CYCLE_LENGTH` | 5 | Largest repeating unit (A→B→C→D→E) |
| `CYCLE_REPEAT_THRESHOLD` | 3 | Full repetitions before flagging |

Keys are SHA-256(tool name + serialised args), so calls with different inputs
each time (genuine incremental work) produce distinct keys and are never flagged.

## Changes

- `packages/core/src/telemetry/types.ts` — new `LoopType.CYCLIC_TOOL_CALLS`
- `packages/core/src/services/loopDetectionService.ts` — ring buffer + `checkCyclicToolCallPattern()` + reset
- `packages/core/src/services/loopDetectionService.test.ts` — 5 new tests, 1 updated

## Test plan
- [x] All 49 unit tests pass
- [x] 2-way alternation detected after 3 full cycles
- [x] 3-way rotation detected after 3 full cycles
- [x] Pattern broken by a new call → no false positive
- [x] Session-disable flag respected
- [x] `reset()` clears the ring buffer
