### PR TITLE
fix(core): allow subagents without toolConfig to register MCP tools

### DIFF
--- a/packages/core/src/agents/local-executor.test.ts
+++ b/packages/core/src/agents/local-executor.test.ts
@@ -505,6 +505,45 @@ describe('LocalAgentExecutor', () => {
       expect(agentRegistry.getTool(subAgentName)).toBeUndefined();
     });
 
+    it('should auto-register MCP tools when toolConfig is undefined without throwing', async () => {
+      const serverName = 'mcp-server';
+      const toolName = 'mcp-tool';
+
+      const mockMcpTool = {
+        tool: vi.fn(),
+        callTool: vi.fn(),
+      } as unknown as CallableTool;
+
+      const mcpTool = new DiscoveredMCPTool(
+        mockMcpTool,
+        serverName,
+        toolName,
+        'A test MCP tool',
+        {},
+        mockConfig.messageBus,
+      );
+
+      parentToolRegistry.registerTool(mcpTool);
+
+      // Create definition and force toolConfig to be undefined
+      const definition = createTestDefinition();
+      definition.toolConfig = undefined;
+
+      // Should NOT throw
+      const executor = await LocalAgentExecutor.create(
+        definition,
+        mockConfig,
+        onActivity,
+      );
+
+      const agentRegistry = executor['toolRegistry'];
+
+      // MCP tool should be registered under its qualified name
+      expect(agentRegistry.getTool(mcpTool.name)).toBeDefined();
+      // Built-in tools should still be present
+      expect(agentRegistry.getTool(LS_TOOL_NAME)).toBeDefined();
+    });
+
     it('should automatically qualify MCP tools in agent definitions', async () => {
       const serverName = 'mcp-server';
       const toolName = 'mcp-tool';


### PR DESCRIPTION
## Summary

When a subagent has no explicit `toolConfig`, it defaults to registering all tools from the parent registry. MCP tools are stored under their short names (e.g., `remote_get_asset`), but the `registerToolByName` guard in `local-executor.ts` rejects any MCP tool name without the `__` separator — causing a hard crash for any subagent without a tool list.

This fix bypasses the qualified-name check when auto-populating all tools, while keeping the guard intact for explicit tool references in agent definitions.

## Details

In the `else` branch of `LocalAgentExecutor.create()` (no `toolConfig`), MCP tools retrieved from `getAllToolNames()` are now registered directly to the agent's isolated registry, skipping the qualified-name validation that is only relevant for explicitly listed tools.

## Related Issues

Fixes #20166

## How to Validate

1. Run the new test:
   ```bash
   npm test -w @google/gemini-cli-core -- src/agents/local-executor.test.ts
   ```
2. Verify the new test `should auto-register MCP tools when toolConfig is undefined without throwing` passes.
3. Verify the existing test `should enforce qualified names for MCP tools in agent definitions` still passes (the explicit-config guard is preserved).

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
