### PR TITLE
feat: support Shift+Enter via \n with Ctrl+J compatibility

### DIFF
--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -211,7 +211,10 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.HISTORY_DOWN]: [{ key: 'n', shift: false, ctrl: true }],
   [Command.REVERSE_SEARCH]: [{ key: 'r', ctrl: true }],
   [Command.REWIND]: [{ key: 'double escape' }],
-  [Command.SUBMIT_REVERSE_SEARCH]: [{ key: 'return', ctrl: false }],
+  [Command.SUBMIT_REVERSE_SEARCH]: [
+    { key: 'return', ctrl: false },
+    { key: 'return', shift: true },
+  ],
   [Command.ACCEPT_SUGGESTION_REVERSE_SEARCH]: [{ key: 'tab', shift: false }],
 
   // Navigation
@@ -234,6 +237,7 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.ACCEPT_SUGGESTION]: [
     { key: 'tab', shift: false },
     { key: 'return', ctrl: false },
+    { key: 'return', shift: true },
   ],
   [Command.COMPLETION_UP]: [
     { key: 'up', shift: false },
@@ -489,7 +493,7 @@ export const commandDescriptions: Readonly<Record<Command, string>> = {
   [Command.SUBMIT]: 'Submit the current prompt.',
   [Command.NEWLINE]: 'Insert a newline without submitting.',
   [Command.OPEN_EXTERNAL_EDITOR]:
-    'Open the current prompt or the plan in an external editor.',
+    'Open the current prompt in an external editor.',
   [Command.PASTE_CLIPBOARD]: 'Paste from the clipboard.',
 
   // App Controls

--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -155,16 +155,17 @@ describe('KeypressContext', () => {
       },
     );
 
-    it('should recognize \n (LF) as ctrl+j', async () => {
+    it('should recognize \\n (LF) as Shift+Enter', async () => {
       const { keyHandler } = setupKeypressTest();
 
       act(() => stdin.write('\n'));
 
+      expect(keyHandler).toHaveBeenCalledTimes(1);
       expect(keyHandler).toHaveBeenCalledWith(
         expect.objectContaining({
-          name: 'j',
-          shift: false,
-          ctrl: true,
+          name: 'return',
+          shift: true,
+          ctrl: false,
           cmd: false,
         }),
       );

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -585,9 +585,11 @@ function* emitKeys(
       // carriage return
       name = 'return';
       alt = escaped;
-    } else if (escaped && ch === '\n') {
-      // Alt+Enter (linefeed), should be consistent with carriage return
+    } else if (ch === '\n') {
+      // line feed - treat as Shift+Enter for terminals that send \n or are mapped
+      // also handles Alt+Enter (linefeed) if escaped
       name = 'return';
+      shift = !escaped;
       alt = escaped;
     } else if (ch === '\t') {
       // tab


### PR DESCRIPTION
  Summary


  This PR enables support for Shift+Enter multiline input in standard terminal environments by explicitly mapping the line feed character (\n) to a return event with shift: true. It prioritizes security
  and UI consistency by ensuring a single, predictable action per keypress.

  Details


  Standard terminals (like iTerm2, GNOME Terminal, or tmux environments) often send a simple carriage return (\r) for both Enter and Shift+Enter. To enable multiline input, users frequently map
  Shift+Enter to send a line feed (\n) in their terminal settings.


   - Security: Removed the previously proposed dual-emission of Ctrl+J for \n characters. This prevents a paste-jacking vulnerability where a pasted newline could bypass the bufferFastReturn protection
     and trigger an immediate command submission.
   - Consistency: Literal \n characters are now captured and translated into exactly one event: a return event with the shift modifier. This prevents double-action bugs in modes like Reverse Search
     (Ctrl+R).
   - Compatibility: Updated the SUBMIT_REVERSE_SEARCH and ACCEPT_SUGGESTION bindings in packages/cli/src/config/keyBindings.ts to explicitly accept this shifted return event. This ensures that Ctrl+J
     (and mapped Shift+Enter) continues to function correctly for common submission/acceptance actions outside the main prompt.
   - Main Prompt: In the primary input field, Shift+Enter correctly triggers NEWLINE because the SUBMIT binding explicitly requires shift: false.

  Related Issues

  Fixes https://github.com/google-gemini/gemini-cli/issues/4161


  How to Validate


   1. Unit Tests:
     Verify that \n results in exactly one event (return + shift):


   1    npm test packages/cli/src/ui/contexts/KeypressContext.test.tsx
   2. Manual Validation:
      - In the Main Prompt: Press Ctrl+J (or Shift+Enter if mapped to \n). Result: A newline is inserted; the prompt is NOT submitted.
      - In Reverse Search (Ctrl+R): Type a search query and press Ctrl+J. Result: The selected history item is submitted.
      - In Suggestions: Press Ctrl+J to accept an inline suggestion. Result: The suggestion is accepted.

  Pre-Merge Checklist


   - [x] Updated relevant documentation and README (if needed)
   - [x] Added/updated tests
   - [x] Noted breaking changes (if any) - None; single-emission improves security over previous versions.
   - [ ] Validated on required platforms/methods:
     - [ ] MacOS
       - [x] npm run
     - [ ] Linux
       - [x] npm run
