### PR TITLE
feat(acp): extract and stream plan events from agent thoughts

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -444,9 +444,6 @@ their corresponding top-level category object in your `settings.json` file.
         "extends": "base",
         "modelConfig": {
           "generateContentConfig": {
-            "thinkingConfig": {
-              "includeThoughts": true
-            },
             "temperature": 1,
             "topP": 0.95,
             "topK": 64
@@ -458,6 +455,7 @@ their corresponding top-level category object in your `settings.json` file.
         "modelConfig": {
           "generateContentConfig": {
             "thinkingConfig": {
+              "includeThoughts": true,
               "thinkingBudget": 8192
             }
           }
@@ -468,6 +466,31 @@ their corresponding top-level category object in your `settings.json` file.
         "modelConfig": {
           "generateContentConfig": {
             "thinkingConfig": {
+              "includeThoughts": true,
+              "thinkingLevel": "HIGH"
+            }
+          }
+        }
+      },
+      "gemini-3.1-pro-preview": {
+        "extends": "chat-base-3",
+        "modelConfig": {
+          "model": "gemini-3.1-pro-preview",
+          "generateContentConfig": {
+            "thinkingConfig": {
+              "includeThoughts": true,
+              "thinkingLevel": "HIGH"
+            }
+          }
+        }
+      },
+      "gemini-3.1-pro-preview-customtools": {
+        "extends": "chat-base-3",
+        "modelConfig": {
+          "model": "gemini-3.1-pro-preview-customtools",
+          "generateContentConfig": {
+            "thinkingConfig": {
+              "includeThoughts": true,
               "thinkingLevel": "HIGH"
             }
           }
@@ -476,13 +499,37 @@ their corresponding top-level category object in your `settings.json` file.
       "gemini-3-pro-preview": {
         "extends": "chat-base-3",
         "modelConfig": {
-          "model": "gemini-3-pro-preview"
+          "model": "gemini-3-pro-preview",
+          "generateContentConfig": {
+            "thinkingConfig": {
+              "includeThoughts": true,
+              "thinkingLevel": "HIGH"
+            }
+          }
         }
       },
       "gemini-3-flash-preview": {
         "extends": "chat-base-3",
         "modelConfig": {
-          "model": "gemini-3-flash-preview"
+          "model": "gemini-3-flash-preview",
+          "generateContentConfig": {
+            "thinkingConfig": {
+              "includeThoughts": true,
+              "thinkingLevel": "HIGH"
+            }
+          }
+        }
+      },
+      "gemini-3.1-flash-lite-preview": {
+        "extends": "chat-base-3",
+        "modelConfig": {
+          "model": "gemini-3.1-flash-lite-preview",
+          "generateContentConfig": {
+            "thinkingConfig": {
+              "includeThoughts": true,
+              "thinkingLevel": "HIGH"
+            }
+          }
         }
       },
       "gemini-2.5-pro": {
@@ -512,7 +559,13 @@ their corresponding top-level category object in your `settings.json` file.
       "gemini-3-flash-base": {
         "extends": "base",
         "modelConfig": {
-          "model": "gemini-3-flash-preview"
+          "model": "gemini-3-flash-preview",
+          "generateContentConfig": {
+            "thinkingConfig": {
+              "includeThoughts": true,
+              "thinkingLevel": "HIGH"
+            }
+          }
         }
       },
       "classifier": {

--- a/packages/cli/src/acp/acpClient.test.ts
+++ b/packages/cli/src/acp/acpClient.test.ts
@@ -91,52 +91,44 @@ vi.mock('../ui/commands/initCommand.js', () => ({
     action: vi.fn(),
   },
 }));
-vi.mock(
-  '@google/gemini-cli-core',
-  async (
-    importOriginal: () => Promise<typeof import('@google/gemini-cli-core')>,
-  ) => {
-    const actual = await importOriginal();
-    return {
-      ...actual,
-      ReadManyFilesTool: vi.fn().mockImplementation(() => ({
-        name: 'read_many_files',
-        kind: 'read',
-        build: vi.fn().mockReturnValue({
-          getDescription: () => 'Read files',
-          toolLocations: () => [],
-          execute: vi.fn().mockResolvedValue({
-            llmContent: ['--- file.txt ---\n\nFile content\n\n'],
-          }),
-        }),
-      })),
-      logToolCall: vi.fn(),
-      isWithinRoot: vi.fn().mockReturnValue(true),
-      LlmRole: {
-        MAIN: 'main',
-        SUBAGENT: 'subagent',
-        UTILITY_TOOL: 'utility_tool',
-        UTILITY_COMPRESSOR: 'utility_compressor',
-        UTILITY_SUMMARIZER: 'utility_summarizer',
-        UTILITY_ROUTER: 'utility_router',
-        UTILITY_LOOP_DETECTOR: 'utility_loop_detector',
-        UTILITY_NEXT_SPEAKER: 'utility_next_speaker',
-        UTILITY_EDIT_CORRECTOR: 'utility_edit_corrector',
-        UTILITY_AUTOCOMPLETE: 'utility_autocomplete',
-        UTILITY_FAST_ACK_HELPER: 'utility_fast_ack_helper',
-      },
-      CoreToolCallStatus: {
-        Validating: 'validating',
-        Scheduled: 'scheduled',
-        Error: 'error',
-        Success: 'success',
-        Executing: 'executing',
-        Cancelled: 'cancelled',
-        AwaitingApproval: 'awaiting_approval',
-      },
-    };
+const { actualCore } = await vi.hoisted(async () => {
+  const actual = await import('@google/gemini-cli-core');
+  return { actualCore: actual };
+});
+
+vi.mock('@google/gemini-cli-core', () => ({
+  ...actualCore,
+  ReadManyFilesTool: vi.fn().mockImplementation(() => ({
+    name: 'read_many_files',
+    kind: 'read',
+    build: vi.fn().mockReturnValue({
+      getDescription: () => 'Read files',
+      toolLocations: () => [],
+      execute: vi.fn().mockResolvedValue({
+        llmContent: ['--- file.txt ---\n\nFile content\n\n'],
+      }),
+    }),
+  })),
+  logToolCall: vi.fn(),
+  isWithinRoot: vi.fn().mockReturnValue(true),
+  // Ensure critical enums/objects are present if they were overridden
+  LlmRole: {
+    ...actualCore.LlmRole,
+    MAIN: 'main',
+    SUBAGENT: 'subagent',
+    UTILITY_TOOL: 'utility_tool',
   },
-);
+  CoreToolCallStatus: {
+    ...actualCore.CoreToolCallStatus,
+    Validating: 'validating',
+    Scheduled: 'scheduled',
+    Error: 'error',
+    Success: 'success',
+    Executing: 'executing',
+    Cancelled: 'cancelled',
+    AwaitingApproval: 'awaiting_approval',
+  },
+}));
 
 // Helper to create mock streams
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1587,5 +1579,44 @@ describe('Session', () => {
     });
 
     expect(handleCommandSpy).toHaveBeenCalledWith('/memory', expect.anything());
+  });
+
+  it('should extract and emit plan events from thought chunks', async () => {
+    const stream = createMockStream([
+      {
+        type: StreamEventType.CHUNK,
+        value: {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    thought: '- [TODO] First task\n- [x] Done task',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    mockChat.sendMessageStream.mockResolvedValue(stream);
+
+    await session.prompt({
+      sessionId: 'session-1',
+      prompt: [{ type: 'text', text: 'Hi' }],
+    });
+
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: 'plan',
+          entries: [
+            { content: 'First task', status: 'pending', priority: 'medium' },
+            { content: 'Done task', status: 'completed', priority: 'medium' },
+          ],
+        }),
+      }),
+    );
   });
 });

--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -49,6 +49,8 @@ import {
   getDisplayString,
 } from '@google/gemini-cli-core';
 import * as acp from '@agentclientprotocol/sdk';
+import { z } from 'zod';
+import { extractPlanEntries } from './planParser.js';
 import { AcpFileSystemService } from './fileSystemService.js';
 import { getAcpErrorMessage } from './acpErrors.js';
 import { Readable, Writable } from 'node:stream';
@@ -64,7 +66,6 @@ import {
 } from '../config/settings.js';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { z } from 'zod';
 
 import { randomUUID } from 'node:crypto';
 import { loadCliConfig, type CliArgs } from '../config/config.js';
@@ -716,13 +717,16 @@ export class Session {
           (await this.config.getGemini31Launched?.()) ?? false,
         );
         const responseStream = await chat.sendMessageStream(
-          { model },
+          { model, isChatModel: true },
           nextMessage?.parts ?? [],
           promptId,
           pendingSend.signal,
           LlmRole.MAIN,
         );
         nextMessage = null;
+
+        let currentThoughtTextBuffer = '';
+        let currentTurnPlanStr = '';
 
         for await (const resp of responseStream) {
           if (pendingSend.signal.aborted) {
@@ -736,13 +740,52 @@ export class Session {
           ) {
             const candidate = resp.value.candidates[0];
             for (const part of candidate.content?.parts ?? []) {
-              if (!part.text) {
+              const thoughtValue = (part as { thought?: unknown }).thought;
+              debugLogger.log(
+                `[ACP] Received part: thought=${
+                  thoughtValue ? typeof thoughtValue : 'undefined'
+                }, text=${part.text ? 'present' : 'empty'}`,
+              );
+              if (typeof thoughtValue === 'string') {
+                debugLogger.log(
+                  `[ACP] Thought content: ${thoughtValue.substring(0, 50)}...`,
+                );
+              }
+
+              if (part.thought) {
+                const thoughtSubText =
+                  typeof part.thought === 'string'
+                    ? part.thought
+                    : (part.text ?? '');
+                currentThoughtTextBuffer += thoughtSubText;
+                const entries = extractPlanEntries(currentThoughtTextBuffer);
+                if (entries) {
+                  const newPlanStr = JSON.stringify(entries);
+                  if (newPlanStr !== currentTurnPlanStr) {
+                    currentTurnPlanStr = newPlanStr;
+                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                    this.sendUpdate({
+                      sessionUpdate: 'plan',
+                      entries,
+                    });
+                  }
+                }
+              }
+
+              const textToStream =
+                typeof part.thought === 'string'
+                  ? part.thought
+                  : (part.text ?? '');
+
+              if (!textToStream) {
                 continue;
               }
 
               const content: acp.ContentBlock = {
                 type: 'text',
-                text: part.text,
+                text: part.thought
+                  ? textToStream.replace(/\\n/g, '\n')
+                  : textToStream,
               };
 
               // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/packages/cli/src/acp/planParser.test.ts
+++ b/packages/cli/src/acp/planParser.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractPlanEntries } from './planParser.js';
+
+describe('planParser', () => {
+  it('should extract simple tasks', () => {
+    const text = `
+- [ ] Task 1
+- [x] Task 2
+- [/] Task 3
+    `;
+    const entries = extractPlanEntries(text);
+    expect(entries).toEqual([
+      { content: 'Task 1', status: 'pending', priority: 'medium' },
+      { content: 'Task 2', status: 'completed', priority: 'medium' },
+      { content: 'Task 3', status: 'in_progress', priority: 'medium' },
+    ]);
+  });
+
+  it('should ignore tasks in code blocks', () => {
+    const text = `
+- [ ] Valid task
+\`\`\`
+- [ ] Ignored task
+\`\`\`
+    `;
+    const entries = extractPlanEntries(text);
+    expect(entries).toEqual([
+      { content: 'Valid task', status: 'pending', priority: 'medium' },
+    ]);
+  });
+
+  it('should handle alternative status labels', () => {
+    const text = `
+1. [TODO] Task 1
+2. [DONE] Task 2
+3. [IN_PROGRESS] Task 3
+    `;
+    const entries = extractPlanEntries(text);
+    expect(entries).toEqual([
+      { content: 'Task 1', status: 'pending', priority: 'medium' },
+      { content: 'Task 2', status: 'completed', priority: 'medium' },
+      { content: 'Task 3', status: 'in_progress', priority: 'medium' },
+    ]);
+  });
+
+  it('should return null if no tasks are found', () => {
+    const text = 'Just some text without tasks.';
+    expect(extractPlanEntries(text)).toBeNull();
+  });
+});

--- a/packages/cli/src/acp/planParser.ts
+++ b/packages/cli/src/acp/planParser.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type PlanEntry } from '@agentclientprotocol/sdk';
+
+/**
+ * Extracts plan entries from the provided markdown text.
+ * It ignores content within triple-backtick code blocks.
+ */
+export function extractPlanEntries(text: string): PlanEntry[] | null {
+  // 1. Strip triple-backtick code blocks to avoid false positives.
+  const textWithoutCodeBlocks = text.replace(/```[\s\S]*?(?:```|$)/g, '');
+
+  // 2. Match markdown list items with task indicators.
+  // Supports: - [ ], - [x], - [/], 1. [TODO], 2. [DONE], - [] etc.
+  const taskRegex =
+    /^\s*(?:[-*]|\d+\.)\s*\[\s*(x|X|\/| |DONE|TODO|IN_PROGRESS|IN PROGRESS|PENDING|COMPLETED)?\s*\]\s+(.*?)$/gm;
+
+  const entries: PlanEntry[] = [];
+  let match;
+
+  while ((match = taskRegex.exec(textWithoutCodeBlocks)) !== null) {
+    const rawStatus = (match[1] || '').toUpperCase().trim();
+    const content = match[2].trim();
+
+    if (!content) continue;
+
+    let status: 'pending' | 'in_progress' | 'completed' = 'pending';
+
+    switch (rawStatus) {
+      case 'X':
+      case 'DONE':
+      case 'COMPLETED':
+        status = 'completed';
+        break;
+      case '/':
+      case 'IN_PROGRESS':
+      case 'IN PROGRESS':
+        status = 'in_progress';
+        break;
+      case '':
+      case 'TODO':
+      case 'PENDING':
+      default:
+        status = 'pending';
+        break;
+    }
+
+    entries.push({ content, status, priority: 'medium' });
+  }
+
+  return entries.length > 0 ? entries : null;
+}

--- a/packages/cli/src/ui/components/__snapshots__/ConfigInitDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ConfigInitDisplay.test.tsx.snap
@@ -18,19 +18,7 @@ Spinner Connecting to MCP servers... (0/5) - Waiting for: s1, s2, s3, +2 more
 "
 `;
 
-exports[`ConfigInitDisplay > truncates list of waiting servers if too many 2`] = `
-"
-Spinner Connecting to MCP servers... (0/5) - Waiting for: s1, s2, s3, +2 more
-"
-`;
-
 exports[`ConfigInitDisplay > updates message on McpClientUpdate event 1`] = `
-"
-Spinner Connecting to MCP servers... (1/2) - Waiting for: server2
-"
-`;
-
-exports[`ConfigInitDisplay > updates message on McpClientUpdate event 2`] = `
 "
 Spinner Connecting to MCP servers... (1/2) - Waiting for: server2
 "

--- a/packages/core/src/code_assist/converter.test.ts
+++ b/packages/core/src/code_assist/converter.test.ts
@@ -221,6 +221,15 @@ describe('converter', () => {
         frequencyPenalty: 0.8,
         seed: 9,
         responseMimeType: 'application/json',
+        responseSchema: undefined,
+        responseJsonSchema: undefined,
+        routingConfig: undefined,
+        modelSelectionConfig: undefined,
+        responseModalities: undefined,
+        mediaResolution: undefined,
+        speechConfig: undefined,
+        audioTimestamp: undefined,
+        thinkingConfig: undefined,
       });
     });
   });

--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -164,6 +164,7 @@ function toVertexGenerateContentRequest(
   req: GenerateContentParameters,
   sessionId?: string,
 ): VertexGenerateContentRequest {
+  const generationConfig = toVertexGenerationConfig(req.config);
   return {
     contents: toContents(req.contents),
     systemInstruction: maybeToContent(req.config?.systemInstruction),
@@ -172,7 +173,7 @@ function toVertexGenerateContentRequest(
     toolConfig: req.config?.toolConfig,
     labels: req.config?.labels,
     safetySettings: req.config?.safetySettings,
-    generationConfig: toVertexGenerationConfig(req.config),
+    generationConfig,
     session_id: sessionId,
   };
 }
@@ -247,8 +248,9 @@ function toPart(part: PartUnion): Part {
   // Handle thought parts for CountToken API compatibility
   // The CountToken API expects parts to have certain required "oneof" fields initialized,
   // but thought parts don't conform to this schema and cause API failures
-  if ('thought' in part && part.thought) {
-    const thoughtText = `[Thought: ${part.thought}]`;
+  const thoughtValue = (part as { thought?: unknown }).thought;
+  if ('thought' in part && thoughtValue) {
+    const thoughtText = `[Thought: ${String(thoughtValue)}]`;
 
     const newPart = { ...part };
     delete (newPart as Record<string, unknown>)['thought'];
@@ -287,6 +289,7 @@ function toVertexGenerationConfig(
   if (!config) {
     return undefined;
   }
+
   return {
     temperature: config.temperature,
     topP: config.topP,

--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -25,9 +25,6 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
       extends: 'base',
       modelConfig: {
         generateContentConfig: {
-          thinkingConfig: {
-            includeThoughts: true,
-          },
           temperature: 1,
           topP: 0.95,
           topK: 64,
@@ -39,6 +36,7 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
       modelConfig: {
         generateContentConfig: {
           thinkingConfig: {
+            includeThoughts: true,
             thinkingBudget: DEFAULT_THINKING_MODE,
           },
         },
@@ -49,6 +47,7 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
       modelConfig: {
         generateContentConfig: {
           thinkingConfig: {
+            includeThoughts: true,
             thinkingLevel: ThinkingLevel.HIGH,
           },
         },
@@ -59,16 +58,64 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
     // ensure these model configs can be used interactively.
     // TODO(joshualitt): Introduce internal base configs for the various models,
     // note: we will have to think carefully about names.
+    'gemini-3.1-pro-preview': {
+      extends: 'chat-base-3',
+      modelConfig: {
+        model: 'gemini-3.1-pro-preview',
+        generateContentConfig: {
+          thinkingConfig: {
+            includeThoughts: true,
+            thinkingLevel: ThinkingLevel.HIGH,
+          },
+        },
+      },
+    },
+    'gemini-3.1-pro-preview-customtools': {
+      extends: 'chat-base-3',
+      modelConfig: {
+        model: 'gemini-3.1-pro-preview-customtools',
+        generateContentConfig: {
+          thinkingConfig: {
+            includeThoughts: true,
+            thinkingLevel: ThinkingLevel.HIGH,
+          },
+        },
+      },
+    },
     'gemini-3-pro-preview': {
       extends: 'chat-base-3',
       modelConfig: {
         model: 'gemini-3-pro-preview',
+        generateContentConfig: {
+          thinkingConfig: {
+            includeThoughts: true,
+            thinkingLevel: ThinkingLevel.HIGH,
+          },
+        },
       },
     },
     'gemini-3-flash-preview': {
       extends: 'chat-base-3',
       modelConfig: {
         model: 'gemini-3-flash-preview',
+        generateContentConfig: {
+          thinkingConfig: {
+            includeThoughts: true,
+            thinkingLevel: ThinkingLevel.HIGH,
+          },
+        },
+      },
+    },
+    'gemini-3.1-flash-lite-preview': {
+      extends: 'chat-base-3',
+      modelConfig: {
+        model: 'gemini-3.1-flash-lite-preview',
+        generateContentConfig: {
+          thinkingConfig: {
+            includeThoughts: true,
+            thinkingLevel: ThinkingLevel.HIGH,
+          },
+        },
       },
     },
     'gemini-2.5-pro': {
@@ -100,6 +147,12 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
       extends: 'base',
       modelConfig: {
         model: 'gemini-3-flash-preview',
+        generateContentConfig: {
+          thinkingConfig: {
+            includeThoughts: true,
+            thinkingLevel: ThinkingLevel.HIGH,
+          },
+        },
       },
     },
     classifier: {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -1039,9 +1039,13 @@ export class GeminiChat {
     }
 
     const thoughtPart = content.parts[0];
-    if (thoughtPart.text) {
+    const rawText =
+      typeof thoughtPart.thought === 'string'
+        ? thoughtPart.thought
+        : thoughtPart.text;
+
+    if (rawText) {
       // Extract subject and description using the same logic as turn.ts
-      const rawText = thoughtPart.text;
       const subjectStringMatches = rawText.match(/\*\*(.*?)\*\*/s);
       const subject = subjectStringMatches
         ? subjectStringMatches[1].trim()

--- a/packages/core/src/services/test-data/resolved-aliases-retry.golden.json
+++ b/packages/core/src/services/test-data/resolved-aliases-retry.golden.json
@@ -9,9 +9,6 @@
     "generateContentConfig": {
       "temperature": 1,
       "topP": 0.95,
-      "thinkingConfig": {
-        "includeThoughts": true
-      },
       "topK": 64
     }
   },
@@ -19,22 +16,46 @@
     "generateContentConfig": {
       "temperature": 1,
       "topP": 0.95,
+      "topK": 64,
       "thinkingConfig": {
         "includeThoughts": true,
         "thinkingBudget": 8192
-      },
-      "topK": 64
+      }
     }
   },
   "chat-base-3": {
     "generateContentConfig": {
       "temperature": 1,
       "topP": 0.95,
+      "topK": 64,
       "thinkingConfig": {
         "includeThoughts": true,
         "thinkingLevel": "HIGH"
-      },
-      "topK": 64
+      }
+    }
+  },
+  "gemini-3.1-pro-preview": {
+    "model": "gemini-3.1-pro-preview",
+    "generateContentConfig": {
+      "temperature": 1,
+      "topP": 0.95,
+      "topK": 64,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      }
+    }
+  },
+  "gemini-3.1-pro-preview-customtools": {
+    "model": "gemini-3.1-pro-preview-customtools",
+    "generateContentConfig": {
+      "temperature": 1,
+      "topP": 0.95,
+      "topK": 64,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      }
     }
   },
   "gemini-3-pro-preview": {
@@ -42,11 +63,11 @@
     "generateContentConfig": {
       "temperature": 1,
       "topP": 0.95,
+      "topK": 64,
       "thinkingConfig": {
         "includeThoughts": true,
         "thinkingLevel": "HIGH"
-      },
-      "topK": 64
+      }
     }
   },
   "gemini-3-flash-preview": {
@@ -54,11 +75,23 @@
     "generateContentConfig": {
       "temperature": 1,
       "topP": 0.95,
+      "topK": 64,
       "thinkingConfig": {
         "includeThoughts": true,
         "thinkingLevel": "HIGH"
-      },
-      "topK": 64
+      }
+    }
+  },
+  "gemini-3.1-flash-lite-preview": {
+    "model": "gemini-3.1-flash-lite-preview",
+    "generateContentConfig": {
+      "temperature": 1,
+      "topP": 0.95,
+      "topK": 64,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      }
     }
   },
   "gemini-2.5-pro": {
@@ -66,11 +99,11 @@
     "generateContentConfig": {
       "temperature": 1,
       "topP": 0.95,
+      "topK": 64,
       "thinkingConfig": {
         "includeThoughts": true,
         "thinkingBudget": 8192
-      },
-      "topK": 64
+      }
     }
   },
   "gemini-2.5-flash": {
@@ -78,11 +111,11 @@
     "generateContentConfig": {
       "temperature": 1,
       "topP": 0.95,
+      "topK": 64,
       "thinkingConfig": {
         "includeThoughts": true,
         "thinkingBudget": 8192
-      },
-      "topK": 64
+      }
     }
   },
   "gemini-2.5-flash-lite": {
@@ -90,11 +123,11 @@
     "generateContentConfig": {
       "temperature": 1,
       "topP": 0.95,
+      "topK": 64,
       "thinkingConfig": {
         "includeThoughts": true,
         "thinkingBudget": 8192
-      },
-      "topK": 64
+      }
     }
   },
   "gemini-2.5-flash-base": {
@@ -108,7 +141,11 @@
     "model": "gemini-3-flash-preview",
     "generateContentConfig": {
       "temperature": 0,
-      "topP": 1
+      "topP": 1,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      }
     }
   },
   "classifier": {
@@ -175,6 +212,10 @@
     "generateContentConfig": {
       "temperature": 0,
       "topP": 1,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      },
       "tools": [
         {
           "googleSearch": {}
@@ -187,6 +228,10 @@
     "generateContentConfig": {
       "temperature": 0,
       "topP": 1,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      },
       "tools": [
         {
           "urlContext": {}
@@ -198,14 +243,22 @@
     "model": "gemini-3-flash-preview",
     "generateContentConfig": {
       "temperature": 0,
-      "topP": 1
+      "topP": 1,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      }
     }
   },
   "loop-detection": {
     "model": "gemini-3-flash-preview",
     "generateContentConfig": {
       "temperature": 0,
-      "topP": 1
+      "topP": 1,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      }
     }
   },
   "loop-detection-double-check": {
@@ -219,14 +272,22 @@
     "model": "gemini-3-flash-preview",
     "generateContentConfig": {
       "temperature": 0,
-      "topP": 1
+      "topP": 1,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      }
     }
   },
   "next-speaker-checker": {
     "model": "gemini-3-flash-preview",
     "generateContentConfig": {
       "temperature": 0,
-      "topP": 1
+      "topP": 1,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      }
     }
   },
   "chat-compression-3-pro": {

--- a/packages/core/src/services/test-data/resolved-aliases.golden.json
+++ b/packages/core/src/services/test-data/resolved-aliases.golden.json
@@ -9,9 +9,6 @@
     "generateContentConfig": {
       "temperature": 1,
       "topP": 0.95,
-      "thinkingConfig": {
-        "includeThoughts": true
-      },
       "topK": 64
     }
   },
@@ -19,22 +16,46 @@
     "generateContentConfig": {
       "temperature": 1,
       "topP": 0.95,
+      "topK": 64,
       "thinkingConfig": {
         "includeThoughts": true,
         "thinkingBudget": 8192
-      },
-      "topK": 64
+      }
     }
   },
   "chat-base-3": {
     "generateContentConfig": {
       "temperature": 1,
       "topP": 0.95,
+      "topK": 64,
       "thinkingConfig": {
         "includeThoughts": true,
         "thinkingLevel": "HIGH"
-      },
-      "topK": 64
+      }
+    }
+  },
+  "gemini-3.1-pro-preview": {
+    "model": "gemini-3.1-pro-preview",
+    "generateContentConfig": {
+      "temperature": 1,
+      "topP": 0.95,
+      "topK": 64,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      }
+    }
+  },
+  "gemini-3.1-pro-preview-customtools": {
+    "model": "gemini-3.1-pro-preview-customtools",
+    "generateContentConfig": {
+      "temperature": 1,
+      "topP": 0.95,
+      "topK": 64,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      }
     }
   },
   "gemini-3-pro-preview": {
@@ -42,11 +63,11 @@
     "generateContentConfig": {
       "temperature": 1,
       "topP": 0.95,
+      "topK": 64,
       "thinkingConfig": {
         "includeThoughts": true,
         "thinkingLevel": "HIGH"
-      },
-      "topK": 64
+      }
     }
   },
   "gemini-3-flash-preview": {
@@ -54,11 +75,23 @@
     "generateContentConfig": {
       "temperature": 1,
       "topP": 0.95,
+      "topK": 64,
       "thinkingConfig": {
         "includeThoughts": true,
         "thinkingLevel": "HIGH"
-      },
-      "topK": 64
+      }
+    }
+  },
+  "gemini-3.1-flash-lite-preview": {
+    "model": "gemini-3.1-flash-lite-preview",
+    "generateContentConfig": {
+      "temperature": 1,
+      "topP": 0.95,
+      "topK": 64,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      }
     }
   },
   "gemini-2.5-pro": {
@@ -66,11 +99,11 @@
     "generateContentConfig": {
       "temperature": 1,
       "topP": 0.95,
+      "topK": 64,
       "thinkingConfig": {
         "includeThoughts": true,
         "thinkingBudget": 8192
-      },
-      "topK": 64
+      }
     }
   },
   "gemini-2.5-flash": {
@@ -78,11 +111,11 @@
     "generateContentConfig": {
       "temperature": 1,
       "topP": 0.95,
+      "topK": 64,
       "thinkingConfig": {
         "includeThoughts": true,
         "thinkingBudget": 8192
-      },
-      "topK": 64
+      }
     }
   },
   "gemini-2.5-flash-lite": {
@@ -90,11 +123,11 @@
     "generateContentConfig": {
       "temperature": 1,
       "topP": 0.95,
+      "topK": 64,
       "thinkingConfig": {
         "includeThoughts": true,
         "thinkingBudget": 8192
-      },
-      "topK": 64
+      }
     }
   },
   "gemini-2.5-flash-base": {
@@ -108,7 +141,11 @@
     "model": "gemini-3-flash-preview",
     "generateContentConfig": {
       "temperature": 0,
-      "topP": 1
+      "topP": 1,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      }
     }
   },
   "classifier": {
@@ -175,6 +212,10 @@
     "generateContentConfig": {
       "temperature": 0,
       "topP": 1,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      },
       "tools": [
         {
           "googleSearch": {}
@@ -187,6 +228,10 @@
     "generateContentConfig": {
       "temperature": 0,
       "topP": 1,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      },
       "tools": [
         {
           "urlContext": {}
@@ -198,14 +243,22 @@
     "model": "gemini-3-flash-preview",
     "generateContentConfig": {
       "temperature": 0,
-      "topP": 1
+      "topP": 1,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      }
     }
   },
   "loop-detection": {
     "model": "gemini-3-flash-preview",
     "generateContentConfig": {
       "temperature": 0,
-      "topP": 1
+      "topP": 1,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      }
     }
   },
   "loop-detection-double-check": {
@@ -219,14 +272,22 @@
     "model": "gemini-3-flash-preview",
     "generateContentConfig": {
       "temperature": 0,
-      "topP": 1
+      "topP": 1,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      }
     }
   },
   "next-speaker-checker": {
     "model": "gemini-3-flash-preview",
     "generateContentConfig": {
       "temperature": 0,
-      "topP": 1
+      "topP": 1,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingLevel": "HIGH"
+      }
     }
   },
   "chat-compression-3-pro": {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -629,7 +629,7 @@
     "modelConfigs": {
       "title": "Model Configs",
       "description": "Model configurations.",
-      "markdownDescription": "Model configurations.\n\n- Category: `Model`\n- Requires restart: `no`\n- Default: `{\n  \"aliases\": {\n    \"base\": {\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"temperature\": 0,\n          \"topP\": 1\n        }\n      }\n    },\n    \"chat-base\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"thinkingConfig\": {\n            \"includeThoughts\": true\n          },\n          \"temperature\": 1,\n          \"topP\": 0.95,\n          \"topK\": 64\n        }\n      }\n    },\n    \"chat-base-2.5\": {\n      \"extends\": \"chat-base\",\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"thinkingConfig\": {\n            \"thinkingBudget\": 8192\n          }\n        }\n      }\n    },\n    \"chat-base-3\": {\n      \"extends\": \"chat-base\",\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"thinkingConfig\": {\n            \"thinkingLevel\": \"HIGH\"\n          }\n        }\n      }\n    },\n    \"gemini-3-pro-preview\": {\n      \"extends\": \"chat-base-3\",\n      \"modelConfig\": {\n        \"model\": \"gemini-3-pro-preview\"\n      }\n    },\n    \"gemini-3-flash-preview\": {\n      \"extends\": \"chat-base-3\",\n      \"modelConfig\": {\n        \"model\": \"gemini-3-flash-preview\"\n      }\n    },\n    \"gemini-2.5-pro\": {\n      \"extends\": \"chat-base-2.5\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-pro\"\n      }\n    },\n    \"gemini-2.5-flash\": {\n      \"extends\": \"chat-base-2.5\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash\"\n      }\n    },\n    \"gemini-2.5-flash-lite\": {\n      \"extends\": \"chat-base-2.5\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\"\n      }\n    },\n    \"gemini-2.5-flash-base\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash\"\n      }\n    },\n    \"gemini-3-flash-base\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-3-flash-preview\"\n      }\n    },\n    \"classifier\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\",\n        \"generateContentConfig\": {\n          \"maxOutputTokens\": 1024,\n          \"thinkingConfig\": {\n            \"thinkingBudget\": 512\n          }\n        }\n      }\n    },\n    \"prompt-completion\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\",\n        \"generateContentConfig\": {\n          \"temperature\": 0.3,\n          \"maxOutputTokens\": 16000,\n          \"thinkingConfig\": {\n            \"thinkingBudget\": 0\n          }\n        }\n      }\n    },\n    \"fast-ack-helper\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\",\n        \"generateContentConfig\": {\n          \"temperature\": 0.2,\n          \"maxOutputTokens\": 120,\n          \"thinkingConfig\": {\n            \"thinkingBudget\": 0\n          }\n        }\n      }\n    },\n    \"edit-corrector\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\",\n        \"generateContentConfig\": {\n          \"thinkingConfig\": {\n            \"thinkingBudget\": 0\n          }\n        }\n      }\n    },\n    \"summarizer-default\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\",\n        \"generateContentConfig\": {\n          \"maxOutputTokens\": 2000\n        }\n      }\n    },\n    \"summarizer-shell\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\",\n        \"generateContentConfig\": {\n          \"maxOutputTokens\": 2000\n        }\n      }\n    },\n    \"web-search\": {\n      \"extends\": \"gemini-3-flash-base\",\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"tools\": [\n            {\n              \"googleSearch\": {}\n            }\n          ]\n        }\n      }\n    },\n    \"web-fetch\": {\n      \"extends\": \"gemini-3-flash-base\",\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"tools\": [\n            {\n              \"urlContext\": {}\n            }\n          ]\n        }\n      }\n    },\n    \"web-fetch-fallback\": {\n      \"extends\": \"gemini-3-flash-base\",\n      \"modelConfig\": {}\n    },\n    \"loop-detection\": {\n      \"extends\": \"gemini-3-flash-base\",\n      \"modelConfig\": {}\n    },\n    \"loop-detection-double-check\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-3-pro-preview\"\n      }\n    },\n    \"llm-edit-fixer\": {\n      \"extends\": \"gemini-3-flash-base\",\n      \"modelConfig\": {}\n    },\n    \"next-speaker-checker\": {\n      \"extends\": \"gemini-3-flash-base\",\n      \"modelConfig\": {}\n    },\n    \"chat-compression-3-pro\": {\n      \"modelConfig\": {\n        \"model\": \"gemini-3-pro-preview\"\n      }\n    },\n    \"chat-compression-3-flash\": {\n      \"modelConfig\": {\n        \"model\": \"gemini-3-flash-preview\"\n      }\n    },\n    \"chat-compression-2.5-pro\": {\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-pro\"\n      }\n    },\n    \"chat-compression-2.5-flash\": {\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash\"\n      }\n    },\n    \"chat-compression-2.5-flash-lite\": {\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\"\n      }\n    },\n    \"chat-compression-default\": {\n      \"modelConfig\": {\n        \"model\": \"gemini-3-pro-preview\"\n      }\n    }\n  },\n  \"overrides\": [\n    {\n      \"match\": {\n        \"model\": \"chat-base\",\n        \"isRetry\": true\n      },\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"temperature\": 1\n        }\n      }\n    }\n  ],\n  \"modelDefinitions\": {\n    \"gemini-3.1-pro-preview\": {\n      \"tier\": \"pro\",\n      \"family\": \"gemini-3\",\n      \"isPreview\": true,\n      \"dialogLocation\": \"manual\",\n      \"features\": {\n        \"thinking\": true,\n        \"multimodalToolUse\": true\n      }\n    },\n    \"gemini-3.1-pro-preview-customtools\": {\n      \"tier\": \"pro\",\n      \"family\": \"gemini-3\",\n      \"isPreview\": true,\n      \"features\": {\n        \"thinking\": true,\n        \"multimodalToolUse\": true\n      }\n    },\n    \"gemini-3-pro-preview\": {\n      \"tier\": \"pro\",\n      \"family\": \"gemini-3\",\n      \"isPreview\": true,\n      \"dialogLocation\": \"manual\",\n      \"features\": {\n        \"thinking\": true,\n        \"multimodalToolUse\": true\n      }\n    },\n    \"gemini-3-flash-preview\": {\n      \"tier\": \"flash\",\n      \"family\": \"gemini-3\",\n      \"isPreview\": true,\n      \"dialogLocation\": \"manual\",\n      \"features\": {\n        \"thinking\": false,\n        \"multimodalToolUse\": true\n      }\n    },\n    \"gemini-2.5-pro\": {\n      \"tier\": \"pro\",\n      \"family\": \"gemini-2.5\",\n      \"isPreview\": false,\n      \"dialogLocation\": \"manual\",\n      \"features\": {\n        \"thinking\": false,\n        \"multimodalToolUse\": false\n      }\n    },\n    \"gemini-2.5-flash\": {\n      \"tier\": \"flash\",\n      \"family\": \"gemini-2.5\",\n      \"isPreview\": false,\n      \"dialogLocation\": \"manual\",\n      \"features\": {\n        \"thinking\": false,\n        \"multimodalToolUse\": false\n      }\n    },\n    \"gemini-2.5-flash-lite\": {\n      \"tier\": \"flash-lite\",\n      \"family\": \"gemini-2.5\",\n      \"isPreview\": false,\n      \"dialogLocation\": \"manual\",\n      \"features\": {\n        \"thinking\": false,\n        \"multimodalToolUse\": false\n      }\n    },\n    \"auto\": {\n      \"tier\": \"auto\",\n      \"isPreview\": true,\n      \"features\": {\n        \"thinking\": true,\n        \"multimodalToolUse\": false\n      }\n    },\n    \"pro\": {\n      \"tier\": \"pro\",\n      \"isPreview\": false,\n      \"features\": {\n        \"thinking\": true,\n        \"multimodalToolUse\": false\n      }\n    },\n    \"flash\": {\n      \"tier\": \"flash\",\n      \"isPreview\": false,\n      \"features\": {\n        \"thinking\": false,\n        \"multimodalToolUse\": false\n      }\n    },\n    \"flash-lite\": {\n      \"tier\": \"flash-lite\",\n      \"isPreview\": false,\n      \"features\": {\n        \"thinking\": false,\n        \"multimodalToolUse\": false\n      }\n    },\n    \"auto-gemini-3\": {\n      \"displayName\": \"Auto (Gemini 3)\",\n      \"tier\": \"auto\",\n      \"isPreview\": true,\n      \"dialogLocation\": \"main\",\n      \"dialogDescription\": \"Let Gemini CLI decide the best model for the task: gemini-3.1-pro, gemini-3-flash\",\n      \"features\": {\n        \"thinking\": true,\n        \"multimodalToolUse\": false\n      }\n    },\n    \"auto-gemini-2.5\": {\n      \"displayName\": \"Auto (Gemini 2.5)\",\n      \"tier\": \"auto\",\n      \"isPreview\": false,\n      \"dialogLocation\": \"main\",\n      \"dialogDescription\": \"Let Gemini CLI decide the best model for the task: gemini-2.5-pro, gemini-2.5-flash\",\n      \"features\": {\n        \"thinking\": false,\n        \"multimodalToolUse\": false\n      }\n    }\n  }\n}`",
+      "markdownDescription": "Model configurations.\n\n- Category: `Model`\n- Requires restart: `no`\n- Default: `{\n  \"aliases\": {\n    \"base\": {\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"temperature\": 0,\n          \"topP\": 1\n        }\n      }\n    },\n    \"chat-base\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"temperature\": 1,\n          \"topP\": 0.95,\n          \"topK\": 64\n        }\n      }\n    },\n    \"chat-base-2.5\": {\n      \"extends\": \"chat-base\",\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"thinkingConfig\": {\n            \"includeThoughts\": true,\n            \"thinkingBudget\": 8192\n          }\n        }\n      }\n    },\n    \"chat-base-3\": {\n      \"extends\": \"chat-base\",\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"thinkingConfig\": {\n            \"includeThoughts\": true,\n            \"thinkingLevel\": \"HIGH\"\n          }\n        }\n      }\n    },\n    \"gemini-3.1-pro-preview\": {\n      \"extends\": \"chat-base-3\",\n      \"modelConfig\": {\n        \"model\": \"gemini-3.1-pro-preview\",\n        \"generateContentConfig\": {\n          \"thinkingConfig\": {\n            \"includeThoughts\": true,\n            \"thinkingLevel\": \"HIGH\"\n          }\n        }\n      }\n    },\n    \"gemini-3.1-pro-preview-customtools\": {\n      \"extends\": \"chat-base-3\",\n      \"modelConfig\": {\n        \"model\": \"gemini-3.1-pro-preview-customtools\",\n        \"generateContentConfig\": {\n          \"thinkingConfig\": {\n            \"includeThoughts\": true,\n            \"thinkingLevel\": \"HIGH\"\n          }\n        }\n      }\n    },\n    \"gemini-3-pro-preview\": {\n      \"extends\": \"chat-base-3\",\n      \"modelConfig\": {\n        \"model\": \"gemini-3-pro-preview\",\n        \"generateContentConfig\": {\n          \"thinkingConfig\": {\n            \"includeThoughts\": true,\n            \"thinkingLevel\": \"HIGH\"\n          }\n        }\n      }\n    },\n    \"gemini-3-flash-preview\": {\n      \"extends\": \"chat-base-3\",\n      \"modelConfig\": {\n        \"model\": \"gemini-3-flash-preview\",\n        \"generateContentConfig\": {\n          \"thinkingConfig\": {\n            \"includeThoughts\": true,\n            \"thinkingLevel\": \"HIGH\"\n          }\n        }\n      }\n    },\n    \"gemini-3.1-flash-lite-preview\": {\n      \"extends\": \"chat-base-3\",\n      \"modelConfig\": {\n        \"model\": \"gemini-3.1-flash-lite-preview\",\n        \"generateContentConfig\": {\n          \"thinkingConfig\": {\n            \"includeThoughts\": true,\n            \"thinkingLevel\": \"HIGH\"\n          }\n        }\n      }\n    },\n    \"gemini-2.5-pro\": {\n      \"extends\": \"chat-base-2.5\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-pro\"\n      }\n    },\n    \"gemini-2.5-flash\": {\n      \"extends\": \"chat-base-2.5\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash\"\n      }\n    },\n    \"gemini-2.5-flash-lite\": {\n      \"extends\": \"chat-base-2.5\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\"\n      }\n    },\n    \"gemini-2.5-flash-base\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash\"\n      }\n    },\n    \"gemini-3-flash-base\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-3-flash-preview\",\n        \"generateContentConfig\": {\n          \"thinkingConfig\": {\n            \"includeThoughts\": true,\n            \"thinkingLevel\": \"HIGH\"\n          }\n        }\n      }\n    },\n    \"classifier\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\",\n        \"generateContentConfig\": {\n          \"maxOutputTokens\": 1024,\n          \"thinkingConfig\": {\n            \"thinkingBudget\": 512\n          }\n        }\n      }\n    },\n    \"prompt-completion\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\",\n        \"generateContentConfig\": {\n          \"temperature\": 0.3,\n          \"maxOutputTokens\": 16000,\n          \"thinkingConfig\": {\n            \"thinkingBudget\": 0\n          }\n        }\n      }\n    },\n    \"fast-ack-helper\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\",\n        \"generateContentConfig\": {\n          \"temperature\": 0.2,\n          \"maxOutputTokens\": 120,\n          \"thinkingConfig\": {\n            \"thinkingBudget\": 0\n          }\n        }\n      }\n    },\n    \"edit-corrector\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\",\n        \"generateContentConfig\": {\n          \"thinkingConfig\": {\n            \"thinkingBudget\": 0\n          }\n        }\n      }\n    },\n    \"summarizer-default\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\",\n        \"generateContentConfig\": {\n          \"maxOutputTokens\": 2000\n        }\n      }\n    },\n    \"summarizer-shell\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\",\n        \"generateContentConfig\": {\n          \"maxOutputTokens\": 2000\n        }\n      }\n    },\n    \"web-search\": {\n      \"extends\": \"gemini-3-flash-base\",\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"tools\": [\n            {\n              \"googleSearch\": {}\n            }\n          ]\n        }\n      }\n    },\n    \"web-fetch\": {\n      \"extends\": \"gemini-3-flash-base\",\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"tools\": [\n            {\n              \"urlContext\": {}\n            }\n          ]\n        }\n      }\n    },\n    \"web-fetch-fallback\": {\n      \"extends\": \"gemini-3-flash-base\",\n      \"modelConfig\": {}\n    },\n    \"loop-detection\": {\n      \"extends\": \"gemini-3-flash-base\",\n      \"modelConfig\": {}\n    },\n    \"loop-detection-double-check\": {\n      \"extends\": \"base\",\n      \"modelConfig\": {\n        \"model\": \"gemini-3-pro-preview\"\n      }\n    },\n    \"llm-edit-fixer\": {\n      \"extends\": \"gemini-3-flash-base\",\n      \"modelConfig\": {}\n    },\n    \"next-speaker-checker\": {\n      \"extends\": \"gemini-3-flash-base\",\n      \"modelConfig\": {}\n    },\n    \"chat-compression-3-pro\": {\n      \"modelConfig\": {\n        \"model\": \"gemini-3-pro-preview\"\n      }\n    },\n    \"chat-compression-3-flash\": {\n      \"modelConfig\": {\n        \"model\": \"gemini-3-flash-preview\"\n      }\n    },\n    \"chat-compression-2.5-pro\": {\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-pro\"\n      }\n    },\n    \"chat-compression-2.5-flash\": {\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash\"\n      }\n    },\n    \"chat-compression-2.5-flash-lite\": {\n      \"modelConfig\": {\n        \"model\": \"gemini-2.5-flash-lite\"\n      }\n    },\n    \"chat-compression-default\": {\n      \"modelConfig\": {\n        \"model\": \"gemini-3-pro-preview\"\n      }\n    }\n  },\n  \"overrides\": [\n    {\n      \"match\": {\n        \"model\": \"chat-base\",\n        \"isRetry\": true\n      },\n      \"modelConfig\": {\n        \"generateContentConfig\": {\n          \"temperature\": 1\n        }\n      }\n    }\n  ],\n  \"modelDefinitions\": {\n    \"gemini-3.1-pro-preview\": {\n      \"tier\": \"pro\",\n      \"family\": \"gemini-3\",\n      \"isPreview\": true,\n      \"dialogLocation\": \"manual\",\n      \"features\": {\n        \"thinking\": true,\n        \"multimodalToolUse\": true\n      }\n    },\n    \"gemini-3.1-pro-preview-customtools\": {\n      \"tier\": \"pro\",\n      \"family\": \"gemini-3\",\n      \"isPreview\": true,\n      \"features\": {\n        \"thinking\": true,\n        \"multimodalToolUse\": true\n      }\n    },\n    \"gemini-3-pro-preview\": {\n      \"tier\": \"pro\",\n      \"family\": \"gemini-3\",\n      \"isPreview\": true,\n      \"dialogLocation\": \"manual\",\n      \"features\": {\n        \"thinking\": true,\n        \"multimodalToolUse\": true\n      }\n    },\n    \"gemini-3-flash-preview\": {\n      \"tier\": \"flash\",\n      \"family\": \"gemini-3\",\n      \"isPreview\": true,\n      \"dialogLocation\": \"manual\",\n      \"features\": {\n        \"thinking\": false,\n        \"multimodalToolUse\": true\n      }\n    },\n    \"gemini-2.5-pro\": {\n      \"tier\": \"pro\",\n      \"family\": \"gemini-2.5\",\n      \"isPreview\": false,\n      \"dialogLocation\": \"manual\",\n      \"features\": {\n        \"thinking\": false,\n        \"multimodalToolUse\": false\n      }\n    },\n    \"gemini-2.5-flash\": {\n      \"tier\": \"flash\",\n      \"family\": \"gemini-2.5\",\n      \"isPreview\": false,\n      \"dialogLocation\": \"manual\",\n      \"features\": {\n        \"thinking\": false,\n        \"multimodalToolUse\": false\n      }\n    },\n    \"gemini-2.5-flash-lite\": {\n      \"tier\": \"flash-lite\",\n      \"family\": \"gemini-2.5\",\n      \"isPreview\": false,\n      \"dialogLocation\": \"manual\",\n      \"features\": {\n        \"thinking\": false,\n        \"multimodalToolUse\": false\n      }\n    },\n    \"auto\": {\n      \"tier\": \"auto\",\n      \"isPreview\": true,\n      \"features\": {\n        \"thinking\": true,\n        \"multimodalToolUse\": false\n      }\n    },\n    \"pro\": {\n      \"tier\": \"pro\",\n      \"isPreview\": false,\n      \"features\": {\n        \"thinking\": true,\n        \"multimodalToolUse\": false\n      }\n    },\n    \"flash\": {\n      \"tier\": \"flash\",\n      \"isPreview\": false,\n      \"features\": {\n        \"thinking\": false,\n        \"multimodalToolUse\": false\n      }\n    },\n    \"flash-lite\": {\n      \"tier\": \"flash-lite\",\n      \"isPreview\": false,\n      \"features\": {\n        \"thinking\": false,\n        \"multimodalToolUse\": false\n      }\n    },\n    \"auto-gemini-3\": {\n      \"displayName\": \"Auto (Gemini 3)\",\n      \"tier\": \"auto\",\n      \"isPreview\": true,\n      \"dialogLocation\": \"main\",\n      \"dialogDescription\": \"Let Gemini CLI decide the best model for the task: gemini-3.1-pro, gemini-3-flash\",\n      \"features\": {\n        \"thinking\": true,\n        \"multimodalToolUse\": false\n      }\n    },\n    \"auto-gemini-2.5\": {\n      \"displayName\": \"Auto (Gemini 2.5)\",\n      \"tier\": \"auto\",\n      \"isPreview\": false,\n      \"dialogLocation\": \"main\",\n      \"dialogDescription\": \"Let Gemini CLI decide the best model for the task: gemini-2.5-pro, gemini-2.5-flash\",\n      \"features\": {\n        \"thinking\": false,\n        \"multimodalToolUse\": false\n      }\n    }\n  }\n}`",
       "default": {
         "aliases": {
           "base": {
@@ -644,9 +644,6 @@
             "extends": "base",
             "modelConfig": {
               "generateContentConfig": {
-                "thinkingConfig": {
-                  "includeThoughts": true
-                },
                 "temperature": 1,
                 "topP": 0.95,
                 "topK": 64
@@ -658,6 +655,7 @@
             "modelConfig": {
               "generateContentConfig": {
                 "thinkingConfig": {
+                  "includeThoughts": true,
                   "thinkingBudget": 8192
                 }
               }
@@ -668,6 +666,31 @@
             "modelConfig": {
               "generateContentConfig": {
                 "thinkingConfig": {
+                  "includeThoughts": true,
+                  "thinkingLevel": "HIGH"
+                }
+              }
+            }
+          },
+          "gemini-3.1-pro-preview": {
+            "extends": "chat-base-3",
+            "modelConfig": {
+              "model": "gemini-3.1-pro-preview",
+              "generateContentConfig": {
+                "thinkingConfig": {
+                  "includeThoughts": true,
+                  "thinkingLevel": "HIGH"
+                }
+              }
+            }
+          },
+          "gemini-3.1-pro-preview-customtools": {
+            "extends": "chat-base-3",
+            "modelConfig": {
+              "model": "gemini-3.1-pro-preview-customtools",
+              "generateContentConfig": {
+                "thinkingConfig": {
+                  "includeThoughts": true,
                   "thinkingLevel": "HIGH"
                 }
               }
@@ -676,13 +699,37 @@
           "gemini-3-pro-preview": {
             "extends": "chat-base-3",
             "modelConfig": {
-              "model": "gemini-3-pro-preview"
+              "model": "gemini-3-pro-preview",
+              "generateContentConfig": {
+                "thinkingConfig": {
+                  "includeThoughts": true,
+                  "thinkingLevel": "HIGH"
+                }
+              }
             }
           },
           "gemini-3-flash-preview": {
             "extends": "chat-base-3",
             "modelConfig": {
-              "model": "gemini-3-flash-preview"
+              "model": "gemini-3-flash-preview",
+              "generateContentConfig": {
+                "thinkingConfig": {
+                  "includeThoughts": true,
+                  "thinkingLevel": "HIGH"
+                }
+              }
+            }
+          },
+          "gemini-3.1-flash-lite-preview": {
+            "extends": "chat-base-3",
+            "modelConfig": {
+              "model": "gemini-3.1-flash-lite-preview",
+              "generateContentConfig": {
+                "thinkingConfig": {
+                  "includeThoughts": true,
+                  "thinkingLevel": "HIGH"
+                }
+              }
             }
           },
           "gemini-2.5-pro": {
@@ -712,7 +759,13 @@
           "gemini-3-flash-base": {
             "extends": "base",
             "modelConfig": {
-              "model": "gemini-3-flash-preview"
+              "model": "gemini-3-flash-preview",
+              "generateContentConfig": {
+                "thinkingConfig": {
+                  "includeThoughts": true,
+                  "thinkingLevel": "HIGH"
+                }
+              }
             }
           },
           "classifier": {
@@ -1003,7 +1056,7 @@
         "aliases": {
           "title": "Model Config Aliases",
           "description": "Named presets for model configs. Can be used in place of a model name and can inherit from other aliases using an `extends` property.",
-          "markdownDescription": "Named presets for model configs. Can be used in place of a model name and can inherit from other aliases using an `extends` property.\n\n- Category: `Model`\n- Requires restart: `no`\n- Default: `{\n  \"base\": {\n    \"modelConfig\": {\n      \"generateContentConfig\": {\n        \"temperature\": 0,\n        \"topP\": 1\n      }\n    }\n  },\n  \"chat-base\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"generateContentConfig\": {\n        \"thinkingConfig\": {\n          \"includeThoughts\": true\n        },\n        \"temperature\": 1,\n        \"topP\": 0.95,\n        \"topK\": 64\n      }\n    }\n  },\n  \"chat-base-2.5\": {\n    \"extends\": \"chat-base\",\n    \"modelConfig\": {\n      \"generateContentConfig\": {\n        \"thinkingConfig\": {\n          \"thinkingBudget\": 8192\n        }\n      }\n    }\n  },\n  \"chat-base-3\": {\n    \"extends\": \"chat-base\",\n    \"modelConfig\": {\n      \"generateContentConfig\": {\n        \"thinkingConfig\": {\n          \"thinkingLevel\": \"HIGH\"\n        }\n      }\n    }\n  },\n  \"gemini-3-pro-preview\": {\n    \"extends\": \"chat-base-3\",\n    \"modelConfig\": {\n      \"model\": \"gemini-3-pro-preview\"\n    }\n  },\n  \"gemini-3-flash-preview\": {\n    \"extends\": \"chat-base-3\",\n    \"modelConfig\": {\n      \"model\": \"gemini-3-flash-preview\"\n    }\n  },\n  \"gemini-2.5-pro\": {\n    \"extends\": \"chat-base-2.5\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-pro\"\n    }\n  },\n  \"gemini-2.5-flash\": {\n    \"extends\": \"chat-base-2.5\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash\"\n    }\n  },\n  \"gemini-2.5-flash-lite\": {\n    \"extends\": \"chat-base-2.5\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\"\n    }\n  },\n  \"gemini-2.5-flash-base\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash\"\n    }\n  },\n  \"gemini-3-flash-base\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-3-flash-preview\"\n    }\n  },\n  \"classifier\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\",\n      \"generateContentConfig\": {\n        \"maxOutputTokens\": 1024,\n        \"thinkingConfig\": {\n          \"thinkingBudget\": 512\n        }\n      }\n    }\n  },\n  \"prompt-completion\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\",\n      \"generateContentConfig\": {\n        \"temperature\": 0.3,\n        \"maxOutputTokens\": 16000,\n        \"thinkingConfig\": {\n          \"thinkingBudget\": 0\n        }\n      }\n    }\n  },\n  \"fast-ack-helper\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\",\n      \"generateContentConfig\": {\n        \"temperature\": 0.2,\n        \"maxOutputTokens\": 120,\n        \"thinkingConfig\": {\n          \"thinkingBudget\": 0\n        }\n      }\n    }\n  },\n  \"edit-corrector\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\",\n      \"generateContentConfig\": {\n        \"thinkingConfig\": {\n          \"thinkingBudget\": 0\n        }\n      }\n    }\n  },\n  \"summarizer-default\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\",\n      \"generateContentConfig\": {\n        \"maxOutputTokens\": 2000\n      }\n    }\n  },\n  \"summarizer-shell\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\",\n      \"generateContentConfig\": {\n        \"maxOutputTokens\": 2000\n      }\n    }\n  },\n  \"web-search\": {\n    \"extends\": \"gemini-3-flash-base\",\n    \"modelConfig\": {\n      \"generateContentConfig\": {\n        \"tools\": [\n          {\n            \"googleSearch\": {}\n          }\n        ]\n      }\n    }\n  },\n  \"web-fetch\": {\n    \"extends\": \"gemini-3-flash-base\",\n    \"modelConfig\": {\n      \"generateContentConfig\": {\n        \"tools\": [\n          {\n            \"urlContext\": {}\n          }\n        ]\n      }\n    }\n  },\n  \"web-fetch-fallback\": {\n    \"extends\": \"gemini-3-flash-base\",\n    \"modelConfig\": {}\n  },\n  \"loop-detection\": {\n    \"extends\": \"gemini-3-flash-base\",\n    \"modelConfig\": {}\n  },\n  \"loop-detection-double-check\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-3-pro-preview\"\n    }\n  },\n  \"llm-edit-fixer\": {\n    \"extends\": \"gemini-3-flash-base\",\n    \"modelConfig\": {}\n  },\n  \"next-speaker-checker\": {\n    \"extends\": \"gemini-3-flash-base\",\n    \"modelConfig\": {}\n  },\n  \"chat-compression-3-pro\": {\n    \"modelConfig\": {\n      \"model\": \"gemini-3-pro-preview\"\n    }\n  },\n  \"chat-compression-3-flash\": {\n    \"modelConfig\": {\n      \"model\": \"gemini-3-flash-preview\"\n    }\n  },\n  \"chat-compression-2.5-pro\": {\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-pro\"\n    }\n  },\n  \"chat-compression-2.5-flash\": {\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash\"\n    }\n  },\n  \"chat-compression-2.5-flash-lite\": {\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\"\n    }\n  },\n  \"chat-compression-default\": {\n    \"modelConfig\": {\n      \"model\": \"gemini-3-pro-preview\"\n    }\n  }\n}`",
+          "markdownDescription": "Named presets for model configs. Can be used in place of a model name and can inherit from other aliases using an `extends` property.\n\n- Category: `Model`\n- Requires restart: `no`\n- Default: `{\n  \"base\": {\n    \"modelConfig\": {\n      \"generateContentConfig\": {\n        \"temperature\": 0,\n        \"topP\": 1\n      }\n    }\n  },\n  \"chat-base\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"generateContentConfig\": {\n        \"temperature\": 1,\n        \"topP\": 0.95,\n        \"topK\": 64\n      }\n    }\n  },\n  \"chat-base-2.5\": {\n    \"extends\": \"chat-base\",\n    \"modelConfig\": {\n      \"generateContentConfig\": {\n        \"thinkingConfig\": {\n          \"includeThoughts\": true,\n          \"thinkingBudget\": 8192\n        }\n      }\n    }\n  },\n  \"chat-base-3\": {\n    \"extends\": \"chat-base\",\n    \"modelConfig\": {\n      \"generateContentConfig\": {\n        \"thinkingConfig\": {\n          \"includeThoughts\": true,\n          \"thinkingLevel\": \"HIGH\"\n        }\n      }\n    }\n  },\n  \"gemini-3.1-pro-preview\": {\n    \"extends\": \"chat-base-3\",\n    \"modelConfig\": {\n      \"model\": \"gemini-3.1-pro-preview\",\n      \"generateContentConfig\": {\n        \"thinkingConfig\": {\n          \"includeThoughts\": true,\n          \"thinkingLevel\": \"HIGH\"\n        }\n      }\n    }\n  },\n  \"gemini-3.1-pro-preview-customtools\": {\n    \"extends\": \"chat-base-3\",\n    \"modelConfig\": {\n      \"model\": \"gemini-3.1-pro-preview-customtools\",\n      \"generateContentConfig\": {\n        \"thinkingConfig\": {\n          \"includeThoughts\": true,\n          \"thinkingLevel\": \"HIGH\"\n        }\n      }\n    }\n  },\n  \"gemini-3-pro-preview\": {\n    \"extends\": \"chat-base-3\",\n    \"modelConfig\": {\n      \"model\": \"gemini-3-pro-preview\",\n      \"generateContentConfig\": {\n        \"thinkingConfig\": {\n          \"includeThoughts\": true,\n          \"thinkingLevel\": \"HIGH\"\n        }\n      }\n    }\n  },\n  \"gemini-3-flash-preview\": {\n    \"extends\": \"chat-base-3\",\n    \"modelConfig\": {\n      \"model\": \"gemini-3-flash-preview\",\n      \"generateContentConfig\": {\n        \"thinkingConfig\": {\n          \"includeThoughts\": true,\n          \"thinkingLevel\": \"HIGH\"\n        }\n      }\n    }\n  },\n  \"gemini-3.1-flash-lite-preview\": {\n    \"extends\": \"chat-base-3\",\n    \"modelConfig\": {\n      \"model\": \"gemini-3.1-flash-lite-preview\",\n      \"generateContentConfig\": {\n        \"thinkingConfig\": {\n          \"includeThoughts\": true,\n          \"thinkingLevel\": \"HIGH\"\n        }\n      }\n    }\n  },\n  \"gemini-2.5-pro\": {\n    \"extends\": \"chat-base-2.5\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-pro\"\n    }\n  },\n  \"gemini-2.5-flash\": {\n    \"extends\": \"chat-base-2.5\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash\"\n    }\n  },\n  \"gemini-2.5-flash-lite\": {\n    \"extends\": \"chat-base-2.5\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\"\n    }\n  },\n  \"gemini-2.5-flash-base\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash\"\n    }\n  },\n  \"gemini-3-flash-base\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-3-flash-preview\",\n      \"generateContentConfig\": {\n        \"thinkingConfig\": {\n          \"includeThoughts\": true,\n          \"thinkingLevel\": \"HIGH\"\n        }\n      }\n    }\n  },\n  \"classifier\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\",\n      \"generateContentConfig\": {\n        \"maxOutputTokens\": 1024,\n        \"thinkingConfig\": {\n          \"thinkingBudget\": 512\n        }\n      }\n    }\n  },\n  \"prompt-completion\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\",\n      \"generateContentConfig\": {\n        \"temperature\": 0.3,\n        \"maxOutputTokens\": 16000,\n        \"thinkingConfig\": {\n          \"thinkingBudget\": 0\n        }\n      }\n    }\n  },\n  \"fast-ack-helper\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\",\n      \"generateContentConfig\": {\n        \"temperature\": 0.2,\n        \"maxOutputTokens\": 120,\n        \"thinkingConfig\": {\n          \"thinkingBudget\": 0\n        }\n      }\n    }\n  },\n  \"edit-corrector\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\",\n      \"generateContentConfig\": {\n        \"thinkingConfig\": {\n          \"thinkingBudget\": 0\n        }\n      }\n    }\n  },\n  \"summarizer-default\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\",\n      \"generateContentConfig\": {\n        \"maxOutputTokens\": 2000\n      }\n    }\n  },\n  \"summarizer-shell\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\",\n      \"generateContentConfig\": {\n        \"maxOutputTokens\": 2000\n      }\n    }\n  },\n  \"web-search\": {\n    \"extends\": \"gemini-3-flash-base\",\n    \"modelConfig\": {\n      \"generateContentConfig\": {\n        \"tools\": [\n          {\n            \"googleSearch\": {}\n          }\n        ]\n      }\n    }\n  },\n  \"web-fetch\": {\n    \"extends\": \"gemini-3-flash-base\",\n    \"modelConfig\": {\n      \"generateContentConfig\": {\n        \"tools\": [\n          {\n            \"urlContext\": {}\n          }\n        ]\n      }\n    }\n  },\n  \"web-fetch-fallback\": {\n    \"extends\": \"gemini-3-flash-base\",\n    \"modelConfig\": {}\n  },\n  \"loop-detection\": {\n    \"extends\": \"gemini-3-flash-base\",\n    \"modelConfig\": {}\n  },\n  \"loop-detection-double-check\": {\n    \"extends\": \"base\",\n    \"modelConfig\": {\n      \"model\": \"gemini-3-pro-preview\"\n    }\n  },\n  \"llm-edit-fixer\": {\n    \"extends\": \"gemini-3-flash-base\",\n    \"modelConfig\": {}\n  },\n  \"next-speaker-checker\": {\n    \"extends\": \"gemini-3-flash-base\",\n    \"modelConfig\": {}\n  },\n  \"chat-compression-3-pro\": {\n    \"modelConfig\": {\n      \"model\": \"gemini-3-pro-preview\"\n    }\n  },\n  \"chat-compression-3-flash\": {\n    \"modelConfig\": {\n      \"model\": \"gemini-3-flash-preview\"\n    }\n  },\n  \"chat-compression-2.5-pro\": {\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-pro\"\n    }\n  },\n  \"chat-compression-2.5-flash\": {\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash\"\n    }\n  },\n  \"chat-compression-2.5-flash-lite\": {\n    \"modelConfig\": {\n      \"model\": \"gemini-2.5-flash-lite\"\n    }\n  },\n  \"chat-compression-default\": {\n    \"modelConfig\": {\n      \"model\": \"gemini-3-pro-preview\"\n    }\n  }\n}`",
           "default": {
             "base": {
               "modelConfig": {
@@ -1017,9 +1070,6 @@
               "extends": "base",
               "modelConfig": {
                 "generateContentConfig": {
-                  "thinkingConfig": {
-                    "includeThoughts": true
-                  },
                   "temperature": 1,
                   "topP": 0.95,
                   "topK": 64
@@ -1031,6 +1081,7 @@
               "modelConfig": {
                 "generateContentConfig": {
                   "thinkingConfig": {
+                    "includeThoughts": true,
                     "thinkingBudget": 8192
                   }
                 }
@@ -1041,6 +1092,31 @@
               "modelConfig": {
                 "generateContentConfig": {
                   "thinkingConfig": {
+                    "includeThoughts": true,
+                    "thinkingLevel": "HIGH"
+                  }
+                }
+              }
+            },
+            "gemini-3.1-pro-preview": {
+              "extends": "chat-base-3",
+              "modelConfig": {
+                "model": "gemini-3.1-pro-preview",
+                "generateContentConfig": {
+                  "thinkingConfig": {
+                    "includeThoughts": true,
+                    "thinkingLevel": "HIGH"
+                  }
+                }
+              }
+            },
+            "gemini-3.1-pro-preview-customtools": {
+              "extends": "chat-base-3",
+              "modelConfig": {
+                "model": "gemini-3.1-pro-preview-customtools",
+                "generateContentConfig": {
+                  "thinkingConfig": {
+                    "includeThoughts": true,
                     "thinkingLevel": "HIGH"
                   }
                 }
@@ -1049,13 +1125,37 @@
             "gemini-3-pro-preview": {
               "extends": "chat-base-3",
               "modelConfig": {
-                "model": "gemini-3-pro-preview"
+                "model": "gemini-3-pro-preview",
+                "generateContentConfig": {
+                  "thinkingConfig": {
+                    "includeThoughts": true,
+                    "thinkingLevel": "HIGH"
+                  }
+                }
               }
             },
             "gemini-3-flash-preview": {
               "extends": "chat-base-3",
               "modelConfig": {
-                "model": "gemini-3-flash-preview"
+                "model": "gemini-3-flash-preview",
+                "generateContentConfig": {
+                  "thinkingConfig": {
+                    "includeThoughts": true,
+                    "thinkingLevel": "HIGH"
+                  }
+                }
+              }
+            },
+            "gemini-3.1-flash-lite-preview": {
+              "extends": "chat-base-3",
+              "modelConfig": {
+                "model": "gemini-3.1-flash-lite-preview",
+                "generateContentConfig": {
+                  "thinkingConfig": {
+                    "includeThoughts": true,
+                    "thinkingLevel": "HIGH"
+                  }
+                }
               }
             },
             "gemini-2.5-pro": {
@@ -1085,7 +1185,13 @@
             "gemini-3-flash-base": {
               "extends": "base",
               "modelConfig": {
-                "model": "gemini-3-flash-preview"
+                "model": "gemini-3-flash-preview",
+                "generateContentConfig": {
+                  "thinkingConfig": {
+                    "includeThoughts": true,
+                    "thinkingLevel": "HIGH"
+                  }
+                }
               }
             },
             "classifier": {


### PR DESCRIPTION

## Summary

* Extract the agent's internal plans from its stream of thoughts and propagates them to the editor via ACP.
* This enhances real-time visibility into the agent's checklist-style action plans as it thinks, allowing it to render the agent's intended steps before it begins tool execution properly in all ACP compliant IDEs

## Details

- Updated default model configurations (Gemini 3/3.1) to enforce `includeThoughts: true` and `ThinkingLevel.HIGH`.
- Extended the code assist converters to safely extract and format the `thought` field, preventing type errors during `CountToken` API calls.
- Implemented real-time `extractPlanEntries` parsing using regex that gracefully extracts markdown task lists (e.g., `[TODO]`, `[x]`, `[]`) while safely ignoring content inside code blocks.
- Added logic in the ACP client that incrementally reads the agent's thought buffer and emits `sessionUpdate: 'plan'` events directly to the IDE whenever the tracked tasks change.
- Formatted `agent_thought_chunk` outputs to replace escaped literal newlines (`\n`) with actual native newlines, ensuring the IDE chat displays main thought sections cleanly without visual artifacts.
- Added comprehensive unit tests for the plan parser and ACP integration.

An example agent thought chunk looks like this:


```
{
  "sessionId": "f225186c-a90c-4274-b6e6-4eaa389d1738",
  "update": {
    "sessionUpdate": "agent_thought_chunk",
    "content": {
      "type": "text",
      "text": "**Initiating the Next Phase**   I'm now focused on the next step: outlining the plan's components. I'll need to define the major phases of this parser design and their interdependencies, ensuring a clear and logical structure. This involves breaking down the process to be followed into a series of well-defined steps.   "
    }
  }
}
```

## Zed IDE

<img width="1260" height="1014" alt="image" src="https://github.com/user-attachments/assets/d5cfabb1-058e-458a-b253-ed3f6790cfcc" />

## Jetbrains IDE

![jb_plan_events](https://github.com/user-attachments/assets/b7534612-2e35-4123-b0b8-100e51024152)



## Related Issues

Fixes [#1574 (maintainers-gemini-cli)](https://github.com/google-gemini/maintainers-gemini-cli/issues/1574)

## How to Validate

1. Connect IDE to gemini-cli via acp config or other relevant config for the IDE (JB or Zed)
2. Prompt the Model to Generate a Plan via the IDE
3. Observe the Result
* _Expected Behavior_: As the agent streams its response back to IDE, the UI should intercept the `sessionUpdate: 'plan'` events over the ACP protocol. Expect to see a structured native Plan UI (often rendered as native interactive checkboxes) appear dynamically in the IDE chat UI before or during the agent's actual execution of those steps.
* _Watch for State Changes_: As the agent proceeds to accomplish the tasks, watch if the checklist items visually transition from "Pending" to "Completed" (or checked off) in the UI.



## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [✅] Added/updated tests (if needed)
- [✅] Noted breaking changes (if any)
- [✅] Validated on required platforms/methods:
  - [✅] MacOS
    - [✅] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
