### PR TITLE
feat: add GEMINI_BASE_URL override for @google/genai path

### DIFF
--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -171,6 +171,7 @@ export async function createContentGenerator(
     const apiKeyAuthMechanism =
       process.env['GEMINI_API_KEY_AUTH_MECHANISM'] || 'x-goog-api-key';
     const apiVersionEnv = process.env['GOOGLE_GENAI_API_VERSION'];
+    const customBaseUrlEnv = process.env['GEMINI_BASE_URL'];
 
     const baseHeaders: Record<string, string> = {
       ...customHeadersMap,
@@ -214,7 +215,10 @@ export async function createContentGenerator(
           'x-gemini-api-privileged-user-id': `${installationId}`,
         };
       }
-      const httpOptions = { headers };
+      const httpOptions = {
+        headers,
+        ...(customBaseUrlEnv && { baseUrl: customBaseUrlEnv }),
+      };
 
       const googleGenAI = new GoogleGenAI({
         apiKey: config.apiKey === '' ? undefined : config.apiKey,


### PR DESCRIPTION
Note: Opening as a Draft! Happy to add unit tests and update relevants docs if the team approves this architectural approach!

## Summary

Adds a ```GEMINI_BASE_URL``` env var to override the default Google API endpoint for standard API key authentication (@google/genai path). This unblocks users behind corporate firewalls/proxies, matching the routing flexibility already present in the Code Assist OAuth path.

## Details

Reads ```GEMINI_BASE_URL``` in ```src/contentgenerator.ts``` and passes it to ```httpOptions.baseUrl``` for ```GoogleGenAI```.

Safely falls back to default Google servers if unset.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

Spun up a local Node.js reverse proxy configured to forward traffic to ```generativelanguage.googleapis.com``` on ```port 8080```.

Added ```GEMINI_BASE_URL="http://localhost:8080"``` alongside ```GEMINI_API_KEY``` in the .env file.

Ran npm start and entered a prompt.

Expected: The local proxy logs the intercepted POST requests (e.g., to ```/v1beta/models/gemini-3-flash-preview:streamGenerateContent```), and the CLI successfully streams the AI's response back to the terminal, proving the network traffic bypassed the default URL and obeyed the custom routing.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ X] Validated on required platforms/methods:
  - [X ] MacOS
    - [ X] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

Fixes #16743