### PR TITLE
feat(cli): Add --playground flag for Antigravity playgrounds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2292,7 +2292,6 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -2473,7 +2472,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2523,7 +2521,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
       "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2898,7 +2895,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.0.tgz",
       "integrity": "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2932,7 +2928,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.0.tgz",
       "integrity": "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/resources": "2.5.0"
@@ -2987,7 +2982,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.0.tgz",
       "integrity": "sha512-VzRf8LzotASEyNDUxTdaJ9IRJ1/h692WyArDBInf5puLCjxbICD6XkHgpuudis56EndyS7LYFmtTMny6UABNdQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/resources": "2.5.0",
@@ -4184,7 +4178,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4458,7 +4451,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -5306,7 +5298,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7860,7 +7851,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8493,7 +8483,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9788,7 +9777,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
       "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10068,7 +10056,6 @@
       "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.4.11.tgz",
       "integrity": "sha512-93LQlzT7vvZ1XJcmOMwN4s+6W334QegendeHOMnEJBlhnpIzr8bws6/aOEHG8ZCuVD/vNeeea5m1msHIdAY6ig==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.1",
         "ansi-escapes": "^7.0.0",
@@ -13718,7 +13705,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13729,7 +13715,6 @@
       "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -15689,7 +15674,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15913,8 +15897,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.20.3",
@@ -15922,7 +15905,6 @@
       "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -16082,7 +16064,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16291,7 +16272,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -16405,7 +16385,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16418,7 +16397,6 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -17063,7 +17041,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -17463,7 +17440,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -72,6 +72,7 @@ export interface CliArgs {
   query: string | undefined;
   model: string | undefined;
   sandbox: boolean | string | undefined;
+  playground: boolean | undefined;
   debug: boolean | undefined;
   prompt: string | undefined;
   promptInteractive: string | undefined;
@@ -146,6 +147,11 @@ export async function parseArguments(
           alias: 's',
           type: 'boolean',
           description: 'Run in sandbox?',
+        })
+        .option('playground', {
+          type: 'boolean',
+          description:
+            'Create a new playground directory in the Antigravity playgrounds folder and start the CLI there.',
         })
 
         .option('yolo', {

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -474,6 +474,7 @@ describe('gemini.tsx main function kitty protocol', () => {
     vi.mocked(parseArguments).mockResolvedValue({
       model: undefined,
       sandbox: undefined,
+      playground: undefined,
       debug: undefined,
       prompt: undefined,
       promptInteractive: undefined,

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -370,6 +370,27 @@ export async function main() {
   const argv = await parseArguments(settings.merged);
   parseArgsHandle?.end();
 
+  // Handle --playground flag: create new playground directory and cd into it
+  if (argv.playground) {
+    const { setupPlayground, getPlaygroundsPath } = await import(
+      './utils/playground.js'
+    );
+    try {
+      const playgroundPath = setupPlayground();
+      coreEvents.emitFeedback(
+        'info',
+        `Created new playground: ${playgroundPath}`,
+      );
+    } catch (error) {
+      const playgroundsPath = getPlaygroundsPath();
+      writeToStderr(
+        `Error: Could not create playground directory in ${playgroundsPath}.\n${error instanceof Error ? error.message : String(error)}\n`,
+      );
+      await runExitCleanup();
+      process.exit(ExitCodes.FATAL_INPUT_ERROR);
+    }
+  }
+
   if (
     (argv.allowedTools && argv.allowedTools.length > 0) ||
     (settings.merged.tools?.allowed && settings.merged.tools.allowed.length > 0)

--- a/packages/cli/src/utils/playground.test.ts
+++ b/packages/cli/src/utils/playground.test.ts
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  getPlaygroundsPath,
+  generatePlaygroundName,
+  createPlaygroundDirectory,
+  setupPlayground,
+} from './playground.js';
+
+vi.mock('node:fs');
+vi.mock('@google/gemini-cli-core', () => ({
+  homedir: () => '/home/testuser',
+  debugLogger: {
+    log: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('playground utilities', () => {
+  const originalPlatform = process.platform;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+    process.env = originalEnv;
+    // Restore chdir mock
+    vi.restoreAllMocks();
+  });
+
+  describe('getPlaygroundsPath', () => {
+    it('should return environment variable path when set', () => {
+      process.env['ANTIGRAVITY_PLAYGROUNDS_PATH'] = '/custom/playgrounds';
+      expect(getPlaygroundsPath()).toBe('/custom/playgrounds');
+    });
+
+    it('should return macOS default path when on darwin', () => {
+      delete process.env['ANTIGRAVITY_PLAYGROUNDS_PATH'];
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      expect(getPlaygroundsPath()).toBe(
+        path.join(
+          '/home/testuser',
+          'Library',
+          'Application Support',
+          'Antigravity',
+          'User',
+          'playgrounds',
+        ),
+      );
+    });
+
+    it('should return Windows default path when on win32', () => {
+      delete process.env['ANTIGRAVITY_PLAYGROUNDS_PATH'];
+      process.env['APPDATA'] = 'C:\\Users\\test\\AppData\\Roaming';
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      expect(getPlaygroundsPath()).toBe(
+        path.join(
+          'C:\\Users\\test\\AppData\\Roaming',
+          'Antigravity',
+          'User',
+          'playgrounds',
+        ),
+      );
+    });
+
+    it('should return Linux default path when on linux', () => {
+      delete process.env['ANTIGRAVITY_PLAYGROUNDS_PATH'];
+      delete process.env['XDG_CONFIG_HOME'];
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      expect(getPlaygroundsPath()).toBe(
+        path.join(
+          '/home/testuser',
+          '.config',
+          'Antigravity',
+          'User',
+          'playgrounds',
+        ),
+      );
+    });
+
+    it('should use XDG_CONFIG_HOME on Linux when set', () => {
+      delete process.env['ANTIGRAVITY_PLAYGROUNDS_PATH'];
+      process.env['XDG_CONFIG_HOME'] = '/custom/config';
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      expect(getPlaygroundsPath()).toBe(
+        path.join('/custom/config', 'Antigravity', 'User', 'playgrounds'),
+      );
+    });
+  });
+
+  describe('generatePlaygroundName', () => {
+    it('should generate a name starting with playground-', () => {
+      const name = generatePlaygroundName();
+      expect(name).toMatch(/^playground-\d{14}-[a-z0-9]{6}$/);
+    });
+
+    it('should generate unique names on repeated calls', () => {
+      const name1 = generatePlaygroundName();
+      const name2 = generatePlaygroundName();
+      expect(name1).not.toBe(name2);
+    });
+  });
+
+  describe('createPlaygroundDirectory', () => {
+    it('should create parent directory if it does not exist', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+
+      process.env['ANTIGRAVITY_PLAYGROUNDS_PATH'] = '/test/playgrounds';
+      const result = createPlaygroundDirectory();
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith('/test/playgrounds', {
+        recursive: true,
+      });
+      expect(result).toMatch(/^\/test\/playgrounds\/playground-/);
+    });
+
+    it('should not create parent directory if it already exists', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+
+      process.env['ANTIGRAVITY_PLAYGROUNDS_PATH'] = '/test/playgrounds';
+      createPlaygroundDirectory();
+
+      // Only called once for the playground directory itself
+      expect(fs.mkdirSync).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setupPlayground', () => {
+    it('should create directory and change to it', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+      const chdirSpy = vi.spyOn(process, 'chdir').mockImplementation(() => {});
+
+      process.env['ANTIGRAVITY_PLAYGROUNDS_PATH'] = '/test/playgrounds';
+      const result = setupPlayground();
+
+      expect(result).toMatch(/^\/test\/playgrounds\/playground-/);
+      expect(chdirSpy).toHaveBeenCalledWith(result);
+    });
+  });
+});

--- a/packages/cli/src/utils/playground.ts
+++ b/packages/cli/src/utils/playground.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { homedir, debugLogger } from '@google/gemini-cli-core';
+
+/**
+ * Default playgrounds folder path for different platforms.
+ * Users can override this with the ANTIGRAVITY_PLAYGROUNDS_PATH environment variable.
+ */
+function getDefaultPlaygroundsPath(): string {
+  const platform = process.platform;
+  const home = homedir();
+
+  switch (platform) {
+    case 'darwin':
+      return path.join(
+        home,
+        'Library',
+        'Application Support',
+        'Antigravity',
+        'User',
+        'playgrounds',
+      );
+    case 'win32':
+      return path.join(
+        process.env['APPDATA'] || path.join(home, 'AppData', 'Roaming'),
+        'Antigravity',
+        'User',
+        'playgrounds',
+      );
+    default:
+      // Linux and other Unix-like systems
+      return path.join(
+        process.env['XDG_CONFIG_HOME'] || path.join(home, '.config'),
+        'Antigravity',
+        'User',
+        'playgrounds',
+      );
+  }
+}
+
+/**
+ * Gets the playgrounds folder path from environment variable or uses default.
+ */
+export function getPlaygroundsPath(): string {
+  return (
+    process.env['ANTIGRAVITY_PLAYGROUNDS_PATH'] || getDefaultPlaygroundsPath()
+  );
+}
+
+/**
+ * Generates a unique playground directory name using timestamp and random suffix.
+ * Format: playground-YYYYMMDD-HHMMSS-XXXXXX
+ */
+export function generatePlaygroundName(): string {
+  const now = new Date();
+  const timestamp = now
+    .toISOString()
+    .replace(/[-:T]/g, '')
+    .replace(/\..+/, '')
+    .substring(0, 14); // YYYYMMDDHHMMSS
+
+  const randomSuffix = Math.random().toString(36).substring(2, 8);
+  return `playground-${timestamp}-${randomSuffix}`;
+}
+
+/**
+ * Creates a new playground directory and returns the full path.
+ * @returns The full path to the created playground directory.
+ * @throws Error if the directory cannot be created.
+ */
+export function createPlaygroundDirectory(): string {
+  const playgroundsPath = getPlaygroundsPath();
+  const playgroundName = generatePlaygroundName();
+  const fullPath = path.join(playgroundsPath, playgroundName);
+
+  debugLogger.log(`Creating playground directory: ${fullPath}`);
+
+  // Ensure the parent playgrounds directory exists
+  if (!fs.existsSync(playgroundsPath)) {
+    fs.mkdirSync(playgroundsPath, { recursive: true });
+  }
+
+  // Create the new playground directory
+  fs.mkdirSync(fullPath, { recursive: true });
+
+  return fullPath;
+}
+
+/**
+ * Sets up a new playground environment by creating the directory and changing to it.
+ * @returns The path of the created playground directory.
+ */
+export function setupPlayground(): string {
+  const playgroundPath = createPlaygroundDirectory();
+  process.chdir(playgroundPath);
+  debugLogger.log(`Changed working directory to: ${playgroundPath}`);
+  return playgroundPath;
+}


### PR DESCRIPTION
## Summary

This PR adds a new `--playground` flag to gemini-cli that automates the creation and setup of a fresh playground project directory within the Antigravity playgrounds folder.


## Details

### Problem Statement

Currently, users must manually:
1. Navigate to their desired directory
2. Create a new folder
3. cd into the folder
4. Start gemini-cli

This creates unnecessary friction when starting quick experiments or new projects, especially in the Antigravity IDE.

### Solution

The `--playground` flag automates this workflow by:
1. Creating a uniquely-named directory in the Antigravity playgrounds folder
2. Automatically changing into that directory
3. Starting gemini-cli with all other CLI flags functional (e.g., `-p`, `-i`, `--yolo`, `-m`)

### Changes

- **`packages/cli/src/config/config.ts`**: Added `playground` field to `CliArgs` interface and `--playground` flag to yargs options
- **`packages/cli/src/utils/playground.ts`**: New utility module with functions to manage playground directory creation
  - `getPlaygroundsPath()` - Returns platform-specific playgrounds folder path
  - `generatePlaygroundName()` - Creates unique, timestamped directory names
  - `createPlaygroundDirectory()` - Creates the directory with proper error handling
  - `setupPlayground()` - Sets up and changes to the new playground
- **`packages/cli/src/gemini.tsx`**: Integrated playground setup logic after argument parsing
- **`packages/cli/src/utils/playground.test.ts`**: Comprehensive unit tests (10 tests, all passing)


## Related Issues
[#20262](https://github.com/google-gemini/gemini-cli/issues/20262)

## How to Validate

**Start in new playground with interactive mode**
`gemini --playground
`
**Start in new playground with a direct prompt (headless)**
`gemini --playground -p "list files in current directory"
`
**Start in new playground with YOLO mode**
`gemini --playground --yolo
`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
