### PR TITLE
fix(core): disable retries for code assist oauth and server requests

### DIFF
--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -138,6 +138,7 @@ async function initOauthClient(
     clientSecret: OAUTH_CLIENT_SECRET,
     transporterOptions: {
       proxy: config.getProxy(),
+      retry: false,
     },
   });
   const useEncryptedStorage = getUseEncryptedStorageFlag();

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -305,6 +305,7 @@ export class CodeAssistServer implements ContentGenerator {
       responseType: 'json',
       body: JSON.stringify(req),
       signal,
+      retry: false,
     });
     return res.data;
   }


### PR DESCRIPTION
## Summary

This PR disables retries for OAuth client and server requests within the Code Assist functionality. By setting `retry: false` in both `oauth2.ts` and `server.ts`, we prevent unnecessary retry attempts for these specific operations, as we are handling our own retries in retryWithBackoff in retry.ts.

## Details

- In `packages/core/src/code_assist/oauth2.ts`, the `transporterOptions` for the Google OAuth2 client now includes `retry: false`.
- In `packages/core/src/code_assist/server.ts`, the fetch call in `CodeAssistServer` now includes `retry: false` in its options.

## Related Issues

Fixes #20557

## How to Validate

1. Verify that Code Assist requests do not perform automatic retries upon receiving a failure response from the server or during the OAuth handshake.
2. Ensure that the error handling for these requests still functions correctly as expected.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
