### PR TITLE
fix(core): use customtools model for gemini-3.1-pro-preview for api key users

### DIFF
--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -62,6 +62,11 @@ export function resolveModel(
       }
       return PREVIEW_GEMINI_MODEL;
     }
+    case PREVIEW_GEMINI_3_1_MODEL: {
+      return useCustomToolModel
+        ? PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL
+        : PREVIEW_GEMINI_3_1_MODEL;
+    }
     case DEFAULT_GEMINI_MODEL_AUTO: {
       return DEFAULT_GEMINI_MODEL;
     }

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -64,6 +64,7 @@ import type { RetryAvailabilityContext } from '../utils/retry.js';
 import { partToString } from '../utils/partUtils.js';
 import { coreEvents, CoreEvent } from '../utils/events.js';
 import type { LlmRole } from '../telemetry/types.js';
+import { AuthType } from './contentGenerator.js';
 
 const MAX_TURNS = 100;
 
@@ -539,11 +540,15 @@ export class GeminiClient {
       return this.currentSequenceModel;
     }
 
+    const useCustomToolModel =
+      this.config.getContentGeneratorConfig()?.authType === AuthType.USE_GEMINI;
+
     // Availability logic: The configured model is the source of truth,
     // including any permanent fallbacks (config.setModel) or manual overrides.
     return resolveModel(
       this.config.getActiveModel(),
       this.config.getGemini31LaunchedSync?.() ?? false,
+      useCustomToolModel,
     );
   }
 

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -151,6 +151,7 @@ export async function createContentGenerator(
       config.authType === AuthType.USE_GEMINI ||
         config.authType === AuthType.USE_VERTEX_AI ||
         ((await gcConfig.getGemini31Launched?.()) ?? false),
+      config.authType === AuthType.USE_GEMINI,
     );
     const customHeadersEnv =
       process.env['GEMINI_CLI_CUSTOM_HEADERS'] || undefined;

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -52,6 +52,7 @@ import {
 } from '../availability/policyHelpers.js';
 import { coreEvents } from '../utils/events.js';
 import type { LlmRole } from '../telemetry/types.js';
+import { AuthType } from './contentGenerator.js';
 
 export enum StreamEventType {
   /** A regular content chunk from the API. */
@@ -494,13 +495,24 @@ export class GeminiChat {
 
     const apiCall = async () => {
       const useGemini3_1 = (await this.config.getGemini31Launched?.()) ?? false;
+      const useCustomToolModel =
+        this.config.getContentGeneratorConfig()?.authType ===
+        AuthType.USE_GEMINI;
       // Default to the last used model (which respects arguments/availability selection)
-      let modelToUse = resolveModel(lastModelToUse, useGemini3_1);
+      let modelToUse = resolveModel(
+        lastModelToUse,
+        useGemini3_1,
+        useCustomToolModel,
+      );
 
       // If the active model has changed (e.g. due to a fallback updating the config),
       // we switch to the new active model.
       if (this.config.getActiveModel() !== initialActiveModel) {
-        modelToUse = resolveModel(this.config.getActiveModel(), useGemini3_1);
+        modelToUse = resolveModel(
+          this.config.getActiveModel(),
+          useGemini3_1,
+          useCustomToolModel,
+        );
       }
 
       if (modelToUse !== lastModelToUse) {


### PR DESCRIPTION
## Summary

This PR updates the model resolution logic for the `gemini-3.1-pro-preview`
model to automatically use `gemini-3.1-pro-preview-customtools` exclusively for
API Key users (`AuthType.USE_GEMINI`) during the actual LLM call.

## Details

The following updates were made across the core layers:

- `packages/core/src/config/models.ts`: Updated `resolveModel` to process
  `PREVIEW_GEMINI_3_1_MODEL` and conditionally return
  `PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL` when the `useCustomToolModel` flag is
  provided.
- `packages/core/src/core/client.ts`: Extracted `useCustomToolModel` dynamically
  based on the current auth type (`AuthType.USE_GEMINI`) and passed it to
  `resolveModel` inside `_getActiveModelForCurrentTurn()` so token counting
  limits match the `customtools` model limit accurately.
- `packages/core/src/core/geminiChat.ts`: Extracted `useCustomToolModel` and
  passed it to `resolveModel` in the execution layer (`apiCall`) right before
  the stream request to enforce the swap.
- `packages/core/src/core/contentGenerator.ts`: Passed the evaluated
  `useCustomToolModel` flag inside `createContentGenerator()` to ensure the
  generated configuration, HTTP Client setup, and `User-Agent` explicitly
  reflect the `customtools` model.

## Related Issues

## How to Validate

1. Start Gemini CLI logged in via an API Key (`--auth gemini-api-key`).
2. Run `/model gemini-3.1-pro-preview`.
3. Verify via DevTools or server logs that requests target
   `gemini-3.1-pro-preview-customtools`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
