### PR TITLE
fix(tokenCalculation): estimate tokens for audio and video inline parts

### DIFF
--- a/packages/core/src/utils/tokenCalculation.test.ts
+++ b/packages/core/src/utils/tokenCalculation.test.ts
@@ -178,6 +178,86 @@ describe('tokenCalculation', () => {
       // PDF estimate: 25800 tokens (~100 pages at 258 tokens/page)
       expect(count).toBe(25800);
     });
+
+    it('should estimate audio tokens from inline data size in fallback', async () => {
+      vi.mocked(mockContentGenerator.countTokens).mockRejectedValue(
+        new Error('API error'),
+      );
+      // Simulate ~10s of 32kbps audio: 10 * 32000 / 8 = 40000 raw bytes
+      // base64 size ≈ 40000 / 0.75 ≈ 53333 chars
+      const audioBase64 = 'A'.repeat(53333);
+      const request = [
+        { inlineData: { mimeType: 'audio/mp3', data: audioBase64 } },
+      ];
+
+      const count = await calculateRequestTokenCount(
+        request,
+        mockContentGenerator,
+        model,
+      );
+
+      // ~10s * 32 tokens/s = 320 tokens
+      expect(count).toBeGreaterThanOrEqual(310);
+      expect(count).toBeLessThanOrEqual(330);
+    });
+
+    it('should use fixed audio estimate when inline data is absent in fallback', async () => {
+      vi.mocked(mockContentGenerator.countTokens).mockRejectedValue(
+        new Error('API error'),
+      );
+      const request = [
+        { fileData: { mimeType: 'audio/wav', fileUri: 'gs://bucket/file' } },
+      ];
+
+      const count = await calculateRequestTokenCount(
+        request,
+        mockContentGenerator,
+        model,
+      );
+
+      // Fixed audio fallback: 1000 tokens
+      expect(count).toBe(1000);
+    });
+
+    it('should estimate video tokens from inline data size in fallback', async () => {
+      vi.mocked(mockContentGenerator.countTokens).mockRejectedValue(
+        new Error('API error'),
+      );
+      // Simulate ~5s of 1Mbps video: 5 * 1_000_000 / 8 = 625000 raw bytes
+      // base64 size ≈ 625000 / 0.75 ≈ 833333 chars
+      const videoBase64 = 'A'.repeat(833333);
+      const request = [
+        { inlineData: { mimeType: 'video/mp4', data: videoBase64 } },
+      ];
+
+      const count = await calculateRequestTokenCount(
+        request,
+        mockContentGenerator,
+        model,
+      );
+
+      // ~5s * 258 tokens/s = 1290 tokens
+      expect(count).toBeGreaterThanOrEqual(1280);
+      expect(count).toBeLessThanOrEqual(1300);
+    });
+
+    it('should use fixed video estimate when inline data is absent in fallback', async () => {
+      vi.mocked(mockContentGenerator.countTokens).mockRejectedValue(
+        new Error('API error'),
+      );
+      const request = [
+        { fileData: { mimeType: 'video/webm', fileUri: 'gs://bucket/clip' } },
+      ];
+
+      const count = await calculateRequestTokenCount(
+        request,
+        mockContentGenerator,
+        model,
+      );
+
+      // Fixed video fallback: 5160 tokens (~20s clip)
+      expect(count).toBe(5160);
+    });
   });
 
   describe('estimateTokenCountSync', () => {

--- a/packages/core/src/utils/tokenCalculation.ts
+++ b/packages/core/src/utils/tokenCalculation.ts
@@ -19,6 +19,18 @@ const IMAGE_TOKEN_ESTIMATE = 3000;
 // Fixed token estimate for PDFs (~100 pages at 258 tokens/page)
 // See: https://ai.google.dev/gemini-api/docs/document-processing
 const PDF_TOKEN_ESTIMATE = 25800;
+// Audio: 32 tokens/second at an assumed 32 kbps bitrate
+// See: https://ai.google.dev/gemini-api/docs/audio
+const AUDIO_TOKENS_PER_SECOND = 32;
+const AUDIO_ASSUMED_BITRATE_BPS = 32_000;
+// Fallback when audio size is unavailable (~31s clip)
+const AUDIO_FIXED_TOKEN_ESTIMATE = 1_000;
+// Video: 258 tokens/second at an assumed 1 Mbps bitrate
+// See: https://ai.google.dev/gemini-api/docs/vision#video-token-counting
+const VIDEO_TOKENS_PER_SECOND = 258;
+const VIDEO_ASSUMED_BITRATE_BPS = 1_000_000;
+// Fallback when video size is unavailable (~20s clip)
+const VIDEO_FIXED_TOKEN_ESTIMATE = 5_160;
 
 // Maximum number of characters to process with the full character-by-character heuristic.
 // Above this, we use a faster approximation to avoid performance bottlenecks.
@@ -50,7 +62,7 @@ function estimateTextTokens(text: string): number {
 }
 
 /**
- * Heuristic estimation for media parts (images, PDFs) using fixed safe estimates.
+ * Heuristic estimation for media parts (images, PDFs, audio, video).
  */
 function estimateMediaTokens(part: Part): number | undefined {
   const inlineData = 'inlineData' in part ? part.inlineData : undefined;
@@ -65,6 +77,24 @@ function estimateMediaTokens(part: Part): number | undefined {
     // PDFs: 25,800 tokens (~100 pages at 258 tokens/page)
     // See: https://ai.google.dev/gemini-api/docs/document-processing
     return PDF_TOKEN_ESTIMATE;
+  } else if (mimeType?.startsWith('audio/')) {
+    // Audio: 32 tokens/second. Estimate duration from base64 size if available.
+    // See: https://ai.google.dev/gemini-api/docs/audio
+    if (inlineData?.data) {
+      const rawBytes = inlineData.data.length * 0.75;
+      const durationSeconds = (rawBytes * 8) / AUDIO_ASSUMED_BITRATE_BPS;
+      return Math.ceil(durationSeconds * AUDIO_TOKENS_PER_SECOND);
+    }
+    return AUDIO_FIXED_TOKEN_ESTIMATE;
+  } else if (mimeType?.startsWith('video/')) {
+    // Video: 258 tokens/second. Estimate duration from base64 size if available.
+    // See: https://ai.google.dev/gemini-api/docs/vision#video-token-counting
+    if (inlineData?.data) {
+      const rawBytes = inlineData.data.length * 0.75;
+      const durationSeconds = (rawBytes * 8) / VIDEO_ASSUMED_BITRATE_BPS;
+      return Math.ceil(durationSeconds * VIDEO_TOKENS_PER_SECOND);
+    }
+    return VIDEO_FIXED_TOKEN_ESTIMATE;
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary

Fixes #20655

Audio and video `inlineData` parts previously fell through to a generic
`JSON.stringify(part).length / 4` fallback in `estimateTokenCountSync`.
Because that operates on the raw base64 string, it grossly overestimates
the real token cost (by up to 2–3×), inflating context-window accounting
and prematurely triggering token-limit warnings for voice-mode sessions.

### Root cause

`estimateMediaTokens()` in `tokenCalculation.ts` handled `image/` and
`application/pdf` but returned `undefined` for `audio/*` and `video/*`,
causing the fallback path to fire.

### Fix

Added duration-based estimation for audio and video parts using the rates
published in the Gemini API documentation:

| Media | Tokens/second | Assumed bitrate |
|-------|--------------|-----------------|
| Audio | 32 tok/s     | 32 kbps         |
| Video | 258 tok/s    | 1 Mbps          |

When `inlineData.data` is present the base64 length is used to approximate
raw byte size → duration → tokens. When only a `fileUri` is available
(i.e. a `fileData` part with no inline bytes), safe fixed fallbacks are
used: **1 000 tokens** for audio (~31 s clip) and **5 160 tokens** for
video (~20 s clip).

## Test plan

- [x] `should estimate audio tokens from inline data size in fallback` — verifies ~10 s of 32 kbps audio → ~320 tokens
- [x] `should use fixed audio estimate when inline data is absent in fallback` — `fileData` audio → 1 000 tokens
- [x] `should estimate video tokens from inline data size in fallback` — verifies ~5 s of 1 Mbps video → ~1 290 tokens
- [x] `should use fixed video estimate when inline data is absent in fallback` — `fileData` video → 5 160 tokens
- [x] All pre-existing `tokenCalculation` tests continue to pass (19 total)

```bash
npx vitest run packages/core/src/utils/tokenCalculation.test.ts
# ✓ 19 tests passed
