### PR TITLE
Add install instructions for arch linux

### DIFF
--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -26,6 +26,7 @@ installation methods:
 - npm
 - Homebrew
 - MacPorts
+- Arch Linux (pacman)
 - Anaconda
 
 Note that Gemini CLI comes pre-installed on
@@ -48,6 +49,12 @@ brew install gemini-cli
 
 ```bash
 sudo port install gemini-cli
+```
+
+### Install globally with Arch Linux (pacman)
+
+```bash
+sudo pacman -S gemini-cli
 ```
 
 ### Install with Anaconda (for restricted environments)


### PR DESCRIPTION
## Summary

This PR adds installation instructions for Arch Linux users using the pacman package manager to the Getting Started guide.

## Details

The changes include:
 - Adding "Arch Linux (pacman)" to the list of recommended installation methods.
 - Providing a dedicated section with the command sudo pacman -S gemini-cli.


This ensures that Arch Linux users have clear, native instructions for installing the Gemini CLI. Arch supports gemini-cli, see [arch wiki](https://archlinux.org/packages/extra/x86_64/gemini-cli/) and [arch package source files](https://gitlab.archlinux.org/archlinux/packaging/packages/gemini-cli).

## Related Issues

N/A

## How to Validate

FYI: Validated on my setup since I use arch btw.

- Install arch linux
- Run `sudo pacman -S gemini-cli`
- Run gemini-cli

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
