### PR TITLE
fix(windows): force UTF-8 output encoding for PowerShell child processes

### DIFF
--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -429,7 +429,11 @@ describe('getShellConfiguration', () => {
       delete process.env['ComSpec'];
       const config = getShellConfiguration();
       expect(config.executable).toBe('powershell.exe');
-      expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
+      expect(config.argsPrefix).toEqual([
+        '-NoProfile',
+        '-Command',
+        '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $OutputEncoding = [System.Text.Encoding]::UTF8;',
+      ]);
       expect(config.shell).toBe('powershell');
     });
 
@@ -438,7 +442,11 @@ describe('getShellConfiguration', () => {
       process.env['ComSpec'] = cmdPath;
       const config = getShellConfiguration();
       expect(config.executable).toBe('powershell.exe');
-      expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
+      expect(config.argsPrefix).toEqual([
+        '-NoProfile',
+        '-Command',
+        '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $OutputEncoding = [System.Text.Encoding]::UTF8;',
+      ]);
       expect(config.shell).toBe('powershell');
     });
 
@@ -448,7 +456,11 @@ describe('getShellConfiguration', () => {
       process.env['ComSpec'] = psPath;
       const config = getShellConfiguration();
       expect(config.executable).toBe(psPath);
-      expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
+      expect(config.argsPrefix).toEqual([
+        '-NoProfile',
+        '-Command',
+        '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $OutputEncoding = [System.Text.Encoding]::UTF8;',
+      ]);
       expect(config.shell).toBe('powershell');
     });
 
@@ -457,7 +469,11 @@ describe('getShellConfiguration', () => {
       process.env['ComSpec'] = pwshPath;
       const config = getShellConfiguration();
       expect(config.executable).toBe(pwshPath);
-      expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
+      expect(config.argsPrefix).toEqual([
+        '-NoProfile',
+        '-Command',
+        '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $OutputEncoding = [System.Text.Encoding]::UTF8;',
+      ]);
       expect(config.shell).toBe('powershell');
     });
 
@@ -465,7 +481,11 @@ describe('getShellConfiguration', () => {
       process.env['ComSpec'] = 'C:\\Path\\To\\POWERSHELL.EXE';
       const config = getShellConfiguration();
       expect(config.executable).toBe('C:\\Path\\To\\POWERSHELL.EXE');
-      expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
+      expect(config.argsPrefix).toEqual([
+        '-NoProfile',
+        '-Command',
+        '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $OutputEncoding = [System.Text.Encoding]::UTF8;',
+      ]);
       expect(config.shell).toBe('powershell');
     });
   });

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -541,10 +541,27 @@ export function parseCommandDetails(
  * This ensures we can execute command strings predictably and securely across platforms
  * using the `spawn(executable, [...argsPrefix, commandString], { shell: false })` pattern.
  *
+ * On Windows, callers do `spawn(exe, [...argsPrefix, command])`. PowerShell
+ * concatenates all arguments that follow `-Command` with spaces, so the extra
+ * element in `argsPrefix` acts as a script prefix that is prepended to every
+ * command without requiring any changes at call sites.
+ *
  * @returns The ShellConfiguration for the current environment.
  */
 export function getShellConfiguration(): ShellConfiguration {
   if (isWindows()) {
+    // PowerShell 5.1 defaults to the system OEM code page for console output,
+    // which causes Node.js to misinterpret non-ASCII characters. Prepend a
+    // one-liner that forces UTF-8 for both the byte stream sent to the OS
+    // ([Console]::OutputEncoding) and PowerShell's internal pipeline
+    // ($OutputEncoding). Because PowerShell joins all args after -Command with
+    // spaces, this prefix is transparently prepended to every command.
+    const powershellArgsPrefix = [
+      '-NoProfile',
+      '-Command',
+      '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $OutputEncoding = [System.Text.Encoding]::UTF8;',
+    ];
+
     const comSpec = process.env['ComSpec'];
     if (comSpec) {
       const executable = comSpec.toLowerCase();
@@ -554,7 +571,7 @@ export function getShellConfiguration(): ShellConfiguration {
       ) {
         return {
           executable: comSpec,
-          argsPrefix: ['-NoProfile', '-Command'],
+          argsPrefix: powershellArgsPrefix,
           shell: 'powershell',
         };
       }
@@ -563,7 +580,7 @@ export function getShellConfiguration(): ShellConfiguration {
     // Default to PowerShell for all other Windows configurations.
     return {
       executable: 'powershell.exe',
-      argsPrefix: ['-NoProfile', '-Command'],
+      argsPrefix: powershellArgsPrefix,
       shell: 'powershell',
     };
   }


### PR DESCRIPTION
## Problem

PowerShell 5.1 (the default shell on Windows) uses the system OEM code
page (e.g. CP437 on US English machines, CP850 in Western Europe) for
console stdout/stderr. When Gemini CLI reads those bytes it decodes them
as UTF-8, silently corrupting any non-ASCII character — accented letters,
CJK glyphs, symbols — in command output, error messages, and agentic
tool results.

## Root Cause

`getShellConfiguration()` in `shell-utils.ts` returns
`argsPrefix: ['-NoProfile', '-Command']` for PowerShell. No encoding
initialisation is performed before the user command runs, so the OEM
code page remains active for the lifetime of each shell invocation.

## Fix

PowerShell concatenates **all** arguments that follow `-Command` into a
single script string (separated by spaces). This means an extra element
appended to `argsPrefix` is transparently prepended to every command at
zero call-site cost.

The new `argsPrefix` for PowerShell:
[
'-NoProfile',
'-Command',
'[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $OutputEncoding = [System.Text.Encoding]::UTF8;',
]


- **`[Console]::OutputEncoding`** — sets the encoding for the raw bytes
  written to the OS stdout/stderr pipe (what Node.js actually reads).
- **`$OutputEncoding`** — sets PowerShell's internal pipeline encoding
  (`Write-Output`, `Out-String`, `ConvertTo-Json`, etc.).

No changes to the four call sites that do `[...argsPrefix, command]`
(`shellExecutionService.ts` ×2, `hookRunner.ts`, `value-resolver.ts`).

## Changes

- **`packages/core/src/utils/shell-utils.ts`** — extend
  `powershellArgsPrefix` with the UTF-8 init statement; update JSDoc.
- **`packages/core/src/utils/shell-utils.test.ts`** — update all
  `argsPrefix` assertions for the Windows PowerShell paths.

## Test Plan

- [x] All 57 `shell-utils` unit tests pass.
- [ ] Manual: run `Write-Host "héllo wörld"` via Gemini CLI on a Windows
  machine with a non-UTF-8 OEM locale — verify the output is correct.
- [ ] Manual: run a command that outputs CJK characters and confirm no
  `?` substitution.

Fixes #20968
