### PR TITLE
chore(github): require prompt approvers for agent prompt files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,8 @@
 # Docs have a dedicated approver group in addition to maintainers
 /docs/ @google-gemini/gemini-cli-maintainers @google-gemini/gemini-cli-docs
 /README.md @google-gemini/gemini-cli-maintainers @google-gemini/gemini-cli-docs
+
+# Prompt contents and tool definitions require reviews from prompt approvers
+/packages/core/src/prompts/snippets.ts @google-gemini/gemini-cli-prompt-approvers
+/packages/core/src/prompts/snippets.legacy.ts @google-gemini/gemini-cli-prompt-approvers
+/packages/core/src/tools/ @google-gemini/gemini-cli-prompt-approvers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,7 +16,7 @@
 /docs/ @google-gemini/gemini-cli-maintainers @google-gemini/gemini-cli-docs
 /README.md @google-gemini/gemini-cli-maintainers @google-gemini/gemini-cli-docs
 
-# Prompt contents and tool definitions require reviews from prompt approvers
-/packages/core/src/prompts/snippets.ts @google-gemini/gemini-cli-prompt-approvers
-/packages/core/src/prompts/snippets.legacy.ts @google-gemini/gemini-cli-prompt-approvers
+# Prompt contents, tool definitions, and evals require reviews from prompt approvers
+/packages/core/src/prompts/ @google-gemini/gemini-cli-prompt-approvers
 /packages/core/src/tools/ @google-gemini/gemini-cli-prompt-approvers
+/evals/ @google-gemini/gemini-cli-prompt-approvers


### PR DESCRIPTION
## Summary

Adds `@google-gemini/gemini-cli-prompt-approvers` as a required reviewer for files that contain content included in the agent prompt, specifically `snippets.ts`, `snippets.legacy.ts`, and the tool definitions in `packages/core/src/tools/`.

## Details

Updating the `.github/CODEOWNERS` file to enforce review policies on prompt-related files. This ensures that changes to the core prompt and tools used by the AI agent are properly vetted by the prompt approvers.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

1. Check the `.github/CODEOWNERS` file for the new entries.
2. Verify that changes to the specified files in a test PR trigger the review requirement.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
