### PR TITLE
docs: fix broken markdown links in main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,14 +282,14 @@ gemini
   quickly.
 - [**Authentication Setup**](./docs/get-started/authentication.md) - Detailed
   auth configuration.
-- [**Configuration Guide**](./docs/get-started/configuration.md) - Settings and
+- [**Configuration Guide**](./docs/reference/configuration.md) - Settings and
   customization.
-- [**Keyboard Shortcuts**](./docs/cli/keyboard-shortcuts.md) - Productivity
+- [**Keyboard Shortcuts**](./docs/reference/keyboard-shortcuts.md) - Productivity
   tips.
 
 ### Core Features
 
-- [**Commands Reference**](./docs/cli/commands.md) - All slash commands
+- [**Commands Reference**](./docs/reference/commands.md) - All slash commands
   (`/help`, `/chat`, etc).
 - [**Custom Commands**](./docs/cli/custom-commands.md) - Create your own
   reusable commands.
@@ -323,15 +323,15 @@ gemini
 - [**Enterprise Guide**](./docs/cli/enterprise.md) - Deploy and manage in a
   corporate environment.
 - [**Telemetry & Monitoring**](./docs/cli/telemetry.md) - Usage tracking.
-- [**Tools API Development**](./docs/core/tools-api.md) - Create custom tools.
+- [**Tools API Development**](./docs/reference/tools-api.md) - Create custom tools.
 - [**Local development**](./docs/local-development.md) - Local development
   tooling.
 
 ### Troubleshooting & Support
 
-- [**Troubleshooting Guide**](./docs/troubleshooting.md) - Common issues and
+- [**Troubleshooting Guide**](./docs/resources/troubleshooting.md) - Common issues and
   solutions.
-- [**FAQ**](./docs/faq.md) - Frequently asked questions.
+- [**FAQ**](./docs/resources/faq.md) - Frequently asked questions.
 - Use `/bug` command to report issues directly from the CLI.
 
 ### Using MCP Servers
@@ -377,12 +377,12 @@ for planned features and priorities.
 
 ### Uninstall
 
-See the [Uninstall Guide](docs/cli/uninstall.md) for removal instructions.
+See the [Uninstall Guide](./docs/resources/uninstall.md) for removal instructions.
 
 ## 📄 Legal
 
 - **License**: [Apache License 2.0](LICENSE)
-- **Terms of Service**: [Terms & Privacy](./docs/tos-privacy.md)
+- **Terms of Service**: [Terms & Privacy](./docs/resources/tos-privacy.md)
 - **Security**: [Security Policy](SECURITY.md)
 
 ---


### PR DESCRIPTION
## Summary

Updated link paths to certain links on the main README.md file so that they point to the proper files

## Details

Hi team! 👋
I am exploring the codebase as a prospective GSoC 2026 contributor and noticed that several documentation links in the main README.md were broken or leading to wrong folders.

## Additional fixes

I also found that architecture.md file does not exist in the docs folder

## Related to

Fixes #20288



## Changes included:

Updated relative links to point to the correct files:
configuration.md
keyboard-shortcuts.md
tools-api.md
troubleshooting.md
faq.md
commands.md
uninstall.md
tos-privacy.md


Testing:
Verified locally that clicking the links in the Markdown preview now correctly resolves to the respective files in the repository.

## How to Validate

1.Open the main README.md file.
2.Click on the links to the above mentioned files.
3.Now it will lead to the correct file locations.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
