### PR TITLE
fix: YOLO mode still asking for plan approval in non-interactive mode

### DIFF
--- a/packages/core/src/prompts/promptProvider.ts
+++ b/packages/core/src/prompts/promptProvider.ts
@@ -160,9 +160,8 @@ export class PromptProvider {
               CodebaseInvestigatorAgent.name,
             ),
             enableWriteTodosTool: enabledToolNames.has(WRITE_TODOS_TOOL_NAME),
-            enableEnterPlanModeTool: enabledToolNames.has(
-              ENTER_PLAN_MODE_TOOL_NAME,
-            ),
+            enableEnterPlanModeTool:
+              enabledToolNames.has(ENTER_PLAN_MODE_TOOL_NAME) && !isYoloMode,
             enableGrep: enabledToolNames.has(GREP_TOOL_NAME),
             enableGlob: enabledToolNames.has(GLOB_TOOL_NAME),
             approvedPlan: approvedPlanPath
@@ -192,7 +191,7 @@ export class PromptProvider {
         interactiveYoloMode: this.withSection(
           'interactiveYoloMode',
           () => true,
-          isYoloMode && interactiveMode,
+          isYoloMode,
         ),
         gitRepo: this.withSection(
           'git',


### PR DESCRIPTION
When using --yolo or --approval-mode yolo with --output-format stream-json or --prompt (non-interactive/headless mode), the CLI was still asking for plan approval.

Two bugs fixed in promptProvider.ts:
1. The 'Autonomous Mode (YOLO)' system prompt section was only injected when interactiveMode was true. Changed condition from 'isYoloMode && interactiveMode' to just 'isYoloMode'.
2. enableEnterPlanModeTool was true in YOLO mode, causing the model to call enter_plan_mode and ask 'Does this plan sound good to you?'. Added '&& !isYoloMode' to suppress this.

Fixes #13561

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
