### PR TITLE
fix(agents): fix subagent failing to load MCP tools when toolConfig i…

### DIFF
--- a/packages/core/src/agents/local-executor.test.ts
+++ b/packages/core/src/agents/local-executor.test.ts
@@ -501,6 +501,34 @@ describe('LocalAgentExecutor', () => {
       expect(agentRegistry.getTool(subAgentName)).toBeUndefined();
     });
 
+    it('should include MCP tools when toolConfig is undefined', async () => {
+      const mockMcpTool = {
+        tool: vi.fn(),
+        callTool: vi.fn(),
+      } as unknown as CallableTool;
+
+      const mcpTool = new DiscoveredMCPTool(
+        mockMcpTool,
+        'test-server',
+        'test-tool',
+        'A test MCP tool',
+        {},
+        mockConfig.getMessageBus(),
+      );
+      parentToolRegistry.registerTool(mcpTool);
+
+      const definition = createTestDefinition();
+      definition.toolConfig = undefined;
+
+      const executor = await LocalAgentExecutor.create(
+        definition,
+        mockConfig,
+        onActivity,
+      );
+
+      expect(executor['toolRegistry'].getTool(mcpTool.name)).toBeDefined();
+    });
+
     it('should enforce qualified names for MCP tools in agent definitions', async () => {
       const serverName = 'mcp-server';
       const toolName = 'mcp-tool';


### PR DESCRIPTION
## Summary

When a subagent has no explicit `toolConfig`, it failed to load MCP tools. The fallback path used short MCP tool names (e.g. `remote_get_asset`) which hit a guard that throws if the name doesn't contain `__`.

## Details

- In `create()`: replaced `getAllToolNames()` + `registerToolByName()` with `getAllTools()` + `registerTool()` in the fallback path. The `__` guard is only meant for user-supplied tool names, not the "load all tools" path.
- In `prepareToolsList()`: added missing `else` branch so the model receives tool schemas when `toolConfig` is undefined.

## Related Issues

Fixes #20166

## How to Validate

1. Register an MCP server in `~/.gemini/settings.json`
2. Create a subagent definition with no `toolConfig`
3. Before: fails with `MCP tool 'x' must be requested with its server prefix`
4. After: subagent starts and MCP tools are available

Or run the unit test:
```bash
npx vitest run packages/core/src/agents/local-executor.test.ts



