### PR TITLE
Add support for ssh:// URLs in extension installation.

### DIFF
--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -1150,7 +1150,8 @@ export async function inferInstallMetadata(
     source.startsWith('http://') ||
     source.startsWith('https://') ||
     source.startsWith('git@') ||
-    source.startsWith('sso://')
+    source.startsWith('sso://') ||
+    source.startsWith('ssh://')
   ) {
     return {
       source,


### PR DESCRIPTION
## Summary

This PR adds support for `ssh://` protocols when installing extensions. It ensures that remote repositories accessed via SSH (such as those hosted on Gerrit) are correctly identified as Git sources rather than local file paths.

## Details

In the `inferInstallMetadata` function, the logic for distinguishing between remote git sources and local directories was missing the `ssh://` prefix. This caused the CLI to mistakenly categorize SSH URLs as local paths, leading to errors when users attempted to use git-specific options like `--ref` or `--auto-update` (e.g.,
receiving the error: `"--ref and --auto-update are not applicable for local extensions."`).

By adding `ssh://` to the recognized protocol list, these sources are now correctly passed to the git cloning logic.

## Related Issues

Fixes the issue where extensions using `ssh://` URLs could not be installed with a specific `--ref`.

## How to Validate

1. Run the extension install command using an SSH URL and a git ref: `gemini extensions install ssh://sample.com/your-repo --ref development`
2. **Expected Result:** The extension is cloned successfully from the remote source using the specified branch.
3. **Actual Result (before fix):** The command fails with `Error: --ref and --auto-update are not applicable for local extensions.`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
  - [ ] Windows
  - [x] Linux
    - [x] npm run
    - [x] npx
