### PR TITLE
fix(core): increase default headers timeout to 5 minutes

### DIFF
--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -8,7 +8,7 @@ import { getErrorMessage, isNodeError } from './errors.js';
 import { URL } from 'node:url';
 import { Agent, ProxyAgent, setGlobalDispatcher } from 'undici';
 
-const DEFAULT_HEADERS_TIMEOUT = 60000; // 60 seconds
+const DEFAULT_HEADERS_TIMEOUT = 300000; // 5 minutes
 const DEFAULT_BODY_TIMEOUT = 300000; // 5 minutes
 
 // Configure default global dispatcher with higher timeouts


### PR DESCRIPTION
This PR fixes a timeout issue introduced in https://github.com/google-gemini/gemini-cli/pull/20441

**Issue:**
The previous PR inadvertently set the default `headersTimeout` for the `undici` global dispatcher to 60 seconds (60,000 ms). This overridden Node.js's native default of 5 minutes (300,000 ms), causing nightly evaluations and long-running context queries to fail abruptly with `HeadersTimeoutError: Headers Timeout Error` (`UND_ERR_HEADERS_TIMEOUT`).

**Fix:**
This PR restores the 5-minute timeout window by increasing `DEFAULT_HEADERS_TIMEOUT` to 300,000 ms, ensuring complex model generation requests have sufficient time to return their initial response headers.