### PR TITLE
fix(core): remove unsafe type assertions in multimodal content pipeline

### DIFF
--- a/packages/core/src/utils/partUtils.test.ts
+++ b/packages/core/src/utils/partUtils.test.ts
@@ -90,6 +90,11 @@ describe('partUtils', () => {
       expect(partToString(part, verboseOptions)).toBe('[Thought: thinking]');
     });
 
+    it('should handle thought part with undefined text', () => {
+      const part: Part = { thought: true };
+      expect(partToString(part, verboseOptions)).toBe('[Thought: ]');
+    });
+
     it('should return descriptive string for codeExecutionResult part', () => {
       const part = { codeExecutionResult: {} } as Part;
       expect(partToString(part, verboseOptions)).toBe(

--- a/packages/core/src/utils/partUtils.test.ts
+++ b/packages/core/src/utils/partUtils.test.ts
@@ -86,7 +86,7 @@ describe('partUtils', () => {
     });
 
     it('should return descriptive string for thought part', () => {
-      const part = { thought: 'thinking' } as unknown as Part;
+      const part: Part = { thought: true, text: 'thinking' };
       expect(partToString(part, verboseOptions)).toBe('[Thought: thinking]');
     });
 

--- a/packages/core/src/utils/partUtils.ts
+++ b/packages/core/src/utils/partUtils.ts
@@ -29,21 +29,17 @@ export function partToString(
     return value.map((part) => partToString(part, options)).join('');
   }
 
-  // Cast to Part, assuming it might contain project-specific fields
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-  const part = value as Part & {
-    videoMetadata?: unknown;
-    thought?: string;
-    codeExecutionResult?: unknown;
-    executableCode?: unknown;
-  };
+  // After ruling out string and array, value is narrowed to Part.
+  // All checked fields (videoMetadata, thought, codeExecutionResult,
+  // executableCode) are declared on the Part interface from @google/genai.
+  const part: Part = value;
 
   if (options?.verbose) {
     if (part.videoMetadata !== undefined) {
       return `[Video Metadata]`;
     }
     if (part.thought !== undefined) {
-      return `[Thought: ${part.thought}]`;
+      return `[Thought: ${part.text ?? ''}]`;
     }
     if (part.codeExecutionResult !== undefined) {
       return `[Code Execution Result]`;


### PR DESCRIPTION
Related to #19735

## Summary

Remove three `@typescript-eslint/no-unsafe-type-assertion` eslint-disable
suppressions from the multimodal content handling path (`partUtils.ts` and
`mcp-tool.ts`), replacing unsafe `as` casts with proper runtime type guards.

## Changes

### `partUtils.ts` — Remove redundant intersection cast

The `partToString()` function cast `value` to `Part & { videoMetadata?; thought?; codeExecutionResult?; executableCode? }` with an eslint-disable suppression. However, all four fields already exist on the `Part` interface from `@google/genai`, making the intersection cast unnecessary. After ruling out `string` and `Array` in the preceding checks, TypeScript correctly narrows `value` to `Part`.

Also fixes the verbose thought display: the old code interpolated `part.thought` (a `boolean` flag) instead of `part.text` (the actual thought content). This aligns with how the rest of the codebase handles thought parts (e.g., `turn.ts`, `semantic.ts`).

### `mcp-tool.ts` — Replace two unsafe casts with shared helper

Both `transformMcpContentToParts()` and `getStringifiedResultForDisplay()` extracted MCP content via:
```ts
funcResponse?.response?.['content'] as McpContentBlock[]
```
Since `response` is `Record<string, unknown>`, the `['content']` access returns `unknown`, making the `as McpContentBlock[]` cast unsafe.

**Fix:** Extract a shared `parseMcpContent()` helper that:
1. Reads `['content']` as `unknown`
2. Validates it's an array via `Array.isArray()`
3. Filters elements through an `isMcpContentBlock()` type guard (checks for `typeof value === 'object'` with a string `type` field)
4. Returns `McpContentBlock[] | null`

The type guard intentionally checks only the basic block shape (object with string `type`) rather than validating against known type values, so that unrecognised block types still flow through to each consumer's `default` switch case for display.

### `partUtils.test.ts` — Fix incorrect test mock

Updated the thought part test to use the correct `Part` shape (`{ thought: true, text: 'thinking' }`) instead of the invalid `{ thought: 'thinking' }` which required a double cast through `unknown`.

## Verification

- `npx tsc --noEmit` — zero errors
- `npx eslint` — zero errors on all modified files, no remaining suppressions
- `npx vitest run` — 80/80 tests pass (37 partUtils + 43 mcp-tool)