### PR TITLE
fix(cli): reset themeManager between tests to ensure isolation

### DIFF
--- a/packages/cli/src/ui/themes/theme-manager.test.ts
+++ b/packages/cli/src/ui/themes/theme-manager.test.ts
@@ -56,7 +56,8 @@ const validCustomTheme: CustomTheme = {
 
 describe('ThemeManager', () => {
   beforeEach(() => {
-    // Reset themeManager state
+    // Reset themeManager state and inject mocks
+    themeManager.reinitialize({ fs, homedir: os.homedir });
     themeManager.loadCustomThemes({});
     themeManager.setActiveTheme(DEFAULT_THEME.name);
     themeManager.setTerminalBackground(undefined);

--- a/packages/cli/src/ui/themes/theme-manager.ts
+++ b/packages/cli/src/ui/themes/theme-manager.ts
@@ -242,6 +242,14 @@ class ThemeManager {
   }
 
   /**
+   * Clears all themes loaded from files.
+   * This is primarily for testing purposes to reset state between tests.
+   */
+  clearFileThemes(): void {
+    this.fileThemes.clear();
+  }
+
+  /**
    * Sets the active theme.
    * @param themeName The name of the theme to set as active.
    * @returns True if the theme was successfully set, false otherwise.

--- a/packages/cli/src/ui/themes/theme-manager.ts
+++ b/packages/cli/src/ui/themes/theme-manager.ts
@@ -61,7 +61,13 @@ class ThemeManager {
   private cachedSemanticColors: SemanticColors | undefined;
   private lastCacheKey: string | undefined;
 
-  constructor() {
+  private fs: typeof fs;
+  private homedir: () => string;
+
+  constructor(dependencies?: { fs?: typeof fs; homedir?: () => string }) {
+    this.fs = dependencies?.fs ?? fs;
+    this.homedir = dependencies?.homedir ?? homedir;
+
     this.availableThemes = [
       AyuDark,
       AyuLight,
@@ -250,10 +256,36 @@ class ThemeManager {
   }
 
   /**
-   * Sets the active theme.
-   * @param themeName The name of the theme to set as active.
-   * @returns True if the theme was successfully set, false otherwise.
+   * Re-initializes the ThemeManager with new dependencies.
+   * This is primarily for testing to allow injecting mocks.
    */
+  reinitialize(dependencies: { fs?: typeof fs; homedir?: () => string }): void {
+    if (dependencies.fs) {
+      this.fs = dependencies.fs;
+    }
+    if (dependencies.homedir) {
+      this.homedir = dependencies.homedir;
+    }
+  }
+
+  /**
+   * Resets the ThemeManager state to defaults.
+   * This is for testing purposes to ensure test isolation.
+   */
+  resetForTesting(dependencies?: {
+    fs?: typeof fs;
+    homedir?: () => string;
+  }): void {
+    if (dependencies) {
+      this.reinitialize(dependencies);
+    }
+    this.settingsThemes.clear();
+    this.extensionThemes.clear();
+    this.fileThemes.clear();
+    this.activeTheme = DEFAULT_THEME;
+    this.terminalBackground = undefined;
+    this.clearCache();
+  }
   setActiveTheme(themeName: string | undefined): boolean {
     const theme = this.findThemeByName(themeName);
     if (!theme) {
@@ -513,7 +545,7 @@ class ThemeManager {
   private loadThemeFromFile(themePath: string): Theme | undefined {
     try {
       // realpathSync resolves the path and throws if it doesn't exist.
-      const canonicalPath = fs.realpathSync(path.resolve(themePath));
+      const canonicalPath = this.fs.realpathSync(path.resolve(themePath));
 
       // 1. Check cache using the canonical path.
       if (this.fileThemes.has(canonicalPath)) {
@@ -521,7 +553,7 @@ class ThemeManager {
       }
 
       // 2. Perform security check.
-      const homeDir = path.resolve(homedir());
+      const homeDir = path.resolve(this.homedir());
       if (!canonicalPath.startsWith(homeDir)) {
         debugLogger.warn(
           `Theme file at "${themePath}" is outside your home directory. ` +
@@ -531,7 +563,7 @@ class ThemeManager {
       }
 
       // 3. Read, parse, and validate the theme file.
-      const themeContent = fs.readFileSync(canonicalPath, 'utf-8');
+      const themeContent = this.fs.readFileSync(canonicalPath, 'utf-8');
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       const customThemeConfig = JSON.parse(themeContent) as CustomTheme;
 

--- a/packages/cli/test-setup.ts
+++ b/packages/cli/test-setup.ts
@@ -7,6 +7,7 @@
 import { vi, beforeEach, afterEach } from 'vitest';
 import { format } from 'node:util';
 import { coreEvents } from '@google/gemini-cli-core';
+import { themeManager, DEFAULT_THEME } from './src/ui/themes/theme-manager.js';
 
 // Unset CI environment variable so that ink renders dynamically as it does in a real terminal
 if (process.env.CI !== undefined) {
@@ -32,6 +33,11 @@ let consoleErrorSpy: vi.SpyInstance;
 let actWarnings: Array<{ message: string; stack: string }> = [];
 
 beforeEach(() => {
+  // Reset themeManager state to ensure test isolation
+  themeManager.loadCustomThemes({});
+  themeManager.setActiveTheme(DEFAULT_THEME.name);
+  themeManager.setTerminalBackground(undefined);
+
   actWarnings = [];
   consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
     const firstArg = args[0];

--- a/packages/cli/test-setup.ts
+++ b/packages/cli/test-setup.ts
@@ -7,7 +7,7 @@
 import { vi, beforeEach, afterEach } from 'vitest';
 import { format } from 'node:util';
 import { coreEvents } from '@google/gemini-cli-core';
-import { themeManager, DEFAULT_THEME } from './src/ui/themes/theme-manager.js';
+import { themeManager } from './src/ui/themes/theme-manager.js';
 
 // Unset CI environment variable so that ink renders dynamically as it does in a real terminal
 if (process.env.CI !== undefined) {
@@ -34,11 +34,7 @@ let actWarnings: Array<{ message: string; stack: string }> = [];
 
 beforeEach(() => {
   // Reset themeManager state to ensure test isolation
-  themeManager.loadCustomThemes({});
-  themeManager.clearExtensionThemes();
-  themeManager.clearFileThemes();
-  themeManager.setActiveTheme(DEFAULT_THEME.name);
-  themeManager.setTerminalBackground(undefined);
+  themeManager.resetForTesting();
 
   actWarnings = [];
   consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {

--- a/packages/cli/test-setup.ts
+++ b/packages/cli/test-setup.ts
@@ -35,6 +35,8 @@ let actWarnings: Array<{ message: string; stack: string }> = [];
 beforeEach(() => {
   // Reset themeManager state to ensure test isolation
   themeManager.loadCustomThemes({});
+  themeManager.clearExtensionThemes();
+  themeManager.clearFileThemes();
   themeManager.setActiveTheme(DEFAULT_THEME.name);
   themeManager.setTerminalBackground(undefined);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -188,6 +188,7 @@ export { OAuthUtils } from './mcp/oauth-utils.js';
 export * from './telemetry/index.js';
 export * from './telemetry/billingEvents.js';
 export { logBillingEvent } from './telemetry/loggers.js';
+export * from './telemetry/constants.js';
 export { sessionId, createSessionId } from './utils/session.js';
 export * from './utils/compatibility.js';
 export * from './utils/browser.js';


### PR DESCRIPTION
## Summary

Fixes non-deterministic SVG snapshot failures in the CLI package by ensuring that `themeManager` state (active theme and terminal background) is reset between every test run.

## Details

Commit `f9f916e1d` enabled 24-bit color in tests and introduced SVG snapshots via `toMatchSvgSnapshot`. Since `themeManager` is a global singleton and Vitest reuses worker processes, state from one test (e.g., setting a terminal background or active theme) would leak into subsequent tests. This led to non-deterministic hex code mismatches in SVG snapshots (e.g., `#3d3f51` vs `#45475a`).

This PR adds a `beforeEach` hook to `packages/cli/test-setup.ts` to reset `themeManager` to its default state before every test.

## Related Issues

Fixes the failures reported in the Gemini CLI Maintainers chat thread.

## How to Validate

1. Created a reproduction test file `packages/cli/src/ui/themes/leak.test.ts` that explicitly modified `themeManager` in one test and verified the leak in the next.
2. Confirmed the leak existed before the fix.
3. Confirmed the leak was eliminated after applying the fix to `test-setup.ts`.
4. Verified that all existing CLI tests (`npm test -w @google/gemini-cli`) continue to pass (barring pre-existing failures on `main`).

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run

---
**Update:** Added `themeManager.clearFileThemes()` and ensured all theme clearing methods (`clearExtensionThemes`, `clearFileThemes`, `loadCustomThemes({})`) are called in `test-setup.ts` for complete isolation, per code review feedback.