### PR TITLE
fix: optimize loadSettings calls during startup (#17988)

### DIFF
--- a/packages/cli/src/config/auth.test.ts
+++ b/packages/cli/src/config/auth.test.ts
@@ -7,6 +7,7 @@
 import { AuthType } from '@google/gemini-cli-core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { validateAuthMethod } from './auth.js';
+import type { MergedSettings } from './settings.js';
 
 vi.mock('./settings.js', () => ({
   loadEnvironment: vi.fn(),
@@ -94,6 +95,7 @@ describe('validateAuthMethod', () => {
     for (const [key, value] of Object.entries(envs)) {
       vi.stubEnv(key, value as string);
     }
-    expect(validateAuthMethod(authType)).toBe(expected);
+    const mockSettings = {} as MergedSettings;
+    expect(validateAuthMethod(authType, mockSettings)).toBe(expected);
   });
 });

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -5,10 +5,14 @@
  */
 
 import { AuthType } from '@google/gemini-cli-core';
-import { loadEnvironment, loadSettings } from './settings.js';
+import { loadEnvironment, type MergedSettings } from './settings.js';
 
-export function validateAuthMethod(authMethod: string): string | null {
-  loadEnvironment(loadSettings().merged, process.cwd());
+export function validateAuthMethod(
+  authMethod: string,
+  settings: MergedSettings,
+  workspaceDir: string = process.cwd(),
+): string | null {
+  loadEnvironment(settings, workspaceDir);
   if (
     authMethod === AuthType.LOGIN_WITH_GOOGLE ||
     authMethod === AuthType.COMPUTE_ADC

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -47,6 +47,7 @@ import {
 import {
   type Settings,
   type MergedSettings,
+  type LoadedSettings,
   saveModelChange,
   loadSettings,
 } from './settings.js';
@@ -439,6 +440,7 @@ export interface LoadCliConfigOptions {
   projectHooks?: { [K in HookEventName]?: HookDefinition[] } & {
     disabled?: string[];
   };
+  loadedSettings?: LoadedSettings;
 }
 
 export async function loadCliConfig(
@@ -447,10 +449,15 @@ export async function loadCliConfig(
   argv: CliArgs,
   options: LoadCliConfigOptions = {},
 ): Promise<Config> {
-  const { cwd = process.cwd(), projectHooks } = options;
+  const {
+    cwd = process.cwd(),
+    projectHooks,
+    loadedSettings: providedLoadedSettings,
+  } = options;
   const debugMode = isDebugMode(argv);
 
-  const loadedSettings = loadSettings(cwd);
+  // Use provided loadedSettings if available, otherwise load them (for backward compatibility)
+  const loadedSettings = providedLoadedSettings ?? loadSettings(cwd);
 
   if (argv.sandbox) {
     process.env['GEMINI_SANDBOX'] = 'true';

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -439,6 +439,7 @@ export async function main() {
 
   const partialConfig = await loadCliConfig(settings.merged, sessionId, argv, {
     projectHooks: settings.workspace.settings.hooks,
+    loadedSettings: settings,
   });
   adminControlsListner.setConfig(partialConfig);
 
@@ -454,6 +455,7 @@ export async function main() {
       ) {
         const err = validateAuthMethod(
           settings.merged.security.auth.selectedType,
+          settings.merged,
         );
         if (err) {
           throw new Error(err);
@@ -563,6 +565,7 @@ export async function main() {
     const loadConfigHandle = startupProfiler.start('load_cli_config');
     const config = await loadCliConfig(settings.merged, sessionId, argv, {
       projectHooks: settings.workspace.settings.hooks,
+      loadedSettings: settings,
     });
     loadConfigHandle?.end();
 

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -846,17 +846,13 @@ Logging in with Google... Restarting Gemini CLI to continue.
 
       const error = validateAuthMethod(
         settings.merged.security.auth.selectedType,
+        settings.merged,
       );
       if (error) {
         onAuthError(error);
       }
     }
-  }, [
-    settings.merged.security.auth.selectedType,
-    settings.merged.security.auth.enforcedType,
-    settings.merged.security.auth.useExternal,
-    onAuthError,
-  ]);
+  }, [settings.merged, onAuthError]);
 
   const { isModelDialogOpen, openModelDialog, closeModelDialog } =
     useModelCommand();

--- a/packages/cli/src/ui/auth/useAuth.test.tsx
+++ b/packages/cli/src/ui/auth/useAuth.test.tsx
@@ -17,7 +17,7 @@ import { renderHook } from '../../test-utils/render.js';
 import { useAuthCommand, validateAuthMethodWithSettings } from './useAuth.js';
 import { AuthType, type Config } from '@google/gemini-cli-core';
 import { AuthState } from '../types.js';
-import type { LoadedSettings } from '../../config/settings.js';
+import type { LoadedSettings, MergedSettings } from '../../config/settings.js';
 import { waitFor } from '../../test-utils/async.js';
 
 // Mock dependencies
@@ -34,7 +34,8 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
 });
 
 vi.mock('../../config/auth.js', () => ({
-  validateAuthMethod: (authType: AuthType) => mockValidateAuthMethod(authType),
+  validateAuthMethod: (authType: AuthType, settings: MergedSettings) =>
+    mockValidateAuthMethod(authType, settings),
 }));
 
 describe('useAuth', () => {
@@ -118,6 +119,7 @@ describe('useAuth', () => {
       expect(error).toBe('Validation Error');
       expect(mockValidateAuthMethod).toHaveBeenCalledWith(
         AuthType.LOGIN_WITH_GOOGLE,
+        settings.merged,
       );
     });
   });

--- a/packages/cli/src/ui/auth/useAuth.ts
+++ b/packages/cli/src/ui/auth/useAuth.ts
@@ -31,7 +31,7 @@ export function validateAuthMethodWithSettings(
   if (authType === AuthType.USE_GEMINI) {
     return null;
   }
-  return validateAuthMethod(authType);
+  return validateAuthMethod(authType, settings.merged);
 }
 
 export const useAuthCommand = (

--- a/packages/cli/src/validateNonInterActiveAuth.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.ts
@@ -42,7 +42,7 @@ export async function validateNonInteractiveAuth(
     const authType: AuthType = effectiveAuthType;
 
     if (!useExternalAuth) {
-      const err = validateAuthMethod(String(authType));
+      const err = validateAuthMethod(String(authType), settings.merged);
       if (err != null) {
         throw new Error(err);
       }

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -367,7 +367,10 @@ export class GeminiAgent {
       mcpServers: mergedMcpServers,
     };
 
-    const config = await loadCliConfig(settings, sessionId, this.argv, { cwd });
+    const config = await loadCliConfig(settings, sessionId, this.argv, {
+      cwd,
+      loadedSettings: currentSettings,
+    });
 
     return config;
   }


### PR DESCRIPTION
## Summary

Optimizes startup performance by reducing `loadSettings` calls from 3 to 1, eliminating redundant I/O operations and migration writes during initialization.

## Details

**Problem:** `loadSettings` was being called 3 times during startup:
1. `gemini.tsx:348` - Main startup call (necessary)
2. `config/auth.ts:11` - Inside `validateAuthMethod()` (unnecessary - settings already available)
3. `config/config.ts:453` - Inside `loadCliConfig()` (unnecessary - already receives `settings.merged`)

**Solution:**
- Modified `validateAuthMethod()` to accept `settings: MergedSettings` parameter instead of loading internally
- Modified `loadCliConfig()` to accept optional `loadedSettings: LoadedSettings` parameter
- Updated all call sites to pass already-loaded settings

**Impact:** 
- 66% reduction in startup I/O operations
- 66% reduction in migration operations during startup
- Backward compatible (optional parameter with fallback)

## Related Issues

Fixes #17988

## How to Validate

1. **Verify single call during startup:**
   ```bash
   npm start -- --help 2>&1 | grep -c "loadSettings"
   # Should output: 1 (or 0 if no debug output)
   ```

2. **Run test suite:**
   ```bash
   npm test
   # All 751 tests should pass
   ```

3. **Test backward compatibility:**
   - Code that doesn't pass `loadedSettings` to `loadCliConfig()` should still work (falls back to loading)

4. **Verify functionality:**
   ```bash
   npm start -- --version
   # Should work normally without errors
   ```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
  - Updated `auth.test.ts` for new `validateAuthMethod` signature
  - Updated `useAuth.test.tsx` for new signature
- [x] Noted breaking changes (if any)
  - `validateAuthMethod()` signature changed (all call sites updated)
  - `loadCliConfig()` accepts optional parameter (backward compatible)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
