### PR TITLE
remove hardcoded tiername when missing tier

### DIFF
--- a/packages/cli/src/ui/components/UserIdentity.test.tsx
+++ b/packages/cli/src/ui/components/UserIdentity.test.tsx
@@ -47,6 +47,7 @@ describe('<UserIdentity />', () => {
     const output = lastFrame();
     expect(output).toContain('test@example.com');
     expect(output).toContain('/auth');
+    expect(output).not.toContain('/upgrade');
     unmount();
   });
 
@@ -74,6 +75,7 @@ describe('<UserIdentity />', () => {
     const output = lastFrame();
     expect(output).toContain('Logged in with Google');
     expect(output).toContain('/auth');
+    expect(output).not.toContain('/upgrade');
     unmount();
   });
 
@@ -130,6 +132,26 @@ describe('<UserIdentity />', () => {
     const output = lastFrame();
     expect(output).toContain(`Authenticated with ${AuthType.USE_GEMINI}`);
     expect(output).toContain('/auth');
+    expect(output).not.toContain('/upgrade');
+    unmount();
+  });
+
+  it('should render specific tier name when provided', async () => {
+    const mockConfig = makeFakeConfig();
+    vi.spyOn(mockConfig, 'getContentGeneratorConfig').mockReturnValue({
+      authType: AuthType.LOGIN_WITH_GOOGLE,
+      model: 'gemini-pro',
+    } as unknown as ContentGeneratorConfig);
+    vi.spyOn(mockConfig, 'getUserTierName').mockReturnValue('Enterprise Tier');
+
+    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
+      <UserIdentity config={mockConfig} />,
+    );
+    await waitUntilReady();
+
+    const output = lastFrame();
+    expect(output).toContain('Enterprise Tier');
+    expect(output).toContain('/upgrade');
     unmount();
   });
 });

--- a/packages/cli/src/ui/components/UserIdentity.tsx
+++ b/packages/cli/src/ui/components/UserIdentity.tsx
@@ -53,12 +53,14 @@ export const UserIdentity: React.FC<UserIdentityProps> = ({ config }) => {
       </Box>
 
       {/* Tier Name /upgrade */}
-      <Box>
-        <Text color={theme.text.primary} wrap="truncate-end">
-          {tierName ?? 'Gemini Code Assist for individuals'}
-        </Text>
-        <Text color={theme.text.secondary}> /upgrade</Text>
-      </Box>
+      {tierName && (
+        <Box>
+          <Text color={theme.text.primary} wrap="truncate-end">
+            {tierName}
+          </Text>
+          <Text color={theme.text.secondary}> /upgrade</Text>
+        </Box>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
## Summary

When missing tiername, it was hardcoding standard tier. should not show this.

## Details


## Related Issues

Fixes #21021

## How to Validate

Run the `UserIdentity` tests:
```bash
npm test -w @google/gemini-cli -- src/ui/components/UserIdentity.test.tsx
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker