### PR TITLE
Fix/enforce check model output content return value

### DIFF
--- a/evals/grep_search_functionality.eval.ts
+++ b/evals/grep_search_functionality.eval.ts
@@ -25,10 +25,13 @@ describe('grep_search_functionality', () => {
     assert: async (rig: TestRig, result: string) => {
       await rig.waitForToolCall('grep_search');
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/L2: world/, /L3: hello world/],
-        testName: `${TEST_PREFIX}simple search`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/L2: world/, /L3: hello world/],
+          testName: `${TEST_PREFIX}simple search`,
+        }),
+        'Model output content check failed for simple search',
+      ).toBe(true);
     },
   });
 
@@ -54,11 +57,14 @@ describe('grep_search_functionality', () => {
       ).toBe(true);
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/L1: Hello/],
-        forbiddenContent: [/L2: hello/],
-        testName: `${TEST_PREFIX}case-sensitive search`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/L1: Hello/],
+          forbiddenContent: [/L2: hello/],
+          testName: `${TEST_PREFIX}case-sensitive search`,
+        }),
+        'Model output content check failed for case-sensitive search',
+      ).toBe(true);
     },
   });
 
@@ -84,11 +90,14 @@ describe('grep_search_functionality', () => {
       ).toBe(true);
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/file1.txt/, /file2.txt/],
-        forbiddenContent: [/L1:/],
-        testName: `${TEST_PREFIX}names_only search`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/file1.txt/, /file2.txt/],
+          forbiddenContent: [/L1:/],
+          testName: `${TEST_PREFIX}names_only search`,
+        }),
+        'Model output content check failed for names_only search',
+      ).toBe(true);
     },
   });
 
@@ -114,11 +123,14 @@ describe('grep_search_functionality', () => {
       ).toBe(true);
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/file.js/],
-        forbiddenContent: [/file.ts/],
-        testName: `${TEST_PREFIX}include_pattern glob search`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/file.js/],
+          forbiddenContent: [/file.ts/],
+          testName: `${TEST_PREFIX}include_pattern glob search`,
+        }),
+        'Model output content check failed for include_pattern glob search',
+      ).toBe(true);
     },
   });
 
@@ -144,11 +156,14 @@ describe('grep_search_functionality', () => {
       ).toBe(true);
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/unique_string_1/],
-        forbiddenContent: [/unique_string_2/],
-        testName: `${TEST_PREFIX}subdirectory search`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/unique_string_1/],
+          forbiddenContent: [/unique_string_2/],
+          testName: `${TEST_PREFIX}subdirectory search`,
+        }),
+        'Model output content check failed for subdirectory search',
+      ).toBe(true);
     },
   });
 
@@ -161,10 +176,13 @@ describe('grep_search_functionality', () => {
     assert: async (rig: TestRig, result: string) => {
       await rig.waitForToolCall('grep_search');
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/No matches found/],
-        testName: `${TEST_PREFIX}no matches`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/No matches found/],
+          testName: `${TEST_PREFIX}no matches`,
+        }),
+        'Model output content check failed for no matches',
+      ).toBe(true);
     },
   });
 });

--- a/evals/plan_mode.eval.ts
+++ b/evals/plan_mode.eval.ts
@@ -50,10 +50,13 @@ describe('plan_mode', () => {
       ).not.toContain('README.md');
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/plan mode|read-only|cannot modify|refuse|exiting/i],
-        testName: `${TEST_PREFIX}should refuse file modification`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/plan mode|read-only|cannot modify|refuse|exiting/i],
+          testName: `${TEST_PREFIX}should refuse file modification`,
+        }),
+        'Model output content check failed for refuse file modification',
+      ).toBe(true);
     },
   });
 
@@ -91,10 +94,13 @@ describe('plan_mode', () => {
       ).toBe(false);
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/plan mode|read-only|cannot modify|refuse|exit/i],
-        testName: `${TEST_PREFIX}should refuse saving docs to repo`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/plan mode|read-only|cannot modify|refuse|exit/i],
+          testName: `${TEST_PREFIX}should refuse saving docs to repo`,
+        }),
+        'Model output content check failed for refuse saving docs to repo',
+      ).toBe(true);
     },
   });
 

--- a/evals/save_memory.eval.ts
+++ b/evals/save_memory.eval.ts
@@ -29,10 +29,13 @@ describe('save_memory', () => {
       );
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: 'blue',
-        testName: `${TEST_PREFIX}${rememberingFavoriteColor}`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: 'blue',
+          testName: `${TEST_PREFIX}${rememberingFavoriteColor}`,
+        }),
+        'Model output content check failed for favorite color',
+      ).toBe(true);
     },
   });
   const rememberingCommandRestrictions = 'Agent remembers command restrictions';
@@ -49,10 +52,13 @@ describe('save_memory', () => {
       );
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/not run npm commands|remember|ok/i],
-        testName: `${TEST_PREFIX}${rememberingCommandRestrictions}`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/not run npm commands|remember|ok/i],
+          testName: `${TEST_PREFIX}${rememberingCommandRestrictions}`,
+        }),
+        'Model output content check failed for command restrictions',
+      ).toBe(true);
     },
   });
 
@@ -70,10 +76,13 @@ describe('save_memory', () => {
       );
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/always|ok|remember|will do/i],
-        testName: `${TEST_PREFIX}${rememberingWorkflow}`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/always|ok|remember|will do/i],
+          testName: `${TEST_PREFIX}${rememberingWorkflow}`,
+        }),
+        'Model output content check failed for workflow preferences',
+      ).toBe(true);
     },
   });
 
@@ -96,10 +105,13 @@ describe('save_memory', () => {
       ).toBe(false);
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        testName: `${TEST_PREFIX}${ignoringTemporaryInformation}`,
-        forbiddenContent: [/remember|will do/i],
-      });
+      expect(
+        checkModelOutputContent(result, {
+          testName: `${TEST_PREFIX}${ignoringTemporaryInformation}`,
+          forbiddenContent: [/remember|will do/i],
+        }),
+        'Model output content check failed for ignoring temporary info',
+      ).toBe(true);
     },
   });
 
@@ -117,10 +129,13 @@ describe('save_memory', () => {
       );
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/Buddy/i],
-        testName: `${TEST_PREFIX}${rememberingPetName}`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/Buddy/i],
+          testName: `${TEST_PREFIX}${rememberingPetName}`,
+        }),
+        'Model output content check failed for pet name',
+      ).toBe(true);
     },
   });
 
@@ -138,10 +153,13 @@ describe('save_memory', () => {
       );
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/npm run dev|start server|ok|remember|will do/i],
-        testName: `${TEST_PREFIX}${rememberingCommandAlias}`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/npm run dev|start server|ok|remember|will do/i],
+          testName: `${TEST_PREFIX}${rememberingCommandAlias}`,
+        }),
+        'Model output content check failed for command alias',
+      ).toBe(true);
     },
   });
 
@@ -191,10 +209,13 @@ describe('save_memory', () => {
       );
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/tabs instead of spaces|ok|remember|will do/i],
-        testName: `${TEST_PREFIX}${rememberingCodingStyle}`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/tabs instead of spaces|ok|remember|will do/i],
+          testName: `${TEST_PREFIX}${rememberingCodingStyle}`,
+        }),
+        'Model output content check failed for coding style',
+      ).toBe(true);
     },
   });
 
@@ -273,10 +294,13 @@ describe('save_memory', () => {
       );
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/June 15th|ok|remember|will do/i],
-        testName: `${TEST_PREFIX}${rememberingBirthday}`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/June 15th|ok|remember|will do/i],
+          testName: `${TEST_PREFIX}${rememberingBirthday}`,
+        }),
+        'Model output content check failed for birthday',
+      ).toBe(true);
     },
   });
 });


### PR DESCRIPTION
## Summary
Wraps all 16 `checkModelOutputContent()` call sites in `expect(...).toBe(true)` so content validation mismatches now properly fail the test instead of being silently discarded via `console.warn()`

## Details

`checkModelOutputContent()`  in `test-rig.ts` returns a boolean but only calls `console.warn()` on mismatch — it never throws or calls `expect()` . All 16 call sites across 3 eval files were discarding this return value, making content validation effectively a no-op. Tests would pass even when LLM output was completely wrong.

**Changed files (16 call sites):**

* `grep_search_functionality.eval.ts`  — 6 calls
* `save_memory.eval.ts` — 8 calls
* `plan_mode.eval.t`  — 2 calls
Each call now includes a descriptive failure message for clear error reporting.

## Related Issues

Fixes #20547


## How to Validate

1. Run `npx tsc --noEmit` — zero new errors (3 pre-existing errors in unrelated files remain)
2. Run ```npx eslint grep_search_functionality.eval.ts  save_memory.eval.ts evals/plan_mode.eval.ts``` — zero errors
3. Grep for bare `checkModelOutputContent( calls (not wrapped in [expect])`:
   * ```grep -n "checkModelOutputContent" evals/*.eval.ts```
   *  All 16 usage sites should now be inside `expect(...)`

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [ ] npm run
    - [x] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
