### PR TITLE
core: document ripgrep binary selection and system-rg blocker

### DIFF
--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -49,7 +49,23 @@ async function resolveExistingRgPath(): Promise<string | null> {
 }
 
 let ripgrepAcquisitionPromise: Promise<string | null> | null = null;
-
+/**
+ * Ensures a ripgrep binary is available.
+ *
+ * NOTE:
+ * - The Gemini CLI currently prefers a managed ripgrep binary downloaded
+ *   into its global bin directory.
+ * - Even if ripgrep is available on the system PATH, it is intentionally
+ *   not used at this time.
+ *
+ * Preference for system-installed ripgrep is blocked on:
+ * - checksum verification of external binaries
+ * - internalization of the get-ripgrep dependency
+ *
+ * See:
+ * - feat(core): Prefer rg in system path (#11847)
+ * - Move get-ripgrep to third_party (#12099)
+ */
 async function ensureRipgrepAvailable(): Promise<string | null> {
   const existingPath = await resolveExistingRgPath();
   if (existingPath) {


### PR DESCRIPTION
## Summary

This PR documents the current ripgrep selection behavior in Gemini CLI.

The CLI intentionally uses a managed ripgrep binary and does not yet prefer a system-installed rg, pending checksum verification and internalization of get-ripgrep.

No runtime behavior is changed.
<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
