### PR TITLE
fix(cli): skip 404 errors in setup-github file downloads

### DIFF
--- a/packages/cli/src/ui/commands/setupGithubCommand.test.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.test.ts
@@ -14,6 +14,7 @@ import {
   setupGithubCommand,
   updateGitignore,
   GITHUB_WORKFLOW_PATHS,
+  GITHUB_COMMANDS_PATHS,
 } from './setupGithubCommand.js';
 import type { CommandContext } from './types.js';
 import * as commandUtils from '../utils/commandUtils.js';
@@ -192,14 +193,14 @@ describe('setupGithubCommand', async () => {
     }
   });
 
-  it('throws an error when download fails', async () => {
+  it('throws an error when download fails with non-404 error', async () => {
     const fakeRepoRoot = scratchDir;
     const fakeReleaseVersion = 'v1.2.3';
 
     vi.mocked(global.fetch).mockResolvedValue(
-      new Response('Not Found', {
-        status: 404,
-        statusText: 'Not Found',
+      new Response('Internal Server Error', {
+        status: 500,
+        statusText: 'Internal Server Error',
       }),
     );
 
@@ -215,7 +216,75 @@ describe('setupGithubCommand', async () => {
 
     await expect(
       setupGithubCommand.action?.({} as CommandContext, ''),
-    ).rejects.toThrow(/Invalid response code downloading.*404 - Not Found/);
+    ).rejects.toThrow(
+      /Invalid response code downloading.*500 - Internal Server Error/,
+    );
+  });
+
+  it('skips files that return 404 without failing', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    const fakeRepoRoot = scratchDir;
+    const fakeReleaseVersion = 'v1.2.3';
+
+    vi.mocked(global.fetch).mockImplementation(async (url) => {
+      const filename = path.basename(url.toString());
+      if (filename.endsWith('.toml')) {
+        return new Response('Not Found', {
+          status: 404,
+          statusText: 'Not Found',
+        });
+      }
+      return new Response(filename, {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'Content-Type': 'text/plain' },
+      });
+    });
+
+    vi.mocked(gitUtils.isGitHubRepository).mockReturnValueOnce(true);
+    vi.mocked(gitUtils.getGitRepoRoot).mockReturnValueOnce(fakeRepoRoot);
+    vi.mocked(gitUtils.getLatestGitHubRelease).mockResolvedValueOnce(
+      fakeReleaseVersion,
+    );
+    vi.mocked(gitUtils.getGitHubRepoInfo).mockReturnValue({
+      owner: 'fake',
+      repo: 'repo',
+    });
+    vi.mocked(commandUtils.getUrlOpenCommand).mockReturnValueOnce(
+      'fakeOpenCommand',
+    );
+
+    const result = (await setupGithubCommand.action?.(
+      {} as CommandContext,
+      '',
+    )) as ToolActionReturn;
+
+    // Command should succeed
+    expect(result.toolName).toBe('run_shell_command');
+
+    // Verify that workflow .yml files were downloaded
+    const workflows = GITHUB_WORKFLOW_PATHS.map((p) => path.basename(p));
+    for (const workflow of workflows) {
+      const workflowFile = path.join(
+        scratchDir,
+        '.github',
+        'workflows',
+        workflow,
+      );
+      const contents = await fs.readFile(workflowFile, 'utf8');
+      expect(contents).toContain(workflow);
+    }
+
+    // Verify that .toml command files were NOT written (404 was skipped)
+    const commands = GITHUB_COMMANDS_PATHS.map((p) => path.basename(p));
+    for (const cmd of commands) {
+      const cmdFile = path.join(scratchDir, '.github', 'commands', cmd);
+      const exists = await fs
+        .access(cmdFile)
+        .then(() => true)
+        .catch(() => false);
+      expect(exists).toBe(false);
+    }
   });
 });
 

--- a/packages/cli/src/ui/commands/setupGithubCommand.test.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.test.ts
@@ -197,9 +197,9 @@ describe('setupGithubCommand', async () => {
     const fakeReleaseVersion = 'v1.2.3';
 
     vi.mocked(global.fetch).mockResolvedValue(
-      new Response('Internal Server Error', {
-        status: 500,
-        statusText: 'Internal Server Error',
+      new Response('Not Found', {
+        status: 404,
+        statusText: 'Not Found',
       }),
     );
 
@@ -215,9 +215,7 @@ describe('setupGithubCommand', async () => {
 
     await expect(
       setupGithubCommand.action?.({} as CommandContext, ''),
-    ).rejects.toThrow(
-      /Invalid response code downloading.*500 - Internal Server Error/,
-    );
+    ).rejects.toThrow(/Invalid response code downloading.*404 - Not Found/);
   });
 });
 

--- a/packages/cli/src/ui/commands/setupGithubCommand.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.ts
@@ -25,6 +25,7 @@ import { debugLogger } from '@google/gemini-cli-core';
 export const GITHUB_WORKFLOW_PATHS = [
   'gemini-dispatch/gemini-dispatch.yml',
   'gemini-assistant/gemini-invoke.yml',
+  'gemini-assistant/gemini-plan-execute.yml',
   'issue-triage/gemini-triage.yml',
   'issue-triage/gemini-scheduled-triage.yml',
   'pr-review/gemini-review.yml',
@@ -32,6 +33,7 @@ export const GITHUB_WORKFLOW_PATHS = [
 
 export const GITHUB_COMMANDS_PATHS = [
   'gemini-assistant/gemini-invoke.toml',
+  'gemini-assistant/gemini-plan-execute.toml',
   'issue-triage/gemini-scheduled-triage.toml',
   'issue-triage/gemini-triage.toml',
   'pr-review/gemini-review.toml',
@@ -128,10 +130,6 @@ async function downloadFiles({
         } as RequestInit);
 
         if (!response.ok) {
-          if (response.status === 404) {
-            debugLogger.warn(`File not found, skipping: ${endpoint}`);
-            return;
-          }
           throw new Error(
             `Invalid response code downloading ${endpoint}: ${response.status} - ${response.statusText}`,
           );

--- a/packages/cli/src/ui/commands/setupGithubCommand.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.ts
@@ -128,6 +128,10 @@ async function downloadFiles({
         } as RequestInit);
 
         if (!response.ok) {
+          if (response.status === 404) {
+            debugLogger.warn(`File not found, skipping: ${endpoint}`);
+            return;
+          }
           throw new Error(
             `Invalid response code downloading ${endpoint}: ${response.status} - ${response.statusText}`,
           );


### PR DESCRIPTION
## Summary

The `/setup-github` command crashes when the latest `run-gemini-cli` release tag is missing some hardcoded file paths (e.g., `.toml` files were absent in v0.1.14, causing 404 errors). This PR makes the download gracefully skip 404 responses instead of failing the entire command.

## Details

The [downloadFiles](cci:1://file:///home/h30s/Project/gemini-cli/packages/cli/src/ui/commands/setupGithubCommand.ts:102:0-164:1) function in [setupGithubCommand.ts](cci:7://file:///home/h30s/Project/gemini-cli/packages/cli/src/ui/commands/setupGithubCommand.ts:0:0-0:0) now checks for HTTP 404 specifically and skips the file with a `debugLogger.debug` message, rather than throwing. All other non-OK responses (500, 403, etc.) still throw as before. This prevents the command from breaking when the upstream `run-gemini-cli` release doesn't include every file in the hardcoded lists.

## Related Issues

Fixes #13552

## How to Validate

1. Run the updated tests:
   ```bash
   npm test -w packages/cli -- src/ui/commands/setupGithubCommand.test.ts

2.Verify all 11 tests pass, including:
- `throws an error when download fails with non-404 error` confirms 500 still throws
- `skips files that return 404 without failing` confirms 404 is skipped gracefully and only available files are downloaded

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
