### PR TITLE
fix(core): explicitly allow codebase_investigator and cli_help in read-only mode

### DIFF
--- a/packages/core/src/policy/policies/read-only.toml
+++ b/packages/core/src/policy/policies/read-only.toml
@@ -53,11 +53,6 @@ decision = "allow"
 priority = 50
 
 [[rule]]
-toolName = "codebase_investigator"
-decision = "allow"
-priority = 50
-
-[[rule]]
-toolName = "cli_help"
+toolName = ["codebase_investigator", "cli_help"]
 decision = "allow"
 priority = 50

--- a/packages/core/src/policy/policies/read-only.toml
+++ b/packages/core/src/policy/policies/read-only.toml
@@ -51,3 +51,13 @@ priority = 50
 toolName = "google_web_search"
 decision = "allow"
 priority = 50
+
+[[rule]]
+toolName = "codebase_investigator"
+decision = "allow"
+priority = 50
+
+[[rule]]
+toolName = "cli_help"
+decision = "allow"
+priority = 50


### PR DESCRIPTION
## Summary

Explicitly allow `codebase_investigator` and `cli_help` subagents in `read-only.toml`.

## Details

Adding these tools to `plan.toml` (restricted to `plan` mode) causes `AgentRegistry` to skip its dynamic `ALLOW` rule for these local agents. This happens because `AgentRegistry` only adds dynamic rules if no static rules (TOML/Settings) exist for the tool. 

Since the rule in `plan.toml` is restricted to `modes = ["plan"]`, it does not apply in default mode, leading the policy engine to fall back to the system's `defaultDecision: PolicyDecision.ASK_USER`. 

Adding them explicitly to `read-only.toml` ensures they are correctly allowed across all modes as they are safe, read-only tools.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/21158

## How to Validate

1. Verify `packages/core/src/policy/policies/read-only.toml` contains the new rules for `codebase_investigator` and `cli_help`.
2. Run policy tests: `npm test -w @google/gemini-cli-core -- src/policy/policy-engine.test.ts src/policy/workspace-policy.test.ts src/availability/policyCatalog.test.ts`

Also manually verified in default and auto-edit that no permission is needed to run `codebase_investigator` and `cli_help` subagent

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed) - Validated with existing policy tests.
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
