### PR TITLE
feat(policy): Propagate Tool Annotations for MCP Servers

### DIFF
--- a/docs/cli/plan-mode.md
+++ b/docs/cli/plan-mode.md
@@ -143,13 +143,27 @@ based on the task description.
 
 ### Customizing Policies
 
-Plan Mode is designed to be read-only by default to ensure safety during the
-research phase. However, you may occasionally need to allow specific tools to
-assist in your planning.
+Plan Mode's default tool restrictions are managed by the [policy engine] and
+defined in the built-in [`plan.toml`] file. The built-in policy (Tier 1)
+enforces the read-only state, but you can customize these rules by creating your
+own policies in your `~/.gemini/policies/` directory (Tier 2).
 
-Because user policies (Tier 2) have a higher base priority than built-in
-policies (Tier 1), you can override Plan Mode's default restrictions by creating
-a rule in your `~/.gemini/policies/` directory.
+#### Example: Automatically approve read-only MCP tools
+
+By default, read-only MCP tools require user confirmation in Plan Mode. You can
+use `toolAnnotations` and the `mcpName` wildcard to customize this behavior for
+your specific environment.
+
+`~/.gemini/policies/mcp-read-only.toml`
+
+```toml
+[[rule]]
+mcpName = "*"
+toolAnnotations = { readOnlyHint = true }
+decision = "allow"
+priority = 100
+modes = ["plan"]
+```
 
 #### Example: Allow git commands in Plan Mode
 
@@ -243,3 +257,5 @@ argsPattern = "\"file_path\":\"[^\"]+[\\\\/]+\\.gemini[\\\\/]+plans[\\\\/]+[\\w-
 [`exit_plan_mode`]: /docs/tools/planning.md#2-exit_plan_mode-exitplanmode
 [`ask_user`]: /docs/tools/ask-user.md
 [YOLO mode]: /docs/reference/configuration.md#command-line-arguments
+[`plan.toml`]:
+  https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/policy/policies/plan.toml

--- a/docs/reference/policy-engine.md
+++ b/docs/reference/policy-engine.md
@@ -205,6 +205,10 @@ toolName = "run_shell_command"
 # to form a composite name like "mcpName__toolName".
 mcpName = "my-custom-server"
 
+# (Optional) Metadata hints provided by the tool. A rule matches if all
+# key-value pairs provided here are present in the tool's annotations.
+toolAnnotations = { readOnlyHint = true }
+
 # (Optional) A regex to match against the tool's arguments.
 argsPattern = '"command":"(git|npm)'
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1597,7 +1597,9 @@ export class Config {
    *
    * May change over time.
    */
-  getExcludeTools(): Set<string> | undefined {
+  getExcludeTools(
+    toolMetadata?: Map<string, Record<string, unknown>>,
+  ): Set<string> | undefined {
     // Right now this is present for backward compatibility with settings.json exclude
     const excludeToolsSet = new Set([...(this.excludeTools ?? [])]);
     for (const extension of this.getExtensionLoader().getExtensions()) {
@@ -1609,7 +1611,7 @@ export class Config {
       }
     }
 
-    const policyExclusions = this.policyEngine.getExcludedTools();
+    const policyExclusions = this.policyEngine.getExcludedTools(toolMetadata);
     for (const tool of policyExclusions) {
       excludeToolsSet.add(tool);
     }

--- a/packages/core/src/confirmation-bus/message-bus.test.ts
+++ b/packages/core/src/confirmation-bus/message-bus.test.ts
@@ -140,6 +140,29 @@ describe('MessageBus', () => {
       expect(requestHandler).toHaveBeenCalledWith(request);
     });
 
+    it('should forward toolAnnotations to policyEngine.check', async () => {
+      const checkSpy = vi.spyOn(policyEngine, 'check').mockResolvedValue({
+        decision: PolicyDecision.ALLOW,
+      });
+
+      const annotations = { readOnlyHint: true };
+      const request: ToolConfirmationRequest = {
+        type: MessageBusType.TOOL_CONFIRMATION_REQUEST,
+        toolCall: { name: 'test-tool', args: {} },
+        correlationId: '123',
+        serverName: 'test-server',
+        toolAnnotations: annotations,
+      };
+
+      await messageBus.publish(request);
+
+      expect(checkSpy).toHaveBeenCalledWith(
+        { name: 'test-tool', args: {} },
+        'test-server',
+        annotations,
+      );
+    });
+
     it('should emit other message types directly', async () => {
       const successHandler = vi.fn();
       messageBus.subscribe(

--- a/packages/core/src/confirmation-bus/message-bus.ts
+++ b/packages/core/src/confirmation-bus/message-bus.ts
@@ -55,6 +55,7 @@ export class MessageBus extends EventEmitter {
         const { decision } = await this.policyEngine.check(
           message.toolCall,
           message.serverName,
+          message.toolAnnotations,
         );
 
         switch (decision) {

--- a/packages/core/src/confirmation-bus/types.ts
+++ b/packages/core/src/confirmation-bus/types.ts
@@ -35,6 +35,10 @@ export interface ToolConfirmationRequest {
   correlationId: string;
   serverName?: string;
   /**
+   * Optional tool annotations (e.g., readOnlyHint, destructiveHint) from MCP.
+   */
+  toolAnnotations?: Record<string, unknown>;
+  /**
    * Optional rich details for the confirmation UI (diffs, counts, etc.)
    */
   details?: SerializableConfirmationDetails;

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -1926,13 +1926,14 @@ describe('CoreToolScheduler Sequential Execution', () => {
     isModifiableSpy.mockRestore();
   });
 
-  it('should pass serverName to policy engine for DiscoveredMCPTool', async () => {
+  it('should pass serverName and toolAnnotations to policy engine for DiscoveredMCPTool', async () => {
     const mockMcpTool = {
       tool: async () => ({ functionDeclarations: [] }),
       callTool: async () => [],
     };
     const serverName = 'test-server';
     const toolName = 'test-tool';
+    const annotations = { readOnlyHint: true };
     const mcpTool = new DiscoveredMCPTool(
       mockMcpTool as unknown as CallableTool,
       serverName,
@@ -1940,6 +1941,13 @@ describe('CoreToolScheduler Sequential Execution', () => {
       'description',
       { type: 'object', properties: {} },
       createMockMessageBus() as unknown as MessageBus,
+      undefined, // trust
+      true, // isReadOnly
+      undefined, // nameOverride
+      undefined, // cliConfig
+      undefined, // extensionName
+      undefined, // extensionId
+      annotations, // toolAnnotations
     );
 
     const mockToolRegistry = {
@@ -1989,6 +1997,7 @@ describe('CoreToolScheduler Sequential Execution', () => {
     expect(mockPolicyEngineCheck).toHaveBeenCalledWith(
       expect.objectContaining({ name: toolName }),
       serverName,
+      annotations,
     );
   });
 

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -624,10 +624,11 @@ export class CoreToolScheduler {
           toolCall.tool instanceof DiscoveredMCPTool
             ? toolCall.tool.serverName
             : undefined;
+        const toolAnnotations = toolCall.tool.toolAnnotations;
 
         const { decision, rule } = await this.config
           .getPolicyEngine()
-          .check(toolCallForPolicy, serverName);
+          .check(toolCallForPolicy, serverName, toolAnnotations);
 
         if (decision === PolicyDecision.DENY) {
           const { errorMessage, errorType } = getPolicyDenialError(

--- a/packages/core/src/policy/policies/plan.toml
+++ b/packages/core/src/policy/policies/plan.toml
@@ -37,6 +37,13 @@ deny_message = "You are in Plan Mode with access to read-only tools. Execution o
 # Explicitly Allow Read-Only Tools in Plan mode.
 
 [[rule]]
+mcpName = "*"
+toolAnnotations = { readOnlyHint = true }
+decision = "ask_user"
+priority = 70
+modes = ["plan"]
+
+[[rule]]
 toolName = ["glob", "grep_search", "list_directory", "read_file", "google_web_search", "activate_skill"]
 decision = "allow"
 priority = 70

--- a/packages/core/src/scheduler/policy.test.ts
+++ b/packages/core/src/scheduler/policy.test.ts
@@ -59,10 +59,11 @@ describe('policy.ts', () => {
       expect(mockPolicyEngine.check).toHaveBeenCalledWith(
         { name: 'test-tool', args: {} },
         undefined,
+        undefined,
       );
     });
 
-    it('should pass serverName for MCP tools', async () => {
+    it('should pass serverName and toolAnnotations for MCP tools', async () => {
       const mockPolicyEngine = {
         check: vi.fn().mockResolvedValue({ decision: PolicyDecision.ALLOW }),
       } as unknown as Mocked<PolicyEngine>;
@@ -73,6 +74,7 @@ describe('policy.ts', () => {
 
       const mcpTool = Object.create(DiscoveredMCPTool.prototype);
       mcpTool.serverName = 'my-server';
+      mcpTool._toolAnnotations = { readOnlyHint: true };
 
       const toolCall = {
         request: { name: 'mcp-tool', args: {} },
@@ -83,6 +85,7 @@ describe('policy.ts', () => {
       expect(mockPolicyEngine.check).toHaveBeenCalledWith(
         { name: 'mcp-tool', args: {} },
         'my-server',
+        { readOnlyHint: true },
       );
     });
 

--- a/packages/core/src/scheduler/policy.ts
+++ b/packages/core/src/scheduler/policy.ts
@@ -54,11 +54,14 @@ export async function checkPolicy(
       ? toolCall.tool.serverName
       : undefined;
 
+  const toolAnnotations = toolCall.tool.toolAnnotations;
+
   const result = await config
     .getPolicyEngine()
     .check(
       { name: toolCall.request.name, args: toolCall.request.args },
       serverName,
+      toolAnnotations,
     );
 
   const { decision } = result;

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -82,6 +82,7 @@ export class DiscoveredMCPToolInvocation extends BaseToolInvocation<
     private readonly cliConfig?: Config,
     private readonly toolDescription?: string,
     private readonly toolParameterSchema?: unknown,
+    toolAnnotationsData?: Record<string, unknown>,
   ) {
     // Use composite format for policy checks: serverName__toolName
     // This enables server wildcards (e.g., "google-workspace__*")
@@ -93,6 +94,7 @@ export class DiscoveredMCPToolInvocation extends BaseToolInvocation<
       `${serverName}${MCP_QUALIFIED_NAME_SEPARATOR}${serverToolName}`,
       displayName,
       serverName,
+      toolAnnotationsData,
     );
   }
 
@@ -257,6 +259,7 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
     private readonly cliConfig?: Config,
     override readonly extensionName?: string,
     override readonly extensionId?: string,
+    private readonly _toolAnnotations?: Record<string, unknown>,
   ) {
     super(
       nameOverride ?? generateValidName(serverToolName),
@@ -282,6 +285,10 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
     return super.isReadOnly;
   }
 
+  override get toolAnnotations(): Record<string, unknown> | undefined {
+    return this._toolAnnotations;
+  }
+
   getFullyQualifiedPrefix(): string {
     return `${this.serverName}${MCP_QUALIFIED_NAME_SEPARATOR}`;
   }
@@ -304,6 +311,7 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
       this.cliConfig,
       this.extensionName,
       this.extensionId,
+      this._toolAnnotations,
     );
   }
 
@@ -324,6 +332,7 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
       this.cliConfig,
       this.description,
       this.parameterSchema,
+      this._toolAnnotations,
     );
   }
 }

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -441,13 +441,25 @@ export class ToolRegistry {
     }
   }
 
+  private buildToolMetadata(): Map<string, Record<string, unknown>> {
+    const toolMetadata = new Map<string, Record<string, unknown>>();
+    for (const [name, tool] of this.allKnownTools) {
+      if (tool.toolAnnotations) {
+        toolMetadata.set(name, tool.toolAnnotations);
+      }
+    }
+    return toolMetadata;
+  }
+
   /**
    * @returns All the tools that are not excluded.
    */
   private getActiveTools(): AnyDeclarativeTool[] {
+    const toolMetadata = this.buildToolMetadata();
     const excludedTools =
-      this.expandExcludeToolsWithAliases(this.config.getExcludeTools()) ??
-      new Set([]);
+      this.expandExcludeToolsWithAliases(
+        this.config.getExcludeTools(toolMetadata),
+      ) ?? new Set([]);
     const activeTools: AnyDeclarativeTool[] = [];
     for (const tool of this.allKnownTools.values()) {
       if (this.isActiveTool(tool, excludedTools)) {
@@ -487,8 +499,9 @@ export class ToolRegistry {
     excludeTools?: Set<string>,
   ): boolean {
     excludeTools ??=
-      this.expandExcludeToolsWithAliases(this.config.getExcludeTools()) ??
-      new Set([]);
+      this.expandExcludeToolsWithAliases(
+        this.config.getExcludeTools(this.buildToolMetadata()),
+      ) ?? new Set([]);
 
     // Filter tools in Plan Mode to only allow approved read-only tools.
     const isPlanMode =

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -91,6 +91,7 @@ export abstract class BaseToolInvocation<
     readonly _toolName?: string,
     readonly _toolDisplayName?: string,
     readonly _serverName?: string,
+    readonly _toolAnnotations?: Record<string, unknown>,
   ) {}
 
   abstract getDescription(): string;
@@ -199,6 +200,7 @@ export abstract class BaseToolInvocation<
         args: this.params as Record<string, unknown>,
       },
       serverName: this._serverName,
+      toolAnnotations: this._toolAnnotations,
     };
 
     return new Promise<'ALLOW' | 'DENY' | 'ASK_USER'>((resolve) => {
@@ -370,6 +372,10 @@ export abstract class DeclarativeTool<
 
   get isReadOnly(): boolean {
     return READ_ONLY_KINDS.includes(this.kind);
+  }
+
+  get toolAnnotations(): Record<string, unknown> | undefined {
+    return undefined;
   }
 
   getSchema(_modelId?: string): FunctionDeclaration {


### PR DESCRIPTION
Fixes #19654
Followup on https://github.com/google-gemini/gemini-cli/pull/20029

- Add annotations property to ToolBuilder and DeclarativeTool base classes to store semantic metadata.
- Update DiscoveredMCPTool to preserve and propagate annotations captured during MCP discovery.
- Propagate tool metadata to the Policy Engine during execution via checkPolicy.
- Migrate hardcoded Plan Mode read-only logic to declarative rules in plan.toml, maintaining ask_user behavior for MCP tools.
- Add unit and integration tests for metadata propagation and standard MCP behavioral hints.


