### PR TITLE
fix(shell): fix use of env -S for BSD OSes

### DIFF
--- a/packages/a2a-server/src/http/server.ts
+++ b/packages/a2a-server/src/http/server.ts
@@ -1,4 +1,5 @@
-#!/usr/bin/env -S node --no-warnings=DEP0040
+#!/usr/bin/env sh
+':' //; exec node --no-warnings=DEP0040 "$0" "$@"
 
 /**
  * @license

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -1,4 +1,5 @@
-#!/usr/bin/env -S node --no-warnings=DEP0040
+#!/usr/bin/env sh
+':' //; exec node --no-warnings=DEP0040 "$0" "$@"
 
 /**
  * @license


### PR DESCRIPTION
## Summary

This small change allows BSD systems to run `gemini-cli` without changing the `DEP0040` no-warning, and avoiding the use of `env -S`.

## Details

Avoid use of `env -S`. 

## Related Issues

`gemini-cli` don´t work on OpenBSD/FreeBSD using `env -S`

## How to Validate

Building packages and work on Alpine Linux and OpenBSD. 

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
