### PR TITLE
Code: fix typo 'the the' in multiple files

### DIFF
--- a/evals/test-helper.ts
+++ b/evals/test-helper.ts
@@ -107,7 +107,7 @@ export function evalTest(policy: EvalPolicy, evalCase: EvalCase) {
         execSync('git config user.name "Test User"', execOptions);
 
         // Temporarily disable the interactive editor and git pager
-        // to avoid hanging the tests. It seems the the agent isn't
+        // to avoid hanging the tests. It seems the agent isn't
         // consistently honoring the instructions to avoid interactive
         // commands.
         execSync('git config core.editor "true"', execOptions);

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx
@@ -510,7 +510,7 @@ describe('useSlashCommandProcessor', () => {
       );
     });
 
-    it('sets isProcessing to false if the the input is not a command', async () => {
+    it('sets isProcessing to false if the input is not a command', async () => {
       const setMockIsProcessing = vi.fn();
       const result = await setupProcessorHook({
         setIsProcessing: setMockIsProcessing,


### PR DESCRIPTION
## Summary

Fix typo 'the the' to 'the' in `evals/test-helper.ts` and `packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx`.

## Details

Identified a repeated "the" in a comment and a test description during codebase inspection.

## Related Issues

N/A

## How to Validate

Review the diff. The changes are strictly text-based in a comment and a test name.  

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
