### PR TITLE
perf(core): fix OOM crash in long-running sessions

### DIFF
--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -691,9 +691,13 @@ export class GeminiChat {
     const history = curated
       ? extractCuratedHistory(this.history)
       : this.history;
-    // Deep copy the history to avoid mutating the history outside of the
-    // chat session.
-    return structuredClone(history);
+    // Return a shallow copy of the array to prevent callers from mutating
+    // the internal history array (push/pop/splice). Content objects are
+    // shared references — callers MUST NOT mutate them in place.
+    // This replaces a prior structuredClone() which deep-copied the entire
+    // conversation on every call, causing O(n) memory pressure per turn
+    // that compounded into OOM crashes in long-running sessions.
+    return [...history];
   }
 
   /**

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -241,6 +241,7 @@ export class Turn {
   readonly pendingToolCalls: ToolCallRequestInfo[] = [];
   private debugResponses: GenerateContentResponse[] = [];
   private pendingCitations = new Set<string>();
+  private cachedResponseText: string | undefined = undefined;
   finishReason: FinishReason | undefined = undefined;
 
   constructor(
@@ -432,11 +433,15 @@ export class Turn {
   /**
    * Get the concatenated response text from all responses in this turn.
    * This extracts and joins all text content from the model's responses.
+   * The result is cached since this is called multiple times per turn.
    */
   getResponseText(): string {
-    return this.debugResponses
-      .map((response) => getResponseText(response))
-      .filter((text): text is string => text !== null)
-      .join(' ');
+    if (this.cachedResponseText === undefined) {
+      this.cachedResponseText = this.debugResponses
+        .map((response) => getResponseText(response))
+        .filter((text): text is string => text !== null)
+        .join(' ');
+    }
+    return this.cachedResponseText;
   }
 }


### PR DESCRIPTION
Replace structuredClone() in getHistory() with a shallow array copy.
The deep clone ran on every turn's hot path, duplicating the entire
conversation history (50-100MB+ in long sessions) multiple times per
turn. Verified all 8 production callers — only one mutated Content
objects (nextSpeakerChecker), and that mutation was dead code (pushed
to a clone that was immediately discarded).

Replace Array.shift() in the event backlog with a head pointer and
amortized compaction. shift() on a 10K-element array is O(n); the
new approach is O(1) amortized with identical FIFO semantics.

Cache Turn.getResponseText() result to avoid redundant recomputation
across its two call sites per turn.

Fixes #19607

fix(core): remove unknown cast for backlog

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
