### PR TITLE
feat: evolve --resume to support resuming sessions from any folder via session ID

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -228,7 +228,7 @@ export async function parseArguments(
           // one, and not being passed at all.
           skipValidation: true,
           description:
-            'Resume a previous session. Use "latest" for most recent or index number (e.g. --resume 5)',
+            'Resume a previous session. Use "latest" for most recent, index number (e.g. --resume 5), or a full session UUID to resume from any folder.',
           coerce: (value: string): string => {
             // When --resume passed with a value (`gemini --resume 123`): value = "123" (string)
             // When --resume passed without a value (`gemini --resume`): value = "" (string)

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -705,6 +705,14 @@ export async function main() {
         };
         // Use the existing session ID to continue recording to the same session
         config.setSessionId(resumedSessionData.conversation.sessionId);
+
+        // Warn the user if the session was found in a different project
+        if (result.isCrossProject) {
+          coreEvents.emitFeedback(
+            'warning',
+            `Resuming session from a different project folder. The original project context may differ from the current directory.`,
+          );
+        }
       } catch (error) {
         if (
           error instanceof SessionError &&

--- a/packages/cli/src/ui/components/SessionSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/SessionSummaryDisplay.tsx
@@ -18,13 +18,13 @@ export const SessionSummaryDisplay: React.FC<SessionSummaryDisplayProps> = ({
 }) => {
   const { stats } = useSessionStats();
   const { shell } = getShellConfiguration();
-  const footer = `To resume this session: gemini --resume ${escapeShellArg(stats.sessionId, shell)}`;
+  const resumeCommand = `gemini --resume ${escapeShellArg(stats.sessionId, shell)}`;
 
   return (
     <StatsDisplay
       title="Agent powering down. Goodbye!"
       duration={duration}
-      footer={footer}
+      footer={`Tip: Resume this session from any folder with: ${resumeCommand}`}
     />
   );
 };

--- a/packages/cli/src/ui/components/__snapshots__/SessionSummaryDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/SessionSummaryDisplay.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`<SessionSummaryDisplay /> > renders the summary display with a title 1`
 │                                                                                                  │
 │  Savings Highlight: 500 (50.0%) of input tokens were served from the cache, reducing costs.      │
 │                                                                                                  │
-│  To resume this session: gemini --resume test-session                                            │
+│  Tip: Resume this session from any folder with: gemini --resume test-session                     │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
 `;

--- a/packages/cli/src/utils/sessionUtils.test.ts
+++ b/packages/cli/src/utils/sessionUtils.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   SessionSelector,
   extractFirstUserMessage,
@@ -13,7 +13,7 @@ import {
   SessionError,
 } from './sessionUtils.js';
 import type { Config, MessageRecord } from '@google/gemini-cli-core';
-import { SESSION_FILE_PREFIX } from '@google/gemini-cli-core';
+import { SESSION_FILE_PREFIX, Storage } from '@google/gemini-cli-core';
 import * as fs from 'node:fs/promises';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -537,6 +537,318 @@ describe('SessionSelector', () => {
     // Should only list the main session
     expect(sessions.length).toBe(1);
     expect(sessions[0].id).toBe(mainSessionId);
+  });
+
+  describe('findSessionGlobal', () => {
+    let globalTmpDir: string;
+
+    beforeEach(() => {
+      // Point Storage.getGlobalTempDir to our test temp dir
+      globalTmpDir = path.join(tmpDir, 'global-tmp');
+      vi.spyOn(Storage, 'getGlobalTempDir').mockReturnValue(globalTmpDir);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should find a session across different project directories by UUID', async () => {
+      const sessionId = randomUUID();
+
+      // Create a "different project" directory with a session
+      const otherProjectChatsDir = path.join(
+        globalTmpDir,
+        'other-project',
+        'chats',
+      );
+      await fs.mkdir(otherProjectChatsDir, { recursive: true });
+
+      const session = {
+        sessionId,
+        projectHash: 'other-project-hash',
+        startTime: '2024-01-01T10:00:00.000Z',
+        lastUpdated: '2024-01-01T10:30:00.000Z',
+        messages: [
+          {
+            type: 'user',
+            content: 'Hello from another project',
+            id: 'msg1',
+            timestamp: '2024-01-01T10:00:00.000Z',
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(
+          otherProjectChatsDir,
+          `${SESSION_FILE_PREFIX}2024-01-01T10-00-${sessionId.slice(0, 8)}.json`,
+        ),
+        JSON.stringify(session, null, 2),
+      );
+
+      const sessionSelector = new SessionSelector(config);
+      const result = await sessionSelector.findSessionGlobal(sessionId);
+
+      expect(result).not.toBeNull();
+      expect(result!.sessionData.sessionId).toBe(sessionId);
+      expect(result!.sessionData.messages[0].content).toBe(
+        'Hello from another project',
+      );
+      expect(result!.isCrossProject).toBe(true);
+    });
+
+    it('should return null when no matching session is found globally', async () => {
+      // Create a project directory with an unrelated session
+      const otherProjectChatsDir = path.join(
+        globalTmpDir,
+        'other-project',
+        'chats',
+      );
+      await fs.mkdir(otherProjectChatsDir, { recursive: true });
+
+      const otherSessionId = randomUUID();
+      const session = {
+        sessionId: otherSessionId,
+        projectHash: 'other-project-hash',
+        startTime: '2024-01-01T10:00:00.000Z',
+        lastUpdated: '2024-01-01T10:30:00.000Z',
+        messages: [
+          {
+            type: 'user',
+            content: 'Unrelated session',
+            id: 'msg1',
+            timestamp: '2024-01-01T10:00:00.000Z',
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(
+          otherProjectChatsDir,
+          `${SESSION_FILE_PREFIX}2024-01-01T10-00-${otherSessionId.slice(0, 8)}.json`,
+        ),
+        JSON.stringify(session, null, 2),
+      );
+
+      const sessionSelector = new SessionSelector(config);
+      const result = await sessionSelector.findSessionGlobal(randomUUID());
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when global temp dir does not exist', async () => {
+      vi.spyOn(Storage, 'getGlobalTempDir').mockReturnValue(
+        path.join(tmpDir, 'nonexistent-dir'),
+      );
+
+      const sessionSelector = new SessionSelector(config);
+      const result = await sessionSelector.findSessionGlobal(randomUUID());
+
+      expect(result).toBeNull();
+    });
+
+    it('should skip projects without chats directories', async () => {
+      const sessionId = randomUUID();
+
+      // Create a project dir without chats subdirectory
+      const emptyProjectDir = path.join(globalTmpDir, 'empty-project');
+      await fs.mkdir(emptyProjectDir, { recursive: true });
+
+      // Create another project with the session
+      const otherProjectChatsDir = path.join(
+        globalTmpDir,
+        'valid-project',
+        'chats',
+      );
+      await fs.mkdir(otherProjectChatsDir, { recursive: true });
+
+      const session = {
+        sessionId,
+        projectHash: 'valid-project-hash',
+        startTime: '2024-01-01T10:00:00.000Z',
+        lastUpdated: '2024-01-01T10:30:00.000Z',
+        messages: [
+          {
+            type: 'user',
+            content: 'Found in valid project',
+            id: 'msg1',
+            timestamp: '2024-01-01T10:00:00.000Z',
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(
+          otherProjectChatsDir,
+          `${SESSION_FILE_PREFIX}2024-01-01T10-00-${sessionId.slice(0, 8)}.json`,
+        ),
+        JSON.stringify(session, null, 2),
+      );
+
+      const sessionSelector = new SessionSelector(config);
+      const result = await sessionSelector.findSessionGlobal(sessionId);
+
+      expect(result).not.toBeNull();
+      expect(result!.sessionData.sessionId).toBe(sessionId);
+    });
+
+    it('should skip corrupted session files', async () => {
+      const sessionId = randomUUID();
+
+      const projectChatsDir = path.join(
+        globalTmpDir,
+        'project-with-corrupted',
+        'chats',
+      );
+      await fs.mkdir(projectChatsDir, { recursive: true });
+
+      // Write a corrupted file
+      await fs.writeFile(
+        path.join(
+          projectChatsDir,
+          `${SESSION_FILE_PREFIX}2024-01-01T10-00-${sessionId.slice(0, 8)}.json`,
+        ),
+        'not valid json {{{',
+      );
+
+      const sessionSelector = new SessionSelector(config);
+      const result = await sessionSelector.findSessionGlobal(sessionId);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('resolveSession with cross-project fallback', () => {
+    let globalTmpDir: string;
+
+    beforeEach(() => {
+      globalTmpDir = path.join(tmpDir, 'global-tmp');
+      vi.spyOn(Storage, 'getGlobalTempDir').mockReturnValue(globalTmpDir);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should fall back to global search when UUID not found locally', async () => {
+      const sessionId = randomUUID();
+
+      // Create the local chats dir (empty)
+      const localChatsDir = path.join(tmpDir, 'chats');
+      await fs.mkdir(localChatsDir, { recursive: true });
+
+      // Create a different project with the target session
+      const otherProjectChatsDir = path.join(
+        globalTmpDir,
+        'other-project',
+        'chats',
+      );
+      await fs.mkdir(otherProjectChatsDir, { recursive: true });
+
+      const session = {
+        sessionId,
+        projectHash: 'other-project-hash',
+        startTime: '2024-01-01T10:00:00.000Z',
+        lastUpdated: '2024-01-01T10:30:00.000Z',
+        messages: [
+          {
+            type: 'user',
+            content: 'Cross-project session',
+            id: 'msg1',
+            timestamp: '2024-01-01T10:00:00.000Z',
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(
+          otherProjectChatsDir,
+          `${SESSION_FILE_PREFIX}2024-01-01T10-00-${sessionId.slice(0, 8)}.json`,
+        ),
+        JSON.stringify(session, null, 2),
+      );
+
+      const sessionSelector = new SessionSelector(config);
+      const result = await sessionSelector.resolveSession(sessionId);
+
+      expect(result.sessionData.sessionId).toBe(sessionId);
+      expect(result.isCrossProject).toBe(true);
+    });
+
+    it('should prefer local session over global when UUID exists locally', async () => {
+      const sessionId = randomUUID();
+
+      // Create local chats dir with the session
+      const localChatsDir = path.join(tmpDir, 'chats');
+      await fs.mkdir(localChatsDir, { recursive: true });
+
+      const localSession = {
+        sessionId,
+        projectHash: 'local-project-hash',
+        startTime: '2024-01-01T10:00:00.000Z',
+        lastUpdated: '2024-01-01T10:30:00.000Z',
+        messages: [
+          {
+            type: 'user',
+            content: 'Local session',
+            id: 'msg1',
+            timestamp: '2024-01-01T10:00:00.000Z',
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(
+          localChatsDir,
+          `${SESSION_FILE_PREFIX}2024-01-01T10-00-${sessionId.slice(0, 8)}.json`,
+        ),
+        JSON.stringify(localSession, null, 2),
+      );
+
+      const sessionSelector = new SessionSelector(config);
+      const result = await sessionSelector.resolveSession(sessionId);
+
+      expect(result.sessionData.sessionId).toBe(sessionId);
+      // Should NOT be cross-project since it was found locally
+      expect(result.isCrossProject).toBeUndefined();
+    });
+
+    it('should not fall back to global search for numeric index identifiers', async () => {
+      // Create local chats dir with one session
+      const localChatsDir = path.join(tmpDir, 'chats');
+      await fs.mkdir(localChatsDir, { recursive: true });
+
+      const sessionId = randomUUID();
+      const session = {
+        sessionId,
+        projectHash: 'local-project-hash',
+        startTime: '2024-01-01T10:00:00.000Z',
+        lastUpdated: '2024-01-01T10:30:00.000Z',
+        messages: [
+          {
+            type: 'user',
+            content: 'Only session',
+            id: 'msg1',
+            timestamp: '2024-01-01T10:00:00.000Z',
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(
+          localChatsDir,
+          `${SESSION_FILE_PREFIX}2024-01-01T10-00-${sessionId.slice(0, 8)}.json`,
+        ),
+        JSON.stringify(session, null, 2),
+      );
+
+      const sessionSelector = new SessionSelector(config);
+
+      // Index 999 doesn't exist, should throw without trying global search
+      await expect(sessionSelector.resolveSession('999')).rejects.toThrow(
+        SessionError,
+      );
+    });
   });
 });
 

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -489,22 +489,17 @@ export class SessionSelector {
         continue;
       }
 
-      // Optimization: only check files whose name contains the truncated session ID
-      const candidates = files.filter(
-        (f) =>
-          f.startsWith(SESSION_FILE_PREFIX) &&
-          f.endsWith('.json') &&
-          f.includes(truncatedId),
+      // Get all session files first
+      const allSessionFiles = files.filter(
+        (f) => f.startsWith(SESSION_FILE_PREFIX) && f.endsWith('.json'),
       );
+
+      // Optimization: only check files whose name contains the truncated session ID
+      const candidates = allSessionFiles.filter((f) => f.includes(truncatedId));
 
       // If no filename matches, also fall back to checking all session files
       // (handles older naming conventions)
-      const filesToCheck =
-        candidates.length > 0
-          ? candidates
-          : files.filter(
-              (f) => f.startsWith(SESSION_FILE_PREFIX) && f.endsWith('.json'),
-            );
+      const filesToCheck = candidates.length > 0 ? candidates : allSessionFiles;
 
       for (const file of filesToCheck) {
         const filePath = path.join(chatsDir, file);


### PR DESCRIPTION


## Summary

Adds cross-project session resolution when a UUID is provided to --resume.
If the session UUID is not found in the current project, the CLI now
searches across all project directories in ~/.gemini/tmp/ to find it.

Changes:
- Add findSessionGlobal() method to search all projects by UUID
- Add UUID fallback in resolveSession() (only for UUID identifiers,
  not for numeric indexes or \"latest\")
- Show cross-project warning when resuming from a different folder
- Update exit message to display session-specific resume command
  with the session UUID for easy copy-paste
- Update --resume help text to mention UUID and cross-folder usage
- Add comprehensive tests for global search and cross-project fallback

Closed #20480

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [ ] Docker
