### PR TITLE
feat(core): implement native support for blocking hook execution via policy files

### DIFF
--- a/packages/core/src/hooks/hookEventHandler.test.ts
+++ b/packages/core/src/hooks/hookEventHandler.test.ts
@@ -22,6 +22,7 @@ import type { HookPlanner } from './hookPlanner.js';
 import type { HookRunner } from './hookRunner.js';
 import type { HookAggregator } from './hookAggregator.js';
 
+
 // Mock debugLogger
 const mockDebugLogger = vi.hoisted(() => ({
   log: vi.fn(),
@@ -72,6 +73,9 @@ describe('HookEventHandler', () => {
             .fn()
             .mockReturnValue('/test/project/.gemini/tmp/chats/session.json'),
         }),
+      }),
+      getPolicyEngine: vi.fn().mockReturnValue({
+        checkHook: vi.fn().mockResolvedValue({ decision: 'allow' }),
       }),
     } as unknown as Config;
 

--- a/packages/core/src/hooks/hookSystem.test.ts
+++ b/packages/core/src/hooks/hookSystem.test.ts
@@ -88,8 +88,21 @@ describe('HookSystem Integration', () => {
     });
 
     // Provide getMessageBus mock for MessageBus integration tests
-    (config as unknown as { getMessageBus: () => unknown }).getMessageBus =
-      () => undefined;
+    // Provide getMessageBus mock for MessageBus integration tests
+    (
+      config as unknown as {
+        getMessageBus: () => unknown;
+        getPolicyEngine: () => unknown;
+      }
+    ).getMessageBus = () => undefined;
+    (
+      config as unknown as {
+        getMessageBus: () => unknown;
+        getPolicyEngine: () => unknown;
+      }
+    ).getPolicyEngine = () => ({
+      checkHook: vi.fn().mockResolvedValue({ decision: 'allow' }),
+    });
 
     hookSystem = new HookSystem(config);
 
@@ -297,8 +310,19 @@ describe('HookSystem Integration', () => {
       });
 
       (
-        configWithDisabled as unknown as { getMessageBus: () => unknown }
+        configWithDisabled as unknown as {
+          getMessageBus: () => unknown;
+          getPolicyEngine: () => unknown;
+        }
       ).getMessageBus = () => undefined;
+      (
+        configWithDisabled as unknown as {
+          getMessageBus: () => unknown;
+          getPolicyEngine: () => unknown;
+        }
+      ).getPolicyEngine = () => ({
+        checkHook: vi.fn().mockResolvedValue({ decision: 'allow' }),
+      });
 
       const systemWithDisabled = new HookSystem(configWithDisabled);
       await systemWithDisabled.initialize();
@@ -362,8 +386,19 @@ describe('HookSystem Integration', () => {
       });
 
       (
-        configForDisabling as unknown as { getMessageBus: () => unknown }
+        configForDisabling as unknown as {
+          getMessageBus: () => unknown;
+          getPolicyEngine: () => unknown;
+        }
       ).getMessageBus = () => undefined;
+      (
+        configForDisabling as unknown as {
+          getMessageBus: () => unknown;
+          getPolicyEngine: () => unknown;
+        }
+      ).getPolicyEngine = () => ({
+        checkHook: vi.fn().mockResolvedValue({ decision: 'allow' }),
+      });
 
       const systemForDisabling = new HookSystem(configForDisabling);
       await systemForDisabling.initialize();

--- a/packages/core/src/hooks/runtimeHooks.test.ts
+++ b/packages/core/src/hooks/runtimeHooks.test.ts
@@ -38,8 +38,21 @@ describe('Runtime Hooks', () => {
     });
 
     // Stub getMessageBus
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (config as any).getMessageBus = () => undefined;
+     
+    (
+      config as unknown as {
+        getMessageBus: () => unknown;
+        getPolicyEngine: () => unknown;
+      }
+    ).getMessageBus = () => undefined;
+    (
+      config as unknown as {
+        getMessageBus: () => unknown;
+        getPolicyEngine: () => unknown;
+      }
+    ).getPolicyEngine = () => ({
+      checkHook: vi.fn().mockResolvedValue({ decision: 'allow' }),
+    });
 
     hookSystem = new HookSystem(config);
   });

--- a/packages/core/src/policy/config.test.ts
+++ b/packages/core/src/policy/config.test.ts
@@ -58,6 +58,7 @@ describe('createPolicyEngineConfig', () => {
     const loadPoliciesSpy = vi.spyOn(tomlLoader, 'loadPoliciesFromToml');
     loadPoliciesSpy.mockResolvedValue({
       rules: [],
+      hookRules: [],
       checkers: [],
       errors: [],
     });

--- a/packages/core/src/policy/config.ts
+++ b/packages/core/src/policy/config.ts
@@ -13,6 +13,7 @@ import {
   type PolicyEngineConfig,
   PolicyDecision,
   type PolicyRule,
+  type HookRule,
   type ApprovalMode,
   type PolicySettings,
 } from './types.js';
@@ -197,6 +198,7 @@ export async function createPolicyEngineConfig(
   // Load policies from TOML files
   const {
     rules: tomlRules,
+    hookRules: tomlHookRules,
     checkers: tomlCheckers,
     errors,
   } = await loadPoliciesFromToml(securePolicyDirs, (p) => {
@@ -231,6 +233,7 @@ export async function createPolicyEngineConfig(
   }
 
   const rules: PolicyRule[] = [...tomlRules];
+  const hookRules: HookRule[] = [...tomlHookRules];
   const checkers = [...tomlCheckers];
 
   // Priority system for policy rules:
@@ -376,6 +379,7 @@ export async function createPolicyEngineConfig(
 
   return {
     rules,
+    hookRules,
     checkers,
     defaultDecision: PolicyDecision.ASK_USER,
     approvalMode,

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -809,8 +809,11 @@ export class PolicyEngine {
       if (rule.hookName && rule.hookName !== hookConfig.name) {
         continue;
       }
-      if (rule.commandPattern && hookConfig.command) {
-        if (!rule.commandPattern.test(hookConfig.command)) {
+      if (rule.commandPattern) {
+        if (
+          !hookConfig.command ||
+          !rule.commandPattern.test(hookConfig.command)
+        ) {
           continue;
         }
       }

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -11,6 +11,7 @@ import {
   type PolicyRule,
   type SafetyCheckerRule,
   type HookCheckerRule,
+  type HookRule,
   ApprovalMode,
   type CheckResult,
 } from './types.js';
@@ -162,6 +163,7 @@ export class PolicyEngine {
   private rules: PolicyRule[];
   private checkers: SafetyCheckerRule[];
   private hookCheckers: HookCheckerRule[];
+  private hookRules: HookRule[];
   private readonly defaultDecision: PolicyDecision;
   private readonly nonInteractive: boolean;
   private readonly checkerRunner?: CheckerRunner;
@@ -175,6 +177,9 @@ export class PolicyEngine {
       (a, b) => (b.priority ?? 0) - (a.priority ?? 0),
     );
     this.hookCheckers = (config.hookCheckers ?? []).sort(
+      (a, b) => (b.priority ?? 0) - (a.priority ?? 0),
+    );
+    this.hookRules = (config.hookRules ?? []).sort(
       (a, b) => (b.priority ?? 0) - (a.priority ?? 0),
     );
     this.defaultDecision = config.defaultDecision ?? PolicyDecision.ASK_USER;
@@ -788,5 +793,48 @@ export class PolicyEngine {
       return PolicyDecision.DENY;
     }
     return decision;
+  }
+
+  /**
+   * Check if a hook execution is allowed based on the configured hook policies.
+   */
+  async checkHook(
+    hookConfig: { name?: string; command?: string },
+    eventName: string,
+  ): Promise<{ decision: PolicyDecision; rule?: HookRule }> {
+    for (const rule of this.hookRules) {
+      if (rule.eventName && rule.eventName !== eventName) {
+        continue;
+      }
+      if (rule.hookName && rule.hookName !== hookConfig.name) {
+        continue;
+      }
+      if (rule.commandPattern && hookConfig.command) {
+        if (!rule.commandPattern.test(hookConfig.command)) {
+          continue;
+        }
+      }
+
+      // If it matches all defined criteria
+      debugLogger.debug(
+        `[PolicyEngine.checkHook] MATCHED hook rule: eventName=${rule.eventName || 'any'}, hookName=${rule.hookName || 'any'}, commandPattern=${rule.commandPattern?.source || 'none'}, decision=${rule.decision}`,
+      );
+
+      let decision = rule.decision;
+      // Hook executions are completely headless and non-interactive.
+      if (decision === PolicyDecision.ASK_USER) {
+        decision = PolicyDecision.DENY;
+      }
+
+      return { decision, rule };
+    }
+
+    // Default decision if no rule matches.
+    let decision = this.defaultDecision;
+    if (decision === PolicyDecision.ASK_USER || this.nonInteractive) {
+      decision = PolicyDecision.DENY;
+    }
+
+    return { decision };
   }
 }

--- a/packages/core/src/policy/toml-loader.test.ts
+++ b/packages/core/src/policy/toml-loader.test.ts
@@ -421,8 +421,51 @@ name = "allowed-path"
 `);
 
       expect(result.checkers).toHaveLength(1);
-      expect(result.checkers[0].priority).toBe(1.1); // tier 1 + 100/1000
       expect(result.checkers[0].source).toBe('Default: test.toml');
+    });
+
+    it('should parse [[hook_rule]] configurations correctly', async () => {
+      const result = await runLoadPoliciesFromToml(`
+[[hook_rule]]
+hookName = "git-status-hook"
+eventName = "BeforeTool"
+commandPrefix = "git status"
+decision = "allow"
+priority = 50
+deny_message = "Git status is not allowed"
+`);
+
+      expect(result.hookRules).toHaveLength(1);
+      expect(result.hookRules[0].hookName).toBe('git-status-hook');
+      expect(result.hookRules[0].eventName).toBe('BeforeTool');
+      expect(result.hookRules[0].decision).toBe(PolicyDecision.ALLOW);
+      expect(result.hookRules[0].priority).toBe(1.05); // tier 1 + 50/1000
+      expect(result.hookRules[0].denyMessage).toBe('Git status is not allowed');
+
+      // commandPrefix should be converted to regex
+      expect(result.hookRules[0].commandPattern?.test('git status')).toBe(true);
+      expect(result.hookRules[0].commandPattern?.test('git log')).toBe(false);
+    });
+
+    it('should parse hook rules with commandRegex', async () => {
+      const result = await runLoadPoliciesFromToml(`
+[[hook_rule]]
+eventName = "BeforeAgent"
+commandRegex = "npm run .*"
+decision = "deny"
+priority = 100
+`);
+
+      expect(result.hookRules).toHaveLength(1);
+      expect(result.hookRules[0].eventName).toBe('BeforeAgent');
+      expect(result.hookRules[0].decision).toBe(PolicyDecision.DENY);
+
+      expect(result.hookRules[0].commandPattern?.test('npm run build')).toBe(
+        true,
+      );
+      expect(result.hookRules[0].commandPattern?.test('npm install')).toBe(
+        false,
+      );
     });
   });
 

--- a/packages/core/src/policy/toml-loader.test.ts
+++ b/packages/core/src/policy/toml-loader.test.ts
@@ -447,11 +447,11 @@ deny_message = "Git status is not allowed"
       expect(result.hookRules[0].commandPattern?.test('git log')).toBe(false);
     });
 
-    it('should parse hook rules with commandRegex', async () => {
+    it('should parse hook rules with commandPattern', async () => {
       const result = await runLoadPoliciesFromToml(`
 [[hook_rule]]
 eventName = "BeforeAgent"
-commandRegex = "npm run .*"
+commandPattern = "npm run .*"
 decision = "deny"
 priority = 100
 `);

--- a/packages/core/src/policy/toml-loader.ts
+++ b/packages/core/src/policy/toml-loader.ts
@@ -11,8 +11,9 @@ import {
   type SafetyCheckerConfig,
   type SafetyCheckerRule,
   InProcessCheckerType,
+  type HookRule,
 } from './types.js';
-import { buildArgsPatterns, isSafeRegExp } from './utils.js';
+import { buildArgsPatterns, isSafeRegExp, escapeRegex } from './utils.js';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import toml from '@iarna/toml';
@@ -52,6 +53,30 @@ const PolicyRuleSchema = z.object({
 });
 
 /**
+ * Schema for a single hook rule in the TOML file.
+ */
+const HookRuleSchema = z.object({
+  hookName: z.string().optional(),
+  eventName: z.string().optional(),
+  commandPrefix: z.union([z.string(), z.array(z.string())]).optional(),
+  commandRegex: z.string().optional(),
+  argsPattern: z.string().optional(),
+  decision: z.nativeEnum(PolicyDecision),
+  priority: z
+    .number({
+      required_error: 'priority is required',
+      invalid_type_error: 'priority must be a number',
+    })
+    .int({ message: 'priority must be an integer' })
+    .min(0, { message: 'priority must be >= 0' })
+    .max(999, {
+      message:
+        'priority must be <= 999 to prevent tier overflow. Priorities >= 1000 would jump to the next tier.',
+    }),
+  deny_message: z.string().optional(),
+});
+
+/**
  * Schema for a single safety checker rule in the TOML file.
  */
 const SafetyCheckerRuleSchema = z.object({
@@ -84,6 +109,7 @@ const SafetyCheckerRuleSchema = z.object({
  */
 const PolicyFileSchema = z.object({
   rule: z.array(PolicyRuleSchema).optional(),
+  hook_rule: z.array(HookRuleSchema).optional(),
   safety_checker: z.array(SafetyCheckerRuleSchema).optional(),
 });
 
@@ -121,6 +147,7 @@ export interface PolicyFileError {
  */
 export interface PolicyLoadResult {
   rules: PolicyRule[];
+  hookRules: HookRule[];
   checkers: SafetyCheckerRule[];
   errors: PolicyFileError[];
 }
@@ -268,6 +295,7 @@ export async function loadPoliciesFromToml(
   getPolicyTier: (path: string) => number,
 ): Promise<PolicyLoadResult> {
   const rules: PolicyRule[] = [];
+  const hookRules: HookRule[] = [];
   const checkers: SafetyCheckerRule[] = [];
   const errors: PolicyFileError[] = [];
 
@@ -436,6 +464,72 @@ export async function loadPoliciesFromToml(
 
         rules.push(...parsedRules);
 
+        // Transform hook rules
+        const parsedHookRules: HookRule[] = (
+          validationResult.data.hook_rule ?? []
+        )
+          .map((rule) => {
+            const hookRule: HookRule = {
+              hookName: rule.hookName,
+              eventName: rule.eventName,
+              decision: rule.decision,
+              priority: transformPriority(rule.priority, tier),
+              source: `${tierName.charAt(0).toUpperCase() + tierName.slice(1)}: ${file}`,
+              denyMessage: rule.deny_message,
+            };
+
+            let commandPatternStr: string | undefined;
+
+            if (rule.commandPrefix) {
+              // Convert prefix strings into an exact starting prefix matcher
+              const prefixes = Array.isArray(rule.commandPrefix)
+                ? rule.commandPrefix
+                : [rule.commandPrefix];
+              const escapedPrefixes = prefixes.map((p) => escapeRegex(p));
+              commandPatternStr = `^(${escapedPrefixes.join('|')})(\\s|$)`;
+            } else if (rule.commandRegex) {
+              commandPatternStr = rule.commandRegex;
+            } else if (rule.argsPattern) {
+              commandPatternStr = rule.argsPattern;
+            }
+
+            if (commandPatternStr) {
+              try {
+                hookRule.commandPattern = new RegExp(commandPatternStr);
+              } catch (e) {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+                const error = e as Error;
+                errors.push({
+                  filePath,
+                  fileName: file,
+                  tier: tierName,
+                  errorType: 'regex_compilation',
+                  message: 'Invalid regex pattern in hook rule',
+                  details: `Pattern: ${commandPatternStr}\nError: ${error.message}`,
+                });
+                return null;
+              }
+
+              if (!isSafeRegExp(commandPatternStr)) {
+                errors.push({
+                  filePath,
+                  fileName: file,
+                  tier: tierName,
+                  errorType: 'regex_compilation',
+                  message:
+                    'Unsafe regex pattern in hook rule (potential ReDoS)',
+                  details: `Pattern: ${commandPatternStr}`,
+                });
+                return null;
+              }
+            }
+
+            return hookRule;
+          })
+          .filter((rule): rule is HookRule => rule !== null);
+
+        hookRules.push(...parsedHookRules);
+
         // Transform checkers
         const parsedCheckers: SafetyCheckerRule[] = (
           validationResult.data.safety_checker ?? []
@@ -530,5 +624,5 @@ export async function loadPoliciesFromToml(
     }
   }
 
-  return { rules, checkers, errors };
+  return { rules, hookRules, checkers, errors };
 }

--- a/packages/core/src/policy/toml-loader.ts
+++ b/packages/core/src/policy/toml-loader.ts
@@ -59,8 +59,7 @@ const HookRuleSchema = z.object({
   hookName: z.string().optional(),
   eventName: z.string().optional(),
   commandPrefix: z.union([z.string(), z.array(z.string())]).optional(),
-  commandRegex: z.string().optional(),
-  argsPattern: z.string().optional(),
+  commandPattern: z.string().optional(),
   decision: z.nativeEnum(PolicyDecision),
   priority: z
     .number({
@@ -487,10 +486,8 @@ export async function loadPoliciesFromToml(
                 : [rule.commandPrefix];
               const escapedPrefixes = prefixes.map((p) => escapeRegex(p));
               commandPatternStr = `^(${escapedPrefixes.join('|')})(\\s|$)`;
-            } else if (rule.commandRegex) {
-              commandPatternStr = rule.commandRegex;
-            } else if (rule.argsPattern) {
-              commandPatternStr = rule.argsPattern;
+            } else if (rule.commandPattern) {
+              commandPatternStr = rule.commandPattern;
             }
 
             if (commandPatternStr) {

--- a/packages/core/src/policy/types.ts
+++ b/packages/core/src/policy/types.ts
@@ -98,6 +98,46 @@ export type SafetyCheckerConfig =
   | ExternalCheckerConfig
   | InProcessCheckerConfig;
 
+export interface HookRule {
+  /**
+   * The name of the hook this rule applies to.
+   * If undefined, the rule applies to all hooks.
+   */
+  hookName?: string;
+
+  /**
+   * The name of the event this rule applies to.
+   * If undefined, the rule applies to all events.
+   */
+  eventName?: string;
+
+  /**
+   * Pattern to match against the hook command.
+   */
+  commandPattern?: RegExp;
+
+  /**
+   * The decision to make when this rule matches.
+   */
+  decision: PolicyDecision;
+
+  /**
+   * Priority of this rule. Higher numbers take precedence.
+   * Default is 0.
+   */
+  priority?: number;
+
+  /**
+   * Source of this rule.
+   */
+  source?: string;
+
+  /**
+   * Optional message to display when this rule results in a DENY decision.
+   */
+  denyMessage?: string;
+}
+
 export interface PolicyRule {
   /**
    * A unique name for the policy rule, useful for identification and debugging.
@@ -254,6 +294,11 @@ export interface PolicyEngineConfig {
    * List of safety checkers to apply to hook executions.
    */
   hookCheckers?: HookCheckerRule[];
+
+  /**
+   * List of hook rules to apply to hook executions.
+   */
+  hookRules?: HookRule[];
 
   /**
    * Default decision when no rules match.


### PR DESCRIPTION
## Summary
Implemented native support for blocking the execution of hooks using policy files (`.toml`). Previously, hooks were unintentionally subjected to policy checks by routing their execution through the message bus as `run_shell_command` tools. This PR introduces explicit `[[hook_rule]]` configurations in policy files to enforce whether a hook is allowed or denied without relying on the message bus.

## Details
- Introduced `HookRule` to `PolicyEngineConfig`. 
- Added `HookRuleSchema` in `toml-loader.ts` to parse `[[hook_rule]]` items from `.toml` files.
- Added `checkHook` to `PolicyEngine` prioritizing matching rules for `eventName`, `hookName`, and `commandPattern`.
- Modified `HookEventHandler`'s `executeHooks` to filter out denied hooks and appropriately log decisions without invoking `hookRunner`.
- `ASK_USER` decisions uniformly downgraded to `DENY` due to headless hook invocation.

## Related Issues
Fixes:  #17406

## How to Validate
1. Define a `[[hook_rule]]` in `~/.gemini/policies/project.toml` with `decision = "deny"` for `eventName = "BeforeTool"`.
2. Trigger a hook and verify standard output logs its blockage properly.
3. Test suite can be validated with `npm run test -- -w @google/gemini-cli-core`.

## Pre-Merge Checklist
- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
