### PR TITLE
feat(ui): add dynamic status badges for gcloud and venv to footer

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -133,6 +133,7 @@ import { useMcpStatus } from './hooks/useMcpStatus.js';
 import { useApprovalModeIndicator } from './hooks/useApprovalModeIndicator.js';
 import { useSessionStats } from './contexts/SessionContext.js';
 import { useGitBranchName } from './hooks/useGitBranchName.js';
+import { useStatusBadges } from './hooks/useStatusBadges.js';
 import {
   useConfirmUpdateRequests,
   useExtensionUpdates,
@@ -430,6 +431,7 @@ export const AppContainer = (props: AppContainerProps) => {
   // Additional hooks moved from App.tsx
   const { stats: sessionStats } = useSessionStats();
   const branchName = useGitBranchName(config.getTargetDir());
+  const statusBadges = useStatusBadges();
 
   // Layout measurements
   const mainControlsRef = useRef<DOMElement>(null);
@@ -2341,6 +2343,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
           ...pendingGeminiHistoryItems,
         ]),
       hintBuffer: '',
+      statusBadges,
     }),
     [
       isThemeDialogOpen,
@@ -2461,6 +2464,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       adminSettingsChanged,
       newAgents,
       showIsExpandableHint,
+      statusBadges,
     ],
   );
 

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -95,6 +95,12 @@ export const Footer: React.FC = () => {
               )}
             </Text>
           )}
+          {uiState.statusBadges.map((badge, i) => (
+            <Text key={i}>
+              {' '}
+              <Text color={badge.color || theme.text.accent}>{badge.text}</Text>
+            </Text>
+          ))}
           {debugMode && (
             <Text color={theme.status.error}>
               {' ' + (debugMessage || '--debug')}

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -64,6 +64,11 @@ export interface QuotaState {
   validationRequest: ValidationDialogRequest | null;
 }
 
+export interface StatusBadge {
+  text: string;
+  color?: string;
+}
+
 export interface UIState {
   history: HistoryItem[];
   historyManager: UseHistoryManagerReturn;
@@ -189,6 +194,7 @@ export interface UIState {
     text: string;
     type: TransientMessageType;
   } | null;
+  statusBadges: StatusBadge[];
 }
 
 export const UIStateContext = createContext<UIState | null>(null);

--- a/packages/cli/src/ui/hooks/useStatusBadges.ts
+++ b/packages/cli/src/ui/hooks/useStatusBadges.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { spawnAsync } from '@google/gemini-cli-core';
+import process from 'node:process';
+import { type StatusBadge } from '../contexts/UIStateContext.js';
+import { theme } from '../semantic-colors.js';
+
+export function useStatusBadges(): StatusBadge[] {
+  const [badges, setBadges] = useState<StatusBadge[]>([]);
+
+  const fetchBadges = useCallback(async () => {
+    const newBadges: StatusBadge[] = [];
+
+    // 1. GCloud
+    try {
+      // Get active config and project in one go or separate
+      const { stdout: projectStdout } = await spawnAsync('gcloud', [
+        'config',
+        'get-value',
+        'project',
+      ]);
+      const project = projectStdout.toString().trim();
+
+      if (project && !project.includes('(unset)')) {
+        const { stdout: configStdout } = await spawnAsync('gcloud', [
+          'config',
+          'configurations',
+          'list',
+          '--filter',
+          'IS_ACTIVE=true',
+          '--format',
+          'value(name)',
+        ]);
+        const activeConfig = configStdout.toString().trim();
+
+        newBadges.push({
+          text: `gcloud(${activeConfig || 'default'}):${project}`,
+          color: theme.text.accent,
+        });
+      }
+    } catch (_e) {
+      // Ignore errors if gcloud is not installed or configured
+    }
+
+    // 2. Python Venv
+    const venvPath = process.env['VIRTUAL_ENV'];
+    if (venvPath) {
+      const venvName = venvPath.split('/').pop();
+      newBadges.push({
+        text: `venv:${venvName}`,
+        color: theme.status.warning,
+      });
+    }
+
+    setBadges(newBadges);
+  }, []);
+
+  useEffect(() => {
+    // Initial fetch
+    void fetchBadges();
+
+    // Poll every 30 seconds to be respectful of resources
+    const interval = setInterval(() => {
+      void fetchBadges();
+    }, 30000);
+
+    return () => clearInterval(interval);
+  }, [fetchBadges]);
+
+  return badges;
+}


### PR DESCRIPTION
## Summary

This PR adds support for dynamic "status badges" in the Gemini CLI footer. These badges allow the UI to surface environmental context that is crucial for developers working across multiple projects or virtual environments. 

Specifically, this initial implementation adds support for:
- **Active gcloud configuration and project ID** (e.g., `gcloud(default):my-project`)
- **Active Python Virtual Environment** (e.g., `venv:my-env`)

## Details

- **`useStatusBadges.ts` Hook**: A new hook that polls (every 30s) and retrieves the current `gcloud` and `VIRTUAL_ENV` state using `spawnAsync` and `process.env`.
- **Global UI State**: Added `statusBadges` to `UIState` and `UIStateContext` to centralize environment metadata.
- **Footer Integration**: Modified `Footer.tsx` to render the badges next to the CWD and Branch info.
- **Styling**: Badges use semantic theme colors (`theme.text.accent` for gcloud, `theme.status.warning` for venv) to remain consistent with the rest of the application.

This change is a localized implementation of the larger "Extension UI API" proposal in #20476, providing immediate value while demonstrating the architectural pattern.

## Related Issues

Related to #20476
Related to #8191 (Statusline customization)

## How to Validate

1. Run `npm install` and `npm run build`.
2. Activate a python venv: `source venv/bin/activate`.
3. Set a gcloud project: `gcloud config set project my-test-project`.
4. Start the CLI: `npm start`.
5. Observe the new badges in the bottom-left of the footer.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS (npm run build, npm start)
