### PR TITLE
fix: add missing JSON output for AgentExecutionStopped in non-interactive mode

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -2033,6 +2033,10 @@ describe('runNonInteractive', () => {
             session_id: 'test-session-id',
             response: 'Partial content',
             stats: MOCK_SESSION_METRICS,
+            error: {
+              type: 'AgentExecutionStopped',
+              message: 'Agent execution stopped: Stopped by hook',
+            },
           },
           null,
           2,
@@ -2068,6 +2072,8 @@ describe('runNonInteractive', () => {
       const output = getWrittenOutput();
       expect(output).toContain('"type":"result"');
       expect(output).toContain('"status":"success"');
+      expect(output).toContain('"AgentExecutionStopped"');
+      expect(output).toContain('Agent execution stopped: Stopped by hook');
     });
 
     it('should handle AgentExecutionBlocked event', async () => {

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -2003,6 +2003,73 @@ describe('runNonInteractive', () => {
       expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
     });
 
+    it('should write JSON output when AgentExecutionStopped event is received in JSON mode', async () => {
+      vi.mocked(mockConfig.getOutputFormat).mockReturnValue(OutputFormat.JSON);
+      vi.mocked(uiTelemetryService.getMetrics).mockReturnValue(
+        MOCK_SESSION_METRICS,
+      );
+
+      const events: ServerGeminiStreamEvent[] = [
+        { type: GeminiEventType.Content, value: 'Partial content' },
+        {
+          type: GeminiEventType.AgentExecutionStopped,
+          value: { reason: 'Stopped by hook' },
+        },
+      ];
+      mockGeminiClient.sendMessageStream.mockReturnValue(
+        createStreamFromEvents(events),
+      );
+
+      await runNonInteractive({
+        config: mockConfig,
+        settings: mockSettings,
+        input: 'test stop json',
+        prompt_id: 'prompt-id-stop-json',
+      });
+
+      expect(processStdoutSpy).toHaveBeenCalledWith(
+        JSON.stringify(
+          {
+            session_id: 'test-session-id',
+            response: 'Partial content',
+            stats: MOCK_SESSION_METRICS,
+          },
+          null,
+          2,
+        ),
+      );
+    });
+
+    it('should emit result event when AgentExecutionStopped event is received in streaming JSON mode', async () => {
+      vi.mocked(mockConfig.getOutputFormat).mockReturnValue(
+        OutputFormat.STREAM_JSON,
+      );
+      vi.mocked(uiTelemetryService.getMetrics).mockReturnValue(
+        MOCK_SESSION_METRICS,
+      );
+
+      const events: ServerGeminiStreamEvent[] = [
+        {
+          type: GeminiEventType.AgentExecutionStopped,
+          value: { reason: 'Stopped by hook' },
+        },
+      ];
+      mockGeminiClient.sendMessageStream.mockReturnValue(
+        createStreamFromEvents(events),
+      );
+
+      await runNonInteractive({
+        config: mockConfig,
+        settings: mockSettings,
+        input: 'test stop stream',
+        prompt_id: 'prompt-id-stop-stream',
+      });
+
+      const output = getWrittenOutput();
+      expect(output).toContain('"type":"result"');
+      expect(output).toContain('"status":"success"');
+    });
+
     it('should handle AgentExecutionBlocked event', async () => {
       const allEvents: ServerGeminiStreamEvent[] = [
         {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -382,6 +382,14 @@ export async function runNonInteractive({
                   durationMs,
                 ),
               });
+            } else if (config.getOutputFormat() === OutputFormat.JSON) {
+              const formatter = new JsonFormatter();
+              const stats = uiTelemetryService.getMetrics();
+              textOutput.write(
+                formatter.format(config.getSessionId(), responseText, stats),
+              );
+            } else {
+              textOutput.ensureTrailingNewline(); // Ensure a final newline
             }
             return;
           } else if (event.type === GeminiEventType.AgentExecutionBlocked) {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -377,6 +377,10 @@ export async function runNonInteractive({
                 type: JsonStreamEventType.RESULT,
                 timestamp: new Date().toISOString(),
                 status: 'success',
+                error: {
+                  type: 'AgentExecutionStopped',
+                  message: stopMessage,
+                },
                 stats: streamFormatter.convertToStreamStats(
                   metrics,
                   durationMs,
@@ -386,7 +390,10 @@ export async function runNonInteractive({
               const formatter = new JsonFormatter();
               const stats = uiTelemetryService.getMetrics();
               textOutput.write(
-                formatter.format(config.getSessionId(), responseText, stats),
+                formatter.format(config.getSessionId(), responseText, stats, {
+                  type: 'AgentExecutionStopped',
+                  message: stopMessage,
+                }),
               );
             } else {
               textOutput.ensureTrailingNewline(); // Ensure a final newline


### PR DESCRIPTION
## Description
Fixes #20453
The `AgentExecutionStopped` event handler in non-interactive mode was missing JSON output format handling. When using `--output-format json`, the CLI would exit silently with no output when the agent was stopped by hooks or policies.
## Changes
### `packages/cli/src/nonInteractiveCli.ts`
- Added `else if (OutputFormat.JSON)` branch to the `AgentExecutionStopped` event handler, using `JsonFormatter` to produce proper JSON output with session ID, response text, and stats
- Added `else` branch with `ensureTrailingNewline()` for TEXT mode consistency
- This matches the existing pattern used by the `STOP_EXECUTION` tool error handler
### `packages/cli/src/nonInteractiveCli.test.ts`
- Added test: `should write JSON output when AgentExecutionStopped event is received in JSON mode`
- Added test: `should emit result event when AgentExecutionStopped event is received in streaming JSON mode`
## Testing
- All 47 tests pass (45 existing + 2 new)
- New tests verify JSON and STREAM_JSON output for `AgentExecutionStopped` events
- Existing TEXT mode test continues to pass unchanged
## Before/After
**Before (JSON mode + AgentExecutionStopped):** No output — silent exit
**After (JSON mode + AgentExecutionStopped):** Proper JSON output with session_id, response, and stats
