### PR TITLE
Fix Tip alert in custom command docs

### DIFF
--- a/docs/cli/custom-commands.md
+++ b/docs/cli/custom-commands.md
@@ -30,7 +30,8 @@ separator (`/` or `\`) being converted to a colon (`:`).
 - A file at `<project>/.gemini/commands/git/commit.toml` becomes the namespaced
   command `/git:commit`.
 
-> [!TIP] After creating or modifying `.toml` command files, run
+> [!TIP]
+> After creating or modifying `.toml` command files, run
 > `/commands reload` to pick up your changes without restarting the CLI.
 
 ## TOML file format (v1)


### PR DESCRIPTION
## Summary

Fix [!TIP] alert in docs not rendering.

<img width="759" height="367" alt="image" src="https://github.com/user-attachments/assets/f494026d-dba2-4f14-b5c5-0a2fb6459eef" />

https://geminicli.com/docs/cli/custom-commands/

## Details

GitHub requires the tag to sit by itself on the first line of the alert.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

Compile docs and check

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
