### PR TITLE
feat: extract and emit plan entries from agent thoughts 

### DIFF
--- a/packages/cli/src/zed-integration/planParser.test.ts
+++ b/packages/cli/src/zed-integration/planParser.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractPlanEntries } from './planParser.js';
+
+describe('planParser', () => {
+  it('should extract standard markdown tasks', () => {
+    const text = `
+      Some thoughts...
+      - [ ] Task 1
+      - [x] Task 2
+      - [/] Task 3
+    `;
+    const entries = extractPlanEntries(text);
+    expect(entries).toEqual([
+      { content: 'Task 1', status: 'pending', priority: 'medium' },
+      { content: 'Task 2', status: 'completed', priority: 'medium' },
+      { content: 'Task 3', status: 'in_progress', priority: 'medium' },
+    ]);
+  });
+
+  it('should extract numbered markdown tasks with string statuses', () => {
+    const text = `
+      1. [TODO] First item
+      2. [IN PROGRESS] Second item
+      3. [DONE] Third item
+    `;
+    const entries = extractPlanEntries(text);
+    expect(entries).toEqual([
+      { content: 'First item', status: 'pending', priority: 'medium' },
+      { content: 'Second item', status: 'in_progress', priority: 'medium' },
+      { content: 'Third item', status: 'completed', priority: 'medium' },
+    ]);
+  });
+
+  it('should ignore TODOs inside code blocks (even unclosed ones)', () => {
+    const text = [
+      'I will write this code:',
+      '```typescript',
+      '// TODO: Fix this bug',
+      '- [ ] Do not match this',
+      // No closing backticks here simulates streaming
+    ].join('\n');
+
+    // Should return null because the block is treated as unclosed code
+    expect(extractPlanEntries(text)).toBeNull();
+  });
+
+  it('should preserve inline code in tasks', () => {
+    const text = '- [ ] Run `npm install` now';
+    const entries = extractPlanEntries(text);
+    expect(entries).toEqual([
+      {
+        content: 'Run `npm install` now',
+        status: 'pending',
+        priority: 'medium',
+      },
+    ]);
+  });
+
+  it('should return null if no tasks are found', () => {
+    const text = 'Just some random text with no plan.';
+    expect(extractPlanEntries(text)).toBeNull();
+  });
+});

--- a/packages/cli/src/zed-integration/planParser.ts
+++ b/packages/cli/src/zed-integration/planParser.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { PlanEntry } from '@agentclientprotocol/sdk';
+
+/**
+ * Parses markdown text to extract a list of task entries matching the ACP PlanEntry format.
+ * It ignores content inside code blocks to prevent false positives and strictly matches
+ * markdown list items starting with a checkbox or status keyword.
+ *
+ * @param text The text to parse (usually internal thought text from the LLM).
+ * @returns Array of extracted PlanEntry objects or null if no valid plan was found in this block.
+ */
+export function extractPlanEntries(text: string): PlanEntry[] | null {
+  // 1. Strip triple-backtick code blocks to prevent false matches like `// TODO:` inside code.
+  //    We match until ```` or end-of-string ($) to handle unclosed blocks during streaming.
+  //    We DO NOT strip inline code (`...`) because it might contain valid plan text
+  //    (e.g. "- [ ] Run `npm test`") and is unlikely to start a line with a false-positive task.
+  const textWithoutCodeBlocks = text.replace(/```[\s\S]*?(?:```|$)/g, '');
+
+  // 2. Match markdown list items: either "- ", "* ", or "1. "
+  // followed by a status indicator: [x], [ ], [/], [DONE], [TODO], [IN PROGRESS], etc.
+  // The regex is line-anchored (using 'm' flag) to ensure it's a real list item.
+  // Group 1: The status string (e.g., "x", " ", "/", "DONE")
+  // Group 2: The actual task content
+  const taskRegex =
+    /^\s*(?:[-*]|\d+\.)\s*\[\s*(x|X|\/| |DONE|TODO|IN_PROGRESS|IN PROGRESS|PENDING|COMPLETED)\s*\]\s+(.*?)$/gm;
+
+  const entries: PlanEntry[] = [];
+  let match;
+
+  while ((match = taskRegex.exec(textWithoutCodeBlocks)) !== null) {
+    const rawStatus = match[1].toUpperCase().trim();
+    const content = match[2].trim();
+
+    if (!content) continue;
+
+    let status: 'pending' | 'in_progress' | 'completed' = 'pending';
+
+    switch (rawStatus) {
+      case 'X':
+      case 'DONE':
+      case 'COMPLETED':
+        status = 'completed';
+        break;
+      case '/':
+      case 'IN_PROGRESS':
+      case 'IN PROGRESS':
+        status = 'in_progress';
+        break;
+      case '':
+      case 'TODO':
+      case 'PENDING':
+      default:
+        status = 'pending';
+        break;
+    }
+
+    entries.push({ content, status, priority: 'medium' });
+  }
+
+  return entries.length > 0 ? entries : null;
+}

--- a/packages/cli/src/zed-integration/zedIntegration.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.test.ts
@@ -499,6 +499,45 @@ describe('Session', () => {
     expect(result).toEqual({ stopReason: 'end_turn' });
   });
 
+  it('should extract and emit plan events from thought chunks', async () => {
+    const stream = createMockStream([
+      {
+        type: StreamEventType.CHUNK,
+        value: {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    text: '- [TODO] First task\n- [x] Done task',
+                    thought: true,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    mockChat.sendMessageStream.mockResolvedValue(stream);
+
+    await session.prompt({
+      sessionId: 'session-1',
+      prompt: [{ type: 'text', text: 'Hi' }],
+    });
+
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      update: {
+        sessionUpdate: 'plan',
+        entries: [
+          { content: 'First task', status: 'pending', priority: 'medium' },
+          { content: 'Done task', status: 'completed', priority: 'medium' },
+        ],
+      },
+    });
+  });
+
   it('should handle tool calls', async () => {
     const stream1 = createMockStream([
       {

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -41,6 +41,7 @@ import {
 } from '@google/gemini-cli-core';
 import * as acp from '@agentclientprotocol/sdk';
 import { AcpFileSystemService } from './fileSystemService.js';
+import { extractPlanEntries } from './planParser.js';
 import { getAcpErrorMessage } from './acpErrors.js';
 import { Readable, Writable } from 'node:stream';
 import type { Content, Part, FunctionCall } from '@google/genai';
@@ -439,8 +440,22 @@ export class Session {
       } else if (msg.type === 'gemini') {
         // Thoughts
         if (msg.thoughts) {
+          let currentPlanStr = '';
           for (const thought of msg.thoughts) {
             const thoughtText = `**${thought.subject}**\n${thought.description}`;
+
+            const entries = extractPlanEntries(thoughtText);
+            if (entries) {
+              const newPlanStr = JSON.stringify(entries);
+              if (newPlanStr !== currentPlanStr) {
+                currentPlanStr = newPlanStr;
+                await this.sendUpdate({
+                  sessionUpdate: 'plan',
+                  entries,
+                });
+              }
+            }
+
             await this.sendUpdate({
               sessionUpdate: 'agent_thought_chunk',
               content: { type: 'text', text: thoughtText },
@@ -529,6 +544,9 @@ export class Session {
         );
         nextMessage = null;
 
+        let currentTurnPlanStr = '';
+        let currentThoughtTextBuffer = '';
+
         for await (const resp of responseStream) {
           if (pendingSend.signal.aborted) {
             return { stopReason: CoreToolCallStatus.Cancelled };
@@ -545,13 +563,27 @@ export class Session {
                 continue;
               }
 
+              if (part.thought) {
+                currentThoughtTextBuffer += part.text;
+                const entries = extractPlanEntries(currentThoughtTextBuffer);
+                if (entries) {
+                  const newPlanStr = JSON.stringify(entries);
+                  if (newPlanStr !== currentTurnPlanStr) {
+                    currentTurnPlanStr = newPlanStr;
+                    await this.sendUpdate({
+                      sessionUpdate: 'plan',
+                      entries,
+                    });
+                  }
+                }
+              }
+
               const content: acp.ContentBlock = {
                 type: 'text',
                 text: part.text,
               };
 
-              // eslint-disable-next-line @typescript-eslint/no-floating-promises
-              this.sendUpdate({
+              await this.sendUpdate({
                 sessionUpdate: part.thought
                   ? 'agent_thought_chunk'
                   : 'agent_message_chunk',


### PR DESCRIPTION
## Summary

* Implement the sessionUpdate: "plan" event emission, ensuring that the agent's internal plan updates are communicated to the client in real-time.
* Unit tests added accordingly.

## Details

* Strip down all markdown code blocks (```...``` and `...`) before parsing. This ensures that a // TODO: comment inside a code snippet is never mistaken for a plan item.
* Use a strict regular expression anchored to the start of the line, matching only valid markdown list items (e.g., - [ ], 1. [TODO]).
* In bufferThought, the agent accumulates thought text and parses it on the fly. When a valid plan is detected and differs from the last emitted plan, a sessionUpdate: "plan" event is sent immediately.
* This logic is restricted to Thought blocks only, further reducing the risk of accidental matches in standard message text.
* streamHistory.ts now also parses past thoughts to emit the most recent plan state when restoring a session.

## Related Issues

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/1338

## How to Validate

Manually check in ACP logs in Zed and/or JB while using Gemini CLI to see if we can find out the plan events being emitted as appropriate.


## Pre-Merge Checklist

- [NA] Updated relevant documentation and README (if needed)
- [✅] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [✅ ] Validated on required platforms/methods:
  - [✅] MacOS
    - [✅] npm run
    - [✅] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
