### PR TITLE
fix(core): reduce LLM-based loop detection false positives

### DIFF
--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -12,6 +12,7 @@ import type {
   GenerateContentResponse,
 } from '@google/genai';
 import { createUserContent } from '@google/genai';
+import { partListUnionToString } from './geminiRequest.js';
 import {
   getDirectoryContextString,
   getInitialChatHistory,
@@ -802,7 +803,7 @@ export class GeminiClient {
     const messageBus = this.config.getMessageBus();
 
     if (this.lastPromptId !== prompt_id) {
-      this.loopDetector.reset(prompt_id);
+      this.loopDetector.reset(prompt_id, partListUnionToString(request));
       this.hookStateMap.delete(this.lastPromptId);
       this.lastPromptId = prompt_id;
       this.currentSequenceModel = null;

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -806,15 +806,15 @@ describe('LoopDetectionService LLM Checks', () => {
   };
 
   it('should not trigger LLM check before LLM_CHECK_AFTER_TURNS', async () => {
-    await advanceTurns(29);
+    await advanceTurns(39);
     expect(mockBaseLlmClient.generateJson).not.toHaveBeenCalled();
   });
 
-  it('should trigger LLM check on the 30th turn', async () => {
+  it('should trigger LLM check on the 40th turn', async () => {
     mockBaseLlmClient.generateJson = vi
       .fn()
       .mockResolvedValue({ unproductive_state_confidence: 0.1 });
-    await advanceTurns(30);
+    await advanceTurns(40);
     expect(mockBaseLlmClient.generateJson).toHaveBeenCalledTimes(1);
     expect(mockBaseLlmClient.generateJson).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -828,12 +828,12 @@ describe('LoopDetectionService LLM Checks', () => {
   });
 
   it('should detect a cognitive loop when confidence is high', async () => {
-    // First check at turn 30
+    // First check at turn 40
     mockBaseLlmClient.generateJson = vi.fn().mockResolvedValue({
       unproductive_state_confidence: 0.85,
       unproductive_state_analysis: 'Repetitive actions',
     });
-    await advanceTurns(30);
+    await advanceTurns(40);
     expect(mockBaseLlmClient.generateJson).toHaveBeenCalledTimes(1);
     expect(mockBaseLlmClient.generateJson).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -842,14 +842,14 @@ describe('LoopDetectionService LLM Checks', () => {
     );
 
     // The confidence of 0.85 will result in a low interval.
-    // The interval will be: 5 + (15 - 5) * (1 - 0.85) = 5 + 10 * 0.15 = 6.5 -> rounded to 7
-    await advanceTurns(6); // advance to turn 36
+    // The interval will be: 7 + (15 - 7) * (1 - 0.85) = 7 + 8 * 0.15 = 8.2 -> rounded to 8
+    await advanceTurns(7); // advance to turn 47
 
     mockBaseLlmClient.generateJson = vi.fn().mockResolvedValue({
       unproductive_state_confidence: 0.95,
       unproductive_state_analysis: 'Repetitive actions',
     });
-    const finalResult = await service.turnStarted(abortController.signal); // This is turn 37
+    const finalResult = await service.turnStarted(abortController.signal); // This is turn 48
 
     expect(finalResult).toBe(true);
     expect(loggers.logLoopDetected).toHaveBeenCalledWith(
@@ -867,7 +867,7 @@ describe('LoopDetectionService LLM Checks', () => {
       unproductive_state_confidence: 0.5,
       unproductive_state_analysis: 'Looks okay',
     });
-    await advanceTurns(30);
+    await advanceTurns(40);
     const result = await service.turnStarted(abortController.signal);
     expect(result).toBe(false);
     expect(loggers.logLoopDetected).not.toHaveBeenCalled();
@@ -875,16 +875,17 @@ describe('LoopDetectionService LLM Checks', () => {
 
   it('should adjust the check interval based on confidence', async () => {
     // Confidence is 0.0, so interval should be MAX_LLM_CHECK_INTERVAL (15)
+    // Interval = 7 + (15 - 7) * (1 - 0.0) = 15
     mockBaseLlmClient.generateJson = vi
       .fn()
       .mockResolvedValue({ unproductive_state_confidence: 0.0 });
-    await advanceTurns(30); // First check at turn 30
+    await advanceTurns(40); // First check at turn 40
     expect(mockBaseLlmClient.generateJson).toHaveBeenCalledTimes(1);
 
-    await advanceTurns(14); // Advance to turn 44
+    await advanceTurns(14); // Advance to turn 54
     expect(mockBaseLlmClient.generateJson).toHaveBeenCalledTimes(1);
 
-    await service.turnStarted(abortController.signal); // Turn 45
+    await service.turnStarted(abortController.signal); // Turn 55
     expect(mockBaseLlmClient.generateJson).toHaveBeenCalledTimes(2);
   });
 
@@ -892,7 +893,7 @@ describe('LoopDetectionService LLM Checks', () => {
     mockBaseLlmClient.generateJson = vi
       .fn()
       .mockRejectedValue(new Error('API error'));
-    await advanceTurns(30);
+    await advanceTurns(40);
     const result = await service.turnStarted(abortController.signal);
     expect(result).toBe(false);
     expect(loggers.logLoopDetected).not.toHaveBeenCalled();
@@ -901,7 +902,7 @@ describe('LoopDetectionService LLM Checks', () => {
   it('should not trigger LLM check when disabled for session', async () => {
     service.disableForSession();
     expect(loggers.logLoopDetectionDisabled).toHaveBeenCalledTimes(1);
-    await advanceTurns(30);
+    await advanceTurns(40);
     const result = await service.turnStarted(abortController.signal);
     expect(result).toBe(false);
     expect(mockBaseLlmClient.generateJson).not.toHaveBeenCalled();
@@ -924,7 +925,7 @@ describe('LoopDetectionService LLM Checks', () => {
       .fn()
       .mockResolvedValue({ unproductive_state_confidence: 0.1 });
 
-    await advanceTurns(30);
+    await advanceTurns(40);
 
     expect(mockBaseLlmClient.generateJson).toHaveBeenCalledTimes(1);
     const calledArg = vi.mocked(mockBaseLlmClient.generateJson).mock
@@ -949,7 +950,7 @@ describe('LoopDetectionService LLM Checks', () => {
         unproductive_state_analysis: 'Main says loop',
       });
 
-    await advanceTurns(30);
+    await advanceTurns(40);
 
     // It should have called generateJson twice
     expect(mockBaseLlmClient.generateJson).toHaveBeenCalledTimes(2);
@@ -989,7 +990,7 @@ describe('LoopDetectionService LLM Checks', () => {
         unproductive_state_analysis: 'Main says no loop',
       });
 
-    await advanceTurns(30);
+    await advanceTurns(40);
 
     expect(mockBaseLlmClient.generateJson).toHaveBeenCalledTimes(2);
     expect(mockBaseLlmClient.generateJson).toHaveBeenNthCalledWith(
@@ -1009,12 +1010,12 @@ describe('LoopDetectionService LLM Checks', () => {
     expect(loggers.logLoopDetected).not.toHaveBeenCalled();
 
     // But should have updated the interval based on the main model's confidence (0.89)
-    // Interval = 5 + (15-5) * (1 - 0.89) = 5 + 10 * 0.11 = 5 + 1.1 = 6.1 -> 6
+    // Interval = 7 + (15-7) * (1 - 0.89) = 7 + 8 * 0.11 = 7 + 0.88 = 7.88 -> 8
 
-    // Advance by 6 turns
-    await advanceTurns(6);
+    // Advance by 7 turns
+    await advanceTurns(7);
 
-    // Next turn (37) should trigger another check
+    // Next turn (48) should trigger another check
     await service.turnStarted(abortController.signal);
     expect(mockBaseLlmClient.generateJson).toHaveBeenCalledTimes(3);
   });
@@ -1032,7 +1033,7 @@ describe('LoopDetectionService LLM Checks', () => {
       unproductive_state_analysis: 'Flash says loop',
     });
 
-    await advanceTurns(30);
+    await advanceTurns(40);
 
     // It should have called generateJson only once
     expect(mockBaseLlmClient.generateJson).toHaveBeenCalledTimes(1);
@@ -1051,5 +1052,54 @@ describe('LoopDetectionService LLM Checks', () => {
         confirmed_by_model: 'gemini-2.5-flash',
       }),
     );
+  });
+
+  it('should include user prompt in LLM check contents when provided', async () => {
+    service.reset('test-prompt-id', 'Add license headers to all files');
+
+    mockBaseLlmClient.generateJson = vi
+      .fn()
+      .mockResolvedValue({ unproductive_state_confidence: 0.1 });
+
+    await advanceTurns(40);
+
+    expect(mockBaseLlmClient.generateJson).toHaveBeenCalledTimes(1);
+    const calledArg = vi.mocked(mockBaseLlmClient.generateJson).mock
+      .calls[0][0];
+    // First content should be the user prompt context
+    expect(calledArg.contents[0]).toEqual({
+      role: 'user',
+      parts: [
+        {
+          text: 'Original user request for this task:\nAdd license headers to all files',
+        },
+      ],
+    });
+  });
+
+  it('should not include user prompt in contents when not provided', async () => {
+    service.reset('test-prompt-id');
+
+    vi.mocked(mockGeminiClient.getHistory).mockReturnValue([
+      {
+        role: 'model',
+        parts: [{ text: 'Some response' }],
+      },
+    ]);
+
+    mockBaseLlmClient.generateJson = vi
+      .fn()
+      .mockResolvedValue({ unproductive_state_confidence: 0.1 });
+
+    await advanceTurns(40);
+
+    expect(mockBaseLlmClient.generateJson).toHaveBeenCalledTimes(1);
+    const calledArg = vi.mocked(mockBaseLlmClient.generateJson).mock
+      .calls[0][0];
+    // First content should be the history, not a user prompt message
+    expect(calledArg.contents[0]).toEqual({
+      role: 'model',
+      parts: [{ text: 'Some response' }],
+    });
   });
 });

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -1066,12 +1066,12 @@ describe('LoopDetectionService LLM Checks', () => {
     expect(mockBaseLlmClient.generateJson).toHaveBeenCalledTimes(1);
     const calledArg = vi.mocked(mockBaseLlmClient.generateJson).mock
       .calls[0][0];
-    // First content should be the user prompt context
+    // First content should be the user prompt context wrapped in XML
     expect(calledArg.contents[0]).toEqual({
       role: 'user',
       parts: [
         {
-          text: 'Original user request for this task:\nAdd license headers to all files',
+          text: '<original_user_request>\nAdd license headers to all files\n</original_user_request>',
         },
       ],
     });

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -484,7 +484,7 @@ export class LoopDetectionService {
               role: 'user' as const,
               parts: [
                 {
-                  text: `Original user request for this task:\n${this.userPrompt}`,
+                  text: `<original_user_request>\n${this.userPrompt}\n</original_user_request>`,
                 },
               ],
             },

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -75,9 +75,9 @@ An unproductive state requires BOTH of the following to be true:
 2. The repetition produces NO net change or forward progress toward the user's goal.
 
 Specific patterns to look for:
-- **Alternating cycles:** The assistant cycles between a small set of actions (e.g., tool_A → tool_B → tool_A → tool_B) with no observable change in state across iterations.
-- **Semantic repetition:** The assistant calls the same tool with semantically equivalent arguments (same file, same line range, same content) repeatedly, without advancing the task.
-- **Cognitive loops:** The assistant repeatedly asks the same question, expresses the same confusion, or regenerates the same analysis without acting on it.
+- **Alternating cycles with no net effect:** The assistant cycles between the same actions (e.g., edit_file → run_build → edit_file → run_build) where each iteration applies the same edit and encounters the same error, making zero progress. Note: alternating between actions is only a loop if the arguments and outcomes are substantively identical each cycle. If the assistant is modifying different code or getting different errors, that is debugging progress, not a loop.
+- **Semantic repetition with identical outcomes:** The assistant calls the same tool with semantically equivalent arguments (same file, same line range, same content) multiple times consecutively, and each call produces the same outcome. This does NOT include build/test commands that are re-run after making code changes between invocations — re-running a build to verify a fix is normal workflow.
+- **Stuck reasoning:** The assistant produces multiple consecutive text responses that restate the same plan, question, or analysis without taking any new action or making a decision. This does NOT include command output that happens to contain repeated status lines or warnings.
 
 ## What is NOT an unproductive state
 


### PR DESCRIPTION
## Summary

Reduces false positives in LLM-based loop detection by providing task context, tightening the system prompt, and tuning check frequency thresholds.

## Details

The LLM-based loop detector was flagging legitimate batch operations (e.g., cross-file refactoring, adding headers to multiple files) as unproductive loops. Root causes:

1. **No task context:** The loop-check LLM received only recent turns with no knowledge of the original user request, making it impossible to distinguish intentional batch work from actual loops.
2. **Vague system prompt:** Subjective language like "a decent number of times" biased toward over-detection. The incremental-progress exception only covered same-file edits, not cross-file operations. The prompt also overlapped with the heuristic layer by describing identical-tool-call scenarios that are already caught before the LLM check runs.
3. **Aggressive check timing:** First check at turn 30 with interval of 3 was too early/frequent for complex tasks.
4. **No argument differentiation:** The prompt didn't instruct the LLM to compare tool arguments, so calls to the same tool on different files looked like repetition.

**Changes:**

- **User prompt context:** Pass the original user request to the loop-detection LLM as the first content message so it can evaluate repetition in context of the task goal. Updated `reset()` signature and callsite in `client.ts`.
- **System prompt rewrite:** Removed overlap with heuristic layer (identical tool calls already caught at layer 1). Clarified "consecutive assistant turns" → "consecutive model actions". Added explicit cross-file/batch exceptions and mandatory argument analysis (file paths, line numbers, content). Removed assumptions about function response visibility in trimmed history.
- **Threshold tuning:** `LLM_CHECK_AFTER_TURNS` 30→40, `DEFAULT_LLM_CHECK_INTERVAL` 3→10, `MIN_LLM_CHECK_INTERVAL` 5→7.

## Related Issues

Related to #18551

## How to Validate

1. Run the loop detection tests:
   ```bash
   npm test -w @google/gemini-cli-core -- src/services/loopDetectionService.test.ts
   ```
2. Verify all 51 tests pass, including two new tests for user prompt inclusion/exclusion in LLM check contents.
3. Run client tests to confirm no regressions:
   ```bash
   npm test -w @google/gemini-cli-core -- src/core/client.test.ts
   ```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker