### PR TITLE
feat(cli): automatically accept workspace policy changes

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -699,7 +699,6 @@ export async function loadCliConfig(
     await resolveWorkspacePolicyState({
       cwd,
       trustedFolder,
-      interactive,
     });
 
   const policyEngineConfig = await createPolicyEngineConfig(

--- a/packages/cli/src/config/workspace-policy-cli.test.ts
+++ b/packages/cli/src/config/workspace-policy-cli.test.ts
@@ -164,7 +164,7 @@ describe('Workspace-Level Policy CLI Integration', () => {
     );
   });
 
-  it('should set policyUpdateConfirmationRequest if integrity MISMATCH in interactive mode', async () => {
+  it('should automatically accept if integrity MISMATCH in interactive mode', async () => {
     vi.mocked(isWorkspaceTrusted).mockReturnValue({
       isTrusted: true,
       source: 'file',
@@ -186,24 +186,23 @@ describe('Workspace-Level Policy CLI Integration', () => {
       cwd: MOCK_CWD,
     });
 
-    expect(config.getPolicyUpdateConfirmationRequest()).toEqual({
-      scope: 'workspace',
-      identifier: MOCK_CWD,
-      policyDir: expect.stringContaining(path.join('.gemini', 'policies')),
-      newHash: 'new-hash',
-    });
-    // In interactive mode without accept flag, it waits for user confirmation (handled by UI),
-    // so it currently DOES NOT pass the directory to createPolicyEngineConfig yet.
-    // The UI will handle the confirmation and reload/update.
+    expect(config.getPolicyUpdateConfirmationRequest()).toBeUndefined();
+    expect(mockAcceptIntegrity).toHaveBeenCalledWith(
+      'workspace',
+      MOCK_CWD,
+      'new-hash',
+    );
     expect(ServerConfig.createPolicyEngineConfig).toHaveBeenCalledWith(
       expect.objectContaining({
-        workspacePoliciesDir: undefined,
+        workspacePoliciesDir: expect.stringContaining(
+          path.join('.gemini', 'policies'),
+        ),
       }),
       expect.anything(),
     );
   });
 
-  it('should set policyUpdateConfirmationRequest if integrity is NEW with files (first time seen) in interactive mode', async () => {
+  it('should automatically accept if integrity is NEW with files (first time seen) in interactive mode', async () => {
     vi.mocked(isWorkspaceTrusted).mockReturnValue({
       isTrusted: true,
       source: 'file',
@@ -222,16 +221,18 @@ describe('Workspace-Level Policy CLI Integration', () => {
       cwd: MOCK_CWD,
     });
 
-    expect(config.getPolicyUpdateConfirmationRequest()).toEqual({
-      scope: 'workspace',
-      identifier: MOCK_CWD,
-      policyDir: expect.stringContaining(path.join('.gemini', 'policies')),
-      newHash: 'new-hash',
-    });
+    expect(config.getPolicyUpdateConfirmationRequest()).toBeUndefined();
+    expect(mockAcceptIntegrity).toHaveBeenCalledWith(
+      'workspace',
+      MOCK_CWD,
+      'new-hash',
+    );
 
     expect(ServerConfig.createPolicyEngineConfig).toHaveBeenCalledWith(
       expect.objectContaining({
-        workspacePoliciesDir: undefined,
+        workspacePoliciesDir: expect.stringContaining(
+          path.join('.gemini', 'policies'),
+        ),
       }),
       expect.anything(),
     );


### PR DESCRIPTION
## Summary

Hides the PolicyUpdateDialog and automatically accepts workspace policy updates to reduce user friction. Workspace policies are now automatically accepted and loaded in both interactive and non-interactive modes.

## Details

- Updated `resolveWorkspacePolicyState` in `packages/cli/src/config/policy.ts` to automatically accept and load policies, bypassing the interactive dialog.
- Switched from `writeToStderr` to `debugLogger.warn` for notifying about policy updates to reduce terminal noise.
- Removed the unused `interactive` parameter from `resolveWorkspacePolicyState` and its call sites.
- Added a TODO comment for the preserved `policyUpdateConfirmationRequest` infrastructure.
- Updated unit and integration tests to reflect automatic policy acceptance.

## Related Issues

Fixes #20336

## How to Validate

1. Initialize a workspace with policies.
2. Modify a policy file in `.gemini/policies/`.
3. Run the CLI in interactive mode (e.g., `npm run start`).
4. Observe that the policy change is automatically accepted and loaded without showing a dialog.
5. Verify that `debugLogger.warn` logs the update in debug mode.
6. Run tests: `npm test -w @google/gemini-cli -- src/config/policy.test.ts src/config/workspace-policy-cli.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
  - [ ] Linux
