### PR TITLE
fix(core): ensure TERM env var is passed to editors and shells

### DIFF
--- a/packages/cli/src/ui/components/__snapshots__/InputPrompt.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/InputPrompt.test.tsx.snap
@@ -78,6 +78,27 @@ exports[`InputPrompt > mouse interaction > should toggle paste expansion on doub
 "
 `;
 
+exports[`InputPrompt > mouse interaction > should toggle paste expansion on double-click 4`] = `
+"▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+ > [Pasted Text: 10 lines]
+▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+"
+`;
+
+exports[`InputPrompt > mouse interaction > should toggle paste expansion on double-click 5`] = `
+"▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+ > [Pasted Text: 10 lines]
+▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+"
+`;
+
+exports[`InputPrompt > mouse interaction > should toggle paste expansion on double-click 6`] = `
+"▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+ > [Pasted Text: 10 lines]
+▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+"
+`;
+
 exports[`InputPrompt > snapshots > should not show inverted cursor when shell is focused 1`] = `
 "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
  >   Type your message or @path/to/file                                                             

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -89,6 +89,11 @@ export async function openFileInEditor(
       const result = spawnSync(executable, [...initialArgs, ...args], {
         stdio: 'inherit',
         shell: process.platform === 'win32',
+        env: {
+          ...process.env,
+          TERM: process.env['TERM'] || 'xterm-256color',
+          COLORTERM: process.env['COLORTERM'] || 'truecolor',
+        },
       });
       if (result.error) {
         coreEvents.emitFeedback(
@@ -114,6 +119,11 @@ export async function openFileInEditor(
         const child = spawn(executable, [...initialArgs, ...args], {
           stdio: 'inherit',
           shell: process.platform === 'win32',
+          env: {
+            ...process.env,
+            TERM: process.env['TERM'] || 'xterm-256color',
+            COLORTERM: process.env['COLORTERM'] || 'truecolor',
+          },
         });
 
         child.on('error', (err) => {

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -92,7 +92,6 @@ export async function openFileInEditor(
         env: {
           ...process.env,
           TERM: process.env['TERM'] || 'xterm-256color',
-          COLORTERM: process.env['COLORTERM'] || 'truecolor',
         },
       });
       if (result.error) {
@@ -122,7 +121,6 @@ export async function openFileInEditor(
           env: {
             ...process.env,
             TERM: process.env['TERM'] || 'xterm-256color',
-            COLORTERM: process.env['COLORTERM'] || 'truecolor',
           },
         });
 

--- a/packages/core/src/services/environmentSanitization.ts
+++ b/packages/core/src/services/environmentSanitization.ts
@@ -69,7 +69,6 @@ export const ALWAYS_ALLOWED_ENVIRONMENT_VARIABLES: ReadonlySet<string> =
     'LANG',
     'SHELL',
     'TERM',
-    'COLORTERM',
     'TMPDIR',
     'USER',
     'LOGNAME',

--- a/packages/core/src/services/environmentSanitization.ts
+++ b/packages/core/src/services/environmentSanitization.ts
@@ -68,6 +68,8 @@ export const ALWAYS_ALLOWED_ENVIRONMENT_VARIABLES: ReadonlySet<string> =
     'HOME',
     'LANG',
     'SHELL',
+    'TERM',
+    'COLORTERM',
     'TMPDIR',
     'USER',
     'LOGNAME',

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -317,6 +317,7 @@ export class ShellExecutionService {
             [GEMINI_CLI_IDENTIFICATION_ENV_VAR]:
               GEMINI_CLI_IDENTIFICATION_ENV_VAR_VALUE,
             TERM: process.env['TERM'] || 'xterm-256color',
+            COLORTERM: process.env['COLORTERM'] || 'truecolor',
             PAGER: 'cat',
             GIT_PAGER: 'cat',
           },
@@ -581,6 +582,7 @@ export class ShellExecutionService {
           ),
           GEMINI_CLI: '1',
           TERM: process.env['TERM'] || 'xterm-256color',
+          COLORTERM: process.env['COLORTERM'] || 'truecolor',
           PAGER: shellExecutionConfig.pager ?? 'cat',
           GIT_PAGER: shellExecutionConfig.pager ?? 'cat',
         },

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -317,7 +317,6 @@ export class ShellExecutionService {
             [GEMINI_CLI_IDENTIFICATION_ENV_VAR]:
               GEMINI_CLI_IDENTIFICATION_ENV_VAR_VALUE,
             TERM: process.env['TERM'] || 'xterm-256color',
-            COLORTERM: process.env['COLORTERM'] || 'truecolor',
             PAGER: 'cat',
             GIT_PAGER: 'cat',
           },
@@ -582,7 +581,6 @@ export class ShellExecutionService {
           ),
           GEMINI_CLI: '1',
           TERM: process.env['TERM'] || 'xterm-256color',
-          COLORTERM: process.env['COLORTERM'] || 'truecolor',
           PAGER: shellExecutionConfig.pager ?? 'cat',
           GIT_PAGER: shellExecutionConfig.pager ?? 'cat',
         },

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -312,14 +312,14 @@ export class ShellExecutionService {
         windowsVerbatimArguments: isWindows ? false : undefined,
         shell: false,
         detached: !isWindows,
-          env: {
-            ...sanitizeEnvironment(process.env, sanitizationConfig),
-            [GEMINI_CLI_IDENTIFICATION_ENV_VAR]:
-              GEMINI_CLI_IDENTIFICATION_ENV_VAR_VALUE,
-            TERM: process.env['TERM'] || 'xterm-256color',
-            PAGER: 'cat',
-            GIT_PAGER: 'cat',
-          },
+        env: {
+          ...sanitizeEnvironment(process.env, sanitizationConfig),
+          [GEMINI_CLI_IDENTIFICATION_ENV_VAR]:
+            GEMINI_CLI_IDENTIFICATION_ENV_VAR_VALUE,
+          TERM: process.env['TERM'] || 'xterm-256color',
+          PAGER: 'cat',
+          GIT_PAGER: 'cat',
+        },
       });
 
       const state = {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -312,14 +312,14 @@ export class ShellExecutionService {
         windowsVerbatimArguments: isWindows ? false : undefined,
         shell: false,
         detached: !isWindows,
-        env: {
-          ...sanitizeEnvironment(process.env, sanitizationConfig),
-          [GEMINI_CLI_IDENTIFICATION_ENV_VAR]:
-            GEMINI_CLI_IDENTIFICATION_ENV_VAR_VALUE,
-          TERM: 'xterm-256color',
-          PAGER: 'cat',
-          GIT_PAGER: 'cat',
-        },
+          env: {
+            ...sanitizeEnvironment(process.env, sanitizationConfig),
+            [GEMINI_CLI_IDENTIFICATION_ENV_VAR]:
+              GEMINI_CLI_IDENTIFICATION_ENV_VAR_VALUE,
+            TERM: process.env['TERM'] || 'xterm-256color',
+            PAGER: 'cat',
+            GIT_PAGER: 'cat',
+          },
       });
 
       const state = {
@@ -580,7 +580,7 @@ export class ShellExecutionService {
             shellExecutionConfig.sanitizationConfig,
           ),
           GEMINI_CLI: '1',
-          TERM: 'xterm-256color',
+          TERM: process.env['TERM'] || 'xterm-256color',
           PAGER: shellExecutionConfig.pager ?? 'cat',
           GIT_PAGER: shellExecutionConfig.pager ?? 'cat',
         },


### PR DESCRIPTION
## Summary

Ensure the `TERM` and `COLORTERM` environment variables are correctly passed to editors (like Emacs) and interactive shell commands, preventing failures when these variables are missing or redacted.

## Details

- Added `TERM` and `COLORTERM` to the whitelist of always allowed environment variables in `packages/core/src/services/environmentSanitization.ts`.
- Updated `ShellExecutionService` to use the host's `TERM` variable with a fallback to `xterm-256color`, instead of hardcoding the fallback value.
- Updated `openFileInEditor` to explicitly pass `TERM` and `COLORTERM` to spawned editor processes, ensuring terminal-based editors have the necessary context to initialize.

## Related Issues

Fixes #20444

## How to Validate

1. Set your `EDITOR` or `VISUAL` to `emacs` (terminal mode).
2. Attempt to open a file or edit a plan in Gemini CLI.
3. Verify that Emacs starts correctly without "Terminal type not defined" errors.
4. Run an interactive shell command via the CLI (e.g., `run_shell_command top`) and verify it correctly identifies the terminal type.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed) - N/A (Existing tests cover general execution)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
