### PR TITLE
feat(cli): add /visualize slash command for Mermaid + ASCII diagrams

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -56,6 +56,7 @@ import { skillsCommand } from '../ui/commands/skillsCommand.js';
 import { settingsCommand } from '../ui/commands/settingsCommand.js';
 import { shellsCommand } from '../ui/commands/shellsCommand.js';
 import { vimCommand } from '../ui/commands/vimCommand.js';
+import { visualizeCommand } from '../ui/commands/visualizeCommand.js';
 import { setupGithubCommand } from '../ui/commands/setupGithubCommand.js';
 import { terminalSetupCommand } from '../ui/commands/terminalSetupCommand.js';
 
@@ -183,6 +184,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       settingsCommand,
       shellsCommand,
       vimCommand,
+      visualizeCommand,
       setupGithubCommand,
       terminalSetupCommand,
     ];

--- a/packages/cli/src/ui/commands/visualizeCommand.ts
+++ b/packages/cli/src/ui/commands/visualizeCommand.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  SlashCommand,
+  SlashCommandActionReturn,
+  CommandContext,
+} from './types.js';
+import { CommandKind } from './types.js';
+
+const VISUALIZE_PROMPT = `You are a visualization assistant. The user wants you to analyze the current codebase or context and create a visual diagram.
+
+Your task:
+1. Analyze the codebase/context relevant to the user's request.
+2. Generate a Mermaid diagram syntax that accurately represents what the user asked to visualize.
+3. Present the Mermaid syntax in a fenced code block with the \`mermaid\` language tag.
+4. Then, render an ASCII text art version of the same diagram directly in your response so it displays in the terminal.
+
+ASCII diagram rules:
+- Use box-drawing characters for boxes: ─ │ ┌ ┐ └ ┘
+- Use ┬ on the bottom border of a parent box where the line exits downward.
+- Use │ for vertical lines between boxes, with a ▼ arrow at the end just before the child box.
+- Lines MUST connect directly to box borders — no floating gaps.
+- Example of a single parent-child connection:
+  ┌──────────┐
+  │  Parent   │
+  └────┬──────┘
+       │
+       ▼
+  ┌──────────┐
+  │  Child    │
+  └──────────┘
+- Example of a parent with multiple children:
+  ┌──────────────┐
+  │    Parent     │
+  └──┬─────┬────┬┘
+     │     │    │
+     ▼     ▼    ▼
+  ┌────┐┌────┐┌────┐
+  │ A  ││ B  ││ C  │
+  └────┘└────┘└────┘
+- Always include ▼ arrows to show direction of flow.
+- Keep boxes aligned and use consistent spacing.
+
+Always provide BOTH the Mermaid syntax (for future use) and the ASCII rendering (for immediate terminal display).
+
+The user wants to visualize: `;
+
+export const visualizeCommand: SlashCommand = {
+  name: 'visualize',
+  description:
+    'Analyze the codebase and generate a Mermaid diagram rendered as ASCII art',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: false,
+  action: async (
+    context: CommandContext,
+    args: string,
+  ): Promise<SlashCommandActionReturn> => {
+    const userRequest = args?.trim() || context.invocation?.args?.trim() || '';
+
+    if (!userRequest) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content:
+          'Please specify what to visualize. Usage: /visualize <description>\nExample: /visualize architecture of this project',
+      };
+    }
+
+    return {
+      type: 'submit_prompt',
+      content: [{ text: VISUALIZE_PROMPT + userRequest }],
+    };
+  },
+};

--- a/packages/cli/src/ui/commands/visualizeCommand.ts
+++ b/packages/cli/src/ui/commands/visualizeCommand.ts
@@ -45,9 +45,7 @@ ASCII diagram rules:
 - Always include ▼ arrows to show direction of flow.
 - Keep boxes aligned and use consistent spacing.
 
-Always provide BOTH the Mermaid syntax (for future use) and the ASCII rendering (for immediate terminal display).
-
-The user wants to visualize: `;
+Always provide BOTH the Mermaid syntax (for future use) and the ASCII rendering (for immediate terminal display).`;
 
 export const visualizeCommand: SlashCommand = {
   name: 'visualize',
@@ -72,7 +70,10 @@ export const visualizeCommand: SlashCommand = {
 
     return {
       type: 'submit_prompt',
-      content: [{ text: VISUALIZE_PROMPT + userRequest }],
+      content: [
+        { text: VISUALIZE_PROMPT },
+        { text: `User request: ${userRequest}` },
+      ],
     };
   },
 };


### PR DESCRIPTION
## Summary

Adds a `/visualize` slash command that analyzes the codebase and generates both Mermaid diagram syntax and ASCII text art renderings for terminal display.

## Details

- New file: `packages/cli/src/ui/commands/visualizeCommand.ts`
- Registered in `BuiltinCommandLoader.ts`
- Returns `submit_prompt` so Gemini processes the visualization request in the agentic loop
- Outputs both Mermaid syntax (for future use) and ASCII art (for immediate terminal display)

## Usage

/visualize architecture of this project
/visualize data flow of the auth module
/visualize class hierarchy of the tools system