### PR TITLE
fix(cli): fix enabling kitty codes on Windows Terminal

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -786,6 +786,8 @@ export function KeypressProvider({
   );
 
   useEffect(() => {
+    terminalCapabilityManager.enableSupportedModes();
+
     const wasRaw = stdin.isRaw;
     if (wasRaw === false) {
       setRawMode(true);

--- a/packages/cli/src/ui/utils/terminalCapabilityManager.test.ts
+++ b/packages/cli/src/ui/utils/terminalCapabilityManager.test.ts
@@ -98,6 +98,7 @@ describe('TerminalCapabilityManager', () => {
     stdin.emit('data', Buffer.from('\x1b[?62c'));
 
     await promise;
+    manager.enableSupportedModes();
     expect(manager.isKittyProtocolEnabled()).toBe(true);
   });
 
@@ -141,6 +142,8 @@ describe('TerminalCapabilityManager', () => {
     // Should resolve without waiting for timeout
     await promise;
 
+    manager.enableSupportedModes();
+
     expect(manager.isKittyProtocolEnabled()).toBe(true);
     expect(manager.getTerminalBackgroundColor()).toBe('#000000');
   });
@@ -156,6 +159,7 @@ describe('TerminalCapabilityManager', () => {
     vi.advanceTimersByTime(1000);
 
     await promise;
+    manager.enableSupportedModes();
     expect(manager.isKittyProtocolEnabled()).toBe(true);
   });
 
@@ -167,6 +171,7 @@ describe('TerminalCapabilityManager', () => {
     stdin.emit('data', Buffer.from('\x1b[?62c'));
 
     await promise;
+    manager.enableSupportedModes();
     expect(manager.isKittyProtocolEnabled()).toBe(false);
   });
 
@@ -181,6 +186,7 @@ describe('TerminalCapabilityManager', () => {
     stdin.emit('data', Buffer.from('\x1b[?62c'));
 
     await promise;
+    manager.enableSupportedModes();
     expect(manager.isKittyProtocolEnabled()).toBe(true);
   });
 
@@ -196,6 +202,8 @@ describe('TerminalCapabilityManager', () => {
 
       await promise;
 
+      manager.enableSupportedModes();
+
       expect(enableModifyOtherKeys).toHaveBeenCalled();
     });
 
@@ -209,6 +217,8 @@ describe('TerminalCapabilityManager', () => {
       stdin.emit('data', Buffer.from('\x1b[?62c'));
 
       await promise;
+
+      manager.enableSupportedModes();
 
       expect(enableModifyOtherKeys).not.toHaveBeenCalled();
     });
@@ -224,6 +234,7 @@ describe('TerminalCapabilityManager', () => {
       stdin.emit('data', Buffer.from('\x1b[?62c'));
 
       await promise;
+      manager.enableSupportedModes();
       expect(manager.isKittyProtocolEnabled()).toBe(true);
 
       expect(enableKittyKeyboardProtocol).toHaveBeenCalled();
@@ -241,6 +252,8 @@ describe('TerminalCapabilityManager', () => {
 
       await promise;
 
+      manager.enableSupportedModes();
+
       expect(manager.isKittyProtocolEnabled()).toBe(false);
       expect(enableModifyOtherKeys).toHaveBeenCalled();
     });
@@ -257,6 +270,8 @@ describe('TerminalCapabilityManager', () => {
 
       await promise;
 
+      manager.enableSupportedModes();
+
       expect(enableModifyOtherKeys).toHaveBeenCalled();
     });
 
@@ -272,6 +287,8 @@ describe('TerminalCapabilityManager', () => {
 
       await promise;
 
+      manager.enableSupportedModes();
+
       expect(manager.getTerminalBackgroundColor()).toBe('#1a1a1a');
       expect(manager.getTerminalName()).toBe('tmux');
 
@@ -286,6 +303,8 @@ describe('TerminalCapabilityManager', () => {
       stdin.emit('data', Buffer.from('\x1b[?62c'));
 
       await promise;
+
+      manager.enableSupportedModes();
 
       expect(manager.isKittyProtocolEnabled()).toBe(false);
       expect(enableModifyOtherKeys).not.toHaveBeenCalled();

--- a/packages/cli/src/ui/utils/terminalCapabilityManager.ts
+++ b/packages/cli/src/ui/utils/terminalCapabilityManager.ts
@@ -138,9 +138,6 @@ export class TerminalCapabilityManager {
           process.stdin.setRawMode(false);
         }
         this.detectionComplete = true;
-
-        this.enableSupportedModes();
-
         resolve();
       };
 
@@ -246,9 +243,11 @@ export class TerminalCapabilityManager {
   enableSupportedModes() {
     try {
       if (this.kittySupported) {
+        debugLogger.log('Enabling Kitty keyboard protocol');
         enableKittyKeyboardProtocol();
         this.kittyEnabled = true;
       } else if (this.modifyOtherKeysSupported) {
+        debugLogger.log('Enabling modifyOtherKeys');
         enableModifyOtherKeys();
       }
       // Always enable bracketed paste since it'll be ignored if unsupported.


### PR DESCRIPTION
## Summary

fix enabling kitty codes on Windows Terminal

## Details

We used to enable kitty mode _before_ starting up ink but this leads to issues in Windows Terminal. This is because enabling alternate Buffer mode seems to reset the kitty code state on Windows Terminal.

## Related Issues

Fixes #20882

## How to Validate

Run Windows Terminal Canary (version 1.25+) and verify that `shift+enter` works.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
