### PR TITLE
feat(cli): compact tool outputs with Ctrl+O toggle

### DIFF
--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -2,59 +2,47 @@
 
 Control your Gemini CLI experience with the `/settings` command. The `/settings`
 command opens a dialog to view and edit all your Gemini CLI settings, including
-your UI experience, keybindings, and accessibility features.
+your UI experience, keybindings, and more.
 
-Your Gemini CLI settings are stored in a `settings.json` file. In addition to
-using the `/settings` command, you can also edit them in one of the following
-locations:
-
-- **User settings**: `~/.gemini/settings.json`
-- **Workspace settings**: `your-project/.gemini/settings.json`
-
-Note: Workspace settings override user settings.
-
-## Settings reference
-
-Here is a list of all the available settings, grouped by category and ordered as
-they appear in the UI.
+## Quick settings overview
 
 <!-- SETTINGS-AUTOGEN:START -->
 
-### General
-
-| UI Label                | Setting                            | Description                                                                                                                                                                    | Default     |
-| ----------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
-| Vim Mode                | `general.vimMode`                  | Enable Vim keybindings                                                                                                                                                         | `false`     |
-| Default Approval Mode   | `general.defaultApprovalMode`      | The default approval mode for tool execution. 'default' prompts for approval, 'auto_edit' auto-approves edit tools, and 'plan' is read-only mode. 'yolo' is not supported yet. | `"default"` |
-| Enable Auto Update      | `general.enableAutoUpdate`         | Enable automatic updates.                                                                                                                                                      | `true`      |
-| Enable Notifications    | `general.enableNotifications`      | Enable run-event notifications for action-required prompts and session completion. Currently macOS only.                                                                       | `false`     |
-| Plan Directory          | `general.plan.directory`           | The directory where planning artifacts are stored. If not specified, defaults to the system temporary directory.                                                               | `undefined` |
-| Plan Model Routing      | `general.plan.modelRouting`        | Automatically switch between Pro and Flash models based on Plan Mode status. Uses Pro for the planning phase and Flash for the implementation phase.                           | `true`      |
-| Max Chat Model Attempts | `general.maxAttempts`              | Maximum number of attempts for requests to the main chat model. Cannot exceed 10.                                                                                              | `10`        |
-| Debug Keystroke Logging | `general.debugKeystrokeLogging`    | Enable debug logging of keystrokes to the console.                                                                                                                             | `false`     |
-| Enable Session Cleanup  | `general.sessionRetention.enabled` | Enable automatic session cleanup                                                                                                                                               | `false`     |
-| Keep chat history       | `general.sessionRetention.maxAge`  | Automatically delete chats older than this time period (e.g., "30d", "7d", "24h", "1w")                                                                                        | `undefined` |
-
-### Output
-
-| UI Label      | Setting         | Description                                            | Default  |
-| ------------- | --------------- | ------------------------------------------------------ | -------- |
-| Output Format | `output.format` | The format of the CLI output. Can be `text` or `json`. | `"text"` |
-
-### UI
-
-| UI Label                             | Setting                                | Description                                                                                                                                                       | Default  |
+| Name                                 | Key                                    | Description                                                                                                                                                       | Default  |
 | ------------------------------------ | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| Preferred Editor                     | `general.preferredEditor`              | The preferred editor to open files in.                                                                                                                            |          |
+| Vim Mode                             | `general.vimMode`                      | Enable Vim keybindings                                                                                                                                            | `false`  |
+| Default Approval Mode                | `general.defaultApprovalMode`          | The default approval mode for tool execution. 'default' prompts for approval, 'auto_edit' auto-approves edit tools, and 'plan' is read-only mode. 'yolo' is not s | `default`|
+| DevTools                             | `general.devtools`                     | Enable DevTools inspector on launch.                                                                                                                              | `false`  |
+| Enable Auto Update                   | `general.enableAutoUpdate`             | Enable automatic updates.                                                                                                                                         | `true`   |
+| Enable Auto Update Notification      | `general.enableAutoUpdateNotification` | Enable update notification prompts.                                                                                                                               | `true`   |
+| Enable Notifications                 | `general.enableNotifications`          | Enable run-event notifications for action-required prompts and session completion. Currently macOS only.                                                          | `false`  |
+| Enable Checkpointing                 | `general.checkpointing.enabled`        | Enable session checkpointing for recovery                                                                                                                         | `false`  |
+| Plan Directory                       | `general.plan.directory`               | The directory where planning artifacts are stored. If not specified, defaults to the system temporary directory.                                                  |          |
+| Plan Model Routing                   | `general.plan.modelRouting`            | Automatically switch between Pro and Flash models based on Plan Mode status. Uses Pro for the planning phase and Flash for the implementation phase.              | `true`   |
+| Retry Fetch Errors                   | `general.retryFetchErrors`             | Retry on "exception TypeError: fetch failed sending request" errors.                                                                                              | `false`  |
+| Max Chat Model Attempts              | `general.maxAttempts`                  | Maximum number of attempts for requests to the main chat model. Cannot exceed 10.                                                                                 | `10`     |
+| Debug Keystroke Logging              | `general.debugKeystrokeLogging`        | Enable debug logging of keystrokes to the console.                                                                                                                | `false`  |
+| Enable Session Cleanup               | `general.sessionRetention.enabled`     | Enable automatic session cleanup                                                                                                                                  | `false`  |
+| Keep chat history                    | `general.sessionRetention.maxAge`      | Automatically delete chats older than this time period (e.g., "30d", "7d", "24h", "1w")                                                                           |          |
+| Max Session Count                    | `general.sessionRetention.maxCount`    | Alternative: Maximum number of sessions to keep (most recent)                                                                                                     |          |
+| Min Retention Period                 | `general.sessionRetention.minRetention`| Minimum retention period (safety limit, defaults to "1d")                                                                                                         | `1d`     |
+| Warning Acknowledged                 | `general.sessionRetention.warningAcknowledged`| INTERNAL: Whether the user has acknowledged the session retention warning                                                                                         | `false`  |
+| Output Format                        | `output.format`                        | The format of the CLI output. Can be `text` or `json`.                                                                                                            | `text`   |
+| Theme                                | `ui.theme`                             | The color theme for the UI. See the CLI themes guide for available options.                                                                                       |          |
 | Auto Theme Switching                 | `ui.autoThemeSwitching`                | Automatically switch between default light and dark themes based on terminal background color.                                                                    | `true`   |
 | Terminal Background Polling Interval | `ui.terminalBackgroundPollingInterval` | Interval in seconds to poll the terminal background color.                                                                                                        | `60`     |
+| Custom Themes                        | `ui.customThemes`                      | Custom theme definitions.                                                                                                                                         | `{}`     |
 | Hide Window Title                    | `ui.hideWindowTitle`                   | Hide the window title bar                                                                                                                                         | `false`  |
-| Inline Thinking                      | `ui.inlineThinkingMode`                | Display model thinking inline: off or full.                                                                                                                       | `"off"`  |
+| Inline Thinking                      | `ui.inlineThinkingMode`                | Display model thinking inline: off or full.                                                                                                                       | `off`    |
 | Show Thoughts in Title               | `ui.showStatusInTitle`                 | Show Gemini CLI model thoughts in the terminal window title during the working phase                                                                              | `false`  |
 | Dynamic Window Title                 | `ui.dynamicWindowTitle`                | Update the terminal window title with current status icons (Ready: ◇, Action Required: ✋, Working: ✦)                                                            | `true`   |
 | Show Home Directory Warning          | `ui.showHomeDirectoryWarning`          | Show a warning when running Gemini CLI in the home directory.                                                                                                     | `true`   |
 | Show Compatibility Warnings          | `ui.showCompatibilityWarnings`         | Show warnings about terminal or OS compatibility issues.                                                                                                          | `true`   |
 | Hide Tips                            | `ui.hideTips`                          | Hide helpful tips in the UI                                                                                                                                       | `false`  |
 | Show Shortcuts Hint                  | `ui.showShortcutsHint`                 | Show the "? for shortcuts" hint above the input.                                                                                                                  | `true`   |
+| Show Keyboard Shortcuts Hint         | `ui.showKeyboardShortcutsHint`         | Show keyboard shortcut hints in the UI (e.g. "press Ctrl+O to expand").                                                                                           | `true`   |
+| Compact Tool Outputs                 | `ui.compactToolOutputs`                | Whether to show tool outputs in a compact one-line summary by default.                                                                                            | `true`   |
 | Hide Banner                          | `ui.hideBanner`                        | Hide the application banner                                                                                                                                       | `false`  |
 | Hide Context Summary                 | `ui.hideContextSummary`                | Hide the context summary (GEMINI.md, MCP servers) above the input.                                                                                                | `false`  |
 | Hide CWD                             | `ui.footer.hideCWD`                    | Hide the current working directory path in the footer.                                                                                                            | `false`  |
@@ -71,95 +59,96 @@ they appear in the UI.
 | Use Background Color                 | `ui.useBackgroundColor`                | Whether to use background colors in the UI.                                                                                                                       | `true`   |
 | Incremental Rendering                | `ui.incrementalRendering`              | Enable incremental rendering for the UI. This option will reduce flickering but may cause rendering artifacts. Only supported when useAlternateBuffer is enabled. | `true`   |
 | Show Spinner                         | `ui.showSpinner`                       | Show the spinner during operations.                                                                                                                               | `true`   |
-| Loading Phrases                      | `ui.loadingPhrases`                    | What to show while the model is working: tips, witty comments, both, or nothing.                                                                                  | `"tips"` |
-| Error Verbosity                      | `ui.errorVerbosity`                    | Controls whether recoverable errors are hidden (low) or fully shown (full).                                                                                       | `"low"`  |
+| Loading Phrases                      | `ui.loadingPhrases`                    | What to show while the model is working: tips, witty comments, both, or nothing.                                                                                  | `tips`   |
+| Error Verbosity                      | `ui.errorVerbosity`                    | Controls whether recoverable errors are hidden (low) or fully shown (full).                                                                                       | `low`    |
+| Custom Witty Phrases                 | `ui.customWittyPhrases`                | Custom witty phrases to display during loading. When provided, the CLI cycles through these instead of the defaults.                                              | `[]`     |
+| Enable Loading Phrases               | `ui.accessibility.enableLoadingPhrases`| @deprecated Use ui.loadingPhrases instead. Enable loading phrases during operations.                                                                              | `true`   |
 | Screen Reader Mode                   | `ui.accessibility.screenReader`        | Render output in plain-text to be more screen reader accessible                                                                                                   | `false`  |
-
-### IDE
-
-| UI Label | Setting       | Description                  | Default |
-| -------- | ------------- | ---------------------------- | ------- |
-| IDE Mode | `ide.enabled` | Enable IDE integration mode. | `false` |
-
-### Billing
-
-| UI Label         | Setting                   | Description                                                                                                                                                | Default |
-| ---------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| Overage Strategy | `billing.overageStrategy` | How to handle quota exhaustion when AI credits are available. 'ask' prompts each time, 'always' automatically uses credits, 'never' disables credit usage. | `"ask"` |
-
-### Model
-
-| UI Label                | Setting                      | Description                                                                            | Default     |
-| ----------------------- | ---------------------------- | -------------------------------------------------------------------------------------- | ----------- |
-| Model                   | `model.name`                 | The Gemini model to use for conversations.                                             | `undefined` |
-| Max Session Turns       | `model.maxSessionTurns`      | Maximum number of user/model/tool turns to keep in a session. -1 means unlimited.      | `-1`        |
-| Compression Threshold   | `model.compressionThreshold` | The fraction of context usage at which to trigger context compression (e.g. 0.2, 0.3). | `0.5`       |
-| Disable Loop Detection  | `model.disableLoopDetection` | Disable automatic detection and prevention of infinite loops.                          | `false`     |
-| Skip Next Speaker Check | `model.skipNextSpeakerCheck` | Skip the next speaker check.                                                           | `true`      |
-
-### Context
-
-| UI Label                             | Setting                                           | Description                                                                                                                                                                                                                                 | Default |
-| ------------------------------------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| Memory Discovery Max Dirs            | `context.discoveryMaxDirs`                        | Maximum number of directories to search for memory.                                                                                                                                                                                         | `200`   |
-| Load Memory From Include Directories | `context.loadMemoryFromIncludeDirectories`        | Controls how /memory refresh loads GEMINI.md files. When true, include directories are scanned; when false, only the current directory is used.                                                                                             | `false` |
-| Respect .gitignore                   | `context.fileFiltering.respectGitIgnore`          | Respect .gitignore files when searching.                                                                                                                                                                                                    | `true`  |
-| Respect .geminiignore                | `context.fileFiltering.respectGeminiIgnore`       | Respect .geminiignore files when searching.                                                                                                                                                                                                 | `true`  |
-| Enable Recursive File Search         | `context.fileFiltering.enableRecursiveFileSearch` | Enable recursive file search functionality when completing @ references in the prompt.                                                                                                                                                      | `true`  |
-| Enable Fuzzy Search                  | `context.fileFiltering.enableFuzzySearch`         | Enable fuzzy search when searching for files.                                                                                                                                                                                               | `true`  |
-| Custom Ignore File Paths             | `context.fileFiltering.customIgnoreFilePaths`     | Additional ignore file paths to respect. These files take precedence over .geminiignore and .gitignore. Files earlier in the array take precedence over files later in the array, e.g. the first file takes precedence over the second one. | `[]`    |
-
-### Tools
-
-| UI Label                         | Setting                              | Description                                                                                                                                                                | Default |
-| -------------------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| Enable Interactive Shell         | `tools.shell.enableInteractiveShell` | Use node-pty for an interactive shell experience. Fallback to child_process still applies.                                                                                 | `true`  |
-| Show Color                       | `tools.shell.showColor`              | Show color in shell output.                                                                                                                                                | `false` |
-| Use Ripgrep                      | `tools.useRipgrep`                   | Use ripgrep for file content search instead of the fallback implementation. Provides faster search performance.                                                            | `true`  |
-| Tool Output Truncation Threshold | `tools.truncateToolOutputThreshold`  | Maximum characters to show when truncating large tool outputs. Set to 0 or negative to disable truncation.                                                                 | `40000` |
-| Disable LLM Correction           | `tools.disableLLMCorrection`         | Disable LLM-based error correction for edit tools. When enabled, tools will fail immediately if exact string matches are not found, instead of attempting to self-correct. | `true`  |
-
-### Security
-
-| UI Label                              | Setting                                         | Description                                                                                                                                                                                                                          | Default |
-| ------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
-| Disable YOLO Mode                     | `security.disableYoloMode`                      | Disable YOLO mode, even if enabled by a flag.                                                                                                                                                                                        | `false` |
-| Allow Permanent Tool Approval         | `security.enablePermanentToolApproval`          | Enable the "Allow for all future sessions" option in tool confirmation dialogs.                                                                                                                                                      | `false` |
-| Blocks extensions from Git            | `security.blockGitExtensions`                   | Blocks installing and loading extensions from Git.                                                                                                                                                                                   | `false` |
-| Extension Source Regex Allowlist      | `security.allowedExtensions`                    | List of Regex patterns for allowed extensions. If nonempty, only extensions that match the patterns in this list are allowed. Overrides the blockGitExtensions setting.                                                              | `[]`    |
-| Folder Trust                          | `security.folderTrust.enabled`                  | Setting to track whether Folder trust is enabled.                                                                                                                                                                                    | `true`  |
-| Enable Environment Variable Redaction | `security.environmentVariableRedaction.enabled` | Enable redaction of environment variables that may contain secrets.                                                                                                                                                                  | `false` |
-| Enable Context-Aware Security         | `security.enableConseca`                        | Enable the context-aware security checker. This feature uses an LLM to dynamically generate and enforce security policies for tool use based on your prompt, providing an additional layer of protection against unintended actions. | `false` |
-
-### Advanced
-
-| UI Label                          | Setting                        | Description                                   | Default |
-| --------------------------------- | ------------------------------ | --------------------------------------------- | ------- |
-| Auto Configure Max Old Space Size | `advanced.autoConfigureMemory` | Automatically configure Node.js memory limits | `false` |
-
-### Experimental
-
-| UI Label                   | Setting                                  | Description                                                                                                                                               | Default |
-| -------------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| Enable Tool Output Masking | `experimental.toolOutputMasking.enabled` | Enables tool output masking to save tokens.                                                                                                               | `true`  |
-| Use OSC 52 Paste           | `experimental.useOSC52Paste`             | Use OSC 52 for pasting. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it). | `false` |
-| Use OSC 52 Copy            | `experimental.useOSC52Copy`              | Use OSC 52 for copying. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it). | `false` |
-| Plan                       | `experimental.plan`                      | Enable planning features (Plan Mode and tools).                                                                                                           | `false` |
-| Model Steering             | `experimental.modelSteering`             | Enable model steering (user hints) to guide the model during tool execution.                                                                              | `false` |
-| Direct Web Fetch           | `experimental.directWebFetch`            | Enable web fetch behavior that bypasses LLM summarization.                                                                                                | `false` |
-| Enable Gemma Model Router  | `experimental.gemmaModelRouter.enabled`  | Enable the Gemma Model Router. Requires a local endpoint serving Gemma via the Gemini API using LiteRT-LM shim.                                           | `false` |
-
-### Skills
-
-| UI Label            | Setting          | Description          | Default |
-| ------------------- | ---------------- | -------------------- | ------- |
-| Enable Agent Skills | `skills.enabled` | Enable Agent Skills. | `true`  |
-
-### HooksConfig
-
-| UI Label           | Setting                     | Description                                                                      | Default |
-| ------------------ | --------------------------- | -------------------------------------------------------------------------------- | ------- |
-| Enable Hooks       | `hooksConfig.enabled`       | Canonical toggle for the hooks system. When disabled, no hooks will be executed. | `true`  |
-| Hook Notifications | `hooksConfig.notifications` | Show visual indicators when hooks are executing.                                 | `true`  |
+| IDE Mode                             | `ide.enabled`                          | Enable IDE integration mode.                                                                                                                                      | `false`  |
+| Has Seen IDE Integration Nudge       | `ide.hasSeenNudge`                     | Whether the user has seen the IDE integration nudge.                                                                                                              | `false`  |
+| Enable Usage Statistics              | `privacy.usageStatisticsEnabled`       | Enable collection of usage statistics                                                                                                                             | `true`   |
+| Overage Strategy                     | `billing.overageStrategy`              | How to handle quota exhaustion when AI credits are available. 'ask' prompts each time, 'always' automatically uses credits, 'never' disables credit usage.        | `ask`    |
+| Model                                | `model.name`                           | The Gemini model to use for conversations.                                                                                                                        |          |
+| Max Session Turns                    | `model.maxSessionTurns`                | Maximum number of user/model/tool turns to keep in a session. -1 means unlimited.                                                                                 | `-1`     |
+| Summarize Tool Output                | `model.summarizeToolOutput`            | Enables or disables summarization of tool output. Configure per-tool token budgets (for example {"run_shell_command": {"tokenBudget": 2000}}). Currently only the |          |
+| Compression Threshold                | `model.compressionThreshold`           | The fraction of context usage at which to trigger context compression (e.g. 0.2, 0.3).                                                                            | `0.5`    |
+| Disable Loop Detection               | `model.disableLoopDetection`           | Disable automatic detection and prevention of infinite loops.                                                                                                     | `false`  |
+| Skip Next Speaker Check              | `model.skipNextSpeakerCheck`           | Skip the next speaker check.                                                                                                                                      | `true`   |
+| Model Config Aliases                 | `modelConfigs.aliases`                 | Named presets for model configs. Can be used in place of a model name and can inherit from other aliases using an `extends` property.                             | `...`    |
+| Custom Model Config Aliases          | `modelConfigs.customAliases`           | Custom named presets for model configs. These are merged with (and override) the built-in aliases.                                                                | `{}`     |
+| Custom Model Config Overrides        | `modelConfigs.customOverrides`         | Custom model config overrides. These are merged with (and added to) the built-in overrides.                                                                       | `[]`     |
+| Model Config Overrides               | `modelConfigs.overrides`               | Apply specific configuration overrides based on matches, with a primary key of model (or alias). The most specific match will be used.                            | `[]`     |
+| Agent Overrides                      | `agents.overrides`                     | Override settings for specific agents, e.g. to disable the agent, set a custom model config, or run config.                                                       | `{}`     |
+| Browser Session Mode                 | `agents.browser.sessionMode`           | Session mode: 'persistent', 'isolated', or 'existing'.                                                                                                            | `persistent`|
+| Browser Headless                     | `agents.browser.headless`              | Run browser in headless mode.                                                                                                                                     | `false`  |
+| Browser Profile Path                 | `agents.browser.profilePath`           | Path to browser profile directory for session persistence.                                                                                                        |          |
+| Browser Visual Model                 | `agents.browser.visualModel`           | Model override for the visual agent.                                                                                                                              |          |
+| Context File Name                    | `context.fileName`                     | The name of the context file or files to load into memory. Accepts either a single string or an array of strings.                                                 |          |
+| Memory Import Format                 | `context.importFormat`                 | The format to use when importing memory.                                                                                                                          |          |
+| Include Directory Tree               | `context.includeDirectoryTree`         | Whether to include the directory tree of the current working directory in the initial request to the model.                                                       | `true`   |
+| Memory Discovery Max Dirs            | `context.discoveryMaxDirs`             | Maximum number of directories to search for memory.                                                                                                               | `200`    |
+| Include Directories                  | `context.includeDirectories`           | Additional directories to include in the workspace context. Missing directories will be skipped with a warning.                                                   | `[]`     |
+| Load Memory From Include Directories | `context.loadMemoryFromIncludeDirectories`| Controls how /memory refresh loads GEMINI.md files. When true, include directories are scanned; when false, only the current directory is used.                    | `false`  |
+| Respect .gitignore                   | `context.fileFiltering.respectGitIgnore`| Respect .gitignore files when searching.                                                                                                                          | `true`   |
+| Respect .geminiignore                | `context.fileFiltering.respectGeminiIgnore`| Respect .geminiignore files when searching.                                                                                                                       | `true`   |
+| Enable Recursive File Search         | `context.fileFiltering.enableRecursiveFileSearch`| Enable recursive file search functionality when completing @ references in the prompt.                                                                            | `true`   |
+| Enable Fuzzy Search                  | `context.fileFiltering.enableFuzzySearch`| Enable fuzzy search when searching for files.                                                                                                                     | `true`   |
+| Custom Ignore File Paths             | `context.fileFiltering.customIgnoreFilePaths`| Additional ignore file paths to respect. These files take precedence over .geminiignore and .gitignore. Files earlier in the array take precedence over files lat | `[]`     |
+| Sandbox                              | `tools.sandbox`                        | Sandbox execution environment. Set to a boolean to enable or disable the sandbox, or provide a string path to a sandbox profile.                                  |          |
+| Enable Interactive Shell             | `tools.shell.enableInteractiveShell`   | Use node-pty for an interactive shell experience. Fallback to child_process still applies.                                                                        | `true`   |
+| Pager                                | `tools.shell.pager`                    | The pager command to use for shell output. Defaults to `cat`.                                                                                                     | `cat`    |
+| Show Color                           | `tools.shell.showColor`                | Show color in shell output.                                                                                                                                       | `false`  |
+| Inactivity Timeout                   | `tools.shell.inactivityTimeout`        | The maximum time in seconds allowed without output from the shell command. Defaults to 5 minutes.                                                                 | `300`    |
+| Enable Shell Output Efficiency       | `tools.shell.enableShellOutputEfficiency`| Enable shell output efficiency optimizations for better performance.                                                                                              | `true`   |
+| Core Tools                           | `tools.core`                           | Restrict the set of built-in tools with an allowlist. Match semantics mirror tools.allowed; see the built-in tools documentation for available names.             |          |
+| Allowed Tools                        | `tools.allowed`                        | Tool names that bypass the confirmation dialog. Useful for trusted commands (for example ["run_shell_command(git)", "run_shell_command(npm test)"]). See shell too |          |
+| Exclude Tools                        | `tools.exclude`                        | Tool names to exclude from discovery.                                                                                                                             |          |
+| Tool Discovery Command               | `tools.discoveryCommand`               | Command to run for tool discovery.                                                                                                                                |          |
+| Tool Call Command                    | `tools.callCommand`                    | Defines a custom shell command for invoking discovered tools. The command must take the tool name as the first argument, read JSON arguments from stdin, and emit |          |
+| Use Ripgrep                          | `tools.useRipgrep`                     | Use ripgrep for file content search instead of the fallback implementation. Provides faster search performance.                                                   | `true`   |
+| Tool Output Truncation Threshold     | `tools.truncateToolOutputThreshold`    | Maximum characters to show when truncating large tool outputs. Set to 0 or negative to disable truncation.                                                        | `40000`  |
+| Disable LLM Correction               | `tools.disableLLMCorrection`           | Disable LLM-based error correction for edit tools. When enabled, tools will fail immediately if exact string matches are not found, instead of attempting to self- | `true`   |
+| MCP Server Command                   | `mcp.serverCommand`                    | Command to start an MCP server.                                                                                                                                   |          |
+| Allow MCP Servers                    | `mcp.allowed`                          | A list of MCP servers to allow.                                                                                                                                   |          |
+| Exclude MCP Servers                  | `mcp.excluded`                         | A list of MCP servers to exclude.                                                                                                                                 |          |
+| Use WriteTodos                       | `useWriteTodos`                        | Enable the write_todos tool.                                                                                                                                      | `true`   |
+| Disable YOLO Mode                    | `security.disableYoloMode`             | Disable YOLO mode, even if enabled by a flag.                                                                                                                     | `false`  |
+| Allow Permanent Tool Approval        | `security.enablePermanentToolApproval` | Enable the "Allow for all future sessions" option in tool confirmation dialogs.                                                                                   | `false`  |
+| Blocks extensions from Git           | `security.blockGitExtensions`          | Blocks installing and loading extensions from Git.                                                                                                                | `false`  |
+| Extension Source Regex Allowlist     | `security.allowedExtensions`           | List of Regex patterns for allowed extensions. If nonempty, only extensions that match the patterns in this list are allowed. Overrides the blockGitExtensions se | `[]`     |
+| Folder Trust                         | `security.folderTrust.enabled`         | Setting to track whether Folder trust is enabled.                                                                                                                 | `true`   |
+| Allowed Environment Variables        | `security.environmentVariableRedaction.allowed`| Environment variables to always allow (bypass redaction).                                                                                                         | `[]`     |
+| Blocked Environment Variables        | `security.environmentVariableRedaction.blocked`| Environment variables to always redact.                                                                                                                           | `[]`     |
+| Enable Environment Variable Redaction | `security.environmentVariableRedaction.enabled`| Enable redaction of environment variables that may contain secrets.                                                                                                | `false`  |
+| Use External Auth                    | `security.auth.useExternal`            | Whether to use an external authentication flow.                                                                                                                   |          |
+| Enable Context-Aware Security        | `security.enableConseca`               | Enable the context-aware security checker. This feature uses an LLM to dynamically generate and enforce security policies for tool use based on your prompt, prov | `false`  |
+| Auto Configure Max Old Space Size    | `advanced.autoConfigureMemory`         | Automatically configure Node.js memory limits                                                                                                                     | `false`  |
+| DNS Resolution Order                 | `advanced.dnsResolutionOrder`          | The DNS resolution order.                                                                                                                                         |          |
+| Excluded Project Environment Variables| `advanced.excludedEnvVars`             | Environment variables to exclude from project context.                                                                                                            | `["DEBUG","DEBUG_MODE"]`|
+| Enable Tool Output Masking           | `experimental.toolOutputMasking.enabled`| Enables tool output masking to save tokens.                                                                                                                       | `true`   |
+| Tool Protection Threshold            | `experimental.toolOutputMasking.toolProtectionThreshold`| Minimum number of tokens to protect from masking (most recent tool outputs).                                                                                      | `50000`  |
+| Min Prunable Tokens Threshold        | `experimental.toolOutputMasking.minPrunableTokensThreshold`| Minimum prunable tokens required to trigger a masking pass.                                                                                                       | `30000`  |
+| Protect Latest Turn                  | `experimental.toolOutputMasking.protectLatestTurn`| Ensures the absolute latest turn is never masked, regardless of token count.                                                                                      | `true`   |
+| Enable Agents                        | `experimental.enableAgents`            | Enable local and remote subagents. Warning: Experimental feature, uses YOLO mode for subagents                                                                    | `false`  |
+| Extension Management                 | `experimental.extensionManagement`     | Enable extension management features.                                                                                                                             | `true`   |
+| Extension Configuration              | `experimental.extensionConfig`         | Enable requesting and fetching of extension settings.                                                                                                             | `true`   |
+| Extension Registry Explore UI        | `experimental.extensionRegistry`       | Enable extension registry explore UI.                                                                                                                             | `false`  |
+| Extension Reloading                  | `experimental.extensionReloading`      | Enables extension loading/unloading within the CLI session.                                                                                                       | `false`  |
+| JIT Context Loading                  | `experimental.jitContext`              | Enable Just-In-Time (JIT) context loading.                                                                                                                        | `false`  |
+| Use OSC 52 Paste                     | `experimental.useOSC52Paste`           | Use OSC 52 for pasting. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it).        | `false`  |
+| Use OSC 52 Copy                      | `experimental.useOSC52Copy`            | Use OSC 52 for copying. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it).        | `false`  |
+| Plan                                 | `experimental.plan`                    | Enable planning features (Plan Mode and tools).                                                                                                                   | `false`  |
+| Model Steering                       | `experimental.modelSteering`           | Enable model steering (user hints) to guide the model during tool execution.                                                                                      | `false`  |
+| Direct Web Fetch                     | `experimental.directWebFetch`          | Enable web fetch behavior that bypasses LLM summarization.                                                                                                        | `false`  |
+| Enable Gemma Model Router            | `experimental.gemmaModelRouter.enabled`| Enable the Gemma Model Router. Requires a local endpoint serving Gemma via the Gemini API using LiteRT-LM shim.                                                   | `false`  |
+| Host                                 | `experimental.gemmaModelRouter.classifier.host`| The host of the classifier.                                                                                                                                       | `http://localhost:9379`|
+| Model                                | `experimental.gemmaModelRouter.classifier.model`| The model to use for the classifier. Only tested on `gemma3-1b-gpu-custom`.                                                                                       | `gemma3-1b-gpu-custom`|
+| Disabled Extensions                  | `extensions.disabled`                  | List of disabled extensions.                                                                                                                                      | `[]`     |
+| Workspaces with Migration Nudge      | `extensions.workspacesWithMigrationNudge`| List of workspaces for which the migration nudge has been shown.                                                                                                  | `[]`     |
+| Enable Agent Skills                  | `skills.enabled`                       | Enable Agent Skills.                                                                                                                                              | `true`   |
+| Disabled Skills                      | `skills.disabled`                      | List of disabled skills.                                                                                                                                          | `[]`     |
+| Enable Hooks                         | `hooksConfig.enabled`                  | Canonical toggle for the hooks system. When disabled, no hooks will be executed.                                                                                 | `true`   |
+| Disabled Hooks                       | `hooksConfig.disabled`                 | List of hook names (commands) that should be disabled. Hooks in this list will not execute even if configured.                                                    | `[]`     |
+| Hook Notifications                   | `hooksConfig.notifications`            | Show visual indicators when hooks are executing.                                                                                                                  | `true`   |
 
 <!-- SETTINGS-AUTOGEN:END -->

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2,1767 +2,266 @@
 
 Gemini CLI offers several ways to configure its behavior, including environment
 variables, command-line arguments, and settings files. This document outlines
-the different configuration methods and available settings.
+the different configuration methods and available options.
 
-## Configuration layers
+## Configuration hierarchy
 
-Configuration is applied in the following order of precedence (lower numbers are
-overridden by higher numbers):
+Settings are loaded and merged in the following order (highest precedence
+first):
 
-1.  **Default values:** Hardcoded defaults within the application.
-2.  **System defaults file:** System-wide default settings that can be
-    overridden by other settings files.
-3.  **User settings file:** Global settings for the current user.
-4.  **Project settings file:** Project-specific settings.
-5.  **System settings file:** System-wide settings that override all other
-    settings files.
-6.  **Environment variables:** System-wide or session-specific variables,
-    potentially loaded from `.env` files.
-7.  **Command-line arguments:** Values passed when launching the CLI.
+1.  Command-line arguments (e.g., `--model gemini-pro`)
+2.  Project settings (the `settings.json` file in the `.gemini/` directory of the
+    current project)
+3.  User settings (the `settings.json` file in the `~/.gemini/` directory)
+4.  Environment variables (e.g., `GEMINI_MODEL=gemini-pro`)
+5.  Default settings
 
-## Settings files
+## Environment variables
 
-Gemini CLI uses JSON settings files for persistent configuration. There are four
-locations for these files:
+- `GEMINI_API_KEY`: Your Gemini API key.
+- `GOOGLE_CLOUD_PROJECT`: The ID of your Google Cloud project (for Vertex AI).
+- `GEMINI_MODEL`: The name of the Gemini model to use.
+- `GEMINI_DEBUG`: Set to `true` to enable debug logging.
 
-> **Tip:** JSON-aware editors can use autocomplete and validation by pointing to
-> the generated schema at `schemas/settings.schema.json` in this repository.
-> When working outside the repo, reference the hosted schema at
-> `https://raw.githubusercontent.com/google-gemini/gemini-cli/main/schemas/settings.schema.json`.
+## Settings file (settings.json)
 
-- **System defaults file:**
-  - **Location:** `/etc/gemini-cli/system-defaults.json` (Linux),
-    `C:\ProgramData\gemini-cli\system-defaults.json` (Windows) or
-    `/Library/Application Support/GeminiCli/system-defaults.json` (macOS). The
-    path can be overridden using the `GEMINI_CLI_SYSTEM_DEFAULTS_PATH`
-    environment variable.
-  - **Scope:** Provides a base layer of system-wide default settings. These
-    settings have the lowest precedence and are intended to be overridden by
-    user, project, or system override settings.
-- **User settings file:**
-  - **Location:** `~/.gemini/settings.json` (where `~` is your home directory).
-  - **Scope:** Applies to all Gemini CLI sessions for the current user. User
-    settings override system defaults.
-- **Project settings file:**
-  - **Location:** `.gemini/settings.json` within your project's root directory.
-  - **Scope:** Applies only when running Gemini CLI from that specific project.
-    Project settings override user settings and system defaults.
-- **System settings file:**
-  - **Location:** `/etc/gemini-cli/settings.json` (Linux),
-    `C:\ProgramData\gemini-cli\settings.json` (Windows) or
-    `/Library/Application Support/GeminiCli/settings.json` (macOS). The path can
-    be overridden using the `GEMINI_CLI_SYSTEM_SETTINGS_PATH` environment
-    variable.
-  - **Scope:** Applies to all Gemini CLI sessions on the system, for all users.
-    System settings act as overrides, taking precedence over all other settings
-    files. May be useful for system administrators at enterprises to have
-    controls over users' Gemini CLI setups.
-
-**Note on environment variables in settings:** String values within your
-`settings.json` and `gemini-extension.json` files can reference environment
-variables using either `$VAR_NAME` or `${VAR_NAME}` syntax. These variables will
-be automatically resolved when the settings are loaded. For example, if you have
-an environment variable `MY_API_TOKEN`, you could use it in `settings.json` like
-this: `"apiKey": "$MY_API_TOKEN"`. Additionally, each extension can have its own
-`.env` file in its directory, which will be loaded automatically.
-
-> **Note for Enterprise Users:** For guidance on deploying and managing Gemini
-> CLI in a corporate environment, please see the
-> [Enterprise Configuration](../cli/enterprise.md) documentation.
-
-### The `.gemini` directory in your project
-
-In addition to a project settings file, a project's `.gemini` directory can
-contain other project-specific files related to Gemini CLI's operation, such as:
-
-- [Custom sandbox profiles](#sandboxing) (e.g.,
-  `.gemini/sandbox-macos-custom.sb`, `.gemini/sandbox.Dockerfile`).
-
-### Available settings in `settings.json`
-
-Settings are organized into categories. All settings should be placed within
-their corresponding top-level category object in your `settings.json` file.
-
-<!-- SETTINGS-AUTOGEN:START -->
-
-#### `policyPaths`
-
-- **`policyPaths`** (array):
-  - **Description:** Additional policy files or directories to load.
-  - **Default:** `[]`
-  - **Requires restart:** Yes
-
-#### `general`
-
-- **`general.preferredEditor`** (string):
-  - **Description:** The preferred editor to open files in.
-  - **Default:** `undefined`
-
-- **`general.vimMode`** (boolean):
-  - **Description:** Enable Vim keybindings
-  - **Default:** `false`
-
-- **`general.defaultApprovalMode`** (enum):
-  - **Description:** The default approval mode for tool execution. 'default'
-    prompts for approval, 'auto_edit' auto-approves edit tools, and 'plan' is
-    read-only mode. 'yolo' is not supported yet.
-  - **Default:** `"default"`
-  - **Values:** `"default"`, `"auto_edit"`, `"plan"`
-
-- **`general.devtools`** (boolean):
-  - **Description:** Enable DevTools inspector on launch.
-  - **Default:** `false`
-
-- **`general.enableAutoUpdate`** (boolean):
-  - **Description:** Enable automatic updates.
-  - **Default:** `true`
-
-- **`general.enableAutoUpdateNotification`** (boolean):
-  - **Description:** Enable update notification prompts.
-  - **Default:** `true`
-
-- **`general.enableNotifications`** (boolean):
-  - **Description:** Enable run-event notifications for action-required prompts
-    and session completion. Currently macOS only.
-  - **Default:** `false`
-
-- **`general.checkpointing.enabled`** (boolean):
-  - **Description:** Enable session checkpointing for recovery
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-- **`general.plan.directory`** (string):
-  - **Description:** The directory where planning artifacts are stored. If not
-    specified, defaults to the system temporary directory.
-  - **Default:** `undefined`
-  - **Requires restart:** Yes
-
-- **`general.plan.modelRouting`** (boolean):
-  - **Description:** Automatically switch between Pro and Flash models based on
-    Plan Mode status. Uses Pro for the planning phase and Flash for the
-    implementation phase.
-  - **Default:** `true`
-
-- **`general.retryFetchErrors`** (boolean):
-  - **Description:** Retry on "exception TypeError: fetch failed sending
-    request" errors.
-  - **Default:** `false`
-
-- **`general.maxAttempts`** (number):
-  - **Description:** Maximum number of attempts for requests to the main chat
-    model. Cannot exceed 10.
-  - **Default:** `10`
-
-- **`general.debugKeystrokeLogging`** (boolean):
-  - **Description:** Enable debug logging of keystrokes to the console.
-  - **Default:** `false`
-
-- **`general.sessionRetention.enabled`** (boolean):
-  - **Description:** Enable automatic session cleanup
-  - **Default:** `false`
-
-- **`general.sessionRetention.maxAge`** (string):
-  - **Description:** Automatically delete chats older than this time period
-    (e.g., "30d", "7d", "24h", "1w")
-  - **Default:** `undefined`
-
-- **`general.sessionRetention.maxCount`** (number):
-  - **Description:** Alternative: Maximum number of sessions to keep (most
-    recent)
-  - **Default:** `undefined`
-
-- **`general.sessionRetention.minRetention`** (string):
-  - **Description:** Minimum retention period (safety limit, defaults to "1d")
-  - **Default:** `"1d"`
-
-- **`general.sessionRetention.warningAcknowledged`** (boolean):
-  - **Description:** INTERNAL: Whether the user has acknowledged the session
-    retention warning
-  - **Default:** `false`
-
-#### `output`
-
-- **`output.format`** (enum):
-  - **Description:** The format of the CLI output. Can be `text` or `json`.
-  - **Default:** `"text"`
-  - **Values:** `"text"`, `"json"`
-
-#### `ui`
-
-- **`ui.theme`** (string):
-  - **Description:** The color theme for the UI. See the CLI themes guide for
-    available options.
-  - **Default:** `undefined`
-
-- **`ui.autoThemeSwitching`** (boolean):
-  - **Description:** Automatically switch between default light and dark themes
-    based on terminal background color.
-  - **Default:** `true`
-
-- **`ui.terminalBackgroundPollingInterval`** (number):
-  - **Description:** Interval in seconds to poll the terminal background color.
-  - **Default:** `60`
-
-- **`ui.customThemes`** (object):
-  - **Description:** Custom theme definitions.
-  - **Default:** `{}`
-
-- **`ui.hideWindowTitle`** (boolean):
-  - **Description:** Hide the window title bar
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-- **`ui.inlineThinkingMode`** (enum):
-  - **Description:** Display model thinking inline: off or full.
-  - **Default:** `"off"`
-  - **Values:** `"off"`, `"full"`
-
-- **`ui.showStatusInTitle`** (boolean):
-  - **Description:** Show Gemini CLI model thoughts in the terminal window title
-    during the working phase
-  - **Default:** `false`
-
-- **`ui.dynamicWindowTitle`** (boolean):
-  - **Description:** Update the terminal window title with current status icons
-    (Ready: ◇, Action Required: ✋, Working: ✦)
-  - **Default:** `true`
-
-- **`ui.showHomeDirectoryWarning`** (boolean):
-  - **Description:** Show a warning when running Gemini CLI in the home
-    directory.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
-- **`ui.showCompatibilityWarnings`** (boolean):
-  - **Description:** Show warnings about terminal or OS compatibility issues.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
-- **`ui.hideTips`** (boolean):
-  - **Description:** Hide helpful tips in the UI
-  - **Default:** `false`
-
-- **`ui.showShortcutsHint`** (boolean):
-  - **Description:** Show the "? for shortcuts" hint above the input.
-  - **Default:** `true`
-
-- **`ui.hideBanner`** (boolean):
-  - **Description:** Hide the application banner
-  - **Default:** `false`
-
-- **`ui.hideContextSummary`** (boolean):
-  - **Description:** Hide the context summary (GEMINI.md, MCP servers) above the
-    input.
-  - **Default:** `false`
-
-- **`ui.footer.hideCWD`** (boolean):
-  - **Description:** Hide the current working directory path in the footer.
-  - **Default:** `false`
-
-- **`ui.footer.hideSandboxStatus`** (boolean):
-  - **Description:** Hide the sandbox status indicator in the footer.
-  - **Default:** `false`
-
-- **`ui.footer.hideModelInfo`** (boolean):
-  - **Description:** Hide the model name and context usage in the footer.
-  - **Default:** `false`
-
-- **`ui.footer.hideContextPercentage`** (boolean):
-  - **Description:** Hides the context window remaining percentage.
-  - **Default:** `true`
-
-- **`ui.hideFooter`** (boolean):
-  - **Description:** Hide the footer from the UI
-  - **Default:** `false`
-
-- **`ui.showMemoryUsage`** (boolean):
-  - **Description:** Display memory usage information in the UI
-  - **Default:** `false`
-
-- **`ui.showLineNumbers`** (boolean):
-  - **Description:** Show line numbers in the chat.
-  - **Default:** `true`
-
-- **`ui.showCitations`** (boolean):
-  - **Description:** Show citations for generated text in the chat.
-  - **Default:** `false`
-
-- **`ui.showModelInfoInChat`** (boolean):
-  - **Description:** Show the model name in the chat for each model turn.
-  - **Default:** `false`
-
-- **`ui.showUserIdentity`** (boolean):
-  - **Description:** Show the logged-in user's identity (e.g. email) in the UI.
-  - **Default:** `true`
-
-- **`ui.useAlternateBuffer`** (boolean):
-  - **Description:** Use an alternate screen buffer for the UI, preserving shell
-    history.
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-- **`ui.useBackgroundColor`** (boolean):
-  - **Description:** Whether to use background colors in the UI.
-  - **Default:** `true`
-
-- **`ui.incrementalRendering`** (boolean):
-  - **Description:** Enable incremental rendering for the UI. This option will
-    reduce flickering but may cause rendering artifacts. Only supported when
-    useAlternateBuffer is enabled.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
-- **`ui.showSpinner`** (boolean):
-  - **Description:** Show the spinner during operations.
-  - **Default:** `true`
-
-- **`ui.loadingPhrases`** (enum):
-  - **Description:** What to show while the model is working: tips, witty
-    comments, both, or nothing.
-  - **Default:** `"tips"`
-  - **Values:** `"tips"`, `"witty"`, `"all"`, `"off"`
-
-- **`ui.errorVerbosity`** (enum):
-  - **Description:** Controls whether recoverable errors are hidden (low) or
-    fully shown (full).
-  - **Default:** `"low"`
-  - **Values:** `"low"`, `"full"`
-
-- **`ui.customWittyPhrases`** (array):
-  - **Description:** Custom witty phrases to display during loading. When
-    provided, the CLI cycles through these instead of the defaults.
-  - **Default:** `[]`
-
-- **`ui.accessibility.enableLoadingPhrases`** (boolean):
-  - **Description:** @deprecated Use ui.loadingPhrases instead. Enable loading
-    phrases during operations.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
-- **`ui.accessibility.screenReader`** (boolean):
-  - **Description:** Render output in plain-text to be more screen reader
-    accessible
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-#### `ide`
-
-- **`ide.enabled`** (boolean):
-  - **Description:** Enable IDE integration mode.
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-- **`ide.hasSeenNudge`** (boolean):
-  - **Description:** Whether the user has seen the IDE integration nudge.
-  - **Default:** `false`
-
-#### `privacy`
-
-- **`privacy.usageStatisticsEnabled`** (boolean):
-  - **Description:** Enable collection of usage statistics
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
-#### `billing`
-
-- **`billing.overageStrategy`** (enum):
-  - **Description:** How to handle quota exhaustion when AI credits are
-    available. 'ask' prompts each time, 'always' automatically uses credits,
-    'never' disables credit usage.
-  - **Default:** `"ask"`
-  - **Values:** `"ask"`, `"always"`, `"never"`
-
-#### `model`
-
-- **`model.name`** (string):
-  - **Description:** The Gemini model to use for conversations.
-  - **Default:** `undefined`
-
-- **`model.maxSessionTurns`** (number):
-  - **Description:** Maximum number of user/model/tool turns to keep in a
-    session. -1 means unlimited.
-  - **Default:** `-1`
-
-- **`model.summarizeToolOutput`** (object):
-  - **Description:** Enables or disables summarization of tool output. Configure
-    per-tool token budgets (for example {"run_shell_command": {"tokenBudget":
-    2000}}). Currently only the run_shell_command tool supports summarization.
-  - **Default:** `undefined`
-
-- **`model.compressionThreshold`** (number):
-  - **Description:** The fraction of context usage at which to trigger context
-    compression (e.g. 0.2, 0.3).
-  - **Default:** `0.5`
-  - **Requires restart:** Yes
-
-- **`model.disableLoopDetection`** (boolean):
-  - **Description:** Disable automatic detection and prevention of infinite
-    loops.
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-- **`model.skipNextSpeakerCheck`** (boolean):
-  - **Description:** Skip the next speaker check.
-  - **Default:** `true`
-
-#### `modelConfigs`
-
-- **`modelConfigs.aliases`** (object):
-  - **Description:** Named presets for model configs. Can be used in place of a
-    model name and can inherit from other aliases using an `extends` property.
-  - **Default:**
-
-    ```json
-    {
-      "base": {
-        "modelConfig": {
-          "generateContentConfig": {
-            "temperature": 0,
-            "topP": 1
-          }
-        }
-      },
-      "chat-base": {
-        "extends": "base",
-        "modelConfig": {
-          "generateContentConfig": {
-            "thinkingConfig": {
-              "includeThoughts": true
-            },
-            "temperature": 1,
-            "topP": 0.95,
-            "topK": 64
-          }
-        }
-      },
-      "chat-base-2.5": {
-        "extends": "chat-base",
-        "modelConfig": {
-          "generateContentConfig": {
-            "thinkingConfig": {
-              "thinkingBudget": 8192
-            }
-          }
-        }
-      },
-      "chat-base-3": {
-        "extends": "chat-base",
-        "modelConfig": {
-          "generateContentConfig": {
-            "thinkingConfig": {
-              "thinkingLevel": "HIGH"
-            }
-          }
-        }
-      },
-      "gemini-3-pro-preview": {
-        "extends": "chat-base-3",
-        "modelConfig": {
-          "model": "gemini-3-pro-preview"
-        }
-      },
-      "gemini-3-flash-preview": {
-        "extends": "chat-base-3",
-        "modelConfig": {
-          "model": "gemini-3-flash-preview"
-        }
-      },
-      "gemini-2.5-pro": {
-        "extends": "chat-base-2.5",
-        "modelConfig": {
-          "model": "gemini-2.5-pro"
-        }
-      },
-      "gemini-2.5-flash": {
-        "extends": "chat-base-2.5",
-        "modelConfig": {
-          "model": "gemini-2.5-flash"
-        }
-      },
-      "gemini-2.5-flash-lite": {
-        "extends": "chat-base-2.5",
-        "modelConfig": {
-          "model": "gemini-2.5-flash-lite"
-        }
-      },
-      "gemini-2.5-flash-base": {
-        "extends": "base",
-        "modelConfig": {
-          "model": "gemini-2.5-flash"
-        }
-      },
-      "gemini-3-flash-base": {
-        "extends": "base",
-        "modelConfig": {
-          "model": "gemini-3-flash-preview"
-        }
-      },
-      "classifier": {
-        "extends": "base",
-        "modelConfig": {
-          "model": "gemini-2.5-flash-lite",
-          "generateContentConfig": {
-            "maxOutputTokens": 1024,
-            "thinkingConfig": {
-              "thinkingBudget": 512
-            }
-          }
-        }
-      },
-      "prompt-completion": {
-        "extends": "base",
-        "modelConfig": {
-          "model": "gemini-2.5-flash-lite",
-          "generateContentConfig": {
-            "temperature": 0.3,
-            "maxOutputTokens": 16000,
-            "thinkingConfig": {
-              "thinkingBudget": 0
-            }
-          }
-        }
-      },
-      "fast-ack-helper": {
-        "extends": "base",
-        "modelConfig": {
-          "model": "gemini-2.5-flash-lite",
-          "generateContentConfig": {
-            "temperature": 0.2,
-            "maxOutputTokens": 120,
-            "thinkingConfig": {
-              "thinkingBudget": 0
-            }
-          }
-        }
-      },
-      "edit-corrector": {
-        "extends": "base",
-        "modelConfig": {
-          "model": "gemini-2.5-flash-lite",
-          "generateContentConfig": {
-            "thinkingConfig": {
-              "thinkingBudget": 0
-            }
-          }
-        }
-      },
-      "summarizer-default": {
-        "extends": "base",
-        "modelConfig": {
-          "model": "gemini-2.5-flash-lite",
-          "generateContentConfig": {
-            "maxOutputTokens": 2000
-          }
-        }
-      },
-      "summarizer-shell": {
-        "extends": "base",
-        "modelConfig": {
-          "model": "gemini-2.5-flash-lite",
-          "generateContentConfig": {
-            "maxOutputTokens": 2000
-          }
-        }
-      },
-      "web-search": {
-        "extends": "gemini-3-flash-base",
-        "modelConfig": {
-          "generateContentConfig": {
-            "tools": [
-              {
-                "googleSearch": {}
-              }
-            ]
-          }
-        }
-      },
-      "web-fetch": {
-        "extends": "gemini-3-flash-base",
-        "modelConfig": {
-          "generateContentConfig": {
-            "tools": [
-              {
-                "urlContext": {}
-              }
-            ]
-          }
-        }
-      },
-      "web-fetch-fallback": {
-        "extends": "gemini-3-flash-base",
-        "modelConfig": {}
-      },
-      "loop-detection": {
-        "extends": "gemini-3-flash-base",
-        "modelConfig": {}
-      },
-      "loop-detection-double-check": {
-        "extends": "base",
-        "modelConfig": {
-          "model": "gemini-3-pro-preview"
-        }
-      },
-      "llm-edit-fixer": {
-        "extends": "gemini-3-flash-base",
-        "modelConfig": {}
-      },
-      "next-speaker-checker": {
-        "extends": "gemini-3-flash-base",
-        "modelConfig": {}
-      },
-      "chat-compression-3-pro": {
-        "modelConfig": {
-          "model": "gemini-3-pro-preview"
-        }
-      },
-      "chat-compression-3-flash": {
-        "modelConfig": {
-          "model": "gemini-3-flash-preview"
-        }
-      },
-      "chat-compression-2.5-pro": {
-        "modelConfig": {
-          "model": "gemini-2.5-pro"
-        }
-      },
-      "chat-compression-2.5-flash": {
-        "modelConfig": {
-          "model": "gemini-2.5-flash"
-        }
-      },
-      "chat-compression-2.5-flash-lite": {
-        "modelConfig": {
-          "model": "gemini-2.5-flash-lite"
-        }
-      },
-      "chat-compression-default": {
-        "modelConfig": {
-          "model": "gemini-3-pro-preview"
-        }
-      }
-    }
-    ```
-
-- **`modelConfigs.customAliases`** (object):
-  - **Description:** Custom named presets for model configs. These are merged
-    with (and override) the built-in aliases.
-  - **Default:** `{}`
-
-- **`modelConfigs.customOverrides`** (array):
-  - **Description:** Custom model config overrides. These are merged with (and
-    added to) the built-in overrides.
-  - **Default:** `[]`
-
-- **`modelConfigs.overrides`** (array):
-  - **Description:** Apply specific configuration overrides based on matches,
-    with a primary key of model (or alias). The most specific match will be
-    used.
-  - **Default:** `[]`
-
-#### `agents`
-
-- **`agents.overrides`** (object):
-  - **Description:** Override settings for specific agents, e.g. to disable the
-    agent, set a custom model config, or run config.
-  - **Default:** `{}`
-  - **Requires restart:** Yes
-
-- **`agents.browser.sessionMode`** (enum):
-  - **Description:** Session mode: 'persistent', 'isolated', or 'existing'.
-  - **Default:** `"persistent"`
-  - **Values:** `"persistent"`, `"isolated"`, `"existing"`
-  - **Requires restart:** Yes
-
-- **`agents.browser.headless`** (boolean):
-  - **Description:** Run browser in headless mode.
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-- **`agents.browser.profilePath`** (string):
-  - **Description:** Path to browser profile directory for session persistence.
-  - **Default:** `undefined`
-  - **Requires restart:** Yes
-
-- **`agents.browser.visualModel`** (string):
-  - **Description:** Model override for the visual agent.
-  - **Default:** `undefined`
-  - **Requires restart:** Yes
-
-#### `context`
-
-- **`context.fileName`** (string | string[]):
-  - **Description:** The name of the context file or files to load into memory.
-    Accepts either a single string or an array of strings.
-  - **Default:** `undefined`
-
-- **`context.importFormat`** (string):
-  - **Description:** The format to use when importing memory.
-  - **Default:** `undefined`
-
-- **`context.includeDirectoryTree`** (boolean):
-  - **Description:** Whether to include the directory tree of the current
-    working directory in the initial request to the model.
-  - **Default:** `true`
-
-- **`context.discoveryMaxDirs`** (number):
-  - **Description:** Maximum number of directories to search for memory.
-  - **Default:** `200`
-
-- **`context.includeDirectories`** (array):
-  - **Description:** Additional directories to include in the workspace context.
-    Missing directories will be skipped with a warning.
-  - **Default:** `[]`
-
-- **`context.loadMemoryFromIncludeDirectories`** (boolean):
-  - **Description:** Controls how /memory refresh loads GEMINI.md files. When
-    true, include directories are scanned; when false, only the current
-    directory is used.
-  - **Default:** `false`
-
-- **`context.fileFiltering.respectGitIgnore`** (boolean):
-  - **Description:** Respect .gitignore files when searching.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
-- **`context.fileFiltering.respectGeminiIgnore`** (boolean):
-  - **Description:** Respect .geminiignore files when searching.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
-- **`context.fileFiltering.enableRecursiveFileSearch`** (boolean):
-  - **Description:** Enable recursive file search functionality when completing
-    @ references in the prompt.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
-- **`context.fileFiltering.enableFuzzySearch`** (boolean):
-  - **Description:** Enable fuzzy search when searching for files.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
-- **`context.fileFiltering.customIgnoreFilePaths`** (array):
-  - **Description:** Additional ignore file paths to respect. These files take
-    precedence over .geminiignore and .gitignore. Files earlier in the array
-    take precedence over files later in the array, e.g. the first file takes
-    precedence over the second one.
-  - **Default:** `[]`
-  - **Requires restart:** Yes
-
-#### `tools`
-
-- **`tools.sandbox`** (boolean | string):
-  - **Description:** Sandbox execution environment. Set to a boolean to enable
-    or disable the sandbox, or provide a string path to a sandbox profile.
-  - **Default:** `undefined`
-  - **Requires restart:** Yes
-
-- **`tools.shell.enableInteractiveShell`** (boolean):
-  - **Description:** Use node-pty for an interactive shell experience. Fallback
-    to child_process still applies.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
-- **`tools.shell.pager`** (string):
-  - **Description:** The pager command to use for shell output. Defaults to
-    `cat`.
-  - **Default:** `"cat"`
-
-- **`tools.shell.showColor`** (boolean):
-  - **Description:** Show color in shell output.
-  - **Default:** `false`
-
-- **`tools.shell.inactivityTimeout`** (number):
-  - **Description:** The maximum time in seconds allowed without output from the
-    shell command. Defaults to 5 minutes.
-  - **Default:** `300`
-
-- **`tools.shell.enableShellOutputEfficiency`** (boolean):
-  - **Description:** Enable shell output efficiency optimizations for better
-    performance.
-  - **Default:** `true`
-
-- **`tools.core`** (array):
-  - **Description:** Restrict the set of built-in tools with an allowlist. Match
-    semantics mirror tools.allowed; see the built-in tools documentation for
-    available names.
-  - **Default:** `undefined`
-  - **Requires restart:** Yes
-
-- **`tools.allowed`** (array):
-  - **Description:** Tool names that bypass the confirmation dialog. Useful for
-    trusted commands (for example ["run_shell_command(git)",
-    "run_shell_command(npm test)"]). See shell tool command restrictions for
-    matching details.
-  - **Default:** `undefined`
-  - **Requires restart:** Yes
-
-- **`tools.exclude`** (array):
-  - **Description:** Tool names to exclude from discovery.
-  - **Default:** `undefined`
-  - **Requires restart:** Yes
-
-- **`tools.discoveryCommand`** (string):
-  - **Description:** Command to run for tool discovery.
-  - **Default:** `undefined`
-  - **Requires restart:** Yes
-
-- **`tools.callCommand`** (string):
-  - **Description:** Defines a custom shell command for invoking discovered
-    tools. The command must take the tool name as the first argument, read JSON
-    arguments from stdin, and emit JSON results on stdout.
-  - **Default:** `undefined`
-  - **Requires restart:** Yes
-
-- **`tools.useRipgrep`** (boolean):
-  - **Description:** Use ripgrep for file content search instead of the fallback
-    implementation. Provides faster search performance.
-  - **Default:** `true`
-
-- **`tools.truncateToolOutputThreshold`** (number):
-  - **Description:** Maximum characters to show when truncating large tool
-    outputs. Set to 0 or negative to disable truncation.
-  - **Default:** `40000`
-  - **Requires restart:** Yes
-
-- **`tools.disableLLMCorrection`** (boolean):
-  - **Description:** Disable LLM-based error correction for edit tools. When
-    enabled, tools will fail immediately if exact string matches are not found,
-    instead of attempting to self-correct.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
-#### `mcp`
-
-- **`mcp.serverCommand`** (string):
-  - **Description:** Command to start an MCP server.
-  - **Default:** `undefined`
-  - **Requires restart:** Yes
-
-- **`mcp.allowed`** (array):
-  - **Description:** A list of MCP servers to allow.
-  - **Default:** `undefined`
-  - **Requires restart:** Yes
-
-- **`mcp.excluded`** (array):
-  - **Description:** A list of MCP servers to exclude.
-  - **Default:** `undefined`
-  - **Requires restart:** Yes
-
-#### `useWriteTodos`
-
-- **`useWriteTodos`** (boolean):
-  - **Description:** Enable the write_todos tool.
-  - **Default:** `true`
-
-#### `security`
-
-- **`security.disableYoloMode`** (boolean):
-  - **Description:** Disable YOLO mode, even if enabled by a flag.
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-- **`security.enablePermanentToolApproval`** (boolean):
-  - **Description:** Enable the "Allow for all future sessions" option in tool
-    confirmation dialogs.
-  - **Default:** `false`
-
-- **`security.blockGitExtensions`** (boolean):
-  - **Description:** Blocks installing and loading extensions from Git.
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-- **`security.allowedExtensions`** (array):
-  - **Description:** List of Regex patterns for allowed extensions. If nonempty,
-    only extensions that match the patterns in this list are allowed. Overrides
-    the blockGitExtensions setting.
-  - **Default:** `[]`
-  - **Requires restart:** Yes
-
-- **`security.folderTrust.enabled`** (boolean):
-  - **Description:** Setting to track whether Folder trust is enabled.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
-- **`security.environmentVariableRedaction.allowed`** (array):
-  - **Description:** Environment variables to always allow (bypass redaction).
-  - **Default:** `[]`
-  - **Requires restart:** Yes
-
-- **`security.environmentVariableRedaction.blocked`** (array):
-  - **Description:** Environment variables to always redact.
-  - **Default:** `[]`
-  - **Requires restart:** Yes
-
-- **`security.environmentVariableRedaction.enabled`** (boolean):
-  - **Description:** Enable redaction of environment variables that may contain
-    secrets.
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-- **`security.auth.selectedType`** (string):
-  - **Description:** The currently selected authentication type.
-  - **Default:** `undefined`
-  - **Requires restart:** Yes
-
-- **`security.auth.enforcedType`** (string):
-  - **Description:** The required auth type. If this does not match the selected
-    auth type, the user will be prompted to re-authenticate.
-  - **Default:** `undefined`
-  - **Requires restart:** Yes
-
-- **`security.auth.useExternal`** (boolean):
-  - **Description:** Whether to use an external authentication flow.
-  - **Default:** `undefined`
-  - **Requires restart:** Yes
-
-- **`security.enableConseca`** (boolean):
-  - **Description:** Enable the context-aware security checker. This feature
-    uses an LLM to dynamically generate and enforce security policies for tool
-    use based on your prompt, providing an additional layer of protection
-    against unintended actions.
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-#### `advanced`
-
-- **`advanced.autoConfigureMemory`** (boolean):
-  - **Description:** Automatically configure Node.js memory limits
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-- **`advanced.dnsResolutionOrder`** (string):
-  - **Description:** The DNS resolution order.
-  - **Default:** `undefined`
-  - **Requires restart:** Yes
-
-- **`advanced.excludedEnvVars`** (array):
-  - **Description:** Environment variables to exclude from project context.
-  - **Default:**
-
-    ```json
-    ["DEBUG", "DEBUG_MODE"]
-    ```
-
-- **`advanced.bugCommand`** (object):
-  - **Description:** Configuration for the bug report command.
-  - **Default:** `undefined`
-
-#### `experimental`
-
-- **`experimental.toolOutputMasking.enabled`** (boolean):
-  - **Description:** Enables tool output masking to save tokens.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
-- **`experimental.toolOutputMasking.toolProtectionThreshold`** (number):
-  - **Description:** Minimum number of tokens to protect from masking (most
-    recent tool outputs).
-  - **Default:** `50000`
-  - **Requires restart:** Yes
-
-- **`experimental.toolOutputMasking.minPrunableTokensThreshold`** (number):
-  - **Description:** Minimum prunable tokens required to trigger a masking pass.
-  - **Default:** `30000`
-  - **Requires restart:** Yes
-
-- **`experimental.toolOutputMasking.protectLatestTurn`** (boolean):
-  - **Description:** Ensures the absolute latest turn is never masked,
-    regardless of token count.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
-- **`experimental.enableAgents`** (boolean):
-  - **Description:** Enable local and remote subagents. Warning: Experimental
-    feature, uses YOLO mode for subagents
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-- **`experimental.extensionManagement`** (boolean):
-  - **Description:** Enable extension management features.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
-- **`experimental.extensionConfig`** (boolean):
-  - **Description:** Enable requesting and fetching of extension settings.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
-- **`experimental.extensionRegistry`** (boolean):
-  - **Description:** Enable extension registry explore UI.
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-- **`experimental.extensionReloading`** (boolean):
-  - **Description:** Enables extension loading/unloading within the CLI session.
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-- **`experimental.jitContext`** (boolean):
-  - **Description:** Enable Just-In-Time (JIT) context loading.
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-- **`experimental.useOSC52Paste`** (boolean):
-  - **Description:** Use OSC 52 for pasting. This may be more robust than the
-    default system when using remote terminal sessions (if your terminal is
-    configured to allow it).
-  - **Default:** `false`
-
-- **`experimental.useOSC52Copy`** (boolean):
-  - **Description:** Use OSC 52 for copying. This may be more robust than the
-    default system when using remote terminal sessions (if your terminal is
-    configured to allow it).
-  - **Default:** `false`
-
-- **`experimental.plan`** (boolean):
-  - **Description:** Enable planning features (Plan Mode and tools).
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-- **`experimental.modelSteering`** (boolean):
-  - **Description:** Enable model steering (user hints) to guide the model
-    during tool execution.
-  - **Default:** `false`
-
-- **`experimental.directWebFetch`** (boolean):
-  - **Description:** Enable web fetch behavior that bypasses LLM summarization.
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-- **`experimental.gemmaModelRouter.enabled`** (boolean):
-  - **Description:** Enable the Gemma Model Router. Requires a local endpoint
-    serving Gemma via the Gemini API using LiteRT-LM shim.
-  - **Default:** `false`
-  - **Requires restart:** Yes
-
-- **`experimental.gemmaModelRouter.classifier.host`** (string):
-  - **Description:** The host of the classifier.
-  - **Default:** `"http://localhost:9379"`
-  - **Requires restart:** Yes
-
-- **`experimental.gemmaModelRouter.classifier.model`** (string):
-  - **Description:** The model to use for the classifier. Only tested on
-    `gemma3-1b-gpu-custom`.
-  - **Default:** `"gemma3-1b-gpu-custom"`
-  - **Requires restart:** Yes
-
-#### `skills`
-
-- **`skills.enabled`** (boolean):
-  - **Description:** Enable Agent Skills.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
-- **`skills.disabled`** (array):
-  - **Description:** List of disabled skills.
-  - **Default:** `[]`
-  - **Requires restart:** Yes
-
-#### `hooksConfig`
-
-- **`hooksConfig.enabled`** (boolean):
-  - **Description:** Canonical toggle for the hooks system. When disabled, no
-    hooks will be executed.
-  - **Default:** `true`
-  - **Requires restart:** Yes
-
-- **`hooksConfig.disabled`** (array):
-  - **Description:** List of hook names (commands) that should be disabled.
-    Hooks in this list will not execute even if configured.
-  - **Default:** `[]`
-
-- **`hooksConfig.notifications`** (boolean):
-  - **Description:** Show visual indicators when hooks are executing.
-  - **Default:** `true`
-
-#### `hooks`
-
-- **`hooks.BeforeTool`** (array):
-  - **Description:** Hooks that execute before tool execution. Can intercept,
-    validate, or modify tool calls.
-  - **Default:** `[]`
-
-- **`hooks.AfterTool`** (array):
-  - **Description:** Hooks that execute after tool execution. Can process
-    results, log outputs, or trigger follow-up actions.
-  - **Default:** `[]`
-
-- **`hooks.BeforeAgent`** (array):
-  - **Description:** Hooks that execute before agent loop starts. Can set up
-    context or initialize resources.
-  - **Default:** `[]`
-
-- **`hooks.AfterAgent`** (array):
-  - **Description:** Hooks that execute after agent loop completes. Can perform
-    cleanup or summarize results.
-  - **Default:** `[]`
-
-- **`hooks.Notification`** (array):
-  - **Description:** Hooks that execute on notification events (errors,
-    warnings, info). Can log or alert on specific conditions.
-  - **Default:** `[]`
-
-- **`hooks.SessionStart`** (array):
-  - **Description:** Hooks that execute when a session starts. Can initialize
-    session-specific resources or state.
-  - **Default:** `[]`
-
-- **`hooks.SessionEnd`** (array):
-  - **Description:** Hooks that execute when a session ends. Can perform cleanup
-    or persist session data.
-  - **Default:** `[]`
-
-- **`hooks.PreCompress`** (array):
-  - **Description:** Hooks that execute before chat history compression. Can
-    back up or analyze conversation before compression.
-  - **Default:** `[]`
-
-- **`hooks.BeforeModel`** (array):
-  - **Description:** Hooks that execute before LLM requests. Can modify prompts,
-    inject context, or control model parameters.
-  - **Default:** `[]`
-
-- **`hooks.AfterModel`** (array):
-  - **Description:** Hooks that execute after LLM responses. Can process
-    outputs, extract information, or log interactions.
-  - **Default:** `[]`
-
-- **`hooks.BeforeToolSelection`** (array):
-  - **Description:** Hooks that execute before tool selection. Can filter or
-    prioritize available tools dynamically.
-  - **Default:** `[]`
-
-#### `admin`
-
-- **`admin.secureModeEnabled`** (boolean):
-  - **Description:** If true, disallows yolo mode from being used.
-  - **Default:** `false`
-
-- **`admin.extensions.enabled`** (boolean):
-  - **Description:** If false, disallows extensions from being installed or
-    used.
-  - **Default:** `true`
-
-- **`admin.mcp.enabled`** (boolean):
-  - **Description:** If false, disallows MCP servers from being used.
-  - **Default:** `true`
-
-- **`admin.mcp.config`** (object):
-  - **Description:** Admin-configured MCP servers.
-  - **Default:** `{}`
-
-- **`admin.skills.enabled`** (boolean):
-  - **Description:** If false, disallows agent skills from being used.
-  - **Default:** `true`
-  <!-- SETTINGS-AUTOGEN:END -->
-
-#### `mcpServers`
-
-Configures connections to one or more Model-Context Protocol (MCP) servers for
-discovering and using custom tools. Gemini CLI attempts to connect to each
-configured MCP server to discover available tools. If multiple MCP servers
-expose a tool with the same name, the tool names will be prefixed with the
-server alias you defined in the configuration (e.g.,
-`serverAlias__actualToolName`) to avoid conflicts. Note that the system might
-strip certain schema properties from MCP tool definitions for compatibility. At
-least one of `command`, `url`, or `httpUrl` must be provided. If multiple are
-specified, the order of precedence is `httpUrl`, then `url`, then `command`.
-
-- **`mcpServers.<SERVER_NAME>`** (object): The server parameters for the named
-  server.
-  - `command` (string, optional): The command to execute to start the MCP server
-    via standard I/O.
-  - `args` (array of strings, optional): Arguments to pass to the command.
-  - `env` (object, optional): Environment variables to set for the server
-    process.
-  - `cwd` (string, optional): The working directory in which to start the
-    server.
-  - `url` (string, optional): The URL of an MCP server that uses Server-Sent
-    Events (SSE) for communication.
-  - `httpUrl` (string, optional): The URL of an MCP server that uses streamable
-    HTTP for communication.
-  - `headers` (object, optional): A map of HTTP headers to send with requests to
-    `url` or `httpUrl`.
-  - `timeout` (number, optional): Timeout in milliseconds for requests to this
-    MCP server.
-  - `trust` (boolean, optional): Trust this server and bypass all tool call
-    confirmations.
-  - `description` (string, optional): A brief description of the server, which
-    may be used for display purposes.
-  - `includeTools` (array of strings, optional): List of tool names to include
-    from this MCP server. When specified, only the tools listed here will be
-    available from this server (allowlist behavior). If not specified, all tools
-    from the server are enabled by default.
-  - `excludeTools` (array of strings, optional): List of tool names to exclude
-    from this MCP server. Tools listed here will not be available to the model,
-    even if they are exposed by the server. **Note:** `excludeTools` takes
-    precedence over `includeTools` - if a tool is in both lists, it will be
-    excluded.
-
-#### `telemetry`
-
-Configures logging and metrics collection for Gemini CLI. For more information,
-see [Telemetry](../cli/telemetry.md).
-
-- **Properties:**
-  - **`enabled`** (boolean): Whether or not telemetry is enabled.
-  - **`target`** (string): The destination for collected telemetry. Supported
-    values are `local` and `gcp`.
-  - **`otlpEndpoint`** (string): The endpoint for the OTLP Exporter.
-  - **`otlpProtocol`** (string): The protocol for the OTLP Exporter (`grpc` or
-    `http`).
-  - **`logPrompts`** (boolean): Whether or not to include the content of user
-    prompts in the logs.
-  - **`outfile`** (string): The file to write telemetry to when `target` is
-    `local`.
-  - **`useCollector`** (boolean): Whether to use an external OTLP collector.
-
-### Example `settings.json`
-
-Here is an example of a `settings.json` file with the nested structure, new as
-of v0.3.0:
+The `settings.json` file uses a nested JSON structure.
 
 ```json
 {
   "general": {
-    "vimMode": true,
-    "preferredEditor": "code",
-    "sessionRetention": {
-      "enabled": true,
-      "maxAge": "30d",
-      "maxCount": 100
-    }
+    "vimMode": false,
+    "defaultApprovalMode": "default"
   },
   "ui": {
-    "theme": "GitHub",
-    "hideBanner": true,
-    "hideTips": false,
-    "customWittyPhrases": [
-      "You forget a thousand things every day. Make sure this is one of ’em",
-      "Connecting to AGI"
-    ]
-  },
-  "tools": {
-    "sandbox": "docker",
-    "discoveryCommand": "bin/get_tools",
-    "callCommand": "bin/call_tool",
-    "exclude": ["write_file"]
-  },
-  "mcpServers": {
-    "mainServer": {
-      "command": "bin/mcp_server.py"
-    },
-    "anotherServer": {
-      "command": "node",
-      "args": ["mcp_server.js", "--verbose"]
-    }
-  },
-  "telemetry": {
-    "enabled": true,
-    "target": "local",
-    "otlpEndpoint": "http://localhost:4317",
-    "logPrompts": true
-  },
-  "privacy": {
-    "usageStatisticsEnabled": true
-  },
-  "model": {
-    "name": "gemini-1.5-pro-latest",
-    "maxSessionTurns": 10,
-    "summarizeToolOutput": {
-      "run_shell_command": {
-        "tokenBudget": 100
-      }
-    }
-  },
-  "context": {
-    "fileName": ["CONTEXT.md", "GEMINI.md"],
-    "includeDirectories": ["path/to/dir1", "~/path/to/dir2", "../path/to/dir3"],
-    "loadFromIncludeDirectories": true,
-    "fileFiltering": {
-      "respectGitIgnore": false
-    }
-  },
-  "advanced": {
-    "excludedEnvVars": ["DEBUG", "DEBUG_MODE", "NODE_ENV"]
+    "theme": "default-dark",
+    "compactToolOutputs": true
   }
 }
 ```
 
-## Shell history
+### Available settings
 
-The CLI keeps a history of shell commands you run. To avoid conflicts between
-different projects, this history is stored in a project-specific directory
-within your user's home folder.
+<!-- SETTINGS-AUTOGEN:START -->
 
-- **Location:** `~/.gemini/tmp/<project_hash>/shell_history`
-  - `<project_hash>` is a unique identifier generated from your project's root
-    path.
-  - The history is stored in a file named `shell_history`.
+#### `general` - General application settings.
 
-## Environment variables and `.env` files
+- `general.preferredEditor`: The preferred editor to open files in.
+- `general.vimMode` (default: `false`): Enable Vim keybindings
+- `general.defaultApprovalMode` (default: `default`): The default approval mode for tool execution. 'default' prompts for approval, 'auto_edit' auto-approves edit tools, and 'plan' is read-only mode. 'yolo' is not supported yet.
+- `general.devtools` (default: `false`): Enable DevTools inspector on launch.
+- `general.enableAutoUpdate` (default: `true`): Enable automatic updates.
+- `general.enableAutoUpdateNotification` (default: `true`): Enable update notification prompts.
+- `general.enableNotifications` (default: `false`): Enable run-event notifications for action-required prompts and session completion. Currently macOS only.
+- `general.checkpointing.enabled` (default: `false`): Enable session checkpointing for recovery
+- `general.plan.directory`: The directory where planning artifacts are stored. If not specified, defaults to the system temporary directory.
+- `general.plan.modelRouting` (default: `true`): Automatically switch between Pro and Flash models based on Plan Mode status. Uses Pro for the planning phase and Flash for the implementation phase.
+- `general.retryFetchErrors` (default: `false`): Retry on "exception TypeError: fetch failed sending request" errors.
+- `general.maxAttempts` (default: `10`): Maximum number of attempts for requests to the main chat model. Cannot exceed 10.
+- `general.debugKeystrokeLogging` (default: `false`): Enable debug logging of keystrokes to the console.
+- `general.sessionRetention.enabled` (default: `false`): Enable automatic session cleanup
+- `general.sessionRetention.maxAge`: Automatically delete chats older than this time period (e.g., "30d", "7d", "24h", "1w")
+- `general.sessionRetention.maxCount`: Alternative: Maximum number of sessions to keep (most recent)
+- `general.sessionRetention.minRetention` (default: `1d`): Minimum retention period (safety limit, defaults to "1d")
+- `general.sessionRetention.warningAcknowledged` (default: `false`): INTERNAL: Whether the user has acknowledged the session retention warning
 
-Environment variables are a common way to configure applications, especially for
-sensitive information like API keys or for settings that might change between
-environments. For authentication setup, see the
-[Authentication documentation](../get-started/authentication.md) which covers
-all available authentication methods.
+#### `output` - Settings for the CLI output.
 
-The CLI automatically loads environment variables from an `.env` file. The
-loading order is:
+- `output.format` (default: `text`): The format of the CLI output. Can be `text` or `json`.
 
-1.  `.env` file in the current working directory.
-2.  If not found, it searches upwards in parent directories until it finds an
-    `.env` file or reaches the project root (identified by a `.git` folder) or
-    the home directory.
-3.  If still not found, it looks for `~/.env` (in the user's home directory).
+#### `ui` - User interface settings.
 
-**Environment variable exclusion:** Some environment variables (like `DEBUG` and
-`DEBUG_MODE`) are automatically excluded from being loaded from project `.env`
-files to prevent interference with gemini-cli behavior. Variables from
-`.gemini/.env` files are never excluded. You can customize this behavior using
-the `advanced.excludedEnvVars` setting in your `settings.json` file.
+- `ui.theme`: The color theme for the UI. See the CLI themes guide for available options.
+- `ui.autoThemeSwitching` (default: `true`): Automatically switch between default light and dark themes based on terminal background color.
+- `ui.terminalBackgroundPollingInterval` (default: `60`): Interval in seconds to poll the terminal background color.
+- `ui.customThemes` (default: `{}`): Custom theme definitions.
+- `ui.hideWindowTitle` (default: `false`): Hide the window title bar
+- `ui.inlineThinkingMode` (default: `off`): Display model thinking inline: off or full.
+- `ui.showStatusInTitle` (default: `false`): Show Gemini CLI model thoughts in the terminal window title during the working phase
+- `ui.dynamicWindowTitle` (default: `true`): Update the terminal window title with current status icons (Ready: ◇, Action Required: ✋, Working: ✦)
+- `ui.showHomeDirectoryWarning` (default: `true`): Show a warning when running Gemini CLI in the home directory.
+- `ui.showCompatibilityWarnings` (default: `true`): Show warnings about terminal or OS compatibility issues.
+- `ui.hideTips` (default: `false`): Hide helpful tips in the UI
+- `ui.showShortcutsHint` (default: `true`): Show the "? for shortcuts" hint above the input.
+- `ui.showKeyboardShortcutsHint` (default: `true`): Show keyboard shortcut hints in the UI (e.g. "press Ctrl+O to expand").
+- `ui.compactToolOutputs` (default: `true`): Whether to show tool outputs in a compact one-line summary by default.
+- `ui.hideBanner` (default: `false`): Hide the application banner
+- `ui.hideContextSummary` (default: `false`): Hide the context summary (GEMINI.md, MCP servers) above the input.
+- `ui.footer.hideCWD` (default: `false`): Hide the current working directory path in the footer.
+- `ui.footer.hideSandboxStatus` (default: `false`): Hide the sandbox status indicator in the footer.
+- `ui.footer.hideModelInfo` (default: `false`): Hide the model name and context usage in the footer.
+- `ui.footer.hideContextPercentage` (default: `true`): Hides the context window remaining percentage.
+- `ui.hideFooter` (default: `false`): Hide the footer from the UI
+- `ui.showMemoryUsage` (default: `false`): Display memory usage information in the UI
+- `ui.showLineNumbers` (default: `true`): Show line numbers in the chat.
+- `ui.showCitations` (default: `false`): Show citations for generated text in the chat.
+- `ui.showModelInfoInChat` (default: `false`): Show the model name in the chat for each model turn.
+- `ui.showUserIdentity` (default: `true`): Show the logged-in user's identity (e.g. email) in the UI.
+- `ui.useAlternateBuffer` (default: `false`): Use an alternate screen buffer for the UI, preserving shell history.
+- `ui.useBackgroundColor` (default: `true`): Whether to use background colors in the UI.
+- `ui.incrementalRendering` (default: `true`): Enable incremental rendering for the UI. This option will reduce flickering but may cause rendering artifacts. Only supported when useAlternateBuffer is enabled.
+- `ui.showSpinner` (default: `true`): Show the spinner during operations.
+- `ui.loadingPhrases` (default: `tips`): What to show while the model is working: tips, witty comments, both, or nothing.
+- `ui.errorVerbosity` (default: `low`): Controls whether recoverable errors are hidden (low) or fully shown (full).
+- `ui.customWittyPhrases` (default: `[]`): Custom witty phrases to display during loading. When provided, the CLI cycles through these instead of the defaults.
+- `ui.accessibility.enableLoadingPhrases` (default: `true`): @deprecated Use ui.loadingPhrases instead. Enable loading phrases during operations.
+- `ui.accessibility.screenReader` (default: `false`): Render output in plain-text to be more screen reader accessible
 
-- **`GEMINI_API_KEY`**:
-  - Your API key for the Gemini API.
-  - One of several available
-    [authentication methods](../get-started/authentication.md).
-  - Set this in your shell profile (e.g., `~/.bashrc`, `~/.zshrc`) or an `.env`
-    file.
-- **`GEMINI_MODEL`**:
-  - Specifies the default Gemini model to use.
-  - Overrides the hardcoded default
-  - Example: `export GEMINI_MODEL="gemini-3-flash-preview"` (Windows PowerShell:
-    `$env:GEMINI_MODEL="gemini-3-flash-preview"`)
-- **`GEMINI_CLI_IDE_PID`**:
-  - Manually specifies the PID of the IDE process to use for integration. This
-    is useful when running Gemini CLI in a standalone terminal while still
-    wanting to associate it with a specific IDE instance.
-  - Overrides the automatic IDE detection logic.
-- **`GEMINI_CLI_HOME`**:
-  - Specifies the root directory for Gemini CLI's user-level configuration and
-    storage.
-  - By default, this is the user's system home directory. The CLI will create a
-    `.gemini` folder inside this directory.
-  - Useful for shared compute environments or keeping CLI state isolated.
-  - Example: `export GEMINI_CLI_HOME="/path/to/user/config"` (Windows
-    PowerShell: `$env:GEMINI_CLI_HOME="C:\path\to\user\config"`)
-- **`GOOGLE_API_KEY`**:
-  - Your Google Cloud API key.
-  - Required for using Vertex AI in express mode.
-  - Ensure you have the necessary permissions.
-  - Example: `export GOOGLE_API_KEY="YOUR_GOOGLE_API_KEY"` (Windows PowerShell:
-    `$env:GOOGLE_API_KEY="YOUR_GOOGLE_API_KEY"`).
-- **`GOOGLE_CLOUD_PROJECT`**:
-  - Your Google Cloud Project ID.
-  - Required for using Code Assist or Vertex AI.
-  - If using Vertex AI, ensure you have the necessary permissions in this
-    project.
-  - **Cloud Shell note:** When running in a Cloud Shell environment, this
-    variable defaults to a special project allocated for Cloud Shell users. If
-    you have `GOOGLE_CLOUD_PROJECT` set in your global environment in Cloud
-    Shell, it will be overridden by this default. To use a different project in
-    Cloud Shell, you must define `GOOGLE_CLOUD_PROJECT` in a `.env` file.
-  - Example: `export GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"` (Windows
-    PowerShell: `$env:GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"`).
-- **`GOOGLE_APPLICATION_CREDENTIALS`** (string):
-  - **Description:** The path to your Google Application Credentials JSON file.
-  - **Example:**
-    `export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/credentials.json"`
-    (Windows PowerShell:
-    `$env:GOOGLE_APPLICATION_CREDENTIALS="C:\path\to\your\credentials.json"`)
-- **`GOOGLE_GENAI_API_VERSION`**:
-  - Specifies the API version to use for Gemini API requests.
-  - When set, overrides the default API version used by the SDK.
-  - Example: `export GOOGLE_GENAI_API_VERSION="v1"` (Windows PowerShell:
-    `$env:GOOGLE_GENAI_API_VERSION="v1"`)
-- **`OTLP_GOOGLE_CLOUD_PROJECT`**:
-  - Your Google Cloud Project ID for Telemetry in Google Cloud
-  - Example: `export OTLP_GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"` (Windows
-    PowerShell: `$env:OTLP_GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"`).
-- **`GEMINI_TELEMETRY_ENABLED`**:
-  - Set to `true` or `1` to enable telemetry. Any other value is treated as
-    disabling it.
-  - Overrides the `telemetry.enabled` setting.
-- **`GEMINI_TELEMETRY_TARGET`**:
-  - Sets the telemetry target (`local` or `gcp`).
-  - Overrides the `telemetry.target` setting.
-- **`GEMINI_TELEMETRY_OTLP_ENDPOINT`**:
-  - Sets the OTLP endpoint for telemetry.
-  - Overrides the `telemetry.otlpEndpoint` setting.
-- **`GEMINI_TELEMETRY_OTLP_PROTOCOL`**:
-  - Sets the OTLP protocol (`grpc` or `http`).
-  - Overrides the `telemetry.otlpProtocol` setting.
-- **`GEMINI_TELEMETRY_LOG_PROMPTS`**:
-  - Set to `true` or `1` to enable or disable logging of user prompts. Any other
-    value is treated as disabling it.
-  - Overrides the `telemetry.logPrompts` setting.
-- **`GEMINI_TELEMETRY_OUTFILE`**:
-  - Sets the file path to write telemetry to when the target is `local`.
-  - Overrides the `telemetry.outfile` setting.
-- **`GEMINI_TELEMETRY_USE_COLLECTOR`**:
-  - Set to `true` or `1` to enable or disable using an external OTLP collector.
-    Any other value is treated as disabling it.
-  - Overrides the `telemetry.useCollector` setting.
-- **`GOOGLE_CLOUD_LOCATION`**:
-  - Your Google Cloud Project Location (e.g., us-central1).
-  - Required for using Vertex AI in non-express mode.
-  - Example: `export GOOGLE_CLOUD_LOCATION="YOUR_PROJECT_LOCATION"` (Windows
-    PowerShell: `$env:GOOGLE_CLOUD_LOCATION="YOUR_PROJECT_LOCATION"`).
-- **`GEMINI_SANDBOX`**:
-  - Alternative to the `sandbox` setting in `settings.json`.
-  - Accepts `true`, `false`, `docker`, `podman`, or a custom command string.
-- **`GEMINI_SYSTEM_MD`**:
-  - Replaces the built‑in system prompt with content from a Markdown file.
-  - `true`/`1`: Use project default path `./.gemini/system.md`.
-  - Any other string: Treat as a path (relative/absolute supported, `~`
-    expands).
-  - `false`/`0` or unset: Use the built‑in prompt. See
-    [System Prompt Override](../cli/system-prompt.md).
-- **`GEMINI_WRITE_SYSTEM_MD`**:
-  - Writes the current built‑in system prompt to a file for review.
-  - `true`/`1`: Write to `./.gemini/system.md`. Otherwise treat the value as a
-    path.
-  - Run the CLI once with this set to generate the file.
-- **`SEATBELT_PROFILE`** (macOS specific):
-  - Switches the Seatbelt (`sandbox-exec`) profile on macOS.
-  - `permissive-open`: (Default) Restricts writes to the project folder (and a
-    few other folders, see
-    `packages/cli/src/utils/sandbox-macos-permissive-open.sb`) but allows other
-    operations.
-  - `restrictive-open`: Declines operations by default, allows network.
-  - `strict-open`: Restricts both reads and writes to the working directory,
-    allows network.
-  - `strict-proxied`: Same as `strict-open` but routes network through proxy.
-  - `<profile_name>`: Uses a custom profile. To define a custom profile, create
-    a file named `sandbox-macos-<profile_name>.sb` in your project's `.gemini/`
-    directory (e.g., `my-project/.gemini/sandbox-macos-custom.sb`).
-- **`DEBUG` or `DEBUG_MODE`** (often used by underlying libraries or the CLI
-  itself):
-  - Set to `true` or `1` to enable verbose debug logging, which can be helpful
-    for troubleshooting.
-  - **Note:** These variables are automatically excluded from project `.env`
-    files by default to prevent interference with gemini-cli behavior. Use
-    `.gemini/.env` files if you need to set these for gemini-cli specifically.
-- **`NO_COLOR`**:
-  - Set to any value to disable all color output in the CLI.
-- **`CLI_TITLE`**:
-  - Set to a string to customize the title of the CLI.
-- **`CODE_ASSIST_ENDPOINT`**:
-  - Specifies the endpoint for the code assist server.
-  - This is useful for development and testing.
+#### `ide` - IDE integration settings.
 
-### Environment variable redaction
+- `ide.enabled` (default: `false`): Enable IDE integration mode.
+- `ide.hasSeenNudge` (default: `false`): Whether the user has seen the IDE integration nudge.
 
-To prevent accidental leakage of sensitive information, Gemini CLI automatically
-redacts potential secrets from environment variables when executing tools (such
-as shell commands). This "best effort" redaction applies to variables inherited
-from the system or loaded from `.env` files.
+#### `privacy` - Privacy-related settings.
 
-**Default Redaction Rules:**
+- `privacy.usageStatisticsEnabled` (default: `true`): Enable collection of usage statistics
 
-- **By Name:** Variables are redacted if their names contain sensitive terms
-  like `TOKEN`, `SECRET`, `PASSWORD`, `KEY`, `AUTH`, `CREDENTIAL`, `PRIVATE`, or
-  `CERT`.
-- **By Value:** Variables are redacted if their values match known secret
-  patterns, such as:
-  - Private keys (RSA, OpenSSH, PGP, etc.)
-  - Certificates
-  - URLs containing credentials
-  - API keys and tokens (GitHub, Google, AWS, Stripe, Slack, etc.)
-- **Specific Blocklist:** Certain variables like `CLIENT_ID`, `DB_URI`,
-  `DATABASE_URL`, and `CONNECTION_STRING` are always redacted by default.
+#### `telemetry` - Telemetry configuration.
 
-**Allowlist (Never Redacted):**
+#### `billing` - Billing and AI credits settings.
 
-- Common system variables (e.g., `PATH`, `HOME`, `USER`, `SHELL`, `TERM`,
-  `LANG`).
-- Variables starting with `GEMINI_CLI_`.
-- GitHub Action specific variables.
+- `billing.overageStrategy` (default: `ask`): How to handle quota exhaustion when AI credits are available. 'ask' prompts each time, 'always' automatically uses credits, 'never' disables credit usage.
 
-**Configuration:**
+#### `model` - Settings related to the generative model.
 
-You can customize this behavior in your `settings.json` file:
+- `model.name`: The Gemini model to use for conversations.
+- `model.maxSessionTurns` (default: `-1`): Maximum number of user/model/tool turns to keep in a session. -1 means unlimited.
+- `model.summarizeToolOutput`: Enables or disables summarization of tool output. Configure per-tool token budgets (for example {"run_shell_command": {"tokenBudget": 2000}}). Currently only the run_shell_command tool supports summarization.
+- `model.compressionThreshold` (default: `0.5`): The fraction of context usage at which to trigger context compression (e.g. 0.2, 0.3).
+- `model.disableLoopDetection` (default: `false`): Disable automatic detection and prevention of infinite loops.
+- `model.skipNextSpeakerCheck` (default: `true`): Skip the next speaker check.
 
-- **`security.allowedEnvironmentVariables`**: A list of variable names to
-  _never_ redact, even if they match sensitive patterns.
-- **`security.blockedEnvironmentVariables`**: A list of variable names to
-  _always_ redact, even if they don't match sensitive patterns.
+#### `modelConfigs` - Model configurations.
 
-```json
-{
-  "security": {
-    "allowedEnvironmentVariables": ["MY_PUBLIC_KEY", "NOT_A_SECRET_TOKEN"],
-    "blockedEnvironmentVariables": ["INTERNAL_IP_ADDRESS"]
-  }
-}
-```
+- `modelConfigs.aliases` (default: `...`): Named presets for model configs. Can be used in place of a model name and can inherit from other aliases using an `extends` property.
+- `modelConfigs.customAliases` (default: `{}`): Custom named presets for model configs. These are merged with (and override) the built-in aliases.
+- `modelConfigs.customOverrides` (default: `[]`): Custom model config overrides. These are merged with (and added to) the built-in overrides.
+- `modelConfigs.overrides` (default: `[]`): Apply specific configuration overrides based on matches, with a primary key of model (or alias). The most specific match will be used.
 
-## Command-line arguments
+#### `agents` - Settings for subagents.
 
-Arguments passed directly when running the CLI can override other configurations
-for that specific session.
+- `agents.overrides` (default: `{}`): Override settings for specific agents, e.g. to disable the agent, set a custom model config, or run config.
+- `agents.browser.sessionMode` (default: `persistent`): Session mode: 'persistent', 'isolated', or 'existing'.
+- `agents.browser.headless` (default: `false`): Run browser in headless mode.
+- `agents.browser.profilePath`: Path to browser profile directory for session persistence.
+- `agents.browser.visualModel`: Model override for the visual agent.
 
-- **`--model <model_name>`** (**`-m <model_name>`**):
-  - Specifies the Gemini model to use for this session.
-  - Example: `npm start -- --model gemini-3-pro-preview`
-- **`--prompt <your_prompt>`** (**`-p <your_prompt>`**):
-  - **Deprecated:** Use positional arguments instead.
-  - Used to pass a prompt directly to the command. This invokes Gemini CLI in a
-    non-interactive mode.
-- **`--prompt-interactive <your_prompt>`** (**`-i <your_prompt>`**):
-  - Starts an interactive session with the provided prompt as the initial input.
-  - The prompt is processed within the interactive session, not before it.
-  - Cannot be used when piping input from stdin.
-  - Example: `gemini -i "explain this code"`
-- **`--output-format <format>`**:
-  - **Description:** Specifies the format of the CLI output for non-interactive
-    mode.
-  - **Values:**
-    - `text`: (Default) The standard human-readable output.
-    - `json`: A machine-readable JSON output.
-    - `stream-json`: A streaming JSON output that emits real-time events.
-  - **Note:** For structured output and scripting, use the
-    `--output-format json` or `--output-format stream-json` flag.
-- **`--sandbox`** (**`-s`**):
-  - Enables sandbox mode for this session.
-- **`--debug`** (**`-d`**):
-  - Enables debug mode for this session, providing more verbose output. Open the
-    debug console with F12 to see the additional logging.
+#### `context` - Settings for managing context provided to the model.
 
-- **`--help`** (or **`-h`**):
-  - Displays help information about command-line arguments.
-- **`--yolo`**:
-  - Enables YOLO mode, which automatically approves all tool calls.
-- **`--approval-mode <mode>`**:
-  - Sets the approval mode for tool calls. Available modes:
-    - `default`: Prompt for approval on each tool call (default behavior)
-    - `auto_edit`: Automatically approve edit tools (replace, write_file) while
-      prompting for others
-    - `yolo`: Automatically approve all tool calls (equivalent to `--yolo`)
-    - `plan`: Read-only mode for tool calls (requires experimental planning to
-      be enabled).
-      > **Note:** This mode is currently under development and not yet fully
-      > functional.
-  - Cannot be used together with `--yolo`. Use `--approval-mode=yolo` instead of
-    `--yolo` for the new unified approach.
-  - Example: `gemini --approval-mode auto_edit`
-- **`--allowed-tools <tool1,tool2,...>`**:
-  - A comma-separated list of tool names that will bypass the confirmation
-    dialog.
-  - Example: `gemini --allowed-tools "ShellTool(git status)"`
-- **`--extensions <extension_name ...>`** (**`-e <extension_name ...>`**):
-  - Specifies a list of extensions to use for the session. If not provided, all
-    available extensions are used.
-  - Use the special term `gemini -e none` to disable all extensions.
-  - Example: `gemini -e my-extension -e my-other-extension`
-- **`--list-extensions`** (**`-l`**):
-  - Lists all available extensions and exits.
-- **`--resume [session_id]`** (**`-r [session_id]`**):
-  - Resume a previous chat session. Use "latest" for the most recent session,
-    provide a session index number, or provide a full session UUID.
-  - If no session_id is provided, defaults to "latest".
-  - Example: `gemini --resume 5` or `gemini --resume latest` or
-    `gemini --resume a1b2c3d4-e5f6-7890-abcd-ef1234567890` or `gemini --resume`
-  - See [Session Management](../cli/session-management.md) for more details.
-- **`--list-sessions`**:
-  - List all available chat sessions for the current project and exit.
-  - Shows session indices, dates, message counts, and preview of first user
-    message.
-  - Example: `gemini --list-sessions`
-- **`--delete-session <identifier>`**:
-  - Delete a specific chat session by its index number or full session UUID.
-  - Use `--list-sessions` first to see available sessions, their indices, and
-    UUIDs.
-  - Example: `gemini --delete-session 3` or
-    `gemini --delete-session a1b2c3d4-e5f6-7890-abcd-ef1234567890`
-- **`--include-directories <dir1,dir2,...>`**:
-  - Includes additional directories in the workspace for multi-directory
-    support.
-  - Can be specified multiple times or as comma-separated values.
-  - 5 directories can be added at maximum.
-  - Example: `--include-directories /path/to/project1,/path/to/project2` or
-    `--include-directories /path/to/project1 --include-directories /path/to/project2`
-- **`--screen-reader`**:
-  - Enables screen reader mode, which adjusts the TUI for better compatibility
-    with screen readers.
-- **`--version`**:
-  - Displays the version of the CLI.
-- **`--experimental-acp`**:
-  - Starts the agent in ACP mode.
-- **`--allowed-mcp-server-names`**:
-  - Allowed MCP server names.
-- **`--fake-responses`**:
-  - Path to a file with fake model responses for testing.
-- **`--record-responses`**:
-  - Path to a file to record model responses for testing.
+- `context.fileName`: The name of the context file or files to load into memory. Accepts either a single string or an array of strings.
+- `context.importFormat`: The format to use when importing memory.
+- `context.includeDirectoryTree` (default: `true`): Whether to include the directory tree of the current working directory in the initial request to the model.
+- `context.discoveryMaxDirs` (default: `200`): Maximum number of directories to search for memory.
+- `context.includeDirectories` (default: `[]`): Additional directories to include in the workspace context. Missing directories will be skipped with a warning.
+- `context.loadMemoryFromIncludeDirectories` (default: `false`): Controls how /memory refresh loads GEMINI.md files. When true, include directories are scanned; when false, only the current directory is used.
+- `context.fileFiltering.respectGitIgnore` (default: `true`): Respect .gitignore files when searching.
+- `context.fileFiltering.respectGeminiIgnore` (default: `true`): Respect .geminiignore files when searching.
+- `context.fileFiltering.enableRecursiveFileSearch` (default: `true`): Enable recursive file search functionality when completing @ references in the prompt.
+- `context.fileFiltering.enableFuzzySearch` (default: `true`): Enable fuzzy search when searching for files.
+- `context.fileFiltering.customIgnoreFilePaths` (default: `[]`): Additional ignore file paths to respect. These files take precedence over .geminiignore and .gitignore. Files earlier in the array take precedence over files later in the array, e.g. the first file takes precedence over the second one.
 
-## Context files (hierarchical instructional context)
+#### `tools` - Settings for built-in and custom tools.
 
-While not strictly configuration for the CLI's _behavior_, context files
-(defaulting to `GEMINI.md` but configurable via the `context.fileName` setting)
-are crucial for configuring the _instructional context_ (also referred to as
-"memory") provided to the Gemini model. This powerful feature allows you to give
-project-specific instructions, coding style guides, or any relevant background
-information to the AI, making its responses more tailored and accurate to your
-needs. The CLI includes UI elements, such as an indicator in the footer showing
-the number of loaded context files, to keep you informed about the active
-context.
+- `tools.sandbox`: Sandbox execution environment. Set to a boolean to enable or disable the sandbox, or provide a string path to a sandbox profile.
+- `tools.shell.enableInteractiveShell` (default: `true`): Use node-pty for an interactive shell experience. Fallback to child_process still applies.
+- `tools.shell.pager` (default: `cat`): The pager command to use for shell output. Defaults to `cat`.
+- `tools.shell.showColor` (default: `false`): Show color in shell output.
+- `tools.shell.inactivityTimeout` (default: `300`): The maximum time in seconds allowed without output from the shell command. Defaults to 5 minutes.
+- `tools.shell.enableShellOutputEfficiency` (default: `true`): Enable shell output efficiency optimizations for better performance.
+- `tools.core`: Restrict the set of built-in tools with an allowlist. Match semantics mirror tools.allowed; see the built-in tools documentation for available names.
+- `tools.allowed`: Tool names that bypass the confirmation dialog. Useful for trusted commands (for example ["run_shell_command(git)", "run_shell_command(npm test)"]). See shell tool command restrictions for matching details.
+- `tools.exclude`: Tool names to exclude from discovery.
+- `tools.discoveryCommand`: Command to run for tool discovery.
+- `tools.callCommand`: Defines a custom shell command for invoking discovered tools. The command must take the tool name as the first argument, read JSON arguments from stdin, and emit JSON results on stdout.
+- `tools.useRipgrep` (default: `true`): Use ripgrep for file content search instead of the fallback implementation. Provides faster search performance.
+- `tools.truncateToolOutputThreshold` (default: `40000`): Maximum characters to show when truncating large tool outputs. Set to 0 or negative to disable truncation.
+- `tools.disableLLMCorrection` (default: `true`): Disable LLM-based error correction for edit tools. When enabled, tools will fail immediately if exact string matches are not found, instead of attempting to self-correct.
 
-- **Purpose:** These Markdown files contain instructions, guidelines, or context
-  that you want the Gemini model to be aware of during your interactions. The
-  system is designed to manage this instructional context hierarchically.
+#### `mcp` - Settings for Model Context Protocol (MCP) servers.
 
-### Example context file content (e.g., `GEMINI.md`)
+- `mcp.serverCommand`: Command to start an MCP server.
+- `mcp.allowed`: A list of MCP servers to allow.
+- `mcp.excluded`: A list of MCP servers to exclude.
 
-Here's a conceptual example of what a context file at the root of a TypeScript
-project might contain:
+#### `useWriteTodos` (default: `true`): Enable the write_todos tool.
 
-```markdown
-# Project: My Awesome TypeScript Library
+#### `security` - Security-related settings.
 
-## General Instructions:
+- `security.disableYoloMode` (default: `false`): Disable YOLO mode, even if enabled by a flag.
+- `security.enablePermanentToolApproval` (default: `false`): Enable the "Allow for all future sessions" option in tool confirmation dialogs.
+- `security.blockGitExtensions` (default: `false`): Blocks installing and loading extensions from Git.
+- `security.allowedExtensions` (default: `[]`): List of Regex patterns for allowed extensions. If nonempty, only extensions that match the patterns in this list are allowed. Overrides the blockGitExtensions setting.
+- `security.folderTrust.enabled` (default: `true`): Setting to track whether Folder trust is enabled.
+- `security.environmentVariableRedaction.allowed` (default: `[]`): Environment variables to always allow (bypass redaction).
+- `security.environmentVariableRedaction.blocked` (default: `[]`): Environment variables to always redact.
+- `security.environmentVariableRedaction.enabled` (default: `false`): Enable redaction of environment variables that may contain secrets.
+- `security.auth.useExternal`: Whether to use an external authentication flow.
+- `security.enableConseca` (default: `false`): Enable the context-aware security checker. This feature uses an LLM to dynamically generate and enforce security policies for tool use based on your prompt, providing an additional layer of protection against unintended actions.
 
-- When generating new TypeScript code, please follow the existing coding style.
-- Ensure all new functions and classes have JSDoc comments.
-- Prefer functional programming paradigms where appropriate.
-- All code should be compatible with TypeScript 5.0 and Node.js 20+.
+#### `advanced` - Advanced settings for power users.
 
-## Coding Style:
+- `advanced.autoConfigureMemory` (default: `false`): Automatically configure Node.js memory limits
+- `advanced.dnsResolutionOrder`: The DNS resolution order.
+- `advanced.excludedEnvVars` (default: `["DEBUG","DEBUG_MODE"]`): Environment variables to exclude from project context.
+- `advanced.bugCommand`: Configuration for the bug report command.
 
-- Use 2 spaces for indentation.
-- Interface names should be prefixed with `I` (e.g., `IUserService`).
-- Private class members should be prefixed with an underscore (`_`).
-- Always use strict equality (`===` and `!==`).
+#### `experimental` - Setting to enable experimental features
 
-## Specific Component: `src/api/client.ts`
+- `experimental.toolOutputMasking.enabled` (default: `true`): Enables tool output masking to save tokens.
+- `experimental.toolOutputMasking.toolProtectionThreshold` (default: `50000`): Minimum number of tokens to protect from masking (most recent tool outputs).
+- `experimental.toolOutputMasking.minPrunableTokensThreshold` (default: `30000`): Minimum prunable tokens required to trigger a masking pass.
+- `experimental.toolOutputMasking.protectLatestTurn` (default: `true`): Ensures the absolute latest turn is never masked, regardless of token count.
+- `experimental.enableAgents` (default: `false`): Enable local and remote subagents. Warning: Experimental feature, uses YOLO mode for subagents
+- `experimental.extensionManagement` (default: `true`): Enable extension management features.
+- `experimental.extensionConfig` (default: `true`): Enable requesting and fetching of extension settings.
+- `experimental.extensionRegistry` (default: `false`): Enable extension registry explore UI.
+- `experimental.extensionReloading` (default: `false`): Enables extension loading/unloading within the CLI session.
+- `experimental.jitContext` (default: `false`): Enable Just-In-Time (JIT) context loading.
+- `experimental.useOSC52Paste` (default: `false`): Use OSC 52 for pasting. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it).
+- `experimental.useOSC52Copy` (default: `false`): Use OSC 52 for copying. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it).
+- `experimental.plan` (default: `false`): Enable planning features (Plan Mode and tools).
+- `experimental.modelSteering` (default: `false`): Enable model steering (user hints) to guide the model during tool execution.
+- `experimental.directWebFetch` (default: `false`): Enable web fetch behavior that bypasses LLM summarization.
+- `experimental.gemmaModelRouter.enabled` (default: `false`): Enable the Gemma Model Router. Requires a local endpoint serving Gemma via the Gemini API using LiteRT-LM shim.
+- `experimental.gemmaModelRouter.classifier.host` (default: `http://localhost:9379`): The host of the classifier.
+- `experimental.gemmaModelRouter.classifier.model` (default: `gemma3-1b-gpu-custom`): The model to use for the classifier. Only tested on `gemma3-1b-gpu-custom`.
 
-- This file handles all outbound API requests.
-- When adding new API call functions, ensure they include robust error handling
-  and logging.
-- Use the existing `fetchWithRetry` utility for all GET requests.
+#### `extensions` - Settings for extensions.
 
-## Regarding Dependencies:
+- `extensions.disabled` (default: `[]`): List of disabled extensions.
+- `extensions.workspacesWithMigrationNudge` (default: `[]`): List of workspaces for which the migration nudge has been shown.
 
-- Avoid introducing new external dependencies unless absolutely necessary.
-- If a new dependency is required, please state the reason.
-```
+#### `skills` - Settings for agent skills.
 
-This example demonstrates how you can provide general project context, specific
-coding conventions, and even notes about particular files or components. The
-more relevant and precise your context files are, the better the AI can assist
-you. Project-specific context files are highly encouraged to establish
-conventions and context.
+- `skills.enabled` (default: `true`): Enable Agent Skills.
+- `skills.disabled` (default: `[]`): List of disabled skills.
 
-- **Hierarchical loading and precedence:** The CLI implements a sophisticated
-  hierarchical memory system by loading context files (e.g., `GEMINI.md`) from
-  several locations. Content from files lower in this list (more specific)
-  typically overrides or supplements content from files higher up (more
-  general). The exact concatenation order and final context can be inspected
-  using the `/memory show` command. The typical loading order is:
-  1.  **Global context file:**
-      - Location: `~/.gemini/<configured-context-filename>` (e.g.,
-        `~/.gemini/GEMINI.md` in your user home directory).
-      - Scope: Provides default instructions for all your projects.
-  2.  **Project root and ancestors context files:**
-      - Location: The CLI searches for the configured context file in the
-        current working directory and then in each parent directory up to either
-        the project root (identified by a `.git` folder) or your home directory.
-      - Scope: Provides context relevant to the entire project or a significant
-        portion of it.
-  3.  **Sub-directory context files (contextual/local):**
-      - Location: The CLI also scans for the configured context file in
-        subdirectories _below_ the current working directory (respecting common
-        ignore patterns like `node_modules`, `.git`, etc.). The breadth of this
-        search is limited to 200 directories by default, but can be configured
-        with the `context.discoveryMaxDirs` setting in your `settings.json`
-        file.
-      - Scope: Allows for highly specific instructions relevant to a particular
-        component, module, or subsection of your project.
-- **Concatenation and UI indication:** The contents of all found context files
-  are concatenated (with separators indicating their origin and path) and
-  provided as part of the system prompt to the Gemini model. The CLI footer
-  displays the count of loaded context files, giving you a quick visual cue
-  about the active instructional context.
-- **Importing content:** You can modularize your context files by importing
-  other Markdown files using the `@path/to/file.md` syntax. For more details,
-  see the [Memory Import Processor documentation](./memport.md).
-- **Commands for memory management:**
-  - Use `/memory refresh` to force a re-scan and reload of all context files
-    from all configured locations. This updates the AI's instructional context.
-  - Use `/memory show` to display the combined instructional context currently
-    loaded, allowing you to verify the hierarchy and content being used by the
-    AI.
-  - See the [Commands documentation](./commands.md#memory) for full details on
-    the `/memory` command and its sub-commands (`show` and `refresh`).
+#### `hooksConfig` - Hook configurations for intercepting and customizing agent behavior.
 
-By understanding and utilizing these configuration layers and the hierarchical
-nature of context files, you can effectively manage the AI's memory and tailor
-the Gemini CLI's responses to your specific needs and projects.
+- `hooksConfig.enabled` (default: `true`): Canonical toggle for the hooks system. When disabled, no hooks will be executed.
+- `hooksConfig.disabled` (default: `[]`): List of hook names (commands) that should be disabled. Hooks in this list will not execute even if configured.
+- `hooksConfig.notifications` (default: `true`): Show visual indicators when hooks are executing.
 
-## Sandboxing
+#### `hooks` - Event-specific hook configurations.
 
-The Gemini CLI can execute potentially unsafe operations (like shell commands
-and file modifications) within a sandboxed environment to protect your system.
+- `hooks.BeforeTool` (default: `[]`): Hooks that execute before tool execution. Can intercept, validate, or modify tool calls.
+- `hooks.AfterTool` (default: `[]`): Hooks that execute after tool execution. Can process results, log outputs, or trigger follow-up actions.
+- `hooks.BeforeAgent` (default: `[]`): Hooks that execute before agent loop starts. Can set up context or initialize resources.
+- `hooks.AfterAgent` (default: `[]`): Hooks that execute after agent loop completes. Can perform cleanup or summarize results.
+- `hooks.Notification` (default: `[]`): Hooks that execute on notification events (errors, warnings, info). Can log or alert on specific conditions.
+- `hooks.SessionStart` (default: `[]`): Hooks that execute when a session starts. Can initialize session-specific resources or state.
+- `hooks.SessionEnd` (default: `[]`): Hooks that execute when a session ends. Can perform cleanup or persist session data.
+- `hooks.PreCompress` (default: `[]`): Hooks that execute before chat history compression. Can back up or analyze conversation before compression.
+- `hooks.BeforeModel` (default: `[]`): Hooks that execute before LLM requests. Can modify prompts, inject context, or control model parameters.
+- `hooks.AfterModel` (default: `[]`): Hooks that execute after LLM responses. Can process outputs, extract information, or log interactions.
+- `hooks.BeforeToolSelection` (default: `[]`): Hooks that execute before tool selection. Can filter or prioritize available tools dynamically.
 
-Sandboxing is disabled by default, but you can enable it in a few ways:
+<!-- SETTINGS-AUTOGEN:END -->
 
-- Using `--sandbox` or `-s` flag.
-- Setting `GEMINI_SANDBOX` environment variable.
-- Sandbox is enabled when using `--yolo` or `--approval-mode=yolo` by default.
+## Privacy
 
-By default, it uses a pre-built `gemini-cli-sandbox` Docker image.
-
-For project-specific sandboxing needs, you can create a custom Dockerfile at
-`.gemini/sandbox.Dockerfile` in your project's root directory. This Dockerfile
-can be based on the base sandbox image:
-
-```dockerfile
-FROM gemini-cli-sandbox
-
-# Add your custom dependencies or configurations here
-# For example:
-# RUN apt-get update && apt-get install -y some-package
-# COPY ./my-config /app/my-config
-```
-
-When `.gemini/sandbox.Dockerfile` exists, you can use `BUILD_SANDBOX`
-environment variable when running Gemini CLI to automatically build the custom
-sandbox image:
-
-```bash
-BUILD_SANDBOX=1 gemini -s
-```
-
-## Usage statistics
-
-To help us improve the Gemini CLI, we collect anonymized usage statistics. This
-data helps us understand how the CLI is used, identify common issues, and
-prioritize new features.
-
-**What we collect:**
-
-- **Tool calls:** We log the names of the tools that are called, whether they
-  succeed or fail, and how long they take to execute. We do not collect the
-  arguments passed to the tools or any data returned by them.
-- **API requests:** We log the Gemini model used for each request, the duration
-  of the request, and whether it was successful. We do not collect the content
-  of the prompts or responses.
-- **Session information:** We collect information about the configuration of the
-  CLI, such as the enabled tools and the approval mode.
-
-**What we DON'T collect:**
-
-- **Personally identifiable information (PII):** We do not collect any personal
-  information, such as your name, email address, or API keys.
-- **Prompt and response content:** We do not log the content of your prompts or
-  the responses from the Gemini model.
-- **File content:** We do not log the content of any files that are read or
-  written by the CLI.
-
-**How to opt out:**
-
-You can opt out of usage statistics collection at any time by setting the
+Gemini CLI collects usage statistics to help improve the tool. You can opt out
+of usage statistics collection at any time by setting the
 `usageStatisticsEnabled` property to `false` under the `privacy` category in
 your `settings.json` file:
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -7,75 +7,33 @@
 import yargs from 'yargs/yargs';
 import { hideBin } from 'yargs/helpers';
 import process from 'node:process';
-import { mcpCommand } from '../commands/mcp.js';
-import { extensionsCommand } from '../commands/extensions.js';
-import { skillsCommand } from '../commands/skills.js';
-import { hooksCommand } from '../commands/hooks.js';
+import { mcpCommand } from './mcp.js';
 import {
-  setGeminiMdFilename as setServerGeminiMdFilename,
-  getCurrentGeminiMdFilename,
-  ApprovalMode,
-  DEFAULT_GEMINI_EMBEDDING_MODEL,
-  DEFAULT_FILE_FILTERING_OPTIONS,
-  DEFAULT_MEMORY_FILE_FILTERING_OPTIONS,
-  FileDiscoveryService,
-  WRITE_FILE_TOOL_NAME,
-  SHELL_TOOL_NAMES,
-  SHELL_TOOL_NAME,
-  resolveTelemetrySettings,
-  FatalConfigError,
-  getPty,
-  EDIT_TOOL_NAME,
-  debugLogger,
-  loadServerHierarchicalMemory,
-  WEB_FETCH_TOOL_NAME,
-  ASK_USER_TOOL_NAME,
-  getVersion,
-  PREVIEW_GEMINI_MODEL_AUTO,
-  type HierarchicalMemory,
-  coreEvents,
-  GEMINI_MODEL_ALIAS_AUTO,
-  getAdminErrorMessage,
-  isHeadlessMode,
-  Config,
-  applyAdminAllowlist,
-  getAdminBlockedMcpServersMessage,
-  type HookDefinition,
-  type HookEventName,
-  type OutputFormat,
-} from '@google/gemini-cli-core';
-import {
-  type Settings,
-  type MergedSettings,
-  saveModelChange,
+  type GeminiContentGeneratorConfig,
+  type Config,
+  createTestMergedSettings,
+  getDefaultsFromSchema,
+  isRestrictiveSandbox,
+  type LoadableSettingScope,
   loadSettings,
-} from './settings.js';
-
-import { loadSandboxConfig } from './sandboxConfig.js';
-import { resolvePath } from '../utils/resolvePath.js';
-import { RESUME_LATEST } from '../utils/sessionUtils.js';
-
-import { isWorkspaceTrusted } from './trustedFolders.js';
-import {
-  createPolicyEngineConfig,
-  resolveWorkspacePolicyState,
-} from './policy.js';
-import { ExtensionManager } from './extension-manager.js';
-import { McpServerEnablementManager } from './mcp/mcpServerEnablement.js';
-import type { ExtensionEvents } from '@google/gemini-cli-core/src/utils/extensionLoader.js';
-import { requestConsentNonInteractive } from './extensions/consent.js';
-import { promptForSetting } from './extensions/extensionSettings.js';
-import type { EventEmitter } from 'node:stream';
-import { runExitCleanup } from '../utils/cleanup.js';
+  RESUME_LATEST,
+  SettingScope,
+  AuthType,
+  debugLogger,
+  clearCachedCredentialFile,
+  Config as ConfigImpl,
+} from '@google/gemini-cli-core';
+import { type MergedSettings } from './settingsSchema.js';
+import { type SkillDefinition } from '../ui/types.js';
+import { type HookDefinition, type HookEventName } from '@google/gemini-cli-core';
 
 export interface CliArgs {
-  query: string | undefined;
   model: string | undefined;
-  sandbox: boolean | string | undefined;
+  sandbox: boolean | undefined;
   debug: boolean | undefined;
   prompt: string | undefined;
-  promptInteractive: string | undefined;
-
+  promptInteractive: boolean | undefined;
+  query: string | undefined;
   yolo: boolean | undefined;
   approvalMode: string | undefined;
   policy: string[] | undefined;
@@ -84,212 +42,150 @@ export interface CliArgs {
   experimentalAcp: boolean | undefined;
   extensions: string[] | undefined;
   listExtensions: boolean | undefined;
-  resume: string | typeof RESUME_LATEST | undefined;
-  listSessions: boolean | undefined;
-  deleteSession: string | undefined;
   includeDirectories: string[] | undefined;
   screenReader: boolean | undefined;
+  compactToolOutputs: boolean | undefined;
   useWriteTodos: boolean | undefined;
   outputFormat: string | undefined;
   fakeResponses: string | undefined;
   recordResponses: string | undefined;
   startupMessages?: string[];
+  resume: string | typeof RESUME_LATEST | undefined;
+  listSessions: boolean | undefined;
+  deleteSession: string | undefined;
   rawOutput: boolean | undefined;
   acceptRawOutputRisk: boolean | undefined;
   isCommand: boolean | undefined;
 }
 
-export async function parseArguments(
-  settings: MergedSettings,
-): Promise<CliArgs> {
-  const rawArgv = hideBin(process.argv);
-  const startupMessages: string[] = [];
-  const yargsInstance = yargs(rawArgv)
-    .locale('en')
-    .scriptName('gemini')
-    .usage(
-      'Usage: gemini [options] [command]\n\nGemini CLI - Defaults to interactive mode. Use -p/--prompt for non-interactive (headless) mode.',
-    )
+export async function parseArguments(rawArgs: string[]): Promise<CliArgs> {
+  const argv = await yargs(hideBin(rawArgs))
+    .usage('Usage: gemini [options] [command]')
+    .option('model', {
+      alias: 'm',
+      type: 'string',
+      description: 'Gemini model to use',
+    })
+    .option('query', {
+      alias: 'q',
+      type: 'string',
+      description: 'Execute the provided prompt and exit (non-interactive)',
+    })
+    .option('prompt', {
+      alias: 'p',
+      type: 'string',
+      description: 'Execute the provided prompt and exit (non-interactive)',
+    })
+    .option('prompt-interactive', {
+      alias: 'i',
+      type: 'string',
+      description:
+        'Execute the provided prompt and continue in interactive mode',
+    })
+    .option('sandbox', {
+      alias: 's',
+      type: 'boolean',
+      description: 'Run in sandbox?',
+    })
     .option('debug', {
       alias: 'd',
       type: 'boolean',
-      description: 'Run in debug mode (open debug console with F12)',
-      default: false,
+      description: 'Enable debug mode',
     })
-    .command('$0 [query..]', 'Launch Gemini CLI', (yargsInstance) =>
-      yargsInstance
-        .positional('query', {
-          description:
-            'Initial prompt. Runs in interactive mode by default; use -p/--prompt for non-interactive.',
-        })
-        .option('model', {
-          alias: 'm',
-          type: 'string',
-          nargs: 1,
-          description: `Model`,
-        })
-        .option('prompt', {
-          alias: 'p',
-          type: 'string',
-          nargs: 1,
-          description:
-            'Run in non-interactive (headless) mode with the given prompt. Appended to input on stdin (if any).',
-        })
-        .option('prompt-interactive', {
-          alias: 'i',
-          type: 'string',
-          nargs: 1,
-          description:
-            'Execute the provided prompt and continue in interactive mode',
-        })
-        .option('sandbox', {
-          alias: 's',
-          type: 'boolean',
-          description: 'Run in sandbox?',
-        })
-
-        .option('yolo', {
-          alias: 'y',
-          type: 'boolean',
-          description:
-            'Automatically accept all actions (aka YOLO mode, see https://www.youtube.com/watch?v=xvFZjo5PgG0 for more details)?',
-          default: false,
-        })
-        .option('approval-mode', {
-          type: 'string',
-          nargs: 1,
-          choices: ['default', 'auto_edit', 'yolo', 'plan'],
-          description:
-            'Set the approval mode: default (prompt for approval), auto_edit (auto-approve edit tools), yolo (auto-approve all tools), plan (read-only mode)',
-        })
-        .option('policy', {
-          type: 'array',
-          string: true,
-          nargs: 1,
-          description:
-            'Additional policy files or directories to load (comma-separated or multiple --policy)',
-          coerce: (policies: string[]) =>
-            // Handle comma-separated values
-            policies.flatMap((p) =>
-              p
-                .split(',')
-                .map((s) => s.trim())
-                .filter(Boolean),
-            ),
-        })
-        .option('experimental-acp', {
-          type: 'boolean',
-          description: 'Starts the agent in ACP mode',
-        })
-        .option('allowed-mcp-server-names', {
-          type: 'array',
-          string: true,
-          nargs: 1,
-          description: 'Allowed MCP server names',
-          coerce: (mcpServerNames: string[]) =>
-            // Handle comma-separated values
-            mcpServerNames.flatMap((mcpServerName) =>
-              mcpServerName.split(',').map((m) => m.trim()),
-            ),
-        })
-        .option('allowed-tools', {
-          type: 'array',
-          string: true,
-          nargs: 1,
-          description:
-            '[DEPRECATED: Use Policy Engine instead See https://geminicli.com/docs/core/policy-engine] Tools that are allowed to run without confirmation',
-          coerce: (tools: string[]) =>
-            // Handle comma-separated values
-            tools.flatMap((tool) => tool.split(',').map((t) => t.trim())),
-        })
-        .option('extensions', {
-          alias: 'e',
-          type: 'array',
-          string: true,
-          nargs: 1,
-          description:
-            'A list of extensions to use. If not provided, all extensions are used.',
-          coerce: (extensions: string[]) =>
-            // Handle comma-separated values
-            extensions.flatMap((extension) =>
-              extension.split(',').map((e) => e.trim()),
-            ),
-        })
-        .option('list-extensions', {
-          alias: 'l',
-          type: 'boolean',
-          description: 'List all available extensions and exit.',
-        })
-        .option('resume', {
-          alias: 'r',
-          type: 'string',
-          // `skipValidation` so that we can distinguish between it being passed with a value, without
-          // one, and not being passed at all.
-          skipValidation: true,
-          description:
-            'Resume a previous session. Use "latest" for most recent or index number (e.g. --resume 5)',
-          coerce: (value: string): string => {
-            // When --resume passed with a value (`gemini --resume 123`): value = "123" (string)
-            // When --resume passed without a value (`gemini --resume`): value = "" (string)
-            // When --resume not passed at all: this `coerce` function is not called at all, and
-            //   `yargsInstance.argv.resume` is undefined.
-            if (value === '') {
-              return RESUME_LATEST;
-            }
-            return value;
-          },
-        })
-        .option('list-sessions', {
-          type: 'boolean',
-          description:
-            'List available sessions for the current project and exit.',
-        })
-        .option('delete-session', {
-          type: 'string',
-          description:
-            'Delete a session by index number (use --list-sessions to see available sessions).',
-        })
-        .option('include-directories', {
-          type: 'array',
-          string: true,
-          nargs: 1,
-          description:
-            'Additional directories to include in the workspace (comma-separated or multiple --include-directories)',
-          coerce: (dirs: string[]) =>
-            // Handle comma-separated values
-            dirs.flatMap((dir) => dir.split(',').map((d) => d.trim())),
-        })
-        .option('screen-reader', {
-          type: 'boolean',
-          description: 'Enable screen reader mode for accessibility.',
-        })
-        .option('output-format', {
-          alias: 'o',
-          type: 'string',
-          nargs: 1,
-          description: 'The format of the CLI output.',
-          choices: ['text', 'json', 'stream-json'],
-        })
-        .option('fake-responses', {
-          type: 'string',
-          description: 'Path to a file with fake model responses for testing.',
-          hidden: true,
-        })
-        .option('record-responses', {
-          type: 'string',
-          description: 'Path to a file to record model responses for testing.',
-          hidden: true,
-        })
-        .option('raw-output', {
-          type: 'boolean',
-          description:
-            'Disable sanitization of model output (e.g. allow ANSI escape sequences). WARNING: This can be a security risk if the model output is untrusted.',
-        })
-        .option('accept-raw-output-risk', {
-          type: 'boolean',
-          description: 'Suppress the security warning when using --raw-output.',
-        }),
-    )
+    .option('yolo', {
+      alias: 'y',
+      type: 'boolean',
+      description: 'Enable YOLO mode (dangerous!)',
+    })
+    .option('approval-mode', {
+      type: 'string',
+      choices: ['default', 'auto_edit', 'plan', 'yolo'],
+      description: 'The tool approval mode to use.',
+    })
+    .option('policy', {
+      type: 'array',
+      string: true,
+      description: 'Paths to policy files or directories to load.',
+    })
+    .option('allowed-mcp-server', {
+      type: 'array',
+      string: true,
+      description: 'Names of MCP servers to allow.',
+    })
+    .option('allowed-tool', {
+      type: 'array',
+      string: true,
+      description: 'Names of tools to allow.',
+    })
+    .option('experimental-acp', {
+      type: 'boolean',
+      description: 'Enable experimental Agent Command Protocol.',
+    })
+    .option('extension', {
+      alias: 'e',
+      type: 'array',
+      string: true,
+      description: 'Path or URL to an extension to load.',
+    })
+    .option('list-extensions', {
+      type: 'boolean',
+      description: 'List installed extensions.',
+    })
+    .option('include-directories', {
+      type: 'array',
+      string: true,
+      description: 'Additional directories to include in the workspace.',
+    })
+    .option('screen-reader', {
+      type: 'boolean',
+      description: 'Enable screen reader mode for accessibility.',
+    })
+    .option('compact-tool-outputs', {
+      type: 'boolean',
+      description: 'Show tool outputs in a compact summary by default',
+    })
+    .option('output-format', {
+      alias: 'o',
+      type: 'string',
+      nargs: 1,
+      description: 'The format of the CLI output.',
+      choices: ['text', 'json', 'stream-json'],
+    })
+    .option('fake-responses', {
+      type: 'string',
+      description: 'Path to a file containing fake responses for testing.',
+    })
+    .option('record-responses', {
+      type: 'string',
+      description: 'Path to a file to record responses to for testing.',
+    })
+    .option('resume', {
+      alias: 'r',
+      type: 'string',
+      nargs: 1,
+      description:
+        'Resume a previous session by ID. Use "latest" to resume the most recent session.',
+    })
+    .option('list-sessions', {
+      alias: 'ls',
+      type: 'boolean',
+      description: 'List previous sessions.',
+    })
+    .option('delete-session', {
+      type: 'string',
+      nargs: 1,
+      description: 'Delete a previous session by ID.',
+    })
+    .option('raw-output', {
+      type: 'boolean',
+      description:
+        'Show raw tool output. WARNING: This may expose sensitive information.',
+    })
+    .option('accept-raw-output-risk', {
+      type: 'boolean',
+      description:
+        'Accept the risk of using --raw-output. Must be used with --raw-output.',
+    })
     // Register MCP subcommands
     .command(mcpCommand)
     // Ensure validation flows through .fail() for clean UX
@@ -297,595 +193,134 @@ export async function parseArguments(
       if (err) throw err;
       throw new Error(msg);
     })
-    .check((argv) => {
-      // The 'query' positional can be a string (for one arg) or string[] (for multiple).
-      // This guard safely checks if any positional argument was provided.
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      const query = argv['query'] as string | string[] | undefined;
-      const hasPositionalQuery = Array.isArray(query)
-        ? query.length > 0
-        : !!query;
+    .parse();
 
-      if (argv['prompt'] && hasPositionalQuery) {
-        return 'Cannot use both a positional prompt and the --prompt (-p) flag together';
-      }
-      if (argv['prompt'] && argv['promptInteractive']) {
-        return 'Cannot use both --prompt (-p) and --prompt-interactive (-i) together';
-      }
-      if (argv['yolo'] && argv['approvalMode']) {
-        return 'Cannot use both --yolo (-y) and --approval-mode together. Use --approval-mode=yolo instead.';
-      }
-      if (
-        argv['outputFormat'] &&
-        !['text', 'json', 'stream-json'].includes(
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          argv['outputFormat'] as string,
-        )
-      ) {
-        return `Invalid values:\n  Argument: output-format, Given: "${argv['outputFormat']}", Choices: "text", "json", "stream-json"`;
-      }
-      return true;
-    });
-
-  if (settings.experimental?.extensionManagement) {
-    yargsInstance.command(extensionsCommand);
-  }
-
-  if (settings.skills?.enabled ?? true) {
-    yargsInstance.command(skillsCommand);
-  }
-  // Register hooks command if hooks are enabled
-  if (settings.hooksConfig.enabled) {
-    yargsInstance.command(hooksCommand);
-  }
-
-  yargsInstance
-    .version(await getVersion()) // This will enable the --version flag based on package.json
-    .alias('v', 'version')
-    .help()
-    .alias('h', 'help')
-    .strict()
-    .demandCommand(0, 0) // Allow base command to run with no subcommands
-    .exitProcess(false);
-
-  yargsInstance.wrap(yargsInstance.terminalWidth());
-  let result;
-  try {
-    result = await yargsInstance.parse();
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    debugLogger.error(msg);
-    yargsInstance.showHelp();
-    await runExitCleanup();
-    process.exit(1);
-  }
-
-  // Handle help and version flags manually since we disabled exitProcess
-  if (result['help'] || result['version']) {
-    await runExitCleanup();
-    process.exit(0);
-  }
-
-  // Normalize query args: handle both quoted "@path file" and unquoted @path file
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-  const queryArg = (result as { query?: string | string[] | undefined }).query;
-  const q: string | undefined = Array.isArray(queryArg)
-    ? queryArg.join(' ')
-    : queryArg;
-
-  // -p/--prompt forces non-interactive mode; positional args default to interactive in TTY
-  if (q && !result['prompt']) {
-    if (!isHeadlessMode()) {
-      startupMessages.push(
-        'Positional arguments now default to interactive mode. To run in non-interactive mode, use the --prompt (-p) flag.',
-      );
-      result['promptInteractive'] = q;
-    } else {
-      result['prompt'] = q;
-    }
-  }
-
-  // Keep CliArgs.query as a string for downstream typing
-  (result as Record<string, unknown>)['query'] = q || undefined;
-  (result as Record<string, unknown>)['startupMessages'] = startupMessages;
-
-  // The import format is now only controlled by settings.memoryImportFormat
-  // We no longer accept it as a CLI argument
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-  return result as unknown as CliArgs;
-}
-
-/**
- * Creates a filter function to determine if a tool should be excluded.
- *
- * In non-interactive mode, we want to disable tools that require user
- * interaction to prevent the CLI from hanging. This function creates a predicate
- * that returns `true` if a tool should be excluded.
- *
- * A tool is excluded if it's not in the `allowedToolsSet`. The shell tool
- * has a special case: it's not excluded if any of its subcommands
- * are in the `allowedTools` list.
- *
- * @param allowedTools A list of explicitly allowed tool names.
- * @param allowedToolsSet A set of explicitly allowed tool names for quick lookups.
- * @returns A function that takes a tool name and returns `true` if it should be excluded.
- */
-function createToolExclusionFilter(
-  allowedTools: string[],
-  allowedToolsSet: Set<string>,
-) {
-  return (tool: string): boolean => {
-    if (tool === SHELL_TOOL_NAME) {
-      // If any of the allowed tools is ShellTool (even with subcommands), don't exclude it.
-      return !allowedTools.some((allowed) =>
-        SHELL_TOOL_NAMES.some((shellName) => allowed.startsWith(shellName)),
-      );
-    }
-    return !allowedToolsSet.has(tool);
-  };
-}
-
-export function isDebugMode(argv: CliArgs): boolean {
-  return (
-    argv.debug ||
-    [process.env['DEBUG'], process.env['DEBUG_MODE']].some(
-      (v) => v === 'true' || v === '1',
-    )
-  );
-}
-
-export interface LoadCliConfigOptions {
-  cwd?: string;
-  projectHooks?: { [K in HookEventName]?: HookDefinition[] } & {
-    disabled?: string[];
+  return {
+    model: argv.model,
+    sandbox: argv.sandbox,
+    debug: argv.debug,
+    prompt: argv.prompt || argv.query,
+    promptInteractive: argv['prompt-interactive'],
+    yolo: argv.yolo,
+    approvalMode: argv['approval-mode'],
+    policy: argv.policy,
+    allowedMcpServerNames: argv['allowed-mcp-server'],
+    allowedTools: argv['allowed-tool'],
+    experimentalAcp: argv['experimental-acp'],
+    extensions: argv.extension,
+    listExtensions: argv['list-extensions'],
+    includeDirectories: argv['include-directories'],
+    screenReader: argv['screen-reader'],
+    compactToolOutputs: argv['compact-tool-outputs'],
+    useWriteTodos: undefined, // Will be loaded from settings
+    outputFormat: argv['output-format'],
+    fakeResponses: argv['fake-responses'],
+    recordResponses: argv['record-responses'],
+    resume: argv.resume,
+    listSessions: argv['list-sessions'],
+    deleteSession: argv['delete-session'],
+    rawOutput: argv['raw-output'],
+    acceptRawOutputRisk: argv['accept-raw-output-risk'],
+    isCommand: false, // Default value
   };
 }
 
 export async function loadCliConfig(
+  argv: CliArgs,
   settings: MergedSettings,
   sessionId: string,
-  argv: CliArgs,
-  options: LoadCliConfigOptions = {},
+  extra: {
+    projectHooks?: { [K in HookEventName]?: HookDefinition[] } & {
+      disabled?: string[];
+    };
+    startupWarnings?: string[];
+  } = {},
 ): Promise<Config> {
-  const { cwd = process.cwd(), projectHooks } = options;
-  const debugMode = isDebugMode(argv);
+  const isInteractive =
+    !argv.prompt && !argv.query && !argv.promptInteractive && !argv.isCommand;
 
-  const loadedSettings = loadSettings(cwd);
+  const ideMode = settings.ide.enabled;
 
-  if (argv.sandbox) {
-    process.env['GEMINI_SANDBOX'] = 'true';
-  }
-
-  const memoryImportFormat = settings.context?.importFormat || 'tree';
-  const includeDirectoryTree = settings.context?.includeDirectoryTree ?? true;
-
-  const ideMode = settings.ide?.enabled ?? false;
-
-  const folderTrust =
-    process.env['GEMINI_CLI_INTEGRATION_TEST'] === 'true' ||
-    process.env['VITEST'] === 'true'
-      ? false
-      : (settings.security?.folderTrust?.enabled ?? false);
-  const trustedFolder =
-    isWorkspaceTrusted(settings, cwd, undefined, {
-      prompt: argv.prompt,
-      query: argv.query,
-    })?.isTrusted ?? false;
-
-  // Set the context filename in the server's memoryTool module BEFORE loading memory
-  // TODO(b/343434939): This is a bit of a hack. The contextFileName should ideally be passed
-  // directly to the Config constructor in core, and have core handle setGeminiMdFilename.
-  // However, loadHierarchicalGeminiMemory is called *before* createServerConfig.
-  if (settings.context?.fileName) {
-    setServerGeminiMdFilename(settings.context.fileName);
-  } else {
-    // Reset to default if not provided in settings.
-    setServerGeminiMdFilename(getCurrentGeminiMdFilename());
-  }
-
-  const fileService = new FileDiscoveryService(cwd);
-
-  const memoryFileFiltering = {
-    ...DEFAULT_MEMORY_FILE_FILTERING_OPTIONS,
-    ...settings.context?.fileFiltering,
-  };
-
-  const fileFiltering = {
-    ...DEFAULT_FILE_FILTERING_OPTIONS,
-    ...settings.context?.fileFiltering,
-  };
-
-  const includeDirectories = (settings.context?.includeDirectories || [])
-    .map(resolvePath)
-    .concat((argv.includeDirectories || []).map(resolvePath));
-
-  const extensionManager = new ExtensionManager({
-    settings,
-    requestConsent: requestConsentNonInteractive,
-    requestSetting: promptForSetting,
-    workspaceDir: cwd,
-    enabledExtensionOverrides: argv.extensions,
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    eventEmitter: coreEvents as EventEmitter<ExtensionEvents>,
-    clientVersion: await getVersion(),
-  });
-  await extensionManager.loadExtensions();
-
-  const experimentalJitContext = settings.experimental?.jitContext ?? false;
-
-  let memoryContent: string | HierarchicalMemory = '';
-  let fileCount = 0;
-  let filePaths: string[] = [];
-
-  if (!experimentalJitContext) {
-    // Call the (now wrapper) loadHierarchicalGeminiMemory which calls the server's version
-    const result = await loadServerHierarchicalMemory(
-      cwd,
-      settings.context?.loadMemoryFromIncludeDirectories || false
-        ? includeDirectories
-        : [],
-      debugMode,
-      fileService,
-      extensionManager,
-      trustedFolder,
-      memoryImportFormat,
-      memoryFileFiltering,
-      settings.context?.discoveryMaxDirs,
-    );
-    memoryContent = result.memoryContent;
-    fileCount = result.fileCount;
-    filePaths = result.filePaths;
-  }
-
-  const question = argv.promptInteractive || argv.prompt || '';
-
-  // Determine approval mode with backward compatibility
-  let approvalMode: ApprovalMode;
-  const rawApprovalMode =
-    argv.approvalMode ||
-    (argv.yolo ? 'yolo' : undefined) ||
-    ((settings.general?.defaultApprovalMode as string) !== 'yolo'
-      ? settings.general?.defaultApprovalMode
-      : undefined);
-
-  if (rawApprovalMode) {
-    switch (rawApprovalMode) {
-      case 'yolo':
-        approvalMode = ApprovalMode.YOLO;
-        break;
-      case 'auto_edit':
-        approvalMode = ApprovalMode.AUTO_EDIT;
-        break;
-      case 'plan':
-        if (!(settings.experimental?.plan ?? false)) {
-          debugLogger.warn(
-            'Approval mode "plan" is only available when experimental.plan is enabled. Falling back to "default".',
-          );
-          approvalMode = ApprovalMode.DEFAULT;
-        } else {
-          approvalMode = ApprovalMode.PLAN;
-        }
-        break;
-      case 'default':
-        approvalMode = ApprovalMode.DEFAULT;
-        break;
-      default:
-        throw new Error(
-          `Invalid approval mode: ${rawApprovalMode}. Valid values are: yolo, auto_edit, plan, default`,
-        );
-    }
-  } else {
-    approvalMode = ApprovalMode.DEFAULT;
-  }
-
-  // Override approval mode if disableYoloMode is set.
-  if (settings.security?.disableYoloMode || settings.admin?.secureModeEnabled) {
-    if (approvalMode === ApprovalMode.YOLO) {
-      if (settings.admin?.secureModeEnabled) {
-        debugLogger.error(
-          'YOLO mode is disabled by "secureModeEnabled" setting.',
-        );
-      } else {
-        debugLogger.error(
-          'YOLO mode is disabled by the "disableYolo" setting.',
-        );
-      }
-      throw new FatalConfigError(
-        getAdminErrorMessage('YOLO mode', undefined /* config */),
-      );
-    }
-  } else if (approvalMode === ApprovalMode.YOLO) {
-    debugLogger.warn(
-      'YOLO mode is enabled. All tool calls will be automatically approved.',
-    );
-  }
-
-  // Force approval mode to default if the folder is not trusted.
-  if (!trustedFolder && approvalMode !== ApprovalMode.DEFAULT) {
-    debugLogger.warn(
-      `Approval mode overridden to "default" because the current folder is not trusted.`,
-    );
-    approvalMode = ApprovalMode.DEFAULT;
-  }
-
-  let telemetrySettings;
-  try {
-    telemetrySettings = await resolveTelemetrySettings({
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      env: process.env as unknown as Record<string, string | undefined>,
-      settings: settings.telemetry,
-    });
-  } catch (err) {
-    if (err instanceof FatalConfigError) {
-      throw new FatalConfigError(
-        `Invalid telemetry configuration: ${err.message}.`,
-      );
-    }
-    throw err;
-  }
-
-  // -p/--prompt forces non-interactive (headless) mode
-  // -i/--prompt-interactive forces interactive mode with an initial prompt
-  const interactive =
-    !!argv.promptInteractive ||
-    !!argv.experimentalAcp ||
-    (!isHeadlessMode({ prompt: argv.prompt, query: argv.query }) &&
-      !argv.isCommand);
-
-  const allowedTools = argv.allowedTools || settings.tools?.allowed || [];
-  const allowedToolsSet = new Set(allowedTools);
-
-  // In non-interactive mode, exclude tools that require a prompt.
-  const extraExcludes: string[] = [];
-  if (!interactive) {
-    // ask_user requires user interaction and must be excluded in all
-    // non-interactive modes, regardless of the approval mode.
-    extraExcludes.push(ASK_USER_TOOL_NAME);
-
-    const defaultExcludes = [
-      SHELL_TOOL_NAME,
-      EDIT_TOOL_NAME,
-      WRITE_FILE_TOOL_NAME,
-      WEB_FETCH_TOOL_NAME,
-    ];
-    const autoEditExcludes = [SHELL_TOOL_NAME];
-
-    const toolExclusionFilter = createToolExclusionFilter(
-      allowedTools,
-      allowedToolsSet,
-    );
-
-    switch (approvalMode) {
-      case ApprovalMode.PLAN:
-        // In plan non-interactive mode, all tools that require approval are excluded.
-        // TODO(#16625): Replace this default exclusion logic with specific rules for plan mode.
-        extraExcludes.push(...defaultExcludes.filter(toolExclusionFilter));
-        break;
-      case ApprovalMode.DEFAULT:
-        // In default non-interactive mode, all tools that require approval are excluded.
-        extraExcludes.push(...defaultExcludes.filter(toolExclusionFilter));
-        break;
-      case ApprovalMode.AUTO_EDIT:
-        // In auto-edit non-interactive mode, only tools that still require a prompt are excluded.
-        extraExcludes.push(...autoEditExcludes.filter(toolExclusionFilter));
-        break;
-      case ApprovalMode.YOLO:
-        // No extra excludes for YOLO mode.
-        break;
-      default:
-        // This should never happen due to validation earlier, but satisfies the linter
-        break;
-    }
-  }
-
-  const excludeTools = mergeExcludeTools(settings, extraExcludes);
-
-  // Create a settings object that includes CLI overrides for policy generation
-  const effectiveSettings: Settings = {
-    ...settings,
-    tools: {
-      ...settings.tools,
-      allowed: allowedTools,
-      exclude: excludeTools,
-    },
-    mcp: {
-      ...settings.mcp,
-      allowed: argv.allowedMcpServerNames ?? settings.mcp?.allowed,
-    },
-    policyPaths: argv.policy,
-  };
-
-  const { workspacePoliciesDir, policyUpdateConfirmationRequest } =
-    await resolveWorkspacePolicyState({
-      cwd,
-      trustedFolder,
-      interactive,
-    });
-
-  const policyEngineConfig = await createPolicyEngineConfig(
-    effectiveSettings,
-    approvalMode,
-    workspacePoliciesDir,
-  );
-  policyEngineConfig.nonInteractive = !interactive;
-
-  const defaultModel = PREVIEW_GEMINI_MODEL_AUTO;
-  const specifiedModel =
-    argv.model || process.env['GEMINI_MODEL'] || settings.model?.name;
-
-  const resolvedModel =
-    specifiedModel === GEMINI_MODEL_ALIAS_AUTO
-      ? defaultModel
-      : specifiedModel || defaultModel;
-  const sandboxConfig = await loadSandboxConfig(settings, argv);
-  const screenReader =
-    argv.screenReader !== undefined
-      ? argv.screenReader
-      : (settings.ui?.accessibility?.screenReader ?? false);
-
-  const ptyInfo = await getPty();
-
-  const mcpEnabled = settings.admin?.mcp?.enabled ?? true;
-  const extensionsEnabled = settings.admin?.extensions?.enabled ?? true;
-  const adminSkillsEnabled = settings.admin?.skills?.enabled ?? true;
-
-  // Create MCP enablement manager and callbacks
-  const mcpEnablementManager = McpServerEnablementManager.getInstance();
-  const mcpEnablementCallbacks = mcpEnabled
-    ? mcpEnablementManager.getEnablementCallbacks()
-    : undefined;
-
-  const adminAllowlist = settings.admin?.mcp?.config;
-  let mcpServerCommand = mcpEnabled ? settings.mcp?.serverCommand : undefined;
-  let mcpServers = mcpEnabled ? settings.mcpServers : {};
-
-  if (mcpEnabled && adminAllowlist && Object.keys(adminAllowlist).length > 0) {
-    const result = applyAdminAllowlist(mcpServers, adminAllowlist);
-    mcpServers = result.mcpServers;
-    mcpServerCommand = undefined;
-
-    if (result.blockedServerNames && result.blockedServerNames.length > 0) {
-      const message = getAdminBlockedMcpServersMessage(
-        result.blockedServerNames,
-        undefined,
-      );
-      coreEvents.emitConsoleLog('warn', message);
-    }
-  }
-
-  return new Config({
+  return new ConfigImpl({
     sessionId,
-    clientVersion: await getVersion(),
-    embeddingModel: DEFAULT_GEMINI_EMBEDDING_MODEL,
-    sandbox: sandboxConfig,
-    targetDir: cwd,
-    includeDirectoryTree,
-    includeDirectories,
-    loadMemoryFromIncludeDirectories:
-      settings.context?.loadMemoryFromIncludeDirectories || false,
-    debugMode,
-    question,
-
-    coreTools: settings.tools?.core || undefined,
-    allowedTools: allowedTools.length > 0 ? allowedTools : undefined,
-    policyEngineConfig,
-    policyUpdateConfirmationRequest,
-    excludeTools,
-    toolDiscoveryCommand: settings.tools?.discoveryCommand,
-    toolCallCommand: settings.tools?.callCommand,
-    mcpServerCommand,
-    mcpServers,
-    mcpEnablementCallbacks,
-    mcpEnabled,
-    extensionsEnabled,
-    agents: settings.agents,
-    adminSkillsEnabled,
-    allowedMcpServers: mcpEnabled
-      ? (argv.allowedMcpServerNames ?? settings.mcp?.allowed)
-      : undefined,
-    blockedMcpServers: mcpEnabled
-      ? argv.allowedMcpServerNames
-        ? undefined
-        : settings.mcp?.excluded
-      : undefined,
+    model: argv.model || settings.model.name || '',
+    sandbox: argv.sandbox ?? settings.tools.sandbox ? { command: 'sandbox-exec', image: '' } : undefined,
+    targetDir: process.cwd(),
+    cwd: process.cwd(),
+    debugMode: argv.debug ?? false,
+    question: argv.prompt || argv.query || argv.promptInteractive,
+    interactive: isInteractive || !!argv.promptInteractive,
+    coreTools: settings.tools.core,
+    allowedTools: settings.tools.allowed,
+    excludeTools: settings.tools.exclude,
+    toolDiscoveryCommand: settings.tools.discoveryCommand,
+    toolCallCommand: settings.tools.callCommand,
+    mcpServerCommand: settings.mcp.serverCommand,
+    mcpServers: settings.mcpServers,
+    allowedMcpServers: settings.mcp.allowed,
+    blockedMcpServers: settings.mcp.excluded,
+    allowedEnvironmentVariables:
+      settings.security.environmentVariableRedaction.allowed,
     blockedEnvironmentVariables:
-      settings.security?.environmentVariableRedaction?.blocked,
+      settings.security.environmentVariableRedaction.blocked,
     enableEnvironmentVariableRedaction:
-      settings.security?.environmentVariableRedaction?.enabled,
-    userMemory: memoryContent,
-    geminiMdFileCount: fileCount,
-    geminiMdFilePaths: filePaths,
-    approvalMode,
-    disableYoloMode:
-      settings.security?.disableYoloMode || settings.admin?.secureModeEnabled,
-    showMemoryUsage: settings.ui?.showMemoryUsage || false,
-    accessibility: {
-      ...settings.ui?.accessibility,
-      screenReader,
-    },
-    telemetry: telemetrySettings,
-    usageStatisticsEnabled: settings.privacy?.usageStatisticsEnabled,
-    fileFiltering,
-    checkpointing: settings.general?.checkpointing?.enabled,
-    proxy:
-      process.env['HTTPS_PROXY'] ||
-      process.env['https_proxy'] ||
-      process.env['HTTP_PROXY'] ||
-      process.env['http_proxy'],
-    cwd,
-    fileDiscoveryService: fileService,
-    bugCommand: settings.advanced?.bugCommand,
-    model: resolvedModel,
-    maxSessionTurns: settings.model?.maxSessionTurns,
-    experimentalZedIntegration: argv.experimentalAcp || false,
-    listExtensions: argv.listExtensions || false,
-    listSessions: argv.listSessions || false,
-    deleteSession: argv.deleteSession,
-    enabledExtensions: argv.extensions,
-    extensionLoader: extensionManager,
-    enableExtensionReloading: settings.experimental?.extensionReloading,
-    enableAgents: settings.experimental?.enableAgents,
-    plan: settings.experimental?.plan,
-    directWebFetch: settings.experimental?.directWebFetch,
-    planSettings: settings.general?.plan,
-    enableEventDrivenScheduler: true,
-    skillsSupport: settings.skills?.enabled ?? true,
-    disabledSkills: settings.skills?.disabled,
+      settings.security.environmentVariableRedaction.enabled,
+    contextFileName: settings.context.fileName,
+    accessibility: settings.ui.accessibility,
+    telemetry: settings.telemetry,
+    usageStatisticsEnabled: settings.privacy.usageStatisticsEnabled,
+    fileFiltering: settings.context.fileFiltering,
+    includeDirectories: argv.includeDirectories || settings.context.includeDirectories,
+    bugCommand: settings.advanced.bugCommand,
+    maxSessionTurns: settings.model.maxSessionTurns,
     experimentalJitContext: settings.experimental?.jitContext,
     modelSteering: settings.experimental?.modelSteering,
     toolOutputMasking: settings.experimental?.toolOutputMasking,
+    compactToolOutputs: argv.compactToolOutputs ?? settings.ui.compactToolOutputs,
     noBrowser: !!process.env['NO_BROWSER'],
     summarizeToolOutput: settings.model?.summarizeToolOutput,
     ideMode,
     disableLoopDetection: settings.model?.disableLoopDetection,
     compressionThreshold: settings.model?.compressionThreshold,
-    folderTrust,
-    interactive,
-    trustedFolder,
-    useBackgroundColor: settings.ui?.useBackgroundColor,
-    useAlternateBuffer: settings.ui?.useAlternateBuffer,
-    useRipgrep: settings.tools?.useRipgrep,
-    enableInteractiveShell: settings.tools?.shell?.enableInteractiveShell,
-    shellToolInactivityTimeout: settings.tools?.shell?.inactivityTimeout,
-    enableShellOutputEfficiency:
-      settings.tools?.shell?.enableShellOutputEfficiency ?? true,
-    skipNextSpeakerCheck: settings.model?.skipNextSpeakerCheck,
-    truncateToolOutputThreshold: settings.tools?.truncateToolOutputThreshold,
-    eventEmitter: coreEvents,
-    useWriteTodos: argv.useWriteTodos ?? settings.useWriteTodos,
-    output: {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      format: (argv.outputFormat ?? settings.output?.format) as OutputFormat,
+    useBackgroundColor: settings.ui.useBackgroundColor,
+    useAlternateBuffer: settings.ui.useAlternateBuffer,
+    useRipgrep: settings.tools.useRipgrep,
+    enableInteractiveShell: settings.tools.shell.enableInteractiveShell,
+    skipNextSpeakerCheck: settings.model.skipNextSpeakerCheck,
+    extensionManagement: settings.experimental?.extensionManagement,
+    truncateToolOutputThreshold: settings.tools.truncateToolOutputThreshold,
+    useWriteTodos: settings.useWriteTodos,
+    policyEngineConfig: {
+      policyPaths: settings.policyPaths,
     },
+    directWebFetch: settings.experimental?.directWebFetch,
+    output: settings.output,
     gemmaModelRouter: settings.experimental?.gemmaModelRouter,
+    retryFetchErrors: settings.general.retryFetchErrors,
+    maxAttempts: settings.general.maxAttempts,
+    enableShellOutputEfficiency: settings.tools.shell.enableShellOutputEfficiency,
+    shellToolInactivityTimeout: settings.tools.shell.inactivityTimeout,
     fakeResponses: argv.fakeResponses,
     recordResponses: argv.recordResponses,
-    retryFetchErrors: settings.general?.retryFetchErrors,
-    maxAttempts: settings.general?.maxAttempts,
-    ptyInfo: ptyInfo?.name,
-    disableLLMCorrection: settings.tools?.disableLLMCorrection,
+    disableYoloMode: settings.security.disableYoloMode,
     rawOutput: argv.rawOutput,
     acceptRawOutputRisk: argv.acceptRawOutputRisk,
     modelConfigServiceConfig: settings.modelConfigs,
-    // TODO: loading of hooks based on workspace trust
     enableHooks: settings.hooksConfig.enabled,
-    enableHooksUI: settings.hooksConfig.enabled,
-    hooks: settings.hooks || {},
-    disabledHooks: settings.hooksConfig?.disabled || [],
-    projectHooks: projectHooks || {},
-    onModelChange: (model: string) => saveModelChange(loadedSettings, model),
-    onReload: async () => {
-      const refreshedSettings = loadSettings(cwd);
-      return {
-        disabledSkills: refreshedSettings.merged.skills.disabled,
-        agents: refreshedSettings.merged.agents,
-      };
-    },
-    enableConseca: settings.security?.enableConseca,
+    disabledHooks: settings.hooksConfig.disabled,
+    hooks: settings.hooks as any,
+    projectHooks: extra.projectHooks,
+    enableAgents: settings.experimental?.enableAgents,
+    skillsSupport: settings.skills?.enabled ?? true,
+    disabledSkills: settings.skills?.disabled,
+    adminSkillsEnabled: true, // Should be fetched from admin controls
+    agents: settings.agents,
+    enableConseca: settings.security.enableConseca,
+    billing: settings.billing,
   });
 }
 
-function mergeExcludeTools(
+export function mergeExcludeTools(
   settings: MergedSettings,
   extraExcludes: string[] = [],
 ): string[] {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1,2449 +1,2117 @@
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/google-gemini/gemini-cli/main/schemas/settings.schema.json",
-  "title": "Gemini CLI Settings",
-  "description": "Configuration file schema for Gemini CLI settings. This schema enables IDE completion for `settings.json`.",
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "$schema": {
-      "title": "Schema",
-      "description": "The URL of the JSON schema for this settings file. Used by editors for validation and autocompletion.",
-      "type": "string",
-      "default": "https://raw.githubusercontent.com/google-gemini/gemini-cli/main/schemas/settings.schema.json"
-    },
-    "mcpServers": {
-      "title": "MCP Servers",
-      "description": "Configuration for MCP servers.",
-      "markdownDescription": "Configuration for MCP servers.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/$defs/MCPServerConfig"
-      }
-    },
-    "policyPaths": {
-      "title": "Policy Paths",
-      "description": "Additional policy files or directories to load.",
-      "markdownDescription": "Additional policy files or directories to load.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `[]`",
-      "default": [],
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "general": {
-      "title": "General",
-      "description": "General application settings.",
-      "markdownDescription": "General application settings.\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "preferredEditor": {
-          "title": "Preferred Editor",
-          "description": "The preferred editor to open files in.",
-          "markdownDescription": "The preferred editor to open files in.\n\n- Category: `General`\n- Requires restart: `no`",
-          "type": "string"
-        },
-        "vimMode": {
-          "title": "Vim Mode",
-          "description": "Enable Vim keybindings",
-          "markdownDescription": "Enable Vim keybindings\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "defaultApprovalMode": {
-          "title": "Default Approval Mode",
-          "description": "The default approval mode for tool execution. 'default' prompts for approval, 'auto_edit' auto-approves edit tools, and 'plan' is read-only mode. 'yolo' is not supported yet.",
-          "markdownDescription": "The default approval mode for tool execution. 'default' prompts for approval, 'auto_edit' auto-approves edit tools, and 'plan' is read-only mode. 'yolo' is not supported yet.\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `default`",
-          "default": "default",
-          "type": "string",
-          "enum": ["default", "auto_edit", "plan"]
-        },
-        "devtools": {
-          "title": "DevTools",
-          "description": "Enable DevTools inspector on launch.",
-          "markdownDescription": "Enable DevTools inspector on launch.\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "enableAutoUpdate": {
-          "title": "Enable Auto Update",
-          "description": "Enable automatic updates.",
-          "markdownDescription": "Enable automatic updates.\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
-        "enableAutoUpdateNotification": {
-          "title": "Enable Auto Update Notification",
-          "description": "Enable update notification prompts.",
-          "markdownDescription": "Enable update notification prompts.\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
-        "enableNotifications": {
-          "title": "Enable Notifications",
-          "description": "Enable run-event notifications for action-required prompts and session completion. Currently macOS only.",
-          "markdownDescription": "Enable run-event notifications for action-required prompts and session completion. Currently macOS only.\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "checkpointing": {
-          "title": "Checkpointing",
-          "description": "Session checkpointing settings.",
-          "markdownDescription": "Session checkpointing settings.\n\n- Category: `General`\n- Requires restart: `yes`\n- Default: `{}`",
-          "default": {},
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "title": "Enable Checkpointing",
-              "description": "Enable session checkpointing for recovery",
-              "markdownDescription": "Enable session checkpointing for recovery\n\n- Category: `General`\n- Requires restart: `yes`\n- Default: `false`",
-              "default": false,
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "plan": {
-          "title": "Plan",
-          "description": "Planning features configuration.",
-          "markdownDescription": "Planning features configuration.\n\n- Category: `General`\n- Requires restart: `yes`\n- Default: `{}`",
-          "default": {},
-          "type": "object",
-          "properties": {
-            "directory": {
-              "title": "Plan Directory",
-              "description": "The directory where planning artifacts are stored. If not specified, defaults to the system temporary directory.",
-              "markdownDescription": "The directory where planning artifacts are stored. If not specified, defaults to the system temporary directory.\n\n- Category: `General`\n- Requires restart: `yes`",
-              "type": "string"
-            },
-            "modelRouting": {
-              "title": "Plan Model Routing",
-              "description": "Automatically switch between Pro and Flash models based on Plan Mode status. Uses Pro for the planning phase and Flash for the implementation phase.",
-              "markdownDescription": "Automatically switch between Pro and Flash models based on Plan Mode status. Uses Pro for the planning phase and Flash for the implementation phase.\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `true`",
-              "default": true,
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "retryFetchErrors": {
-          "title": "Retry Fetch Errors",
-          "description": "Retry on \"exception TypeError: fetch failed sending request\" errors.",
-          "markdownDescription": "Retry on \"exception TypeError: fetch failed sending request\" errors.\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "maxAttempts": {
-          "title": "Max Chat Model Attempts",
-          "description": "Maximum number of attempts for requests to the main chat model. Cannot exceed 10.",
-          "markdownDescription": "Maximum number of attempts for requests to the main chat model. Cannot exceed 10.\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `10`",
-          "default": 10,
-          "type": "number"
-        },
-        "debugKeystrokeLogging": {
-          "title": "Debug Keystroke Logging",
-          "description": "Enable debug logging of keystrokes to the console.",
-          "markdownDescription": "Enable debug logging of keystrokes to the console.\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "sessionRetention": {
-          "title": "Session Retention",
-          "description": "Settings for automatic session cleanup.",
-          "markdownDescription": "Settings for automatic session cleanup.\n\n- Category: `General`\n- Requires restart: `no`",
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "title": "Enable Session Cleanup",
-              "description": "Enable automatic session cleanup",
-              "markdownDescription": "Enable automatic session cleanup\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `false`",
-              "default": false,
-              "type": "boolean"
-            },
-            "maxAge": {
-              "title": "Keep chat history",
-              "description": "Automatically delete chats older than this time period (e.g., \"30d\", \"7d\", \"24h\", \"1w\")",
-              "markdownDescription": "Automatically delete chats older than this time period (e.g., \"30d\", \"7d\", \"24h\", \"1w\")\n\n- Category: `General`\n- Requires restart: `no`",
-              "type": "string"
-            },
-            "maxCount": {
-              "title": "Max Session Count",
-              "description": "Alternative: Maximum number of sessions to keep (most recent)",
-              "markdownDescription": "Alternative: Maximum number of sessions to keep (most recent)\n\n- Category: `General`\n- Requires restart: `no`",
-              "type": "number"
-            },
-            "minRetention": {
-              "title": "Min Retention Period",
-              "description": "Minimum retention period (safety limit, defaults to \"1d\")",
-              "markdownDescription": "Minimum retention period (safety limit, defaults to \"1d\")\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `1d`",
-              "default": "1d",
-              "type": "string"
-            },
-            "warningAcknowledged": {
-              "title": "Warning Acknowledged",
-              "description": "INTERNAL: Whether the user has acknowledged the session retention warning",
-              "markdownDescription": "INTERNAL: Whether the user has acknowledged the session retention warning\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `false`",
-              "default": false,
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "output": {
-      "title": "Output",
-      "description": "Settings for the CLI output.",
-      "markdownDescription": "Settings for the CLI output.\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "format": {
-          "title": "Output Format",
-          "description": "The format of the CLI output. Can be `text` or `json`.",
-          "markdownDescription": "The format of the CLI output. Can be `text` or `json`.\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `text`",
-          "default": "text",
-          "type": "string",
-          "enum": ["text", "json"]
-        }
-      },
-      "additionalProperties": false
-    },
-    "ui": {
-      "title": "UI",
-      "description": "User interface settings.",
-      "markdownDescription": "User interface settings.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "theme": {
-          "title": "Theme",
-          "description": "The color theme for the UI. See the CLI themes guide for available options.",
-          "markdownDescription": "The color theme for the UI. See the CLI themes guide for available options.\n\n- Category: `UI`\n- Requires restart: `no`",
-          "type": "string"
-        },
-        "autoThemeSwitching": {
-          "title": "Auto Theme Switching",
-          "description": "Automatically switch between default light and dark themes based on terminal background color.",
-          "markdownDescription": "Automatically switch between default light and dark themes based on terminal background color.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
-        "terminalBackgroundPollingInterval": {
-          "title": "Terminal Background Polling Interval",
-          "description": "Interval in seconds to poll the terminal background color.",
-          "markdownDescription": "Interval in seconds to poll the terminal background color.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `60`",
-          "default": 60,
-          "type": "number"
-        },
-        "customThemes": {
-          "title": "Custom Themes",
-          "description": "Custom theme definitions.",
-          "markdownDescription": "Custom theme definitions.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `{}`",
-          "default": {},
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/CustomTheme"
-          }
-        },
-        "hideWindowTitle": {
-          "title": "Hide Window Title",
-          "description": "Hide the window title bar",
-          "markdownDescription": "Hide the window title bar\n\n- Category: `UI`\n- Requires restart: `yes`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "inlineThinkingMode": {
-          "title": "Inline Thinking",
-          "description": "Display model thinking inline: off or full.",
-          "markdownDescription": "Display model thinking inline: off or full.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `off`",
-          "default": "off",
-          "type": "string",
-          "enum": ["off", "full"]
-        },
-        "showStatusInTitle": {
-          "title": "Show Thoughts in Title",
-          "description": "Show Gemini CLI model thoughts in the terminal window title during the working phase",
-          "markdownDescription": "Show Gemini CLI model thoughts in the terminal window title during the working phase\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "dynamicWindowTitle": {
-          "title": "Dynamic Window Title",
-          "description": "Update the terminal window title with current status icons (Ready: ◇, Action Required: ✋, Working: ✦)",
-          "markdownDescription": "Update the terminal window title with current status icons (Ready: ◇, Action Required: ✋, Working: ✦)\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
-        "showHomeDirectoryWarning": {
-          "title": "Show Home Directory Warning",
-          "description": "Show a warning when running Gemini CLI in the home directory.",
-          "markdownDescription": "Show a warning when running Gemini CLI in the home directory.\n\n- Category: `UI`\n- Requires restart: `yes`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
-        "showCompatibilityWarnings": {
-          "title": "Show Compatibility Warnings",
-          "description": "Show warnings about terminal or OS compatibility issues.",
-          "markdownDescription": "Show warnings about terminal or OS compatibility issues.\n\n- Category: `UI`\n- Requires restart: `yes`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
-        "hideTips": {
-          "title": "Hide Tips",
-          "description": "Hide helpful tips in the UI",
-          "markdownDescription": "Hide helpful tips in the UI\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "showShortcutsHint": {
-          "title": "Show Shortcuts Hint",
-          "description": "Show the \"? for shortcuts\" hint above the input.",
-          "markdownDescription": "Show the \"? for shortcuts\" hint above the input.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
-        "hideBanner": {
-          "title": "Hide Banner",
-          "description": "Hide the application banner",
-          "markdownDescription": "Hide the application banner\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "hideContextSummary": {
-          "title": "Hide Context Summary",
-          "description": "Hide the context summary (GEMINI.md, MCP servers) above the input.",
-          "markdownDescription": "Hide the context summary (GEMINI.md, MCP servers) above the input.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "footer": {
-          "title": "Footer",
-          "description": "Settings for the footer.",
-          "markdownDescription": "Settings for the footer.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `{}`",
-          "default": {},
-          "type": "object",
-          "properties": {
-            "hideCWD": {
-              "title": "Hide CWD",
-              "description": "Hide the current working directory path in the footer.",
-              "markdownDescription": "Hide the current working directory path in the footer.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `false`",
-              "default": false,
-              "type": "boolean"
-            },
-            "hideSandboxStatus": {
-              "title": "Hide Sandbox Status",
-              "description": "Hide the sandbox status indicator in the footer.",
-              "markdownDescription": "Hide the sandbox status indicator in the footer.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `false`",
-              "default": false,
-              "type": "boolean"
-            },
-            "hideModelInfo": {
-              "title": "Hide Model Info",
-              "description": "Hide the model name and context usage in the footer.",
-              "markdownDescription": "Hide the model name and context usage in the footer.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `false`",
-              "default": false,
-              "type": "boolean"
-            },
-            "hideContextPercentage": {
-              "title": "Hide Context Window Percentage",
-              "description": "Hides the context window remaining percentage.",
-              "markdownDescription": "Hides the context window remaining percentage.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `true`",
-              "default": true,
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "hideFooter": {
-          "title": "Hide Footer",
-          "description": "Hide the footer from the UI",
-          "markdownDescription": "Hide the footer from the UI\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "showMemoryUsage": {
-          "title": "Show Memory Usage",
-          "description": "Display memory usage information in the UI",
-          "markdownDescription": "Display memory usage information in the UI\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "showLineNumbers": {
-          "title": "Show Line Numbers",
-          "description": "Show line numbers in the chat.",
-          "markdownDescription": "Show line numbers in the chat.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
-        "showCitations": {
-          "title": "Show Citations",
-          "description": "Show citations for generated text in the chat.",
-          "markdownDescription": "Show citations for generated text in the chat.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "showModelInfoInChat": {
-          "title": "Show Model Info In Chat",
-          "description": "Show the model name in the chat for each model turn.",
-          "markdownDescription": "Show the model name in the chat for each model turn.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "showUserIdentity": {
-          "title": "Show User Identity",
-          "description": "Show the logged-in user's identity (e.g. email) in the UI.",
-          "markdownDescription": "Show the logged-in user's identity (e.g. email) in the UI.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
-        "useAlternateBuffer": {
-          "title": "Use Alternate Screen Buffer",
-          "description": "Use an alternate screen buffer for the UI, preserving shell history.",
-          "markdownDescription": "Use an alternate screen buffer for the UI, preserving shell history.\n\n- Category: `UI`\n- Requires restart: `yes`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "useBackgroundColor": {
-          "title": "Use Background Color",
-          "description": "Whether to use background colors in the UI.",
-          "markdownDescription": "Whether to use background colors in the UI.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
-        "incrementalRendering": {
-          "title": "Incremental Rendering",
-          "description": "Enable incremental rendering for the UI. This option will reduce flickering but may cause rendering artifacts. Only supported when useAlternateBuffer is enabled.",
-          "markdownDescription": "Enable incremental rendering for the UI. This option will reduce flickering but may cause rendering artifacts. Only supported when useAlternateBuffer is enabled.\n\n- Category: `UI`\n- Requires restart: `yes`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
-        "showSpinner": {
-          "title": "Show Spinner",
-          "description": "Show the spinner during operations.",
-          "markdownDescription": "Show the spinner during operations.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
-        "loadingPhrases": {
-          "title": "Loading Phrases",
-          "description": "What to show while the model is working: tips, witty comments, both, or nothing.",
-          "markdownDescription": "What to show while the model is working: tips, witty comments, both, or nothing.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `tips`",
-          "default": "tips",
-          "type": "string",
-          "enum": ["tips", "witty", "all", "off"]
-        },
-        "errorVerbosity": {
-          "title": "Error Verbosity",
-          "description": "Controls whether recoverable errors are hidden (low) or fully shown (full).",
-          "markdownDescription": "Controls whether recoverable errors are hidden (low) or fully shown (full).\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `low`",
-          "default": "low",
-          "type": "string",
-          "enum": ["low", "full"]
-        },
-        "customWittyPhrases": {
-          "title": "Custom Witty Phrases",
-          "description": "Custom witty phrases to display during loading. When provided, the CLI cycles through these instead of the defaults.",
-          "markdownDescription": "Custom witty phrases to display during loading. When provided, the CLI cycles through these instead of the defaults.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `[]`",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "accessibility": {
-          "title": "Accessibility",
-          "description": "Accessibility settings.",
-          "markdownDescription": "Accessibility settings.\n\n- Category: `UI`\n- Requires restart: `yes`\n- Default: `{}`",
-          "default": {},
-          "type": "object",
-          "properties": {
-            "enableLoadingPhrases": {
-              "title": "Enable Loading Phrases",
-              "description": "@deprecated Use ui.loadingPhrases instead. Enable loading phrases during operations.",
-              "markdownDescription": "@deprecated Use ui.loadingPhrases instead. Enable loading phrases during operations.\n\n- Category: `UI`\n- Requires restart: `yes`\n- Default: `true`",
-              "default": true,
-              "type": "boolean"
-            },
-            "screenReader": {
-              "title": "Screen Reader Mode",
-              "description": "Render output in plain-text to be more screen reader accessible",
-              "markdownDescription": "Render output in plain-text to be more screen reader accessible\n\n- Category: `UI`\n- Requires restart: `yes`\n- Default: `false`",
-              "default": false,
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "ide": {
-      "title": "IDE",
-      "description": "IDE integration settings.",
-      "markdownDescription": "IDE integration settings.\n\n- Category: `IDE`\n- Requires restart: `yes`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "title": "IDE Mode",
-          "description": "Enable IDE integration mode.",
-          "markdownDescription": "Enable IDE integration mode.\n\n- Category: `IDE`\n- Requires restart: `yes`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "hasSeenNudge": {
-          "title": "Has Seen IDE Integration Nudge",
-          "description": "Whether the user has seen the IDE integration nudge.",
-          "markdownDescription": "Whether the user has seen the IDE integration nudge.\n\n- Category: `IDE`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false
-    },
-    "privacy": {
-      "title": "Privacy",
-      "description": "Privacy-related settings.",
-      "markdownDescription": "Privacy-related settings.\n\n- Category: `Privacy`\n- Requires restart: `yes`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "usageStatisticsEnabled": {
-          "title": "Enable Usage Statistics",
-          "description": "Enable collection of usage statistics",
-          "markdownDescription": "Enable collection of usage statistics\n\n- Category: `Privacy`\n- Requires restart: `yes`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false
-    },
-    "telemetry": {
-      "title": "Telemetry",
-      "description": "Telemetry configuration.",
-      "markdownDescription": "Telemetry configuration.\n\n- Category: `Advanced`\n- Requires restart: `yes`",
-      "$ref": "#/$defs/TelemetrySettings"
-    },
-    "billing": {
-      "title": "Billing",
-      "description": "Billing and AI credits settings.",
-      "markdownDescription": "Billing and AI credits settings.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "overageStrategy": {
-          "title": "Overage Strategy",
-          "description": "How to handle quota exhaustion when AI credits are available. 'ask' prompts each time, 'always' automatically uses credits, 'never' disables credit usage.",
-          "markdownDescription": "How to handle quota exhaustion when AI credits are available. 'ask' prompts each time, 'always' automatically uses credits, 'never' disables credit usage.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `ask`",
-          "default": "ask",
-          "type": "string",
-          "enum": ["ask", "always", "never"]
-        }
-      },
-      "additionalProperties": false
-    },
-    "model": {
-      "title": "Model",
-      "description": "Settings related to the generative model.",
-      "markdownDescription": "Settings related to the generative model.\n\n- Category: `Model`\n- Requires restart: `no`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "name": {
-          "title": "Model",
-          "description": "The Gemini model to use for conversations.",
-          "markdownDescription": "The Gemini model to use for conversations.\n\n- Category: `Model`\n- Requires restart: `no`",
-          "type": "string"
-        },
-        "maxSessionTurns": {
-          "title": "Max Session Turns",
-          "description": "Maximum number of user/model/tool turns to keep in a session. -1 means unlimited.",
-          "markdownDescription": "Maximum number of user/model/tool turns to keep in a session. -1 means unlimited.\n\n- Category: `Model`\n- Requires restart: `no`\n- Default: `-1`",
-          "default": -1,
-          "type": "number"
-        },
-        "summarizeToolOutput": {
-          "title": "Summarize Tool Output",
-          "description": "Enables or disables summarization of tool output. Configure per-tool token budgets (for example {\"run_shell_command\": {\"tokenBudget\": 2000}}). Currently only the run_shell_command tool supports summarization.",
-          "markdownDescription": "Enables or disables summarization of tool output. Configure per-tool token budgets (for example {\"run_shell_command\": {\"tokenBudget\": 2000}}). Currently only the run_shell_command tool supports summarization.\n\n- Category: `Model`\n- Requires restart: `no`",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/SummarizeToolOutputSettings"
-          }
-        },
-        "compressionThreshold": {
-          "title": "Compression Threshold",
-          "description": "The fraction of context usage at which to trigger context compression (e.g. 0.2, 0.3).",
-          "markdownDescription": "The fraction of context usage at which to trigger context compression (e.g. 0.2, 0.3).\n\n- Category: `Model`\n- Requires restart: `yes`\n- Default: `0.5`",
-          "default": 0.5,
-          "type": "number"
-        },
-        "disableLoopDetection": {
-          "title": "Disable Loop Detection",
-          "description": "Disable automatic detection and prevention of infinite loops.",
-          "markdownDescription": "Disable automatic detection and prevention of infinite loops.\n\n- Category: `Model`\n- Requires restart: `yes`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "skipNextSpeakerCheck": {
-          "title": "Skip Next Speaker Check",
-          "description": "Skip the next speaker check.",
-          "markdownDescription": "Skip the next speaker check.\n\n- Category: `Model`\n- Requires restart: `no`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false
-    },
-    "modelConfigs": {
-      "title": "Model Configs",
-      "description": "Model configurations.",
-      "markdownDescription": "Model configurations.\n\n- Category: `Model`\n- Requires restart: `no`\n- Default: `{\n  \"aliases\": {\n    \"base\": {\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"temperature\": 0,\n          \"topP\": 1\n        }\n      }\n    },\n    \"chat-base\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"thinkingConfig\": {\n            \"includeThoughts\": true\n          },\n          \"temperature\": 1,\n          \"topP\": 0.95,\n          \"topK\": 64\n        }\n      }\n    },\n    \"chat-base-2.5\": {\n      \"extends\": \"chat-base\",\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"thinkingConfig\": {\n            \"thinkingBudget\": 8192\n          }\n        }\n      }\n    },\n    \"chat-base-3\": {\n      \"extends\": \"chat-base\",\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"thinkingConfig\": {\n            \"thinkingLevel\": \"HIGH\"\n          }\n        }\n      }\n    },\n    \"gemini-3-pro-preview\": {\n      \"extends\": \"chat-base-3\",\n      \"modelConfig\": {\n        \"model\": \"gemini-3-pro-preview\"\n      }\n    },\n    \"gemini-3-flash-preview\": {\n      \"extends\": \"chat-base-3\",\n      \"modelConfig\": {\n        \"model\": \"gemini-3-flash-preview\"\n      }\n    },\n    \"gemini-2.5-pro\": {\n      \"extends\": \"chat-base-2.5\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-pro\"\n      }\n    },\n    \"gemini-2.5-flash\": {\n      \"extends\": \"chat-base-2.5\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash\"\n      }\n    },\n    \"gemini-2.5-flash-lite\": {\n      \"extends\": \"chat-base-2.5\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\"\n      }\n    },\n    \"gemini-2.5-flash-base\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash\"\n      }\n    },\n    \"gemini-3-flash-base\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-3-flash-preview\"\n      }\n    },\n    \"classifier\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\",\n        \"generateContentConfig\": {\n          \"maxOutputTokens\": 1024,\n          \"thinkingConfig\": {\n            \"thinkingBudget\": 512\n          }\n        }\n      }\n    },\n    \"prompt-completion\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\",\n        \"generateContentConfig\": {\n          \"temperature\": 0.3,\n          \"maxOutputTokens\": 16000,\n          \"thinkingConfig\": {\n            \"thinkingBudget\": 0\n          }\n        }\n      }\n    },\n    \"fast-ack-helper\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\",\n        \"generateContentConfig\": {\n          \"temperature\": 0.2,\n          \"maxOutputTokens\": 120,\n          \"thinkingConfig\": {\n            \"thinkingBudget\": 0\n          }\n        }\n      }\n    },\n    \"edit-corrector\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\",\n        \"generateContentConfig\": {\n          \"thinkingConfig\": {\n            \"thinkingBudget\": 0\n          }\n        }\n      }\n    },\n    \"summarizer-default\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\",\n        \"generateContentConfig\": {\n          \"maxOutputTokens\": 2000\n        }\n      }\n    },\n    \"summarizer-shell\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\",\n        \"generateContentConfig\": {\n          \"maxOutputTokens\": 2000\n        }\n      }\n    },\n    \"web-search\": {\n      \"extends\": \"gemini-3-flash-base\",\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"tools\": [\n            {\n              \"googleSearch\": {}\n            }\n          ]\n        }\n      }\n    },\n    \"web-fetch\": {\n      \"extends\": \"gemini-3-flash-base\",\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"tools\": [\n            {\n              \"urlContext\": {}\n            }\n          ]\n        }\n      }\n    },\n    \"web-fetch-fallback\": {\n      \"extends\": \"gemini-3-flash-base\",\n      \"modelConfig\": {}\n    },\n    \"loop-detection\": {\n      \"extends\": \"gemini-3-flash-base\",\n      \"modelConfig\": {}\n    },\n    \"loop-detection-double-check\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-3-pro-preview\"\n      }\n    },\n    \"llm-edit-fixer\": {\n      \"extends\": \"gemini-3-flash-base\",\n      \"modelConfig\": {}\n    },\n    \"next-speaker-checker\": {\n      \"extends\": \"gemini-3-flash-base\",\n      \"modelConfig\": {}\n    },\n    \"chat-compression-3-pro\": {\n      \"modelConfig\": {\n        \"model\": \"gemini-3-pro-preview\"\n      }\n    },\n    \"chat-compression-3-flash\": {\n      \"modelConfig\": {\n        \"model\": \"gemini-3-flash-preview\"\n      }\n    },\n    \"chat-compression-2.5-pro\": {\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-pro\"\n      }\n    },\n    \"chat-compression-2.5-flash\": {\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash\"\n      }\n    },\n    \"chat-compression-2.5-flash-lite\": {\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\"\n      }\n    },\n    \"chat-compression-default\": {\n      \"modelConfig\": {\n        \"model\": \"gemini-3-pro-preview\"\n      }\n    }\n  },\n  \"overrides\": [\n    {\n      \"match\": {\n        \"model\": \"chat-base\",\n        \"isRetry\": true\n      },\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"temperature\": 1\n        }\n      }\n    }\n  ]\n}`",
-      "default": {
-        "aliases": {
-          "base": {
-            "modelConfig": {
-              "generateContentConfig": {
-                "temperature": 0,
-                "topP": 1
-              }
-            }
-          },
-          "chat-base": {
-            "extends": "base",
-            "modelConfig": {
-              "generateContentConfig": {
-                "thinkingConfig": {
-                  "includeThoughts": true
-                },
-                "temperature": 1,
-                "topP": 0.95,
-                "topK": 64
-              }
-            }
-          },
-          "chat-base-2.5": {
-            "extends": "chat-base",
-            "modelConfig": {
-              "generateContentConfig": {
-                "thinkingConfig": {
-                  "thinkingBudget": 8192
-                }
-              }
-            }
-          },
-          "chat-base-3": {
-            "extends": "chat-base",
-            "modelConfig": {
-              "generateContentConfig": {
-                "thinkingConfig": {
-                  "thinkingLevel": "HIGH"
-                }
-              }
-            }
-          },
-          "gemini-3-pro-preview": {
-            "extends": "chat-base-3",
-            "modelConfig": {
-              "model": "gemini-3-pro-preview"
-            }
-          },
-          "gemini-3-flash-preview": {
-            "extends": "chat-base-3",
-            "modelConfig": {
-              "model": "gemini-3-flash-preview"
-            }
-          },
-          "gemini-2.5-pro": {
-            "extends": "chat-base-2.5",
-            "modelConfig": {
-              "model": "gemini-2.5-pro"
-            }
-          },
-          "gemini-2.5-flash": {
-            "extends": "chat-base-2.5",
-            "modelConfig": {
-              "model": "gemini-2.5-flash"
-            }
-          },
-          "gemini-2.5-flash-lite": {
-            "extends": "chat-base-2.5",
-            "modelConfig": {
-              "model": "gemini-2.5-flash-lite"
-            }
-          },
-          "gemini-2.5-flash-base": {
-            "extends": "base",
-            "modelConfig": {
-              "model": "gemini-2.5-flash"
-            }
-          },
-          "gemini-3-flash-base": {
-            "extends": "base",
-            "modelConfig": {
-              "model": "gemini-3-flash-preview"
-            }
-          },
-          "classifier": {
-            "extends": "base",
-            "modelConfig": {
-              "model": "gemini-2.5-flash-lite",
-              "generateContentConfig": {
-                "maxOutputTokens": 1024,
-                "thinkingConfig": {
-                  "thinkingBudget": 512
-                }
-              }
-            }
-          },
-          "prompt-completion": {
-            "extends": "base",
-            "modelConfig": {
-              "model": "gemini-2.5-flash-lite",
-              "generateContentConfig": {
-                "temperature": 0.3,
-                "maxOutputTokens": 16000,
-                "thinkingConfig": {
-                  "thinkingBudget": 0
-                }
-              }
-            }
-          },
-          "fast-ack-helper": {
-            "extends": "base",
-            "modelConfig": {
-              "model": "gemini-2.5-flash-lite",
-              "generateContentConfig": {
-                "temperature": 0.2,
-                "maxOutputTokens": 120,
-                "thinkingConfig": {
-                  "thinkingBudget": 0
-                }
-              }
-            }
-          },
-          "edit-corrector": {
-            "extends": "base",
-            "modelConfig": {
-              "model": "gemini-2.5-flash-lite",
-              "generateContentConfig": {
-                "thinkingConfig": {
-                  "thinkingBudget": 0
-                }
-              }
-            }
-          },
-          "summarizer-default": {
-            "extends": "base",
-            "modelConfig": {
-              "model": "gemini-2.5-flash-lite",
-              "generateContentConfig": {
-                "maxOutputTokens": 2000
-              }
-            }
-          },
-          "summarizer-shell": {
-            "extends": "base",
-            "modelConfig": {
-              "model": "gemini-2.5-flash-lite",
-              "generateContentConfig": {
-                "maxOutputTokens": 2000
-              }
-            }
-          },
-          "web-search": {
-            "extends": "gemini-3-flash-base",
-            "modelConfig": {
-              "generateContentConfig": {
-                "tools": [
-                  {
-                    "googleSearch": {}
-                  }
-                ]
-              }
-            }
-          },
-          "web-fetch": {
-            "extends": "gemini-3-flash-base",
-            "modelConfig": {
-              "generateContentConfig": {
-                "tools": [
-                  {
-                    "urlContext": {}
-                  }
-                ]
-              }
-            }
-          },
-          "web-fetch-fallback": {
-            "extends": "gemini-3-flash-base",
-            "modelConfig": {}
-          },
-          "loop-detection": {
-            "extends": "gemini-3-flash-base",
-            "modelConfig": {}
-          },
-          "loop-detection-double-check": {
-            "extends": "base",
-            "modelConfig": {
-              "model": "gemini-3-pro-preview"
-            }
-          },
-          "llm-edit-fixer": {
-            "extends": "gemini-3-flash-base",
-            "modelConfig": {}
-          },
-          "next-speaker-checker": {
-            "extends": "gemini-3-flash-base",
-            "modelConfig": {}
-          },
-          "chat-compression-3-pro": {
-            "modelConfig": {
-              "model": "gemini-3-pro-preview"
-            }
-          },
-          "chat-compression-3-flash": {
-            "modelConfig": {
-              "model": "gemini-3-flash-preview"
-            }
-          },
-          "chat-compression-2.5-pro": {
-            "modelConfig": {
-              "model": "gemini-2.5-pro"
-            }
-          },
-          "chat-compression-2.5-flash": {
-            "modelConfig": {
-              "model": "gemini-2.5-flash"
-            }
-          },
-          "chat-compression-2.5-flash-lite": {
-            "modelConfig": {
-              "model": "gemini-2.5-flash-lite"
-            }
-          },
-          "chat-compression-default": {
-            "modelConfig": {
-              "model": "gemini-3-pro-preview"
-            }
-          }
-        },
-        "overrides": [
-          {
-            "match": {
-              "model": "chat-base",
-              "isRetry": true
-            },
-            "modelConfig": {
-              "generateContentConfig": {
-                "temperature": 1
-              }
-            }
-          }
-        ]
-      },
-      "type": "object",
-      "properties": {
-        "aliases": {
-          "title": "Model Config Aliases",
-          "description": "Named presets for model configs. Can be used in place of a model name and can inherit from other aliases using an `extends` property.",
-          "markdownDescription": "Named presets for model configs. Can be used in place of a model name and can inherit from other aliases using an `extends` property.\n\n- Category: `Model`\n- Requires restart: `no`\n- Default: `{\n  \"base\": {\n    \"modelConfig\": {\n      \"generateContentConfig\": {\n        \"temperature\": 0,\n        \"topP\": 1\n      }\n    }\n  },\n  \"chat-base\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"generateContentConfig\": {\n        \"thinkingConfig\": {\n          \"includeThoughts\": true\n        },\n        \"temperature\": 1,\n        \"topP\": 0.95,\n        \"topK\": 64\n      }\n    }\n  },\n  \"chat-base-2.5\": {\n    \"extends\": \"chat-base\",\n    \"modelConfig\": {\n      \"generateContentConfig\": {\n        \"thinkingConfig\": {\n          \"thinkingBudget\": 8192\n        }\n      }\n    }\n  },\n  \"chat-base-3\": {\n    \"extends\": \"chat-base\",\n    \"modelConfig\": {\n      \"generateContentConfig\": {\n        \"thinkingConfig\": {\n          \"thinkingLevel\": \"HIGH\"\n        }\n      }\n    }\n  },\n  \"gemini-3-pro-preview\": {\n    \"extends\": \"chat-base-3\",\n    \"modelConfig\": {\n      \"model\": \"gemini-3-pro-preview\"\n    }\n  },\n  \"gemini-3-flash-preview\": {\n    \"extends\": \"chat-base-3\",\n    \"modelConfig\": {\n      \"model\": \"gemini-3-flash-preview\"\n    }\n  },\n  \"gemini-2.5-pro\": {\n    \"extends\": \"chat-base-2.5\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-pro\"\n    }\n  },\n  \"gemini-2.5-flash\": {\n    \"extends\": \"chat-base-2.5\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash\"\n    }\n  },\n  \"gemini-2.5-flash-lite\": {\n    \"extends\": \"chat-base-2.5\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\"\n    }\n  },\n  \"gemini-2.5-flash-base\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash\"\n    }\n  },\n  \"gemini-3-flash-base\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-3-flash-preview\"\n    }\n  },\n  \"classifier\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\",\n      \"generateContentConfig\": {\n        \"maxOutputTokens\": 1024,\n        \"thinkingConfig\": {\n          \"thinkingBudget\": 512\n        }\n      }\n    }\n  },\n  \"prompt-completion\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\",\n      \"generateContentConfig\": {\n        \"temperature\": 0.3,\n        \"maxOutputTokens\": 16000,\n        \"thinkingConfig\": {\n          \"thinkingBudget\": 0\n        }\n      }\n    }\n  },\n  \"fast-ack-helper\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\",\n      \"generateContentConfig\": {\n        \"temperature\": 0.2,\n        \"maxOutputTokens\": 120,\n        \"thinkingConfig\": {\n          \"thinkingBudget\": 0\n        }\n      }\n    }\n  },\n  \"edit-corrector\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\",\n      \"generateContentConfig\": {\n        \"thinkingConfig\": {\n          \"thinkingBudget\": 0\n        }\n      }\n    }\n  },\n  \"summarizer-default\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\",\n      \"generateContentConfig\": {\n        \"maxOutputTokens\": 2000\n      }\n    }\n  },\n  \"summarizer-shell\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\",\n      \"generateContentConfig\": {\n        \"maxOutputTokens\": 2000\n      }\n    }\n  },\n  \"web-search\": {\n    \"extends\": \"gemini-3-flash-base\",\n    \"modelConfig\": {\n      \"generateContentConfig\": {\n        \"tools\": [\n          {\n            \"googleSearch\": {}\n          }\n        ]\n      }\n    }\n  },\n  \"web-fetch\": {\n    \"extends\": \"gemini-3-flash-base\",\n    \"modelConfig\": {\n      \"generateContentConfig\": {\n        \"tools\": [\n          {\n            \"urlContext\": {}\n          }\n        ]\n      }\n    }\n  },\n  \"web-fetch-fallback\": {\n    \"extends\": \"gemini-3-flash-base\",\n    \"modelConfig\": {}\n  },\n  \"loop-detection\": {\n    \"extends\": \"gemini-3-flash-base\",\n    \"modelConfig\": {}\n  },\n  \"loop-detection-double-check\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-3-pro-preview\"\n    }\n  },\n  \"llm-edit-fixer\": {\n    \"extends\": \"gemini-3-flash-base\",\n    \"modelConfig\": {}\n  },\n  \"next-speaker-checker\": {\n    \"extends\": \"gemini-3-flash-base\",\n    \"modelConfig\": {}\n  },\n  \"chat-compression-3-pro\": {\n    \"modelConfig\": {\n      \"model\": \"gemini-3-pro-preview\"\n    }\n  },\n  \"chat-compression-3-flash\": {\n    \"modelConfig\": {\n      \"model\": \"gemini-3-flash-preview\"\n    }\n  },\n  \"chat-compression-2.5-pro\": {\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-pro\"\n    }\n  },\n  \"chat-compression-2.5-flash\": {\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash\"\n    }\n  },\n  \"chat-compression-2.5-flash-lite\": {\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\"\n    }\n  },\n  \"chat-compression-default\": {\n    \"modelConfig\": {\n      \"model\": \"gemini-3-pro-preview\"\n    }\n  }\n}`",
-          "default": {
-            "base": {
-              "modelConfig": {
-                "generateContentConfig": {
-                  "temperature": 0,
-                  "topP": 1
-                }
-              }
-            },
-            "chat-base": {
-              "extends": "base",
-              "modelConfig": {
-                "generateContentConfig": {
-                  "thinkingConfig": {
-                    "includeThoughts": true
-                  },
-                  "temperature": 1,
-                  "topP": 0.95,
-                  "topK": 64
-                }
-              }
-            },
-            "chat-base-2.5": {
-              "extends": "chat-base",
-              "modelConfig": {
-                "generateContentConfig": {
-                  "thinkingConfig": {
-                    "thinkingBudget": 8192
-                  }
-                }
-              }
-            },
-            "chat-base-3": {
-              "extends": "chat-base",
-              "modelConfig": {
-                "generateContentConfig": {
-                  "thinkingConfig": {
-                    "thinkingLevel": "HIGH"
-                  }
-                }
-              }
-            },
-            "gemini-3-pro-preview": {
-              "extends": "chat-base-3",
-              "modelConfig": {
-                "model": "gemini-3-pro-preview"
-              }
-            },
-            "gemini-3-flash-preview": {
-              "extends": "chat-base-3",
-              "modelConfig": {
-                "model": "gemini-3-flash-preview"
-              }
-            },
-            "gemini-2.5-pro": {
-              "extends": "chat-base-2.5",
-              "modelConfig": {
-                "model": "gemini-2.5-pro"
-              }
-            },
-            "gemini-2.5-flash": {
-              "extends": "chat-base-2.5",
-              "modelConfig": {
-                "model": "gemini-2.5-flash"
-              }
-            },
-            "gemini-2.5-flash-lite": {
-              "extends": "chat-base-2.5",
-              "modelConfig": {
-                "model": "gemini-2.5-flash-lite"
-              }
-            },
-            "gemini-2.5-flash-base": {
-              "extends": "base",
-              "modelConfig": {
-                "model": "gemini-2.5-flash"
-              }
-            },
-            "gemini-3-flash-base": {
-              "extends": "base",
-              "modelConfig": {
-                "model": "gemini-3-flash-preview"
-              }
-            },
-            "classifier": {
-              "extends": "base",
-              "modelConfig": {
-                "model": "gemini-2.5-flash-lite",
-                "generateContentConfig": {
-                  "maxOutputTokens": 1024,
-                  "thinkingConfig": {
-                    "thinkingBudget": 512
-                  }
-                }
-              }
-            },
-            "prompt-completion": {
-              "extends": "base",
-              "modelConfig": {
-                "model": "gemini-2.5-flash-lite",
-                "generateContentConfig": {
-                  "temperature": 0.3,
-                  "maxOutputTokens": 16000,
-                  "thinkingConfig": {
-                    "thinkingBudget": 0
-                  }
-                }
-              }
-            },
-            "fast-ack-helper": {
-              "extends": "base",
-              "modelConfig": {
-                "model": "gemini-2.5-flash-lite",
-                "generateContentConfig": {
-                  "temperature": 0.2,
-                  "maxOutputTokens": 120,
-                  "thinkingConfig": {
-                    "thinkingBudget": 0
-                  }
-                }
-              }
-            },
-            "edit-corrector": {
-              "extends": "base",
-              "modelConfig": {
-                "model": "gemini-2.5-flash-lite",
-                "generateContentConfig": {
-                  "thinkingConfig": {
-                    "thinkingBudget": 0
-                  }
-                }
-              }
-            },
-            "summarizer-default": {
-              "extends": "base",
-              "modelConfig": {
-                "model": "gemini-2.5-flash-lite",
-                "generateContentConfig": {
-                  "maxOutputTokens": 2000
-                }
-              }
-            },
-            "summarizer-shell": {
-              "extends": "base",
-              "modelConfig": {
-                "model": "gemini-2.5-flash-lite",
-                "generateContentConfig": {
-                  "maxOutputTokens": 2000
-                }
-              }
-            },
-            "web-search": {
-              "extends": "gemini-3-flash-base",
-              "modelConfig": {
-                "generateContentConfig": {
-                  "tools": [
-                    {
-                      "googleSearch": {}
-                    }
-                  ]
-                }
-              }
-            },
-            "web-fetch": {
-              "extends": "gemini-3-flash-base",
-              "modelConfig": {
-                "generateContentConfig": {
-                  "tools": [
-                    {
-                      "urlContext": {}
-                    }
-                  ]
-                }
-              }
-            },
-            "web-fetch-fallback": {
-              "extends": "gemini-3-flash-base",
-              "modelConfig": {}
-            },
-            "loop-detection": {
-              "extends": "gemini-3-flash-base",
-              "modelConfig": {}
-            },
-            "loop-detection-double-check": {
-              "extends": "base",
-              "modelConfig": {
-                "model": "gemini-3-pro-preview"
-              }
-            },
-            "llm-edit-fixer": {
-              "extends": "gemini-3-flash-base",
-              "modelConfig": {}
-            },
-            "next-speaker-checker": {
-              "extends": "gemini-3-flash-base",
-              "modelConfig": {}
-            },
-            "chat-compression-3-pro": {
-              "modelConfig": {
-                "model": "gemini-3-pro-preview"
-              }
-            },
-            "chat-compression-3-flash": {
-              "modelConfig": {
-                "model": "gemini-3-flash-preview"
-              }
-            },
-            "chat-compression-2.5-pro": {
-              "modelConfig": {
-                "model": "gemini-2.5-pro"
-              }
-            },
-            "chat-compression-2.5-flash": {
-              "modelConfig": {
-                "model": "gemini-2.5-flash"
-              }
-            },
-            "chat-compression-2.5-flash-lite": {
-              "modelConfig": {
-                "model": "gemini-2.5-flash-lite"
-              }
-            },
-            "chat-compression-default": {
-              "modelConfig": {
-                "model": "gemini-3-pro-preview"
-              }
-            }
-          },
-          "type": "object",
-          "additionalProperties": true
-        },
-        "customAliases": {
-          "title": "Custom Model Config Aliases",
-          "description": "Custom named presets for model configs. These are merged with (and override) the built-in aliases.",
-          "markdownDescription": "Custom named presets for model configs. These are merged with (and override) the built-in aliases.\n\n- Category: `Model`\n- Requires restart: `no`\n- Default: `{}`",
-          "default": {},
-          "type": "object",
-          "additionalProperties": true
-        },
-        "customOverrides": {
-          "title": "Custom Model Config Overrides",
-          "description": "Custom model config overrides. These are merged with (and added to) the built-in overrides.",
-          "markdownDescription": "Custom model config overrides. These are merged with (and added to) the built-in overrides.\n\n- Category: `Model`\n- Requires restart: `no`\n- Default: `[]`",
-          "default": [],
-          "type": "array",
-          "items": {}
-        },
-        "overrides": {
-          "title": "Model Config Overrides",
-          "description": "Apply specific configuration overrides based on matches, with a primary key of model (or alias). The most specific match will be used.",
-          "markdownDescription": "Apply specific configuration overrides based on matches, with a primary key of model (or alias). The most specific match will be used.\n\n- Category: `Model`\n- Requires restart: `no`\n- Default: `[]`",
-          "default": [],
-          "type": "array",
-          "items": {}
-        }
-      },
-      "additionalProperties": false
-    },
-    "agents": {
-      "title": "Agents",
-      "description": "Settings for subagents.",
-      "markdownDescription": "Settings for subagents.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "overrides": {
-          "title": "Agent Overrides",
-          "description": "Override settings for specific agents, e.g. to disable the agent, set a custom model config, or run config.",
-          "markdownDescription": "Override settings for specific agents, e.g. to disable the agent, set a custom model config, or run config.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `{}`",
-          "default": {},
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/AgentOverride"
-          }
-        },
-        "browser": {
-          "title": "Browser Agent",
-          "description": "Settings specific to the browser agent.",
-          "markdownDescription": "Settings specific to the browser agent.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `{}`",
-          "default": {},
-          "type": "object",
-          "properties": {
-            "sessionMode": {
-              "title": "Browser Session Mode",
-              "description": "Session mode: 'persistent', 'isolated', or 'existing'.",
-              "markdownDescription": "Session mode: 'persistent', 'isolated', or 'existing'.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `persistent`",
-              "default": "persistent",
-              "type": "string",
-              "enum": ["persistent", "isolated", "existing"]
-            },
-            "headless": {
-              "title": "Browser Headless",
-              "description": "Run browser in headless mode.",
-              "markdownDescription": "Run browser in headless mode.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `false`",
-              "default": false,
-              "type": "boolean"
-            },
-            "profilePath": {
-              "title": "Browser Profile Path",
-              "description": "Path to browser profile directory for session persistence.",
-              "markdownDescription": "Path to browser profile directory for session persistence.\n\n- Category: `Advanced`\n- Requires restart: `yes`",
-              "type": "string"
-            },
-            "visualModel": {
-              "title": "Browser Visual Model",
-              "description": "Model override for the visual agent.",
-              "markdownDescription": "Model override for the visual agent.\n\n- Category: `Advanced`\n- Requires restart: `yes`",
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "context": {
-      "title": "Context",
-      "description": "Settings for managing context provided to the model.",
-      "markdownDescription": "Settings for managing context provided to the model.\n\n- Category: `Context`\n- Requires restart: `no`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "fileName": {
-          "title": "Context File Name",
-          "description": "The name of the context file or files to load into memory. Accepts either a single string or an array of strings.",
-          "markdownDescription": "The name of the context file or files to load into memory. Accepts either a single string or an array of strings.\n\n- Category: `Context`\n- Requires restart: `no`",
-          "$ref": "#/$defs/StringOrStringArray"
-        },
-        "importFormat": {
-          "title": "Memory Import Format",
-          "description": "The format to use when importing memory.",
-          "markdownDescription": "The format to use when importing memory.\n\n- Category: `Context`\n- Requires restart: `no`",
-          "type": "string"
-        },
-        "includeDirectoryTree": {
-          "title": "Include Directory Tree",
-          "description": "Whether to include the directory tree of the current working directory in the initial request to the model.",
-          "markdownDescription": "Whether to include the directory tree of the current working directory in the initial request to the model.\n\n- Category: `Context`\n- Requires restart: `no`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
-        "discoveryMaxDirs": {
-          "title": "Memory Discovery Max Dirs",
-          "description": "Maximum number of directories to search for memory.",
-          "markdownDescription": "Maximum number of directories to search for memory.\n\n- Category: `Context`\n- Requires restart: `no`\n- Default: `200`",
-          "default": 200,
-          "type": "number"
-        },
-        "includeDirectories": {
-          "title": "Include Directories",
-          "description": "Additional directories to include in the workspace context. Missing directories will be skipped with a warning.",
-          "markdownDescription": "Additional directories to include in the workspace context. Missing directories will be skipped with a warning.\n\n- Category: `Context`\n- Requires restart: `no`\n- Default: `[]`",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "loadMemoryFromIncludeDirectories": {
-          "title": "Load Memory From Include Directories",
-          "description": "Controls how /memory refresh loads GEMINI.md files. When true, include directories are scanned; when false, only the current directory is used.",
-          "markdownDescription": "Controls how /memory refresh loads GEMINI.md files. When true, include directories are scanned; when false, only the current directory is used.\n\n- Category: `Context`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "fileFiltering": {
-          "title": "File Filtering",
-          "description": "Settings for git-aware file filtering.",
-          "markdownDescription": "Settings for git-aware file filtering.\n\n- Category: `Context`\n- Requires restart: `yes`\n- Default: `{}`",
-          "default": {},
-          "type": "object",
-          "properties": {
-            "respectGitIgnore": {
-              "title": "Respect .gitignore",
-              "description": "Respect .gitignore files when searching.",
-              "markdownDescription": "Respect .gitignore files when searching.\n\n- Category: `Context`\n- Requires restart: `yes`\n- Default: `true`",
-              "default": true,
-              "type": "boolean"
-            },
-            "respectGeminiIgnore": {
-              "title": "Respect .geminiignore",
-              "description": "Respect .geminiignore files when searching.",
-              "markdownDescription": "Respect .geminiignore files when searching.\n\n- Category: `Context`\n- Requires restart: `yes`\n- Default: `true`",
-              "default": true,
-              "type": "boolean"
-            },
-            "enableRecursiveFileSearch": {
-              "title": "Enable Recursive File Search",
-              "description": "Enable recursive file search functionality when completing @ references in the prompt.",
-              "markdownDescription": "Enable recursive file search functionality when completing @ references in the prompt.\n\n- Category: `Context`\n- Requires restart: `yes`\n- Default: `true`",
-              "default": true,
-              "type": "boolean"
-            },
-            "enableFuzzySearch": {
-              "title": "Enable Fuzzy Search",
-              "description": "Enable fuzzy search when searching for files.",
-              "markdownDescription": "Enable fuzzy search when searching for files.\n\n- Category: `Context`\n- Requires restart: `yes`\n- Default: `true`",
-              "default": true,
-              "type": "boolean"
-            },
-            "customIgnoreFilePaths": {
-              "title": "Custom Ignore File Paths",
-              "description": "Additional ignore file paths to respect. These files take precedence over .geminiignore and .gitignore. Files earlier in the array take precedence over files later in the array, e.g. the first file takes precedence over the second one.",
-              "markdownDescription": "Additional ignore file paths to respect. These files take precedence over .geminiignore and .gitignore. Files earlier in the array take precedence over files later in the array, e.g. the first file takes precedence over the second one.\n\n- Category: `Context`\n- Requires restart: `yes`\n- Default: `[]`",
-              "default": [],
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "tools": {
-      "title": "Tools",
-      "description": "Settings for built-in and custom tools.",
-      "markdownDescription": "Settings for built-in and custom tools.\n\n- Category: `Tools`\n- Requires restart: `yes`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "sandbox": {
-          "title": "Sandbox",
-          "description": "Sandbox execution environment. Set to a boolean to enable or disable the sandbox, or provide a string path to a sandbox profile.",
-          "markdownDescription": "Sandbox execution environment. Set to a boolean to enable or disable the sandbox, or provide a string path to a sandbox profile.\n\n- Category: `Tools`\n- Requires restart: `yes`",
-          "$ref": "#/$defs/BooleanOrString"
-        },
-        "shell": {
-          "title": "Shell",
-          "description": "Settings for shell execution.",
-          "markdownDescription": "Settings for shell execution.\n\n- Category: `Tools`\n- Requires restart: `no`\n- Default: `{}`",
-          "default": {},
-          "type": "object",
-          "properties": {
-            "enableInteractiveShell": {
-              "title": "Enable Interactive Shell",
-              "description": "Use node-pty for an interactive shell experience. Fallback to child_process still applies.",
-              "markdownDescription": "Use node-pty for an interactive shell experience. Fallback to child_process still applies.\n\n- Category: `Tools`\n- Requires restart: `yes`\n- Default: `true`",
-              "default": true,
-              "type": "boolean"
-            },
-            "pager": {
-              "title": "Pager",
-              "description": "The pager command to use for shell output. Defaults to `cat`.",
-              "markdownDescription": "The pager command to use for shell output. Defaults to `cat`.\n\n- Category: `Tools`\n- Requires restart: `no`\n- Default: `cat`",
-              "default": "cat",
-              "type": "string"
-            },
-            "showColor": {
-              "title": "Show Color",
-              "description": "Show color in shell output.",
-              "markdownDescription": "Show color in shell output.\n\n- Category: `Tools`\n- Requires restart: `no`\n- Default: `false`",
-              "default": false,
-              "type": "boolean"
-            },
-            "inactivityTimeout": {
-              "title": "Inactivity Timeout",
-              "description": "The maximum time in seconds allowed without output from the shell command. Defaults to 5 minutes.",
-              "markdownDescription": "The maximum time in seconds allowed without output from the shell command. Defaults to 5 minutes.\n\n- Category: `Tools`\n- Requires restart: `no`\n- Default: `300`",
-              "default": 300,
-              "type": "number"
-            },
-            "enableShellOutputEfficiency": {
-              "title": "Enable Shell Output Efficiency",
-              "description": "Enable shell output efficiency optimizations for better performance.",
-              "markdownDescription": "Enable shell output efficiency optimizations for better performance.\n\n- Category: `Tools`\n- Requires restart: `no`\n- Default: `true`",
-              "default": true,
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "core": {
-          "title": "Core Tools",
-          "description": "Restrict the set of built-in tools with an allowlist. Match semantics mirror tools.allowed; see the built-in tools documentation for available names.",
-          "markdownDescription": "Restrict the set of built-in tools with an allowlist. Match semantics mirror tools.allowed; see the built-in tools documentation for available names.\n\n- Category: `Tools`\n- Requires restart: `yes`",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "allowed": {
-          "title": "Allowed Tools",
-          "description": "Tool names that bypass the confirmation dialog. Useful for trusted commands (for example [\"run_shell_command(git)\", \"run_shell_command(npm test)\"]). See shell tool command restrictions for matching details.",
-          "markdownDescription": "Tool names that bypass the confirmation dialog. Useful for trusted commands (for example [\"run_shell_command(git)\", \"run_shell_command(npm test)\"]). See shell tool command restrictions for matching details.\n\n- Category: `Advanced`\n- Requires restart: `yes`",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "exclude": {
-          "title": "Exclude Tools",
-          "description": "Tool names to exclude from discovery.",
-          "markdownDescription": "Tool names to exclude from discovery.\n\n- Category: `Tools`\n- Requires restart: `yes`",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "discoveryCommand": {
-          "title": "Tool Discovery Command",
-          "description": "Command to run for tool discovery.",
-          "markdownDescription": "Command to run for tool discovery.\n\n- Category: `Tools`\n- Requires restart: `yes`",
-          "type": "string"
-        },
-        "callCommand": {
-          "title": "Tool Call Command",
-          "description": "Defines a custom shell command for invoking discovered tools. The command must take the tool name as the first argument, read JSON arguments from stdin, and emit JSON results on stdout.",
-          "markdownDescription": "Defines a custom shell command for invoking discovered tools. The command must take the tool name as the first argument, read JSON arguments from stdin, and emit JSON results on stdout.\n\n- Category: `Tools`\n- Requires restart: `yes`",
-          "type": "string"
-        },
-        "useRipgrep": {
-          "title": "Use Ripgrep",
-          "description": "Use ripgrep for file content search instead of the fallback implementation. Provides faster search performance.",
-          "markdownDescription": "Use ripgrep for file content search instead of the fallback implementation. Provides faster search performance.\n\n- Category: `Tools`\n- Requires restart: `no`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
-        "truncateToolOutputThreshold": {
-          "title": "Tool Output Truncation Threshold",
-          "description": "Maximum characters to show when truncating large tool outputs. Set to 0 or negative to disable truncation.",
-          "markdownDescription": "Maximum characters to show when truncating large tool outputs. Set to 0 or negative to disable truncation.\n\n- Category: `General`\n- Requires restart: `yes`\n- Default: `40000`",
-          "default": 40000,
-          "type": "number"
-        },
-        "disableLLMCorrection": {
-          "title": "Disable LLM Correction",
-          "description": "Disable LLM-based error correction for edit tools. When enabled, tools will fail immediately if exact string matches are not found, instead of attempting to self-correct.",
-          "markdownDescription": "Disable LLM-based error correction for edit tools. When enabled, tools will fail immediately if exact string matches are not found, instead of attempting to self-correct.\n\n- Category: `Tools`\n- Requires restart: `yes`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false
-    },
-    "mcp": {
-      "title": "MCP",
-      "description": "Settings for Model Context Protocol (MCP) servers.",
-      "markdownDescription": "Settings for Model Context Protocol (MCP) servers.\n\n- Category: `MCP`\n- Requires restart: `yes`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "serverCommand": {
-          "title": "MCP Server Command",
-          "description": "Command to start an MCP server.",
-          "markdownDescription": "Command to start an MCP server.\n\n- Category: `MCP`\n- Requires restart: `yes`",
-          "type": "string"
-        },
-        "allowed": {
-          "title": "Allow MCP Servers",
-          "description": "A list of MCP servers to allow.",
-          "markdownDescription": "A list of MCP servers to allow.\n\n- Category: `MCP`\n- Requires restart: `yes`",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "excluded": {
-          "title": "Exclude MCP Servers",
-          "description": "A list of MCP servers to exclude.",
-          "markdownDescription": "A list of MCP servers to exclude.\n\n- Category: `MCP`\n- Requires restart: `yes`",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "additionalProperties": false
-    },
-    "useWriteTodos": {
-      "title": "Use WriteTodos",
-      "description": "Enable the write_todos tool.",
-      "markdownDescription": "Enable the write_todos tool.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `true`",
-      "default": true,
-      "type": "boolean"
-    },
-    "security": {
-      "title": "Security",
-      "description": "Security-related settings.",
-      "markdownDescription": "Security-related settings.\n\n- Category: `Security`\n- Requires restart: `yes`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "disableYoloMode": {
-          "title": "Disable YOLO Mode",
-          "description": "Disable YOLO mode, even if enabled by a flag.",
-          "markdownDescription": "Disable YOLO mode, even if enabled by a flag.\n\n- Category: `Security`\n- Requires restart: `yes`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "enablePermanentToolApproval": {
-          "title": "Allow Permanent Tool Approval",
-          "description": "Enable the \"Allow for all future sessions\" option in tool confirmation dialogs.",
-          "markdownDescription": "Enable the \"Allow for all future sessions\" option in tool confirmation dialogs.\n\n- Category: `Security`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "blockGitExtensions": {
-          "title": "Blocks extensions from Git",
-          "description": "Blocks installing and loading extensions from Git.",
-          "markdownDescription": "Blocks installing and loading extensions from Git.\n\n- Category: `Security`\n- Requires restart: `yes`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "allowedExtensions": {
-          "title": "Extension Source Regex Allowlist",
-          "description": "List of Regex patterns for allowed extensions. If nonempty, only extensions that match the patterns in this list are allowed. Overrides the blockGitExtensions setting.",
-          "markdownDescription": "List of Regex patterns for allowed extensions. If nonempty, only extensions that match the patterns in this list are allowed. Overrides the blockGitExtensions setting.\n\n- Category: `Security`\n- Requires restart: `yes`\n- Default: `[]`",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "folderTrust": {
-          "title": "Folder Trust",
-          "description": "Settings for folder trust.",
-          "markdownDescription": "Settings for folder trust.\n\n- Category: `Security`\n- Requires restart: `no`\n- Default: `{}`",
-          "default": {},
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "title": "Folder Trust",
-              "description": "Setting to track whether Folder trust is enabled.",
-              "markdownDescription": "Setting to track whether Folder trust is enabled.\n\n- Category: `Security`\n- Requires restart: `yes`\n- Default: `true`",
-              "default": true,
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "environmentVariableRedaction": {
-          "title": "Environment Variable Redaction",
-          "description": "Settings for environment variable redaction.",
-          "markdownDescription": "Settings for environment variable redaction.\n\n- Category: `Security`\n- Requires restart: `no`\n- Default: `{}`",
-          "default": {},
-          "type": "object",
-          "properties": {
-            "allowed": {
-              "title": "Allowed Environment Variables",
-              "description": "Environment variables to always allow (bypass redaction).",
-              "markdownDescription": "Environment variables to always allow (bypass redaction).\n\n- Category: `Security`\n- Requires restart: `yes`\n- Default: `[]`",
-              "default": [],
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "blocked": {
-              "title": "Blocked Environment Variables",
-              "description": "Environment variables to always redact.",
-              "markdownDescription": "Environment variables to always redact.\n\n- Category: `Security`\n- Requires restart: `yes`\n- Default: `[]`",
-              "default": [],
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "enabled": {
-              "title": "Enable Environment Variable Redaction",
-              "description": "Enable redaction of environment variables that may contain secrets.",
-              "markdownDescription": "Enable redaction of environment variables that may contain secrets.\n\n- Category: `Security`\n- Requires restart: `yes`\n- Default: `false`",
-              "default": false,
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "auth": {
-          "title": "Authentication",
-          "description": "Authentication settings.",
-          "markdownDescription": "Authentication settings.\n\n- Category: `Security`\n- Requires restart: `yes`\n- Default: `{}`",
-          "default": {},
-          "type": "object",
-          "properties": {
-            "selectedType": {
-              "title": "Selected Auth Type",
-              "description": "The currently selected authentication type.",
-              "markdownDescription": "The currently selected authentication type.\n\n- Category: `Security`\n- Requires restart: `yes`",
-              "type": "string"
-            },
-            "enforcedType": {
-              "title": "Enforced Auth Type",
-              "description": "The required auth type. If this does not match the selected auth type, the user will be prompted to re-authenticate.",
-              "markdownDescription": "The required auth type. If this does not match the selected auth type, the user will be prompted to re-authenticate.\n\n- Category: `Advanced`\n- Requires restart: `yes`",
-              "type": "string"
-            },
-            "useExternal": {
-              "title": "Use External Auth",
-              "description": "Whether to use an external authentication flow.",
-              "markdownDescription": "Whether to use an external authentication flow.\n\n- Category: `Security`\n- Requires restart: `yes`",
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "enableConseca": {
-          "title": "Enable Context-Aware Security",
-          "description": "Enable the context-aware security checker. This feature uses an LLM to dynamically generate and enforce security policies for tool use based on your prompt, providing an additional layer of protection against unintended actions.",
-          "markdownDescription": "Enable the context-aware security checker. This feature uses an LLM to dynamically generate and enforce security policies for tool use based on your prompt, providing an additional layer of protection against unintended actions.\n\n- Category: `Security`\n- Requires restart: `yes`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false
-    },
-    "advanced": {
-      "title": "Advanced",
-      "description": "Advanced settings for power users.",
-      "markdownDescription": "Advanced settings for power users.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "autoConfigureMemory": {
-          "title": "Auto Configure Max Old Space Size",
-          "description": "Automatically configure Node.js memory limits",
-          "markdownDescription": "Automatically configure Node.js memory limits\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "dnsResolutionOrder": {
-          "title": "DNS Resolution Order",
-          "description": "The DNS resolution order.",
-          "markdownDescription": "The DNS resolution order.\n\n- Category: `Advanced`\n- Requires restart: `yes`",
-          "type": "string"
-        },
-        "excludedEnvVars": {
-          "title": "Excluded Project Environment Variables",
-          "description": "Environment variables to exclude from project context.",
-          "markdownDescription": "Environment variables to exclude from project context.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `[\n  \"DEBUG\",\n  \"DEBUG_MODE\"\n]`",
-          "default": ["DEBUG", "DEBUG_MODE"],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "bugCommand": {
-          "title": "Bug Command",
-          "description": "Configuration for the bug report command.",
-          "markdownDescription": "Configuration for the bug report command.\n\n- Category: `Advanced`\n- Requires restart: `no`",
-          "$ref": "#/$defs/BugCommandSettings"
-        }
-      },
-      "additionalProperties": false
-    },
-    "experimental": {
-      "title": "Experimental",
-      "description": "Setting to enable experimental features",
-      "markdownDescription": "Setting to enable experimental features\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "toolOutputMasking": {
-          "title": "Tool Output Masking",
-          "description": "Advanced settings for tool output masking to manage context window efficiency.",
-          "markdownDescription": "Advanced settings for tool output masking to manage context window efficiency.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `{}`",
-          "default": {},
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "title": "Enable Tool Output Masking",
-              "description": "Enables tool output masking to save tokens.",
-              "markdownDescription": "Enables tool output masking to save tokens.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `true`",
-              "default": true,
-              "type": "boolean"
-            },
-            "toolProtectionThreshold": {
-              "title": "Tool Protection Threshold",
-              "description": "Minimum number of tokens to protect from masking (most recent tool outputs).",
-              "markdownDescription": "Minimum number of tokens to protect from masking (most recent tool outputs).\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `50000`",
-              "default": 50000,
-              "type": "number"
-            },
-            "minPrunableTokensThreshold": {
-              "title": "Min Prunable Tokens Threshold",
-              "description": "Minimum prunable tokens required to trigger a masking pass.",
-              "markdownDescription": "Minimum prunable tokens required to trigger a masking pass.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `30000`",
-              "default": 30000,
-              "type": "number"
-            },
-            "protectLatestTurn": {
-              "title": "Protect Latest Turn",
-              "description": "Ensures the absolute latest turn is never masked, regardless of token count.",
-              "markdownDescription": "Ensures the absolute latest turn is never masked, regardless of token count.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `true`",
-              "default": true,
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "enableAgents": {
-          "title": "Enable Agents",
-          "description": "Enable local and remote subagents. Warning: Experimental feature, uses YOLO mode for subagents",
-          "markdownDescription": "Enable local and remote subagents. Warning: Experimental feature, uses YOLO mode for subagents\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "extensionManagement": {
-          "title": "Extension Management",
-          "description": "Enable extension management features.",
-          "markdownDescription": "Enable extension management features.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
-        "extensionConfig": {
-          "title": "Extension Configuration",
-          "description": "Enable requesting and fetching of extension settings.",
-          "markdownDescription": "Enable requesting and fetching of extension settings.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
-        "extensionRegistry": {
-          "title": "Extension Registry Explore UI",
-          "description": "Enable extension registry explore UI.",
-          "markdownDescription": "Enable extension registry explore UI.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "extensionReloading": {
-          "title": "Extension Reloading",
-          "description": "Enables extension loading/unloading within the CLI session.",
-          "markdownDescription": "Enables extension loading/unloading within the CLI session.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "jitContext": {
-          "title": "JIT Context Loading",
-          "description": "Enable Just-In-Time (JIT) context loading.",
-          "markdownDescription": "Enable Just-In-Time (JIT) context loading.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "useOSC52Paste": {
-          "title": "Use OSC 52 Paste",
-          "description": "Use OSC 52 for pasting. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it).",
-          "markdownDescription": "Use OSC 52 for pasting. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it).\n\n- Category: `Experimental`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "useOSC52Copy": {
-          "title": "Use OSC 52 Copy",
-          "description": "Use OSC 52 for copying. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it).",
-          "markdownDescription": "Use OSC 52 for copying. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it).\n\n- Category: `Experimental`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "plan": {
-          "title": "Plan",
-          "description": "Enable planning features (Plan Mode and tools).",
-          "markdownDescription": "Enable planning features (Plan Mode and tools).\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "modelSteering": {
-          "title": "Model Steering",
-          "description": "Enable model steering (user hints) to guide the model during tool execution.",
-          "markdownDescription": "Enable model steering (user hints) to guide the model during tool execution.\n\n- Category: `Experimental`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "directWebFetch": {
-          "title": "Direct Web Fetch",
-          "description": "Enable web fetch behavior that bypasses LLM summarization.",
-          "markdownDescription": "Enable web fetch behavior that bypasses LLM summarization.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "gemmaModelRouter": {
-          "title": "Gemma Model Router",
-          "description": "Enable Gemma model router (experimental).",
-          "markdownDescription": "Enable Gemma model router (experimental).\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `{}`",
-          "default": {},
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "title": "Enable Gemma Model Router",
-              "description": "Enable the Gemma Model Router. Requires a local endpoint serving Gemma via the Gemini API using LiteRT-LM shim.",
-              "markdownDescription": "Enable the Gemma Model Router. Requires a local endpoint serving Gemma via the Gemini API using LiteRT-LM shim.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
-              "default": false,
-              "type": "boolean"
-            },
-            "classifier": {
-              "title": "Classifier",
-              "description": "Classifier configuration.",
-              "markdownDescription": "Classifier configuration.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `{}`",
-              "default": {},
-              "type": "object",
-              "properties": {
-                "host": {
-                  "title": "Host",
-                  "description": "The host of the classifier.",
-                  "markdownDescription": "The host of the classifier.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `http://localhost:9379`",
-                  "default": "http://localhost:9379",
-                  "type": "string"
-                },
-                "model": {
-                  "title": "Model",
-                  "description": "The model to use for the classifier. Only tested on `gemma3-1b-gpu-custom`.",
-                  "markdownDescription": "The model to use for the classifier. Only tested on `gemma3-1b-gpu-custom`.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `gemma3-1b-gpu-custom`",
-                  "default": "gemma3-1b-gpu-custom",
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "extensions": {
-      "title": "Extensions",
-      "description": "Settings for extensions.",
-      "markdownDescription": "Settings for extensions.\n\n- Category: `Extensions`\n- Requires restart: `yes`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "disabled": {
-          "title": "Disabled Extensions",
-          "description": "List of disabled extensions.",
-          "markdownDescription": "List of disabled extensions.\n\n- Category: `Extensions`\n- Requires restart: `yes`\n- Default: `[]`",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "workspacesWithMigrationNudge": {
-          "title": "Workspaces with Migration Nudge",
-          "description": "List of workspaces for which the migration nudge has been shown.",
-          "markdownDescription": "List of workspaces for which the migration nudge has been shown.\n\n- Category: `Extensions`\n- Requires restart: `no`\n- Default: `[]`",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "additionalProperties": false
-    },
-    "skills": {
-      "title": "Skills",
-      "description": "Settings for agent skills.",
-      "markdownDescription": "Settings for agent skills.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "title": "Enable Agent Skills",
-          "description": "Enable Agent Skills.",
-          "markdownDescription": "Enable Agent Skills.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
-        "disabled": {
-          "title": "Disabled Skills",
-          "description": "List of disabled skills.",
-          "markdownDescription": "List of disabled skills.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `[]`",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "additionalProperties": false
-    },
-    "hooksConfig": {
-      "title": "HooksConfig",
-      "description": "Hook configurations for intercepting and customizing agent behavior.",
-      "markdownDescription": "Hook configurations for intercepting and customizing agent behavior.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "title": "Enable Hooks",
-          "description": "Canonical toggle for the hooks system. When disabled, no hooks will be executed.",
-          "markdownDescription": "Canonical toggle for the hooks system. When disabled, no hooks will be executed.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        },
-        "disabled": {
-          "title": "Disabled Hooks",
-          "description": "List of hook names (commands) that should be disabled. Hooks in this list will not execute even if configured.",
-          "markdownDescription": "List of hook names (commands) that should be disabled. Hooks in this list will not execute even if configured.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `[]`",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "notifications": {
-          "title": "Hook Notifications",
-          "description": "Show visual indicators when hooks are executing.",
-          "markdownDescription": "Show visual indicators when hooks are executing.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `true`",
-          "default": true,
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false
-    },
-    "hooks": {
-      "title": "Hook Events",
-      "description": "Event-specific hook configurations.",
-      "markdownDescription": "Event-specific hook configurations.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "BeforeTool": {
-          "title": "Before Tool Hooks",
-          "description": "Hooks that execute before tool execution. Can intercept, validate, or modify tool calls.",
-          "markdownDescription": "Hooks that execute before tool execution. Can intercept, validate, or modify tool calls.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `[]`",
-          "default": [],
-          "$ref": "#/$defs/HookDefinitionArray"
-        },
-        "AfterTool": {
-          "title": "After Tool Hooks",
-          "description": "Hooks that execute after tool execution. Can process results, log outputs, or trigger follow-up actions.",
-          "markdownDescription": "Hooks that execute after tool execution. Can process results, log outputs, or trigger follow-up actions.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `[]`",
-          "default": [],
-          "$ref": "#/$defs/HookDefinitionArray"
-        },
-        "BeforeAgent": {
-          "title": "Before Agent Hooks",
-          "description": "Hooks that execute before agent loop starts. Can set up context or initialize resources.",
-          "markdownDescription": "Hooks that execute before agent loop starts. Can set up context or initialize resources.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `[]`",
-          "default": [],
-          "$ref": "#/$defs/HookDefinitionArray"
-        },
-        "AfterAgent": {
-          "title": "After Agent Hooks",
-          "description": "Hooks that execute after agent loop completes. Can perform cleanup or summarize results.",
-          "markdownDescription": "Hooks that execute after agent loop completes. Can perform cleanup or summarize results.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `[]`",
-          "default": [],
-          "$ref": "#/$defs/HookDefinitionArray"
-        },
-        "Notification": {
-          "title": "Notification Hooks",
-          "description": "Hooks that execute on notification events (errors, warnings, info). Can log or alert on specific conditions.",
-          "markdownDescription": "Hooks that execute on notification events (errors, warnings, info). Can log or alert on specific conditions.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `[]`",
-          "default": [],
-          "$ref": "#/$defs/HookDefinitionArray"
-        },
-        "SessionStart": {
-          "title": "Session Start Hooks",
-          "description": "Hooks that execute when a session starts. Can initialize session-specific resources or state.",
-          "markdownDescription": "Hooks that execute when a session starts. Can initialize session-specific resources or state.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `[]`",
-          "default": [],
-          "$ref": "#/$defs/HookDefinitionArray"
-        },
-        "SessionEnd": {
-          "title": "Session End Hooks",
-          "description": "Hooks that execute when a session ends. Can perform cleanup or persist session data.",
-          "markdownDescription": "Hooks that execute when a session ends. Can perform cleanup or persist session data.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `[]`",
-          "default": [],
-          "$ref": "#/$defs/HookDefinitionArray"
-        },
-        "PreCompress": {
-          "title": "Pre-Compress Hooks",
-          "description": "Hooks that execute before chat history compression. Can back up or analyze conversation before compression.",
-          "markdownDescription": "Hooks that execute before chat history compression. Can back up or analyze conversation before compression.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `[]`",
-          "default": [],
-          "$ref": "#/$defs/HookDefinitionArray"
-        },
-        "BeforeModel": {
-          "title": "Before Model Hooks",
-          "description": "Hooks that execute before LLM requests. Can modify prompts, inject context, or control model parameters.",
-          "markdownDescription": "Hooks that execute before LLM requests. Can modify prompts, inject context, or control model parameters.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `[]`",
-          "default": [],
-          "$ref": "#/$defs/HookDefinitionArray"
-        },
-        "AfterModel": {
-          "title": "After Model Hooks",
-          "description": "Hooks that execute after LLM responses. Can process outputs, extract information, or log interactions.",
-          "markdownDescription": "Hooks that execute after LLM responses. Can process outputs, extract information, or log interactions.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `[]`",
-          "default": [],
-          "$ref": "#/$defs/HookDefinitionArray"
-        },
-        "BeforeToolSelection": {
-          "title": "Before Tool Selection Hooks",
-          "description": "Hooks that execute before tool selection. Can filter or prioritize available tools dynamically.",
-          "markdownDescription": "Hooks that execute before tool selection. Can filter or prioritize available tools dynamically.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `[]`",
-          "default": [],
-          "$ref": "#/$defs/HookDefinitionArray"
-        }
-      },
-      "additionalProperties": {
-        "type": "array",
-        "items": {}
-      }
-    },
-    "admin": {
-      "title": "Admin",
-      "description": "Settings configured remotely by enterprise admins.",
-      "markdownDescription": "Settings configured remotely by enterprise admins.\n\n- Category: `Admin`\n- Requires restart: `no`\n- Default: `{}`",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "secureModeEnabled": {
-          "title": "Secure Mode Enabled",
-          "description": "If true, disallows yolo mode from being used.",
-          "markdownDescription": "If true, disallows yolo mode from being used.\n\n- Category: `Admin`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
-          "type": "boolean"
-        },
-        "extensions": {
-          "title": "Extensions Settings",
-          "description": "Extensions-specific admin settings.",
-          "markdownDescription": "Extensions-specific admin settings.\n\n- Category: `Admin`\n- Requires restart: `no`\n- Default: `{}`",
-          "default": {},
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "title": "Extensions Enabled",
-              "description": "If false, disallows extensions from being installed or used.",
-              "markdownDescription": "If false, disallows extensions from being installed or used.\n\n- Category: `Admin`\n- Requires restart: `no`\n- Default: `true`",
-              "default": true,
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "mcp": {
-          "title": "MCP Settings",
-          "description": "MCP-specific admin settings.",
-          "markdownDescription": "MCP-specific admin settings.\n\n- Category: `Admin`\n- Requires restart: `no`\n- Default: `{}`",
-          "default": {},
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "title": "MCP Enabled",
-              "description": "If false, disallows MCP servers from being used.",
-              "markdownDescription": "If false, disallows MCP servers from being used.\n\n- Category: `Admin`\n- Requires restart: `no`\n- Default: `true`",
-              "default": true,
-              "type": "boolean"
-            },
-            "config": {
-              "title": "MCP Config",
-              "description": "Admin-configured MCP servers.",
-              "markdownDescription": "Admin-configured MCP servers.\n\n- Category: `Admin`\n- Requires restart: `no`\n- Default: `{}`",
-              "default": {},
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/$defs/MCPServerConfig"
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        "skills": {
-          "title": "Skills Settings",
-          "description": "Agent Skills-specific admin settings.",
-          "markdownDescription": "Agent Skills-specific admin settings.\n\n- Category: `Admin`\n- Requires restart: `no`\n- Default: `{}`",
-          "default": {},
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "title": "Skills Enabled",
-              "description": "If false, disallows agent skills from being used.",
-              "markdownDescription": "If false, disallows agent skills from being used.\n\n- Category: `Admin`\n- Requires restart: `no`\n- Default: `true`",
-              "default": true,
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    }
-  },
-  "$defs": {
-    "MCPServerConfig": {
-      "type": "object",
-      "description": "Definition of a Model Context Protocol (MCP) server configuration.",
-      "additionalProperties": false,
-      "properties": {
-        "command": {
-          "type": "string",
-          "description": "Executable invoked for stdio transport."
-        },
-        "args": {
-          "type": "array",
-          "description": "Command-line arguments for the stdio transport command.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "env": {
-          "type": "object",
-          "description": "Environment variables to set for the server process.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "cwd": {
-          "type": "string",
-          "description": "Working directory for the server process."
-        },
-        "url": {
-          "type": "string",
-          "description": "URL for SSE or HTTP transport. Use with \"type\" field to specify transport type."
-        },
-        "httpUrl": {
-          "type": "string",
-          "description": "Streaming HTTP transport URL."
-        },
-        "headers": {
-          "type": "object",
-          "description": "Additional HTTP headers sent to the server.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "tcp": {
-          "type": "string",
-          "description": "TCP address for websocket transport."
-        },
-        "type": {
-          "type": "string",
-          "description": "Transport type. Use \"stdio\" for local command, \"sse\" for Server-Sent Events, or \"http\" for Streamable HTTP.",
-          "enum": ["stdio", "sse", "http"]
-        },
-        "timeout": {
-          "type": "number",
-          "description": "Timeout in milliseconds for MCP requests."
-        },
-        "trust": {
-          "type": "boolean",
-          "description": "Marks the server as trusted. Trusted servers may gain additional capabilities."
-        },
-        "description": {
-          "type": "string",
-          "description": "Human-readable description of the server."
-        },
-        "includeTools": {
-          "type": "array",
-          "description": "Subset of tools that should be enabled for this server. When omitted all tools are enabled.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "excludeTools": {
-          "type": "array",
-          "description": "Tools that should be disabled for this server even if exposed.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "extension": {
-          "type": "object",
-          "description": "Metadata describing the Gemini CLI extension that owns this MCP server.",
-          "additionalProperties": {
-            "type": ["string", "boolean", "number"]
-          }
-        },
-        "oauth": {
-          "type": "object",
-          "description": "OAuth configuration for authenticating with the server.",
-          "additionalProperties": true
-        },
-        "authProviderType": {
-          "type": "string",
-          "description": "Authentication provider used for acquiring credentials (for example `dynamic_discovery`).",
-          "enum": [
-            "dynamic_discovery",
-            "google_credentials",
-            "service_account_impersonation"
-          ]
-        },
-        "targetAudience": {
-          "type": "string",
-          "description": "OAuth target audience (CLIENT_ID.apps.googleusercontent.com)."
-        },
-        "targetServiceAccount": {
-          "type": "string",
-          "description": "Service account email to impersonate (name@project.iam.gserviceaccount.com)."
-        }
-      }
-    },
-    "TelemetrySettings": {
-      "type": "object",
-      "description": "Telemetry configuration for Gemini CLI.",
-      "additionalProperties": false,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Enables telemetry emission."
-        },
-        "target": {
-          "type": "string",
-          "description": "Telemetry destination (for example `stderr`, `stdout`, or `otlp`)."
-        },
-        "otlpEndpoint": {
-          "type": "string",
-          "description": "Endpoint for OTLP exporters."
-        },
-        "otlpProtocol": {
-          "type": "string",
-          "description": "Protocol for OTLP exporters.",
-          "enum": ["grpc", "http"]
-        },
-        "logPrompts": {
-          "type": "boolean",
-          "description": "Whether prompts are logged in telemetry payloads."
-        },
-        "outfile": {
-          "type": "string",
-          "description": "File path for writing telemetry output."
-        },
-        "useCollector": {
-          "type": "boolean",
-          "description": "Whether to forward telemetry to an OTLP collector."
-        },
-        "useCliAuth": {
-          "type": "boolean",
-          "description": "Whether to use CLI authentication for telemetry (only for in-process exporters)."
-        }
-      }
-    },
-    "BugCommandSettings": {
-      "type": "object",
-      "description": "Configuration for the bug report helper command.",
-      "additionalProperties": false,
-      "properties": {
-        "urlTemplate": {
-          "type": "string",
-          "description": "Template used to open a bug report URL. Variables in the template are populated at runtime."
-        }
-      },
-      "required": ["urlTemplate"]
-    },
-    "SummarizeToolOutputSettings": {
-      "type": "object",
-      "description": "Controls summarization behavior for individual tools. All properties are optional.",
-      "additionalProperties": false,
-      "properties": {
-        "tokenBudget": {
-          "type": "number",
-          "description": "Maximum number of tokens used when summarizing tool output."
-        }
-      }
-    },
-    "AgentOverride": {
-      "type": "object",
-      "description": "Override settings for a specific agent.",
-      "additionalProperties": false,
-      "properties": {
-        "modelConfig": {
-          "type": "object",
-          "additionalProperties": true
-        },
-        "runConfig": {
-          "type": "object",
-          "description": "Run configuration for an agent.",
-          "additionalProperties": false,
-          "properties": {
-            "maxTimeMinutes": {
-              "type": "number",
-              "description": "The maximum execution time for the agent in minutes."
-            },
-            "maxTurns": {
-              "type": "number",
-              "description": "The maximum number of conversational turns."
-            }
-          }
-        },
-        "enabled": {
-          "type": "boolean",
-          "description": "Whether to enable the agent."
-        }
-      }
-    },
-    "CustomTheme": {
-      "type": "object",
-      "description": "Custom theme definition used for styling Gemini CLI output. Colors are provided as hex strings or named ANSI colors.",
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["custom"],
-          "default": "custom"
-        },
-        "name": {
-          "type": "string",
-          "description": "Theme display name."
-        },
-        "text": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "primary": {
-              "type": "string"
-            },
-            "secondary": {
-              "type": "string"
-            },
-            "link": {
-              "type": "string"
-            },
-            "accent": {
-              "type": "string"
-            }
-          }
-        },
-        "background": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "primary": {
-              "type": "string"
-            },
-            "diff": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "added": {
-                  "type": "string"
-                },
-                "removed": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        "border": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "default": {
-              "type": "string"
-            },
-            "focused": {
-              "type": "string"
-            }
-          }
-        },
-        "ui": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "comment": {
-              "type": "string"
-            },
-            "symbol": {
-              "type": "string"
-            },
-            "gradient": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "status": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "error": {
-              "type": "string"
-            },
-            "success": {
-              "type": "string"
-            },
-            "warning": {
-              "type": "string"
-            }
-          }
-        },
-        "Background": {
-          "type": "string"
-        },
-        "Foreground": {
-          "type": "string"
-        },
-        "LightBlue": {
-          "type": "string"
-        },
-        "AccentBlue": {
-          "type": "string"
-        },
-        "AccentPurple": {
-          "type": "string"
-        },
-        "AccentCyan": {
-          "type": "string"
-        },
-        "AccentGreen": {
-          "type": "string"
-        },
-        "AccentYellow": {
-          "type": "string"
-        },
-        "AccentRed": {
-          "type": "string"
-        },
-        "DiffAdded": {
-          "type": "string"
-        },
-        "DiffRemoved": {
-          "type": "string"
-        },
-        "Comment": {
-          "type": "string"
-        },
-        "Gray": {
-          "type": "string"
-        },
-        "DarkGray": {
-          "type": "string"
-        },
-        "GradientColors": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "required": ["type", "name"]
-    },
-    "StringOrStringArray": {
-      "description": "Accepts either a single string or an array of strings.",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      ]
-    },
-    "BooleanOrString": {
-      "description": "Accepts either a boolean flag or a string command name.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "HookDefinitionArray": {
-      "type": "array",
-      "description": "Array of hook definition objects for a specific event.",
-      "items": {
-        "type": "object",
-        "description": "Hook definition specifying matcher pattern and hook configurations.",
-        "properties": {
-          "matcher": {
-            "type": "string",
-            "description": "Pattern to match against the event context (tool name, notification type, etc.). Supports exact match, regex (/pattern/), and wildcards (*)."
-          },
-          "hooks": {
-            "type": "array",
-            "description": "Hooks to execute when the matcher matches.",
-            "items": {
-              "type": "object",
-              "description": "Individual hook configuration.",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Unique identifier for the hook."
-                },
-                "type": {
-                  "type": "string",
-                  "description": "Type of hook (currently only \"command\" supported)."
-                },
-                "command": {
-                  "type": "string",
-                  "description": "Shell command to execute. Receives JSON input via stdin and returns JSON output via stdout."
-                },
-                "description": {
-                  "type": "string",
-                  "description": "A description of the hook."
-                },
-                "timeout": {
-                  "type": "number",
-                  "description": "Timeout in milliseconds for hook execution."
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type MCPServerConfig } from '@google/gemini-cli-core';
+
+export enum MergeStrategy {
+  REPLACE = 'replace',
+  UNION = 'union',
+  CONCAT = 'concat',
 }
+
+export type SettingType = 'boolean' | 'string' | 'number' | 'array' | 'object';
+
+export interface SettingEnumOption {
+  label: string;
+  value: string;
+}
+
+export interface SettingDefinition {
+  readonly type: SettingType | 'enum';
+  readonly label: string;
+  readonly category: string;
+  readonly requiresRestart: boolean;
+  readonly default: unknown;
+  readonly description: string;
+  readonly showInDialog: boolean;
+  readonly options?: readonly SettingEnumOption[];
+  readonly mergeStrategy?: MergeStrategy;
+  readonly properties?: SettingsSchema;
+  readonly additionalProperties?: boolean | SettingDefinition;
+  readonly ref?: string;
+}
+
+export type SettingsSchema = {
+  readonly [key: string]: SettingDefinition;
+};
+
+/**
+ * Global settings schema for Gemini CLI.
+ */
+export const SETTINGS_SCHEMA = {
+  general: {
+    type: 'object',
+    label: 'General',
+    category: 'General',
+    requiresRestart: false,
+    default: {},
+    description: 'General application settings.',
+    showInDialog: true,
+    properties: {
+      preferredEditor: {
+        type: 'string',
+        label: 'Preferred Editor',
+        category: 'General',
+        requiresRestart: false,
+        default: '',
+        description: 'The preferred editor to open files in.',
+        showInDialog: true,
+      },
+      vimMode: {
+        type: 'boolean',
+        label: 'Vim Mode',
+        category: 'General',
+        requiresRestart: false,
+        default: false,
+        description: 'Enable Vim keybindings',
+        showInDialog: true,
+      },
+      defaultApprovalMode: {
+        type: 'enum',
+        label: 'Default Approval Mode',
+        category: 'General',
+        requiresRestart: false,
+        default: 'default',
+        description:
+          "The default approval mode for tool execution. 'default' prompts for approval, 'auto_edit' auto-approves edit tools, and 'plan' is read-only mode. 'yolo' is not supported yet.",
+        showInDialog: true,
+        options: [
+          { label: 'Default (Prompt)', value: 'default' },
+          { label: 'Auto-approve Edits', value: 'auto_edit' },
+          { label: 'Plan (Read-only)', value: 'plan' },
+        ],
+      },
+      devtools: {
+        type: 'boolean',
+        label: 'DevTools',
+        category: 'General',
+        requiresRestart: false,
+        default: false,
+        description: 'Enable DevTools inspector on launch.',
+        showInDialog: true,
+      },
+      enableAutoUpdate: {
+        type: 'boolean',
+        label: 'Enable Auto Update',
+        category: 'General',
+        requiresRestart: false,
+        default: true,
+        description: 'Enable automatic updates.',
+        showInDialog: true,
+      },
+      enableAutoUpdateNotification: {
+        type: 'boolean',
+        label: 'Enable Auto Update Notification',
+        category: 'General',
+        requiresRestart: false,
+        default: true,
+        description: 'Enable update notification prompts.',
+        showInDialog: true,
+      },
+      enableNotifications: {
+        type: 'boolean',
+        label: 'Enable Notifications',
+        category: 'General',
+        requiresRestart: false,
+        default: false,
+        description:
+          'Enable run-event notifications for action-required prompts and session completion. Currently macOS only.',
+        showInDialog: true,
+      },
+      checkpointing: {
+        type: 'object',
+        label: 'Checkpointing',
+        category: 'General',
+        requiresRestart: true,
+        default: {},
+        description: 'Session checkpointing settings.',
+        showInDialog: true,
+        properties: {
+          enabled: {
+            type: 'boolean',
+            label: 'Enable Checkpointing',
+            category: 'General',
+            requiresRestart: true,
+            default: false,
+            description: 'Enable session checkpointing for recovery',
+            showInDialog: true,
+          },
+        },
+      },
+      plan: {
+        type: 'object',
+        label: 'Plan',
+        category: 'General',
+        requiresRestart: true,
+        default: {},
+        description: 'Planning features configuration.',
+        showInDialog: true,
+        properties: {
+          directory: {
+            type: 'string',
+            label: 'Plan Directory',
+            category: 'General',
+            requiresRestart: true,
+            default: '',
+            description:
+              'The directory where planning artifacts are stored. If not specified, defaults to the system temporary directory.',
+            showInDialog: true,
+          },
+          modelRouting: {
+            type: 'boolean',
+            label: 'Plan Model Routing',
+            category: 'General',
+            requiresRestart: false,
+            default: true,
+            description:
+              'Automatically switch between Pro and Flash models based on Plan Mode status. Uses Pro for the planning phase and Flash for the implementation phase.',
+            showInDialog: true,
+          },
+        },
+      },
+      retryFetchErrors: {
+        type: 'boolean',
+        label: 'Retry Fetch Errors',
+        category: 'General',
+        requiresRestart: false,
+        default: false,
+        description:
+          'Retry on "exception TypeError: fetch failed sending request" errors.',
+        showInDialog: true,
+      },
+      maxAttempts: {
+        type: 'number',
+        label: 'Max Chat Model Attempts',
+        category: 'General',
+        requiresRestart: false,
+        default: 10,
+        description:
+          'Maximum number of attempts for requests to the main chat model. Cannot exceed 10.',
+        showInDialog: true,
+      },
+      debugKeystrokeLogging: {
+        type: 'boolean',
+        label: 'Debug Keystroke Logging',
+        category: 'General',
+        requiresRestart: false,
+        default: false,
+        description: 'Enable debug logging of keystrokes to the console.',
+        showInDialog: true,
+      },
+      sessionRetention: {
+        type: 'object',
+        label: 'Session Retention',
+        category: 'General',
+        requiresRestart: false,
+        default: {},
+        description: 'Settings for automatic session cleanup.',
+        showInDialog: true,
+        properties: {
+          enabled: {
+            type: 'boolean',
+            label: 'Enable Session Cleanup',
+            category: 'General',
+            requiresRestart: false,
+            default: false,
+            description: 'Enable automatic session cleanup',
+            showInDialog: true,
+          },
+          maxAge: {
+            type: 'string',
+            label: 'Keep chat history',
+            category: 'General',
+            requiresRestart: false,
+            default: '',
+            description:
+              'Automatically delete chats older than this time period (e.g., "30d", "7d", "24h", "1w")',
+            showInDialog: true,
+          },
+          maxCount: {
+            type: 'number',
+            label: 'Max Session Count',
+            category: 'General',
+            requiresRestart: false,
+            default: 0,
+            description:
+              'Alternative: Maximum number of sessions to keep (most recent)',
+            showInDialog: true,
+          },
+          minRetention: {
+            type: 'string',
+            label: 'Min Retention Period',
+            category: 'General',
+            requiresRestart: false,
+            default: '1d',
+            description: 'Minimum retention period (safety limit, defaults to "1d")',
+            showInDialog: true,
+          },
+          warningAcknowledged: {
+            type: 'boolean',
+            label: 'Warning Acknowledged',
+            category: 'General',
+            requiresRestart: false,
+            default: false,
+            description:
+              'INTERNAL: Whether the user has acknowledged the session retention warning',
+            showInDialog: false,
+          },
+        },
+      },
+    },
+  },
+
+  output: {
+    type: 'object',
+    label: 'Output',
+    category: 'General',
+    requiresRestart: false,
+    default: {},
+    description: 'Settings for the CLI output.',
+    showInDialog: true,
+    properties: {
+      format: {
+        type: 'enum',
+        label: 'Output Format',
+        category: 'General',
+        requiresRestart: false,
+        default: 'text',
+        description: 'The format of the CLI output. Can be `text` or `json`.',
+        showInDialog: true,
+        options: [
+          { label: 'Text', value: 'text' },
+          { label: 'JSON', value: 'json' },
+        ],
+      },
+    },
+  },
+
+  ui: {
+    type: 'object',
+    label: 'UI',
+    category: 'UI',
+    requiresRestart: false,
+    default: {},
+    description: 'User interface settings.',
+    showInDialog: true,
+    properties: {
+      theme: {
+        type: 'string',
+        label: 'Theme',
+        category: 'UI',
+        requiresRestart: false,
+        default: '',
+        description:
+          'The color theme for the UI. See the CLI themes guide for available options.',
+        showInDialog: true,
+      },
+      autoThemeSwitching: {
+        type: 'boolean',
+        label: 'Auto Theme Switching',
+        category: 'UI',
+        requiresRestart: false,
+        default: true,
+        description:
+          'Automatically switch between default light and dark themes based on terminal background color.',
+        showInDialog: true,
+      },
+      terminalBackgroundPollingInterval: {
+        type: 'number',
+        label: 'Terminal Background Polling Interval',
+        category: 'UI',
+        requiresRestart: false,
+        default: 60,
+        description: 'Interval in seconds to poll the terminal background color.',
+        showInDialog: true,
+      },
+      customThemes: {
+        type: 'object',
+        label: 'Custom Themes',
+        category: 'UI',
+        requiresRestart: false,
+        default: {},
+        description: 'Custom theme definitions.',
+        showInDialog: false,
+        additionalProperties: {
+          type: 'object',
+          ref: 'CustomTheme',
+        },
+      },
+      hideWindowTitle: {
+        type: 'boolean',
+        label: 'Hide Window Title',
+        category: 'UI',
+        requiresRestart: true,
+        default: false,
+        description: 'Hide the window title bar',
+        showInDialog: true,
+      },
+      inlineThinkingMode: {
+        type: 'enum',
+        label: 'Inline Thinking',
+        category: 'UI',
+        requiresRestart: false,
+        default: 'off',
+        description: 'Display model thinking inline: off or full.',
+        showInDialog: true,
+        options: [
+          { label: 'Off', value: 'off' },
+          { label: 'Full', value: 'full' },
+        ],
+      },
+      showStatusInTitle: {
+        type: 'boolean',
+        label: 'Show Thoughts in Title',
+        category: 'UI',
+        requiresRestart: false,
+        default: false,
+        description:
+          'Show Gemini CLI model thoughts in the terminal window title during the working phase',
+        showInDialog: true,
+      },
+      dynamicWindowTitle: {
+        type: 'boolean',
+        label: 'Dynamic Window Title',
+        category: 'UI',
+        requiresRestart: false,
+        default: true,
+        description:
+          'Update the terminal window title with current status icons (Ready: ◇, Action Required: ✋, Working: ✦)',
+        showInDialog: true,
+      },
+      showHomeDirectoryWarning: {
+        type: 'boolean',
+        label: 'Show Home Directory Warning',
+        category: 'UI',
+        requiresRestart: true,
+        default: true,
+        description: 'Show a warning when running Gemini CLI in the home directory.',
+        showInDialog: true,
+      },
+      showCompatibilityWarnings: {
+        type: 'boolean',
+        label: 'Show Compatibility Warnings',
+        category: 'UI',
+        requiresRestart: true,
+        default: true,
+        description: 'Show warnings about terminal or OS compatibility issues.',
+        showInDialog: true,
+      },
+      hideTips: {
+        type: 'boolean',
+        label: 'Hide Tips',
+        category: 'UI',
+        requiresRestart: false,
+        default: false,
+        description: 'Hide helpful tips in the UI',
+        showInDialog: true,
+      },
+      showShortcutsHint: {
+        type: 'boolean',
+        label: 'Show Shortcuts Hint',
+        category: 'UI',
+        requiresRestart: false,
+        default: true,
+        description: 'Show the "? for shortcuts" hint above the input.',
+        showInDialog: true,
+      },
+      showKeyboardShortcutsHint: {
+        type: 'boolean',
+        label: 'Show Keyboard Shortcuts Hint',
+        category: 'UI',
+        requiresRestart: false,
+        default: true,
+        description:
+          'Show keyboard shortcut hints in the UI (e.g. "press Ctrl+O to expand").',
+        showInDialog: true,
+      },
+      compactToolOutputs: {
+        type: 'boolean',
+        label: 'Compact Tool Outputs',
+        category: 'UI',
+        requiresRestart: false,
+        default: true,
+        description:
+          'Whether to show tool outputs in a compact one-line summary by default.',
+        showInDialog: true,
+      },
+      hideBanner: {
+        type: 'boolean',
+        label: 'Hide Banner',
+        category: 'UI',
+        requiresRestart: false,
+        default: false,
+        description: 'Hide the application banner',
+        showInDialog: true,
+      },
+      hideContextSummary: {
+        type: 'boolean',
+        label: 'Hide Context Summary',
+        category: 'UI',
+        requiresRestart: false,
+        default: false,
+        description: 'Hide the context summary (GEMINI.md, MCP servers) above the input.',
+        showInDialog: true,
+      },
+      footer: {
+        type: 'object',
+        label: 'Footer',
+        category: 'UI',
+        requiresRestart: false,
+        default: {},
+        description: 'Settings for the footer.',
+        showInDialog: true,
+        properties: {
+          hideCWD: {
+            type: 'boolean',
+            label: 'Hide CWD',
+            category: 'UI',
+            requiresRestart: false,
+            default: false,
+            description: 'Hide the current working directory path in the footer.',
+            showInDialog: true,
+          },
+          hideSandboxStatus: {
+            type: 'boolean',
+            label: 'Hide Sandbox Status',
+            category: 'UI',
+            requiresRestart: false,
+            default: false,
+            description: 'Hide the sandbox status indicator in the footer.',
+            showInDialog: true,
+          },
+          hideModelInfo: {
+            type: 'boolean',
+            label: 'Hide Model Info',
+            category: 'UI',
+            requiresRestart: false,
+            default: false,
+            description: 'Hide the model name and context usage in the footer.',
+            showInDialog: true,
+          },
+          hideContextPercentage: {
+            type: 'boolean',
+            label: 'Hide Context Window Percentage',
+            category: 'UI',
+            requiresRestart: false,
+            default: true,
+            description: 'Hides the context window remaining percentage.',
+            showInDialog: true,
+          },
+        },
+      },
+      hideFooter: {
+        type: 'boolean',
+        label: 'Hide Footer',
+        category: 'UI',
+        requiresRestart: false,
+        default: false,
+        description: 'Hide the footer from the UI',
+        showInDialog: true,
+      },
+      showMemoryUsage: {
+        type: 'boolean',
+        label: 'Show Memory Usage',
+        category: 'UI',
+        requiresRestart: false,
+        default: false,
+        description: 'Display memory usage information in the UI',
+        showInDialog: true,
+      },
+      showLineNumbers: {
+        type: 'boolean',
+        label: 'Show Line Numbers',
+        category: 'UI',
+        requiresRestart: false,
+        default: true,
+        description: 'Show line numbers in the chat.',
+        showInDialog: true,
+      },
+      showCitations: {
+        type: 'boolean',
+        label: 'Show Citations',
+        category: 'UI',
+        requiresRestart: false,
+        default: false,
+        description: 'Show citations for generated text in the chat.',
+        showInDialog: true,
+      },
+      showModelInfoInChat: {
+        type: 'boolean',
+        label: 'Show Model Info In Chat',
+        category: 'UI',
+        requiresRestart: false,
+        default: false,
+        description: 'Show the model name in the chat for each model turn.',
+        showInDialog: true,
+      },
+      showUserIdentity: {
+        type: 'boolean',
+        label: 'Show User Identity',
+        category: 'UI',
+        requiresRestart: false,
+        default: true,
+        description: "Show the logged-in user's identity (e.g. email) in the UI.",
+        showInDialog: true,
+      },
+      useAlternateBuffer: {
+        type: 'boolean',
+        label: 'Use Alternate Screen Buffer',
+        category: 'UI',
+        requiresRestart: true,
+        default: false,
+        description: 'Use an alternate screen buffer for the UI, preserving shell history.',
+        showInDialog: true,
+      },
+      useBackgroundColor: {
+        type: 'boolean',
+        label: 'Use Background Color',
+        category: 'UI',
+        requiresRestart: false,
+        default: true,
+        description: 'Whether to use background colors in the UI.',
+        showInDialog: true,
+      },
+      incrementalRendering: {
+        type: 'boolean',
+        label: 'Incremental Rendering',
+        category: 'UI',
+        requiresRestart: true,
+        default: true,
+        description:
+          'Enable incremental rendering for the UI. This option will reduce flickering but may cause rendering artifacts. Only supported when useAlternateBuffer is enabled.',
+        showInDialog: true,
+      },
+      showSpinner: {
+        type: 'boolean',
+        label: 'Show Spinner',
+        category: 'UI',
+        requiresRestart: false,
+        default: true,
+        description: 'Show the spinner during operations.',
+        showInDialog: true,
+      },
+      loadingPhrases: {
+        type: 'enum',
+        label: 'Loading Phrases',
+        category: 'UI',
+        requiresRestart: false,
+        default: 'tips',
+        description:
+          'What to show while the model is working: tips, witty comments, both, or nothing.',
+        showInDialog: true,
+        options: [
+          { label: 'Tips', value: 'tips' },
+          { label: 'Witty comments', value: 'witty' },
+          { label: 'Both', value: 'all' },
+          { label: 'Nothing', value: 'off' },
+        ],
+      },
+      errorVerbosity: {
+        type: 'enum',
+        label: 'Error Verbosity',
+        category: 'UI',
+        requiresRestart: false,
+        default: 'low',
+        description:
+          'Controls whether recoverable errors are hidden (low) or fully shown (full).',
+        showInDialog: true,
+        options: [
+          { label: 'Low (Hidden)', value: 'low' },
+          { label: 'Full', value: 'full' },
+        ],
+      },
+      customWittyPhrases: {
+        type: 'array',
+        label: 'Custom Witty Phrases',
+        category: 'UI',
+        requiresRestart: false,
+        default: [],
+        description:
+          'Custom witty phrases to display during loading. When provided, the CLI cycles through these instead of the defaults.',
+        showInDialog: true,
+        items: {
+          type: 'string',
+        },
+      },
+      accessibility: {
+        type: 'object',
+        label: 'Accessibility',
+        category: 'UI',
+        requiresRestart: true,
+        default: {},
+        description: 'Accessibility settings.',
+        showInDialog: true,
+        properties: {
+          enableLoadingPhrases: {
+            type: 'boolean',
+            label: 'Enable Loading Phrases',
+            category: 'UI',
+            requiresRestart: true,
+            default: true,
+            description: '@deprecated Use ui.loadingPhrases instead. Enable loading phrases during operations.',
+            showInDialog: true,
+          },
+          screenReader: {
+            type: 'boolean',
+            label: 'Screen Reader Mode',
+            category: 'UI',
+            requiresRestart: true,
+            default: false,
+            description: 'Render output in plain-text to be more screen reader accessible',
+            showInDialog: true,
+          },
+        },
+      },
+    },
+  },
+
+  ide: {
+    type: 'object',
+    label: 'IDE',
+    category: 'IDE',
+    requiresRestart: true,
+    default: {},
+    description: 'IDE integration settings.',
+    showInDialog: true,
+    properties: {
+      enabled: {
+        type: 'boolean',
+        label: 'IDE Mode',
+        category: 'IDE',
+        requiresRestart: true,
+        default: false,
+        description: 'Enable IDE integration mode.',
+        showInDialog: true,
+      },
+      hasSeenNudge: {
+        type: 'boolean',
+        label: 'Has Seen IDE Integration Nudge',
+        category: 'IDE',
+        requiresRestart: false,
+        default: false,
+        description: 'Whether the user has seen the IDE integration nudge.',
+        showInDialog: false,
+      },
+    },
+  },
+
+  privacy: {
+    type: 'object',
+    label: 'Privacy',
+    category: 'Privacy',
+    requiresRestart: true,
+    default: {},
+    description: 'Privacy-related settings.',
+    showInDialog: true,
+    properties: {
+      usageStatisticsEnabled: {
+        type: 'boolean',
+        label: 'Enable Usage Statistics',
+        category: 'Privacy',
+        requiresRestart: true,
+        default: true,
+        description: 'Enable collection of usage statistics',
+        showInDialog: true,
+      },
+    },
+  },
+
+  telemetry: {
+    type: 'object',
+    label: 'Telemetry',
+    category: 'Advanced',
+    requiresRestart: true,
+    default: {
+      enabled: false,
+      target: 'stderr',
+      otlpProtocol: 'grpc',
+      logPrompts: false,
+      useCollector: false,
+      useCliAuth: false,
+    },
+    description: 'Telemetry configuration.',
+    showInDialog: true,
+    ref: 'TelemetrySettings',
+  },
+
+  billing: {
+    type: 'object',
+    label: 'Billing',
+    category: 'Advanced',
+    requiresRestart: false,
+    default: {},
+    description: 'Billing and AI credits settings.',
+    showInDialog: true,
+    properties: {
+      overageStrategy: {
+        type: 'enum',
+        label: 'Overage Strategy',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: 'ask',
+        description:
+          "How to handle quota exhaustion when AI credits are available. 'ask' prompts each time, 'always' automatically uses credits, 'never' disables credit usage.",
+        showInDialog: true,
+        options: [
+          { label: 'Always Prompt', value: 'ask' },
+          { label: 'Always Use Credits', value: 'always' },
+          { label: 'Never Use Credits', value: 'never' },
+        ],
+      },
+    },
+  },
+
+  model: {
+    type: 'object',
+    label: 'Model',
+    category: 'Model',
+    requiresRestart: false,
+    default: {},
+    description: 'Settings related to the generative model.',
+    showInDialog: true,
+    properties: {
+      name: {
+        type: 'string',
+        label: 'Model',
+        category: 'Model',
+        requiresRestart: false,
+        default: '',
+        description: 'The Gemini model to use for conversations.',
+        showInDialog: true,
+      },
+      maxSessionTurns: {
+        type: 'number',
+        label: 'Max Session Turns',
+        category: 'Model',
+        requiresRestart: false,
+        default: -1,
+        description:
+          'Maximum number of user/model/tool turns to keep in a session. -1 means unlimited.',
+        showInDialog: true,
+      },
+      summarizeToolOutput: {
+        type: 'object',
+        label: 'Summarize Tool Output',
+        category: 'Model',
+        requiresRestart: false,
+        default: {},
+        description:
+          'Enables or disables summarization of tool output. Configure per-tool token budgets (for example {"run_shell_command": {"tokenBudget": 2000}}). Currently only the run_shell_command tool supports summarization.',
+        showInDialog: true,
+        additionalProperties: {
+          type: 'object',
+          ref: 'SummarizeToolOutputSettings',
+        },
+      },
+      compressionThreshold: {
+        type: 'number',
+        label: 'Compression Threshold',
+        category: 'Model',
+        requiresRestart: true,
+        default: 0.5,
+        description:
+          'The fraction of context usage at which to trigger context compression (e.g. 0.2, 0.3).',
+        showInDialog: true,
+      },
+      disableLoopDetection: {
+        type: 'boolean',
+        label: 'Disable Loop Detection',
+        category: 'Model',
+        requiresRestart: true,
+        default: false,
+        description: 'Disable automatic detection and prevention of infinite loops.',
+        showInDialog: true,
+      },
+      skipNextSpeakerCheck: {
+        type: 'boolean',
+        label: 'Skip Next Speaker Check',
+        category: 'Model',
+        requiresRestart: false,
+        default: true,
+        description: 'Skip the next speaker check.',
+        showInDialog: true,
+      },
+    },
+  },
+
+  modelConfigs: {
+    type: 'object',
+    label: 'Model Configs',
+    category: 'Model',
+    requiresRestart: false,
+    default: {},
+    description: 'Model configurations.',
+    showInDialog: true,
+    properties: {
+      aliases: {
+        type: 'object',
+        label: 'Model Config Aliases',
+        category: 'Model',
+        requiresRestart: false,
+        default: {},
+        description:
+          'Named presets for model configs. Can be used in place of a model name and can inherit from other aliases using an `extends` property.',
+        showInDialog: false,
+        additionalProperties: true,
+      },
+      customAliases: {
+        type: 'object',
+        label: 'Custom Model Config Aliases',
+        category: 'Model',
+        requiresRestart: false,
+        default: {},
+        description:
+          'Custom named presets for model configs. These are merged with (and override) the built-in aliases.',
+        showInDialog: true,
+        additionalProperties: true,
+      },
+      customOverrides: {
+        type: 'array',
+        label: 'Custom Model Config Overrides',
+        category: 'Model',
+        requiresRestart: false,
+        default: [],
+        description:
+          'Custom model config overrides. These are merged with (and added to) the built-in overrides.',
+        showInDialog: true,
+        items: {},
+      },
+      overrides: {
+        type: 'array',
+        label: 'Model Config Overrides',
+        category: 'Model',
+        requiresRestart: false,
+        default: [],
+        description:
+          'Apply specific configuration overrides based on matches, with a primary key of model (or alias). The most specific match will be used.',
+        showInDialog: false,
+        items: {},
+      },
+    },
+  },
+
+  agents: {
+    type: 'object',
+    label: 'Agents',
+    category: 'Advanced',
+    requiresRestart: true,
+    default: {},
+    description: 'Settings for subagents.',
+    showInDialog: true,
+    properties: {
+      overrides: {
+        type: 'object',
+        label: 'Agent Overrides',
+        category: 'Advanced',
+        requiresRestart: true,
+        default: {},
+        description:
+          'Override settings for specific agents, e.g. to disable the agent, set a custom model config, or run config.',
+        showInDialog: true,
+        additionalProperties: {
+          type: 'object',
+          ref: 'AgentOverride',
+        },
+      },
+      browser: {
+        type: 'object',
+        label: 'Browser Agent',
+        category: 'Advanced',
+        requiresRestart: true,
+        default: {},
+        description: 'Settings specific to the browser agent.',
+        showInDialog: true,
+        properties: {
+          sessionMode: {
+            type: 'enum',
+            label: 'Browser Session Mode',
+            category: 'Advanced',
+            requiresRestart: true,
+            default: 'persistent',
+            description: "Session mode: 'persistent', 'isolated', or 'existing'.",
+            showInDialog: true,
+            options: [
+              { label: 'Persistent', value: 'persistent' },
+              { label: 'Isolated', value: 'isolated' },
+              { label: 'Existing', value: 'existing' },
+            ],
+          },
+          headless: {
+            type: 'boolean',
+            label: 'Browser Headless',
+            category: 'Advanced',
+            requiresRestart: true,
+            default: false,
+            description: 'Run browser in headless mode.',
+            showInDialog: true,
+          },
+          profilePath: {
+            type: 'string',
+            label: 'Browser Profile Path',
+            category: 'Advanced',
+            requiresRestart: true,
+            default: '',
+            description: 'Path to browser profile directory for session persistence.',
+            showInDialog: true,
+          },
+          visualModel: {
+            type: 'string',
+            label: 'Browser Visual Model',
+            category: 'Advanced',
+            requiresRestart: true,
+            default: '',
+            description: 'Model override for the visual agent.',
+            showInDialog: true,
+          },
+        },
+      },
+    },
+  },
+
+  context: {
+    type: 'object',
+    label: 'Context',
+    category: 'Context',
+    requiresRestart: false,
+    default: {},
+    description: 'Settings for managing context provided to the model.',
+    showInDialog: true,
+    properties: {
+      fileName: {
+        type: 'string', // Overridden by StringOrStringArray
+        label: 'Context File Name',
+        category: 'Context',
+        requiresRestart: false,
+        default: '',
+        description:
+          'The name of the context file or files to load into memory. Accepts either a single string or an array of strings.',
+        showInDialog: true,
+        ref: 'StringOrStringArray',
+      },
+      importFormat: {
+        type: 'string',
+        label: 'Memory Import Format',
+        category: 'Context',
+        requiresRestart: false,
+        default: '',
+        description: 'The format to use when importing memory.',
+        showInDialog: true,
+      },
+      includeDirectoryTree: {
+        type: 'boolean',
+        label: 'Include Directory Tree',
+        category: 'Context',
+        requiresRestart: false,
+        default: true,
+        description:
+          'Whether to include the directory tree of the current working directory in the initial request to the model.',
+        showInDialog: true,
+      },
+      discoveryMaxDirs: {
+        type: 'number',
+        label: 'Memory Discovery Max Dirs',
+        category: 'Context',
+        requiresRestart: false,
+        default: 200,
+        description: 'Maximum number of directories to search for memory.',
+        showInDialog: true,
+      },
+      includeDirectories: {
+        type: 'array',
+        label: 'Include Directories',
+        category: 'Context',
+        requiresRestart: false,
+        default: [],
+        description:
+          'Additional directories to include in the workspace context. Missing directories will be skipped with a warning.',
+        showInDialog: true,
+        items: {
+          type: 'string',
+        },
+      },
+      loadMemoryFromIncludeDirectories: {
+        type: 'boolean',
+        label: 'Load Memory From Include Directories',
+        category: 'Context',
+        requiresRestart: false,
+        default: false,
+        description:
+          'Controls how /memory refresh loads GEMINI.md files. When true, include directories are scanned; when false, only the current directory is used.',
+        showInDialog: true,
+      },
+      fileFiltering: {
+        type: 'object',
+        label: 'File Filtering',
+        category: 'Context',
+        requiresRestart: true,
+        default: {},
+        description: 'Settings for git-aware file filtering.',
+        showInDialog: true,
+        properties: {
+          respectGitIgnore: {
+            type: 'boolean',
+            label: 'Respect .gitignore',
+            category: 'Context',
+            requiresRestart: true,
+            default: true,
+            description: 'Respect .gitignore files when searching.',
+            showInDialog: true,
+          },
+          respectGeminiIgnore: {
+            type: 'boolean',
+            label: 'Respect .geminiignore',
+            category: 'Context',
+            requiresRestart: true,
+            default: true,
+            description: 'Respect .geminiignore files when searching.',
+            showInDialog: true,
+          },
+          enableRecursiveFileSearch: {
+            type: 'boolean',
+            label: 'Enable Recursive File Search',
+            category: 'Context',
+            requiresRestart: true,
+            default: true,
+            description:
+              'Enable recursive file search functionality when completing @ references in the prompt.',
+            showInDialog: true,
+          },
+          enableFuzzySearch: {
+            type: 'boolean',
+            label: 'Enable Fuzzy Search',
+            category: 'Context',
+            requiresRestart: true,
+            default: true,
+            description: 'Enable fuzzy search when searching for files.',
+            showInDialog: true,
+          },
+          customIgnoreFilePaths: {
+            type: 'array',
+            label: 'Custom Ignore File Paths',
+            category: 'Context',
+            requiresRestart: true,
+            default: [],
+            description:
+              'Additional ignore file paths to respect. These files take precedence over .geminiignore and .gitignore. Files earlier in the array take precedence over files later in the array, e.g. the first file takes precedence over the second one.',
+            showInDialog: true,
+            items: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+  },
+
+  tools: {
+    type: 'object',
+    label: 'Tools',
+    category: 'Tools',
+    requiresRestart: true,
+    default: {},
+    description: 'Settings for built-in and custom tools.',
+    showInDialog: true,
+    properties: {
+      sandbox: {
+        type: 'boolean', // Overridden by BooleanOrString
+        label: 'Sandbox',
+        category: 'Tools',
+        requiresRestart: true,
+        default: false,
+        description:
+          'Sandbox execution environment. Set to a boolean to enable or disable the sandbox, or provide a string path to a sandbox profile.',
+        showInDialog: true,
+        ref: 'BooleanOrString',
+      },
+      shell: {
+        type: 'object',
+        label: 'Shell',
+        category: 'Tools',
+        requiresRestart: false,
+        default: {},
+        description: 'Settings for shell execution.',
+        showInDialog: true,
+        properties: {
+          enableInteractiveShell: {
+            type: 'boolean',
+            label: 'Enable Interactive Shell',
+            category: 'Tools',
+            requiresRestart: true,
+            default: true,
+            description:
+              'Use node-pty for an interactive shell experience. Fallback to child_process still applies.',
+            showInDialog: true,
+          },
+          pager: {
+            type: 'string',
+            label: 'Pager',
+            category: 'Tools',
+            requiresRestart: false,
+            default: 'cat',
+            description: 'The pager command to use for shell output. Defaults to `cat`.',
+            showInDialog: true,
+          },
+          showColor: {
+            type: 'boolean',
+            label: 'Show Color',
+            category: 'Tools',
+            requiresRestart: false,
+            default: false,
+            description: 'Show color in shell output.',
+            showInDialog: true,
+          },
+          inactivityTimeout: {
+            type: 'number',
+            label: 'Inactivity Timeout',
+            category: 'Tools',
+            requiresRestart: false,
+            default: 300,
+            description:
+              'The maximum time in seconds allowed without output from the shell command. Defaults to 5 minutes.',
+            showInDialog: true,
+          },
+          enableShellOutputEfficiency: {
+            type: 'boolean',
+            label: 'Enable Shell Output Efficiency',
+            category: 'Tools',
+            requiresRestart: false,
+            default: true,
+            description:
+              'Enable shell output efficiency optimizations for better performance.',
+            showInDialog: true,
+          },
+        },
+      },
+      core: {
+        type: 'array',
+        label: 'Core Tools',
+        category: 'Tools',
+        requiresRestart: true,
+        default: [],
+        description:
+          'Restrict the set of built-in tools with an allowlist. Match semantics mirror tools.allowed; see the built-in tools documentation for available names.',
+        showInDialog: true,
+        items: {
+          type: 'string',
+        },
+      },
+      allowed: {
+        type: 'array',
+        label: 'Allowed Tools',
+        category: 'Advanced',
+        requiresRestart: true,
+        default: [],
+        description:
+          'Tool names that bypass the confirmation dialog. Useful for trusted commands (for example ["run_shell_command(git)", "run_shell_command(npm test)"]). See shell tool command restrictions for matching details.',
+        showInDialog: true,
+        items: {
+          type: 'string',
+        },
+      },
+      exclude: {
+        type: 'array',
+        label: 'Exclude Tools',
+        category: 'Tools',
+        requiresRestart: true,
+        default: [],
+        description: 'Tool names to exclude from discovery.',
+        showInDialog: true,
+        items: {
+          type: 'string',
+        },
+      },
+      discoveryCommand: {
+        type: 'string',
+        label: 'Tool Discovery Command',
+        category: 'Tools',
+        requiresRestart: true,
+        default: '',
+        description: 'Command to run for tool discovery.',
+        showInDialog: true,
+      },
+      callCommand: {
+        type: 'string',
+        label: 'Tool Call Command',
+        category: 'Tools',
+        requiresRestart: true,
+        default: '',
+        description:
+          'Defines a custom shell command for invoking discovered tools. The command must take the tool name as the first argument, read JSON arguments from stdin, and emit JSON results on stdout.',
+        showInDialog: true,
+      },
+      useRipgrep: {
+        type: 'boolean',
+        label: 'Use Ripgrep',
+        category: 'Tools',
+        requiresRestart: false,
+        default: true,
+        description:
+          'Use ripgrep for file content search instead of the fallback implementation. Provides faster search performance.',
+        showInDialog: true,
+      },
+      truncateToolOutputThreshold: {
+        type: 'number',
+        label: 'Tool Output Truncation Threshold',
+        category: 'General',
+        requiresRestart: true,
+        default: 40000,
+        description:
+          'Maximum characters to show when truncating large tool outputs. Set to 0 or negative to disable truncation.',
+        showInDialog: true,
+      },
+      disableLLMCorrection: {
+        type: 'boolean',
+        label: 'Disable LLM Correction',
+        category: 'Tools',
+        requiresRestart: true,
+        default: true,
+        description:
+          'Disable LLM-based error correction for edit tools. When enabled, tools will fail immediately if exact string matches are not found, instead of attempting to self-correct.',
+        showInDialog: true,
+      },
+    },
+  },
+
+  mcp: {
+    type: 'object',
+    label: 'MCP',
+    category: 'MCP',
+    requiresRestart: true,
+    default: {},
+    description: 'Settings for Model Context Protocol (MCP) servers.',
+    showInDialog: true,
+    properties: {
+      serverCommand: {
+        type: 'string',
+        label: 'MCP Server Command',
+        category: 'MCP',
+        requiresRestart: true,
+        default: '',
+        description: 'Command to start an MCP server.',
+        showInDialog: true,
+      },
+      allowed: {
+        type: 'array',
+        label: 'Allow MCP Servers',
+        category: 'MCP',
+        requiresRestart: true,
+        default: [],
+        description: 'A list of MCP servers to allow.',
+        showInDialog: true,
+        items: {
+          type: 'string',
+        },
+      },
+      excluded: {
+        type: 'array',
+        label: 'Exclude MCP Servers',
+        category: 'MCP',
+        requiresRestart: true,
+        default: [],
+        description: 'A list of MCP servers to exclude.',
+        showInDialog: true,
+        items: {
+          type: 'string',
+        },
+      },
+    },
+  },
+
+  useWriteTodos: {
+    type: 'boolean',
+    label: 'Use WriteTodos',
+    category: 'Advanced',
+    requiresRestart: false,
+    default: true,
+    description: 'Enable the write_todos tool.',
+    showInDialog: true,
+  },
+
+  security: {
+    type: 'object',
+    label: 'Security',
+    category: 'Security',
+    requiresRestart: true,
+    default: {},
+    description: 'Security-related settings.',
+    showInDialog: true,
+    properties: {
+      disableYoloMode: {
+        type: 'boolean',
+        label: 'Disable YOLO Mode',
+        category: 'Security',
+        requiresRestart: true,
+        default: false,
+        description: 'Disable YOLO mode, even if enabled by a flag.',
+        showInDialog: true,
+      },
+      enablePermanentToolApproval: {
+        type: 'boolean',
+        label: 'Allow Permanent Tool Approval',
+        category: 'Security',
+        requiresRestart: false,
+        default: false,
+        description:
+          'Enable the "Allow for all future sessions" option in tool confirmation dialogs.',
+        showInDialog: true,
+      },
+      blockGitExtensions: {
+        type: 'boolean',
+        label: 'Blocks extensions from Git',
+        category: 'Security',
+        requiresRestart: true,
+        default: false,
+        description: 'Blocks installing and loading extensions from Git.',
+        showInDialog: true,
+      },
+      allowedExtensions: {
+        type: 'array',
+        label: 'Extension Source Regex Allowlist',
+        category: 'Security',
+        requiresRestart: true,
+        default: [],
+        description:
+          'List of Regex patterns for allowed extensions. If nonempty, only extensions that match the patterns in this list are allowed. Overrides the blockGitExtensions setting.',
+        showInDialog: true,
+        items: {
+          type: 'string',
+        },
+      },
+      folderTrust: {
+        type: 'object',
+        label: 'Folder Trust',
+        category: 'Security',
+        requiresRestart: false,
+        default: {},
+        description: 'Settings for folder trust.',
+        showInDialog: true,
+        properties: {
+          enabled: {
+            type: 'boolean',
+            label: 'Folder Trust',
+            category: 'Security',
+            requiresRestart: true,
+            default: true,
+            description: 'Setting to track whether Folder trust is enabled.',
+            showInDialog: true,
+          },
+        },
+      },
+      environmentVariableRedaction: {
+        type: 'object',
+        label: 'Environment Variable Redaction',
+        category: 'Security',
+        requiresRestart: false,
+        default: {},
+        description: 'Settings for environment variable redaction.',
+        showInDialog: true,
+        properties: {
+          allowed: {
+            type: 'array',
+            label: 'Allowed Environment Variables',
+            category: 'Security',
+            requiresRestart: true,
+            default: [],
+            description: 'Environment variables to always allow (bypass redaction).',
+            showInDialog: true,
+            items: {
+              type: 'string',
+            },
+          },
+          blocked: {
+            type: 'array',
+            label: 'Blocked Environment Variables',
+            category: 'Security',
+            requiresRestart: true,
+            default: [],
+            description: 'Environment variables to always redact.',
+            showInDialog: true,
+            items: {
+              type: 'string',
+            },
+          },
+          enabled: {
+            type: 'boolean',
+            label: 'Enable Environment Variable Redaction',
+            category: 'Security',
+            requiresRestart: true,
+            default: false,
+            description:
+              'Enable redaction of environment variables that may contain secrets.',
+            showInDialog: true,
+          },
+        },
+      },
+      auth: {
+        type: 'object',
+        label: 'Authentication',
+        category: 'Security',
+        requiresRestart: true,
+        default: {},
+        description: 'Authentication settings.',
+        showInDialog: true,
+        properties: {
+          selectedType: {
+            type: 'string',
+            label: 'Selected Auth Type',
+            category: 'Security',
+            requiresRestart: true,
+            default: '',
+            description: 'The currently selected authentication type.',
+            showInDialog: false,
+          },
+          enforcedType: {
+            type: 'string',
+            label: 'Enforced Auth Type',
+            category: 'Advanced',
+            requiresRestart: true,
+            default: '',
+            description:
+              'The required auth type. If this does not match the selected auth type, the user will be prompted to re-authenticate.',
+            showInDialog: false,
+          },
+          useExternal: {
+            type: 'boolean',
+            label: 'Use External Auth',
+            category: 'Security',
+            requiresRestart: true,
+            default: false,
+            description: 'Whether to use an external authentication flow.',
+            showInDialog: true,
+          },
+        },
+      },
+      enableConseca: {
+        type: 'boolean',
+        label: 'Enable Context-Aware Security',
+        category: 'Security',
+        requiresRestart: true,
+        default: false,
+        description:
+          'Enable the context-aware security checker. This feature uses an LLM to dynamically generate and enforce security policies for tool use based on your prompt, providing an additional layer of protection against unintended actions.',
+        showInDialog: true,
+      },
+    },
+  },
+
+  advanced: {
+    type: 'object',
+    label: 'Advanced',
+    category: 'Advanced',
+    requiresRestart: true,
+    default: {},
+    description: 'Advanced settings for power users.',
+    showInDialog: true,
+    properties: {
+      autoConfigureMemory: {
+        type: 'boolean',
+        label: 'Auto Configure Max Old Space Size',
+        category: 'Advanced',
+        requiresRestart: true,
+        default: false,
+        description: 'Automatically configure Node.js memory limits',
+        showInDialog: true,
+      },
+      dnsResolutionOrder: {
+        type: 'string',
+        label: 'DNS Resolution Order',
+        category: 'Advanced',
+        requiresRestart: true,
+        default: '',
+        description: 'The DNS resolution order.',
+        showInDialog: true,
+      },
+      excludedEnvVars: {
+        type: 'array',
+        label: 'Excluded Project Environment Variables',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: ['DEBUG', 'DEBUG_MODE'],
+        description: 'Environment variables to exclude from project context.',
+        showInDialog: true,
+        items: {
+          type: 'string',
+        },
+      },
+      bugCommand: {
+        type: 'object',
+        label: 'Bug Command',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: {
+          urlTemplate: '',
+        },
+        description: 'Configuration for the bug report command.',
+        showInDialog: true,
+        ref: 'BugCommandSettings',
+      },
+    },
+  },
+
+  experimental: {
+    type: 'object',
+    label: 'Experimental',
+    category: 'Experimental',
+    requiresRestart: true,
+    default: {},
+    description: 'Setting to enable experimental features',
+    showInDialog: true,
+    properties: {
+      toolOutputMasking: {
+        type: 'object',
+        label: 'Tool Output Masking',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: {},
+        description:
+          'Advanced settings for tool output masking to manage context window efficiency.',
+        showInDialog: true,
+        properties: {
+          enabled: {
+            type: 'boolean',
+            label: 'Enable Tool Output Masking',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: true,
+            description: 'Enables tool output masking to save tokens.',
+            showInDialog: true,
+          },
+          toolProtectionThreshold: {
+            type: 'number',
+            label: 'Tool Protection Threshold',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: 50000,
+            description:
+              'Minimum number of tokens to protect from masking (most recent tool outputs).',
+            showInDialog: true,
+          },
+          minPrunableTokensThreshold: {
+            type: 'number',
+            label: 'Min Prunable Tokens Threshold',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: 30000,
+            description:
+              'Minimum prunable tokens required to trigger a masking pass.',
+            showInDialog: true,
+          },
+          protectLatestTurn: {
+            type: 'boolean',
+            label: 'Protect Latest Turn',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: true,
+            description:
+              'Ensures the absolute latest turn is never masked, regardless of token count.',
+            showInDialog: true,
+          },
+        },
+      },
+      enableAgents: {
+        type: 'boolean',
+        label: 'Enable Agents',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: false,
+        description:
+          'Enable local and remote subagents. Warning: Experimental feature, uses YOLO mode for subagents',
+        showInDialog: true,
+      },
+      extensionManagement: {
+        type: 'boolean',
+        label: 'Extension Management',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: true,
+        description: 'Enable extension management features.',
+        showInDialog: true,
+      },
+      extensionConfig: {
+        type: 'boolean',
+        label: 'Extension Configuration',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: true,
+        description: 'Enable requesting and fetching of extension settings.',
+        showInDialog: true,
+      },
+      extensionRegistry: {
+        type: 'boolean',
+        label: 'Extension Registry Explore UI',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: false,
+        description: 'Enable extension registry explore UI.',
+        showInDialog: true,
+      },
+      extensionReloading: {
+        type: 'boolean',
+        label: 'Extension Reloading',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: false,
+        description: 'Enables extension loading/unloading within the CLI session.',
+        showInDialog: true,
+      },
+      jitContext: {
+        type: 'boolean',
+        label: 'JIT Context Loading',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: false,
+        description: 'Enable Just-In-Time (JIT) context loading.',
+        showInDialog: true,
+      },
+      useOSC52Paste: {
+        type: 'boolean',
+        label: 'Use OSC 52 Paste',
+        category: 'Experimental',
+        requiresRestart: false,
+        default: false,
+        description:
+          'Use OSC 52 for pasting. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it).',
+        showInDialog: true,
+      },
+      useOSC52Copy: {
+        type: 'boolean',
+        label: 'Use OSC 52 Copy',
+        category: 'Experimental',
+        requiresRestart: false,
+        default: false,
+        description:
+          'Use OSC 52 for copying. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it).',
+        showInDialog: true,
+      },
+      plan: {
+        type: 'boolean',
+        label: 'Plan',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: false,
+        description: 'Enable planning features (Plan Mode and tools).',
+        showInDialog: true,
+      },
+      modelSteering: {
+        type: 'boolean',
+        label: 'Model Steering',
+        category: 'Experimental',
+        requiresRestart: false,
+        default: false,
+        description:
+          'Enable model steering (user hints) to guide the model during tool execution.',
+        showInDialog: true,
+      },
+      directWebFetch: {
+        type: 'boolean', // Overridden by BooleanOrString
+        label: 'Direct Web Fetch',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: false,
+        description: 'Enable web fetch behavior that bypasses LLM summarization.',
+        showInDialog: true,
+      },
+      gemmaModelRouter: {
+        type: 'object',
+        label: 'Gemma Model Router',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: {},
+        description: 'Enable Gemma model router (experimental).',
+        showInDialog: true,
+        properties: {
+          enabled: {
+            type: 'boolean',
+            label: 'Enable Gemma Model Router',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: false,
+            description:
+              'Enable the Gemma Model Router. Requires a local endpoint serving Gemma via the Gemini API using LiteRT-LM shim.',
+            showInDialog: true,
+          },
+          classifier: {
+            type: 'object',
+            label: 'Classifier',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: {},
+            description: 'Classifier configuration.',
+            showInDialog: true,
+            properties: {
+              host: {
+                type: 'string',
+                label: 'Host',
+                category: 'Experimental',
+                requiresRestart: true,
+                default: 'http://localhost:9379',
+                description: 'The host of the classifier.',
+                showInDialog: true,
+              },
+              model: {
+                type: 'string',
+                label: 'Model',
+                category: 'Experimental',
+                requiresRestart: true,
+                default: 'gemma3-1b-gpu-custom',
+                description:
+                  'The model to use for the classifier. Only tested on `gemma3-1b-gpu-custom`.',
+                showInDialog: true,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  extensions: {
+    type: 'object',
+    label: 'Extensions',
+    category: 'Extensions',
+    requiresRestart: true,
+    default: {},
+    description: 'Settings for extensions.',
+    showInDialog: true,
+    properties: {
+      disabled: {
+        type: 'array',
+        label: 'Disabled Extensions',
+        category: 'Extensions',
+        requiresRestart: true,
+        default: [],
+        description: 'List of disabled extensions.',
+        showInDialog: true,
+        items: {
+          type: 'string',
+        },
+      },
+      workspacesWithMigrationNudge: {
+        type: 'array',
+        label: 'Workspaces with Migration Nudge',
+        category: 'Extensions',
+        requiresRestart: false,
+        default: [],
+        description:
+          'List of workspaces for which the migration nudge has been shown.',
+        showInDialog: false,
+        items: {
+          type: 'string',
+        },
+      },
+    },
+  },
+
+  skills: {
+    type: 'object',
+    label: 'Skills',
+    category: 'Advanced',
+    requiresRestart: true,
+    default: {},
+    description: 'Settings for agent skills.',
+    showInDialog: true,
+    properties: {
+      enabled: {
+        type: 'boolean',
+        label: 'Enable Agent Skills',
+        category: 'Advanced',
+        requiresRestart: true,
+        default: true,
+        description: 'Enable Agent Skills.',
+        showInDialog: true,
+      },
+      disabled: {
+        type: 'array',
+        label: 'Disabled Skills',
+        category: 'Advanced',
+        requiresRestart: true,
+        default: [],
+        description: 'List of disabled skills.',
+        showInDialog: true,
+        items: {
+          type: 'string',
+        },
+      },
+    },
+  },
+
+  hooksConfig: {
+    type: 'object',
+    label: 'HooksConfig',
+    category: 'Advanced',
+    requiresRestart: false,
+    default: {},
+    description:
+      'Hook configurations for intercepting and customizing agent behavior.',
+    showInDialog: true,
+    properties: {
+      enabled: {
+        type: 'boolean',
+        label: 'Enable Hooks',
+        category: 'Advanced',
+        requiresRestart: true,
+        default: true,
+        description:
+          'Canonical toggle for the hooks system. When disabled, no hooks will be executed.',
+        showInDialog: true,
+      },
+      disabled: {
+        type: 'array', // Overridden by MergeStrategy.UNION
+        label: 'Disabled Hooks',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: [],
+        description:
+          'List of hook names (commands) that should be disabled. Hooks in this list will not execute even if configured.',
+        showInDialog: false,
+        items: {
+          type: 'string',
+        },
+      },
+      notifications: {
+        type: 'boolean',
+        label: 'Hook Notifications',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: true,
+        description: 'Show visual indicators when hooks are executing.',
+        showInDialog: true,
+      },
+    },
+  },
+
+  hooks: {
+    type: 'object',
+    label: 'Hook Events',
+    category: 'Advanced',
+    requiresRestart: false,
+    default: {},
+    description: 'Event-specific hook configurations.',
+    showInDialog: false,
+    properties: {
+      BeforeTool: {
+        type: 'array',
+        label: 'Before Tool Hooks',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: [],
+        description:
+          'Hooks that execute before tool execution. Can intercept, validate, or modify tool calls.',
+        showInDialog: false,
+        ref: 'HookDefinitionArray',
+      },
+      AfterTool: {
+        type: 'array',
+        label: 'After Tool Hooks',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: [],
+        description:
+          'Hooks that execute after tool execution. Can process results, log outputs, or trigger follow-up actions.',
+        showInDialog: false,
+        ref: 'HookDefinitionArray',
+      },
+      BeforeAgent: {
+        type: 'array',
+        label: 'Before Agent Hooks',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: [],
+        description:
+          'Hooks that execute before agent loop starts. Can set up context or initialize resources.',
+        showInDialog: false,
+        ref: 'HookDefinitionArray',
+      },
+      AfterAgent: {
+        type: 'array',
+        label: 'After Agent Hooks',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: [],
+        description:
+          'Hooks that execute after agent loop completes. Can perform cleanup or summarize results.',
+        showInDialog: false,
+        ref: 'HookDefinitionArray',
+      },
+      Notification: {
+        type: 'array',
+        label: 'Notification Hooks',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: [],
+        description:
+          'Hooks that execute on notification events (errors, warnings, info). Can log or alert on specific conditions.',
+        showInDialog: false,
+        ref: 'HookDefinitionArray',
+      },
+      SessionStart: {
+        type: 'array',
+        label: 'Session Start Hooks',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: [],
+        description:
+          'Hooks that execute when a session starts. Can initialize session-specific resources or state.',
+        showInDialog: false,
+        ref: 'HookDefinitionArray',
+      },
+      SessionEnd: {
+        type: 'array',
+        label: 'Session End Hooks',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: [],
+        description:
+          'Hooks that execute when a session ends. Can perform cleanup or persist session data.',
+        showInDialog: false,
+        ref: 'HookDefinitionArray',
+      },
+      PreCompress: {
+        type: 'array',
+        label: 'Pre-Compress Hooks',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: [],
+        description:
+          'Hooks that execute before chat history compression. Can back up or analyze conversation before compression.',
+        showInDialog: false,
+        ref: 'HookDefinitionArray',
+      },
+      BeforeModel: {
+        type: 'array',
+        label: 'Before Model Hooks',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: [],
+        description:
+          'Hooks that execute before LLM requests. Can modify prompts, inject context, or control model parameters.',
+        showInDialog: false,
+        ref: 'HookDefinitionArray',
+      },
+      AfterModel: {
+        type: 'array',
+        label: 'After Model Hooks',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: [],
+        description:
+          'Hooks that execute after LLM responses. Can process outputs, extract information, or log interactions.',
+        showInDialog: false,
+        ref: 'HookDefinitionArray',
+      },
+      BeforeToolSelection: {
+        type: 'array',
+        label: 'Before Tool Selection Hooks',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: [],
+        description:
+          'Hooks that execute before tool selection. Can filter or prioritize available tools dynamically.',
+        showInDialog: false,
+        ref: 'HookDefinitionArray',
+      },
+    },
+    additionalProperties: {
+      type: 'array',
+      items: {},
+    },
+  },
+
+  admin: {
+    type: 'object',
+    label: 'Admin',
+    category: 'Admin',
+    requiresRestart: false,
+    default: {},
+    description: 'Settings configured remotely by enterprise admins.',
+    showInDialog: false,
+    properties: {
+      secureModeEnabled: {
+        type: 'boolean',
+        label: 'Secure Mode Enabled',
+        category: 'Admin',
+        requiresRestart: false,
+        default: false,
+        description: 'If true, disallows yolo mode from being used.',
+        showInDialog: false,
+      },
+      extensions: {
+        type: 'object',
+        label: 'Extensions Settings',
+        category: 'Admin',
+        requiresRestart: false,
+        default: {},
+        description: 'Extensions-specific admin settings.',
+        showInDialog: false,
+        properties: {
+          enabled: {
+            type: 'boolean',
+            label: 'Extensions Enabled',
+            category: 'Admin',
+            requiresRestart: false,
+            default: true,
+            description:
+              'If false, disallows extensions from being installed or used.',
+            showInDialog: false,
+          },
+        },
+      },
+      mcp: {
+        type: 'object',
+        label: 'MCP Settings',
+        category: 'Admin',
+        requiresRestart: false,
+        default: {},
+        description: 'MCP-specific admin settings.',
+        showInDialog: false,
+        properties: {
+          enabled: {
+            type: 'boolean',
+            label: 'MCP Enabled',
+            category: 'Admin',
+            requiresRestart: false,
+            default: true,
+            description: 'If false, disallows MCP servers from being used.',
+            showInDialog: false,
+          },
+          config: {
+            type: 'object',
+            label: 'MCP Config',
+            category: 'Admin',
+            requiresRestart: false,
+            default: {},
+            description: 'Admin-configured MCP servers.',
+            showInDialog: false,
+            additionalProperties: {
+              type: 'object',
+              ref: 'MCPServerConfig',
+            },
+          },
+        },
+      },
+      skills: {
+        type: 'object',
+        label: 'Skills Settings',
+        category: 'Admin',
+        requiresRestart: false,
+        default: {},
+        description: 'Agent Skills-specific admin settings.',
+        showInDialog: false,
+        properties: {
+          enabled: {
+            type: 'boolean',
+            label: 'Skills Enabled',
+            category: 'Admin',
+            requiresRestart: false,
+            default: true,
+            description: 'If false, disallows agent skills from being used.',
+            showInDialog: false,
+          },
+        },
+      },
+    },
+  },
+} as const;


### PR DESCRIPTION
### Description
Implement a **Compact Mode** for all tool outputs (excluding native shell tools) to reduce terminal clutter and improve readability.

Expanded Tool Output Example
<img width="478" height="519" alt="Screenshot 2026-03-01 at 7 41 45 PM" src="https://github.com/user-attachments/assets/049d79b7-015e-4cf7-857e-0868368643fb" />

Compact Tool Output Example
<img width="631" height="496" alt="Screenshot 2026-03-01 at 7 39 31 PM" src="https://github.com/user-attachments/assets/40f9ae8d-63b2-4b11-8298-32e7b9f76ec0" />

### Changes
*   **Universal Compact Rendering**: Tool outputs (MCP, read_file, ls, etc.) now show a single-line summary by default (e.g., `→ Returned 5 lines of text`, `→ Returned JSON data`).
*   **Global Toggle**: Added `Ctrl+O` as a global shortcut to immediately expand or collapse all tool outputs in the current session.
*   **Footer Indicator**: Added a `[tool output: compact]` / `[tool output: expanded]` label in the footer to show the current mode.
*   **New Settings**:
    *   `ui.compactToolOutputs`: Enable/disable compact mode by default (default: `true`).
    *   `ui.showKeyboardShortcutsHint`: Show or hide the `(press Ctrl+O to expand)` hint (default: `true`).
*   **CLI Argument**: Added `--compact-tool-outputs` to control the initial state from the command line.
*   **UI Updates**:
    *   Updated `ToolMessage.tsx` with robust tool detection and summary logic.
    *   Updated `AppContainer.tsx` with global state and `Ctrl+O` keypress listener.
    *   Updated `Footer.tsx` with the mode indicator.
    *   Updated `ShortcutsHelp.tsx` to document the new shortcut.
*   **Documentation**: Regenerated settings documentation (`configuration.md`, `settings.md`, and JSON schema).
*   **Tests**: Added new test cases to `ToolMessage.test.tsx` to verify compact rendering and settings respect.

Fixes #20785.