### PR TITLE
fix punycode2

### DIFF
--- a/packages/a2a-server/src/http/server.ts
+++ b/packages/a2a-server/src/http/server.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --no-warnings=DEP0040
 
 /**
  * @license

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --no-warnings=DEP0040
 
 /**
  * @license

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -32,7 +32,7 @@ execSync('node ./scripts/check-build-status.js', {
   cwd: root,
 });
 
-const nodeArgs = [];
+const nodeArgs = ['--no-warnings=DEP0040'];
 let sandboxCommand = undefined;
 try {
   sandboxCommand = execSync('node scripts/sandbox_command.js', {


### PR DESCRIPTION
## Summary

Fixes #19818 by disabling the punycode warning.

Unfortunately deps on punycode are too deep and the warning is too hard to remove so this is the only viable path forward.

Repro:

vm use 24.13.1
npx -y https://github.com/google-gemini/gemini-cli#fix_punycode2
