### PR TITLE
fix(core): resolve subagent session collision

### DIFF
--- a/packages/core/src/agents/local-executor.test.ts
+++ b/packages/core/src/agents/local-executor.test.ts
@@ -582,6 +582,12 @@ describe('LocalAgentExecutor', () => {
 
       // Verify other properties still work
       expect(passedConfig.getMessageBus()).toBe(mockConfig.getMessageBus());
+
+      // Verify referential equality for methods
+      const bus1 = passedConfig.getMessageBus();
+      const bus2 = passedConfig.getMessageBus();
+      expect(bus1).toBe(bus2);
+      expect(bus1).toBeDefined();
     });
   });
 

--- a/packages/core/src/agents/local-executor.test.ts
+++ b/packages/core/src/agents/local-executor.test.ts
@@ -28,6 +28,7 @@ import {
   StreamEventType,
   type StreamEvent,
 } from '../core/geminiChat.js';
+import { createSessionId } from '../utils/session.js';
 import {
   type FunctionCall,
   type Part,
@@ -140,6 +141,11 @@ vi.mock('../telemetry/clearcut-logger/clearcut-logger.js', () => ({
   ClearcutLogger: class {
     log() {}
   },
+}));
+
+vi.mock('../utils/session.js', () => ({
+  createSessionId: vi.fn(() => 'test-subagent-session-id'),
+  sessionId: 'mock-parent-session-id',
 }));
 
 vi.mock('../utils/promptIdContext.js', async (importOriginal) => {
@@ -549,6 +555,33 @@ describe('LocalAgentExecutor', () => {
       ).rejects.toThrow(/must be requested with its server prefix/);
 
       getToolSpy.mockRestore();
+    });
+
+    it('should provide a unique session ID to subagents via Proxy', async () => {
+      const definition = createTestDefinition([]);
+      const executor = await LocalAgentExecutor.create(
+        definition,
+        mockConfig,
+        onActivity,
+      );
+
+      // Call createChatObject (it's private)
+      // @ts-expect-error - testing private method
+      await executor.createChatObject({ goal: 'test' }, []);
+
+      // Check that GeminiChat was instantiated with the proxied config
+      expect(MockedGeminiChat).toHaveBeenCalled();
+      expect(createSessionId).toHaveBeenCalled();
+      const passedConfig = MockedGeminiChat.mock.calls[0][0];
+
+      // Verify it's a proxy/different object but same base behavior
+      expect(passedConfig).not.toBe(mockConfig);
+
+      // Verify getSessionId returns the new session ID
+      expect(passedConfig.getSessionId()).toBe('test-subagent-session-id');
+
+      // Verify other properties still work
+      expect(passedConfig.getMessageBus()).toBe(mockConfig.getMessageBus());
     });
   });
 


### PR DESCRIPTION
## Summary

This PR resolves a session collision bug where custom subagents (like`cli_help`) share the parent's `sessionId`, leading to the parent's session state being overwritten by the subagent's initialization.

## Details

The fix ensures that each subagent execution receives a unique, ephemeral `sessionId`. To achieve this without modifying the global configuration or core classes in a breaking way, I implemented a JavaScript `Proxy` for the `Config`object passed to `GeminiChat` within `LocalAgentExecutor`.

The proxy intercepts `getSessionId()` calls and returns a freshly generated UUID (using `createSessionId()`). All other configuration properties and methods are transparently delegated to the original parent `Config`. This allows subagents
to have their own session files with unique IDs while preserving the parent's interaction history.

## Related Issues

Closes #20258

## How to Validate

1. **Manual Verification**:
   - Run the CLI: `npm run start`
   - Invoke a custom subagent: `@cli_help what is your name?`
   - Exit the CLI.
   - Check the `.gemini/tmp/<hash>/chats/` directory. You should see two distinct session files.
   - Resume the session: `npm run start -- --resume latest`. Verify the parent state is preserved.

2. **Automated Verification**:
   - Run the new unit test: `npm test -w @google/gemini-cli-core -- src/agents/local-executor.test.ts`
   - Verify the test case `should provide a unique session ID to subagents via Proxy` passes.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
