### PR TITLE
fix(core): thread abort signal through chat compression

### DIFF
--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -239,7 +239,7 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
   ): Promise<AgentTurnResult> {
     const promptId = `${this.agentId}#${turnCounter}`;
 
-    await this.tryCompressChat(chat, promptId);
+    await this.tryCompressChat(chat, promptId, combinedSignal);
 
     const { functionCalls } = await promptIdContext.run(promptId, async () =>
       this.callModel(chat, currentMessage, combinedSignal, promptId),
@@ -668,6 +668,7 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
   private async tryCompressChat(
     chat: GeminiChat,
     prompt_id: string,
+    abortSignal?: AbortSignal,
   ): Promise<void> {
     const model = this.definition.modelConfig.model ?? DEFAULT_GEMINI_MODEL;
 
@@ -678,6 +679,7 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
       model,
       this.runtimeContext,
       this.hasFailedCompressionAttempt,
+      abortSignal,
     );
 
     if (

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -574,7 +574,7 @@ export class GeminiClient {
     // Check for context window overflow
     const modelForLimitCheck = this._getActiveModelForCurrentTurn();
 
-    const compressed = await this.tryCompressChat(prompt_id, false);
+    const compressed = await this.tryCompressChat(prompt_id, false, signal);
 
     if (compressed.compressionStatus === CompressionStatus.COMPRESSED) {
       yield { type: GeminiEventType.ChatCompressed, value: compressed };
@@ -1049,6 +1049,7 @@ export class GeminiClient {
   async tryCompressChat(
     prompt_id: string,
     force: boolean = false,
+    abortSignal?: AbortSignal,
   ): Promise<ChatCompressionInfo> {
     // If the model is 'auto', we will use a placeholder model to check.
     // Compression occurs before we choose a model, so calling `count_tokens`
@@ -1062,6 +1063,7 @@ export class GeminiClient {
       model,
       this.config,
       this.hasFailedCompressionAttempt,
+      abortSignal,
     );
 
     if (


### PR DESCRIPTION
## Summary

- Thread the parent abort signal from `processTurn` and `executeTurn` through `tryCompressChat` into the compression service
- Ctrl+C during chat compression now cancels the in-flight `generateContent` API calls immediately

## Details

When the CLI triggers chat compression (summarization + verification LLM calls), pressing Ctrl+C didn't cancel the underlying API requests. Both `generateContent` calls in `chatCompressionService.compress()` were receiving a throwaway `new AbortController().signal` because `tryCompressChat` in both `client.ts` and `local-executor.ts` never forwarded the parent abort signal.

The fix adds an optional `abortSignal` parameter to both `tryCompressChat` methods and passes through the signals that are already available at the call sites (`signal` in `processTurn`, `combinedSignal` in `executeTurn`).

## Related Issues

Fixes #20405

## How to Validate

1. Start a long conversation that triggers chat compression
2. Press Ctrl+C while compression is running
3. Verify the API calls are cancelled immediately (no lingering requests)

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) — N/A
- [x] Added/updated tests (if needed) — Existing tests cover the compression flow; typecheck confirms signature compatibility
- [x] Noted breaking changes (if any) — None (parameter is optional)
- [x] Validated on required platforms/methods:
  - [x] Linux `npm run`