### PR TITLE
fix(core): Resolve garbled multibyte character output on Windows Powershell

### DIFF
--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -304,7 +304,18 @@ export class ShellExecutionService {
       const isWindows = os.platform() === 'win32';
       const { executable, argsPrefix, shell } = getShellConfiguration();
       const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
-      const spawnArgs = [...argsPrefix, guardedCommand];
+
+      // Force PowerShell on Windows to use UTF-8 encoding.
+      // Without this, multibyte characters (e.g., Japanese, Chinese) appear garbled.
+      const isPowerShell =
+        isWindows &&
+        (executable.toLowerCase().includes('powershell') ||
+          executable.toLowerCase().includes('pwsh'));
+      const finalCommand = isPowerShell
+        ? `$OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; ${guardedCommand}`
+        : guardedCommand;
+
+      const spawnArgs = [...argsPrefix, finalCommand];
 
       const child = cpSpawn(executable, spawnArgs, {
         cwd,
@@ -566,7 +577,20 @@ export class ShellExecutionService {
       }
 
       const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
-      const args = [...argsPrefix, guardedCommand];
+
+      // Force PowerShell on Windows to use UTF-8 encoding.
+      // Without this, multibyte characters (e.g., Japanese, Chinese) appear garbled.
+      const isWindows = process.platform === 'win32';
+      const isPowerShell =
+        isWindows &&
+        (executable.toLowerCase().includes('powershell') ||
+          executable.toLowerCase().includes('pwsh'));
+
+      const finalCommand = isPowerShell
+        ? `$OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; ${guardedCommand}`
+        : guardedCommand;
+
+      const args = [...argsPrefix, finalCommand];
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const ptyProcess = ptyInfo.module.spawn(executable, args, {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -28,6 +28,7 @@ import {
   type EnvironmentSanitizationConfig,
 } from './environmentSanitization.js';
 import { killProcessGroup } from '../utils/process-utils.js';
+import path from 'node:path';
 const { Terminal } = pkg;
 
 const MAX_CHILD_PROCESS_BUFFER_SIZE = 16 * 1024 * 1024; // 16MB
@@ -929,10 +930,10 @@ export class ShellExecutionService {
   ): string {
     // Force PowerShell on Windows to use UTF-8 encoding.
     // Without this, multibyte characters (e.g., Japanese, Chinese) appear garbled.
+    const exeName = path.basename(executable).toLowerCase();
     const isPowerShell =
       isWindows &&
-      (executable.toLowerCase().includes('powershell') ||
-        executable.toLowerCase().includes('pwsh'));
+      (exeName.startsWith('powershell') || exeName.startsWith('pwsh'));
 
     if (isPowerShell) {
       return `$OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; ${command}`;

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -304,16 +304,12 @@ export class ShellExecutionService {
       const isWindows = os.platform() === 'win32';
       const { executable, argsPrefix, shell } = getShellConfiguration();
       const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
-
-      // Force PowerShell on Windows to use UTF-8 encoding.
-      // Without this, multibyte characters (e.g., Japanese, Chinese) appear garbled.
-      const isPowerShell =
-        isWindows &&
-        (executable.toLowerCase().includes('powershell') ||
-          executable.toLowerCase().includes('pwsh'));
-      const finalCommand = isPowerShell
-        ? `$OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; ${guardedCommand}`
-        : guardedCommand;
+      const finalCommand =
+        ShellExecutionService.applyWindowsPowerShellEncodingFix(
+          guardedCommand,
+          executable,
+          isWindows,
+        );
 
       const spawnArgs = [...argsPrefix, finalCommand];
 
@@ -577,19 +573,13 @@ export class ShellExecutionService {
       }
 
       const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
-
-      // Force PowerShell on Windows to use UTF-8 encoding.
-      // Without this, multibyte characters (e.g., Japanese, Chinese) appear garbled.
       const isWindows = process.platform === 'win32';
-      const isPowerShell =
-        isWindows &&
-        (executable.toLowerCase().includes('powershell') ||
-          executable.toLowerCase().includes('pwsh'));
-
-      const finalCommand = isPowerShell
-        ? `$OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; ${guardedCommand}`
-        : guardedCommand;
-
+      const finalCommand =
+        ShellExecutionService.applyWindowsPowerShellEncodingFix(
+          guardedCommand,
+          executable,
+          isWindows,
+        );
       const args = [...argsPrefix, finalCommand];
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -930,6 +920,25 @@ export class ShellExecutionService {
         };
       }
     }
+  }
+
+  private static applyWindowsPowerShellEncodingFix(
+    command: string,
+    executable: string,
+    isWindows: boolean,
+  ): string {
+    // Force PowerShell on Windows to use UTF-8 encoding.
+    // Without this, multibyte characters (e.g., Japanese, Chinese) appear garbled.
+    const isPowerShell =
+      isWindows &&
+      (executable.toLowerCase().includes('powershell') ||
+        executable.toLowerCase().includes('pwsh'));
+
+    if (isPowerShell) {
+      return `$OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; ${command}`;
+    }
+
+    return command;
   }
 
   /**


### PR DESCRIPTION

## Summary

This fix forces UTF-8 encoding for PowerShell/pwsh execution on Windows to prevent garbled output (mojibake) when handling multibyte characters (Japanese, Korean, Chinese, etc.) in shell commands and git logs.

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

In Windows environments, PowerShell child processes often default to legacy code pages (e.g., 932 for Japanese), causing node-pty and child_process to capture garbled text.

This PR injects $OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; specifically for PowerShell/pwsh before the main command execution. This ensures the entire stream is correctly encoded as UTF-8 without modifying the user's global system settings. Both executeWithPty and childProcessFallback have been patched, as seen in the implementation.

I have not included any test for this fix because they might be a little too crazy and I'd love to have your feedback first in case you estimate that there should be added some tests, though I've validated manually on both Windows and Linux. 

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

Fixes #12468
Related to #18046

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

How to Validate
On Windows (PowerShell/pwsh):

Run: npm start

Command: echo "こんにちは世界！"

Expected: Clear Japanese output instead of random symbols.

Command: git log (on a repo with multibyte commit messages).

Expected: Correct rendering of non-ASCII characters.

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
