### PR TITLE
test(cli): skipped test 'should combine and resolve paths from settings and CLI arguments' passes and should be enabled

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1905,7 +1905,7 @@ describe('loadCliConfig with includeDirectories', () => {
     vi.restoreAllMocks();
   });
 
-  it.skip('should combine and resolve paths from settings and CLI arguments', async () => {
+  it('should combine and resolve paths from settings and CLI arguments', async () => {
     const mockCwd = path.resolve(path.sep, 'home', 'user', 'project');
     process.argv = [
       'node',


### PR DESCRIPTION
## Description
In `packages/cli/src/config/config.test.ts`, the test `'should combine and resolve paths from settings and CLI arguments'` is marked as `it.skip` but the underlying implementation is correct and the test passes when enabled.

## Investigation
When `it.skip` is changed to `it`, the test passes successfully as part of the full suite (191/191 tests pass). The path combining logic in `loadCliConfig` already correctly implements the behavior the test is verifying.

## Impact
Without this test active, regressions in include directory path resolution from settings and CLI arguments would go undetected.

## Fix
Changed `it.skip` to `it` on line 1908 of `packages/cli/src/config/config.test.ts`.

Fixes #20816