### PR TITLE
chore(core): update UTM_MEDIUM to desktop

### DIFF
--- a/packages/core/src/billing/billing.ts
+++ b/packages/core/src/billing/billing.ts
@@ -51,8 +51,7 @@ const ACCOUNT_CHOOSER_URL = 'https://accounts.google.com/AccountChooser';
 
 /** UTM parameters for CLI tracking */
 const UTM_SOURCE = 'gemini_cli';
-// TODO: change to 'desktop' when G1 service fix is rolled out
-const UTM_MEDIUM = 'web';
+const UTM_MEDIUM = 'desktop';
 
 /**
  * Wraps a URL in the AccountChooser redirect to maintain user context.


### PR DESCRIPTION
## Summary

This PR updates the `UTM_MEDIUM` constant in `packages/core/src/billing/billing.ts` from `'web'` to `'desktop'`. 

## Details

This change addresses the `TODO` comment in the source code, which indicates that the value should be `desktop` for URLs generated by the CLI.

## Related Issues

N/A 

## How to Validate

The change can be validated by reviewing the diff and running the tests for `packages/core/src/billing/billing.test.ts`. 

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
