### PR TITLE
fix(cli): enable skipped cleanupExpiredSessions error handling test

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -243,6 +243,27 @@ vi.mock('./deferred.js', () => ({
   defer: vi.fn((m) => m),
 }));
 
+vi.mock('./utils/sessionCleanup.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('./utils/sessionCleanup.js')>();
+  return {
+    ...actual,
+    cleanupExpiredSessions: vi.fn().mockResolvedValue({
+      disabled: false,
+      scanned: 0,
+      deleted: 0,
+      skipped: 0,
+      failed: 0,
+    }),
+    cleanupToolOutputFiles: vi.fn().mockResolvedValue({
+      disabled: false,
+      scanned: 0,
+      deleted: 0,
+      failed: 0,
+    }),
+  };
+});
+
 vi.mock('./ui/utils/mouse.js', () => ({
   enableMouseEvents: vi.fn(),
   disableMouseEvents: vi.fn(),
@@ -747,7 +768,11 @@ describe('gemini.tsx main function kitty protocol', () => {
     emitFeedbackSpy.mockRestore();
   });
 
-  it.skip('should log error when cleanupExpiredSessions fails', async () => {
+  it('should log error when cleanupExpiredSessions fails', async () => {
+    // Set SANDBOX to simulate being inside the sandbox so main() does not
+    // attempt to relaunch and instead proceeds to config loading and cleanup.
+    vi.stubEnv('SANDBOX', 'true');
+
     const { cleanupExpiredSessions } = await import(
       './utils/sessionCleanup.js'
     );
@@ -783,8 +808,6 @@ describe('gemini.tsx main function kitty protocol', () => {
       }),
     );
 
-    // The mock is already set up at the top of the test
-
     try {
       await main();
     } catch (e) {
@@ -792,12 +815,12 @@ describe('gemini.tsx main function kitty protocol', () => {
     }
 
     expect(debugLoggerErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'Failed to cleanup expired sessions: Cleanup failed',
-      ),
+      'Failed to cleanup expired sessions:',
+      expect.any(Error),
     );
-    expect(processExitSpy).toHaveBeenCalledWith(0); // Should not exit on cleanup failure
+    expect(processExitSpy).toHaveBeenCalledWith(0);
     processExitSpy.mockRestore();
+    debugLoggerErrorSpy.mockRestore();
   });
 
   it('should read from stdin in non-interactive mode', async () => {

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -821,6 +821,7 @@ describe('gemini.tsx main function kitty protocol', () => {
     expect(processExitSpy).toHaveBeenCalledWith(0);
     processExitSpy.mockRestore();
     debugLoggerErrorSpy.mockRestore();
+    vi.unstubAllEnvs();
   });
 
   it('should read from stdin in non-interactive mode', async () => {


### PR DESCRIPTION
## Summary
- Enables the previously-skipped test `should log error when cleanupExpiredSessions fails` in `packages/cli/src/gemini.test.tsx`
- The test was skipped because `cleanupExpiredSessions` was dynamically imported without a module-level `vi.mock()`, causing `vi.mocked()` to return the real function without `mockRejectedValue`

## Root causes fixed
1. **Missing module mock**: Added `vi.mock('./utils/sessionCleanup.js')` with `importOriginal` to preserve non-function exports like `DEFAULT_MIN_RETENTION` while mocking the async functions
2. **Wrong execution path**: The test set `SANDBOX=''` (via `beforeEach`), causing `main()` to enter the sandbox relaunch block and `process.exit(0)` before ever reaching the cleanup code. Fixed by setting `SANDBOX=true` so execution proceeds past the sandbox check
3. **Incorrect assertion**: Changed `expect.stringContaining(...)` to match the actual `debugLogger.error` call signature with two separate arguments (string + Error)
4. **Missing cleanup**: Added `debugLoggerErrorSpy.mockRestore()` to prevent spy leakage

## Test plan
- [x] The fixed test passes: `npm test -w @google/gemini-cli -- src/gemini.test.tsx -t "should log error when cleanupExpiredSessions fails"`
- [x] All 35 tests in `gemini.test.tsx` pass (0 failures, 0 skipped)
- [x] ESLint and Prettier pass via pre-commit hooks

Fixes #20704