### PR TITLE
refactor(core): replace manual syncPlanModeTools with declarative policy rules

### DIFF
--- a/integration-tests/plan-mode.test.ts
+++ b/integration-tests/plan-mode.test.ts
@@ -182,10 +182,7 @@ describe('Plan Mode', () => {
         'I want to perform a complex refactoring. Please enter plan mode so we can design it first.',
     });
 
-    const enterPlanCallFound = await rig.waitForToolCall(
-      'enter_plan_mode',
-      10000,
-    );
+    const enterPlanCallFound = await rig.waitForToolCall('enter_plan_mode');
     expect(enterPlanCallFound, 'Expected enter_plan_mode to be called').toBe(
       true,
     );

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -370,10 +370,6 @@ import { McpClientManager } from '../tools/mcp-client-manager.js';
 import { type McpContext } from '../tools/mcp-client.js';
 import type { EnvironmentSanitizationConfig } from '../services/environmentSanitization.js';
 import { getErrorMessage } from '../utils/errors.js';
-import {
-  ENTER_PLAN_MODE_TOOL_NAME,
-  EXIT_PLAN_MODE_TOOL_NAME,
-} from '../tools/tool-names.js';
 
 export type { FileFilteringOptions };
 export {
@@ -1172,7 +1168,6 @@ export class Config implements McpContext {
     }
 
     await this.geminiClient.initialize();
-    this.syncPlanModeTools();
     this.initialized = true;
   }
 
@@ -1998,49 +1993,12 @@ export class Config implements McpContext {
       (currentMode === ApprovalMode.YOLO || mode === ApprovalMode.YOLO);
 
     if (isPlanModeTransition || isYoloModeTransition) {
-      this.syncPlanModeTools();
+      if (this.geminiClient?.isInitialized()) {
+        this.geminiClient.setTools().catch((err) => {
+          debugLogger.error('Failed to update tools', err);
+        });
+      }
       this.updateSystemInstructionIfInitialized();
-    }
-  }
-
-  /**
-   * Synchronizes enter/exit plan mode tools based on current mode.
-   */
-  syncPlanModeTools(): void {
-    const registry = this.getToolRegistry();
-    if (!registry) {
-      return;
-    }
-    const approvalMode = this.getApprovalMode();
-    const isPlanMode = approvalMode === ApprovalMode.PLAN;
-    const isYoloMode = approvalMode === ApprovalMode.YOLO;
-
-    if (isPlanMode) {
-      if (registry.getTool(ENTER_PLAN_MODE_TOOL_NAME)) {
-        registry.unregisterTool(ENTER_PLAN_MODE_TOOL_NAME);
-      }
-      if (!registry.getTool(EXIT_PLAN_MODE_TOOL_NAME)) {
-        registry.registerTool(new ExitPlanModeTool(this, this.messageBus));
-      }
-    } else {
-      if (registry.getTool(EXIT_PLAN_MODE_TOOL_NAME)) {
-        registry.unregisterTool(EXIT_PLAN_MODE_TOOL_NAME);
-      }
-      if (this.planEnabled && !isYoloMode) {
-        if (!registry.getTool(ENTER_PLAN_MODE_TOOL_NAME)) {
-          registry.registerTool(new EnterPlanModeTool(this, this.messageBus));
-        }
-      } else {
-        if (registry.getTool(ENTER_PLAN_MODE_TOOL_NAME)) {
-          registry.unregisterTool(ENTER_PLAN_MODE_TOOL_NAME);
-        }
-      }
-    }
-
-    if (this.geminiClient?.isInitialized()) {
-      this.geminiClient.setTools().catch((err) => {
-        debugLogger.error('Failed to update tools', err);
-      });
     }
   }
 

--- a/packages/core/src/policy/policies/plan.toml
+++ b/packages/core/src/policy/policies/plan.toml
@@ -55,6 +55,13 @@ decision = "ask_user"
 priority = 70
 modes = ["plan"]
 
+[[rule]]
+toolName = "enter_plan_mode"
+decision = "deny"
+priority = 70
+modes = ["plan"]
+deny_message = "You are already in Plan Mode."
+
 # Allow write_file and replace for .md files in the plans directory (cross-platform)
 [[rule]]
 toolName = ["write_file", "replace"]

--- a/packages/core/src/policy/policies/plan.toml
+++ b/packages/core/src/policy/policies/plan.toml
@@ -5,26 +5,54 @@
 #
 # Priority bands (tiers):
 # - Default policies (TOML): 1 + priority/1000 (e.g., priority 100 → 1.100)
-# - Workspace policies (TOML): 2 + priority/1000 (e.g., priority 100 → 2.100)
-# - User policies (TOML): 3 + priority/1000 (e.g., priority 100 → 3.100)
-# - Admin policies (TOML): 4 + priority/1000 (e.g., priority 100 → 4.100)
+# - Extension policies (TOML): 2 + priority/1000 (e.g., priority 100 → 2.100)
+# - Workspace policies (TOML): 3 + priority/1000 (e.g., priority 100 → 3.100)
+# - User policies (TOML): 4 + priority/1000 (e.g., priority 100 → 4.100)
+# - Admin policies (TOML): 5 + priority/1000 (e.g., priority 100 → 5.100)
 #
-# This ensures Admin > User > Workspace > Default hierarchy is always preserved,
+# This ensures Admin > User > Workspace > Extension > Default hierarchy is always preserved,
 # while allowing user-specified priorities to work within each tier.
 #
-# Settings-based and dynamic rules (all in user tier 3.x):
-#   3.95: Tools that the user has selected as "Always Allow" in the interactive UI
-#   3.9:  MCP servers excluded list (security: persistent server blocks)
-#   3.4:  Command line flag --exclude-tools (explicit temporary blocks)
-#   3.3:  Command line flag --allowed-tools (explicit temporary allows)
-#   3.2:  MCP servers with trust=true (persistent trusted servers)
-#   3.1:  MCP servers allowed list (persistent general server allows)
+# Settings-based and dynamic rules (all in user tier 4.x):
+#   4.95: Tools that the user has selected as "Always Allow" in the interactive UI
+#   4.9:  MCP servers excluded list (security: persistent server blocks)
+#   4.4:  Command line flag --exclude-tools (explicit temporary blocks)
+#   4.3:  Command line flag --allowed-tools (explicit temporary allows)
+#   4.2:  MCP servers with trust=true (persistent trusted servers)
+#   4.1:  MCP servers allowed list (persistent general server allows)
 #
 # TOML policy priorities (before transformation):
 #   10: Write tools default to ASK_USER (becomes 1.010 in default tier)
 #   60: Plan mode catch-all DENY override (becomes 1.060 in default tier)
 #   70: Plan mode explicit ALLOW override (becomes 1.070 in default tier)
 #   999: YOLO mode allow-all (becomes 1.999 in default tier)
+
+# Mode Transitions (into/out of Plan Mode)
+
+[[rule]]
+toolName = "enter_plan_mode"
+decision = "ask_user"
+priority = 50
+
+[[rule]]
+toolName = "enter_plan_mode"
+decision = "deny"
+priority = 70
+modes = ["plan"]
+deny_message = "You are already in Plan Mode."
+
+[[rule]]
+toolName = "exit_plan_mode"
+decision = "ask_user"
+priority = 70
+modes = ["plan"]
+
+[[rule]]
+toolName = "exit_plan_mode"
+decision = "deny"
+priority = 50
+deny_message = "You are not currently in Plan Mode. Use enter_plan_mode first to design a plan."
+
 
 # Catch-All: Deny everything by default in Plan mode.
 
@@ -50,17 +78,10 @@ priority = 70
 modes = ["plan"]
 
 [[rule]]
-toolName = ["ask_user", "exit_plan_mode", "save_memory"]
+toolName = ["ask_user", "save_memory"]
 decision = "ask_user"
 priority = 70
 modes = ["plan"]
-
-[[rule]]
-toolName = "enter_plan_mode"
-decision = "deny"
-priority = 70
-modes = ["plan"]
-deny_message = "You are already in Plan Mode."
 
 # Allow write_file and replace for .md files in the plans directory (cross-platform)
 [[rule]]

--- a/packages/core/src/policy/policies/read-only.toml
+++ b/packages/core/src/policy/policies/read-only.toml
@@ -5,20 +5,21 @@
 #
 # Priority bands (tiers):
 # - Default policies (TOML): 1 + priority/1000 (e.g., priority 100 → 1.100)
-# - Workspace policies (TOML): 2 + priority/1000 (e.g., priority 100 → 2.100)
-# - User policies (TOML): 3 + priority/1000 (e.g., priority 100 → 3.100)
-# - Admin policies (TOML): 4 + priority/1000 (e.g., priority 100 → 4.100)
+# - Extension policies (TOML): 2 + priority/1000 (e.g., priority 100 → 2.100)
+# - Workspace policies (TOML): 3 + priority/1000 (e.g., priority 100 → 3.100)
+# - User policies (TOML): 4 + priority/1000 (e.g., priority 100 → 4.100)
+# - Admin policies (TOML): 5 + priority/1000 (e.g., priority 100 → 5.100)
 #
-# This ensures Admin > User > Workspace > Default hierarchy is always preserved,
+# This ensures Admin > User > Workspace > Extension > Default hierarchy is always preserved,
 # while allowing user-specified priorities to work within each tier.
 #
-# Settings-based and dynamic rules (all in user tier 3.x):
-#   3.95: Tools that the user has selected as "Always Allow" in the interactive UI
-#   3.9:  MCP servers excluded list (security: persistent server blocks)
-#   3.4:  Command line flag --exclude-tools (explicit temporary blocks)
-#   3.3:  Command line flag --allowed-tools (explicit temporary allows)
-#   3.2:  MCP servers with trust=true (persistent trusted servers)
-#   3.1:  MCP servers allowed list (persistent general server allows)
+# Settings-based and dynamic rules (all in user tier 4.x):
+#   4.95: Tools that the user has selected as "Always Allow" in the interactive UI
+#   4.9:  MCP servers excluded list (security: persistent server blocks)
+#   4.4:  Command line flag --exclude-tools (explicit temporary blocks)
+#   4.3:  Command line flag --allowed-tools (explicit temporary allows)
+#   4.2:  MCP servers with trust=true (persistent trusted servers)
+#   4.1:  MCP servers allowed list (persistent general server allows)
 #
 # TOML policy priorities (before transformation):
 #   10: Write tools default to ASK_USER (becomes 1.010 in default tier)

--- a/packages/core/src/policy/policies/write.toml
+++ b/packages/core/src/policy/policies/write.toml
@@ -32,6 +32,13 @@ decision = "ask_user"
 priority = 10
 
 [[rule]]
+toolName = "exit_plan_mode"
+decision = "deny"
+priority = 10
+modes = ["default", "autoEdit"]
+deny_message = "You are not in Plan Mode."
+
+[[rule]]
 toolName = "replace"
 decision = "allow"
 priority = 15

--- a/packages/core/src/policy/policies/write.toml
+++ b/packages/core/src/policy/policies/write.toml
@@ -5,20 +5,21 @@
 #
 # Priority bands (tiers):
 # - Default policies (TOML): 1 + priority/1000 (e.g., priority 100 → 1.100)
-# - Workspace policies (TOML): 2 + priority/1000 (e.g., priority 100 → 2.100)
-# - User policies (TOML): 3 + priority/1000 (e.g., priority 100 → 3.100)
-# - Admin policies (TOML): 4 + priority/1000 (e.g., priority 100 → 4.100)
+# - Extension policies (TOML): 2 + priority/1000 (e.g., priority 100 → 2.100)
+# - Workspace policies (TOML): 3 + priority/1000 (e.g., priority 100 → 3.100)
+# - User policies (TOML): 4 + priority/1000 (e.g., priority 100 → 4.100)
+# - Admin policies (TOML): 5 + priority/1000 (e.g., priority 100 → 5.100)
 #
-# This ensures Admin > User > Workspace > Default hierarchy is always preserved,
+# This ensures Admin > User > Workspace > Extension > Default hierarchy is always preserved,
 # while allowing user-specified priorities to work within each tier.
 #
-# Settings-based and dynamic rules (all in user tier 3.x):
-#   3.95: Tools that the user has selected as "Always Allow" in the interactive UI
-#   3.9:  MCP servers excluded list (security: persistent server blocks)
-#   3.4:  Command line flag --exclude-tools (explicit temporary blocks)
-#   3.3:  Command line flag --allowed-tools (explicit temporary allows)
-#   3.2:  MCP servers with trust=true (persistent trusted servers)
-#   3.1:  MCP servers allowed list (persistent general server allows)
+# Settings-based and dynamic rules (all in user tier 4.x):
+#   4.95: Tools that the user has selected as "Always Allow" in the interactive UI
+#   4.9:  MCP servers excluded list (security: persistent server blocks)
+#   4.4:  Command line flag --exclude-tools (explicit temporary blocks)
+#   4.3:  Command line flag --allowed-tools (explicit temporary allows)
+#   4.2:  MCP servers with trust=true (persistent trusted servers)
+#   4.1:  MCP servers allowed list (persistent general server allows)
 #
 # TOML policy priorities (before transformation):
 #   10: Write tools default to ASK_USER (becomes 1.010 in default tier)
@@ -30,13 +31,6 @@
 toolName = "replace"
 decision = "ask_user"
 priority = 10
-
-[[rule]]
-toolName = "exit_plan_mode"
-decision = "deny"
-priority = 10
-modes = ["default", "autoEdit"]
-deny_message = "You are not in Plan Mode."
 
 [[rule]]
 toolName = "replace"

--- a/packages/core/src/policy/policies/yolo.toml
+++ b/packages/core/src/policy/policies/yolo.toml
@@ -36,6 +36,12 @@ decision = "ask_user"
 priority = 999
 modes = ["yolo"]
 
+[[rule]]
+toolName = ["enter_plan_mode", "exit_plan_mode"]
+decision = "deny"
+priority = 999
+modes = ["yolo"]
+
 # Allow everything else in YOLO mode
 [[rule]]
 decision = "allow"

--- a/packages/core/src/policy/policies/yolo.toml
+++ b/packages/core/src/policy/policies/yolo.toml
@@ -5,20 +5,21 @@
 #
 # Priority bands (tiers):
 # - Default policies (TOML): 1 + priority/1000 (e.g., priority 100 → 1.100)
-# - Workspace policies (TOML): 2 + priority/1000 (e.g., priority 100 → 2.100)
-# - User policies (TOML): 3 + priority/1000 (e.g., priority 100 → 3.100)
-# - Admin policies (TOML): 4 + priority/1000 (e.g., priority 100 → 4.100)
+# - Extension policies (TOML): 2 + priority/1000 (e.g., priority 100 → 2.100)
+# - Workspace policies (TOML): 3 + priority/1000 (e.g., priority 100 → 3.100)
+# - User policies (TOML): 4 + priority/1000 (e.g., priority 100 → 4.100)
+# - Admin policies (TOML): 5 + priority/1000 (e.g., priority 100 → 5.100)
 #
-# This ensures Admin > User > Workspace > Default hierarchy is always preserved,
+# This ensures Admin > User > Workspace > Extension > Default hierarchy is always preserved,
 # while allowing user-specified priorities to work within each tier.
 #
-# Settings-based and dynamic rules (all in user tier 3.x):
-#   3.95: Tools that the user has selected as "Always Allow" in the interactive UI
-#   3.9:  MCP servers excluded list (security: persistent server blocks)
-#   3.4:  Command line flag --exclude-tools (explicit temporary blocks)
-#   3.3:  Command line flag --allowed-tools (explicit temporary allows)
-#   3.2:  MCP servers with trust=true (persistent trusted servers)
-#   3.1:  MCP servers allowed list (persistent general server allows)
+# Settings-based and dynamic rules (all in user tier 4.x):
+#   4.95: Tools that the user has selected as "Always Allow" in the interactive UI
+#   4.9:  MCP servers excluded list (security: persistent server blocks)
+#   4.4:  Command line flag --exclude-tools (explicit temporary blocks)
+#   4.3:  Command line flag --allowed-tools (explicit temporary allows)
+#   4.2:  MCP servers with trust=true (persistent trusted servers)
+#   4.1:  MCP servers allowed list (persistent general server allows)
 #
 # TOML policy priorities (before transformation):
 #   10: Write tools default to ASK_USER (becomes 1.010 in default tier)
@@ -36,6 +37,9 @@ decision = "ask_user"
 priority = 999
 modes = ["yolo"]
 
+# Plan mode transitions are blocked in YOLO mode to maintain state consistency
+# and because planning currently requires human interaction (plan approval),
+# which conflicts with YOLO's autonomous nature.
 [[rule]]
 toolName = ["enter_plan_mode", "exit_plan_mode"]
 decision = "deny"

--- a/packages/core/src/tools/ask-user.ts
+++ b/packages/core/src/tools/ask-user.ts
@@ -28,9 +28,11 @@ export class AskUserTool extends BaseDeclarativeTool<
   AskUserParams,
   ToolResult
 > {
+  static readonly Name = ASK_USER_TOOL_NAME;
+
   constructor(messageBus: MessageBus) {
     super(
-      ASK_USER_TOOL_NAME,
+      AskUserTool.Name,
       ASK_USER_DISPLAY_NAME,
       ASK_USER_DEFINITION.base.description!,
       Kind.Communicate,

--- a/packages/core/src/tools/enter-plan-mode.ts
+++ b/packages/core/src/tools/enter-plan-mode.ts
@@ -27,12 +27,14 @@ export class EnterPlanModeTool extends BaseDeclarativeTool<
   EnterPlanModeParams,
   ToolResult
 > {
+  static readonly Name = ENTER_PLAN_MODE_TOOL_NAME;
+
   constructor(
     private config: Config,
     messageBus: MessageBus,
   ) {
     super(
-      ENTER_PLAN_MODE_TOOL_NAME,
+      EnterPlanModeTool.Name,
       'Enter Plan Mode',
       ENTER_PLAN_MODE_DEFINITION.base.description!,
       Kind.Plan,

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -35,6 +35,8 @@ export class ExitPlanModeTool extends BaseDeclarativeTool<
   ExitPlanModeParams,
   ToolResult
 > {
+  static readonly Name = EXIT_PLAN_MODE_TOOL_NAME;
+
   constructor(
     private config: Config,
     messageBus: MessageBus,
@@ -42,7 +44,7 @@ export class ExitPlanModeTool extends BaseDeclarativeTool<
     const plansDir = config.storage.getPlansDir();
     const definition = getExitPlanModeDefinition(plansDir);
     super(
-      EXIT_PLAN_MODE_TOOL_NAME,
+      ExitPlanModeTool.Name,
       'Exit Plan Mode',
       definition.base.description!,
       Kind.Plan,


### PR DESCRIPTION
Unified plan-related tool visibility management by leveraging the existing Policy Engine instead of imperative registration/unregistration.

Key changes:
- Removed syncPlanModeTools from Config class and its calls during initialization and mode transitions.
- Added declarative DENY rules to plan.toml, write.toml, and yolo.toml to control enter_plan_mode and exit_plan_mode visibility based on the current ApprovalMode.

Closes https://github.com/google-gemini/gemini-cli/issues/20595

----
Plan mode has `ExitPlanMode` tool

<img width="405" height="360" alt="Screenshot 2026-02-27 at 2 12 37 PM" src="https://github.com/user-attachments/assets/addd454a-802b-49ab-a3c1-1179dc9a7342" />

----
Default mode has `EnterPlanMode` tool
<img width="468" height="443" alt="Screenshot 2026-02-27 at 2 12 52 PM" src="https://github.com/user-attachments/assets/b1cf4609-7166-4f7b-a280-f167cd2b4802" />

----
Auto-Edit mode has `EnterPlanMode` tool
<img width="494" height="444" alt="Screenshot 2026-02-27 at 2 13 06 PM" src="https://github.com/user-attachments/assets/153940ef-2903-4329-b0d2-4bbfa326069a" />

----
YOLO mode does not have `EnterPlanMode` or  `EnterPlanMode` tools
<img width="452" height="423" alt="Screenshot 2026-02-27 at 2 13 21 PM" src="https://github.com/user-attachments/assets/2bb2de42-9471-4dc5-807b-2cfa19125945" />