### PR TITLE
feat(core): support GOOGLE_GEMINI_BASE_URL for custom API endpoints

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1376,6 +1376,22 @@ the `advanced.excludedEnvVars` setting in your `settings.json` file.
   - When set, overrides the default API version used by the SDK.
   - Example: `export GOOGLE_GENAI_API_VERSION="v1"` (Windows PowerShell:
     `$env:GOOGLE_GENAI_API_VERSION="v1"`)
+- **`GOOGLE_GEMINI_BASE_URL`**:
+  - Overrides the default Gemini API endpoint
+    (`generativelanguage.googleapis.com`).
+  - Use this to point the CLI at a local LLM proxy (such as
+    [Ollama](https://ollama.com) or [LiteLLM](https://litellm.ai)), a mock
+    server for testing, or any custom API-compatible endpoint.
+  - `GOOGLE_GEMINI_BASE_URL` takes priority over `GEMINI_API_BASE_URL` (see
+    below).
+  - If the value is not a valid URL, the CLI logs a warning and falls back to
+    the default endpoint.
+  - Example (Ollama): `export GOOGLE_GEMINI_BASE_URL="http://localhost:11434"`
+  - Example (LiteLLM): `export GOOGLE_GEMINI_BASE_URL="http://localhost:4000"`
+- **`GEMINI_API_BASE_URL`**:
+  - Alias for `GOOGLE_GEMINI_BASE_URL`. Supported for compatibility. When both
+    are set, `GOOGLE_GEMINI_BASE_URL` takes precedence.
+  - Example: `export GEMINI_API_BASE_URL="http://localhost:4000"`
 - **`OTLP_GOOGLE_CLOUD_PROJECT`**:
   - Your Google Cloud Project ID for Telemetry in Google Cloud
   - Example: `export OTLP_GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"` (Windows

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -222,19 +222,16 @@ export class LoggingContentGenerator implements ContentGenerator {
     }
 
     // Case 3: Custom base URL set via GOOGLE_GEMINI_BASE_URL or GEMINI_API_BASE_URL.
+    // resolveCustomBaseUrl() already validates the URL, so new URL() won't throw here.
     const customBaseUrl = resolveCustomBaseUrl();
     if (customBaseUrl) {
-      try {
-        const parsed = new URL(customBaseUrl);
-        const port = parsed.port
-          ? parseInt(parsed.port, 10)
-          : parsed.protocol === 'https:'
-            ? 443
-            : 80;
-        return { address: parsed.hostname, port };
-      } catch {
-        // Invalid URL — fall through to default
-      }
+      const parsed = new URL(customBaseUrl);
+      const port = parsed.port
+        ? parseInt(parsed.port, 10)
+        : parsed.protocol === 'https:'
+          ? 443
+          : 80;
+      return { address: parsed.hostname, port };
     }
 
     // Case 4: Default to the public Gemini API endpoint.

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -31,6 +31,7 @@ import {
   logApiResponse,
 } from '../telemetry/loggers.js';
 import type { ContentGenerator } from './contentGenerator.js';
+import { resolveCustomBaseUrl } from './contentGenerator.js';
 import { CodeAssistServer } from '../code_assist/server.js';
 import { toContents } from '../code_assist/converter.js';
 import { isStructuredError } from '../utils/quotaErrorDetection.js';
@@ -220,7 +221,23 @@ export class LoggingContentGenerator implements ContentGenerator {
       }
     }
 
-    // Case 3: Default to the public Gemini API endpoint.
+    // Case 3: Custom base URL set via GOOGLE_GEMINI_BASE_URL or GEMINI_API_BASE_URL.
+    const customBaseUrl = resolveCustomBaseUrl();
+    if (customBaseUrl) {
+      try {
+        const parsed = new URL(customBaseUrl);
+        const port = parsed.port
+          ? parseInt(parsed.port, 10)
+          : parsed.protocol === 'https:'
+            ? 443
+            : 80;
+        return { address: parsed.hostname, port };
+      } catch {
+        // Invalid URL — fall through to default
+      }
+    }
+
+    // Case 4: Default to the public Gemini API endpoint.
     // This is used when an API key is provided but not for Vertex AI.
     return { address: `generativelanguage.googleapis.com`, port: 443 };
   }


### PR DESCRIPTION
Adds support for GOOGLE_GEMINI_BASE_URL environment variable to override the default Gemini API endpoint. This enables local-first workflows with LLM proxies like Ollama and LiteLLM.

- GOOGLE_GEMINI_BASE_URL takes precedence (matches issue #15430 request)
- GEMINI_API_BASE_URL supported as alias for compatibility
- URL validation with clear warning on invalid values
- Endpoint telemetry updated to reflect custom base URL
- Vitest tests covering all env var combinations and edge cases
- Configuration docs updated

Closes #15430

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [X] Updated relevant documentation and README (if needed)
- [X] Added/updated tests (if needed)
- [X] Noted breaking changes (if any)
- [X] Validated on required platforms/methods:
  - [X] MacOS
    - [X] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
