### PR TITLE
fix(cli): show thinking summary when ui.loadingPhrases is off

### DIFF
--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -229,8 +229,7 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
                 inline
                 thought={
                   uiState.streamingState ===
-                    StreamingState.WaitingForConfirmation ||
-                  settings.merged.ui.loadingPhrases === 'off'
+                  StreamingState.WaitingForConfirmation
                     ? undefined
                     : uiState.thought
                 }
@@ -273,8 +272,7 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
                   inline
                   thought={
                     uiState.streamingState ===
-                      StreamingState.WaitingForConfirmation ||
-                    settings.merged.ui.loadingPhrases === 'off'
+                    StreamingState.WaitingForConfirmation
                       ? undefined
                       : uiState.thought
                   }


### PR DESCRIPTION
Right now if you set ui.loadingPhrases to "off" in settings, the thought prop on both LoadingIndicator instances in Composer.tsx gets set to undefined alongside currentLoadingPhrase. The intent of that setting is to disable the random loading phrases (like "Brewing coffee..."), but the current code also kills the thinking/thought summary that comes from the model's intermediate reasoning, which is a totally different thing.

The fix is straightforward — I just removed the loadingPhrases === 'off' check from the thought prop while keeping it on currentLoadingPhrase where it belongs. So now when you turn off loading phrases you still get to see the thinking summary, and the random phrases are properly hidden. Both LoadingIndicator instances (the full one and the minimal one) are fixed.

Closes #20496.