### PR TITLE
feat(core): improve @file autocomplete to prioritize filenames

### DIFF
--- a/packages/cli/src/ui/hooks/useAtCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.test.ts
@@ -120,8 +120,8 @@ describe('useAtCompletion', () => {
 
       expect(result.current.suggestions.map((s) => s.value)).toEqual([
         'src/',
-        'src/components/',
         'src/index.js',
+        'src/components/',
         'src/components/Button.tsx',
       ]);
     });

--- a/packages/cli/src/ui/hooks/useAtCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.test.ts
@@ -119,10 +119,10 @@ describe('useAtCompletion', () => {
       });
 
       expect(result.current.suggestions.map((s) => s.value)).toEqual([
-        'src/',
         'src/index.js',
-        'src/components/',
         'src/components/Button.tsx',
+        'src/',
+        'src/components/',
       ]);
     });
 

--- a/packages/cli/src/ui/hooks/useAtCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.test.ts
@@ -121,8 +121,8 @@ describe('useAtCompletion', () => {
       expect(result.current.suggestions.map((s) => s.value)).toEqual([
         'src/',
         'src/index.js',
-        'src/components/Button.tsx',
         'src/components/',
+        'src/components/Button.tsx',
       ]);
     });
 

--- a/packages/cli/src/ui/hooks/useAtCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.test.ts
@@ -119,9 +119,9 @@ describe('useAtCompletion', () => {
       });
 
       expect(result.current.suggestions.map((s) => s.value)).toEqual([
+        'src/',
         'src/index.js',
         'src/components/Button.tsx',
-        'src/',
         'src/components/',
       ]);
     });

--- a/packages/core/src/utils/filesearch/fileSearch.test.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.test.ts
@@ -458,12 +458,11 @@ describe('FileSearch', () => {
     // Files are prioritized over directories.
     expect(results[0]).toBe('src/hooks.ts');
     expect(results[1]).toBe('src/utils/hooks.tsx');
-    expect(results[2]).toBe('src/hooks/index.ts');
-    expect(results[3]).toBe('src/hooks-dev/test.ts');
-    expect(results[4]).toBe('src/hooks/');
-    expect(results[5]).toBe('src/hooks-dev/');
+    expect(results[2]).toBe('src/hooks/');
+    expect(results[3]).toBe('src/hooks-dev/');
+    expect(results[4]).toBe('src/hooks/index.ts');
+    expect(results[5]).toBe('src/hooks-dev/test.ts');
   });
-
   it('should return empty array when no matches are found', async () => {
     tmpDir = await createTmpDir({
       src: ['file1.js'],

--- a/packages/core/src/utils/filesearch/fileSearch.test.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.test.ts
@@ -455,11 +455,13 @@ describe('FileSearch', () => {
 
     // The order should prioritize matches closer to the end and shorter strings.
     // FZF matches right-to-left.
-    // src/hooks/ -> length 10, maxPos 8, dist 2
-    // src/hooks.ts -> length 12, maxPos 8, dist 4
-    // src/hooks/index.ts -> length 18, maxPos 8, dist 10
-    expect(results[0]).toBe('src/hooks/');
-    expect(results[1]).toBe('src/hooks.ts');
+    // Files are prioritized over directories.
+    expect(results[0]).toBe('src/hooks.ts');
+    expect(results[1]).toBe('src/utils/hooks.tsx');
+    expect(results[2]).toBe('src/hooks/index.ts');
+    expect(results[3]).toBe('src/hooks-dev/test.ts');
+    expect(results[4]).toBe('src/hooks/');
+    expect(results[5]).toBe('src/hooks-dev/');
   });
 
   it('should return empty array when no matches are found', async () => {

--- a/packages/core/src/utils/filesearch/fileSearch.test.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.test.ts
@@ -455,10 +455,9 @@ describe('FileSearch', () => {
 
     // The order should prioritize matches closer to the end and shorter strings.
     // FZF matches right-to-left.
-    // Files are prioritized over directories.
-    expect(results[0]).toBe('src/hooks.ts');
-    expect(results[1]).toBe('src/utils/hooks.tsx');
-    expect(results[2]).toBe('src/hooks/');
+    expect(results[0]).toBe('src/hooks/');
+    expect(results[1]).toBe('src/hooks.ts');
+    expect(results[2]).toBe('src/utils/hooks.tsx');
     expect(results[3]).toBe('src/hooks-dev/');
     expect(results[4]).toBe('src/hooks/index.ts');
     expect(results[5]).toBe('src/hooks-dev/test.ts');

--- a/packages/core/src/utils/filesearch/fileSearch.test.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.test.ts
@@ -421,6 +421,47 @@ describe('FileSearch', () => {
     );
   });
 
+  it('should prioritize filenames closer to the end of the path and shorter paths', async () => {
+    tmpDir = await createTmpDir({
+      src: {
+        'hooks.ts': '',
+        hooks: {
+          'index.ts': '',
+        },
+        utils: {
+          'hooks.tsx': '',
+        },
+        'hooks-dev': {
+          'test.ts': '',
+        },
+      },
+    });
+
+    const fileSearch = FileSearchFactory.create({
+      projectRoot: tmpDir,
+      fileDiscoveryService: new FileDiscoveryService(tmpDir, {
+        respectGitIgnore: false,
+        respectGeminiIgnore: false,
+      }),
+      ignoreDirs: [],
+      cache: false,
+      cacheTtl: 0,
+      enableRecursiveFileSearch: true,
+      enableFuzzySearch: true,
+    });
+
+    await fileSearch.initialize();
+    const results = await fileSearch.search('hooks');
+
+    // The order should prioritize matches closer to the end and shorter strings.
+    // FZF matches right-to-left.
+    // src/hooks/ -> length 10, maxPos 8, dist 2
+    // src/hooks.ts -> length 12, maxPos 8, dist 4
+    // src/hooks/index.ts -> length 18, maxPos 8, dist 10
+    expect(results[0]).toBe('src/hooks/');
+    expect(results[1]).toBe('src/hooks.ts');
+  });
+
   it('should return empty array when no matches are found', async () => {
     tmpDir = await createTmpDir({
       src: ['file1.js'],

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -241,8 +241,8 @@ class RecursiveFileSearch implements FileSearch {
         fuzzy: this.allFiles.length > 20000 ? 'v1' : 'v2',
         forward: false,
         tiebreakers: [
-          byDirVsFile,
           byBasenamePrefix,
+          byDirVsFile,
           byMatchPosFromEnd,
           byLengthAsc,
         ],

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -13,6 +13,20 @@ import { AsyncFzf, type FzfResultItem } from 'fzf';
 import { unescapePath } from '../paths.js';
 import type { FileDiscoveryService } from '../../services/fileDiscoveryService.js';
 
+const byLengthAsc = (a: FzfResultItem<string>, b: FzfResultItem<string>) =>
+  a.item.length - b.item.length;
+
+const byMatchPosFromEnd = (
+  a: FzfResultItem<string>,
+  b: FzfResultItem<string>,
+) => {
+  const maxPosA = Math.max(-1, ...a.positions);
+  const maxPosB = Math.max(-1, ...b.positions);
+  const distA = a.item.length - maxPosA;
+  const distB = b.item.length - maxPosB;
+  return distA - distB;
+};
+
 export interface FileSearchOptions {
   projectRoot: string;
   ignoreDirs: string[];
@@ -192,6 +206,8 @@ class RecursiveFileSearch implements FileSearch {
       // files, because the v2 algorithm is just too slow in those cases.
       this.fzf = new AsyncFzf(this.allFiles, {
         fuzzy: this.allFiles.length > 20000 ? 'v1' : 'v2',
+        forward: false,
+        tiebreakers: [byMatchPosFromEnd, byLengthAsc],
       });
     }
   }

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -17,15 +17,6 @@ import type { FileDiscoveryService } from '../../services/fileDiscoveryService.j
 const byLengthAsc = (a: { item: string }, b: { item: string }) =>
   a.item.length - b.item.length;
 
-// Tiebreaker: Prefers files over directories.
-const byDirVsFile = (a: { item: string }, b: { item: string }) => {
-  const aIsDir = a.item.endsWith('/');
-  const bIsDir = b.item.endsWith('/');
-  if (aIsDir && !bIsDir) return 1; // a (dir) after b (file)
-  if (!aIsDir && bIsDir) return -1; // a (file) before b (dir)
-  return 0;
-};
-
 // Tiebreaker: Prefers matches at the start of the filename (basename prefix).
 const byBasenamePrefix = (
   a: { item: string; positions: Set<number> },
@@ -240,12 +231,7 @@ class RecursiveFileSearch implements FileSearch {
       this.fzf = new AsyncFzf(this.allFiles, {
         fuzzy: this.allFiles.length > 20000 ? 'v1' : 'v2',
         forward: false,
-        tiebreakers: [
-          byBasenamePrefix,
-          byDirVsFile,
-          byMatchPosFromEnd,
-          byLengthAsc,
-        ],
+        tiebreakers: [byBasenamePrefix, byMatchPosFromEnd, byLengthAsc],
       });
     }
   }

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -13,12 +13,45 @@ import { AsyncFzf, type FzfResultItem } from 'fzf';
 import { unescapePath } from '../paths.js';
 import type { FileDiscoveryService } from '../../services/fileDiscoveryService.js';
 
-const byLengthAsc = (a: FzfResultItem<string>, b: FzfResultItem<string>) =>
+// Tiebreaker: Prefers shorter paths.
+const byLengthAsc = (a: { item: string }, b: { item: string }) =>
   a.item.length - b.item.length;
 
+// Tiebreaker: Prefers files over directories.
+const byDirVsFile = (a: { item: string }, b: { item: string }) => {
+  const aIsDir = a.item.endsWith('/');
+  const bIsDir = b.item.endsWith('/');
+  if (aIsDir && !bIsDir) return 1; // a (dir) after b (file)
+  if (!aIsDir && bIsDir) return -1; // a (file) before b (dir)
+  return 0;
+};
+
+// Tiebreaker: Prefers matches at the start of the filename (basename prefix).
+const byBasenamePrefix = (
+  a: { item: string; positions: Set<number> },
+  b: { item: string; positions: Set<number> },
+) => {
+  const getBasenameStart = (p: string) => {
+    const trimmed = p.endsWith('/') ? p.slice(0, -1) : p;
+    return Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\')) + 1;
+  };
+  const aDiff = Math.min(...a.positions) - getBasenameStart(a.item);
+  const bDiff = Math.min(...b.positions) - getBasenameStart(b.item);
+
+  const aIsFilenameMatch = aDiff >= 0;
+  const bIsFilenameMatch = bDiff >= 0;
+
+  if (aIsFilenameMatch && !bIsFilenameMatch) return -1;
+  if (!aIsFilenameMatch && bIsFilenameMatch) return 1;
+  if (aIsFilenameMatch && bIsFilenameMatch) return aDiff - bDiff;
+
+  return 0; // Both are directory matches, let subsequent tiebreakers decide.
+};
+
+// Tiebreaker: Prefers matches closer to the end of the path.
 const byMatchPosFromEnd = (
-  a: FzfResultItem<string>,
-  b: FzfResultItem<string>,
+  a: { item: string; positions: Set<number> },
+  b: { item: string; positions: Set<number> },
 ) => {
   const maxPosA = Math.max(-1, ...a.positions);
   const maxPosB = Math.max(-1, ...b.positions);
@@ -207,7 +240,12 @@ class RecursiveFileSearch implements FileSearch {
       this.fzf = new AsyncFzf(this.allFiles, {
         fuzzy: this.allFiles.length > 20000 ? 'v1' : 'v2',
         forward: false,
-        tiebreakers: [byMatchPosFromEnd, byLengthAsc],
+        tiebreakers: [
+          byDirVsFile,
+          byBasenamePrefix,
+          byMatchPosFromEnd,
+          byLengthAsc,
+        ],
       });
     }
   }


### PR DESCRIPTION
## Summary

Improves the behavior of the `@` file autocomplete feature to prioritize actual filenames and folder names over matching parent directory structures, providing a more intuitive search experience.

## Details

Updated the `AsyncFzf` configuration in `RecursiveFileSearch` to evaluate matches right-to-left (`forward: false`) and introduced a sophisticated multi-stage tiebreaker sequence to refine result ranking:

1. **`byBasenamePrefix`**: Prioritizes matches that start at the beginning of the actual filename or folder name. For example, a search for `hooks` will now correctly rank the folder `/src/hooks/` higher than a file deep inside it like `/src/hooks/index.ts`.
2. **`byMatchPosFromEnd`**: Scores matches based on their distance from the end of the file path, favoring matches that are closer to the extension/filename.
3. **`byLengthAsc`**: Prefers shorter, cleaner paths to break final ties.

These changes ensure that searching for a string like `hooks` consistently ranks `hooks.ts` or a `hooks/` directory at the top, rather than files where the term only appears as part of a parent directory name.

## Related Issues

Fixes #21063

## How to Validate

1. Run the test suite: `npm test -w @google/gemini-cli-core`
2. Run the CLI test suite: `npm test -w @google/gemini-cli -- src/ui/hooks/useAtCompletion.test.ts`
3. Start the CLI and verify search ranking for queries like `@hooks` correctly prioritizes the filename/folder name over the path.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker