### PR TITLE
feat(cli): add Sublime Text and Emacs Client editors, improve error messages and documentation

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -110,9 +110,14 @@ their corresponding top-level category object in your `settings.json` file.
     built-in supported identifiers. Use /editor in the CLI to pick
     interactively, or leave unset to use $VISUAL/$EDITOR.
   - **Default:** `undefined`
-  - **Values:** `"vscode"`, `"vscodium"`, `"cursor"`, `"windsurf"`, `"zed"`,
+  - **Values:** `"vscode"`, `"vscodium"`, `"windsurf"`, `"cursor"`, `"zed"`,
     `"antigravity"`, `"sublimetext"`, `"lapce"`, `"nova"`, `"bbedit"`, `"vim"`,
-    `"neovim"`, `"emacs"`, `"emacsclient"`, `"hx"`, `"micro"`
+    `"neovim"`, `"emacs"`, `"hx"`, `"emacsclient"`, `"micro"`
+
+- **`general.openEditorInNewWindow`** (boolean):
+  - **Description:** Open VS Code-family editors in a new window when editing
+    files.
+  - **Default:** `false`
 
 - **`general.vimMode`** (boolean):
   - **Description:** Enable Vim keybindings

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -106,7 +106,10 @@ their corresponding top-level category object in your `settings.json` file.
 #### `general`
 
 - **`general.preferredEditor`** (string):
-  - **Description:** The preferred editor to open files in.
+  - **Description:** The preferred editor to open files in. Must be one of the
+    built-in supported identifiers — run /editor in the CLI for the full list.
+    Power users who need an editor not in this list can leave this unset and
+    configure $VISUAL or $EDITOR in their shell environment instead.
   - **Default:** `undefined`
 
 - **`general.vimMode`** (boolean):

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -107,9 +107,8 @@ their corresponding top-level category object in your `settings.json` file.
 
 - **`general.preferredEditor`** (string):
   - **Description:** The preferred editor to open files in. Must be one of the
-    built-in supported identifiers — run /editor in the CLI for the full list.
-    Power users who need an editor not in this list can leave this unset and
-    configure $VISUAL or $EDITOR in their shell environment instead.
+    built-in supported identifiers. Use /editor in the CLI to pick
+    interactively, or leave unset to use $VISUAL/$EDITOR.
   - **Default:** `undefined`
 
 - **`general.vimMode`** (boolean):

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -105,39 +105,14 @@ their corresponding top-level category object in your `settings.json` file.
 
 #### `general`
 
-- **`general.preferredEditor`** (string):
+- **`general.preferredEditor`** (enum):
   - **Description:** The preferred editor to open files in. Must be one of the
     built-in supported identifiers. Use /editor in the CLI to pick
     interactively, or leave unset to use $VISUAL/$EDITOR.
   - **Default:** `undefined`
-  - **Accepted values:**
-
-    | Identifier    | Editor                                         | Platform |
-    | ------------- | ---------------------------------------------- | -------- |
-    | `vscode`      | Visual Studio Code                             | All      |
-    | `vscodium`    | VSCodium                                       | All      |
-    | `cursor`      | Cursor                                         | All      |
-    | `windsurf`    | Windsurf                                       | All      |
-    | `zed`         | Zed                                            | All      |
-    | `antigravity` | Antigravity                                    | All      |
-    | `sublimetext` | Sublime Text                                   | All      |
-    | `lapce`       | Lapce                                          | All      |
-    | `nova`        | Nova                                           | macOS    |
-    | `bbedit`      | BBEdit                                         | macOS    |
-    | `vim`         | Vim                                            | All      |
-    | `neovim`      | Neovim                                         | All      |
-    | `emacs`       | Emacs                                          | All      |
-    | `emacsclient` | Emacs Client (requires a running Emacs daemon) | All      |
-    | `hx`          | Helix                                          | All      |
-    | `micro`       | Micro                                          | All      |
-
-  - **`$VISUAL` / `$EDITOR` fallback:** If `preferredEditor` is not set, the CLI
-    falls back to the `$VISUAL` environment variable, then `$EDITOR`, and
-    finally `vi` (Unix) or `notepad` (Windows). This lets you use any editor not
-    in the list above — including editors with custom arguments like
-    `emacsclient -nw` — by setting the environment variable directly.
-  - **Note:** Setting an unrecognized identifier produces a clear error at
-    runtime. To configure your editor interactively, use the `/editor` command.
+  - **Values:** `"vscode"`, `"vscodium"`, `"cursor"`, `"windsurf"`, `"zed"`,
+    `"antigravity"`, `"sublimetext"`, `"lapce"`, `"nova"`, `"bbedit"`, `"vim"`,
+    `"neovim"`, `"emacs"`, `"emacsclient"`, `"hx"`, `"micro"`
 
 - **`general.vimMode`** (boolean):
   - **Description:** Enable Vim keybindings

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -106,8 +106,9 @@ their corresponding top-level category object in your `settings.json` file.
 #### `general`
 
 - **`general.preferredEditor`** (string):
-  - **Description:** The preferred editor to open files in when using the
-    external editor feature (Ctrl-X).
+  - **Description:** The preferred editor to open files in. Must be one of the
+    built-in supported identifiers. Use /editor in the CLI to pick
+    interactively, or leave unset to use $VISUAL/$EDITOR.
   - **Default:** `undefined`
   - **Accepted values:**
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -106,10 +106,37 @@ their corresponding top-level category object in your `settings.json` file.
 #### `general`
 
 - **`general.preferredEditor`** (string):
-  - **Description:** The preferred editor to open files in. Must be one of the
-    built-in supported identifiers. Use /editor in the CLI to pick
-    interactively, or leave unset to use $VISUAL/$EDITOR.
+  - **Description:** The preferred editor to open files in when using the
+    external editor feature (Ctrl-X).
   - **Default:** `undefined`
+  - **Accepted values:**
+
+    | Identifier    | Editor                                         | Platform |
+    | ------------- | ---------------------------------------------- | -------- |
+    | `vscode`      | Visual Studio Code                             | All      |
+    | `vscodium`    | VSCodium                                       | All      |
+    | `cursor`      | Cursor                                         | All      |
+    | `windsurf`    | Windsurf                                       | All      |
+    | `zed`         | Zed                                            | All      |
+    | `antigravity` | Antigravity                                    | All      |
+    | `sublimetext` | Sublime Text                                   | All      |
+    | `lapce`       | Lapce                                          | All      |
+    | `nova`        | Nova                                           | macOS    |
+    | `bbedit`      | BBEdit                                         | macOS    |
+    | `vim`         | Vim                                            | All      |
+    | `neovim`      | Neovim                                         | All      |
+    | `emacs`       | Emacs                                          | All      |
+    | `emacsclient` | Emacs Client (requires a running Emacs daemon) | All      |
+    | `hx`          | Helix                                          | All      |
+    | `micro`       | Micro                                          | All      |
+
+  - **`$VISUAL` / `$EDITOR` fallback:** If `preferredEditor` is not set, the CLI
+    falls back to the `$VISUAL` environment variable, then `$EDITOR`, and
+    finally `vi` (Unix) or `notepad` (Windows). This lets you use any editor not
+    in the list above — including editors with custom arguments like
+    `emacsclient -nw` — by setting the environment variable directly.
+  - **Note:** Setting an unrecognized identifier produces a clear error at
+    runtime. To configure your editor interactively, use the `/editor` command.
 
 - **`general.vimMode`** (boolean):
   - **Description:** Enable Vim keybindings

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -197,8 +197,11 @@ const SETTINGS_SCHEMA = {
         category: 'General',
         requiresRestart: false,
         default: undefined as string | undefined,
-        description:
-          'The preferred editor to open files in. Must be one of the built-in supported identifiers — run /editor in the CLI for the full list. Power users who need an editor not in this list can leave this unset and configure $VISUAL or $EDITOR in their shell environment instead.',
+        description: oneLine`
+          The preferred editor to open files in. Must be one of the built-in
+          supported identifiers. Use /editor in the CLI to pick interactively,
+          or leave unset to use $VISUAL/$EDITOR.
+        `,
         showInDialog: false,
       },
       vimMode: {

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -192,7 +192,7 @@ const SETTINGS_SCHEMA = {
     showInDialog: false,
     properties: {
       preferredEditor: {
-        type: 'string',
+        type: 'enum',
         label: 'Preferred Editor',
         category: 'General',
         requiresRestart: false,
@@ -203,6 +203,24 @@ const SETTINGS_SCHEMA = {
           or leave unset to use $VISUAL/$EDITOR.
         `,
         showInDialog: false,
+        options: [
+          { value: 'vscode', label: 'VS Code' },
+          { value: 'vscodium', label: 'VSCodium' },
+          { value: 'cursor', label: 'Cursor' },
+          { value: 'windsurf', label: 'Windsurf' },
+          { value: 'zed', label: 'Zed' },
+          { value: 'antigravity', label: 'Antigravity' },
+          { value: 'sublimetext', label: 'Sublime Text' },
+          { value: 'lapce', label: 'Lapce' },
+          { value: 'nova', label: 'Nova (macOS)' },
+          { value: 'bbedit', label: 'BBEdit (macOS)' },
+          { value: 'vim', label: 'Vim' },
+          { value: 'neovim', label: 'Neovim' },
+          { value: 'emacs', label: 'Emacs' },
+          { value: 'emacsclient', label: 'Emacs Client' },
+          { value: 'hx', label: 'Helix' },
+          { value: 'micro', label: 'Micro' },
+        ],
       },
       vimMode: {
         type: 'boolean',

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -197,7 +197,8 @@ const SETTINGS_SCHEMA = {
         category: 'General',
         requiresRestart: false,
         default: undefined as string | undefined,
-        description: 'The preferred editor to open files in.',
+        description:
+          'The preferred editor to open files in. Must be one of the built-in supported identifiers — run /editor in the CLI for the full list. Power users who need an editor not in this list can leave this unset and configure $VISUAL or $EDITOR in their shell environment instead.',
         showInDialog: false,
       },
       vimMode: {

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -12,6 +12,7 @@
 import {
   DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
   DEFAULT_MODEL_CONFIGS,
+  EDITOR_OPTIONS,
   AuthProviderType,
   type MCPServerConfig,
   type RequiredMcpServerConfig,
@@ -203,24 +204,7 @@ const SETTINGS_SCHEMA = {
           or leave unset to use $VISUAL/$EDITOR.
         `,
         showInDialog: false,
-        options: [
-          { value: 'vscode', label: 'VS Code' },
-          { value: 'vscodium', label: 'VSCodium' },
-          { value: 'cursor', label: 'Cursor' },
-          { value: 'windsurf', label: 'Windsurf' },
-          { value: 'zed', label: 'Zed' },
-          { value: 'antigravity', label: 'Antigravity' },
-          { value: 'sublimetext', label: 'Sublime Text' },
-          { value: 'lapce', label: 'Lapce' },
-          { value: 'nova', label: 'Nova (macOS)' },
-          { value: 'bbedit', label: 'BBEdit (macOS)' },
-          { value: 'vim', label: 'Vim' },
-          { value: 'neovim', label: 'Neovim' },
-          { value: 'emacs', label: 'Emacs' },
-          { value: 'emacsclient', label: 'Emacs Client' },
-          { value: 'hx', label: 'Helix' },
-          { value: 'micro', label: 'Micro' },
-        ],
+        options: EDITOR_OPTIONS,
       },
       vimMode: {
         type: 'boolean',

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -206,6 +206,16 @@ const SETTINGS_SCHEMA = {
         showInDialog: false,
         options: EDITOR_OPTIONS,
       },
+      openEditorInNewWindow: {
+        type: 'boolean',
+        label: 'Open Editor in New Window',
+        category: 'General',
+        requiresRestart: false,
+        default: false,
+        description:
+          'Open VS Code-family editors in a new window when editing files.',
+        showInDialog: false,
+      },
       vimMode: {
         type: 'boolean',
         label: 'Vim Mode',

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -47,7 +47,6 @@ import { MouseProvider } from './contexts/MouseContext.js';
 import { ScrollProvider } from './contexts/ScrollProvider.js';
 import {
   type StartupWarning,
-  type EditorType,
   type Config,
   type IdeInfo,
   type IdeContext,
@@ -68,6 +67,7 @@ import {
   ShellExecutionService,
   saveApiKey,
   debugLogger,
+  isValidEditorType,
   coreEvents,
   CoreEvent,
   flattenMemory,
@@ -609,11 +609,10 @@ export const AppContainer = (props: AppContainerProps) => {
 
   const staticAreaMaxItemHeight = Math.max(terminalHeight * 4, 100);
 
-  const getPreferredEditor = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    () => settings.merged.general.preferredEditor as EditorType,
-    [settings.merged.general.preferredEditor],
-  );
+  const getPreferredEditor = useCallback(() => {
+    const val = settings.merged.general.preferredEditor;
+    return isValidEditorType(val) ? val : undefined;
+  }, [settings.merged.general.preferredEditor]);
 
   const buffer = useTextBuffer({
     initialText: '',

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -614,6 +614,11 @@ export const AppContainer = (props: AppContainerProps) => {
     return isValidEditorType(val) ? val : undefined;
   }, [settings.merged.general.preferredEditor]);
 
+  const getOpenEditorInNewWindow = useCallback(
+    () => settings.merged.general.openEditorInNewWindow,
+    [settings.merged.general.openEditorInNewWindow],
+  );
+
   const buffer = useTextBuffer({
     initialText: '',
     viewport: { height: 10, width: inputWidth },
@@ -622,6 +627,7 @@ export const AppContainer = (props: AppContainerProps) => {
     escapePastedPaths: true,
     shellModeActive,
     getPreferredEditor,
+    getOpenEditorInNewWindow,
   });
   const bufferRef = useRef(buffer);
   useEffect(() => {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -614,11 +614,6 @@ export const AppContainer = (props: AppContainerProps) => {
     return isValidEditorType(val) ? val : undefined;
   }, [settings.merged.general.preferredEditor]);
 
-  const getOpenEditorInNewWindow = useCallback(
-    () => settings.merged.general.openEditorInNewWindow,
-    [settings.merged.general.openEditorInNewWindow],
-  );
-
   const buffer = useTextBuffer({
     initialText: '',
     viewport: { height: 10, width: inputWidth },
@@ -627,7 +622,6 @@ export const AppContainer = (props: AppContainerProps) => {
     escapePastedPaths: true,
     shellModeActive,
     getPreferredEditor,
-    getOpenEditorInNewWindow,
   });
   const bufferRef = useRef(buffer);
   useEffect(() => {

--- a/packages/cli/src/ui/components/EditorSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/EditorSettingsDialog.tsx
@@ -22,7 +22,6 @@ import {
   type EditorType,
   isEditorAvailable,
   EDITOR_DISPLAY_NAMES,
-  coreEvents,
 } from '@google/gemini-cli-core';
 import { useKeypress } from '../hooks/useKeypress.js';
 
@@ -128,8 +127,7 @@ export function EditorSettingsDialog({
   ) {
     mergedEditorName =
       EDITOR_DISPLAY_NAMES[
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        settings.merged.general.preferredEditor as EditorType
+        settings.merged.general.preferredEditor
       ];
   }
 

--- a/packages/cli/src/ui/components/EditorSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/EditorSettingsDialog.tsx
@@ -72,10 +72,6 @@ export function EditorSettingsDialog({
       )
     : 0;
   if (editorIndex === -1) {
-    coreEvents.emitFeedback(
-      'error',
-      `Editor is not supported: ${currentPreference}`,
-    );
     editorIndex = 0;
   }
 
@@ -161,6 +157,7 @@ export function EditorSettingsDialog({
           onSelect={handleEditorSelect}
           isFocused={focusedSection === 'editor'}
           key={selectedScope}
+          maxItemsToShow={editorItems.length}
         />
 
         <Box marginTop={1} flexDirection="column">

--- a/packages/cli/src/ui/components/EditorSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/EditorSettingsDialog.tsx
@@ -126,9 +126,7 @@ export function EditorSettingsDialog({
     isEditorAvailable(settings.merged.general.preferredEditor)
   ) {
     mergedEditorName =
-      EDITOR_DISPLAY_NAMES[
-        settings.merged.general.preferredEditor
-      ];
+      EDITOR_DISPLAY_NAMES[settings.merged.general.preferredEditor];
   }
 
   return (

--- a/packages/cli/src/ui/components/shared/performance.test.ts
+++ b/packages/cli/src/ui/components/shared/performance.test.ts
@@ -9,6 +9,17 @@ import { renderHook } from '../../../test-utils/render.js';
 import { useTextBuffer } from './text-buffer.js';
 import { parseInputForHighlighting } from '../../utils/highlight.js';
 
+vi.mock('../../contexts/SettingsContext.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../contexts/SettingsContext.js')>();
+  return {
+    ...actual,
+    useSettings: () => ({
+      merged: { general: { openEditorInNewWindow: false } },
+    }),
+  };
+});
+
 describe('text-buffer performance', () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -44,6 +44,17 @@ import { cpLen } from '../../utils/textUtils.js';
 import { type Key } from '../../hooks/useKeypress.js';
 import { escapePath } from '@google/gemini-cli-core';
 
+vi.mock('../../contexts/SettingsContext.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../contexts/SettingsContext.js')>();
+  return {
+    ...actual,
+    useSettings: () => ({
+      merged: { general: { openEditorInNewWindow: false } },
+    }),
+  };
+});
+
 const defaultVisualLayout: VisualLayout = {
   visualLines: [''],
   logicalToVisualMap: [[[0, 0]]],

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -13,6 +13,7 @@ import { LRUCache } from 'mnemonist';
 import {
   coreEvents,
   debugLogger,
+  getErrorMessage,
   unescapePath,
   type EditorType,
 } from '@google/gemini-cli-core';
@@ -3342,11 +3343,7 @@ export function useTextBuffer({
 
       dispatch({ type: 'set_text', payload: newText, pushToUndo: false });
     } catch (err) {
-      coreEvents.emitFeedback(
-        'error',
-        '[useTextBuffer] external editor error',
-        err,
-      );
+      coreEvents.emitFeedback('error', getErrorMessage(err), err);
     } finally {
       try {
         fs.unlinkSync(filePath);

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -31,6 +31,7 @@ import type { VimAction } from './vim-buffer-actions.js';
 import { handleVimAction } from './vim-buffer-actions.js';
 import { LRU_BUFFER_PERF_CACHE_LIMIT } from '../../constants.js';
 import { openFileInEditor } from '../../utils/editorUtils.js';
+import { useSettings } from '../../contexts/SettingsContext.js';
 import { useKeyMatchers } from '../../hooks/useKeyMatchers.js';
 
 export const LARGE_PASTE_LINE_THRESHOLD = 5;
@@ -772,7 +773,6 @@ interface UseTextBufferProps {
   inputFilter?: (text: string) => string; // Optional filter for input text
   singleLine?: boolean;
   getPreferredEditor?: () => EditorType | undefined;
-  getOpenEditorInNewWindow?: () => boolean | undefined;
 }
 
 interface UndoHistoryEntry {
@@ -2841,8 +2841,8 @@ export function useTextBuffer({
   inputFilter,
   singleLine = false,
   getPreferredEditor,
-  getOpenEditorInNewWindow,
 }: UseTextBufferProps): TextBuffer {
+  const settings = useSettings();
   const keyMatchers = useKeyMatchers();
   const initialState = useMemo((): TextBufferState => {
     const lines = initialText.split('\n');
@@ -3328,7 +3328,7 @@ export function useTextBuffer({
         stdin,
         setRawMode,
         getPreferredEditor?.(),
-        getOpenEditorInNewWindow?.(),
+        settings.merged.general.openEditorInNewWindow,
       );
 
       let newText = fs.readFileSync(filePath, 'utf8');
@@ -3365,7 +3365,7 @@ export function useTextBuffer({
     stdin,
     setRawMode,
     getPreferredEditor,
-    getOpenEditorInNewWindow,
+    settings.merged.general.openEditorInNewWindow,
   ]);
 
   const handleInput = useCallback(

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -772,6 +772,7 @@ interface UseTextBufferProps {
   inputFilter?: (text: string) => string; // Optional filter for input text
   singleLine?: boolean;
   getPreferredEditor?: () => EditorType | undefined;
+  getOpenEditorInNewWindow?: () => boolean | undefined;
 }
 
 interface UndoHistoryEntry {
@@ -2840,6 +2841,7 @@ export function useTextBuffer({
   inputFilter,
   singleLine = false,
   getPreferredEditor,
+  getOpenEditorInNewWindow,
 }: UseTextBufferProps): TextBuffer {
   const keyMatchers = useKeyMatchers();
   const initialState = useMemo((): TextBufferState => {
@@ -3326,6 +3328,7 @@ export function useTextBuffer({
         stdin,
         setRawMode,
         getPreferredEditor?.(),
+        getOpenEditorInNewWindow?.(),
       );
 
       let newText = fs.readFileSync(filePath, 'utf8');
@@ -3356,7 +3359,14 @@ export function useTextBuffer({
         /* ignore */
       }
     }
-  }, [text, pastedContent, stdin, setRawMode, getPreferredEditor]);
+  }, [
+    text,
+    pastedContent,
+    stdin,
+    setRawMode,
+    getPreferredEditor,
+    getOpenEditorInNewWindow,
+  ]);
 
   const handleInput = useCallback(
     (key: Key): boolean => {

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -36,12 +36,14 @@ const HEURISTIC_GUI_COMMANDS = [
  * @param stdin The stdin stream from Ink/Node
  * @param setRawMode Function to toggle raw mode
  * @param preferredEditorType The user's preferred editor from config
+ * @param openInNewWindow Whether to open VS Code-family editors in a new window
  */
 export async function openFileInEditor(
   filePath: string,
   stdin: ReadStream | null | undefined,
   setRawMode: ((mode: boolean) => void) | undefined,
   preferredEditorType?: EditorType,
+  openInNewWindow?: boolean,
 ): Promise<void> {
   let command: string | undefined = undefined;
   const args = [filePath];
@@ -62,7 +64,11 @@ export async function openFileInEditor(
     if (isGuiEditor(preferredEditorType)) {
       args.unshift(getEditorWaitFlag(preferredEditorType));
     }
-    extraArgs.push(...getEditorExtraArgs(preferredEditorType));
+    extraArgs.push(
+      ...getEditorExtraArgs(preferredEditorType, {
+        newWindow: openInNewWindow,
+      }),
+    );
   }
 
   if (!command) {
@@ -79,7 +85,9 @@ export async function openFileInEditor(
         ) {
           args.unshift(getEditorWaitFlag(resolvedType));
         }
-        extraArgs.push(...getEditorExtraArgs(resolvedType));
+        extraArgs.push(
+          ...getEditorExtraArgs(resolvedType, { newWindow: openInNewWindow }),
+        );
       } else {
         // Heuristic fallback for commands not in the registry
         const lower = envCommand.toLowerCase();

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -81,6 +81,11 @@ export async function openFileInEditor(
     args.unshift('-i', 'NONE');
   }
 
+  if (isTerminal && executable === 'emacsclient') {
+    // Pass -nw to force terminal (no-window) mode.
+    args.unshift('-nw');
+  }
+
   const wasRaw = stdin?.isRaw ?? false;
   setRawMode?.(false);
 

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -97,6 +97,17 @@ export async function openFileInEditor(
     args.unshift('-nw');
   }
 
+  function handleEditorError(err: Error, context: string): void {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      coreEvents.emitFeedback(
+        'error',
+        `Could not find editor '${executable}'. Check your $VISUAL/$EDITOR setting.`,
+      );
+    } else {
+      coreEvents.emitFeedback('error', context, err);
+    }
+  }
+
   const wasRaw = stdin?.isRaw ?? false;
   setRawMode?.(false);
 
@@ -107,18 +118,10 @@ export async function openFileInEditor(
         shell: process.platform === 'win32',
       });
       if (result.error) {
-        if ((result.error as NodeJS.ErrnoException).code === 'ENOENT') {
-          coreEvents.emitFeedback(
-            'error',
-            `Could not find editor '${executable}'. Check your $VISUAL/$EDITOR setting.`,
-          );
-        } else {
-          coreEvents.emitFeedback(
-            'error',
-            '[editorUtils] external terminal editor error',
-            result.error,
-          );
-        }
+        handleEditorError(
+          result.error,
+          '[editorUtils] external terminal editor error',
+        );
         throw result.error;
       }
       if (typeof result.status === 'number' && result.status !== 0) {
@@ -140,18 +143,7 @@ export async function openFileInEditor(
         });
 
         child.on('error', (err) => {
-          if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-            coreEvents.emitFeedback(
-              'error',
-              `Could not find editor '${executable}'. Check your $VISUAL/$EDITOR setting.`,
-            );
-          } else {
-            coreEvents.emitFeedback(
-              'error',
-              '[editorUtils] external editor spawn error',
-              err,
-            );
-          }
+          handleEditorError(err, '[editorUtils] external editor spawn error');
           reject(err);
         });
 

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -20,6 +20,14 @@ import {
   resolveEditorTypeFromCommand,
 } from '@google/gemini-cli-core';
 
+const HEURISTIC_GUI_COMMANDS = [
+  'code',
+  'cursor',
+  'subl',
+  'zed',
+  'atom',
+] as const;
+
 /**
  * Opens a file in an external editor and waits for it to close.
  * Handles raw mode switching to ensure the editor can interact with the terminal.
@@ -73,9 +81,7 @@ export async function openFileInEditor(
       } else {
         // Heuristic fallback for commands not in the registry
         const lower = envCommand.toLowerCase();
-        const isGui = ['code', 'cursor', 'subl', 'zed', 'atom'].some((g) =>
-          lower.includes(g),
-        );
+        const isGui = HEURISTIC_GUI_COMMANDS.some((g) => lower.includes(g));
         if (isGui && !lower.includes('--wait') && !lower.includes('-w')) {
           args.unshift(lower.includes('subl') ? '-w' : '--wait');
         }

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -11,6 +11,7 @@ import {
   CoreEvent,
   type EditorType,
   getEditorCommand,
+  isEditorAvailable,
   isGuiEditor,
   isTerminalEditor,
 } from '@google/gemini-cli-core';
@@ -34,9 +35,19 @@ export async function openFileInEditor(
   const args = [filePath];
 
   if (preferredEditorType) {
-    command = getEditorCommand(preferredEditorType);
-    if (isGuiEditor(preferredEditorType)) {
-      args.unshift('--wait');
+    if (isEditorAvailable(preferredEditorType)) {
+      command = getEditorCommand(preferredEditorType);
+      if (isGuiEditor(preferredEditorType)) {
+        args.unshift('--wait');
+      }
+    } else {
+      coreEvents.emitFeedback(
+        'error',
+        `Editor '${preferredEditorType}' is not recognized or not installed. ` +
+          `Run /editor to pick a supported editor, or set $VISUAL/$EDITOR in your shell ` +
+          `to your preferred editor.`,
+      );
+      return;
     }
   }
 
@@ -96,11 +107,18 @@ export async function openFileInEditor(
         shell: process.platform === 'win32',
       });
       if (result.error) {
-        coreEvents.emitFeedback(
-          'error',
-          '[editorUtils] external terminal editor error',
-          result.error,
-        );
+        if ((result.error as NodeJS.ErrnoException).code === 'ENOENT') {
+          coreEvents.emitFeedback(
+            'error',
+            `Could not find editor '${executable}'. Check your $VISUAL/$EDITOR setting.`,
+          );
+        } else {
+          coreEvents.emitFeedback(
+            'error',
+            '[editorUtils] external terminal editor error',
+            result.error,
+          );
+        }
         throw result.error;
       }
       if (typeof result.status === 'number' && result.status !== 0) {
@@ -122,11 +140,18 @@ export async function openFileInEditor(
         });
 
         child.on('error', (err) => {
-          coreEvents.emitFeedback(
-            'error',
-            '[editorUtils] external editor spawn error',
-            err,
-          );
+          if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+            coreEvents.emitFeedback(
+              'error',
+              `Could not find editor '${executable}'. Check your $VISUAL/$EDITOR setting.`,
+            );
+          } else {
+            coreEvents.emitFeedback(
+              'error',
+              '[editorUtils] external editor spawn error',
+              err,
+            );
+          }
           reject(err);
         });
 

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -31,6 +31,7 @@ const HEURISTIC_GUI_COMMANDS = [
   'subl',
   'zed',
   'atom',
+  'agy',
 ] as const;
 
 /**

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -17,6 +17,7 @@ import {
   isGuiEditor,
   isTerminalEditor,
   isValidEditorType,
+  resolveEditorTypeFromCommand,
 } from '@google/gemini-cli-core';
 
 /**
@@ -55,18 +56,29 @@ export async function openFileInEditor(
   }
 
   if (!command) {
-    command = process.env['VISUAL'] ?? process.env['EDITOR'];
-    if (command) {
-      const lowerCommand = command.toLowerCase();
-      const isGui = ['code', 'cursor', 'subl', 'zed', 'atom'].some((gui) =>
-        lowerCommand.includes(gui),
-      );
-      if (
-        isGui &&
-        !lowerCommand.includes('--wait') &&
-        !lowerCommand.includes('-w')
-      ) {
-        args.unshift(lowerCommand.includes('subl') ? '-w' : '--wait');
+    const envCommand = process.env['VISUAL'] ?? process.env['EDITOR'];
+    if (envCommand) {
+      command = envCommand;
+      const [envExecutable = ''] = envCommand.split(' ');
+      const resolvedType = resolveEditorTypeFromCommand(envExecutable);
+      if (resolvedType) {
+        if (
+          isGuiEditor(resolvedType) &&
+          !envCommand.includes('--wait') &&
+          !envCommand.includes('-w')
+        ) {
+          args.unshift(getEditorWaitFlag(resolvedType));
+        }
+        extraArgs.push(...getEditorExtraArgs(resolvedType));
+      } else {
+        // Heuristic fallback for commands not in the registry
+        const lower = envCommand.toLowerCase();
+        const isGui = ['code', 'cursor', 'subl', 'zed', 'atom'].some((g) =>
+          lower.includes(g),
+        );
+        if (isGui && !lower.includes('--wait') && !lower.includes('-w')) {
+          args.unshift(lower.includes('subl') ? '-w' : '--wait');
+        }
       }
     }
   }

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -50,11 +50,13 @@ export async function openFileInEditor(
 
   if (preferredEditorType) {
     if (!isValidEditorType(preferredEditorType)) {
-      throw new Error(
+      coreEvents.emitFeedback(
+        'error',
         `Editor '${preferredEditorType}' is not a recognized editor identifier. ` +
           `Supported editors: ${ALL_EDITORS.join(', ')}. ` +
           `Use /editor to select one, or set the $VISUAL or $EDITOR environment variable.`,
       );
+      return;
     }
     command = getEditorCommand(preferredEditorType);
     if (isGuiEditor(preferredEditorType)) {
@@ -137,17 +139,23 @@ export async function openFileInEditor(
       );
       if (result.error) {
         const spawnErr = result.error as NodeJS.ErrnoException;
-        throw spawnErr.code === 'ENOENT'
-          ? new Error(
-              `Editor command '${executable}' was not found in PATH. Install it or use /editor to choose another editor.`,
-            )
-          : result.error;
+        coreEvents.emitFeedback(
+          'error',
+          spawnErr.code === 'ENOENT'
+            ? `Editor command '${executable}' was not found in PATH. Install it or use /editor to choose another editor.`
+            : (spawnErr.message ?? String(spawnErr)),
+        );
+        return;
       }
       if (typeof result.status === 'number' && result.status !== 0) {
-        throw new Error(`External editor exited with status ${result.status}`);
+        coreEvents.emitFeedback(
+          'error',
+          `External editor exited with status ${result.status}`,
+        );
+        return;
       }
     } else {
-      await new Promise<void>((resolve, reject) => {
+      await new Promise<void>((resolve) => {
         const child = spawn(
           executable,
           [...initialArgs, ...extraArgs, ...args],
@@ -159,20 +167,22 @@ export async function openFileInEditor(
 
         child.on('error', (err) => {
           const spawnErr = err as NodeJS.ErrnoException;
-          reject(
+          resolve();
+          coreEvents.emitFeedback(
+            'error',
             spawnErr.code === 'ENOENT'
-              ? new Error(
-                  `Editor command '${executable}' was not found in PATH. Install it or use /editor to choose another editor.`,
-                )
-              : err,
+              ? `Editor command '${executable}' was not found in PATH. Install it or use /editor to choose another editor.`
+              : (spawnErr.message ?? String(spawnErr)),
           );
         });
 
         child.on('close', (status) => {
+          resolve();
           if (typeof status === 'number' && status !== 0) {
-            reject(new Error(`External editor exited with status ${status}`));
-          } else {
-            resolve();
+            coreEvents.emitFeedback(
+              'error',
+              `External editor exited with status ${status}`,
+            );
           }
         });
       });

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -20,6 +20,11 @@ import {
   resolveEditorTypeFromCommand,
 } from '@google/gemini-cli-core';
 
+/**
+ * Command name substrings used to guess whether an unknown $VISUAL/$EDITOR
+ * value is a GUI editor. This is a fallback for editors not in the registry;
+ * registered editors are detected via resolveEditorTypeFromCommand instead.
+ */
 const HEURISTIC_GUI_COMMANDS = [
   'code',
   'cursor',

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -7,13 +7,16 @@
 import { spawn, spawnSync } from 'node:child_process';
 import type { ReadStream } from 'node:tty';
 import {
-  coreEvents,
+  ALL_EDITORS,
   CoreEvent,
+  coreEvents,
   type EditorType,
   getEditorCommand,
-  isEditorAvailable,
+  getEditorExtraArgs,
+  getEditorWaitFlag,
   isGuiEditor,
   isTerminalEditor,
+  isValidEditorType,
 } from '@google/gemini-cli-core';
 
 /**
@@ -33,22 +36,22 @@ export async function openFileInEditor(
 ): Promise<void> {
   let command: string | undefined = undefined;
   const args = [filePath];
+  // Extra args that come before the file path (e.g. -nw for emacsclient)
+  const extraArgs: string[] = [];
 
   if (preferredEditorType) {
-    if (isEditorAvailable(preferredEditorType)) {
-      command = getEditorCommand(preferredEditorType);
-      if (isGuiEditor(preferredEditorType)) {
-        args.unshift('--wait');
-      }
-    } else {
-      coreEvents.emitFeedback(
-        'error',
-        `Editor '${preferredEditorType}' is not recognized or not installed. ` +
-          `Run /editor to pick a supported editor, or set $VISUAL/$EDITOR in your shell ` +
-          `to your preferred editor.`,
+    if (!isValidEditorType(preferredEditorType)) {
+      throw new Error(
+        `Editor '${preferredEditorType}' is not a recognized editor identifier. ` +
+          `Supported editors: ${ALL_EDITORS.join(', ')}. ` +
+          `Use /editor to select one, or set the $VISUAL or $EDITOR environment variable.`,
       );
-      return;
     }
+    command = getEditorCommand(preferredEditorType);
+    if (isGuiEditor(preferredEditorType)) {
+      args.unshift(getEditorWaitFlag(preferredEditorType));
+    }
+    extraArgs.push(...getEditorExtraArgs(preferredEditorType));
   }
 
   if (!command) {
@@ -77,7 +80,16 @@ export async function openFileInEditor(
   // Determine if we should use sync or async based on the command/editor type.
   // If we have a preferredEditorType, we can check if it's a terminal editor.
   // Otherwise, we guess based on the command name.
-  const terminalEditors = ['vi', 'vim', 'nvim', 'emacs', 'hx', 'nano'];
+  const terminalEditors = [
+    'vi',
+    'vim',
+    'nvim',
+    'emacs',
+    'emacsclient',
+    'hx',
+    'nano',
+    'micro',
+  ];
   const isTerminal = preferredEditorType
     ? isTerminalEditor(preferredEditorType)
     : terminalEditors.some((te) => executable.toLowerCase().includes(te));
@@ -92,72 +104,55 @@ export async function openFileInEditor(
     args.unshift('-i', 'NONE');
   }
 
-  if (isTerminal && executable === 'emacsclient') {
-    // Pass -nw to force terminal (no-window) mode.
-    args.unshift('-nw');
-  }
-
-  function handleEditorError(err: Error, context: string): void {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-      coreEvents.emitFeedback(
-        'error',
-        `Could not find editor '${executable}'. Check your $VISUAL/$EDITOR setting.`,
-      );
-    } else {
-      coreEvents.emitFeedback('error', context, err);
-    }
-  }
-
   const wasRaw = stdin?.isRaw ?? false;
   setRawMode?.(false);
 
   try {
     if (isTerminal) {
-      const result = spawnSync(executable, [...initialArgs, ...args], {
-        stdio: 'inherit',
-        shell: process.platform === 'win32',
-      });
+      const result = spawnSync(
+        executable,
+        [...initialArgs, ...extraArgs, ...args],
+        {
+          stdio: 'inherit',
+          shell: process.platform === 'win32',
+        },
+      );
       if (result.error) {
-        handleEditorError(
-          result.error,
-          '[editorUtils] external terminal editor error',
-        );
-        throw result.error;
+        const spawnErr = result.error as NodeJS.ErrnoException;
+        throw spawnErr.code === 'ENOENT'
+          ? new Error(
+              `Editor command '${executable}' was not found in PATH. Install it or use /editor to choose another editor.`,
+            )
+          : result.error;
       }
       if (typeof result.status === 'number' && result.status !== 0) {
-        const err = new Error(
-          `External editor exited with status ${result.status}`,
-        );
-        coreEvents.emitFeedback(
-          'error',
-          '[editorUtils] external editor error',
-          err,
-        );
-        throw err;
+        throw new Error(`External editor exited with status ${result.status}`);
       }
     } else {
       await new Promise<void>((resolve, reject) => {
-        const child = spawn(executable, [...initialArgs, ...args], {
-          stdio: 'inherit',
-          shell: process.platform === 'win32',
-        });
+        const child = spawn(
+          executable,
+          [...initialArgs, ...extraArgs, ...args],
+          {
+            stdio: 'inherit',
+            shell: process.platform === 'win32',
+          },
+        );
 
         child.on('error', (err) => {
-          handleEditorError(err, '[editorUtils] external editor spawn error');
-          reject(err);
+          const spawnErr = err as NodeJS.ErrnoException;
+          reject(
+            spawnErr.code === 'ENOENT'
+              ? new Error(
+                  `Editor command '${executable}' was not found in PATH. Install it or use /editor to choose another editor.`,
+                )
+              : err,
+          );
         });
 
         child.on('close', (status) => {
           if (typeof status === 'number' && status !== 0) {
-            const err = new Error(
-              `External editor exited with status ${status}`,
-            );
-            coreEvents.emitFeedback(
-              'error',
-              '[editorUtils] external editor error',
-              err,
-            );
-            reject(err);
+            reject(new Error(`External editor exited with status ${status}`));
           } else {
             resolve();
           }

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -25,6 +25,7 @@ import {
   getEditorWaitFlag,
   getEditorExtraArgs,
   resolveEditorAsync,
+  resolveEditorTypeFromCommand,
   type EditorType,
 } from './editor.js';
 import { coreEvents, CoreEvent } from './events.js';
@@ -898,6 +899,25 @@ describe('editor utils', () => {
       for (const editor of standardGuiEditors) {
         expect(getEditorWaitFlag(editor)).toBe('--wait');
       }
+    });
+  });
+
+  describe('resolveEditorTypeFromCommand', () => {
+    it('should resolve known command names to their editor type', () => {
+      expect(resolveEditorTypeFromCommand('cursor')).toBe('cursor');
+      expect(resolveEditorTypeFromCommand('code')).toBe('vscode');
+      expect(resolveEditorTypeFromCommand('codium')).toBe('vscodium');
+      expect(resolveEditorTypeFromCommand('vim')).toBe('vim');
+    });
+
+    it('should be case-insensitive', () => {
+      expect(resolveEditorTypeFromCommand('Cursor')).toBe('cursor');
+      expect(resolveEditorTypeFromCommand('CODE')).toBe('vscode');
+    });
+
+    it('should return undefined for unknown commands', () => {
+      expect(resolveEditorTypeFromCommand('unknowntool')).toBeUndefined();
+      expect(resolveEditorTypeFromCommand('')).toBeUndefined();
     });
   });
 

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -84,6 +84,7 @@ describe('editor utils', () => {
         win32Commands: ['agy.cmd', 'antigravity.cmd', 'antigravity'],
       },
       { editor: 'hx', commands: ['hx'], win32Commands: ['hx'] },
+      { editor: 'sublime', commands: ['subl'], win32Commands: ['subl'] },
     ];
 
     for (const { editor, commands, win32Commands } of testCases) {
@@ -339,6 +340,16 @@ describe('editor utils', () => {
       });
     });
 
+    it('should return the correct command for sublime', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/subl'));
+      const command = getDiffCommand('old.txt', 'new.txt', 'sublime');
+      expect(command).toEqual({
+        command: 'subl',
+        args: ['--wait', 'old.txt'],
+      });
+    });
+
     it('should return null for an unsupported editor', () => {
       // @ts-expect-error Testing unsupported editor
       const command = getDiffCommand('old.txt', 'new.txt', 'foobar');
@@ -353,6 +364,7 @@ describe('editor utils', () => {
       'windsurf',
       'cursor',
       'zed',
+      'sublime',
     ];
 
     for (const editor of guiEditors) {
@@ -544,6 +556,7 @@ describe('editor utils', () => {
       'windsurf',
       'cursor',
       'zed',
+      'sublime',
     ];
     for (const editor of guiEditors) {
       it(`should not allow ${editor} in sandbox mode`, () => {

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -21,6 +21,9 @@ import {
   allowEditorTypeInSandbox,
   isEditorAvailable,
   isEditorAvailableAsync,
+  isValidEditorType,
+  getEditorWaitFlag,
+  getEditorExtraArgs,
   resolveEditorAsync,
   type EditorType,
 } from './editor.js';
@@ -84,12 +87,20 @@ describe('editor utils', () => {
         win32Commands: ['agy.cmd', 'antigravity.cmd', 'antigravity'],
       },
       { editor: 'hx', commands: ['hx'], win32Commands: ['hx'] },
-      { editor: 'sublime', commands: ['subl'], win32Commands: ['subl'] },
+      {
+        editor: 'sublimetext',
+        commands: ['subl'],
+        win32Commands: ['subl'],
+      },
+      { editor: 'lapce', commands: ['lapce'], win32Commands: ['lapce'] },
+      { editor: 'nova', commands: ['nova'], win32Commands: ['nova'] },
+      { editor: 'bbedit', commands: ['bbedit'], win32Commands: ['bbedit'] },
       {
         editor: 'emacsclient',
         commands: ['emacsclient'],
         win32Commands: ['emacsclient'],
       },
+      { editor: 'micro', commands: ['micro'], win32Commands: ['micro'] },
     ];
 
     for (const { editor, commands, win32Commands } of testCases) {
@@ -194,6 +205,7 @@ describe('editor utils', () => {
         commands: ['agy', 'antigravity'],
         win32Commands: ['agy.cmd', 'antigravity.cmd', 'antigravity'],
       },
+      { editor: 'bbedit', commands: ['bbedit'], win32Commands: ['bbedit'] },
     ];
 
     for (const { editor, commands, win32Commands } of guiEditors) {
@@ -337,11 +349,11 @@ describe('editor utils', () => {
       });
     });
 
-    it('should return the correct command for helix', () => {
-      const command = getDiffCommand('old.txt', 'new.txt', 'hx');
+    it('should return the correct command for emacsclient', () => {
+      const command = getDiffCommand('old.txt', 'new.txt', 'emacsclient');
       expect(command).toEqual({
-        command: 'hx',
-        args: ['--vsplit', '--', 'old.txt', 'new.txt'],
+        command: 'emacsclient',
+        args: ['-nw', '--eval', '(ediff "old.txt" "new.txt")'],
       });
     });
 
@@ -361,14 +373,28 @@ describe('editor utils', () => {
       });
     });
 
-    it('should return the correct command for sublime', () => {
-      Object.defineProperty(process, 'platform', { value: 'linux' });
-      (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/subl'));
-      const command = getDiffCommand('old.txt', 'new.txt', 'sublime');
+    it('should return the correct command for helix', () => {
+      const command = getDiffCommand('old.txt', 'new.txt', 'hx');
       expect(command).toEqual({
-        command: 'subl',
-        args: ['--wait', 'new.txt'],
+        command: 'hx',
+        args: ['--vsplit', '--', 'old.txt', 'new.txt'],
       });
+    });
+
+    it('should return null for sublimetext (no CLI diff support)', () => {
+      expect(getDiffCommand('old.txt', 'new.txt', 'sublimetext')).toBeNull();
+    });
+
+    it('should return null for lapce (no CLI diff support)', () => {
+      expect(getDiffCommand('old.txt', 'new.txt', 'lapce')).toBeNull();
+    });
+
+    it('should return null for nova (no CLI diff support)', () => {
+      expect(getDiffCommand('old.txt', 'new.txt', 'nova')).toBeNull();
+    });
+
+    it('should return null for micro (no CLI diff support)', () => {
+      expect(getDiffCommand('old.txt', 'new.txt', 'micro')).toBeNull();
     });
 
     it('should return null for an unsupported editor', () => {
@@ -385,7 +411,7 @@ describe('editor utils', () => {
       'windsurf',
       'cursor',
       'zed',
-      'sublime',
+      'bbedit',
     ];
 
     for (const editor of guiEditors) {
@@ -506,12 +532,13 @@ describe('editor utils', () => {
       });
     }
 
+    // micro has no CLI diff support (getDiffCommand returns null) so is excluded here
     const terminalEditors: EditorType[] = [
       'vim',
       'neovim',
       'emacs',
-      'emacsclient',
       'hx',
+      'emacsclient',
     ];
 
     for (const editor of terminalEditors) {
@@ -592,7 +619,10 @@ describe('editor utils', () => {
       'windsurf',
       'cursor',
       'zed',
-      'sublime',
+      'sublimetext',
+      'lapce',
+      'nova',
+      'bbedit',
     ];
     for (const editor of guiEditors) {
       it(`should not allow ${editor} in sandbox mode`, () => {
@@ -824,6 +854,82 @@ describe('editor utils', () => {
       const result = await resolvePromise;
       expect(result).toBe('vim');
       expect(emitSpy).toHaveBeenCalledWith(CoreEvent.RequestEditorSelection);
+    });
+  });
+
+  describe('isValidEditorType', () => {
+    it('should return true for known editor identifiers', () => {
+      expect(isValidEditorType('vscode')).toBe(true);
+      expect(isValidEditorType('vim')).toBe(true);
+      expect(isValidEditorType('sublimetext')).toBe(true);
+      expect(isValidEditorType('emacsclient')).toBe(true);
+      expect(isValidEditorType('micro')).toBe(true);
+      expect(isValidEditorType('lapce')).toBe(true);
+      expect(isValidEditorType('nova')).toBe(true);
+      expect(isValidEditorType('bbedit')).toBe(true);
+    });
+
+    it('should return false for unrecognized strings', () => {
+      expect(isValidEditorType('emacsclient -nw')).toBe(false);
+      expect(isValidEditorType('subl')).toBe(false);
+      expect(isValidEditorType('code')).toBe(false);
+      expect(isValidEditorType('')).toBe(false);
+      expect(isValidEditorType('notepad')).toBe(false);
+    });
+  });
+
+  describe('getEditorWaitFlag', () => {
+    it('should return -w for sublimetext', () => {
+      expect(getEditorWaitFlag('sublimetext')).toBe('-w');
+    });
+
+    it('should return --wait for all other GUI editors', () => {
+      const standardGuiEditors: EditorType[] = [
+        'vscode',
+        'vscodium',
+        'windsurf',
+        'cursor',
+        'zed',
+        'antigravity',
+        'lapce',
+        'nova',
+        'bbedit',
+      ];
+      for (const editor of standardGuiEditors) {
+        expect(getEditorWaitFlag(editor)).toBe('--wait');
+      }
+    });
+  });
+
+  describe('getEditorExtraArgs', () => {
+    it('should return [-nw] for emacsclient', () => {
+      expect(getEditorExtraArgs('emacsclient')).toEqual(['-nw']);
+    });
+
+    it('should return [--new-window] for VS Code-family editors', () => {
+      const vscodeEditors: EditorType[] = [
+        'vscode',
+        'vscodium',
+        'cursor',
+        'windsurf',
+      ];
+      for (const editor of vscodeEditors) {
+        expect(getEditorExtraArgs(editor)).toEqual(['--new-window']);
+      }
+    });
+
+    it('should return [] for all other editors', () => {
+      const otherEditors: EditorType[] = [
+        'vim',
+        'neovim',
+        'emacs',
+        'hx',
+        'sublimetext',
+        'micro',
+      ];
+      for (const editor of otherEditors) {
+        expect(getEditorExtraArgs(editor)).toEqual([]);
+      }
     });
   });
 });

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -926,7 +926,7 @@ describe('editor utils', () => {
       expect(getEditorExtraArgs('emacsclient')).toEqual(['-nw']);
     });
 
-    it('should return [--new-window] for VS Code-family editors', () => {
+    it('should return [] for VS Code-family editors by default', () => {
       const vscodeEditors: EditorType[] = [
         'vscode',
         'vscodium',
@@ -934,7 +934,33 @@ describe('editor utils', () => {
         'windsurf',
       ];
       for (const editor of vscodeEditors) {
-        expect(getEditorExtraArgs(editor)).toEqual(['--new-window']);
+        expect(getEditorExtraArgs(editor)).toEqual([]);
+      }
+    });
+
+    it('should return [--new-window] for VS Code-family editors when newWindow is true', () => {
+      const vscodeEditors: EditorType[] = [
+        'vscode',
+        'vscodium',
+        'cursor',
+        'windsurf',
+      ];
+      for (const editor of vscodeEditors) {
+        expect(getEditorExtraArgs(editor, { newWindow: true })).toEqual([
+          '--new-window',
+        ]);
+      }
+    });
+
+    it('should return [] for VS Code-family editors when newWindow is false', () => {
+      const vscodeEditors: EditorType[] = [
+        'vscode',
+        'vscodium',
+        'cursor',
+        'windsurf',
+      ];
+      for (const editor of vscodeEditors) {
+        expect(getEditorExtraArgs(editor, { newWindow: false })).toEqual([]);
       }
     });
 

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -367,7 +367,7 @@ describe('editor utils', () => {
       const command = getDiffCommand('old.txt', 'new.txt', 'sublime');
       expect(command).toEqual({
         command: 'subl',
-        args: ['--wait', 'old.txt'],
+        args: ['--wait', 'new.txt'],
       });
     });
 

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -85,6 +85,11 @@ describe('editor utils', () => {
       },
       { editor: 'hx', commands: ['hx'], win32Commands: ['hx'] },
       { editor: 'sublime', commands: ['subl'], win32Commands: ['subl'] },
+      {
+        editor: 'emacsclient',
+        commands: ['emacsclient'],
+        win32Commands: ['emacsclient'],
+      },
     ];
 
     for (const { editor, commands, win32Commands } of testCases) {
@@ -340,6 +345,22 @@ describe('editor utils', () => {
       });
     });
 
+    it('should return the correct command for emacsclient with escaped paths', () => {
+      const command = getDiffCommand(
+        'old file "quote".txt',
+        'new file \\back\\slash.txt',
+        'emacsclient',
+      );
+      expect(command).toEqual({
+        command: 'emacsclient',
+        args: [
+          '-nw',
+          '--eval',
+          '(ediff "old file \\"quote\\".txt" "new file \\\\back\\\\slash.txt")',
+        ],
+      });
+    });
+
     it('should return the correct command for sublime', () => {
       Object.defineProperty(process, 'platform', { value: 'linux' });
       (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/subl'));
@@ -485,7 +506,13 @@ describe('editor utils', () => {
       });
     }
 
-    const terminalEditors: EditorType[] = ['vim', 'neovim', 'emacs', 'hx'];
+    const terminalEditors: EditorType[] = [
+      'vim',
+      'neovim',
+      'emacs',
+      'emacsclient',
+      'hx',
+    ];
 
     for (const editor of terminalEditors) {
       it(`should call spawnSync for ${editor}`, async () => {
@@ -530,6 +557,15 @@ describe('editor utils', () => {
 
     it('should allow emacs when not in sandbox mode', () => {
       expect(allowEditorTypeInSandbox('emacs')).toBe(true);
+    });
+
+    it('should allow emacsclient in sandbox mode', () => {
+      vi.stubEnv('SANDBOX', 'sandbox');
+      expect(allowEditorTypeInSandbox('emacsclient')).toBe(true);
+    });
+
+    it('should allow emacsclient when not in sandbox mode', () => {
+      expect(allowEditorTypeInSandbox('emacsclient')).toBe(true);
     });
 
     it('should allow neovim in sandbox mode', () => {

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -336,6 +336,7 @@ describe('editor utils', () => {
     }
 
     it('should return the correct command for emacs with escaped paths', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
       const command = getDiffCommand(
         'old file "quote".txt',
         'new file \\back\\slash.txt',

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -17,16 +17,22 @@ const GUI_EDITORS = [
   'cursor',
   'zed',
   'antigravity',
-  'sublime',
+  'sublimetext',
+  'lapce',
+  'nova',
+  'bbedit',
 ] as const;
 const TERMINAL_EDITORS = [
   'vim',
   'neovim',
   'emacs',
-  'emacsclient',
   'hx',
+  'emacsclient',
+  'micro',
 ] as const;
 const EDITORS = [...GUI_EDITORS, ...TERMINAL_EDITORS] as const;
+
+export const ALL_EDITORS: readonly string[] = EDITORS;
 
 const GUI_EDITORS_SET = new Set<string>(GUI_EDITORS);
 const TERMINAL_EDITORS_SET = new Set<string>(TERMINAL_EDITORS);
@@ -63,14 +69,18 @@ export const EDITOR_DISPLAY_NAMES: Record<EditorType, string> = {
   emacsclient: 'Emacs Client',
   antigravity: 'Antigravity',
   hx: 'Helix',
-  sublime: 'Sublime Text',
+  sublimetext: 'Sublime Text',
+  lapce: 'Lapce',
+  nova: 'Nova',
+  bbedit: 'BBEdit',
+  micro: 'Micro',
 };
 
 export function getEditorDisplayName(editor: EditorType): string {
   return EDITOR_DISPLAY_NAMES[editor] || editor;
 }
 
-function isValidEditorType(editor: string): editor is EditorType {
+export function isValidEditorType(editor: string): editor is EditorType {
   return EDITORS_SET.has(editor);
 }
 
@@ -135,7 +145,12 @@ const editorCommands: Record<
     default: ['agy', 'antigravity'],
   },
   hx: { win32: ['hx'], default: ['hx'] },
-  sublime: { win32: ['subl'], default: ['subl'] },
+  sublimetext: { win32: ['subl'], default: ['subl'] },
+  lapce: { win32: ['lapce'], default: ['lapce'] },
+  // nova and bbedit are macOS-only; commandExists will return false on other platforms
+  nova: { win32: ['nova'], default: ['nova'] },
+  bbedit: { win32: ['bbedit'], default: ['bbedit'] },
+  micro: { win32: ['micro'], default: ['micro'] },
 };
 
 function getEditorCommands(editor: EditorType): string[] {
@@ -165,6 +180,39 @@ export function getEditorCommand(editor: EditorType): string {
     commands.slice(0, -1).find((cmd) => commandExists(cmd)) ||
     commands[commands.length - 1]
   );
+}
+
+/**
+ * Per-editor wait flags for GUI editors. Most use '--wait'; exceptions are listed here.
+ */
+const editorWaitFlags: Partial<Record<EditorType, string>> = {
+  sublimetext: '-w', // subl uses -w instead of --wait
+};
+
+/**
+ * Returns the flag used to make a GUI editor block until the file is closed.
+ */
+export function getEditorWaitFlag(editor: EditorType): string {
+  return editorWaitFlags[editor] ?? '--wait';
+}
+
+/**
+ * Per-editor extra arguments prepended to the command invocation.
+ */
+const editorExtraArgs: Partial<Record<EditorType, string[]>> = {
+  emacsclient: ['-nw'], // Force terminal (no-window) mode
+  vscode: ['--new-window'], // Force a new window to open the file directly
+  vscodium: ['--new-window'],
+  cursor: ['--new-window'],
+  windsurf: ['--new-window'],
+};
+
+/**
+ * Returns any extra arguments that must be passed to the editor executable
+ * (in addition to the file path and any wait flag).
+ */
+export function getEditorExtraArgs(editor: EditorType): string[] {
+  return editorExtraArgs[editor] ?? [];
 }
 
 export function allowEditorTypeInSandbox(editor: EditorType): boolean {
@@ -248,8 +296,6 @@ export function getDiffCommand(
     case 'zed':
     case 'antigravity':
       return { command, args: ['--wait', '--diff', oldPath, newPath] };
-    case 'sublime':
-      return { command, args: ['--wait', newPath] };
     case 'vim':
     case 'neovim':
       return {
@@ -296,6 +342,9 @@ export function getDiffCommand(
         command: 'hx',
         args: ['--vsplit', '--', oldPath, newPath],
       };
+    case 'bbedit':
+      return { command, args: ['--wait', '--diff', oldPath, newPath] };
+    // sublimetext, lapce, nova, micro do not support CLI-driven diff views
     default:
       return null;
   }

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -19,7 +19,13 @@ const GUI_EDITORS = [
   'antigravity',
   'sublime',
 ] as const;
-const TERMINAL_EDITORS = ['vim', 'neovim', 'emacs', 'hx'] as const;
+const TERMINAL_EDITORS = [
+  'vim',
+  'neovim',
+  'emacs',
+  'emacsclient',
+  'hx',
+] as const;
 const EDITORS = [...GUI_EDITORS, ...TERMINAL_EDITORS] as const;
 
 const GUI_EDITORS_SET = new Set<string>(GUI_EDITORS);
@@ -54,6 +60,7 @@ export const EDITOR_DISPLAY_NAMES: Record<EditorType, string> = {
   neovim: 'Neovim',
   zed: 'Zed',
   emacs: 'Emacs',
+  emacsclient: 'Emacs Client',
   antigravity: 'Antigravity',
   hx: 'Helix',
   sublime: 'Sublime Text',
@@ -122,6 +129,7 @@ const editorCommands: Record<
   neovim: { win32: ['nvim'], default: ['nvim'] },
   zed: { win32: ['zed'], default: ['zed', 'zeditor'] },
   emacs: { win32: ['emacs.exe'], default: ['emacs'] },
+  emacsclient: { win32: ['emacsclient'], default: ['emacsclient'] },
   antigravity: {
     win32: ['agy.cmd', 'antigravity.cmd', 'antigravity'],
     default: ['agy', 'antigravity'],
@@ -275,6 +283,15 @@ export function getDiffCommand(
       return {
         command: 'emacs',
         args: [
+          '--eval',
+          `(ediff ${escapeELispString(oldPath)} ${escapeELispString(newPath)})`,
+        ],
+      };
+    case 'emacsclient':
+      return {
+        command: 'emacsclient',
+        args: [
+          '-nw',
           '--eval',
           `(ediff ${escapeELispString(oldPath)} ${escapeELispString(newPath)})`,
         ],

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -223,18 +223,31 @@ export function getEditorWaitFlag(editor: EditorType): string {
  */
 const editorExtraArgs: Partial<Record<EditorType, string[]>> = {
   emacsclient: ['-nw'], // Force terminal (no-window) mode
-  vscode: ['--new-window'], // Force a new window to open the file directly
-  vscodium: ['--new-window'],
-  cursor: ['--new-window'],
-  windsurf: ['--new-window'],
 };
+
+/**
+ * VS Code-family editors that support the --new-window flag.
+ */
+const NEW_WINDOW_EDITORS = new Set<EditorType>([
+  'vscode',
+  'vscodium',
+  'cursor',
+  'windsurf',
+]);
 
 /**
  * Returns any extra arguments that must be passed to the editor executable
  * (in addition to the file path and any wait flag).
  */
-export function getEditorExtraArgs(editor: EditorType): string[] {
-  return editorExtraArgs[editor] ?? [];
+export function getEditorExtraArgs(
+  editor: EditorType,
+  options?: { newWindow?: boolean },
+): string[] {
+  const args = editorExtraArgs[editor] ? [...editorExtraArgs[editor]] : [];
+  if (options?.newWindow && NEW_WINDOW_EDITORS.has(editor)) {
+    args.push('--new-window');
+  }
+  return args;
 }
 
 export function allowEditorTypeInSandbox(editor: EditorType): boolean {

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -80,6 +80,11 @@ export function getEditorDisplayName(editor: EditorType): string {
   return EDITOR_DISPLAY_NAMES[editor] || editor;
 }
 
+export const EDITOR_OPTIONS: ReadonlyArray<{
+  value: EditorType;
+  label: string;
+}> = EDITORS.map((e) => ({ value: e, label: EDITOR_DISPLAY_NAMES[e] }));
+
 export function isValidEditorType(editor: string): editor is EditorType {
   return EDITORS_SET.has(editor);
 }

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -17,6 +17,7 @@ const GUI_EDITORS = [
   'cursor',
   'zed',
   'antigravity',
+  'sublime',
 ] as const;
 const TERMINAL_EDITORS = ['vim', 'neovim', 'emacs', 'hx'] as const;
 const EDITORS = [...GUI_EDITORS, ...TERMINAL_EDITORS] as const;
@@ -55,6 +56,7 @@ export const EDITOR_DISPLAY_NAMES: Record<EditorType, string> = {
   emacs: 'Emacs',
   antigravity: 'Antigravity',
   hx: 'Helix',
+  sublime: 'Sublime Text',
 };
 
 export function getEditorDisplayName(editor: EditorType): string {
@@ -125,6 +127,7 @@ const editorCommands: Record<
     default: ['agy', 'antigravity'],
   },
   hx: { win32: ['hx'], default: ['hx'] },
+  sublime: { win32: ['subl'], default: ['subl'] },
 };
 
 function getEditorCommands(editor: EditorType): string[] {
@@ -237,6 +240,8 @@ export function getDiffCommand(
     case 'zed':
     case 'antigravity':
       return { command, args: ['--wait', '--diff', oldPath, newPath] };
+    case 'sublime':
+      return { command, args: ['--wait', oldPath] };
     case 'vim':
     case 'neovim':
       return {

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -249,7 +249,7 @@ export function getDiffCommand(
     case 'antigravity':
       return { command, args: ['--wait', '--diff', oldPath, newPath] };
     case 'sublime':
-      return { command, args: ['--wait', oldPath] };
+      return { command, args: ['--wait', newPath] };
     case 'vim':
     case 'neovim':
       return {
@@ -280,22 +280,17 @@ export function getDiffCommand(
         ],
       };
     case 'emacs':
+    case 'emacsclient': {
+      const extraArgs = editor === 'emacsclient' ? ['-nw'] : [];
       return {
-        command: 'emacs',
+        command,
         args: [
+          ...extraArgs,
           '--eval',
           `(ediff ${escapeELispString(oldPath)} ${escapeELispString(newPath)})`,
         ],
       };
-    case 'emacsclient':
-      return {
-        command: 'emacsclient',
-        args: [
-          '-nw',
-          '--eval',
-          `(ediff ${escapeELispString(oldPath)} ${escapeELispString(newPath)})`,
-        ],
-      };
+    }
     case 'hx':
       return {
         command: 'hx',

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -183,6 +183,23 @@ export function getEditorCommand(editor: EditorType): string {
 }
 
 /**
+ * Given a command name (e.g. "cursor", "code"), returns the EditorType that uses
+ * that command, or undefined if no match is found.
+ */
+export function resolveEditorTypeFromCommand(
+  command: string,
+): EditorType | undefined {
+  const lowerCmd = command.toLowerCase();
+  for (const editor of EDITORS) {
+    const commands = getEditorCommands(editor);
+    if (commands.some((c) => c.toLowerCase() === lowerCmd)) {
+      return editor;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Per-editor wait flags for GUI editors. Most use '--wait'; exceptions are listed here.
  */
 const editorWaitFlags: Partial<Record<EditorType, string>> = {

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -233,6 +233,7 @@ const NEW_WINDOW_EDITORS = new Set<EditorType>([
   'vscodium',
   'cursor',
   'windsurf',
+  'antigravity',
 ]);
 
 /**

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -188,16 +188,23 @@ export function getEditorCommand(editor: EditorType): string {
 }
 
 /**
- * Given a command name (e.g. "cursor", "code"), returns the EditorType that uses
- * that command, or undefined if no match is found.
+ * Given a command name (e.g. "cursor", "code", "code.cmd"), returns the
+ * EditorType that uses that command, or undefined if no match is found.
+ *
+ * This intentionally checks command names across all platforms (both `default`
+ * and `win32` lists) so that, for example, `$EDITOR=code` is recognized as
+ * vscode on Windows and `$EDITOR=code.cmd` is recognized as vscode on macOS.
  */
 export function resolveEditorTypeFromCommand(
   command: string,
 ): EditorType | undefined {
   const lowerCmd = command.toLowerCase();
   for (const editor of EDITORS) {
-    const commands = getEditorCommands(editor);
-    if (commands.some((c) => c.toLowerCase() === lowerCmd)) {
+    const { win32, default: nonWin32 } = editorCommands[editor];
+    if (
+      win32.some((c) => c.toLowerCase() === lowerCmd) ||
+      nonWin32.some((c) => c.toLowerCase() === lowerCmd)
+    ) {
       return editor;
     }
   }

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -73,6 +73,13 @@
             "micro"
           ]
         },
+        "openEditorInNewWindow": {
+          "title": "Open Editor in New Window",
+          "description": "Open VS Code-family editors in a new window when editing files.",
+          "markdownDescription": "Open VS Code-family editors in a new window when editing files.\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `false`",
+          "default": false,
+          "type": "boolean"
+        },
         "vimMode": {
           "title": "Vim Mode",
           "description": "Enable Vim keybindings",

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -51,9 +51,27 @@
       "properties": {
         "preferredEditor": {
           "title": "Preferred Editor",
-          "description": "The preferred editor to open files in. Must be one of the built-in supported identifiers. Use /editor in the CLI to pick interactively, or leave unset to use $VISUAL/$EDITOR.",
-          "markdownDescription": "The preferred editor to open files in. Must be one of the built-in supported identifiers. Use /editor in the CLI to pick interactively, or leave unset to use $VISUAL/$EDITOR.\n\n- Category: `General`\n- Requires restart: `no`",
-          "type": "string"
+          "description": "The preferred editor to open files in when using the external editor feature (Ctrl-X). Accepted values: vscode, vscodium, cursor, windsurf, zed, antigravity, sublimetext, lapce, nova, bbedit, vim, neovim, emacs, emacsclient, hx, micro. If not set, falls back to $VISUAL, then $EDITOR, then vi/notepad.",
+          "markdownDescription": "The preferred editor to open files in when using the external editor feature (Ctrl-X).\n\nAccepted identifiers: `vscode`, `vscodium`, `cursor`, `windsurf`, `zed`, `antigravity`, `sublimetext`, `lapce`, `nova` (macOS), `bbedit` (macOS), `vim`, `neovim`, `emacs`, `emacsclient`, `hx`, `micro`.\n\nIf not set, falls back to `$VISUAL`, then `$EDITOR`, then `vi` (Unix) / `notepad` (Windows). Use `/editor` to configure interactively.\n\n- Category: `General`\n- Requires restart: `no`",
+          "type": "string",
+          "enum": [
+            "vscode",
+            "vscodium",
+            "cursor",
+            "windsurf",
+            "zed",
+            "antigravity",
+            "sublimetext",
+            "lapce",
+            "nova",
+            "bbedit",
+            "vim",
+            "neovim",
+            "emacs",
+            "emacsclient",
+            "hx",
+            "micro"
+          ]
         },
         "vimMode": {
           "title": "Vim Mode",

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -51,8 +51,8 @@
       "properties": {
         "preferredEditor": {
           "title": "Preferred Editor",
-          "description": "The preferred editor to open files in.",
-          "markdownDescription": "The preferred editor to open files in.\n\n- Category: `General`\n- Requires restart: `no`",
+          "description": "The preferred editor to open files in. Must be one of the built-in supported identifiers — run /editor in the CLI for the full list. Power users who need an editor not in this list can leave this unset and configure $VISUAL or $EDITOR in their shell environment instead.",
+          "markdownDescription": "The preferred editor to open files in. Must be one of the built-in supported identifiers — run /editor in the CLI for the full list. Power users who need an editor not in this list can leave this unset and configure $VISUAL or $EDITOR in their shell environment instead.\n\n- Category: `General`\n- Requires restart: `no`",
           "type": "string"
         },
         "vimMode": {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -51,8 +51,8 @@
       "properties": {
         "preferredEditor": {
           "title": "Preferred Editor",
-          "description": "The preferred editor to open files in. Must be one of the built-in supported identifiers — run /editor in the CLI for the full list. Power users who need an editor not in this list can leave this unset and configure $VISUAL or $EDITOR in their shell environment instead.",
-          "markdownDescription": "The preferred editor to open files in. Must be one of the built-in supported identifiers — run /editor in the CLI for the full list. Power users who need an editor not in this list can leave this unset and configure $VISUAL or $EDITOR in their shell environment instead.\n\n- Category: `General`\n- Requires restart: `no`",
+          "description": "The preferred editor to open files in. Must be one of the built-in supported identifiers. Use /editor in the CLI to pick interactively, or leave unset to use $VISUAL/$EDITOR.",
+          "markdownDescription": "The preferred editor to open files in. Must be one of the built-in supported identifiers. Use /editor in the CLI to pick interactively, or leave unset to use $VISUAL/$EDITOR.\n\n- Category: `General`\n- Requires restart: `no`",
           "type": "string"
         },
         "vimMode": {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -57,8 +57,8 @@
           "enum": [
             "vscode",
             "vscodium",
-            "cursor",
             "windsurf",
+            "cursor",
             "zed",
             "antigravity",
             "sublimetext",
@@ -68,8 +68,8 @@
             "vim",
             "neovim",
             "emacs",
-            "emacsclient",
             "hx",
+            "emacsclient",
             "micro"
           ]
         },

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -51,8 +51,8 @@
       "properties": {
         "preferredEditor": {
           "title": "Preferred Editor",
-          "description": "The preferred editor to open files in when using the external editor feature (Ctrl-X). Accepted values: vscode, vscodium, cursor, windsurf, zed, antigravity, sublimetext, lapce, nova, bbedit, vim, neovim, emacs, emacsclient, hx, micro. If not set, falls back to $VISUAL, then $EDITOR, then vi/notepad.",
-          "markdownDescription": "The preferred editor to open files in when using the external editor feature (Ctrl-X).\n\nAccepted identifiers: `vscode`, `vscodium`, `cursor`, `windsurf`, `zed`, `antigravity`, `sublimetext`, `lapce`, `nova` (macOS), `bbedit` (macOS), `vim`, `neovim`, `emacs`, `emacsclient`, `hx`, `micro`.\n\nIf not set, falls back to `$VISUAL`, then `$EDITOR`, then `vi` (Unix) / `notepad` (Windows). Use `/editor` to configure interactively.\n\n- Category: `General`\n- Requires restart: `no`",
+          "description": "The preferred editor to open files in. Must be one of the built-in supported identifiers. Use /editor in the CLI to pick interactively, or leave unset to use $VISUAL/$EDITOR.",
+          "markdownDescription": "The preferred editor to open files in. Must be one of the built-in supported identifiers. Use /editor in the CLI to pick interactively, or leave unset to use $VISUAL/$EDITOR.\n\n- Category: `General`\n- Requires restart: `no`",
           "type": "string",
           "enum": [
             "vscode",


### PR DESCRIPTION
## Summary

Addresses #21084 by improving external editor support across three areas: adds
**Sublime Text** and **Emacs Client** to the built-in editor list, emits clear
error messages when editor configuration is invalid or a command is missing, and
extends the documentation and JSON schema for `preferredEditor`.

## Details

**New editors** (`packages/core/src/utils/editor.ts`):

- **Sublime Text** (`sublime`): added as a GUI editor using the `subl` command.
  Opens files with `--wait`. Diff view opens the new file only, as `subl` does
  not support a `--diff` flag.
- **Emacs Client** (`emacsclient`): added as a terminal editor. Automatically
  injects `-nw` (terminal mode) when opening a file. Diff view uses
  `emacsclient -nw --eval "(ediff ...)"`, consistent with the existing `emacs`
  implementation.

**Error handling** (`packages/cli/src/ui/utils/editorUtils.ts`):

Two cases that previously produced a cryptic internal error are now handled
gracefully:

1. **Unrecognized `preferredEditor`**: validates the editor type before use and
   emits a user-friendly message instead of a generic error. For example,
   setting `"preferredEditor": "nvim"` (the binary name) instead of the
   supported identifier `"neovim"` previously produced:
   ```
   ✕ [useTextBuffer] external editor error
   ```
   It now produces:
   ```
   ✕ Editor 'nvim' is not recognized or not installed. Run /editor to pick a
     supported editor, or set $VISUAL/$EDITOR in your shell to your preferred
     editor.
   ```
2. **Missing `$VISUAL`/`$EDITOR` command**: detects `ENOENT` on spawn and emits
   a clear message pointing the user to check their environment variable.

Note: `$VISUAL`/`$EDITOR` continue to accept any editor command, not just the
built-in supported types, preserving full flexibility for power users.

**Documentation** (`docs/reference/configuration.md`,
`schemas/settings.schema.json`, `packages/cli/src/config/settingsSchema.ts`):

- The `description` field for `preferredEditor` in `settingsSchema.ts` has been
  updated to explain the built-in identifier requirement, the `/editor` command
  as the canonical way to discover supported values, and the `$VISUAL`/`$EDITOR`
  escape hatch for power users. Both `docs/reference/configuration.md` and
  `schemas/settings.schema.json` are regenerated from this source and updated
  accordingly.

## Related Issues

Closes #21084

## Note for maintainers: enum constraint in the JSON schema

The current implementation leaves `preferredEditor` typed as a plain `string` in
`settingsSchema.ts`, so the JSON schema carries no `enum` constraint and IDEs
offer no autocomplete for valid editor identifiers.

A cleaner solution would be to change the definition to `type: 'enum'` and list
the supported values via `options`, mirroring how `defaultApprovalMode` is
defined. This would cause the generation script to emit an `enum` array in the
JSON schema and a `Values:` line in the documentation automatically, and would
keep everything in sync with the code. For example:

```ts
preferredEditor: {
  type: 'enum',
  label: 'Preferred Editor',
  category: 'General',
  requiresRestart: false,
  default: undefined as EditorType | undefined,
  description: '...',
  showInDialog: false,
  options: (EDITORS as readonly EditorType[]).map((e) => ({
    value: e,
    label: EDITOR_DISPLAY_NAMES[e],
  })),
},
```

This is a slightly more invasive change (it touches the settings type system and
may affect dialog rendering), so I have left it out of this PR. I am happy to
implement it based on your feedback.

## How to Validate

**Sublime Text:**

1. Set `"preferredEditor": "sublime"` in `~/.gemini/settings.json`
2. Open Gemini CLI and press `CTRL-X` to open the external editor
3. Sublime Text should open the buffer file and wait until it is closed

**Emacs Client:**

1. Start an Emacs daemon: `emacs --daemon`
2. Set `"preferredEditor": "emacsclient"` in `~/.gemini/settings.json`
3. Open Gemini CLI and press `CTRL-X` to open the external editor
4. Emacs Client should open in terminal mode (`-nw`) and wait until the buffer
   is closed

**Graceful error for unrecognized `preferredEditor`:**

1. Set `"preferredEditor": "emacsclient -nw"` in `~/.gemini/settings.json`
2. Press `CTRL-X` in Gemini CLI
3. Expected:
   `Editor 'emacsclient -nw' is not recognized or not installed. Run /editor to pick a supported editor, or set $VISUAL/$EDITOR in your shell to your preferred editor.`
4. Expected: no crash, no unhandled promise rejection

**Graceful error for missing `$VISUAL`/`$EDITOR` command:**

1. Run `export EDITOR="nonexistent-editor"` in your shell
2. Remove `preferredEditor` from `settings.json`
3. Press `CTRL-X` in Gemini CLI
4. Expected:
   `Could not find editor 'nonexistent-editor'. Check your $VISUAL/$EDITOR setting.`
5. Expected: no crash, no unhandled promise rejection

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker