### PR TITLE
feat(cli): add --google-cloud-location flag for Vertex AI

### DIFF
--- a/docs/cli/cli-reference.md
+++ b/docs/cli/cli-reference.md
@@ -48,6 +48,7 @@ and parameters.
 | `--delete-session`               | -     | string  | -         | Delete a session by index number (use `--list-sessions` to see available sessions)                                                                                     |
 | `--include-directories`          | -     | array   | -         | Additional directories to include in the workspace (comma-separated or multiple flags)                                                                                 |
 | `--screen-reader`                | -     | boolean | -         | Enable screen reader mode for accessibility                                                                                                                            |
+| `--google-cloud-location`        | -     | string  | -         | Google Cloud location for Vertex AI (e.g., `us-central1`). Overrides the `GOOGLE_CLOUD_LOCATION` environment variable.                                                 |
 | `--output-format`                | `-o`  | string  | `text`    | The format of the CLI output. Choices: `text`, `json`, `stream-json`                                                                                                   |
 
 ## Model selection

--- a/docs/get-started/authentication.md
+++ b/docs/get-started/authentication.md
@@ -121,7 +121,20 @@ Regardless of your authentication method for Vertex AI, you'll need to set
 enabled, and `GOOGLE_CLOUD_LOCATION` to the location of your Vertex AI resources
 or the location where you want to run your jobs.
 
+You can set the location using either:
+
+- The `--google-cloud-location` CLI flag (takes priority), or
+- The `GOOGLE_CLOUD_LOCATION` environment variable.
+
 For example:
+
+**Using the CLI flag**
+
+```bash
+gemini --google-cloud-location us-central1
+```
+
+**Using environment variables**
 
 **macOS/Linux**
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1407,6 +1407,7 @@ the `advanced.excludedEnvVars` setting in your `settings.json` file.
 - **`GOOGLE_CLOUD_LOCATION`**:
   - Your Google Cloud Project Location (e.g., us-central1).
   - Required for using Vertex AI in non-express mode.
+  - Can be overridden by the `--google-cloud-location` CLI flag.
   - Example: `export GOOGLE_CLOUD_LOCATION="YOUR_PROJECT_LOCATION"` (Windows
     PowerShell: `$env:GOOGLE_CLOUD_LOCATION="YOUR_PROJECT_LOCATION"`).
 - **`GEMINI_SANDBOX`**:

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -75,6 +75,7 @@ export interface CliArgs {
   debug: boolean | undefined;
   prompt: string | undefined;
   promptInteractive: string | undefined;
+  googleCloudLocation: string | undefined;
 
   yolo: boolean | undefined;
   approvalMode: string | undefined;
@@ -180,6 +181,10 @@ export async function parseArguments(
         .option('experimental-acp', {
           type: 'boolean',
           description: 'Starts the agent in ACP mode',
+        })
+        .option('google-cloud-location', {
+          type: 'string',
+          description: 'The Google Cloud location to use',
         })
         .option('allowed-mcp-server-names', {
           type: 'array',
@@ -538,6 +543,7 @@ export async function loadCliConfig(
   }
 
   const question = argv.promptInteractive || argv.prompt || '';
+  const googleCloudLocation = argv.googleCloudLocation || '';
 
   // Determine approval mode with backward compatibility
   let approvalMode: ApprovalMode;
@@ -765,6 +771,7 @@ export async function loadCliConfig(
       settings.context?.loadMemoryFromIncludeDirectories || false,
     debugMode,
     question,
+    googleCloudLocation,
 
     coreTools: settings.tools?.core || undefined,
     allowedTools: allowedTools.length > 0 ? allowedTools : undefined,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -543,7 +543,7 @@ export async function loadCliConfig(
   }
 
   const question = argv.promptInteractive || argv.prompt || '';
-  const googleCloudLocation = argv.googleCloudLocation || '';
+  const googleCloudLocation = argv.googleCloudLocation;
 
   // Determine approval mode with backward compatibility
   let approvalMode: ApprovalMode;

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -497,6 +497,7 @@ describe('gemini.tsx main function kitty protocol', () => {
       recordResponses: undefined,
       rawOutput: undefined,
       acceptRawOutputRisk: undefined,
+      googleCloudLocation: undefined,
       isCommand: undefined,
     });
 

--- a/packages/core/src/agents/agentLoader.ts
+++ b/packages/core/src/agents/agentLoader.ts
@@ -417,7 +417,7 @@ export function markdownToAgentDefinition(
     return {
       kind: 'remote',
       name: markdown.name,
-      description: markdown.description || '(Loading description...)',
+      description: markdown.description || '',
       displayName: markdown.display_name,
       agentCardUrl: markdown.agent_card_url,
       auth: markdown.auth

--- a/packages/core/src/agents/registry.test.ts
+++ b/packages/core/src/agents/registry.test.ts
@@ -572,6 +572,181 @@ describe('AgentRegistry', () => {
       );
     });
 
+    it('should merge user and agent description and skills when registering a remote agent', async () => {
+      const remoteAgent: AgentDefinition = {
+        kind: 'remote',
+        name: 'RemoteAgentWithDescription',
+        description: 'User-provided description',
+        agentCardUrl: 'https://example.com/card',
+        inputConfig: { inputSchema: { type: 'object' } },
+      };
+
+      const mockAgentCard = {
+        name: 'RemoteAgentWithDescription',
+        description: 'Card-provided description',
+        skills: [
+          { name: 'Skill1', description: 'Desc1' },
+          { name: 'Skill2', description: 'Desc2' },
+        ],
+      };
+
+      vi.mocked(A2AClientManager.getInstance).mockReturnValue({
+        loadAgent: vi.fn().mockResolvedValue(mockAgentCard),
+        clearCache: vi.fn(),
+      } as unknown as A2AClientManager);
+
+      await registry.testRegisterAgent(remoteAgent);
+
+      const registered = registry.getDefinition('RemoteAgentWithDescription');
+      expect(registered?.description).toBe(
+        'User Description: User-provided description\nAgent Description: Card-provided description\nSkills:\nSkill1: Desc1\nSkill2: Desc2',
+      );
+    });
+
+    it('should include skills when agent description is empty', async () => {
+      const remoteAgent: AgentDefinition = {
+        kind: 'remote',
+        name: 'RemoteAgentWithSkillsOnly',
+        description: 'User-provided description',
+        agentCardUrl: 'https://example.com/card',
+        inputConfig: { inputSchema: { type: 'object' } },
+      };
+
+      const mockAgentCard = {
+        name: 'RemoteAgentWithSkillsOnly',
+        description: '',
+        skills: [{ name: 'Skill1', description: 'Desc1' }],
+      };
+
+      vi.mocked(A2AClientManager.getInstance).mockReturnValue({
+        loadAgent: vi.fn().mockResolvedValue(mockAgentCard),
+        clearCache: vi.fn(),
+      } as unknown as A2AClientManager);
+
+      await registry.testRegisterAgent(remoteAgent);
+
+      const registered = registry.getDefinition('RemoteAgentWithSkillsOnly');
+      expect(registered?.description).toBe(
+        'User Description: User-provided description\nSkills:\nSkill1: Desc1',
+      );
+    });
+
+    it('should handle empty user or agent descriptions and no skills during merging', async () => {
+      const remoteAgent: AgentDefinition = {
+        kind: 'remote',
+        name: 'RemoteAgentWithEmptyAgentDescription',
+        description: 'User-provided description',
+        agentCardUrl: 'https://example.com/card',
+        inputConfig: { inputSchema: { type: 'object' } },
+      };
+
+      const mockAgentCard = {
+        name: 'RemoteAgentWithEmptyAgentDescription',
+        description: '', // Empty agent description
+        skills: [],
+      };
+
+      vi.mocked(A2AClientManager.getInstance).mockReturnValue({
+        loadAgent: vi.fn().mockResolvedValue(mockAgentCard),
+        clearCache: vi.fn(),
+      } as unknown as A2AClientManager);
+
+      await registry.testRegisterAgent(remoteAgent);
+
+      const registered = registry.getDefinition(
+        'RemoteAgentWithEmptyAgentDescription',
+      );
+      // Should only contain user description
+      expect(registered?.description).toBe(
+        'User Description: User-provided description',
+      );
+    });
+
+    it('should not accumulate descriptions on repeated registration', async () => {
+      const remoteAgent: AgentDefinition = {
+        kind: 'remote',
+        name: 'RemoteAgentAccumulationTest',
+        description: 'User-provided description',
+        agentCardUrl: 'https://example.com/card',
+        inputConfig: { inputSchema: { type: 'object' } },
+      };
+
+      const mockAgentCard = {
+        name: 'RemoteAgentAccumulationTest',
+        description: 'Card-provided description',
+        skills: [{ name: 'Skill1', description: 'Desc1' }],
+      };
+
+      vi.mocked(A2AClientManager.getInstance).mockReturnValue({
+        loadAgent: vi.fn().mockResolvedValue(mockAgentCard),
+        clearCache: vi.fn(),
+      } as unknown as A2AClientManager);
+
+      // Register first time
+      await registry.testRegisterAgent(remoteAgent);
+      let registered = registry.getDefinition('RemoteAgentAccumulationTest');
+      const firstDescription = registered?.description;
+      expect(firstDescription).toBe(
+        'User Description: User-provided description\nAgent Description: Card-provided description\nSkills:\nSkill1: Desc1',
+      );
+
+      // Register second time with the SAME object
+      await registry.testRegisterAgent(remoteAgent);
+      registered = registry.getDefinition('RemoteAgentAccumulationTest');
+      expect(registered?.description).toBe(firstDescription);
+    });
+
+    it('should allow registering a remote agent with an empty initial description', async () => {
+      const remoteAgent: AgentDefinition = {
+        kind: 'remote',
+        name: 'EmptyDescAgent',
+        description: '', // Empty initial description
+        agentCardUrl: 'https://example.com/card',
+        inputConfig: { inputSchema: { type: 'object' } },
+      };
+
+      vi.mocked(A2AClientManager.getInstance).mockReturnValue({
+        loadAgent: vi.fn().mockResolvedValue({
+          name: 'EmptyDescAgent',
+          description: 'Loaded from card',
+        }),
+        clearCache: vi.fn(),
+      } as unknown as A2AClientManager);
+
+      await registry.testRegisterAgent(remoteAgent);
+
+      const registered = registry.getDefinition('EmptyDescAgent');
+      expect(registered?.description).toBe(
+        'Agent Description: Loaded from card',
+      );
+    });
+
+    it('should provide fallback for skill descriptions if missing in the card', async () => {
+      const remoteAgent: AgentDefinition = {
+        kind: 'remote',
+        name: 'SkillFallbackAgent',
+        description: 'User description',
+        agentCardUrl: 'https://example.com/card',
+        inputConfig: { inputSchema: { type: 'object' } },
+      };
+
+      vi.mocked(A2AClientManager.getInstance).mockReturnValue({
+        loadAgent: vi.fn().mockResolvedValue({
+          name: 'SkillFallbackAgent',
+          description: 'Card description',
+          skills: [{ name: 'SkillNoDesc' }], // Missing description
+        }),
+        clearCache: vi.fn(),
+      } as unknown as A2AClientManager);
+
+      await registry.testRegisterAgent(remoteAgent);
+
+      const registered = registry.getDefinition('SkillFallbackAgent');
+      expect(registered?.description).toContain(
+        'SkillNoDesc: No description provided',
+      );
+    });
+
     it('should handle special characters in agent names', async () => {
       const specialAgent = {
         ...MOCK_AGENT_V1,

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -335,9 +335,10 @@ export class AgentRegistry {
     }
 
     // Basic validation
-    if (!definition.name || !definition.description) {
+    // Remote agents can have an empty description initially as it will be populated from the AgentCard
+    if (!definition.name) {
       debugLogger.warn(
-        `[AgentRegistry] Skipping invalid agent definition. Missing name or description.`,
+        `[AgentRegistry] Skipping invalid agent definition. Missing name.`,
       );
       return;
     }
@@ -360,24 +361,48 @@ export class AgentRegistry {
       debugLogger.log(`[AgentRegistry] Overriding agent '${definition.name}'`);
     }
 
+    const remoteDef = definition;
+
+    // Capture the original description from the first registration
+    if (remoteDef.originalDescription === undefined) {
+      remoteDef.originalDescription = remoteDef.description;
+    }
+
     // Log remote A2A agent registration for visibility.
     try {
       const clientManager = A2AClientManager.getInstance();
       // Use ADCHandler to ensure we can load agents hosted on secure platforms (e.g. Vertex AI)
       const authHandler = new ADCHandler();
       const agentCard = await clientManager.loadAgent(
-        definition.name,
-        definition.agentCardUrl,
+        remoteDef.name,
+        remoteDef.agentCardUrl,
         authHandler,
       );
+
+      const userDescription = remoteDef.originalDescription;
+      const agentDescription = agentCard.description;
+      const descriptions: string[] = [];
+
+      if (userDescription?.trim()) {
+        descriptions.push(`User Description: ${userDescription.trim()}`);
+      }
+      if (agentDescription?.trim()) {
+        descriptions.push(`Agent Description: ${agentDescription.trim()}`);
+      }
       if (agentCard.skills && agentCard.skills.length > 0) {
-        definition.description = agentCard.skills
+        const skillsList = agentCard.skills
           .map(
             (skill: { name: string; description: string }) =>
-              `${skill.name}: ${skill.description}`,
+              `${skill.name}: ${skill.description || 'No description provided'}`,
           )
           .join('\n');
+        descriptions.push(`Skills:\n${skillsList}`);
       }
+
+      if (descriptions.length > 0) {
+        definition.description = descriptions.join('\n');
+      }
+
       if (this.config.getDebugMode()) {
         debugLogger.log(
           `[AgentRegistry] Registered remote agent '${definition.name}' with card: ${definition.agentCardUrl}`,

--- a/packages/core/src/agents/types.ts
+++ b/packages/core/src/agents/types.ts
@@ -119,6 +119,8 @@ export interface RemoteAgentDefinition<
 > extends BaseAgentDefinition<TOutput> {
   kind: 'remote';
   agentCardUrl: string;
+  /** The user-provided description, before any remote card merging. */
+  originalDescription?: string;
   /**
    * Optional authentication configuration for the remote agent.
    * If not specified, the agent will try to use defaults based on the AgentCard's

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -460,6 +460,7 @@ export interface ConfigParameters {
   targetDir: string;
   debugMode: boolean;
   question?: string;
+  googleCloudLocation?: string;
 
   coreTools?: string[];
   /** @deprecated Use Policy Engine instead */
@@ -586,6 +587,7 @@ export class Config implements McpContext {
   private mcpClientManager?: McpClientManager;
   private allowedMcpServers: string[];
   private blockedMcpServers: string[];
+  private readonly googleCloudLocation?: string;
   private allowedEnvironmentVariables: string[];
   private blockedEnvironmentVariables: string[];
   private readonly enableEnvironmentVariableRedaction: boolean;
@@ -816,6 +818,7 @@ export class Config implements McpContext {
     this.blockedEnvironmentVariables = params.blockedEnvironmentVariables ?? [];
     this.enableEnvironmentVariableRedaction =
       params.enableEnvironmentVariableRedaction ?? false;
+    this.googleCloudLocation = params.googleCloudLocation ?? undefined;
     this.userMemory = params.userMemory ?? '';
     this.geminiMdFileCount = params.geminiMdFileCount ?? 0;
     this.geminiMdFilePaths = params.geminiMdFilePaths ?? [];
@@ -1393,6 +1396,10 @@ export class Config implements McpContext {
 
   getActiveModel(): string {
     return this._activeModel ?? this.model;
+  }
+
+  getGoogleCloudLocation(): string | undefined {
+    return this.googleCloudLocation;
   }
 
   setActiveModel(model: string): void {

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -110,10 +110,11 @@ export async function createContentGeneratorConfig(
     process.env['GOOGLE_CLOUD_PROJECT'] ||
     process.env['GOOGLE_CLOUD_PROJECT_ID'] ||
     undefined;
+  const cliLocation = config.getGoogleCloudLocation();
   const googleCloudLocation =
-    config.getGoogleCloudLocation() ||
-    process.env['GOOGLE_CLOUD_LOCATION'] ||
-    undefined;
+    cliLocation !== undefined && cliLocation.trim() !== ''
+      ? cliLocation.trim()
+      : process.env['GOOGLE_CLOUD_LOCATION'];
 
   const contentGeneratorConfig: ContentGeneratorConfig = {
     authType,

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -110,7 +110,10 @@ export async function createContentGeneratorConfig(
     process.env['GOOGLE_CLOUD_PROJECT'] ||
     process.env['GOOGLE_CLOUD_PROJECT_ID'] ||
     undefined;
-  const googleCloudLocation = process.env['GOOGLE_CLOUD_LOCATION'] || undefined;
+  const googleCloudLocation =
+    config.getGoogleCloudLocation() ||
+    process.env['GOOGLE_CLOUD_LOCATION'] ||
+    undefined;
 
   const contentGeneratorConfig: ContentGeneratorConfig = {
     authType,

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -212,9 +212,11 @@ export class LoggingContentGenerator implements ContentGenerator {
 
     // Case 2: Using an API key for Vertex AI.
     if (genConfig?.vertexai) {
+      const cliLocation = this.config.getGoogleCloudLocation();
       const googleCloudLocation =
-        this.config.getGoogleCloudLocation() ||
-        process.env['GOOGLE_CLOUD_LOCATION'];
+        cliLocation !== undefined && cliLocation.trim() !== ''
+          ? cliLocation.trim()
+          : process.env['GOOGLE_CLOUD_LOCATION'];
       if (googleCloudLocation) {
         return {
           address: `${googleCloudLocation}-aiplatform.googleapis.com`,

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -212,9 +212,14 @@ export class LoggingContentGenerator implements ContentGenerator {
 
     // Case 2: Using an API key for Vertex AI.
     if (genConfig?.vertexai) {
-      const location = process.env['GOOGLE_CLOUD_LOCATION'];
-      if (location) {
-        return { address: `${location}-aiplatform.googleapis.com`, port: 443 };
+      const googleCloudLocation =
+        this.config.getGoogleCloudLocation() ||
+        process.env['GOOGLE_CLOUD_LOCATION'];
+      if (googleCloudLocation) {
+        return {
+          address: `${googleCloudLocation}-aiplatform.googleapis.com`,
+          port: 443,
+        };
       } else {
         return { address: 'unknown', port: 0 };
       }


### PR DESCRIPTION
## Summary

Add a `--google-cloud-location` CLI flag so users can specify the Google Cloud location for Vertex AI without relying solely on the `GOOGLE_CLOUD_LOCATION` environment variable.

## Details

Currently, the Google Cloud location for Vertex AI can only be configured via the `GOOGLE_CLOUD_LOCATION` environment variable. This PR adds a `--google-cloud-location` CLI flag that takes precedence over the environment variable, providing a more convenient and explicit way to set the location per invocation.

Changes:
- Added `--google-cloud-location` option to the CLI argument parser (`packages/cli/src/config/config.ts`)
- Threaded the new option through `ConfigParameters` and the `Config` class (`packages/core/src/config/config.ts`)
- Updated `contentGenerator.ts` and `loggingContentGenerator.ts` to prefer the CLI flag over the environment variable
- Updated existing tests to include the new field
- Updated documentation:
  - `docs/cli/cli-reference.md` — added flag to the CLI Options table
  - `docs/get-started/authentication.md` — added flag usage example in the Vertex AI section
  - `docs/reference/configuration.md` — noted the env var can be overridden by the CLI flag

The flag value takes priority over the `GOOGLE_CLOUD_LOCATION` environment variable when both are set.

## Related Issues

#20761 

## How to Validate

1. Run with the flag: `npx gemini --google-cloud-location us-central1`
2. Verify the Vertex AI endpoint uses `us-central1-aiplatform.googleapis.com`
3. Set `GOOGLE_CLOUD_LOCATION=europe-west1` and run with `--google-cloud-location us-central1` — the flag should take precedence (`us-central1`)
4. Run without the flag but with `GOOGLE_CLOUD_LOCATION=europe-west1` — should fall back to the env var (`europe-west1`)
5. Run tests: `npm test`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker