### PR TITLE
Return updated line numbers with post-replace diff

### DIFF
--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -415,6 +415,9 @@ describe('EditTool', () => {
         { start: 2, end: 3 },
         { start: 5, end: 6 },
       ]);
+      expect(result.newContent).toBe(
+        '  line1\n  replacement\n  line3\n  replacement\n  line5',
+      );
     });
 
     it('should correctly calculate matchRanges for regex replacements', async () => {

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -229,7 +229,7 @@ async function calculateFlexibleReplacement(
 
   let flexibleOccurrences = 0;
   const matchRanges: Array<{ start: number; end: number }> = [];
-  let lineOffset = 0;
+  let currentOriginalLine = 1;
   let i = 0;
   while (i <= sourceLines.length - searchLinesStripped.length) {
     const window = sourceLines.slice(i, i + searchLinesStripped.length);
@@ -241,21 +241,24 @@ async function calculateFlexibleReplacement(
     if (isMatch) {
       flexibleOccurrences++;
       matchRanges.push({
-        start: i + 1 - lineOffset,
-        end: i + searchLinesStripped.length - lineOffset,
+        start: currentOriginalLine,
+        end: currentOriginalLine + searchLinesStripped.length - 1,
       });
       const firstLineInMatch = window[0];
       const indentationMatch = firstLineInMatch.match(/^([ \t]*)/);
       const indentation = indentationMatch ? indentationMatch[1] : '';
       const newBlockWithIndent = applyIndentation(replaceLines, indentation);
-      sourceLines.splice(
-        i,
-        searchLinesStripped.length,
-        newBlockWithIndent.join('\n'),
-      );
-      lineOffset += replaceLines.length - searchLinesStripped.length;
-      i += replaceLines.length;
+
+      let replacementText = newBlockWithIndent.join('\n');
+      if (window[window.length - 1].endsWith('\n')) {
+        replacementText += '\n';
+      }
+
+      sourceLines.splice(i, searchLinesStripped.length, replacementText);
+      currentOriginalLine += searchLinesStripped.length;
+      i++;
     } else {
+      currentOriginalLine++;
       i++;
     }
   }

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -137,22 +137,7 @@ async function calculateExactReplacement(
   const normalizedSearch = old_string.replace(/\r\n/g, '\n');
   const normalizedReplace = new_string.replace(/\r\n/g, '\n');
 
-  const matchRanges: Array<{ start: number; end: number }> = [];
-  let index = normalizedCode.indexOf(normalizedSearch);
-  while (index !== -1) {
-    const startLine = normalizedCode
-      .substring(0, index)
-      .split(String.fromCharCode(10)).length;
-    const endLine =
-      startLine + normalizedSearch.split(String.fromCharCode(10)).length - 1;
-    matchRanges.push({ start: startLine, end: endLine });
-    index = normalizedCode.indexOf(
-      normalizedSearch,
-      index + normalizedSearch.length,
-    );
-  }
-
-  const exactOccurrences = matchRanges.length;
+  const exactOccurrences = normalizedCode.split(normalizedSearch).length - 1;
 
   if (!params.allow_multiple && exactOccurrences > 1) {
     return {
@@ -160,8 +145,6 @@ async function calculateExactReplacement(
       occurrences: exactOccurrences,
       finalOldString: normalizedSearch,
       finalNewString: normalizedReplace,
-      strategy: 'exact',
-      matchRanges,
     };
   }
 
@@ -177,8 +160,6 @@ async function calculateExactReplacement(
       occurrences: exactOccurrences,
       finalOldString: normalizedSearch,
       finalNewString: normalizedReplace,
-      strategy: 'exact',
-      matchRanges,
     };
   }
 
@@ -257,11 +238,11 @@ async function calculateRegexReplacement(
 
   let processedString = normalizedSearch;
   for (const delim of delimiters) {
-    processedString = processedString.split('\n').join(` ${delim} `);
+    processedString = processedString.split(delim).join(` ${delim} `);
   }
 
   // Split by any whitespace and remove empty strings.
-  const tokens = processedString.split(String.fromCharCode(10)).filter(Boolean);
+  const tokens = processedString.split(/\s+/).filter(Boolean);
 
   if (tokens.length === 0) {
     return null;
@@ -566,7 +547,6 @@ class EditToolInvocation
       error: undefined,
       originalLineEnding,
       strategy: secondAttemptResult.strategy,
-      matchRanges: secondAttemptResult.matchRanges,
     };
   }
 
@@ -679,7 +659,6 @@ class EditToolInvocation
         error: undefined,
         originalLineEnding,
         strategy: replacementResult.strategy,
-        matchRanges: replacementResult.matchRanges,
       };
     }
 


### PR DESCRIPTION
## Summary

In the past week or so I merged https://github.com/google-gemini/gemini-cli/pull/19240 which reduced the failure rate of the replace tool by ~1-2%. Shortly after, I merged https://github.com/google-gemini/gemini-cli/pull/19574 which made the agent significantly faster by eliminating a bunch of read turns.

 19574 unfortunately regressed replace tool success rate back to about where it was because the smaller view of the updated file meant that the agent's understanding of line numbers got out of sync without it realizing.

This change adds in a start_line, end_line, and total doc length into the response from replace, filling in these context gaps for the agent without requiring a verification read. Initial evals seem to show that the regression to replace success rate is fixed.
