### PR TITLE
fix(sandbox): add timeout to proxy health check to prevent infinite hang

### DIFF
--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -197,9 +197,10 @@ export async function start_sandbox(
           await execAsync(
             `timeout 30 bash -c 'until timeout 0.25 curl -s http://localhost:8877; do sleep 0.25; done'`,
           );
-        } catch {
+        } catch (e) {
+          debugLogger.error('Proxy health check failed:', e);
           throw new FatalSandboxError(
-            `Proxy health check timed out after 30s. Verify that GEMINI_SANDBOX_PROXY_COMMAND is correct: '${proxyCommand}'`,
+            `Proxy health check failed or timed out after 30s. Verify that GEMINI_SANDBOX_PROXY_COMMAND is correct: '${proxyCommand}'`,
           );
         }
       }
@@ -736,9 +737,10 @@ export async function start_sandbox(
         await execAsync(
           `timeout 30 bash -c 'until timeout 0.25 curl -s http://localhost:8877; do sleep 0.25; done'`,
         );
-      } catch {
+      } catch (e) {
+        debugLogger.error('Proxy health check failed:', e);
         throw new FatalSandboxError(
-          `Proxy health check timed out after 30s. Verify that GEMINI_SANDBOX_PROXY_COMMAND is correct: '${proxyCommand}'`,
+          `Proxy health check failed or timed out after 30s. Verify that GEMINI_SANDBOX_PROXY_COMMAND is correct: '${proxyCommand}'`,
         );
       }
       // connect proxy container to sandbox network

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -193,9 +193,15 @@ export async function start_sandbox(
           );
         });
         debugLogger.log('waiting for proxy to start ...');
-        await execAsync(
-          `until timeout 0.25 curl -s http://localhost:8877; do sleep 0.25; done`,
-        );
+        try {
+          await execAsync(
+            `timeout 30 bash -c 'until timeout 0.25 curl -s http://localhost:8877; do sleep 0.25; done'`,
+          );
+        } catch {
+          throw new FatalSandboxError(
+            `Proxy health check timed out after 30s. Verify that GEMINI_SANDBOX_PROXY_COMMAND is correct: '${proxyCommand}'`,
+          );
+        }
       }
       // spawn child and let it inherit stdio
       process.stdin.pause();
@@ -726,9 +732,15 @@ export async function start_sandbox(
         );
       });
       debugLogger.log('waiting for proxy to start ...');
-      await execAsync(
-        `until timeout 0.25 curl -s http://localhost:8877; do sleep 0.25; done`,
-      );
+      try {
+        await execAsync(
+          `timeout 30 bash -c 'until timeout 0.25 curl -s http://localhost:8877; do sleep 0.25; done'`,
+        );
+      } catch {
+        throw new FatalSandboxError(
+          `Proxy health check timed out after 30s. Verify that GEMINI_SANDBOX_PROXY_COMMAND is correct: '${proxyCommand}'`,
+        );
+      }
       // connect proxy container to sandbox network
       // (workaround for older versions of docker that don't support multiple --network args)
       await execAsync(

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -43,6 +43,8 @@ import {
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 
+const PROXY_HEALTH_CHECK_TIMEOUT_SECS = 30;
+
 export async function start_sandbox(
   config: SandboxConfig,
   nodeArgs: string[] = [],
@@ -184,25 +186,38 @@ export async function start_sandbox(
         proxyProcess.stderr?.on('data', (data) => {
           debugLogger.debug(`[PROXY STDERR]: ${data.toString().trim()}`);
         });
-        proxyProcess.on('close', (code, signal) => {
-          if (sandboxProcess?.pid) {
-            process.kill(-sandboxProcess.pid, 'SIGTERM');
-          }
-          throw new FatalSandboxError(
-            `Proxy command '${proxyCommand}' exited with code ${code}, signal ${signal}`,
+        // Use a shared promise so early proxy crashes and health check
+        // timeouts are both handled through a single awaited promise,
+        // avoiding unhandled exceptions from the close event callback.
+        const seatbeltProxyReady = new Promise<void>((resolve, reject) => {
+          proxyProcess!.on('close', (code, signal) => {
+            if (sandboxProcess?.pid) {
+              process.kill(-sandboxProcess.pid, 'SIGTERM');
+            }
+            reject(
+              new FatalSandboxError(
+                `Proxy command '${proxyCommand}' exited with code ${code}, signal ${signal}`,
+              ),
+            );
+          });
+
+          execAsync(
+            `timeout ${PROXY_HEALTH_CHECK_TIMEOUT_SECS} bash -c 'until timeout 0.25 curl -s http://localhost:8877; do sleep 0.25; done'`,
+          ).then(
+            () => resolve(),
+            (e) => {
+              debugLogger.error('Proxy health check failed:', e);
+              reject(
+                new FatalSandboxError(
+                  `Proxy health check failed or timed out after ${PROXY_HEALTH_CHECK_TIMEOUT_SECS}s. Verify that GEMINI_SANDBOX_PROXY_COMMAND is correct: '${proxyCommand}'`,
+                ),
+              );
+            },
           );
         });
+
         debugLogger.log('waiting for proxy to start ...');
-        try {
-          await execAsync(
-            `timeout 30 bash -c 'until timeout 0.25 curl -s http://localhost:8877; do sleep 0.25; done'`,
-          );
-        } catch (e) {
-          debugLogger.error('Proxy health check failed:', e);
-          throw new FatalSandboxError(
-            `Proxy health check failed or timed out after 30s. Verify that GEMINI_SANDBOX_PROXY_COMMAND is correct: '${proxyCommand}'`,
-          );
-        }
+        await seatbeltProxyReady;
       }
       // spawn child and let it inherit stdio
       process.stdin.pause();
@@ -724,25 +739,38 @@ export async function start_sandbox(
       proxyProcess.stderr?.on('data', (data) => {
         debugLogger.debug(`[PROXY STDERR]: ${data.toString().trim()}`);
       });
-      proxyProcess.on('close', (code, signal) => {
-        if (sandboxProcess?.pid) {
-          process.kill(-sandboxProcess.pid, 'SIGTERM');
-        }
-        throw new FatalSandboxError(
-          `Proxy container command '${command} ${proxyContainerArgs.join(' ')}' exited with code ${code}, signal ${signal}`,
+// Use a shared promise so early proxy crashes and health check
+      // timeouts are both handled through a single awaited promise,
+      // avoiding unhandled exceptions from the close event callback.
+      const dockerProxyReady = new Promise<void>((resolve, reject) => {
+        proxyProcess!.on('close', (code, signal) => {
+          if (sandboxProcess?.pid) {
+            process.kill(-sandboxProcess.pid, 'SIGTERM');
+          }
+          reject(
+            new FatalSandboxError(
+              `Proxy container command '${command} ${proxyContainerArgs.join(' ')}' exited with code ${code}, signal ${signal}`,
+            ),
+          );
+        });
+
+        execAsync(
+          `timeout ${PROXY_HEALTH_CHECK_TIMEOUT_SECS} bash -c 'until timeout 0.25 curl -s http://localhost:8877; do sleep 0.25; done'`,
+        ).then(
+          () => resolve(),
+          (e) => {
+            debugLogger.error('Proxy health check failed:', e);
+            reject(
+              new FatalSandboxError(
+                `Proxy health check failed or timed out after ${PROXY_HEALTH_CHECK_TIMEOUT_SECS}s. Verify that GEMINI_SANDBOX_PROXY_COMMAND is correct: '${proxyCommand}'`,
+              ),
+            );
+          },
         );
       });
+
       debugLogger.log('waiting for proxy to start ...');
-      try {
-        await execAsync(
-          `timeout 30 bash -c 'until timeout 0.25 curl -s http://localhost:8877; do sleep 0.25; done'`,
-        );
-      } catch (e) {
-        debugLogger.error('Proxy health check failed:', e);
-        throw new FatalSandboxError(
-          `Proxy health check failed or timed out after 30s. Verify that GEMINI_SANDBOX_PROXY_COMMAND is correct: '${proxyCommand}'`,
-        );
-      }
+      await dockerProxyReady;
       // connect proxy container to sandbox network
       // (workaround for older versions of docker that don't support multiple --network args)
       await execAsync(


### PR DESCRIPTION
The proxy health check loop in `sandbox.ts` runs indefinitely if 
the proxy fails to start:
```bash
until timeout 0.25 curl -s http://localhost:8877; do sleep 0.25; done
```

If `GEMINI_SANDBOX_PROXY_COMMAND` points to an invalid command, a 
missing binary, or a script that crashes on startup, this loop 
never exits and the CLI hangs with no error message.

## Fix

Wrap the health check in a 30-second global timeout. On failure, 
throw a `FatalSandboxError` with the failing command for debugging.

Applied to both the Seatbelt (macOS) and Docker sandbox paths.

## How to reproduce
```bash
GEMINI_SANDBOX_PROXY_COMMAND="nonexistent-command" gemini -s
# Before: hangs forever
# After: fails after 30s with clear error message
```

## Test plan

- `npm test` — all existing sandbox tests pass
- Manual: tested with invalid proxy command, confirms timeout 
  fires after 30s with descriptive error
- Manual: tested with valid proxy command, confirms normal 
  startup is unaffected

Fixes #20851