### PR TITLE
Updated broken links in README for configuration and shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,9 +282,9 @@ gemini
   quickly.
 - [**Authentication Setup**](./docs/get-started/authentication.md) - Detailed
   auth configuration.
-- [**Configuration Guide**](./docs/get-started/configuration.md) - Settings and
+- [**Configuration Guide**](https://google-gemini.github.io/gemini-cli/docs/get-started/configuration.html) - Settings and
   customization.
-- [**Keyboard Shortcuts**](./docs/cli/keyboard-shortcuts.md) - Productivity
+- [**Keyboard Shortcuts**](https://google-gemini.github.io/gemini-cli/docs/cli/keyboard-shortcuts.html) - Productivity
   tips.
 
 ### Core Features


### PR DESCRIPTION
Summary
Replaces broken relative file paths in the README with absolute URLs pointing directly to the official GitHub Pages documentation.

Details
The local markdown links for the "Configuration Guide" (./docs/get-started/configuration.md) and "Keyboard Shortcuts" (./docs/cli/keyboard-shortcuts.md) were not resolving correctly for users browsing the main repository page. I updated these to point to their live .html counterparts on https://google-gemini.github.io/gemini-cli/... to ensure users are routed to the properly formatted documentation site.

Related Issues
How to Validate
Navigate to the updated README.md file in this branch.

Scroll to the links for "Configuration Guide" and "Keyboard Shortcuts".

Click both links and verify they successfully open the live, published GitHub Pages documentation.

Pre-Merge Checklist
[x] Updated relevant documentation and README (if needed)

[ ] Added/updated tests (if needed)

[ ] Noted breaking changes (if any)

[ ] Validated on required platforms/methods:

[ ] MacOS

[ ] npm run

[ ] npx

[ ] Docker

[ ] Podman

[ ] Seatbelt

[ ] Windows

[ ] npm run

[ ] npx

[ ] Docker

[ ] Linux

[ ] npm run

[ ] npx

[ ] Docker