### PR TITLE
fix(github): resolve actionlint and yamllint regressions from #19443

### DIFF
--- a/.github/actions/create-pull-request/action.yml
+++ b/.github/actions/create-pull-request/action.yml
@@ -39,10 +39,10 @@ runs:
       if: "inputs.dry-run != 'true'"
       env:
         GH_TOKEN: '${{ inputs.github-token }}'
-        INPUTS_BRANCH_NAME: ${{ inputs.branch-name }}
-        INPUTS_PR_TITLE: ${{ inputs.pr-title }}
-        INPUTS_PR_BODY: ${{ inputs.pr-body }}
-        INPUTS_BASE_BRANCH: ${{ inputs.base-branch }}
+        INPUTS_BRANCH_NAME: '${{ inputs.branch-name }}'
+        INPUTS_PR_TITLE: '${{ inputs.pr-title }}'
+        INPUTS_PR_BODY: '${{ inputs.pr-body }}'
+        INPUTS_BASE_BRANCH: '${{ inputs.base-branch }}'
       shell: 'bash'
       working-directory: '${{ inputs.working-directory }}'
       run: |

--- a/.github/actions/npm-auth-token/action.yml
+++ b/.github/actions/npm-auth-token/action.yml
@@ -44,8 +44,8 @@ runs:
         fi
         echo "auth-token=$AUTH_TOKEN" >> $GITHUB_OUTPUT
       env:
-        INPUTS_GITHUB_TOKEN: ${{ inputs.github-token }}
-        INPUTS_PACKAGE_NAME: ${{ inputs.package-name }}
-        INPUTS_WOMBAT_TOKEN_CLI: ${{ inputs.wombat-token-cli }}
-        INPUTS_WOMBAT_TOKEN_CORE: ${{ inputs.wombat-token-core }}
-        INPUTS_WOMBAT_TOKEN_A2A_SERVER: ${{ inputs.wombat-token-a2a-server }}
+        INPUTS_GITHUB_TOKEN: '${{ inputs.github-token }}'
+        INPUTS_PACKAGE_NAME: '${{ inputs.package-name }}'
+        INPUTS_WOMBAT_TOKEN_CLI: '${{ inputs.wombat-token-cli }}'
+        INPUTS_WOMBAT_TOKEN_CORE: '${{ inputs.wombat-token-core }}'
+        INPUTS_WOMBAT_TOKEN_A2A_SERVER: '${{ inputs.wombat-token-a2a-server }}'

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -97,7 +97,7 @@ runs:
         git switch -c "${BRANCH_NAME}"
         echo "BRANCH_NAME=${BRANCH_NAME}" >> "${GITHUB_OUTPUT}"
       env:
-        INPUTS_RELEASE_TAG: ${{ inputs.release-tag }}
+        INPUTS_RELEASE_TAG: '${{ inputs.release-tag }}'
 
     - name: '⬆️ Update package versions'
       working-directory: '${{ inputs.working-directory }}'
@@ -105,7 +105,7 @@ runs:
       run: |
         npm run release:version "${INPUTS_RELEASE_VERSION}"
       env:
-        INPUTS_RELEASE_VERSION: ${{ inputs.release-version }}
+        INPUTS_RELEASE_VERSION: '${{ inputs.release-version }}'
 
     - name: '💾 Commit and Conditionally Push package versions'
       working-directory: '${{ inputs.working-directory }}'
@@ -167,8 +167,8 @@ runs:
       working-directory: '${{ inputs.working-directory }}'
       env:
         NODE_AUTH_TOKEN: '${{ steps.core-token.outputs.auth-token }}'
-        INPUTS_DRY_RUN: ${{ inputs.dry-run }}
-        INPUTS_CORE_PACKAGE_NAME: ${{ inputs.core-package-name }}
+        INPUTS_DRY_RUN: '${{ inputs.dry-run }}'
+        INPUTS_CORE_PACKAGE_NAME: '${{ inputs.core-package-name }}'
       shell: 'bash'
       run: |
         npm publish \
@@ -187,10 +187,10 @@ runs:
         --workspace="${INPUTS_A2A_PACKAGE_NAME}" \
         --save-exact
       env:
-        INPUTS_CORE_PACKAGE_NAME: ${{ inputs.core-package-name }}
-        INPUTS_RELEASE_VERSION: ${{ inputs.release-version }}
-        INPUTS_CLI_PACKAGE_NAME: ${{ inputs.cli-package-name }}
-        INPUTS_A2A_PACKAGE_NAME: ${{ inputs.a2a-package-name }}
+        INPUTS_CORE_PACKAGE_NAME: '${{ inputs.core-package-name }}'
+        INPUTS_RELEASE_VERSION: '${{ inputs.release-version }}'
+        INPUTS_CLI_PACKAGE_NAME: '${{ inputs.cli-package-name }}'
+        INPUTS_A2A_PACKAGE_NAME: '${{ inputs.a2a-package-name }}'
 
     - name: 'Get CLI Token'
       uses: './.github/actions/npm-auth-token'
@@ -206,8 +206,8 @@ runs:
       working-directory: '${{ inputs.working-directory }}'
       env:
         NODE_AUTH_TOKEN: '${{ steps.cli-token.outputs.auth-token }}'
-        INPUTS_DRY_RUN: ${{ inputs.dry-run }}
-        INPUTS_CLI_PACKAGE_NAME: ${{ inputs.cli-package-name }}
+        INPUTS_DRY_RUN: '${{ inputs.dry-run }}'
+        INPUTS_CLI_PACKAGE_NAME: '${{ inputs.cli-package-name }}'
       shell: 'bash'
       run: |
         npm publish \
@@ -230,8 +230,8 @@ runs:
       working-directory: '${{ inputs.working-directory }}'
       env:
         NODE_AUTH_TOKEN: '${{ steps.a2a-token.outputs.auth-token }}'
-        INPUTS_DRY_RUN: ${{ inputs.dry-run }}
-        INPUTS_A2A_PACKAGE_NAME: ${{ inputs.a2a-package-name }}
+        INPUTS_DRY_RUN: '${{ inputs.dry-run }}'
+        INPUTS_A2A_PACKAGE_NAME: '${{ inputs.a2a-package-name }}'
       shell: 'bash'
       # Tag staging for initial release
       run: |
@@ -273,9 +273,9 @@ runs:
       if: "${{ inputs.dry-run != 'true' && inputs.skip-github-release != 'true' && inputs.npm-tag != 'dev' && inputs.npm-registry-url != 'https://npm.pkg.github.com/' }}"
       env:
         GITHUB_TOKEN: '${{ inputs.github-release-token || inputs.github-token }}'
-        INPUTS_RELEASE_TAG: ${{ inputs.release-tag }}
-        STEPS_RELEASE_BRANCH_OUTPUTS_BRANCH_NAME: ${{ steps.release_branch.outputs.BRANCH_NAME }}
-        INPUTS_PREVIOUS_TAG: ${{ inputs.previous-tag }}
+        INPUTS_RELEASE_TAG: '${{ inputs.release-tag }}'
+        STEPS_RELEASE_BRANCH_OUTPUTS_BRANCH_NAME: '${{ steps.release_branch.outputs.BRANCH_NAME }}'
+        INPUTS_PREVIOUS_TAG: '${{ inputs.previous-tag }}'
       shell: 'bash'
       run: |
         gh release create "${INPUTS_RELEASE_TAG}" \
@@ -296,4 +296,4 @@ runs:
         git push origin --delete "${STEPS_RELEASE_BRANCH_OUTPUTS_BRANCH_NAME}"
 
       env:
-        STEPS_RELEASE_BRANCH_OUTPUTS_BRANCH_NAME: ${{ steps.release_branch.outputs.BRANCH_NAME }}
+        STEPS_RELEASE_BRANCH_OUTPUTS_BRANCH_NAME: '${{ steps.release_branch.outputs.BRANCH_NAME }}'

--- a/.github/actions/push-docker/action.yml
+++ b/.github/actions/push-docker/action.yml
@@ -55,7 +55,7 @@ runs:
         REF_NAME="${INPUTS_REF_NAME}"
         echo "name=${REF_NAME%/merge}" >> $GITHUB_OUTPUT
       env:
-        INPUTS_REF_NAME: ${{ inputs.ref-name }}
+        INPUTS_REF_NAME: '${{ inputs.ref-name }}'
     - name: 'Build and Push the Docker Image'
       uses: 'docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83' # ratchet:docker/build-push-action@v6
       with:

--- a/.github/actions/push-sandbox/action.yml
+++ b/.github/actions/push-sandbox/action.yml
@@ -67,15 +67,15 @@ runs:
         echo "Determined image tag: $FINAL_TAG"
         echo "FINAL_TAG=$FINAL_TAG" >> $GITHUB_OUTPUT
       env:
-        INPUTS_GITHUB_REF_NAME: ${{ inputs.github-ref-name }}
-        INPUTS_GITHUB_SHA: ${{ inputs.github-sha }}
+        INPUTS_GITHUB_REF_NAME: '${{ inputs.github-ref-name }}'
+        INPUTS_GITHUB_SHA: '${{ inputs.github-sha }}'
     - name: 'build'
       id: 'docker_build'
       shell: 'bash'
       env:
         GEMINI_SANDBOX_IMAGE_TAG: '${{ steps.image_tag.outputs.FINAL_TAG }}'
         GEMINI_SANDBOX: 'docker'
-        STEPS_IMAGE_TAG_OUTPUTS_FINAL_TAG: ${{ steps.image_tag.outputs.FINAL_TAG }}
+        STEPS_IMAGE_TAG_OUTPUTS_FINAL_TAG: '${{ steps.image_tag.outputs.FINAL_TAG }}'
       run: |-
         npm run build:sandbox -- \
           --image google/gemini-cli-sandbox:${STEPS_IMAGE_TAG_OUTPUTS_FINAL_TAG} \
@@ -95,7 +95,7 @@ runs:
       run: |-
         docker push "${STEPS_DOCKER_BUILD_OUTPUTS_URI}"
       env:
-        STEPS_DOCKER_BUILD_OUTPUTS_URI: ${{ steps.docker_build.outputs.uri }}
+        STEPS_DOCKER_BUILD_OUTPUTS_URI: '${{ steps.docker_build.outputs.uri }}'
     - name: 'Create issue on failure'
       if: |-
         ${{ failure() }}

--- a/.github/actions/setup-npmrc/action.yml
+++ b/.github/actions/setup-npmrc/action.yml
@@ -21,4 +21,4 @@ runs:
         echo ""//npm.pkg.github.com/:_authToken=${INPUTS_GITHUB_TOKEN}"" >> ~/.npmrc
         echo ""@google:registry=https://wombat-dressing-room.appspot.com"" >> ~/.npmrc
       env:
-        INPUTS_GITHUB_TOKEN: ${{ inputs.github-token }}
+        INPUTS_GITHUB_TOKEN: '${{ inputs.github-token }}'

--- a/.github/actions/tag-npm-release/action.yml
+++ b/.github/actions/tag-npm-release/action.yml
@@ -71,9 +71,9 @@ runs:
         ${{ inputs.dry-run != 'true' }}
       env:
         NODE_AUTH_TOKEN: '${{ steps.core-token.outputs.auth-token }}'
-        INPUTS_CORE_PACKAGE_NAME: ${{ inputs.core-package-name }}
-        INPUTS_VERSION: ${{ inputs.version }}
-        INPUTS_CHANNEL: ${{ inputs.channel }}
+        INPUTS_CORE_PACKAGE_NAME: '${{ inputs.core-package-name }}'
+        INPUTS_VERSION: '${{ inputs.version }}'
+        INPUTS_CHANNEL: '${{ inputs.channel }}'
       shell: 'bash'
       working-directory: '${{ inputs.working-directory }}'
       run: |
@@ -94,9 +94,9 @@ runs:
         ${{ inputs.dry-run != 'true' }}
       env:
         NODE_AUTH_TOKEN: '${{ steps.cli-token.outputs.auth-token }}'
-        INPUTS_CLI_PACKAGE_NAME: ${{ inputs.cli-package-name }}
-        INPUTS_VERSION: ${{ inputs.version }}
-        INPUTS_CHANNEL: ${{ inputs.channel }}
+        INPUTS_CLI_PACKAGE_NAME: '${{ inputs.cli-package-name }}'
+        INPUTS_VERSION: '${{ inputs.version }}'
+        INPUTS_CHANNEL: '${{ inputs.channel }}'
       shell: 'bash'
       working-directory: '${{ inputs.working-directory }}'
       run: |
@@ -117,9 +117,9 @@ runs:
         ${{ inputs.dry-run == 'false' }}
       env:
         NODE_AUTH_TOKEN: '${{ steps.a2a-token.outputs.auth-token }}'
-        INPUTS_A2A_PACKAGE_NAME: ${{ inputs.a2a-package-name }}
-        INPUTS_VERSION: ${{ inputs.version }}
-        INPUTS_CHANNEL: ${{ inputs.channel }}
+        INPUTS_A2A_PACKAGE_NAME: '${{ inputs.a2a-package-name }}'
+        INPUTS_VERSION: '${{ inputs.version }}'
+        INPUTS_CHANNEL: '${{ inputs.channel }}'
       shell: 'bash'
       working-directory: '${{ inputs.working-directory }}'
       run: |
@@ -134,12 +134,12 @@ runs:
         echo "Dry run: Would have added tag '${INPUTS_CHANNEL}' to version '${INPUTS_VERSION}' for ${INPUTS_CLI_PACKAGE_NAME}, ${INPUTS_CORE_PACKAGE_NAME}, and ${INPUTS_A2A_PACKAGE_NAME}."
 
       env:
-        INPUTS_CHANNEL: ${{ inputs.channel }}
+        INPUTS_CHANNEL: '${{ inputs.channel }}'
 
-        INPUTS_VERSION: ${{ inputs.version }}
+        INPUTS_VERSION: '${{ inputs.version }}'
 
-        INPUTS_CLI_PACKAGE_NAME: ${{ inputs.cli-package-name }}
+        INPUTS_CLI_PACKAGE_NAME: '${{ inputs.cli-package-name }}'
 
-        INPUTS_CORE_PACKAGE_NAME: ${{ inputs.core-package-name }}
+        INPUTS_CORE_PACKAGE_NAME: '${{ inputs.core-package-name }}'
 
-        INPUTS_A2A_PACKAGE_NAME: ${{ inputs.a2a-package-name }}
+        INPUTS_A2A_PACKAGE_NAME: '${{ inputs.a2a-package-name }}'

--- a/.github/actions/verify-release/action.yml
+++ b/.github/actions/verify-release/action.yml
@@ -69,8 +69,8 @@ runs:
           exit 1
         fi
       env:
-        INPUTS_EXPECTED_VERSION: ${{ inputs.expected-version }}
-        INPUTS_NPM_PACKAGE: ${{ inputs.npm-package }}
+        INPUTS_EXPECTED_VERSION: '${{ inputs.expected-version }}'
+        INPUTS_NPM_PACKAGE: '${{ inputs.npm-package }}'
 
     - name: 'Clear npm cache'
       shell: 'bash'
@@ -86,8 +86,8 @@ runs:
           exit 1
         fi
       env:
-        INPUTS_NPM_PACKAGE: ${{ inputs.npm-package }}
-        INPUTS_EXPECTED_VERSION: ${{ inputs.expected-version }}
+        INPUTS_NPM_PACKAGE: '${{ inputs.npm-package }}'
+        INPUTS_EXPECTED_VERSION: '${{ inputs.expected-version }}'
 
     - name: 'Install dependencies for integration tests'
       shell: 'bash'

--- a/.github/workflows/chained_e2e.yml
+++ b/.github/workflows/chained_e2e.yml
@@ -329,10 +329,10 @@ jobs:
           fi
           echo "All required E2E jobs passed!"
         env:
-          NEEDS_E2E_LINUX_RESULT: ${{ needs.e2e_linux.result }}
-          NEEDS_E2E_MAC_RESULT: ${{ needs.e2e_mac.result }}
-          NEEDS_E2E_WINDOWS_RESULT: ${{ needs.e2e_windows.result }}
-          NEEDS_EVALS_RESULT: ${{ needs.evals.result }}
+          NEEDS_E2E_LINUX_RESULT: '${{ needs.e2e_linux.result }}'
+          NEEDS_E2E_MAC_RESULT: '${{ needs.e2e_mac.result }}'
+          NEEDS_E2E_WINDOWS_RESULT: '${{ needs.e2e_windows.result }}'
+          NEEDS_EVALS_RESULT: '${{ needs.evals.result }}'
 
   set_workflow_status:
     runs-on: 'gemini-cli-ubuntu-16-core'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,10 +476,10 @@ jobs:
           fi
           echo "All CI jobs passed!"
         env:
-          NEEDS_LINT_RESULT: ${{ needs.lint.result }}
-          NEEDS_LINK_CHECKER_RESULT: ${{ needs.link_checker.result }}
-          NEEDS_TEST_LINUX_RESULT: ${{ needs.test_linux.result }}
-          NEEDS_TEST_MAC_RESULT: ${{ needs.test_mac.result }}
-          NEEDS_TEST_WINDOWS_RESULT: ${{ needs.test_windows.result }}
-          NEEDS_CODEQL_RESULT: ${{ needs.codeql.result }}
-          NEEDS_BUNDLE_SIZE_RESULT: ${{ needs.bundle_size.result }}
+          NEEDS_LINT_RESULT: '${{ needs.lint.result }}'
+          NEEDS_LINK_CHECKER_RESULT: '${{ needs.link_checker.result }}'
+          NEEDS_TEST_LINUX_RESULT: '${{ needs.test_linux.result }}'
+          NEEDS_TEST_MAC_RESULT: '${{ needs.test_mac.result }}'
+          NEEDS_TEST_WINDOWS_RESULT: '${{ needs.test_windows.result }}'
+          NEEDS_CODEQL_RESULT: '${{ needs.codeql.result }}'
+          NEEDS_BUNDLE_SIZE_RESULT: '${{ needs.bundle_size.result }}'

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -44,5 +44,5 @@ jobs:
       - name: 'Run evaluation'
         working-directory: '/app'
         run: |
-          poetry run exp_run --experiment-mode=on-demand --branch-or-commit=${GITHUB_REF_NAME} --model-name=gemini-2.5-pro --dataset=swebench_verified --concurrency=15
+          poetry run exp_run --experiment-mode=on-demand --branch-or-commit="${GITHUB_REF_NAME}" --model-name=gemini-2.5-pro --dataset=swebench_verified --concurrency=15
           poetry run python agent_prototypes/scripts/parse_gcli_logs_experiment.py --experiment_dir=experiments/adhoc/gcli_temp_exp --gcs-bucket="${EVAL_GCS_BUCKET}" --gcs-path=gh_action_artifacts

--- a/.github/workflows/release-patch-3-release.yml
+++ b/.github/workflows/release-patch-3-release.yml
@@ -118,7 +118,7 @@ jobs:
           ORIGINAL_RELEASE_VERSION: '${{ steps.patch_version.outputs.RELEASE_VERSION }}'
           ORIGINAL_RELEASE_TAG: '${{ steps.patch_version.outputs.RELEASE_TAG }}'
           ORIGINAL_PREVIOUS_TAG: '${{ steps.patch_version.outputs.PREVIOUS_TAG }}'
-          VARS_CLI_PACKAGE_NAME: ${{vars.CLI_PACKAGE_NAME}}
+          VARS_CLI_PACKAGE_NAME: '${{ vars.CLI_PACKAGE_NAME }}'
         run: |
           echo "🔍 Verifying no concurrent patch releases have occurred..."
 
@@ -168,10 +168,10 @@ jobs:
           echo "  NPM Tag: ${STEPS_PATCH_VERSION_OUTPUTS_NPM_TAG}"
           echo "  Previous Tag: ${STEPS_PATCH_VERSION_OUTPUTS_PREVIOUS_TAG}"
         env:
-          STEPS_PATCH_VERSION_OUTPUTS_RELEASE_VERSION: ${{ steps.patch_version.outputs.RELEASE_VERSION }}
-          STEPS_PATCH_VERSION_OUTPUTS_RELEASE_TAG: ${{ steps.patch_version.outputs.RELEASE_TAG }}
-          STEPS_PATCH_VERSION_OUTPUTS_NPM_TAG: ${{ steps.patch_version.outputs.NPM_TAG }}
-          STEPS_PATCH_VERSION_OUTPUTS_PREVIOUS_TAG: ${{ steps.patch_version.outputs.PREVIOUS_TAG }}
+          STEPS_PATCH_VERSION_OUTPUTS_RELEASE_VERSION: '${{ steps.patch_version.outputs.RELEASE_VERSION }}'
+          STEPS_PATCH_VERSION_OUTPUTS_RELEASE_TAG: '${{ steps.patch_version.outputs.RELEASE_TAG }}'
+          STEPS_PATCH_VERSION_OUTPUTS_NPM_TAG: '${{ steps.patch_version.outputs.NPM_TAG }}'
+          STEPS_PATCH_VERSION_OUTPUTS_PREVIOUS_TAG: '${{ steps.patch_version.outputs.PREVIOUS_TAG }}'
 
       - name: 'Run Tests'
         if: "${{github.event.inputs.force_skip_tests != 'true'}}"

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -366,18 +366,18 @@ jobs:
           git switch -c "${BRANCH_NAME}"
           echo "BRANCH_NAME=${BRANCH_NAME}" >> "${GITHUB_OUTPUT}"
         env:
-          NEEDS_CALCULATE_VERSIONS_OUTPUTS_NEXT_NIGHTLY_VERSION: ${{ needs.calculate-versions.outputs.NEXT_NIGHTLY_VERSION }}
+          NEEDS_CALCULATE_VERSIONS_OUTPUTS_NEXT_NIGHTLY_VERSION: '${{ needs.calculate-versions.outputs.NEXT_NIGHTLY_VERSION }}'
 
       - name: 'Update package versions'
         run: 'npm run release:version "${NEEDS_CALCULATE_VERSIONS_OUTPUTS_NEXT_NIGHTLY_VERSION}"'
         env:
-          NEEDS_CALCULATE_VERSIONS_OUTPUTS_NEXT_NIGHTLY_VERSION: ${{ needs.calculate-versions.outputs.NEXT_NIGHTLY_VERSION }}
+          NEEDS_CALCULATE_VERSIONS_OUTPUTS_NEXT_NIGHTLY_VERSION: '${{ needs.calculate-versions.outputs.NEXT_NIGHTLY_VERSION }}'
 
       - name: 'Commit and Push package versions'
         env:
           BRANCH_NAME: '${{ steps.release_branch.outputs.BRANCH_NAME }}'
           DRY_RUN: '${{ github.event.inputs.dry_run }}'
-          NEEDS_CALCULATE_VERSIONS_OUTPUTS_NEXT_NIGHTLY_VERSION: ${{ needs.calculate-versions.outputs.NEXT_NIGHTLY_VERSION }}
+          NEEDS_CALCULATE_VERSIONS_OUTPUTS_NEXT_NIGHTLY_VERSION: '${{ needs.calculate-versions.outputs.NEXT_NIGHTLY_VERSION }}'
         run: |-
           git add package.json packages/*/package.json
           if [ -f package-lock.json ]; then


### PR DESCRIPTION
This PR fixes several linting regressions introduced in #19443 (which was force-merged). These issues include brittle shell scripting in workflows and inconsistent YAML formatting in actions.

#### Problem
The force-merge of #19443 bypassed CI checks, resulting in:
- **Shellcheck SC2086:** Unquoted variables in shell scripts which can lead to word splitting or globbing failures.
- **Yamllint `quoted-strings` violations:** Missing quotes for GitHub Actions expressions within `env` blocks, violating the repository's linting standards.

#### Changes
1.  **Fixed Shellcheck SC2086** in `.github/workflows/eval.yml` by quoting `"${GITHUB_REF_NAME}"`.
2.  **Resolved `quoted-strings` warnings** in 12 files by applying single quotes to GHA expressions (e.g., `VALUE: '${{ inputs.param }}'`).

#### Verification
Validated the fixes locally using the project's linting script:
- `node scripts/lint.js --actionlint` (Passes)
- `node scripts/lint.js --yamllint` (Passes)

Fixes https://github.com/google-gemini/gemini-cli/issues/20466