### PR TITLE
docs: fix broken Keyboard Shortcuts link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ gemini
   auth configuration.
 - [**Configuration Guide**](./docs/get-started/configuration.md) - Settings and
   customization.
-- [**Keyboard Shortcuts**](./docs/cli/keyboard-shortcuts.md) - Productivity
+- [**Keyboard Shortcuts**](https://github.com/google-gemini/gemini-cli/blob/main/docs/reference/keyboard-shortcuts.md) - Productivity
   tips.
 
 ### Core Features

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ gemini
   auth configuration.
 - [**Configuration Guide**](./docs/get-started/configuration.md) - Settings and
   customization.
-- [**Keyboard Shortcuts**](https://github.com/google-gemini/gemini-cli/blob/main/docs/reference/keyboard-shortcuts.md) - Productivity
+- [**Keyboard Shortcuts**](./docs/reference/keyboard-shortcuts.md) - Productivity
   tips.
 
 ### Core Features


### PR DESCRIPTION
Fixes #20781.

The link for "Keyboard Shortcuts - Productivity tips" in the README.md currently points to `./docs/cli/keyboard-shortcuts.md`, which does not exist. It has been updated to point to `https://github.com/google-gemini/gemini-cli/blob/main/docs/reference/keyboard-shortcuts.md`.