### PR TITLE
Add shutdown performance profiling summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ npm install -g @google/gemini-cli@nightly
   information
 - Conversation checkpointing to save and resume complex sessions
 - Custom context files (GEMINI.md) to tailor behavior for your projects
+- Session shutdown performance insights, including throughput, startup timing,
+  tool profiling (grouped by MCP server), and model API performance
 
 ### GitHub Integration
 

--- a/packages/cli/src/ui/commands/quitCommand.test.ts
+++ b/packages/cli/src/ui/commands/quitCommand.test.ts
@@ -8,6 +8,7 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { quitCommand } from './quitCommand.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import { formatDuration } from '../utils/formatters.js';
+import { startupProfiler } from '@google/gemini-cli-core';
 
 vi.mock('../utils/formatters.js');
 
@@ -16,11 +17,12 @@ describe('quitCommand', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2025-01-01T01:00:00Z'));
     vi.mocked(formatDuration).mockReturnValue('1h 0m 0s');
+    vi.spyOn(startupProfiler, 'getLastStartupStats').mockReturnValue([]);
   });
 
   afterEach(() => {
     vi.useRealTimers();
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   it('returns a QuitActionReturn object with the correct messages', () => {
@@ -47,6 +49,8 @@ describe('quitCommand', () => {
         {
           type: 'quit',
           duration: '1h 0m 0s',
+          wallTimeMs: 3600000,
+          startupPhases: undefined,
           id: expect.any(Number),
         },
       ],

--- a/packages/cli/src/ui/commands/quitCommand.ts
+++ b/packages/cli/src/ui/commands/quitCommand.ts
@@ -5,6 +5,7 @@
  */
 
 import { formatDuration } from '../utils/formatters.js';
+import { startupProfiler } from '@google/gemini-cli-core';
 import { CommandKind, type SlashCommand } from './types.js';
 
 export const quitCommand: SlashCommand = {
@@ -17,6 +18,12 @@ export const quitCommand: SlashCommand = {
     const now = Date.now();
     const { sessionStartTime } = context.session.stats;
     const wallDuration = now - sessionStartTime.getTime();
+    const startupPhases = startupProfiler
+      .getLastStartupStats()
+      .map((phase) => ({
+        name: phase.name,
+        durationMs: phase.duration_ms,
+      }));
 
     return {
       type: 'quit',
@@ -29,6 +36,8 @@ export const quitCommand: SlashCommand = {
         {
           type: 'quit',
           duration: formatDuration(wallDuration),
+          wallTimeMs: wallDuration,
+          startupPhases: startupPhases.length > 0 ? startupPhases : undefined,
           id: now,
         },
       ],

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -173,7 +173,11 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
         <ModelMessage model={itemForDisplay.model} />
       )}
       {itemForDisplay.type === 'quit' && (
-        <SessionSummaryDisplay duration={itemForDisplay.duration} />
+        <SessionSummaryDisplay
+          duration={itemForDisplay.duration}
+          wallTimeMs={itemForDisplay.wallTimeMs}
+          startupPhases={itemForDisplay.startupPhases}
+        />
       )}
       {itemForDisplay.type === 'tool_group' && (
         <ToolGroupMessage

--- a/packages/cli/src/ui/components/SessionSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/SessionSummaryDisplay.tsx
@@ -4,19 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { StartupPhaseMetric } from '../types.js';
 import type React from 'react';
 import { StatsDisplay } from './StatsDisplay.js';
 
 interface SessionSummaryDisplayProps {
   duration: string;
+  wallTimeMs?: number;
+  startupPhases?: StartupPhaseMetric[];
 }
 
 export const SessionSummaryDisplay: React.FC<SessionSummaryDisplayProps> = ({
   duration,
+  wallTimeMs,
+  startupPhases,
 }) => (
   <StatsDisplay
     title="Agent powering down. Goodbye!"
     duration={duration}
+    wallTimeMs={wallTimeMs}
+    startupPhases={startupPhases}
+    showPerformanceProfile={wallTimeMs !== undefined}
     footer="Tip: Resume a previous session using gemini --resume or /resume"
   />
 );

--- a/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -27,10 +27,11 @@ import {
   getDisplayString,
   isAutoModel,
   AuthType,
+  DiscoveredMCPTool,
 } from '@google/gemini-cli-core';
 import { useSettings } from '../contexts/SettingsContext.js';
 import { useConfig } from '../contexts/ConfigContext.js';
-import type { QuotaStats } from '../types.js';
+import type { QuotaStats, StartupPhaseMetric } from '../types.js';
 import { QuotaStatsInfo } from './QuotaStatsInfo.js';
 
 // A more flexible and powerful StatRow component
@@ -385,8 +386,55 @@ const ModelUsageTable: React.FC<{
   );
 };
 
+interface ToolProfileSummary {
+  name: string;
+  category: string;
+  toolCall: string;
+  calls: number;
+  avgDurationMs: number;
+  totalDurationMs: number;
+  successRate: number;
+}
+
+const getPerMinuteRate = (count: number, wallTimeMs: number): number => {
+  if (wallTimeMs <= 0) {
+    return 0;
+  }
+  return count / (wallTimeMs / 60000);
+};
+
+const formatPhaseName = (phaseName: string): string =>
+  phaseName.replaceAll('_', ' ');
+
+const splitToolName = (
+  name: string,
+): { category: string; toolCall: string } => {
+  const firstDot = name.indexOf('.');
+  if (firstDot <= 0) {
+    return { category: 'core', toolCall: name };
+  }
+
+  return {
+    category: name.slice(0, firstDot),
+    toolCall: name.slice(firstDot + 1),
+  };
+};
+
+const getToolCategorization = (
+  toolName: string,
+  config: ReturnType<typeof useConfig>,
+): { category: string; toolCall: string } => {
+  const tool = config.getToolRegistry()?.getTool(toolName);
+  if (tool instanceof DiscoveredMCPTool) {
+    return { category: tool.serverName, toolCall: toolName };
+  }
+
+  return splitToolName(toolName);
+};
+
 interface StatsDisplayProps {
   duration: string;
+  wallTimeMs?: number;
   title?: string;
   quotas?: RetrieveUserQuotaResponse;
   footer?: string;
@@ -396,10 +444,13 @@ interface StatsDisplayProps {
   currentModel?: string;
   quotaStats?: QuotaStats;
   creditBalance?: number;
+  startupPhases?: StartupPhaseMetric[];
+  showPerformanceProfile?: boolean;
 }
 
 export const StatsDisplay: React.FC<StatsDisplayProps> = ({
   duration,
+  wallTimeMs,
   title,
   quotas,
   footer,
@@ -409,6 +460,8 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({
   currentModel,
   quotaStats,
   creditBalance,
+  startupPhases,
+  showPerformanceProfile = false,
 }) => {
   const { stats } = useSessionStats();
   const { metrics } = stats;
@@ -439,6 +492,75 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({
     computed.agreementRate,
     agreementThresholds,
   );
+  const effectiveWallTimeMs =
+    wallTimeMs ?? Math.max(0, Date.now() - stats.sessionStartTime.getTime());
+  const totalApiRequests = Object.values(models).reduce(
+    (acc, model) => acc + model.api.totalRequests,
+    0,
+  );
+  const promptsPerMinute = getPerMinuteRate(
+    stats.promptCount,
+    effectiveWallTimeMs,
+  );
+  const toolsPerMinute = getPerMinuteRate(
+    tools.totalCalls,
+    effectiveWallTimeMs,
+  );
+  const apiRequestsPerMinute = getPerMinuteRate(
+    totalApiRequests,
+    effectiveWallTimeMs,
+  );
+
+  const sortedStartupPhases = [...(startupPhases ?? [])]
+    .filter((phase) => phase.durationMs > 0)
+    .sort((a, b) => b.durationMs - a.durationMs);
+  const totalStartupMs = sortedStartupPhases.reduce(
+    (acc, phase) => acc + phase.durationMs,
+    0,
+  );
+  const topStartupPhases = sortedStartupPhases.slice(0, 3);
+  const slowestStartupPhase = topStartupPhases[0];
+
+  const toolProfiles: ToolProfileSummary[] = Object.entries(tools.byName)
+    .filter(([, toolStats]) => toolStats.count > 0)
+    .map(([name, toolStats]) => {
+      const { category, toolCall } = getToolCategorization(name, config);
+      return {
+        name,
+        category,
+        toolCall,
+        calls: toolStats.count,
+        avgDurationMs: toolStats.durationMs / toolStats.count,
+        totalDurationMs: toolStats.durationMs,
+        successRate: (toolStats.success / toolStats.count) * 100,
+      };
+    })
+    .sort((a, b) => {
+      const byCategory = a.category.localeCompare(b.category);
+      if (byCategory !== 0) {
+        return byCategory;
+      }
+      return b.totalDurationMs - a.totalDurationMs;
+    });
+
+  const modelPerformanceRows = Object.entries(models)
+    .filter(([, modelMetrics]) => modelMetrics.api.totalRequests > 0)
+    .map(([modelName, modelMetrics]) => {
+      const requests = modelMetrics.api.totalRequests;
+      const errors = modelMetrics.api.totalErrors;
+      const errorRate = requests > 0 ? (errors / requests) * 100 : 0;
+      const avgLatencyMs =
+        requests > 0 ? modelMetrics.api.totalLatencyMs / requests : 0;
+
+      return {
+        modelKey: modelName,
+        modelName: getDisplayString(modelName.replace('-001', '')),
+        requests,
+        errors,
+        errorRate,
+        avgLatencyMs,
+      };
+    });
 
   const renderTitle = () => {
     if (title) {
@@ -562,6 +684,160 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({
           </Text>
         </SubStatRow>
       </Section>
+      {showPerformanceProfile && (
+        <Section title="Throughput">
+          <StatRow title="Prompts:">
+            <Text color={theme.text.primary}>
+              {stats.promptCount.toLocaleString()}
+            </Text>
+          </StatRow>
+          <StatRow title="API Requests:">
+            <Text color={theme.text.primary}>
+              {totalApiRequests.toLocaleString()}
+            </Text>
+          </StatRow>
+          <SubStatRow title="Prompts / min:">
+            <Text color={theme.text.primary}>
+              {promptsPerMinute.toFixed(2)}
+            </Text>
+          </SubStatRow>
+          <SubStatRow title="Tool Calls / min:">
+            <Text color={theme.text.primary}>{toolsPerMinute.toFixed(2)}</Text>
+          </SubStatRow>
+          <SubStatRow title="API Reqs / min:">
+            <Text color={theme.text.primary}>
+              {apiRequestsPerMinute.toFixed(2)}
+            </Text>
+          </SubStatRow>
+        </Section>
+      )}
+      {showPerformanceProfile && sortedStartupPhases.length > 0 && (
+        <Section title="Startup">
+          <StatRow title="Startup Total:">
+            <Text color={theme.text.primary}>
+              {formatDuration(totalStartupMs)}
+            </Text>
+          </StatRow>
+          {topStartupPhases.map((phase) => {
+            const phasePercent =
+              totalStartupMs > 0
+                ? (phase.durationMs / totalStartupMs) * 100
+                : 0;
+            return (
+              <SubStatRow
+                key={phase.name}
+                title={`${formatPhaseName(phase.name)}:`}
+              >
+                <Text color={theme.text.primary}>
+                  {formatDuration(phase.durationMs)}{' '}
+                  <Text color={theme.text.secondary}>
+                    ({phasePercent.toFixed(1)}%)
+                  </Text>
+                </Text>
+              </SubStatRow>
+            );
+          })}
+          {slowestStartupPhase && (
+            <SubStatRow title="Slowest Phase:">
+              <Text color={theme.text.primary}>
+                {formatPhaseName(slowestStartupPhase.name)}
+              </Text>
+            </SubStatRow>
+          )}
+        </Section>
+      )}
+      {showPerformanceProfile && toolProfiles.length > 0 && (
+        <Section title="Tool Profiling">
+          <Box>
+            <Box width={18}>
+              <Text bold color={theme.text.link}>
+                Category
+              </Text>
+            </Box>
+            <Box width={20}>
+              <Text bold color={theme.text.link}>
+                Tool Call
+              </Text>
+            </Box>
+            <Box width={9} justifyContent="flex-end">
+              <Text bold color={theme.text.link}>
+                Avg
+              </Text>
+            </Box>
+            <Box width={9} justifyContent="flex-end">
+              <Text bold color={theme.text.link}>
+                Total
+              </Text>
+            </Box>
+            <Box width={7} justifyContent="flex-end">
+              <Text bold color={theme.text.link}>
+                Calls
+              </Text>
+            </Box>
+            <Box width={9} justifyContent="flex-end">
+              <Text bold color={theme.text.link}>
+                Success
+              </Text>
+            </Box>
+          </Box>
+          <Box
+            borderStyle="single"
+            borderBottom={true}
+            borderTop={false}
+            borderLeft={false}
+            borderRight={false}
+            borderColor={theme.border.default}
+            width={74}
+          />
+          {toolProfiles.slice(0, 8).map((tool) => (
+            <Box key={tool.name}>
+              <Box width={18}>
+                <Text color={theme.text.link} wrap="truncate-end">
+                  {tool.category}
+                </Text>
+              </Box>
+              <Box width={20}>
+                <Text color={theme.text.primary} wrap="truncate-end">
+                  {tool.toolCall}
+                </Text>
+              </Box>
+              <Box width={9} justifyContent="flex-end">
+                <Text color={theme.text.primary}>
+                  {formatDuration(tool.avgDurationMs)}
+                </Text>
+              </Box>
+              <Box width={9} justifyContent="flex-end">
+                <Text color={theme.text.primary}>
+                  {formatDuration(tool.totalDurationMs)}
+                </Text>
+              </Box>
+              <Box width={7} justifyContent="flex-end">
+                <Text color={theme.text.primary}>
+                  {tool.calls.toLocaleString()}
+                </Text>
+              </Box>
+              <Box width={9} justifyContent="flex-end">
+                <Text color={theme.text.primary}>
+                  {tool.successRate.toFixed(1)}%
+                </Text>
+              </Box>
+            </Box>
+          ))}
+        </Section>
+      )}
+      {showPerformanceProfile && modelPerformanceRows.length > 0 && (
+        <Section title="Model API Performance">
+          {modelPerformanceRows.map((row) => (
+            <StatRow key={row.modelKey} title={`${row.modelName}:`}>
+              <Text color={theme.text.primary}>
+                {row.requests.toLocaleString()} reqs,{' '}
+                {row.errors.toLocaleString()} errs ({row.errorRate.toFixed(1)}
+                %), {formatDuration(row.avgLatencyMs)} avg
+              </Text>
+            </StatRow>
+          ))}
+        </Section>
+      )}
       <ModelUsageTable
         models={models}
         quotas={quotas}

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -189,6 +189,8 @@ export const useSlashCommandProcessor = (
         historyItemContent = {
           type: 'quit',
           duration: message.duration,
+          wallTimeMs: message.wallTimeMs,
+          startupPhases: message.startupPhases,
         };
       } else if (message.type === MessageType.COMPRESSION) {
         historyItemContent = {

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -199,6 +199,11 @@ export interface QuotaStats {
   resetTime?: string;
 }
 
+export interface StartupPhaseMetric {
+  name: string;
+  durationMs: number;
+}
+
 export type HistoryItemStats = HistoryItemQuotaBase & {
   type: 'stats';
   duration: string;
@@ -222,6 +227,8 @@ export type HistoryItemModel = HistoryItemBase & {
 export type HistoryItemQuit = HistoryItemBase & {
   type: 'quit';
   duration: string;
+  wallTimeMs?: number;
+  startupPhases?: StartupPhaseMetric[];
 };
 
 export type HistoryItemToolGroup = HistoryItemBase & {
@@ -462,6 +469,8 @@ export type Message =
       type: MessageType.QUIT;
       timestamp: Date;
       duration: string;
+      wallTimeMs?: number;
+      startupPhases?: StartupPhaseMetric[];
       content?: string;
     }
   | {

--- a/packages/core/src/telemetry/startupProfiler.ts
+++ b/packages/core/src/telemetry/startupProfiler.ts
@@ -33,6 +33,7 @@ export interface StartupPhaseHandle {
  */
 export class StartupProfiler {
   private phases: Map<string, StartupPhase> = new Map();
+  private lastFlushedPhases: StartupPhaseStats[] = [];
   private static instance: StartupProfiler;
 
   private constructor() {}
@@ -219,6 +220,7 @@ export class StartupProfiler {
     }
 
     if (startupPhases.length > 0) {
+      this.lastFlushedPhases = startupPhases;
       logStartupStats(
         config,
         new StartupStatsEvent(
@@ -242,6 +244,13 @@ export class StartupProfiler {
 
     // Clear all phases.
     this.phases.clear();
+  }
+
+  /**
+   * Returns the last startup phase measurements captured by flush().
+   */
+  getLastStartupStats(): StartupPhaseStats[] {
+    return [...this.lastFlushedPhases];
   }
 }
 


### PR DESCRIPTION
## Summary
- add shutdown performance sections to session summary: Throughput, Startup, Tool Profiling, and Model API Performance
- plumb startup phase and wall-time telemetry into quit history so shutdown rendering can compute performance metrics
- refactor tool profiling into a compact table with category grouping by MCP server and per-tool avg/total/calls/success columns
- update README with a feature bullet for shutdown performance insights

## Example

<img width="776" height="894" alt="Screenshot 2026-03-02 at 8 49 36 PM" src="https://github.com/user-attachments/assets/596385c3-e05a-4a2b-b78b-d5f54e4bbedb" />

## Testing
- npm run test --workspace @google/gemini-cli -- src/ui/commands/quitCommand.test.ts src/ui/components/SessionSummaryDisplay.test.tsx src/ui/components/HistoryItemDisplay.test.tsx src/ui/components/StatsDisplay.test.tsx