### PR TITLE
fix(core,cli): dispose Scheduler instances to prevent McpProgress listener leaks

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -54,6 +54,10 @@ const mockCoreEvents = vi.hoisted(() => ({
 }));
 
 const mockSchedulerSchedule = vi.hoisted(() => vi.fn());
+const mockSchedulerDispose = vi.hoisted(() => vi.fn());
+const mockConvertSessionToClientHistory = vi.hoisted(() =>
+  vi.fn((messages: unknown[]) => messages),
+);
 
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const original =
@@ -71,6 +75,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     Scheduler: class {
       schedule = mockSchedulerSchedule;
       cancelAll = vi.fn();
+      dispose = mockSchedulerDispose;
     },
     isTelemetrySdkInitialized: vi.fn().mockReturnValue(true),
     ChatRecordingService: MockChatRecordingService,
@@ -78,6 +83,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
       getMetrics: vi.fn(),
     },
     coreEvents: mockCoreEvents,
+    convertSessionToClientHistory: mockConvertSessionToClientHistory,
     createWorkingStdio: vi.fn(() => ({
       stdout: process.stdout,
       stderr: process.stderr,
@@ -132,6 +138,8 @@ describe('runNonInteractive', () => {
 
   beforeEach(async () => {
     mockSchedulerSchedule.mockReset();
+    mockSchedulerDispose.mockReset();
+    mockConvertSessionToClientHistory.mockClear();
 
     mockCommandServiceCreate.mockResolvedValue({
       getCommands: mockGetCommands,
@@ -264,6 +272,7 @@ describe('runNonInteractive', () => {
       'Test input',
     );
     expect(getWrittenOutput()).toBe('Hello World\n');
+    expect(mockSchedulerDispose).toHaveBeenCalledTimes(1);
     // Note: Telemetry shutdown is now handled in runExitCleanup() in cleanup.ts
     // so we no longer expect shutdownTelemetry to be called directly here
   });
@@ -908,6 +917,7 @@ describe('runNonInteractive', () => {
         2,
       ),
     );
+    expect(mockSchedulerDispose).toHaveBeenCalledTimes(1);
   });
 
   it('should handle FatalInputError with custom exit code in JSON format', async () => {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -182,6 +182,7 @@ export async function runNonInteractive({
     };
 
     let errorToHandle: unknown | undefined;
+    let scheduler: Scheduler | undefined;
     try {
       consolePatcher.patch();
 
@@ -210,7 +211,7 @@ export async function runNonInteractive({
       });
 
       const geminiClient = config.getGeminiClient();
-      const scheduler = new Scheduler({
+      scheduler = new Scheduler({
         config,
         messageBus: config.getMessageBus(),
         getPreferredEditor: () => undefined,
@@ -523,6 +524,7 @@ export async function runNonInteractive({
       // Cleanup stdin cancellation before other cleanup
       cleanupStdinCancellation();
 
+      scheduler?.dispose();
       consolePatcher.cleanup();
       coreEvents.off(CoreEvent.UserFeedback, handleUserFeedback);
     }

--- a/packages/core/src/agents/agent-scheduler.test.ts
+++ b/packages/core/src/agents/agent-scheduler.test.ts
@@ -12,9 +12,13 @@ import type { ToolRegistry } from '../tools/tool-registry.js';
 import type { ToolCallRequestInfo } from '../scheduler/types.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 
+const mockSchedulerSchedule = vi.hoisted(() => vi.fn());
+const mockSchedulerDispose = vi.hoisted(() => vi.fn());
+
 vi.mock('../scheduler/scheduler.js', () => ({
   Scheduler: vi.fn().mockImplementation(() => ({
-    schedule: vi.fn().mockResolvedValue([{ status: 'success' }]),
+    schedule: mockSchedulerSchedule,
+    dispose: mockSchedulerDispose,
   })),
 }));
 
@@ -24,6 +28,10 @@ describe('agent-scheduler', () => {
   let mockMessageBus: Mocked<MessageBus>;
 
   beforeEach(() => {
+    mockSchedulerSchedule.mockReset();
+    mockSchedulerSchedule.mockResolvedValue([{ status: 'success' }]);
+    mockSchedulerDispose.mockReset();
+
     mockMessageBus = {} as Mocked<MessageBus>;
     mockToolRegistry = {
       getTool: vi.fn(),
@@ -70,5 +78,49 @@ describe('agent-scheduler', () => {
     // Verify that the scheduler's config has the overridden tool registry
     const schedulerConfig = vi.mocked(Scheduler).mock.calls[0][0].config;
     expect(schedulerConfig.getToolRegistry()).toBe(mockToolRegistry);
+  });
+
+  it('should dispose scheduler after successful scheduling', async () => {
+    const requests: ToolCallRequestInfo[] = [
+      {
+        callId: 'call-2',
+        name: 'test-tool',
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'prompt-2',
+      },
+    ];
+
+    await scheduleAgentTools(mockConfig as unknown as Config, requests, {
+      schedulerId: 'subagent-2',
+      toolRegistry: mockToolRegistry as unknown as ToolRegistry,
+      signal: new AbortController().signal,
+    });
+
+    expect(mockSchedulerDispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should dispose scheduler when scheduling throws', async () => {
+    mockSchedulerSchedule.mockRejectedValueOnce(new Error('schedule failed'));
+
+    const requests: ToolCallRequestInfo[] = [
+      {
+        callId: 'call-3',
+        name: 'test-tool',
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'prompt-3',
+      },
+    ];
+
+    await expect(
+      scheduleAgentTools(mockConfig as unknown as Config, requests, {
+        schedulerId: 'subagent-3',
+        toolRegistry: mockToolRegistry as unknown as ToolRegistry,
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow('schedule failed');
+
+    expect(mockSchedulerDispose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/agents/agent-scheduler.ts
+++ b/packages/core/src/agents/agent-scheduler.ts
@@ -67,5 +67,9 @@ export async function scheduleAgentTools(
     onWaitingForConfirmation,
   });
 
-  return scheduler.schedule(requests, signal);
+  try {
+    return await scheduler.schedule(requests, signal);
+  } finally {
+    scheduler.dispose();
+  }
 }


### PR DESCRIPTION
Fixes #21006

## Summary
- fix a scheduler lifecycle leak in `scheduleAgentTools` by ensuring `Scheduler.dispose()` always runs via `try/finally`
- harden non-interactive CLI cleanup by disposing the root scheduler in `finally`
- add regression tests for success/error disposal paths in both core and CLI scheduler usages

## Why
`Scheduler` subscribes to `CoreEvent.McpProgress` during construction. Repeated scheduler creation without deterministic disposal can accumulate listeners over long-running tool orchestration flows.

## Changes
- `packages/core/src/agents/agent-scheduler.ts`
  - wrap `scheduler.schedule(...)` in `try/finally`
  - call `scheduler.dispose()` in `finally`
- `packages/core/src/agents/agent-scheduler.test.ts`
  - add tests asserting dispose on success and on thrown schedule errors
- `packages/cli/src/nonInteractiveCli.ts`
  - move scheduler reference outside `try`
  - dispose scheduler in `finally`
- `packages/cli/src/nonInteractiveCli.test.ts`
  - add disposal assertions in normal and error paths
  - add `convertSessionToClientHistory` mock to keep resumed-session test deterministic under module mocking

## Validation
- ✅ `npm run test --workspace @google/gemini-cli-core -- src/agents/agent-scheduler.test.ts`
- ✅ `npm run test --workspace @google/gemini-cli -- src/nonInteractiveCli.test.ts`
- ⚠️ Workspace typecheck currently fails on upstream baseline in this environment with many pre-existing errors unrelated to this patch.


