### PR TITLE
fix(evals): use top-level timeout in answer-vs-act eval

### DIFF
--- a/evals/answer-vs-act.eval.ts
+++ b/evals/answer-vs-act.eval.ts
@@ -138,7 +138,7 @@ describe('Answer vs. ask eval', () => {
     name: 'should not edit files when user notes an issue',
     prompt: 'The add function subtracts numbers.',
     files: FILES,
-    params: { timeout: 20000 }, // 20s timeout
+    timeout: 20000, // 20s timeout
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
 


### PR DESCRIPTION
## Summary

Fixes #20649

This PR fixes a behavioral eval configuration bug where a timeout was defined in the wrong field and therefore ignored by the eval harness.

**Impact**
- Ensures the intended 20s timeout is enforced for the affected eval case.
- Prevents unintended long-running behavior for that scenario.

## Details

### What changed
- Updated one test case in [evals/answer-vs-act.eval.ts](evals/answer-vs-act.eval.ts):
  - From: `params: { timeout: 20000 }`
  - To: `timeout: 20000`

### Why this is correct
- The harness uses top-level `evalCase.timeout` when running tests.
- `evalCase.params` is used for rig setup, not runtime timeout control.

### Scope
- Single-file, single-line functional change.
- No API or product behavior changes outside this eval case.

## Related Issues

Related to timeout wiring bug in behavioral eval configuration.

## How to Validate

1. Confirm the PR scope:
   - `git diff -- evals/answer-vs-act.eval.ts`
   - Expected: only timeout field placement changed.

2. Confirm harness expectation:
   - Verify timeout is consumed via top-level `evalCase.timeout` in [evals/test-helper.ts](evals/test-helper.ts).

3. Run targeted eval (requires API key):
   - PowerShell:
     - `$env:GEMINI_API_KEY="<your_key>"`
     - `npm run test:all_evals -- evals/answer-vs-act.eval.ts -t "should not edit files when user notes an issue"`
   - Expected:
     - Test runs with configured timeout path from top-level field.

4. Confirm no extra files:
   - `git status --short`
   - Expected: only [evals/answer-vs-act.eval.ts](evals/answer-vs-act.eval.ts) in this PR.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) — None
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run (targeted command path validated; full pass requires `GEMINI_API_KEY`)
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker