### PR TITLE
fix(test): enable skipped compression failure test

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -520,7 +520,7 @@ describe('Gemini Client (client.ts)', () => {
         expect(client['chat']).toBe(mockOriginalChat);
       });
 
-      it.skip('will not attempt to compress context after a failure', async () => {
+      it('will not attempt to compress context after a failure', async () => {
         const { client } = setup({
           originalTokenCount: 100,
           newTokenCount: 200,


### PR DESCRIPTION
## Summary

Fixes #20767

The test `'will not attempt to compress context after a failure'` in `packages/core/src/core/client.test.ts` was marked as `it.skip` but the underlying implementation is correct and the test passes when enabled. The `hasFailedCompressionAttempt` flag logic in `tryCompressChat` already correctly implements the behavior the test is verifying.

Without this test active, regressions in the compression failure handling would go undetected.

## Test plan

- [x] All 72 tests in `client.test.ts` pass (including the re-enabled test)
- [x] ESLint and Prettier checks pass via pre-commit hooks