### PR TITLE
Feat(vertex-ai): add configurable location support for Vertex AI

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -850,6 +850,7 @@ export async function loadCliConfig(
     enableShellOutputEfficiency:
       settings.tools?.shell?.enableShellOutputEfficiency ?? true,
     skipNextSpeakerCheck: settings.model?.skipNextSpeakerCheck,
+    vertexAiLocation: settings.model?.vertexAiLocation,
     truncateToolOutputThreshold: settings.tools?.truncateToolOutputThreshold,
     eventEmitter: coreEvents,
     useWriteTodos: argv.useWriteTodos ?? settings.useWriteTodos,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -950,6 +950,16 @@ const SETTINGS_SCHEMA = {
         description: 'Skip the next speaker check.',
         showInDialog: true,
       },
+      vertexAiLocation: {
+        type: 'string',
+        label: 'Vertex AI Location',
+        category: 'Model',
+        requiresRestart: true,
+        default: undefined as string | undefined,
+        description:
+          'The Google Cloud location for Vertex AI (e.g. "global", "us-central1"). Defaults to "us-central1". Use "global" to access preview models.',
+        showInDialog: true,
+      },
     },
   },
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -491,6 +491,7 @@ export interface ConfigParameters {
   };
   checkpointing?: boolean;
   proxy?: string;
+  vertexAiLocation?: string;
   cwd: string;
   fileDiscoveryService?: FileDiscoveryService;
   includeDirectories?: string[];
@@ -855,6 +856,9 @@ export class Config implements McpContext {
     };
     this.checkpointing = params.checkpointing ?? false;
     this.proxy = params.proxy;
+    if (params.vertexAiLocation) {
+      process.env['GOOGLE_CLOUD_LOCATION'] = params.vertexAiLocation;
+    }
     this.cwd = params.cwd ?? process.cwd();
     this.fileDiscoveryService = params.fileDiscoveryService ?? null;
     this.bugCommand = params.bugCommand;

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -91,6 +91,7 @@ export function getAuthTypeFromEnv(): AuthType | undefined {
 export type ContentGeneratorConfig = {
   apiKey?: string;
   vertexai?: boolean;
+  location?: string;
   authType?: AuthType;
   proxy?: string;
 };
@@ -138,6 +139,7 @@ export async function createContentGeneratorConfig(
   ) {
     contentGeneratorConfig.apiKey = googleApiKey;
     contentGeneratorConfig.vertexai = true;
+    contentGeneratorConfig.location = googleCloudLocation;
 
     return contentGeneratorConfig;
   }
@@ -219,6 +221,7 @@ export async function createContentGenerator(
       const googleGenAI = new GoogleGenAI({
         apiKey: config.apiKey === '' ? undefined : config.apiKey,
         vertexai: config.vertexai,
+        location: config.location,
         httpOptions,
         ...(apiVersionEnv && { apiVersion: apiVersionEnv }),
       });


### PR DESCRIPTION
## Summary
Vertex AI preview models (e.g. `gemini-3.1-pro-preview`) are only available in the `global` region, but the CLI was hardcoded to use `us-central1` via the `GOOGLE_CLOUD_LOCATION` environment variable. This blocked users from accessing early access and preview models entirely, resulting in a 404 API error. This PR adds a `model.vertexAiLocation` setting to allow users to configure the Vertex AI location directly from `settings.json`.

## Details
Four files were changed:

- **`packages/core/src/core/contentGenerator.ts`** — Added `location` field to `ContentGeneratorConfig` type, populated it from `GOOGLE_CLOUD_LOCATION` env var, and passed it to the `GoogleGenAI` constructor.
- **`packages/core/src/config/config.ts`** — Added `vertexAiLocation` to the `ConfigParameters` interface and wired it to set `GOOGLE_CLOUD_LOCATION` env var on initialization.
- **`packages/cli/src/config/settingsSchema.ts`** — Added `vertexAiLocation` setting under the `model` category with description and restart requirement.
- **`packages/cli/src/config/config.ts`** — Wired `settings.model?.vertexAiLocation` to the Config params.

## Related Issues
Fixed issue #20761

## How to Validate
1. Set up Vertex AI auth with `GOOGLE_CLOUD_PROJECT` env var
2. Add to `~/.gemini/settings.json`:
```json
{
  "model": {
    "vertexAiLocation": "global"
  }
}
```
3. Run `gemini` and use a preview model like `gemini-3.1-pro-preview`
4. The 404 error should no longer appear
5. Alternatively set `GOOGLE_CLOUD_LOCATION=global` env var directly

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) — No breaking changes
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker