### PR TITLE
fix(cli): Do not show ghost text if it perfectly matches typed text

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -791,15 +791,15 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           return true;
         }
 
-        if (shellModeActive) {
-          setShellModeActive(false);
+        if (completion.showSuggestions) {
+          completion.resetCompletionState();
+          setExpandedSuggestionIndex(-1);
           resetEscapeState();
           return true;
         }
 
-        if (completion.showSuggestions) {
-          completion.resetCompletionState();
-          setExpandedSuggestionIndex(-1);
+        if (shellModeActive) {
+          setShellModeActive(false);
           resetEscapeState();
           return true;
         }

--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
@@ -524,6 +524,25 @@ describe('useCommandCompletion', () => {
 
       expect(result.current.textBuffer.text).toBe('@src\\components\\');
     });
+
+    it('should not show ghost text if the typed text extends past the common prefix', async () => {
+      // "ls " is already typed. The common prefix is "ls".
+      // Since "ls" length <= "ls " length, no ghost text should be shown.
+      const text = 'ls ';
+      const cursorOffset = text.length;
+
+      const { result } = renderCommandCompletionHook(
+        text,
+        cursorOffset,
+        true, // shellModeActive
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoadingSuggestions).toBe(false);
+      });
+
+      expect(result.current.promptCompletion.text).toBe('');
+    });
   });
 
   describe('prompt completion filtering', () => {

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -271,6 +271,11 @@ export function useCommandCompletion({
           }
         }
 
+        // Prevent showing ghost text if the text to insert exactly matches what the user typed
+        if (textToInsert === query) {
+          return basePromptCompletion;
+        }
+
         const newText =
           currentLine.substring(0, start) +
           textToInsert +


### PR DESCRIPTION
This fixes an issue where if the user typed `ls ` and the ghost text was `ls`, the UI would show `ls ls` because the ghost text perfectly matched the typed text but without the trailing space.