### PR TITLE
fix(core): handle optional response fields from code assist API

### DIFF
--- a/packages/cli/src/ui/hooks/usePrivacySettings.ts
+++ b/packages/cli/src/ui/hooks/usePrivacySettings.ts
@@ -103,7 +103,7 @@ async function getRemoteDataCollectionOptIn(
 ): Promise<boolean> {
   try {
     const resp = await server.getCodeAssistGlobalUserSetting();
-    return resp.freeTierDataCollectionOptin;
+    return resp.freeTierDataCollectionOptin ?? true;
   } catch (error: unknown) {
     if (error && typeof error === 'object' && 'response' in error) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
@@ -128,5 +128,5 @@ async function setRemoteDataCollectionOptIn(
     cloudaicompanionProject: server.projectId,
     freeTierDataCollectionOptin: optIn,
   });
-  return resp.freeTierDataCollectionOptin;
+  return resp.freeTierDataCollectionOptin ?? optIn;
 }

--- a/packages/cli/src/ui/hooks/usePrivacySettings.ts
+++ b/packages/cli/src/ui/hooks/usePrivacySettings.ts
@@ -10,6 +10,7 @@ import {
   type CodeAssistServer,
   UserTierId,
   getCodeAssistServer,
+  debugLogger,
 } from '@google/gemini-cli-core';
 
 export interface PrivacyState {
@@ -103,6 +104,11 @@ async function getRemoteDataCollectionOptIn(
 ): Promise<boolean> {
   try {
     const resp = await server.getCodeAssistGlobalUserSetting();
+    if (resp.freeTierDataCollectionOptin === undefined) {
+      debugLogger.warn(
+        'Warning: Code Assist API did not return freeTierDataCollectionOptin. Defaulting to true.',
+      );
+    }
     return resp.freeTierDataCollectionOptin ?? true;
   } catch (error: unknown) {
     if (error && typeof error === 'object' && 'response' in error) {
@@ -128,5 +134,10 @@ async function setRemoteDataCollectionOptIn(
     cloudaicompanionProject: server.projectId,
     freeTierDataCollectionOptin: optIn,
   });
+  if (resp.freeTierDataCollectionOptin === undefined) {
+    debugLogger.warn(
+      `Warning: Code Assist API did not return freeTierDataCollectionOptin. Defaulting to ${optIn}.`,
+    );
+  }
   return resp.freeTierDataCollectionOptin ?? optIn;
 }

--- a/packages/core/src/code_assist/converter.test.ts
+++ b/packages/core/src/code_assist/converter.test.ts
@@ -246,7 +246,7 @@ describe('converter', () => {
       };
       const genaiRes = fromGenerateContentResponse(codeAssistRes);
       expect(genaiRes).toBeInstanceOf(GenerateContentResponse);
-      expect(genaiRes.candidates).toEqual(codeAssistRes.response.candidates);
+      expect(genaiRes.candidates).toEqual(codeAssistRes.response!.candidates);
     });
 
     it('should handle prompt feedback and usage metadata', () => {
@@ -266,10 +266,10 @@ describe('converter', () => {
       };
       const genaiRes = fromGenerateContentResponse(codeAssistRes);
       expect(genaiRes.promptFeedback).toEqual(
-        codeAssistRes.response.promptFeedback,
+        codeAssistRes.response!.promptFeedback,
       );
       expect(genaiRes.usageMetadata).toEqual(
-        codeAssistRes.response.usageMetadata,
+        codeAssistRes.response!.usageMetadata,
       );
     });
 
@@ -296,7 +296,7 @@ describe('converter', () => {
       };
       const genaiRes = fromGenerateContentResponse(codeAssistRes);
       expect(genaiRes.automaticFunctionCallingHistory).toEqual(
-        codeAssistRes.response.automaticFunctionCallingHistory,
+        codeAssistRes.response!.automaticFunctionCallingHistory,
       );
     });
 

--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -72,12 +72,12 @@ interface VertexGenerationConfig {
 }
 
 export interface CaGenerateContentResponse {
-  response: VertexGenerateContentResponse;
+  response?: VertexGenerateContentResponse;
   traceId?: string;
 }
 
 interface VertexGenerateContentResponse {
-  candidates: Candidate[];
+  candidates?: Candidate[];
   automaticFunctionCallingHistory?: Content[];
   promptFeedback?: GenerateContentResponsePromptFeedback;
   usageMetadata?: GenerateContentResponseUsageMetadata;
@@ -94,7 +94,7 @@ interface VertexCountTokenRequest {
 }
 
 export interface CaCountTokenResponse {
-  totalTokens: number;
+  totalTokens?: number;
 }
 
 export function toCountTokenRequest(
@@ -112,7 +112,7 @@ export function fromCountTokenResponse(
   res: CaCountTokenResponse,
 ): CountTokensResponse {
   return {
-    totalTokens: res.totalTokens,
+    totalTokens: res.totalTokens ?? 0,
   };
 }
 

--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -27,6 +27,7 @@ import type {
   ToolConfig,
 } from '@google/genai';
 import { GenerateContentResponse } from '@google/genai';
+import { debugLogger } from '../utils/debugLogger.js';
 
 export interface CAGenerateContentRequest {
   model: string;
@@ -111,6 +112,11 @@ export function toCountTokenRequest(
 export function fromCountTokenResponse(
   res: CaCountTokenResponse,
 ): CountTokensResponse {
+  if (res.totalTokens === undefined) {
+    debugLogger.warn(
+      'Warning: Code Assist API did not return totalTokens. Defaulting to 0.',
+    );
+  }
   return {
     totalTokens: res.totalTokens ?? 0,
   };

--- a/packages/core/src/code_assist/types.ts
+++ b/packages/core/src/code_assist/types.ts
@@ -60,7 +60,7 @@ export interface LoadCodeAssistResponse {
  * GeminiUserTier reflects the structure received from the CodeAssist when calling LoadCodeAssist.
  */
 export interface GeminiUserTier {
-  id: UserTierId;
+  id?: UserTierId;
   name?: string;
   description?: string;
   // This value is used to declare whether a given tier requires the user to configure the project setting on the IDE settings or not.
@@ -79,10 +79,10 @@ export interface GeminiUserTier {
  * @param tierName name of the tier.
  */
 export interface IneligibleTier {
-  reasonCode: IneligibleTierReasonCode;
-  reasonMessage: string;
-  tierId: UserTierId;
-  tierName: string;
+  reasonCode?: IneligibleTierReasonCode;
+  reasonMessage?: string;
+  tierId?: UserTierId;
+  tierName?: string;
   validationErrorMessage?: string;
   validationUrl?: string;
   validationUrlLinkText?: string;
@@ -127,7 +127,7 @@ export type UserTierId = (typeof UserTierId)[keyof typeof UserTierId] | string;
  * privacy notice.
  */
 export interface PrivacyNotice {
-  showNotice: boolean;
+  showNotice?: boolean;
   noticeText?: string;
 }
 
@@ -145,7 +145,7 @@ export interface OnboardUserRequest {
  * http://google3/google/longrunning/operations.proto;rcl=698857719;l=107
  */
 export interface LongRunningOperationResponse {
-  name: string;
+  name?: string;
   done?: boolean;
   response?: OnboardUserResponse;
 }
@@ -157,8 +157,8 @@ export interface LongRunningOperationResponse {
 export interface OnboardUserResponse {
   // tslint:disable-next-line:enforce-name-casing This is the name of the field in the proto.
   cloudaicompanionProject?: {
-    id: string;
-    name: string;
+    id?: string;
+    name?: string;
   };
 }
 
@@ -195,7 +195,7 @@ export interface SetCodeAssistGlobalUserSettingRequest {
 
 export interface CodeAssistGlobalUserSettingResponse {
   cloudaicompanionProject?: string;
-  freeTierDataCollectionOptin: boolean;
+  freeTierDataCollectionOptin?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR makes several fields within the Code Assist API responses optional and ensures the system handles these cases gracefully. Specifically, it updates the type definitions in `packages/core/src/code_assist/types.ts` and `converter.ts` to reflect the possibility of missing data (e.g., `id`, `name`, `candidates`, `totalTokens`) and provides robust fallbacks in `setup.ts` when tier IDs are missing.

## Details

- Updated `CaGenerateContentResponse`, `VertexGenerateContentResponse`, and `CaCountTokenResponse` in `converter.ts` to make properties optional and provide safe fallbacks.
- Updated `GeminiUserTier`, `IneligibleTier`, `PrivacyNotice`, `LongRunningOperationResponse`, `OnboardUserResponse`, and `CodeAssistGlobalUserSettingResponse` in `types.ts` to make their respective properties optional.
- Updated `setup.ts` to log warnings when the user tier ID is not returned from the Code Assist API (`loadCodeAssist` or `onboardUser`) and defaults to the `STANDARD` tier securely.

## Related Issues

Fixes #20187

## How to Validate

1. Run the local test suite using `npm run test`
2. Ensure no typing errors by running `npm run typecheck`
3. Verify the Code Assist connection sets up as expected and defaults to `STANDARD` if a mocked API response is provided without tier IDs.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
