### PR TITLE
test(cli): fix flaky ToolResultDisplay overflow test

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolResultDisplayOverflow.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolResultDisplayOverflow.test.tsx
@@ -8,7 +8,6 @@ import { describe, it, expect } from 'vitest';
 import { ToolGroupMessage } from './ToolGroupMessage.js';
 import { renderWithProviders } from '../../../test-utils/render.js';
 import { StreamingState, type IndividualToolCallDisplay } from '../../types.js';
-import { OverflowProvider } from '../../contexts/OverflowContext.js';
 import { waitFor } from '../../../test-utils/async.js';
 import { CoreToolCallStatus } from '@google/gemini-cli-core';
 
@@ -32,16 +31,14 @@ describe('ToolResultDisplay Overflow', () => {
       },
     ];
 
-    const { lastFrame } = renderWithProviders(
-      <OverflowProvider>
-        <ToolGroupMessage
-          item={{ id: 1, type: 'tool_group', tools: toolCalls }}
-          toolCalls={toolCalls}
-          availableTerminalHeight={15} // Small height to force overflow
-          terminalWidth={80}
-          isExpandable={true}
-        />
-      </OverflowProvider>,
+    const { lastFrame, waitUntilReady } = renderWithProviders(
+      <ToolGroupMessage
+        item={{ id: 1, type: 'tool_group', tools: toolCalls }}
+        toolCalls={toolCalls}
+        availableTerminalHeight={15} // Small height to force overflow
+        terminalWidth={80}
+        isExpandable={true}
+      />,
       {
         uiState: {
           streamingState: StreamingState.Idle,
@@ -51,12 +48,13 @@ describe('ToolResultDisplay Overflow', () => {
       },
     );
 
-    // ResizeObserver might take a tick
-    await waitFor(() =>
-      expect(lastFrame()?.toLowerCase()).toContain(
-        'press ctrl+o to show more lines',
-      ),
-    );
+    await waitUntilReady();
+
+    // ResizeObserver might take a tick, though ToolGroupMessage calculates overflow synchronously
+    await waitFor(() => {
+      const frame = lastFrame();
+      expect(frame.toLowerCase()).toContain('press ctrl+o to show more lines');
+    });
 
     const frame = lastFrame();
     expect(frame).toBeDefined();


### PR DESCRIPTION
## Summary
This PR fixes the flaky test `should display "press ctrl-o" hint when content overflows in ToolGroupMessage` in `packages/cli/src/ui/components/messages/ToolResultDisplayOverflow.test.tsx`.

## Details
The flakiness appears to be caused by a race condition between Ink's asynchronous layout measurement/scrolling and the test's assertions. By calling `waitUntilReady()`, we ensure that the layout effects (like `useLayoutEffect` for content measurement) have settled and the terminal output has stabilized before we check for the overflow hint. Additionally, a redundant `OverflowProvider` was removed as `renderWithProviders` already includes one.

## Related Issues
Fixes #20511

## How to Validate
Run the test multiple times to verify it is no longer flaky:
`for i in {1..20}; do npm test -w @google/gemini-cli -- src/ui/components/messages/ToolResultDisplayOverflow.test.tsx || exit 1; done`

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
