### PR TITLE
fix(core): generate unique session IDs for subagents

### DIFF
--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -101,6 +101,40 @@ describe('ChatRecordingService', () => {
       expect(conversation.kind).toBe('subagent');
     });
 
+    it('should generate a unique session ID for subagents', () => {
+      chatRecordingService.initialize(undefined, 'subagent');
+      chatRecordingService.recordMessage({
+        type: 'user',
+        content: 'ping',
+        model: 'm',
+      });
+
+      const sessionFile = chatRecordingService.getConversationFilePath()!;
+      const conversation = JSON.parse(
+        fs.readFileSync(sessionFile, 'utf8'),
+      ) as ConversationRecord;
+
+      // The subagent session ID should differ from the parent config's ID
+      expect(conversation.sessionId).not.toBe('test-session-id');
+    });
+
+    it('should use the parent session ID for main sessions', () => {
+      chatRecordingService.initialize(undefined, 'main');
+      chatRecordingService.recordMessage({
+        type: 'user',
+        content: 'ping',
+        model: 'm',
+      });
+
+      const sessionFile = chatRecordingService.getConversationFilePath()!;
+      const conversation = JSON.parse(
+        fs.readFileSync(sessionFile, 'utf8'),
+      ) as ConversationRecord;
+
+      // Main sessions should keep the config-provided session ID
+      expect(conversation.sessionId).toBe('test-session-id');
+    });
+
     it('should resume from an existing session if provided', () => {
       const chatsDir = path.join(testTempDir, 'chats');
       fs.mkdirSync(chatsDir, { recursive: true });

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -154,6 +154,13 @@ export class ChatRecordingService {
   ): void {
     try {
       this.kind = kind;
+
+      // Subagents must use their own unique session ID to avoid colliding
+      // with the parent session's file name and session data.
+      if (kind === 'subagent' && !resumedSessionData) {
+        this.sessionId = randomUUID();
+      }
+
       if (resumedSessionData) {
         // Resume from existing session
         this.conversationFile = resumedSessionData.filePath;


### PR DESCRIPTION
## Description

Subagents currently inherit the parent session's ID via `config.getSessionId()`, which means both the parent and its subagent write session recordings to files keyed by the same session ID under `.gemini/tmp/*/chats/`. On clean exit this is masked by automatic cleanup, but on abrupt termination (crash, SIGKILL) the stale subagent file persists and blocks session resumption — the parent cannot distinguish its own recording from the subagent's.

This change generates a fresh `randomUUID()` for subagent sessions inside `ChatRecordingService.initialize()`, giving each subagent its own isolated file path. Resumed subagent sessions continue to load from their existing file as before.

## Changes

- **`packages/core/src/services/chatRecordingService.ts`** — When `kind === 'subagent'` and not resuming, reassign `this.sessionId` to a new UUID before the conversation file is created.
- **`packages/core/src/services/chatRecordingService.test.ts`** — Two new tests verifying subagents get a unique session ID and main sessions keep the config-provided one.

## Testing

- All existing `chatRecordingService` tests pass (27/27)
- All `local-executor` tests pass (40/40)
- All `geminiChat` tests pass (48/48)
- `npm run preflight` passes (build + lint + format + tests)

Fixes #20258