### PR TITLE
ui(cli): reduce length of Ctrl+O hint

### DIFF
--- a/packages/cli/src/ui/components/ToastDisplay.test.tsx
+++ b/packages/cli/src/ui/components/ToastDisplay.test.tsx
@@ -187,7 +187,9 @@ describe('ToastDisplay', () => {
       constrainHeight: true,
     });
     await waitUntilReady();
-    expect(lastFrame()).toContain('Press Ctrl+O to show more lines');
+    expect(lastFrame()).toContain(
+      'Ctrl+O to show more lines of the last response',
+    );
   });
 
   it('renders collapse hint when showIsExpandableHint is true and constrainHeight is false', async () => {
@@ -196,6 +198,8 @@ describe('ToastDisplay', () => {
       constrainHeight: false,
     });
     await waitUntilReady();
-    expect(lastFrame()).toContain('Press Ctrl+O to collapse lines');
+    expect(lastFrame()).toContain(
+      'Ctrl+O to collapse lines of the last response',
+    );
   });
 });

--- a/packages/cli/src/ui/components/ToastDisplay.tsx
+++ b/packages/cli/src/ui/components/ToastDisplay.tsx
@@ -78,7 +78,7 @@ export const ToastDisplay: React.FC = () => {
     const action = uiState.constrainHeight ? 'show more' : 'collapse';
     return (
       <Text color={theme.text.accent}>
-        Press Ctrl+O to {action} lines for the most recent response
+        Ctrl+O to {action} lines of the last response
       </Text>
     );
   }


### PR DESCRIPTION
## Summary

Reduces the length of the Ctrl+O expansion hint in the `ToastDisplay` component to improve UX on smaller terminals (<= 80 columns) and provide a more concise interface.

## Details

- Removed "Press" prefix from the hint.
- Changed "for the most recent response" to "of the last response".
- Updated `ToastDisplay.test.tsx` to match the new strings.

## Related Issues

Related to #20455
(Ref: https://github.com/google-gemini/gemini-cli/issues/20455#issuecomment-3968712840)

## How to Validate

Run the component tests:
```bash
npm test -w @google/gemini-cli -- src/ui/components/ToastDisplay.test.tsx
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
