### PR TITLE
feat(telemetry): add per-prompt execution timing foundation

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -128,6 +128,13 @@ describe('runNonInteractive', () => {
       totalLinesAdded: 0,
       totalLinesRemoved: 0,
     },
+    prompts: {
+      count: 0,
+      totalWallClockMs: 0,
+      minMs: Infinity,
+      maxMs: 0,
+      lastMs: 0,
+    },
   };
 
   beforeEach(async () => {

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -60,6 +60,13 @@ const mockSessionStats: SessionStatsState = {
       totalLinesAdded: 0,
       totalLinesRemoved: 0,
     },
+    prompts: {
+      count: 0,
+      totalWallClockMs: 0,
+      minMs: Infinity,
+      maxMs: 0,
+      lastMs: 0,
+    },
   },
 };
 

--- a/packages/cli/src/ui/components/GradientRegression.test.tsx
+++ b/packages/cli/src/ui/components/GradientRegression.test.tsx
@@ -55,6 +55,13 @@ const mockSessionStats: SessionStatsState = {
       byName: {},
     },
     files: { totalLinesAdded: 0, totalLinesRemoved: 0 },
+    prompts: {
+      count: 0,
+      totalWallClockMs: 0,
+      minMs: Infinity,
+      maxMs: 0,
+      lastMs: 0,
+    },
   },
 };
 

--- a/packages/cli/src/ui/components/ModelStatsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/ModelStatsDisplay.test.tsx
@@ -101,6 +101,13 @@ describe('<ModelStatsDisplay />', () => {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
       },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
+      },
     });
 
     expect(lastFrame()).toContain(
@@ -143,6 +150,13 @@ describe('<ModelStatsDisplay />', () => {
       files: {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
+      },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
       },
     });
 
@@ -201,6 +215,13 @@ describe('<ModelStatsDisplay />', () => {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
       },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
+      },
     });
 
     const output = lastFrame();
@@ -258,6 +279,13 @@ describe('<ModelStatsDisplay />', () => {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
       },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
+      },
     });
 
     const output = lastFrame();
@@ -305,6 +333,13 @@ describe('<ModelStatsDisplay />', () => {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
       },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
+      },
     });
 
     expect(lastFrame()).toMatchSnapshot();
@@ -344,6 +379,13 @@ describe('<ModelStatsDisplay />', () => {
       files: {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
+      },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
       },
     });
 
@@ -401,6 +443,13 @@ describe('<ModelStatsDisplay />', () => {
         files: {
           totalLinesAdded: 0,
           totalLinesRemoved: 0,
+        },
+        prompts: {
+          count: 0,
+          totalWallClockMs: 0,
+          minMs: Infinity,
+          maxMs: 0,
+          lastMs: 0,
         },
       },
       80,
@@ -462,6 +511,13 @@ describe('<ModelStatsDisplay />', () => {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
       },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
+      },
     });
 
     const output = lastFrame();
@@ -518,6 +574,13 @@ describe('<ModelStatsDisplay />', () => {
           files: {
             totalLinesAdded: 0,
             totalLinesRemoved: 0,
+          },
+          prompts: {
+            count: 0,
+            totalWallClockMs: 0,
+            minMs: Infinity,
+            maxMs: 0,
+            lastMs: 0,
           },
         },
         lastPromptTokenCount: 0,
@@ -598,6 +661,13 @@ describe('<ModelStatsDisplay />', () => {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
       },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
+      },
     });
 
     const output = lastFrame();
@@ -656,6 +726,13 @@ describe('<ModelStatsDisplay />', () => {
       files: {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
+      },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
       },
     });
 

--- a/packages/cli/src/ui/components/SessionSummaryDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SessionSummaryDisplay.test.tsx
@@ -80,6 +80,13 @@ describe('<SessionSummaryDisplay />', () => {
         totalLinesAdded: 42,
         totalLinesRemoved: 15,
       },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
+      },
     };
 
     const { lastFrame, unmount } = await renderWithMockedStats(metrics);

--- a/packages/cli/src/ui/components/StatsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.test.tsx
@@ -64,6 +64,13 @@ const createTestMetrics = (
     totalLinesAdded: 0,
     totalLinesRemoved: 0,
   },
+  prompts: {
+    count: 0,
+    totalWallClockMs: 0,
+    minMs: Infinity,
+    maxMs: 0,
+    lastMs: 0,
+  },
   ...overrides,
 });
 

--- a/packages/cli/src/ui/components/ToolStatsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/ToolStatsDisplay.test.tsx
@@ -62,6 +62,13 @@ describe('<ToolStatsDisplay />', () => {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
       },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
+      },
     });
 
     expect(lastFrame()).toContain(
@@ -103,6 +110,13 @@ describe('<ToolStatsDisplay />', () => {
       files: {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
+      },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
       },
     });
 
@@ -157,6 +171,13 @@ describe('<ToolStatsDisplay />', () => {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
       },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
+      },
     });
 
     const output = lastFrame();
@@ -199,6 +220,13 @@ describe('<ToolStatsDisplay />', () => {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
       },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
+      },
     });
 
     expect(lastFrame()).toMatchSnapshot();
@@ -237,6 +265,13 @@ describe('<ToolStatsDisplay />', () => {
       files: {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
+      },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
       },
     });
 

--- a/packages/cli/src/ui/contexts/SessionContext.test.tsx
+++ b/packages/cli/src/ui/contexts/SessionContext.test.tsx
@@ -133,6 +133,13 @@ describe('SessionStatsContext', () => {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
       },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
+      },
     };
 
     act(() => {
@@ -195,6 +202,13 @@ describe('SessionStatsContext', () => {
       files: {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
+      },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
       },
     };
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -38,6 +38,7 @@ import {
   generateSteeringAckMessage,
   GeminiCliOperation,
   getPlanModeExitMessage,
+  uiTelemetryService,
 } from '@google/gemini-cli-core';
 import type {
   Config,
@@ -1412,6 +1413,7 @@ export const useGeminiStream = (
             lastQueryRef.current = queryToSend;
             lastPromptIdRef.current = prompt_id!;
 
+            const promptStartTime = Date.now();
             try {
               const stream = geminiClient.sendMessageStream(
                 queryToSend,
@@ -1499,6 +1501,9 @@ export const useGeminiStream = (
                 maybeAddLowVerbosityFailureNote(userMessageTimestamp);
               }
             } finally {
+              uiTelemetryService.recordPromptDuration(
+                Date.now() - promptStartTime,
+              );
               if (activeQueryIdRef.current === queryId) {
                 setIsResponding(false);
               }

--- a/packages/cli/src/ui/utils/computeStats.test.ts
+++ b/packages/cli/src/ui/utils/computeStats.test.ts
@@ -140,6 +140,13 @@ describe('computeSessionStats', () => {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
       },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
+      },
     };
 
     const result = computeSessionStats(metrics);
@@ -191,6 +198,13 @@ describe('computeSessionStats', () => {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
       },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
+      },
     };
 
     const result = computeSessionStats(metrics);
@@ -231,6 +245,13 @@ describe('computeSessionStats', () => {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
       },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
+      },
     };
 
     const result = computeSessionStats(metrics);
@@ -252,6 +273,13 @@ describe('computeSessionStats', () => {
       files: {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
+      },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
       },
     };
 
@@ -275,6 +303,13 @@ describe('computeSessionStats', () => {
       files: {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
+      },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
       },
     };
 
@@ -301,6 +336,13 @@ describe('computeSessionStats', () => {
       files: {
         totalLinesAdded: 42,
         totalLinesRemoved: 18,
+      },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
       },
     };
 

--- a/packages/core/src/output/json-formatter.test.ts
+++ b/packages/core/src/output/json-formatter.test.ts
@@ -129,6 +129,13 @@ describe('JsonFormatter', () => {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
       },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
+      },
     };
     const formatted = formatter.format(undefined, response, stats);
     const expected = {
@@ -242,6 +249,13 @@ describe('JsonFormatter', () => {
       files: {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
+      },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
       },
     };
     const error: JsonError = {

--- a/packages/core/src/output/stream-json-formatter.test.ts
+++ b/packages/core/src/output/stream-json-formatter.test.ts
@@ -270,6 +270,13 @@ describe('StreamJsonFormatter', () => {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
       },
+      prompts: {
+        count: 0,
+        totalWallClockMs: 0,
+        minMs: Infinity,
+        maxMs: 0,
+        lastMs: 0,
+      },
     });
 
     it('should aggregate token counts from single model', () => {
@@ -440,6 +447,13 @@ describe('StreamJsonFormatter', () => {
           totalLinesAdded: 0,
           totalLinesRemoved: 0,
         },
+        prompts: {
+          count: 0,
+          totalWallClockMs: 0,
+          minMs: Infinity,
+          maxMs: 0,
+          lastMs: 0,
+        },
       };
 
       const result = formatter.convertToStreamStats(metrics, 1000);
@@ -466,6 +480,13 @@ describe('StreamJsonFormatter', () => {
         files: {
           totalLinesAdded: 0,
           totalLinesRemoved: 0,
+        },
+        prompts: {
+          count: 0,
+          totalWallClockMs: 0,
+          minMs: Infinity,
+          maxMs: 0,
+          lastMs: 0,
         },
       };
 


### PR DESCRIPTION
## Summary

Implements the foundational data layer for per-prompt wall-clock timing, as proposed in issue #20633.

## What this PR does

- Adds a `PromptMetrics` interface to `SessionMetrics` in `uiTelemetry.ts` tracking `count`, `totalWallClockMs`, `minMs`, `maxMs`, and `lastMs` across a session
- Adds `recordPromptDuration(durationMs)` method to `UiTelemetryService` — mutates the metrics and emits an `'update'` event (consistent with existing patterns)
- Hooks the **interactive execution path** in `useGeminiStream.ts` using a `try/finally` block around `sendMessageStream()` to capture accurate wall-clock time regardless of success or cancellation
- Updates all affected test fixtures to include the new `prompts` field

## What it does NOT do (intentionally)

- Does **not** hook the non-interactive path (planned for PR 2)
- Does **not** surface data in `/stats` yet (planned for PR 3)

This is a pure data-collection foundation with no user-visible changes.

## Test coverage

All existing tests pass. Fixtures updated mechanically to satisfy the new required field on `SessionMetrics`.

## Related

- Issue: #20633
- Followed by: PR 2 (non-interactive path), PR 3 (/stats surface)
