### PR TITLE
Fix #20402: Stale config capture in onModelChange

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -450,8 +450,6 @@ export async function loadCliConfig(
   const { cwd = process.cwd(), projectHooks } = options;
   const debugMode = isDebugMode(argv);
 
-  const loadedSettings = loadSettings(cwd);
-
   if (argv.sandbox) {
     process.env['GEMINI_SANDBOX'] = 'true';
   }
@@ -873,7 +871,7 @@ export async function loadCliConfig(
     hooks: settings.hooks || {},
     disabledHooks: settings.hooksConfig?.disabled || [],
     projectHooks: projectHooks || {},
-    onModelChange: (model: string) => saveModelChange(loadedSettings, model),
+    onModelChange: (model: string) => saveModelChange(loadSettings(cwd), model),
     onReload: async () => {
       const refreshedSettings = loadSettings(cwd);
       return {


### PR DESCRIPTION
Fixes #20402
**Summary**
The onModelChange callback holds onto a single snapshot of loadedSettings taken at boot. If .gemini/settings.json is changed later (e.g. via hot-reload), that snapshot becomes stale. When the model is saved, the CLI writes the old snapshot back and overwrites the new config.

**Steps to reproduce**
Run gemini to boot the CLI. (loadedSettings snapshot is captured.)
Edit .gemini/settings.json (e.g. add a new system prompt) and trigger a hot-reload.
onReload correctly reloads settings from disk using loadSettings(cwd).
Run /model gemini-1.5-pro.
onModelChange calls saveModelChange(loadedSettings, model) with the boot-time snapshot.
The CLI writes the stale snapshot back to disk, overwriting the changes from step 2.
Expected behavior
onModelChange should mirror onReload: call loadSettings(cwd) when the callback runs, instead of using a captured snapshot.

**Fix**
Change:
onModelChange: (model: string) => saveModelChange(loadedSettings, model)
to:
onModelChange: (model: string) => saveModelChange(loadSettings(cwd), model)
