### PR TITLE
feat(telemetry): add specific PR, issue, and custom tracking IDs for GitHub Actions

### DIFF
--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -342,7 +342,7 @@ Captures startup configuration and user prompt submissions.
     - `github_workflow_name` (string, optional)
     - `github_repository_hash` (string, optional)
     - `github_event_name` (string, optional)
-    - `github_event_number_hash` (string, optional)
+    - `github_event_number` (string, optional)
 
 - `gemini_cli.user_prompt`: Emitted when a user submits a prompt.
   - **Attributes**:

--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -339,6 +339,10 @@ Captures startup configuration and user prompt submissions.
     - `mcp_tools` (string, if applicable)
     - `mcp_tools_count` (int, if applicable)
     - `output_format` ("text", "json", or "stream-json")
+    - `github_workflow_name` (string, optional)
+    - `github_repository_hash` (string, optional)
+    - `github_event_name` (string, optional)
+    - `github_event_number_hash` (string, optional)
 
 - `gemini_cli.user_prompt`: Emitted when a user submits a prompt.
   - **Attributes**:

--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -342,7 +342,9 @@ Captures startup configuration and user prompt submissions.
     - `github_workflow_name` (string, optional)
     - `github_repository_hash` (string, optional)
     - `github_event_name` (string, optional)
-    - `github_event_number` (string, optional)
+    - `github_pr_number` (string, optional)
+    - `github_issue_number` (string, optional)
+    - `github_custom_tracking_id` (string, optional)
 
 - `gemini_cli.user_prompt`: Emitted when a user submits a prompt.
   - **Attributes**:

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -641,9 +641,9 @@ describe('ClearcutLogger', () => {
     });
 
     it('does not include event number when GH_EVENT_NUMBER is not set', () => {
-      const { logger } = setup({});
       vi.stubEnv('GH_EVENT_NUMBER', undefined);
       vi.stubEnv('GITHUB_REPOSITORY', 'google-gemini/gemini-cli');
+      const { logger } = setup({});
 
       const event = logger?.createLogEvent(EventNames.API_ERROR, []);
       const hasEventNumber = event?.event_metadata[0].some(
@@ -655,9 +655,9 @@ describe('ClearcutLogger', () => {
     });
 
     it('does not include event number when GITHUB_REPOSITORY is not set', () => {
-      const { logger } = setup({});
       vi.stubEnv('GH_EVENT_NUMBER', '123');
       vi.stubEnv('GITHUB_REPOSITORY', undefined);
+      const { logger } = setup({});
 
       const event = logger?.createLogEvent(EventNames.API_ERROR, []);
       const hasEventNumber = event?.event_metadata[0].some(

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -195,6 +195,9 @@ describe('ClearcutLogger', () => {
     vi.stubEnv('MONOSPACE_ENV', '');
     vi.stubEnv('REPLIT_USER', '');
     vi.stubEnv('__COG_BASHRC_SOURCED', '');
+    vi.stubEnv('GH_PR_NUMBER', '');
+    vi.stubEnv('GH_ISSUE_NUMBER', '');
+    vi.stubEnv('GH_CUSTOM_TRACKING_ID', '');
   });
 
   function setup({
@@ -621,29 +624,82 @@ describe('ClearcutLogger', () => {
     });
   });
 
-  describe('GH_EVENT_NUMBER metadata', () => {
-    it('includes event number when GH_EVENT_NUMBER is set', () => {
-      vi.stubEnv('GH_EVENT_NUMBER', '123');
+  describe('GH_PR_NUMBER metadata', () => {
+    it('includes PR number when GH_PR_NUMBER is set', () => {
+      vi.stubEnv('GH_PR_NUMBER', '123');
       const { logger } = setup({});
 
       const event = logger?.createLogEvent(EventNames.API_ERROR, []);
 
       expect(event?.event_metadata[0]).toContainEqual({
-        gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_EVENT_NUMBER,
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_PR_NUMBER,
         value: '123',
       });
     });
 
-    it('does not include event number when GH_EVENT_NUMBER is not set', () => {
-      vi.stubEnv('GH_EVENT_NUMBER', undefined);
+    it('does not include PR number when GH_PR_NUMBER is not set', () => {
+      vi.stubEnv('GH_PR_NUMBER', undefined);
       const { logger } = setup({});
 
       const event = logger?.createLogEvent(EventNames.API_ERROR, []);
-      const hasEventNumber = event?.event_metadata[0].some(
+      const hasPRNumber = event?.event_metadata[0].some(
         (item) =>
-          item.gemini_cli_key === EventMetadataKey.GEMINI_CLI_GH_EVENT_NUMBER,
+          item.gemini_cli_key === EventMetadataKey.GEMINI_CLI_GH_PR_NUMBER,
       );
-      expect(hasEventNumber).toBe(false);
+      expect(hasPRNumber).toBe(false);
+    });
+  });
+
+  describe('GH_ISSUE_NUMBER metadata', () => {
+    it('includes issue number when GH_ISSUE_NUMBER is set', () => {
+      vi.stubEnv('GH_ISSUE_NUMBER', '456');
+      const { logger } = setup({});
+
+      const event = logger?.createLogEvent(EventNames.API_ERROR, []);
+
+      expect(event?.event_metadata[0]).toContainEqual({
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_ISSUE_NUMBER,
+        value: '456',
+      });
+    });
+
+    it('does not include issue number when GH_ISSUE_NUMBER is not set', () => {
+      vi.stubEnv('GH_ISSUE_NUMBER', undefined);
+      const { logger } = setup({});
+
+      const event = logger?.createLogEvent(EventNames.API_ERROR, []);
+      const hasIssueNumber = event?.event_metadata[0].some(
+        (item) =>
+          item.gemini_cli_key === EventMetadataKey.GEMINI_CLI_GH_ISSUE_NUMBER,
+      );
+      expect(hasIssueNumber).toBe(false);
+    });
+  });
+
+  describe('GH_CUSTOM_TRACKING_ID metadata', () => {
+    it('includes custom tracking ID when GH_CUSTOM_TRACKING_ID is set', () => {
+      vi.stubEnv('GH_CUSTOM_TRACKING_ID', 'abc-789');
+      const { logger } = setup({});
+
+      const event = logger?.createLogEvent(EventNames.API_ERROR, []);
+
+      expect(event?.event_metadata[0]).toContainEqual({
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_CUSTOM_TRACKING_ID,
+        value: 'abc-789',
+      });
+    });
+
+    it('does not include custom tracking ID when GH_CUSTOM_TRACKING_ID is not set', () => {
+      vi.stubEnv('GH_CUSTOM_TRACKING_ID', undefined);
+      const { logger } = setup({});
+
+      const event = logger?.createLogEvent(EventNames.API_ERROR, []);
+      const hasTrackingId = event?.event_metadata[0].some(
+        (item) =>
+          item.gemini_cli_key ===
+          EventMetadataKey.GEMINI_CLI_GH_CUSTOM_TRACKING_ID,
+      );
+      expect(hasTrackingId).toBe(false);
     });
   });
 

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { createHash } from 'node:crypto';
 import {
   vi,
   describe,
@@ -623,47 +622,26 @@ describe('ClearcutLogger', () => {
   });
 
   describe('GH_EVENT_NUMBER metadata', () => {
-    it('includes hashed event number when GH_EVENT_NUMBER and GITHUB_REPOSITORY are set', () => {
+    it('includes event number when GH_EVENT_NUMBER is set', () => {
       vi.stubEnv('GH_EVENT_NUMBER', '123');
-      vi.stubEnv('GITHUB_REPOSITORY', 'google-gemini/gemini-cli');
       const { logger } = setup({});
 
       const event = logger?.createLogEvent(EventNames.API_ERROR, []);
 
-      const expectedHash = createHash('sha256')
-        .update('google-gemini/gemini-cli/123')
-        .digest('hex');
-
       expect(event?.event_metadata[0]).toContainEqual({
-        gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_EVENT_NUMBER_HASH,
-        value: expectedHash,
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_EVENT_NUMBER,
+        value: '123',
       });
     });
 
     it('does not include event number when GH_EVENT_NUMBER is not set', () => {
       vi.stubEnv('GH_EVENT_NUMBER', undefined);
-      vi.stubEnv('GITHUB_REPOSITORY', 'google-gemini/gemini-cli');
       const { logger } = setup({});
 
       const event = logger?.createLogEvent(EventNames.API_ERROR, []);
       const hasEventNumber = event?.event_metadata[0].some(
         (item) =>
-          item.gemini_cli_key ===
-          EventMetadataKey.GEMINI_CLI_GH_EVENT_NUMBER_HASH,
-      );
-      expect(hasEventNumber).toBe(false);
-    });
-
-    it('does not include event number when GITHUB_REPOSITORY is not set', () => {
-      vi.stubEnv('GH_EVENT_NUMBER', '123');
-      vi.stubEnv('GITHUB_REPOSITORY', undefined);
-      const { logger } = setup({});
-
-      const event = logger?.createLogEvent(EventNames.API_ERROR, []);
-      const hasEventNumber = event?.event_metadata[0].some(
-        (item) =>
-          item.gemini_cli_key ===
-          EventMetadataKey.GEMINI_CLI_GH_EVENT_NUMBER_HASH,
+          item.gemini_cli_key === EventMetadataKey.GEMINI_CLI_GH_EVENT_NUMBER,
       );
       expect(hasEventNumber).toBe(false);
     });

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { createHash } from 'node:crypto';
 import {
   vi,
   describe,
@@ -593,6 +594,78 @@ describe('ClearcutLogger', () => {
           item.gemini_cli_key === EventMetadataKey.GEMINI_CLI_GH_WORKFLOW_NAME,
       );
       expect(hasWorkflowName).toBe(false);
+    });
+  });
+
+  describe('GITHUB_EVENT_NAME metadata', () => {
+    it('includes event name when GITHUB_EVENT_NAME is set', () => {
+      const { logger } = setup({});
+      vi.stubEnv('GITHUB_EVENT_NAME', 'issues');
+
+      const event = logger?.createLogEvent(EventNames.API_ERROR, []);
+      expect(event?.event_metadata[0]).toContainEqual({
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_EVENT_NAME,
+        value: 'issues',
+      });
+    });
+
+    it('does not include event name when GITHUB_EVENT_NAME is not set', () => {
+      const { logger } = setup({});
+      vi.stubEnv('GITHUB_EVENT_NAME', undefined);
+
+      const event = logger?.createLogEvent(EventNames.API_ERROR, []);
+      const hasEventName = event?.event_metadata[0].some(
+        (item) =>
+          item.gemini_cli_key === EventMetadataKey.GEMINI_CLI_GH_EVENT_NAME,
+      );
+      expect(hasEventName).toBe(false);
+    });
+  });
+
+  describe('GH_EVENT_NUMBER metadata', () => {
+    it('includes hashed event number when GH_EVENT_NUMBER and GITHUB_REPOSITORY are set', () => {
+      vi.stubEnv('GH_EVENT_NUMBER', '123');
+      vi.stubEnv('GITHUB_REPOSITORY', 'google-gemini/gemini-cli');
+      const { logger } = setup({});
+
+      const event = logger?.createLogEvent(EventNames.API_ERROR, []);
+
+      const expectedHash = createHash('sha256')
+        .update('google-gemini/gemini-cli/123')
+        .digest('hex');
+
+      expect(event?.event_metadata[0]).toContainEqual({
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_EVENT_NUMBER_HASH,
+        value: expectedHash,
+      });
+    });
+
+    it('does not include event number when GH_EVENT_NUMBER is not set', () => {
+      const { logger } = setup({});
+      vi.stubEnv('GH_EVENT_NUMBER', undefined);
+      vi.stubEnv('GITHUB_REPOSITORY', 'google-gemini/gemini-cli');
+
+      const event = logger?.createLogEvent(EventNames.API_ERROR, []);
+      const hasEventNumber = event?.event_metadata[0].some(
+        (item) =>
+          item.gemini_cli_key ===
+          EventMetadataKey.GEMINI_CLI_GH_EVENT_NUMBER_HASH,
+      );
+      expect(hasEventNumber).toBe(false);
+    });
+
+    it('does not include event number when GITHUB_REPOSITORY is not set', () => {
+      const { logger } = setup({});
+      vi.stubEnv('GH_EVENT_NUMBER', '123');
+      vi.stubEnv('GITHUB_REPOSITORY', undefined);
+
+      const event = logger?.createLogEvent(EventNames.API_ERROR, []);
+      const hasEventNumber = event?.event_metadata[0].some(
+        (item) =>
+          item.gemini_cli_key ===
+          EventMetadataKey.GEMINI_CLI_GH_EVENT_NUMBER_HASH,
+      );
+      expect(hasEventNumber).toBe(false);
     });
   });
 

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -429,14 +429,10 @@ export class ClearcutLogger {
       });
     }
 
-    if (ghEventNumber && this.hashedGHRepositoryName) {
-      const ghRepositoryName = determineGHRepositoryName()!;
-      const hashedEventNumber = createHash('sha256')
-        .update(`${ghRepositoryName}/${ghEventNumber}`)
-        .digest('hex');
+    if (ghEventNumber) {
       baseMetadata.push({
-        gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_EVENT_NUMBER_HASH,
-        value: hashedEventNumber,
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_EVENT_NUMBER,
+        value: ghEventNumber,
       });
     }
 

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -198,10 +198,24 @@ function determineGHEventName(): string | undefined {
 }
 
 /**
- * Determines the GitHub event number if the CLI is running in a GitHub Actions environment.
+ * Determines the GitHub Pull Request number if the CLI is running in a GitHub Actions environment.
  */
-function determineGHEventNumber(): string | undefined {
-  return process.env['GH_EVENT_NUMBER'];
+function determineGHPRNumber(): string | undefined {
+  return process.env['GH_PR_NUMBER'];
+}
+
+/**
+ * Determines the GitHub Issue number if the CLI is running in a GitHub Actions environment.
+ */
+function determineGHIssueNumber(): string | undefined {
+  return process.env['GH_ISSUE_NUMBER'];
+}
+
+/**
+ * Determines the GitHub custom tracking ID if the CLI is running in a GitHub Actions environment.
+ */
+function determineGHCustomTrackingId(): string | undefined {
+  return process.env['GH_CUSTOM_TRACKING_ID'];
 }
 
 /**
@@ -387,7 +401,9 @@ export class ClearcutLogger {
     const surface = determineSurface();
     const ghWorkflowName = determineGHWorkflowName();
     const ghEventName = determineGHEventName();
-    const ghEventNumber = determineGHEventNumber();
+    const ghPRNumber = determineGHPRNumber();
+    const ghIssueNumber = determineGHIssueNumber();
+    const ghCustomTrackingId = determineGHCustomTrackingId();
     const baseMetadata: EventValue[] = [
       ...data,
       {
@@ -429,10 +445,24 @@ export class ClearcutLogger {
       });
     }
 
-    if (ghEventNumber) {
+    if (ghPRNumber) {
       baseMetadata.push({
-        gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_EVENT_NUMBER,
-        value: ghEventNumber,
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_PR_NUMBER,
+        value: ghPRNumber,
+      });
+    }
+
+    if (ghIssueNumber) {
+      baseMetadata.push({
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_ISSUE_NUMBER,
+        value: ghIssueNumber,
+      });
+    }
+
+    if (ghCustomTrackingId) {
+      baseMetadata.push({
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_CUSTOM_TRACKING_ID,
+        value: ghCustomTrackingId,
       });
     }
 

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -191,6 +191,20 @@ function determineGHRepositoryName(): string | undefined {
 }
 
 /**
+ * Determines the GitHub event name if the CLI is running in a GitHub Actions environment.
+ */
+function determineGHEventName(): string | undefined {
+  return process.env['GITHUB_EVENT_NAME'];
+}
+
+/**
+ * Determines the GitHub event number if the CLI is running in a GitHub Actions environment.
+ */
+function determineGHEventNumber(): string | undefined {
+  return process.env['GH_EVENT_NUMBER'];
+}
+
+/**
  * Clearcut URL to send logging events to.
  */
 const CLEARCUT_URL = 'https://play.googleapis.com/log?format=json&hasfast=true';
@@ -372,6 +386,8 @@ export class ClearcutLogger {
     const email = this.userAccountManager.getCachedGoogleAccount();
     const surface = determineSurface();
     const ghWorkflowName = determineGHWorkflowName();
+    const ghEventName = determineGHEventName();
+    const ghEventNumber = determineGHEventNumber();
     const baseMetadata: EventValue[] = [
       ...data,
       {
@@ -404,6 +420,26 @@ export class ClearcutLogger {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_REPOSITORY_NAME_HASH,
         value: this.hashedGHRepositoryName,
       });
+    }
+
+    if (ghEventName) {
+      baseMetadata.push({
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_EVENT_NAME,
+        value: ghEventName,
+      });
+    }
+
+    if (ghEventNumber && this.hashedGHRepositoryName) {
+      const ghRepositoryName = determineGHRepositoryName();
+      if (ghRepositoryName) {
+        const hashedEventNumber = createHash('sha256')
+          .update(`${ghRepositoryName}/${ghEventNumber}`)
+          .digest('hex');
+        baseMetadata.push({
+          gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_EVENT_NUMBER_HASH,
+          value: hashedEventNumber,
+        });
+      }
     }
 
     const logEvent: LogEvent = {

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -430,16 +430,14 @@ export class ClearcutLogger {
     }
 
     if (ghEventNumber && this.hashedGHRepositoryName) {
-      const ghRepositoryName = determineGHRepositoryName();
-      if (ghRepositoryName) {
-        const hashedEventNumber = createHash('sha256')
-          .update(`${ghRepositoryName}/${ghEventNumber}`)
-          .digest('hex');
-        baseMetadata.push({
-          gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_EVENT_NUMBER_HASH,
-          value: hashedEventNumber,
-        });
-      }
+      const ghRepositoryName = determineGHRepositoryName()!;
+      const hashedEventNumber = createHash('sha256')
+        .update(`${ghRepositoryName}/${ghEventNumber}`)
+        .digest('hex');
+      baseMetadata.push({
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_GH_EVENT_NUMBER_HASH,
+        value: hashedEventNumber,
+      });
     }
 
     const logEvent: LogEvent = {

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -7,13 +7,17 @@
 // Defines valid event metadata keys for Clearcut logging.
 export enum EventMetadataKey {
   // Deleted enums: 24
+
   // Next ID: 176
+
+
+
 
   GEMINI_CLI_KEY_UNKNOWN = 0,
 
-  // ==========================================================================
+  // ====
   // Start Session Event Keys
-  // ===========================================================================
+  // =====
 
   // Logs the model id used in the session.
   GEMINI_CLI_START_SESSION_MODEL = 1,
@@ -54,9 +58,9 @@ export enum EventMetadataKey {
   // Logs the output format of the session.
   GEMINI_CLI_START_SESSION_OUTPUT_FORMAT = 94,
 
-  // ==========================================================================
+  // ====
   // Startup Stats Event Keys
-  // ==========================================================================
+  // ====
 
   // Logs the array of startup phases.
   GEMINI_CLI_STARTUP_PHASES = 172,
@@ -70,16 +74,16 @@ export enum EventMetadataKey {
   // Logs whether the CLI is running in docker for startup stats.
   GEMINI_CLI_STARTUP_IS_DOCKER = 175,
 
-  // ==========================================================================
+  // ====
   // User Prompt Event Keys
-  // ===========================================================================
+  // =====
 
   // Logs the length of the prompt.
   GEMINI_CLI_USER_PROMPT_LENGTH = 13,
 
-  // ==========================================================================
+  // ====
   // Tool Call Event Keys
-  // ===========================================================================
+  // =====
 
   // Logs the function name.
   GEMINI_CLI_TOOL_CALL_NAME = 14,
@@ -105,9 +109,9 @@ export enum EventMetadataKey {
   // Logs the length of tool output
   GEMINI_CLI_TOOL_CALL_CONTENT_LENGTH = 93,
 
-  // ==========================================================================
+  // ====
   // Replace Tool Call Event Keys
-  // ===========================================================================
+  // =====
 
   // Logs a edit tool strategy choice.
   GEMINI_CLI_EDIT_STRATEGY = 109,
@@ -118,16 +122,16 @@ export enum EventMetadataKey {
   // Logs the reason for web fetch fallback.
   GEMINI_CLI_WEB_FETCH_FALLBACK_REASON = 116,
 
-  // ==========================================================================
+  // ====
   // GenAI API Request Event Keys
-  // ===========================================================================
+  // =====
 
   // Logs the model id of the request.
   GEMINI_CLI_API_REQUEST_MODEL = 20,
 
-  // ==========================================================================
+  // ====
   // GenAI API Response Event Keys
-  // ===========================================================================
+  // =====
 
   // Logs the model id of the API call.
   GEMINI_CLI_API_RESPONSE_MODEL = 21,
@@ -168,9 +172,9 @@ export enum EventMetadataKey {
   // Logs the token count from MCP servers (tool definitions + tool inputs/outputs).
   GEMINI_CLI_API_RESPONSE_CONTEXT_BREAKDOWN_MCP_SERVERS = 171,
 
-  // ==========================================================================
+  // ====
   // GenAI API Error Event Keys
-  // ===========================================================================
+  // =====
 
   // Logs the model id of the API call.
   GEMINI_CLI_API_ERROR_MODEL = 30,
@@ -184,16 +188,16 @@ export enum EventMetadataKey {
   // Logs the duration of the API call in milliseconds.
   GEMINI_CLI_API_ERROR_DURATION_MS = 33,
 
-  // ==========================================================================
+  // ====
   // End Session Event Keys
-  // ===========================================================================
+  // =====
 
   // Logs the end of a session.
   GEMINI_CLI_END_SESSION_ID = 34,
 
-  // ==========================================================================
+  // ====
   // Shared Keys
-  // ===========================================================================
+  // =====
 
   // Logs the Prompt Id
   GEMINI_CLI_PROMPT_ID = 35,
@@ -231,16 +235,22 @@ export enum EventMetadataKey {
   // Logs the repository name of the GitHub Action that triggered the session.
   GEMINI_CLI_GH_REPOSITORY_NAME_HASH = 132,
 
-  // ==========================================================================
+  // Logs the event name of the GitHub Action that triggered the session.
+  GEMINI_CLI_GH_EVENT_NAME = 172,
+
+  // Logs the hashed event number of the GitHub Action that triggered the session.
+  GEMINI_CLI_GH_EVENT_NUMBER_HASH = 173,
+
+  // ====
   // Loop Detected Event Keys
-  // ===========================================================================
+  // =====
 
   // Logs the type of loop detected.
   GEMINI_CLI_LOOP_DETECTED_TYPE = 38,
 
-  // ==========================================================================
+  // ====
   // Slash Command Event Keys
-  // ===========================================================================
+  // =====
 
   // Logs the name of the slash command.
   GEMINI_CLI_SLASH_COMMAND_NAME = 41,
@@ -251,9 +261,9 @@ export enum EventMetadataKey {
   // Logs the status of the slash command (e.g. 'success', 'error')
   GEMINI_CLI_SLASH_COMMAND_STATUS = 51,
 
-  // ==========================================================================
+  // ====
   // Next Speaker Check Event Keys
-  // ===========================================================================
+  // =====
 
   // Logs the finish reason of the previous streamGenerateContent response
   GEMINI_CLI_RESPONSE_FINISH_REASON = 43,
@@ -261,16 +271,16 @@ export enum EventMetadataKey {
   // Logs the result of the next speaker check
   GEMINI_CLI_NEXT_SPEAKER_CHECK_RESULT = 44,
 
-  // ==========================================================================
+  // ====
   // Malformed JSON Response Event Keys
-  // ==========================================================================
+  // ====
 
   // Logs the model that produced the malformed JSON response.
   GEMINI_CLI_MALFORMED_JSON_RESPONSE_MODEL = 45,
 
-  // ==========================================================================
+  // ====
   // IDE Connection Event Keys
-  // ===========================================================================
+  // =====
 
   // Logs the type of the IDE connection.
   GEMINI_CLI_IDE_CONNECTION_TYPE = 46,
@@ -299,9 +309,9 @@ export enum EventMetadataKey {
   // Logs user removed characters in edit/write tool response.
   GEMINI_CLI_USER_REMOVED_CHARS = 106,
 
-  // ==========================================================================
+  // ====
   // Kitty Sequence Overflow Event Keys
-  // ===========================================================================
+  // =====
 
   // Do not use.
   DEPRECATED_GEMINI_CLI_KITTY_TRUNCATED_SEQUENCE = 52,
@@ -309,9 +319,9 @@ export enum EventMetadataKey {
   // Logs the length of the kitty sequence that overflowed.
   GEMINI_CLI_KITTY_SEQUENCE_LENGTH = 53,
 
-  // ==========================================================================
+  // ====
   // Conversation Finished Event Keys
-  // ===========================================================================
+  // =====
 
   // Logs the approval mode of the session.
   GEMINI_CLI_APPROVAL_MODE = 58,
@@ -337,9 +347,9 @@ export enum EventMetadataKey {
   // Logs name of MCP tools as comma separated string
   GEMINI_CLI_START_SESSION_MCP_TOOLS = 65,
 
-  // ==========================================================================
+  // ====
   // Research Event Keys
-  // ===========================================================================
+  // =====
 
   // Logs the research opt-in status (true/false)
   GEMINI_CLI_RESEARCH_OPT_IN_STATUS = 66,
@@ -359,9 +369,9 @@ export enum EventMetadataKey {
   // Logs survey responses for research feedback (JSON stringified)
   GEMINI_CLI_RESEARCH_SURVEY_RESPONSES = 71,
 
-  // ==========================================================================
+  // ====
   // File Operation Event Keys
-  // ===========================================================================
+  // =====
 
   // Logs the programming language of the project.
   GEMINI_CLI_PROGRAMMING_LANGUAGE = 56,
@@ -378,9 +388,9 @@ export enum EventMetadataKey {
   // Logs the extension of the file in the file operation.
   GEMINI_CLI_FILE_OPERATION_EXTENSION = 74,
 
-  // ==========================================================================
+  // ====
   // Content Streaming Event Keys
-  // ===========================================================================
+  // =====
 
   // Logs the error message for an invalid chunk.
   GEMINI_CLI_INVALID_CHUNK_ERROR_MESSAGE = 75,
@@ -406,9 +416,9 @@ export enum EventMetadataKey {
   // Logs the current nodejs version
   GEMINI_CLI_NODE_VERSION = 83,
 
-  // ==========================================================================
+  // ====
   // Extension Event Keys
-  // ===========================================================================
+  // =====
 
   // Logs the name of the extension.
   GEMINI_CLI_EXTENSION_NAME = 85,
@@ -446,9 +456,9 @@ export enum EventMetadataKey {
   // Logs the setting scope for an extension disablement.
   GEMINI_CLI_EXTENSION_DISABLE_SETTING_SCOPE = 107,
 
-  // ==========================================================================
+  // ====
   // Tool Output Truncated Event Keys
-  // ===========================================================================
+  // =====
 
   // Logs the original length of the tool output.
   GEMINI_CLI_TOOL_OUTPUT_TRUNCATED_ORIGINAL_LENGTH = 89,
@@ -462,9 +472,9 @@ export enum EventMetadataKey {
   // Logs the number of lines the tool output was truncated to.
   GEMINI_CLI_TOOL_OUTPUT_TRUNCATED_LINES = 92,
 
-  // ==========================================================================
+  // ====
   // Model Router Event Keys
-  // ==========================================================================
+  // ====
 
   // Logs the outcome of a model routing decision (e.g., which route/model was
   // selected).
@@ -486,9 +496,9 @@ export enum EventMetadataKey {
   // Logs an event when the user uses the /model command.
   GEMINI_CLI_MODEL_SLASH_COMMAND = 108,
 
-  // ==========================================================================
+  // ====
   // Agent Event Keys
-  // ==========================================================================
+  // ====
 
   // Logs the name of the agent.
   GEMINI_CLI_AGENT_NAME = 111,
@@ -517,9 +527,9 @@ export enum EventMetadataKey {
   // Logs whether the session is interactive.
   GEMINI_CLI_INTERACTIVE = 125,
 
-  // ==========================================================================
+  // ====
   // LLM Loop Check Event Keys
-  // ==========================================================================
+  // ====
 
   // Logs the confidence score from the flash model loop check.
   GEMINI_CLI_LLM_LOOP_CHECK_FLASH_CONFIDENCE = 126,
@@ -533,9 +543,9 @@ export enum EventMetadataKey {
   // Logs the model that confirmed the loop.
   GEMINI_CLI_LOOP_DETECTED_CONFIRMED_BY_MODEL = 129,
 
-  // ==========================================================================
+  // ====
   // Hook Call Event Keys
-  // ==========================================================================
+  // ====
 
   // Logs the name of the hook event (e.g., 'BeforeTool', 'AfterModel').
   GEMINI_CLI_HOOK_EVENT_NAME = 133,
@@ -561,9 +571,9 @@ export enum EventMetadataKey {
   // Logs total RAM in GB of user machine.
   GEMINI_CLI_RAM_TOTAL_GB = 140,
 
-  // ==========================================================================
+  // ====
   // Approval Mode Event Keys
-  // ==========================================================================
+  // ====
 
   // Logs the active approval mode in the session.
   GEMINI_CLI_ACTIVE_APPROVAL_MODE = 141,
@@ -574,15 +584,15 @@ export enum EventMetadataKey {
   // Logs the duration spent in an approval mode in milliseconds.
   GEMINI_CLI_APPROVAL_MODE_DURATION_MS = 143,
 
-  // ==========================================================================
+  // ====
   // Rewind Event Keys
-  // ==========================================================================
+  // ====
 
   // Logs the outcome of a rewind operation.
   GEMINI_CLI_REWIND_OUTCOME = 144,
 
   // Model Routing Event Keys (Cont.)
-  // ==========================================================================
+  // ====
 
   // Logs the reasoning for the routing decision.
   GEMINI_CLI_ROUTING_REASONING = 145,
@@ -593,9 +603,9 @@ export enum EventMetadataKey {
   // Logs the classifier threshold used.
   GEMINI_CLI_ROUTING_CLASSIFIER_THRESHOLD = 147,
 
-  // ==========================================================================
+  // ====
   // Tool Output Masking Event Keys
-  // ==========================================================================
+  // ====
 
   // Logs the total tokens in the prunable block before masking.
   GEMINI_CLI_TOOL_OUTPUT_MASKING_TOKENS_BEFORE = 148,
@@ -610,7 +620,7 @@ export enum EventMetadataKey {
   GEMINI_CLI_TOOL_OUTPUT_MASKING_TOTAL_PRUNABLE_TOKENS = 151,
 
   // Ask User Stats Event Keys
-  // ==========================================================================
+  // ====
 
   // Logs the types of questions asked in the ask_user tool.
   GEMINI_CLI_ASK_USER_QUESTION_TYPES = 152,
@@ -624,9 +634,9 @@ export enum EventMetadataKey {
   // Logs the number of questions answered in the ask_user tool.
   GEMINI_CLI_ASK_USER_ANSWER_COUNT = 155,
 
-  // ==========================================================================
+  // ====
   // Keychain & Token Storage Event Keys
-  // ==========================================================================
+  // ====
 
   // Logs whether the keychain is available.
   GEMINI_CLI_KEYCHAIN_AVAILABLE = 156,
@@ -637,7 +647,7 @@ export enum EventMetadataKey {
   // Logs whether the token storage type was forced by an environment variable.
   GEMINI_CLI_TOKEN_STORAGE_FORCED = 158,
   // Conseca Event Keys
-  // ==========================================================================
+  // ====
 
   // Logs the policy generation event.
   CONSECA_POLICY_GENERATION = 159,

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -7,17 +7,13 @@
 // Defines valid event metadata keys for Clearcut logging.
 export enum EventMetadataKey {
   // Deleted enums: 24
-
-  // Next ID: 176
-
-
-
+  // Next ID: 180
 
   GEMINI_CLI_KEY_UNKNOWN = 0,
 
-  // ====
+  // ==========================================================================
   // Start Session Event Keys
-  // =====
+  // ===========================================================================
 
   // Logs the model id used in the session.
   GEMINI_CLI_START_SESSION_MODEL = 1,
@@ -58,9 +54,9 @@ export enum EventMetadataKey {
   // Logs the output format of the session.
   GEMINI_CLI_START_SESSION_OUTPUT_FORMAT = 94,
 
-  // ====
+  // ==========================================================================
   // Startup Stats Event Keys
-  // ====
+  // ==========================================================================
 
   // Logs the array of startup phases.
   GEMINI_CLI_STARTUP_PHASES = 172,
@@ -74,16 +70,16 @@ export enum EventMetadataKey {
   // Logs whether the CLI is running in docker for startup stats.
   GEMINI_CLI_STARTUP_IS_DOCKER = 175,
 
-  // ====
+  // ==========================================================================
   // User Prompt Event Keys
-  // =====
+  // ===========================================================================
 
   // Logs the length of the prompt.
   GEMINI_CLI_USER_PROMPT_LENGTH = 13,
 
-  // ====
+  // ==========================================================================
   // Tool Call Event Keys
-  // =====
+  // ===========================================================================
 
   // Logs the function name.
   GEMINI_CLI_TOOL_CALL_NAME = 14,
@@ -109,9 +105,9 @@ export enum EventMetadataKey {
   // Logs the length of tool output
   GEMINI_CLI_TOOL_CALL_CONTENT_LENGTH = 93,
 
-  // ====
+  // ==========================================================================
   // Replace Tool Call Event Keys
-  // =====
+  // ===========================================================================
 
   // Logs a edit tool strategy choice.
   GEMINI_CLI_EDIT_STRATEGY = 109,
@@ -122,16 +118,16 @@ export enum EventMetadataKey {
   // Logs the reason for web fetch fallback.
   GEMINI_CLI_WEB_FETCH_FALLBACK_REASON = 116,
 
-  // ====
+  // ==========================================================================
   // GenAI API Request Event Keys
-  // =====
+  // ===========================================================================
 
   // Logs the model id of the request.
   GEMINI_CLI_API_REQUEST_MODEL = 20,
 
-  // ====
+  // ==========================================================================
   // GenAI API Response Event Keys
-  // =====
+  // ===========================================================================
 
   // Logs the model id of the API call.
   GEMINI_CLI_API_RESPONSE_MODEL = 21,
@@ -172,9 +168,9 @@ export enum EventMetadataKey {
   // Logs the token count from MCP servers (tool definitions + tool inputs/outputs).
   GEMINI_CLI_API_RESPONSE_CONTEXT_BREAKDOWN_MCP_SERVERS = 171,
 
-  // ====
+  // ==========================================================================
   // GenAI API Error Event Keys
-  // =====
+  // ===========================================================================
 
   // Logs the model id of the API call.
   GEMINI_CLI_API_ERROR_MODEL = 30,
@@ -188,16 +184,16 @@ export enum EventMetadataKey {
   // Logs the duration of the API call in milliseconds.
   GEMINI_CLI_API_ERROR_DURATION_MS = 33,
 
-  // ====
+  // ==========================================================================
   // End Session Event Keys
-  // =====
+  // ===========================================================================
 
   // Logs the end of a session.
   GEMINI_CLI_END_SESSION_ID = 34,
 
-  // ====
+  // ==========================================================================
   // Shared Keys
-  // =====
+  // ===========================================================================
 
   // Logs the Prompt Id
   GEMINI_CLI_PROMPT_ID = 35,
@@ -236,21 +232,27 @@ export enum EventMetadataKey {
   GEMINI_CLI_GH_REPOSITORY_NAME_HASH = 132,
 
   // Logs the event name of the GitHub Action that triggered the session.
-  GEMINI_CLI_GH_EVENT_NAME = 172,
+  GEMINI_CLI_GH_EVENT_NAME = 176,
 
-  // Logs the event number (Issue or PR ID) of the GitHub Action that triggered the session.
-  GEMINI_CLI_GH_EVENT_NUMBER = 173,
+  // Logs the Pull Request number if the workflow is operating on a PR.
+  GEMINI_CLI_GH_PR_NUMBER = 177,
 
-  // ====
+  // Logs the Issue number if the workflow is operating on an Issue.
+  GEMINI_CLI_GH_ISSUE_NUMBER = 178,
+
+  // Logs a custom tracking string (e.g. a comma-separated list of issue IDs for scheduled batches).
+  GEMINI_CLI_GH_CUSTOM_TRACKING_ID = 179,
+
+  // ==========================================================================
   // Loop Detected Event Keys
-  // =====
+  // ===========================================================================
 
   // Logs the type of loop detected.
   GEMINI_CLI_LOOP_DETECTED_TYPE = 38,
 
-  // ====
+  // ==========================================================================
   // Slash Command Event Keys
-  // =====
+  // ===========================================================================
 
   // Logs the name of the slash command.
   GEMINI_CLI_SLASH_COMMAND_NAME = 41,
@@ -261,9 +263,9 @@ export enum EventMetadataKey {
   // Logs the status of the slash command (e.g. 'success', 'error')
   GEMINI_CLI_SLASH_COMMAND_STATUS = 51,
 
-  // ====
+  // ==========================================================================
   // Next Speaker Check Event Keys
-  // =====
+  // ===========================================================================
 
   // Logs the finish reason of the previous streamGenerateContent response
   GEMINI_CLI_RESPONSE_FINISH_REASON = 43,
@@ -271,16 +273,16 @@ export enum EventMetadataKey {
   // Logs the result of the next speaker check
   GEMINI_CLI_NEXT_SPEAKER_CHECK_RESULT = 44,
 
-  // ====
+  // ==========================================================================
   // Malformed JSON Response Event Keys
-  // ====
+  // ==========================================================================
 
   // Logs the model that produced the malformed JSON response.
   GEMINI_CLI_MALFORMED_JSON_RESPONSE_MODEL = 45,
 
-  // ====
+  // ==========================================================================
   // IDE Connection Event Keys
-  // =====
+  // ===========================================================================
 
   // Logs the type of the IDE connection.
   GEMINI_CLI_IDE_CONNECTION_TYPE = 46,
@@ -309,9 +311,9 @@ export enum EventMetadataKey {
   // Logs user removed characters in edit/write tool response.
   GEMINI_CLI_USER_REMOVED_CHARS = 106,
 
-  // ====
+  // ==========================================================================
   // Kitty Sequence Overflow Event Keys
-  // =====
+  // ===========================================================================
 
   // Do not use.
   DEPRECATED_GEMINI_CLI_KITTY_TRUNCATED_SEQUENCE = 52,
@@ -319,9 +321,9 @@ export enum EventMetadataKey {
   // Logs the length of the kitty sequence that overflowed.
   GEMINI_CLI_KITTY_SEQUENCE_LENGTH = 53,
 
-  // ====
+  // ==========================================================================
   // Conversation Finished Event Keys
-  // =====
+  // ===========================================================================
 
   // Logs the approval mode of the session.
   GEMINI_CLI_APPROVAL_MODE = 58,
@@ -347,9 +349,9 @@ export enum EventMetadataKey {
   // Logs name of MCP tools as comma separated string
   GEMINI_CLI_START_SESSION_MCP_TOOLS = 65,
 
-  // ====
+  // ==========================================================================
   // Research Event Keys
-  // =====
+  // ===========================================================================
 
   // Logs the research opt-in status (true/false)
   GEMINI_CLI_RESEARCH_OPT_IN_STATUS = 66,
@@ -369,9 +371,9 @@ export enum EventMetadataKey {
   // Logs survey responses for research feedback (JSON stringified)
   GEMINI_CLI_RESEARCH_SURVEY_RESPONSES = 71,
 
-  // ====
+  // ==========================================================================
   // File Operation Event Keys
-  // =====
+  // ===========================================================================
 
   // Logs the programming language of the project.
   GEMINI_CLI_PROGRAMMING_LANGUAGE = 56,
@@ -388,9 +390,9 @@ export enum EventMetadataKey {
   // Logs the extension of the file in the file operation.
   GEMINI_CLI_FILE_OPERATION_EXTENSION = 74,
 
-  // ====
+  // ==========================================================================
   // Content Streaming Event Keys
-  // =====
+  // ===========================================================================
 
   // Logs the error message for an invalid chunk.
   GEMINI_CLI_INVALID_CHUNK_ERROR_MESSAGE = 75,
@@ -416,9 +418,9 @@ export enum EventMetadataKey {
   // Logs the current nodejs version
   GEMINI_CLI_NODE_VERSION = 83,
 
-  // ====
+  // ==========================================================================
   // Extension Event Keys
-  // =====
+  // ===========================================================================
 
   // Logs the name of the extension.
   GEMINI_CLI_EXTENSION_NAME = 85,
@@ -456,9 +458,9 @@ export enum EventMetadataKey {
   // Logs the setting scope for an extension disablement.
   GEMINI_CLI_EXTENSION_DISABLE_SETTING_SCOPE = 107,
 
-  // ====
+  // ==========================================================================
   // Tool Output Truncated Event Keys
-  // =====
+  // ===========================================================================
 
   // Logs the original length of the tool output.
   GEMINI_CLI_TOOL_OUTPUT_TRUNCATED_ORIGINAL_LENGTH = 89,
@@ -472,9 +474,9 @@ export enum EventMetadataKey {
   // Logs the number of lines the tool output was truncated to.
   GEMINI_CLI_TOOL_OUTPUT_TRUNCATED_LINES = 92,
 
-  // ====
+  // ==========================================================================
   // Model Router Event Keys
-  // ====
+  // ==========================================================================
 
   // Logs the outcome of a model routing decision (e.g., which route/model was
   // selected).
@@ -496,9 +498,9 @@ export enum EventMetadataKey {
   // Logs an event when the user uses the /model command.
   GEMINI_CLI_MODEL_SLASH_COMMAND = 108,
 
-  // ====
+  // ==========================================================================
   // Agent Event Keys
-  // ====
+  // ==========================================================================
 
   // Logs the name of the agent.
   GEMINI_CLI_AGENT_NAME = 111,
@@ -527,9 +529,9 @@ export enum EventMetadataKey {
   // Logs whether the session is interactive.
   GEMINI_CLI_INTERACTIVE = 125,
 
-  // ====
+  // ==========================================================================
   // LLM Loop Check Event Keys
-  // ====
+  // ==========================================================================
 
   // Logs the confidence score from the flash model loop check.
   GEMINI_CLI_LLM_LOOP_CHECK_FLASH_CONFIDENCE = 126,
@@ -543,9 +545,9 @@ export enum EventMetadataKey {
   // Logs the model that confirmed the loop.
   GEMINI_CLI_LOOP_DETECTED_CONFIRMED_BY_MODEL = 129,
 
-  // ====
+  // ==========================================================================
   // Hook Call Event Keys
-  // ====
+  // ==========================================================================
 
   // Logs the name of the hook event (e.g., 'BeforeTool', 'AfterModel').
   GEMINI_CLI_HOOK_EVENT_NAME = 133,
@@ -571,9 +573,9 @@ export enum EventMetadataKey {
   // Logs total RAM in GB of user machine.
   GEMINI_CLI_RAM_TOTAL_GB = 140,
 
-  // ====
+  // ==========================================================================
   // Approval Mode Event Keys
-  // ====
+  // ==========================================================================
 
   // Logs the active approval mode in the session.
   GEMINI_CLI_ACTIVE_APPROVAL_MODE = 141,
@@ -584,15 +586,15 @@ export enum EventMetadataKey {
   // Logs the duration spent in an approval mode in milliseconds.
   GEMINI_CLI_APPROVAL_MODE_DURATION_MS = 143,
 
-  // ====
+  // ==========================================================================
   // Rewind Event Keys
-  // ====
+  // ==========================================================================
 
   // Logs the outcome of a rewind operation.
   GEMINI_CLI_REWIND_OUTCOME = 144,
 
   // Model Routing Event Keys (Cont.)
-  // ====
+  // ==========================================================================
 
   // Logs the reasoning for the routing decision.
   GEMINI_CLI_ROUTING_REASONING = 145,
@@ -603,9 +605,9 @@ export enum EventMetadataKey {
   // Logs the classifier threshold used.
   GEMINI_CLI_ROUTING_CLASSIFIER_THRESHOLD = 147,
 
-  // ====
+  // ==========================================================================
   // Tool Output Masking Event Keys
-  // ====
+  // ==========================================================================
 
   // Logs the total tokens in the prunable block before masking.
   GEMINI_CLI_TOOL_OUTPUT_MASKING_TOKENS_BEFORE = 148,
@@ -620,7 +622,7 @@ export enum EventMetadataKey {
   GEMINI_CLI_TOOL_OUTPUT_MASKING_TOTAL_PRUNABLE_TOKENS = 151,
 
   // Ask User Stats Event Keys
-  // ====
+  // ==========================================================================
 
   // Logs the types of questions asked in the ask_user tool.
   GEMINI_CLI_ASK_USER_QUESTION_TYPES = 152,
@@ -634,9 +636,9 @@ export enum EventMetadataKey {
   // Logs the number of questions answered in the ask_user tool.
   GEMINI_CLI_ASK_USER_ANSWER_COUNT = 155,
 
-  // ====
+  // ==========================================================================
   // Keychain & Token Storage Event Keys
-  // ====
+  // ==========================================================================
 
   // Logs whether the keychain is available.
   GEMINI_CLI_KEYCHAIN_AVAILABLE = 156,
@@ -647,7 +649,7 @@ export enum EventMetadataKey {
   // Logs whether the token storage type was forced by an environment variable.
   GEMINI_CLI_TOKEN_STORAGE_FORCED = 158,
   // Conseca Event Keys
-  // ====
+  // ==========================================================================
 
   // Logs the policy generation event.
   CONSECA_POLICY_GENERATION = 159,

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -238,8 +238,8 @@ export enum EventMetadataKey {
   // Logs the event name of the GitHub Action that triggered the session.
   GEMINI_CLI_GH_EVENT_NAME = 172,
 
-  // Logs the hashed event number of the GitHub Action that triggered the session.
-  GEMINI_CLI_GH_EVENT_NUMBER_HASH = 173,
+  // Logs the event number (Issue or PR ID) of the GitHub Action that triggered the session.
+  GEMINI_CLI_GH_EVENT_NUMBER = 173,
 
   // ====
   // Loop Detected Event Keys


### PR DESCRIPTION
## Summary

This PR adds new telemetry attributes to the Gemini CLI to support granular usage metrics for GitHub Actions. These metrics will allow us to track unique Issues and PRs touched by the CLI, and distinguish between different workflow triggers (e.g., Automated vs. Scheduled triage).

Will fix https://github.com/google-gemini/gemini-cli/issues/21130

## Details

- Added `GEMINI_CLI_GH_EVENT_NAME` to `EventMetadataKey`.
- Added specific tracking IDs: `GEMINI_CLI_GH_PR_NUMBER`, `GEMINI_CLI_GH_ISSUE_NUMBER`, and `GEMINI_CLI_GH_CUSTOM_TRACKING_ID` replacing generic `GH_EVENT_NUMBER`.
- Updated `ClearcutLogger` to capture these from environment variables (`GITHUB_EVENT_NAME`, `GH_PR_NUMBER`, `GH_ISSUE_NUMBER`, and `GH_CUSTOM_TRACKING_ID`).
- The PR/Issue number is logged as a raw string ID (e.g., `123`) to avoid fingerprinting PII, relying on the repository context to provide global uniqueness for backend queries.
- Updated telemetry tests in `clearcut-logger.test.ts` to cover the new environment variables and metadata keys.
- Updated telemetry documentation in `docs/cli/telemetry.md`.

## Related Issues

Related to internal PM request for "Gemini CLI GitHub Action Usage Metric".

## How to Validate

1. Run the new tests: `npm test -w @google/gemini-cli-core -- src/telemetry/clearcut-logger/clearcut-logger.test.ts`
2. Verify that when `GITHUB_EVENT_NAME` and specific IDs (`GH_PR_NUMBER`, etc.) are set in the environment, they appear in the Clearcut log metadata as expected.

## Example events

  Sample 1: api_request (Automated Issue Triage)
  Triggered when the CLI sends a prompt to the model during an "Issue Opened" event.

```json
{
  "event_name": "api_request",
  "console_type": "GEMINI_CLI",
  "application": 102,
  "event_metadata": [
    [
      { "gemini_cli_key": 20,  "value": "gemini-1.5-pro" },         // API_REQUEST_MODEL
      { "gemini_cli_key": 39,  "value": "GitHub" },                 // SURFACE
      { "gemini_cli_key": 130, "value": "gemini-triage" },          // GH_WORKFLOW_NAME
      { "gemini_cli_key": 132, "value": "a1b2c3d4..." },            // GH_REPO_HASH
      { "gemini_cli_key": 176, "value": "issues" },                 // GH_EVENT_NAME
      { "gemini_cli_key": 178, "value": "42" }                      // GH_ISSUE_NUMBER (Issue #42)
    ]
  ]
}
```

  Sample 2: api_response (PR Review)
  Triggered when the model returns a response for a Pull Request review.

```json
{
  "event_name": "api_response",
  "console_type": "GEMINI_CLI",
  "application": 102,
  "event_metadata": [
    [
      { "gemini_cli_key": 21,  "value": "gemini-1.5-pro" },         // API_RESPONSE_MODEL
      { "gemini_cli_key": 25,  "value": "1240" },                   // INPUT_TOKEN_COUNT
      { "gemini_cli_key": 26,  "value": "450" },                    // OUTPUT_TOKEN_COUNT
      { "gemini_cli_key": 130, "value": "gemini-review" },          // GH_WORKFLOW_NAME
      { "gemini_cli_key": 176, "value": "pull_request" },           // GH_EVENT_NAME
      { "gemini_cli_key": 177, "value": "101" }                     // GH_PR_NUMBER (PR #101)
    ]
  ]
}
```

  Sample 3: start_session (Scheduled Triage)
  Triggered when the CLI starts up as part of a cron job (Scheduled). 

```json
{
  "event_name": "start_session",
  "console_type": "GEMINI_CLI",
  "application": 102,
  "event_metadata": [
    [
      { "gemini_cli_key": 1,   "value": "gemini-1.5-flash" },       // START_SESSION_MODEL
      { "gemini_cli_key": 130, "value": "gemini-issue-fixer" },     // GH_WORKFLOW_NAME
      { "gemini_cli_key": 176, "value": "schedule" },               // GH_EVENT_NAME
      { "gemini_cli_key": 179, "value": "101,102,103" }             // GH_CUSTOM_TRACKING_ID 
    ]
  ]
}
```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
  - [ ] Windows
  - [x] Linux
