### PR TITLE
feat(core): add missing binary and media file extensions to ignore patterns

### DIFF
--- a/packages/core/src/utils/ignorePatterns.ts
+++ b/packages/core/src/utils/ignorePatterns.ts
@@ -47,6 +47,19 @@ export const BINARY_FILE_PATTERNS: string[] = [
   '**/*.odt',
   '**/*.ods',
   '**/*.odp',
+  '**/*.xz',
+  '**/*.zst',
+  '**/*.lz4',
+  '**/*.sqlite',
+  '**/*.db',
+  '**/*.mdb',
+  '**/*.iso',
+  '**/*.img',
+  '**/*.dmg',
+  '**/*.ttf',
+  '**/*.otf',
+  '**/*.woff',
+  '**/*.woff2',
 ];
 
 /**
@@ -62,6 +75,14 @@ export const MEDIA_FILE_PATTERNS: string[] = [
   '**/*.webp',
   '**/*.bmp',
   '**/*.svg',
+  '**/*.mp3',
+  '**/*.mp4',
+  '**/*.wav',
+  '**/*.avi',
+  '**/*.mov',
+  '**/*.flac',
+  '**/*.ogg',
+  '**/*.mkv',
 ];
 
 /**

--- a/packages/core/src/utils/ignorePatterns.ts
+++ b/packages/core/src/utils/ignorePatterns.ts
@@ -60,6 +60,10 @@ export const BINARY_FILE_PATTERNS: string[] = [
   '**/*.otf',
   '**/*.woff',
   '**/*.woff2',
+  '**/*.mp4',
+  '**/*.avi',
+  '**/*.mov',
+  '**/*.mkv',
 ];
 
 /**
@@ -76,13 +80,9 @@ export const MEDIA_FILE_PATTERNS: string[] = [
   '**/*.bmp',
   '**/*.svg',
   '**/*.mp3',
-  '**/*.mp4',
   '**/*.wav',
-  '**/*.avi',
-  '**/*.mov',
   '**/*.flac',
   '**/*.ogg',
-  '**/*.mkv',
 ];
 
 /**


### PR DESCRIPTION
Summary

Adds commonly encountered binary and media file extensions to the default ignore patterns used by Gemini CLI.
These extensions are frequently present in development repositories but represent binary data. Without excluding them, tools such as read-many-files may attempt to process them as text, which can waste tokens and potentially cause parsing issues.
This change improves the default ignore behavior and aligns with existing exclusions for archives and office files.

Details
The following extensions were added to improve the default ignore patterns:
Binary extensions added to BINARY_FILE_PATTERNS:
.xz
.zst
.lz4
.sqlite
.db
.mdb
.iso
.img
.dmg
Media extensions added to MEDIA_FILE_PATTERNS:
.mp3
.mp4
.wav
.avi
.mov
.flac
.ogg
.mkv
These file types are commonly encountered in repositories containing assets, demos, or local development databases and should not be treated as text files.

Related Issues
Closes #21018

How to Validate

1. Run tests for the core package:

    cd packages/core
    npm run test

2. Verify that all tests pass.

3. Confirm that the new file extensions appear in:

    packages/core/src/utils/ignorePatterns.ts

4. Confirm that binary/media files with these extensions are excluded by tools such as read-many-files.

Pre-Merge Checklist

 ->Updated relevant documentation and README (if needed)

 ->Added/updated tests (not required — existing tests pass)

 ->Noted breaking changes (none)

Validated on:

 ->MacOS

     ->npm run