### PR TITLE
fix(ci): handle empty APP_ID in stale PR closer

### DIFF
--- a/.github/workflows/gemini-scheduled-stale-pr-closer.yml
+++ b/.github/workflows/gemini-scheduled-stale-pr-closer.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
+        env:
+          APP_ID: '${{ secrets.APP_ID }}'
+        if: |-
+          ${{ env.APP_ID != '' }}
         uses: 'actions/create-github-app-token@v2'
         with:
           app-id: '${{ secrets.APP_ID }}'
@@ -33,7 +37,7 @@ jobs:
         env:
           DRY_RUN: '${{ inputs.dry_run }}'
         with:
-          github-token: '${{ steps.generate_token.outputs.token }}'
+          github-token: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           script: |
             const dryRun = process.env.DRY_RUN === 'true';
             const thirtyDaysAgo = new Date();


### PR DESCRIPTION
## Summary

This PR fixes a bug in the `close-stale-prs` workflow where it fails for PRs from forks due to missing `APP_ID` and `PRIVATE_KEY` secrets.

## Details

GitHub Actions secrets are not available to workflows triggered by `pull_request` from forks. The `actions/create-github-app-token` action was failing because `APP_ID` was empty. This change adds a conditional check for `APP_ID` and falls back to `secrets.GITHUB_TOKEN` for the subsequent `github-script` step, which is consistent with other workflows in the repository.

## Related Issues

Related to #20639

## How to Validate

1. Check the logs of the `close-stale-prs` job in a PR from a fork (like #20639).
2. Observe that it no longer fails with `Error: [@octokit/auth-app] appId option is required`.
3. The `generate_token` step should be skipped, and the `Process Stale PRs` step should use `GITHUB_TOKEN`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run lint:ci (actionlint passed)
