### PR TITLE
feat: add network traffic proxy with domain filtering for sandboxed execution

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -43,6 +43,8 @@ import {
   type HookDefinition,
   type HookEventName,
   type OutputFormat,
+  DomainFilterAction,
+  type NetworkProxyConfig,
 } from '@google/gemini-cli-core';
 import {
   type Settings,
@@ -901,16 +903,7 @@ function mergeExcludeTools(
  */
 function buildNetworkProxyConfig(
   settings: MergedSettings,
-): {
-  enabled: boolean;
-  httpPort: number;
-  socksPort: number;
-  defaultAction: 'allow' | 'deny' | 'prompt';
-  rules: Array<{ pattern: string; action: 'allow' | 'deny' }>;
-  enableLogging: boolean;
-  maxLogEntries: number;
-  promptForUnknownDomains: boolean;
-} | undefined {
+): NetworkProxyConfig | undefined {
   const proxySettings = settings.security?.networkProxy;
   if (!proxySettings?.enabled) {
     return undefined;
@@ -918,26 +911,33 @@ function buildNetworkProxyConfig(
 
   // Build rules from allowedDomains and blockedDomains.
   // Allowed domains come first so they take priority over blocked domains.
-  const rules: Array<{ pattern: string; action: 'allow' | 'deny' }> = [];
+  const rules: Array<{ pattern: string; action: DomainFilterAction }> = [];
 
   const allowed = proxySettings.allowedDomains ?? [];
   for (const pattern of allowed) {
-    rules.push({ pattern, action: 'allow' });
+    rules.push({ pattern, action: DomainFilterAction.ALLOW });
   }
 
   const blocked = proxySettings.blockedDomains ?? [];
   for (const pattern of blocked) {
-    rules.push({ pattern, action: 'deny' });
+    rules.push({ pattern, action: DomainFilterAction.DENY });
   }
+
+  const defaultActionStr = proxySettings.defaultAction ?? 'prompt';
+  const defaultAction = defaultActionStr === 'allow'
+    ? DomainFilterAction.ALLOW
+    : defaultActionStr === 'deny'
+      ? DomainFilterAction.DENY
+      : DomainFilterAction.PROMPT;
 
   return {
     enabled: true,
     httpPort: proxySettings.httpPort ?? 0,
     socksPort: proxySettings.socksPort ?? 0,
-    defaultAction: proxySettings.defaultAction ?? 'prompt',
+    defaultAction,
     rules,
     enableLogging: proxySettings.enableLogging ?? false,
     maxLogEntries: 1000,
-    promptForUnknownDomains: proxySettings.defaultAction === 'prompt',
+    promptForUnknownDomains: defaultAction === DomainFilterAction.PROMPT,
   };
 }

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -938,6 +938,5 @@ function buildNetworkProxyConfig(
     rules,
     enableLogging: proxySettings.enableLogging ?? false,
     maxLogEntries: 1000,
-    promptForUnknownDomains: defaultAction === DomainFilterAction.PROMPT,
   };
 }

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -934,7 +934,7 @@ function buildNetworkProxyConfig(
     enabled: true,
     httpPort: proxySettings.httpPort ?? 0,
     socksPort: proxySettings.socksPort ?? 0,
-    defaultAction: (proxySettings.defaultAction as 'allow' | 'deny' | 'prompt') ?? 'prompt',
+    defaultAction: proxySettings.defaultAction ?? 'prompt',
     rules,
     enableLogging: proxySettings.enableLogging ?? false,
     maxLogEntries: 1000,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1567,6 +1567,95 @@ const SETTINGS_SCHEMA = {
           'Enable the context-aware security checker. This feature uses an LLM to dynamically generate and enforce security policies for tool use based on your prompt, providing an additional layer of protection against unintended actions.',
         showInDialog: true,
       },
+      networkProxy: {
+        type: 'object',
+        label: 'Network Proxy',
+        category: 'Security',
+        requiresRestart: true,
+        default: {},
+        description:
+          'Network traffic proxy for sandboxed command execution. Routes traffic through a controlled gateway with domain filtering.',
+        showInDialog: false,
+        properties: {
+          enabled: {
+            type: 'boolean',
+            label: 'Enable Network Proxy',
+            category: 'Security',
+            requiresRestart: true,
+            default: false,
+            description:
+              'Enable the network proxy layer for sandboxed commands. Routes HTTP/HTTPS and TCP traffic through a local proxy with domain filtering.',
+            showInDialog: true,
+          },
+          defaultAction: {
+            type: 'enum',
+            label: 'Default Domain Action',
+            category: 'Security',
+            requiresRestart: true,
+            default: 'prompt',
+            description:
+              'Action to take when a domain does not match any rule. "allow" permits traffic, "deny" blocks it, "prompt" asks the user.',
+            showInDialog: true,
+            options: [
+              { value: 'allow', label: 'Allow' },
+              { value: 'deny', label: 'Deny' },
+              { value: 'prompt', label: 'Prompt' },
+            ] as const,
+          },
+          allowedDomains: {
+            type: 'array',
+            label: 'Allowed Domains',
+            category: 'Security',
+            requiresRestart: false,
+            default: [] as string[],
+            description:
+              'Domains to always allow. Supports wildcards: *.example.com matches all subdomains.',
+            showInDialog: true,
+            items: { type: 'string' },
+          },
+          blockedDomains: {
+            type: 'array',
+            label: 'Blocked Domains',
+            category: 'Security',
+            requiresRestart: false,
+            default: [] as string[],
+            description:
+              'Domains to always block. Supports wildcards: *.evil.com blocks all subdomains.',
+            showInDialog: true,
+            items: { type: 'string' },
+          },
+          enableLogging: {
+            type: 'boolean',
+            label: 'Enable Traffic Logging',
+            category: 'Security',
+            requiresRestart: false,
+            default: false,
+            description:
+              'Log proxy traffic for security auditing. Logs are kept in memory only for the session duration.',
+            showInDialog: true,
+          },
+          httpPort: {
+            type: 'number',
+            label: 'HTTP Proxy Port',
+            category: 'Security',
+            requiresRestart: true,
+            default: 0,
+            description:
+              'Port for the HTTP/HTTPS proxy. Use 0 for auto-assignment.',
+            showInDialog: false,
+          },
+          socksPort: {
+            type: 'number',
+            label: 'SOCKS5 Proxy Port',
+            category: 'Security',
+            requiresRestart: true,
+            default: 0,
+            description:
+              'Port for the SOCKS5 proxy (non-HTTP traffic). Use 0 for auto-assignment.',
+            showInDialog: false,
+          },
+        },
+      },
     },
   },
 

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1591,7 +1591,7 @@ const SETTINGS_SCHEMA = {
             type: 'enum',
             label: 'Default Domain Action',
             category: 'Security',
-            requiresRestart: true,
+            requiresRestart: false,
             default: 'prompt',
             description:
               'Action to take when a domain does not match any rule. "allow" permits traffic, "deny" blocks it, "prompt" asks the user.',

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -588,6 +588,20 @@ export async function main() {
     const messageBus = config.getMessageBus();
     createPolicyUpdater(policyEngine, messageBus, config.storage);
 
+    // Start network proxy if enabled in settings
+    const networkProxyManager = config.getNetworkProxyManager();
+    if (networkProxyManager) {
+      try {
+        await networkProxyManager.start();
+        debugLogger.log('Network proxy started');
+      } catch (e) {
+        debugLogger.error('Failed to start network proxy:', e);
+      }
+      registerCleanup(async () => {
+        await networkProxyManager.stop();
+      });
+    }
+
     // Register SessionEnd hook to fire on graceful exit
     // This runs before telemetry shutdown in runExitCleanup()
     registerCleanup(async () => {

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -48,3 +48,16 @@ export { getCodeAssistServer } from './src/code_assist/codeAssist.js';
 export { getExperiments } from './src/code_assist/experiments/experiments.js';
 export { ExperimentFlags } from './src/code_assist/experiments/flagNames.js';
 export { getErrorStatus, ModelNotFoundError } from './src/utils/httpErrors.js';
+
+export { NetworkProxyManager } from './src/services/networkProxy/networkProxyManager.js';
+export {
+  DomainFilterAction,
+  DEFAULT_NETWORK_PROXY_CONFIG,
+} from './src/services/networkProxy/types.js';
+export type {
+  NetworkProxyConfig,
+  DomainRule,
+  ProxyConnectionRecord,
+  ProxyServerAddresses,
+  ProxyStatus,
+} from './src/services/networkProxy/types.js';

--- a/packages/core/src/services/networkProxy/baseProxy.ts
+++ b/packages/core/src/services/networkProxy/baseProxy.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EventEmitter } from 'node:events';
+import { checkDomain } from './domainMatcher.js';
+import type { DomainRule, DomainCheckResult } from './types.js';
+import { DomainFilterAction } from './types.js';
+
+export interface BaseProxyOptions {
+  rules: DomainRule[];
+  defaultAction: DomainFilterAction;
+}
+
+/**
+ * Shared base class for HttpProxy and SocksProxy.
+ *
+ * Encapsulates domain filtering logic: rule evaluation, session-level
+ * decision caching, and the PROMPT flow that emits 'domainCheck' events.
+ */
+export abstract class BaseProxy extends EventEmitter {
+  protected rules: DomainRule[];
+  protected defaultAction: DomainFilterAction;
+  protected connectionCount = 0;
+  protected deniedCount = 0;
+  protected sessionDecisions = new Map<string, DomainFilterAction>();
+
+  constructor(options: BaseProxyOptions) {
+    super();
+    this.rules = options.rules;
+    this.defaultAction = options.defaultAction;
+  }
+
+  abstract start(): Promise<number>;
+  abstract stop(): Promise<void>;
+  abstract getPort(): number;
+
+  getConnectionCount(): number {
+    return this.connectionCount;
+  }
+
+  getDeniedCount(): number {
+    return this.deniedCount;
+  }
+
+  updateRules(rules: DomainRule[]): void {
+    this.rules = rules;
+  }
+
+  updateDefaultAction(action: DomainFilterAction): void {
+    this.defaultAction = action;
+  }
+
+  recordSessionDecision(domain: string, action: DomainFilterAction): void {
+    this.sessionDecisions.set(domain.toLowerCase(), action);
+  }
+
+  /**
+   * Resolves the filtering action for a given hostname.
+   * Checks session-level decisions first, then rules, then default.
+   * If the resolved action is PROMPT, emits 'domainCheck' and waits
+   * for a response.
+   */
+  protected async resolveAction(hostname: string): Promise<DomainFilterAction> {
+    const sessionAction = this.sessionDecisions.get(hostname.toLowerCase());
+    if (sessionAction !== undefined) {
+      return sessionAction;
+    }
+
+    const result: DomainCheckResult = checkDomain(
+      hostname,
+      this.rules,
+      this.defaultAction,
+    );
+
+    if (result.action !== DomainFilterAction.PROMPT) {
+      return result.action;
+    }
+
+    return new Promise<DomainFilterAction>((resolve) => {
+      const hasListeners = this.emit('domainCheck', hostname, (decision: DomainFilterAction) => {
+        this.sessionDecisions.set(hostname.toLowerCase(), decision);
+        resolve(decision);
+      });
+
+      if (!hasListeners) {
+        resolve(DomainFilterAction.DENY);
+      }
+    });
+  }
+}

--- a/packages/core/src/services/networkProxy/domainMatcher.test.ts
+++ b/packages/core/src/services/networkProxy/domainMatcher.test.ts
@@ -51,6 +51,15 @@ describe('matchesDomainPattern', () => {
   it('trims whitespace', () => {
     expect(matchesDomainPattern('  example.com  ', 'example.com')).toBe(true);
   });
+
+  it('normalizes trailing dots in hostnames', () => {
+    expect(matchesDomainPattern('example.com', 'example.com.')).toBe(true);
+    expect(matchesDomainPattern('example.com.', 'example.com')).toBe(true);
+  });
+
+  it('normalizes trailing dots with wildcard patterns', () => {
+    expect(matchesDomainPattern('*.example.com', 'sub.example.com.')).toBe(true);
+  });
 });
 
 describe('checkDomain', () => {

--- a/packages/core/src/services/networkProxy/domainMatcher.test.ts
+++ b/packages/core/src/services/networkProxy/domainMatcher.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  matchesDomainPattern,
+  checkDomain,
+  checkDomainWithConfig,
+  extractHostname,
+  extractPort,
+} from './domainMatcher.js';
+import { DomainFilterAction, DEFAULT_NETWORK_PROXY_CONFIG } from './types.js';
+import type { DomainRule } from './types.js';
+
+describe('matchesDomainPattern', () => {
+  it('matches exact domain', () => {
+    expect(matchesDomainPattern('example.com', 'example.com')).toBe(true);
+  });
+
+  it('rejects non-matching exact domain', () => {
+    expect(matchesDomainPattern('example.com', 'other.com')).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(matchesDomainPattern('Example.COM', 'example.com')).toBe(true);
+    expect(matchesDomainPattern('example.com', 'EXAMPLE.COM')).toBe(true);
+  });
+
+  it('matches wildcard subdomain', () => {
+    expect(matchesDomainPattern('*.example.com', 'sub.example.com')).toBe(true);
+    expect(matchesDomainPattern('*.example.com', 'a.b.example.com')).toBe(true);
+  });
+
+  it('wildcard matches the base domain itself', () => {
+    expect(matchesDomainPattern('*.example.com', 'example.com')).toBe(true);
+  });
+
+  it('wildcard does not match unrelated domains', () => {
+    expect(matchesDomainPattern('*.example.com', 'notexample.com')).toBe(false);
+    expect(matchesDomainPattern('*.example.com', 'other.com')).toBe(false);
+  });
+
+  it('full wildcard matches everything', () => {
+    expect(matchesDomainPattern('*', 'anything.com')).toBe(true);
+    expect(matchesDomainPattern('*', 'sub.domain.example.org')).toBe(true);
+  });
+
+  it('trims whitespace', () => {
+    expect(matchesDomainPattern('  example.com  ', 'example.com')).toBe(true);
+  });
+});
+
+describe('checkDomain', () => {
+  const rules: DomainRule[] = [
+    { pattern: '*.googleapis.com', action: DomainFilterAction.ALLOW },
+    { pattern: 'evil.com', action: DomainFilterAction.DENY },
+    { pattern: '*.internal.corp', action: DomainFilterAction.DENY },
+  ];
+
+  it('returns ALLOW for matching allowlisted domain', () => {
+    const result = checkDomain('storage.googleapis.com', rules, DomainFilterAction.PROMPT);
+    expect(result.action).toBe(DomainFilterAction.ALLOW);
+    expect(result.matchedRule?.pattern).toBe('*.googleapis.com');
+  });
+
+  it('returns DENY for matching denylisted domain', () => {
+    const result = checkDomain('evil.com', rules, DomainFilterAction.PROMPT);
+    expect(result.action).toBe(DomainFilterAction.DENY);
+  });
+
+  it('returns default action for unmatched domain', () => {
+    const result = checkDomain('unknown.com', rules, DomainFilterAction.PROMPT);
+    expect(result.action).toBe(DomainFilterAction.PROMPT);
+    expect(result.matchedRule).toBeUndefined();
+  });
+
+  it('first matching rule wins', () => {
+    const overlappingRules: DomainRule[] = [
+      { pattern: '*.example.com', action: DomainFilterAction.ALLOW },
+      { pattern: 'bad.example.com', action: DomainFilterAction.DENY },
+    ];
+    const result = checkDomain('bad.example.com', overlappingRules, DomainFilterAction.PROMPT);
+    expect(result.action).toBe(DomainFilterAction.ALLOW);
+  });
+
+  it('handles empty rules list', () => {
+    const result = checkDomain('example.com', [], DomainFilterAction.DENY);
+    expect(result.action).toBe(DomainFilterAction.DENY);
+  });
+});
+
+describe('checkDomainWithConfig', () => {
+  it('delegates to checkDomain with config values', () => {
+    const config = {
+      ...DEFAULT_NETWORK_PROXY_CONFIG,
+      rules: [
+        { pattern: '*.google.com', action: DomainFilterAction.ALLOW },
+      ],
+      defaultAction: DomainFilterAction.DENY,
+    };
+    const result = checkDomainWithConfig('api.google.com', config);
+    expect(result.action).toBe(DomainFilterAction.ALLOW);
+
+    const denied = checkDomainWithConfig('evil.com', config);
+    expect(denied.action).toBe(DomainFilterAction.DENY);
+  });
+});
+
+describe('extractHostname', () => {
+  it('extracts host from host:port format', () => {
+    expect(extractHostname('example.com:443')).toBe('example.com');
+  });
+
+  it('returns raw value when no port', () => {
+    expect(extractHostname('example.com')).toBe('example.com');
+  });
+
+  it('extracts hostname from full URL', () => {
+    expect(extractHostname('https://example.com/path')).toBe('example.com');
+    expect(extractHostname('http://api.example.com:8080/v1')).toBe('api.example.com');
+  });
+
+  it('handles IPv6 in host:port', () => {
+    expect(extractHostname('[::1]:8080')).toBe('[::1]');
+  });
+
+  it('returns input for unparseable values', () => {
+    expect(extractHostname('not a url at all')).toBe('not a url at all');
+  });
+});
+
+describe('extractPort', () => {
+  it('extracts port from host:port format', () => {
+    expect(extractPort('example.com:8080')).toBe(8080);
+    expect(extractPort('example.com:443')).toBe(443);
+  });
+
+  it('returns default port when not specified', () => {
+    expect(extractPort('example.com')).toBe(80);
+    expect(extractPort('example.com', 443)).toBe(443);
+  });
+
+  it('extracts port from full URL', () => {
+    expect(extractPort('http://example.com:9090/path')).toBe(9090);
+    expect(extractPort('https://example.com/path')).toBe(443);
+    expect(extractPort('http://example.com/path')).toBe(80);
+  });
+});

--- a/packages/core/src/services/networkProxy/domainMatcher.test.ts
+++ b/packages/core/src/services/networkProxy/domainMatcher.test.ts
@@ -127,6 +127,14 @@ describe('extractHostname', () => {
     expect(extractHostname('[::1]:8080')).toBe('[::1]');
   });
 
+  it('handles full IPv6 address in host:port', () => {
+    expect(extractHostname('[2001:db8::1]:443')).toBe('[2001:db8::1]');
+  });
+
+  it('handles IPv6 in full URL', () => {
+    expect(extractHostname('http://[::1]:3000/path')).toBe('[::1]');
+  });
+
   it('returns input for unparseable values', () => {
     expect(extractHostname('not a url at all')).toBe('not a url at all');
   });
@@ -147,5 +155,14 @@ describe('extractPort', () => {
     expect(extractPort('http://example.com:9090/path')).toBe(9090);
     expect(extractPort('https://example.com/path')).toBe(443);
     expect(extractPort('http://example.com/path')).toBe(80);
+  });
+
+  it('extracts port from IPv6 host:port', () => {
+    expect(extractPort('[::1]:8080')).toBe(8080);
+    expect(extractPort('[2001:db8::1]:443')).toBe(443);
+  });
+
+  it('extracts port from IPv6 URL', () => {
+    expect(extractPort('http://[::1]:3000/path')).toBe(3000);
   });
 });

--- a/packages/core/src/services/networkProxy/domainMatcher.ts
+++ b/packages/core/src/services/networkProxy/domainMatcher.ts
@@ -17,8 +17,15 @@ import type { DomainRule, DomainCheckResult, NetworkProxyConfig, DomainFilterAct
  * Matching is case-insensitive.
  */
 export function matchesDomainPattern(pattern: string, hostname: string): boolean {
-  const normalizedPattern = pattern.toLowerCase().trim();
-  const normalizedHost = hostname.toLowerCase().trim();
+  let normalizedPattern = pattern.toLowerCase().trim();
+  if (normalizedPattern.endsWith('.') && normalizedPattern.length > 1) {
+    normalizedPattern = normalizedPattern.slice(0, -1);
+  }
+
+  let normalizedHost = hostname.toLowerCase().trim();
+  if (normalizedHost.endsWith('.') && normalizedHost.length > 1) {
+    normalizedHost = normalizedHost.slice(0, -1);
+  }
 
   if (normalizedPattern === '*') {
     return true;

--- a/packages/core/src/services/networkProxy/domainMatcher.ts
+++ b/packages/core/src/services/networkProxy/domainMatcher.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { DomainRule, DomainCheckResult, NetworkProxyConfig } from './types.js';
+import { DomainFilterAction } from './types.js';
+
+/**
+ * Checks whether a domain pattern matches a given hostname.
+ *
+ * Supported patterns:
+ *   - Exact match: "example.com" matches "example.com"
+ *   - Wildcard prefix: "*.example.com" matches "sub.example.com", "a.b.example.com"
+ *   - Full wildcard: "*" matches everything
+ *
+ * Matching is case-insensitive.
+ */
+export function matchesDomainPattern(pattern: string, hostname: string): boolean {
+  const normalizedPattern = pattern.toLowerCase().trim();
+  const normalizedHost = hostname.toLowerCase().trim();
+
+  // Full wildcard
+  if (normalizedPattern === '*') {
+    return true;
+  }
+
+  // Wildcard subdomain match: *.example.com
+  if (normalizedPattern.startsWith('*.')) {
+    const suffix = normalizedPattern.slice(2); // "example.com"
+    // Must match the suffix exactly, or be a subdomain of it
+    return normalizedHost === suffix || normalizedHost.endsWith('.' + suffix);
+  }
+
+  // Exact match
+  return normalizedHost === normalizedPattern;
+}
+
+/**
+ * Evaluates a hostname against an ordered list of domain rules.
+ * Returns the action from the first matching rule, or the default action.
+ */
+export function checkDomain(
+  hostname: string,
+  rules: DomainRule[],
+  defaultAction: DomainFilterAction,
+): DomainCheckResult {
+  for (const rule of rules) {
+    if (matchesDomainPattern(rule.pattern, hostname)) {
+      return {
+        domain: hostname,
+        action: rule.action,
+        matchedRule: rule,
+      };
+    }
+  }
+
+  return {
+    domain: hostname,
+    action: defaultAction,
+  };
+}
+
+/**
+ * Convenience function that checks a domain using a full NetworkProxyConfig.
+ */
+export function checkDomainWithConfig(
+  hostname: string,
+  config: NetworkProxyConfig,
+): DomainCheckResult {
+  return checkDomain(hostname, config.rules, config.defaultAction);
+}
+
+/**
+ * Extracts the hostname from an HTTP request URL or CONNECT target.
+ * Handles both "host:port" format (from CONNECT) and full URLs.
+ */
+export function extractHostname(target: string): string {
+  // CONNECT requests come in as "host:port"
+  if (!target.includes('://')) {
+    const colonIdx = target.lastIndexOf(':');
+    if (colonIdx > 0) {
+      return target.substring(0, colonIdx);
+    }
+    return target;
+  }
+
+  // Full URL
+  try {
+    return new URL(target).hostname;
+  } catch {
+    return target;
+  }
+}
+
+/**
+ * Extracts the port from an HTTP request URL or CONNECT target.
+ * Returns the default port for the protocol if not specified.
+ */
+export function extractPort(target: string, defaultPort: number = 80): number {
+  if (!target.includes('://')) {
+    const colonIdx = target.lastIndexOf(':');
+    if (colonIdx > 0) {
+      const port = parseInt(target.substring(colonIdx + 1), 10);
+      return isNaN(port) ? defaultPort : port;
+    }
+    return defaultPort;
+  }
+
+  try {
+    const url = new URL(target);
+    if (url.port) {
+      return parseInt(url.port, 10);
+    }
+    return url.protocol === 'https:' ? 443 : 80;
+  } catch {
+    return defaultPort;
+  }
+}

--- a/packages/core/src/services/networkProxy/domainMatcher.ts
+++ b/packages/core/src/services/networkProxy/domainMatcher.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { DomainRule, DomainCheckResult, NetworkProxyConfig } from './types.js';
-import { DomainFilterAction } from './types.js';
+import type { DomainRule, DomainCheckResult, NetworkProxyConfig, DomainFilterAction } from './types.js';
 
 /**
  * Checks whether a domain pattern matches a given hostname.

--- a/packages/core/src/services/networkProxy/domainMatcher.ts
+++ b/packages/core/src/services/networkProxy/domainMatcher.ts
@@ -20,7 +20,6 @@ export function matchesDomainPattern(pattern: string, hostname: string): boolean
   const normalizedPattern = pattern.toLowerCase().trim();
   const normalizedHost = hostname.toLowerCase().trim();
 
-  // Full wildcard
   if (normalizedPattern === '*') {
     return true;
   }
@@ -32,7 +31,6 @@ export function matchesDomainPattern(pattern: string, hostname: string): boolean
     return normalizedHost === suffix || normalizedHost.endsWith('.' + suffix);
   }
 
-  // Exact match
   return normalizedHost === normalizedPattern;
 }
 
@@ -85,7 +83,6 @@ export function extractHostname(target: string): string {
     return target;
   }
 
-  // Full URL
   try {
     return new URL(target).hostname;
   } catch {

--- a/packages/core/src/services/networkProxy/domainPromptHandler.test.ts
+++ b/packages/core/src/services/networkProxy/domainPromptHandler.test.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * @license
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
@@ -10,8 +10,9 @@ import { DomainPromptHandler } from './domainPromptHandler.js';
 import { DomainFilterAction } from './types.js';
 import type { NetworkProxyManager } from './networkProxyManager.js';
 
-function createMockManager(): EventEmitter & Partial<NetworkProxyManager> {
-  return new EventEmitter();
+function createMockManager(): NetworkProxyManager {
+  // We only need the EventEmitter interface for testing domainCheck events
+  return new EventEmitter() as unknown as NetworkProxyManager;
 }
 
 describe('DomainPromptHandler', () => {
@@ -19,7 +20,7 @@ describe('DomainPromptHandler', () => {
     const manager = createMockManager();
     const callback = vi.fn().mockResolvedValue(DomainFilterAction.ALLOW);
     const handler = new DomainPromptHandler(
-      manager as NetworkProxyManager,
+      manager,
       callback,
     );
 
@@ -38,7 +39,7 @@ describe('DomainPromptHandler', () => {
     const manager = createMockManager();
     const callback = vi.fn().mockResolvedValue(DomainFilterAction.ALLOW);
     const handler = new DomainPromptHandler(
-      manager as NetworkProxyManager,
+      manager,
       callback,
     );
 
@@ -53,7 +54,7 @@ describe('DomainPromptHandler', () => {
     const manager = createMockManager();
     const callback = vi.fn().mockResolvedValue(DomainFilterAction.ALLOW);
     const handler = new DomainPromptHandler(
-      manager as NetworkProxyManager,
+      manager,
       callback,
     );
 
@@ -73,7 +74,7 @@ describe('DomainPromptHandler', () => {
     const manager = createMockManager();
     const callback = vi.fn().mockResolvedValue(DomainFilterAction.DENY);
     const handler = new DomainPromptHandler(
-      manager as NetworkProxyManager,
+      manager,
       callback,
     );
 
@@ -92,7 +93,7 @@ describe('DomainPromptHandler', () => {
     const manager = createMockManager();
     const callback = vi.fn().mockRejectedValue(new Error('prompt failed'));
     const handler = new DomainPromptHandler(
-      manager as NetworkProxyManager,
+      manager,
       callback,
     );
 
@@ -111,7 +112,7 @@ describe('DomainPromptHandler', () => {
     const manager = createMockManager();
     const callback = vi.fn().mockResolvedValue(DomainFilterAction.ALLOW);
     const handler = new DomainPromptHandler(
-      manager as NetworkProxyManager,
+      manager,
       callback,
     );
 

--- a/packages/core/src/services/networkProxy/domainPromptHandler.test.ts
+++ b/packages/core/src/services/networkProxy/domainPromptHandler.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { DomainPromptHandler } from './domainPromptHandler.js';
+import { DomainFilterAction } from './types.js';
+import type { NetworkProxyManager } from './networkProxyManager.js';
+
+function createMockManager(): EventEmitter & Partial<NetworkProxyManager> {
+  return new EventEmitter();
+}
+
+describe('DomainPromptHandler', () => {
+  it('attaches and detaches correctly', () => {
+    const manager = createMockManager();
+    const callback = vi.fn().mockResolvedValue(DomainFilterAction.ALLOW);
+    const handler = new DomainPromptHandler(
+      manager as NetworkProxyManager,
+      callback,
+    );
+
+    expect(handler.isAttached()).toBe(false);
+
+    handler.attach();
+    expect(handler.isAttached()).toBe(true);
+    expect(manager.listenerCount('domainCheck')).toBe(1);
+
+    handler.detach();
+    expect(handler.isAttached()).toBe(false);
+    expect(manager.listenerCount('domainCheck')).toBe(0);
+  });
+
+  it('does not double-attach', () => {
+    const manager = createMockManager();
+    const callback = vi.fn().mockResolvedValue(DomainFilterAction.ALLOW);
+    const handler = new DomainPromptHandler(
+      manager as NetworkProxyManager,
+      callback,
+    );
+
+    handler.attach();
+    handler.attach(); // should be a no-op
+    expect(manager.listenerCount('domainCheck')).toBe(1);
+
+    handler.detach();
+  });
+
+  it('calls the prompt callback with the hostname', async () => {
+    const manager = createMockManager();
+    const callback = vi.fn().mockResolvedValue(DomainFilterAction.ALLOW);
+    const handler = new DomainPromptHandler(
+      manager as NetworkProxyManager,
+      callback,
+    );
+
+    handler.attach();
+
+    const decision = await new Promise<DomainFilterAction>((resolve) => {
+      manager.emit('domainCheck', 'test.example.com', resolve);
+    });
+
+    expect(callback).toHaveBeenCalledWith('test.example.com');
+    expect(decision).toBe(DomainFilterAction.ALLOW);
+
+    handler.detach();
+  });
+
+  it('relays deny decisions from the callback', async () => {
+    const manager = createMockManager();
+    const callback = vi.fn().mockResolvedValue(DomainFilterAction.DENY);
+    const handler = new DomainPromptHandler(
+      manager as NetworkProxyManager,
+      callback,
+    );
+
+    handler.attach();
+
+    const decision = await new Promise<DomainFilterAction>((resolve) => {
+      manager.emit('domainCheck', 'blocked.com', resolve);
+    });
+
+    expect(decision).toBe(DomainFilterAction.DENY);
+
+    handler.detach();
+  });
+
+  it('denies on callback failure for safety', async () => {
+    const manager = createMockManager();
+    const callback = vi.fn().mockRejectedValue(new Error('prompt failed'));
+    const handler = new DomainPromptHandler(
+      manager as NetworkProxyManager,
+      callback,
+    );
+
+    handler.attach();
+
+    const decision = await new Promise<DomainFilterAction>((resolve) => {
+      manager.emit('domainCheck', 'error.com', resolve);
+    });
+
+    expect(decision).toBe(DomainFilterAction.DENY);
+
+    handler.detach();
+  });
+
+  it('detach is safe to call when not attached', () => {
+    const manager = createMockManager();
+    const callback = vi.fn().mockResolvedValue(DomainFilterAction.ALLOW);
+    const handler = new DomainPromptHandler(
+      manager as NetworkProxyManager,
+      callback,
+    );
+
+    // Should not throw
+    handler.detach();
+    expect(handler.isAttached()).toBe(false);
+  });
+});

--- a/packages/core/src/services/networkProxy/domainPromptHandler.ts
+++ b/packages/core/src/services/networkProxy/domainPromptHandler.ts
@@ -91,13 +91,11 @@ export function createConsoleDomainPrompt(): DomainPromptCallback {
 
     return new Promise<DomainFilterAction>((resolve) => {
       rl.question(
-        `\nNetwork proxy: "${hostname}" wants to connect. Allow? [y/N/a(always)] `,
+        `\nNetwork proxy: "${hostname}" wants to connect. Allow? [y/N] `,
         (answer) => {
           rl.close();
           const normalized = answer.trim().toLowerCase();
           if (normalized === 'y' || normalized === 'yes') {
-            resolve(DomainFilterAction.ALLOW);
-          } else if (normalized === 'a' || normalized === 'always') {
             resolve(DomainFilterAction.ALLOW);
           } else {
             resolve(DomainFilterAction.DENY);

--- a/packages/core/src/services/networkProxy/domainPromptHandler.ts
+++ b/packages/core/src/services/networkProxy/domainPromptHandler.ts
@@ -8,11 +8,8 @@ import type { NetworkProxyManager } from './networkProxyManager.js';
 import { DomainFilterAction } from './types.js';
 
 /**
- * Callback type for asking the user whether to allow or deny a domain.
- *
- * The implementation should present the domain to the user and return
- * their decision. This decouples the proxy layer from any specific UI
- * framework (CLI readline, Ink, VS Code, etc.).
+ * Prompt callback for asking the user whether to allow or deny a domain.
+ * Implementation is UI-agnostic (CLI readline, Ink, VS Code, etc.).
  */
 export type DomainPromptCallback = (
   hostname: string,
@@ -25,15 +22,6 @@ export type DomainPromptCallback = (
  * and defaultAction is 'prompt'), it emits a 'domainCheck' event. This handler
  * intercepts that event, calls the provided prompt callback to get the user's
  * decision, and relays the answer back to the proxy.
- *
- * Usage:
- *   const handler = new DomainPromptHandler(proxyManager, async (host) => {
- *     // Show prompt to user, return their decision
- *     return DomainFilterAction.ALLOW;
- *   });
- *   handler.attach();
- *   // ... later
- *   handler.detach();
  */
 export class DomainPromptHandler {
   private attached = false;

--- a/packages/core/src/services/networkProxy/domainPromptHandler.ts
+++ b/packages/core/src/services/networkProxy/domainPromptHandler.ts
@@ -11,7 +11,7 @@ import { DomainFilterAction } from './types.js';
  * Strips ANSI escape sequences and control characters from a hostname
  * to prevent terminal injection attacks.
  */
-function sanitizeHostname(hostname: string): string {
+export function sanitizeHostname(hostname: string): string {
   // Remove ANSI escape sequences
   // eslint-disable-next-line no-control-regex
   return hostname.replace(/[\x00-\x1f\x7f-\x9f]|\x1b\[[0-9;]*[a-zA-Z]/g, '');

--- a/packages/core/src/services/networkProxy/domainPromptHandler.ts
+++ b/packages/core/src/services/networkProxy/domainPromptHandler.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { NetworkProxyManager } from './networkProxyManager.js';
+import { DomainFilterAction } from './types.js';
+
+/**
+ * Callback type for asking the user whether to allow or deny a domain.
+ *
+ * The implementation should present the domain to the user and return
+ * their decision. This decouples the proxy layer from any specific UI
+ * framework (CLI readline, Ink, VS Code, etc.).
+ */
+export type DomainPromptCallback = (
+  hostname: string,
+) => Promise<DomainFilterAction>;
+
+/**
+ * Connects a NetworkProxyManager's domainCheck events to a user-facing prompt.
+ *
+ * When the proxy encounters a domain that resolves to PROMPT (no matching rule
+ * and defaultAction is 'prompt'), it emits a 'domainCheck' event. This handler
+ * intercepts that event, calls the provided prompt callback to get the user's
+ * decision, and relays the answer back to the proxy.
+ *
+ * Usage:
+ *   const handler = new DomainPromptHandler(proxyManager, async (host) => {
+ *     // Show prompt to user, return their decision
+ *     return DomainFilterAction.ALLOW;
+ *   });
+ *   handler.attach();
+ *   // ... later
+ *   handler.detach();
+ */
+export class DomainPromptHandler {
+  private attached = false;
+  private listener: ((hostname: string, respond: (action: DomainFilterAction) => void) => void) | null = null;
+
+  constructor(
+    private readonly manager: NetworkProxyManager,
+    private readonly promptCallback: DomainPromptCallback,
+  ) {}
+
+  /**
+   * Starts listening for domain check events.
+   */
+  attach(): void {
+    if (this.attached) {
+      return;
+    }
+
+    this.listener = (hostname: string, respond: (action: DomainFilterAction) => void) => {
+      this.promptCallback(hostname)
+        .then((decision) => {
+          respond(decision);
+        })
+        .catch(() => {
+          // On prompt failure, deny for safety
+          respond(DomainFilterAction.DENY);
+        });
+    };
+
+    this.manager.on('domainCheck', this.listener);
+    this.attached = true;
+  }
+
+  /**
+   * Stops listening for domain check events.
+   */
+  detach(): void {
+    if (!this.attached || !this.listener) {
+      return;
+    }
+    this.manager.removeListener('domainCheck', this.listener);
+    this.listener = null;
+    this.attached = false;
+  }
+
+  isAttached(): boolean {
+    return this.attached;
+  }
+}
+
+/**
+ * Creates a simple console-based domain prompt callback.
+ *
+ * This is used as a fallback when no UI-specific prompt is available.
+ * For interactive CLI sessions, the CLI layer should provide a richer
+ * prompt using Ink or readline.
+ */
+export function createConsoleDomainPrompt(): DomainPromptCallback {
+  return async (hostname: string): Promise<DomainFilterAction> => {
+    // In non-interactive mode or when no proper prompt is available,
+    // deny unknown domains by default for security.
+    const readline = await import('node:readline');
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stderr,
+    });
+
+    return new Promise<DomainFilterAction>((resolve) => {
+      rl.question(
+        `\nNetwork proxy: "${hostname}" wants to connect. Allow? [y/N/a(always)] `,
+        (answer) => {
+          rl.close();
+          const normalized = answer.trim().toLowerCase();
+          if (normalized === 'y' || normalized === 'yes') {
+            resolve(DomainFilterAction.ALLOW);
+          } else if (normalized === 'a' || normalized === 'always') {
+            resolve(DomainFilterAction.ALLOW);
+          } else {
+            resolve(DomainFilterAction.DENY);
+          }
+        },
+      );
+    });
+  };
+}

--- a/packages/core/src/services/networkProxy/domainPromptHandler.ts
+++ b/packages/core/src/services/networkProxy/domainPromptHandler.ts
@@ -102,11 +102,11 @@ export function createConsoleDomainPrompt(): DomainPromptCallback {
     const safe = sanitizeHostname(hostname);
     return new Promise<DomainFilterAction>((resolve) => {
       rl.question(
-        `\nNetwork proxy: "${safe}" wants to connect. Allow? [y/N] `,
+        `\nNetwork proxy: "${safe}" wants to connect. Allow? [Y/n] `,
         (answer) => {
           rl.close();
           const normalized = answer.trim().toLowerCase();
-          if (normalized === 'y' || normalized === 'yes') {
+          if (normalized === 'y' || normalized === '') {
             resolve(DomainFilterAction.ALLOW);
           } else {
             resolve(DomainFilterAction.DENY);

--- a/packages/core/src/services/networkProxy/httpProxy.test.ts
+++ b/packages/core/src/services/networkProxy/httpProxy.test.ts
@@ -1,0 +1,369 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as http from 'node:http';
+import * as net from 'node:net';
+import { HttpProxy } from './httpProxy.js';
+import { DomainFilterAction } from './types.js';
+import type { ProxyConnectionRecord } from './types.js';
+
+function httpGet(
+  proxyPort: number,
+  targetUrl: string,
+): Promise<{ statusCode: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(targetUrl);
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port: proxyPort,
+        path: targetUrl,
+        method: 'GET',
+        headers: { Host: parsed.host },
+      },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk: Buffer) => {
+          body += chunk.toString();
+        });
+        res.on('end', () => {
+          resolve({ statusCode: res.statusCode ?? 0, body });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+function httpConnect(
+  proxyPort: number,
+  target: string,
+): Promise<{ statusCode: number; socket: net.Socket }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      hostname: '127.0.0.1',
+      port: proxyPort,
+      method: 'CONNECT',
+      path: target,
+    });
+    req.on('connect', (res, socket) => {
+      resolve({ statusCode: res.statusCode ?? 0, socket });
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('HttpProxy', () => {
+  let proxy: HttpProxy;
+  let echoServer: http.Server;
+  let echoPort: number;
+
+  afterEach(async () => {
+    if (proxy) {
+      await proxy.stop();
+    }
+    if (echoServer) {
+      await new Promise<void>((resolve) => {
+        echoServer.close(() => resolve());
+        echoServer.closeAllConnections();
+      });
+    }
+  });
+
+  async function startEchoServer(): Promise<number> {
+    return new Promise((resolve) => {
+      echoServer = http.createServer((req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end(`echo: ${req.url}`);
+      });
+      echoServer.listen(0, '127.0.0.1', () => {
+        const addr = echoServer.address();
+        if (addr && typeof addr === 'object') {
+          echoPort = addr.port;
+          resolve(echoPort);
+        }
+      });
+    });
+  }
+
+  it('starts and stops without errors', async () => {
+    proxy = new HttpProxy({
+      port: 0,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+
+    const port = await proxy.start();
+    expect(port).toBeGreaterThan(0);
+    expect(proxy.getPort()).toBe(port);
+
+    await proxy.stop();
+    expect(proxy.getPort()).toBe(port); // port number is retained
+  });
+
+  it('allows connections when default action is allow', async () => {
+    await startEchoServer();
+
+    proxy = new HttpProxy({
+      port: 0,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+    const proxyPort = await proxy.start();
+
+    const result = await httpGet(
+      proxyPort,
+      `http://127.0.0.1:${echoPort}/hello`,
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(result.body).toContain('echo: /hello');
+    expect(proxy.getConnectionCount()).toBe(1);
+    expect(proxy.getDeniedCount()).toBe(0);
+  });
+
+  it('denies connections when default action is deny', async () => {
+    proxy = new HttpProxy({
+      port: 0,
+      rules: [],
+      defaultAction: DomainFilterAction.DENY,
+    });
+    const proxyPort = await proxy.start();
+
+    const result = await httpGet(
+      proxyPort,
+      'http://example.com/test',
+    );
+
+    expect(result.statusCode).toBe(403);
+    expect(result.body).toContain('Blocked by network proxy policy');
+    expect(proxy.getDeniedCount()).toBe(1);
+  });
+
+  it('allows domains matching allow rules even when default is deny', async () => {
+    await startEchoServer();
+
+    proxy = new HttpProxy({
+      port: 0,
+      rules: [{ pattern: '127.0.0.1', action: DomainFilterAction.ALLOW }],
+      defaultAction: DomainFilterAction.DENY,
+    });
+    const proxyPort = await proxy.start();
+
+    const result = await httpGet(
+      proxyPort,
+      `http://127.0.0.1:${echoPort}/allowed`,
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(result.body).toContain('echo: /allowed');
+  });
+
+  it('blocks domains matching deny rules even when default is allow', async () => {
+    proxy = new HttpProxy({
+      port: 0,
+      rules: [{ pattern: 'blocked.example.com', action: DomainFilterAction.DENY }],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+    const proxyPort = await proxy.start();
+
+    const result = await httpGet(
+      proxyPort,
+      'http://blocked.example.com/test',
+    );
+
+    expect(result.statusCode).toBe(403);
+    expect(proxy.getDeniedCount()).toBe(1);
+  });
+
+  it('emits connection events on allowed requests', async () => {
+    await startEchoServer();
+
+    proxy = new HttpProxy({
+      port: 0,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+    const proxyPort = await proxy.start();
+
+    const records: ProxyConnectionRecord[] = [];
+    proxy.on('connection', (record: ProxyConnectionRecord) => {
+      records.push(record);
+    });
+
+    await httpGet(proxyPort, `http://127.0.0.1:${echoPort}/test`);
+
+    expect(records).toHaveLength(1);
+    expect(records[0].host).toBe('127.0.0.1');
+    expect(records[0].action).toBe(DomainFilterAction.ALLOW);
+    expect(records[0].protocol).toBe('http');
+  });
+
+  it('emits denied events on blocked requests', async () => {
+    proxy = new HttpProxy({
+      port: 0,
+      rules: [],
+      defaultAction: DomainFilterAction.DENY,
+    });
+    const proxyPort = await proxy.start();
+
+    const deniedRecords: ProxyConnectionRecord[] = [];
+    proxy.on('denied', (record: ProxyConnectionRecord) => {
+      deniedRecords.push(record);
+    });
+
+    await httpGet(proxyPort, 'http://example.com/test');
+
+    expect(deniedRecords).toHaveLength(1);
+    expect(deniedRecords[0].action).toBe(DomainFilterAction.DENY);
+  });
+
+  it('denies CONNECT requests when domain is blocked', async () => {
+    proxy = new HttpProxy({
+      port: 0,
+      rules: [],
+      defaultAction: DomainFilterAction.DENY,
+    });
+    const proxyPort = await proxy.start();
+
+    const result = await httpConnect(proxyPort, 'blocked.example.com:443');
+
+    expect(result.statusCode).toBe(403);
+    result.socket.destroy();
+    expect(proxy.getDeniedCount()).toBe(1);
+  });
+
+  it('supports wildcard domain rules', async () => {
+    proxy = new HttpProxy({
+      port: 0,
+      rules: [
+        { pattern: '*.blocked.com', action: DomainFilterAction.DENY },
+      ],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+    const proxyPort = await proxy.start();
+
+    const result = await httpGet(
+      proxyPort,
+      'http://api.blocked.com/test',
+    );
+
+    expect(result.statusCode).toBe(403);
+    expect(proxy.getDeniedCount()).toBe(1);
+  });
+
+  it('respects session decisions from recordSessionDecision', async () => {
+    await startEchoServer();
+
+    proxy = new HttpProxy({
+      port: 0,
+      rules: [],
+      defaultAction: DomainFilterAction.DENY,
+    });
+    const proxyPort = await proxy.start();
+
+    // Record a session-level allow for 127.0.0.1
+    proxy.recordSessionDecision('127.0.0.1', DomainFilterAction.ALLOW);
+
+    const result = await httpGet(
+      proxyPort,
+      `http://127.0.0.1:${echoPort}/session-allowed`,
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(result.body).toContain('echo: /session-allowed');
+  });
+
+  it('handles PROMPT action by emitting domainCheck event', async () => {
+    await startEchoServer();
+
+    proxy = new HttpProxy({
+      port: 0,
+      rules: [
+        { pattern: '127.0.0.1', action: DomainFilterAction.PROMPT },
+      ],
+      defaultAction: DomainFilterAction.DENY,
+    });
+    const proxyPort = await proxy.start();
+
+    // Listen for domainCheck and approve the domain
+    proxy.on('domainCheck', (hostname: string, respond: (action: DomainFilterAction) => void) => {
+      respond(DomainFilterAction.ALLOW);
+    });
+
+    const result = await httpGet(
+      proxyPort,
+      `http://127.0.0.1:${echoPort}/prompted`,
+    );
+
+    expect(result.statusCode).toBe(200);
+  });
+
+  it('denies PROMPT domains when no listener is attached', async () => {
+    proxy = new HttpProxy({
+      port: 0,
+      rules: [
+        { pattern: 'unhandled.com', action: DomainFilterAction.PROMPT },
+      ],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+    const proxyPort = await proxy.start();
+
+    // No domainCheck listener attached
+
+    const result = await httpGet(
+      proxyPort,
+      'http://unhandled.com/test',
+    );
+
+    expect(result.statusCode).toBe(403);
+  });
+
+  it('updates rules at runtime', async () => {
+    proxy = new HttpProxy({
+      port: 0,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+    const proxyPort = await proxy.start();
+
+    // Initially allowed
+    const result1 = await httpGet(proxyPort, 'http://example.com/test');
+    expect(result1.statusCode).not.toBe(403);
+
+    // Now add a deny rule
+    proxy.updateRules([
+      { pattern: 'example.com', action: DomainFilterAction.DENY },
+    ]);
+
+    const result2 = await httpGet(proxyPort, 'http://example.com/test');
+    expect(result2.statusCode).toBe(403);
+  });
+
+  it('tracks connection and denied counts correctly', async () => {
+    proxy = new HttpProxy({
+      port: 0,
+      rules: [
+        { pattern: 'allowed.com', action: DomainFilterAction.ALLOW },
+        { pattern: 'blocked.com', action: DomainFilterAction.DENY },
+      ],
+      defaultAction: DomainFilterAction.DENY,
+    });
+    const proxyPort = await proxy.start();
+
+    await httpGet(proxyPort, 'http://blocked.com/1');
+    await httpGet(proxyPort, 'http://blocked.com/2');
+    // allowed.com will fail to connect (no actual server) but the domain
+    // check itself succeeds → connection count goes up
+    await httpGet(proxyPort, 'http://allowed.com/3').catch(() => {});
+
+    expect(proxy.getConnectionCount()).toBe(3);
+    expect(proxy.getDeniedCount()).toBe(2);
+  });
+});

--- a/packages/core/src/services/networkProxy/httpProxy.test.ts
+++ b/packages/core/src/services/networkProxy/httpProxy.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, afterEach } from 'vitest';
 import * as http from 'node:http';
-import * as net from 'node:net';
+import type * as net from 'node:net';
 import { HttpProxy } from './httpProxy.js';
 import { DomainFilterAction } from './types.js';
 import type { ProxyConnectionRecord } from './types.js';

--- a/packages/core/src/services/networkProxy/httpProxy.ts
+++ b/packages/core/src/services/networkProxy/httpProxy.ts
@@ -58,11 +58,11 @@ export class HttpProxy extends EventEmitter {
   async start(): Promise<number> {
     return new Promise((resolve, reject) => {
       this.server = http.createServer((req, res) => {
-        this.handleRequest(req, res);
+        void this.handleRequest(req, res);
       });
 
       this.server.on('connect', (req, clientSocket, head) => {
-        this.handleConnect(req, clientSocket, head);
+        void this.handleConnect(req, clientSocket, head);
       });
 
       this.server.on('error', (err) => {

--- a/packages/core/src/services/networkProxy/httpProxy.ts
+++ b/packages/core/src/services/networkProxy/httpProxy.ts
@@ -6,6 +6,7 @@
 
 import * as http from 'node:http';
 import * as net from 'node:net';
+import type { Duplex } from 'node:stream';
 import { EventEmitter } from 'node:events';
 import { checkDomain, extractHostname, extractPort } from './domainMatcher.js';
 import type {
@@ -127,7 +128,7 @@ export class HttpProxy extends EventEmitter {
    */
   private async handleConnect(
     req: http.IncomingMessage,
-    clientSocket: net.Socket,
+    clientSocket: Duplex,
     head: Buffer,
   ): Promise<void> {
     const target = req.url ?? '';

--- a/packages/core/src/services/networkProxy/httpProxy.ts
+++ b/packages/core/src/services/networkProxy/httpProxy.ts
@@ -16,13 +16,9 @@ import type {
 import { DomainFilterAction } from './types.js';
 
 export interface HttpProxyOptions {
-  /** Port to listen on. 0 = auto-assign. */
   port: number;
-  /** Hostname to bind to. Defaults to '127.0.0.1'. */
   host?: string;
-  /** Domain filtering rules. */
   rules: DomainRule[];
-  /** Default action when no rule matches. */
   defaultAction: DomainFilterAction;
 }
 
@@ -53,7 +49,6 @@ export class HttpProxy extends EventEmitter {
 
   /**
    * Starts the HTTP proxy server.
-   * Returns a promise that resolves once the server is listening.
    */
   async start(): Promise<number> {
     return new Promise((resolve, reject) => {
@@ -236,7 +231,6 @@ export class HttpProxy extends EventEmitter {
 
     this.emit('connection', record);
 
-    // Forward the request
     const proxyReq = http.request(
       {
         hostname,

--- a/packages/core/src/services/networkProxy/httpProxy.ts
+++ b/packages/core/src/services/networkProxy/httpProxy.ts
@@ -1,0 +1,299 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as http from 'node:http';
+import * as net from 'node:net';
+import { EventEmitter } from 'node:events';
+import { checkDomain, extractHostname, extractPort } from './domainMatcher.js';
+import type {
+  DomainRule,
+  DomainCheckResult,
+  ProxyConnectionRecord,
+} from './types.js';
+import { DomainFilterAction } from './types.js';
+
+export interface HttpProxyOptions {
+  /** Port to listen on. 0 = auto-assign. */
+  port: number;
+  /** Hostname to bind to. Defaults to '127.0.0.1'. */
+  host?: string;
+  /** Domain filtering rules. */
+  rules: DomainRule[];
+  /** Default action when no rule matches. */
+  defaultAction: DomainFilterAction;
+}
+
+/**
+ * Events emitted by the HttpProxy:
+ * - 'connection': Fired for every connection attempt with a ProxyConnectionRecord.
+ * - 'denied': Fired when a connection is blocked with a ProxyConnectionRecord.
+ * - 'domainCheck': Fired when a domain needs a user prompt (action=PROMPT).
+ *                  Listener should resolve/reject the provided promise callbacks.
+ * - 'error': Fired on server-level errors.
+ */
+export class HttpProxy extends EventEmitter {
+  private server: http.Server | null = null;
+  private boundPort: number = 0;
+  private rules: DomainRule[];
+  private defaultAction: DomainFilterAction;
+  private connectionCount = 0;
+  private deniedCount = 0;
+
+  // Tracks domains that the user has approved/denied during this session
+  private sessionDecisions = new Map<string, DomainFilterAction>();
+
+  constructor(private readonly options: HttpProxyOptions) {
+    super();
+    this.rules = options.rules;
+    this.defaultAction = options.defaultAction;
+  }
+
+  /**
+   * Starts the HTTP proxy server.
+   * Returns a promise that resolves once the server is listening.
+   */
+  async start(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      this.server = http.createServer((req, res) => {
+        this.handleRequest(req, res);
+      });
+
+      this.server.on('connect', (req, clientSocket, head) => {
+        this.handleConnect(req, clientSocket, head);
+      });
+
+      this.server.on('error', (err) => {
+        this.emit('error', err);
+        reject(err);
+      });
+
+      const host = this.options.host ?? '127.0.0.1';
+      this.server.listen(this.options.port, host, () => {
+        const addr = this.server!.address();
+        if (addr && typeof addr === 'object') {
+          this.boundPort = addr.port;
+        }
+        resolve(this.boundPort);
+      });
+    });
+  }
+
+  /**
+   * Stops the proxy server and destroys all active connections.
+   */
+  async stop(): Promise<void> {
+    return new Promise((resolve) => {
+      if (!this.server) {
+        resolve();
+        return;
+      }
+      this.server.close(() => {
+        this.server = null;
+        resolve();
+      });
+      // Force close any hanging connections
+      this.server.closeAllConnections();
+    });
+  }
+
+  getPort(): number {
+    return this.boundPort;
+  }
+
+  getConnectionCount(): number {
+    return this.connectionCount;
+  }
+
+  getDeniedCount(): number {
+    return this.deniedCount;
+  }
+
+  updateRules(rules: DomainRule[]): void {
+    this.rules = rules;
+  }
+
+  updateDefaultAction(action: DomainFilterAction): void {
+    this.defaultAction = action;
+  }
+
+  /**
+   * Records a user's session-level decision for a domain so we don't prompt again.
+   */
+  recordSessionDecision(domain: string, action: DomainFilterAction): void {
+    this.sessionDecisions.set(domain.toLowerCase(), action);
+  }
+
+  /**
+   * Handles HTTP CONNECT method for HTTPS tunnelling.
+   * This is the main mechanism for filtering HTTPS traffic by domain.
+   */
+  private async handleConnect(
+    req: http.IncomingMessage,
+    clientSocket: net.Socket,
+    head: Buffer,
+  ): Promise<void> {
+    const target = req.url ?? '';
+    const hostname = extractHostname(target);
+    const port = extractPort(target, 443);
+
+    const action = await this.resolveAction(hostname);
+
+    const record: ProxyConnectionRecord = {
+      timestamp: new Date().toISOString(),
+      protocol: 'https',
+      host: hostname,
+      port,
+      action,
+    };
+
+    this.connectionCount++;
+
+    if (action === DomainFilterAction.DENY) {
+      this.deniedCount++;
+      this.emit('denied', record);
+      this.emit('connection', record);
+      clientSocket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+      clientSocket.destroy();
+      return;
+    }
+
+    this.emit('connection', record);
+
+    // Establish TCP tunnel to the target
+    const serverSocket = net.connect(port, hostname, () => {
+      clientSocket.write(
+        'HTTP/1.1 200 Connection Established\r\n' +
+          'Proxy-Agent: gemini-cli-proxy\r\n' +
+          '\r\n',
+      );
+      serverSocket.write(head);
+      serverSocket.pipe(clientSocket);
+      clientSocket.pipe(serverSocket);
+    });
+
+    serverSocket.on('error', (err) => {
+      clientSocket.write('HTTP/1.1 502 Bad Gateway\r\n\r\n');
+      clientSocket.destroy();
+      this.emit('error', err);
+    });
+
+    clientSocket.on('error', () => {
+      serverSocket.destroy();
+    });
+  }
+
+  /**
+   * Handles plain HTTP requests (non-CONNECT).
+   * Forwards the request to the target server if allowed.
+   */
+  private async handleRequest(
+    clientReq: http.IncomingMessage,
+    clientRes: http.ServerResponse,
+  ): Promise<void> {
+    const url = clientReq.url ?? '';
+
+    let hostname: string;
+    let port: number;
+    let requestPath: string;
+
+    try {
+      const parsed = new URL(url);
+      hostname = parsed.hostname;
+      port = parsed.port ? parseInt(parsed.port, 10) : 80;
+      requestPath = parsed.pathname + parsed.search;
+    } catch {
+      // Relative URL - use Host header
+      hostname = extractHostname(clientReq.headers.host ?? '');
+      port = extractPort(clientReq.headers.host ?? '', 80);
+      requestPath = url;
+    }
+
+    const action = await this.resolveAction(hostname);
+
+    const record: ProxyConnectionRecord = {
+      timestamp: new Date().toISOString(),
+      protocol: 'http',
+      host: hostname,
+      port,
+      action,
+      method: clientReq.method,
+      url,
+    };
+
+    this.connectionCount++;
+
+    if (action === DomainFilterAction.DENY) {
+      this.deniedCount++;
+      this.emit('denied', record);
+      this.emit('connection', record);
+      clientRes.writeHead(403, { 'Content-Type': 'text/plain' });
+      clientRes.end('Blocked by network proxy policy');
+      return;
+    }
+
+    this.emit('connection', record);
+
+    // Forward the request
+    const proxyReq = http.request(
+      {
+        hostname,
+        port,
+        path: requestPath,
+        method: clientReq.method,
+        headers: { ...clientReq.headers, host: `${hostname}:${port}` },
+      },
+      (proxyRes) => {
+        clientRes.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+        proxyRes.pipe(clientRes, { end: true });
+      },
+    );
+
+    proxyReq.on('error', (err) => {
+      clientRes.writeHead(502, { 'Content-Type': 'text/plain' });
+      clientRes.end(`Proxy error: ${err.message}`);
+    });
+
+    clientReq.pipe(proxyReq, { end: true });
+  }
+
+  /**
+   * Resolves the filtering action for a given hostname.
+   * Checks session-level decisions first, then rules, then default.
+   * If the resolved action is PROMPT, emits 'domainCheck' and waits
+   * for a response.
+   */
+  private async resolveAction(hostname: string): Promise<DomainFilterAction> {
+    // Check session-level overrides first
+    const sessionAction = this.sessionDecisions.get(hostname.toLowerCase());
+    if (sessionAction !== undefined) {
+      return sessionAction;
+    }
+
+    const result: DomainCheckResult = checkDomain(
+      hostname,
+      this.rules,
+      this.defaultAction,
+    );
+
+    if (result.action !== DomainFilterAction.PROMPT) {
+      return result.action;
+    }
+
+    // Need to prompt - emit event and wait for response
+    return new Promise<DomainFilterAction>((resolve) => {
+      const hasListeners = this.emit('domainCheck', hostname, (decision: DomainFilterAction) => {
+        // Save session decision so we don't prompt again
+        this.sessionDecisions.set(hostname.toLowerCase(), decision);
+        resolve(decision);
+      });
+
+      // If nobody is listening for prompts, deny by default for safety
+      if (!hasListeners) {
+        resolve(DomainFilterAction.DENY);
+      }
+    });
+  }
+}

--- a/packages/core/src/services/networkProxy/index.ts
+++ b/packages/core/src/services/networkProxy/index.ts
@@ -11,6 +11,7 @@ export { TrafficLogger } from './trafficLogger.js';
 export {
   DomainPromptHandler,
   createConsoleDomainPrompt,
+  sanitizeHostname,
 } from './domainPromptHandler.js';
 export type { DomainPromptCallback } from './domainPromptHandler.js';
 export {

--- a/packages/core/src/services/networkProxy/index.ts
+++ b/packages/core/src/services/networkProxy/index.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { NetworkProxyManager } from './networkProxyManager.js';
+export { HttpProxy } from './httpProxy.js';
+export { SocksProxy } from './socksProxy.js';
+export { TrafficLogger } from './trafficLogger.js';
+export {
+  matchesDomainPattern,
+  checkDomain,
+  checkDomainWithConfig,
+  extractHostname,
+  extractPort,
+} from './domainMatcher.js';
+export {
+  DomainFilterAction,
+  DEFAULT_NETWORK_PROXY_CONFIG,
+} from './types.js';
+export type {
+  DomainRule,
+  DomainCheckResult,
+  ProxyConnectionRecord,
+  NetworkProxyConfig,
+  ProxyServerAddresses,
+  ProxyStatus,
+} from './types.js';
+export type { TrafficSummary } from './trafficLogger.js';

--- a/packages/core/src/services/networkProxy/index.ts
+++ b/packages/core/src/services/networkProxy/index.ts
@@ -9,6 +9,11 @@ export { HttpProxy } from './httpProxy.js';
 export { SocksProxy } from './socksProxy.js';
 export { TrafficLogger } from './trafficLogger.js';
 export {
+  DomainPromptHandler,
+  createConsoleDomainPrompt,
+} from './domainPromptHandler.js';
+export type { DomainPromptCallback } from './domainPromptHandler.js';
+export {
   matchesDomainPattern,
   checkDomain,
   checkDomainWithConfig,

--- a/packages/core/src/services/networkProxy/index.ts
+++ b/packages/core/src/services/networkProxy/index.ts
@@ -5,6 +5,8 @@
  */
 
 export { NetworkProxyManager } from './networkProxyManager.js';
+export { BaseProxy } from './baseProxy.js';
+export type { BaseProxyOptions } from './baseProxy.js';
 export { HttpProxy } from './httpProxy.js';
 export { SocksProxy } from './socksProxy.js';
 export { TrafficLogger } from './trafficLogger.js';

--- a/packages/core/src/services/networkProxy/networkProxyManager.test.ts
+++ b/packages/core/src/services/networkProxy/networkProxyManager.test.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * @license
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
@@ -172,9 +172,7 @@ describe('NetworkProxyManager', () => {
       records.push(record);
     });
 
-    const httpPort = parseInt(
-      manager.getAddresses().httpProxy!.split(':')[1],
-    );
+    const httpPort = parseInt(manager.getAddresses().httpProxy!.split(':')[1], 10);
     await httpGetViaProxy(
       httpPort,
       `http://127.0.0.1:${echoPort}/test`,
@@ -198,9 +196,7 @@ describe('NetworkProxyManager', () => {
       deniedRecords.push(record);
     });
 
-    const httpPort = parseInt(
-      manager.getAddresses().httpProxy!.split(':')[1],
-    );
+    const httpPort = parseInt(manager.getAddresses().httpProxy!.split(':')[1], 10);
     await httpGetViaProxy(httpPort, 'http://example.com/test');
 
     expect(deniedRecords).toHaveLength(1);
@@ -218,9 +214,7 @@ describe('NetworkProxyManager', () => {
 
     await manager.start();
 
-    const httpPort = parseInt(
-      manager.getAddresses().httpProxy!.split(':')[1],
-    );
+    const httpPort = parseInt(manager.getAddresses().httpProxy!.split(':')[1], 10);
     await httpGetViaProxy(
       httpPort,
       `http://127.0.0.1:${echoPort}/logged`,
@@ -246,9 +240,7 @@ describe('NetworkProxyManager', () => {
       { pattern: 'example.com', action: DomainFilterAction.DENY },
     ]);
 
-    const httpPort = parseInt(
-      manager.getAddresses().httpProxy!.split(':')[1],
-    );
+    const httpPort = parseInt(manager.getAddresses().httpProxy!.split(':')[1], 10);
     const result = await httpGetViaProxy(httpPort, 'http://example.com/test');
 
     expect(result.statusCode).toBe(403);
@@ -265,9 +257,7 @@ describe('NetworkProxyManager', () => {
 
     manager.updateDefaultAction(DomainFilterAction.DENY);
 
-    const httpPort = parseInt(
-      manager.getAddresses().httpProxy!.split(':')[1],
-    );
+    const httpPort = parseInt(manager.getAddresses().httpProxy!.split(':')[1], 10);
     const result = await httpGetViaProxy(httpPort, 'http://example.com/test');
 
     expect(result.statusCode).toBe(403);
@@ -286,9 +276,7 @@ describe('NetworkProxyManager', () => {
 
     manager.recordSessionDecision('127.0.0.1', DomainFilterAction.ALLOW);
 
-    const httpPort = parseInt(
-      manager.getAddresses().httpProxy!.split(':')[1],
-    );
+    const httpPort = parseInt(manager.getAddresses().httpProxy!.split(':')[1], 10);
     const result = await httpGetViaProxy(
       httpPort,
       `http://127.0.0.1:${echoPort}/session`,

--- a/packages/core/src/services/networkProxy/networkProxyManager.test.ts
+++ b/packages/core/src/services/networkProxy/networkProxyManager.test.ts
@@ -1,0 +1,337 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { NetworkProxyManager } from './networkProxyManager.js';
+import { DomainFilterAction } from './types.js';
+import type { ProxyConnectionRecord } from './types.js';
+import * as http from 'node:http';
+
+function httpGetViaProxy(
+  proxyPort: number,
+  targetUrl: string,
+): Promise<{ statusCode: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(targetUrl);
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port: proxyPort,
+        path: targetUrl,
+        method: 'GET',
+        headers: { Host: parsed.host },
+      },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk: Buffer) => {
+          body += chunk.toString();
+        });
+        res.on('end', () => {
+          resolve({ statusCode: res.statusCode ?? 0, body });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('NetworkProxyManager', () => {
+  let manager: NetworkProxyManager;
+  let echoServer: http.Server;
+
+  afterEach(async () => {
+    if (manager) {
+      await manager.stop();
+    }
+    if (echoServer) {
+      await new Promise<void>((resolve) => {
+        echoServer.close(() => resolve());
+        echoServer.closeAllConnections();
+      });
+    }
+  });
+
+  async function startEchoServer(): Promise<number> {
+    return new Promise((resolve) => {
+      echoServer = http.createServer((req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end(`echo: ${req.url}`);
+      });
+      echoServer.listen(0, '127.0.0.1', () => {
+        const addr = echoServer.address();
+        if (addr && typeof addr === 'object') {
+          resolve(addr.port);
+        }
+      });
+    });
+  }
+
+  it('starts both proxy servers on auto-assigned ports', async () => {
+    manager = new NetworkProxyManager({
+      enabled: true,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+
+    const addresses = await manager.start();
+
+    expect(addresses.httpProxy).toBeDefined();
+    expect(addresses.socksProxy).toBeDefined();
+    expect(manager.isRunning()).toBe(true);
+  });
+
+  it('stops cleanly', async () => {
+    manager = new NetworkProxyManager({
+      enabled: true,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+
+    await manager.start();
+    await manager.stop();
+
+    expect(manager.isRunning()).toBe(false);
+  });
+
+  it('does not start twice', async () => {
+    manager = new NetworkProxyManager({
+      enabled: true,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+
+    const addresses1 = await manager.start();
+    const addresses2 = await manager.start();
+
+    expect(addresses1).toEqual(addresses2);
+  });
+
+  it('returns correct status', async () => {
+    manager = new NetworkProxyManager({
+      enabled: true,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+
+    await manager.start();
+
+    const status = manager.getStatus();
+    expect(status.running).toBe(true);
+    expect(status.connectionCount).toBe(0);
+    expect(status.deniedCount).toBe(0);
+    expect(status.addresses.httpProxy).toBeDefined();
+    expect(status.addresses.socksProxy).toBeDefined();
+  });
+
+  it('returns proxy environment variables when running', async () => {
+    manager = new NetworkProxyManager({
+      enabled: true,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+
+    await manager.start();
+
+    const env = manager.getProxyEnvironment();
+    expect(env['HTTP_PROXY']).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    expect(env['HTTPS_PROXY']).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    expect(env['http_proxy']).toBe(env['HTTP_PROXY']);
+    expect(env['https_proxy']).toBe(env['HTTPS_PROXY']);
+    expect(env['ALL_PROXY']).toMatch(/^socks5:\/\/127\.0\.0\.1:\d+$/);
+    expect(env['all_proxy']).toBe(env['ALL_PROXY']);
+  });
+
+  it('returns empty env when not running', () => {
+    manager = new NetworkProxyManager({
+      enabled: true,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+
+    const env = manager.getProxyEnvironment();
+    expect(env).toEqual({});
+  });
+
+  it('forwards connection events from HTTP proxy', async () => {
+    const echoPort = await startEchoServer();
+
+    manager = new NetworkProxyManager({
+      enabled: true,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+
+    await manager.start();
+
+    const records: ProxyConnectionRecord[] = [];
+    manager.on('connection', (record: ProxyConnectionRecord) => {
+      records.push(record);
+    });
+
+    const httpPort = parseInt(
+      manager.getAddresses().httpProxy!.split(':')[1],
+    );
+    await httpGetViaProxy(
+      httpPort,
+      `http://127.0.0.1:${echoPort}/test`,
+    );
+
+    expect(records).toHaveLength(1);
+    expect(records[0].host).toBe('127.0.0.1');
+  });
+
+  it('forwards denied events', async () => {
+    manager = new NetworkProxyManager({
+      enabled: true,
+      rules: [],
+      defaultAction: DomainFilterAction.DENY,
+    });
+
+    await manager.start();
+
+    const deniedRecords: ProxyConnectionRecord[] = [];
+    manager.on('denied', (record: ProxyConnectionRecord) => {
+      deniedRecords.push(record);
+    });
+
+    const httpPort = parseInt(
+      manager.getAddresses().httpProxy!.split(':')[1],
+    );
+    await httpGetViaProxy(httpPort, 'http://example.com/test');
+
+    expect(deniedRecords).toHaveLength(1);
+  });
+
+  it('logs traffic when logging is enabled', async () => {
+    const echoPort = await startEchoServer();
+
+    manager = new NetworkProxyManager({
+      enabled: true,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+      enableLogging: true,
+    });
+
+    await manager.start();
+
+    const httpPort = parseInt(
+      manager.getAddresses().httpProxy!.split(':')[1],
+    );
+    await httpGetViaProxy(
+      httpPort,
+      `http://127.0.0.1:${echoPort}/logged`,
+    );
+
+    const logger = manager.getTrafficLogger();
+    const entries = logger.getRecords();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].host).toBe('127.0.0.1');
+  });
+
+  it('updates rules on both proxies at runtime', async () => {
+    manager = new NetworkProxyManager({
+      enabled: true,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+
+    await manager.start();
+
+    // Update rules to block example.com
+    manager.updateRules([
+      { pattern: 'example.com', action: DomainFilterAction.DENY },
+    ]);
+
+    const httpPort = parseInt(
+      manager.getAddresses().httpProxy!.split(':')[1],
+    );
+    const result = await httpGetViaProxy(httpPort, 'http://example.com/test');
+
+    expect(result.statusCode).toBe(403);
+  });
+
+  it('updates default action at runtime', async () => {
+    manager = new NetworkProxyManager({
+      enabled: true,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+
+    await manager.start();
+
+    manager.updateDefaultAction(DomainFilterAction.DENY);
+
+    const httpPort = parseInt(
+      manager.getAddresses().httpProxy!.split(':')[1],
+    );
+    const result = await httpGetViaProxy(httpPort, 'http://example.com/test');
+
+    expect(result.statusCode).toBe(403);
+  });
+
+  it('records session decisions on both proxies', async () => {
+    const echoPort = await startEchoServer();
+
+    manager = new NetworkProxyManager({
+      enabled: true,
+      rules: [],
+      defaultAction: DomainFilterAction.DENY,
+    });
+
+    await manager.start();
+
+    manager.recordSessionDecision('127.0.0.1', DomainFilterAction.ALLOW);
+
+    const httpPort = parseInt(
+      manager.getAddresses().httpProxy!.split(':')[1],
+    );
+    const result = await httpGetViaProxy(
+      httpPort,
+      `http://127.0.0.1:${echoPort}/session`,
+    );
+
+    expect(result.statusCode).toBe(200);
+  });
+
+  it('emits started and stopped events', async () => {
+    manager = new NetworkProxyManager({
+      enabled: true,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+
+    let started = false;
+    let stopped = false;
+
+    manager.on('started', () => {
+      started = true;
+    });
+    manager.on('stopped', () => {
+      stopped = true;
+    });
+
+    await manager.start();
+    expect(started).toBe(true);
+
+    await manager.stop();
+    expect(stopped).toBe(true);
+  });
+
+  it('exposes read-only config', async () => {
+    manager = new NetworkProxyManager({
+      enabled: true,
+      rules: [{ pattern: 'foo.com', action: DomainFilterAction.ALLOW }],
+      defaultAction: DomainFilterAction.DENY,
+    });
+
+    const config = manager.getConfig();
+    expect(config.enabled).toBe(true);
+    expect(config.defaultAction).toBe(DomainFilterAction.DENY);
+    expect(config.rules).toHaveLength(1);
+    expect(config.rules[0].pattern).toBe('foo.com');
+  });
+});

--- a/packages/core/src/services/networkProxy/networkProxyManager.ts
+++ b/packages/core/src/services/networkProxy/networkProxyManager.ts
@@ -1,0 +1,237 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EventEmitter } from 'node:events';
+import { HttpProxy } from './httpProxy.js';
+import { SocksProxy } from './socksProxy.js';
+import { TrafficLogger } from './trafficLogger.js';
+import type {
+  NetworkProxyConfig,
+  ProxyConnectionRecord,
+  ProxyServerAddresses,
+  ProxyStatus,
+  DomainRule,
+} from './types.js';
+import { DomainFilterAction, DEFAULT_NETWORK_PROXY_CONFIG } from './types.js';
+
+/**
+ * Central manager for the network proxy system.
+ *
+ * Coordinates the HTTP and SOCKS5 proxy servers, traffic logging,
+ * and domain check events. Provides a single entry point for the
+ * rest of the application to interact with the proxy layer.
+ *
+ * Events:
+ * - 'connection': Fired for every proxied connection.
+ * - 'denied': Fired when a connection is blocked by a rule.
+ * - 'domainCheck': Fired when a domain needs user approval.
+ *   Signature: (hostname: string, respond: (action: DomainFilterAction) => void)
+ * - 'started': Fired when all proxy servers are running.
+ * - 'stopped': Fired when all proxy servers have shut down.
+ * - 'error': Fired on proxy server errors.
+ */
+export class NetworkProxyManager extends EventEmitter {
+  private httpProxy: HttpProxy | null = null;
+  private socksProxy: SocksProxy | null = null;
+  private trafficLogger: TrafficLogger;
+  private config: NetworkProxyConfig;
+  private running = false;
+
+  constructor(config?: Partial<NetworkProxyConfig>) {
+    super();
+    this.config = { ...DEFAULT_NETWORK_PROXY_CONFIG, ...config };
+    this.trafficLogger = new TrafficLogger(
+      this.config.maxLogEntries,
+      this.config.enableLogging,
+    );
+  }
+
+  /**
+   * Starts both proxy servers and wires up event forwarding.
+   * Returns the bound addresses.
+   */
+  async start(): Promise<ProxyServerAddresses> {
+    if (this.running) {
+      return this.getAddresses();
+    }
+
+    const addresses: ProxyServerAddresses = {};
+
+    // Start HTTP proxy
+    this.httpProxy = new HttpProxy({
+      port: this.config.httpPort,
+      rules: this.config.rules,
+      defaultAction: this.config.defaultAction,
+    });
+
+    this.wireProxyEvents(this.httpProxy);
+    const httpPort = await this.httpProxy.start();
+    addresses.httpProxy = `127.0.0.1:${httpPort}`;
+
+    // Start SOCKS5 proxy
+    this.socksProxy = new SocksProxy({
+      port: this.config.socksPort,
+      rules: this.config.rules,
+      defaultAction: this.config.defaultAction,
+    });
+
+    this.wireProxyEvents(this.socksProxy);
+    const socksPort = await this.socksProxy.start();
+    addresses.socksProxy = `127.0.0.1:${socksPort}`;
+
+    this.running = true;
+    this.emit('started', addresses);
+
+    return addresses;
+  }
+
+  /**
+   * Stops both proxy servers and cleans up.
+   */
+  async stop(): Promise<void> {
+    const shutdowns: Promise<void>[] = [];
+
+    if (this.httpProxy) {
+      shutdowns.push(this.httpProxy.stop());
+    }
+    if (this.socksProxy) {
+      shutdowns.push(this.socksProxy.stop());
+    }
+
+    await Promise.all(shutdowns);
+
+    this.httpProxy = null;
+    this.socksProxy = null;
+    this.running = false;
+
+    this.emit('stopped');
+  }
+
+  /**
+   * Returns the current addresses of the running proxy servers.
+   */
+  getAddresses(): ProxyServerAddresses {
+    return {
+      httpProxy: this.httpProxy
+        ? `127.0.0.1:${this.httpProxy.getPort()}`
+        : undefined,
+      socksProxy: this.socksProxy
+        ? `127.0.0.1:${this.socksProxy.getPort()}`
+        : undefined,
+    };
+  }
+
+  /**
+   * Returns a snapshot of the proxy system's status.
+   */
+  getStatus(): ProxyStatus {
+    const httpCount = this.httpProxy?.getConnectionCount() ?? 0;
+    const socksCount = this.socksProxy?.getConnectionCount() ?? 0;
+    const httpDenied = this.httpProxy?.getDeniedCount() ?? 0;
+    const socksDenied = this.socksProxy?.getDeniedCount() ?? 0;
+
+    return {
+      running: this.running,
+      addresses: this.getAddresses(),
+      connectionCount: httpCount + socksCount,
+      deniedCount: httpDenied + socksDenied,
+    };
+  }
+
+  /**
+   * Returns the traffic logger for querying connection history.
+   */
+  getTrafficLogger(): TrafficLogger {
+    return this.trafficLogger;
+  }
+
+  /**
+   * Returns the current proxy configuration.
+   */
+  getConfig(): Readonly<NetworkProxyConfig> {
+    return this.config;
+  }
+
+  /**
+   * Updates domain filtering rules on both proxies at runtime.
+   */
+  updateRules(rules: DomainRule[]): void {
+    this.config = { ...this.config, rules };
+    this.httpProxy?.updateRules(rules);
+    this.socksProxy?.updateRules(rules);
+  }
+
+  /**
+   * Updates the default action for unmatched domains.
+   */
+  updateDefaultAction(action: DomainFilterAction): void {
+    this.config = { ...this.config, defaultAction: action };
+    this.httpProxy?.updateDefaultAction(action);
+    this.socksProxy?.updateDefaultAction(action);
+  }
+
+  /**
+   * Records a user's domain decision so future connections aren't prompted again.
+   */
+  recordSessionDecision(domain: string, action: DomainFilterAction): void {
+    this.httpProxy?.recordSessionDecision(domain, action);
+    this.socksProxy?.recordSessionDecision(domain, action);
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  /**
+   * Returns the environment variables that should be set on child processes
+   * so that their network traffic flows through the proxy.
+   */
+  getProxyEnvironment(): Record<string, string> {
+    if (!this.running) {
+      return {};
+    }
+
+    const env: Record<string, string> = {};
+    const addresses = this.getAddresses();
+
+    if (addresses.httpProxy) {
+      const httpUrl = `http://${addresses.httpProxy}`;
+      env['HTTP_PROXY'] = httpUrl;
+      env['http_proxy'] = httpUrl;
+      env['HTTPS_PROXY'] = httpUrl;
+      env['https_proxy'] = httpUrl;
+    }
+
+    if (addresses.socksProxy) {
+      env['ALL_PROXY'] = `socks5://${addresses.socksProxy}`;
+      env['all_proxy'] = `socks5://${addresses.socksProxy}`;
+    }
+
+    return env;
+  }
+
+  /**
+   * Wires up event forwarding from a proxy server to this manager.
+   */
+  private wireProxyEvents(proxy: HttpProxy | SocksProxy): void {
+    proxy.on('connection', (record: ProxyConnectionRecord) => {
+      this.trafficLogger.log(record);
+      this.emit('connection', record);
+    });
+
+    proxy.on('denied', (record: ProxyConnectionRecord) => {
+      this.emit('denied', record);
+    });
+
+    proxy.on('domainCheck', (hostname: string, respond: (action: DomainFilterAction) => void) => {
+      this.emit('domainCheck', hostname, respond);
+    });
+
+    proxy.on('error', (err: Error) => {
+      this.emit('error', err);
+    });
+  }
+}

--- a/packages/core/src/services/networkProxy/networkProxyManager.ts
+++ b/packages/core/src/services/networkProxy/networkProxyManager.ts
@@ -14,8 +14,9 @@ import type {
   ProxyServerAddresses,
   ProxyStatus,
   DomainRule,
+  DomainFilterAction,
 } from './types.js';
-import { DomainFilterAction, DEFAULT_NETWORK_PROXY_CONFIG } from './types.js';
+import { DEFAULT_NETWORK_PROXY_CONFIG } from './types.js';
 
 /**
  * Central manager for the network proxy system.
@@ -92,7 +93,7 @@ export class NetworkProxyManager extends EventEmitter {
    * Stops both proxy servers and cleans up.
    */
   async stop(): Promise<void> {
-    const shutdowns: Promise<void>[] = [];
+    const shutdowns: Array<Promise<void>> = [];
 
     if (this.httpProxy) {
       shutdowns.push(this.httpProxy.stop());

--- a/packages/core/src/services/networkProxy/networkProxyManager.ts
+++ b/packages/core/src/services/networkProxy/networkProxyManager.ts
@@ -19,11 +19,8 @@ import type {
 import { DEFAULT_NETWORK_PROXY_CONFIG } from './types.js';
 
 /**
- * Central manager for the network proxy system.
- *
  * Coordinates the HTTP and SOCKS5 proxy servers, traffic logging,
- * and domain check events. Provides a single entry point for the
- * rest of the application to interact with the proxy layer.
+ * and domain check events.
  *
  * Events:
  * - 'connection': Fired for every proxied connection.
@@ -52,7 +49,6 @@ export class NetworkProxyManager extends EventEmitter {
 
   /**
    * Starts both proxy servers and wires up event forwarding.
-   * Returns the bound addresses.
    */
   async start(): Promise<ProxyServerAddresses> {
     if (this.running) {
@@ -111,9 +107,6 @@ export class NetworkProxyManager extends EventEmitter {
     this.emit('stopped');
   }
 
-  /**
-   * Returns the current addresses of the running proxy servers.
-   */
   getAddresses(): ProxyServerAddresses {
     return {
       httpProxy: this.httpProxy
@@ -125,9 +118,6 @@ export class NetworkProxyManager extends EventEmitter {
     };
   }
 
-  /**
-   * Returns a snapshot of the proxy system's status.
-   */
   getStatus(): ProxyStatus {
     const httpCount = this.httpProxy?.getConnectionCount() ?? 0;
     const socksCount = this.socksProxy?.getConnectionCount() ?? 0;
@@ -142,16 +132,10 @@ export class NetworkProxyManager extends EventEmitter {
     };
   }
 
-  /**
-   * Returns the traffic logger for querying connection history.
-   */
   getTrafficLogger(): TrafficLogger {
     return this.trafficLogger;
   }
 
-  /**
-   * Returns the current proxy configuration.
-   */
   getConfig(): Readonly<NetworkProxyConfig> {
     return this.config;
   }

--- a/packages/core/src/services/networkProxy/socksProxy.test.ts
+++ b/packages/core/src/services/networkProxy/socksProxy.test.ts
@@ -1,0 +1,326 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as net from 'node:net';
+import { SocksProxy } from './socksProxy.js';
+import { DomainFilterAction } from './types.js';
+import type { ProxyConnectionRecord } from './types.js';
+
+/**
+ * Performs a SOCKS5 handshake and CONNECT request to the given proxy.
+ * Returns the reply code from the proxy.
+ */
+async function socks5Connect(
+  proxyPort: number,
+  targetHost: string,
+  targetPort: number,
+): Promise<{ replyCode: number; socket: net.Socket }> {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(proxyPort, '127.0.0.1', () => {
+      // Step 1: Send greeting with no-auth method
+      socket.write(Buffer.from([0x05, 0x01, 0x00]));
+    });
+
+    let phase: 'greeting' | 'request' | 'done' = 'greeting';
+
+    socket.on('data', (data: Buffer) => {
+      if (phase === 'greeting') {
+        // Server should respond with [0x05, 0x00] (version, no-auth)
+        if (data[0] !== 0x05 || data[1] !== 0x00) {
+          socket.destroy();
+          reject(new Error(`Bad greeting response: ${data[0]}, ${data[1]}`));
+          return;
+        }
+
+        phase = 'request';
+
+        // Step 2: Send CONNECT request with domain address type
+        const hostBuf = Buffer.from(targetHost, 'ascii');
+        const portBuf = Buffer.alloc(2);
+        portBuf.writeUInt16BE(targetPort);
+
+        const request = Buffer.concat([
+          Buffer.from([0x05, 0x01, 0x00, 0x03, hostBuf.length]),
+          hostBuf,
+          portBuf,
+        ]);
+        socket.write(request);
+      } else if (phase === 'request') {
+        phase = 'done';
+        // Reply: [VER, REP, RSV, ATYP, BND.ADDR, BND.PORT]
+        const replyCode = data[1];
+        resolve({ replyCode, socket });
+      }
+    });
+
+    socket.on('error', reject);
+  });
+}
+
+describe('SocksProxy', () => {
+  let proxy: SocksProxy;
+  let echoServer: net.Server;
+  let echoPort: number;
+
+  afterEach(async () => {
+    if (proxy) {
+      await proxy.stop();
+    }
+    if (echoServer) {
+      await new Promise<void>((resolve) => {
+        echoServer.close(() => resolve());
+      });
+    }
+  });
+
+  async function startEchoTcpServer(): Promise<number> {
+    return new Promise((resolve) => {
+      echoServer = net.createServer((socket) => {
+        socket.on('data', (data) => {
+          socket.write(`echo: ${data.toString()}`);
+        });
+      });
+      echoServer.listen(0, '127.0.0.1', () => {
+        const addr = echoServer.address();
+        if (addr && typeof addr === 'object') {
+          echoPort = addr.port;
+          resolve(echoPort);
+        }
+      });
+    });
+  }
+
+  it('starts and stops without errors', async () => {
+    proxy = new SocksProxy({
+      port: 0,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+
+    const port = await proxy.start();
+    expect(port).toBeGreaterThan(0);
+    expect(proxy.getPort()).toBe(port);
+
+    await proxy.stop();
+  });
+
+  it('allows CONNECT when default action is allow', async () => {
+    await startEchoTcpServer();
+
+    proxy = new SocksProxy({
+      port: 0,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+    const proxyPort = await proxy.start();
+
+    const { replyCode, socket } = await socks5Connect(
+      proxyPort,
+      '127.0.0.1',
+      echoPort,
+    );
+
+    expect(replyCode).toBe(0x00); // success
+    expect(proxy.getConnectionCount()).toBe(1);
+
+    socket.destroy();
+  });
+
+  it('denies CONNECT when default action is deny', async () => {
+    proxy = new SocksProxy({
+      port: 0,
+      rules: [],
+      defaultAction: DomainFilterAction.DENY,
+    });
+    const proxyPort = await proxy.start();
+
+    const { replyCode, socket } = await socks5Connect(
+      proxyPort,
+      'blocked.example.com',
+      443,
+    );
+
+    expect(replyCode).toBe(0x02); // connection not allowed
+    expect(proxy.getDeniedCount()).toBe(1);
+
+    socket.destroy();
+  });
+
+  it('allows domains matching allow rules when default is deny', async () => {
+    await startEchoTcpServer();
+
+    proxy = new SocksProxy({
+      port: 0,
+      rules: [{ pattern: '127.0.0.1', action: DomainFilterAction.ALLOW }],
+      defaultAction: DomainFilterAction.DENY,
+    });
+    const proxyPort = await proxy.start();
+
+    const { replyCode, socket } = await socks5Connect(
+      proxyPort,
+      '127.0.0.1',
+      echoPort,
+    );
+
+    expect(replyCode).toBe(0x00);
+    socket.destroy();
+  });
+
+  it('blocks domains matching deny rules when default is allow', async () => {
+    proxy = new SocksProxy({
+      port: 0,
+      rules: [
+        { pattern: 'evil.example.com', action: DomainFilterAction.DENY },
+      ],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+    const proxyPort = await proxy.start();
+
+    const { replyCode, socket } = await socks5Connect(
+      proxyPort,
+      'evil.example.com',
+      443,
+    );
+
+    expect(replyCode).toBe(0x02);
+    expect(proxy.getDeniedCount()).toBe(1);
+    socket.destroy();
+  });
+
+  it('emits connection events', async () => {
+    await startEchoTcpServer();
+
+    proxy = new SocksProxy({
+      port: 0,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+    const proxyPort = await proxy.start();
+
+    const records: ProxyConnectionRecord[] = [];
+    proxy.on('connection', (record: ProxyConnectionRecord) => {
+      records.push(record);
+    });
+
+    const { socket } = await socks5Connect(proxyPort, '127.0.0.1', echoPort);
+    socket.destroy();
+
+    expect(records).toHaveLength(1);
+    expect(records[0].host).toBe('127.0.0.1');
+    expect(records[0].protocol).toBe('tcp');
+    expect(records[0].action).toBe(DomainFilterAction.ALLOW);
+  });
+
+  it('emits denied events on blocked connections', async () => {
+    proxy = new SocksProxy({
+      port: 0,
+      rules: [],
+      defaultAction: DomainFilterAction.DENY,
+    });
+    const proxyPort = await proxy.start();
+
+    const deniedRecords: ProxyConnectionRecord[] = [];
+    proxy.on('denied', (record: ProxyConnectionRecord) => {
+      deniedRecords.push(record);
+    });
+
+    const { socket } = await socks5Connect(
+      proxyPort,
+      'blocked.example.com',
+      443,
+    );
+    socket.destroy();
+
+    expect(deniedRecords).toHaveLength(1);
+    expect(deniedRecords[0].action).toBe(DomainFilterAction.DENY);
+  });
+
+  it('respects session decisions', async () => {
+    await startEchoTcpServer();
+
+    proxy = new SocksProxy({
+      port: 0,
+      rules: [],
+      defaultAction: DomainFilterAction.DENY,
+    });
+    const proxyPort = await proxy.start();
+
+    proxy.recordSessionDecision('127.0.0.1', DomainFilterAction.ALLOW);
+
+    const { replyCode, socket } = await socks5Connect(
+      proxyPort,
+      '127.0.0.1',
+      echoPort,
+    );
+
+    expect(replyCode).toBe(0x00);
+    socket.destroy();
+  });
+
+  it('updates rules at runtime', async () => {
+    proxy = new SocksProxy({
+      port: 0,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+    const proxyPort = await proxy.start();
+
+    // Add deny rule
+    proxy.updateRules([
+      { pattern: 'target.com', action: DomainFilterAction.DENY },
+    ]);
+
+    const { replyCode, socket } = await socks5Connect(
+      proxyPort,
+      'target.com',
+      80,
+    );
+
+    expect(replyCode).toBe(0x02);
+    socket.destroy();
+  });
+
+  it('rejects non-SOCKS5 connections gracefully', async () => {
+    proxy = new SocksProxy({
+      port: 0,
+      rules: [],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+    const proxyPort = await proxy.start();
+
+    // Send garbage data
+    const destroyed = await new Promise<boolean>((resolve) => {
+      const socket = net.connect(proxyPort, '127.0.0.1', () => {
+        socket.write(Buffer.from([0x04, 0x01, 0x00])); // SOCKS4 greeting
+      });
+      socket.on('close', () => resolve(true));
+      socket.on('error', () => resolve(true));
+    });
+
+    expect(destroyed).toBe(true);
+  });
+
+  it('supports wildcard domain rules', async () => {
+    proxy = new SocksProxy({
+      port: 0,
+      rules: [
+        { pattern: '*.blocked.org', action: DomainFilterAction.DENY },
+      ],
+      defaultAction: DomainFilterAction.ALLOW,
+    });
+    const proxyPort = await proxy.start();
+
+    const { replyCode, socket } = await socks5Connect(
+      proxyPort,
+      'api.blocked.org',
+      8080,
+    );
+
+    expect(replyCode).toBe(0x02);
+    socket.destroy();
+  });
+});

--- a/packages/core/src/services/networkProxy/socksProxy.ts
+++ b/packages/core/src/services/networkProxy/socksProxy.ts
@@ -1,0 +1,343 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as net from 'node:net';
+import { EventEmitter } from 'node:events';
+import { checkDomain } from './domainMatcher.js';
+import type { DomainRule, ProxyConnectionRecord } from './types.js';
+import { DomainFilterAction } from './types.js';
+
+// SOCKS5 protocol constants
+const SOCKS_VERSION = 0x05;
+
+// Authentication methods
+const AUTH_NO_AUTH = 0x00;
+const AUTH_NO_ACCEPTABLE = 0xff;
+
+// Command types
+const CMD_CONNECT = 0x01;
+
+// Address types
+const ATYP_IPV4 = 0x01;
+const ATYP_DOMAIN = 0x03;
+const ATYP_IPV6 = 0x04;
+
+// Reply codes
+const REP_SUCCESS = 0x00;
+const REP_GENERAL_FAILURE = 0x01;
+const REP_CONNECTION_NOT_ALLOWED = 0x02;
+const REP_HOST_UNREACHABLE = 0x04;
+const REP_COMMAND_NOT_SUPPORTED = 0x07;
+const REP_ADDRESS_TYPE_NOT_SUPPORTED = 0x08;
+
+export interface SocksProxyOptions {
+  /** Port to listen on. 0 = auto-assign. */
+  port: number;
+  /** Hostname to bind to. Defaults to '127.0.0.1'. */
+  host?: string;
+  /** Domain filtering rules. */
+  rules: DomainRule[];
+  /** Default action when no rule matches. */
+  defaultAction: DomainFilterAction;
+}
+
+/**
+ * A minimal SOCKS5 proxy server that supports the CONNECT command.
+ *
+ * This handles non-HTTP TCP traffic (SSH, database connections, etc.)
+ * with the same domain filtering rules as the HTTP proxy.
+ *
+ * Events:
+ * - 'connection': Emitted for each connection attempt.
+ * - 'denied': Emitted when a connection is blocked.
+ * - 'domainCheck': Emitted when a domain needs user prompting.
+ * - 'error': Emitted on server-level errors.
+ */
+export class SocksProxy extends EventEmitter {
+  private server: net.Server | null = null;
+  private boundPort: number = 0;
+  private rules: DomainRule[];
+  private defaultAction: DomainFilterAction;
+  private connectionCount = 0;
+  private deniedCount = 0;
+  private sessionDecisions = new Map<string, DomainFilterAction>();
+
+  constructor(private readonly options: SocksProxyOptions) {
+    super();
+    this.rules = options.rules;
+    this.defaultAction = options.defaultAction;
+  }
+
+  async start(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      this.server = net.createServer((socket) => {
+        this.handleConnection(socket);
+      });
+
+      this.server.on('error', (err) => {
+        this.emit('error', err);
+        reject(err);
+      });
+
+      const host = this.options.host ?? '127.0.0.1';
+      this.server.listen(this.options.port, host, () => {
+        const addr = this.server!.address();
+        if (addr && typeof addr === 'object') {
+          this.boundPort = addr.port;
+        }
+        resolve(this.boundPort);
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    return new Promise((resolve) => {
+      if (!this.server) {
+        resolve();
+        return;
+      }
+      this.server.close(() => {
+        this.server = null;
+        resolve();
+      });
+    });
+  }
+
+  getPort(): number {
+    return this.boundPort;
+  }
+
+  getConnectionCount(): number {
+    return this.connectionCount;
+  }
+
+  getDeniedCount(): number {
+    return this.deniedCount;
+  }
+
+  updateRules(rules: DomainRule[]): void {
+    this.rules = rules;
+  }
+
+  updateDefaultAction(action: DomainFilterAction): void {
+    this.defaultAction = action;
+  }
+
+  recordSessionDecision(domain: string, action: DomainFilterAction): void {
+    this.sessionDecisions.set(domain.toLowerCase(), action);
+  }
+
+  /**
+   * Handles a new SOCKS5 client connection.
+   * Implements the SOCKS5 handshake, then the CONNECT command.
+   */
+  private handleConnection(clientSocket: net.Socket): void {
+    clientSocket.once('data', (data) => {
+      this.handleGreeting(clientSocket, data);
+    });
+
+    clientSocket.on('error', () => {
+      clientSocket.destroy();
+    });
+  }
+
+  /**
+   * Processes the SOCKS5 greeting (version + auth methods).
+   * We only support no-authentication for local proxy use.
+   */
+  private handleGreeting(clientSocket: net.Socket, data: Buffer): void {
+    if (data.length < 3 || data[0] !== SOCKS_VERSION) {
+      clientSocket.destroy();
+      return;
+    }
+
+    const nmethods = data[1];
+    const methods = data.subarray(2, 2 + nmethods);
+
+    // Check if no-auth is offered
+    let supportsNoAuth = false;
+    for (let i = 0; i < methods.length; i++) {
+      if (methods[i] === AUTH_NO_AUTH) {
+        supportsNoAuth = true;
+        break;
+      }
+    }
+
+    if (!supportsNoAuth) {
+      // No acceptable auth method
+      clientSocket.write(Buffer.from([SOCKS_VERSION, AUTH_NO_ACCEPTABLE]));
+      clientSocket.destroy();
+      return;
+    }
+
+    // Accept no-auth
+    clientSocket.write(Buffer.from([SOCKS_VERSION, AUTH_NO_AUTH]));
+
+    // Wait for the CONNECT request
+    clientSocket.once('data', (requestData) => {
+      this.handleRequest(clientSocket, requestData);
+    });
+  }
+
+  /**
+   * Processes the SOCKS5 request (CONNECT command).
+   */
+  private async handleRequest(clientSocket: net.Socket, data: Buffer): Promise<void> {
+    if (data.length < 4 || data[0] !== SOCKS_VERSION) {
+      this.sendReply(clientSocket, REP_GENERAL_FAILURE);
+      clientSocket.destroy();
+      return;
+    }
+
+    const cmd = data[1];
+    // data[2] is reserved
+    const atyp = data[3];
+
+    if (cmd !== CMD_CONNECT) {
+      this.sendReply(clientSocket, REP_COMMAND_NOT_SUPPORTED);
+      clientSocket.destroy();
+      return;
+    }
+
+    let hostname: string;
+    let port: number;
+    let offset: number;
+
+    switch (atyp) {
+      case ATYP_IPV4: {
+        if (data.length < 10) {
+          this.sendReply(clientSocket, REP_GENERAL_FAILURE);
+          clientSocket.destroy();
+          return;
+        }
+        hostname = `${data[4]}.${data[5]}.${data[6]}.${data[7]}`;
+        port = data.readUInt16BE(8);
+        offset = 10;
+        break;
+      }
+
+      case ATYP_DOMAIN: {
+        const domainLen = data[4];
+        if (data.length < 5 + domainLen + 2) {
+          this.sendReply(clientSocket, REP_GENERAL_FAILURE);
+          clientSocket.destroy();
+          return;
+        }
+        hostname = data.subarray(5, 5 + domainLen).toString('ascii');
+        port = data.readUInt16BE(5 + domainLen);
+        offset = 7 + domainLen;
+        break;
+      }
+
+      case ATYP_IPV6: {
+        if (data.length < 22) {
+          this.sendReply(clientSocket, REP_GENERAL_FAILURE);
+          clientSocket.destroy();
+          return;
+        }
+        // Format IPv6 as bracket notation for readability
+        const parts: string[] = [];
+        for (let i = 0; i < 16; i += 2) {
+          parts.push(data.readUInt16BE(4 + i).toString(16));
+        }
+        hostname = parts.join(':');
+        port = data.readUInt16BE(20);
+        offset = 22;
+        break;
+      }
+
+      default:
+        this.sendReply(clientSocket, REP_ADDRESS_TYPE_NOT_SUPPORTED);
+        clientSocket.destroy();
+        return;
+    }
+
+    // Evaluate domain filtering
+    const action = await this.resolveAction(hostname);
+
+    const record: ProxyConnectionRecord = {
+      timestamp: new Date().toISOString(),
+      protocol: 'tcp',
+      host: hostname,
+      port,
+      action,
+    };
+
+    this.connectionCount++;
+
+    if (action === DomainFilterAction.DENY) {
+      this.deniedCount++;
+      this.emit('denied', record);
+      this.emit('connection', record);
+      this.sendReply(clientSocket, REP_CONNECTION_NOT_ALLOWED);
+      clientSocket.destroy();
+      return;
+    }
+
+    this.emit('connection', record);
+
+    // Establish upstream connection
+    const targetSocket = net.connect(port, hostname, () => {
+      this.sendReply(clientSocket, REP_SUCCESS);
+      targetSocket.pipe(clientSocket);
+      clientSocket.pipe(targetSocket);
+    });
+
+    targetSocket.on('error', () => {
+      this.sendReply(clientSocket, REP_HOST_UNREACHABLE);
+      clientSocket.destroy();
+    });
+
+    clientSocket.on('error', () => {
+      targetSocket.destroy();
+    });
+  }
+
+  /**
+   * Sends a SOCKS5 reply with the given status code.
+   * Uses 0.0.0.0:0 as the bound address (we don't expose it).
+   */
+  private sendReply(socket: net.Socket, reply: number): void {
+    const response = Buffer.alloc(10);
+    response[0] = SOCKS_VERSION;
+    response[1] = reply;
+    response[2] = 0x00; // Reserved
+    response[3] = ATYP_IPV4;
+    // Bound address: 0.0.0.0
+    response[4] = 0;
+    response[5] = 0;
+    response[6] = 0;
+    response[7] = 0;
+    // Bound port: 0
+    response.writeUInt16BE(0, 8);
+
+    socket.write(response);
+  }
+
+  private async resolveAction(hostname: string): Promise<DomainFilterAction> {
+    const sessionAction = this.sessionDecisions.get(hostname.toLowerCase());
+    if (sessionAction !== undefined) {
+      return sessionAction;
+    }
+
+    const result = checkDomain(hostname, this.rules, this.defaultAction);
+
+    if (result.action !== DomainFilterAction.PROMPT) {
+      return result.action;
+    }
+
+    return new Promise<DomainFilterAction>((resolve) => {
+      const hasListeners = this.emit('domainCheck', hostname, (decision: DomainFilterAction) => {
+        this.sessionDecisions.set(hostname.toLowerCase(), decision);
+        resolve(decision);
+      });
+
+      if (!hasListeners) {
+        resolve(DomainFilterAction.DENY);
+      }
+    });
+  }
+}

--- a/packages/core/src/services/networkProxy/socksProxy.ts
+++ b/packages/core/src/services/networkProxy/socksProxy.ts
@@ -34,13 +34,9 @@ const REP_COMMAND_NOT_SUPPORTED = 0x07;
 const REP_ADDRESS_TYPE_NOT_SUPPORTED = 0x08;
 
 export interface SocksProxyOptions {
-  /** Port to listen on. 0 = auto-assign. */
   port: number;
-  /** Hostname to bind to. Defaults to '127.0.0.1'. */
   host?: string;
-  /** Domain filtering rules. */
   rules: DomainRule[];
-  /** Default action when no rule matches. */
   defaultAction: DomainFilterAction;
 }
 
@@ -251,7 +247,6 @@ export class SocksProxy extends EventEmitter {
         return;
     }
 
-    // Evaluate domain filtering
     const action = await this.resolveAction(hostname);
 
     const record: ProxyConnectionRecord = {

--- a/packages/core/src/services/networkProxy/socksProxy.ts
+++ b/packages/core/src/services/networkProxy/socksProxy.ts
@@ -178,7 +178,7 @@ export class SocksProxy extends EventEmitter {
 
     // Wait for the CONNECT request
     clientSocket.once('data', (requestData) => {
-      this.handleRequest(clientSocket, requestData);
+      void this.handleRequest(clientSocket, requestData);
     });
   }
 
@@ -204,7 +204,6 @@ export class SocksProxy extends EventEmitter {
 
     let hostname: string;
     let port: number;
-    let offset: number;
 
     switch (atyp) {
       case ATYP_IPV4: {
@@ -215,7 +214,6 @@ export class SocksProxy extends EventEmitter {
         }
         hostname = `${data[4]}.${data[5]}.${data[6]}.${data[7]}`;
         port = data.readUInt16BE(8);
-        offset = 10;
         break;
       }
 
@@ -228,7 +226,6 @@ export class SocksProxy extends EventEmitter {
         }
         hostname = data.subarray(5, 5 + domainLen).toString('ascii');
         port = data.readUInt16BE(5 + domainLen);
-        offset = 7 + domainLen;
         break;
       }
 
@@ -245,7 +242,6 @@ export class SocksProxy extends EventEmitter {
         }
         hostname = parts.join(':');
         port = data.readUInt16BE(20);
-        offset = 22;
         break;
       }
 

--- a/packages/core/src/services/networkProxy/trafficLogger.test.ts
+++ b/packages/core/src/services/networkProxy/trafficLogger.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TrafficLogger } from './trafficLogger.js';
+import type { ProxyConnectionRecord } from './types.js';
+import { DomainFilterAction } from './types.js';
+
+function makeRecord(
+  host: string,
+  action: DomainFilterAction = DomainFilterAction.ALLOW,
+  protocol: ProxyConnectionRecord['protocol'] = 'https',
+): ProxyConnectionRecord {
+  return {
+    timestamp: new Date().toISOString(),
+    protocol,
+    host,
+    port: 443,
+    action,
+  };
+}
+
+describe('TrafficLogger', () => {
+  let logger: TrafficLogger;
+
+  beforeEach(() => {
+    logger = new TrafficLogger(100, true);
+  });
+
+  it('logs and retrieves records', () => {
+    logger.log(makeRecord('example.com'));
+    logger.log(makeRecord('google.com'));
+
+    expect(logger.getEntryCount()).toBe(2);
+    expect(logger.getRecords()).toHaveLength(2);
+  });
+
+  it('does not log when disabled', () => {
+    logger.setEnabled(false);
+    logger.log(makeRecord('example.com'));
+    expect(logger.getEntryCount()).toBe(0);
+  });
+
+  it('trims oldest entries when over capacity', () => {
+    const small = new TrafficLogger(3, true);
+    small.log(makeRecord('a.com'));
+    small.log(makeRecord('b.com'));
+    small.log(makeRecord('c.com'));
+    small.log(makeRecord('d.com'));
+
+    expect(small.getEntryCount()).toBe(3);
+    expect(small.getRecords()[0].host).toBe('b.com');
+  });
+
+  it('getRecentRecords returns last N records', () => {
+    logger.log(makeRecord('a.com'));
+    logger.log(makeRecord('b.com'));
+    logger.log(makeRecord('c.com'));
+
+    const recent = logger.getRecentRecords(2);
+    expect(recent).toHaveLength(2);
+    expect(recent[0].host).toBe('b.com');
+    expect(recent[1].host).toBe('c.com');
+  });
+
+  it('getRecordsByHost filters by hostname', () => {
+    logger.log(makeRecord('example.com'));
+    logger.log(makeRecord('google.com'));
+    logger.log(makeRecord('example.com'));
+
+    const filtered = logger.getRecordsByHost('example.com');
+    expect(filtered).toHaveLength(2);
+  });
+
+  it('getRecordsByAction filters by action', () => {
+    logger.log(makeRecord('a.com', DomainFilterAction.ALLOW));
+    logger.log(makeRecord('b.com', DomainFilterAction.DENY));
+    logger.log(makeRecord('c.com', DomainFilterAction.ALLOW));
+
+    expect(logger.getRecordsByAction(DomainFilterAction.ALLOW)).toHaveLength(2);
+    expect(logger.getRecordsByAction(DomainFilterAction.DENY)).toHaveLength(1);
+  });
+
+  it('getSummary returns correct statistics', () => {
+    logger.log(makeRecord('example.com', DomainFilterAction.ALLOW));
+    logger.log(makeRecord('example.com', DomainFilterAction.ALLOW));
+    logger.log(makeRecord('google.com', DomainFilterAction.DENY));
+    logger.log(makeRecord('evil.com', DomainFilterAction.DENY));
+
+    const summary = logger.getSummary();
+    expect(summary.totalConnections).toBe(4);
+    expect(summary.allowedConnections).toBe(2);
+    expect(summary.deniedConnections).toBe(2);
+    expect(summary.uniqueHosts).toBe(3);
+    expect(summary.topHosts[0].host).toBe('example.com');
+    expect(summary.topHosts[0].count).toBe(2);
+  });
+
+  it('clear removes all records', () => {
+    logger.log(makeRecord('a.com'));
+    logger.log(makeRecord('b.com'));
+    logger.clear();
+    expect(logger.getEntryCount()).toBe(0);
+  });
+});

--- a/packages/core/src/services/networkProxy/trafficLogger.ts
+++ b/packages/core/src/services/networkProxy/trafficLogger.ts
@@ -44,14 +44,14 @@ export class TrafficLogger {
   /**
    * Returns all recorded connection logs.
    */
-  getRecords(): ReadonlyArray<ProxyConnectionRecord> {
+  getRecords(): readonly ProxyConnectionRecord[] {
     return this.records;
   }
 
   /**
    * Returns the most recent N records.
    */
-  getRecentRecords(count: number): ReadonlyArray<ProxyConnectionRecord> {
+  getRecentRecords(count: number): readonly ProxyConnectionRecord[] {
     if (count >= this.records.length) {
       return this.records;
     }
@@ -61,7 +61,7 @@ export class TrafficLogger {
   /**
    * Returns records filtered by hostname.
    */
-  getRecordsByHost(hostname: string): ReadonlyArray<ProxyConnectionRecord> {
+  getRecordsByHost(hostname: string): readonly ProxyConnectionRecord[] {
     const normalized = hostname.toLowerCase();
     return this.records.filter((r) => r.host.toLowerCase() === normalized);
   }
@@ -71,7 +71,7 @@ export class TrafficLogger {
    */
   getRecordsByAction(
     action: ProxyConnectionRecord['action'],
-  ): ReadonlyArray<ProxyConnectionRecord> {
+  ): readonly ProxyConnectionRecord[] {
     return this.records.filter((r) => r.action === action);
   }
 

--- a/packages/core/src/services/networkProxy/trafficLogger.ts
+++ b/packages/core/src/services/networkProxy/trafficLogger.ts
@@ -9,7 +9,7 @@ import type { ProxyConnectionRecord } from './types.js';
 /**
  * In-memory traffic logger for proxy connections.
  *
- * Keeps a bounded ring buffer of connection records for auditing.
+ * Keeps a bounded list of connection records for auditing.
  * Logging is opt-in and controlled by user settings. No data is
  * persisted to disk or sent externally — records live only in memory
  * for the duration of the session.

--- a/packages/core/src/services/networkProxy/trafficLogger.ts
+++ b/packages/core/src/services/networkProxy/trafficLogger.ts
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProxyConnectionRecord } from './types.js';
+
+/**
+ * In-memory traffic logger for proxy connections.
+ *
+ * Keeps a bounded ring buffer of connection records for auditing.
+ * Logging is opt-in and controlled by user settings. No data is
+ * persisted to disk or sent externally — records live only in memory
+ * for the duration of the session.
+ */
+export class TrafficLogger {
+  private records: ProxyConnectionRecord[] = [];
+  private readonly maxEntries: number;
+  private enabled: boolean;
+
+  constructor(maxEntries: number = 1000, enabled: boolean = false) {
+    this.maxEntries = maxEntries;
+    this.enabled = enabled;
+  }
+
+  /**
+   * Records a proxy connection event. No-ops if logging is disabled.
+   */
+  log(record: ProxyConnectionRecord): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    this.records.push(record);
+
+    // Trim if over capacity (drop oldest entries)
+    if (this.records.length > this.maxEntries) {
+      const overflow = this.records.length - this.maxEntries;
+      this.records.splice(0, overflow);
+    }
+  }
+
+  /**
+   * Returns all recorded connection logs.
+   */
+  getRecords(): ReadonlyArray<ProxyConnectionRecord> {
+    return this.records;
+  }
+
+  /**
+   * Returns the most recent N records.
+   */
+  getRecentRecords(count: number): ReadonlyArray<ProxyConnectionRecord> {
+    if (count >= this.records.length) {
+      return this.records;
+    }
+    return this.records.slice(-count);
+  }
+
+  /**
+   * Returns records filtered by hostname.
+   */
+  getRecordsByHost(hostname: string): ReadonlyArray<ProxyConnectionRecord> {
+    const normalized = hostname.toLowerCase();
+    return this.records.filter((r) => r.host.toLowerCase() === normalized);
+  }
+
+  /**
+   * Returns records filtered by action (allow/deny).
+   */
+  getRecordsByAction(
+    action: ProxyConnectionRecord['action'],
+  ): ReadonlyArray<ProxyConnectionRecord> {
+    return this.records.filter((r) => r.action === action);
+  }
+
+  /**
+   * Returns summary statistics about the logged traffic.
+   */
+  getSummary(): TrafficSummary {
+    const hostCounts = new Map<string, number>();
+    let allowedCount = 0;
+    let deniedCount = 0;
+
+    for (const record of this.records) {
+      const host = record.host.toLowerCase();
+      hostCounts.set(host, (hostCounts.get(host) ?? 0) + 1);
+
+      if (record.action === 'allow') {
+        allowedCount++;
+      } else if (record.action === 'deny') {
+        deniedCount++;
+      }
+    }
+
+    // Sort hosts by frequency, descending
+    const topHosts = [...hostCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([host, count]) => ({ host, count }));
+
+    return {
+      totalConnections: this.records.length,
+      allowedConnections: allowedCount,
+      deniedConnections: deniedCount,
+      uniqueHosts: hostCounts.size,
+      topHosts,
+    };
+  }
+
+  /**
+   * Clears all logged records.
+   */
+  clear(): void {
+    this.records = [];
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+  }
+
+  getEntryCount(): number {
+    return this.records.length;
+  }
+}
+
+export interface TrafficSummary {
+  totalConnections: number;
+  allowedConnections: number;
+  deniedConnections: number;
+  uniqueHosts: number;
+  topHosts: Array<{ host: string; count: number }>;
+}

--- a/packages/core/src/services/networkProxy/types.ts
+++ b/packages/core/src/services/networkProxy/types.ts
@@ -71,7 +71,6 @@ export interface NetworkProxyConfig {
 
   enableLogging: boolean;
   maxLogEntries: number;
-  promptForUnknownDomains: boolean;
 }
 
 /**
@@ -103,5 +102,4 @@ export const DEFAULT_NETWORK_PROXY_CONFIG: NetworkProxyConfig = {
   rules: [],
   enableLogging: false,
   maxLogEntries: 1000,
-  promptForUnknownDomains: true,
 };

--- a/packages/core/src/services/networkProxy/types.ts
+++ b/packages/core/src/services/networkProxy/types.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Filtering action to apply when a domain is matched against a rule.
+ */
+export enum DomainFilterAction {
+  ALLOW = 'allow',
+  DENY = 'deny',
+  PROMPT = 'prompt',
+}
+
+/**
+ * A single domain filtering rule, supporting exact and wildcard patterns.
+ *
+ * Examples:
+ *   - "example.com" -> matches exactly example.com
+ *   - "*.example.com" -> matches any subdomain of example.com
+ *   - "*" -> matches everything
+ */
+export interface DomainRule {
+  /** The domain pattern to match against. Supports wildcard prefix: *.example.com */
+  pattern: string;
+  /** Action to take when this rule matches. */
+  action: DomainFilterAction;
+}
+
+/**
+ * Result of checking a domain against the filtering rules.
+ */
+export interface DomainCheckResult {
+  /** The domain that was checked. */
+  domain: string;
+  /** Resolved action after evaluating rules. */
+  action: DomainFilterAction;
+  /** The rule that matched, if any. */
+  matchedRule?: DomainRule;
+}
+
+/**
+ * Represents a single recorded connection through the proxy.
+ */
+export interface ProxyConnectionRecord {
+  /** Timestamp of the connection in ISO format. */
+  timestamp: string;
+  /** Protocol used: 'http', 'https', or 'tcp'. */
+  protocol: 'http' | 'https' | 'tcp';
+  /** Target hostname or IP. */
+  host: string;
+  /** Target port. */
+  port: number;
+  /** Action that was taken (allow/deny). */
+  action: DomainFilterAction;
+  /** HTTP method if applicable. */
+  method?: string;
+  /** Full URL if applicable (HTTP only, HTTPS only shows CONNECT target). */
+  url?: string;
+}
+
+/**
+ * Configuration for the network proxy system.
+ */
+export interface NetworkProxyConfig {
+  /** Whether the network proxy feature is enabled. */
+  enabled: boolean;
+
+  /** Port for the HTTP/HTTPS proxy to listen on. 0 = auto-assign. */
+  httpPort: number;
+
+  /** Port for the SOCKS5 proxy to listen on. 0 = auto-assign. */
+  socksPort: number;
+
+  /** Default action when no rule matches a domain. */
+  defaultAction: DomainFilterAction;
+
+  /** Ordered list of domain filtering rules. First match wins. */
+  rules: DomainRule[];
+
+  /** Whether to log traffic for auditing. Opt-in for privacy. */
+  enableLogging: boolean;
+
+  /** Maximum number of traffic log entries to keep in memory. */
+  maxLogEntries: number;
+
+  /** Whether to prompt the user for new/unknown domains. */
+  promptForUnknownDomains: boolean;
+}
+
+/**
+ * Addresses the proxy servers are actually listening on after startup.
+ */
+export interface ProxyServerAddresses {
+  /** Bound HTTP proxy address in host:port format. */
+  httpProxy?: string;
+  /** Bound SOCKS5 proxy address in host:port format. */
+  socksProxy?: string;
+}
+
+/**
+ * Status of the proxy system.
+ */
+export interface ProxyStatus {
+  /** Whether the proxy is currently running. */
+  running: boolean;
+  /** Addresses the proxy is listening on. */
+  addresses: ProxyServerAddresses;
+  /** Number of connections processed. */
+  connectionCount: number;
+  /** Number of connections denied. */
+  deniedCount: number;
+}
+
+/**
+ * Default configuration values for the network proxy.
+ */
+export const DEFAULT_NETWORK_PROXY_CONFIG: NetworkProxyConfig = {
+  enabled: false,
+  httpPort: 0,
+  socksPort: 0,
+  defaultAction: DomainFilterAction.PROMPT,
+  rules: [],
+  enableLogging: false,
+  maxLogEntries: 1000,
+  promptForUnknownDomains: true,
+};

--- a/packages/core/src/services/networkProxy/types.ts
+++ b/packages/core/src/services/networkProxy/types.ts
@@ -22,9 +22,8 @@ export enum DomainFilterAction {
  *   - "*" -> matches everything
  */
 export interface DomainRule {
-  /** The domain pattern to match against. Supports wildcard prefix: *.example.com */
+  /** Supports wildcard prefix: *.example.com */
   pattern: string;
-  /** Action to take when this rule matches. */
   action: DomainFilterAction;
 }
 
@@ -32,11 +31,8 @@ export interface DomainRule {
  * Result of checking a domain against the filtering rules.
  */
 export interface DomainCheckResult {
-  /** The domain that was checked. */
   domain: string;
-  /** Resolved action after evaluating rules. */
   action: DomainFilterAction;
-  /** The rule that matched, if any. */
   matchedRule?: DomainRule;
 }
 
@@ -44,19 +40,14 @@ export interface DomainCheckResult {
  * Represents a single recorded connection through the proxy.
  */
 export interface ProxyConnectionRecord {
-  /** Timestamp of the connection in ISO format. */
+  /** ISO timestamp. */
   timestamp: string;
-  /** Protocol used: 'http', 'https', or 'tcp'. */
   protocol: 'http' | 'https' | 'tcp';
-  /** Target hostname or IP. */
   host: string;
-  /** Target port. */
   port: number;
-  /** Action that was taken (allow/deny). */
   action: DomainFilterAction;
-  /** HTTP method if applicable. */
   method?: string;
-  /** Full URL if applicable (HTTP only, HTTPS only shows CONNECT target). */
+  /** Full URL (HTTP only; HTTPS shows CONNECT target). */
   url?: string;
 }
 
@@ -64,13 +55,12 @@ export interface ProxyConnectionRecord {
  * Configuration for the network proxy system.
  */
 export interface NetworkProxyConfig {
-  /** Whether the network proxy feature is enabled. */
   enabled: boolean;
 
-  /** Port for the HTTP/HTTPS proxy to listen on. 0 = auto-assign. */
+  /** 0 = auto-assign. */
   httpPort: number;
 
-  /** Port for the SOCKS5 proxy to listen on. 0 = auto-assign. */
+  /** 0 = auto-assign. */
   socksPort: number;
 
   /** Default action when no rule matches a domain. */
@@ -79,13 +69,8 @@ export interface NetworkProxyConfig {
   /** Ordered list of domain filtering rules. First match wins. */
   rules: DomainRule[];
 
-  /** Whether to log traffic for auditing. Opt-in for privacy. */
   enableLogging: boolean;
-
-  /** Maximum number of traffic log entries to keep in memory. */
   maxLogEntries: number;
-
-  /** Whether to prompt the user for new/unknown domains. */
   promptForUnknownDomains: boolean;
 }
 
@@ -93,9 +78,7 @@ export interface NetworkProxyConfig {
  * Addresses the proxy servers are actually listening on after startup.
  */
 export interface ProxyServerAddresses {
-  /** Bound HTTP proxy address in host:port format. */
   httpProxy?: string;
-  /** Bound SOCKS5 proxy address in host:port format. */
   socksProxy?: string;
 }
 
@@ -103,13 +86,9 @@ export interface ProxyServerAddresses {
  * Status of the proxy system.
  */
 export interface ProxyStatus {
-  /** Whether the proxy is currently running. */
   running: boolean;
-  /** Addresses the proxy is listening on. */
   addresses: ProxyServerAddresses;
-  /** Number of connections processed. */
   connectionCount: number;
-  /** Number of connections denied. */
   deniedCount: number;
 }
 

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -107,6 +107,12 @@ export interface ShellExecutionConfig {
   disableDynamicLineTrimming?: boolean;
   scrollback?: number;
   maxSerializedLines?: number;
+  /**
+   * Additional environment variables for network proxy configuration.
+   * When the network proxy is active, this includes HTTP_PROXY, HTTPS_PROXY,
+   * ALL_PROXY, etc. to route child process traffic through the proxy.
+   */
+  proxyEnvironment?: Record<string, string>;
 }
 
 /**
@@ -253,6 +259,7 @@ export class ShellExecutionService {
       onOutputEvent,
       abortSignal,
       shellExecutionConfig.sanitizationConfig,
+      shellExecutionConfig.proxyEnvironment,
     );
   }
 
@@ -299,6 +306,7 @@ export class ShellExecutionService {
     onOutputEvent: (event: ShellOutputEvent) => void,
     abortSignal: AbortSignal,
     sanitizationConfig: EnvironmentSanitizationConfig,
+    proxyEnvironment?: Record<string, string>,
   ): ShellExecutionHandle {
     try {
       const isWindows = os.platform() === 'win32';
@@ -319,6 +327,7 @@ export class ShellExecutionService {
           TERM: 'xterm-256color',
           PAGER: 'cat',
           GIT_PAGER: 'cat',
+          ...(proxyEnvironment ?? {}),
         },
       });
 
@@ -583,6 +592,7 @@ export class ShellExecutionService {
           TERM: 'xterm-256color',
           PAGER: shellExecutionConfig.pager ?? 'cat',
           GIT_PAGER: shellExecutionConfig.pager ?? 'cat',
+          ...(shellExecutionConfig.proxyEnvironment ?? {}),
         },
         handleFlowControl: true,
       });

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -278,6 +278,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
             sanitizationConfig:
               shellExecutionConfig?.sanitizationConfig ??
               this.config.sanitizationConfig,
+            proxyEnvironment: this.config.getNetworkProxyManager()?.getProxyEnvironment(),
           },
         );
 

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -32,6 +32,7 @@ import { WEB_FETCH_DEFINITION } from './definitions/coreTools.js';
 import { resolveToolDeclaration } from './definitions/resolver.js';
 import { LRUCache } from 'mnemonist';
 import { checkDomainWithConfig, extractHostname } from '../services/networkProxy/domainMatcher.js';
+import { sanitizeHostname } from '../services/networkProxy/domainPromptHandler.js';
 
 const URL_FETCH_TIMEOUT_MS = 10000;
 const MAX_CONTENT_LENGTH = 100000;
@@ -540,8 +541,7 @@ Response: ${truncateString(rawResponseText, 10000, '\n\n... [Error response trun
           ? 'is blocked by network proxy policy'
           : 'requires approval, which is not supported by the web-fetch tool';
       // Sanitize hostname to prevent terminal injection via control characters
-      // eslint-disable-next-line no-control-regex
-      const safeHost = hostname.replace(/[\x00-\x1f\x7f-\x9f]|\x1b\[[0-9;]*[a-zA-Z]/g, '');
+      const safeHost = sanitizeHostname(hostname);
       const errorMessage = `Domain '${safeHost}' ${reason}.`;
       debugLogger.warn(`[WebFetchTool] ${errorMessage}`);
       return {


### PR DESCRIPTION
## Summary

This PR introduces a transparent network proxy system that gives users visibility and control over outbound network traffic made by shell commands and tool invocations. It adds HTTP/HTTPS and SOCKS5 proxy servers with configurable domain filtering rules, enabling allow/deny/prompt policies per domain.

This is motivated by the security consideration that agent-executed shell commands can make arbitrary network requests. The proxy layer acts as a controlled gateway, letting users whitelist trusted domains, block unwanted destinations, and get prompted for anything else.

## Architecture

The implementation lives in `packages/core/src/services/networkProxy/` as a self-contained module with clean boundaries, integrated into the existing configuration and tool execution paths.

### Core Components

**Type Foundation** (`types.ts`)
- `DomainFilterAction` enum (`ALLOW`, `DENY`, `PROMPT`) drives all filtering decisions
- `NetworkProxyConfig` defines the complete proxy configuration surface
- `DomainRule` supports exact matches and wildcard patterns (`*.example.com`)
- `ProxyConnectionRecord` captures connection metadata for audit logging
- `DEFAULT_NETWORK_PROXY_CONFIG` provides safe defaults (proxy disabled, default action is `PROMPT`)

**Domain Matcher** (`domainMatcher.ts`)
- Pure functions for pattern matching: `matchesDomainPattern()`, `checkDomain()`, `checkDomainWithConfig()`
- Supports exact match (`example.com`), wildcard prefix (`*.example.com`), and catch-all (`*`)
- Case-insensitive matching with first-match-wins rule evaluation
- URL hostname and port extraction utilities

**HTTP/HTTPS Proxy** (`httpProxy.ts`)
- Standard HTTP forwarding proxy with CONNECT tunneling for HTTPS
- Handles plain HTTP requests by forwarding and relaying responses
- CONNECT method support for TLS passthrough with domain filtering applied at the tunnel establishment phase
- Emits `connection`, `denied`, and `domainCheck` events for monitoring and interactive prompting
- When action is `PROMPT`, suspends the connection until a response is received via the `domainCheck` event callback

**SOCKS5 Proxy** (`socksProxy.ts`)
- RFC 1928-compliant SOCKS5 CONNECT proxy for non-HTTP TCP traffic
- Implements the SOCKS5 handshake: version negotiation → authentication (NO_AUTH) → CONNECT request → relay
- Supports IPv4, IPv6, and domain name address types
- Same domain filtering and event model as the HTTP proxy

**Traffic Logger** (`trafficLogger.ts`)
- Bounded in-memory connection log with configurable `maxLogEntries` limit
- Tracks per-domain connection counts and denied request counts
- Provides `getSummary()` for aggregate traffic analysis
- Ring-buffer behavior: oldest entries are evicted when the limit is reached

**Network Proxy Manager** (`networkProxyManager.ts`)
- Orchestrator: creates, starts, and stops both proxy servers
- Forwards events (`connection`, `denied`, `domainCheck`, `error`) from both proxies through a unified EventEmitter interface
- Provides `getProxyEnvironment()` which returns `HTTP_PROXY`, `HTTPS_PROXY`, and `ALL_PROXY` environment variables pointing to the local proxy addresses
- Exposes `getStatus()` for runtime inspection and `addRule()` for dynamic rule updates

**Domain Prompt Handler** (`domainPromptHandler.ts`)
- Bridges proxy `domainCheck` events to user-facing prompts
- UI-agnostic via `DomainPromptCallback` — accepts any async function `(hostname) => Promise<DomainFilterAction>`
- Includes `createConsoleDomainPrompt()` factory for terminal-based interactions
- Attach/detach lifecycle for clean resource management

### Integration Points

**Configuration** (`packages/core/src/config/config.ts`, `packages/cli/src/config/config.ts`)
- Added `networkProxy` field to `ConfigParameters` accepting `NetworkProxyConfig`
- Lazy-initialized `NetworkProxyManager` via `getNetworkProxyManager()` — only instantiated when config has `enabled: true`
- `getNetworkProxyConfig()` getter for direct config access (used by web-fetch tool)
- CLI config maps user settings to `NetworkProxyConfig`, converting string setting values to `DomainFilterAction` enum values

**Settings Schema** (`packages/cli/src/config/settingsSchema.ts`)
- Added `networkProxy` settings group under Security category with these user-facing options:
  - `enabled` — toggle the proxy on/off (default: `false`)
  - `defaultAction` — enum: `allow` / `deny` / `prompt` (default: `prompt`)
  - `allowedDomains` — array of whitelisted domain patterns
  - `blockedDomains` — array of blocked domain patterns
  - `enableLogging` — toggle traffic audit logging
  - `httpPort` / `socksPort` — manual port assignment (default: `0` for auto-assign)

**Shell Execution** (`shellExecutionService.ts`, `shell.ts`)
- Added optional `proxyEnvironment` field to `ShellExecutionConfig`
- Proxy env vars (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`) are spread into the spawned process environment
- Applied in both `childProcessFallback` and PTY execution paths
- Shell tool passes proxy environment on every command execution via `this.config.getNetworkProxyManager()?.getProxyEnvironment()`

**Web Fetch Tool** (`web-fetch.ts`)
- Added `checkDomainPolicy()` private method that evaluates the target URL's hostname against proxy config rules
- Enforced in all three execution paths: `execute()`, `executeFallback()`, and `executeExperimental()`
- Denied domains return a clean `ToolResult` with an informative error message

**Application Lifecycle** (`gemini.tsx`)
- Proxy starts during CLI initialization (after config load, before agent loop)
- Registered with `registerCleanup()` for graceful shutdown on exit

## Testing

75 tests across 6 test suites covering:

| Suite | Tests | Coverage |
|---|---|---|
| `domainMatcher.test.ts` | 22 | Pattern matching (exact, wildcard, catch-all, case insensitivity), rule evaluation order, hostname/port extraction |
| `trafficLogger.test.ts` | 8 | Logging, capacity limits, summary aggregation, enable/disable behavior |
| `httpProxy.test.ts` | 14 | Server lifecycle, HTTP forwarding, CONNECT tunneling, domain allow/deny/prompt, event emission, concurrent connections |
| `socksProxy.test.ts` | 11 | SOCKS5 handshake, CONNECT flow, domain filtering, IPv4/IPv6/domain address types, protocol error handling |
| `networkProxyManager.test.ts` | 14 | Manager start/stop, env var generation, event forwarding, status reporting, rule management, idempotent operations |
| `domainPromptHandler.test.ts` | 6 | Attach/detach lifecycle, prompt callback integration, error fallback to DENY, event wiring |

## How to Test

```bash
# Run all proxy tests
npx vitest run packages/core/src/services/networkProxy/

# Enable proxy via settings (settings.json or GEMINI_* env)
# Set security.networkProxy.enabled = true
# Optionally configure allowedDomains / blockedDomains
```

Related to #20381
closes  #20381 