### PR TITLE
fix(core): handle resume/update invalid-argument failures

### DIFF
--- a/integration-tests/resume_repro_signature_normalization.responses
+++ b/integration-tests/resume_repro_signature_normalization.responses
@@ -1,0 +1,3 @@
+{"method":"generateContentStream","response":[{"candidates":[{"content":{"parts":[{"functionCall":{"name":"list_directory","args":{"path":"."}}}],"role":"model"},"finishReason":"STOP","index":0}]}]}
+{"method":"generateContentStream","response":[{"candidates":[{"content":{"parts":[{"text":"List complete."}],"role":"model"},"finishReason":"STOP","index":0}]}]}
+{"method":"generateContentStream","response":[{"candidates":[{"content":{"parts":[{"text":"Resume complete."}],"role":"model"},"finishReason":"STOP","index":0}]}]}

--- a/packages/cli/src/ui/utils/restartGating.test.ts
+++ b/packages/cli/src/ui/utils/restartGating.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  isCommandAllowedDuringRestart,
+  shouldBlockPromptForRestart,
+} from './restartGating.js';
+
+describe('restartGating', () => {
+  it.each(['/about', '/help', '/quit'])(
+    'allows %s during restart-required mode',
+    (command) => {
+      expect(isCommandAllowedDuringRestart(command)).toBe(true);
+      expect(shouldBlockPromptForRestart(command, true)).toBe(false);
+    },
+  );
+
+  it('allows supported commands with arguments', () => {
+    expect(isCommandAllowedDuringRestart('/help commands')).toBe(true);
+    expect(isCommandAllowedDuringRestart('/about details')).toBe(true);
+  });
+
+  it.each(['normal prompt', '/clear', '//comment', ''])(
+    'blocks "%s" during restart-required mode',
+    (query) => {
+      expect(shouldBlockPromptForRestart(query, true)).toBe(true);
+    },
+  );
+
+  it('does not block anything when restart is not required', () => {
+    expect(shouldBlockPromptForRestart('normal prompt', false)).toBe(false);
+    expect(shouldBlockPromptForRestart('/clear', false)).toBe(false);
+    expect(shouldBlockPromptForRestart('/help', false)).toBe(false);
+  });
+});

--- a/packages/cli/src/ui/utils/restartGating.ts
+++ b/packages/cli/src/ui/utils/restartGating.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isSlashCommand } from './commandUtils.js';
+
+const RESTART_REQUIRED_ALLOWED_COMMANDS = new Set(['/about', '/help', '/quit']);
+
+export const isCommandAllowedDuringRestart = (query: string): boolean => {
+  if (!isSlashCommand(query)) {
+    return false;
+  }
+
+  const [commandName] = query.split(/\s+/, 1);
+  return (
+    commandName !== undefined &&
+    RESTART_REQUIRED_ALLOWED_COMMANDS.has(commandName.toLowerCase())
+  );
+};
+
+export const shouldBlockPromptForRestart = (
+  query: string,
+  restartRequired: boolean,
+): boolean => restartRequired && !isCommandAllowedDuringRestart(query.trim());

--- a/packages/cli/src/utils/handleAutoUpdate.test.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.test.ts
@@ -285,13 +285,15 @@ describe('handleAutoUpdate', () => {
 describe('setUpdateHandler', () => {
   let addItem: ReturnType<typeof vi.fn>;
   let setUpdateInfo: ReturnType<typeof vi.fn>;
+  let setRestartRequired: ReturnType<typeof vi.fn>;
   let unregister: () => void;
 
   beforeEach(() => {
     addItem = vi.fn();
     setUpdateInfo = vi.fn();
+    setRestartRequired = vi.fn();
     vi.useFakeTimers();
-    unregister = setUpdateHandler(addItem, setUpdateInfo);
+    unregister = setUpdateHandler(addItem, setUpdateInfo, setRestartRequired);
   });
 
   afterEach(() => {
@@ -320,6 +322,7 @@ describe('setUpdateHandler', () => {
     // Access the actual emitter to emit events
     updateEventEmitter.emit('update-received', updateInfo);
 
+    expect(setRestartRequired).toHaveBeenCalledWith(false);
     expect(setUpdateInfo).toHaveBeenCalledWith(updateInfo);
 
     // Advance timers to trigger timeout
@@ -338,6 +341,7 @@ describe('setUpdateHandler', () => {
   it('should handle update-failed event', () => {
     updateEventEmitter.emit('update-failed', { message: 'Failed' });
 
+    expect(setRestartRequired).toHaveBeenCalledWith(false);
     expect(setUpdateInfo).toHaveBeenCalledWith(null);
     expect(addItem).toHaveBeenCalledWith(
       {
@@ -351,6 +355,7 @@ describe('setUpdateHandler', () => {
   it('should handle update-success event', () => {
     updateEventEmitter.emit('update-success', { message: 'Success' });
 
+    expect(setRestartRequired).toHaveBeenCalledWith(true);
     expect(setUpdateInfo).toHaveBeenCalledWith(null);
     expect(addItem).toHaveBeenCalledWith(
       {

--- a/packages/cli/src/utils/handleAutoUpdate.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.ts
@@ -100,9 +100,11 @@ export function handleAutoUpdate(
 export function setUpdateHandler(
   addItem: (item: Omit<HistoryItem, 'id'>, timestamp: number) => void,
   setUpdateInfo: (info: UpdateObject | null) => void,
+  setRestartRequired: (required: boolean) => void,
 ) {
   let successfullyInstalled = false;
   const handleUpdateReceived = (info: UpdateObject) => {
+    setRestartRequired(false);
     setUpdateInfo(info);
     const savedMessage = info.message;
     setTimeout(() => {
@@ -120,6 +122,7 @@ export function setUpdateHandler(
   };
 
   const handleUpdateFailed = () => {
+    setRestartRequired(false);
     setUpdateInfo(null);
     addItem(
       {
@@ -132,6 +135,7 @@ export function setUpdateHandler(
 
   const handleUpdateSuccess = () => {
     successfullyInstalled = true;
+    setRestartRequired(true);
     setUpdateInfo(null);
     addItem(
       {

--- a/packages/core/src/utils/sessionUtils.test.ts
+++ b/packages/core/src/utils/sessionUtils.test.ts
@@ -145,4 +145,112 @@ describe('convertSessionToClientHistory', () => {
       },
     ]);
   });
+
+  it('should deduplicate function calls by id when already present in content', () => {
+    const messages: ConversationRecord['messages'] = [
+      {
+        id: 'msg1',
+        type: 'user',
+        timestamp: '2024-01-01T10:00:00Z',
+        content: 'List files',
+      },
+      {
+        id: 'msg2',
+        type: 'gemini',
+        timestamp: '2024-01-01T10:01:00Z',
+        content: [
+          { text: 'Let me check.' },
+          { functionCall: { name: 'ls', args: { dir: '.' }, id: 'call123' } },
+        ],
+        toolCalls: [
+          {
+            id: 'call123',
+            name: 'ls',
+            args: { dir: '.' },
+            status: CoreToolCallStatus.Success,
+            timestamp: '2024-01-01T10:01:05Z',
+            result: 'file.txt',
+          },
+        ],
+      },
+    ];
+
+    const history = convertSessionToClientHistory(messages);
+    const modelTurn = history[1];
+    const functionCalls =
+      modelTurn?.parts
+        .filter((p) => !!p.functionCall)
+        .map((p) => p.functionCall) ?? [];
+
+    expect(functionCalls).toHaveLength(1);
+    expect(functionCalls[0]?.id).toBe('call123');
+  });
+
+  it('should deduplicate by stable args fingerprint with count-based matching when content function calls have no id', () => {
+    const messages: ConversationRecord['messages'] = [
+      {
+        id: 'msg1',
+        type: 'user',
+        timestamp: '2024-01-01T10:00:00Z',
+        content: 'Run tool',
+      },
+      {
+        id: 'msg2',
+        type: 'gemini',
+        timestamp: '2024-01-01T10:01:00Z',
+        content: [
+          {
+            functionCall: {
+              name: 'ls',
+              args: { dir: '.', options: { recursive: true, depth: 1 } },
+            },
+          },
+          {
+            functionCall: {
+              name: 'ls',
+              args: { options: { depth: 1, recursive: true }, dir: '.' },
+            },
+          },
+        ],
+        toolCalls: [
+          {
+            id: 'call1',
+            name: 'ls',
+            args: { options: { recursive: true, depth: 1 }, dir: '.' },
+            status: CoreToolCallStatus.Success,
+            timestamp: '2024-01-01T10:01:05Z',
+            result: 'first',
+          },
+          {
+            id: 'call2',
+            name: 'ls',
+            args: { dir: '.', options: { depth: 1, recursive: true } },
+            status: CoreToolCallStatus.Success,
+            timestamp: '2024-01-01T10:01:06Z',
+            result: 'second',
+          },
+          {
+            id: 'call3',
+            name: 'ls',
+            args: { dir: '.', options: { depth: 1, recursive: true } },
+            status: CoreToolCallStatus.Success,
+            timestamp: '2024-01-01T10:01:07Z',
+            result: 'third',
+          },
+        ],
+      },
+    ];
+
+    const history = convertSessionToClientHistory(messages);
+    const modelTurn = history[1];
+    const functionCalls =
+      modelTurn?.parts
+        .filter((p) => !!p.functionCall)
+        .map((p) => p.functionCall) ?? [];
+
+    expect(functionCalls).toHaveLength(3);
+    expect(functionCalls[0]?.id).toBeUndefined();
+    expect(functionCalls[1]?.id).toBeUndefined();
+    expect(functionCalls[2]?.id).toBe('call3');
+  });
 });

--- a/packages/sdk/src/agent.integration.test.ts
+++ b/packages/sdk/src/agent.integration.test.ts
@@ -144,11 +144,13 @@ describe('GeminiCliAgent Integration', () => {
   });
 
   it('propagates errors from dynamic instructions', async () => {
+    const goldenFile = getGoldenPath('agent-static-instructions');
     const agent = new GeminiCliAgent({
       instructions: () => {
         throw new Error('Dynamic instruction failure');
       },
       model: 'gemini-2.0-flash',
+      fakeResponses: goldenFile,
     });
 
     const session = agent.session();


### PR DESCRIPTION
## Summary
 This PR fixes the `Request contains an invalid argument` failures seen after resume/update flows (Issue #18811)

## Details
  Core request normalization:
  - Replaced active looponly thought signature logic with full history normalization.
  - Added two modes:
    - `require` for modern models (add synthetic `thoughtSignature` where missing)
    - `strip` for non-modern paths (remove `thoughtSignature`)
  - Normalization now runs per API attempt so model fallback is handled correctly.
  - Normalization is re-applied after hook-modified contents.
  - Added one compatibility retry on invalid-argument errors with flipped normalization mode.

  Session resume robustness:
  - In `convertSessionToClientHistory()`, deduplicated function calls that appear in both `msg.content` and `msg.toolCalls`.
  - Dedup uses:
    - function call `id` first
    - stable args fingerprint fallback
    - count-based matching to avoid dropping legitimate repeated calls.

  CLI update UX hardening:
  - Added restart-required state after successful auto-update.
  - While restart is required, blocks normal prompts.
  - Allows only `/help`, `/about`, and `/quit`.

  Test updates:
  - Expanded core tests for full-history normalization, strip mode, idempotency, fallback behavior, and compatibility retry.
  - Added session dedup tests (id + stable fingerprint count matching).
  - Added CLI tests for restart gating and update-state handling.
  - Added integration resume repro test with signature normalization fixture.
  - Hardened one SDK integration test to use deterministic fake responses.

## Related Issues

<!-- Fixes #18811  -->

## How to Validate

<!-- 
     - `npm run lint`
     - `npm run test`
     - `npm run preflight`
    
     Edge cases to verify manually:
  - Resume a session on `gemini-3-flash-preview` with legacy history missing signatures -> no invalid-argument error.
  - Session with duplicated tool calls in content/toolCalls -> no duplicate functionCall parts in rebuilt history.
  - After auto-update success -> normal prompt blocked; `/help`, `/about`, `/quit` still work.
  

  4. Run integration test suite (no sandbox):
     - `npm run test:integration:sandbox:none`
     - Expected: integration tests pass, including resume repro flow.

  Edge cases to verify manually:
  - Resume a session on `gemini-3-flash-preview` with legacy history missing signatures -> no invalid-argument error.
  - Session with duplicated tool calls in content/toolCalls -> no duplicate functionCall parts in rebuilt history.
  - After auto-update success -> normal prompt blocked; `/help`, `/about`, `/quit` still work.. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [X] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
