### PR TITLE
fix(evals): honor timeout in answer-vs-act eval

### DIFF
--- a/evals/answer-vs-act.eval.ts
+++ b/evals/answer-vs-act.eval.ts
@@ -136,9 +136,9 @@ describe('Answer vs. ask eval', () => {
    */
   evalTest('USUALLY_PASSES', {
     name: 'should not edit files when user notes an issue',
+    timeout: 20000,
     prompt: 'The add function subtracts numbers.',
     files: FILES,
-    params: { timeout: 20000 }, // 20s timeout
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
 


### PR DESCRIPTION
Fixes #20649

## Summary
The eval case `should not edit files when user notes an issue` set a 20s timeout under `params.timeout`, but the eval harness reads timeouts from top-level `evalCase.timeout`. This moves the timeout to the correct field so it’s honored.

## What changed
- Move `timeout: 20000` from `params` to top-level `timeout` for the affected eval case.

## How to validate
- `npm run lint`
- `npm run format`
- (Optional, requires API key) `npm run test:all_evals -- evals/answer-vs-act.eval.ts -t "should not edit files when user notes an issue"`

## Notes
On Windows, running evals may fail due to symlink permissions for `node_modules` (EPERM). This is unrelated to the timeout change.