### PR TITLE
fix(cli): resolve autoThemeSwitching when background hasn't changed but theme mismatches

### DIFF
--- a/packages/cli/src/ui/hooks/useTerminalTheme.test.tsx
+++ b/packages/cli/src/ui/hooks/useTerminalTheme.test.tsx
@@ -196,6 +196,36 @@ describe('useTerminalTheme', () => {
     expect(mockHandleThemeSelect).not.toHaveBeenCalled();
   });
 
+  it('should switch theme even if terminal background report is identical to previousColor if current theme is mismatched', () => {
+    // Background is dark at startup
+    config.setTerminalBackground('#000000');
+    vi.mocked(config.setTerminalBackground).mockClear();
+    // But theme is light
+    mockSettings.merged.ui.theme = 'default-light';
+
+    const refreshStatic = vi.fn();
+    const { unmount } = renderHook(() =>
+      useTerminalTheme(mockHandleThemeSelect, config, refreshStatic),
+    );
+
+    const handler = mockSubscribe.mock.calls[0][0];
+
+    // Terminal reports the same dark background
+    handler('rgb:0000/0000/0000');
+
+    expect(config.setTerminalBackground).not.toHaveBeenCalled();
+    expect(themeManager.setTerminalBackground).not.toHaveBeenCalled();
+    expect(refreshStatic).not.toHaveBeenCalled();
+    // But it SHOULD select the dark theme because of the mismatch!
+    expect(mockHandleThemeSelect).toHaveBeenCalledWith(
+      'default',
+      expect.anything(),
+    );
+
+    mockSettings.merged.ui.theme = 'default';
+    unmount();
+  });
+
   it('should not switch theme if autoThemeSwitching is disabled', () => {
     mockSettings.merged.ui.autoThemeSwitching = false;
     const { unmount } = renderHook(() =>

--- a/packages/cli/src/ui/hooks/useTerminalTheme.ts
+++ b/packages/cli/src/ui/hooks/useTerminalTheme.ts
@@ -59,14 +59,6 @@ export function useTerminalTheme(
       if (!hexColor) return;
 
       const previousColor = config.getTerminalBackground();
-
-      if (previousColor === hexColor) {
-        return;
-      }
-
-      config.setTerminalBackground(hexColor);
-      themeManager.setTerminalBackground(hexColor);
-
       const luminance = getLuminance(hexColor);
       const currentThemeName = settings.merged.ui.theme;
 
@@ -76,6 +68,16 @@ export function useTerminalTheme(
         DEFAULT_THEME.name,
         DefaultLight.name,
       );
+
+      if (previousColor === hexColor) {
+        if (newTheme) {
+          void handleThemeSelect(newTheme, SettingScope.User);
+        }
+        return;
+      }
+
+      config.setTerminalBackground(hexColor);
+      themeManager.setTerminalBackground(hexColor);
 
       if (newTheme) {
         void handleThemeSelect(newTheme, SettingScope.User);


### PR DESCRIPTION
## Summary

Fixes an issue where `autoThemeSwitching` would not work if the terminal background color hadn't changed since the application started, but the active theme was mismatched (e.g. a Light theme on a Dark background). 
The bug was caused by an early return inside `handleTerminalBackground` that bypassed the theme-switching logic when `previousColor === hexColor`. 

## Details

Moved the logic for evaluating the theme (`getLuminance`, `shouldSwitchTheme`) to happen *before* the early return check, so the theme matching logic still runs and correctly applies the theme even when the background hasn't changed.
Included a new unit test in `useTerminalTheme.test.tsx` to explicitly verify this edge-case behavior.

## Related Issues

Fixes #20705

## How to Validate

1. Open Gemini CLI in a terminal with a dark background but with your `ui.theme` set to `default-light` (and `autoThemeSwitching` enabled).
2. Start the CLI. Wait for the `terminalBackgroundPollingInterval` (default 60s).
3. Observe that the theme now correctly switches to the default dark theme, instead of remaining permanently stuck on light.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
