### PR TITLE
feat(cli): add /stats perf subcommand with memory and startup timing display

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -385,6 +385,9 @@ Slash commands provide meta-level control over the CLI itself.
       counts and quota information.
   - **`tools`**:
     - **Description:** Show tool-specific usage statistics.
+  - **`perf`**:
+    - **Description:** Show a performance dashboard with current memory usage,
+      startup phase timings, and runtime API/tool timing breakdown.
 
 ### `/terminal-setup`
 

--- a/packages/cli/src/ui/commands/statsCommand.ts
+++ b/packages/cli/src/ui/commands/statsCommand.ts
@@ -4,16 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import process from 'node:process';
 import type {
   HistoryItemStats,
   HistoryItemModelStats,
   HistoryItemToolStats,
+  HistoryItemPerfStats,
 } from '../types.js';
 import { MessageType } from '../types.js';
 import { formatDuration } from '../utils/formatters.js';
 import {
   UserAccountManager,
   getG1CreditBalance,
+  startupProfiler,
 } from '@google/gemini-cli-core';
 import {
   type CommandContext,
@@ -129,6 +132,26 @@ export const statsCommand: SlashCommand = {
         context.ui.addItem({
           type: MessageType.TOOL_STATS,
         } as HistoryItemToolStats);
+      },
+    },
+    {
+      name: 'perf',
+      description: 'Show memory usage and startup performance breakdown',
+      kind: CommandKind.BUILT_IN,
+      autoExecute: true,
+      action: (context: CommandContext) => {
+        const memoryUsage = process.memoryUsage();
+        const startupPhases = startupProfiler.getLastFlushResults();
+        context.ui.addItem({
+          type: MessageType.PERF_STATS,
+          memoryUsage: {
+            rss: memoryUsage.rss,
+            heapUsed: memoryUsage.heapUsed,
+            heapTotal: memoryUsage.heapTotal,
+            external: memoryUsage.external,
+          },
+          startupPhases,
+        } as HistoryItemPerfStats);
       },
     },
   ],

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -22,6 +22,7 @@ import { AboutBox } from './AboutBox.js';
 import { StatsDisplay } from './StatsDisplay.js';
 import { ModelStatsDisplay } from './ModelStatsDisplay.js';
 import { ToolStatsDisplay } from './ToolStatsDisplay.js';
+import { PerfDisplay } from './PerfDisplay.js';
 import { SessionSummaryDisplay } from './SessionSummaryDisplay.js';
 import { Help } from './Help.js';
 import type { SlashCommand } from '../commands/types.js';
@@ -169,6 +170,12 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
         />
       )}
       {itemForDisplay.type === 'tool_stats' && <ToolStatsDisplay />}
+      {itemForDisplay.type === 'perf_stats' && (
+        <PerfDisplay
+          memoryUsage={itemForDisplay.memoryUsage}
+          startupPhases={itemForDisplay.startupPhases}
+        />
+      )}
       {itemForDisplay.type === 'model' && (
         <ModelMessage model={itemForDisplay.model} />
       )}

--- a/packages/cli/src/ui/components/PerfDisplay.test.tsx
+++ b/packages/cli/src/ui/components/PerfDisplay.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render } from '../../test-utils/render.js';
+import { describe, it, expect, vi } from 'vitest';
+import { PerfDisplay } from './PerfDisplay.js';
+import * as SessionContext from '../contexts/SessionContext.js';
+import type { SessionMetrics } from '../contexts/SessionContext.js';
+import { ToolCallDecision } from '@google/gemini-cli-core';
+import type { StartupPhaseStats } from '@google/gemini-cli-core';
+
+vi.mock('../contexts/SessionContext.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof SessionContext>();
+  return {
+    ...actual,
+    useSessionStats: vi.fn(),
+  };
+});
+
+const useSessionStatsMock = vi.mocked(SessionContext.useSessionStats);
+
+const emptyMetrics: SessionMetrics = {
+  models: {},
+  tools: {
+    totalCalls: 0,
+    totalSuccess: 0,
+    totalFail: 0,
+    totalDurationMs: 0,
+    totalDecisions: {
+      accept: 0,
+      reject: 0,
+      modify: 0,
+      [ToolCallDecision.AUTO_ACCEPT]: 0,
+    },
+    byName: {},
+  },
+  files: {
+    totalLinesAdded: 0,
+    totalLinesRemoved: 0,
+  },
+};
+
+const renderWithMockedStats = async (
+  memoryUsage: {
+    rss: number;
+    heapUsed: number;
+    heapTotal: number;
+    external: number;
+  },
+  startupPhases: StartupPhaseStats[] | null,
+  metrics: SessionMetrics = emptyMetrics,
+) => {
+  useSessionStatsMock.mockReturnValue({
+    stats: {
+      sessionId: 'test-session-id',
+      sessionStartTime: new Date(),
+      metrics,
+      lastPromptTokenCount: 0,
+      promptCount: 0,
+    },
+    getPromptCount: () => 0,
+    startNewPrompt: vi.fn(),
+  });
+
+  const result = render(
+    <PerfDisplay memoryUsage={memoryUsage} startupPhases={startupPhases} />,
+  );
+  await result.waitUntilReady();
+  return result;
+};
+
+describe('<PerfDisplay />', () => {
+  const baseMemory = {
+    rss: 100 * 1024 * 1024,
+    heapUsed: 50 * 1024 * 1024,
+    heapTotal: 100 * 1024 * 1024,
+    external: 5 * 1024 * 1024,
+  };
+
+  it('should render the Performance Stats header', async () => {
+    const { lastFrame, unmount } = await renderWithMockedStats(
+      baseMemory,
+      null,
+    );
+    expect(lastFrame()).toContain('Performance Stats');
+    unmount();
+  });
+
+  it('should render memory usage section', async () => {
+    const { lastFrame, unmount } = await renderWithMockedStats(
+      baseMemory,
+      null,
+    );
+    const output = lastFrame();
+    expect(output).toContain('Memory Usage');
+    expect(output).toContain('RSS:');
+    expect(output).toContain('Heap Used:');
+    expect(output).toContain('External:');
+    unmount();
+  });
+
+  it('should display correct MB values for memory', async () => {
+    const { lastFrame, unmount } = await renderWithMockedStats(
+      baseMemory,
+      null,
+    );
+    const output = lastFrame();
+    expect(output).toContain('100.0 MB'); // RSS
+    expect(output).toContain('50.0 / 100.0 MB'); // Heap Used / Total
+    expect(output).toContain('5.0 MB'); // External
+    unmount();
+  });
+
+  it('should show "no startup data" message when startupPhases is null', async () => {
+    const { lastFrame, unmount } = await renderWithMockedStats(
+      baseMemory,
+      null,
+    );
+    expect(lastFrame()).toContain('No startup timing data available');
+    unmount();
+  });
+
+  it('should render startup phase rows when phases are provided', async () => {
+    const phases: StartupPhaseStats[] = [
+      {
+        name: 'config-load',
+        duration_ms: 42.5,
+        cpu_usage_user_usec: 1000,
+        cpu_usage_system_usec: 500,
+        start_time_usec: 0,
+        end_time_usec: 42500,
+      },
+      {
+        name: 'tool-discovery',
+        duration_ms: 100.0,
+        cpu_usage_user_usec: 2000,
+        cpu_usage_system_usec: 800,
+        start_time_usec: 42500,
+        end_time_usec: 142500,
+      },
+    ];
+
+    const { lastFrame, unmount } = await renderWithMockedStats(
+      baseMemory,
+      phases,
+    );
+    const output = lastFrame();
+    expect(output).toContain('config-load');
+    expect(output).toContain('42.5 ms');
+    expect(output).toContain('tool-discovery');
+    expect(output).toContain('100.0 ms');
+    unmount();
+  });
+
+  it('should render runtime performance section', async () => {
+    const { lastFrame, unmount } = await renderWithMockedStats(
+      baseMemory,
+      null,
+    );
+    const output = lastFrame();
+    expect(output).toContain('Runtime Performance');
+    expect(output).toContain('API Time:');
+    expect(output).toContain('Tool Time:');
+    expect(output).toContain('Cache Efficiency:');
+    unmount();
+  });
+
+  it('should display heap percentage', async () => {
+    const { lastFrame, unmount } = await renderWithMockedStats(
+      baseMemory,
+      null,
+    );
+    // heapUsed=50MB, heapTotal=100MB → 50.0%
+    expect(lastFrame()).toContain('50.0%');
+    unmount();
+  });
+
+  it('should match snapshot with no startup phases', async () => {
+    const { lastFrame, unmount } = await renderWithMockedStats(
+      baseMemory,
+      null,
+    );
+    expect(lastFrame()).toMatchSnapshot();
+    unmount();
+  });
+
+  it('should match snapshot with startup phases', async () => {
+    const phases: StartupPhaseStats[] = [
+      {
+        name: 'init',
+        duration_ms: 10.0,
+        cpu_usage_user_usec: 500,
+        cpu_usage_system_usec: 200,
+        start_time_usec: 0,
+        end_time_usec: 10000,
+      },
+    ];
+    const { lastFrame, unmount } = await renderWithMockedStats(
+      baseMemory,
+      phases,
+    );
+    expect(lastFrame()).toMatchSnapshot();
+    unmount();
+  });
+});

--- a/packages/cli/src/ui/components/PerfDisplay.test.tsx
+++ b/packages/cli/src/ui/components/PerfDisplay.test.tsx
@@ -119,7 +119,9 @@ describe('<PerfDisplay />', () => {
       baseMemory,
       null,
     );
-    expect(lastFrame()).toContain('No startup timing data available');
+    expect(lastFrame()).toContain(
+      'No startup timing data was recorded for this session.',
+    );
     unmount();
   });
 

--- a/packages/cli/src/ui/components/PerfDisplay.tsx
+++ b/packages/cli/src/ui/components/PerfDisplay.tsx
@@ -89,8 +89,7 @@ export const PerfDisplay: React.FC<PerfDisplayProps> = ({
       </Text>
       {startupPhases === null ? (
         <Text color={theme.text.secondary}>
-          No startup timing data available (run `/stats perf` earlier in the
-          session).
+          No startup timing data was recorded for this session.
         </Text>
       ) : (
         startupPhases.map((phase) => (

--- a/packages/cli/src/ui/components/PerfDisplay.tsx
+++ b/packages/cli/src/ui/components/PerfDisplay.tsx
@@ -1,0 +1,145 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box, Text } from 'ink';
+import { theme } from '../semantic-colors.js';
+import { formatDuration } from '../utils/formatters.js';
+import { getStatusColor } from '../utils/displayUtils.js';
+import { computeSessionStats } from '../utils/computeStats.js';
+import { useSessionStats } from '../contexts/SessionContext.js';
+import type { StartupPhaseStats } from '@google/gemini-cli-core';
+
+const HEAP_WARNING_THRESHOLD = 75; // % of heapTotal — yellow
+const HEAP_CRITICAL_THRESHOLD = 90; // % of heapTotal — red
+
+interface PerfDisplayProps {
+  memoryUsage: {
+    rss: number;
+    heapUsed: number;
+    heapTotal: number;
+    external: number;
+  };
+  startupPhases: StartupPhaseStats[] | null;
+}
+
+export const PerfDisplay: React.FC<PerfDisplayProps> = ({
+  memoryUsage,
+  startupPhases,
+}) => {
+  const { stats } = useSessionStats();
+  const computed = computeSessionStats(stats.metrics);
+
+  const toMB = (bytes: number) => (bytes / (1024 * 1024)).toFixed(1);
+  const heapPercent =
+    memoryUsage.heapTotal > 0
+      ? (memoryUsage.heapUsed / memoryUsage.heapTotal) * 100
+      : 0;
+  const heapColor = getStatusColor(heapPercent, {
+    green: HEAP_WARNING_THRESHOLD,
+    yellow: HEAP_CRITICAL_THRESHOLD,
+  });
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={theme.border.default}
+      flexDirection="column"
+      paddingTop={1}
+      paddingX={2}
+    >
+      <Text bold color={theme.text.accent}>
+        Performance Stats
+      </Text>
+      <Box height={1} />
+
+      {/* Memory section */}
+      <Text bold color={theme.text.primary}>
+        Memory Usage
+      </Text>
+      <Box>
+        <Box width={28}>
+          <Text color={theme.text.link}>RSS:</Text>
+        </Box>
+        <Text color={theme.text.primary}>{toMB(memoryUsage.rss)} MB</Text>
+      </Box>
+      <Box>
+        <Box width={28}>
+          <Text color={theme.text.link}>Heap Used:</Text>
+        </Box>
+        <Text color={heapColor}>
+          {toMB(memoryUsage.heapUsed)} / {toMB(memoryUsage.heapTotal)} MB (
+          {heapPercent.toFixed(1)}%)
+        </Text>
+      </Box>
+      <Box>
+        <Box width={28}>
+          <Text color={theme.text.link}>External:</Text>
+        </Box>
+        <Text color={theme.text.primary}>{toMB(memoryUsage.external)} MB</Text>
+      </Box>
+      <Box height={1} />
+
+      {/* Startup phases section */}
+      <Text bold color={theme.text.primary}>
+        Startup Phases
+      </Text>
+      {startupPhases === null ? (
+        <Text color={theme.text.secondary}>
+          No startup timing data available (run `/stats perf` earlier in the
+          session).
+        </Text>
+      ) : (
+        startupPhases.map((phase) => (
+          <Box key={phase.name}>
+            <Box width={32}>
+              <Text color={theme.text.link}>{phase.name}:</Text>
+            </Box>
+            <Text color={theme.text.primary}>
+              {phase.duration_ms.toFixed(1)} ms
+            </Text>
+          </Box>
+        ))
+      )}
+      <Box height={1} />
+
+      {/* Runtime performance section */}
+      <Text bold color={theme.text.primary}>
+        Runtime Performance
+      </Text>
+      <Box>
+        <Box width={28}>
+          <Text color={theme.text.link}>API Time:</Text>
+        </Box>
+        <Text color={theme.text.primary}>
+          {formatDuration(computed.totalApiTime)}{' '}
+          <Text color={theme.text.secondary}>
+            ({computed.apiTimePercent.toFixed(1)}%)
+          </Text>
+        </Text>
+      </Box>
+      <Box>
+        <Box width={28}>
+          <Text color={theme.text.link}>Tool Time:</Text>
+        </Box>
+        <Text color={theme.text.primary}>
+          {formatDuration(computed.totalToolTime)}{' '}
+          <Text color={theme.text.secondary}>
+            ({computed.toolTimePercent.toFixed(1)}%)
+          </Text>
+        </Text>
+      </Box>
+      <Box>
+        <Box width={28}>
+          <Text color={theme.text.link}>Cache Efficiency:</Text>
+        </Box>
+        <Text color={theme.text.primary}>
+          {computed.cacheEfficiency.toFixed(1)}%
+        </Text>
+      </Box>
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -185,6 +185,12 @@ export const useSlashCommandProcessor = (
         historyItemContent = {
           type: 'tool_stats',
         };
+      } else if (message.type === MessageType.PERF_STATS) {
+        historyItemContent = {
+          type: 'perf_stats',
+          memoryUsage: message.memoryUsage,
+          startupPhases: message.startupPhases,
+        };
       } else if (message.type === MessageType.QUIT) {
         historyItemContent = {
           type: 'quit',

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -216,6 +216,17 @@ export type HistoryItemToolStats = HistoryItemBase & {
   type: 'tool_stats';
 };
 
+export type HistoryItemPerfStats = HistoryItemBase & {
+  type: 'perf_stats';
+  memoryUsage: {
+    rss: number;
+    heapUsed: number;
+    heapTotal: number;
+    external: number;
+  };
+  startupPhases: Array<import('@google/gemini-cli-core').StartupPhaseStats> | null;
+};
+
 export type HistoryItemModel = HistoryItemBase & {
   type: 'model';
   model: string;
@@ -368,6 +379,7 @@ export type HistoryItemWithoutId =
   | HistoryItemStats
   | HistoryItemModelStats
   | HistoryItemToolStats
+  | HistoryItemPerfStats
   | HistoryItemModel
   | HistoryItemQuit
   | HistoryItemCompression
@@ -393,6 +405,7 @@ export enum MessageType {
   STATS = 'stats',
   MODEL_STATS = 'model_stats',
   TOOL_STATS = 'tool_stats',
+  PERF_STATS = 'perf_stats',
   QUIT = 'quit',
   GEMINI = 'gemini',
   COMPRESSION = 'compression',
@@ -444,6 +457,20 @@ export type Message =
   | {
       type: MessageType.TOOL_STATS;
       timestamp: Date;
+      content?: string;
+    }
+  | {
+      type: MessageType.PERF_STATS;
+      timestamp: Date;
+      memoryUsage: {
+        rss: number;
+        heapUsed: number;
+        heapTotal: number;
+        external: number;
+      };
+      startupPhases:
+        | Array<import('@google/gemini-cli-core').StartupPhaseStats>
+        | null;
       content?: string;
     }
   | {

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -52,7 +52,11 @@ export {
   logConsecaPolicyGeneration,
   logConsecaVerdict,
 } from './conseca-logger.js';
-export type { SlashCommandEvent, ChatCompressionEvent } from './types.js';
+export type {
+  SlashCommandEvent,
+  ChatCompressionEvent,
+  StartupPhaseStats,
+} from './types.js';
 export {
   SlashCommandStatus,
   EndSessionEvent,

--- a/packages/core/src/telemetry/startupProfiler.ts
+++ b/packages/core/src/telemetry/startupProfiler.ts
@@ -33,6 +33,7 @@ export interface StartupPhaseHandle {
  */
 export class StartupProfiler {
   private phases: Map<string, StartupPhase> = new Map();
+  private lastFlushResults: StartupPhaseStats[] | null = null;
   private static instance: StartupProfiler;
 
   private constructor() {}
@@ -42,6 +43,12 @@ export class StartupProfiler {
       StartupProfiler.instance = new StartupProfiler();
     }
     return StartupProfiler.instance;
+  }
+
+  /** Returns the startup phase timings from the most recent flush, or null if
+   *  flush() has not been called yet. */
+  getLastFlushResults(): StartupPhaseStats[] | null {
+    return this.lastFlushResults;
   }
 
   /**
@@ -229,6 +236,8 @@ export class StartupProfiler {
         ),
       );
     }
+
+    this.lastFlushResults = startupPhases.length > 0 ? startupPhases : null;
 
     // Clear performance marks and measures for all tracked phases.
     for (const phaseName of this.phases.keys()) {


### PR DESCRIPTION
Fixes #21142

## Summary

- Adds `/stats perf` subcommand showing a performance dashboard with three sections: **Memory Usage** (RSS, heap used/total with colour-coded thresholds at 75%/90%, external), **Startup Phases** (timing breakdown from `startupProfiler`, persisted across the flush so the data is still available later in the session), and **Runtime Performance** (API time %, tool time %, cache efficiency from the existing `computeSessionStats()` utility).
- Extends `startupProfiler` with `getLastFlushResults()` so startup timing data isn't lost after the profiler clears its internal state.
- Exports `StartupPhaseStats` type from `@google/gemini-cli-core` for use in the CLI package.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/telemetry/startupProfiler.ts` | Persist last flush results; add `getLastFlushResults()` getter |
| `packages/core/src/telemetry/index.ts` | Export `StartupPhaseStats` type |
| `packages/cli/src/ui/types.ts` | Add `PERF_STATS` MessageType and `HistoryItemPerfStats` type |
| `packages/cli/src/ui/hooks/slashCommandProcessor.ts` | Handle `PERF_STATS` in `addMessage()` |
| `packages/cli/src/ui/commands/statsCommand.ts` | Add `perf` subcommand |
| `packages/cli/src/ui/components/HistoryItemDisplay.tsx` | Render `PerfDisplay` for `perf_stats` |
| `packages/cli/src/ui/components/PerfDisplay.tsx` | New Ink component (memory, startup phases, runtime perf) |
| `packages/cli/src/ui/components/PerfDisplay.test.tsx` | Unit tests for `PerfDisplay` |
| `docs/reference/commands.md` | Document the new `perf` subcommand |

## Test plan

- [ ] `npm run preflight` passes (ESLint, Prettier, all unit tests including `PerfDisplay.test.tsx`)
- [ ] `npm start` → `/stats perf` renders the bordered box with all three sections
- [ ] Startup phases appear with correct phase names and durations
- [ ] Memory values (RSS, heap, external) are reasonable for a fresh session (typically 50–200 MB)
- [ ] Heap colour changes to yellow above 75% and red above 90%