### PR TITLE
fix(scripts): handle signal death and null exit code in start.js

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -21,6 +21,7 @@ import { spawn, execSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readFileSync } from 'node:fs';
+import { constants } from 'node:os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
@@ -73,6 +74,11 @@ if (isInDebugMode) {
 }
 const child = spawn('node', nodeArgs, { stdio: 'inherit', env });
 
-child.on('close', (code) => {
-  process.exit(code);
+child.on('close', (code, signal) => {
+  if (signal) {
+    console.error(`\nGemini CLI was terminated by signal: ${signal}`);
+    const signalNumber = constants.signals[signal];
+    process.exit(signalNumber ? 128 + signalNumber : 1);
+  }
+  process.exit(code ?? 1);
 });


### PR DESCRIPTION
## Summary

- Fix silent exit on signal death: print diagnostic message and exit with `128 + signal_number` per Unix convention
- Guard null exit code with `?? 1` to prevent `process.exit(null)` → `process.exit(0)`

## Details

When the CLI child process is killed by a signal (e.g., SIGSEGV from a Node.js version mismatch), the `close` event fires with `code=null` and `signal='SIGSEGV'`. The current handler only captures `code`, so `process.exit(null)` is called — which Node.js treats as `process.exit(0)`, silently masking the crash as a success.

This fix adds the `signal` parameter to the `close` handler, prints a diagnostic message to stderr, and exits with `128 + signal_number` following the Unix convention (e.g., SIGSEGV → 139). For non-signal exits where `code` could still be `null`, a `?? 1` fallback ensures a non-zero exit.

## Related Issues

Fixes #21086

## How to Validate

- `npm run lint` — passes
- `npm start` + `kill -SEGV $(pgrep -f "node.*packages/cli")` → prints `Gemini CLI was terminated by signal: SIGSEGV` and exits with code 139
- `npm start` normal exit → no extra output, exit code 0

## Pre-Merge Checklist

- [NA] Updated relevant documentation and README (if needed)
- [NA] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker