### PR TITLE
fix: model persistence for all scenarios

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -2198,6 +2198,23 @@ describe('Config getHooks', () => {
 
       expect(onModelChange).not.toHaveBeenCalled();
     });
+
+    it('should call onModelChange when persisting a model that was previously temporary', () => {
+      const onModelChange = vi.fn();
+      const config = new Config({
+        ...baseParams,
+        model: 'some-other-model',
+        onModelChange,
+      });
+
+      // Temporary selection
+      config.setModel(DEFAULT_GEMINI_MODEL, true);
+      expect(onModelChange).not.toHaveBeenCalled();
+
+      // Persist selection of the same model
+      config.setModel(DEFAULT_GEMINI_MODEL, false);
+      expect(onModelChange).toHaveBeenCalledWith(DEFAULT_GEMINI_MODEL);
+    });
   });
 });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1403,9 +1403,9 @@ export class Config implements McpContext {
       // When the user explicitly sets a model, that becomes the active model.
       this._activeModel = newModel;
       coreEvents.emitModelChanged(newModel);
-      if (this.onModelChange && !isTemporary) {
-        this.onModelChange(newModel);
-      }
+    }
+    if (this.onModelChange && !isTemporary) {
+      this.onModelChange(newModel);
     }
     this.modelAvailabilityService.reset();
   }


### PR DESCRIPTION
## Summary

* ensure onModelChange is same model is selected once with persistence flag off and immediately again with persistence flag on. 
* This is annoyance to the user and should be fixed.

TEST=config.test.ts new case added and also manual

## Details

* In `config.ts` setModel function, the check if (this.model !== newModel || this._activeModel !== newModel) wrapped both the state update and the persistence logic (this.onModelChange). Since selecting the identical manual model string meant the state didn't change, the logic bypassed persistence saving when toggling from "Remember: false" to "Remember: true".

* Moved the this.onModelChange call to the outer level so that it always executes if `!isTemporary` is true, ensuring that even if the active model didn't change visually, the persistence logic is applied securely.

## Related Issues

Fixes #19864 

## How to Validate

* Try to set model with the persist flag off via `/model`
* Do this again but toggle persist flag to on - this time. 
* It should save the model for future sessions.


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [✅] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [✅] Validated on required platforms/methods:
  - [✅] MacOS
    - [✅] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
