### PR TITLE
fix(core): move environment value pattern checks above ALWAYS_ALLOWED check to improve redaction security

### DIFF
--- a/packages/core/src/services/environmentSanitization.test.ts
+++ b/packages/core/src/services/environmentSanitization.test.ts
@@ -130,6 +130,18 @@ describe('sanitizeEnvironment', () => {
     });
   });
 
+  it('should redact always-allowed variable names if their values contain sensitive patterns', () => {
+    const env = {
+      PATH: 'AKIAxxxxxxxxxxxxxxxx',
+      GEMINI_CLI_TEST: '-----BEGIN CERTIFICATE-----...',
+      SAFE_VAR: 'is-safe',
+    };
+    const sanitized = sanitizeEnvironment(env, EMPTY_OPTIONS);
+    expect(sanitized).toEqual({
+      SAFE_VAR: 'is-safe',
+    });
+  });
+
   it('should not redact variables that look similar to sensitive patterns', () => {
     const env = {
       // Not a credential in URL

--- a/packages/core/src/services/environmentSanitization.ts
+++ b/packages/core/src/services/environmentSanitization.ts
@@ -156,6 +156,15 @@ function shouldRedactEnvironmentVariable(
     return true;
   }
 
+  // Redact if the value looks like a key/cert.
+  if (value) {
+    for (const pattern of NEVER_ALLOWED_VALUE_PATTERNS) {
+      if (pattern.test(value)) {
+        return true;
+      }
+    }
+  }
+
   // These are never redacted.
   if (
     ALWAYS_ALLOWED_ENVIRONMENT_VARIABLES.has(key) ||
@@ -177,15 +186,6 @@ function shouldRedactEnvironmentVariable(
   for (const pattern of NEVER_ALLOWED_NAME_PATTERNS) {
     if (pattern.test(key)) {
       return true;
-    }
-  }
-
-  // Redact if the value looks like a key/cert.
-  if (value) {
-    for (const pattern of NEVER_ALLOWED_VALUE_PATTERNS) {
-      if (pattern.test(value)) {
-        return true;
-      }
     }
   }
 


### PR DESCRIPTION
Fixes #15349

### Summary
This PR addresses the security vulnerability reported in #15349. Previously, `shouldRedactEnvironmentVariable` checked if a key was in `ALWAYS_ALLOWED_ENVIRONMENT_VARIABLES` before checking its value against `NEVER_ALLOWED_VALUE_PATTERNS`. This meant that sensitive values (such as credentials, API keys, or JWT tokens) would be exposed in logs or telemetry if they happened to be stored in "allowed" keys (like `ISSUE_BODY`, `DESCRIPTION`, or `GEMINI_CLI_FOO`).

The logic has been updated so that the regex validation for `NEVER_ALLOWED_VALUE_PATTERNS` takes precedence, ensuring values that securely match confidential patterns are consistently redacted, regardless of their variable names.

### Changes
- Moved value pattern redaction logic above `ALWAYS_ALLOWED_ENVIRONMENT_VARIABLES` in `shouldRedactEnvironmentVariable`.
- Added a targeted automated test to ensure that typically-allowed variables are properly redacted when their values match highly-sensitive regex patterns.