### PR TITLE
fix: correct typos in comments and documentation

### DIFF
--- a/evals/frugalReads.eval.ts
+++ b/evals/frugalReads.eval.ts
@@ -99,7 +99,7 @@ describe('Frugal reads eval', () => {
         );
       }
 
-      // Ranged read shoud be frugal and just enough to satisfy the task at hand.
+      // Ranged read should be frugal and just enough to satisfy the task at hand.
       expect(
         totalLinesRead,
         'Agent read more of the file than expected',

--- a/packages/a2a-server/development-extension-rfc.md
+++ b/packages/a2a-server/development-extension-rfc.md
@@ -413,7 +413,7 @@ This method allows the client to execute a slash command. Following the initial
 mechanism to communicate the command's progress and output. All subsequent
 updates, including textual output, agent thoughts, and any required user
 confirmations for tool calls (like executing a shell command), will be sent as
-`TaskStatusUpdateEvent` messages, re-using the schemas defined above.
+`TaskStatusUpdateEvent` messages, reusing the schemas defined above.
 
 ```proto
 // Request to execute a specific slash command.

--- a/packages/cli/src/ui/components/AskUserDialog.test.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.test.tsx
@@ -1046,7 +1046,7 @@ describe('AskUserDialog', () => {
         { width: 120 },
       );
 
-      // Answer Q1 and Q2 sequentialy
+      // Answer Q1 and Q2 sequentially
       act(() => {
         stdin.write('\r'); // Select A1 for Q1 -> triggers autoAdvance
       });

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -1508,7 +1508,7 @@ function calculateVisualCursorFromLayout(
   const [visualRow, startColInLogical] =
     segmentsForLogicalLine[targetSegmentIndex];
 
-  // Find the coordinates in transformed space in order to conver to visual
+  // Find the coordinates in transformed space in order to convert to visual
   const transformedToLogicalMap = transformedToLogicalMaps[logicalRow] ?? [];
   let transformedCol = 0;
   for (let i = 0; i < transformedToLogicalMap.length; i++) {

--- a/packages/cli/src/ui/utils/clipboardUtils.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.ts
@@ -418,7 +418,7 @@ export async function cleanupOldClipboardImages(
   }
 }
 /**
- * Splits a pasted text block up into escaped path segements if it's a legal
+ * Splits a pasted text block up into escaped path segments if it's a legal
  * drag-and-drop string.
  *
  * There are multiple ways drag-and-drop paths might be escaped:
@@ -430,7 +430,7 @@ export async function cleanupOldClipboardImages(
  * When wrapped in single quotes, actual single quotes in the filename are
  * escaped with "'\''". For example: '/path/to/my '\''fancy file'\''.png'
  *
- * When wrapped in double quotes, actual double quotes are not an issue becuase
+ * When wrapped in double quotes, actual double quotes are not an issue because
  * windows doesn't allow them in filenames.
  *
  * On all systems, a single drag-and-drop may include both wrapped and bare

--- a/packages/core/src/availability/policyHelpers.ts
+++ b/packages/core/src/availability/policyHelpers.ts
@@ -144,7 +144,7 @@ export function resolvePolicyAction(
 
 /**
  * Creates a context provider for retry logic that returns the availability
- * sevice and resolves the current model's policy.
+ * service and resolves the current model's policy.
  *
  * @param modelGetter A function that returns the model ID currently being attempted.
  *        (Allows handling dynamic model changes during retries).

--- a/packages/core/src/utils/customHeaderUtils.ts
+++ b/packages/core/src/utils/customHeaderUtils.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * Parses custom headers and returns a map of key and vallues
+ * Parses custom headers and returns a map of key and values
  */
 export function parseCustomHeaders(
   envValue: string | undefined,


### PR DESCRIPTION
## Summary

This PR fixes 8 spelling mistakes found in code comments and documentation files using codespell. All corrections are in human-readable prose (comments, docstrings, and markdown documentation), not in variable names, function names, or code logic.

## Changes

Fixed the following typos across the codebase:

### packages/cli/src/ui/utils/clipboardUtils.ts
- `segements` → `segments` (line 421)
- `becuase` → `because` (line 433)

### packages/core/src/utils/customHeaderUtils.ts
- `vallues` → `values` (line 8)

### packages/core/src/availability/policyHelpers.ts
- `sevice` → `service` (line 147)

### packages/cli/src/ui/components/AskUserDialog.test.tsx
- `sequentialy` → `sequentially` (line 1049)

### packages/cli/src/ui/components/shared/text-buffer.ts
- `conver` → `convert` (line 1511)

### evals/frugalReads.eval.ts
- `shoud` → `should` (line 102)

### packages/a2a-server/development-extension-rfc.md
- `re-using` → `reusing` (line 416)

## Testing

No behavior changes - these are documentation/comment-only fixes. The codebase's functionality remains unchanged.

## Checklist

- [x] All changes are in comments/docstrings/documentation only
- [x] No variable names, function names, or identifiers were modified
- [x] No test APIs or technical terms were corrected
- [x] No auto-generated files were modified