### PR TITLE
fix(core): wire abort signal through chat compression LLM calls

### DIFF
--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -323,7 +323,7 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
   ): Promise<AgentTurnResult> {
     const promptId = `${this.agentId}#${turnCounter}`;
 
-    await this.tryCompressChat(chat, promptId);
+    await this.tryCompressChat(chat, promptId, combinedSignal);
 
     const { functionCalls } = await promptIdContext.run(promptId, async () =>
       this.callModel(chat, currentMessage, combinedSignal, promptId),
@@ -810,6 +810,7 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
   private async tryCompressChat(
     chat: GeminiChat,
     prompt_id: string,
+    abortSignal: AbortSignal,
   ): Promise<void> {
     const model = this.definition.modelConfig.model ?? DEFAULT_GEMINI_MODEL;
 
@@ -820,6 +821,7 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
       model,
       this.context.config,
       this.hasFailedCompressionAttempt,
+      abortSignal,
     );
 
     if (

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -608,7 +608,7 @@ export class GeminiClient {
     // Check for context window overflow
     const modelForLimitCheck = this._getActiveModelForCurrentTurn();
 
-    const compressed = await this.tryCompressChat(prompt_id, false);
+    const compressed = await this.tryCompressChat(prompt_id, false, signal);
 
     if (compressed.compressionStatus === CompressionStatus.COMPRESSED) {
       yield { type: GeminiEventType.ChatCompressed, value: compressed };
@@ -1158,11 +1158,16 @@ export class GeminiClient {
   async tryCompressChat(
     prompt_id: string,
     force: boolean = false,
+    abortSignal?: AbortSignal,
   ): Promise<ChatCompressionInfo> {
     // If the model is 'auto', we will use a placeholder model to check.
     // Compression occurs before we choose a model, so calling `count_tokens`
     // before the model is chosen would result in an error.
     const model = this._getActiveModelForCurrentTurn();
+
+    // Use the provided signal, or create a no-op signal as a fallback for
+    // callers that don't have one (e.g. the /compress command).
+    const signal = abortSignal ?? new AbortController().signal;
 
     const { newHistory, info } = await this.compressionService.compress(
       this.getChat(),
@@ -1171,6 +1176,7 @@ export class GeminiClient {
       model,
       this.config,
       this.hasFailedCompressionAttempt,
+      signal,
     );
 
     if (

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -139,6 +139,7 @@ describe('ChatCompressionService', () => {
   let testTempDir: string;
   const mockModel = 'gemini-2.5-pro';
   const mockPromptId = 'test-prompt-id';
+  const mockAbortSignal = new AbortController().signal;
 
   beforeEach(() => {
     testTempDir = fs.mkdtempSync(
@@ -216,6 +217,7 @@ describe('ChatCompressionService', () => {
       mockModel,
       mockConfig,
       false,
+      mockAbortSignal,
     );
     expect(result.info.compressionStatus).toBe(CompressionStatus.NOOP);
     expect(result.newHistory).toBeNull();
@@ -232,6 +234,7 @@ describe('ChatCompressionService', () => {
       mockModel,
       mockConfig,
       false,
+      mockAbortSignal,
     );
     // It should now attempt compression even if previously failed (logic removed)
     // But since history is small, it will be NOOP due to threshold
@@ -258,6 +261,7 @@ describe('ChatCompressionService', () => {
       mockModel,
       mockConfig,
       false,
+      mockAbortSignal,
     );
     expect(result.info.compressionStatus).toBe(CompressionStatus.NOOP);
     expect(result.newHistory).toBeNull();
@@ -281,6 +285,7 @@ describe('ChatCompressionService', () => {
       mockModel,
       mockConfig,
       false,
+      mockAbortSignal,
     );
 
     expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
@@ -322,6 +327,7 @@ describe('ChatCompressionService', () => {
       mockModel,
       mockConfig,
       false,
+      mockAbortSignal,
     );
 
     expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
@@ -349,6 +355,7 @@ describe('ChatCompressionService', () => {
       mockModel,
       mockConfig,
       false,
+      mockAbortSignal,
     );
 
     const firstCall = vi.mocked(mockConfig.getBaseLlmClient().generateContent)
@@ -380,6 +387,7 @@ describe('ChatCompressionService', () => {
       mockModel,
       mockConfig,
       false,
+      mockAbortSignal,
     );
 
     const firstCallText = (
@@ -407,6 +415,7 @@ describe('ChatCompressionService', () => {
       mockModel,
       mockConfig,
       false,
+      mockAbortSignal,
     );
 
     const firstCallText = (
@@ -433,6 +442,7 @@ describe('ChatCompressionService', () => {
       mockModel,
       mockConfig,
       false,
+      mockAbortSignal,
     );
 
     expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
@@ -470,6 +480,7 @@ describe('ChatCompressionService', () => {
       mockModel,
       mockConfig,
       false,
+      mockAbortSignal,
     );
 
     expect(result.info.compressionStatus).toBe(
@@ -510,6 +521,7 @@ describe('ChatCompressionService', () => {
       mockModel,
       mockConfig,
       false,
+      mockAbortSignal,
     );
 
     expect(result.info.compressionStatus).toBe(
@@ -566,6 +578,7 @@ describe('ChatCompressionService', () => {
         mockModel,
         mockConfig,
         false,
+        mockAbortSignal,
       );
 
       expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
@@ -632,6 +645,7 @@ describe('ChatCompressionService', () => {
         mockModel,
         mockConfig,
         false,
+        mockAbortSignal,
       );
 
       // Verify it compressed
@@ -698,6 +712,7 @@ describe('ChatCompressionService', () => {
         mockModel,
         mockConfig,
         false,
+        mockAbortSignal,
       );
 
       expect(result.newHistory).not.toBeNull();
@@ -765,6 +780,7 @@ describe('ChatCompressionService', () => {
         mockModel,
         mockConfig,
         false,
+        mockAbortSignal,
       );
 
       expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
@@ -822,6 +838,7 @@ describe('ChatCompressionService', () => {
         mockModel,
         mockConfig,
         false,
+        mockAbortSignal,
       );
 
       expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
@@ -879,6 +896,7 @@ describe('ChatCompressionService', () => {
         mockModel,
         mockConfig,
         false,
+        mockAbortSignal,
       );
 
       expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -156,13 +156,13 @@ async function truncateHistoryToBudget(
           } else if (responseObj && typeof responseObj === 'object') {
             if (
               'output' in responseObj &&
-              // eslint-disable-next-line no-restricted-syntax
+               
               typeof responseObj['output'] === 'string'
             ) {
               contentStr = responseObj['output'];
             } else if (
               'content' in responseObj &&
-              // eslint-disable-next-line no-restricted-syntax
+               
               typeof responseObj['content'] === 'string'
             ) {
               contentStr = responseObj['content'];
@@ -238,7 +238,7 @@ export class ChatCompressionService {
     model: string,
     config: Config,
     hasFailedCompressionAttempt: boolean,
-    abortSignal?: AbortSignal,
+    abortSignal: AbortSignal,
   ): Promise<{ newHistory: Content[] | null; info: ChatCompressionInfo }> {
     const curatedHistory = chat.getHistory(true);
 
@@ -367,8 +367,7 @@ export class ChatCompressionService {
       ],
       systemInstruction: { text: getCompressionPrompt(config) },
       promptId,
-      // TODO(joshualitt): wire up a sensible abort signal,
-      abortSignal: abortSignal ?? new AbortController().signal,
+      abortSignal,
       role: LlmRole.UTILITY_COMPRESSOR,
     });
     const summary = getResponseText(summaryResponse) ?? '';
@@ -397,7 +396,7 @@ export class ChatCompressionService {
         systemInstruction: { text: getCompressionPrompt(config) },
         promptId: `${promptId}-verify`,
         role: LlmRole.UTILITY_COMPRESSOR,
-        abortSignal: abortSignal ?? new AbortController().signal,
+        abortSignal,
       });
 
     const finalSummary = (


### PR DESCRIPTION
## Summary

Wire the parent abort signal through chat compression LLM calls so Ctrl+C actually cancels in-flight compression requests.

## Details

The compression service's two LLM calls (summarization + verification) created throwaway `AbortController` signals that could never be aborted. This meant user cancellation didn't stop compression requests, wasting API tokens and blocking cancellation.

Changes:
- Pass `combinedSignal` from `executeTurn` through `tryCompressChat` into the compression service in `local-executor.ts`
- Pass `signal` from `processTurn` through `tryCompressChat` in `client.ts`
- Make `abortSignal` required in `compress()` to prevent future regressions
- The `/compress` command (no parent signal) gets a no-op fallback in `GeminiClient.tryCompressChat`
- Remove the `TODO(joshualitt)` that called for this fix
- Update all test call sites

## Related Issues

Fixes #20405

## How to Validate

1. Start a long conversation to trigger compression
2. Press Ctrl+C during compression -- it should cancel immediately
3. Run `/compress` manually -- should still work (no-op fallback signal)
4. `npm test -- packages/core/src/services/chatCompressionService.test.ts` passes

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
