### PR TITLE
feat(plan): inject message when user manually exits Plan mode

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1445,14 +1445,24 @@ export const useGeminiStream = (
         streamingState === StreamingState.Idle
       ) {
         if (geminiClient) {
-          void geminiClient.addHistory({
-            role: 'user',
-            parts: [
-              {
-                text: getPlanModeExitMessage(newApprovalMode, true),
-              },
-            ],
-          });
+          try {
+            await geminiClient.addHistory({
+              role: 'user',
+              parts: [
+                {
+                  text: getPlanModeExitMessage(newApprovalMode, true),
+                },
+              ],
+            });
+          } catch (error) {
+            onDebugMessage(
+              `Failed to notify model of Plan Mode exit: ${getErrorMessage(error)}`,
+            );
+            addItem({
+              type: MessageType.ERROR,
+              text: 'Failed to update the model about exiting Plan Mode. The model might be out of sync. Please consider restarting the session if you see unexpected behavior.',
+            });
+          }
         }
       }
       previousApprovalModeRef.current = newApprovalMode;
@@ -1495,7 +1505,7 @@ export const useGeminiStream = (
         }
       }
     },
-    [config, toolCalls, geminiClient, streamingState],
+    [config, toolCalls, geminiClient, streamingState, addItem, onDebugMessage],
   );
 
   const handleCompletedTools = useCallback(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -78,6 +78,7 @@ export * from './utils/authConsent.js';
 export * from './utils/googleQuotaErrors.js';
 export * from './utils/fileUtils.js';
 export * from './utils/planUtils.js';
+export * from './utils/approvalModeUtils.js';
 export * from './utils/fileDiffUtils.js';
 export * from './utils/retry.js';
 export * from './utils/shell-utils.js';

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -20,30 +20,12 @@ import type { Config } from '../config/config.js';
 import { EXIT_PLAN_MODE_TOOL_NAME } from './tool-names.js';
 import { validatePlanPath, validatePlanContent } from '../utils/planUtils.js';
 import { ApprovalMode } from '../policy/types.js';
-import { checkExhaustive } from '../utils/checks.js';
 import { resolveToRealPath, isSubpath } from '../utils/paths.js';
 import { logPlanExecution } from '../telemetry/loggers.js';
 import { PlanExecutionEvent } from '../telemetry/types.js';
 import { getExitPlanModeDefinition } from './definitions/coreTools.js';
 import { resolveToolDeclaration } from './definitions/resolver.js';
-
-/**
- * Returns a human-readable description for an approval mode.
- */
-function getApprovalModeDescription(mode: ApprovalMode): string {
-  switch (mode) {
-    case ApprovalMode.AUTO_EDIT:
-      return 'Auto-Edit mode (edits will be applied automatically)';
-    case ApprovalMode.DEFAULT:
-      return 'Default mode (edits will require confirmation)';
-    case ApprovalMode.YOLO:
-    case ApprovalMode.PLAN:
-      // YOLO and PLAN are not valid modes to enter when exiting plan mode
-      throw new Error(`Unexpected approval mode: ${mode}`);
-    default:
-      checkExhaustive(mode);
-  }
-}
+import { getPlanModeExitMessage } from '../utils/approvalModeUtils.js';
 
 export interface ExitPlanModeParams {
   plan_path: string;
@@ -227,10 +209,10 @@ export class ExitPlanModeInvocation extends BaseToolInvocation<
 
       logPlanExecution(this.config, new PlanExecutionEvent(newMode));
 
-      const description = getApprovalModeDescription(newMode);
+      const exitMessage = getPlanModeExitMessage(newMode);
 
       return {
-        llmContent: `Plan approved. Switching to ${description}.
+        llmContent: `${exitMessage}
 
 The approved implementation plan is stored at: ${resolvedPlanPath}
 Read and follow the plan strictly during implementation.`,

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -204,6 +204,11 @@ export class ExitPlanModeInvocation extends BaseToolInvocation<
     const payload = this.approvalPayload;
     if (payload?.approved) {
       const newMode = payload.approvalMode ?? ApprovalMode.DEFAULT;
+
+      if (newMode === ApprovalMode.PLAN || newMode === ApprovalMode.YOLO) {
+        throw new Error(`Unexpected approval mode: ${newMode}`);
+      }
+
       this.config.setApprovalMode(newMode);
       this.config.setApprovedPlanPath(resolvedPlanPath);
 

--- a/packages/core/src/utils/approvalModeUtils.test.ts
+++ b/packages/core/src/utils/approvalModeUtils.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ApprovalMode } from '../policy/types.js';
+import {
+  getApprovalModeDescription,
+  getPlanModeExitMessage,
+} from './approvalModeUtils.js';
+
+describe('approvalModeUtils', () => {
+  describe('getApprovalModeDescription', () => {
+    it('should return correct description for DEFAULT mode', () => {
+      expect(getApprovalModeDescription(ApprovalMode.DEFAULT)).toBe(
+        'Default mode (edits will require confirmation)',
+      );
+    });
+
+    it('should return correct description for AUTO_EDIT mode', () => {
+      expect(getApprovalModeDescription(ApprovalMode.AUTO_EDIT)).toBe(
+        'Auto-Edit mode (edits will be applied automatically)',
+      );
+    });
+
+    it('should return correct description for PLAN mode', () => {
+      expect(getApprovalModeDescription(ApprovalMode.PLAN)).toBe(
+        'Plan mode (read-only planning)',
+      );
+    });
+
+    it('should return correct description for YOLO mode', () => {
+      expect(getApprovalModeDescription(ApprovalMode.YOLO)).toBe(
+        'YOLO mode (all tool calls auto-approved)',
+      );
+    });
+  });
+
+  describe('getPlanModeExitMessage', () => {
+    it('should return standard message when not manual', () => {
+      expect(getPlanModeExitMessage(ApprovalMode.DEFAULT, false)).toBe(
+        'Plan approved. Switching to Default mode (edits will require confirmation).',
+      );
+    });
+
+    it('should return manual message when manual is true', () => {
+      expect(getPlanModeExitMessage(ApprovalMode.AUTO_EDIT, true)).toBe(
+        'User has manually exited Plan Mode. Switching to Auto-Edit mode (edits will be applied automatically).',
+      );
+    });
+
+    it('should default to non-manual message', () => {
+      expect(getPlanModeExitMessage(ApprovalMode.YOLO)).toBe(
+        'Plan approved. Switching to YOLO mode (all tool calls auto-approved).',
+      );
+    });
+  });
+});

--- a/packages/core/src/utils/approvalModeUtils.ts
+++ b/packages/core/src/utils/approvalModeUtils.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ApprovalMode } from '../policy/types.js';
+import { checkExhaustive } from './checks.js';
+
+/**
+ * Returns a human-readable description for an approval mode.
+ */
+export function getApprovalModeDescription(mode: ApprovalMode): string {
+  switch (mode) {
+    case ApprovalMode.AUTO_EDIT:
+      return 'Auto-Edit mode (edits will be applied automatically)';
+    case ApprovalMode.DEFAULT:
+      return 'Default mode (edits will require confirmation)';
+    case ApprovalMode.PLAN:
+      return 'Plan mode (read-only planning)';
+    case ApprovalMode.YOLO:
+      return 'YOLO mode (all tool calls auto-approved)';
+    default:
+      return checkExhaustive(mode);
+  }
+}
+
+/**
+ * Generates a consistent message for plan mode transitions.
+ */
+export function getPlanModeExitMessage(
+  newMode: ApprovalMode,
+  isManual: boolean = false,
+): string {
+  const description = getApprovalModeDescription(newMode);
+  const prefix = isManual
+    ? 'User has manually exited Plan Mode.'
+    : 'Plan approved.';
+  return `${prefix} Switching to ${description}.`;
+}


### PR DESCRIPTION
When the user manually exits Plan Mode (e.g. via Shift+Tab), the model might still think it's in Plan Mode. This change detects manual exits and injects a notification message into the conversation history so the model stays synchronized.

It also centralizes approval mode descriptions and transition messages into a new utility for consistency across the CLI and core tools.

Fixes #20103
Fixes #19256

<img width="873" height="118" alt="Screenshot 2026-02-24 at 1 33 50 PM" src="https://github.com/user-attachments/assets/8b366aac-1862-46bb-a06f-d98e9482ddc2" />
