### PR TITLE
Refactor Common Settings Logic for Hooks, Skills, and Agents

### DIFF
--- a/packages/cli/src/ui/commands/agentsCommand.test.ts
+++ b/packages/cli/src/ui/commands/agentsCommand.test.ts
@@ -154,7 +154,7 @@ describe('agentsCommand', () => {
 
     vi.mocked(enableAgent).mockReturnValue({
       status: 'success',
-      agentName: 'test-agent',
+      featureName: 'test-agent',
       action: 'enable',
       modifiedScopes: [],
       alreadyInStateScopes: [],
@@ -241,7 +241,7 @@ describe('agentsCommand', () => {
     });
     vi.mocked(disableAgent).mockReturnValue({
       status: 'success',
-      agentName: 'test-agent',
+      featureName: 'test-agent',
       action: 'disable',
       modifiedScopes: [],
       alreadyInStateScopes: [],

--- a/packages/cli/src/utils/agentSettings.ts
+++ b/packages/cli/src/utils/agentSettings.ts
@@ -4,29 +4,52 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { type SettingScope, type LoadedSettings } from '../config/settings.js';
 import {
-  SettingScope,
-  isLoadableSettingScope,
-  type LoadedSettings,
-} from '../config/settings.js';
-import type { ModifiedScope } from './skillSettings.js';
+  type FeatureActionResult,
+  type FeatureToggleConfig,
+  enableFeature,
+  disableFeature,
+} from './featureToggleUtils.js';
 
-export type AgentActionStatus = 'success' | 'no-op' | 'error';
+export type AgentActionResult = FeatureActionResult;
 
 /**
- * Metadata representing the result of an agent settings operation.
+ * Agents use an override-based toggle: `agents.overrides.<name>.enabled`
+ * is set to `true` or `false`.
+ *
+ * The enable flow treats a scope as "disabled" when the override is not
+ * explicitly `true` (i.e., absent or false).
+ * The disable flow treats a scope as "already disabled" only when the
+ * override is explicitly `false`.
  */
-export interface AgentActionResult {
-  status: AgentActionStatus;
-  agentName: string;
-  action: 'enable' | 'disable';
-  /** Scopes where the agent's state was actually changed. */
-  modifiedScopes: ModifiedScope[];
-  /** Scopes where the agent was already in the desired state. */
-  alreadyInStateScopes: ModifiedScope[];
-  /** Error message if status is 'error'. */
-  error?: string;
-}
+const agentEnableConfig: FeatureToggleConfig = {
+  isDisabledInScope(scopeFile, featureName) {
+    return (
+      scopeFile.settings.agents?.overrides?.[featureName]?.enabled !== true
+    );
+  },
+  applyEnable(settings, scope, featureName) {
+    settings.setValue(scope, `agents.overrides.${featureName}.enabled`, true);
+  },
+  applyDisable() {
+    // Not used via the enable config.
+  },
+};
+
+const agentDisableConfig: FeatureToggleConfig = {
+  isDisabledInScope(scopeFile, featureName) {
+    return (
+      scopeFile.settings.agents?.overrides?.[featureName]?.enabled === false
+    );
+  },
+  applyEnable() {
+    // Not used via the disable config.
+  },
+  applyDisable(settings, scope, featureName) {
+    settings.setValue(scope, `agents.overrides.${featureName}.enabled`, false);
+  },
+};
 
 /**
  * Enables an agent by ensuring it is enabled in any writable scope (User and Workspace).
@@ -36,51 +59,7 @@ export function enableAgent(
   settings: LoadedSettings,
   agentName: string,
 ): AgentActionResult {
-  const writableScopes = [SettingScope.Workspace, SettingScope.User];
-  const foundInDisabledScopes: ModifiedScope[] = [];
-  const alreadyEnabledScopes: ModifiedScope[] = [];
-
-  for (const scope of writableScopes) {
-    if (isLoadableSettingScope(scope)) {
-      const scopePath = settings.forScope(scope).path;
-      const agentOverrides =
-        settings.forScope(scope).settings.agents?.overrides;
-      const isEnabled = agentOverrides?.[agentName]?.enabled === true;
-
-      if (!isEnabled) {
-        foundInDisabledScopes.push({ scope, path: scopePath });
-      } else {
-        alreadyEnabledScopes.push({ scope, path: scopePath });
-      }
-    }
-  }
-
-  if (foundInDisabledScopes.length === 0) {
-    return {
-      status: 'no-op',
-      agentName,
-      action: 'enable',
-      modifiedScopes: [],
-      alreadyInStateScopes: alreadyEnabledScopes,
-    };
-  }
-
-  const modifiedScopes: ModifiedScope[] = [];
-  for (const { scope, path } of foundInDisabledScopes) {
-    if (isLoadableSettingScope(scope)) {
-      // Explicitly enable it.
-      settings.setValue(scope, `agents.overrides.${agentName}.enabled`, true);
-      modifiedScopes.push({ scope, path });
-    }
-  }
-
-  return {
-    status: 'success',
-    agentName,
-    action: 'enable',
-    modifiedScopes,
-    alreadyInStateScopes: alreadyEnabledScopes,
-  };
+  return enableFeature(settings, agentName, agentEnableConfig);
 }
 
 /**
@@ -91,56 +70,5 @@ export function disableAgent(
   agentName: string,
   scope: SettingScope,
 ): AgentActionResult {
-  if (!isLoadableSettingScope(scope)) {
-    return {
-      status: 'error',
-      agentName,
-      action: 'disable',
-      modifiedScopes: [],
-      alreadyInStateScopes: [],
-      error: `Invalid settings scope: ${scope}`,
-    };
-  }
-
-  const scopePath = settings.forScope(scope).path;
-  const agentOverrides = settings.forScope(scope).settings.agents?.overrides;
-  const isEnabled = agentOverrides?.[agentName]?.enabled !== false;
-
-  if (!isEnabled) {
-    return {
-      status: 'no-op',
-      agentName,
-      action: 'disable',
-      modifiedScopes: [],
-      alreadyInStateScopes: [{ scope, path: scopePath }],
-    };
-  }
-
-  // Check if it's already disabled in the other writable scope
-  const otherScope =
-    scope === SettingScope.Workspace
-      ? SettingScope.User
-      : SettingScope.Workspace;
-  const alreadyDisabledInOther: ModifiedScope[] = [];
-
-  if (isLoadableSettingScope(otherScope)) {
-    const otherOverrides =
-      settings.forScope(otherScope).settings.agents?.overrides;
-    if (otherOverrides?.[agentName]?.enabled === false) {
-      alreadyDisabledInOther.push({
-        scope: otherScope,
-        path: settings.forScope(otherScope).path,
-      });
-    }
-  }
-
-  settings.setValue(scope, `agents.overrides.${agentName}.enabled`, false);
-
-  return {
-    status: 'success',
-    agentName,
-    action: 'disable',
-    modifiedScopes: [{ scope, path: scopePath }],
-    alreadyInStateScopes: alreadyDisabledInOther,
-  };
+  return disableFeature(settings, agentName, scope, agentDisableConfig);
 }

--- a/packages/cli/src/utils/agentUtils.test.ts
+++ b/packages/cli/src/utils/agentUtils.test.ts
@@ -27,7 +27,7 @@ describe('agentUtils', () => {
     it('should return error message if status is error', () => {
       const result: AgentActionResult = {
         status: 'error',
-        agentName: 'my-agent',
+        featureName: 'my-agent',
         action: 'enable',
         modifiedScopes: [],
         alreadyInStateScopes: [],
@@ -41,7 +41,7 @@ describe('agentUtils', () => {
     it('should return default error message if status is error and no error message provided', () => {
       const result: AgentActionResult = {
         status: 'error',
-        agentName: 'my-agent',
+        featureName: 'my-agent',
         action: 'enable',
         modifiedScopes: [],
         alreadyInStateScopes: [],
@@ -54,7 +54,7 @@ describe('agentUtils', () => {
     it('should return no-op message for enable', () => {
       const result: AgentActionResult = {
         status: 'no-op',
-        agentName: 'my-agent',
+        featureName: 'my-agent',
         action: 'enable',
         modifiedScopes: [],
         alreadyInStateScopes: [],
@@ -67,7 +67,7 @@ describe('agentUtils', () => {
     it('should return no-op message for disable', () => {
       const result: AgentActionResult = {
         status: 'no-op',
-        agentName: 'my-agent',
+        featureName: 'my-agent',
         action: 'disable',
         modifiedScopes: [],
         alreadyInStateScopes: [],
@@ -80,7 +80,7 @@ describe('agentUtils', () => {
     it('should return success message for enable (single scope)', () => {
       const result: AgentActionResult = {
         status: 'success',
-        agentName: 'my-agent',
+        featureName: 'my-agent',
         action: 'enable',
         modifiedScopes: [
           { scope: SettingScope.User, path: '/path/to/user/settings' },
@@ -95,7 +95,7 @@ describe('agentUtils', () => {
     it('should return success message for enable (two scopes)', () => {
       const result: AgentActionResult = {
         status: 'success',
-        agentName: 'my-agent',
+        featureName: 'my-agent',
         action: 'enable',
         modifiedScopes: [
           { scope: SettingScope.User, path: '/path/to/user/settings' },
@@ -115,7 +115,7 @@ describe('agentUtils', () => {
     it('should return success message for disable (single scope)', () => {
       const result: AgentActionResult = {
         status: 'success',
-        agentName: 'my-agent',
+        featureName: 'my-agent',
         action: 'disable',
         modifiedScopes: [
           { scope: SettingScope.User, path: '/path/to/user/settings' },
@@ -130,7 +130,7 @@ describe('agentUtils', () => {
     it('should return success message for disable (two scopes)', () => {
       const result: AgentActionResult = {
         status: 'success',
-        agentName: 'my-agent',
+        featureName: 'my-agent',
         action: 'disable',
         modifiedScopes: [
           { scope: SettingScope.User, path: '/path/to/user/settings' },

--- a/packages/cli/src/utils/agentUtils.ts
+++ b/packages/cli/src/utils/agentUtils.ts
@@ -19,7 +19,7 @@ export function renderAgentActionFeedback(
   result: AgentActionResult,
   formatScope: (label: string, path: string) => string,
 ): string {
-  const { agentName, action, status, error } = result;
+  const { featureName: agentName, action, status, error } = result;
 
   if (status === 'error') {
     return (

--- a/packages/cli/src/utils/featureToggleUtils.ts
+++ b/packages/cli/src/utils/featureToggleUtils.ts
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  SettingScope,
+  isLoadableSettingScope,
+  type LoadableSettingScope,
+  type LoadedSettings,
+  type SettingsFile,
+} from '../config/settings.js';
+
+export interface ModifiedScope {
+  scope: SettingScope;
+  path: string;
+}
+
+export type FeatureActionStatus = 'success' | 'no-op' | 'error';
+
+/**
+ * Metadata representing the result of a feature settings operation.
+ */
+export interface FeatureActionResult {
+  status: FeatureActionStatus;
+  featureName: string;
+  action: 'enable' | 'disable';
+  /** Scopes where the feature's state was actually changed. */
+  modifiedScopes: ModifiedScope[];
+  /** Scopes where the feature was already in the desired state. */
+  alreadyInStateScopes: ModifiedScope[];
+  /** Error message if status is 'error'. */
+  error?: string;
+}
+
+/**
+ * Strategy interface for checking and updating a feature's enabled/disabled
+ * state within a settings scope.
+ */
+export interface FeatureToggleConfig {
+  /** Returns true if the feature is currently in the disabled state for this scope. */
+  isDisabledInScope(scopeSettings: SettingsFile, featureName: string): boolean;
+  /** Applies the enable action for the feature in the given scope. */
+  applyEnable(
+    settings: LoadedSettings,
+    scope: LoadableSettingScope,
+    featureName: string,
+  ): void;
+  /** Applies the disable action for the feature in the given scope. */
+  applyDisable(
+    settings: LoadedSettings,
+    scope: LoadableSettingScope,
+    featureName: string,
+  ): void;
+}
+
+const WRITABLE_SCOPES = [SettingScope.Workspace, SettingScope.User];
+
+/**
+ * Enables a feature by applying the enable action across all writable scopes
+ * where the feature is currently disabled.
+ */
+export function enableFeature(
+  settings: LoadedSettings,
+  featureName: string,
+  config: FeatureToggleConfig,
+): FeatureActionResult {
+  const foundInDisabledScopes: ModifiedScope[] = [];
+  const alreadyEnabledScopes: ModifiedScope[] = [];
+
+  for (const scope of WRITABLE_SCOPES) {
+    if (isLoadableSettingScope(scope)) {
+      const scopeFile = settings.forScope(scope);
+      if (config.isDisabledInScope(scopeFile, featureName)) {
+        foundInDisabledScopes.push({ scope, path: scopeFile.path });
+      } else {
+        alreadyEnabledScopes.push({ scope, path: scopeFile.path });
+      }
+    }
+  }
+
+  if (foundInDisabledScopes.length === 0) {
+    return {
+      status: 'no-op',
+      featureName,
+      action: 'enable',
+      modifiedScopes: [],
+      alreadyInStateScopes: alreadyEnabledScopes,
+    };
+  }
+
+  const modifiedScopes: ModifiedScope[] = [];
+  for (const { scope, path } of foundInDisabledScopes) {
+    if (isLoadableSettingScope(scope)) {
+      config.applyEnable(settings, scope, featureName);
+      modifiedScopes.push({ scope, path });
+    }
+  }
+
+  return {
+    status: 'success',
+    featureName,
+    action: 'enable',
+    modifiedScopes,
+    alreadyInStateScopes: alreadyEnabledScopes,
+  };
+}
+
+/**
+ * Disables a feature by applying the disable action in the specified scope.
+ */
+export function disableFeature(
+  settings: LoadedSettings,
+  featureName: string,
+  scope: SettingScope,
+  config: FeatureToggleConfig,
+): FeatureActionResult {
+  if (!isLoadableSettingScope(scope)) {
+    return {
+      status: 'error',
+      featureName,
+      action: 'disable',
+      modifiedScopes: [],
+      alreadyInStateScopes: [],
+      error: `Invalid settings scope: ${scope}`,
+    };
+  }
+
+  const scopeFile = settings.forScope(scope);
+
+  if (config.isDisabledInScope(scopeFile, featureName)) {
+    return {
+      status: 'no-op',
+      featureName,
+      action: 'disable',
+      modifiedScopes: [],
+      alreadyInStateScopes: [{ scope, path: scopeFile.path }],
+    };
+  }
+
+  // Check if it's already disabled in the other writable scope
+  const otherScope =
+    scope === SettingScope.Workspace
+      ? SettingScope.User
+      : SettingScope.Workspace;
+  const alreadyDisabledInOther: ModifiedScope[] = [];
+
+  if (isLoadableSettingScope(otherScope)) {
+    const otherScopeFile = settings.forScope(otherScope);
+    if (config.isDisabledInScope(otherScopeFile, featureName)) {
+      alreadyDisabledInOther.push({
+        scope: otherScope,
+        path: otherScopeFile.path,
+      });
+    }
+  }
+
+  config.applyDisable(settings, scope, featureName);
+
+  return {
+    status: 'success',
+    featureName,
+    action: 'disable',
+    modifiedScopes: [{ scope, path: scopeFile.path }],
+    alreadyInStateScopes: alreadyDisabledInOther,
+  };
+}
+
+/**
+ * Creates a FeatureToggleConfig for features that use a disabled-list pattern
+ * (e.g., `skills.disabled` or `hooksConfig.disabled`).
+ *
+ * @param settingsKey The dot-separated path to the disabled array (e.g., 'skills.disabled').
+ * @param getDisabledList A function that extracts the disabled array from scope settings.
+ */
+export function createListBasedToggleConfig(
+  settingsKey: string,
+  getDisabledList: (settings: SettingsFile) => string[] | undefined,
+): FeatureToggleConfig {
+  return {
+    isDisabledInScope(scopeFile, featureName) {
+      return getDisabledList(scopeFile)?.includes(featureName) ?? false;
+    },
+    applyEnable(settings, scope, featureName) {
+      const currentDisabled = getDisabledList(settings.forScope(scope)) ?? [];
+      const newDisabled = currentDisabled.filter(
+        (name) => name !== featureName,
+      );
+      settings.setValue(scope, settingsKey, newDisabled);
+    },
+    applyDisable(settings, scope, featureName) {
+      const currentDisabled = getDisabledList(settings.forScope(scope)) ?? [];
+      const newDisabled = [...currentDisabled, featureName];
+      settings.setValue(scope, settingsKey, newDisabled);
+    },
+  };
+}

--- a/packages/cli/src/utils/hookSettings.ts
+++ b/packages/cli/src/utils/hookSettings.ts
@@ -4,30 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  SettingScope,
-  isLoadableSettingScope,
-  type LoadedSettings,
-} from '../config/settings.js';
+import { type SettingScope, type LoadedSettings } from '../config/settings.js';
 import { getErrorMessage } from '@google/gemini-cli-core';
-import type { ModifiedScope } from './skillSettings.js';
+import {
+  type FeatureActionResult,
+  enableFeature,
+  disableFeature,
+  createListBasedToggleConfig,
+} from './featureToggleUtils.js';
 
-export type HookActionStatus = 'success' | 'no-op' | 'error';
+export type HookActionResult = FeatureActionResult;
 
-/**
- * Metadata representing the result of a hook settings operation.
- */
-export interface HookActionResult {
-  status: HookActionStatus;
-  hookName: string;
-  action: 'enable' | 'disable';
-  /** Scopes where the hook's state was actually changed. */
-  modifiedScopes: ModifiedScope[];
-  /** Scopes where the hook was already in the desired state. */
-  alreadyInStateScopes: ModifiedScope[];
-  /** Error message if status is 'error'. */
-  error?: string;
-}
+const hookToggleConfig = createListBasedToggleConfig(
+  'hooksConfig.disabled',
+  (scopeFile) => scopeFile.settings.hooksConfig?.disabled,
+);
 
 /**
  * Enables a hook by removing it from all writable disabled lists (User and Workspace).
@@ -36,64 +27,18 @@ export function enableHook(
   settings: LoadedSettings,
   hookName: string,
 ): HookActionResult {
-  const writableScopes = [SettingScope.Workspace, SettingScope.User];
-  const foundInDisabledScopes: ModifiedScope[] = [];
-  const alreadyEnabledScopes: ModifiedScope[] = [];
-
-  for (const scope of writableScopes) {
-    if (isLoadableSettingScope(scope)) {
-      const scopePath = settings.forScope(scope).path;
-      const scopeDisabled =
-        settings.forScope(scope).settings.hooksConfig?.disabled;
-      if (scopeDisabled?.includes(hookName)) {
-        foundInDisabledScopes.push({ scope, path: scopePath });
-      } else {
-        alreadyEnabledScopes.push({ scope, path: scopePath });
-      }
-    }
-  }
-
-  if (foundInDisabledScopes.length === 0) {
-    return {
-      status: 'no-op',
-      hookName,
-      action: 'enable',
-      modifiedScopes: [],
-      alreadyInStateScopes: alreadyEnabledScopes,
-    };
-  }
-
-  const modifiedScopes: ModifiedScope[] = [];
   try {
-    for (const { scope, path } of foundInDisabledScopes) {
-      if (isLoadableSettingScope(scope)) {
-        const currentScopeDisabled =
-          settings.forScope(scope).settings.hooksConfig?.disabled ?? [];
-        const newDisabled = currentScopeDisabled.filter(
-          (name) => name !== hookName,
-        );
-        settings.setValue(scope, 'hooksConfig.disabled', newDisabled);
-        modifiedScopes.push({ scope, path });
-      }
-    }
+    return enableFeature(settings, hookName, hookToggleConfig);
   } catch (error) {
     return {
       status: 'error',
-      hookName,
+      featureName: hookName,
       action: 'enable',
-      modifiedScopes,
-      alreadyInStateScopes: alreadyEnabledScopes,
+      modifiedScopes: [],
+      alreadyInStateScopes: [],
       error: `Failed to enable hook: ${getErrorMessage(error)}`,
     };
   }
-
-  return {
-    status: 'success',
-    hookName,
-    action: 'enable',
-    modifiedScopes,
-    alreadyInStateScopes: alreadyEnabledScopes,
-  };
 }
 
 /**
@@ -104,57 +49,5 @@ export function disableHook(
   hookName: string,
   scope: SettingScope,
 ): HookActionResult {
-  if (!isLoadableSettingScope(scope)) {
-    return {
-      status: 'error',
-      hookName,
-      action: 'disable',
-      modifiedScopes: [],
-      alreadyInStateScopes: [],
-      error: `Invalid settings scope: ${scope}`,
-    };
-  }
-
-  const scopePath = settings.forScope(scope).path;
-  const currentScopeDisabled =
-    settings.forScope(scope).settings.hooksConfig?.disabled ?? [];
-
-  if (currentScopeDisabled.includes(hookName)) {
-    return {
-      status: 'no-op',
-      hookName,
-      action: 'disable',
-      modifiedScopes: [],
-      alreadyInStateScopes: [{ scope, path: scopePath }],
-    };
-  }
-
-  // Check if it's already disabled in the other writable scope
-  const otherScope =
-    scope === SettingScope.Workspace
-      ? SettingScope.User
-      : SettingScope.Workspace;
-  const alreadyDisabledInOther: ModifiedScope[] = [];
-
-  if (isLoadableSettingScope(otherScope)) {
-    const otherScopeDisabled =
-      settings.forScope(otherScope).settings.hooksConfig?.disabled;
-    if (otherScopeDisabled?.includes(hookName)) {
-      alreadyDisabledInOther.push({
-        scope: otherScope,
-        path: settings.forScope(otherScope).path,
-      });
-    }
-  }
-
-  const newDisabled = [...currentScopeDisabled, hookName];
-  settings.setValue(scope, 'hooksConfig.disabled', newDisabled);
-
-  return {
-    status: 'success',
-    hookName,
-    action: 'disable',
-    modifiedScopes: [{ scope, path: scopePath }],
-    alreadyInStateScopes: alreadyDisabledInOther,
-  };
+  return disableFeature(settings, hookName, scope, hookToggleConfig);
 }

--- a/packages/cli/src/utils/hookUtils.test.ts
+++ b/packages/cli/src/utils/hookUtils.test.ts
@@ -17,7 +17,7 @@ describe('hookUtils', () => {
     it('should render error message', () => {
       const result: HookActionResult = {
         status: 'error',
-        hookName: 'test-hook',
+        featureName: 'test-hook',
         action: 'enable',
         modifiedScopes: [],
         alreadyInStateScopes: [],
@@ -31,7 +31,7 @@ describe('hookUtils', () => {
     it('should render default error message if error string is missing', () => {
       const result: HookActionResult = {
         status: 'error',
-        hookName: 'test-hook',
+        featureName: 'test-hook',
         action: 'enable',
         modifiedScopes: [],
         alreadyInStateScopes: [],
@@ -46,7 +46,7 @@ describe('hookUtils', () => {
     it('should render no-op message for enable', () => {
       const result: HookActionResult = {
         status: 'no-op',
-        hookName: 'test-hook',
+        featureName: 'test-hook',
         action: 'enable',
         modifiedScopes: [],
         alreadyInStateScopes: [],
@@ -59,7 +59,7 @@ describe('hookUtils', () => {
     it('should render no-op message for disable', () => {
       const result: HookActionResult = {
         status: 'no-op',
-        hookName: 'test-hook',
+        featureName: 'test-hook',
         action: 'disable',
         modifiedScopes: [],
         alreadyInStateScopes: [],
@@ -72,7 +72,7 @@ describe('hookUtils', () => {
     it('should render success message for enable (single scope)', () => {
       const result: HookActionResult = {
         status: 'success',
-        hookName: 'test-hook',
+        featureName: 'test-hook',
         action: 'enable',
         modifiedScopes: [{ scope: SettingScope.User, path: '/path/user.json' }],
         alreadyInStateScopes: [
@@ -90,7 +90,7 @@ describe('hookUtils', () => {
       // E.g. Workspace doesn't exist or isn't loadable, so only User is affected.
       const result: HookActionResult = {
         status: 'success',
-        hookName: 'test-hook',
+        featureName: 'test-hook',
         action: 'enable',
         modifiedScopes: [{ scope: SettingScope.User, path: '/path/user.json' }],
         alreadyInStateScopes: [],
@@ -105,7 +105,7 @@ describe('hookUtils', () => {
     it('should render success message for disable (single scope)', () => {
       const result: HookActionResult = {
         status: 'success',
-        hookName: 'test-hook',
+        featureName: 'test-hook',
         action: 'disable',
         modifiedScopes: [
           { scope: SettingScope.Workspace, path: '/path/workspace.json' },
@@ -123,7 +123,7 @@ describe('hookUtils', () => {
       // E.g. Disabled in Workspace, but ALREADY disabled in User.
       const result: HookActionResult = {
         status: 'success',
-        hookName: 'test-hook',
+        featureName: 'test-hook',
         action: 'disable',
         modifiedScopes: [
           { scope: SettingScope.Workspace, path: '/path/workspace.json' },

--- a/packages/cli/src/utils/hookUtils.ts
+++ b/packages/cli/src/utils/hookUtils.ts
@@ -16,7 +16,7 @@ export function renderHookActionFeedback(
   result: HookActionResult,
   formatScope: (label: string, path: string) => string,
 ): string {
-  const { hookName, action, status, error } = result;
+  const { featureName: hookName, action, status, error } = result;
 
   if (status === 'error') {
     return (

--- a/packages/cli/src/utils/skillSettings.ts
+++ b/packages/cli/src/utils/skillSettings.ts
@@ -4,33 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { type SettingScope, type LoadedSettings } from '../config/settings.js';
 import {
-  SettingScope,
-  isLoadableSettingScope,
-  type LoadedSettings,
-} from '../config/settings.js';
+  type FeatureActionResult,
+  enableFeature,
+  disableFeature,
+  createListBasedToggleConfig,
+} from './featureToggleUtils.js';
 
-export interface ModifiedScope {
-  scope: SettingScope;
-  path: string;
-}
+export type { ModifiedScope } from './featureToggleUtils.js';
 
-export type SkillActionStatus = 'success' | 'no-op' | 'error';
+export type SkillActionResult = FeatureActionResult;
 
-/**
- * Metadata representing the result of a skill settings operation.
- */
-export interface SkillActionResult {
-  status: SkillActionStatus;
-  skillName: string;
-  action: 'enable' | 'disable';
-  /** Scopes where the skill's state was actually changed. */
-  modifiedScopes: ModifiedScope[];
-  /** Scopes where the skill was already in the desired state. */
-  alreadyInStateScopes: ModifiedScope[];
-  /** Error message if status is 'error'. */
-  error?: string;
-}
+const skillToggleConfig = createListBasedToggleConfig(
+  'skills.disabled',
+  (scopeFile) => scopeFile.settings.skills?.disabled,
+);
 
 /**
  * Enables a skill by removing it from all writable disabled lists (User and Workspace).
@@ -39,52 +28,7 @@ export function enableSkill(
   settings: LoadedSettings,
   skillName: string,
 ): SkillActionResult {
-  const writableScopes = [SettingScope.Workspace, SettingScope.User];
-  const foundInDisabledScopes: ModifiedScope[] = [];
-  const alreadyEnabledScopes: ModifiedScope[] = [];
-
-  for (const scope of writableScopes) {
-    if (isLoadableSettingScope(scope)) {
-      const scopePath = settings.forScope(scope).path;
-      const scopeDisabled = settings.forScope(scope).settings.skills?.disabled;
-      if (scopeDisabled?.includes(skillName)) {
-        foundInDisabledScopes.push({ scope, path: scopePath });
-      } else {
-        alreadyEnabledScopes.push({ scope, path: scopePath });
-      }
-    }
-  }
-
-  if (foundInDisabledScopes.length === 0) {
-    return {
-      status: 'no-op',
-      skillName,
-      action: 'enable',
-      modifiedScopes: [],
-      alreadyInStateScopes: alreadyEnabledScopes,
-    };
-  }
-
-  const modifiedScopes: ModifiedScope[] = [];
-  for (const { scope, path } of foundInDisabledScopes) {
-    if (isLoadableSettingScope(scope)) {
-      const currentScopeDisabled =
-        settings.forScope(scope).settings.skills?.disabled ?? [];
-      const newDisabled = currentScopeDisabled.filter(
-        (name) => name !== skillName,
-      );
-      settings.setValue(scope, 'skills.disabled', newDisabled);
-      modifiedScopes.push({ scope, path });
-    }
-  }
-
-  return {
-    status: 'success',
-    skillName,
-    action: 'enable',
-    modifiedScopes,
-    alreadyInStateScopes: alreadyEnabledScopes,
-  };
+  return enableFeature(settings, skillName, skillToggleConfig);
 }
 
 /**
@@ -95,57 +39,5 @@ export function disableSkill(
   skillName: string,
   scope: SettingScope,
 ): SkillActionResult {
-  if (!isLoadableSettingScope(scope)) {
-    return {
-      status: 'error',
-      skillName,
-      action: 'disable',
-      modifiedScopes: [],
-      alreadyInStateScopes: [],
-      error: `Invalid settings scope: ${scope}`,
-    };
-  }
-
-  const scopePath = settings.forScope(scope).path;
-  const currentScopeDisabled =
-    settings.forScope(scope).settings.skills?.disabled ?? [];
-
-  if (currentScopeDisabled.includes(skillName)) {
-    return {
-      status: 'no-op',
-      skillName,
-      action: 'disable',
-      modifiedScopes: [],
-      alreadyInStateScopes: [{ scope, path: scopePath }],
-    };
-  }
-
-  // Check if it's already disabled in the other writable scope
-  const otherScope =
-    scope === SettingScope.Workspace
-      ? SettingScope.User
-      : SettingScope.Workspace;
-  const alreadyDisabledInOther: ModifiedScope[] = [];
-
-  if (isLoadableSettingScope(otherScope)) {
-    const otherScopeDisabled =
-      settings.forScope(otherScope).settings.skills?.disabled;
-    if (otherScopeDisabled?.includes(skillName)) {
-      alreadyDisabledInOther.push({
-        scope: otherScope,
-        path: settings.forScope(otherScope).path,
-      });
-    }
-  }
-
-  const newDisabled = [...currentScopeDisabled, skillName];
-  settings.setValue(scope, 'skills.disabled', newDisabled);
-
-  return {
-    status: 'success',
-    skillName,
-    action: 'disable',
-    modifiedScopes: [{ scope, path: scopePath }],
-    alreadyInStateScopes: alreadyDisabledInOther,
-  };
+  return disableFeature(settings, skillName, scope, skillToggleConfig);
 }

--- a/packages/cli/src/utils/skillUtils.ts
+++ b/packages/cli/src/utils/skillUtils.ts
@@ -30,7 +30,7 @@ export function renderSkillActionFeedback(
   result: SkillActionResult,
   formatScope: (label: string, path: string) => string,
 ): string {
-  const { skillName, action, status, error } = result;
+  const { featureName: skillName, action, status, error } = result;
 
   if (status === 'error') {
     return (


### PR DESCRIPTION
## Summary

Refactors duplicated enable/disable settings logic across `hookSettings.ts`, `skillSettings.ts`, and `agentSettings.ts` into a shared generic utility, reducing ~300 lines of near-identical code.

## Details

- Created `featureToggleUtils.ts` with shared `ModifiedScope, FeatureActionResult, FeatureToggleConfig` interfaces and generic `enableFeature()/disableFeature()` functions
- Added `createListBasedToggleConfig()` factory for list-based features (skills, hooks)
- Agents use custom override-based configs for their boolean toggle pattern
- Each settings file is now a thin wrapper delegating to the shared utility
- Unified the result type's name field to `featureName` (previously skillName/hookName/agentName)

## Related Issues

Fixes #17348 

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [X] Added/updated tests (if needed)
- [X] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
