### PR TITLE
test(cli): add missing tests for agentSettings.ts and skillSettings.ts

### DIFF
--- a/packages/cli/src/utils/agentSettings.test.ts
+++ b/packages/cli/src/utils/agentSettings.test.ts
@@ -127,6 +127,16 @@ describe('agentSettings', () => {
 
       expect(result.status).toBe('success');
       expect(result.modifiedScopes).toHaveLength(2);
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'agents.overrides.test-agent.enabled',
+        true,
+      );
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.Workspace,
+        'agents.overrides.test-agent.enabled',
+        true,
+      );
     });
   });
 

--- a/packages/cli/src/utils/agentSettings.test.ts
+++ b/packages/cli/src/utils/agentSettings.test.ts
@@ -1,0 +1,233 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { enableAgent, disableAgent } from './agentSettings.js';
+import { SettingScope, type LoadedSettings } from '../config/settings.js';
+
+describe('agentSettings', () => {
+  let mockSettings: LoadedSettings;
+  let mockUser: {
+    path: string;
+    settings: { agents?: { overrides?: Record<string, { enabled: boolean }> } };
+  };
+  let mockWorkspace: {
+    path: string;
+    settings: { agents?: { overrides?: Record<string, { enabled: boolean }> } };
+  };
+  let mockSetValue: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockUser = {
+      path: '/mock/user.json',
+      settings: { agents: { overrides: {} } },
+    };
+    mockWorkspace = {
+      path: '/mock/workspace.json',
+      settings: { agents: { overrides: {} } },
+    };
+    mockSetValue = vi.fn();
+
+    mockSettings = {
+      forScope: (scope: SettingScope) => {
+        if (scope === SettingScope.User) return mockUser;
+        if (scope === SettingScope.Workspace) return mockWorkspace;
+        return mockUser;
+      },
+      setValue: mockSetValue,
+    } as unknown as LoadedSettings;
+  });
+
+  describe('enableAgent', () => {
+    it('should return no-op if agent is already enabled in all scopes', () => {
+      mockUser.settings.agents!.overrides!['test-agent'] = { enabled: true };
+      mockWorkspace.settings.agents!.overrides!['test-agent'] = {
+        enabled: true,
+      };
+
+      const result = enableAgent(mockSettings, 'test-agent');
+
+      expect(result.status).toBe('no-op');
+      expect(result.action).toBe('enable');
+      expect(result.agentName).toBe('test-agent');
+      expect(result.modifiedScopes).toHaveLength(0);
+      expect(result.alreadyInStateScopes).toHaveLength(2);
+      expect(mockSetValue).not.toHaveBeenCalled();
+    });
+
+    it('should enable agent in User scope if not enabled there', () => {
+      mockWorkspace.settings.agents!.overrides!['test-agent'] = {
+        enabled: true,
+      };
+
+      const result = enableAgent(mockSettings, 'test-agent');
+
+      expect(result.status).toBe('success');
+      expect(result.modifiedScopes).toContainEqual({
+        scope: SettingScope.User,
+        path: '/mock/user.json',
+      });
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'agents.overrides.test-agent.enabled',
+        true,
+      );
+    });
+
+    it('should enable agent in Workspace scope if not enabled there', () => {
+      mockUser.settings.agents!.overrides!['test-agent'] = { enabled: true };
+
+      const result = enableAgent(mockSettings, 'test-agent');
+
+      expect(result.status).toBe('success');
+      expect(result.modifiedScopes).toContainEqual({
+        scope: SettingScope.Workspace,
+        path: '/mock/workspace.json',
+      });
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.Workspace,
+        'agents.overrides.test-agent.enabled',
+        true,
+      );
+    });
+
+    it('should enable agent in BOTH scopes if not enabled in either', () => {
+      const result = enableAgent(mockSettings, 'test-agent');
+
+      expect(result.status).toBe('success');
+      expect(result.modifiedScopes).toHaveLength(2);
+      expect(result.modifiedScopes).toContainEqual({
+        scope: SettingScope.Workspace,
+        path: '/mock/workspace.json',
+      });
+      expect(result.modifiedScopes).toContainEqual({
+        scope: SettingScope.User,
+        path: '/mock/user.json',
+      });
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.Workspace,
+        'agents.overrides.test-agent.enabled',
+        true,
+      );
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'agents.overrides.test-agent.enabled',
+        true,
+      );
+    });
+
+    it('should handle missing agents config gracefully', () => {
+      mockUser.settings = {};
+      mockWorkspace.settings = {};
+
+      const result = enableAgent(mockSettings, 'test-agent');
+
+      expect(result.status).toBe('success');
+      expect(result.modifiedScopes).toHaveLength(2);
+    });
+  });
+
+  describe('disableAgent', () => {
+    it('should disable agent in the requested Workspace scope', () => {
+      const result = disableAgent(
+        mockSettings,
+        'test-agent',
+        SettingScope.Workspace,
+      );
+
+      expect(result.status).toBe('success');
+      expect(result.agentName).toBe('test-agent');
+      expect(result.action).toBe('disable');
+      expect(result.modifiedScopes).toEqual([
+        { scope: SettingScope.Workspace, path: '/mock/workspace.json' },
+      ]);
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.Workspace,
+        'agents.overrides.test-agent.enabled',
+        false,
+      );
+    });
+
+    it('should disable agent in the requested User scope', () => {
+      const result = disableAgent(
+        mockSettings,
+        'test-agent',
+        SettingScope.User,
+      );
+
+      expect(result.status).toBe('success');
+      expect(result.modifiedScopes).toEqual([
+        { scope: SettingScope.User, path: '/mock/user.json' },
+      ]);
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'agents.overrides.test-agent.enabled',
+        false,
+      );
+    });
+
+    it('should return no-op if agent is already disabled in requested scope', () => {
+      mockWorkspace.settings.agents!.overrides!['test-agent'] = {
+        enabled: false,
+      };
+
+      const result = disableAgent(
+        mockSettings,
+        'test-agent',
+        SettingScope.Workspace,
+      );
+
+      expect(result.status).toBe('no-op');
+      expect(result.alreadyInStateScopes).toEqual([
+        { scope: SettingScope.Workspace, path: '/mock/workspace.json' },
+      ]);
+      expect(mockSetValue).not.toHaveBeenCalled();
+    });
+
+    it('should report if agent is already disabled in other scope', () => {
+      mockUser.settings.agents!.overrides!['test-agent'] = { enabled: false };
+
+      const result = disableAgent(
+        mockSettings,
+        'test-agent',
+        SettingScope.Workspace,
+      );
+
+      expect(result.status).toBe('success');
+      expect(result.modifiedScopes).toEqual([
+        { scope: SettingScope.Workspace, path: '/mock/workspace.json' },
+      ]);
+      expect(result.alreadyInStateScopes).toEqual([
+        { scope: SettingScope.User, path: '/mock/user.json' },
+      ]);
+    });
+
+    it('should return error if invalid scope is provided', () => {
+      // @ts-expect-error - Testing runtime check
+      const result = disableAgent(mockSettings, 'test-agent', 'InvalidScope');
+
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('Invalid settings scope');
+    });
+
+    it('should handle missing agents config gracefully when disabling', () => {
+      mockWorkspace.settings = {};
+
+      const result = disableAgent(
+        mockSettings,
+        'test-agent',
+        SettingScope.Workspace,
+      );
+
+      expect(result.status).toBe('success');
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.Workspace,
+        'agents.overrides.test-agent.enabled',
+        false,
+      );
+    });
+  });
+});

--- a/packages/cli/src/utils/skillSettings.test.ts
+++ b/packages/cli/src/utils/skillSettings.test.ts
@@ -1,0 +1,244 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { enableSkill, disableSkill } from './skillSettings.js';
+import { SettingScope, type LoadedSettings } from '../config/settings.js';
+
+describe('skillSettings', () => {
+  let mockSettings: LoadedSettings;
+  let mockUser: {
+    path: string;
+    settings: { skills?: { disabled?: string[] } };
+  };
+  let mockWorkspace: {
+    path: string;
+    settings: { skills?: { disabled?: string[] } };
+  };
+  let mockSetValue: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockUser = {
+      path: '/mock/user.json',
+      settings: { skills: { disabled: [] } },
+    };
+    mockWorkspace = {
+      path: '/mock/workspace.json',
+      settings: { skills: { disabled: [] } },
+    };
+    mockSetValue = vi.fn();
+
+    mockSettings = {
+      forScope: (scope: SettingScope) => {
+        if (scope === SettingScope.User) return mockUser;
+        if (scope === SettingScope.Workspace) return mockWorkspace;
+        return mockUser;
+      },
+      setValue: mockSetValue,
+    } as unknown as LoadedSettings;
+  });
+
+  describe('enableSkill', () => {
+    it('should return no-op if skill is not disabled in any scope', () => {
+      const result = enableSkill(mockSettings, 'test-skill');
+
+      expect(result.status).toBe('no-op');
+      expect(result.action).toBe('enable');
+      expect(result.skillName).toBe('test-skill');
+      expect(result.modifiedScopes).toHaveLength(0);
+      expect(result.alreadyInStateScopes).toHaveLength(2);
+      expect(mockSetValue).not.toHaveBeenCalled();
+    });
+
+    it('should enable skill in User scope if disabled there', () => {
+      mockUser.settings.skills!.disabled = ['test-skill'];
+
+      const result = enableSkill(mockSettings, 'test-skill');
+
+      expect(result.status).toBe('success');
+      expect(result.modifiedScopes).toContainEqual({
+        scope: SettingScope.User,
+        path: '/mock/user.json',
+      });
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'skills.disabled',
+        [],
+      );
+    });
+
+    it('should enable skill in Workspace scope if disabled there', () => {
+      mockWorkspace.settings.skills!.disabled = ['test-skill'];
+
+      const result = enableSkill(mockSettings, 'test-skill');
+
+      expect(result.status).toBe('success');
+      expect(result.modifiedScopes).toContainEqual({
+        scope: SettingScope.Workspace,
+        path: '/mock/workspace.json',
+      });
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.Workspace,
+        'skills.disabled',
+        [],
+      );
+    });
+
+    it('should enable skill in BOTH scopes if disabled in both', () => {
+      mockUser.settings.skills!.disabled = ['test-skill', 'other-skill'];
+      mockWorkspace.settings.skills!.disabled = ['test-skill'];
+
+      const result = enableSkill(mockSettings, 'test-skill');
+
+      expect(result.status).toBe('success');
+      expect(result.modifiedScopes).toHaveLength(2);
+      expect(result.modifiedScopes).toContainEqual({
+        scope: SettingScope.User,
+        path: '/mock/user.json',
+      });
+      expect(result.modifiedScopes).toContainEqual({
+        scope: SettingScope.Workspace,
+        path: '/mock/workspace.json',
+      });
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'skills.disabled',
+        ['other-skill'],
+      );
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.Workspace,
+        'skills.disabled',
+        [],
+      );
+    });
+
+    it('should handle missing skills config gracefully', () => {
+      mockUser.settings = {};
+      mockWorkspace.settings = {};
+
+      const result = enableSkill(mockSettings, 'test-skill');
+
+      expect(result.status).toBe('no-op');
+      expect(result.alreadyInStateScopes).toHaveLength(2);
+    });
+  });
+
+  describe('disableSkill', () => {
+    it('should disable skill in the requested Workspace scope', () => {
+      const result = disableSkill(
+        mockSettings,
+        'test-skill',
+        SettingScope.Workspace,
+      );
+
+      expect(result.status).toBe('success');
+      expect(result.skillName).toBe('test-skill');
+      expect(result.action).toBe('disable');
+      expect(result.modifiedScopes).toEqual([
+        { scope: SettingScope.Workspace, path: '/mock/workspace.json' },
+      ]);
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.Workspace,
+        'skills.disabled',
+        ['test-skill'],
+      );
+    });
+
+    it('should disable skill in the requested User scope', () => {
+      const result = disableSkill(
+        mockSettings,
+        'test-skill',
+        SettingScope.User,
+      );
+
+      expect(result.status).toBe('success');
+      expect(result.modifiedScopes).toEqual([
+        { scope: SettingScope.User, path: '/mock/user.json' },
+      ]);
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'skills.disabled',
+        ['test-skill'],
+      );
+    });
+
+    it('should return no-op if skill is already disabled in requested scope', () => {
+      mockWorkspace.settings.skills!.disabled = ['test-skill'];
+
+      const result = disableSkill(
+        mockSettings,
+        'test-skill',
+        SettingScope.Workspace,
+      );
+
+      expect(result.status).toBe('no-op');
+      expect(result.alreadyInStateScopes).toEqual([
+        { scope: SettingScope.Workspace, path: '/mock/workspace.json' },
+      ]);
+      expect(mockSetValue).not.toHaveBeenCalled();
+    });
+
+    it('should report if skill is already disabled in other scope', () => {
+      mockUser.settings.skills!.disabled = ['test-skill'];
+
+      const result = disableSkill(
+        mockSettings,
+        'test-skill',
+        SettingScope.Workspace,
+      );
+
+      expect(result.status).toBe('success');
+      expect(result.modifiedScopes).toEqual([
+        { scope: SettingScope.Workspace, path: '/mock/workspace.json' },
+      ]);
+      expect(result.alreadyInStateScopes).toEqual([
+        { scope: SettingScope.User, path: '/mock/user.json' },
+      ]);
+    });
+
+    it('should preserve other disabled skills when disabling a new one', () => {
+      mockWorkspace.settings.skills!.disabled = ['other-skill'];
+
+      const result = disableSkill(
+        mockSettings,
+        'test-skill',
+        SettingScope.Workspace,
+      );
+
+      expect(result.status).toBe('success');
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.Workspace,
+        'skills.disabled',
+        ['other-skill', 'test-skill'],
+      );
+    });
+
+    it('should return error if invalid scope is provided', () => {
+      // @ts-expect-error - Testing runtime check
+      const result = disableSkill(mockSettings, 'test-skill', 'InvalidScope');
+
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('Invalid settings scope');
+    });
+
+    it('should handle missing skills config gracefully when disabling', () => {
+      mockWorkspace.settings = {};
+
+      const result = disableSkill(
+        mockSettings,
+        'test-skill',
+        SettingScope.Workspace,
+      );
+
+      expect(result.status).toBe('success');
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.Workspace,
+        'skills.disabled',
+        ['test-skill'],
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`packages/cli/src/utils/agentSettings.ts` and `packages/cli/src/utils/skillSettings.ts` export utility functions used for agent and skill management but had no corresponding test files, unlike other files in the same directory.

## Changes

- Add `agentSettings.test.ts` with 11 tests covering `enableAgent()` and `disableAgent()`
- Add `skillSettings.test.ts` with 12 tests covering `enableSkill()` and `disableSkill()`

Tests cover:
- Success scenarios
- No-op scenarios (already in desired state)
- Invalid scope error handling
- Missing config graceful handling
- Cross-scope reporting

## Testing

All new tests pass locally.

Fixes #20543