### PR TITLE
feat(cli): Invert quota language to 'percent used'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
             npm run test:ci --workspace @google/gemini-cli
           else
             # Explicitly list non-cli packages to ensure they are sharded correctly
-            npm run test:ci --workspace @google/gemini-cli-core --workspace @google/gemini-cli-a2a-server --workspace gemini-cli-vscode-ide-companion --workspace @google/gemini-cli-test-utils --if-present
+            npm run test:ci --workspace @google/gemini-cli-core --workspace @google/gemini-cli-a2a-server --workspace gemini-cli-vscode-ide-companion --workspace @google/gemini-cli-test-utils --if-present -- --coverage.enabled=false
             npm run test:scripts
           fi
 

--- a/packages/cli/src/config/policy.test.ts
+++ b/packages/cli/src/config/policy.test.ts
@@ -183,7 +183,6 @@ describe('resolveWorkspacePolicyState', () => {
       setAutoAcceptWorkspacePolicies(originalValue);
     }
   });
-
   it('should not return workspace policies if cwd is the home directory', async () => {
     const policiesDir = path.join(tempDir, '.gemini', 'policies');
     fs.mkdirSync(policiesDir, { recursive: true });

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -236,7 +236,7 @@ describe('<Footer />', () => {
     );
     await waitUntilReady();
     expect(lastFrame()).toContain('85%');
-    expect(lastFrame()).toMatchSnapshot();
+    expect(normalizeFrame(lastFrame())).toMatchSnapshot();
     unmount();
   });
 

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -235,8 +235,8 @@ describe('<Footer />', () => {
       },
     );
     await waitUntilReady();
-    expect(lastFrame()).toContain('15%');
-    expect(normalizeFrame(lastFrame())).toMatchSnapshot();
+    expect(lastFrame()).toContain('85%');
+    expect(lastFrame()).toMatchSnapshot();
     unmount();
   });
 

--- a/packages/cli/src/ui/components/QuotaDisplay.test.tsx
+++ b/packages/cli/src/ui/components/QuotaDisplay.test.tsx
@@ -5,10 +5,20 @@
  */
 
 import { render } from '../../test-utils/render.js';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { QuotaDisplay } from './QuotaDisplay.js';
 
 describe('QuotaDisplay', () => {
+  beforeEach(() => {
+    vi.stubEnv('TZ', 'America/Los_Angeles');
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-02T20:29:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
   it('should not render when remaining is undefined', async () => {
     const { lastFrame, waitUntilReady, unmount } = render(
       <QuotaDisplay remaining={undefined} limit={100} />,
@@ -36,7 +46,7 @@ describe('QuotaDisplay', () => {
     unmount();
   });
 
-  it('should not render when usage > 20%', async () => {
+  it('should not render when usage < 80%', async () => {
     const { lastFrame, waitUntilReady, unmount } = render(
       <QuotaDisplay remaining={85} limit={100} />,
     );
@@ -45,7 +55,7 @@ describe('QuotaDisplay', () => {
     unmount();
   });
 
-  it('should render yellow when usage < 20%', async () => {
+  it('should render warning when used >= 80%', async () => {
     const { lastFrame, waitUntilReady, unmount } = render(
       <QuotaDisplay remaining={15} limit={100} />,
     );
@@ -54,7 +64,7 @@ describe('QuotaDisplay', () => {
     unmount();
   });
 
-  it('should render red when usage < 5%', async () => {
+  it('should render critical when used >= 95%', async () => {
     const { lastFrame, waitUntilReady, unmount } = render(
       <QuotaDisplay remaining={4} limit={100} />,
     );

--- a/packages/cli/src/ui/components/QuotaDisplay.tsx
+++ b/packages/cli/src/ui/components/QuotaDisplay.tsx
@@ -48,14 +48,16 @@ export const QuotaDisplay: React.FC<QuotaDisplayProps> = ({
   let text: string;
   if (remaining === 0) {
     const resetMsg = resetTime
-      ? `, resets in ${formatResetTime(resetTime, true)}`
+      ? `, resets in ${formatResetTime(resetTime, 'terse')}`
       : '';
     text = terse ? 'Limit reached' : `Limit reached${resetMsg}`;
   } else {
     text = terse
       ? `${usedPercentage.toFixed(0)}%`
       : `${usedPercentage.toFixed(0)}% used${
-          resetTime ? ` (Limit resets in ${formatResetTime(resetTime)})` : ''
+          resetTime
+            ? ` (Limit resets in ${formatResetTime(resetTime, 'terse')})`
+            : ''
         }`;
   }
 

--- a/packages/cli/src/ui/components/QuotaDisplay.tsx
+++ b/packages/cli/src/ui/components/QuotaDisplay.tsx
@@ -7,9 +7,9 @@
 import type React from 'react';
 import { Text } from 'ink';
 import {
-  getStatusColor,
-  QUOTA_THRESHOLD_HIGH,
-  QUOTA_THRESHOLD_MEDIUM,
+  getUsedStatusColor,
+  QUOTA_USED_WARNING_THRESHOLD,
+  QUOTA_USED_CRITICAL_THRESHOLD,
 } from '../utils/displayUtils.js';
 import { formatResetTime } from '../utils/formatters.js';
 
@@ -34,32 +34,34 @@ export const QuotaDisplay: React.FC<QuotaDisplayProps> = ({
     return null;
   }
 
-  const percentage = (remaining / limit) * 100;
+  const usedPercentage = 100 - (remaining / limit) * 100;
 
-  if (!forceShow && percentage > QUOTA_THRESHOLD_HIGH) {
+  if (!forceShow && usedPercentage < QUOTA_USED_WARNING_THRESHOLD) {
     return null;
   }
 
-  const color = getStatusColor(percentage, {
-    green: QUOTA_THRESHOLD_HIGH,
-    yellow: QUOTA_THRESHOLD_MEDIUM,
+  const color = getUsedStatusColor(usedPercentage, {
+    warning: QUOTA_USED_WARNING_THRESHOLD,
+    critical: QUOTA_USED_CRITICAL_THRESHOLD,
   });
 
-  const resetInfo =
-    !terse && resetTime ? `, ${formatResetTime(resetTime)}` : '';
-
+  let text: string;
   if (remaining === 0) {
-    let text = terse
-      ? 'Limit reached'
-      : `/stats Limit reached${resetInfo}${!terse && '. /auth to continue.'}`;
-    if (lowercase) text = text.toLowerCase();
-    return <Text color={color}>{text}</Text>;
+    const resetMsg = resetTime
+      ? `, resets in ${formatResetTime(resetTime, true)}`
+      : '';
+    text = terse ? 'Limit reached' : `Limit reached${resetMsg}`;
+  } else {
+    text = terse
+      ? `${usedPercentage.toFixed(0)}%`
+      : `${usedPercentage.toFixed(0)}% used${
+          resetTime ? ` (Limit resets in ${formatResetTime(resetTime)})` : ''
+        }`;
   }
 
-  let text = terse
-    ? `${percentage.toFixed(0)}%`
-    : `/stats ${percentage.toFixed(0)}% usage remaining${resetInfo}`;
-  if (lowercase) text = text.toLowerCase();
+  if (lowercase) {
+    text = text.toLowerCase();
+  }
 
   return <Text color={color}>{text}</Text>;
 };

--- a/packages/cli/src/ui/components/QuotaStatsInfo.tsx
+++ b/packages/cli/src/ui/components/QuotaStatsInfo.tsx
@@ -9,9 +9,9 @@ import { Box, Text } from 'ink';
 import { theme } from '../semantic-colors.js';
 import { formatResetTime } from '../utils/formatters.js';
 import {
-  getStatusColor,
-  QUOTA_THRESHOLD_HIGH,
-  QUOTA_THRESHOLD_MEDIUM,
+  getUsedStatusColor,
+  QUOTA_USED_WARNING_THRESHOLD,
+  QUOTA_USED_CRITICAL_THRESHOLD,
 } from '../utils/displayUtils.js';
 
 interface QuotaStatsInfoProps {
@@ -31,19 +31,24 @@ export const QuotaStatsInfo: React.FC<QuotaStatsInfoProps> = ({
     return null;
   }
 
-  const percentage = (remaining / limit) * 100;
-  const color = getStatusColor(percentage, {
-    green: QUOTA_THRESHOLD_HIGH,
-    yellow: QUOTA_THRESHOLD_MEDIUM,
+  const usedPercentage = 100 - (remaining / limit) * 100;
+  const color = getUsedStatusColor(usedPercentage, {
+    warning: QUOTA_USED_WARNING_THRESHOLD,
+    critical: QUOTA_USED_CRITICAL_THRESHOLD,
   });
 
   return (
     <Box flexDirection="column" marginTop={0} marginBottom={0}>
       <Text color={color}>
         {remaining === 0
-          ? `Limit reached`
-          : `${percentage.toFixed(0)}% usage remaining`}
-        {resetTime && `, ${formatResetTime(resetTime)}`}
+          ? `Limit reached${
+              resetTime ? `, resets in ${formatResetTime(resetTime, true)}` : ''
+            }`
+          : `${usedPercentage.toFixed(0)}% used${
+              resetTime
+                ? ` (Limit resets in ${formatResetTime(resetTime)})`
+                : ''
+            }`}
       </Text>
       {showDetails && (
         <>

--- a/packages/cli/src/ui/components/QuotaStatsInfo.tsx
+++ b/packages/cli/src/ui/components/QuotaStatsInfo.tsx
@@ -42,11 +42,13 @@ export const QuotaStatsInfo: React.FC<QuotaStatsInfoProps> = ({
       <Text color={color}>
         {remaining === 0
           ? `Limit reached${
-              resetTime ? `, resets in ${formatResetTime(resetTime, true)}` : ''
+              resetTime
+                ? `, resets in ${formatResetTime(resetTime, 'terse')}`
+                : ''
             }`
           : `${usedPercentage.toFixed(0)}% used${
               resetTime
-                ? ` (Limit resets in ${formatResetTime(resetTime)})`
+                ? ` (Limit resets in ${formatResetTime(resetTime, 'terse')})`
                 : ''
             }`}
       </Text>

--- a/packages/cli/src/ui/components/StatsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.test.tsx
@@ -68,6 +68,14 @@ const createTestMetrics = (
 });
 
 describe('<StatsDisplay />', () => {
+  beforeEach(() => {
+    vi.stubEnv('TZ', 'UTC');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('renders only the Performance section in its zero state', async () => {
     const zeroMetrics = createTestMetrics();
 
@@ -466,8 +474,8 @@ describe('<StatsDisplay />', () => {
       const output = lastFrame();
 
       expect(output).toContain('Model usage');
-      expect(output).toContain('25% used');
-      expect(output).toContain('Limit resets in');
+      expect(output).toContain('25%');
+      expect(output).toContain('Usage resets');
       expect(output).toMatchSnapshot();
 
       vi.useRealTimers();
@@ -522,7 +530,7 @@ describe('<StatsDisplay />', () => {
       const output = lastFrame();
 
       // (1 - 710/1100) * 100 = 35.5%
-      expect(output).toContain('35% used');
+      expect(output).toContain('35%');
       expect(output).toContain('Usage limit: 1,100');
       expect(output).toMatchSnapshot();
 
@@ -571,8 +579,8 @@ describe('<StatsDisplay />', () => {
 
       expect(output).toContain('gemini-2.5-flash');
       expect(output).toContain('-'); // for requests
-      expect(output).toContain('50% used');
-      expect(output).toContain('Limit resets in');
+      expect(output).toContain('50%');
+      expect(output).toContain('Usage resets');
       expect(output).toMatchSnapshot();
 
       vi.useRealTimers();

--- a/packages/cli/src/ui/components/StatsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.test.tsx
@@ -465,9 +465,9 @@ describe('<StatsDisplay />', () => {
       await waitUntilReady();
       const output = lastFrame();
 
-      expect(output).toContain('Usage remaining');
-      expect(output).toContain('75.0%');
-      expect(output).toContain('resets in 1h 30m');
+      expect(output).toContain('Model usage');
+      expect(output).toContain('25% used');
+      expect(output).toContain('Limit resets in');
       expect(output).toMatchSnapshot();
 
       vi.useRealTimers();
@@ -521,8 +521,8 @@ describe('<StatsDisplay />', () => {
       await waitUntilReady();
       const output = lastFrame();
 
-      // (10 + 700) / (100 + 1000) = 710 / 1100 = 64.5%
-      expect(output).toContain('65% usage remaining');
+      // (1 - 710/1100) * 100 = 35.5%
+      expect(output).toContain('35% used');
       expect(output).toContain('Usage limit: 1,100');
       expect(output).toMatchSnapshot();
 
@@ -571,8 +571,8 @@ describe('<StatsDisplay />', () => {
 
       expect(output).toContain('gemini-2.5-flash');
       expect(output).toContain('-'); // for requests
-      expect(output).toContain('50.0%');
-      expect(output).toContain('resets in 2h');
+      expect(output).toContain('50% used');
+      expect(output).toContain('Limit resets in');
       expect(output).toMatchSnapshot();
 
       vi.useRealTimers();

--- a/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -19,6 +19,9 @@ import {
   USER_AGREEMENT_RATE_MEDIUM,
   CACHE_EFFICIENCY_HIGH,
   CACHE_EFFICIENCY_MEDIUM,
+  getUsedStatusColor,
+  QUOTA_USED_WARNING_THRESHOLD,
+  QUOTA_USED_CRITICAL_THRESHOLD,
 } from '../utils/displayUtils.js';
 import { computeSessionStats } from '../utils/computeStats.js';
 import {
@@ -168,7 +171,26 @@ const ModelUsageTable: React.FC<{
   const uncachedWidth = 15;
   const cachedWidth = 14;
   const outputTokensWidth = 15;
-  const usageLimitWidth = showQuotaColumn ? 28 : 0;
+  const usageLimitWidth = showQuotaColumn ? 85 : 0;
+
+  const renderProgressBar = (usedFraction: number, color: string) => {
+    const totalSteps = 20;
+    let filledSteps = Math.round(usedFraction * totalSteps);
+
+    // If something is used (fraction > 0) but rounds to 0, show 1 tick.
+    // If < 100% (fraction < 1) but rounds to 20, show 19 ticks.
+    if (usedFraction > 0 && usedFraction < 1) {
+      filledSteps = Math.min(Math.max(filledSteps, 1), totalSteps - 1);
+    }
+
+    const emptySteps = totalSteps - filledSteps;
+    return (
+      <Box flexDirection="row">
+        <Text color={color}>{'▬'.repeat(filledSteps)}</Text>
+        <Text color={theme.border.default}>{'▬'.repeat(emptySteps)}</Text>
+      </Box>
+    );
+  };
 
   const cacheEfficiencyColor = getStatusColor(cacheEfficiency, {
     green: CACHE_EFFICIENCY_HIGH,
@@ -183,19 +205,21 @@ const ModelUsageTable: React.FC<{
       : uncachedWidth + cachedWidth + outputTokensWidth);
 
   const isAuto = currentModel && isAutoModel(currentModel);
-  const modelUsageTitle = isAuto
-    ? `${getDisplayString(currentModel)} Usage`
-    : `Model Usage`;
+  const modelUsageTitle = isAuto ? (
+    <Text color={theme.text.primary} wrap="truncate-end">
+      <Text bold>Model Usage:</Text> {getDisplayString(currentModel)}
+    </Text>
+  ) : (
+    <Text bold color={theme.text.primary} wrap="truncate-end">
+      Model Usage
+    </Text>
+  );
 
   return (
     <Box flexDirection="column" marginBottom={1}>
       {/* Header */}
       <Box alignItems="flex-end">
-        <Box width={nameWidth}>
-          <Text bold color={theme.text.primary} wrap="truncate-end">
-            {modelUsageTitle}
-          </Text>
-        </Box>
+        <Box width={totalWidth}>{modelUsageTitle}</Box>
       </Box>
 
       {isAuto &&
@@ -270,10 +294,11 @@ const ModelUsageTable: React.FC<{
           <Box
             width={usageLimitWidth}
             flexDirection="column"
-            alignItems="flex-end"
+            alignItems="flex-start"
+            paddingLeft={4}
           >
             <Text bold color={theme.text.primary}>
-              Usage remaining
+              Model usage
             </Text>
           </Box>
         )}
@@ -355,16 +380,62 @@ const ModelUsageTable: React.FC<{
           <Box
             width={usageLimitWidth}
             flexDirection="column"
-            alignItems="flex-end"
+            alignItems="flex-start"
+            paddingLeft={4}
           >
-            {row.bucket &&
-              row.bucket.remainingFraction != null &&
-              row.bucket.resetTime && (
-                <Text color={theme.text.secondary} wrap="truncate-end">
-                  {(row.bucket.remainingFraction * 100).toFixed(1)}%{' '}
-                  {formatResetTime(row.bucket.resetTime)}
-                </Text>
-              )}
+            {row.bucket && row.bucket.remainingFraction != null && (
+              <Box flexDirection="row">
+                {(() => {
+                  const actualUsedFraction = 1 - row.bucket.remainingFraction;
+                  // If we have session activity but 0% server usage, show 0.1% as a hint.
+                  const effectiveUsedFraction =
+                    actualUsedFraction === 0 && row.isActive
+                      ? 0.001
+                      : actualUsedFraction;
+
+                  const usedPercentage = effectiveUsedFraction * 100;
+
+                  const statusColor =
+                    getUsedStatusColor(usedPercentage, {
+                      warning: QUOTA_USED_WARNING_THRESHOLD,
+                      critical: QUOTA_USED_CRITICAL_THRESHOLD,
+                    }) ??
+                    (row.isActive ? theme.text.primary : theme.ui.comment);
+
+                  const percentageText =
+                    usedPercentage > 0 && usedPercentage < 1
+                      ? `${usedPercentage.toFixed(1)}% used`
+                      : `${usedPercentage.toFixed(0)}% used`;
+
+                  return (
+                    <>
+                      {renderProgressBar(effectiveUsedFraction, statusColor)}
+                      <Box marginLeft={1}>
+                        <Text wrap="truncate-end">
+                          {row.bucket.remainingFraction === 0 ? (
+                            <Text color={theme.status.error}>
+                              Limit reached
+                              {row.bucket.resetTime &&
+                                `, resets in ${formatResetTime(row.bucket.resetTime, true)}`}
+                            </Text>
+                          ) : (
+                            <>
+                              <Text color={statusColor}>{percentageText}</Text>
+                              <Text color={theme.text.secondary}>
+                                {row.bucket.resetTime &&
+                                formatResetTime(row.bucket.resetTime)
+                                  ? ` (Limit resets in ${formatResetTime(row.bucket.resetTime)})`
+                                  : ''}
+                              </Text>
+                            </>
+                          )}
+                        </Text>
+                      </Box>
+                    </>
+                  );
+                })()}
+              </Box>
+            )}
           </Box>
         </Box>
       ))}

--- a/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -5,7 +5,7 @@
  */
 
 import type React from 'react';
-import { Box, Text } from 'ink';
+import { Box, Text, useStdout } from 'ink';
 import { ThemedGradient } from './ThemedGradient.js';
 import { theme } from '../semantic-colors.js';
 import { formatDuration, formatResetTime } from '../utils/formatters.js';
@@ -158,6 +158,8 @@ const ModelUsageTable: React.FC<{
   useGemini3_1,
   useCustomToolModel,
 }) => {
+  const { stdout } = useStdout();
+  const terminalWidth = stdout?.columns ?? 84;
   const rows = buildModelRows(models, quotas, useGemini3_1, useCustomToolModel);
 
   if (rows.length === 0) {
@@ -166,15 +168,29 @@ const ModelUsageTable: React.FC<{
 
   const showQuotaColumn = !!quotas && rows.some((row) => !!row.bucket);
 
-  const nameWidth = 25;
-  const requestsWidth = 7;
+  const nameWidth = 23;
+  const requestsWidth = 5;
   const uncachedWidth = 15;
   const cachedWidth = 14;
   const outputTokensWidth = 15;
-  const usageLimitWidth = showQuotaColumn ? 85 : 0;
+  const percentageWidth = showQuotaColumn ? 6 : 0;
+  const resetWidth = 22;
 
-  const renderProgressBar = (usedFraction: number, color: string) => {
-    const totalSteps = 20;
+  // Total width of other columns (including parent box paddingX={2})
+  const fixedWidth = nameWidth + requestsWidth + percentageWidth + resetWidth;
+  const outerPadding = 4;
+  const availableForUsage = terminalWidth - outerPadding - fixedWidth;
+
+  const usageLimitWidth = showQuotaColumn
+    ? Math.max(10, Math.min(24, availableForUsage))
+    : 0;
+  const progressBarWidth = Math.max(2, usageLimitWidth - 4);
+
+  const renderProgressBar = (
+    usedFraction: number,
+    color: string,
+    totalSteps = 20,
+  ) => {
     let filledSteps = Math.round(usedFraction * totalSteps);
 
     // If something is used (fraction > 0) but rounds to 0, show 1 tick.
@@ -183,11 +199,13 @@ const ModelUsageTable: React.FC<{
       filledSteps = Math.min(Math.max(filledSteps, 1), totalSteps - 1);
     }
 
-    const emptySteps = totalSteps - filledSteps;
+    const emptySteps = Math.max(0, totalSteps - filledSteps);
     return (
-      <Box flexDirection="row">
-        <Text color={color}>{'▬'.repeat(filledSteps)}</Text>
-        <Text color={theme.border.default}>{'▬'.repeat(emptySteps)}</Text>
+      <Box flexDirection="row" flexShrink={0}>
+        <Text wrap="truncate-end">
+          <Text color={color}>{'▬'.repeat(filledSteps)}</Text>
+          <Text color={theme.border.default}>{'▬'.repeat(emptySteps)}</Text>
+        </Text>
       </Box>
     );
   };
@@ -201,27 +219,13 @@ const ModelUsageTable: React.FC<{
     nameWidth +
     requestsWidth +
     (showQuotaColumn
-      ? usageLimitWidth
+      ? usageLimitWidth + percentageWidth + resetWidth
       : uncachedWidth + cachedWidth + outputTokensWidth);
 
   const isAuto = currentModel && isAutoModel(currentModel);
-  const modelUsageTitle = isAuto ? (
-    <Text color={theme.text.primary} wrap="truncate-end">
-      <Text bold>Model Usage:</Text> {getDisplayString(currentModel)}
-    </Text>
-  ) : (
-    <Text bold color={theme.text.primary} wrap="truncate-end">
-      Model Usage
-    </Text>
-  );
 
   return (
     <Box flexDirection="column" marginBottom={1}>
-      {/* Header */}
-      <Box alignItems="flex-end">
-        <Box width={totalWidth}>{modelUsageTitle}</Box>
-      </Box>
-
       {isAuto &&
         showQuotaColumn &&
         pooledRemaining !== undefined &&
@@ -240,7 +244,7 @@ const ModelUsageTable: React.FC<{
         )}
 
       <Box alignItems="flex-end">
-        <Box width={nameWidth}>
+        <Box width={nameWidth} flexShrink={0}>
           <Text bold color={theme.text.primary}>
             Model
           </Text>
@@ -291,16 +295,31 @@ const ModelUsageTable: React.FC<{
           </>
         )}
         {showQuotaColumn && (
-          <Box
-            width={usageLimitWidth}
-            flexDirection="column"
-            alignItems="flex-start"
-            paddingLeft={4}
-          >
-            <Text bold color={theme.text.primary}>
-              Model usage
-            </Text>
-          </Box>
+          <>
+            <Box
+              width={usageLimitWidth}
+              flexDirection="column"
+              alignItems="flex-start"
+              paddingLeft={4}
+              flexShrink={0}
+            >
+              <Text bold color={theme.text.primary}>
+                Model usage
+              </Text>
+            </Box>
+            <Box width={percentageWidth} flexShrink={0} />
+            <Box
+              width={resetWidth}
+              flexDirection="column"
+              alignItems="flex-start"
+              paddingLeft={2}
+              flexShrink={0}
+            >
+              <Text bold color={theme.text.primary} wrap="truncate-end">
+                Usage resets
+              </Text>
+            </Box>
+          </>
         )}
       </Box>
 
@@ -315,130 +334,150 @@ const ModelUsageTable: React.FC<{
         width={totalWidth}
       ></Box>
 
-      {rows.map((row) => (
-        <Box key={row.key}>
-          <Box width={nameWidth}>
-            <Text
-              color={row.isActive ? theme.text.primary : theme.text.secondary}
-              wrap="truncate-end"
+      {rows.map((row) => {
+        let effectiveUsedFraction = 0;
+        let usedPercentage = 0;
+        let statusColor = theme.ui.comment;
+        let percentageText = '';
+
+        if (row.bucket && row.bucket.remainingFraction != null) {
+          const actualUsedFraction = 1 - row.bucket.remainingFraction;
+          effectiveUsedFraction =
+            actualUsedFraction === 0 && row.isActive
+              ? 0.001
+              : actualUsedFraction;
+          usedPercentage = effectiveUsedFraction * 100;
+          statusColor =
+            getUsedStatusColor(usedPercentage, {
+              warning: QUOTA_USED_WARNING_THRESHOLD,
+              critical: QUOTA_USED_CRITICAL_THRESHOLD,
+            }) ?? (row.isActive ? theme.text.primary : theme.ui.comment);
+          percentageText =
+            usedPercentage > 0 && usedPercentage < 1
+              ? `${usedPercentage.toFixed(1)}%`
+              : `${usedPercentage.toFixed(0)}%`;
+        }
+
+        return (
+          <Box key={row.key}>
+            <Box width={nameWidth} flexShrink={0}>
+              <Text
+                color={row.isActive ? theme.text.primary : theme.text.secondary}
+                wrap="truncate-end"
+              >
+                {row.modelName}
+              </Text>
+            </Box>
+            <Box
+              width={requestsWidth}
+              flexDirection="column"
+              alignItems="flex-end"
+              flexShrink={0}
             >
-              {row.modelName}
-            </Text>
-          </Box>
-          <Box
-            width={requestsWidth}
-            flexDirection="column"
-            alignItems="flex-end"
-            flexShrink={0}
-          >
-            <Text
-              color={row.isActive ? theme.text.primary : theme.text.secondary}
-            >
-              {row.requests}
-            </Text>
-          </Box>
-          {!showQuotaColumn && (
-            <>
-              <Box
-                width={uncachedWidth}
-                flexDirection="column"
-                alignItems="flex-end"
-                flexShrink={0}
+              <Text
+                color={row.isActive ? theme.text.primary : theme.text.secondary}
               >
-                <Text
-                  color={
-                    row.isActive ? theme.text.primary : theme.text.secondary
-                  }
+                {row.requests}
+              </Text>
+            </Box>
+            {!showQuotaColumn && (
+              <>
+                <Box
+                  width={uncachedWidth}
+                  flexDirection="column"
+                  alignItems="flex-end"
+                  flexShrink={0}
                 >
-                  {row.inputTokens}
-                </Text>
-              </Box>
-              <Box
-                width={cachedWidth}
-                flexDirection="column"
-                alignItems="flex-end"
-                flexShrink={0}
-              >
-                <Text color={theme.text.secondary}>{row.cachedTokens}</Text>
-              </Box>
-              <Box
-                width={outputTokensWidth}
-                flexDirection="column"
-                alignItems="flex-end"
-                flexShrink={0}
-              >
-                <Text
-                  color={
-                    row.isActive ? theme.text.primary : theme.text.secondary
-                  }
+                  <Text
+                    color={
+                      row.isActive ? theme.text.primary : theme.text.secondary
+                    }
+                  >
+                    {row.inputTokens}
+                  </Text>
+                </Box>
+                <Box
+                  width={cachedWidth}
+                  flexDirection="column"
+                  alignItems="flex-end"
+                  flexShrink={0}
                 >
-                  {row.outputTokens}
-                </Text>
-              </Box>
-            </>
-          )}
-          <Box
-            width={usageLimitWidth}
-            flexDirection="column"
-            alignItems="flex-start"
-            paddingLeft={4}
-          >
-            {row.bucket && row.bucket.remainingFraction != null && (
-              <Box flexDirection="row">
-                {(() => {
-                  const actualUsedFraction = 1 - row.bucket.remainingFraction;
-                  // If we have session activity but 0% server usage, show 0.1% as a hint.
-                  const effectiveUsedFraction =
-                    actualUsedFraction === 0 && row.isActive
-                      ? 0.001
-                      : actualUsedFraction;
-
-                  const usedPercentage = effectiveUsedFraction * 100;
-
-                  const statusColor =
-                    getUsedStatusColor(usedPercentage, {
-                      warning: QUOTA_USED_WARNING_THRESHOLD,
-                      critical: QUOTA_USED_CRITICAL_THRESHOLD,
-                    }) ??
-                    (row.isActive ? theme.text.primary : theme.ui.comment);
-
-                  const percentageText =
-                    usedPercentage > 0 && usedPercentage < 1
-                      ? `${usedPercentage.toFixed(1)}% used`
-                      : `${usedPercentage.toFixed(0)}% used`;
-
-                  return (
-                    <>
-                      {renderProgressBar(effectiveUsedFraction, statusColor)}
-                      <Box marginLeft={1}>
-                        <Text wrap="truncate-end">
-                          {row.bucket.remainingFraction === 0 ? (
-                            <Text color={theme.status.error}>
-                              Limit reached
-                              {row.bucket.resetTime &&
-                                `, resets in ${formatResetTime(row.bucket.resetTime, true)}`}
-                            </Text>
-                          ) : (
-                            <>
-                              <Text color={statusColor}>{percentageText}</Text>
-                              <Text color={theme.text.secondary}>
-                                {row.bucket.resetTime &&
-                                formatResetTime(row.bucket.resetTime)
-                                  ? ` (Limit resets in ${formatResetTime(row.bucket.resetTime)})`
-                                  : ''}
-                              </Text>
-                            </>
-                          )}
+                  <Text color={theme.text.secondary}>{row.cachedTokens}</Text>
+                </Box>
+                <Box
+                  width={outputTokensWidth}
+                  flexDirection="column"
+                  alignItems="flex-end"
+                  flexShrink={0}
+                >
+                  <Text
+                    color={
+                      row.isActive ? theme.text.primary : theme.text.secondary
+                    }
+                  >
+                    {row.outputTokens}
+                  </Text>
+                </Box>
+              </>
+            )}
+            {showQuotaColumn && (
+              <>
+                <Box
+                  width={usageLimitWidth}
+                  flexDirection="column"
+                  alignItems="flex-start"
+                  paddingLeft={4}
+                  flexShrink={0}
+                >
+                  {row.bucket && row.bucket.remainingFraction != null && (
+                    <Box flexDirection="row" flexShrink={0}>
+                      {renderProgressBar(
+                        effectiveUsedFraction,
+                        statusColor,
+                        progressBarWidth,
+                      )}
+                    </Box>
+                  )}
+                </Box>
+                <Box
+                  width={percentageWidth}
+                  flexDirection="column"
+                  alignItems="flex-end"
+                  flexShrink={0}
+                >
+                  {row.bucket && row.bucket.remainingFraction != null && (
+                    <Box>
+                      {row.bucket.remainingFraction === 0 ? (
+                        <Text color={theme.status.error} wrap="truncate-end">
+                          Limit
                         </Text>
-                      </Box>
-                    </>
-                  );
-                })()}
-              </Box>
+                      ) : (
+                        <Text color={statusColor} wrap="truncate-end">
+                          {percentageText}
+                        </Text>
+                      )}
+                    </Box>
+                  )}
+                </Box>
+                <Box
+                  width={resetWidth}
+                  flexDirection="column"
+                  alignItems="flex-start"
+                  paddingLeft={2}
+                  flexShrink={0}
+                >
+                  <Text color={theme.text.secondary} wrap="truncate-end">
+                    {row.bucket?.resetTime &&
+                    formatResetTime(row.bucket.resetTime, 'column')
+                      ? formatResetTime(row.bucket.resetTime, 'column')
+                      : ''}
+                  </Text>
+                </Box>
+              </>
             )}
           </Box>
-        </Box>
-      ))}
+        );
+      })}
 
       {cacheEfficiency > 0 && !showQuotaColumn && (
         <Box flexDirection="column" marginTop={1}>

--- a/packages/cli/src/ui/components/__snapshots__/Footer.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/Footer.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`<Footer /> > displays "Limit reached" message when remaining is 0 1`] =
 
 exports[`<Footer /> > displays the usage indicator when usage is low 1`] = `
 " workspace (/directory)                                        sandbox      /model       /stats
- ~/project/foo/bar/and/some/more/directories/to/make/it/long   no sandbox   gemini-pro   15%
+ ~/project/foo/bar/and/some/more/directories/to/make/it/long   no sandbox   gemini-pro   85%
 "
 `;
 
@@ -40,6 +40,6 @@ exports[`<Footer /> > footer configuration filtering (golden snapshots) > render
 
 exports[`<Footer /> > hides the usage indicator when usage is not near limit 1`] = `
 " workspace (/directory)                                        sandbox      /model       /stats
- ~/project/foo/bar/and/some/more/directories/to/make/it/long   no sandbox   gemini-pro   85%
+ ~/project/foo/bar/and/some/more/directories/to/make/it/long   no sandbox   gemini-pro   15%
 "
 `;

--- a/packages/cli/src/ui/components/__snapshots__/QuotaDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/QuotaDisplay.test.tsx.snap
@@ -1,12 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`QuotaDisplay > should NOT render reset time when terse is true 1`] = `
-"15%
+"85%
 "
 `;
 
-exports[`QuotaDisplay > should render red when usage < 5% 1`] = `
-"/stats 4% usage remaining
+exports[`QuotaDisplay > should render critical when used >= 95% 1`] = `
+"96% used
 "
 `;
 
@@ -15,12 +15,12 @@ exports[`QuotaDisplay > should render terse limit reached message 1`] = `
 "
 `;
 
-exports[`QuotaDisplay > should render with reset time when provided 1`] = `
-"/stats 15% usage remaining, resets in 1h
+exports[`QuotaDisplay > should render warning when used >= 80% 1`] = `
+"85% used
 "
 `;
 
-exports[`QuotaDisplay > should render yellow when usage < 20% 1`] = `
-"/stats 15% usage remaining
+exports[`QuotaDisplay > should render with reset time when provided 1`] = `
+"85% used (Limit resets in 1 hour at 1:29 PM PST)
 "
 `;

--- a/packages/cli/src/ui/components/__snapshots__/QuotaDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/QuotaDisplay.test.tsx.snap
@@ -21,6 +21,6 @@ exports[`QuotaDisplay > should render warning when used >= 80% 1`] = `
 `;
 
 exports[`QuotaDisplay > should render with reset time when provided 1`] = `
-"85% used (Limit resets in 1 hour at 1:29 PM PST)
+"85% used (Limit resets in 1h)
 "
 `;

--- a/packages/cli/src/ui/components/__snapshots__/SessionSummaryDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/SessionSummaryDisplay.test.tsx.snap
@@ -17,10 +17,9 @@ exports[`<SessionSummaryDisplay /> > renders the summary display with a title 1`
 │    » API Time:               50.2s (100.0%)                                                      │
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
-│  Model Usage                                                                                     │
-│  Model                       Reqs   Input Tokens   Cache Reads  Output Tokens                    │
-│  ────────────────────────────────────────────────────────────────────────────                    │
-│  gemini-2.5-pro                10            500           500          2,000                    │
+│  Model                   Reqs   Input Tokens   Cache Reads  Output Tokens                        │
+│  ────────────────────────────────────────────────────────────────────────                        │
+│  gemini-2.5-pro            10            500           500          2,000                        │
 │                                                                                                  │
 │  Savings Highlight: 500 (50.0%) of input tokens were served from the cache, reducing costs.      │
 │                                                                                                  │

--- a/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
@@ -117,10 +117,9 @@ exports[`<StatsDisplay /> > Conditional Rendering Tests > hides Efficiency secti
 │    » API Time:               100ms (100.0%)                                                      │
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
-│  Model Usage                                                                                     │
-│  Model                       Reqs   Input Tokens   Cache Reads  Output Tokens                    │
-│  ────────────────────────────────────────────────────────────────────────────                    │
-│  gemini-2.5-pro                 1            100             0            100                    │
+│  Model                   Reqs   Input Tokens   Cache Reads  Output Tokens                        │
+│  ────────────────────────────────────────────────────────────────────────                        │
+│  gemini-2.5-pro             1            100             0            100                        │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -162,16 +161,15 @@ exports[`<StatsDisplay /> > Quota Display > renders pooled quota information for
 │    » API Time:               0s (0.0%)                                                           │
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
-│  Model Usage: auto                                                                               │
 │  35% used                                                                                        │
 │  Usage limit: 1,100                                                                              │
 │  Usage limits span all sessions and reset daily.                                                 │
 │  For a full token breakdown, run \`/stats model\`.                                                 │
 │                                                                                                  │
-│  Model                  Reqs    Model usage                                                      │
-│  ────────────────────────────────────────────────────────────────────────────────────────────────│
-│  gemini-2.5-pro            -    ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬ 90% used                                    │
-│  gemini-2.5-flash          -    ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬ 30% used                                    │
+│  Model                   Reqs    Model usage                 Usage resets                        │
+│  ────────────────────────────────────────────────────────────────────────────────                │
+│  gemini-2.5-pro             -    ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬   90%                                      │
+│  gemini-2.5-flash           -    ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬   30%                                      │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -193,10 +191,9 @@ exports[`<StatsDisplay /> > Quota Display > renders quota information for unused
 │    » API Time:               0s (0.0%)                                                           │
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
-│  Model Usage                                                                                     │
-│  Model                  Reqs    Model usage                                                      │
-│  ────────────────────────────────────────────────────────────────────────────────────────────────│
-│  gemini-2.5-flash          -    ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬ 50% used (Limit resets in 2 hours at 6:00 AM│
+│  Model                   Reqs    Model usage                 Usage resets                        │
+│  ────────────────────────────────────────────────────────────────────────────────                │
+│  gemini-2.5-flash           -    ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬   50%  2:00 PM (2h)                        │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -218,10 +215,9 @@ exports[`<StatsDisplay /> > Quota Display > renders quota information when quota
 │    » API Time:               100ms (100.0%)                                                      │
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
-│  Model Usage                                                                                     │
-│  Model                  Reqs    Model usage                                                      │
-│  ────────────────────────────────────────────────────────────────────────────────────────────────│
-│  gemini-2.5-pro            1    ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬ 25% used (Limit resets in 1 hour 30 minutes │
+│  Model                   Reqs    Model usage                 Usage resets                        │
+│  ────────────────────────────────────────────────────────────────────────────────                │
+│  gemini-2.5-pro             1    ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬   25%  1:30 PM (1h 30m)                    │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -283,11 +279,10 @@ exports[`<StatsDisplay /> > renders a table with two models correctly 1`] = `
 │    » API Time:               19.5s (100.0%)                                                      │
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
-│  Model Usage                                                                                     │
-│  Model                       Reqs   Input Tokens   Cache Reads  Output Tokens                    │
-│  ────────────────────────────────────────────────────────────────────────────                    │
-│  gemini-2.5-pro                 3            500           500          2,000                    │
-│  gemini-2.5-flash               5         15,000        10,000         15,000                    │
+│  Model                   Reqs   Input Tokens   Cache Reads  Output Tokens                        │
+│  ────────────────────────────────────────────────────────────────────────                        │
+│  gemini-2.5-pro             3            500           500          2,000                        │
+│  gemini-2.5-flash           5         15,000        10,000         15,000                        │
 │                                                                                                  │
 │  Savings Highlight: 10,500 (40.4%) of input tokens were served from the cache, reducing costs.   │
 │                                                                                                  │
@@ -312,10 +307,9 @@ exports[`<StatsDisplay /> > renders all sections when all data is present 1`] = 
 │    » API Time:               100ms (44.8%)                                                       │
 │    » Tool Time:              123ms (55.2%)                                                       │
 │                                                                                                  │
-│  Model Usage                                                                                     │
-│  Model                       Reqs   Input Tokens   Cache Reads  Output Tokens                    │
-│  ────────────────────────────────────────────────────────────────────────────                    │
-│  gemini-2.5-pro                 1             50            50            100                    │
+│  Model                   Reqs   Input Tokens   Cache Reads  Output Tokens                        │
+│  ────────────────────────────────────────────────────────────────────────                        │
+│  gemini-2.5-pro             1             50            50            100                        │
 │                                                                                                  │
 │  Savings Highlight: 50 (50.0%) of input tokens were served from the cache, reducing costs.       │
 │                                                                                                  │

--- a/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
@@ -162,16 +162,16 @@ exports[`<StatsDisplay /> > Quota Display > renders pooled quota information for
 │    » API Time:               0s (0.0%)                                                           │
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
-│  auto Usage                                                                                      │
-│  65% usage remaining                                                                             │
+│  Model Usage: auto                                                                               │
+│  35% used                                                                                        │
 │  Usage limit: 1,100                                                                              │
 │  Usage limits span all sessions and reset daily.                                                 │
 │  For a full token breakdown, run \`/stats model\`.                                                 │
 │                                                                                                  │
-│  Model                       Reqs             Usage remaining                                    │
-│  ────────────────────────────────────────────────────────────                                    │
-│  gemini-2.5-pro                 -                                                                │
-│  gemini-2.5-flash               -                                                                │
+│  Model                  Reqs    Model usage                                                      │
+│  ────────────────────────────────────────────────────────────────────────────────────────────────│
+│  gemini-2.5-pro            -    ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬ 90% used                                    │
+│  gemini-2.5-flash          -    ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬ 30% used                                    │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -194,9 +194,9 @@ exports[`<StatsDisplay /> > Quota Display > renders quota information for unused
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │  Model Usage                                                                                     │
-│  Model                       Reqs             Usage remaining                                    │
-│  ────────────────────────────────────────────────────────────                                    │
-│  gemini-2.5-flash               -          50.0% resets in 2h                                    │
+│  Model                  Reqs    Model usage                                                      │
+│  ────────────────────────────────────────────────────────────────────────────────────────────────│
+│  gemini-2.5-flash          -    ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬ 50% used (Limit resets in 2 hours at 6:00 AM│
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -219,9 +219,9 @@ exports[`<StatsDisplay /> > Quota Display > renders quota information when quota
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │  Model Usage                                                                                     │
-│  Model                       Reqs             Usage remaining                                    │
-│  ────────────────────────────────────────────────────────────                                    │
-│  gemini-2.5-pro                 1      75.0% resets in 1h 30m                                    │
+│  Model                  Reqs    Model usage                                                      │
+│  ────────────────────────────────────────────────────────────────────────────────────────────────│
+│  gemini-2.5-pro            1    ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬ 25% used (Limit resets in 1 hour 30 minutes │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -60,6 +60,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
   originalRequestName,
   progress,
   progressTotal,
+  progressPercent,
 }) => {
   const isThisShellFocused = checkIsShellFocused(
     name,
@@ -98,6 +99,8 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
           status={status}
           description={description}
           emphasis={emphasis}
+          progressMessage={progressMessage}
+          progressPercent={progressPercent}
           originalRequestName={originalRequestName}
         />
         <FocusHint

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -60,7 +60,6 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
   originalRequestName,
   progress,
   progressTotal,
-  progressPercent,
 }) => {
   const isThisShellFocused = checkIsShellFocused(
     name,
@@ -100,7 +99,6 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
           description={description}
           emphasis={emphasis}
           progressMessage={progressMessage}
-          progressPercent={progressPercent}
           originalRequestName={originalRequestName}
         />
         <FocusHint

--- a/packages/cli/src/ui/components/messages/ToolShared.tsx
+++ b/packages/cli/src/ui/components/messages/ToolShared.tsx
@@ -192,6 +192,8 @@ type ToolInfoProps = {
   description: string;
   status: CoreToolCallStatus;
   emphasis: TextEmphasis;
+  progressMessage?: string;
+  progressPercent?: number;
   originalRequestName?: string;
 };
 
@@ -200,6 +202,8 @@ export const ToolInfo: React.FC<ToolInfoProps> = ({
   description,
   status: coreStatus,
   emphasis,
+  progressMessage: _progressMessage,
+  progressPercent: _progressPercent,
   originalRequestName,
 }) => {
   const status = mapCoreStatusToDisplayStatus(coreStatus);

--- a/packages/cli/src/ui/components/messages/ToolShared.tsx
+++ b/packages/cli/src/ui/components/messages/ToolShared.tsx
@@ -193,7 +193,6 @@ type ToolInfoProps = {
   status: CoreToolCallStatus;
   emphasis: TextEmphasis;
   progressMessage?: string;
-  progressPercent?: number;
   originalRequestName?: string;
 };
 
@@ -203,7 +202,6 @@ export const ToolInfo: React.FC<ToolInfoProps> = ({
   status: coreStatus,
   emphasis,
   progressMessage: _progressMessage,
-  progressPercent: _progressPercent,
   originalRequestName,
 }) => {
   const status = mapCoreStatusToDisplayStatus(coreStatus);

--- a/packages/cli/src/ui/hooks/toolMapping.test.ts
+++ b/packages/cli/src/ui/hooks/toolMapping.test.ts
@@ -325,7 +325,6 @@ describe('toolMapping', () => {
       const result = mapToDisplay(toolCall);
       expect(result.tools[0].originalRequestName).toBe('original_tool');
     });
-
     it('propagates isClientInitiated from tool request', () => {
       const clientInitiatedTool: ScheduledToolCall = {
         status: CoreToolCallStatus.Scheduled,

--- a/packages/cli/src/ui/hooks/useToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.ts
@@ -117,6 +117,20 @@ export function useToolScheduler(
     const handler = (event: ToolCallsUpdateMessage) => {
       const isRoot = event.schedulerId === ROOT_SCHEDULER_ID;
 
+      // Update output timer for UI spinners (Side Effect)
+      const hasExecuting = event.toolCalls.some(
+        (tc) =>
+          tc.status === CoreToolCallStatus.Executing ||
+          ((tc.status === CoreToolCallStatus.Success ||
+            tc.status === CoreToolCallStatus.Error) &&
+            'tailToolCallRequest' in tc &&
+            tc.tailToolCallRequest != null),
+      );
+
+      if (hasExecuting) {
+        setLastToolOutputTime(Date.now());
+      }
+
       setToolCallsMap((prev) => {
         const prevCalls = prev[event.schedulerId] ?? [];
         const prevCallIds = new Set(prevCalls.map((tc) => tc.request.callId));
@@ -151,20 +165,6 @@ export function useToolScheduler(
           [event.schedulerId]: adapted,
         };
       });
-
-      // Update output timer for UI spinners (Side Effect)
-      const hasExecuting = event.toolCalls.some(
-        (tc) =>
-          tc.status === CoreToolCallStatus.Executing ||
-          ((tc.status === CoreToolCallStatus.Success ||
-            tc.status === CoreToolCallStatus.Error) &&
-            'tailToolCallRequest' in tc &&
-            tc.tailToolCallRequest != null),
-      );
-
-      if (hasExecuting) {
-        setLastToolOutputTime(Date.now());
-      }
     };
 
     messageBus.subscribe(MessageBusType.TOOL_CALLS_UPDATE, handler);

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -115,6 +115,7 @@ export interface IndividualToolCallDisplay {
   originalRequestName?: string;
   progress?: number;
   progressTotal?: number;
+  progressPercent?: number;
 }
 
 export interface CompressionProps {

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -115,7 +115,6 @@ export interface IndividualToolCallDisplay {
   originalRequestName?: string;
   progress?: number;
   progressTotal?: number;
-  progressPercent?: number;
 }
 
 export interface CompressionProps {

--- a/packages/cli/src/ui/utils/displayUtils.ts
+++ b/packages/cli/src/ui/utils/displayUtils.ts
@@ -19,6 +19,9 @@ export const CACHE_EFFICIENCY_MEDIUM = 15;
 export const QUOTA_THRESHOLD_HIGH = 20;
 export const QUOTA_THRESHOLD_MEDIUM = 5;
 
+export const QUOTA_USED_WARNING_THRESHOLD = 80;
+export const QUOTA_USED_CRITICAL_THRESHOLD = 95;
+
 // --- Color Logic ---
 export const getStatusColor = (
   value: number,
@@ -35,4 +38,20 @@ export const getStatusColor = (
     return theme.status.error;
   }
   return options.defaultColor ?? theme.status.error;
+};
+
+/**
+ * Gets the status color based on "used" percentage (where higher is worse).
+ */
+export const getUsedStatusColor = (
+  usedPercentage: number,
+  thresholds: { warning: number; critical: number },
+) => {
+  if (usedPercentage >= thresholds.critical) {
+    return theme.status.error;
+  }
+  if (usedPercentage >= thresholds.warning) {
+    return theme.status.warning;
+  }
+  return undefined;
 };

--- a/packages/cli/src/ui/utils/formatters.test.ts
+++ b/packages/cli/src/ui/utils/formatters.test.ts
@@ -10,9 +10,45 @@ import {
   formatBytes,
   formatTimeAgo,
   stripReferenceContent,
+  formatResetTime,
 } from './formatters.js';
 
 describe('formatters', () => {
+  describe('formatResetTime', () => {
+    const NOW = new Date('2025-01-01T12:00:00Z');
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(NOW);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should format full time correctly', () => {
+      const resetTime = new Date(NOW.getTime() + 90 * 60 * 1000).toISOString(); // 1h 30m
+      const result = formatResetTime(resetTime);
+      expect(result).toMatch(/1 hour 30 minutes at \d{1,2}:\d{2} [AP]M/);
+    });
+
+    it('should format terse time correctly', () => {
+      const resetTime = new Date(NOW.getTime() + 90 * 60 * 1000).toISOString(); // 1h 30m
+      expect(formatResetTime(resetTime, 'terse')).toBe('1h 30m');
+    });
+
+    it('should format column time correctly', () => {
+      const resetTime = new Date(NOW.getTime() + 90 * 60 * 1000).toISOString(); // 1h 30m
+      const result = formatResetTime(resetTime, 'column');
+      expect(result).toMatch(/\d{1,2}:\d{2} [AP]M \(1h 30m\)/);
+    });
+
+    it('should handle zero or negative diff by returning empty string', () => {
+      const resetTime = new Date(NOW.getTime() - 1000).toISOString();
+      expect(formatResetTime(resetTime)).toBe('');
+    });
+  });
+
   describe('formatBytes', () => {
     it('should format bytes into KB', () => {
       expect(formatBytes(12345)).toBe('12.1 KB');

--- a/packages/cli/src/ui/utils/formatters.ts
+++ b/packages/cli/src/ui/utils/formatters.ts
@@ -98,26 +98,44 @@ export function stripReferenceContent(text: string): string {
   return text.replace(pattern, '').trim();
 }
 
-export const formatResetTime = (resetTime: string): string => {
-  const diff = new Date(resetTime).getTime() - Date.now();
+export const formatResetTime = (
+  resetTime: string | undefined,
+  terse = false,
+): string => {
+  if (!resetTime) return '';
+  const resetDate = new Date(resetTime);
+  if (isNaN(resetDate.getTime())) return '';
+
+  const diff = resetDate.getTime() - Date.now();
   if (diff <= 0) return '';
 
   const totalMinutes = Math.ceil(diff / (1000 * 60));
   const hours = Math.floor(totalMinutes / 60);
   const minutes = totalMinutes % 60;
 
-  const fmt = (val: number, unit: 'hour' | 'minute') =>
-    new Intl.NumberFormat('en', {
-      style: 'unit',
-      unit,
-      unitDisplay: 'narrow',
-    }).format(val);
-
-  if (hours > 0 && minutes > 0) {
-    return `resets in ${fmt(hours, 'hour')} ${fmt(minutes, 'minute')}`;
-  } else if (hours > 0) {
-    return `resets in ${fmt(hours, 'hour')}`;
+  if (terse) {
+    const hoursStr = hours > 0 ? `${hours}hr` : '';
+    const minutesStr = minutes > 0 ? `${minutes}m` : '';
+    return hoursStr && minutesStr
+      ? `${hoursStr} ${minutesStr}`
+      : hoursStr || minutesStr;
   }
 
-  return `resets in ${fmt(minutes, 'minute')}`;
+  let duration = '';
+  if (hours > 0) {
+    duration = `${hours} hour${hours > 1 ? 's' : ''}`;
+    if (minutes > 0) {
+      duration += ` ${minutes} minute${minutes > 1 ? 's' : ''}`;
+    }
+  } else {
+    duration = `${minutes} minute${minutes > 1 ? 's' : ''}`;
+  }
+
+  const timeStr = new Intl.DateTimeFormat('en-US', {
+    hour: 'numeric',
+    minute: 'numeric',
+    timeZoneName: 'short',
+  }).format(resetDate);
+
+  return `${duration} at ${timeStr}`;
 };

--- a/packages/cli/src/ui/utils/formatters.ts
+++ b/packages/cli/src/ui/utils/formatters.ts
@@ -100,7 +100,7 @@ export function stripReferenceContent(text: string): string {
 
 export const formatResetTime = (
   resetTime: string | undefined,
-  terse = false,
+  format: 'terse' | 'column' | 'full' = 'full',
 ): string => {
   if (!resetTime) return '';
   const resetDate = new Date(resetTime);
@@ -113,12 +113,26 @@ export const formatResetTime = (
   const hours = Math.floor(totalMinutes / 60);
   const minutes = totalMinutes % 60;
 
-  if (terse) {
-    const hoursStr = hours > 0 ? `${hours}hr` : '';
+  const isTerse = format === 'terse';
+  const isColumn = format === 'column';
+
+  if (isTerse || isColumn) {
+    const hoursStr = hours > 0 ? `${hours}h` : '';
     const minutesStr = minutes > 0 ? `${minutes}m` : '';
-    return hoursStr && minutesStr
-      ? `${hoursStr} ${minutesStr}`
-      : hoursStr || minutesStr;
+    const duration =
+      hoursStr && minutesStr
+        ? `${hoursStr} ${minutesStr}`
+        : hoursStr || minutesStr;
+
+    if (isColumn) {
+      const timeStr = new Intl.DateTimeFormat('en-US', {
+        hour: 'numeric',
+        minute: 'numeric',
+      }).format(resetDate);
+      return duration ? `${timeStr} (${duration})` : timeStr;
+    }
+
+    return duration;
   }
 
   let duration = '';

--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -3107,7 +3107,6 @@ describe('PolicyEngine', () => {
       expect(checkers[0].checker.name).toBe('c2');
     });
   });
-
   describe('Tool Annotations', () => {
     it('should match tools by semantic annotations', async () => {
       engine = new PolicyEngine({
@@ -3171,7 +3170,6 @@ describe('PolicyEngine', () => {
       ).toBe(PolicyDecision.ALLOW);
     });
   });
-
   describe('hook checkers', () => {
     it('should add and retrieve hook checkers in priority order', () => {
       engine.addHookChecker({

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -2053,7 +2053,6 @@ describe('mcp-client', () => {
       expect(callArgs.env!['GEMINI_CLI_EXT_VAR']).toBe('ext-value');
       expect(callArgs.env!['RESOLVED_VAR']).toBe('ext-value');
     });
-
     it('should expand environment variables in mcpServerConfig.env and not redact them', async () => {
       const mockedTransport = vi
         .spyOn(SdkClientStdioLib, 'StdioClientTransport')


### PR DESCRIPTION
## Summary

Invert the language around quotas from "percent left" to "percent used" and introduce a refined visual progress indicator in the `/stats` command output.

## Details

### 1. Quota Language Inversion
- Switched from "XX% usage remaining" to "XX% used" across all UI components (Footer, `/stats`, and pre-prompt alerts).
- Updated thresholds for warnings (80% used) and critical alerts (95% used).
- "100% used" state now displays as "Limit reached".

### 2. Visual Progress Indicator
- Added a 20-step visual bar (`▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬`) to the `/stats` table.
<img width="625" height="175" alt="image" src="https://github.com/user-attachments/assets/f8a32ac9-30f4-4869-bbde-2a3781d5aee2" />
- **Left-Aligned:** The "Model usage" column is now left-aligned with consistent padding to ensure bars remain vertically synchronized.
- **Refined Logic:** 
  - Forced initial tick: Any usage > 0 (even 1 request) shows at least one tick.
  - Remaining hint: High usage < 100% shows at least one empty tick.
  - Solid state: 100% usage shows a full bar.
- **Refined Styling:** 
  - Filled steps use the primary text color (or status color if ≥ 80%).
  - Unfilled steps use the border color (`theme.border.default`) to match the input background.

### 3. Resilient Rendering
- Added safety checks to `formatResetTime` to handle missing or invalid reset dates.
- Components now render usage data even if reset times are unavailable (common in certain user tiers).
- Improved statistics title: **Model Usage:** [Model Name] (with bold label).

### 4. Technical Improvements
- Added `getUsedStatusColor` helper for "higher is worse" logic.
- Updated all relevant tests and snapshots (`QuotaDisplay`, `StatsDisplay`, `Footer`).

## Related Issues

Closes #20098

## How to Validate

1. Run `npm test -w @google/gemini-cli -- src/ui/components/QuotaDisplay.test.tsx src/ui/components/StatsDisplay.test.tsx src/ui/components/Footer.test.tsx` to verify UI logic.
2. Manually verify in the CLI footer and `/stats` output.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
