### PR TITLE
fix(cli): prevent sub-agent tool calls from leaking into UI

### DIFF
--- a/packages/cli/src/ui/hooks/useToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.ts
@@ -115,6 +115,12 @@ export function useToolScheduler(
 
   useEffect(() => {
     const handler = (event: ToolCallsUpdateMessage) => {
+      // Only process updates for the root scheduler.
+      // Subagent internal tools should not be displayed in the main tool list.
+      if (event.schedulerId !== ROOT_SCHEDULER_ID) {
+        return;
+      }
+
       // Update output timer for UI spinners (Side Effect)
       const hasExecuting = event.toolCalls.some(
         (tc) =>


### PR DESCRIPTION
## Summary

Filters tool call updates in the CLI UI to only process those from the root scheduler. This prevents internal sub-agent tool calls from leaking into the main UI.

## Details

- Modified `useToolScheduler.ts` to only process events where `schedulerId` matches `ROOT_SCHEDULER_ID`.
- Updated unit tests in `useToolScheduler.test.ts` to ensure non-root updates are ignored and existing root tools are preserved correctly.

## Related Issues

N/A

## How to Validate

Run the unit tests for the tool scheduler:
```bash
npm test -w @google/gemini-cli-cli -- src/ui/hooks/useToolScheduler.test.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
