### PR TITLE
Fix: interactive mode exits on Synology SSH and leaves terminal artifacts (#20213)

### DIFF
--- a/packages/cli/src/ui/utils/commandUtils.test.ts
+++ b/packages/cli/src/ui/utils/commandUtils.test.ts
@@ -184,6 +184,11 @@ describe('commandUtils', () => {
       expect(isAtCommand('hello@file')).toBe(false);
       expect(isAtCommand('text@path')).toBe(false);
     });
+
+    it('should return false for non-string input', () => {
+      expect(isAtCommand(123 as unknown as string)).toBe(false);
+      expect(isAtCommand({ text: '@file' } as unknown as string)).toBe(false);
+    });
   });
 
   describe('isSlashCommand', () => {
@@ -214,6 +219,11 @@ describe('commandUtils', () => {
       expect(isSlashCommand('/* This is a block comment */')).toBe(false);
       expect(isSlashCommand('/*\n * Multi-line comment\n */')).toBe(false);
       expect(isSlashCommand('/*comment without space*/')).toBe(false);
+    });
+
+    it('should return false for non-string input', () => {
+      expect(isSlashCommand(123 as unknown as string)).toBe(false);
+      expect(isSlashCommand({ cmd: '/help' } as unknown as string)).toBe(false);
     });
   });
 

--- a/packages/cli/src/ui/utils/commandUtils.ts
+++ b/packages/cli/src/ui/utils/commandUtils.ts
@@ -20,8 +20,9 @@ import type { Settings } from '../../config/settingsSchema.js';
  * @returns True if the query looks like an '@' command, false otherwise.
  */
 export const isAtCommand = (query: string): boolean =>
+  typeof query === 'string' &&
   // Check if starts with @ OR has a space, then @
-  query.startsWith('@') || /\s@/.test(query);
+  (query.startsWith('@') || /\s@/.test(query));
 
 /**
  * Checks if a query string potentially represents an '/' command.
@@ -31,6 +32,10 @@ export const isAtCommand = (query: string): boolean =>
  * @returns True if the query looks like an '/' command, false otherwise.
  */
 export const isSlashCommand = (query: string): boolean => {
+  if (typeof query !== 'string') {
+    return false;
+  }
+
   if (!query.startsWith('/')) {
     return false;
   }


### PR DESCRIPTION
This PR fixes interactive-mode failures on Synology SSH terminals where Gemini exited immediately and left terminal artifacts (m prefix / raw escape sequences like ^[[O).

What changed
Hardened command parsing:

isSlashCommand and isAtCommand now safely handle non-string inputs and return false instead of throwing.
Prevents TypeError: query.startsWith is not a function.
Made terminal capability probing safer over SSH:

Skip active capability probes on generic SSH terminals (xterm, xterm-256color, screen, tmux, etc.) to avoid escape-sequence leakage/corruption.
Added opt-in override:
GEMINI_CLI_FORCE_TERMINAL_CAPABILITY_PROBES=1|true
Tests
Added/updated tests for:

non-string command input handling (commandUtils.test.ts)
SSH generic-terminal probe skipping behavior (terminalCapabilityManager.test.ts)
Targeted suite result:

59 passed
Expected impact
Interactive mode should remain stable on Synology SSH sessions.
Terminal state should return cleanly on exit (no leading m, no raw control-sequence artifacts).
No behavioral change for standard local terminals unless explicitly overridden.