### PR TITLE
fix(core): match unqualified --allowed-tools names with MCP tool calls

### DIFF
--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -193,12 +193,10 @@ describe('PolicyEngine', () => {
         (await engine.check({ name: 'my-server__tool' }, 'my-server')).decision,
       ).toBe(PolicyDecision.ALLOW);
 
-      // Should NOT match with qualified call but NO serverName
       expect(
         (await engine.check({ name: 'my-server__tool' }, undefined)).decision,
       ).toBe(PolicyDecision.ASK_USER);
 
-      // Should NOT match with qualified call but WRONG serverName
       expect(
         (await engine.check({ name: 'my-server__tool' }, 'wrong-server'))
           .decision,
@@ -225,7 +223,6 @@ describe('PolicyEngine', () => {
           .decision,
       ).toBe(PolicyDecision.ALLOW);
 
-      // Unmatched tools should still be DENY in non-interactive mode
       expect(
         (await engine.check({ name: 'craftMCP__other_tool' }, 'craftMCP'))
           .decision,

--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -178,6 +178,60 @@ describe('PolicyEngine', () => {
       ).toBe(PolicyDecision.ASK_USER);
     });
 
+    it('should match unqualified rule names with qualified tool calls when serverName is provided', async () => {
+      const rules: PolicyRule[] = [
+        {
+          toolName: 'tool',
+          decision: PolicyDecision.ALLOW,
+        },
+      ];
+
+      engine = new PolicyEngine({ rules });
+
+      // Match with unqualified rule name and qualified tool call + serverName
+      expect(
+        (await engine.check({ name: 'my-server__tool' }, 'my-server')).decision,
+      ).toBe(PolicyDecision.ALLOW);
+
+      // Should NOT match with qualified call but NO serverName
+      expect(
+        (await engine.check({ name: 'my-server__tool' }, undefined)).decision,
+      ).toBe(PolicyDecision.ASK_USER);
+
+      // Should NOT match with qualified call but WRONG serverName
+      expect(
+        (await engine.check({ name: 'my-server__tool' }, 'wrong-server'))
+          .decision,
+      ).toBe(PolicyDecision.ASK_USER);
+    });
+
+    it('should ALLOW unqualified rule for MCP tool in non-interactive mode', async () => {
+      const config: PolicyEngineConfig = {
+        nonInteractive: true,
+        rules: [
+          {
+            toolName: 'notify_user',
+            decision: PolicyDecision.ALLOW,
+          },
+        ],
+      };
+
+      engine = new PolicyEngine(config);
+
+      // In non-interactive mode, an unqualified ALLOW rule should still
+      // match a qualified MCP tool call — not fall through to DENY
+      expect(
+        (await engine.check({ name: 'craftMCP__notify_user' }, 'craftMCP'))
+          .decision,
+      ).toBe(PolicyDecision.ALLOW);
+
+      // Unmatched tools should still be DENY in non-interactive mode
+      expect(
+        (await engine.check({ name: 'craftMCP__other_tool' }, 'craftMCP'))
+          .decision,
+      ).toBe(PolicyDecision.DENY);
+    });
+
     it('should match by args pattern', async () => {
       const rules: PolicyRule[] = [
         {

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -124,16 +124,12 @@ function ruleMatches(
         return false;
       }
     } else if (toolCall.name !== rule.toolName) {
-      // Check if rule uses an unqualified name that matches the tool part
-      // of a qualified MCP tool call (e.g., rule "notify_user" should match
-      // call "craftMCP__notify_user" when serverName is "craftMCP").
-      if (
+      // Check if an unqualified rule name matches a qualified MCP tool call
+      const isUnqualifiedMatch =
         serverName &&
         !rule.toolName.includes('__') &&
-        toolCall.name === `${serverName}__${rule.toolName}`
-      ) {
-        // Match: unqualified rule name matches the qualified tool call
-      } else {
+        toolCall.name === `${serverName}__${rule.toolName}`;
+      if (!isUnqualifiedMatch) {
         return false;
       }
     }

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -124,7 +124,18 @@ function ruleMatches(
         return false;
       }
     } else if (toolCall.name !== rule.toolName) {
-      return false;
+      // Check if rule uses an unqualified name that matches the tool part
+      // of a qualified MCP tool call (e.g., rule "notify_user" should match
+      // call "craftMCP__notify_user" when serverName is "craftMCP").
+      if (
+        serverName &&
+        !rule.toolName.includes('__') &&
+        toolCall.name === `${serverName}__${rule.toolName}`
+      ) {
+        // Match: unqualified rule name matches the qualified tool call
+      } else {
+        return false;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #16012
Closes #16012 

## Summary

Fix `--allowed-tools` flag being ignored for MCP tools in non-interactive mode. Unqualified tool names (e.g., `notify_user`) now correctly match qualified MCP tool calls (e.g., `craftMCP__notify_user`).

## Details

When `--allowed-tools=notify_user` is used, `createPolicyEngineConfig` creates a rule with `toolName: "notify_user"`. However, MCP tool calls arrive as `"craftMCP__notify_user"` (qualified with server name). The `ruleMatches()` function in `PolicyEngine` performed strict equality, so the unqualified rule name never matched the qualified tool call. This caused the default `ASK_USER` decision to apply, which becomes `DENY` in non-interactive mode.

The fix adds reverse matching in `ruleMatches()`: when a rule has an unqualified name (no `__`) and a `serverName` is provided, it checks if `serverName__ruleName === toolCall.name`. This mirrors the existing `toolCallsToTry` expansion logic that works in the other direction (qualified rule → unqualified call).

## Related Issues

Fixes #16012

## How to Validate

1. Run the policy engine tests:
   ```bash
   npm test -w @google/gemini-cli-core -- src/policy/policy-engine.test.ts
   ```
2. Look for the two new test cases:
   - `should match unqualified rule names with qualified tool calls when serverName is provided`
   - `should ALLOW unqualified rule for MCP tool in non-interactive mode`
3. Manual test (requires an MCP server extension):
   ```bash
   gemini -p "use notify_user tool" -e craftMCP --allowed-tools=notify_user
   ```
   Should no longer produce "denied by policy" error.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
