### PR TITLE
refactor(policy): use tier constants in tests instead of hardcoded priorities

### DIFF
--- a/packages/core/src/agents/registry.test.ts
+++ b/packages/core/src/agents/registry.test.ts
@@ -30,6 +30,7 @@ import type { ToolRegistry } from '../tools/tool-registry.js';
 import { ThinkingLevel } from '@google/genai';
 import type { AcknowledgedAgentsService } from './acknowledgedAgents.js';
 import { PolicyDecision } from '../policy/types.js';
+import { DEFAULT_POLICY_TIER } from '../policy/config.js';
 
 vi.mock('./agentLoader.js', () => ({
   loadAgentsFromDirectory: vi
@@ -678,7 +679,7 @@ describe('AgentRegistry', () => {
         expect.objectContaining({
           toolName: 'PolicyTestAgent',
           decision: PolicyDecision.ALLOW,
-          priority: 1.05,
+          priority: DEFAULT_POLICY_TIER + 0.05,
         }),
       );
     });
@@ -705,7 +706,7 @@ describe('AgentRegistry', () => {
         expect.objectContaining({
           toolName: 'RemotePolicyAgent',
           decision: PolicyDecision.ASK_USER,
-          priority: 1.05,
+          priority: DEFAULT_POLICY_TIER + 0.05,
         }),
       );
     });

--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -1550,8 +1550,6 @@ describe('PolicyEngine', () => {
 
   describe('Plan Mode vs Subagent Priority (Regression)', () => {
     it('should DENY subagents in Plan Mode despite dynamic allow rules', async () => {
-      // Plan Mode Deny (1.06) > Subagent Allow (1.05)
-
       const fixedRules: PolicyRule[] = [
         {
           decision: PolicyDecision.DENY,

--- a/packages/core/src/policy/workspace-policy.test.ts
+++ b/packages/core/src/policy/workspace-policy.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import nodePath from 'node:path';
 import { ApprovalMode } from './types.js';
+import { USER_POLICY_TIER } from './config.js';
 import { isDirectorySecure } from '../utils/security.js';
 
 // Mock dependencies
@@ -145,7 +146,7 @@ priority = 10
     // Check for all 4 rules
     const defaultRule = rules?.find((r) => r.priority === 1.01);
     const workspaceRule = rules?.find((r) => r.priority === 2.01);
-    const userRule = rules?.find((r) => r.priority === 3.01);
+    const userRule = rules?.find((r) => r.priority === USER_POLICY_TIER + 0.01);
     const adminRule = rules?.find((r) => r.priority === 4.01);
 
     expect(defaultRule).toBeDefined();


### PR DESCRIPTION
## Summary
- Replace hardcoded policy priority float literals in policy-related tests with tier constants and exported priority constants.
- Keep assertions behavior-equivalent while making test intent resilient to tier value refactors.

## Testing
- npx -y npm@11 --prefix "/root/projects/pr-factory/gemini-cli" run preflight

Fixes #20464