### PR TITLE
fix: handle STREAM_JSON output format in validateNonInteractiveAuth

### DIFF
--- a/packages/cli/src/validateNonInterActiveAuth.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.ts
@@ -50,7 +50,10 @@ export async function validateNonInteractiveAuth(
 
     return authType;
   } catch (error) {
-    if (nonInteractiveConfig.getOutputFormat() === OutputFormat.JSON) {
+    if (
+      nonInteractiveConfig.getOutputFormat() === OutputFormat.JSON ||
+      nonInteractiveConfig.getOutputFormat() === OutputFormat.STREAM_JSON
+    ) {
       handleError(
         error instanceof Error ? error : new Error(String(error)),
         nonInteractiveConfig,

--- a/packages/cli/src/validateNonInterActiveAuth.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.ts
@@ -50,10 +50,8 @@ export async function validateNonInteractiveAuth(
 
     return authType;
   } catch (error) {
-    if (
-      nonInteractiveConfig.getOutputFormat() === OutputFormat.JSON ||
-      nonInteractiveConfig.getOutputFormat() === OutputFormat.STREAM_JSON
-    ) {
+    const outputFormat = nonInteractiveConfig.getOutputFormat();
+    if ([OutputFormat.JSON, OutputFormat.STREAM_JSON].includes(outputFormat)) {
       handleError(
         error instanceof Error ? error : new Error(String(error)),
         nonInteractiveConfig,


### PR DESCRIPTION
## fix: handle STREAM_JSON output format in validateNonInteractiveAuth

### Summary

Auth errors in non-interactive `--output-format stream-json` mode produced no structured RESULT event — the stream would end abruptly with no error indication for consumers.

Fixes #20183

### Problem

The `catch` block in `validateNonInteractiveAuth()` only checked for `OutputFormat.JSON`. When `STREAM_JSON` was used, it fell through to the `else` branch which:
1. Logged to `debugLogger` (invisible to stream consumers)
2. Called `process.exit()` without emitting any structured event

### Fix

Added `OutputFormat.STREAM_JSON` to the existing format check, routing both JSON and STREAM_JSON through `handleError()` which already correctly handles all three formats.

### Changes

- **`validateNonInterActiveAuth.ts`**: Added `OutputFormat.STREAM_JSON` to the format condition in the catch block
- **`validateNonInterActiveAuth.test.ts`**: Added 3 new test cases for STREAM_JSON mode covering:
  - No auth configured → emits RESULT event with error
  - Enforced auth type mismatch → emits RESULT event with error
  - `validateAuthMethod` failure → emits RESULT event with error

### Testing

```bash
npm test -w @google/gemini-cli -- src/validateNonInterActiveAuth.test.ts
# 20 tests passed (17 existing + 3 new)
```
