### PR TITLE
feat: add support for gvisor runsc sandbox option for gemini cli

### DIFF
--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -50,6 +50,27 @@ Cross-platform sandboxing with complete process isolation.
 **Note**: Requires building the sandbox image locally or using a published image
 from your organization's registry.
 
+### 3. gVisor / runsc (Linux only)
+
+Strongest isolation available: runs containers inside a user-space kernel via
+[gVisor](https://github.com/google/gvisor). gVisor intercepts all container
+system calls and handles them in a sandboxed kernel written in Go, providing a
+strong security barrier between AI operations and the host OS.
+
+**Prerequisites**:
+
+- Linux only (gVisor does not support macOS or Windows).
+- Install gVisor: see the
+  [official installation guide](https://gvisor.dev/docs/user_guide/install/).
+- Docker must be installed as the container manager.
+
+When `sandbox: true` is set on Linux and both `runsc` and `docker` are detected,
+Gemini CLI automatically prefers gVisor over plain Docker.
+
+**How it works**: Gemini CLI runs `docker run --runtime runsc ...`; Docker
+delays to gVisor's `runsc` OCI runtime, which interposes the container's system
+calls through a user-space kernel rather than passing them directly to the host.
+
 ## Quickstart
 
 ```bash
@@ -73,6 +94,13 @@ $env:GEMINI_SANDBOX="true"
 gemini -p "run the test suite"
 ```
 
+### Using gVisor (Linux only)
+
+```bash
+export GEMINI_SANDBOX=runsc
+gemini -p "run the test suite"
+```
+
 **Configure in settings.json**
 
 ```json
@@ -88,9 +116,18 @@ gemini -p "run the test suite"
 ### Enable sandboxing (in order of precedence)
 
 1. **Command flag**: `-s` or `--sandbox`
-2. **Environment variable**: `GEMINI_SANDBOX=true|docker|podman|sandbox-exec`
+2. **Environment variable**:
+   `GEMINI_SANDBOX=true|docker|podman|sandbox-exec|runsc`
 3. **Settings file**: `"sandbox": true` in the `tools` object of your
    `settings.json` file (e.g., `{"tools": {"sandbox": true}}`).
+
+**Auto-detection order on Linux** (when `sandbox: true`):
+
+1. gVisor (`runsc`) — if `runsc` and `docker` are both installed
+2. Docker — if `docker` is installed
+3. Podman — if `podman` is installed
+
+**Auto-detection order on macOS**: macOS Seatbelt (`sandbox-exec`).
 
 ### macOS Seatbelt profiles
 

--- a/packages/cli/src/config/sandboxConfig.test.ts
+++ b/packages/cli/src/config/sandboxConfig.test.ts
@@ -97,7 +97,7 @@ describe('loadSandboxConfig', () => {
     it('should throw if GEMINI_SANDBOX is an invalid command', async () => {
       process.env['GEMINI_SANDBOX'] = 'invalid-command';
       await expect(loadSandboxConfig({}, {})).rejects.toThrow(
-        "Invalid sandbox command 'invalid-command'. Must be one of docker, podman, sandbox-exec",
+        "Invalid sandbox command 'invalid-command'. Must be one of docker, podman, sandbox-exec, runsc",
       );
     });
 
@@ -178,8 +178,71 @@ describe('loadSandboxConfig', () => {
       await expect(
         loadSandboxConfig({}, { sandbox: 'invalid-command' }),
       ).rejects.toThrow(
-        "Invalid sandbox command 'invalid-command'. Must be one of docker, podman, sandbox-exec",
+        "Invalid sandbox command 'invalid-command'. Must be one of docker, podman, sandbox-exec, runsc",
       );
+    });
+  });
+
+  describe('with sandbox: runsc (gVisor)', () => {
+    it('should use runsc on Linux when runsc and docker are available', async () => {
+      mockedOsPlatform.mockReturnValue('linux');
+      mockedCommandExistsSync.mockImplementation(
+        (cmd) => cmd === 'runsc' || cmd === 'docker',
+      );
+      const config = await loadSandboxConfig({}, { sandbox: 'runsc' });
+      expect(config).toEqual({ command: 'runsc', image: 'default/image' });
+      expect(mockedCommandExistsSync).toHaveBeenCalledWith('runsc');
+      expect(mockedCommandExistsSync).toHaveBeenCalledWith('docker');
+    });
+
+    it('should throw if runsc is specified on a non-Linux platform', async () => {
+      mockedOsPlatform.mockReturnValue('darwin');
+      mockedCommandExistsSync.mockReturnValue(true);
+      await expect(loadSandboxConfig({}, { sandbox: 'runsc' })).rejects.toThrow(
+        'gVisor (runsc) sandboxing is only supported on Linux',
+      );
+    });
+
+    it('should throw if runsc is specified but runsc binary is missing', async () => {
+      mockedOsPlatform.mockReturnValue('linux');
+      mockedCommandExistsSync.mockImplementation((cmd) => cmd === 'docker'); // only docker
+      await expect(loadSandboxConfig({}, { sandbox: 'runsc' })).rejects.toThrow(
+        "Missing 'runsc' (gVisor).",
+      );
+    });
+
+    it('should throw if runsc is specified but docker is missing', async () => {
+      mockedOsPlatform.mockReturnValue('linux');
+      mockedCommandExistsSync.mockImplementation((cmd) => cmd === 'runsc'); // only runsc
+      await expect(loadSandboxConfig({}, { sandbox: 'runsc' })).rejects.toThrow(
+        "'runsc' sandboxing requires Docker to be installed",
+      );
+    });
+
+    it('should auto-detect runsc on Linux when sandbox: true and both runsc+docker available', async () => {
+      mockedOsPlatform.mockReturnValue('linux');
+      mockedCommandExistsSync.mockImplementation(
+        (cmd) => cmd === 'runsc' || cmd === 'docker',
+      );
+      const config = await loadSandboxConfig({}, { sandbox: true });
+      expect(config).toEqual({ command: 'runsc', image: 'default/image' });
+    });
+
+    it('should fall back to docker if runsc is not available on Linux with sandbox: true', async () => {
+      mockedOsPlatform.mockReturnValue('linux');
+      mockedCommandExistsSync.mockImplementation((cmd) => cmd === 'docker');
+      const config = await loadSandboxConfig({}, { sandbox: true });
+      expect(config).toEqual({ command: 'docker', image: 'default/image' });
+    });
+
+    it('should use GEMINI_SANDBOX=runsc env var on Linux with required commands', async () => {
+      process.env['GEMINI_SANDBOX'] = 'runsc';
+      mockedOsPlatform.mockReturnValue('linux');
+      mockedCommandExistsSync.mockImplementation(
+        (cmd) => cmd === 'runsc' || cmd === 'docker',
+      );
+      const config = await loadSandboxConfig({}, {});
+      expect(config).toEqual({ command: 'runsc', image: 'default/image' });
     });
   });
 

--- a/packages/cli/src/config/sandboxConfig.ts
+++ b/packages/cli/src/config/sandboxConfig.ts
@@ -27,6 +27,7 @@ const VALID_SANDBOX_COMMANDS: ReadonlyArray<SandboxConfig['command']> = [
   'docker',
   'podman',
   'sandbox-exec',
+  'runsc',
 ];
 
 function isSandboxCommand(value: string): value is SandboxConfig['command'] {
@@ -63,6 +64,25 @@ function getSandboxCommand(
         )}`,
       );
     }
+    // For runsc, verify both runsc and docker are present (docker is used as the container manager)
+    if (sandbox === 'runsc') {
+      if (os.platform() !== 'linux') {
+        throw new FatalSandboxError(
+          'gVisor (runsc) sandboxing is only supported on Linux',
+        );
+      }
+      if (!commandExists.sync('runsc')) {
+        throw new FatalSandboxError(
+          "Missing 'runsc' (gVisor). See https://gvisor.dev/docs/user_guide/install/ for installation.",
+        );
+      }
+      if (!commandExists.sync('docker')) {
+        throw new FatalSandboxError(
+          "'runsc' sandboxing requires Docker to be installed as the container manager.",
+        );
+      }
+      return 'runsc';
+    }
     // confirm that specified command exists
     if (commandExists.sync(sandbox)) {
       return sandbox;
@@ -76,6 +96,14 @@ function getSandboxCommand(
   // for container-based sandboxing, require sandbox to be enabled explicitly
   if (os.platform() === 'darwin' && commandExists.sync('sandbox-exec')) {
     return 'sandbox-exec';
+  } else if (
+    os.platform() === 'linux' &&
+    commandExists.sync('runsc') &&
+    commandExists.sync('docker') &&
+    sandbox === true
+  ) {
+    // On Linux, prefer gVisor (runsc) over plain Docker when available
+    return 'runsc';
   } else if (commandExists.sync('docker') && sandbox === true) {
     return 'docker';
   } else if (commandExists.sync('podman') && sandbox === true) {

--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -473,5 +473,69 @@ describe('sandbox', () => {
       expect(entrypointCmd).toContain('useradd');
       expect(entrypointCmd).toContain('su -p gemini');
     });
+
+    describe('gVisor (runsc)', () => {
+      it('should use docker with --runtime runsc when command is runsc', async () => {
+        vi.mocked(os.platform).mockReturnValue('linux');
+        const config: SandboxConfig = {
+          command: 'runsc',
+          image: 'gemini-cli-sandbox',
+        };
+
+        // Mock image check to return true (docker images -q)
+        interface MockProcessWithStdout extends EventEmitter {
+          stdout: EventEmitter;
+        }
+        const mockImageCheckProcess =
+          new EventEmitter() as MockProcessWithStdout;
+        mockImageCheckProcess.stdout = new EventEmitter();
+        vi.mocked(spawn).mockImplementationOnce(() => {
+          setTimeout(() => {
+            mockImageCheckProcess.stdout.emit('data', Buffer.from('image-id'));
+            mockImageCheckProcess.emit('close', 0);
+          }, 1);
+          return mockImageCheckProcess as unknown as ReturnType<typeof spawn>;
+        });
+
+        // Mock docker run
+        const mockSpawnProcess = new EventEmitter() as unknown as ReturnType<
+          typeof spawn
+        >;
+        mockSpawnProcess.on = vi.fn().mockImplementation((event, cb) => {
+          if (event === 'close') {
+            setTimeout(() => cb(0), 10);
+          }
+          return mockSpawnProcess;
+        });
+        vi.mocked(spawn).mockImplementationOnce(() => mockSpawnProcess);
+
+        await start_sandbox(config, [], undefined, ['arg1']);
+
+        // image check should use 'docker' (containerCommand), not 'runsc'
+        expect(spawn).toHaveBeenNthCalledWith(
+          1,
+          'docker',
+          expect.arrayContaining(['images', '-q', 'gemini-cli-sandbox']),
+        );
+        // docker run should include --runtime runsc
+        expect(spawn).toHaveBeenNthCalledWith(
+          2,
+          'docker',
+          expect.arrayContaining(['run', '--runtime', 'runsc']),
+          expect.objectContaining({ stdio: 'inherit' }),
+        );
+      });
+
+      it('should throw FatalSandboxError if runsc is used on non-Linux', async () => {
+        vi.mocked(os.platform).mockReturnValue('darwin');
+        const config: SandboxConfig = {
+          command: 'runsc',
+          image: 'gemini-cli-sandbox',
+        };
+        await expect(start_sandbox(config)).rejects.toThrow(
+          'gVisor (runsc) sandboxing is only supported on Linux',
+        );
+      });
+    });
   });
 });

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -205,6 +205,17 @@ export async function start_sandbox(
 
     debugLogger.log(`hopping into sandbox (command: ${config.command}) ...`);
 
+    // gVisor (runsc) is only supported on Linux; it uses Docker as the container manager
+    // with --runtime=runsc passed to `docker run` for kernel-level isolation.
+    if (config.command === 'runsc' && os.platform() !== 'linux') {
+      throw new FatalSandboxError(
+        'gVisor (runsc) sandboxing is only supported on Linux',
+      );
+    }
+    const containerCommand =
+      config.command === 'runsc' ? 'docker' : config.command;
+    const useGvisor = config.command === 'runsc';
+
     // determine full path for gemini-cli to distinguish linked vs installed setting
     const gcPath = process.argv[1] ? fs.realpathSync(process.argv[1]) : '';
 
@@ -246,7 +257,7 @@ export async function start_sandbox(
             stdio: 'inherit',
             env: {
               ...process.env,
-              GEMINI_SANDBOX: config.command, // in case sandbox is enabled via flags (see config.ts under cli package)
+              GEMINI_SANDBOX: config.command, // preserve original command (e.g. runsc) for env var
             },
           },
         );
@@ -255,7 +266,7 @@ export async function start_sandbox(
 
     // stop if image is missing
     if (
-      !(await ensureSandboxImageIsPresent(config.command, image, cliConfig))
+      !(await ensureSandboxImageIsPresent(containerCommand, image, cliConfig))
     ) {
       const remedy =
         image === LOCAL_DEV_SANDBOX_IMAGE_NAME
@@ -269,6 +280,11 @@ export async function start_sandbox(
     // use interactive mode and auto-remove container on exit
     // run init binary inside container to forward signals & reap zombies
     const args = ['run', '-i', '--rm', '--init', '--workdir', containerWorkdir];
+
+    // use gVisor OCI runtime if enabled (Linux only)
+    if (useGvisor) {
+      args.push('--runtime', 'runsc');
+    }
 
     // add custom flags from SANDBOX_FLAGS
     if (process.env['SANDBOX_FLAGS']) {
@@ -410,7 +426,7 @@ export async function start_sandbox(
       // if using proxy, switch to internal networking through proxy
       if (proxy) {
         execSync(
-          `${config.command} network inspect ${SANDBOX_NETWORK_NAME} || ${config.command} network create --internal ${SANDBOX_NETWORK_NAME}`,
+          `${containerCommand} network inspect ${SANDBOX_NETWORK_NAME} || ${containerCommand} network create --internal ${SANDBOX_NETWORK_NAME}`,
         );
         args.push('--network', SANDBOX_NETWORK_NAME);
         // if proxy command is set, create a separate network w/ host access (i.e. non-internal)
@@ -418,7 +434,7 @@ export async function start_sandbox(
         // this allows proxy to work even on rootless podman on macos with host<->vm<->container isolation
         if (proxyCommand) {
           execSync(
-            `${config.command} network inspect ${SANDBOX_PROXY_NAME} || ${config.command} network create ${SANDBOX_PROXY_NAME}`,
+            `${containerCommand} network inspect ${SANDBOX_PROXY_NAME} || ${containerCommand} network create ${SANDBOX_PROXY_NAME}`,
           );
         }
       }
@@ -437,7 +453,7 @@ export async function start_sandbox(
     } else {
       let index = 0;
       const containerNameCheck = (
-        await execAsync(`${config.command} ps -a --format "{{.Names}}"`)
+        await execAsync(`${containerCommand} ps -a --format "{{.Names}}"`)
       ).stdout.trim();
       while (containerNameCheck.includes(`${imageName}-${index}`)) {
         index++;
@@ -588,6 +604,7 @@ export async function start_sandbox(
 
     // for podman only, use empty --authfile to skip unnecessary auth refresh overhead
     if (config.command === 'podman') {
+      // runsc uses docker, so this check remains for podman explicitly
       const emptyAuthFilePath = path.join(os.tmpdir(), 'empty_auth.json');
       fs.writeFileSync(emptyAuthFilePath, '{}', 'utf-8');
       args.push('--authfile', emptyAuthFilePath);
@@ -651,7 +668,7 @@ export async function start_sandbox(
 
     if (proxyCommand) {
       // run proxyCommand in its own container
-      const proxyContainerCommand = `${config.command} run --rm --init ${userFlag} --name ${SANDBOX_PROXY_NAME} --network ${SANDBOX_PROXY_NAME} -p 8877:8877 -v ${process.cwd()}:${workdir} --workdir ${workdir} ${image} ${proxyCommand}`;
+      const proxyContainerCommand = `${containerCommand} run --rm --init ${userFlag} --name ${SANDBOX_PROXY_NAME} --network ${SANDBOX_PROXY_NAME} -p 8877:8877 -v ${process.cwd()}:${workdir} --workdir ${workdir} ${image} ${proxyCommand}`;
       proxyProcess = spawn(proxyContainerCommand, {
         stdio: ['ignore', 'pipe', 'pipe'],
         shell: true,
@@ -660,7 +677,7 @@ export async function start_sandbox(
       // install handlers to stop proxy on exit/signal
       const stopProxy = () => {
         debugLogger.log('stopping proxy container ...');
-        execSync(`${config.command} rm -f ${SANDBOX_PROXY_NAME}`);
+        execSync(`${containerCommand} rm -f ${SANDBOX_PROXY_NAME}`);
       };
       process.off('exit', stopProxy);
       process.on('exit', stopProxy);
@@ -691,13 +708,13 @@ export async function start_sandbox(
       // connect proxy container to sandbox network
       // (workaround for older versions of docker that don't support multiple --network args)
       await execAsync(
-        `${config.command} network connect ${SANDBOX_NETWORK_NAME} ${SANDBOX_PROXY_NAME}`,
+        `${containerCommand} network connect ${SANDBOX_NETWORK_NAME} ${SANDBOX_PROXY_NAME}`,
       );
     }
 
     // spawn child and let it inherit stdio
     process.stdin.pause();
-    sandboxProcess = spawn(config.command, args, {
+    sandboxProcess = spawn(containerCommand, args, {
       stdio: 'inherit',
     });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -425,7 +425,7 @@ export enum AuthProviderType {
 }
 
 export interface SandboxConfig {
-  command: 'docker' | 'podman' | 'sandbox-exec';
+  command: 'docker' | 'podman' | 'sandbox-exec' | 'runsc';
   image: string;
 }
 


### PR DESCRIPTION
## Summary
Implemented gVisor (runsc) as an additional sandbox option for Gemini CLI, providing kernel-level isolation through user-space system call interception on Linux systems.
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details
- Core Type Definition
  Added runsc to SandboxConfig command type union

- Sandbox Configuration & Auto-detection
Added runsc to VALID_SANDBOX_COMMANDS
Explicit runsc validation as it verifies platform is Linux-only
Ensures both runsc and docker binaries are installed

- Sandbox Runtime Integration
Linux-only runtime check at startup
Introduces containerCommand variable while preserving original config.command for env var propagation
All existing config.command references replaced with containerCommand for Docker/Podman execution

- Documentation
Added detailed documentation for the installation guide of gvisor for sandbox option for gemini cli.

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues
fixes #15875 
<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate
```yaml

npm run build

# Run sandbox-specific tests
npx vitest run packages/cli/src/config/sandboxConfig.test.ts \
                packages/cli/src/utils/sandbox.test.ts
                
                
```
<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [x] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
