### PR TITLE
feat(cli): add /new command to start a fresh session while preserving…

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -38,6 +38,7 @@ import { hooksCommand } from '../ui/commands/hooksCommand.js';
 import { ideCommand } from '../ui/commands/ideCommand.js';
 import { initCommand } from '../ui/commands/initCommand.js';
 import { mcpCommand } from '../ui/commands/mcpCommand.js';
+import { newCommand } from '../ui/commands/newCommand.js';
 import { memoryCommand } from '../ui/commands/memoryCommand.js';
 import { modelCommand } from '../ui/commands/modelCommand.js';
 import { oncallCommand } from '../ui/commands/oncallCommand.js';
@@ -90,6 +91,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
           : chatCommand.subCommands,
       },
       clearCommand,
+      newCommand,
       commandsCommand,
       compressCommand,
       copyCommand,

--- a/packages/cli/src/ui/commands/newCommand.test.ts
+++ b/packages/cli/src/ui/commands/newCommand.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { newCommand } from './newCommand.js';
+import { type CommandContext } from './types.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+
+// Mock the telemetry service
+vi.mock('@google/gemini-cli-core', async () => {
+  const actual = await vi.importActual('@google/gemini-cli-core');
+  return {
+    ...actual,
+    uiTelemetryService: {
+      setLastPromptTokenCount: vi.fn(),
+    },
+  };
+});
+
+import type { GeminiClient } from '@google/gemini-cli-core';
+import { uiTelemetryService } from '@google/gemini-cli-core';
+
+describe('newCommand', () => {
+  let mockContext: CommandContext;
+  let mockResetChat: ReturnType<typeof vi.fn>;
+  let mockHintClear: ReturnType<typeof vi.fn>;
+  let mockInitialize: ReturnType<typeof vi.fn>;
+  let mockSetSessionId: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockResetChat = vi.fn().mockResolvedValue(undefined);
+    mockHintClear = vi.fn();
+    mockInitialize = vi.fn();
+    mockSetSessionId = vi.fn();
+    vi.clearAllMocks();
+
+    mockContext = createMockCommandContext({
+      services: {
+        config: {
+          getGeminiClient: () =>
+            ({
+              resetChat: mockResetChat,
+              getChat: () => ({
+                getChatRecordingService: () => ({
+                  initialize: mockInitialize,
+                }),
+              }),
+            }) as unknown as GeminiClient,
+          setSessionId: mockSetSessionId,
+          getEnableHooks: vi.fn().mockReturnValue(false),
+          getMessageBus: vi.fn().mockReturnValue(undefined),
+          getHookSystem: vi.fn().mockReturnValue({
+            fireSessionEndEvent: vi.fn().mockResolvedValue(undefined),
+            fireSessionStartEvent: vi.fn().mockResolvedValue(undefined),
+          }),
+          userHintService: {
+            clear: mockHintClear,
+          },
+        },
+      },
+    });
+  });
+
+  it('should reset chat, assign a new session ID, reinitialize recording, reset telemetry, and clear UI', async () => {
+    if (!newCommand.action) {
+      throw new Error('newCommand must have an action.');
+    }
+
+    await newCommand.action(mockContext, '');
+
+    expect(mockContext.ui.setDebugMessage).toHaveBeenCalledWith(
+      'Starting new session and preserving current conversation.',
+    );
+    expect(mockResetChat).toHaveBeenCalledTimes(1);
+    expect(mockSetSessionId).toHaveBeenCalledTimes(1);
+    expect(mockInitialize).toHaveBeenCalledTimes(1);
+    expect(mockHintClear).toHaveBeenCalledTimes(1);
+    expect(uiTelemetryService.setLastPromptTokenCount).toHaveBeenCalledWith(0);
+    expect(mockContext.ui.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('should assign a new session ID before reinitializing the recording service', async () => {
+    if (!newCommand.action) {
+      throw new Error('newCommand must have an action.');
+    }
+
+    await newCommand.action(mockContext, '');
+
+    const setSessionIdOrder = mockSetSessionId.mock.invocationCallOrder[0];
+    const initializeOrder = mockInitialize.mock.invocationCallOrder[0];
+
+    expect(setSessionIdOrder).toBeLessThan(initializeOrder);
+  });
+
+  it('should not attempt to reset chat if config service is not available', async () => {
+    if (!newCommand.action) {
+      throw new Error('newCommand must have an action.');
+    }
+
+    const nullConfigContext = createMockCommandContext({
+      services: {
+        config: null,
+      },
+    });
+
+    await newCommand.action(nullConfigContext, '');
+
+    expect(nullConfigContext.ui.setDebugMessage).toHaveBeenCalledWith(
+      'Starting new session.',
+    );
+    expect(mockResetChat).not.toHaveBeenCalled();
+    expect(uiTelemetryService.setLastPromptTokenCount).toHaveBeenCalledWith(0);
+    expect(nullConfigContext.ui.clear).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/ui/commands/newCommand.ts
+++ b/packages/cli/src/ui/commands/newCommand.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  uiTelemetryService,
+  SessionEndReason,
+  SessionStartSource,
+  flushTelemetry,
+} from '@google/gemini-cli-core';
+import type { SlashCommand } from './types.js';
+import { CommandKind } from './types.js';
+import { MessageType } from '../types.js';
+import { randomUUID } from 'node:crypto';
+
+export const newCommand: SlashCommand = {
+  name: 'new',
+  description:
+    'Start a new conversation while preserving the current session for /resume',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: async (context, _args) => {
+    const geminiClient = context.services.config?.getGeminiClient();
+    const config = context.services.config;
+    const chatRecordingService = context.services.config
+      ?.getGeminiClient()
+      ?.getChat()
+      .getChatRecordingService();
+
+    // Fire SessionEnd hook before starting a new session
+    const hookSystem = config?.getHookSystem();
+    if (hookSystem) {
+      await hookSystem.fireSessionEndEvent(SessionEndReason.Clear);
+    }
+
+    if (geminiClient) {
+      context.ui.setDebugMessage(
+        'Starting new session and preserving current conversation.',
+      );
+      await geminiClient.resetChat();
+    } else {
+      context.ui.setDebugMessage('Starting new session.');
+    }
+
+    // Reset user steering hints
+    config?.userHintService.clear();
+
+    // Assign a new session ID before re-initializing the recording service.
+    // This ensures the previous session's recording is preserved on disk under
+    // its original session ID and remains available via /resume.
+    if (config && chatRecordingService) {
+      const newSessionId = randomUUID();
+      config.setSessionId(newSessionId);
+      chatRecordingService.initialize();
+    }
+
+    // Fire SessionStart hook for the new session
+    let result;
+    if (hookSystem) {
+      result = await hookSystem.fireSessionStartEvent(SessionStartSource.Clear);
+    }
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    if (config) {
+      await flushTelemetry(config);
+    }
+
+    uiTelemetryService.setLastPromptTokenCount(0);
+    context.ui.clear();
+
+    if (result?.systemMessage) {
+      context.ui.addItem(
+        {
+          type: MessageType.INFO,
+          text: result.systemMessage,
+        },
+        Date.now(),
+      );
+    }
+  },
+};


### PR DESCRIPTION
feat(cli): add /new command to start a fresh session

Introduce a built-in /new command that starts a new conversation
while preserving the current session for later use with /resume.

The command:
- Executes session end/start lifecycle hooks
- Assigns a new session ID before reinitializing chat recording
- Flushes telemetry
- Resets chat state and UI hints

Includes unit tests covering lifecycle ordering and behavior
when the config service is absent.

Fixes #16848 