### PR TITLE
fix(ui): suppress redundant failure note when tool error note is shown

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -1058,9 +1058,9 @@ describe('useGeminiStream', () => {
     );
     expect(noteIndex).toBeGreaterThanOrEqual(0);
     expect(stopIndex).toBeGreaterThanOrEqual(0);
-    expect(failureHintIndex).toBeGreaterThanOrEqual(0);
+    // The failure hint should NOT be present if the suppressed error note was shown
+    expect(failureHintIndex).toBe(-1);
     expect(noteIndex).toBeLessThan(stopIndex);
-    expect(stopIndex).toBeLessThan(failureHintIndex);
   });
 
   it('should group multiple cancelled tool call responses into a single history entry', async () => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -597,7 +597,10 @@ export const useGeminiStream = (
       if (!isLowErrorVerbosity || config.getDebugMode()) {
         return;
       }
-      if (lowVerbosityFailureNoteShownRef.current) {
+      if (
+        lowVerbosityFailureNoteShownRef.current ||
+        suppressedToolErrorNoteShownRef.current
+      ) {
         return;
       }
 


### PR DESCRIPTION
## Summary

Consolidate error diagnostic notes in the UI to avoid redundancy when both internal tool failures and final request failures occur simultaneously.

Existing failure:
<img width="3454" height="632" alt="image" src="https://github.com/user-attachments/assets/0b441048-7596-457d-aa68-1925f739d705" />


## Details

In low verbosity mode, the UI previously showed two identical "Press F12 for diagnostics" notes if a tool failed before the final request failure. This change suppresses the generic "This request failed..." note if the more specific "Some internal tool attempts failed..." note is already shown, as both provide the same diagnostic advice.

## Related Issues

N/A

## How to Validate

1. Trigger a scenario where a tool fails (e.g., a STOP_EXECUTION error) in low verbosity mode.
2. Observe that only one diagnostic note is shown instead of two.
3. Run `npm test -w @google/gemini-cli -- src/ui/hooks/useGeminiStream.test.tsx` to verify the fix.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
