### PR TITLE
test(cli): fix skipped test for cleanupExpiredSessions error handling

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -791,14 +791,12 @@ describe('gemini.tsx main function kitty protocol', () => {
       }),
     );
 
-    process.env['GEMINI_API_KEY'] = 'test-key';
+    vi.stubEnv('GEMINI_API_KEY', 'test-key');
     vi.stubEnv('SANDBOX', 'true');
     try {
       await main();
     } catch (e) {
       if (!(e instanceof MockProcessExitError)) throw e;
-    } finally {
-      delete process.env['GEMINI_API_KEY'];
     }
 
     expect(debugLoggerErrorSpy).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

Fixes #20704

The test `should log error when cleanupExpiredSessions fails` in `packages/cli/src/gemini.test.tsx` has been skipped since it was introduced in commit e6344a8c2. This PR fixes the underlying issues and unskips it.

## Root Causes Fixed

1. **Missing module-level mock** — `./utils/sessionCleanup.js` had no `vi.mock()` at the top of the file. The dynamic `await import()` inside the test body returned the real module, so `vi.mocked()` had no `mockRejectedValue` method. Fixed by adding a proper `vi.mock` using `importOriginal` to preserve other exports like `DEFAULT_MIN_RETENTION`.

2. **Wrong code path reached** — `cleanupExpiredSessions` is only called after the sandbox check block, which requires `SANDBOX` env var to be set. The test was not setting it, so execution exited before reaching the cleanup code. Fixed by adding `vi.stubEnv('SANDBOX', 'true')` and `GEMINI_API_KEY`.

3. **Wrong assertion** — The test expected a single string argument to `debugLogger.error`, but the source calls it with two args: the message string and the error object. Fixed the assertion to match the actual call signature.

## Testing

All 35 tests in `gemini.test.tsx` pass.