### PR TITLE
fix(core): use platform-aware command separator in git prompt

### DIFF
--- a/packages/core/src/prompts/promptProvider.ts
+++ b/packages/core/src/prompts/promptProvider.ts
@@ -187,7 +187,10 @@ export class PromptProvider {
         ),
         gitRepo: this.withSection(
           'git',
-          () => ({ interactive: interactiveMode }),
+          () => ({
+            interactive: interactiveMode,
+            isWindows: process.platform === 'win32',
+          }),
           isGitRepository(process.cwd()) ? true : false,
         ),
         finalReminder: isModernModel

--- a/packages/core/src/prompts/snippets.test.ts
+++ b/packages/core/src/prompts/snippets.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderGitRepo } from './snippets.js';
+
+describe('renderGitRepo', () => {
+  it('should return empty string when options is undefined', () => {
+    expect(renderGitRepo(undefined)).toBe('');
+  });
+
+  it('should use && as command separator on non-Windows platforms', () => {
+    const result = renderGitRepo({ interactive: true, isWindows: false });
+    expect(result).toContain('git status && git diff HEAD && git log -n 3');
+    expect(result).not.toContain('`;`');
+    expect(result).not.toContain('PowerShell 5.1');
+  });
+
+  it('should use ; as command separator on Windows', () => {
+    const result = renderGitRepo({ interactive: true, isWindows: true });
+    expect(result).toContain('git status ; git diff HEAD ; git log -n 3');
+    expect(result).not.toContain('git status && git diff HEAD');
+  });
+
+  it('should include PowerShell 5.1 guidance on Windows', () => {
+    const result = renderGitRepo({ interactive: true, isWindows: true });
+    expect(result).toContain('PowerShell 5.1');
+    expect(result).toContain('semicolon');
+  });
+
+  it('should not include PowerShell guidance on non-Windows', () => {
+    const result = renderGitRepo({ interactive: false, isWindows: false });
+    expect(result).not.toContain('PowerShell 5.1');
+  });
+});

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -408,7 +408,7 @@ export function renderGitRepo(options?: GitRepoOptions): string {
   - \`git diff HEAD\` to review all changes (including unstaged changes) to tracked files in work tree since last commit.
     - \`git diff --staged\` to review only staged changes when a partial commit makes sense or was requested by the user.
   - \`git log -n 3\` to review recent commit messages and match their style (verbosity, formatting, signature line, etc.)
-- Combine shell commands whenever possible to save time/steps, e.g. \`git status ${options.isWindows ? ';' : '&&'} git diff HEAD ${options.isWindows ? ';' : '&&'} git log -n 3\`.${options.isWindows ? ' On Windows PowerShell, always use `;` (semicolon) as the command separator instead of `&&`, because `&&` is not supported in PowerShell 5.1.' : ''}
+- Combine shell commands whenever possible to save time/steps, e.g. \`${['git status', 'git diff HEAD', 'git log -n 3'].join(options.isWindows ? ' ; ' : ' && ')}\`.${options.isWindows ? ' On Windows PowerShell, always use `;` (semicolon) as the command separator instead of `&&`, because `&&` is not supported in PowerShell 5.1.' : ''}
 - Always propose a draft commit message. Never just ask the user to give you the full commit message.
 - Prefer commit messages that are clear, concise, and focused more on "why" and less on "what".${gitRepoKeepUserInformed(options.interactive)}
 - After each commit, confirm that it was successful by running \`git status\`.

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -77,6 +77,7 @@ export type SandboxMode = 'macos-seatbelt' | 'generic' | 'outside';
 
 export interface GitRepoOptions {
   interactive: boolean;
+  isWindows: boolean;
 }
 
 export interface PlanningWorkflowOptions {
@@ -407,7 +408,7 @@ export function renderGitRepo(options?: GitRepoOptions): string {
   - \`git diff HEAD\` to review all changes (including unstaged changes) to tracked files in work tree since last commit.
     - \`git diff --staged\` to review only staged changes when a partial commit makes sense or was requested by the user.
   - \`git log -n 3\` to review recent commit messages and match their style (verbosity, formatting, signature line, etc.)
-- Combine shell commands whenever possible to save time/steps, e.g. \`git status && git diff HEAD && git log -n 3\`.
+- Combine shell commands whenever possible to save time/steps, e.g. \`git status ${options.isWindows ? ';' : '&&'} git diff HEAD ${options.isWindows ? ';' : '&&'} git log -n 3\`.${options.isWindows ? ' On Windows PowerShell, always use `;` (semicolon) as the command separator instead of `&&`, because `&&` is not supported in PowerShell 5.1.' : ''}
 - Always propose a draft commit message. Never just ask the user to give you the full commit message.
 - Prefer commit messages that are clear, concise, and focused more on "why" and less on "what".${gitRepoKeepUserInformed(options.interactive)}
 - After each commit, confirm that it was successful by running \`git status\`.


### PR DESCRIPTION
## Summary

Fixes #20773

The system prompt in `renderGitRepo()` hardcodes `&&` as the shell command separator in its example: `git status && git diff HEAD && git log -n 3`. On **Windows PowerShell 5.1** (the default Windows shell), `&&` is not a valid operator and throws a `ParserError`.

## Changes

- **`snippets.ts`**: Added `isWindows: boolean` to `GitRepoOptions`. Updated `renderGitRepo()` to dynamically use `;` on Windows and `&&` on POSIX in the command chaining example.
- **`promptProvider.ts`**: Passes `process.platform === 'win32'` as `isWindows` to the git repo prompt options.
- **`snippets.test.ts`** (NEW): Added 5 unit tests verifying the platform-aware command separator behavior.

## Why this approach?

As discussed in #20773, a hybrid fix was proposed:

1. **Code-level**: Update the hardcoded example to use the correct separator per platform (provides correct "few-shot" learning for the model)
2. **Prompt-level**: Add explicit guidance about `;` vs `&&` on Windows (reinforces the instruction even if the model's training biases it toward `&&`)

This PR implements both. The fix is scoped to the git section of the system prompt, which is the primary place where command chaining is explicitly suggested to the model.

As @Safouane noted, local `GEMINI.md` instructions are sometimes ignored by the model, so having this in the core system prompt is the most reliable approach.

## Testing

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npx vitest run packages/core/src/prompts/snippets.test.ts` — 5/5 tests pass ✅
- `npx vitest run packages/core/src/prompts/promptProvider.test.ts` — 5/5 tests pass ✅
