### PR TITLE
restrict /assign to help-wanted issues

### DIFF
--- a/.github/workflows/gemini-self-assign-issue.yml
+++ b/.github/workflows/gemini-self-assign-issue.yml
@@ -48,6 +48,24 @@ jobs:
             const repo = context.repo.repo;
             const MAX_ISSUES_ASSIGNED = 3;
 
+            const issue = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+            });
+
+            const hasHelpWantedLabel = issue.data.labels.some(label => label.name === 'help wanted');
+
+            if (!hasHelpWantedLabel) {
+              await github.rest.issues.createComment({
+                owner: owner,
+                repo: repo,
+                issue_number: issueNumber,
+                body: `👋 @${commenter}, thanks for your interest in this issue! We're reserving self-assignment for issues that have been marked with the \`help wanted\` label. Feel free to check out our list of [issues that need attention](https://github.com/google-gemini/gemini-cli/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).`
+              });
+              return;
+            }
+
             // Search for open issues already assigned to the commenter in this repo
             const { data: assignedIssues } = await github.rest.search.issuesAndPullRequests({
               q: `is:issue repo:${owner}/${repo} assignee:${commenter} is:open`,
@@ -63,13 +81,6 @@ jobs:
               });
               return; // exit
             }
-
-            // Check if the issue is already assigned
-            const issue = await github.rest.issues.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-            });
 
             if (issue.data.assignees.length > 0) {
               // Comment that it's already assigned


### PR DESCRIPTION
## Summary

Restrict `/assign` to issues with the `help-wanted` label.