### PR TITLE
feat(core): add robustness tests, logging, and metrics for CodeAssistServer SSE parsing

### DIFF
--- a/packages/core/src/code_assist/server.test.ts
+++ b/packages/core/src/code_assist/server.test.ts
@@ -671,4 +671,190 @@ describe('CodeAssistServer', () => {
     expect(requestPostSpy).toHaveBeenCalledWith('retrieveUserQuota', req);
     expect(response).toEqual(mockResponse);
   });
+
+  describe('robustness testing', () => {
+    it('should not crash on random error objects in loadCodeAssist (isVpcScAffectedUser)', async () => {
+      const { server } = createTestServer();
+      const errors = [
+        null,
+        undefined,
+        'string error',
+        123,
+        { some: 'object' },
+        new Error('standard error'),
+        { response: {} },
+        { response: { data: {} } },
+      ];
+
+      for (const err of errors) {
+        vi.spyOn(server, 'requestPost').mockRejectedValueOnce(err);
+        try {
+          await server.loadCodeAssist({ metadata: {} });
+        } catch (e) {
+          expect(e).toBe(err);
+        }
+      }
+    });
+
+    it('should handle randomly fragmented SSE streams gracefully', async () => {
+      const { server, mockRequest } = createTestServer();
+      const { Readable } = await import('node:stream');
+
+      const fragmentedCases = [
+        ['d', 'ata: {"foo":', ' "bar"}\n\n'],
+        ['data: {"foo": "bar"}\n', '\n'],
+        ['data: ', '{"foo": "bar"}', '\n\n'],
+        ['data: {"foo": "bar"}\n\n', 'data: {"baz": 1}\n\n'],
+      ];
+
+      for (const chunks of fragmentedCases) {
+        const mockStream = new Readable({
+          read() {
+            for (const chunk of chunks) {
+              this.push(chunk);
+            }
+            this.push(null);
+          },
+        });
+        mockRequest.mockResolvedValueOnce({ data: mockStream });
+
+        const stream = await server.requestStreamingPost('testStream', {});
+        const results = [];
+        try {
+          for await (const res of stream) {
+            results.push(res);
+          }
+        } catch (_e) {
+          // Fragmented JSON might cause SyntaxError, which is fine as long as it doesn't hang
+        }
+      }
+    });
+
+    it('should correctly parse valid JSON split across multiple data lines', async () => {
+      const { server, mockRequest } = createTestServer();
+      const { Readable } = await import('node:stream');
+      const jsonObj = {
+        complex: { structure: [1, 2, 3] },
+        bool: true,
+        str: 'value',
+      };
+      const jsonString = JSON.stringify(jsonObj, null, 2);
+      const lines = jsonString.split('\n');
+      const ssePayload = lines.map((line) => `data: ${line}\n`).join('') + '\n';
+
+      const mockStream = new Readable({
+        read() {
+          this.push(ssePayload);
+          this.push(null);
+        },
+      });
+      mockRequest.mockResolvedValueOnce({ data: mockStream });
+
+      const stream = await server.requestStreamingPost('testStream', {});
+      const results = [];
+      for await (const res of stream) {
+        results.push(res);
+      }
+      expect(results).toHaveLength(1);
+      expect(results[0]).toEqual(jsonObj);
+    });
+
+    it('should not crash on objects partially matching VPC SC error structure', async () => {
+      const { server } = createTestServer();
+      const partialErrors = [
+        { response: { data: { error: { details: [{ reason: 'OTHER' }] } } } },
+        { response: { data: { error: { details: [] } } } },
+        { response: { data: { error: {} } } },
+        { response: { data: {} } },
+      ];
+
+      for (const err of partialErrors) {
+        vi.spyOn(server, 'requestPost').mockRejectedValueOnce(err);
+        try {
+          await server.loadCodeAssist({ metadata: {} });
+        } catch (e) {
+          expect(e).toBe(err);
+        }
+      }
+    });
+
+    it('should correctly ignore arbitrary SSE comments and ID lines and empty lines before data', async () => {
+      const { server, mockRequest } = createTestServer();
+      const { Readable } = await import('node:stream');
+      const jsonObj = { foo: 'bar' };
+      const jsonString = JSON.stringify(jsonObj);
+
+      const ssePayload = `id: 123
+:comment
+retry: 100
+
+data: ${jsonString}
+
+`;
+
+      const mockStream = new Readable({
+        read() {
+          this.push(ssePayload);
+          this.push(null);
+        },
+      });
+      mockRequest.mockResolvedValueOnce({ data: mockStream });
+
+      const stream = await server.requestStreamingPost('testStream', {});
+      const results = [];
+      for await (const res of stream) {
+        results.push(res);
+      }
+      expect(results).toHaveLength(1);
+      expect(results[0]).toEqual(jsonObj);
+    });
+
+    it('should safely process random response streams in generateContentStream (consumed/remaining credits)', async () => {
+      const { mockRequest, client } = createTestServer();
+      const testServer = new CodeAssistServer(
+        client,
+        'test-project',
+        {},
+        'test-session',
+        UserTierId.FREE,
+        undefined,
+        { id: 'test-tier', name: 'tier', availableCredits: [] },
+      );
+      const { Readable } = await import('node:stream');
+
+      const streamResponses = [
+        {
+          traceId: '1',
+          consumedCredits: [{ creditType: 'A', creditAmount: '10' }],
+        },
+        { traceId: '2', remainingCredits: [{ creditType: 'B' }] },
+        { traceId: '3' },
+        { traceId: '4', consumedCredits: null, remainingCredits: undefined },
+      ];
+
+      const mockStream = new Readable({
+        read() {
+          for (const resp of streamResponses) {
+            this.push(`data: ${JSON.stringify(resp)}\n\n`);
+          }
+          this.push(null);
+        },
+      });
+      mockRequest.mockResolvedValueOnce({ data: mockStream });
+      vi.spyOn(testServer, 'recordCodeAssistMetrics').mockResolvedValue(
+        undefined,
+      );
+
+      const stream = await testServer.generateContentStream(
+        { model: 'test-model', contents: [] },
+        'user-prompt-id',
+        LlmRole.MAIN,
+      );
+
+      for await (const _ of stream) {
+        // Drain stream
+      }
+      // Should not crash
+    });
+  });
 });

--- a/packages/core/src/code_assist/server.test.ts
+++ b/packages/core/src/code_assist/server.test.ts
@@ -10,8 +10,14 @@ import { OAuth2Client } from 'google-auth-library';
 import { UserTierId, ActionStatus } from './types.js';
 import { FinishReason } from '@google/genai';
 import { LlmRole } from '../telemetry/types.js';
+import { logInvalidChunk } from '../telemetry/loggers.js';
+import { makeFakeConfig } from '../test-utils/config.js';
 
 vi.mock('google-auth-library');
+vi.mock('../telemetry/loggers.js', () => ({
+  logBillingEvent: vi.fn(),
+  logInvalidChunk: vi.fn(),
+}));
 
 function createTestServer(headers: Record<string, string> = {}) {
   const mockRequest = vi.fn();
@@ -807,6 +813,49 @@ data: ${jsonString}
       }
       expect(results).toHaveLength(1);
       expect(results[0]).toEqual(jsonObj);
+    });
+
+    it('should log InvalidChunkEvent when SSE chunk is not valid JSON', async () => {
+      const config = makeFakeConfig();
+      const mockRequest = vi.fn();
+      const client = { request: mockRequest } as unknown as OAuth2Client;
+      const server = new CodeAssistServer(
+        client,
+        'test-project',
+        {},
+        'test-session',
+        UserTierId.FREE,
+        undefined,
+        undefined,
+        config,
+      );
+
+      const { Readable } = await import('node:stream');
+      const mockStream = new Readable({
+        read() {},
+      });
+
+      mockRequest.mockResolvedValue({ data: mockStream });
+
+      const stream = await server.requestStreamingPost('testStream', {});
+
+      setTimeout(() => {
+        mockStream.push('data: { "invalid": json }\n\n');
+        mockStream.push(null);
+      }, 0);
+
+      const results = [];
+      for await (const res of stream) {
+        results.push(res);
+      }
+
+      expect(results).toHaveLength(0);
+      expect(logInvalidChunk).toHaveBeenCalledWith(
+        config,
+        expect.objectContaining({
+          error_message: expect.stringContaining('Unexpected token'),
+        }),
+      );
     });
 
     it('should safely process random response streams in generateContentStream (consumed/remaining credits)', async () => {

--- a/packages/core/src/code_assist/server.test.ts
+++ b/packages/core/src/code_assist/server.test.ts
@@ -707,13 +707,25 @@ describe('CodeAssistServer', () => {
       const { Readable } = await import('node:stream');
 
       const fragmentedCases = [
-        ['d', 'ata: {"foo":', ' "bar"}\n\n'],
-        ['data: {"foo": "bar"}\n', '\n'],
-        ['data: ', '{"foo": "bar"}', '\n\n'],
-        ['data: {"foo": "bar"}\n\n', 'data: {"baz": 1}\n\n'],
+        {
+          chunks: ['d', 'ata: {"foo":', ' "bar"}\n\n'],
+          expected: [{ foo: 'bar' }],
+        },
+        {
+          chunks: ['data: {"foo": "bar"}\n', '\n'],
+          expected: [{ foo: 'bar' }],
+        },
+        {
+          chunks: ['data: ', '{"foo": "bar"}', '\n\n'],
+          expected: [{ foo: 'bar' }],
+        },
+        {
+          chunks: ['data: {"foo": "bar"}\n\n', 'data: {"baz": 1}\n\n'],
+          expected: [{ foo: 'bar' }, { baz: 1 }],
+        },
       ];
 
-      for (const chunks of fragmentedCases) {
+      for (const { chunks, expected } of fragmentedCases) {
         const mockStream = new Readable({
           read() {
             for (const chunk of chunks) {
@@ -726,13 +738,10 @@ describe('CodeAssistServer', () => {
 
         const stream = await server.requestStreamingPost('testStream', {});
         const results = [];
-        try {
-          for await (const res of stream) {
-            results.push(res);
-          }
-        } catch (_e) {
-          // Fragmented JSON might cause SyntaxError, which is fine as long as it doesn't hang
+        for await (const res of stream) {
+          results.push(res);
         }
+        expect(results).toEqual(expected);
       }
     });
 
@@ -853,7 +862,7 @@ data: ${jsonString}
       expect(logInvalidChunk).toHaveBeenCalledWith(
         config,
         expect.objectContaining({
-          error_message: expect.stringContaining('Unexpected token'),
+          error_message: 'Malformed JSON chunk',
         }),
       );
     });

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -47,7 +47,7 @@ import {
   isOverageEligibleModel,
   shouldAutoUseCredits,
 } from '../billing/billing.js';
-import { logBillingEvent } from '../telemetry/loggers.js';
+import { logBillingEvent, logInvalidChunk } from '../telemetry/loggers.js';
 import { CreditsUsedEvent } from '../telemetry/billingEvents.js';
 import {
   fromCountTokenResponse,
@@ -62,7 +62,8 @@ import {
   recordConversationOffered,
 } from './telemetry.js';
 import { getClientMetadata } from './experiments/client_metadata.js';
-import type { LlmRole } from '../telemetry/types.js';
+import { InvalidChunkEvent, type LlmRole } from '../telemetry/types.js';
+import { getErrorMessage } from '../utils/errors.js';
 /** HTTP options to be used in each of the requests. */
 export interface HttpOptions {
   /** Additional HTTP headers to be sent with the request. */
@@ -466,7 +467,7 @@ export class CodeAssistServer implements ContentGenerator {
       retry: false,
     });
 
-    return (async function* (): AsyncGenerator<T> {
+    return (async function* (server: CodeAssistServer): AsyncGenerator<T> {
       const rl = readline.createInterface({
         input: Readable.from(res.data),
         crlfDelay: Infinity, // Recognizes '\r\n' and '\n' as line breaks
@@ -480,12 +481,22 @@ export class CodeAssistServer implements ContentGenerator {
           if (bufferedLines.length === 0) {
             continue; // no data to yield
           }
-          yield JSON.parse(bufferedLines.join('\n'));
+          const chunk = bufferedLines.join('\n');
+          try {
+            yield JSON.parse(chunk);
+          } catch (e) {
+            if (server.config) {
+              logInvalidChunk(
+                server.config,
+                new InvalidChunkEvent(getErrorMessage(e)),
+              );
+            }
+          }
           bufferedLines = []; // Reset the buffer after yielding
         }
         // Ignore other lines like comments or id fields
       }
-    })();
+    })(this);
   }
 
   private getBaseUrl(): string {

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -63,7 +63,6 @@ import {
 } from './telemetry.js';
 import { getClientMetadata } from './experiments/client_metadata.js';
 import { InvalidChunkEvent, type LlmRole } from '../telemetry/types.js';
-import { getErrorMessage } from '../utils/errors.js';
 /** HTTP options to be used in each of the requests. */
 export interface HttpOptions {
   /** Additional HTTP headers to be sent with the request. */
@@ -484,11 +483,12 @@ export class CodeAssistServer implements ContentGenerator {
           const chunk = bufferedLines.join('\n');
           try {
             yield JSON.parse(chunk);
-          } catch (e) {
+          } catch (_e) {
             if (server.config) {
               logInvalidChunk(
                 server.config,
-                new InvalidChunkEvent(getErrorMessage(e)),
+                // Don't include the chunk content in the log for security/privacy reasons.
+                new InvalidChunkEvent('Malformed JSON chunk'),
               );
             }
           }

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -33,6 +33,7 @@ import {
   logFlashFallback,
   logChatCompression,
   logMalformedJsonResponse,
+  logInvalidChunk,
   logFileOperation,
   logRipgrepFallback,
   logToolOutputTruncated,
@@ -68,6 +69,7 @@ import {
   EVENT_AGENT_START,
   EVENT_AGENT_FINISH,
   EVENT_WEB_FETCH_FALLBACK_ATTEMPT,
+  EVENT_INVALID_CHUNK,
   ApiErrorEvent,
   ApiRequestEvent,
   ApiResponseEvent,
@@ -77,6 +79,7 @@ import {
   FlashFallbackEvent,
   RipgrepFallbackEvent,
   MalformedJsonResponseEvent,
+  InvalidChunkEvent,
   makeChatCompressionEvent,
   FileOperationEvent,
   ToolOutputTruncatedEvent,
@@ -1731,6 +1734,36 @@ describe('loggers', () => {
           'event.timestamp': '2025-01-01T00:00:00.000Z',
           interactive: false,
           model: 'test-model',
+        },
+      });
+    });
+  });
+
+  describe('logInvalidChunk', () => {
+    beforeEach(() => {
+      vi.spyOn(ClearcutLogger.prototype, 'logInvalidChunkEvent');
+    });
+
+    it('logs the event to Clearcut and OTEL', () => {
+      const mockConfig = makeFakeConfig();
+      const event = new InvalidChunkEvent('Unexpected token');
+
+      logInvalidChunk(mockConfig, event);
+
+      expect(
+        ClearcutLogger.prototype.logInvalidChunkEvent,
+      ).toHaveBeenCalledWith(event);
+
+      expect(mockLogger.emit).toHaveBeenCalledWith({
+        body: 'Invalid chunk received from stream.',
+        attributes: {
+          'session.id': 'test-session-id',
+          'user.email': 'test-user@example.com',
+          'installation.id': 'test-installation-id',
+          'event.name': EVENT_INVALID_CHUNK,
+          'event.timestamp': '2025-01-01T00:00:00.000Z',
+          interactive: false,
+          'error.message': 'Unexpected token',
         },
       });
     });

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -1742,6 +1742,7 @@ describe('loggers', () => {
   describe('logInvalidChunk', () => {
     beforeEach(() => {
       vi.spyOn(ClearcutLogger.prototype, 'logInvalidChunkEvent');
+      vi.spyOn(metrics, 'recordInvalidChunk');
     });
 
     it('logs the event to Clearcut and OTEL', () => {
@@ -1766,6 +1767,8 @@ describe('loggers', () => {
           'error.message': 'Unexpected token',
         },
       });
+
+      expect(metrics.recordInvalidChunk).toHaveBeenCalledWith(mockConfig);
     });
   });
 

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -29,6 +29,7 @@ import {
   type ConversationFinishedEvent,
   type ChatCompressionEvent,
   type MalformedJsonResponseEvent,
+  type InvalidChunkEvent,
   type ContentRetryEvent,
   type ContentRetryFailureEvent,
   type RipgrepFallbackEvent,
@@ -457,6 +458,21 @@ export function logMalformedJsonResponse(
   event: MalformedJsonResponseEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logMalformedJsonResponseEvent(event);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
+}
+
+export function logInvalidChunk(
+  config: Config,
+  event: InvalidChunkEvent,
+): void {
+  ClearcutLogger.getInstance(config)?.logInvalidChunkEvent(event);
   bufferTelemetryEvent(() => {
     const logger = logs.getLogger(SERVICE_NAME);
     const logRecord: LogRecord = {

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -76,6 +76,7 @@ import {
   recordPlanExecution,
   recordKeychainAvailability,
   recordTokenStorageInitialization,
+  recordInvalidChunk,
 } from './metrics.js';
 import { bufferTelemetryEvent } from './sdk.js';
 import { uiTelemetryService, type UiEvent } from './uiTelemetry.js';
@@ -480,6 +481,7 @@ export function logInvalidChunk(
       attributes: event.toOpenTelemetryAttributes(config),
     };
     logger.emit(logRecord);
+    recordInvalidChunk(config);
   });
 }
 

--- a/packages/core/src/telemetry/metrics.test.ts
+++ b/packages/core/src/telemetry/metrics.test.ts
@@ -105,6 +105,7 @@ describe('Telemetry Metrics', () => {
   let recordPlanExecutionModule: typeof import('./metrics.js').recordPlanExecution;
   let recordKeychainAvailabilityModule: typeof import('./metrics.js').recordKeychainAvailability;
   let recordTokenStorageInitializationModule: typeof import('./metrics.js').recordTokenStorageInitialization;
+  let recordInvalidChunkModule: typeof import('./metrics.js').recordInvalidChunk;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -154,6 +155,7 @@ describe('Telemetry Metrics', () => {
       metricsJsModule.recordKeychainAvailability;
     recordTokenStorageInitializationModule =
       metricsJsModule.recordTokenStorageInitialization;
+    recordInvalidChunkModule = metricsJsModule.recordInvalidChunk;
 
     const otelApiModule = await import('@opentelemetry/api');
 
@@ -1552,6 +1554,28 @@ describe('Telemetry Metrics', () => {
           'user.email': 'test@example.com',
           type: 'keychain',
           forced: true,
+        });
+      });
+    });
+
+    describe('recordInvalidChunk', () => {
+      it('should not record metrics if not initialized', () => {
+        const config = makeFakeConfig({});
+        recordInvalidChunkModule(config);
+        expect(mockCounterAddFn).not.toHaveBeenCalled();
+      });
+
+      it('should record invalid chunk when initialized', () => {
+        const config = makeFakeConfig({});
+        initializeMetricsModule(config);
+        mockCounterAddFn.mockClear();
+
+        recordInvalidChunkModule(config);
+
+        expect(mockCounterAddFn).toHaveBeenCalledWith(1, {
+          'session.id': 'test-session-id',
+          'installation.id': 'test-installation-id',
+          'user.email': 'test@example.com',
         });
       });
     });


### PR DESCRIPTION
## Summary

This PR introduces manual fuzzing and robustness tests to the `CodeAssistServer` to ensure resilient handling of SSE parsing and error responses. It also adds logging and metrics for invalid SSE chunks.

## Details

- Added manual fuzzing and robustness tests in `server.test.ts` to cover:
  - Randomly fragmented SSE streams.
  - Multi-line JSON parsing within SSE data lines.
  - Filtering of arbitrary SSE comments and ID lines.
  - VPC SC error object structure validation.
  - Credit consumption and remaining credit tracking in streaming responses.
- Implemented `InvalidChunkEvent` logging on SSE parse failure in `CodeAssistServer`.
- Integrated metrics into logging: every time an invalid chunk is logged, the corresponding metric is also incremented.

## Related Issues

Fixes #20191
Partially fixes #20189

## How to Validate

Run the newly added tests:
```bash
npm test -w @google/gemini-cli-core -- src/code_assist/server.test.ts
npm test -w @google/gemini-cli-core -- src/telemetry/loggers.test.ts
npm test -w @google/gemini-cli-core -- src/telemetry/metrics.test.ts
```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
