### PR TITLE
fix(test): use for...of instead of for...in for array iteration

### DIFF
--- a/integration-tests/run_shell_command.test.ts
+++ b/integration-tests/run_shell_command.test.ts
@@ -334,7 +334,7 @@ describe('run_shell_command', () => {
       approvalMode: 'default',
     });
 
-    for (const expected in ['ls', tool]) {
+    for (const expected of ['ls', tool]) {
       const foundToolCall = await rig.waitForToolCall(
         'run_shell_command',
         15000,


### PR DESCRIPTION
## Summary
- Fixes `for...in` to `for...of` in `integration-tests/run_shell_command.test.ts` (line 337)
- `for...in` iterates array **indices** (`"0"`, `"1"`) instead of **values** (`"ls"`, `tool`), causing `waitForToolCall` to check for wrong command names
- The correct `for...of` pattern is already used in the same file at line 361

## Test plan
- [x] The affected test is currently gated behind `it.skip(...)` (line 320), so this fix corrects the logic for when the test is un-skipped
- [x] Verified no other `for...in` array iteration patterns exist in the file
- [x] ESLint and Prettier pass

Fixes #20728