### PR TITLE
fix(shell): preserve trailing newlines to support heredocs

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -293,7 +293,7 @@ describe('ShellTool', () => {
       await promise;
 
       const tmpFile = path.join(os.tmpdir(), 'shell_pgrep_abcdef.tmp');
-      const wrappedCommand = `{ ls; }; __code=$?; pgrep -g 0 >${tmpFile} 2>&1; exit $__code;`;
+      const wrappedCommand = `{ ls\n; }; __code=$?; pgrep -g 0 >${tmpFile} 2>&1; exit $__code;`;
       expect(mockShellExecutionService).toHaveBeenCalledWith(
         wrappedCommand,
         subdir,
@@ -314,7 +314,7 @@ describe('ShellTool', () => {
       await promise;
 
       const tmpFile = path.join(os.tmpdir(), 'shell_pgrep_abcdef.tmp');
-      const wrappedCommand = `{ ls; }; __code=$?; pgrep -g 0 >${tmpFile} 2>&1; exit $__code;`;
+      const wrappedCommand = `{ ls\n; }; __code=$?; pgrep -g 0 >${tmpFile} 2>&1; exit $__code;`;
       expect(mockShellExecutionService).toHaveBeenCalledWith(
         wrappedCommand,
         path.join(tempRootDir, 'subdir'),

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -183,8 +183,10 @@ export class ShellToolInvocation extends BaseToolInvocation<
         ? strippedCommand
         : (() => {
             // wrap command to append subprocess pids (via pgrep) to temporary file
-            let command = strippedCommand.trim();
-            if (!command.endsWith('&')) command += ';';
+            // Use trimStart() only — trimEnd() would strip trailing newlines
+            // needed by heredocs and other multi-line shell constructs.
+            let command = strippedCommand.trimStart();
+            if (!command.trimEnd().endsWith('&')) command += '\n;';
             return `{ ${command} }; __code=$?; pgrep -g 0 >${tempFilePath} 2>&1; exit $__code;`;
           })();
 

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -716,7 +716,7 @@ export function stripShellWrapper(command: string): string {
     }
     return newCommand;
   }
-  return command.trim();
+  return command.trimStart();
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #20755

The `run_shell_command` tool strips trailing newlines from commands via `.trim()` before execution, breaking heredocs and other multi-line shell constructs that require a trailing newline as a delimiter.

**Root cause:** Two locations use `.trim()` on command strings:
1. `packages/core/src/tools/shell.ts` (line 186) — the pgrep wrapper calls `.trim()` before appending `;`, which removes the trailing newline needed by heredoc EOF delimiters
2. `packages/core/src/utils/shell-utils.ts` (`stripShellWrapper`) — returns `command.trim()` for non-wrapped commands

**Fix:**
- Replace `.trim()` with `.trimStart()` to preserve trailing newlines while still removing leading whitespace
- Use `.trimEnd()` only for the `endsWith('&')` background detection check, without modifying the actual command
- Append `\n;` instead of `;` so the semicolon goes on its own line after any trailing newlines

## Test plan
- [x] All 39 shell tool tests pass (updated 2 test expectations for new wrapper format)
- [x] All 56 shell-utils tests pass
- [x] ESLint and Prettier checks pass
- [x] Heredoc commands like `cat <<EOF\ntest\nEOF\n` will now preserve their delimiter newlines

🤖 Generated with [Claude Code](https://claude.com/claude-code)