### PR TITLE
fix(mcp): use httpUrl for http transport backward compatibility

### DIFF
--- a/packages/cli/src/commands/mcp/add.test.ts
+++ b/packages/cli/src/commands/mcp/add.test.ts
@@ -115,8 +115,12 @@ describe('mcp add command', () => {
     expect(mockSetValue).toHaveBeenCalledWith(SettingScope.User, 'mcpServers', {
       'sse-server': {
         url: 'https://example.com/sse-endpoint',
-        type: 'sse',
         headers: { 'X-API-Key': 'your-key' },
+        timeout: undefined,
+        trust: undefined,
+        description: undefined,
+        includeTools: undefined,
+        excludeTools: undefined,
       },
     });
   });
@@ -131,9 +135,13 @@ describe('mcp add command', () => {
       'mcpServers',
       {
         'http-server': {
-          url: 'https://example.com/mcp',
-          type: 'http',
+          httpUrl: 'https://example.com/mcp',
           headers: { Authorization: 'Bearer your-token' },
+          timeout: undefined,
+          trust: undefined,
+          description: undefined,
+          includeTools: undefined,
+          excludeTools: undefined,
         },
       },
     );
@@ -147,8 +155,12 @@ describe('mcp add command', () => {
     expect(mockSetValue).toHaveBeenCalledWith(SettingScope.User, 'mcpServers', {
       'sse-server': {
         url: 'https://example.com/sse',
-        type: 'sse',
         headers: { 'X-API-Key': 'your-key' },
+        timeout: undefined,
+        trust: undefined,
+        description: undefined,
+        includeTools: undefined,
+        excludeTools: undefined,
       },
     });
   });
@@ -163,9 +175,13 @@ describe('mcp add command', () => {
       'mcpServers',
       {
         'http-server': {
-          url: 'https://example.com/mcp',
-          type: 'http',
+          httpUrl: 'https://example.com/mcp',
           headers: { Authorization: 'Bearer your-token' },
+          timeout: undefined,
+          trust: undefined,
+          description: undefined,
+          includeTools: undefined,
+          excludeTools: undefined,
         },
       },
     );

--- a/packages/cli/src/commands/mcp/add.ts
+++ b/packages/cli/src/commands/mcp/add.ts
@@ -69,7 +69,6 @@ async function addMcpServer(
     case 'sse':
       newServer = {
         url: commandOrUrl,
-        type: 'sse',
         headers,
         timeout,
         trust,
@@ -80,8 +79,7 @@ async function addMcpServer(
       break;
     case 'http':
       newServer = {
-        url: commandOrUrl,
-        type: 'http',
+        httpUrl: commandOrUrl,
         headers,
         timeout,
         trust,


### PR DESCRIPTION
## Summary

Fixes the `mcp add` command generating `type` properties in the `settings.json` which trigger unrecognised key validation errors in older CLIs. It implements the backwards compatible fix by setting the `httpUrl` property instead.

## Details

- Removed `type` property generation from HTTP and SSE transport server configurations inside `add.ts`.
- Switched default `url` back to `httpUrl` for HTTP.
- Updated unit tests in `add.test.ts` to assert against the updated backwards-compatible `MCPServerConfig` object shape.
- Fixed an `Unsafe any assertion` TypeScript lint error within `packages/a2a-server/src/agent/task.ts`.

## Related Issues

Resolves #16169

## How to Validate

1. Run `npm run start -- mcp add --scope user --transport http hyphen-mcp https://dev-mcp.hyphen.ai/`.
2. Observe `~/.gemini/settings.json` contains `httpUrl: "https://dev-mcp.hyphen.ai/"` without `type: "http"`.
3. Run `npm run start -- mcp list` and observe it lists successfully without crashing.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
