### PR TITLE
fix(ui): decouple context percentage from model info visibility

### DIFF
--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -381,6 +381,61 @@ describe('<Footer />', () => {
       unmount();
     });
 
+    it('shows the context percentage even when hideModelInfo is true', async () => {
+      const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
+        <Footer />,
+        {
+          width: 120,
+          uiState: { sessionStats: mockSessionStats },
+          settings: createMockSettings({
+            ui: {
+              footer: {
+                hideModelInfo: true,
+                hideContextPercentage: false,
+              },
+            },
+          }),
+        },
+      );
+      await waitUntilReady();
+
+      expect(lastFrame()).not.toContain(defaultProps.model);
+      expect(lastFrame()).toMatch(/\d+% context left/);
+      unmount();
+    });
+
+    it('shows quota stats even when hideModelInfo is true', async () => {
+      const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
+        <Footer />,
+        {
+          width: 120,
+          uiState: {
+            sessionStats: mockSessionStats,
+            quota: {
+              userTier: undefined,
+              stats: { remaining: 15, limit: 100, resetTime: undefined },
+              proQuotaRequest: null,
+              validationRequest: null,
+              overageMenuRequest: null,
+              emptyWalletRequest: null,
+            },
+          },
+          settings: createMockSettings({
+            ui: {
+              footer: {
+                hideModelInfo: true,
+              },
+            },
+          }),
+        },
+      );
+      await waitUntilReady();
+
+      expect(lastFrame()).not.toContain(defaultProps.model);
+      expect(lastFrame()).toContain('15%');
+      unmount();
+    });
+
     it('renders footer with all optional sections hidden (minimal footer)', async () => {
       const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
         <Footer />,

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -71,13 +71,21 @@ export const Footer: React.FC = () => {
   const pathLength = Math.max(20, Math.floor(terminalWidth * 0.25));
   const displayPath = shortenPath(tildeifyPath(targetDir), pathLength);
 
-  const justifyContent =
-    hideCWD && hideModelInfo && hideContextPercentage
-      ? 'center'
-      : 'space-between';
   const displayVimMode = vimEnabled ? vimMode : undefined;
-
   const showDebugProfiler = debugMode || isDevelopment;
+
+  // Determine if anything is visible on the left or right to set layout
+  const showLeftSection = showDebugProfiler || !!displayVimMode || !hideCWD;
+  const showRightSection =
+    !hideModelInfo ||
+    !hideContextPercentage ||
+    !!quotaStats ||
+    showMemoryUsage ||
+    corgiMode ||
+    showErrorSummary;
+
+  const justifyContent =
+    !showLeftSection && !showRightSection ? 'center' : 'space-between';
 
   return (
     <Box

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -71,7 +71,10 @@ export const Footer: React.FC = () => {
   const pathLength = Math.max(20, Math.floor(terminalWidth * 0.25));
   const displayPath = shortenPath(tildeifyPath(targetDir), pathLength);
 
-  const justifyContent = hideCWD && hideModelInfo ? 'center' : 'space-between';
+  const justifyContent =
+    hideCWD && hideModelInfo && hideContextPercentage
+      ? 'center'
+      : 'space-between';
   const displayVimMode = vimEnabled ? vimMode : undefined;
 
   const showDebugProfiler = debugMode || isDevelopment;
@@ -140,15 +143,25 @@ export const Footer: React.FC = () => {
       )}
 
       {/* Right Section: Gemini Label and Console Summary */}
-      {!hideModelInfo && (
+      {(!hideModelInfo ||
+        !hideContextPercentage ||
+        !!quotaStats ||
+        showMemoryUsage ||
+        corgiMode ||
+        showErrorSummary) && (
         <Box alignItems="center" justifyContent="flex-end">
           <Box alignItems="center">
             <Text color={theme.text.primary}>
-              <Text color={theme.text.secondary}>/model </Text>
-              {getDisplayString(model)}
+              {!hideModelInfo && (
+                <>
+                  <Text color={theme.text.secondary}>/model </Text>
+                  {getDisplayString(model)}
+                </>
+              )}
               {!hideContextPercentage && (
                 <>
-                  {' '}
+                  {/* Adds a space between Model Info and Context if BOTH are shown */}
+                  {!hideModelInfo && ' '}
                   <ContextUsageDisplay
                     promptTokenCount={promptTokenCount}
                     model={model}
@@ -158,7 +171,8 @@ export const Footer: React.FC = () => {
               )}
               {quotaStats && (
                 <>
-                  {' '}
+                  {/* Adds a space if either of the previous items are shown */}
+                  {(!hideModelInfo || !hideContextPercentage) && ' '}
                   <QuotaDisplay
                     remaining={quotaStats.remaining}
                     limit={quotaStats.limit}


### PR DESCRIPTION
Fixes #14864

## Summary

Decouples the ```ContextUsageDisplay```, ```QuotaDisplay```, and ```MemoryUsageDisplay``` from the model info visibility toggle in the UI footer.

## Details

Currently, in ```packages/cli/src/ui/components/Footer.tsx```, several stats displays are nested inside the {!hideModelInfo} conditional block. This causes the context percentage and quota stats to disappear when the model info is disabled, even if hideContextPercentage is explicitly set to false.

### Changes:

- Refactored Footer.tsx to evaluate model info, context percentage, and quota visibility independently.
- Updated the justifyContent layout logic so the footer remains properly aligned when mixing and matching these visibility settings.
- Added specific unit tests to Footer.test.tsx to ensure context percentage and quota render correctly when the model info is hidden.

## How to Validate

1. Update ```~/.gemini/settings.json``` to include:
```json
{
  "ui": {
    "footer": {
      "hideModelInfo": true,
      "hideContextPercentage": false
    }
  }
}
```
2. Build and run the CLI locally.
3. Look at the footer on bottom right. The model-name is hidden but context usage is present.
4. Run the targeted test suite to confirm(added new test to validate):
```
npm run test -- Footer.test.tsx
```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [X ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ X] Validated on required platforms/methods:
  - [ X] MacOS
    - [X ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

screenshot with updated ~/.gemini/settings.json:
```json
  "ui": {
    "footer": {
      "hideContextPercentage": false,
      "hideModelInfo": true
    }
  }
```
<img width="1109" height="282" alt="Screenshot 2026-03-01 at 4 09 20 PM" src="https://github.com/user-attachments/assets/64dd545d-db63-41a6-8873-af798e4482ba" />

