### PR TITLE
fix(cli): Map allowedEnvironmentVariables from settings.json

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -730,6 +730,8 @@ export async function loadCliConfig(
         ? undefined
         : settings.mcp?.excluded
       : undefined,
+    allowedEnvironmentVariables:
+      settings.security?.environmentVariableRedaction?.allowed,
     blockedEnvironmentVariables:
       settings.security?.environmentVariableRedaction?.blocked,
     enableEnvironmentVariableRedaction:


### PR DESCRIPTION
## Summary

Resolves an issue where `allowedEnvironmentVariables` from `settings.json` was not successfully mapped to the internal CLI configuration object, leading to unexpected redaction of API keys for developers executing extensions like Nano Banana.

## Details

Version `0.31.0` and above aggressively redacts variables by checking for `<KEY>` identifiers to prevent secret leakages. While `environmentVariableRedaction.allowed` is set up properly in `settings.schema.json`, `config.ts` failed to interpret and pass on this exception list to the `environmentSanitization.ts` service. By mapping `settings.security?.environmentVariableRedaction?.allowed` within `config.ts`, user-defined secrets are properly loaded into MCP execution instances without being unnecessarily scrubbed.

## Related Issues

Closes #20724

## How to Validate

1. Edit your `~/.gemini/settings.json` to include:

   ```json
   {
     "security": {
       "environmentVariableRedaction": {
         "enabled": true,
         "allowed": ["NANOBANANA_GEMINI_API_KEY"]
       }
     }
   }
   ```

2. Export the environment variable `NANOBANANA_GEMINI_API_KEY` in your terminal.

3. Start the Gemini CLI, run the `/nanobanana` skill, and verify that it does not crash or loop infinitely trying to discover a valid credential.

## Pre-Merge Checklist

* [ ] Updated relevant documentation and README (if needed)
* [ ] Added/updated tests (if needed)
* [ ] Noted breaking changes (if any)
* [x] Validated on required platforms/methods:
  * [ ] MacOS
    * [ ] npm run
    * [ ] npx
    * [ ] Docker
    * [ ] Podman
    * [ ] Seatbelt
  * [x] Windows
    * [x] npm run
    * [ ] npx
    * [ ] Docker
  * [ ] Linux
    * [ ] npm run
    * [ ] npx
    * [ ] Docker
