### PR TITLE
fix(cli): support quota error fallbacks for all authentication types

### DIFF
--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -135,6 +135,7 @@ export const DialogManager = ({
         isModelNotFoundError={
           !!uiState.quota.proQuotaRequest.isModelNotFoundError
         }
+        authType={uiState.quota.proQuotaRequest.authType}
         onChoice={uiActions.handleProQuotaChoice}
       />
     );

--- a/packages/cli/src/ui/components/ProQuotaDialog.test.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.test.tsx
@@ -13,6 +13,7 @@ import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
 import {
   PREVIEW_GEMINI_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
+  AuthType,
 } from '@google/gemini-cli-core';
 
 // Mock the child component to make it easier to test the parent
@@ -62,7 +63,7 @@ describe('ProQuotaDialog', () => {
 
   describe('for non-flash model failures', () => {
     describe('when it is a terminal quota error', () => {
-      it('should render switch, upgrade, and stop options for paid tiers', () => {
+      it('should render switch, upgrade, and stop options for LOGIN_WITH_GOOGLE', () => {
         const { unmount } = render(
           <ProQuotaDialog
             failedModel="gemini-2.5-pro"
@@ -70,6 +71,7 @@ describe('ProQuotaDialog', () => {
             message="paid tier quota error"
             isTerminalQuotaError={true}
             isModelNotFoundError={false}
+            authType={AuthType.LOGIN_WITH_GOOGLE}
             onChoice={mockOnChoice}
           />,
         );
@@ -86,6 +88,39 @@ describe('ProQuotaDialog', () => {
                 label: 'Upgrade for higher limits',
                 value: 'upgrade',
                 key: 'upgrade',
+              },
+              {
+                label: 'Stop',
+                value: 'retry_later',
+                key: 'retry_later',
+              },
+            ],
+          }),
+          undefined,
+        );
+        unmount();
+      });
+
+      it('should NOT render upgrade option for USE_GEMINI', () => {
+        const { unmount } = render(
+          <ProQuotaDialog
+            failedModel="gemini-2.5-pro"
+            fallbackModel="gemini-2.5-flash"
+            message="paid tier quota error"
+            isTerminalQuotaError={true}
+            isModelNotFoundError={false}
+            authType={AuthType.USE_GEMINI}
+            onChoice={mockOnChoice}
+          />,
+        );
+
+        expect(RadioButtonSelect).toHaveBeenCalledWith(
+          expect.objectContaining({
+            items: [
+              {
+                label: 'Switch to gemini-2.5-flash',
+                value: 'retry_always',
+                key: 'retry_always',
               },
               {
                 label: 'Stop',
@@ -130,7 +165,7 @@ describe('ProQuotaDialog', () => {
         unmount();
       });
 
-      it('should render switch, upgrade, and stop options for free tier', () => {
+      it('should render switch, upgrade, and stop options for LOGIN_WITH_GOOGLE (free tier)', () => {
         const { unmount } = render(
           <ProQuotaDialog
             failedModel="gemini-2.5-pro"
@@ -138,6 +173,7 @@ describe('ProQuotaDialog', () => {
             message="free tier quota error"
             isTerminalQuotaError={true}
             isModelNotFoundError={false}
+            authType={AuthType.LOGIN_WITH_GOOGLE}
             onChoice={mockOnChoice}
           />,
         );
@@ -204,7 +240,7 @@ describe('ProQuotaDialog', () => {
     });
 
     describe('when it is a model not found error', () => {
-      it('should render switch and stop options regardless of tier', () => {
+      it('should render switch, upgrade, and stop options for LOGIN_WITH_GOOGLE', () => {
         const { unmount } = render(
           <ProQuotaDialog
             failedModel="gemini-3-pro-preview"
@@ -212,6 +248,7 @@ describe('ProQuotaDialog', () => {
             message="You don't have access to gemini-3-pro-preview yet."
             isTerminalQuotaError={false}
             isModelNotFoundError={true}
+            authType={AuthType.LOGIN_WITH_GOOGLE}
             onChoice={mockOnChoice}
           />,
         );
@@ -241,7 +278,7 @@ describe('ProQuotaDialog', () => {
         unmount();
       });
 
-      it('should render switch and stop options for paid tier as well', () => {
+      it('should NOT render upgrade option for USE_GEMINI', () => {
         const { unmount } = render(
           <ProQuotaDialog
             failedModel="gemini-3-pro-preview"
@@ -249,6 +286,7 @@ describe('ProQuotaDialog', () => {
             message="You don't have access to gemini-3-pro-preview yet."
             isTerminalQuotaError={false}
             isModelNotFoundError={true}
+            authType={AuthType.USE_GEMINI}
             onChoice={mockOnChoice}
           />,
         );
@@ -260,11 +298,6 @@ describe('ProQuotaDialog', () => {
                 label: 'Switch to gemini-2.5-pro',
                 value: 'retry_always',
                 key: 'retry_always',
-              },
-              {
-                label: 'Upgrade for higher limits',
-                value: 'upgrade',
-                key: 'upgrade',
               },
               {
                 label: 'Stop',

--- a/packages/cli/src/ui/components/ProQuotaDialog.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.tsx
@@ -8,6 +8,7 @@ import type React from 'react';
 import { Box, Text } from 'ink';
 import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
 import { theme } from '../semantic-colors.js';
+import { AuthType } from '@google/gemini-cli-core';
 
 interface ProQuotaDialogProps {
   failedModel: string;
@@ -15,6 +16,7 @@ interface ProQuotaDialogProps {
   message: string;
   isTerminalQuotaError: boolean;
   isModelNotFoundError?: boolean;
+  authType?: AuthType;
   onChoice: (
     choice: 'retry_later' | 'retry_once' | 'retry_always' | 'upgrade',
   ) => void;
@@ -26,6 +28,7 @@ export function ProQuotaDialog({
   message,
   isTerminalQuotaError,
   isModelNotFoundError,
+  authType,
   onChoice,
 }: ProQuotaDialogProps): React.JSX.Element {
   let items;
@@ -51,11 +54,15 @@ export function ProQuotaDialog({
         value: 'retry_always' as const,
         key: 'retry_always',
       },
-      {
-        label: 'Upgrade for higher limits',
-        value: 'upgrade' as const,
-        key: 'upgrade',
-      },
+      ...(authType === AuthType.LOGIN_WITH_GOOGLE
+        ? [
+            {
+              label: 'Upgrade for higher limits',
+              value: 'upgrade' as const,
+              key: 'upgrade',
+            },
+          ]
+        : []),
       {
         label: `Stop`,
         value: 'retry_later' as const,

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -24,6 +24,7 @@ import type {
   ApprovalMode,
   UserTierId,
   IdeInfo,
+  AuthType,
   FallbackIntent,
   ValidationIntent,
   AgentDefinition,
@@ -42,6 +43,7 @@ export interface ProQuotaDialogRequest {
   message: string;
   isTerminalQuotaError: boolean;
   isModelNotFoundError?: boolean;
+  authType?: AuthType;
   resolve: (intent: FallbackIntent) => void;
 }
 

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -55,14 +55,7 @@ export function useQuotaAndFallback({
       fallbackModel,
       error,
     ): Promise<FallbackIntent | null> => {
-      // Fallbacks are currently only handled for OAuth users.
       const contentGeneratorConfig = config.getContentGeneratorConfig();
-      if (
-        !contentGeneratorConfig ||
-        contentGeneratorConfig.authType !== AuthType.LOGIN_WITH_GOOGLE
-      ) {
-        return null;
-      }
 
       let message: string;
       let isTerminalQuotaError = false;
@@ -78,7 +71,9 @@ export function useQuotaAndFallback({
           error.retryDelayMs ? getResetTimeMessage(error.retryDelayMs) : null,
           `/stats model for usage details`,
           `/model to switch models.`,
-          `/auth to switch to API key.`,
+          contentGeneratorConfig?.authType === AuthType.LOGIN_WITH_GOOGLE
+            ? `/auth to switch to API key.`
+            : null,
         ].filter(Boolean);
         message = messageLines.join('\n');
       } else if (error instanceof ModelNotFoundError) {
@@ -122,6 +117,7 @@ export function useQuotaAndFallback({
             message,
             isTerminalQuotaError,
             isModelNotFoundError,
+            authType: contentGeneratorConfig?.authType,
           });
         },
       );

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -77,6 +77,12 @@ export function getAuthTypeFromEnv(): AuthType | undefined {
   if (process.env['GEMINI_API_KEY']) {
     return AuthType.USE_GEMINI;
   }
+  if (
+    process.env['CLOUD_SHELL'] === 'true' ||
+    process.env['GEMINI_CLI_USE_COMPUTE_ADC'] === 'true'
+  ) {
+    return AuthType.COMPUTE_ADC;
+  }
   return undefined;
 }
 


### PR DESCRIPTION
## Summary

This PR enables model fallback prompts (for persistent quota/429 errors) for all authentication methods, not just `LOGIN_WITH_GOOGLE` OAuth users. It conditionally renders the "switch to API key" message in the fallback dialog only when the user is authenticated via OAuth. It also updates the environment variable parser to properly support `CLOUD_SHELL` and `GEMINI_CLI_USE_COMPUTE_ADC` to resolve to `AuthType.COMPUTE_ADC`.

## Details

- **Fallback Logic Enhancement**: Previously, the fallback dialogs (used to suggest falling back to Gemini Flash when Pro models hit quota limits) early-exited for non-OAuth users in `useQuotaAndFallback`. This restriction has been removed.
- **UI conditional rendering**: The `ProQuotaDialog` now receives the current `authType` and conditionally hides the "Upgrade for higher limits" option for non-OAuth users (e.g. API key users).
- **Environment Parser fix**: `getAuthTypeFromEnv()` was ignoring `CLOUD_SHELL` and `COMPUTE_ADC` environment flags entirely, which has now been fixed. 

Tests have been updated to ensure the fallback dialog correctly triggers and omits the OAuth-specific suggestion and upgrade options for API Key and Vertex users.

## Related Issues

Closes #20338

## How to Validate

- Run the `vitest` tests for `useQuotaAndFallback.test.ts`, `ProQuotaDialog.test.tsx`, and `contentGenerator.test.ts` to see passing tests.
- Locally, authenticate using `GEMINI_API_KEY`, trigger a 429 terminal quota error, and verify the fallback prompt appears and does *not* include the `/auth to switch to API key.` line nor the "Upgrade for higher limits" button.

## Pre-Merge Checklist

- [x] Added/updated tests (if needed)
- [ ] Updated relevant documentation and README (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on MacOS (npm run preflight pass)