### PR TITLE
docs(troubleshooting): add advanced debugging checklist link

### DIFF
--- a/docs/resources/troubleshooting.md
+++ b/docs/resources/troubleshooting.md
@@ -164,6 +164,15 @@ This is especially useful for scripting and automation.
   - Always run `npm run preflight` before committing code. This can catch many
     common issues related to formatting, linting, and type errors.
 
+- **Advanced debugging (RAG / tool workflows):**
+  - If a workflow fails in complex ways (tool calls, retrieval/grounding, CI vs
+    local differences), classify the failure type before changing prompts or
+    code.
+  - Optional checklist (community resource):
+    [WFGY ProblemMap](https://github.com/onestardao/WFGY/blob/main/ProblemMap/README.md)
+  - Workflow: capture prompt + logs/tool outputs → map to a failure class →
+    apply the smallest change → re-run with a minimal repro.
+
 ## Existing GitHub issues similar to yours or creating new issues
 
 If you encounter an issue that was not covered here in this _Troubleshooting


### PR DESCRIPTION
## Summary
Adds a short “Advanced debugging” tip to the troubleshooting guide with an optional checklist link for diagnosing tool/RAG workflow failures.

## Related issues
Fixes #20686

## How to validate
Docs-only change.