### PR TITLE
fix(core): allow /memory add to work in plan mode

### DIFF
--- a/docs/cli/plan-mode.md
+++ b/docs/cli/plan-mode.md
@@ -119,6 +119,7 @@ These are the only allowed tools:
 - **Planning (Write):** [`write_file`] and [`replace`] only allowed for `.md`
   files in the `~/.gemini/tmp/<project>/<session-id>/plans/` directory or your
   [custom plans directory](#custom-plan-directory-and-policies).
+- **Memory:** [`save_memory`]
 - **Skills:** [`activate_skill`] (allows loading specialized instructions and
   resources in a read-only manner)
 
@@ -277,6 +278,7 @@ performance. You can disable this automatic switching in your settings:
 [`google_web_search`]: /docs/tools/web-search.md
 [`replace`]: /docs/tools/file-system.md#6-replace-edit
 [MCP tools]: /docs/tools/mcp-server.md
+[`save_memory`]: /docs/tools/memory.md
 [`activate_skill`]: /docs/cli/skills.md
 [subagents]: /docs/core/subagents.md
 [policy engine]: /docs/reference/policy-engine.md

--- a/packages/core/src/policy/policies/plan.toml
+++ b/packages/core/src/policy/policies/plan.toml
@@ -50,7 +50,7 @@ priority = 70
 modes = ["plan"]
 
 [[rule]]
-toolName = ["ask_user", "exit_plan_mode"]
+toolName = ["ask_user", "exit_plan_mode", "save_memory"]
 decision = "ask_user"
 priority = 70
 modes = ["plan"]

--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -2602,6 +2602,12 @@ describe('PolicyEngine', () => {
             modes: [ApprovalMode.PLAN],
           },
           {
+            toolName: 'save_memory',
+            decision: PolicyDecision.ASK_USER,
+            priority: 70,
+            modes: [ApprovalMode.PLAN],
+          },
+          {
             toolName: 'exit_plan_mode',
             decision: PolicyDecision.ASK_USER,
             priority: 70,
@@ -2638,6 +2644,7 @@ describe('PolicyEngine', () => {
         'web_fetch',
         'write_todos',
         'memory',
+        'save_memory',
         'read_tool',
         'write_tool',
       ]);
@@ -2667,6 +2674,7 @@ describe('PolicyEngine', () => {
       expect(excluded.has('activate_skill')).toBe(false);
       expect(excluded.has('ask_user')).toBe(false);
       expect(excluded.has('exit_plan_mode')).toBe(false);
+      expect(excluded.has('save_memory')).toBe(false);
       // Read-only MCP tool allowed by annotation rule (matched via _serverName)
       expect(excluded.has('read_tool')).toBe(false);
     });


### PR DESCRIPTION
## Summary

/memory add was blocked in plan mode because save_memory is not in the plan mode tool allowlist and the policy engine's catch-all DENY rule rejects it. Plan mode restrictions target the AI agent, not the user. This bypasses both checks when isClientInitiated is true on the request.

## Details

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

Fixes https://github.com/google-gemini/gemini-cli/issues/20347

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
