### PR TITLE
feat(core): introduce Kind.Agent for sub-agent classification

### DIFF
--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -1335,6 +1335,8 @@ function toAcpToolKind(kind: Kind): acp.ToolKind {
     case Kind.SwitchMode:
     case Kind.Other:
       return kind as acp.ToolKind;
+    case Kind.Agent:
+      return 'think';
     case Kind.Plan:
     case Kind.Communicate:
     default:

--- a/packages/core/src/agents/subagent-tool-wrapper.test.ts
+++ b/packages/core/src/agents/subagent-tool-wrapper.test.ts
@@ -70,7 +70,7 @@ describe('SubagentToolWrapper', () => {
       expect(wrapper.name).toBe(mockDefinition.name);
       expect(wrapper.displayName).toBe(mockDefinition.displayName);
       expect(wrapper.description).toBe(mockDefinition.description);
-      expect(wrapper.kind).toBe(Kind.Think);
+      expect(wrapper.kind).toBe(Kind.Agent);
       expect(wrapper.isOutputMarkdown).toBe(true);
       expect(wrapper.canUpdateOutput).toBe(true);
     });

--- a/packages/core/src/agents/subagent-tool-wrapper.ts
+++ b/packages/core/src/agents/subagent-tool-wrapper.ts
@@ -45,7 +45,7 @@ export class SubagentToolWrapper extends BaseDeclarativeTool<
       definition.name,
       definition.displayName ?? definition.name,
       definition.description,
-      Kind.Think,
+      Kind.Agent,
       definition.inputConfig.inputSchema,
       messageBus,
       /* isOutputMarkdown */ true,

--- a/packages/core/src/agents/subagent-tool.test.ts
+++ b/packages/core/src/agents/subagent-tool.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SubagentTool } from './subagent-tool.js';
 import { SubagentToolWrapper } from './subagent-tool-wrapper.js';
+import { Kind } from '../tools/tools.js';
 import type {
   LocalAgentDefinition,
   RemoteAgentDefinition,
@@ -68,6 +69,11 @@ describe('SubAgentInvocation', () => {
     MockSubagentToolWrapper.prototype.build = vi
       .fn()
       .mockReturnValue(mockInnerInvocation);
+  });
+
+  it('should have Kind.Agent', () => {
+    const tool = new SubagentTool(testDefinition, mockConfig, mockMessageBus);
+    expect(tool.kind).toBe(Kind.Agent);
   });
 
   it('should delegate shouldConfirmExecute to the inner sub-invocation (local)', async () => {

--- a/packages/core/src/agents/subagent-tool.ts
+++ b/packages/core/src/agents/subagent-tool.ts
@@ -41,7 +41,7 @@ export class SubagentTool extends BaseDeclarativeTool<AgentInputs, ToolResult> {
       definition.name,
       definition.displayName ?? definition.name,
       definition.description,
-      Kind.Think,
+      Kind.Agent,
       inputSchema,
       messageBus,
       /* isOutputMarkdown */ true,

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -832,6 +832,7 @@ export enum Kind {
   Search = 'search',
   Execute = 'execute',
   Think = 'think',
+  Agent = 'agent',
   Fetch = 'fetch',
   Communicate = 'communicate',
   Plan = 'plan',


### PR DESCRIPTION
## Summary

This PR introduces a new tool category, `Kind.Agent`, to distinguish sub-agents from generic "Thinking" tools. This is the foundational step for enabling parallel execution of sub-agents by signaling to the `Scheduler` that they are independent agent loops.

## Details

- Added `Kind.Agent = 'agent'` to the `Kind` enum in `packages/core/src/tools/tools.ts`.
- Updated `SubagentTool` and `SubagentToolWrapper` to use `Kind.Agent`.
- Updated Zed integration in `packages/cli/src/zed-integration/zedIntegration.ts` to map `Kind.Agent` to `'think'`, maintaining compatibility with the ACP protocol while resolving type/ESLint issues.
- Added test coverage for the new classification in `SubagentTool`.

## Related Issues

Part of the Parallel Sub-Agent Execution initiative.

## How to Validate

1. Run unit tests for core package: `npm test -w @google/gemini-cli-core -- src/agents/subagent-tool.test.ts`
2. Run unit tests for subagent-tool-wrapper: `npm test -w @google/gemini-cli-core -- src/agents/subagent-tool-wrapper.test.ts`
3. Verify type safety: `npm run typecheck -w @google/gemini-cli`
4. Verify Zed integration mapping: Run `npm run lint -w @google/gemini-cli` and ensure no unsafe type assertion errors in `zedIntegration.ts`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
