### PR TITLE
fix(cli): preserve AskUser state on terminal suspend

### DIFF
--- a/packages/cli/src/ui/components/AskUserDialog.test.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.test.tsx
@@ -10,7 +10,7 @@ import { renderWithProviders } from '../../test-utils/render.js';
 import { createMockSettings } from '../../test-utils/settings.js';
 import { makeFakeConfig } from '@google/gemini-cli-core';
 import { waitFor } from '../../test-utils/async.js';
-import { AskUserDialog } from './AskUserDialog.js';
+import { AskUserDialog, resetAskUserDraft } from './AskUserDialog.js';
 import { QuestionType, type Question } from '@google/gemini-cli-core';
 import { UIStateContext, type UIState } from '../contexts/UIStateContext.js';
 
@@ -1451,6 +1451,125 @@ describe('AskUserDialog', () => {
       expect(onSubmit).toHaveBeenCalledWith({
         '0': `TypeScript, ${pastedText}`,
       });
+    });
+  });
+  describe('Suspend/resume state preservation (CTRL-Z)', () => {
+    // Simulates forceRerenderKey bump on SIGCONT: unmount then remount
+    // with the same questions. The askUserDraft store should restore state.
+
+    afterEach(() => {
+      resetAskUserDraft();
+    });
+
+    const renderDialog = (questions: Question[]) =>
+      renderWithProviders(
+        <AskUserDialog
+          questions={questions}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          width={120}
+        />,
+        { width: 120 },
+      );
+
+    it('restores in-progress text answer after suspend/resume', async () => {
+      const q: Question[] = [
+        { question: 'What to build?', header: 'Q', type: QuestionType.TEXT },
+      ];
+
+      const first = await renderDialog(q);
+      for (const char of 'my cool app') writeKey(first.stdin, char);
+      await waitFor(async () => {
+        expect(first.lastFrame()).toContain('my cool app');
+      });
+
+      act(() => first.unmount());
+
+      const second = await renderDialog(q);
+      await waitFor(async () => {
+        expect(second.lastFrame()).toContain('my cool app');
+      });
+      act(() => second.unmount());
+    });
+
+    it('restores choice custom text after suspend/resume', async () => {
+      const q: Question[] = [
+        {
+          question: 'Which database?',
+          header: 'DB',
+          type: QuestionType.CHOICE,
+          options: [{ label: 'PostgreSQL', description: '' }],
+          multiSelect: false,
+        },
+      ];
+
+      const first = await renderDialog(q);
+      writeKey(first.stdin, '\x1b[B'); // Down to Other
+      for (const char of 'Redis') writeKey(first.stdin, char);
+      await waitFor(async () => {
+        expect(first.lastFrame()).toContain('Redis');
+      });
+
+      act(() => first.unmount());
+
+      const second = await renderDialog(q);
+      await waitFor(async () => {
+        expect(second.lastFrame()).toContain('Redis');
+      });
+      act(() => second.unmount());
+    });
+
+    it('does NOT restore draft after successful submission', async () => {
+      const q: Question[] = [
+        { question: 'Your name?', header: 'N', type: QuestionType.TEXT },
+      ];
+      const onSubmit = vi.fn();
+      const first = await renderWithProviders(
+        <AskUserDialog
+          questions={q}
+          onSubmit={onSubmit}
+          onCancel={vi.fn()}
+          width={120}
+        />,
+        { width: 120 },
+      );
+
+      for (const char of 'Alice') writeKey(first.stdin, char);
+      writeKey(first.stdin, '\r');
+      await waitFor(() =>
+        expect(onSubmit).toHaveBeenCalledWith({ '0': 'Alice' }),
+      );
+
+      act(() => first.unmount());
+
+      const second = await renderDialog(q);
+      await waitFor(async () => {
+        expect(second.lastFrame()).not.toContain('Alice');
+      });
+      act(() => second.unmount());
+    });
+
+    it('does NOT restore draft for different questions', async () => {
+      const qA: Question[] = [
+        { question: 'Question A?', header: 'A', type: QuestionType.TEXT },
+      ];
+      const qB: Question[] = [
+        { question: 'Question B?', header: 'B', type: QuestionType.TEXT },
+      ];
+
+      const first = await renderDialog(qA);
+      for (const char of 'answer for A') writeKey(first.stdin, char);
+      await waitFor(async () => {
+        expect(first.lastFrame()).toContain('answer for A');
+      });
+
+      act(() => first.unmount());
+
+      const second = await renderDialog(qB);
+      await waitFor(async () => {
+        expect(second.lastFrame()).not.toContain('answer for A');
+      });
+      act(() => second.unmount());
     });
   });
 });

--- a/packages/cli/src/ui/components/AskUserDialog.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.tsx
@@ -12,6 +12,7 @@ import {
   useEffect,
   useReducer,
   useContext,
+  useState,
 } from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../semantic-colors.js';
@@ -108,6 +109,23 @@ const initialState: AskUserDialogState = {
   isEditingCustomOption: false,
   submitted: false,
 };
+
+/**
+ * Module-level draft store: survives React remounts (e.g. from CTRL-Z
+ * suspend/resume which bumps forceRerenderKey and remounts <App>).
+ * Keyed by the first question's text so we only restore for the same dialog.
+ */
+interface AskUserDraft {
+  questionsKey: string;
+  answers: { [key: string]: string };
+  currentIndex: number;
+}
+let askUserDraft: AskUserDraft | null = null;
+
+/** @internal Exported only for test cleanup. */
+export function resetAskUserDraft(): void {
+  askUserDraft = null;
+}
 
 function askUserDialogReducerLogic(
   state: AskUserDialogState,
@@ -1010,21 +1028,66 @@ export const AskUserDialog: React.FC<AskUserDialogProps> = ({
       ? uiState?.availableTerminalHeight
       : undefined);
 
-  const [state, dispatch] = useReducer(askUserDialogReducerLogic, initialState);
+  // Restore draft state from a previous mount if the same questions are shown
+  // (i.e. the component was remounted due to CTRL-Z suspend/resume).
+  const questionsKey = questions[0]?.question ?? '';
+  const restoredDraft =
+    askUserDraft?.questionsKey === questionsKey ? askUserDraft : null;
+
+  const [state, dispatch] = useReducer(
+    askUserDialogReducerLogic,
+    restoredDraft
+      ? { ...initialState, answers: restoredDraft.answers }
+      : initialState,
+  );
   const { answers, isEditingCustomOption, submitted } = state;
 
   const reviewTabIndex = questions.length;
   const tabCount =
     questions.length > 1 ? questions.length + 1 : questions.length;
 
+  const [restoredIndex] = useState(() => restoredDraft?.currentIndex ?? 0);
+
   const { currentIndex, goToNextTab, goToPrevTab } = useTabbedNavigation({
     tabCount,
     isActive: !submitted && questions.length > 1,
     enableArrowNavigation: false, // We'll handle arrows via textBuffer callbacks or manually
     enableTabKey: false, // We'll handle tab manually to match existing behavior
+    initialIndex: restoredIndex,
   });
 
   const currentQuestionIndex = currentIndex;
+
+  // Save draft state whenever answers or currentIndex change so we can
+  // restore them after a remount. Use refs so the cleanup closure always
+  // reads the latest values (avoids stale closure on unmount).
+  const answersRef = useRef(answers);
+  answersRef.current = answers;
+  const currentIndexRef = useRef(currentQuestionIndex);
+  currentIndexRef.current = currentQuestionIndex;
+  const submittedRef = useRef(submitted);
+  submittedRef.current = submitted;
+
+  useEffect(() => {
+    // Clear any stale draft for a different dialog on mount.
+    if (askUserDraft && askUserDraft.questionsKey !== questionsKey) {
+      askUserDraft = null;
+    }
+    return () => {
+      // On unmount, persist draft so the next mount can restore it.
+      // Use refs to read latest state, not the stale closure values.
+      if (!submittedRef.current) {
+        askUserDraft = {
+          questionsKey,
+          answers: answersRef.current,
+          currentIndex: currentIndexRef.current,
+        };
+      } else {
+        askUserDraft = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleEditingCustomOption = useCallback((isEditing: boolean) => {
     dispatch({ type: 'SET_EDITING_CUSTOM', payload: { isEditing } });
@@ -1041,10 +1104,12 @@ export const AskUserDialog: React.FC<AskUserDialogProps> = ({
     (key: Key) => {
       if (submitted) return false;
       if (keyMatchers[Command.ESCAPE](key)) {
+        askUserDraft = null;
         onCancel();
         return true;
       } else if (keyMatchers[Command.QUIT](key)) {
         if (!isEditingCustomOption) {
+          askUserDraft = null;
           onCancel();
         }
         // Return false to let ctrl-C bubble up to AppContainer for exit flow


### PR DESCRIPTION
## Summary

When suspending the CLI via Ctrl+Z, the React App tree remounts, which destroys the local AskUserDialog state (including the user's typing progress). This PR introduces a module-level askUserDraft store keyed by the serialized questions array. The draft persists answers and the current tab index outside of the React lifecycle across remounts, ensuring that any typed text is fully restored upon resuming the CLI.

## Related Issues

Fixes #20838

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [x] Docker