### PR TITLE
fix(partUtils): show rich summary for audio/video inlineData in verbose mode

### DIFF
--- a/packages/core/src/utils/partUtils.test.ts
+++ b/packages/core/src/utils/partUtils.test.ts
@@ -131,6 +131,26 @@ describe('partUtils', () => {
       expect(partToString(part, verboseOptions)).toBe('');
     });
 
+    it('should return rich summary for audio inlineData part', () => {
+      // ~10s of 32kbps audio: 10 * 32000/8 = 40000 raw bytes -> base64 ~53333 chars
+      const audioBase64 = 'A'.repeat(53333);
+      const part = {
+        inlineData: { mimeType: 'audio/mp3', data: audioBase64 },
+      } as Part;
+      const result = partToString(part, verboseOptions);
+      expect(result).toMatch(/^\[Audio: audio\/mp3, \d+\.\d KB, ~\d+\.\d+s\]$/);
+    });
+
+    it('should return rich summary for video inlineData part', () => {
+      // ~5s of 1Mbps video: 5*1e6/8 = 625000 raw bytes -> base64 ~833333 chars
+      const videoBase64 = 'A'.repeat(833333);
+      const part = {
+        inlineData: { mimeType: 'video/mp4', data: videoBase64 },
+      } as Part;
+      const result = partToString(part, verboseOptions);
+      expect(result).toMatch(/^\[Video: video\/mp4, \d+\.\d KB, ~\d+\.\d+s\]$/);
+    });
+
     it('should handle complex nested arrays with various part types', () => {
       const parts = [
         'start ',
@@ -142,7 +162,7 @@ describe('partUtils', () => {
         ],
       ];
       expect(partToString(parts as Part, verboseOptions)).toBe(
-        'start middle[Function Call: func1] end<audio/mp3>',
+        'start middle[Function Call: func1] end[Audio: audio/mp3, 0.0 KB, ~0.0s]',
       );
     });
   });

--- a/packages/core/src/utils/partUtils.ts
+++ b/packages/core/src/utils/partUtils.ts
@@ -63,7 +63,18 @@ export function partToString(
       return `[Function Response: ${part.functionResponse.name}]`;
     }
     if (part.inlineData !== undefined) {
-      return `<${part.inlineData.mimeType}>`;
+      const mimeType = part.inlineData.mimeType ?? 'unknown';
+      const dataLen = part.inlineData.data?.length ?? 0;
+      if (mimeType.startsWith('audio/') || mimeType.startsWith('video/')) {
+        const isAudio = mimeType.startsWith('audio/');
+        const bitratesBps = isAudio ? 32_000 : 1_000_000;
+        const rawBytes = dataLen * 0.75;
+        const durationS = (rawBytes * 8) / bitratesBps;
+        const sizeKb = (rawBytes / 1024).toFixed(1);
+        const mediaType = isAudio ? 'Audio' : 'Video';
+        return `[${mediaType}: ${mimeType}, ${sizeKb} KB, ~${durationS.toFixed(1)}s]`;
+      }
+      return `<${mimeType}>`;
     }
   }
 


### PR DESCRIPTION

## Summary

Fixes #20656

In verbose mode, `partToString()` displayed audio and video `inlineData`
parts as a bare MIME-type tag (e.g. `<audio/mp3>`), providing no
indication of how large the recording was or how long it would run. This
made it impossible to understand the scope of multimodal voice/video
inputs when inspecting conversation history.

### Before

<audio/mp3>
<video/mp4>


### Fix

When the MIME type is `audio/*` or `video/*`, the verbose renderer now
computes:

- **Size (KB)** — derived from `base64_length × 0.75 / 1024`
- **Duration (s)** — derived from raw bytes and the same assumed bitrates
  used by the token-counting heuristic (32 kbps for audio, 1 Mbps for
  video)

All other `inlineData` types (images, etc.) continue to render as
`<mime/type>` unchanged.

## Test plan

- [x] `should return rich summary for audio inlineData part` — verifies format `[Audio: audio/mp3, X.X KB, ~X.Xs]`
- [x] `should return rich summary for video inlineData part` — verifies format `[Video: video/mp4, X.X KB, ~X.Xs]`
- [x] `should handle complex nested arrays with various part types` — updated to expect `[Audio: audio/mp3, 0.0 KB, ~0.0s]` for zero-length data
- [x] `should return descriptive string for inlineData part` (image) — still passes; images keep `<image/png>` format
- [x] All pre-existing `partUtils` tests continue to pass (39 total)

```bash
npx vitest run packages/core/src/utils/partUtils.test.ts
# ✓ 39 tests passed
