### PR TITLE
Add 3.1 pro preview to behavioral evals.

### DIFF
--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -27,6 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         model:
+          - 'gemini-3.1-pro-preview-customtools'
           - 'gemini-3-pro-preview'
           - 'gemini-3-flash-preview'
           - 'gemini-2.5-pro'


### PR DESCRIPTION
## Summary

Adds Gemini 3.1 pro preview to the nightly run of the behavioral evals tests.

Eval run: https://github.com/google-gemini/gemini-cli/actions/runs/22329951112/job/64609745069

