### PR TITLE
fix(core): create new McpClient on restart to apply updated config

### DIFF
--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -218,30 +218,27 @@ export class McpClientManager {
       (async () => {
         try {
           if (existing) {
+            this.clients.delete(name);
             await existing.disconnect();
           }
 
-          const client =
-            existing ??
-            new McpClient(
-              name,
-              config,
-              this.toolRegistry,
-              this.cliConfig.getPromptRegistry(),
-              this.cliConfig.getResourceRegistry(),
-              this.cliConfig.getWorkspaceContext(),
-              this.cliConfig,
-              this.cliConfig.getDebugMode(),
-              this.clientVersion,
-              async () => {
-                debugLogger.log('Tools changed, updating Gemini context...');
-                await this.scheduleMcpContextRefresh();
-              },
-            );
-          if (!existing) {
-            this.clients.set(name, client);
-            this.eventEmitter?.emit('mcp-client-update', this.clients);
-          }
+          const client = new McpClient(
+            name,
+            config,
+            this.toolRegistry,
+            this.cliConfig.getPromptRegistry(),
+            this.cliConfig.getResourceRegistry(),
+            this.cliConfig.getWorkspaceContext(),
+            this.cliConfig,
+            this.cliConfig.getDebugMode(),
+            this.clientVersion,
+            async () => {
+              debugLogger.log('Tools changed, updating Gemini context...');
+              await this.scheduleMcpContextRefresh();
+            },
+          );
+          this.clients.set(name, client);
+          this.eventEmitter?.emit('mcp-client-update', this.clients);
           try {
             await client.connect();
             await client.discover(this.cliConfig);


### PR DESCRIPTION
## Summary

Fix McpClient instance reuse during server restart/reload that silently ignores updated configurations. Always create a new McpClient with the current config instead of reusing the stale instance.

## Details

In `maybeDiscoverMcpServer()`, the existing `McpClient` was disconnected but then reused via `existing ?? new McpClient(...)`. Since `McpClient` stores its `serverConfig` as `private readonly`, any updated configuration (changed command, args, env, timeout) was silently ignored. The fix disconnects and removes the old client, then always constructs a new `McpClient` with the updated config.

## Related Issues

Fixes #19792

## How to Validate

1. Run the new test directly:
   ```bash
   npm test -w @google/gemini-cli-core -- src/tools/mcp-client-manager.test.ts
   ```
2. Verify the new test `should create a new McpClient with updated config on restart` passes.
3. Verify all 20 existing tests in the file continue to pass.
4. Run full CI checks:
   ```bash
   npm run typecheck
   npm run lint
   npm run test
   ```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
