### PR TITLE
ci(actions): fix PR rate limiter excluding maintainers

### DIFF
--- a/.github/workflows/pr-rate-limiter.yaml
+++ b/.github/workflows/pr-rate-limiter.yaml
@@ -20,9 +20,7 @@ jobs:
       - name: 'Limit open pull requests per user'
         uses: 'Homebrew/actions/limit-pull-requests@9ceb7934560eb61d131dde205a6c2d77b2e1529d' # master
         with:
-          except-author-associations: |
-            MEMBER
-            OWNER
+          except-author-associations: 'MEMBER,OWNER,COLLABORATOR'
           comment-limit: 8
           comment: >
             You already have 7 pull requests open. Please work on getting


### PR DESCRIPTION
## Summary

Fixes an issue where the PR rate limiter was incorrectly closing pull requests opened by repository maintainers.

## Details

The `except-author-associations` configuration in `.github/workflows/pr-rate-limiter.yaml` was previously formatted as a multi-line YAML block. The action expects a comma-separated string. This caused the action to fail to match the `MEMBER` association, leading to maintainer PRs being rate-limited.

## How to Validate

Since this is a `pull_request_target` workflow, the easiest way to validate is to merge this to `main` and monitor if maintainer PRs are no longer improperly closed by the rate limiter bot.