### PR TITLE
docs: remove legacy cmd examples in favor of powershell

### DIFF
--- a/docs/resources/uninstall.md
+++ b/docs/resources/uninstall.md
@@ -19,16 +19,7 @@ can find your npm cache path by running `npm config get cache`.
 rm -rf "$(npm config get cache)/_npx"
 ```
 
-**For Windows**
-
-_Command Prompt_
-
-```cmd
-:: The path is typically %LocalAppData%\npm-cache\_npx
-rmdir /s /q "%LocalAppData%\npm-cache\_npx"
-```
-
-_PowerShell_
+**For Windows (PowerShell)**
 
 ```powershell
 # The path is typically $env:LocalAppData\npm-cache\_npx


### PR DESCRIPTION
## Summary

Removes legacy Command Prompt (CMD) examples from the documentation, standardizing on PowerShell for Windows environments.

## Details

PowerShell has been the default shell on Windows since Windows 10, and Gemini CLI internally defaults to PowerShell for shell command execution. Standardizing the documentation improves consistency and reduces confusion for Windows users.

## Related Issues

Fixes #17138