### PR TITLE
fix(core): disable retries for code assist streaming requests

### DIFF
--- a/packages/core/src/code_assist/server.test.ts
+++ b/packages/core/src/code_assist/server.test.ts
@@ -84,6 +84,7 @@ describe('CodeAssistServer', () => {
       body: expect.any(String),
       signal: undefined,
       retryConfig: {
+        retryDelay: 1000,
         retry: 3,
         noResponseRetries: 3,
         statusCodesToRetry: [
@@ -410,15 +411,7 @@ describe('CodeAssistServer', () => {
         'Content-Type': 'application/json',
       },
       signal: undefined,
-      retryConfig: {
-        retry: 3,
-        noResponseRetries: 3,
-        statusCodesToRetry: [
-          [429, 429],
-          [499, 499],
-          [500, 599],
-        ],
-      },
+      retry: false,
     });
 
     expect(results).toHaveLength(2);

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -62,6 +62,7 @@ export interface HttpOptions {
 
 export const CODE_ASSIST_ENDPOINT = 'https://cloudcode-pa.googleapis.com';
 export const CODE_ASSIST_API_VERSION = 'v1internal';
+const GENERATE_CONTENT_RETRY_DELAY_IN_MILLISECONDS = 1000;
 
 export class CodeAssistServer implements ContentGenerator {
   constructor(
@@ -141,6 +142,7 @@ export class CodeAssistServer implements ContentGenerator {
         this.sessionId,
       ),
       req.config?.abortSignal,
+      GENERATE_CONTENT_RETRY_DELAY_IN_MILLISECONDS,
     );
     const duration = formatProtoJsonDuration(Date.now() - start);
     const streamingLatency: StreamingLatency = {
@@ -294,6 +296,7 @@ export class CodeAssistServer implements ContentGenerator {
     method: string,
     req: object,
     signal?: AbortSignal,
+    retryDelay: number = 100,
   ): Promise<T> {
     const res = await this.client.request<T>({
       url: this.getMethodUrl(method),
@@ -305,6 +308,9 @@ export class CodeAssistServer implements ContentGenerator {
       responseType: 'json',
       body: JSON.stringify(req),
       signal,
+      retryConfig: {
+        retryDelay,
+      },
     });
     return res.data;
   }
@@ -352,6 +358,7 @@ export class CodeAssistServer implements ContentGenerator {
       responseType: 'stream',
       body: JSON.stringify(req),
       signal,
+      retry: false,
     });
 
     return (async function* (): AsyncGenerator<T> {


### PR DESCRIPTION
## Summary

This PR disables retries for Code Assist streaming requests, as we are doing retries in two places.
By setting `retry: false` in `requestStreamingPost` within `server.ts`, we ensure that streaming operations (like `streamGenerateContent`) do not perform automatic retries, as we also have our retries logic in retry.ts with more robust retry logic that has exponential backoffs and UI integration.
Also increase the delay for generateContent to 1000 ms from 100 ms (Gaxios retry default = 100ms) for other non-streaming model calls.

## Details

- Modified `packages/core/src/code_assist/server.ts`: Added `retry: false` to the `client.request` options in `requestStreamingPost`.

## Related Issues

Fixes #20560

## How to Validate

1. Trigger a Code Assist streaming request (e.g., via `generateContentStream`).
2. Simulate a network failure or a non-terminal error status that would normally trigger a retry.
3. Verify that the request fails immediately without attempting a retry.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
