### PR TITLE
feat(core): add vendor-neutral AGENT=gemini environment variable

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1607,6 +1607,7 @@ describe('ShellExecutionService environment variables', () => {
     const ptyEnv = mockPtySpawn.mock.calls[0][2].env;
     expect(ptyEnv).toHaveProperty('MY_TEST_VAR', 'test-value');
     expect(ptyEnv).toHaveProperty('GEMINI_CLI', '1');
+    expect(ptyEnv).toHaveProperty('AGENT', 'gemini');
 
     // Ensure pty process exits
     mockPtyProcess.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
@@ -1626,6 +1627,7 @@ describe('ShellExecutionService environment variables', () => {
     const cpEnv = mockCpSpawn.mock.calls[0][2].env;
     expect(cpEnv).toHaveProperty('MY_TEST_VAR', 'test-value');
     expect(cpEnv).toHaveProperty('GEMINI_CLI', '1');
+    expect(cpEnv).toHaveProperty('AGENT', 'gemini');
 
     // Ensure child_process exits
     mockChildProcess.emit('exit', 0, null);

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -44,6 +44,18 @@ export const GEMINI_CLI_IDENTIFICATION_ENV_VAR = 'GEMINI_CLI';
  */
 export const GEMINI_CLI_IDENTIFICATION_ENV_VAR_VALUE = '1';
 
+/**
+ * A vendor-neutral environment variable that signals to downstream tools
+ * that they are being executed by an AI agent. The value identifies the
+ * specific agent (e.g. "gemini").
+ */
+export const AGENT_IDENTIFICATION_ENV_VAR = 'AGENT';
+
+/**
+ * The value of {@link AGENT_IDENTIFICATION_ENV_VAR}
+ */
+export const AGENT_IDENTIFICATION_ENV_VAR_VALUE = 'gemini';
+
 // We want to allow shell outputs that are close to the context window in size.
 // 300,000 lines is roughly equivalent to a large context window, ensuring
 // we capture significant output from long-running commands.
@@ -316,6 +328,7 @@ export class ShellExecutionService {
           ...sanitizeEnvironment(process.env, sanitizationConfig),
           [GEMINI_CLI_IDENTIFICATION_ENV_VAR]:
             GEMINI_CLI_IDENTIFICATION_ENV_VAR_VALUE,
+          [AGENT_IDENTIFICATION_ENV_VAR]: AGENT_IDENTIFICATION_ENV_VAR_VALUE,
           TERM: 'xterm-256color',
           PAGER: 'cat',
           GIT_PAGER: 'cat',
@@ -580,6 +593,7 @@ export class ShellExecutionService {
             shellExecutionConfig.sanitizationConfig,
           ),
           GEMINI_CLI: '1',
+          [AGENT_IDENTIFICATION_ENV_VAR]: AGENT_IDENTIFICATION_ENV_VAR_VALUE,
           TERM: 'xterm-256color',
           PAGER: shellExecutionConfig.pager ?? 'cat',
           GIT_PAGER: shellExecutionConfig.pager ?? 'cat',

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -592,7 +592,8 @@ export class ShellExecutionService {
             process.env,
             shellExecutionConfig.sanitizationConfig,
           ),
-          GEMINI_CLI: '1',
+          [GEMINI_CLI_IDENTIFICATION_ENV_VAR]:
+            GEMINI_CLI_IDENTIFICATION_ENV_VAR_VALUE,
           [AGENT_IDENTIFICATION_ENV_VAR]: AGENT_IDENTIFICATION_ENV_VAR_VALUE,
           TERM: 'xterm-256color',
           PAGER: shellExecutionConfig.pager ?? 'cat',

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -78,6 +78,8 @@ import { expandEnvVars } from '../utils/envExpansion.js';
 import {
   GEMINI_CLI_IDENTIFICATION_ENV_VAR,
   GEMINI_CLI_IDENTIFICATION_ENV_VAR_VALUE,
+  AGENT_IDENTIFICATION_ENV_VAR,
+  AGENT_IDENTIFICATION_ENV_VAR_VALUE,
 } from '../services/shellExecutionService.js';
 
 export const MCP_DEFAULT_TIMEOUT_MSEC = 10 * 60 * 1000; // default to 10 minutes
@@ -2097,6 +2099,7 @@ export async function createTransport(
     const finalEnv: Record<string, string> = {
       [GEMINI_CLI_IDENTIFICATION_ENV_VAR]:
         GEMINI_CLI_IDENTIFICATION_ENV_VAR_VALUE,
+      [AGENT_IDENTIFICATION_ENV_VAR]: AGENT_IDENTIFICATION_ENV_VAR_VALUE,
       ...extensionEnv,
     };
     for (const [key, value] of Object.entries(sanitizedEnv)) {


### PR DESCRIPTION
## Summary

Add a vendor-neutral `AGENT=gemini` environment variable to all child processes spawned by Gemini CLI, alongside the existing `GEMINI_CLI=1`.

This allows downstream tools to detect they are being executed by an AI agent using a single, standardized variable — without needing to check for each agent's tool-specific variable (`GEMINI_CLI`, `CLAUDECODE`, `CODEX_SANDBOX`, `CURSOR_AGENT`, etc.).

## Details

### Key Changes

- Adds exported constants `AGENT_IDENTIFICATION_ENV_VAR` (`AGENT`) and `AGENT_IDENTIFICATION_ENV_VAR_VALUE` (`gemini`) in `shellExecutionService.ts`
- Sets `AGENT=gemini` in all three child process spawning paths:
  - **child_process.spawn** — fallback shell execution
  - **PTY spawn** — primary interactive shell execution
  - **MCP stdio transport** — MCP server child processes
- Adds test assertions verifying the new variable in both PTY and child_process paths

### Why a standard `AGENT` variable?

Every AI coding agent currently sets its own env var:

| Agent | Variable | Value |
|-------|----------|-------|
| Gemini CLI | `GEMINI_CLI` | `1` |
| Claude Code | `CLAUDECODE` | `1` |
| Codex CLI | `CODEX_SANDBOX` | `seatbelt` |
| Cursor | `CURSOR_AGENT` | `1` |
| Goose | `GOOSE_TERMINAL` | `1` |
| Amp | (internal) | - |

This forces every downstream tool to maintain a detection matrix. A shared `AGENT` variable (analogous to `CI=true`) lets tools write one check:

```bash
if [[ -n "${AGENT:-}" ]]; then
  # Adapt behavior for AI agent execution
fi
```

The value (`gemini`) identifies which agent is running, enabling agent-specific behavior when needed.

### Adoption

[Goose](https://github.com/block/goose) ([PR #7017](https://github.com/block/goose/pull/7017)) and [Amp](https://ampcode.com/manual/appendix#permissions-delegation) already ship `AGENT=<name>`. Consumer-side detection is already happening in [Bun](https://github.com/oven-sh/bun/pull/21135) and [Vercel](https://github.com/vercel/vercel/pull/13736).

See the standardization discussion at [agentsmd/agents.md#136](https://github.com/agentsmd/agents.md/issues/136).

## Related Issues

Relates to #17079

## How to Validate

1. Run Gemini CLI locally: `npm start`
2. Ask it to execute: `echo $AGENT`
3. Should output: `gemini`
4. Run unit tests: `npx vitest run packages/core/src/services/shellExecutionService.test.ts`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
