### PR TITLE
fix(core): preserve TERM and COLORTERM in shell execution

### DIFF
--- a/packages/core/src/services/environmentSanitization.ts
+++ b/packages/core/src/services/environmentSanitization.ts
@@ -68,6 +68,8 @@ export const ALWAYS_ALLOWED_ENVIRONMENT_VARIABLES: ReadonlySet<string> =
     'HOME',
     'LANG',
     'SHELL',
+    'PAGER',
+    'GIT_PAGER',
     'TERM',
     'COLORTERM',
     'TMPDIR',

--- a/packages/core/src/services/environmentSanitization.ts
+++ b/packages/core/src/services/environmentSanitization.ts
@@ -68,6 +68,8 @@ export const ALWAYS_ALLOWED_ENVIRONMENT_VARIABLES: ReadonlySet<string> =
     'HOME',
     'LANG',
     'SHELL',
+    'TERM',
+    'COLORTERM',
     'TMPDIR',
     'USER',
     'LOGNAME',

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -259,9 +259,9 @@ export class ShellExecutionService {
           GEMINI_CLI: '1',
           TERM: 'xterm-256color',
           COLORTERM: 'truecolor',
-          ...sanitizeEnvironment(process.env, sanitizationConfig),
           PAGER: 'cat',
           GIT_PAGER: 'cat',
+          ...sanitizeEnvironment(process.env, sanitizationConfig),
         },
       });
 

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -256,9 +256,10 @@ export class ShellExecutionService {
         shell: false,
         detached: !isWindows,
         env: {
-          ...sanitizeEnvironment(process.env, sanitizationConfig),
           GEMINI_CLI: '1',
           TERM: 'xterm-256color',
+          COLORTERM: 'truecolor',
+          ...sanitizeEnvironment(process.env, sanitizationConfig),
           PAGER: 'cat',
           GIT_PAGER: 'cat',
         },
@@ -470,12 +471,13 @@ export class ShellExecutionService {
         cols,
         rows,
         env: {
+          GEMINI_CLI: '1',
+          TERM: 'xterm-256color',
+          COLORTERM: 'truecolor',
           ...sanitizeEnvironment(
             process.env,
             shellExecutionConfig.sanitizationConfig,
           ),
-          GEMINI_CLI: '1',
-          TERM: 'xterm-256color',
           PAGER: shellExecutionConfig.pager ?? 'cat',
           GIT_PAGER: shellExecutionConfig.pager ?? 'cat',
         },


### PR DESCRIPTION
## Summary

Fixes the issue where `TERM` and `COLORTERM` environment variables were either missing or redacted when executing terminal-based editors and interactive shell commands through the Gemini CLI.

## Details

1. Added `TERM` and `COLORTERM` to `ALWAYS_ALLOWED_ENVIRONMENT_VARIABLES` in `packages/core/src/services/environmentSanitization.ts` to prevent them from being stripped.
2. In `packages/core/src/services/shellExecutionService.ts`, changed the `env` object construction so that defaults for `TERM` (`xterm-256color`) and `COLORTERM` (`truecolor`) are applied *before* spreading the user's sanitized environment, rather than unconditionally overwriting `TERM` afterward. This preserves user-specific configurations if they exist.

## Related Issues

Fixes #20444

## How to Validate

1. Start `gemini-cli`
2. Ask the CLI to open `emacs` or `vim` using the shell tool.
3. Verify that the editor opens cleanly without a "Terminal type not defined" error and retains correct color settings.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
