### PR TITLE
feat: show connected Google account email in /auth and /about commands

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -85,6 +85,7 @@ import {
   buildUserSteeringHintPrompt,
   logBillingEvent,
   ApiKeyUpdatedEvent,
+  UserAccountManager,
 } from '@google/gemini-cli-core';
 import { validateAuthMethod } from '../config/auth.js';
 import process from 'node:process';
@@ -465,6 +466,27 @@ export const AppContainer = (props: AppContainerProps) => {
       generateSummary(config).catch((e) => {
         debugLogger.warn('Background summary generation failed:', e);
       });
+
+      // Show connected account at startup (only for fresh sessions, not resumed)
+      if (
+        sessionStartSource === SessionStartSource.Startup &&
+        config.isInitialized()
+      ) {
+        const authType = config.getContentGeneratorConfig()?.authType;
+        if (authType === AuthType.LOGIN_WITH_GOOGLE) {
+          const userAccountManager = new UserAccountManager();
+          const cachedAccount = userAccountManager.getCachedGoogleAccount();
+          if (cachedAccount) {
+            historyManager.addItem(
+              {
+                type: MessageType.INFO,
+                text: `Authenticated with Google account: ${cachedAccount}`,
+              },
+              Date.now(),
+            );
+          }
+        }
+      }
     })();
     registerCleanup(async () => {
       // Turn off mouse scroll.

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -468,24 +468,24 @@ export const AppContainer = (props: AppContainerProps) => {
       });
 
       // Show connected account at startup (only for fresh sessions, not resumed)
-      if (
-        sessionStartSource === SessionStartSource.Startup &&
-        config.isInitialized()
-      ) {
-        const authType = config.getContentGeneratorConfig()?.authType;
-        if (authType === AuthType.LOGIN_WITH_GOOGLE) {
-          const userAccountManager = new UserAccountManager();
-          const cachedAccount = userAccountManager.getCachedGoogleAccount();
-          if (cachedAccount) {
-            historyManager.addItem(
-              {
-                type: MessageType.INFO,
-                text: `Authenticated with Google account: ${cachedAccount}`,
-              },
-              Date.now(),
-            );
+      // Use setTimeout to ensure history manager is ready
+      if (sessionStartSource === SessionStartSource.Startup) {
+        setTimeout(() => {
+          const authType = config.getContentGeneratorConfig()?.authType;
+          if (authType === AuthType.LOGIN_WITH_GOOGLE) {
+            const userAccountManager = new UserAccountManager();
+            const cachedAccount = userAccountManager.getCachedGoogleAccount();
+            if (cachedAccount) {
+              historyManager.addItem(
+                {
+                  type: MessageType.INFO,
+                  text: `Authenticated with Google account: ${cachedAccount}`,
+                },
+                Date.now(),
+              );
+            }
           }
-        }
+        }, 100);
       }
     })();
     registerCleanup(async () => {

--- a/packages/cli/src/ui/commands/authCommand.test.ts
+++ b/packages/cli/src/ui/commands/authCommand.test.ts
@@ -9,12 +9,14 @@ import { authCommand } from './authCommand.js';
 import { type CommandContext } from './types.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import { SettingScope } from '../../config/settings.js';
+import { UserAccountManager, AuthType } from '@google/gemini-cli-core';
 
 vi.mock('@google/gemini-cli-core', async () => {
   const actual = await vi.importActual('@google/gemini-cli-core');
   return {
     ...actual,
     clearCachedCredentialFile: vi.fn().mockResolvedValue(undefined),
+    UserAccountManager: vi.fn(),
   };
 });
 
@@ -41,16 +43,105 @@ describe('authCommand', () => {
     expect(authCommand.subCommands?.[1]?.name).toBe('logout');
   });
 
-  it('should return a dialog action to open the auth dialog when called with no args', () => {
-    if (!authCommand.action) {
-      throw new Error('The auth command must have an action.');
-    }
+  describe('auth command default action', () => {
+    it('should return a dialog action when no auth is selected', () => {
+      if (!authCommand.action) {
+        throw new Error('The auth command must have an action.');
+      }
 
-    const result = authCommand.action(mockContext, '');
+      mockContext.services.settings.merged.security.auth.selectedType =
+        undefined;
+      mockContext.services.config = null;
 
-    expect(result).toEqual({
-      type: 'dialog',
-      dialog: 'auth',
+      const result = authCommand.action(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'dialog',
+        dialog: 'auth',
+      });
+    });
+
+    it('should show account info when authenticated with Google', () => {
+      if (!authCommand.action) {
+        throw new Error('The auth command must have an action.');
+      }
+
+      const mockGetCachedAccount = vi.fn().mockReturnValue('user@example.com');
+      vi.mocked(UserAccountManager).mockImplementation(
+        () =>
+          ({
+            getCachedGoogleAccount: mockGetCachedAccount,
+          }) as unknown as UserAccountManager,
+      );
+
+      mockContext.services.settings.merged.security.auth.selectedType =
+        AuthType.LOGIN_WITH_GOOGLE;
+      mockContext.services.config = {
+        getContentGeneratorConfig: vi.fn().mockReturnValue({
+          authType: AuthType.LOGIN_WITH_GOOGLE,
+        }),
+      } as unknown as typeof mockContext.services.config;
+
+      const result = authCommand.action(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: expect.stringContaining('user@example.com'),
+      });
+      expect(mockGetCachedAccount).toHaveBeenCalled();
+    });
+
+    it('should show auth method when authenticated with non-Google method', () => {
+      if (!authCommand.action) {
+        throw new Error('The auth command must have an action.');
+      }
+
+      mockContext.services.settings.merged.security.auth.selectedType =
+        AuthType.USE_GEMINI;
+      mockContext.services.config = {
+        getContentGeneratorConfig: vi.fn().mockReturnValue({
+          authType: AuthType.USE_GEMINI,
+        }),
+      } as unknown as typeof mockContext.services.config;
+
+      const result = authCommand.action(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: expect.stringContaining('gemini-api-key'),
+      });
+    });
+
+    it('should handle missing account email gracefully', () => {
+      if (!authCommand.action) {
+        throw new Error('The auth command must have an action.');
+      }
+
+      const mockGetCachedAccount = vi.fn().mockReturnValue(null);
+      vi.mocked(UserAccountManager).mockImplementation(
+        () =>
+          ({
+            getCachedGoogleAccount: mockGetCachedAccount,
+          }) as unknown as UserAccountManager,
+      );
+
+      mockContext.services.settings.merged.security.auth.selectedType =
+        AuthType.LOGIN_WITH_GOOGLE;
+      mockContext.services.config = {
+        getContentGeneratorConfig: vi.fn().mockReturnValue({
+          authType: AuthType.LOGIN_WITH_GOOGLE,
+        }),
+      } as unknown as typeof mockContext.services.config;
+
+      const result = authCommand.action(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: expect.stringContaining('Logged in with Google'),
+      });
     });
   });
 

--- a/packages/cli/src/ui/commands/authCommand.ts
+++ b/packages/cli/src/ui/commands/authCommand.ts
@@ -10,7 +10,12 @@ import type {
   LogoutActionReturn,
 } from './types.js';
 import { CommandKind } from './types.js';
-import { clearCachedCredentialFile } from '@google/gemini-cli-core';
+import {
+  clearCachedCredentialFile,
+  UserAccountManager,
+  AuthType,
+} from '@google/gemini-cli-core';
+import type { MessageActionReturn } from '@google/gemini-cli-core';
 import { SettingScope } from '../../config/settings.js';
 
 const authLoginCommand: SlashCommand = {
@@ -50,7 +55,50 @@ export const authCommand: SlashCommand = {
   description: 'Manage authentication',
   kind: CommandKind.BUILT_IN,
   subCommands: [authLoginCommand, authLogoutCommand],
-  action: (context, args) =>
-    // Default to login if no subcommand is provided
-    authLoginCommand.action!(context, args),
+  action: (context, _args): MessageActionReturn | OpenDialogActionReturn => {
+    // If no subcommand is provided, show current account info
+    const selectedAuthType =
+      context.services.settings.merged.security.auth.selectedType;
+    const authType =
+      context.services.config?.getContentGeneratorConfig()?.authType;
+
+    // Show account info for Google login
+    if (
+      authType === AuthType.LOGIN_WITH_GOOGLE ||
+      selectedAuthType === 'oauth-personal'
+    ) {
+      const userAccountManager = new UserAccountManager();
+      const cachedAccount = userAccountManager.getCachedGoogleAccount();
+
+      if (cachedAccount) {
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: `Currently authenticated with Google account: ${cachedAccount}\n\nUse \`/auth login\` to change authentication method.\nUse \`/auth logout\` to log out.`,
+        };
+      } else {
+        return {
+          type: 'message',
+          messageType: 'info',
+          content:
+            'Logged in with Google (account email not available)\n\nUse `/auth login` to change authentication method.\nUse `/auth logout` to log out.',
+        };
+      }
+    }
+
+    // For other auth types, show current auth method
+    if (selectedAuthType) {
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: `Current authentication method: ${selectedAuthType}\n\nUse \`/auth login\` to change authentication method.\nUse \`/auth logout\` to log out.`,
+      };
+    }
+
+    // No auth selected, open dialog
+    return {
+      type: 'dialog',
+      dialog: 'auth',
+    };
+  },
 };

--- a/packages/cli/src/ui/components/AboutBox.tsx
+++ b/packages/cli/src/ui/components/AboutBox.tsx
@@ -105,6 +105,18 @@ export const AboutBox: React.FC<AboutBoxProps> = ({
           <Text color={theme.text.primary}>{osVersion}</Text>
         </Box>
       </Box>
+      {userEmail && (
+        <Box flexDirection="row">
+          <Box width="35%">
+            <Text bold color={theme.text.link}>
+              Account
+            </Text>
+          </Box>
+          <Box>
+            <Text color={theme.text.primary}>{userEmail}</Text>
+          </Box>
+        </Box>
+      )}
       {showUserIdentity && (
         <Box flexDirection="row">
           <Box width="35%">


### PR DESCRIPTION
## Summary

This PR adds the ability to display the connected Google account email address in the CLI, addressing the need for users to know which account they're authenticated with when switching between personal and work accounts. The account email is now shown in three locations: the `/auth` command, the `/about` command, and as a startup info message.

## Details

- **Enhanced `/auth` command**: When run without subcommands, displays the current Google account email (if authenticated with Google) or the current authentication method
- **Updated `/about` command**: Always shows the account email in a dedicated "Account" field when available (previously only shown when `showUserIdentity` setting was enabled)
- **Startup message**: Shows the connected account email as an info message when the CLI starts (for fresh sessions only)
- All implementations use the existing `UserAccountManager.getCachedGoogleAccount()` method to retrieve the cached account email
- No changes to authentication logic or OAuth flow - only UI display enhancements

## Related Issues

Fixes #18036, #12235

## How to Validate

1. **Test `/auth` command**:
   - Start the CLI: `npm run start`
   - Type `/auth` and press Enter
   - Expected: Should display "Currently authenticated with Google account: your-email@example.com" (or similar message for other auth types)

2. **Test `/about` command**:
   - Type `/about` and press Enter
   - Expected: Should show the account email in the "Account" field in the about box

3. **Test startup message**:
   - Close the CLI completely
   - Start fresh: `npm run start`
   - Expected: Should see an info message at the top of chat history: "ℹ Authenticated with Google account: your-email@example.com"

4. **Test with different auth types**:
   - Verify `/auth` shows appropriate message for non-Google auth methods
   - Verify `/about` only shows account email when using Google login

5. **Test edge cases**:
   - Verify behavior when account email is not cached (should show "Logged in with Google (account email not available)")
   - Verify behavior when not authenticated with Google (should show auth method name)

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
  - Updated `authCommand.test.ts` with tests for new `/auth` behavior
- [x] Noted breaking changes (if any)
  - No breaking changes - only additive UI features
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

## Screenshots

### 1. `/auth` command showing account email

<img width="721" alt="Screenshot of /auth command showing account email" src="https://github.com/user-attachments/assets/044d6a94-e7a5-47dd-9fae-bdbe890d7047" />

### 2. `/about` command showing account email in Account field

<img width="713" alt="Screenshot of /about command showing Account field" src="https://github.com/user-attachments/assets/8f62ab81-769a-4a01-864b-4a6d952c192d" />

### 3. Startup info message showing account email

<img width="718" alt="Screenshot of startup message showing account email" src="https://github.com/user-attachments/assets/dd7544e8-478c-46c0-b97e-21c75ea997b8" />

## Files Changed

- `packages/cli/src/ui/commands/authCommand.ts` - Enhanced to show account info
- `packages/cli/src/ui/commands/authCommand.test.ts` - Updated tests
- `packages/cli/src/ui/components/AboutBox.tsx` - Added Account field display
- `packages/cli/src/ui/AppContainer.tsx` - Added startup message
