### PR TITLE
feat(plan): support opening and modifying plan in external editor

### DIFF
--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -264,7 +264,7 @@ export const defaultKeyBindings: KeyBindingConfig = {
     { key: 'return', shift: true },
     { key: 'j', ctrl: true },
   ],
-  [Command.OPEN_EXTERNAL_EDITOR]: [{ key: 'x', ctrl: true }],
+  [Command.OPEN_EXTERNAL_EDITOR]: [{ key: 'p', ctrl: true }],
   [Command.PASTE_CLIPBOARD]: [
     { key: 'v', ctrl: true },
     { key: 'v', cmd: true },

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -264,7 +264,7 @@ export const defaultKeyBindings: KeyBindingConfig = {
     { key: 'return', shift: true },
     { key: 'j', ctrl: true },
   ],
-  [Command.OPEN_EXTERNAL_EDITOR]: [{ key: 'p', ctrl: true }],
+  [Command.OPEN_EXTERNAL_EDITOR]: [{ key: 'x', ctrl: true }],
   [Command.PASTE_CLIPBOARD]: [
     { key: 'v', ctrl: true },
     { key: 'v', cmd: true },

--- a/packages/cli/src/test-utils/render.tsx
+++ b/packages/cli/src/test-utils/render.tsx
@@ -574,6 +574,7 @@ const mockUIActions: UIActions = {
   onHintSubmit: vi.fn(),
   handleRestart: vi.fn(),
   handleNewAgentsSelect: vi.fn(),
+  getPreferredEditor: vi.fn(),
 };
 
 let capturedOverflowState: OverflowState | undefined;

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -2554,6 +2554,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
         }
         setNewAgents(null);
       },
+      getPreferredEditor,
     }),
     [
       handleThemeSelect,
@@ -2605,6 +2606,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       newAgents,
       config,
       historyManager,
+      getPreferredEditor,
     ],
   );
 

--- a/packages/cli/src/ui/components/AskUserDialog.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.tsx
@@ -183,6 +183,10 @@ interface AskUserDialogProps {
    * Height constraint for scrollable content.
    */
   availableHeight?: number;
+  /**
+   * Custom keyboard shortcut hints (e.g., ["Ctrl+P to edit"])
+   */
+  extraParts?: string[];
 }
 
 interface ReviewViewProps {
@@ -190,6 +194,7 @@ interface ReviewViewProps {
   answers: { [key: string]: string };
   onSubmit: () => void;
   progressHeader?: React.ReactNode;
+  extraParts?: string[];
 }
 
 const ReviewView: React.FC<ReviewViewProps> = ({
@@ -197,6 +202,7 @@ const ReviewView: React.FC<ReviewViewProps> = ({
   answers,
   onSubmit,
   progressHeader,
+  extraParts,
 }) => {
   const unansweredCount = questions.length - Object.keys(answers).length;
   const hasUnanswered = unansweredCount > 0;
@@ -247,6 +253,7 @@ const ReviewView: React.FC<ReviewViewProps> = ({
       <DialogFooter
         primaryAction="Enter to submit"
         navigationActions="Tab/Shift+Tab to edit answers"
+        extraParts={extraParts}
       />
     </Box>
   );
@@ -925,6 +932,7 @@ export const AskUserDialog: React.FC<AskUserDialogProps> = ({
   onActiveTextInputChange,
   width,
   availableHeight: availableHeightProp,
+  extraParts,
 }) => {
   const uiState = useContext(UIStateContext);
   const availableHeight =
@@ -1120,6 +1128,7 @@ export const AskUserDialog: React.FC<AskUserDialogProps> = ({
           answers={answers}
           onSubmit={handleReviewSubmit}
           progressHeader={progressHeader}
+          extraParts={extraParts}
         />
       </Box>
     );
@@ -1143,6 +1152,7 @@ export const AskUserDialog: React.FC<AskUserDialogProps> = ({
             ? undefined
             : '↑/↓ to navigate'
       }
+      extraParts={extraParts}
     />
   );
 

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
@@ -544,7 +544,7 @@ Implement a comprehensive authentication system with multiple providers.
         expect(onFeedback).not.toHaveBeenCalled();
       });
 
-      it('opens plan in external editor when Ctrl+P is pressed', async () => {
+      it('opens plan in external editor when Ctrl+X is pressed', async () => {
         const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
 
         await act(async () => {
@@ -558,9 +558,9 @@ Implement a comprehensive authentication system with multiple providers.
         // Reset the mock to track the second call during refresh
         vi.mocked(processSingleFileContent).mockClear();
 
-        // Press Ctrl+P
+        // Press Ctrl+X
         await act(async () => {
-          writeKey(stdin, '\x10'); // Ctrl+P
+          writeKey(stdin, '\x18'); // Ctrl+X
         });
 
         await waitFor(() => {

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
@@ -11,6 +11,7 @@ import { waitFor } from '../../test-utils/async.js';
 import { ExitPlanModeDialog } from './ExitPlanModeDialog.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { keyMatchers, Command } from '../keyMatchers.js';
+import { openFileInEditor } from '../utils/editorUtils.js';
 import {
   ApprovalMode,
   validatePlanContent,
@@ -18,6 +19,10 @@ import {
   type FileSystemService,
 } from '@google/gemini-cli-core';
 import * as fs from 'node:fs';
+
+vi.mock('../utils/editorUtils.js', () => ({
+  openFileInEditor: vi.fn(),
+}));
 
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const actual =
@@ -144,6 +149,7 @@ Implement a comprehensive authentication system with multiple providers.
         onApprove={onApprove}
         onFeedback={onFeedback}
         onCancel={onCancel}
+        getPreferredEditor={vi.fn()}
         width={80}
         availableHeight={24}
       />,
@@ -153,6 +159,7 @@ Implement a comprehensive authentication system with multiple providers.
           getTargetDir: () => mockTargetDir,
           getIdeMode: () => false,
           isTrustedFolder: () => true,
+          getPreferredEditor: () => undefined,
           storage: {
             getPlansDir: () => mockPlansDir,
           },
@@ -418,6 +425,7 @@ Implement a comprehensive authentication system with multiple providers.
               onApprove={onApprove}
               onFeedback={onFeedback}
               onCancel={onCancel}
+              getPreferredEditor={vi.fn()}
               width={80}
               availableHeight={24}
             />
@@ -534,6 +542,40 @@ Implement a comprehensive authentication system with multiple providers.
           expect(onApprove).toHaveBeenCalledWith(ApprovalMode.DEFAULT);
         });
         expect(onFeedback).not.toHaveBeenCalled();
+      });
+
+      it('opens plan in external editor when Ctrl+P is pressed', async () => {
+        const { stdin, lastFrame } = renderDialog({ useAlternateBuffer });
+
+        await act(async () => {
+          vi.runAllTimers();
+        });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Add user authentication');
+        });
+
+        // Reset the mock to track the second call during refresh
+        vi.mocked(processSingleFileContent).mockClear();
+
+        // Press Ctrl+P
+        await act(async () => {
+          writeKey(stdin, '\x10'); // Ctrl+P
+        });
+
+        await waitFor(() => {
+          expect(openFileInEditor).toHaveBeenCalledWith(
+            mockPlanFullPath,
+            expect.anything(),
+            expect.anything(),
+            undefined,
+          );
+        });
+
+        // Verify that content is refreshed (processSingleFileContent called again)
+        await waitFor(() => {
+          expect(processSingleFileContent).toHaveBeenCalled();
+        });
       });
     },
   );

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
@@ -149,12 +149,13 @@ export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
   const config = useConfig();
   const { stdin, setRawMode } = useStdin();
   const planState = usePlanContent(planPath, config);
+  const { refresh } = planState;
   const [showLoading, setShowLoading] = useState(false);
 
   const handleOpenEditor = useCallback(async () => {
     await openFileInEditor(planPath, stdin, setRawMode, getPreferredEditor());
-    planState.refresh();
-  }, [planPath, stdin, setRawMode, getPreferredEditor, planState]);
+    refresh();
+  }, [planPath, stdin, setRawMode, getPreferredEditor, refresh]);
 
   useKeypress(
     (key) => {

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
@@ -5,25 +5,31 @@
  */
 
 import type React from 'react';
-import { useEffect, useState } from 'react';
-import { Box, Text } from 'ink';
+import { useEffect, useState, useCallback } from 'react';
+import { Box, Text, useStdin } from 'ink';
 import {
   ApprovalMode,
   validatePlanPath,
   validatePlanContent,
   QuestionType,
   type Config,
+  type EditorType,
   processSingleFileContent,
 } from '@google/gemini-cli-core';
 import { theme } from '../semantic-colors.js';
 import { useConfig } from '../contexts/ConfigContext.js';
 import { AskUserDialog } from './AskUserDialog.js';
+import { openFileInEditor } from '../utils/editorUtils.js';
+import { useKeypress } from '../hooks/useKeypress.js';
+import { keyMatchers, Command } from '../keyMatchers.js';
+import { formatCommand } from '../utils/keybindingUtils.js';
 
 export interface ExitPlanModeDialogProps {
   planPath: string;
   onApprove: (approvalMode: ApprovalMode) => void;
   onFeedback: (feedback: string) => void;
   onCancel: () => void;
+  getPreferredEditor: () => EditorType | undefined;
   width: number;
   availableHeight?: number;
 }
@@ -38,6 +44,7 @@ interface PlanContentState {
   status: PlanStatus;
   content?: string;
   error?: string;
+  refresh: () => void;
 }
 
 enum ApprovalOption {
@@ -53,9 +60,14 @@ const StatusMessage: React.FC<{
 }> = ({ children }) => <Box paddingX={1}>{children}</Box>;
 
 function usePlanContent(planPath: string, config: Config): PlanContentState {
-  const [state, setState] = useState<PlanContentState>({
+  const [version, setVersion] = useState(0);
+  const [state, setState] = useState<Omit<PlanContentState, 'refresh'>>({
     status: PlanStatus.Loading,
   });
+
+  const refresh = useCallback(() => {
+    setVersion((v) => v + 1);
+  }, []);
 
   useEffect(() => {
     let ignore = false;
@@ -120,9 +132,9 @@ function usePlanContent(planPath: string, config: Config): PlanContentState {
     return () => {
       ignore = true;
     };
-  }, [planPath, config]);
+  }, [planPath, config, version]);
 
-  return state;
+  return { ...state, refresh };
 }
 
 export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
@@ -130,12 +142,30 @@ export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
   onApprove,
   onFeedback,
   onCancel,
+  getPreferredEditor,
   width,
   availableHeight,
 }) => {
   const config = useConfig();
+  const { stdin, setRawMode } = useStdin();
   const planState = usePlanContent(planPath, config);
   const [showLoading, setShowLoading] = useState(false);
+
+  const handleOpenEditor = useCallback(async () => {
+    await openFileInEditor(planPath, stdin, setRawMode, getPreferredEditor());
+    planState.refresh();
+  }, [planPath, stdin, setRawMode, getPreferredEditor, planState]);
+
+  useKeypress(
+    (key) => {
+      if (keyMatchers[Command.OPEN_EXTERNAL_EDITOR](key)) {
+        void handleOpenEditor();
+        return true;
+      }
+      return false;
+    },
+    { isActive: true, priority: true },
+  );
 
   useEffect(() => {
     if (planState.status !== PlanStatus.Loading) {
@@ -183,6 +213,8 @@ export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
     );
   }
 
+  const editHint = formatCommand(Command.OPEN_EXTERNAL_EDITOR);
+
   return (
     <Box flexDirection="column" width={width}>
       <AskUserDialog
@@ -220,6 +252,7 @@ export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
         onCancel={onCancel}
         width={width}
         availableHeight={availableHeight}
+        extraParts={[`${editHint} to edit plan`]}
       />
     </Box>
   );

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
@@ -15,6 +15,7 @@ import {
   type Config,
   type EditorType,
   processSingleFileContent,
+  debugLogger,
 } from '@google/gemini-cli-core';
 import { theme } from '../semantic-colors.js';
 import { useConfig } from '../contexts/ConfigContext.js';
@@ -153,8 +154,12 @@ export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
   const [showLoading, setShowLoading] = useState(false);
 
   const handleOpenEditor = useCallback(async () => {
-    await openFileInEditor(planPath, stdin, setRawMode, getPreferredEditor());
-    refresh();
+    try {
+      await openFileInEditor(planPath, stdin, setRawMode, getPreferredEditor());
+      refresh();
+    } catch (err) {
+      debugLogger.error('Failed to open plan in editor:', err);
+    }
   }, [planPath, stdin, setRawMode, getPreferredEditor, refresh]);
 
   useKeypress(

--- a/packages/cli/src/ui/components/ToolConfirmationQueue.tsx
+++ b/packages/cli/src/ui/components/ToolConfirmationQueue.tsx
@@ -17,6 +17,7 @@ import { ShowMoreLines } from './ShowMoreLines.js';
 import { StickyHeader } from './StickyHeader.js';
 import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
 import type { SerializableConfirmationDetails } from '@google/gemini-cli-core';
+import { useUIActions } from '../contexts/UIActionsContext.js';
 
 function getConfirmationHeader(
   details: SerializableConfirmationDetails | undefined,
@@ -41,6 +42,7 @@ export const ToolConfirmationQueue: React.FC<ToolConfirmationQueueProps> = ({
   confirmingTool,
 }) => {
   const config = useConfig();
+  const { getPreferredEditor } = useUIActions();
   const isAlternateBuffer = useAlternateBuffer();
   const {
     mainAreaWidth,
@@ -134,6 +136,7 @@ export const ToolConfirmationQueue: React.FC<ToolConfirmationQueueProps> = ({
             callId={tool.callId}
             confirmationDetails={tool.confirmationDetails}
             config={config}
+            getPreferredEditor={getPreferredEditor}
             terminalWidth={mainAreaWidth - 4} // Adjust for parent border/padding
             availableTerminalHeight={availableContentHeight}
             isFocused={true}

--- a/packages/cli/src/ui/components/__snapshots__/ExitPlanModeDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ExitPlanModeDialog.test.tsx.snap
@@ -23,7 +23,7 @@ Files to Modify
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+P to edit plan · Esc to cancel
 "
 `;
 
@@ -50,7 +50,7 @@ Files to Modify
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+P to edit plan · Esc to cancel
 "
 `;
 
@@ -82,7 +82,7 @@ Implementation Steps
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+P to edit plan · Esc to cancel
 "
 `;
 
@@ -109,7 +109,7 @@ Files to Modify
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+P to edit plan · Esc to cancel
 "
 `;
 
@@ -136,7 +136,7 @@ Files to Modify
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+P to edit plan · Esc to cancel
 "
 `;
 
@@ -163,7 +163,7 @@ Files to Modify
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+P to edit plan · Esc to cancel
 "
 `;
 
@@ -216,7 +216,7 @@ Testing Strategy
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+P to edit plan · Esc to cancel
 "
 `;
 
@@ -243,6 +243,6 @@ Files to Modify
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+P to edit plan · Esc to cancel
 "
 `;

--- a/packages/cli/src/ui/components/__snapshots__/ExitPlanModeDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ExitPlanModeDialog.test.tsx.snap
@@ -23,7 +23,7 @@ Files to Modify
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Ctrl+P to edit plan · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
 "
 `;
 
@@ -50,7 +50,7 @@ Files to Modify
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Ctrl+P to edit plan · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
 "
 `;
 
@@ -82,7 +82,7 @@ Implementation Steps
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Ctrl+P to edit plan · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
 "
 `;
 
@@ -109,7 +109,7 @@ Files to Modify
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Ctrl+P to edit plan · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
 "
 `;
 
@@ -136,7 +136,7 @@ Files to Modify
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Ctrl+P to edit plan · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
 "
 `;
 
@@ -163,7 +163,7 @@ Files to Modify
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Ctrl+P to edit plan · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
 "
 `;
 
@@ -216,7 +216,7 @@ Testing Strategy
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Ctrl+P to edit plan · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
 "
 `;
 
@@ -243,6 +243,6 @@ Files to Modify
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Ctrl+P to edit plan · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
 "
 `;

--- a/packages/cli/src/ui/components/__snapshots__/ExitPlanModeDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ExitPlanModeDialog.test.tsx.snap
@@ -23,7 +23,7 @@ Files to Modify
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
 "
 `;
 
@@ -50,7 +50,7 @@ Files to Modify
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
 "
 `;
 
@@ -82,7 +82,7 @@ Implementation Steps
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
 "
 `;
 
@@ -109,7 +109,7 @@ Files to Modify
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
 "
 `;
 
@@ -136,7 +136,7 @@ Files to Modify
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
 "
 `;
 
@@ -163,7 +163,7 @@ Files to Modify
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
 "
 `;
 
@@ -216,7 +216,7 @@ Testing Strategy
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
 "
 `;
 
@@ -243,6 +243,6 @@ Files to Modify
       Approves plan but requires confirmation for each tool
   3.  Type your feedback...
 
-Enter to select · ↑/↓ to navigate · Esc to cancel
+Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
 "
 `;

--- a/packages/cli/src/ui/components/__snapshots__/ToolConfirmationQueue.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ToolConfirmationQueue.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`ToolConfirmationQueue > renders ExitPlanMode tool confirmation with Suc
 │       Approves plan but requires confirmation for each tool                  │
 │   3.  Type your feedback...                                                  │
 │                                                                              │
-│ Enter to select · ↑/↓ to navigate · Esc to cancel                            │
+│ Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 "
 `;

--- a/packages/cli/src/ui/components/messages/RedirectionConfirmation.test.tsx
+++ b/packages/cli/src/ui/components/messages/RedirectionConfirmation.test.tsx
@@ -37,6 +37,7 @@ describe('ToolConfirmationMessage Redirection', () => {
         callId="test-call-id"
         confirmationDetails={confirmationDetails}
         config={mockConfig}
+        getPreferredEditor={vi.fn()}
         availableTerminalHeight={30}
         terminalWidth={100}
       />,

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.test.tsx
@@ -52,6 +52,7 @@ describe('ToolConfirmationMessage', () => {
         callId="test-call-id"
         confirmationDetails={confirmationDetails}
         config={mockConfig}
+        getPreferredEditor={vi.fn()}
         availableTerminalHeight={30}
         terminalWidth={80}
       />,
@@ -78,6 +79,7 @@ describe('ToolConfirmationMessage', () => {
         callId="test-call-id"
         confirmationDetails={confirmationDetails}
         config={mockConfig}
+        getPreferredEditor={vi.fn()}
         availableTerminalHeight={30}
         terminalWidth={80}
       />,
@@ -101,6 +103,7 @@ describe('ToolConfirmationMessage', () => {
         callId="test-call-id"
         confirmationDetails={confirmationDetails}
         config={mockConfig}
+        getPreferredEditor={vi.fn()}
         availableTerminalHeight={30}
         terminalWidth={80}
       />,
@@ -131,6 +134,7 @@ describe('ToolConfirmationMessage', () => {
         callId="test-call-id"
         confirmationDetails={confirmationDetails}
         config={mockConfig}
+        getPreferredEditor={vi.fn()}
         availableTerminalHeight={30}
         terminalWidth={80}
       />,
@@ -161,6 +165,7 @@ describe('ToolConfirmationMessage', () => {
         callId="test-call-id"
         confirmationDetails={confirmationDetails}
         config={mockConfig}
+        getPreferredEditor={vi.fn()}
         availableTerminalHeight={30}
         terminalWidth={80}
       />,
@@ -190,6 +195,7 @@ describe('ToolConfirmationMessage', () => {
         callId="test-call-id"
         confirmationDetails={confirmationDetails}
         config={mockConfig}
+        getPreferredEditor={vi.fn()}
         availableTerminalHeight={30}
         terminalWidth={80}
       />,
@@ -219,6 +225,7 @@ describe('ToolConfirmationMessage', () => {
         callId="test-call-id"
         confirmationDetails={confirmationDetails}
         config={mockConfig}
+        getPreferredEditor={vi.fn()}
         availableTerminalHeight={30}
         terminalWidth={80}
       />,
@@ -300,6 +307,7 @@ describe('ToolConfirmationMessage', () => {
             callId="test-call-id"
             confirmationDetails={details}
             config={mockConfig}
+            getPreferredEditor={vi.fn()}
             availableTerminalHeight={30}
             terminalWidth={80}
           />,
@@ -321,6 +329,7 @@ describe('ToolConfirmationMessage', () => {
             callId="test-call-id"
             confirmationDetails={details}
             config={mockConfig}
+            getPreferredEditor={vi.fn()}
             availableTerminalHeight={30}
             terminalWidth={80}
           />,
@@ -355,6 +364,7 @@ describe('ToolConfirmationMessage', () => {
           callId="test-call-id"
           confirmationDetails={editConfirmationDetails}
           config={mockConfig}
+          getPreferredEditor={vi.fn()}
           availableTerminalHeight={30}
           terminalWidth={80}
         />,
@@ -381,6 +391,7 @@ describe('ToolConfirmationMessage', () => {
           callId="test-call-id"
           confirmationDetails={editConfirmationDetails}
           config={mockConfig}
+          getPreferredEditor={vi.fn()}
           availableTerminalHeight={30}
           terminalWidth={80}
         />,
@@ -425,6 +436,7 @@ describe('ToolConfirmationMessage', () => {
           callId="test-call-id"
           confirmationDetails={editConfirmationDetails}
           config={mockConfig}
+          getPreferredEditor={vi.fn()}
           availableTerminalHeight={30}
           terminalWidth={80}
         />,
@@ -452,6 +464,7 @@ describe('ToolConfirmationMessage', () => {
           callId="test-call-id"
           confirmationDetails={editConfirmationDetails}
           config={mockConfig}
+          getPreferredEditor={vi.fn()}
           availableTerminalHeight={30}
           terminalWidth={80}
         />,
@@ -479,6 +492,7 @@ describe('ToolConfirmationMessage', () => {
           callId="test-call-id"
           confirmationDetails={editConfirmationDetails}
           config={mockConfig}
+          getPreferredEditor={vi.fn()}
           availableTerminalHeight={30}
           terminalWidth={80}
         />,
@@ -505,6 +519,7 @@ describe('ToolConfirmationMessage', () => {
         callId="test-call-id"
         confirmationDetails={confirmationDetails}
         config={mockConfig}
+        getPreferredEditor={vi.fn()}
         availableTerminalHeight={30}
         terminalWidth={80}
       />,
@@ -550,6 +565,7 @@ describe('ToolConfirmationMessage', () => {
         callId="test-call-id"
         confirmationDetails={confirmationDetails}
         config={mockConfig}
+        getPreferredEditor={vi.fn()}
         availableTerminalHeight={30}
         terminalWidth={80}
       />,
@@ -581,6 +597,7 @@ describe('ToolConfirmationMessage', () => {
         callId="test-call-id"
         confirmationDetails={confirmationDetails}
         config={mockConfig}
+        getPreferredEditor={vi.fn()}
         availableTerminalHeight={30}
         terminalWidth={80}
       />,

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -14,6 +14,7 @@ import {
   type Config,
   type ToolConfirmationPayload,
   ToolConfirmationOutcome,
+  type EditorType,
   hasRedirection,
   debugLogger,
 } from '@google/gemini-cli-core';
@@ -49,6 +50,7 @@ export interface ToolConfirmationMessageProps {
   callId: string;
   confirmationDetails: SerializableConfirmationDetails;
   config: Config;
+  getPreferredEditor: () => EditorType | undefined;
   isFocused?: boolean;
   availableTerminalHeight?: number;
   terminalWidth: number;
@@ -60,6 +62,7 @@ export const ToolConfirmationMessage: React.FC<
   callId,
   confirmationDetails,
   config,
+  getPreferredEditor,
   isFocused = true,
   availableTerminalHeight,
   terminalWidth,
@@ -424,6 +427,7 @@ export const ToolConfirmationMessage: React.FC<
       bodyContent = (
         <ExitPlanModeDialog
           planPath={confirmationDetails.planPath}
+          getPreferredEditor={getPreferredEditor}
           onApprove={(approvalMode) => {
             handleConfirm(ToolConfirmationOutcome.ProceedOnce, {
               approved: true,
@@ -629,6 +633,7 @@ export const ToolConfirmationMessage: React.FC<
     hasMcpToolDetails,
     mcpToolDetailsText,
     expandDetailsHintKey,
+    getPreferredEditor,
   ]);
 
   const bodyOverflowDirection: 'top' | 'bottom' =

--- a/packages/cli/src/ui/components/shared/DialogFooter.tsx
+++ b/packages/cli/src/ui/components/shared/DialogFooter.tsx
@@ -15,6 +15,8 @@ export interface DialogFooterProps {
   navigationActions?: string;
   /** Exit shortcut (defaults to "Esc to cancel") */
   cancelAction?: string;
+  /** Custom keyboard shortcut hints (e.g., ["Ctrl+P to edit"]) */
+  extraParts?: string[];
 }
 
 /**
@@ -25,11 +27,13 @@ export const DialogFooter: React.FC<DialogFooterProps> = ({
   primaryAction,
   navigationActions,
   cancelAction = 'Esc to cancel',
+  extraParts = [],
 }) => {
   const parts = [primaryAction];
   if (navigationActions) {
     parts.push(navigationActions);
   }
+  parts.push(...extraParts);
   parts.push(cancelAction);
 
   return (

--- a/packages/cli/src/ui/contexts/UIActionsContext.tsx
+++ b/packages/cli/src/ui/contexts/UIActionsContext.tsx
@@ -87,6 +87,7 @@ export interface UIActions {
   onHintSubmit: (hint: string) => void;
   handleRestart: () => void;
   handleNewAgentsSelect: (choice: NewAgentsChoice) => Promise<void>;
+  getPreferredEditor: () => EditorType | undefined;
 }
 
 export const UIActionsContext = createContext<UIActions | null>(null);

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -70,8 +70,12 @@ export async function openFileInEditor(
   setRawMode?.(false);
 
   try {
+    const commandParts = command.split(' ');
+    const executable = commandParts[0];
+    const initialArgs = commandParts.slice(1);
+
     if (isTerminal) {
-      const result = spawnSync(command, args, {
+      const result = spawnSync(executable, [...initialArgs, ...args], {
         stdio: 'inherit',
         shell: process.platform === 'win32',
       });
@@ -96,7 +100,7 @@ export async function openFileInEditor(
       }
     } else {
       await new Promise<void>((resolve, reject) => {
-        const child = spawn(command, args, {
+        const child = spawn(executable, [...initialArgs, ...args], {
           stdio: 'inherit',
           shell: process.platform === 'win32',
         });

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawn, spawnSync } from 'node:child_process';
+import type { ReadStream } from 'node:tty';
+import {
+  coreEvents,
+  CoreEvent,
+  type EditorType,
+  getEditorCommand,
+  isGuiEditor,
+  isTerminalEditor,
+} from '@google/gemini-cli-core';
+
+/**
+ * Opens a file in an external editor and waits for it to close.
+ * Handles raw mode switching to ensure the editor can interact with the terminal.
+ *
+ * @param filePath Path to the file to open
+ * @param stdin The stdin stream from Ink/Node
+ * @param setRawMode Function to toggle raw mode
+ * @param preferredEditorType The user's preferred editor from config
+ */
+export async function openFileInEditor(
+  filePath: string,
+  stdin: ReadStream | null | undefined,
+  setRawMode: ((mode: boolean) => void) | undefined,
+  preferredEditorType?: EditorType,
+): Promise<void> {
+  let command: string | undefined = undefined;
+  const args = [filePath];
+
+  if (preferredEditorType) {
+    command = getEditorCommand(preferredEditorType);
+    if (isGuiEditor(preferredEditorType)) {
+      args.unshift('--wait');
+    }
+  }
+
+  if (!command) {
+    command = process.env['VISUAL'] ?? process.env['EDITOR'];
+  }
+
+  if (!command) {
+    command = process.platform === 'win32' ? 'notepad' : 'vi';
+  }
+
+  // Determine if we should use sync or async based on the command/editor type.
+  // If we have a preferredEditorType, we can check if it's a terminal editor.
+  // Otherwise, we guess based on the command name.
+  const terminalEditors = ['vi', 'vim', 'nvim', 'emacs', 'hx', 'nano'];
+  const isTerminal = preferredEditorType
+    ? isTerminalEditor(preferredEditorType)
+    : terminalEditors.some((te) => command?.includes(te));
+
+  if (
+    isTerminal &&
+    (command.includes('vi') ||
+      command.includes('vim') ||
+      command.includes('nvim'))
+  ) {
+    // Pass -i NONE to prevent E138 'Can't write viminfo file' errors in restricted environments.
+    args.unshift('-i', 'NONE');
+  }
+
+  const wasRaw = stdin?.isRaw ?? false;
+  setRawMode?.(false);
+
+  const cleanup = (status: number | null) => {
+    if (wasRaw) {
+      setRawMode?.(true);
+    }
+    coreEvents.emit(CoreEvent.ExternalEditorClosed);
+
+    if (typeof status === 'number' && status !== 0) {
+      const err = new Error(`External editor exited with status ${status}`);
+      coreEvents.emitFeedback(
+        'error',
+        '[editorUtils] external editor error',
+        err,
+      );
+      return err;
+    }
+    return null;
+  };
+
+  if (isTerminal) {
+    try {
+      const { status, error } = spawnSync(command, args, {
+        stdio: 'inherit',
+        shell: process.platform === 'win32',
+      });
+      if (error) {
+        throw error;
+      }
+      const err = cleanup(status);
+      if (err) throw err;
+      return;
+    } catch (err) {
+      if (wasRaw) {
+        setRawMode?.(true);
+      }
+      coreEvents.emit(CoreEvent.ExternalEditorClosed);
+      coreEvents.emitFeedback(
+        'error',
+        '[editorUtils] external terminal editor error',
+        err,
+      );
+      throw err;
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
+
+    child.on('error', (err) => {
+      if (wasRaw) {
+        setRawMode?.(true);
+      }
+      coreEvents.emit(CoreEvent.ExternalEditorClosed);
+      coreEvents.emitFeedback(
+        'error',
+        '[editorUtils] external editor spawn error',
+        err,
+      );
+      reject(err);
+    });
+
+    child.on('close', (status) => {
+      const err = cleanup(status);
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Support opening and modifying the current plan in an external editor during Plan Mode approval.

## Details

- Added `Ctrl+X` shortcut to `ExitPlanModeDialog` to open the plan file in an external editor.
- The dialog content is refreshed automatically after the editor is closed.
- Refactored editor spawning logic into a common `editorUtils.ts` utility, which is also now used by `text-buffer.ts`.
- Plumbed `getPreferredEditor` through `UIActions` to ensure the user's preferred editor is respected.
- Updated `AskUserDialog` and `DialogFooter` to support custom keyboard shortcut hints.

## Related Issues

Closes #17721

## How to Validate

1. Enter Plan Mode: `gemini --plan "some task"`
2. Wait for the plan to be generated.
3. In the plan approval dialog, press `Ctrl+X`.
4. The plan file should open in your default or configured editor.
5. Modify the plan (e.g., add/remove a step) and save/close the editor.
6. The CLI should refresh and show the updated plan.

To test opening with a terminal editor like vim make sure that you have a terminal editor selected in `/editor`, same applies with testing with an IDE

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
