### PR TITLE
fix(scripts): handle signal death and null exit code in start.js

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -73,6 +73,7 @@ if (isInDebugMode) {
 }
 const child = spawn('node', nodeArgs, { stdio: 'inherit', env });
 
-child.on('close', (code) => {
-  process.exit(code);
+child.on('close', (code, signal) => {
+  if (signal) console.error(`\nGemini CLI crashed (${signal})`);
+  process.exit(code ?? 1);
 });


### PR DESCRIPTION
## Summary

The `close` handler in `scripts/start.js` silently exits with code 0 when the child process is killed by a signal (SIGSEGV, SIGTERM, etc.), because `code` is `null` and `process.exit(null)` equals `process.exit(0)`.

**Bugs fixed:**
- Signal death (SIGSEGV, SIGTERM, etc.) → `code=null` → `process.exit(null)` → exits as success (code 0)
- No diagnostic output when the CLI is killed by a signal — developers see a silent exit

**Changes:**
- Add `signal` parameter to the `close` handler and print a crash message to stderr
- Guard null exit code with `?? 1` fallback

## Test plan

- [ ] `npm run lint` — passes
- [ ] `npm start` + `kill -SEGV $(pgrep -f "node.*packages/cli")` → prints `Gemini CLI crashed (SIGSEGV)` and exits non-zero
- [ ] `npm start` normal exit → no extra output, exit code 0

Fixes #21082

🤖 Generated with [Claude Code](https://claude.com/claude-code)