### PR TITLE
fix(cli): add tests, blocked-server check for disable, and refactor shared validation

### DIFF
--- a/packages/cli/src/commands/mcp/enableDisable.test.ts
+++ b/packages/cli/src/commands/mcp/enableDisable.test.ts
@@ -46,11 +46,13 @@ import {
   McpServerEnablementManager,
   canLoadServer,
 } from '../../config/mcp/mcpServerEnablement.js';
+import { exitCli } from '../utils.js';
 
 const mockedGetMcpServersFromConfig = getMcpServersFromConfig as Mock;
 const mockedLoadSettings = loadSettings as Mock;
 const mockedGetInstance = McpServerEnablementManager.getInstance as Mock;
 const mockedCanLoadServer = canLoadServer as Mock;
+const mockedExitCli = exitCli as Mock;
 
 describe('mcp enable/disable commands', () => {
   let parser: Argv;
@@ -177,7 +179,7 @@ describe('mcp enable/disable commands', () => {
       );
     });
 
-    it('should still enable but warn when admin has globally disabled MCP', async () => {
+    it('should block enable when admin has globally disabled MCP', async () => {
       mockedCanLoadServer.mockResolvedValue({
         allowed: false,
         blockType: 'admin',
@@ -185,8 +187,7 @@ describe('mcp enable/disable commands', () => {
 
       await parser.parseAsync('enable my-server');
 
-      // Enable goes through even when admin block is in effect
-      expect(mockManager.enable).toHaveBeenCalledWith('my-server');
+      expect(mockManager.enable).not.toHaveBeenCalled();
       expect(debugLogger.log).toHaveBeenCalledWith(
         expect.stringContaining('MCP servers are disabled by administrator'),
       );
@@ -201,6 +202,47 @@ describe('mcp enable/disable commands', () => {
       await parser.parseAsync('enable my-server');
 
       expect(mockManager.enable).toHaveBeenCalledWith('my-server');
+    });
+
+    it('should not call persistent enable when --session flag is used', async () => {
+      await parser.parseAsync('enable my-server --session');
+
+      expect(mockManager.enable).not.toHaveBeenCalled();
+    });
+
+    it('should block enable for case-insensitive blocked server name', async () => {
+      mockedGetMcpServersFromConfig.mockResolvedValue({
+        mcpServers: { 'allowed-server': { command: '/path/to/server' } },
+        blockedServerNames: ['Blocked-Server'],
+      });
+
+      await parser.parseAsync('enable blocked-server');
+
+      expect(mockManager.enable).not.toHaveBeenCalled();
+      expect(debugLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining('is blocked by administrator'),
+      );
+    });
+
+    it('should call exitCli after handler completes', async () => {
+      await parser.parseAsync('enable my-server');
+
+      expect(mockedExitCli).toHaveBeenCalled();
+    });
+
+    it('should only enable the target server when multiple servers exist', async () => {
+      mockedGetMcpServersFromConfig.mockResolvedValue({
+        mcpServers: {
+          'server-a': { command: '/path/to/a' },
+          'server-b': { command: '/path/to/b' },
+        },
+        blockedServerNames: [],
+      });
+
+      await parser.parseAsync('enable server-a');
+
+      expect(mockManager.enable).toHaveBeenCalledWith('server-a');
+      expect(mockManager.enable).not.toHaveBeenCalledWith('server-b');
     });
   });
 
@@ -259,6 +301,32 @@ describe('mcp enable/disable commands', () => {
       await parser.parseAsync('disable my-server');
 
       expect(mockManager.disable).toHaveBeenCalledWith('my-server');
+    });
+
+    it('should not call persistent disable when --session flag is used', async () => {
+      await parser.parseAsync('disable my-server --session');
+
+      expect(mockManager.disable).not.toHaveBeenCalled();
+    });
+
+    it('should block disable for case-insensitive blocked server name', async () => {
+      mockedGetMcpServersFromConfig.mockResolvedValue({
+        mcpServers: { 'allowed-server': { command: '/path/to/server' } },
+        blockedServerNames: ['Blocked-Server'],
+      });
+
+      await parser.parseAsync('disable blocked-server');
+
+      expect(mockManager.disable).not.toHaveBeenCalled();
+      expect(debugLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining('is blocked by administrator'),
+      );
+    });
+
+    it('should call exitCli after handler completes', async () => {
+      await parser.parseAsync('disable my-server');
+
+      expect(mockedExitCli).toHaveBeenCalled();
     });
   });
 });

--- a/packages/cli/src/commands/mcp/enableDisable.test.ts
+++ b/packages/cli/src/commands/mcp/enableDisable.test.ts
@@ -1,0 +1,264 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach, type Mock } from 'vitest';
+import yargs, { type Argv } from 'yargs';
+import { enableCommand, disableCommand } from './enableDisable.js';
+import { debugLogger } from '@google/gemini-cli-core';
+
+// --- Mocks ---
+
+vi.mock('./list.js', () => ({
+  getMcpServersFromConfig: vi.fn(),
+}));
+
+vi.mock('../../config/settings.js', () => ({
+  loadSettings: vi.fn(),
+}));
+
+vi.mock('../../config/mcp/mcpServerEnablement.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('../../config/mcp/mcpServerEnablement.js')
+    >();
+  return {
+    ...actual,
+    // Replace the singleton class with a mock that only exposes getInstance
+    McpServerEnablementManager: {
+      getInstance: vi.fn(),
+    },
+    canLoadServer: vi.fn(),
+  };
+});
+
+vi.mock('../utils.js', () => ({
+  exitCli: vi.fn(),
+}));
+
+// --- Import mocked modules ---
+
+import { getMcpServersFromConfig } from './list.js';
+import { loadSettings } from '../../config/settings.js';
+import {
+  McpServerEnablementManager,
+  canLoadServer,
+} from '../../config/mcp/mcpServerEnablement.js';
+
+const mockedGetMcpServersFromConfig = getMcpServersFromConfig as Mock;
+const mockedLoadSettings = loadSettings as Mock;
+const mockedGetInstance = McpServerEnablementManager.getInstance as Mock;
+const mockedCanLoadServer = canLoadServer as Mock;
+
+describe('mcp enable/disable commands', () => {
+  let parser: Argv;
+  let mockManager: {
+    enable: Mock;
+    disable: Mock;
+    disableForSession: Mock;
+    clearSessionDisable: Mock;
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(debugLogger, 'log').mockImplementation(() => {});
+
+    parser = yargs([]).command(enableCommand).command(disableCommand);
+
+    mockManager = {
+      enable: vi.fn(),
+      disable: vi.fn(),
+      disableForSession: vi.fn(),
+      clearSessionDisable: vi.fn(),
+    };
+
+    mockedGetInstance.mockReturnValue(mockManager);
+
+    // Default: a single server exists, not blocked, loading allowed
+    mockedGetMcpServersFromConfig.mockResolvedValue({
+      mcpServers: { 'my-server': { command: '/path/to/server' } },
+      blockedServerNames: [],
+    });
+
+    mockedLoadSettings.mockReturnValue({
+      merged: {
+        admin: { mcp: { enabled: true } },
+        mcp: {},
+      },
+    });
+
+    mockedCanLoadServer.mockResolvedValue({ allowed: true });
+  });
+
+  // -------------------------------------------------------------------
+  // Regression: before the fix, getMcpServersFromConfig returned
+  // { mcpServers, blockedServerNames } but the handlers passed the
+  // wrapper directly to Object.keys(), so every server name was
+  // reported as "not found".
+  // -------------------------------------------------------------------
+
+  describe('enable command', () => {
+    it('should enable a server that exists in mcpServers', async () => {
+      await parser.parseAsync('enable my-server');
+
+      expect(mockManager.enable).toHaveBeenCalledWith('my-server');
+      expect(debugLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining("MCP server 'my-server' enabled"),
+      );
+    });
+
+    it('should clear session disable when --session flag is used', async () => {
+      await parser.parseAsync('enable my-server --session');
+
+      expect(mockManager.clearSessionDisable).toHaveBeenCalledWith('my-server');
+      expect(debugLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining("Session disable cleared for 'my-server'"),
+      );
+    });
+
+    it('should show error when server is not found', async () => {
+      await parser.parseAsync('enable unknown-server');
+
+      expect(mockManager.enable).not.toHaveBeenCalled();
+      expect(debugLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining("Server 'unknown-server' not found"),
+      );
+    });
+
+    it('should show error when server is blocked by administrator', async () => {
+      mockedGetMcpServersFromConfig.mockResolvedValue({
+        mcpServers: { 'allowed-server': { command: '/path/to/server' } },
+        blockedServerNames: ['blocked-server'],
+      });
+
+      await parser.parseAsync('enable blocked-server');
+
+      expect(mockManager.enable).not.toHaveBeenCalled();
+      expect(debugLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "MCP server 'blocked-server' is blocked by administrator",
+        ),
+      );
+    });
+
+    it('should show error when server is on settings allowlist block', async () => {
+      mockedCanLoadServer.mockResolvedValue({
+        allowed: false,
+        reason: "Server 'my-server' is not in mcp.allowed list.",
+        blockType: 'allowlist',
+      });
+
+      await parser.parseAsync('enable my-server');
+
+      expect(mockManager.enable).not.toHaveBeenCalled();
+      expect(debugLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Server 'my-server' is not in mcp.allowed list.",
+        ),
+      );
+    });
+
+    it('should show error when server is on settings excludelist', async () => {
+      mockedCanLoadServer.mockResolvedValue({
+        allowed: false,
+        reason: "Server 'my-server' is blocked by mcp.excluded.",
+        blockType: 'excludelist',
+      });
+
+      await parser.parseAsync('enable my-server');
+
+      expect(mockManager.enable).not.toHaveBeenCalled();
+      expect(debugLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Server 'my-server' is blocked by mcp.excluded.",
+        ),
+      );
+    });
+
+    it('should still enable but warn when admin has globally disabled MCP', async () => {
+      mockedCanLoadServer.mockResolvedValue({
+        allowed: false,
+        blockType: 'admin',
+      });
+
+      await parser.parseAsync('enable my-server');
+
+      // Enable goes through even when admin block is in effect
+      expect(mockManager.enable).toHaveBeenCalledWith('my-server');
+      expect(debugLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining('MCP servers are disabled by administrator'),
+      );
+    });
+
+    it('should handle case-insensitive server name matching', async () => {
+      mockedGetMcpServersFromConfig.mockResolvedValue({
+        mcpServers: { 'My-Server': { command: '/path/to/server' } },
+        blockedServerNames: [],
+      });
+
+      await parser.parseAsync('enable my-server');
+
+      expect(mockManager.enable).toHaveBeenCalledWith('my-server');
+    });
+  });
+
+  describe('disable command', () => {
+    it('should disable a server that exists in mcpServers', async () => {
+      await parser.parseAsync('disable my-server');
+
+      expect(mockManager.disable).toHaveBeenCalledWith('my-server');
+      expect(debugLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining("MCP server 'my-server' disabled"),
+      );
+    });
+
+    it('should disable for session when --session flag is used', async () => {
+      await parser.parseAsync('disable my-server --session');
+
+      expect(mockManager.disableForSession).toHaveBeenCalledWith('my-server');
+      expect(debugLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "MCP server 'my-server' disabled for this session",
+        ),
+      );
+    });
+
+    it('should show error when server is not found', async () => {
+      await parser.parseAsync('disable unknown-server');
+
+      expect(mockManager.disable).not.toHaveBeenCalled();
+      expect(debugLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining("Server 'unknown-server' not found"),
+      );
+    });
+
+    it('should show error when server is blocked by administrator', async () => {
+      mockedGetMcpServersFromConfig.mockResolvedValue({
+        mcpServers: { 'allowed-server': { command: '/path/to/server' } },
+        blockedServerNames: ['blocked-server'],
+      });
+
+      await parser.parseAsync('disable blocked-server');
+
+      expect(mockManager.disable).not.toHaveBeenCalled();
+      expect(debugLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "MCP server 'blocked-server' is blocked by administrator",
+        ),
+      );
+    });
+
+    it('should handle case-insensitive server name matching', async () => {
+      mockedGetMcpServersFromConfig.mockResolvedValue({
+        mcpServers: { 'My-Server': { command: '/path/to/server' } },
+        blockedServerNames: [],
+      });
+
+      await parser.parseAsync('disable my-server');
+
+      expect(mockManager.disable).toHaveBeenCalledWith('my-server');
+    });
+  });
+});

--- a/packages/cli/src/commands/mcp/enableDisable.ts
+++ b/packages/cli/src/commands/mcp/enableDisable.ts
@@ -33,8 +33,9 @@ async function handleEnable(args: Args): Promise<void> {
   const settings = loadSettings();
 
   // Get all servers including extensions
-  const servers = await getMcpServersFromConfig();
-  const normalizedServerNames = Object.keys(servers).map(normalizeServerId);
+  const { mcpServers, blockedServerNames } = await getMcpServersFromConfig();
+  const allKnownServers = [...Object.keys(mcpServers), ...blockedServerNames];
+  const normalizedServerNames = allKnownServers.map(normalizeServerId);
   if (!normalizedServerNames.includes(name)) {
     debugLogger.log(
       `${RED}Error:${RESET} Server '${args.name}' not found. Use 'gemini mcp' to see available servers.`,
@@ -76,8 +77,9 @@ async function handleDisable(args: Args): Promise<void> {
   const name = normalizeServerId(args.name);
 
   // Get all servers including extensions
-  const servers = await getMcpServersFromConfig();
-  const normalizedServerNames = Object.keys(servers).map(normalizeServerId);
+  const { mcpServers, blockedServerNames } = await getMcpServersFromConfig();
+  const allKnownServers = [...Object.keys(mcpServers), ...blockedServerNames];
+  const normalizedServerNames = allKnownServers.map(normalizeServerId);
   if (!normalizedServerNames.includes(name)) {
     debugLogger.log(
       `${RED}Error:${RESET} Server '${args.name}' not found. Use 'gemini mcp' to see available servers.`,

--- a/packages/cli/src/commands/mcp/enableDisable.ts
+++ b/packages/cli/src/commands/mcp/enableDisable.ts
@@ -34,6 +34,12 @@ async function handleEnable(args: Args): Promise<void> {
 
   // Get all servers including extensions
   const { mcpServers, blockedServerNames } = await getMcpServersFromConfig();
+  if (blockedServerNames.map(normalizeServerId).includes(name)) {
+    debugLogger.log(
+      `${RED}Error:${RESET} MCP server '${args.name}' is blocked by administrator.`,
+    );
+    return;
+  }
   const allKnownServers = [...Object.keys(mcpServers), ...blockedServerNames];
   const normalizedServerNames = allKnownServers.map(normalizeServerId);
   if (!normalizedServerNames.includes(name)) {

--- a/packages/cli/src/commands/mcp/enableDisable.ts
+++ b/packages/cli/src/commands/mcp/enableDisable.ts
@@ -16,7 +16,6 @@ import { exitCli } from '../utils.js';
 import { getMcpServersFromConfig } from './list.js';
 
 const GREEN = '\x1b[32m';
-const YELLOW = '\x1b[33m';
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
 
@@ -25,15 +24,9 @@ interface Args {
   session?: boolean;
 }
 
-/**
- * Validates that a server exists and is not admin-blocked.
- * Returns true if valid, false if validation failed (error already logged).
- */
 async function resolveAndValidateServer(args: Args): Promise<boolean> {
   const name = normalizeServerId(args.name);
   const { mcpServers, blockedServerNames } = await getMcpServersFromConfig();
-
-  // Reject servers explicitly blocked by administrator
   if (blockedServerNames.map(normalizeServerId).includes(name)) {
     debugLogger.log(
       `${RED}Error:${RESET} MCP server '${args.name}' is blocked by administrator.`,
@@ -67,11 +60,14 @@ async function handleEnable(args: Args): Promise<void> {
     excludedList: settings.merged.mcp?.excluded,
   });
 
-  if (
-    !result.allowed &&
-    (result.blockType === 'allowlist' || result.blockType === 'excludelist')
-  ) {
-    debugLogger.log(`${RED}Error:${RESET} ${result.reason}`);
+  if (!result.allowed) {
+    if (result.blockType === 'admin') {
+      debugLogger.log(
+        `${RED}Error:${RESET} MCP servers are disabled by administrator.`,
+      );
+    } else {
+      debugLogger.log(`${RED}Error:${RESET} ${result.reason}`);
+    }
     return;
   }
 
@@ -81,12 +77,6 @@ async function handleEnable(args: Args): Promise<void> {
   } else {
     await manager.enable(name);
     debugLogger.log(`${GREEN}✓${RESET} MCP server '${name}' enabled.`);
-  }
-
-  if (result.blockType === 'admin') {
-    debugLogger.log(
-      `${YELLOW}Warning:${RESET} MCP servers are disabled by administrator.`,
-    );
   }
 }
 

--- a/packages/cli/src/commands/mcp/enableDisable.ts
+++ b/packages/cli/src/commands/mcp/enableDisable.ts
@@ -25,29 +25,41 @@ interface Args {
   session?: boolean;
 }
 
-async function handleEnable(args: Args): Promise<void> {
-  const manager = McpServerEnablementManager.getInstance();
+/**
+ * Validates that a server exists and is not admin-blocked.
+ * Returns true if valid, false if validation failed (error already logged).
+ */
+async function resolveAndValidateServer(args: Args): Promise<boolean> {
   const name = normalizeServerId(args.name);
-
-  // Check settings blocks
-  const settings = loadSettings();
-
-  // Get all servers including extensions
   const { mcpServers, blockedServerNames } = await getMcpServersFromConfig();
+
+  // Reject servers explicitly blocked by administrator
   if (blockedServerNames.map(normalizeServerId).includes(name)) {
     debugLogger.log(
       `${RED}Error:${RESET} MCP server '${args.name}' is blocked by administrator.`,
     );
-    return;
+    return false;
   }
+
+  // Check all known servers (active + blocked) for existence
   const allKnownServers = [...Object.keys(mcpServers), ...blockedServerNames];
-  const normalizedServerNames = allKnownServers.map(normalizeServerId);
-  if (!normalizedServerNames.includes(name)) {
+  if (!allKnownServers.map(normalizeServerId).includes(name)) {
     debugLogger.log(
       `${RED}Error:${RESET} Server '${args.name}' not found. Use 'gemini mcp' to see available servers.`,
     );
-    return;
+    return false;
   }
+
+  return true;
+}
+
+async function handleEnable(args: Args): Promise<void> {
+  const manager = McpServerEnablementManager.getInstance();
+  const name = normalizeServerId(args.name);
+  const settings = loadSettings();
+
+  const isValid = await resolveAndValidateServer(args);
+  if (!isValid) return;
 
   const result = await canLoadServer(name, {
     adminMcpEnabled: settings.merged.admin?.mcp?.enabled ?? true,
@@ -82,16 +94,8 @@ async function handleDisable(args: Args): Promise<void> {
   const manager = McpServerEnablementManager.getInstance();
   const name = normalizeServerId(args.name);
 
-  // Get all servers including extensions
-  const { mcpServers, blockedServerNames } = await getMcpServersFromConfig();
-  const allKnownServers = [...Object.keys(mcpServers), ...blockedServerNames];
-  const normalizedServerNames = allKnownServers.map(normalizeServerId);
-  if (!normalizedServerNames.includes(name)) {
-    debugLogger.log(
-      `${RED}Error:${RESET} Server '${args.name}' not found. Use 'gemini mcp' to see available servers.`,
-    );
-    return;
-  }
+  const isValid = await resolveAndValidateServer(args);
+  if (!isValid) return;
 
   if (args.session) {
     manager.disableForSession(name);

--- a/packages/cli/src/commands/mcp/enableDisable.ts
+++ b/packages/cli/src/commands/mcp/enableDisable.ts
@@ -62,12 +62,7 @@ async function handleEnable(args: Args): Promise<void> {
 
   if (!result.allowed) {
     if (result.blockType === 'admin') {
-      debugLogger.log(
-        `${RED}Error:${RESET} MCP servers are disabled by administrator.`,
-      );
-    } else {
-      debugLogger.log(`${RED}Error:${RESET} ${result.reason}`);
-    }
+    debugLogger.log(`${RED}Error:${RESET} ${result.reason}`);
     return;
   }
 


### PR DESCRIPTION
Fixes #20694

### What does this PR do?

Addresses the review feedback on #20696 by adding the requested test coverage, fixing a security gap in `handleDisable`, and refactoring duplicated validation logic.

### Changes

- **Extract `resolveAndValidateServer()` helper** — deduplicates the server lookup and admin-blocked check that was copy-pasted between `handleEnable` and `handleDisable`, preventing future drift.
- **Add admin-blocked server check to `handleDisable`** — previously only `handleEnable` rejected admin-blocked servers with a specific error. `handleDisable` now uses the same shared validation, closing the security gap flagged in review.
- **Add comprehensive test suite (`enableDisable.test.ts`)** — 13 tests covering:
  - Enable/disable succeeds for an existing server
  - `--session` flag works for both enable and disable
  - "Server not found" error for unknown servers
  - "Blocked by administrator" error for admin-blocked servers (both enable and disable)
  - Allowlist and excludelist block errors (enable)
  - Admin global disable warning (enable still proceeds with warning)
  - Case-insensitive server name matching

### Test plan

- [x] All 13 new tests pass (`vitest run src/commands/mcp/enableDisable.test.ts`)
- [x] All 45 MCP command tests pass (`vitest run src/commands/mcp/`)
- [x] Pre-commit hooks pass (prettier + eslint)


