### PR TITLE
Update CODEOWNERS for README.md reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,3 +14,4 @@
 
 # Docs have a dedicated approver group in addition to maintainers
 /docs/ @google-gemini/gemini-cli-maintainers @google-gemini/gemini-cli-docs
+/README.md @google-gemini/gemini-cli-maintainers @google-gemini/gemini-cli-docs


### PR DESCRIPTION
## Summary

Update CODEOWNERS so README.md can be kept up-to-date by the docs team.

Related to #20125 


