### PR TITLE
fix(core): increase A2A agent timeout to 30 minutes

### DIFF
--- a/packages/core/src/agents/a2a-client-manager.ts
+++ b/packages/core/src/agents/a2a-client-manager.ts
@@ -23,7 +23,19 @@ import {
   createAuthenticatingFetchWithRetry,
 } from '@a2a-js/sdk/client';
 import { v4 as uuidv4 } from 'uuid';
+import { Agent as UndiciAgent } from 'undici';
 import { debugLogger } from '../utils/debugLogger.js';
+
+// Remote agents can take 10+ minutes (e.g. Deep Research).
+// Use a dedicated dispatcher so the global 5-min timeout isn't affected.
+const A2A_TIMEOUT = 1800000; // 30 minutes
+const a2aDispatcher = new UndiciAgent({
+  headersTimeout: A2A_TIMEOUT,
+  bodyTimeout: A2A_TIMEOUT,
+});
+const a2aFetch: typeof fetch = (input, init) =>
+  // @ts-expect-error The `dispatcher` property is a Node.js extension to fetch not present in standard types.
+  fetch(input, { ...init, dispatcher: a2aDispatcher });
 
 export type SendMessageResult =
   | Message
@@ -79,9 +91,9 @@ export class A2AClientManager {
       throw new Error(`Agent with name '${name}' is already loaded.`);
     }
 
-    let fetchImpl: typeof fetch = fetch;
+    let fetchImpl: typeof fetch = a2aFetch;
     if (authHandler) {
-      fetchImpl = createAuthenticatingFetchWithRetry(fetch, authHandler);
+      fetchImpl = createAuthenticatingFetchWithRetry(a2aFetch, authHandler);
     }
 
     const resolver = new DefaultAgentCardResolver({ fetchImpl });


### PR DESCRIPTION
## Summary

Increases the timeout for A2A (Agent-to-Agent) client requests to 30 minutes. This ensures that long-running remote agents, like Deep Research, can complete their tasks without being cut off by the default 5-minute timeout.

## Details

- Added a dedicated `UndiciAgent` (dispatcher) with `headersTimeout` and `bodyTimeout` set to 30 minutes (1,800,000ms).
- Replaced the global `fetch` calls in `A2AClientManager` with a custom `a2aFetch` that uses this dispatcher.
- This change prevents remote agents from timing out on long operations while leaving the global fetch timeout unaffected for other operations.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/21027

## How to Validate

1. Run a long-running A2A agent (e.g., Deep Research).
2. Verify that the request does not time out after 5 minutes and continues until completion (up to 30 minutes).

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
