### PR TITLE
fix(core): truncate excessively long lines in grep search output

### DIFF
--- a/packages/core/src/tools/grep-utils.ts
+++ b/packages/core/src/tools/grep-utils.ts
@@ -200,9 +200,10 @@ export async function formatGrepResults(
       const separator = match.isContext ? '-' : ':';
       // trimEnd to avoid double newlines if line has them, but we want to preserve indentation
       let lineContent = match.line.trimEnd();
-      if (lineContent.length > MAX_LINE_LENGTH_TEXT_FILE) {
+      const graphemes = Array.from(lineContent);
+      if (graphemes.length > MAX_LINE_LENGTH_TEXT_FILE) {
         lineContent =
-          lineContent.substring(0, MAX_LINE_LENGTH_TEXT_FILE) +
+          graphemes.slice(0, MAX_LINE_LENGTH_TEXT_FILE).join('') +
           '... [truncated]';
       }
       llmContent += `L${match.lineNumber}${separator} ${lineContent}\n`;

--- a/packages/core/src/tools/grep-utils.ts
+++ b/packages/core/src/tools/grep-utils.ts
@@ -6,6 +6,7 @@
 
 import fsPromises from 'node:fs/promises';
 import { debugLogger } from '../utils/debugLogger.js';
+import { MAX_LINE_LENGTH_TEXT_FILE } from '../utils/constants.js';
 
 /**
  * Result object for a single grep match
@@ -198,7 +199,13 @@ export async function formatGrepResults(
       // If isContext is undefined, assume it's a match (false)
       const separator = match.isContext ? '-' : ':';
       // trimEnd to avoid double newlines if line has them, but we want to preserve indentation
-      llmContent += `L${match.lineNumber}${separator} ${match.line.trimEnd()}\n`;
+      let lineContent = match.line.trimEnd();
+      if (lineContent.length > MAX_LINE_LENGTH_TEXT_FILE) {
+        lineContent =
+          lineContent.substring(0, MAX_LINE_LENGTH_TEXT_FILE) +
+          '... [truncated]';
+      }
+      llmContent += `L${match.lineNumber}${separator} ${lineContent}\n`;
     });
     llmContent += '---\n';
   }

--- a/packages/core/src/tools/grep.test.ts
+++ b/packages/core/src/tools/grep.test.ts
@@ -562,6 +562,22 @@ describe('GrepTool', () => {
       // Verify context after
       expect(result.llmContent).toContain('L60- Line 60');
     });
+
+    it('should truncate excessively long lines', async () => {
+      const longString = 'a'.repeat(3000);
+      await fs.writeFile(
+        path.join(tempRootDir, 'longline.txt'),
+        `Target match ${longString}`,
+      );
+
+      const params: GrepToolParams = { pattern: 'Target match' };
+      const invocation = grepTool.build(params);
+      const result = await invocation.execute(abortSignal);
+
+      // MAX_LINE_LENGTH_TEXT_FILE is 2000. It should be truncated.
+      expect(result.llmContent).toContain('... [truncated]');
+      expect(result.llmContent).not.toContain(longString);
+    });
   });
 
   describe('getDescription', () => {

--- a/packages/core/src/tools/ripGrep.test.ts
+++ b/packages/core/src/tools/ripGrep.test.ts
@@ -2028,6 +2028,32 @@ describe('RipGrepTool', () => {
       expect(result.llmContent).not.toContain('fileB.txt');
       expect(result.llmContent).toContain('Copyright 2025 Google LLC');
     });
+
+    it('should truncate excessively long lines', async () => {
+      const longString = 'a'.repeat(3000);
+      mockSpawn.mockImplementation(
+        createMockSpawn({
+          outputData:
+            JSON.stringify({
+              type: 'match',
+              data: {
+                path: { text: 'longline.txt' },
+                line_number: 1,
+                lines: { text: `Target match ${longString}\n` },
+              },
+            }) + '\n',
+          exitCode: 0,
+        }),
+      );
+
+      const params: RipGrepToolParams = { pattern: 'Target match', context: 0 };
+      const invocation = grepTool.build(params);
+      const result = await invocation.execute(abortSignal);
+
+      // MAX_LINE_LENGTH_TEXT_FILE is 2000. It should be truncated.
+      expect(result.llmContent).toContain('... [truncated]');
+      expect(result.llmContent).not.toContain(longString);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

This PR fixes a "too long message" error in the CLI by truncating excessively long lines in `grep_search` results.

## Details

When `grep_search` finds matches in files with extremely long lines (e.g., minified JS, base64 strings, or large JSON blobs), the full line content was previously returned to the LLM and the UI. This could cause the CLI to hang or crash during rendering (specifically in `wrap-ansi`) and was inefficient for context usage.

This change enforces a `MAX_LINE_LENGTH_TEXT_FILE` (2000 characters) limit on lines formatted in `grep-utils.ts`. Lines exceeding this limit are truncated and appended with `... [truncated]`.

## Related Issues

N/A (Verified via new unit test)

## How to Validate

1. Run the new unit test: `npm test -w @google/gemini-cli-core -- src/tools/grep.test.ts`
2. Specifically, the test `should truncate excessively long lines` verifies the behavior.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
