### PR TITLE
fix(core): revert auto-save of policies to user space

### DIFF
--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -169,10 +169,7 @@ export class Storage {
   }
 
   getAutoSavedPolicyPath(): string {
-    return path.join(
-      this.getWorkspacePoliciesDir(),
-      AUTO_SAVED_POLICY_FILENAME,
-    );
+    return path.join(Storage.getUserPoliciesDir(), AUTO_SAVED_POLICY_FILENAME);
   }
 
   ensureProjectTempDirExists(): void {

--- a/packages/core/src/policy/config.ts
+++ b/packages/core/src/policy/config.ts
@@ -447,9 +447,8 @@ export function createPolicyUpdater(
       if (message.persist) {
         persistenceQueue = persistenceQueue.then(async () => {
           try {
-            const workspacePoliciesDir = storage.getWorkspacePoliciesDir();
-            await fs.mkdir(workspacePoliciesDir, { recursive: true });
             const policyFile = storage.getAutoSavedPolicyPath();
+            await fs.mkdir(path.dirname(policyFile), { recursive: true });
 
             // Read existing file
             let existingData: { rule?: TomlRule[] } = {};

--- a/packages/core/src/policy/persistence.test.ts
+++ b/packages/core/src/policy/persistence.test.ts
@@ -48,14 +48,8 @@ describe('createPolicyUpdater', () => {
   it('should persist policy when persist flag is true', async () => {
     createPolicyUpdater(policyEngine, messageBus, mockStorage);
 
-    const workspacePoliciesDir = '/mock/project/.gemini/policies';
-    const policyFile = path.join(
-      workspacePoliciesDir,
-      AUTO_SAVED_POLICY_FILENAME,
-    );
-    vi.spyOn(mockStorage, 'getWorkspacePoliciesDir').mockReturnValue(
-      workspacePoliciesDir,
-    );
+    const userPoliciesDir = '/mock/user/.gemini/policies';
+    const policyFile = path.join(userPoliciesDir, AUTO_SAVED_POLICY_FILENAME);
     vi.spyOn(mockStorage, 'getAutoSavedPolicyPath').mockReturnValue(policyFile);
     (fs.mkdir as unknown as Mock).mockResolvedValue(undefined);
     (fs.readFile as unknown as Mock).mockRejectedValue(
@@ -79,8 +73,7 @@ describe('createPolicyUpdater', () => {
     // Wait for async operations (microtasks)
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(mockStorage.getWorkspacePoliciesDir).toHaveBeenCalled();
-    expect(fs.mkdir).toHaveBeenCalledWith(workspacePoliciesDir, {
+    expect(fs.mkdir).toHaveBeenCalledWith(userPoliciesDir, {
       recursive: true,
     });
 
@@ -115,14 +108,8 @@ describe('createPolicyUpdater', () => {
   it('should persist policy with commandPrefix when provided', async () => {
     createPolicyUpdater(policyEngine, messageBus, mockStorage);
 
-    const workspacePoliciesDir = '/mock/project/.gemini/policies';
-    const policyFile = path.join(
-      workspacePoliciesDir,
-      AUTO_SAVED_POLICY_FILENAME,
-    );
-    vi.spyOn(mockStorage, 'getWorkspacePoliciesDir').mockReturnValue(
-      workspacePoliciesDir,
-    );
+    const userPoliciesDir = '/mock/user/.gemini/policies';
+    const policyFile = path.join(userPoliciesDir, AUTO_SAVED_POLICY_FILENAME);
     vi.spyOn(mockStorage, 'getAutoSavedPolicyPath').mockReturnValue(policyFile);
     (fs.mkdir as unknown as Mock).mockResolvedValue(undefined);
     (fs.readFile as unknown as Mock).mockRejectedValue(
@@ -168,14 +155,8 @@ describe('createPolicyUpdater', () => {
   it('should persist policy with mcpName and toolName when provided', async () => {
     createPolicyUpdater(policyEngine, messageBus, mockStorage);
 
-    const workspacePoliciesDir = '/mock/project/.gemini/policies';
-    const policyFile = path.join(
-      workspacePoliciesDir,
-      AUTO_SAVED_POLICY_FILENAME,
-    );
-    vi.spyOn(mockStorage, 'getWorkspacePoliciesDir').mockReturnValue(
-      workspacePoliciesDir,
-    );
+    const userPoliciesDir = '/mock/user/.gemini/policies';
+    const policyFile = path.join(userPoliciesDir, AUTO_SAVED_POLICY_FILENAME);
     vi.spyOn(mockStorage, 'getAutoSavedPolicyPath').mockReturnValue(policyFile);
     (fs.mkdir as unknown as Mock).mockResolvedValue(undefined);
     (fs.readFile as unknown as Mock).mockRejectedValue(
@@ -214,14 +195,8 @@ describe('createPolicyUpdater', () => {
   it('should escape special characters in toolName and mcpName', async () => {
     createPolicyUpdater(policyEngine, messageBus, mockStorage);
 
-    const workspacePoliciesDir = '/mock/project/.gemini/policies';
-    const policyFile = path.join(
-      workspacePoliciesDir,
-      AUTO_SAVED_POLICY_FILENAME,
-    );
-    vi.spyOn(mockStorage, 'getWorkspacePoliciesDir').mockReturnValue(
-      workspacePoliciesDir,
-    );
+    const userPoliciesDir = '/mock/user/.gemini/policies';
+    const policyFile = path.join(userPoliciesDir, AUTO_SAVED_POLICY_FILENAME);
     vi.spyOn(mockStorage, 'getAutoSavedPolicyPath').mockReturnValue(policyFile);
     (fs.mkdir as unknown as Mock).mockResolvedValue(undefined);
     (fs.readFile as unknown as Mock).mockRejectedValue(

--- a/packages/core/src/policy/policy-updater.test.ts
+++ b/packages/core/src/policy/policy-updater.test.ts
@@ -50,8 +50,8 @@ describe('createPolicyUpdater', () => {
 
     messageBus = new MessageBus(policyEngine);
     mockStorage = new Storage('/mock/project');
-    vi.spyOn(mockStorage, 'getWorkspacePoliciesDir').mockReturnValue(
-      '/mock/project/.gemini/policies',
+    vi.spyOn(mockStorage, 'getAutoSavedPolicyPath').mockReturnValue(
+      '/mock/user/.gemini/policies/auto-saved.toml',
     );
   });
 


### PR DESCRIPTION
## Summary

Reverts the auto-save of tool approval policies from the workspace directory back to the global user space (~/.gemini/policies). This is necessary because workspace policies are being temporarily disabled to simplify policy management.

## Details

- Updated `Storage.getAutoSavedPolicyPath` in `packages/core/src/config/storage.ts` to use `getUserPoliciesDir()`.
- Modified `createPolicyUpdater` in `packages/core/src/policy/config.ts` to ensure the parent directory of the policy file is created before writing. This handles cases where `~/.gemini/policies` might not exist.
- Updated persistence tests to reflect the change in storage location and removed redundant mocks for `workspacePoliciesDir`.

## Related Issues

Fixes #20530
Related to #20522

## How to Validate

1. Run the CLI in a workspace.
2. Perform an action that triggers a policy auto-save (e.g., "always allow" a tool).
3. Verify that `auto-saved.toml` is created in `~/.gemini/policies/` and NOT in the workspace's `.gemini/policies/`.
4. Run persistence tests: `npm test -w @google/gemini-cli-core -- src/policy/persistence.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
