### PR TITLE
fix(policy): allow loading policy files via symbolic links

### DIFF
--- a/packages/core/src/policy/config.test.ts
+++ b/packages/core/src/policy/config.test.ts
@@ -115,8 +115,13 @@ describe('createPolicyEngineConfig', () => {
 
     vi.doMock('node:fs/promises', () => ({
       ...actualFs,
-      default: { ...actualFs, readdir: mockReaddir },
+      default: {
+        ...actualFs,
+        readdir: mockReaddir,
+        realpath: vi.fn(async (p) => p),
+      },
       readdir: mockReaddir,
+      realpath: vi.fn(async (p) => p),
     }));
 
     // Mock Storage to avoid actual filesystem access for policy dirs during tests if needed,
@@ -486,10 +491,12 @@ describe('createPolicyEngineConfig', () => {
         readdir: mockReaddir,
         readFile: mockReadFile,
         stat: mockStat,
+        realpath: vi.fn(async (p) => p),
       },
       readdir: mockReaddir,
       readFile: mockReadFile,
       stat: mockStat,
+      realpath: vi.fn(async (p) => p),
     }));
     vi.resetModules();
     const { createPolicyEngineConfig: createConfig } = await import(
@@ -705,10 +712,12 @@ priority = 150
         readFile: mockReadFile,
         readdir: mockReaddir,
         stat: mockStat,
+        realpath: vi.fn(async (p) => p),
       },
       readFile: mockReadFile,
       readdir: mockReaddir,
       stat: mockStat,
+      realpath: vi.fn(async (p) => p),
     }));
 
     vi.resetModules();
@@ -834,10 +843,12 @@ required_context = ["environment"]
         readFile: mockReadFile,
         readdir: mockReaddir,
         stat: mockStat,
+        realpath: vi.fn(async (p) => p),
       },
       readFile: mockReadFile,
       readdir: mockReaddir,
       stat: mockStat,
+      realpath: vi.fn(async (p) => p),
     }));
 
     vi.resetModules();
@@ -956,10 +967,12 @@ name = "invalid-name"
         readFile: mockReadFile,
         readdir: mockReaddir,
         stat: mockStat,
+        realpath: vi.fn(async (p) => p),
       },
       readFile: mockReadFile,
       readdir: mockReaddir,
       stat: mockStat,
+      realpath: vi.fn(async (p) => p),
     }));
 
     vi.resetModules();
@@ -1021,8 +1034,13 @@ name = "invalid-name"
     );
     vi.doMock('node:fs/promises', () => ({
       ...actualFs,
-      default: { ...actualFs, readdir: mockReaddir },
+      default: {
+        ...actualFs,
+        readdir: mockReaddir,
+        realpath: vi.fn(async (p) => p),
+      },
       readdir: mockReaddir,
+      realpath: vi.fn(async (p) => p),
     }));
 
     const { createPolicyEngineConfig } = await import('./config.js');
@@ -1122,10 +1140,12 @@ modes = ["plan"]
         readFile: mockReadFile,
         readdir: mockReaddir,
         stat: mockStat,
+        realpath: vi.fn(async (p) => p),
       },
       readFile: mockReadFile,
       readdir: mockReaddir,
       stat: mockStat,
+      realpath: vi.fn(async (p) => p),
     }));
 
     vi.resetModules();

--- a/packages/core/src/policy/integrity.ts
+++ b/packages/core/src/policy/integrity.ts
@@ -88,7 +88,8 @@ export class PolicyIntegrityManager {
     policyDir: string,
   ): Promise<{ hash: string; fileCount: number }> {
     try {
-      const files = await readPolicyFiles(policyDir);
+      const readResult = await readPolicyFiles(policyDir, 'workspace');
+      const files = readResult.files;
 
       // Sort files by path to ensure deterministic hashing
       files.sort((a, b) => a.path.localeCompare(b.path));

--- a/packages/core/src/policy/integrity.ts
+++ b/packages/core/src/policy/integrity.ts
@@ -43,7 +43,7 @@ export class PolicyIntegrityManager {
     policyDir: string,
   ): Promise<IntegrityResult> {
     const { hash: currentHash, fileCount } =
-      await PolicyIntegrityManager.calculateIntegrityHash(policyDir);
+      await PolicyIntegrityManager.calculateIntegrityHash(policyDir, scope);
     const storedData = await this.loadIntegrityData();
     const key = this.getIntegrityKey(scope, identifier);
     const storedHash = storedData[key];
@@ -86,10 +86,28 @@ export class PolicyIntegrityManager {
    */
   private static async calculateIntegrityHash(
     policyDir: string,
+    scope: string,
   ): Promise<{ hash: string; fileCount: number }> {
     try {
-      const readResult = await readPolicyFiles(policyDir, 'workspace');
-      const files = readResult.files;
+      // Map scope to tierName for readPolicyFiles
+      const tierName =
+        scope === 'user' || scope === 'admin' || scope === 'default'
+          ? scope
+          : 'workspace';
+
+      const { files, errors: readErrors } = await readPolicyFiles(
+        policyDir,
+        tierName,
+      );
+
+      if (readErrors.length > 0) {
+        const errorDetails = readErrors
+          .map((e) => `  - ${e.filePath}: ${e.details}`)
+          .join('\n');
+        debugLogger.error(
+          `[PolicyIntegrity] Unreadable policy files found in ${policyDir}, they will be excluded from the integrity hash:\n${errorDetails}`,
+        );
+      }
 
       // Sort files by path to ensure deterministic hashing
       files.sort((a, b) => a.path.localeCompare(b.path));

--- a/packages/core/src/policy/toml-loader.ts
+++ b/packages/core/src/policy/toml-loader.ts
@@ -165,7 +165,11 @@ export async function readPolicyFiles(
       baseDir = policyPath;
       const dirEntries = await fs.readdir(policyPath, { withFileTypes: true });
       filesToLoad = dirEntries
-        .filter((entry) => entry.isFile() && entry.name.endsWith('.toml'))
+        .filter(
+          (entry) =>
+            (entry.isFile() || entry.isSymbolicLink()) &&
+            entry.name.endsWith('.toml'),
+        )
         .map((entry) => entry.name);
     } else if (stats.isFile() && policyPath.endsWith('.toml')) {
       baseDir = path.dirname(policyPath);
@@ -181,8 +185,13 @@ export async function readPolicyFiles(
   const results: PolicyFile[] = [];
   for (const file of filesToLoad) {
     const filePath = path.join(baseDir, file);
-    const content = await fs.readFile(filePath, 'utf-8');
-    results.push({ path: filePath, content });
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      results.push({ path: filePath, content });
+    } catch (e) {
+      // Ignore individual file read errors (e.g., broken symlinks or directories)
+      // so we don't skip the entire directory.
+    }
   }
   return results;
 }

--- a/packages/core/src/policy/toml-loader.ts
+++ b/packages/core/src/policy/toml-loader.ts
@@ -24,6 +24,7 @@ import path from 'node:path';
 import toml from '@iarna/toml';
 import { z, type ZodError } from 'zod';
 import { isNodeError } from '../utils/errors.js';
+import { isWithinRoot } from '../utils/fileUtils.js';
 import { MCP_TOOL_PREFIX, formatMcpToolName } from '../tools/mcp-tool.js';
 
 /**
@@ -188,7 +189,28 @@ export async function readPolicyFiles(
   for (const file of filesToLoad) {
     const filePath = path.join(baseDir, file);
     try {
-      const content = await fs.readFile(filePath, 'utf-8');
+      const realFilePath = await fs.realpath(filePath);
+
+      // For workspace policies, ensure the symlink doesn't "escape" the policy directory
+      if (tierName === 'workspace') {
+        const realBaseDir = await fs.realpath(baseDir);
+        if (!isWithinRoot(realFilePath, realBaseDir)) {
+          errors.push({
+            filePath,
+            fileName: file,
+            tier: tierName,
+            errorType: 'file_read',
+            message:
+              'Security violation: Symbolic link points outside of the workspace policy directory.',
+            details: `Symlink ${file} resolves to a path outside of the policy folder. Workspace policies are restricted for security.`,
+            suggestion:
+              'To use global policies, place them in your user directory (~/.gemini/policies/) instead.',
+          });
+          continue;
+        }
+      }
+
+      const content = await fs.readFile(realFilePath, 'utf-8');
       results.push({ path: filePath, content });
     } catch (e) {
       errors.push({

--- a/packages/core/src/policy/toml-loader.ts
+++ b/packages/core/src/policy/toml-loader.ts
@@ -155,7 +155,8 @@ export interface PolicyFile {
  */
 export async function readPolicyFiles(
   policyPath: string,
-): Promise<PolicyFile[]> {
+  tierName: 'default' | 'extension' | 'user' | 'workspace' | 'admin',
+): Promise<{ files: PolicyFile[]; errors: PolicyFileError[] }> {
   let filesToLoad: string[] = [];
   let baseDir = '';
 
@@ -177,23 +178,32 @@ export async function readPolicyFiles(
     }
   } catch (e) {
     if (isNodeError(e) && e.code === 'ENOENT') {
-      return [];
+      return { files: [], errors: [] };
     }
     throw e;
   }
 
   const results: PolicyFile[] = [];
+  const errors: PolicyFileError[] = [];
   for (const file of filesToLoad) {
     const filePath = path.join(baseDir, file);
     try {
       const content = await fs.readFile(filePath, 'utf-8');
       results.push({ path: filePath, content });
     } catch (e) {
-      // Ignore individual file read errors (e.g., broken symlinks or directories)
-      // so we don't skip the entire directory.
+      errors.push({
+        filePath,
+        fileName: file,
+        tier: tierName,
+        errorType: 'file_read',
+        message: 'Failed to read policy file',
+        details: isNodeError(e) ? e.message : String(e),
+        suggestion:
+          'Check if the file is a broken symbolic link or an unreadable directory.',
+      });
     }
   }
-  return results;
+  return { files: results, errors };
 }
 
 /**
@@ -341,7 +351,9 @@ export async function loadPoliciesFromToml(
     let policyFiles: PolicyFile[] = [];
 
     try {
-      policyFiles = await readPolicyFiles(p);
+      const readResult = await readPolicyFiles(p, tierName);
+      policyFiles = readResult.files;
+      errors.push(...readResult.errors);
     } catch (e) {
       errors.push({
         filePath: p,

--- a/packages/core/src/policy/workspace-policy.test.ts
+++ b/packages/core/src/policy/workspace-policy.test.ts
@@ -117,6 +117,8 @@ priority = 10
       return '';
     });
 
+    const mockRealpath = vi.fn(async (p) => p);
+
     vi.doMock('node:fs/promises', () => ({
       ...actualFs,
       default: {
@@ -124,10 +126,12 @@ priority = 10
         readdir: mockReaddir,
         readFile: mockReadFile,
         stat: mockStat,
+        realpath: mockRealpath,
       },
       readdir: mockReaddir,
       readFile: mockReadFile,
       stat: mockStat,
+      realpath: mockRealpath,
     }));
 
     const { createPolicyEngineConfig } = await import('./config.js');
@@ -197,6 +201,8 @@ decision="allow"
 priority=10`,
     );
 
+    const mockRealpath = vi.fn(async (p) => p);
+
     vi.doMock('node:fs/promises', () => ({
       ...actualFs,
       default: {
@@ -204,10 +210,12 @@ priority=10`,
         readdir: mockReaddir,
         readFile: mockReadFile,
         stat: mockStat,
+        realpath: mockRealpath,
       },
       readdir: mockReaddir,
       readFile: mockReadFile,
       stat: mockStat,
+      realpath: mockRealpath,
     }));
 
     const { createPolicyEngineConfig } = await import('./config.js');
@@ -262,6 +270,8 @@ decision="allow"
 priority=500`,
     );
 
+    const mockRealpath = vi.fn(async (p) => p);
+
     vi.doMock('node:fs/promises', () => ({
       ...actualFs,
       default: {
@@ -269,10 +279,12 @@ priority=500`,
         readdir: mockReaddir,
         readFile: mockReadFile,
         stat: mockStat,
+        realpath: mockRealpath,
       },
       readdir: mockReaddir,
       readFile: mockReadFile,
       stat: mockStat,
+      realpath: mockRealpath,
     }));
 
     const { createPolicyEngineConfig } = await import('./config.js');


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

Policy files (*.toml) discovered via directory scanning were previously
filtered using strictly `entry.isFile()`, silently ignoring valid files
that were symlinks.

This commit updates the directory filter to include symbolic links.
Furthermore, it refactors the file reading loop inside `readPolicyFiles`
to return an object containing both successfully read files and any
accumulated read errors. This ensures that a single unreadable file
(e.g., a broken symlink or an unreadable directory ending in .toml)
gracefully reports its error instead of throwing an exception and
causing the entire policy directory to be skipped.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

Changes:
- Allowed `isSymbolicLink()` in `fs.readdir` filter for policy files.
- Added per-file `try...catch` to `readPolicyFiles` for robust loading.
- Refactored `readPolicyFiles` return type to `{ files, errors }` to pass
 errors without breaking the directory loading loop.
- Updated calls to `readPolicyFiles` in `toml-loader.ts` and
 `integrity.ts` to accommodate the new signature.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

https://github.com/google-gemini/gemini-cli/issues/20281

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

Pass the test:  
`npm test -w @google/gemini-cli-core -- src/policy/toml-loader.test.ts`

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

~- [ ] Updated relevant documentation and README (if needed)~
~- [ ] Added/updated tests (if needed)~
~- [ ] Noted breaking changes (if any)~
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker

## Misc.

I'm relatively new to the TypeScript and the change is developed by me and Gemini CLI.  Any guidance would be greatly appreciated.