### PR TITLE
fix(core): handle AbortError when ESC cancels tool execution

### DIFF
--- a/packages/core/src/scheduler/tool-executor.test.ts
+++ b/packages/core/src/scheduler/tool-executor.test.ts
@@ -211,6 +211,87 @@ describe('ToolExecutor', () => {
     });
   });
 
+  it('should return cancelled result when executeToolWithHooks rejects with AbortError', async () => {
+    const mockTool = new MockTool({
+      name: 'webSearchTool',
+      description: 'Mock web search',
+    });
+    const invocation = mockTool.build({});
+
+    const abortErr = new Error('The user aborted a request.');
+    abortErr.name = 'AbortError';
+    vi.mocked(coreToolHookTriggers.executeToolWithHooks).mockRejectedValue(
+      abortErr,
+    );
+
+    const scheduledCall: ScheduledToolCall = {
+      status: CoreToolCallStatus.Scheduled,
+      request: {
+        callId: 'call-abort',
+        name: 'webSearchTool',
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'prompt-abort',
+      },
+      tool: mockTool,
+      invocation: invocation as unknown as AnyToolInvocation,
+      startTime: Date.now(),
+    };
+
+    const result = await executor.execute({
+      call: scheduledCall,
+      signal: new AbortController().signal,
+      onUpdateToolCall: vi.fn(),
+    });
+
+    expect(result.status).toBe(CoreToolCallStatus.Cancelled);
+    if (result.status === CoreToolCallStatus.Cancelled) {
+      const response = result.response.responseParts[0]?.functionResponse
+        ?.response as Record<string, unknown>;
+      expect(response['error']).toContain('Operation cancelled.');
+    }
+  });
+
+  it('should return cancelled result when executeToolWithHooks rejects with "Operation cancelled by user" message', async () => {
+    const mockTool = new MockTool({
+      name: 'someTool',
+      description: 'Mock',
+    });
+    const invocation = mockTool.build({});
+
+    const cancelErr = new Error('Operation cancelled by user');
+    vi.mocked(coreToolHookTriggers.executeToolWithHooks).mockRejectedValue(
+      cancelErr,
+    );
+
+    const scheduledCall: ScheduledToolCall = {
+      status: CoreToolCallStatus.Scheduled,
+      request: {
+        callId: 'call-cancel-msg',
+        name: 'someTool',
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'prompt-cancel-msg',
+      },
+      tool: mockTool,
+      invocation: invocation as unknown as AnyToolInvocation,
+      startTime: Date.now(),
+    };
+
+    const result = await executor.execute({
+      call: scheduledCall,
+      signal: new AbortController().signal,
+      onUpdateToolCall: vi.fn(),
+    });
+
+    expect(result.status).toBe(CoreToolCallStatus.Cancelled);
+    if (result.status === CoreToolCallStatus.Cancelled) {
+      const response = result.response.responseParts[0]?.functionResponse
+        ?.response as Record<string, unknown>;
+      expect(response['error']).toContain('User cancelled tool execution.');
+    }
+  });
+
   it('should return cancelled result when signal is aborted', async () => {
     const mockTool = new MockTool({
       name: 'slowTool',

--- a/packages/core/src/scheduler/tool-executor.ts
+++ b/packages/core/src/scheduler/tool-executor.ts
@@ -16,6 +16,7 @@ import {
   type AgentLoopContext,
   type ToolLiveOutput,
 } from '../index.js';
+import { isAbortError } from '../utils/errors.js';
 import { SHELL_TOOL_NAME } from '../tools/tool-names.js';
 import { ShellToolInvocation } from '../tools/shell.js';
 import { DiscoveredMCPTool } from '../tools/mcp-tool.js';
@@ -25,7 +26,6 @@ import {
   formatTruncatedToolOutput,
 } from '../utils/fileUtils.js';
 import { convertToFunctionResponse } from '../utils/generateContentResponseUtilities.js';
-import { isAbortError } from '../utils/errors.js';
 import {
   CoreToolCallStatus,
   type CompletedToolCall,
@@ -160,6 +160,7 @@ export class ToolExecutor {
           }
         } catch (executionError: unknown) {
           spanMetadata.error = executionError;
+<<<<<<< HEAD
           const abortedByError =
             isAbortError(executionError) ||
             (executionError instanceof Error &&
@@ -169,6 +170,14 @@ export class ToolExecutor {
             completedToolCall = await this.createCancelledResult(
               call,
               isAbortError(executionError)
+=======
+          const abortError = isAbortError(executionError);
+          const aborted = signal.aborted || abortError;
+          if (aborted) {
+            completedToolCall = this.createCancelledResult(
+              call,
+              abortError
+>>>>>>> 17d0adb97 (refactor(core): centralize AbortError detection)
                 ? 'Operation cancelled.'
                 : 'User cancelled tool execution.',
             );

--- a/packages/core/src/scheduler/tool-executor.ts
+++ b/packages/core/src/scheduler/tool-executor.ts
@@ -160,7 +160,6 @@ export class ToolExecutor {
           }
         } catch (executionError: unknown) {
           spanMetadata.error = executionError;
-<<<<<<< HEAD
           const abortedByError =
             isAbortError(executionError) ||
             (executionError instanceof Error &&
@@ -170,14 +169,6 @@ export class ToolExecutor {
             completedToolCall = await this.createCancelledResult(
               call,
               isAbortError(executionError)
-=======
-          const abortError = isAbortError(executionError);
-          const aborted = signal.aborted || abortError;
-          if (aborted) {
-            completedToolCall = this.createCancelledResult(
-              call,
-              abortError
->>>>>>> 17d0adb97 (refactor(core): centralize AbortError detection)
                 ? 'Operation cancelled.'
                 : 'User cancelled tool execution.',
             );

--- a/packages/core/src/scheduler/tool-executor.ts
+++ b/packages/core/src/scheduler/tool-executor.ts
@@ -25,6 +25,7 @@ import {
   formatTruncatedToolOutput,
 } from '../utils/fileUtils.js';
 import { convertToFunctionResponse } from '../utils/generateContentResponseUtilities.js';
+import { isAbortError } from '../utils/errors.js';
 import {
   CoreToolCallStatus,
   type CompletedToolCall,
@@ -159,15 +160,17 @@ export class ToolExecutor {
           }
         } catch (executionError: unknown) {
           spanMetadata.error = executionError;
-          const isAbortError =
-            executionError instanceof Error &&
-            (executionError.name === 'AbortError' ||
+          const abortedByError =
+            isAbortError(executionError) ||
+            (executionError instanceof Error &&
               executionError.message.includes('Operation cancelled by user'));
 
-          if (signal.aborted || isAbortError) {
+          if (signal.aborted || abortedByError) {
             completedToolCall = await this.createCancelledResult(
               call,
-              'User cancelled tool execution.',
+              isAbortError(executionError)
+                ? 'Operation cancelled.'
+                : 'User cancelled tool execution.',
             );
           } else {
             const error =

--- a/packages/core/src/tools/web-search.ts
+++ b/packages/core/src/tools/web-search.ts
@@ -16,7 +16,7 @@ import {
 } from './tools.js';
 import { ToolErrorType } from './tool-error.js';
 
-import { getErrorMessage , isAbortError } from '../utils/errors.js';
+import { getErrorMessage, isAbortError } from '../utils/errors.js';
 import { type Config } from '../config/config.js';
 import { getResponseText } from '../utils/partUtils.js';
 import { debugLogger } from '../utils/debugLogger.js';

--- a/packages/core/src/tools/web-search.ts
+++ b/packages/core/src/tools/web-search.ts
@@ -175,6 +175,14 @@ class WebSearchToolInvocation extends BaseToolInvocation<
         sources,
       };
     } catch (error: unknown) {
+      const isAbortError =
+        error instanceof Error && error.name === 'AbortError';
+      if (isAbortError) {
+        return {
+          llmContent: 'Web search was cancelled.',
+          returnDisplay: 'Search cancelled.',
+        };
+      }
       const errorMessage = `Error during web search for query "${
         this.params.query
       }": ${getErrorMessage(error)}`;

--- a/packages/core/src/tools/web-search.ts
+++ b/packages/core/src/tools/web-search.ts
@@ -16,7 +16,7 @@ import {
 } from './tools.js';
 import { ToolErrorType } from './tool-error.js';
 
-import { getErrorMessage } from '../utils/errors.js';
+import { getErrorMessage , isAbortError } from '../utils/errors.js';
 import { type Config } from '../config/config.js';
 import { getResponseText } from '../utils/partUtils.js';
 import { debugLogger } from '../utils/debugLogger.js';
@@ -175,9 +175,7 @@ class WebSearchToolInvocation extends BaseToolInvocation<
         sources,
       };
     } catch (error: unknown) {
-      const isAbortError =
-        error instanceof Error && error.name === 'AbortError';
-      if (isAbortError) {
+      if (isAbortError(error)) {
         return {
           llmContent: 'Web search was cancelled.',
           returnDisplay: 'Search cancelled.',


### PR DESCRIPTION
When a user presses ESC to cancel an in-flight tool call (e.g. google_web_search), the underlying request can reject with AbortError. Treat AbortError as a normal cancellation so the CLI returns to the prompt without surfacing a raw stack trace.

Fixes #20839

## Summary

- Handle `AbortError` during tool execution as a normal cancellation so the CLI shows a clean “Request cancelled” message and returns to the prompt without a stack trace.

## Details

- Treat `AbortError` thrown during tool execution as cancellation (instead of an unhandled exception/error result).
- Ensure `google_web_search` returns a clean cancelled result when the abort is caught within the tool.

## Related Issues

Fixes #20839

## How to Validate

1. Build + start the CLI from source:
   - `npm run build --workspace=@google/gemini-cli-devtools`
   - `npm run build`
   - `npm run start`
2. Trigger a web search (anything that invokes `google_web_search`).
3. While the search is in progress, press `ESC` to cancel.
4. Confirm:
   - The CLI shows a cancellation message (e.g. “Request cancelled.”).
   - No raw `AbortError` stack trace is printed.
   - The CLI returns to the prompt and continues normally.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker