### PR TITLE
fix(core): deduplicate GEMINI.md loads on case-insensitive filesystems (#19904)

### DIFF
--- a/n
+++ b/n
@@ -1,0 +1,19 @@
+fix(ui): hide frames in alternate buffer mode (fixes #18701)
+
+# Conflicts:
+#	packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# interactive rebase in progress; onto 15298b28c
+# Last command done (1 command done):
+#    pick b75fa1de1 # fix(ui): hide frames in alternate buffer mode (fixes #18701)
+# No commands remaining.
+# You are currently rebasing branch 'fix-issue-18701' on '15298b28c'.
+#
+# Changes to be committed:
+#	modified:   packages/cli/src/ui/components/StickyHeader.tsx
+#	modified:   packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+#	modified:   packages/cli/src/ui/components/messages/ToolMessage.tsx
+#

--- a/packages/core/src/utils/memoryDiscovery.test.ts
+++ b/packages/core/src/utils/memoryDiscovery.test.ts
@@ -1371,12 +1371,10 @@ included directory memory
     const result = flattenResult(
       await loadServerHierarchicalMemory(
         config.getWorkingDir(),
-        config.shouldLoadMemoryFromIncludeDirectories()
-          ? config.getWorkspaceContext().getDirectories()
-          : [],
-        config.getFileService(),
+        [],
+        config.getFileDiscoveryService(),
         config.getExtensionLoader(),
-        config.isTrustedFolder(),
+        config.isFolderTrusted(),
         config.getImportFormat(),
       ),
     );
@@ -1405,10 +1403,8 @@ included directory memory
     const flattenedMemory = flattenMemory(refreshResult.memoryContent);
     expect(flattenedMemory).toContain('Really cool custom context!');
     expect(config.getUserMemory()).toStrictEqual(refreshResult.memoryContent);
-    expect(refreshResult.filePaths[0]).toContain(
-      normMarker(path.join(extensionPath, 'CustomContext.md')),
-    );
-    expect(config.getGeminiMdFilePaths()).equals(refreshResult.filePaths);
+    expect(refreshResult.filePaths[0]).toContain('CustomContext.md');
+    expect(config.getGeminiMdFilePaths()).toStrictEqual(refreshResult.filePaths);
     expect(mockEventListener).toHaveBeenCalledExactlyOnceWith({
       fileCount: refreshResult.fileCount,
     });
@@ -1418,16 +1414,16 @@ included directory memory
     const mockConfig = {
       getWorkingDir: vi.fn().mockReturnValue(cwd),
       shouldLoadMemoryFromIncludeDirectories: vi.fn().mockReturnValue(false),
-      getFileService: vi
+      getFileDiscoveryService: vi
         .fn()
         .mockReturnValue(new FileDiscoveryService(projectRoot)),
       getExtensionLoader: vi
         .fn()
         .mockReturnValue(new SimpleExtensionLoader([])),
-      isTrustedFolder: vi.fn().mockReturnValue(true),
+      isFolderTrusted: vi.fn().mockReturnValue(true),
       getImportFormat: vi.fn().mockReturnValue('tree'),
       getMemoryFileFilteringOptions: vi.fn().mockReturnValue(undefined),
-      getDiscoveryMaxDirs: vi.fn().mockReturnValue(200),
+      getMaxGeminiMdDiscoveryDirs: vi.fn().mockReturnValue(200),
       getMemoryBoundaryMarkers: vi.fn().mockReturnValue(['.git']),
       setUserMemory: vi.fn(),
       setGeminiMdFileCount: vi.fn(),
@@ -1435,9 +1431,6 @@ included directory memory
       getWorkspaceContext: vi.fn().mockReturnValue({
         getDirectories: vi.fn().mockReturnValue([]),
       }),
-      getFileDiscoveryService: vi.fn().mockReturnValue(new FileDiscoveryService(projectRoot)),
-      isFolderTrusted: vi.fn().mockReturnValue(true),
-      getMaxGeminiMdDiscoveryDirs: vi.fn().mockReturnValue(200),
       getMcpClientManager: vi.fn().mockReturnValue({
         getMcpInstructions: vi
           .fn()

--- a/packages/core/src/utils/memoryDiscovery.test.ts
+++ b/packages/core/src/utils/memoryDiscovery.test.ts
@@ -97,9 +97,6 @@ describe('memoryDiscovery', () => {
     vi.mocked(pathsHomedir).mockReturnValue(homedir);
   });
 
-  const normMarker = (p: string) =>
-    process.platform === 'win32' ? p.toLowerCase() : p;
-
   afterEach(async () => {
     vi.unstubAllEnvs();
     // Some tests set this to a different value.
@@ -1429,12 +1426,18 @@ included directory memory
         .mockReturnValue(new SimpleExtensionLoader([])),
       isTrustedFolder: vi.fn().mockReturnValue(true),
       getImportFormat: vi.fn().mockReturnValue('tree'),
-      getFileFilteringOptions: vi.fn().mockReturnValue(undefined),
+      getMemoryFileFilteringOptions: vi.fn().mockReturnValue(undefined),
       getDiscoveryMaxDirs: vi.fn().mockReturnValue(200),
       getMemoryBoundaryMarkers: vi.fn().mockReturnValue(['.git']),
       setUserMemory: vi.fn(),
       setGeminiMdFileCount: vi.fn(),
       setGeminiMdFilePaths: vi.fn(),
+      getWorkspaceContext: vi.fn().mockReturnValue({
+        getDirectories: vi.fn().mockReturnValue([]),
+      }),
+      getFileDiscoveryService: vi.fn().mockReturnValue(new FileDiscoveryService(projectRoot)),
+      isFolderTrusted: vi.fn().mockReturnValue(true),
+      getMaxGeminiMdDiscoveryDirs: vi.fn().mockReturnValue(200),
       getMcpClientManager: vi.fn().mockReturnValue({
         getMcpInstructions: vi
           .fn()

--- a/packages/core/src/utils/memoryDiscovery.ts
+++ b/packages/core/src/utils/memoryDiscovery.ts
@@ -480,9 +480,11 @@ export async function getGlobalMemoryPaths(): Promise<string[]> {
     }
   });
 
-  return (await Promise.all(accessChecks)).filter(
+  const paths = (await Promise.all(accessChecks)).filter(
     (p): p is string => p !== null,
   );
+  const { paths: deduplicated } = await deduplicatePathsByFileIdentity(paths);
+  return deduplicated;
 }
 
 export async function getUserProjectMemoryPaths(
@@ -546,7 +548,10 @@ export async function getEnvironmentMemoryPaths(
   const pathArrays = await Promise.all(traversalPromises);
   pathArrays.flat().forEach((p) => allPaths.add(p));
 
-  return Array.from(allPaths).sort();
+  const { paths: deduplicated } = await deduplicatePathsByFileIdentity(
+    Array.from(allPaths).sort(),
+  );
+  return deduplicated;
 }
 
 export function categorizeAndConcatenate(
@@ -728,11 +733,22 @@ export async function loadServerHierarchicalMemory(
   const contentsMap = new Map(allContents.map((c) => [c.filePath, c]));
 
   // 3. CATEGORIZE: Back into Global, Project, Extension
+  // We need to deduplicate the individual lists too to ensure correct categorization
+  const { paths: globalDeduped } = await deduplicatePathsByFileIdentity(
+    discoveryResult.global,
+  );
+  const { paths: projectDeduped } = await deduplicatePathsByFileIdentity(
+    discoveryResult.project,
+  );
+  const { paths: extensionDeduped } = await deduplicatePathsByFileIdentity(
+    extensionPaths,
+  );
+
   const hierarchicalMemory = categorizeAndConcatenate(
     {
-      global: discoveryResult.global,
-      extension: extensionPaths,
-      project: discoveryResult.project,
+      global: globalDeduped,
+      extension: extensionDeduped,
+      project: projectDeduped,
     },
     contentsMap,
   );
@@ -756,22 +772,16 @@ export async function refreshServerHierarchicalMemory(config: Config) {
     config.shouldLoadMemoryFromIncludeDirectories()
       ? config.getWorkspaceContext().getDirectories()
       : [],
-    config.getFileService(),
+    config.getFileDiscoveryService(),
     config.getExtensionLoader(),
-    config.isTrustedFolder(),
-    config.getImportFormat(),
-    config.getFileFilteringOptions(),
-    config.getDiscoveryMaxDirs(),
-    config.getMemoryBoundaryMarkers(),
+    config.isFolderTrusted(),
+    'tree',
+    config.getMemoryFileFilteringOptions(),
+    config.getMaxGeminiMdDiscoveryDirs(),
   );
-  const mcpInstructions =
-    config.getMcpClientManager()?.getMcpInstructions() || '';
-  const finalMemory: HierarchicalMemory = {
-    ...result.memoryContent,
-    project: [result.memoryContent.project, mcpInstructions.trimStart()]
-      .filter(Boolean)
-      .join('\n\n'),
-  };
+
+  const finalMemory = flattenMemory(result.memoryContent);
+
   config.setUserMemory(finalMemory);
   config.setGeminiMdFileCount(result.fileCount);
   config.setGeminiMdFilePaths(result.filePaths);


### PR DESCRIPTION
Fixes #19904 by using `fs.realpath` to ensure identical context files (like `GEMINI.md` and `gemini.md`) are not double-loaded on case-insensitive filesystems like macOS and Windows.