### PR TITLE
added setting errorVerbosity

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -421,6 +421,23 @@ const SETTINGS_SCHEMA = {
     description: 'User interface settings.',
     showInDialog: false,
     properties: {
+      errorVerbosity: {
+        type: 'enum',
+        label: 'Error Verbosity',
+        category: 'UI',
+        requiresRestart: false,
+        default: 'low',
+        description: oneLine`
+          Controls how much recoverable/internal error detail is shown in the interactive UI.
+          Use "low" to hide non-fatal chatter in the main chat history while still surfacing terminal failures.
+          Use "full" to show all error, warning, and info feedback entries.
+        `,
+        showInDialog: true,
+        options: [
+          { value: 'low', label: 'Low (terminal failures only)' },
+          { value: 'full', label: 'Full (all feedback)' },
+        ],
+      },
       theme: {
         type: 'string',
         label: 'Theme',

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -219,6 +219,14 @@
       "default": {},
       "type": "object",
       "properties": {
+        "errorVerbosity": {
+          "title": "Error Verbosity",
+          "description": "Controls how much recoverable/internal error detail is shown in the interactive UI.",
+          "markdownDescription": "Controls how much recoverable/internal error detail is shown in the interactive UI.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `low`\n\n- `low`: Hide non-fatal/recoverable chatter from the main chat history while still surfacing terminal failures.\n- `full`: Show all error, warning, and info feedback in the chat history.",
+          "default": "low",
+          "type": "string",
+          "enum": ["low", "full"]
+        },
         "theme": {
           "title": "Theme",
           "description": "The color theme for the UI. See the CLI themes guide for available options.",


### PR DESCRIPTION
Fixes #20398 

I added a new setting errorVerbosity with two options: low and full. In low mode, the chat UI now only shows real errors in the history and quietly hides info/warning “noise” from retries and recoverable tool failures .In full mode, it works like before and shows all feedback messages, so you still have a way to see everything when you’re debugging.