### PR TITLE
fix(sandbox): pass proxy env vars to seatbelt sandbox process

### DIFF
--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -193,6 +193,7 @@ export async function start_sandbox(
       process.stdin.pause();
       sandboxProcess = spawn(config.command, args, {
         stdio: 'inherit',
+        env: sandboxEnv,
       });
       return await new Promise((resolve, reject) => {
         sandboxProcess?.on('error', reject);


### PR DESCRIPTION
## Summary

Fixes #19187

- The `sandboxEnv` object with `HTTP_PROXY`/`HTTPS_PROXY` env vars is created when `GEMINI_SANDBOX_PROXY_COMMAND` is set (line 136-151), but was never passed to the `spawn()` call for the sandbox-exec process (line 194)
- Sandboxed commands could not see proxy configuration, making the `*-proxied` seatbelt profiles unusable
- Fix: add `env: sandboxEnv` to the spawn options, matching how the Docker sandbox path already passes proxy vars via `--env` flags (lines 399-408)

## Test plan

- [x] All 8 existing sandbox tests pass
- [x] ESLint and Prettier checks pass
- [ ] Manual test: run with `GEMINI_SANDBOX_PROXY_COMMAND` and `SEATBELT_PROFILE=permissive-proxied`, verify curl commands inside sandbox respect proxy