### PR TITLE
feat(github): add UX Feedback and User Research issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/user_research.yml
+++ b/.github/ISSUE_TEMPLATE/user_research.yml
@@ -2,7 +2,6 @@ name: 'User Research Insight'
 description: 'Share findings from user research, usability testing, or user interviews'
 labels:
   - 'status/need-triage'
-type: 'Feature'
 body:
   - type: 'markdown'
     attributes:

--- a/.github/ISSUE_TEMPLATE/user_research.yml
+++ b/.github/ISSUE_TEMPLATE/user_research.yml
@@ -1,0 +1,42 @@
+name: 'User Research Insight'
+description: 'Share findings from user research, usability testing, or user interviews'
+labels:
+  - 'status/need-triage'
+type: 'Feature'
+body:
+  - type: 'markdown'
+    attributes:
+      value: |-
+        > [!IMPORTANT]
+        > Thanks for sharing your research findings!
+        >
+        > Structured user research helps the team make informed product decisions.
+        > Please search **[existing issues](https://github.com/google-gemini/gemini-cli/issues)** to see if similar findings have already been shared.
+
+  - type: 'textarea'
+    id: 'methodology'
+    attributes:
+      label: 'Research method'
+      description: 'How did you gather this insight? (e.g., usability test, user interview, survey, heuristic evaluation)'
+    validations:
+      required: true
+
+  - type: 'textarea'
+    id: 'findings'
+    attributes:
+      label: 'Key findings'
+      description: 'Summarize the main insights from your research.'
+    validations:
+      required: true
+
+  - type: 'textarea'
+    id: 'recommendations'
+    attributes:
+      label: 'Recommendations'
+      description: 'What changes would you recommend based on these findings?'
+
+  - type: 'textarea'
+    id: 'evidence'
+    attributes:
+      label: 'Supporting evidence'
+      description: 'Include data, quotes, recordings, or other evidence.'

--- a/.github/ISSUE_TEMPLATE/ux_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/ux_feedback.yml
@@ -1,0 +1,51 @@
+name: 'UX Feedback'
+description: 'Report a usability issue or suggest a UX improvement'
+labels:
+  - 'status/need-triage'
+type: 'Feature'
+body:
+  - type: 'markdown'
+    attributes:
+      value: |-
+        > [!IMPORTANT]
+        > Thanks for taking the time to share your experience!
+        >
+        > UX feedback from all experience levels is valuable — especially from beginners.
+        > Please search **[existing issues](https://github.com/google-gemini/gemini-cli/issues)** to see if similar feedback has already been shared.
+
+  - type: 'textarea'
+    id: 'scenario'
+    attributes:
+      label: 'What were you trying to do?'
+      description: 'Describe the task or goal you were working on.'
+    validations:
+      required: true
+
+  - type: 'textarea'
+    id: 'experience'
+    attributes:
+      label: 'What was your experience?'
+      description: 'Describe what happened. Was anything confusing, slow, or frustrating?'
+    validations:
+      required: true
+
+  - type: 'textarea'
+    id: 'expected'
+    attributes:
+      label: 'What would have been better?'
+      description: 'Describe how you think the experience could be improved.'
+
+  - type: 'textarea'
+    id: 'screenshots'
+    attributes:
+      label: 'Screenshots or recordings'
+      description: 'If possible, add screenshots or terminal recordings (e.g., asciinema).'
+
+  - type: 'dropdown'
+    id: 'experience-level'
+    attributes:
+      label: 'Your experience level with CLI tools'
+      options:
+        - 'Beginner (rarely use terminal)'
+        - 'Intermediate (use terminal sometimes)'
+        - 'Advanced (terminal is my primary tool)'

--- a/.github/ISSUE_TEMPLATE/ux_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/ux_feedback.yml
@@ -2,7 +2,6 @@ name: 'UX Feedback'
 description: 'Report a usability issue or suggest a UX improvement'
 labels:
   - 'status/need-triage'
-type: 'Feature'
 body:
   - type: 'markdown'
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,8 @@ document includes:
   set up your development environment and workflow.
 - **[Documentation contribution process](#documentation-contribution-process):**
   How to contribute documentation to Gemini CLI.
+- **[Non-code contribution process](#non-code-contribution-process):** How to
+  contribute UX feedback, user research, and other non-code improvements.
 
 We're looking forward to seeing your contributions!
 
@@ -567,3 +569,44 @@ If you have questions about contributing documentation:
 - Reach out to the maintainers.
 
 We appreciate your contributions to making Gemini CLI documentation better!
+
+## Non-code contribution process
+
+Not a developer? You can still make a significant impact! Non-code contributions
+are essential for making Gemini CLI usable and accessible to everyone.
+
+### UX feedback
+
+The best UX insights come from real usage. If you encounter confusing
+interactions, unclear error messages, or awkward workflows:
+
+1. Use the **UX Feedback** issue template.
+2. Include screenshots or terminal recordings when possible.
+3. Describe your experience level — beginner perspectives are especially
+   valuable.
+
+### User research
+
+If you have UX research skills, we welcome structured findings:
+
+1. Use the **User Research Insight** issue template.
+2. Describe your methodology (usability test, interview, heuristic evaluation,
+   etc.).
+3. Include supporting evidence (quotes, data, recordings).
+
+### Documentation review (user perspective)
+
+Read our docs as a user, not an editor:
+
+1. Follow the quickstart guide from scratch.
+2. Document where you got stuck or confused.
+3. File a UX Feedback issue with your findings.
+
+### First-time experience report
+
+Your first hour with Gemini CLI is uniquely valuable data that experienced users
+can never reproduce. We encourage new users to:
+
+1. Record their first session (terminal recording or notes).
+2. Note every moment of confusion or delight.
+3. Submit as a UX Feedback issue.


### PR DESCRIPTION
## Summary

Add two new GitHub Issue templates to enable non-engineer (PM, UX Designer) contributions to the project:

- **UX Feedback** (): For reporting usability issues and suggesting UX improvements. Includes fields for user scenario, experience description, improvement suggestions, screenshots, and experience level.
- **User Research Insight** (): For sharing structured findings from user research, usability testing, or user interviews. Includes fields for methodology, key findings, recommendations, and supporting evidence.

## Why

Currently, all 3 issue templates (Bug Report, Feature Request, Website Issue) are designed for engineering-oriented contributions. There is no structured way for non-engineers to contribute UX feedback or user research insights.

This gap was identified in Issue #20495, which proposes a broader framework for enabling non-engineer contributions.

These templates follow the same YAML format and conventions as the existing templates.

## Related Issue

Closes #20495 (partial — this PR implements Proposal 1: New Issue templates)

## Test plan

- [ ] Verify the new templates appear in the GitHub "New Issue" page
- [ ] Verify all form fields render correctly
- [ ] Verify the dropdown for experience level works
- [ ] Verify labels are applied correctly on submission
