### PR TITLE
feat(core): rename grep_search include parameter to include_pattern

### DIFF
--- a/evals/grep_search_functionality.eval.ts
+++ b/evals/grep_search_functionality.eval.ts
@@ -93,7 +93,7 @@ describe('grep_search_functionality', () => {
   });
 
   evalTest('USUALLY_PASSES', {
-    name: 'should search only within the specified include glob',
+    name: 'should search only within the specified include_pattern glob',
     files: {
       'file.js': 'my_function();',
       'file.ts': 'my_function();',
@@ -105,19 +105,19 @@ describe('grep_search_functionality', () => {
         undefined,
         (args) => {
           const params = JSON.parse(args);
-          return params.include === '*.js';
+          return params.include_pattern === '*.js';
         },
       );
       expect(
         wasToolCalled,
-        'Expected grep_search to be called with include: "*.js"',
+        'Expected grep_search to be called with include_pattern: "*.js"',
       ).toBe(true);
 
       assertModelHasOutput(result);
       checkModelOutputContent(result, {
         expectedContent: [/file.js/],
         forbiddenContent: [/file.ts/],
-        testName: `${TEST_PREFIX}include glob search`,
+        testName: `${TEST_PREFIX}include_pattern glob search`,
       });
     },
   });

--- a/integration-tests/ripgrep-real.test.ts
+++ b/integration-tests/ripgrep-real.test.ts
@@ -102,7 +102,10 @@ describe('ripgrep-real-direct', () => {
       'console.log("hello");\n',
     );
 
-    const invocation = tool.build({ pattern: 'hello', include: '*.js' });
+    const invocation = tool.build({
+      pattern: 'hello',
+      include_pattern: '*.js',
+    });
     const result = await invocation.execute(new AbortController().signal);
 
     expect(result.llmContent).toContain('Found 1 match');

--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -32,7 +32,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like grep_search and/or read_file called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.
@@ -184,7 +184,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like grep_search and/or read_file called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.
@@ -455,7 +455,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like grep_search and/or read_file called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.
@@ -607,7 +607,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like grep_search and/or read_file called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.
@@ -763,7 +763,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like grep_search and/or read_file called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.
@@ -885,7 +885,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like grep_search and/or read_file called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.
@@ -1480,7 +1480,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like grep_search and/or read_file called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.
@@ -1632,7 +1632,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like grep_search and/or read_file called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.
@@ -1775,7 +1775,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like grep_search and/or read_file called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.
@@ -1918,7 +1918,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like grep_search and/or read_file called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.
@@ -2057,7 +2057,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like grep_search and/or read_file called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.
@@ -2196,7 +2196,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like grep_search and/or read_file called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.
@@ -2327,7 +2327,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like grep_search and/or read_file called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.
@@ -2465,7 +2465,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like grep_search and/or read_file called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.
@@ -2845,7 +2845,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like grep_search and/or read_file called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.
@@ -2984,7 +2984,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like grep_search and/or read_file called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.
@@ -3235,7 +3235,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like grep_search and/or read_file called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.
@@ -3374,7 +3374,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like grep_search and/or read_file called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -189,7 +189,7 @@ Use the following guidelines to optimize your search and read patterns.
 </guidelines>
 
 <examples>
-- **Searching:** utilize search tools like ${GREP_TOOL_NAME} and ${GLOB_TOOL_NAME} with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include\` and \`exclude\` parameters).
+- **Searching:** utilize search tools like ${GREP_TOOL_NAME} and ${GLOB_TOOL_NAME} with a conservative result count (\`total_max_matches\`) and a narrow scope (\`include_pattern\` and \`exclude_pattern\` parameters).
 - **Searching and editing:** utilize search tools like ${GREP_TOOL_NAME} with a conservative result count and a narrow scope. Use \`context\`, \`before\`, and/or \`after\` to request enough context to avoid the need to read the file before editing matches.
 - **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
 - **Large files:** utilize search tools like ${GREP_TOOL_NAME} and/or ${READ_FILE_TOOL_NAME} called in parallel with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.

--- a/packages/core/src/tools/definitions/__snapshots__/coreToolsModelSnapshots.test.ts.snap
+++ b/packages/core/src/tools/definitions/__snapshots__/coreToolsModelSnapshots.test.ts.snap
@@ -266,7 +266,7 @@ exports[`coreTools snapshots for specific models > Model: gemini-2.5-pro > snaps
         "description": "Optional: A regular expression pattern to exclude from the search results. If a line matches both the pattern and the exclude_pattern, it will be omitted.",
         "type": "string",
       },
-      "include": {
+      "include_pattern": {
         "description": "Optional: A glob pattern to filter which files are searched (e.g., '*.js', '*.{ts,tsx}', 'src/**'). If omitted, searches all files (respecting potential global ignores).",
         "type": "string",
       },
@@ -333,7 +333,7 @@ exports[`coreTools snapshots for specific models > Model: gemini-2.5-pro > snaps
         "description": "If true, treats the \`pattern\` as a literal string instead of a regular expression. Defaults to false (basic regex) if omitted.",
         "type": "boolean",
       },
-      "include": {
+      "include_pattern": {
         "description": "Glob pattern to filter files (e.g., '*.ts', 'src/**'). Recommended for large repositories to reduce noise. Defaults to all files if omitted.",
         "type": "string",
       },
@@ -1053,7 +1053,7 @@ exports[`coreTools snapshots for specific models > Model: gemini-3-pro-preview >
         "description": "Optional: A regular expression pattern to exclude from the search results. If a line matches both the pattern and the exclude_pattern, it will be omitted.",
         "type": "string",
       },
-      "include": {
+      "include_pattern": {
         "description": "Optional: A glob pattern to filter which files are searched (e.g., '*.js', '*.{ts,tsx}', 'src/**'). If omitted, searches all files (respecting potential global ignores).",
         "type": "string",
       },
@@ -1120,7 +1120,7 @@ exports[`coreTools snapshots for specific models > Model: gemini-3-pro-preview >
         "description": "If true, treats the \`pattern\` as a literal string instead of a regular expression. Defaults to false (basic regex) if omitted.",
         "type": "boolean",
       },
-      "include": {
+      "include_pattern": {
         "description": "Glob pattern to filter files (e.g., '*.ts', 'src/**'). Recommended for large repositories to reduce noise. Defaults to all files if omitted.",
         "type": "string",
       },

--- a/packages/core/src/tools/definitions/model-family-sets/default-legacy.ts
+++ b/packages/core/src/tools/definitions/model-family-sets/default-legacy.ts
@@ -96,7 +96,7 @@ export const DEFAULT_LEGACY_SET: CoreToolSet = {
             'Optional: The absolute path to the directory to search within. If omitted, searches the current working directory.',
           type: 'string',
         },
-        include: {
+        include_pattern: {
           description: `Optional: A glob pattern to filter which files are searched (e.g., '*.js', '*.{ts,tsx}', 'src/**'). If omitted, searches all files (respecting potential global ignores).`,
           type: 'string',
         },
@@ -143,7 +143,7 @@ export const DEFAULT_LEGACY_SET: CoreToolSet = {
             "Directory or file to search. Directories are searched recursively. Relative paths are resolved against current working directory. Defaults to current working directory ('.') if omitted.",
           type: 'string',
         },
-        include: {
+        include_pattern: {
           description:
             "Glob pattern to filter files (e.g., '*.ts', 'src/**'). Recommended for large repositories to reduce noise. Defaults to all files if omitted.",
           type: 'string',

--- a/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts
+++ b/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts
@@ -97,7 +97,7 @@ export const GEMINI_3_SET: CoreToolSet = {
             'Optional: The absolute path to the directory to search within. If omitted, searches the current working directory.',
           type: 'string',
         },
-        include: {
+        include_pattern: {
           description: `Optional: A glob pattern to filter which files are searched (e.g., '*.js', '*.{ts,tsx}', 'src/**'). If omitted, searches all files (respecting potential global ignores).`,
           type: 'string',
         },
@@ -144,7 +144,7 @@ export const GEMINI_3_SET: CoreToolSet = {
             "Directory or file to search. Directories are searched recursively. Relative paths are resolved against current working directory. Defaults to current working directory ('.') if omitted.",
           type: 'string',
         },
-        include: {
+        include_pattern: {
           description:
             "Glob pattern to filter files (e.g., '*.ts', 'src/**'). Recommended for large repositories to reduce noise. Defaults to all files if omitted.",
           type: 'string',

--- a/packages/core/src/tools/grep-utils.ts
+++ b/packages/core/src/tools/grep-utils.ts
@@ -139,7 +139,7 @@ export async function formatGrepResults(
   params: {
     pattern: string;
     names_only?: boolean;
-    include?: string;
+    include_pattern?: string;
     // Context params to determine if auto-context should be skipped
     context?: number;
     before?: number;
@@ -148,10 +148,10 @@ export async function formatGrepResults(
   searchLocationDescription: string,
   totalMaxMatches: number,
 ): Promise<{ llmContent: string; returnDisplay: string }> {
-  const { pattern, names_only, include } = params;
+  const { pattern, names_only, include_pattern } = params;
 
   if (allMatches.length === 0) {
-    const noMatchMsg = `No matches found for pattern "${pattern}" ${searchLocationDescription}${include ? ` (filter: "${include}")` : ''}.`;
+    const noMatchMsg = `No matches found for pattern "${pattern}" ${searchLocationDescription}${include_pattern ? ` (filter: "${include_pattern}")` : ''}.`;
     return { llmContent: noMatchMsg, returnDisplay: `No matches found` };
   }
 
@@ -171,7 +171,7 @@ export async function formatGrepResults(
   if (names_only) {
     const filePaths = Object.keys(matchesByFile).sort();
     let llmContent = `Found ${filePaths.length} files with matches for pattern "${pattern}" ${searchLocationDescription}${
-      include ? ` (filter: "${include}")` : ''
+      include_pattern ? ` (filter: "${include_pattern}")` : ''
     }${
       wasTruncated
         ? ` (results limited to ${totalMaxMatches} matches for performance)`
@@ -184,7 +184,7 @@ export async function formatGrepResults(
     };
   }
 
-  let llmContent = `Found ${matchCount} ${matchTerm} for pattern "${pattern}" ${searchLocationDescription}${include ? ` (filter: "${include}")` : ''}`;
+  let llmContent = `Found ${matchCount} ${matchTerm} for pattern "${pattern}" ${searchLocationDescription}${include_pattern ? ` (filter: "${include_pattern}")` : ''}`;
 
   if (wasTruncated) {
     llmContent += ` (results limited to ${totalMaxMatches} matches for performance)`;

--- a/packages/core/src/tools/grep.test.ts
+++ b/packages/core/src/tools/grep.test.ts
@@ -118,7 +118,7 @@ describe('GrepTool', () => {
       const params: GrepToolParams = {
         pattern: 'hello',
         dir_path: '.',
-        include: '*.txt',
+        include_pattern: '*.txt',
       };
       expect(grepTool.validateToolParams(params)).toBeNull();
     });
@@ -226,7 +226,10 @@ describe('GrepTool', () => {
     }, 30000);
 
     it('should find matches with an include glob', async () => {
-      const params: GrepToolParams = { pattern: 'hello', include: '*.js' };
+      const params: GrepToolParams = {
+        pattern: 'hello',
+        include_pattern: '*.js',
+      };
       const invocation = grepTool.build(params);
       const result = await invocation.execute(abortSignal);
       expect(result.llmContent).toContain(
@@ -247,7 +250,7 @@ describe('GrepTool', () => {
       const params: GrepToolParams = {
         pattern: 'hello',
         dir_path: 'sub',
-        include: '*.js',
+        include_pattern: '*.js',
       };
       const invocation = grepTool.build(params);
       const result = await invocation.execute(abortSignal);
@@ -572,7 +575,7 @@ describe('GrepTool', () => {
     it('should generate correct description with pattern and include', () => {
       const params: GrepToolParams = {
         pattern: 'testPattern',
-        include: '*.ts',
+        include_pattern: '*.ts',
       };
       const invocation = grepTool.build(params);
       expect(invocation.getDescription()).toBe("'testPattern' in *.ts");
@@ -618,7 +621,7 @@ describe('GrepTool', () => {
       await fs.mkdir(dirPath, { recursive: true });
       const params: GrepToolParams = {
         pattern: 'testPattern',
-        include: '*.ts',
+        include_pattern: '*.ts',
         dir_path: path.join('src', 'app'),
       };
       const invocation = grepTool.build(params);

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -48,7 +48,7 @@ export interface GrepToolParams {
   /**
    * File pattern to include in the search (e.g. "*.js", "*.{ts,tsx}")
    */
-  include?: string;
+  include_pattern?: string;
 
   /**
    * Optional: A regular expression pattern to exclude from the search results.
@@ -227,7 +227,7 @@ class GrepToolInvocation extends BaseToolInvocation<
           const matches = await this.performGrepSearch({
             pattern: this.params.pattern,
             path: searchDir,
-            include: this.params.include,
+            include_pattern: this.params.include_pattern,
             exclude_pattern: this.params.exclude_pattern,
             maxMatches: remainingLimit,
             max_matches_per_file: this.params.max_matches_per_file,
@@ -317,7 +317,7 @@ class GrepToolInvocation extends BaseToolInvocation<
   private async performGrepSearch(options: {
     pattern: string;
     path: string; // Expects absolute path
-    include?: string;
+    include_pattern?: string;
     exclude_pattern?: string;
     maxMatches: number;
     max_matches_per_file?: number;
@@ -326,7 +326,7 @@ class GrepToolInvocation extends BaseToolInvocation<
     const {
       pattern,
       path: absolutePath,
-      include,
+      include_pattern,
       exclude_pattern,
       maxMatches,
       max_matches_per_file,
@@ -356,8 +356,8 @@ class GrepToolInvocation extends BaseToolInvocation<
         if (max_matches_per_file) {
           gitArgs.push('--max-count', max_matches_per_file.toString());
         }
-        if (include) {
-          gitArgs.push('--', include);
+        if (include_pattern) {
+          gitArgs.push('--', include_pattern);
         }
 
         try {
@@ -424,8 +424,8 @@ class GrepToolInvocation extends BaseToolInvocation<
         if (max_matches_per_file) {
           grepArgs.push('--max-count', max_matches_per_file.toString());
         }
-        if (include) {
-          grepArgs.push(`--include=${include}`);
+        if (include_pattern) {
+          grepArgs.push(`--include=${include_pattern}`);
         }
         grepArgs.push(pattern);
         grepArgs.push('.');
@@ -471,7 +471,7 @@ class GrepToolInvocation extends BaseToolInvocation<
         'GrepLogic: Falling back to JavaScript grep implementation.',
       );
       strategyUsed = 'javascript fallback';
-      const globPattern = include ? include : '**/*';
+      const globPattern = include_pattern ? include_pattern : '**/*';
       const ignorePatterns = this.fileExclusions.getGlobExcludes();
 
       const filesStream = globStream(globPattern, {
@@ -551,8 +551,8 @@ class GrepToolInvocation extends BaseToolInvocation<
 
   getDescription(): string {
     let description = `'${this.params.pattern}'`;
-    if (this.params.include) {
-      description += ` in ${this.params.include}`;
+    if (this.params.include_pattern) {
+      description += ` in ${this.params.include_pattern}`;
     }
     if (this.params.dir_path) {
       const resolvedPath = path.resolve(

--- a/packages/core/src/tools/ripGrep.test.ts
+++ b/packages/core/src/tools/ripGrep.test.ts
@@ -350,7 +350,7 @@ describe('RipGrepTool', () => {
       },
       {
         name: 'pattern, path, and include',
-        params: { pattern: 'hello', dir_path: '.', include: '*.txt' },
+        params: { pattern: 'hello', dir_path: '.', include_pattern: '*.txt' },
         expected: null,
       },
     ])(
@@ -526,7 +526,10 @@ describe('RipGrepTool', () => {
         }),
       );
 
-      const params: RipGrepToolParams = { pattern: 'hello', include: '*.js' };
+      const params: RipGrepToolParams = {
+        pattern: 'hello',
+        include_pattern: '*.js',
+      };
       const invocation = grepTool.build(params);
       const result = await invocation.execute(abortSignal);
       expect(result.llmContent).toContain(
@@ -564,7 +567,7 @@ describe('RipGrepTool', () => {
       const params: RipGrepToolParams = {
         pattern: 'hello',
         dir_path: 'sub',
-        include: '*.js',
+        include_pattern: '*.js',
       };
       const invocation = grepTool.build(params);
       const result = await invocation.execute(abortSignal);
@@ -1314,7 +1317,7 @@ describe('RipGrepTool', () => {
 
       const params: RipGrepToolParams = {
         pattern: 'content',
-        include: '*.{ts,tsx}',
+        include_pattern: '*.{ts,tsx}',
       };
       const invocation = grepTool.build(params);
       const result = await invocation.execute(abortSignal);
@@ -1350,7 +1353,7 @@ describe('RipGrepTool', () => {
 
       const params: RipGrepToolParams = {
         pattern: 'code',
-        include: 'src/**',
+        include_pattern: 'src/**',
       };
       const invocation = grepTool.build(params);
       const result = await invocation.execute(abortSignal);
@@ -1774,7 +1777,7 @@ describe('RipGrepTool', () => {
       },
       {
         name: 'pattern and include',
-        params: { pattern: 'testPattern', include: '*.ts' },
+        params: { pattern: 'testPattern', include_pattern: '*.ts' },
         expected: "'testPattern' in *.ts within ./",
       },
       {
@@ -1849,7 +1852,7 @@ describe('RipGrepTool', () => {
       await fs.mkdir(dirPath, { recursive: true });
       const params: RipGrepToolParams = {
         pattern: 'testPattern',
-        include: '*.ts',
+        include_pattern: '*.ts',
         dir_path: path.join('src', 'app'),
       };
       const invocation = grepTool.build(params);

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -103,7 +103,7 @@ export interface RipGrepToolParams {
   /**
    * File pattern to include in the search (e.g. "*.js", "*.{ts,tsx}")
    */
-  include?: string;
+  include_pattern?: string;
 
   /**
    * Optional: A regular expression pattern to exclude from the search results.
@@ -246,7 +246,7 @@ class GrepToolInvocation extends BaseToolInvocation<
         allMatches = await this.performRipgrepSearch({
           pattern: this.params.pattern,
           path: searchDirAbs,
-          include: this.params.include,
+          include_pattern: this.params.include_pattern,
           exclude_pattern: this.params.exclude_pattern,
           case_sensitive: this.params.case_sensitive,
           fixed_strings: this.params.fixed_strings,
@@ -329,7 +329,7 @@ class GrepToolInvocation extends BaseToolInvocation<
         pattern: this.params.pattern,
         path: uniqueFiles,
         basePath: searchDirAbs,
-        include: this.params.include,
+        include_pattern: this.params.include_pattern,
         exclude_pattern: this.params.exclude_pattern,
         case_sensitive: this.params.case_sensitive,
         fixed_strings: this.params.fixed_strings,
@@ -360,7 +360,7 @@ class GrepToolInvocation extends BaseToolInvocation<
     pattern: string;
     path: string | string[];
     basePath?: string;
-    include?: string;
+    include_pattern?: string;
     exclude_pattern?: string;
     case_sensitive?: boolean;
     fixed_strings?: boolean;
@@ -376,7 +376,7 @@ class GrepToolInvocation extends BaseToolInvocation<
       pattern,
       path,
       basePath,
-      include,
+      include_pattern,
       exclude_pattern,
       case_sensitive,
       fixed_strings,
@@ -419,8 +419,8 @@ class GrepToolInvocation extends BaseToolInvocation<
       rgArgs.push('--max-count', max_matches_per_file.toString());
     }
 
-    if (include) {
-      rgArgs.push('--glob', include);
+    if (include_pattern) {
+      rgArgs.push('--glob', include_pattern);
     }
 
     if (!no_ignore) {
@@ -543,8 +543,8 @@ class GrepToolInvocation extends BaseToolInvocation<
    */
   getDescription(): string {
     let description = `'${this.params.pattern}'`;
-    if (this.params.include) {
-      description += ` in ${this.params.include}`;
+    if (this.params.include_pattern) {
+      description += ` in ${this.params.include_pattern}`;
     }
     const pathParam = this.params.dir_path || '.';
     const resolvedPath = path.resolve(this.config.getTargetDir(), pathParam);


### PR DESCRIPTION
## Summary

Renamed the `include` parameter to `include_pattern` in the `grep_search` tool across all implementations and definitions to improve naming clarity and consistency.

## Details

- Updated `GrepToolParams` and `RipGrepToolParams` interfaces.
- Modified `GrepTool` and `RipGrepTool` implementations to use `include_pattern`.
- Updated tool definitions for legacy and Gemini 3 model sets.
- Refactored `formatGrepResults` in `grep-utils.ts` to support the new parameter name.
- Updated system prompt snippets to ensure the model uses the correct parameter name.
- Updated snapshots and unit/integration tests to reflect the change.

## Related Issues

Related to #17552

## How to Validate

1. Run unit tests for grep tools: `npm test -w @google/gemini-cli-core -- grep.test.ts ripGrep.test.ts`
2. Run integration tests: `npm test -- integration-tests/ripgrep-real.test.ts`
3. Verify that `grep_search` still functions correctly in the CLI with the new parameter name.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
