### PR TITLE
feat(evals): add overall pass rate row to eval nightly summary table

### DIFF
--- a/scripts/aggregate_evals.js
+++ b/scripts/aggregate_evals.js
@@ -155,9 +155,9 @@ function generateMarkdown(currentStatsByModel, history) {
 
   const models = Object.keys(currentStatsByModel).sort();
 
-  for (const model of models) {
-    const currentStats = currentStatsByModel[model];
-    const totalStats = Object.values(currentStats).reduce(
+  const getPassRate = (statsForModel) => {
+    if (!statsForModel) return '-';
+    const totalStats = Object.values(statsForModel).reduce(
       (acc, stats) => {
         acc.passed += stats.passed;
         acc.total += stats.total;
@@ -165,11 +165,14 @@ function generateMarkdown(currentStatsByModel, history) {
       },
       { passed: 0, total: 0 },
     );
+    return totalStats.total > 0
+      ? ((totalStats.passed / totalStats.total) * 100).toFixed(1) + '%'
+      : '-';
+  };
 
-    const totalPassRate =
-      totalStats.total > 0
-        ? ((totalStats.passed / totalStats.total) * 100).toFixed(1) + '%'
-        : 'N/A';
+  for (const model of models) {
+    const currentStats = currentStatsByModel[model];
+    const totalPassRate = getPassRate(currentStats);
 
     console.log(`#### Model: ${model}`);
     console.log(`**Total Pass Rate: ${totalPassRate}**\n`);
@@ -177,18 +180,22 @@ function generateMarkdown(currentStatsByModel, history) {
     // Header
     let header = '| Test Name |';
     let separator = '| :--- |';
+    let passRateRow = '| **Overall Pass Rate** |';
 
     for (const item of reversedHistory) {
       header += ` [${item.run.databaseId}](${item.run.url}) |`;
       separator += ' :---: |';
+      passRateRow += ` **${getPassRate(item.stats[model])}** |`;
     }
 
     // Add Current column last
     header += ' Current |';
     separator += ' :---: |';
+    passRateRow += ` **${totalPassRate}** |`;
 
     console.log(header);
     console.log(separator);
+    console.log(passRateRow);
 
     // Collect all test names for this model
     const allTestNames = new Set(Object.keys(currentStats));


### PR DESCRIPTION
## Summary

Adds a row below the header in the markdown table showing the overall pass rate for each historical and current run in the nightly evals script.

Makes it easier to spot regressions across runs, at a glance.

## Details

Improves the readability of the `aggregate_evals.js` script output by quickly surfacing the top-level pass/fail percentage of the current and past test runs.

## Related Issues

None.

## How to Validate

1. Provide an artifacts directory to the script or run it locally if you have gh cli access to recent runs.
2. Observe the summary table includes a new row `| **Overall Pass Rate** | ... |`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker