### PR TITLE
fix: use for...of instead of for...in to iterate array values in run_shell_command test

### DIFF
--- a/integration-tests/run_shell_command.test.ts
+++ b/integration-tests/run_shell_command.test.ts
@@ -334,7 +334,7 @@ describe('run_shell_command', () => {
       approvalMode: 'default',
     });
 
-    for (const expected in ['ls', tool]) {
+    for (const expected of ['ls', tool]) {
       const foundToolCall = await rig.waitForToolCall(
         'run_shell_command',
         15000,


### PR DESCRIPTION
## Summary

Fix `for...in` → `for...of` bug in `integration-tests/run_shell_command.test.ts` (line 337). `for...in` iterates array **indices** (`"0"`, `"1"`) instead of **values** (`"ls"`, `tool`), causing `waitForToolCall` to search for nonexistent commands `"0"` and `"1"`.

## Details

- `for (const expected in ['ls', tool])` yields `"0"`, `"1"` (indices), not `"ls"`, `tool` (values).
- The `waitForToolCall` predicate checks `"command": "${expected}"`, so it looks for `"command": "0"` — which never matches.
- The test is currently gated behind `it.skip(...)`, so CI is unaffected, but un-skipping it would produce confusing failures.
- The correct `for...of` pattern is already used in the same file at line 362, confirming this is an unintentional typo.
- One-character fix: `in` → `of`.

## Related Issues

Fixes #20728

## How to Validate

1. **Static verification:**
   ```js
   // Before (for...in — iterates indices)
   for (const x in ['ls', 'wc']) console.log(x);  // "0", "1"

   // After (for...of — iterates values)
   for (const x of ['ls', 'wc']) console.log(x);  // "ls", "wc"
   ```

2. **Check the diff** — only one line changed:
   ```diff
   - for (const expected in ['ls', tool]) {
   + for (const expected of ['ls', tool]) {
   ```

3. **Compare with line 362** in the same file, which already uses the correct `for...of`:
   ```ts
   for (const toolLog of toolLogs) {
   ```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
