### PR TITLE
feat(cli): hide workspace policy update dialog and auto-accept by default

### DIFF
--- a/packages/cli/src/config/policy.test.ts
+++ b/packages/cli/src/config/policy.test.ts
@@ -8,7 +8,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { resolveWorkspacePolicyState } from './policy.js';
+import {
+  resolveWorkspacePolicyState,
+  AUTO_ACCEPT_WORKSPACE_POLICIES,
+  setAutoAcceptWorkspacePolicies,
+} from './policy.js';
 import { writeToStderr } from '@google/gemini-cli-core';
 
 // Mock debugLogger to avoid noise in test output
@@ -68,24 +72,18 @@ describe('resolveWorkspacePolicyState', () => {
     fs.mkdirSync(policiesDir, { recursive: true });
     fs.writeFileSync(path.join(policiesDir, 'policy.toml'), 'rules = []');
 
-    // First call to establish integrity (interactive accept)
+    // First call to establish integrity (interactive auto-accept)
     const firstResult = await resolveWorkspacePolicyState({
       cwd: workspaceDir,
       trustedFolder: true,
       interactive: true,
     });
-    expect(firstResult.policyUpdateConfirmationRequest).toBeDefined();
-
-    // Establish integrity manually as if accepted
-    const { PolicyIntegrityManager } = await import('@google/gemini-cli-core');
-    const integrityManager = new PolicyIntegrityManager();
-    await integrityManager.acceptIntegrity(
-      'workspace',
-      workspaceDir,
-      firstResult.policyUpdateConfirmationRequest!.newHash,
-    );
+    expect(firstResult.workspacePoliciesDir).toBe(policiesDir);
+    expect(firstResult.policyUpdateConfirmationRequest).toBeUndefined();
+    expect(writeToStderr).not.toHaveBeenCalled();
 
     // Second call should match
+
     const result = await resolveWorkspacePolicyState({
       cwd: workspaceDir,
       trustedFolder: true,
@@ -107,26 +105,33 @@ describe('resolveWorkspacePolicyState', () => {
     expect(result.policyUpdateConfirmationRequest).toBeUndefined();
   });
 
-  it('should return confirmation request if changed in interactive mode', async () => {
-    fs.mkdirSync(policiesDir, { recursive: true });
-    fs.writeFileSync(path.join(policiesDir, 'policy.toml'), 'rules = []');
+  it('should return confirmation request if changed in interactive mode when AUTO_ACCEPT is false', async () => {
+    const originalValue = AUTO_ACCEPT_WORKSPACE_POLICIES;
+    setAutoAcceptWorkspacePolicies(false);
 
-    const result = await resolveWorkspacePolicyState({
-      cwd: workspaceDir,
-      trustedFolder: true,
-      interactive: true,
-    });
+    try {
+      fs.mkdirSync(policiesDir, { recursive: true });
+      fs.writeFileSync(path.join(policiesDir, 'policy.toml'), 'rules = []');
 
-    expect(result.workspacePoliciesDir).toBeUndefined();
-    expect(result.policyUpdateConfirmationRequest).toEqual({
-      scope: 'workspace',
-      identifier: workspaceDir,
-      policyDir: policiesDir,
-      newHash: expect.any(String),
-    });
+      const result = await resolveWorkspacePolicyState({
+        cwd: workspaceDir,
+        trustedFolder: true,
+        interactive: true,
+      });
+
+      expect(result.workspacePoliciesDir).toBeUndefined();
+      expect(result.policyUpdateConfirmationRequest).toEqual({
+        scope: 'workspace',
+        identifier: workspaceDir,
+        policyDir: policiesDir,
+        newHash: expect.any(String),
+      });
+    } finally {
+      setAutoAcceptWorkspacePolicies(originalValue);
+    }
   });
 
-  it('should warn and auto-accept if changed in non-interactive mode', async () => {
+  it('should warn and auto-accept if changed in non-interactive mode when AUTO_ACCEPT is true', async () => {
     fs.mkdirSync(policiesDir, { recursive: true });
     fs.writeFileSync(path.join(policiesDir, 'policy.toml'), 'rules = []');
 
@@ -141,6 +146,30 @@ describe('resolveWorkspacePolicyState', () => {
     expect(writeToStderr).toHaveBeenCalledWith(
       expect.stringContaining('Automatically accepting and loading'),
     );
+  });
+
+  it('should warn and auto-accept if changed in non-interactive mode when AUTO_ACCEPT is false', async () => {
+    const originalValue = AUTO_ACCEPT_WORKSPACE_POLICIES;
+    setAutoAcceptWorkspacePolicies(false);
+
+    try {
+      fs.mkdirSync(policiesDir, { recursive: true });
+      fs.writeFileSync(path.join(policiesDir, 'policy.toml'), 'rules = []');
+
+      const result = await resolveWorkspacePolicyState({
+        cwd: workspaceDir,
+        trustedFolder: true,
+        interactive: false,
+      });
+
+      expect(result.workspacePoliciesDir).toBe(policiesDir);
+      expect(result.policyUpdateConfirmationRequest).toBeUndefined();
+      expect(writeToStderr).toHaveBeenCalledWith(
+        expect.stringContaining('Automatically accepting and loading'),
+      );
+    } finally {
+      setAutoAcceptWorkspacePolicies(originalValue);
+    }
   });
 
   it('should not return workspace policies if cwd is the home directory', async () => {

--- a/packages/cli/src/config/policy.test.ts
+++ b/packages/cli/src/config/policy.test.ts
@@ -10,7 +10,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import {
   resolveWorkspacePolicyState,
-  AUTO_ACCEPT_WORKSPACE_POLICIES,
+  autoAcceptWorkspacePolicies,
   setAutoAcceptWorkspacePolicies,
 } from './policy.js';
 import { writeToStderr } from '@google/gemini-cli-core';
@@ -106,7 +106,7 @@ describe('resolveWorkspacePolicyState', () => {
   });
 
   it('should return confirmation request if changed in interactive mode when AUTO_ACCEPT is false', async () => {
-    const originalValue = AUTO_ACCEPT_WORKSPACE_POLICIES;
+    const originalValue = autoAcceptWorkspacePolicies;
     setAutoAcceptWorkspacePolicies(false);
 
     try {
@@ -149,7 +149,7 @@ describe('resolveWorkspacePolicyState', () => {
   });
 
   it('should warn and auto-accept if changed in non-interactive mode when AUTO_ACCEPT is false', async () => {
-    const originalValue = AUTO_ACCEPT_WORKSPACE_POLICIES;
+    const originalValue = autoAcceptWorkspacePolicies;
     setAutoAcceptWorkspacePolicies(false);
 
     try {

--- a/packages/cli/src/config/policy.ts
+++ b/packages/cli/src/config/policy.ts
@@ -17,8 +17,23 @@ import {
   Storage,
   type PolicyUpdateConfirmationRequest,
   writeToStderr,
+  debugLogger,
 } from '@google/gemini-cli-core';
 import { type Settings } from './settings.js';
+
+/**
+ * Temporary flag to automatically accept workspace policies to reduce friction.
+ * Exported as 'let' to allow monkey patching in tests via the setter.
+ */
+export let AUTO_ACCEPT_WORKSPACE_POLICIES = true;
+
+/**
+ * Sets the AUTO_ACCEPT_WORKSPACE_POLICIES flag.
+ * Used primarily for testing purposes.
+ */
+export function setAutoAcceptWorkspacePolicies(value: boolean) {
+  AUTO_ACCEPT_WORKSPACE_POLICIES = value;
+}
 
 export async function createPolicyEngineConfig(
   settings: Settings,
@@ -91,8 +106,8 @@ export async function resolveWorkspacePolicyState(options: {
     ) {
       // No workspace policies found
       workspacePoliciesDir = undefined;
-    } else if (interactive) {
-      // Policies changed or are new, and we are in interactive mode
+    } else if (interactive && !AUTO_ACCEPT_WORKSPACE_POLICIES) {
+      // Policies changed or are new, and we are in interactive mode and auto-accept is disabled
       policyUpdateConfirmationRequest = {
         scope: 'workspace',
         identifier: cwd,
@@ -100,17 +115,23 @@ export async function resolveWorkspacePolicyState(options: {
         newHash: integrityResult.hash,
       };
     } else {
-      // Non-interactive mode: warn and automatically accept/load
+      // Non-interactive mode or auto-accept is enabled: automatically accept/load
       await integrityManager.acceptIntegrity(
         'workspace',
         cwd,
         integrityResult.hash,
       );
       workspacePoliciesDir = potentialWorkspacePoliciesDir;
-      // debugLogger.warn here doesn't show up in the terminal. It is showing up only in debug mode on the debug console
-      writeToStderr(
-        'WARNING: Workspace policies changed or are new. Automatically accepting and loading them in non-interactive mode.\n',
-      );
+
+      if (!interactive) {
+        writeToStderr(
+          'WARNING: Workspace policies changed or are new. Automatically accepting and loading them.\n',
+        );
+      } else {
+        debugLogger.warn(
+          'Workspace policies changed or are new. Automatically accepting and loading them.',
+        );
+      }
     }
   }
 

--- a/packages/cli/src/config/policy.ts
+++ b/packages/cli/src/config/policy.ts
@@ -25,14 +25,14 @@ import { type Settings } from './settings.js';
  * Temporary flag to automatically accept workspace policies to reduce friction.
  * Exported as 'let' to allow monkey patching in tests via the setter.
  */
-export let AUTO_ACCEPT_WORKSPACE_POLICIES = true;
+export let autoAcceptWorkspacePolicies = true;
 
 /**
- * Sets the AUTO_ACCEPT_WORKSPACE_POLICIES flag.
+ * Sets the autoAcceptWorkspacePolicies flag.
  * Used primarily for testing purposes.
  */
 export function setAutoAcceptWorkspacePolicies(value: boolean) {
-  AUTO_ACCEPT_WORKSPACE_POLICIES = value;
+  autoAcceptWorkspacePolicies = value;
 }
 
 export async function createPolicyEngineConfig(
@@ -106,7 +106,7 @@ export async function resolveWorkspacePolicyState(options: {
     ) {
       // No workspace policies found
       workspacePoliciesDir = undefined;
-    } else if (interactive && !AUTO_ACCEPT_WORKSPACE_POLICIES) {
+    } else if (interactive && !autoAcceptWorkspacePolicies) {
       // Policies changed or are new, and we are in interactive mode and auto-accept is disabled
       policyUpdateConfirmationRequest = {
         scope: 'workspace',

--- a/packages/cli/src/config/workspace-policy-cli.test.ts
+++ b/packages/cli/src/config/workspace-policy-cli.test.ts
@@ -10,6 +10,7 @@ import { loadCliConfig, type CliArgs } from './config.js';
 import { createTestMergedSettings } from './settings.js';
 import * as ServerConfig from '@google/gemini-cli-core';
 import { isWorkspaceTrusted } from './trustedFolders.js';
+import * as Policy from './policy.js';
 
 // Mock dependencies
 vi.mock('./trustedFolders.js', () => ({
@@ -164,7 +165,7 @@ describe('Workspace-Level Policy CLI Integration', () => {
     );
   });
 
-  it('should set policyUpdateConfirmationRequest if integrity MISMATCH in interactive mode', async () => {
+  it('should automatically accept and load workspacePoliciesDir if integrity MISMATCH in interactive mode when AUTO_ACCEPT is true', async () => {
     vi.mocked(isWorkspaceTrusted).mockReturnValue({
       isTrusted: true,
       source: 'file',
@@ -186,24 +187,23 @@ describe('Workspace-Level Policy CLI Integration', () => {
       cwd: MOCK_CWD,
     });
 
-    expect(config.getPolicyUpdateConfirmationRequest()).toEqual({
-      scope: 'workspace',
-      identifier: MOCK_CWD,
-      policyDir: expect.stringContaining(path.join('.gemini', 'policies')),
-      newHash: 'new-hash',
-    });
-    // In interactive mode without accept flag, it waits for user confirmation (handled by UI),
-    // so it currently DOES NOT pass the directory to createPolicyEngineConfig yet.
-    // The UI will handle the confirmation and reload/update.
+    expect(config.getPolicyUpdateConfirmationRequest()).toBeUndefined();
+    expect(mockAcceptIntegrity).toHaveBeenCalledWith(
+      'workspace',
+      MOCK_CWD,
+      'new-hash',
+    );
     expect(ServerConfig.createPolicyEngineConfig).toHaveBeenCalledWith(
       expect.objectContaining({
-        workspacePoliciesDir: undefined,
+        workspacePoliciesDir: expect.stringContaining(
+          path.join('.gemini', 'policies'),
+        ),
       }),
       expect.anything(),
     );
   });
 
-  it('should set policyUpdateConfirmationRequest if integrity is NEW with files (first time seen) in interactive mode', async () => {
+  it('should automatically accept and load workspacePoliciesDir if integrity is NEW in interactive mode when AUTO_ACCEPT is true', async () => {
     vi.mocked(isWorkspaceTrusted).mockReturnValue({
       isTrusted: true,
       source: 'file',
@@ -222,18 +222,65 @@ describe('Workspace-Level Policy CLI Integration', () => {
       cwd: MOCK_CWD,
     });
 
-    expect(config.getPolicyUpdateConfirmationRequest()).toEqual({
-      scope: 'workspace',
-      identifier: MOCK_CWD,
-      policyDir: expect.stringContaining(path.join('.gemini', 'policies')),
-      newHash: 'new-hash',
-    });
+    expect(config.getPolicyUpdateConfirmationRequest()).toBeUndefined();
+    expect(mockAcceptIntegrity).toHaveBeenCalledWith(
+      'workspace',
+      MOCK_CWD,
+      'new-hash',
+    );
 
     expect(ServerConfig.createPolicyEngineConfig).toHaveBeenCalledWith(
       expect.objectContaining({
-        workspacePoliciesDir: undefined,
+        workspacePoliciesDir: expect.stringContaining(
+          path.join('.gemini', 'policies'),
+        ),
       }),
       expect.anything(),
     );
+  });
+
+  it('should set policyUpdateConfirmationRequest if integrity MISMATCH in interactive mode when AUTO_ACCEPT is false', async () => {
+    // Monkey patch AUTO_ACCEPT_WORKSPACE_POLICIES using setter
+    const originalValue = Policy.AUTO_ACCEPT_WORKSPACE_POLICIES;
+    Policy.setAutoAcceptWorkspacePolicies(false);
+
+    try {
+      vi.mocked(isWorkspaceTrusted).mockReturnValue({
+        isTrusted: true,
+        source: 'file',
+      });
+      mockCheckIntegrity.mockResolvedValue({
+        status: 'mismatch',
+        hash: 'new-hash',
+        fileCount: 1,
+      });
+      vi.mocked(ServerConfig.isHeadlessMode).mockReturnValue(false); // Interactive
+
+      const settings = createTestMergedSettings();
+      const argv = {
+        query: 'test',
+        promptInteractive: 'test',
+      } as unknown as CliArgs;
+
+      const config = await loadCliConfig(settings, 'test-session', argv, {
+        cwd: MOCK_CWD,
+      });
+
+      expect(config.getPolicyUpdateConfirmationRequest()).toEqual({
+        scope: 'workspace',
+        identifier: MOCK_CWD,
+        policyDir: expect.stringContaining(path.join('.gemini', 'policies')),
+        newHash: 'new-hash',
+      });
+      expect(ServerConfig.createPolicyEngineConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspacePoliciesDir: undefined,
+        }),
+        expect.anything(),
+      );
+    } finally {
+      // Restore for other tests
+      Policy.setAutoAcceptWorkspacePolicies(originalValue);
+    }
   });
 });

--- a/packages/cli/src/config/workspace-policy-cli.test.ts
+++ b/packages/cli/src/config/workspace-policy-cli.test.ts
@@ -240,8 +240,8 @@ describe('Workspace-Level Policy CLI Integration', () => {
   });
 
   it('should set policyUpdateConfirmationRequest if integrity MISMATCH in interactive mode when AUTO_ACCEPT is false', async () => {
-    // Monkey patch AUTO_ACCEPT_WORKSPACE_POLICIES using setter
-    const originalValue = Policy.AUTO_ACCEPT_WORKSPACE_POLICIES;
+    // Monkey patch autoAcceptWorkspacePolicies using setter
+    const originalValue = Policy.autoAcceptWorkspacePolicies;
     Policy.setAutoAcceptWorkspacePolicies(false);
 
     try {


### PR DESCRIPTION
## Summary

Hide the workspace policy update dialog and automatically accept policy changes by default to improve user experience and reduce startup friction in interactive mode.

## Details

- **Default Auto-Accept**: Updated `resolveWorkspacePolicyState` in `packages/cli/src/config/policy.ts` to automatically accept and load policies by default in interactive mode. This matches existing non-interactive logic to reduce startup friction.
- **Configurable Flag**: Introduced `autoAcceptWorkspacePolicies` (let) and a corresponding `setAutoAcceptWorkspacePolicies` setter in `policy.ts` to manage workspace policy behavior while maintaining testability.
- **CamelCase Naming**: Refactored the flag from all-caps `AUTO_ACCEPT_WORKSPACE_POLICIES` to camelCase `autoAcceptWorkspacePolicies` to follow naming conventions for mutable variables.
- **Comprehensive Testing**: Refactored `policy.test.ts` and `workspace-policy-cli.test.ts` to verify the new default behavior while maintaining coverage for the manual confirmation flow by toggling the flag via the setter in tests.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/20336

## How to Validate

1. **Unit Tests**: Run tests for policy logic:
   `npm test -w @google/gemini-cli -- src/config/policy.test.ts`
2. **Integration Tests**: Verify CLI integration and manual confirmation flow:
   `npm test -w @google/gemini-cli -- src/config/workspace-policy-cli.test.ts`
3. **Full Validation**: Run the workspace preflight script:
   `npm run preflight`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt