### PR TITLE
docs: clarify MCP tool policies and name sanitization

### DIFF
--- a/docs/reference/policy-engine.md
+++ b/docs/reference/policy-engine.md
@@ -74,11 +74,21 @@ primary conditions are the tool's name and its arguments.
 
 The `toolName` in the rule must match the name of the tool being called.
 
+- **Qualified MCP Names**: Tools from MCP servers are internally prefixed with
+  their server name (for example, `server__tool`). To match an MCP tool, you
+  must use the qualified name or the `mcpName` field. Unqualified names (for
+  example, `toolName = "my_tool"`) don't match MCP tools.
 - **Wildcards**: You can use wildcards to match multiple tools.
   - `*`: Matches **any tool** (built-in or MCP).
   - `server__*`: Matches any tool from a specific MCP server.
   - `*__toolName`: Matches a specific tool name across **all** MCP servers.
   - `*__*`: Matches **any tool from any MCP server**.
+
+> **Note:** **Built-in Protection**: Unqualified rules for built-in tools (like
+> `read_file` or `run_shell_command`) are strictly scoped. A rule for
+> `read_file` will only match the built-in tool and won't automatically allow
+> `my_server__read_file`. This prevents malicious servers from hijacking
+> permissions of built-in tools.
 
 #### Arguments pattern
 
@@ -164,6 +174,20 @@ A rule matches a tool call if all of its conditions are met:
     are converted to a stable JSON string, which is then tested against the
     provided regular expression. If the arguments don't match the pattern, the
     rule does not apply.
+
+### Name sanitization (The "Underscore Rule")
+
+Gemini CLI sanitizes server and tool names to ensure compatibility with the
+Gemini API.
+
+- **Invalid characters**: Any character that is not a letter, number, underscore
+  (`_`), dot (`.`), colon (`:`), or hyphen (`-`) is replaced with an
+  **underscore**.
+- **Spaces**: Spaces are always converted to underscores. For example, a server
+  named `"Google Drive"` is registered as `"Google_Drive"`.
+- **Case sensitivity**: Matching is case-insensitive.
+
+Your TOML rules must use these sanitized names to match correctly at runtime.
 
 ## Configuration
 

--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -559,6 +559,9 @@ Upon successful connection:
      with underscores
    - Names longer than 63 characters are truncated with middle replacement
      (`___`)
+   - See
+     [Name sanitization](/docs/reference/policy-engine.md#name-sanitization-the-underscore-rule)
+     in the policy engine reference for more details.
 
 ### 3. Conflict resolution
 


### PR DESCRIPTION
## Summary

Clarify MCP tool policy requirements and name sanitization in the documentation.

## Details

Recent security enforcements require MCP tools to be matched using qualified names (`server__tool`) or the `mcpName` field to prevent name-squatting. This PR adds documentation for these requirements and explains the "Underscore Rule" for sanitizing names with spaces.

## Related Issues

N/A (Resolves reported regression through documentation)

## How to Validate

1. Review `docs/reference/policy-engine.md` for the new "Qualified MCP Names" and "Name sanitization" sections.
2. Review `docs/tools/mcp-server.md` for the new cross-reference.
3. Verify that the "Underscore Rule" documentation accurately reflects the `generateValidName` implementation in `packages/core/src/tools/mcp-tool.ts`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
