### PR TITLE
fix(cli): replace unsafe type assertions with safe runtime guards in commands

### DIFF
--- a/packages/cli/src/commands/extensions/configure.ts
+++ b/packages/cli/src/commands/extensions/configure.ts
@@ -5,7 +5,7 @@
  */
 
 import type { CommandModule } from 'yargs';
-import type { ExtensionSettingScope } from '../../config/extensions/extensionSettings.js';
+import { ExtensionSettingScope } from '../../config/extensions/extensionSettings.js';
 import {
   configureAllExtensions,
   configureExtension,
@@ -65,32 +65,27 @@ export const configureCommand: CommandModule<object, ConfigureArgs> = {
 
     const extensionManager = await getExtensionManager();
 
+    const resolvedScope =
+      scope === 'workspace'
+        ? ExtensionSettingScope.WORKSPACE
+        : ExtensionSettingScope.USER;
+
     // Case 1: Configure specific setting for an extension
     if (name && setting) {
       await configureSpecificSetting(
         extensionManager,
         name,
         setting,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        scope as ExtensionSettingScope,
+        resolvedScope,
       );
     }
     // Case 2: Configure all settings for an extension
     else if (name) {
-      await configureExtension(
-        extensionManager,
-        name,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        scope as ExtensionSettingScope,
-      );
+      await configureExtension(extensionManager, name, resolvedScope);
     }
     // Case 3: Configure all extensions
     else {
-      await configureAllExtensions(
-        extensionManager,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        scope as ExtensionSettingScope,
-      );
+      await configureAllExtensions(extensionManager, resolvedScope);
     }
 
     await exitCli();

--- a/packages/cli/src/commands/extensions/link.ts
+++ b/packages/cli/src/commands/extensions/link.ts
@@ -79,10 +79,12 @@ export const linkCommand: CommandModule = {
       .check((_) => true),
   handler: async (argv) => {
     await handleLink({
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      path: argv['path'] as string,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      consent: argv['consent'] as boolean | undefined,
+      path:
+        typeof argv['path'] === 'string'
+          ? argv['path']
+          : String(argv['path'] || ''),
+      consent:
+        typeof argv['consent'] === 'boolean' ? argv['consent'] : undefined,
     });
     await exitCli();
   },

--- a/packages/cli/src/commands/extensions/list.ts
+++ b/packages/cli/src/commands/extensions/list.ts
@@ -62,8 +62,10 @@ export const listCommand: CommandModule = {
     }),
   handler: async (argv) => {
     await handleList({
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      outputFormat: argv['output-format'] as 'text' | 'json',
+      outputFormat:
+        argv['output-format'] === 'text' || argv['output-format'] === 'json'
+          ? argv['output-format']
+          : 'text',
     });
     await exitCli();
   },

--- a/packages/cli/src/commands/extensions/uninstall.ts
+++ b/packages/cli/src/commands/extensions/uninstall.ts
@@ -71,8 +71,9 @@ export const uninstallCommand: CommandModule = {
       }),
   handler: async (argv) => {
     await handleUninstall({
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      names: argv['names'] as string[],
+      names: Array.isArray(argv['names'])
+        ? argv['names'].filter((n) => typeof n === 'string')
+        : [],
     });
     await exitCli();
   },

--- a/packages/cli/src/commands/extensions/validate.ts
+++ b/packages/cli/src/commands/extensions/validate.ts
@@ -100,8 +100,10 @@ export const validateCommand: CommandModule = {
     }),
   handler: async (args) => {
     await handleValidate({
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      path: args['path'] as string,
+      path:
+        typeof args['path'] === 'string'
+          ? args['path']
+          : String(args['path'] || ''),
     });
     await exitCli();
   },

--- a/packages/cli/src/commands/skills/disable.ts
+++ b/packages/cli/src/commands/skills/disable.ts
@@ -53,8 +53,10 @@ export const disableCommand: CommandModule = {
         ? SettingScope.Workspace
         : SettingScope.User;
     await handleDisable({
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      name: argv['name'] as string,
+      name:
+        typeof argv['name'] === 'string'
+          ? argv['name']
+          : String(argv['name'] || ''),
       scope,
     });
     await exitCli();

--- a/packages/cli/src/commands/skills/enable.ts
+++ b/packages/cli/src/commands/skills/enable.ts
@@ -40,8 +40,10 @@ export const enableCommand: CommandModule = {
     }),
   handler: async (argv) => {
     await handleEnable({
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      name: argv['name'] as string,
+      name:
+        typeof argv['name'] === 'string'
+          ? argv['name']
+          : String(argv['name'] || ''),
     });
     await exitCli();
   },

--- a/packages/cli/src/commands/skills/install.ts
+++ b/packages/cli/src/commands/skills/install.ts
@@ -102,14 +102,17 @@ export const installCommand: CommandModule = {
       }),
   handler: async (argv) => {
     await handleInstall({
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      source: argv['source'] as string,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      scope: argv['scope'] as 'user' | 'workspace',
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      path: argv['path'] as string | undefined,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      consent: argv['consent'] as boolean | undefined,
+      source:
+        typeof argv['source'] === 'string'
+          ? argv['source']
+          : String(argv['source'] || ''),
+      scope:
+        argv['scope'] === 'user' || argv['scope'] === 'workspace'
+          ? argv['scope']
+          : 'user',
+      path: typeof argv['path'] === 'string' ? argv['path'] : undefined,
+      consent:
+        typeof argv['consent'] === 'boolean' ? argv['consent'] : undefined,
     });
     await exitCli();
   },

--- a/packages/cli/src/commands/skills/list.ts
+++ b/packages/cli/src/commands/skills/list.ts
@@ -73,8 +73,10 @@ export const listCommand: CommandModule = {
       default: false,
     }),
   handler: async (argv) => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    await handleList({ all: argv['all'] as boolean });
+    await handleList({
+      all:
+        typeof argv['all'] === 'boolean' ? argv['all'] : Boolean(argv['all']),
+    });
     await exitCli();
   },
 };

--- a/packages/cli/src/commands/skills/uninstall.ts
+++ b/packages/cli/src/commands/skills/uninstall.ts
@@ -64,10 +64,14 @@ export const uninstallCommand: CommandModule = {
       }),
   handler: async (argv) => {
     await handleUninstall({
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      name: argv['name'] as string,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      scope: argv['scope'] as 'user' | 'workspace',
+      name:
+        typeof argv['name'] === 'string'
+          ? argv['name']
+          : String(argv['name'] || ''),
+      scope:
+        argv['scope'] === 'user' || argv['scope'] === 'workspace'
+          ? argv['scope']
+          : 'user',
     });
     await exitCli();
   },

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -204,16 +204,9 @@ function parseResponseData(error: GaxiosError): ResponseData | undefined {
 export function isAuthenticationError(error: unknown): boolean {
   // Check for MCP SDK errors with code property
   // (SseError and StreamableHTTPError both have numeric 'code' property)
-  if (
-    error &&
-    typeof error === 'object' &&
-    'code' in error &&
-    typeof (error as { code: unknown }).code === 'number'
-  ) {
-    // Safe access after check
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    const errorCode = (error as { code: number }).code;
-    if (errorCode === 401) {
+  if (error && typeof error === 'object' && 'code' in error) {
+    const errorCode: unknown = (error as Record<string, unknown>)['code'];
+    if (typeof errorCode === 'number' && errorCode === 401) {
       return true;
     }
   }

--- a/packages/core/src/utils/quotaErrorDetection.ts
+++ b/packages/core/src/utils/quotaErrorDetection.ts
@@ -16,14 +16,14 @@ export interface ApiError {
 }
 
 export function isApiError(error: unknown): error is ApiError {
+  if (typeof error !== 'object' || error === null || !('error' in error)) {
+    return false;
+  }
+  const errorProp = (error as { error: unknown }).error;
   return (
-    typeof error === 'object' &&
-    error !== null &&
-    'error' in error &&
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    typeof (error as ApiError).error === 'object' &&
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    'message' in (error as ApiError).error
+    typeof errorProp === 'object' &&
+    errorProp !== null &&
+    'message' in errorProp
   );
 }
 
@@ -32,7 +32,6 @@ export function isStructuredError(error: unknown): error is StructuredError {
     typeof error === 'object' &&
     error !== null &&
     'message' in error &&
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    typeof (error as StructuredError).message === 'string'
+    typeof (error as { message: unknown }).message === 'string'
   );
 }


### PR DESCRIPTION
## Description
Fixes Phase 5 of #19708 (issue 19733: CLI Commands).

Replaces  statements inside  and  and applies safe runtime type checking guards including:
- Type narrowing with typeof strings
- Safe array iteration checks
- Enum comparisons and explicit casting for `ExtensionSettingScope`

Tested via `npm run lint` and `npm run test`.