### PR TITLE
feat(cli): add Sublime Text and Emacs Client editors, fix crash on unrecognized editor

### DIFF
--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -81,6 +81,11 @@ export async function openFileInEditor(
     args.unshift('-i', 'NONE');
   }
 
+  if (isTerminal && executable === 'emacsclient') {
+    // Pass -nw to force terminal (no-window) mode.
+    args.unshift('-nw');
+  }
+
   const wasRaw = stdin?.isRaw ?? false;
   setRawMode?.(false);
 

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -97,6 +97,17 @@ export async function openFileInEditor(
     args.unshift('-nw');
   }
 
+  function handleEditorError(err: Error, context: string): void {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      coreEvents.emitFeedback(
+        'error',
+        `Could not find editor '${executable}'. Check your $VISUAL/$EDITOR setting.`,
+      );
+    } else {
+      coreEvents.emitFeedback('error', context, err);
+    }
+  }
+
   const wasRaw = stdin?.isRaw ?? false;
   setRawMode?.(false);
 
@@ -107,18 +118,10 @@ export async function openFileInEditor(
         shell: process.platform === 'win32',
       });
       if (result.error) {
-        if ((result.error as NodeJS.ErrnoException).code === 'ENOENT') {
-          coreEvents.emitFeedback(
-            'error',
-            `Could not find editor '${executable}'. Check your $VISUAL/$EDITOR setting.`,
-          );
-        } else {
-          coreEvents.emitFeedback(
-            'error',
-            '[editorUtils] external terminal editor error',
-            result.error,
-          );
-        }
+        handleEditorError(
+          result.error,
+          '[editorUtils] external terminal editor error',
+        );
         throw result.error;
       }
       if (typeof result.status === 'number' && result.status !== 0) {
@@ -140,18 +143,7 @@ export async function openFileInEditor(
         });
 
         child.on('error', (err) => {
-          if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-            coreEvents.emitFeedback(
-              'error',
-              `Could not find editor '${executable}'. Check your $VISUAL/$EDITOR setting.`,
-            );
-          } else {
-            coreEvents.emitFeedback(
-              'error',
-              '[editorUtils] external editor spawn error',
-              err,
-            );
-          }
+          handleEditorError(err, '[editorUtils] external editor spawn error');
           reject(err);
         });
 

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -11,6 +11,7 @@ import {
   CoreEvent,
   type EditorType,
   getEditorCommand,
+  isEditorAvailable,
   isGuiEditor,
   isTerminalEditor,
 } from '@google/gemini-cli-core';
@@ -34,9 +35,19 @@ export async function openFileInEditor(
   const args = [filePath];
 
   if (preferredEditorType) {
-    command = getEditorCommand(preferredEditorType);
-    if (isGuiEditor(preferredEditorType)) {
-      args.unshift('--wait');
+    if (isEditorAvailable(preferredEditorType)) {
+      command = getEditorCommand(preferredEditorType);
+      if (isGuiEditor(preferredEditorType)) {
+        args.unshift('--wait');
+      }
+    } else {
+      coreEvents.emitFeedback(
+        'error',
+        `Editor '${preferredEditorType}' is not recognized or not installed. ` +
+          `Run /editor to pick a supported editor, or set $VISUAL/$EDITOR in your shell ` +
+          `to your preferred editor.`,
+      );
+      return;
     }
   }
 
@@ -96,11 +107,18 @@ export async function openFileInEditor(
         shell: process.platform === 'win32',
       });
       if (result.error) {
-        coreEvents.emitFeedback(
-          'error',
-          '[editorUtils] external terminal editor error',
-          result.error,
-        );
+        if ((result.error as NodeJS.ErrnoException).code === 'ENOENT') {
+          coreEvents.emitFeedback(
+            'error',
+            `Could not find editor '${executable}'. Check your $VISUAL/$EDITOR setting.`,
+          );
+        } else {
+          coreEvents.emitFeedback(
+            'error',
+            '[editorUtils] external terminal editor error',
+            result.error,
+          );
+        }
         throw result.error;
       }
       if (typeof result.status === 'number' && result.status !== 0) {
@@ -122,11 +140,18 @@ export async function openFileInEditor(
         });
 
         child.on('error', (err) => {
-          coreEvents.emitFeedback(
-            'error',
-            '[editorUtils] external editor spawn error',
-            err,
-          );
+          if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+            coreEvents.emitFeedback(
+              'error',
+              `Could not find editor '${executable}'. Check your $VISUAL/$EDITOR setting.`,
+            );
+          } else {
+            coreEvents.emitFeedback(
+              'error',
+              '[editorUtils] external editor spawn error',
+              err,
+            );
+          }
           reject(err);
         });
 

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -84,6 +84,7 @@ describe('editor utils', () => {
         win32Commands: ['agy.cmd', 'antigravity.cmd', 'antigravity'],
       },
       { editor: 'hx', commands: ['hx'], win32Commands: ['hx'] },
+      { editor: 'sublime', commands: ['subl'], win32Commands: ['subl'] },
     ];
 
     for (const { editor, commands, win32Commands } of testCases) {
@@ -339,6 +340,16 @@ describe('editor utils', () => {
       });
     });
 
+    it('should return the correct command for sublime', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/subl'));
+      const command = getDiffCommand('old.txt', 'new.txt', 'sublime');
+      expect(command).toEqual({
+        command: 'subl',
+        args: ['--wait', 'old.txt'],
+      });
+    });
+
     it('should return null for an unsupported editor', () => {
       // @ts-expect-error Testing unsupported editor
       const command = getDiffCommand('old.txt', 'new.txt', 'foobar');
@@ -353,6 +364,7 @@ describe('editor utils', () => {
       'windsurf',
       'cursor',
       'zed',
+      'sublime',
     ];
 
     for (const editor of guiEditors) {
@@ -477,6 +489,7 @@ describe('editor utils', () => {
       'windsurf',
       'cursor',
       'zed',
+      'sublime',
     ];
     for (const editor of guiEditors) {
       it(`should not allow ${editor} in sandbox mode`, () => {

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -85,6 +85,11 @@ describe('editor utils', () => {
       },
       { editor: 'hx', commands: ['hx'], win32Commands: ['hx'] },
       { editor: 'sublime', commands: ['subl'], win32Commands: ['subl'] },
+      {
+        editor: 'emacsclient',
+        commands: ['emacsclient'],
+        win32Commands: ['emacsclient'],
+      },
     ];
 
     for (const { editor, commands, win32Commands } of testCases) {
@@ -340,6 +345,22 @@ describe('editor utils', () => {
       });
     });
 
+    it('should return the correct command for emacsclient with escaped paths', () => {
+      const command = getDiffCommand(
+        'old file "quote".txt',
+        'new file \\back\\slash.txt',
+        'emacsclient',
+      );
+      expect(command).toEqual({
+        command: 'emacsclient',
+        args: [
+          '-nw',
+          '--eval',
+          '(ediff "old file \\"quote\\".txt" "new file \\\\back\\\\slash.txt")',
+        ],
+      });
+    });
+
     it('should return the correct command for sublime', () => {
       Object.defineProperty(process, 'platform', { value: 'linux' });
       (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/subl'));
@@ -418,7 +439,13 @@ describe('editor utils', () => {
       });
     }
 
-    const terminalEditors: EditorType[] = ['vim', 'neovim', 'emacs', 'hx'];
+    const terminalEditors: EditorType[] = [
+      'vim',
+      'neovim',
+      'emacs',
+      'emacsclient',
+      'hx',
+    ];
 
     for (const editor of terminalEditors) {
       it(`should call spawnSync for ${editor}`, async () => {
@@ -463,6 +490,15 @@ describe('editor utils', () => {
 
     it('should allow emacs when not in sandbox mode', () => {
       expect(allowEditorTypeInSandbox('emacs')).toBe(true);
+    });
+
+    it('should allow emacsclient in sandbox mode', () => {
+      vi.stubEnv('SANDBOX', 'sandbox');
+      expect(allowEditorTypeInSandbox('emacsclient')).toBe(true);
+    });
+
+    it('should allow emacsclient when not in sandbox mode', () => {
+      expect(allowEditorTypeInSandbox('emacsclient')).toBe(true);
     });
 
     it('should allow neovim in sandbox mode', () => {

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -19,7 +19,13 @@ const GUI_EDITORS = [
   'antigravity',
   'sublime',
 ] as const;
-const TERMINAL_EDITORS = ['vim', 'neovim', 'emacs', 'hx'] as const;
+const TERMINAL_EDITORS = [
+  'vim',
+  'neovim',
+  'emacs',
+  'emacsclient',
+  'hx',
+] as const;
 const EDITORS = [...GUI_EDITORS, ...TERMINAL_EDITORS] as const;
 
 const GUI_EDITORS_SET = new Set<string>(GUI_EDITORS);
@@ -54,6 +60,7 @@ export const EDITOR_DISPLAY_NAMES: Record<EditorType, string> = {
   neovim: 'Neovim',
   zed: 'Zed',
   emacs: 'Emacs',
+  emacsclient: 'Emacs Client',
   antigravity: 'Antigravity',
   hx: 'Helix',
   sublime: 'Sublime Text',
@@ -122,6 +129,7 @@ const editorCommands: Record<
   neovim: { win32: ['nvim'], default: ['nvim'] },
   zed: { win32: ['zed'], default: ['zed', 'zeditor'] },
   emacs: { win32: ['emacs.exe'], default: ['emacs'] },
+  emacsclient: { win32: ['emacsclient'], default: ['emacsclient'] },
   antigravity: {
     win32: ['agy.cmd', 'antigravity.cmd', 'antigravity'],
     default: ['agy', 'antigravity'],
@@ -275,6 +283,15 @@ export function getDiffCommand(
       return {
         command: 'emacs',
         args: [
+          '--eval',
+          `(ediff ${escapeELispString(oldPath)} ${escapeELispString(newPath)})`,
+        ],
+      };
+    case 'emacsclient':
+      return {
+        command: 'emacsclient',
+        args: [
+          '-nw',
           '--eval',
           `(ediff ${escapeELispString(oldPath)} ${escapeELispString(newPath)})`,
         ],

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -17,6 +17,7 @@ const GUI_EDITORS = [
   'cursor',
   'zed',
   'antigravity',
+  'sublime',
 ] as const;
 const TERMINAL_EDITORS = ['vim', 'neovim', 'emacs', 'hx'] as const;
 const EDITORS = [...GUI_EDITORS, ...TERMINAL_EDITORS] as const;
@@ -55,6 +56,7 @@ export const EDITOR_DISPLAY_NAMES: Record<EditorType, string> = {
   emacs: 'Emacs',
   antigravity: 'Antigravity',
   hx: 'Helix',
+  sublime: 'Sublime Text',
 };
 
 export function getEditorDisplayName(editor: EditorType): string {
@@ -125,6 +127,7 @@ const editorCommands: Record<
     default: ['agy', 'antigravity'],
   },
   hx: { win32: ['hx'], default: ['hx'] },
+  sublime: { win32: ['subl'], default: ['subl'] },
 };
 
 function getEditorCommands(editor: EditorType): string[] {
@@ -237,6 +240,8 @@ export function getDiffCommand(
     case 'zed':
     case 'antigravity':
       return { command, args: ['--wait', '--diff', oldPath, newPath] };
+    case 'sublime':
+      return { command, args: ['--wait', oldPath] };
     case 'vim':
     case 'neovim':
       return {

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -249,7 +249,7 @@ export function getDiffCommand(
     case 'antigravity':
       return { command, args: ['--wait', '--diff', oldPath, newPath] };
     case 'sublime':
-      return { command, args: ['--wait', oldPath] };
+      return { command, args: ['--wait', newPath] };
     case 'vim':
     case 'neovim':
       return {
@@ -280,22 +280,17 @@ export function getDiffCommand(
         ],
       };
     case 'emacs':
+    case 'emacsclient': {
+      const extraArgs = editor === 'emacsclient' ? ['-nw'] : [];
       return {
-        command: 'emacs',
+        command,
         args: [
+          ...extraArgs,
           '--eval',
           `(ediff ${escapeELispString(oldPath)} ${escapeELispString(newPath)})`,
         ],
       };
-    case 'emacsclient':
-      return {
-        command: 'emacsclient',
-        args: [
-          '-nw',
-          '--eval',
-          `(ediff ${escapeELispString(oldPath)} ${escapeELispString(newPath)})`,
-        ],
-      };
+    }
     case 'hx':
       return {
         command: 'hx',


### PR DESCRIPTION
## Summary

Addresses #21084 by improving external editor support across three areas: adds
**Sublime Text** and **Emacs Client** to the built-in editor list, emits clear
error messages when editor configuration is invalid or a command is missing, and
extends the documentation and JSON schema for `preferredEditor`.

## Details

**New editors** (`packages/core/src/utils/editor.ts`):

- **Sublime Text** (`sublime`): added as a GUI editor using the `subl` command.
  Opens files with `--wait`. Diff view opens the new file only, as `subl` does
  not support a `--diff` flag.
- **Emacs Client** (`emacsclient`): added as a terminal editor. Automatically
  injects `-nw` (terminal mode) when opening a file. Diff view uses
  `emacsclient -nw --eval "(ediff ...)"`, consistent with the existing `emacs`
  implementation.

**Error handling** (`packages/cli/src/ui/utils/editorUtils.ts`):

Two cases that previously produced a cryptic internal error are now handled
gracefully:

1. **Unrecognized `preferredEditor`**: validates the editor type before use and
   emits a user-friendly message instead of a generic error. For example,
   setting `"preferredEditor": "nvim"` (the binary name) instead of the
   supported identifier `"neovim"` previously produced:
   ```
   ✕ [useTextBuffer] external editor error
   ```
   It now produces:
   ```
   ✕ Editor 'nvim' is not recognized or not installed. Run /editor to pick a
     supported editor, or set $VISUAL/$EDITOR in your shell to your preferred
     editor.
   ```
2. **Missing `$VISUAL`/`$EDITOR` command**: detects `ENOENT` on spawn and emits
   a clear message pointing the user to check their environment variable.

Note: `$VISUAL`/`$EDITOR` continue to accept any editor command, not just the
built-in supported types, preserving full flexibility for power users.

**Documentation** (`docs/reference/configuration.md`,
`schemas/settings.schema.json`, `packages/cli/src/config/settingsSchema.ts`):

- The `description` field for `preferredEditor` in `settingsSchema.ts` has been
  updated to explain the built-in identifier requirement, the `/editor` command
  as the canonical way to discover supported values, and the `$VISUAL`/`$EDITOR`
  escape hatch for power users. Both `docs/reference/configuration.md` and
  `schemas/settings.schema.json` are regenerated from this source and updated
  accordingly.

## Related Issues

Closes #21084

## Note for maintainers: enum constraint in the JSON schema

The current implementation leaves `preferredEditor` typed as a plain `string` in
`settingsSchema.ts`, so the JSON schema carries no `enum` constraint and IDEs
offer no autocomplete for valid editor identifiers.

A cleaner solution would be to change the definition to `type: 'enum'` and list
the supported values via `options`, mirroring how `defaultApprovalMode` is
defined. This would cause the generation script to emit an `enum` array in the
JSON schema and a `Values:` line in the documentation automatically, and would
keep everything in sync with the code. For example:

```ts
preferredEditor: {
  type: 'enum',
  label: 'Preferred Editor',
  category: 'General',
  requiresRestart: false,
  default: undefined as EditorType | undefined,
  description: '...',
  showInDialog: false,
  options: (EDITORS as readonly EditorType[]).map((e) => ({
    value: e,
    label: EDITOR_DISPLAY_NAMES[e],
  })),
},
```

This is a slightly more invasive change (it touches the settings type system and
may affect dialog rendering), so I have left it out of this PR. I am happy to
implement it based on your feedback.

## How to Validate

**Sublime Text:**

1. Set `"preferredEditor": "sublime"` in `~/.gemini/settings.json`
2. Open Gemini CLI and press `CTRL-X` to open the external editor
3. Sublime Text should open the buffer file and wait until it is closed

**Emacs Client:**

1. Start an Emacs daemon: `emacs --daemon`
2. Set `"preferredEditor": "emacsclient"` in `~/.gemini/settings.json`
3. Open Gemini CLI and press `CTRL-X` to open the external editor
4. Emacs Client should open in terminal mode (`-nw`) and wait until the buffer
   is closed

**Graceful error for unrecognized `preferredEditor`:**

1. Set `"preferredEditor": "emacsclient -nw"` in `~/.gemini/settings.json`
2. Press `CTRL-X` in Gemini CLI
3. Expected:
   `Editor 'emacsclient -nw' is not recognized or not installed. Run /editor to pick a supported editor, or set $VISUAL/$EDITOR in your shell to your preferred editor.`
4. Expected: no crash, no unhandled promise rejection

**Graceful error for missing `$VISUAL`/`$EDITOR` command:**

1. Run `export EDITOR="nonexistent-editor"` in your shell
2. Remove `preferredEditor` from `settings.json`
3. Press `CTRL-X` in Gemini CLI
4. Expected:
   `Could not find editor 'nonexistent-editor'. Check your $VISUAL/$EDITOR setting.`
5. Expected: no crash, no unhandled promise rejection

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
