### PR TITLE
fix: prevent spam loop when preferredEditor is invalid

### DIFF
--- a/packages/cli/src/ui/components/EditorSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/EditorSettingsDialog.tsx
@@ -5,7 +5,7 @@
  */
 
 import type React from 'react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../semantic-colors.js';
 import {
@@ -71,13 +71,21 @@ export function EditorSettingsDialog({
         (item: EditorDisplay) => item.type === currentPreference,
       )
     : 0;
-  if (editorIndex === -1) {
-    coreEvents.emitFeedback(
-      'error',
-      `Editor is not supported: ${currentPreference}`,
-    );
+  const isUnsupportedEditor = editorIndex === -1;
+  if (isUnsupportedEditor) {
     editorIndex = 0;
   }
+
+  const hasEmittedUnsupportedError = useRef(false);
+  useEffect(() => {
+    if (isUnsupportedEditor && !hasEmittedUnsupportedError.current) {
+      hasEmittedUnsupportedError.current = true;
+      coreEvents.emitFeedback(
+        'error',
+        `Editor is not supported: ${currentPreference}`,
+      );
+    }
+  }, [isUnsupportedEditor, currentPreference]);
 
   const scopeItems: Array<{
     label: string;

--- a/packages/cli/src/ui/components/EditorSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/EditorSettingsDialog.tsx
@@ -76,14 +76,14 @@ export function EditorSettingsDialog({
     editorIndex = 0;
   }
 
-  const hasEmittedUnsupportedError = useRef(false);
+  const reportedInvalidEditors = useRef(new Set<string>());
   useEffect(() => {
-    if (isUnsupportedEditor && !hasEmittedUnsupportedError.current) {
-      hasEmittedUnsupportedError.current = true;
+    if (isUnsupportedEditor && currentPreference && !reportedInvalidEditors.current.has(currentPreference)) {
       coreEvents.emitFeedback(
         'error',
         `Editor is not supported: ${currentPreference}`,
       );
+      reportedInvalidEditors.current.add(currentPreference);
     }
   }, [isUnsupportedEditor, currentPreference]);
 


### PR DESCRIPTION
## Problem

When `general.preferredEditor` in `settings.json` is set to an invalid/unsupported value, opening the `/editor` menu causes infinite spam of "Editor is not supported" messages, making the UI unusable.

## Root Cause

The error feedback was emitted directly inside the React render function of `EditorSettingsDialog`. Since React re-renders on every state change (and the error emission itself could trigger re-renders via feedback events), this created an infinite loop.

## Fix

Moved the error emission into a `useEffect` hook with a `useRef` guard, ensuring the "Editor is not supported" message is only displayed once per invalid editor value, rather than on every render cycle.

Fixes #16091