### PR TITLE
fix: fixing error while running test in packages/cli

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -18,6 +18,7 @@ import {
   coreEvents,
   homedir,
   type AdminControlsSettings,
+  debugLogger,
 } from '@google/gemini-cli-core';
 import stripJsonComments from 'strip-json-comments';
 import { DefaultLight } from '../ui/themes/default-light.js';
@@ -1034,6 +1035,12 @@ export function migrateDeprecatedSettings(
 
 export function saveSettings(settingsFile: SettingsFile): void {
   try {
+    if (!settingsFile.path) {
+      debugLogger.warn(
+        'Skipping settings save: no settings file path available',
+      );
+      return;
+    }
     // Ensure the directory exists
     const dirPath = path.dirname(settingsFile.path);
     if (!fs.existsSync(dirPath)) {

--- a/packages/core/src/ide/ide-connection-utils.ts
+++ b/packages/core/src/ide/ide-connection-utils.ts
@@ -135,6 +135,9 @@ export async function getConnectionConfigFromFile(
   const portFileDir = path.join(os.tmpdir(), 'gemini', 'ide');
   let portFiles;
   try {
+    if (!fs.existsSync(portFileDir)) {
+      return undefined;
+    }
     portFiles = await fs.promises.readdir(portFileDir);
   } catch (e) {
     logger.debug('Failed to read IDE connection directory:', e);


### PR DESCRIPTION


## Summary

This PR improves robustness in test and headless environments by guarding filesystem access where missing paths are a valid state. It prevents noisy `ENOENT` errors during tests without changing production CLI behavior.



## Details

This PR includes two small defensive fixes:

* **Settings persistence**:
  `saveSettings` now skips writing to disk when no settings file path is available. This avoids filesystem errors in tests and ephemeral environments where a settings file is not expected to exist.

* **IDE auto-detection**:
  IDE connection discovery now treats a missing temporary IDE directory as a valid “no IDE connected” state instead of logging filesystem errors. IDE detection continues to work unchanged when the directory is present.

Both changes are intentionally minimal and do not alter runtime behavior in normal CLI usage.



## Related Issues

Related to test-environment filesystem errors and noisy debug logs during CLI test runs.
#19952 


## How to Validate

1. Run the test suite:

   ```bash
   npm run test
   ```
2. Verify that tests pass without `ENOENT` errors related to:

   * settings file writes
   * IDE connection directory reads
3. (Optional) Run the CLI normally and confirm settings persistence and IDE integration still behave as expected when corresponding files/directories exist.


## Pre-Merge Checklist

* [ ] Updated relevant documentation and README (if needed)
* [ ] Added/updated tests (if needed)
* [ ] Noted breaking changes (if any)
* [x] Validated on required platforms/methods:

  * [ ] MacOS

    * [ ] npm run
    * [ ] npx
    * [ ] Docker
    * [ ] Podman
    * [ ] Seatbelt
  * [x] Windows

    * [x] npm run
    * [ ] npx
    * [ ] Docker
  * [ ] Linux

    * [ ] npm run
    * [ ] npx
    * [ ] Docker
