### PR TITLE
Add fallback to encrypted file for extensions when keychain is missing

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -174,6 +174,8 @@ export type {
   OAuthCredentials,
 } from './mcp/token-storage/types.js';
 export { MCPOAuthTokenStorage } from './mcp/oauth-token-storage.js';
+export { HybridSecretStorage } from './mcp/token-storage/hybrid-secret-storage.js';
+export { KeychainTokenStorage } from './mcp/token-storage/keychain-token-storage.js';
 export type { MCPOAuthConfig } from './mcp/oauth-provider.js';
 export type {
   OAuthAuthorizationServerMetadata,

--- a/packages/core/src/mcp/token-storage/encrypted-file-secret-storage.ts
+++ b/packages/core/src/mcp/token-storage/encrypted-file-secret-storage.ts
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as crypto from 'node:crypto';
+import type { SecretStorage } from './types.js';
+import { GEMINI_DIR, homedir } from '../../utils/paths.js';
+
+export class EncryptedFileSecretStorage implements SecretStorage {
+  private readonly tokenFilePath: string;
+  private readonly encryptionKey: Buffer;
+  private readonly serviceName: string;
+
+  constructor(serviceName: string) {
+    this.serviceName = serviceName;
+    const configDir = path.join(homedir(), GEMINI_DIR);
+    this.tokenFilePath = path.join(configDir, 'extension-secrets-v1.json');
+    this.encryptionKey = this.deriveEncryptionKey();
+  }
+
+  private deriveEncryptionKey(): Buffer {
+    const salt = `${os.hostname()}-${os.userInfo().username}-gemini-cli`;
+    return crypto.scryptSync('gemini-cli-secrets', salt, 32);
+  }
+
+  private encrypt(text: string): string {
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv('aes-256-gcm', this.encryptionKey, iv);
+
+    let encrypted = cipher.update(text, 'utf8', 'hex');
+    encrypted += cipher.final('hex');
+
+    const authTag = cipher.getAuthTag();
+
+    return iv.toString('hex') + ':' + authTag.toString('hex') + ':' + encrypted;
+  }
+
+  private decrypt(encryptedData: string): string {
+    const parts = encryptedData.split(':');
+    if (parts.length !== 3) {
+      throw new Error('Invalid encrypted data format');
+    }
+
+    const iv = Buffer.from(parts[0], 'hex');
+    const authTag = Buffer.from(parts[1], 'hex');
+    const encrypted = parts[2];
+
+    const decipher = crypto.createDecipheriv(
+      'aes-256-gcm',
+      this.encryptionKey,
+      iv,
+    );
+    decipher.setAuthTag(authTag);
+
+    let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+    decrypted += decipher.final('utf8');
+
+    return decrypted;
+  }
+
+  private async ensureDirectoryExists(): Promise<void> {
+    const dir = path.dirname(this.tokenFilePath);
+    await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+  }
+
+  private async loadSecrets(): Promise<Record<string, Record<string, string>>> {
+    try {
+      const data = await fs.readFile(this.tokenFilePath, 'utf-8');
+      const decrypted = this.decrypt(data);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      return JSON.parse(decrypted) as Record<string, Record<string, string>>;
+    } catch (error: unknown) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      const err = error as NodeJS.ErrnoException & { message?: string };
+      if (err.code === 'ENOENT') {
+        return {};
+      }
+      if (
+        err.message?.includes('Invalid encrypted data format') ||
+        err.message?.includes(
+          'Unsupported state or unable to authenticate data',
+        )
+      ) {
+        throw new Error(
+          `Corrupted secret file detected at: ${this.tokenFilePath}
+` + `Please delete or rename this file to resolve the issue.`,
+        );
+      }
+      throw error;
+    }
+  }
+
+  private async saveSecrets(
+    secrets: Record<string, Record<string, string>>,
+  ): Promise<void> {
+    await this.ensureDirectoryExists();
+    const json = JSON.stringify(secrets, null, 2);
+    const encrypted = this.encrypt(json);
+    await fs.writeFile(this.tokenFilePath, encrypted, { mode: 0o600 });
+  }
+
+  async setSecret(key: string, value: string): Promise<void> {
+    const allSecrets = await this.loadSecrets();
+    if (!allSecrets[this.serviceName]) {
+      allSecrets[this.serviceName] = {};
+    }
+    allSecrets[this.serviceName][key] = value;
+    await this.saveSecrets(allSecrets);
+  }
+
+  async getSecret(key: string): Promise<string | null> {
+    const allSecrets = await this.loadSecrets();
+    return allSecrets[this.serviceName]?.[key] || null;
+  }
+
+  async deleteSecret(key: string): Promise<void> {
+    const allSecrets = await this.loadSecrets();
+    if (allSecrets[this.serviceName]?.[key]) {
+      delete allSecrets[this.serviceName][key];
+      // Clean up empty service object
+      if (Object.keys(allSecrets[this.serviceName]).length === 0) {
+        delete allSecrets[this.serviceName];
+      }
+
+      if (Object.keys(allSecrets).length === 0) {
+        try {
+          await fs.unlink(this.tokenFilePath);
+        } catch (error: unknown) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          const err = error as NodeJS.ErrnoException;
+          if (err.code !== 'ENOENT') {
+            throw error;
+          }
+        }
+      } else {
+        await this.saveSecrets(allSecrets);
+      }
+    } else {
+      throw new Error(`No secret found for key: ${key}`);
+    }
+  }
+
+  async listSecrets(): Promise<string[]> {
+    const allSecrets = await this.loadSecrets();
+    return Object.keys(allSecrets[this.serviceName] || {});
+  }
+}

--- a/packages/core/src/mcp/token-storage/hybrid-secret-storage.ts
+++ b/packages/core/src/mcp/token-storage/hybrid-secret-storage.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { KeychainTokenStorage } from './keychain-token-storage.js';
+import { EncryptedFileSecretStorage } from './encrypted-file-secret-storage.js';
+import type { SecretStorage } from './types.js';
+
+export class HybridSecretStorage implements SecretStorage {
+  private storage: SecretStorage | null = null;
+  private storageInitPromise: Promise<SecretStorage> | null = null;
+  private readonly serviceName: string;
+
+  constructor(serviceName: string) {
+    this.serviceName = serviceName;
+  }
+
+  private async initializeStorage(): Promise<SecretStorage> {
+    const keychainStorage = new KeychainTokenStorage(this.serviceName);
+    const isAvailable = await keychainStorage.isAvailable();
+    if (isAvailable) {
+      this.storage = keychainStorage;
+    } else {
+      this.storage = new EncryptedFileSecretStorage(this.serviceName);
+    }
+    return this.storage;
+  }
+
+  private async getStorage(): Promise<SecretStorage> {
+    if (this.storage !== null) {
+      return this.storage;
+    }
+
+    if (!this.storageInitPromise) {
+      this.storageInitPromise = this.initializeStorage();
+    }
+
+    return this.storageInitPromise;
+  }
+
+  async setSecret(key: string, value: string): Promise<void> {
+    const storage = await this.getStorage();
+    await storage.setSecret(key, value);
+  }
+
+  async getSecret(key: string): Promise<string | null> {
+    const storage = await this.getStorage();
+    return storage.getSecret(key);
+  }
+
+  async deleteSecret(key: string): Promise<void> {
+    const storage = await this.getStorage();
+    await storage.deleteSecret(key);
+  }
+
+  async listSecrets(): Promise<string[]> {
+    const storage = await this.getStorage();
+    return storage.listSecrets();
+  }
+}


### PR DESCRIPTION
## Summary

This PR implements a fallback mechanism for extension settings that were
previously only stored in the system keychain. If keychain access fails or is
unavailable, sensitive settings are now automatically and securely stored in an
encrypted file.

## Details

- **New storage implementations**: Added `EncryptedFileSecretStorage` and
  `HybridSecretStorage` to `@google/gemini-cli-core`.
  - `EncryptedFileSecretStorage` uses AES-256-GCM to store secrets in a local
    JSON file (`extension-secrets-v1.json`).
  - `HybridSecretStorage` provides a unified interface that prefers the system
    keychain but falls back to the encrypted file if the keychain is
    non-functional.
- **Refactored extension settings**: Updated the CLI's extension settings logic
  to use the new `HybridSecretStorage`. This ensures that extension
  configurations (like API keys) are persisted even on systems where keychain
  integration is restricted or broken.
- **Improved resilience**: Removed explicit keychain availability checks from
  the CLI layer, as the storage abstraction now handles these transitions
  internally.

## Technical details

- The encryption key for the fallback storage is derived using `scrypt` with a
  machine-specific salt (hostname and username).
- All sensitive data is stored with file permissions restricted to the current
  user (0600).
- Updated existing test suites to verify both keychain and fallback file paths.
## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
