### PR TITLE
feat(cli): restore unsent draft before input history

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -289,7 +289,7 @@ describe('InputPrompt', () => {
       navigateUp: vi.fn(),
       navigateDown: vi.fn(),
       handleSubmit: vi.fn(),
-      saveDraft: vi.fn(),
+      checkpointCurrentInput: vi.fn(),
     };
     mockedUseInputHistory.mockImplementation(({ onSubmit }) => {
       mockInputHistory.handleSubmit = vi.fn((val) => onSubmit(val));
@@ -2548,6 +2548,10 @@ describe('InputPrompt', () => {
         stdin.write('\x03');
         vi.advanceTimersByTime(100);
 
+        expect(mockInputHistory.checkpointCurrentInput).toHaveBeenCalledWith(
+          'text to clear',
+          0,
+        );
         expect(props.buffer.setText).toHaveBeenCalledWith('');
         expect(mockCommandCompletion.resetCompletionState).toHaveBeenCalled();
       });
@@ -2594,10 +2598,106 @@ describe('InputPrompt', () => {
         stdin.write('\x1B\x1B');
         vi.advanceTimersByTime(100);
 
+        expect(mockInputHistory.checkpointCurrentInput).toHaveBeenCalledWith(
+          'some text',
+          0,
+        );
         expect(props.buffer.setText).toHaveBeenCalledWith('');
         expect(props.onSubmit).not.toHaveBeenCalledWith('/rewind');
       });
       unmount();
+    });
+
+    describe('unsent draft checkpoint and Up restore', () => {
+      let storedCheckpoint: { text: string; offset: number } | null;
+
+      beforeEach(() => {
+        storedCheckpoint = null;
+        mockedUseInputHistory.mockImplementation(
+          ({ onChange, currentQuery, userMessages, onSubmit, isActive }) => ({
+            checkpointCurrentInput: (text: string, offset: number) => {
+              if (text.trim()) {
+                storedCheckpoint = { text, offset };
+              }
+            },
+            navigateUp: () => {
+              if (!isActive) return false;
+              if (
+                storedCheckpoint &&
+                (!currentQuery.trim() || currentQuery === storedCheckpoint.text)
+              ) {
+                onChange(storedCheckpoint.text, storedCheckpoint.offset);
+                storedCheckpoint = null;
+                return true;
+              }
+              if (userMessages.length > 0) {
+                onChange(userMessages[userMessages.length - 1], 'start');
+                return true;
+              }
+              return false;
+            },
+            navigateDown: vi.fn(() => false),
+            handleSubmit: vi.fn((val: string) => {
+              if (val.trim()) {
+                onSubmit(val);
+              }
+              storedCheckpoint = null;
+            }),
+          }),
+        );
+      });
+
+      it('should restore checkpointed text on Up after Ctrl-C clear', async () => {
+        props.buffer.setText('recover me');
+        vi.mocked(props.buffer.setText).mockClear();
+
+        const { stdin, unmount } = renderWithProviders(
+          <InputPrompt {...props} />,
+        );
+
+        await act(async () => {
+          stdin.write('\x03');
+          vi.advanceTimersByTime(100);
+        });
+
+        expect(storedCheckpoint).toEqual({ text: 'recover me', offset: 0 });
+
+        await act(async () => {
+          stdin.write('\u001B[A');
+          vi.advanceTimersByTime(100);
+        });
+
+        await waitFor(() => {
+          expect(mockBuffer.setText).toHaveBeenCalledWith('recover me', 0);
+        });
+        unmount();
+      });
+
+      it('should restore checkpointed text on Up after double-Esc clear', async () => {
+        props.buffer.setText('recover esc');
+        vi.mocked(props.buffer.setText).mockClear();
+
+        const { stdin, unmount } = renderWithProviders(
+          <InputPrompt {...props} />,
+        );
+
+        await act(async () => {
+          stdin.write('\x1B\x1B');
+          vi.advanceTimersByTime(100);
+        });
+
+        expect(storedCheckpoint).toEqual({ text: 'recover esc', offset: 0 });
+
+        await act(async () => {
+          stdin.write('\u001B[A');
+          vi.advanceTimersByTime(100);
+        });
+
+        await waitFor(() => {
+          expect(mockBuffer.setText).toHaveBeenCalledWith('recover esc', 0);
+        });
+        unmount();
+      });
     });
 
     it('should reset escape state on any non-ESC key', async () => {
@@ -4421,7 +4521,7 @@ describe('InputPrompt', () => {
           return true;
         },
         handleSubmit: vi.fn((val) => onSubmit(val)),
-        saveDraft: vi.fn(),
+        checkpointCurrentInput: vi.fn(),
       }));
     });
 

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -289,6 +289,7 @@ describe('InputPrompt', () => {
       navigateUp: vi.fn(),
       navigateDown: vi.fn(),
       handleSubmit: vi.fn(),
+      saveDraft: vi.fn(),
     };
     mockedUseInputHistory.mockImplementation(({ onSubmit }) => {
       mockInputHistory.handleSubmit = vi.fn((val) => onSubmit(val));
@@ -4420,6 +4421,7 @@ describe('InputPrompt', () => {
           return true;
         },
         handleSubmit: vi.fn((val) => onSubmit(val)),
+        saveDraft: vi.fn(),
       }));
     });
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -237,8 +237,11 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           setShowEscapePrompt(true);
         } else if (count === 2) {
           resetEscapeState();
-          if (buffer.text.length > 0) {
-            inputHistory.saveDraft(buffer.text, buffer.getOffset());
+          if (buffer.text.trim()) {
+            inputHistory.checkpointCurrentInput(
+              buffer.text,
+              buffer.getOffset(),
+            );
             buffer.setText('');
             resetCompletionState();
           } else if (history.length > 0) {
@@ -1198,8 +1201,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         return false;
       }
 
-      if (keyMatchers[Command.CLEAR_INPUT](key) && buffer.text.trim()) {
-        inputHistory.saveDraft(buffer.text, buffer.getOffset());
+      if (keyMatchers[Command.CLEAR_INPUT](key)) {
+        inputHistory.checkpointCurrentInput(buffer.text, buffer.getOffset());
       }
 
       // Fall back to the text buffer's default input handling for all other keys

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -238,6 +238,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         } else if (count === 2) {
           resetEscapeState();
           if (buffer.text.length > 0) {
+            inputHistory.saveDraft(buffer.text, buffer.getOffset());
             buffer.setText('');
             resetCompletionState();
           } else if (history.length > 0) {
@@ -1195,6 +1196,10 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           return true;
         }
         return false;
+      }
+
+      if (keyMatchers[Command.CLEAR_INPUT](key) && buffer.text.trim()) {
+        inputHistory.saveDraft(buffer.text, buffer.getOffset());
       }
 
       // Fall back to the text buffer's default input handling for all other keys

--- a/packages/cli/src/ui/hooks/useInputHistory.test.ts
+++ b/packages/cli/src/ui/hooks/useInputHistory.test.ts
@@ -81,6 +81,135 @@ describe('useInputHistory', () => {
 
       expect(mockOnSubmit).not.toHaveBeenCalled();
     });
+
+    it('should clear unsent checkpoint on submit so it cannot reappear later', () => {
+      const { result, rerender } = renderHook(
+        (props: { currentQuery: string; currentCursorOffset: number }) =>
+          useInputHistory({
+            userMessages,
+            onSubmit: mockOnSubmit,
+            isActive: true,
+            currentQuery: props.currentQuery,
+            currentCursorOffset: props.currentCursorOffset,
+            onChange: mockOnChange,
+          }),
+        {
+          initialProps: { currentQuery: '', currentCursorOffset: 0 },
+        },
+      );
+
+      act(() => {
+        result.current.checkpointCurrentInput('zombie draft', 2);
+      });
+      act(() => {
+        result.current.handleSubmit('submitted');
+      });
+
+      rerender({ currentQuery: '', currentCursorOffset: 0 });
+      mockOnChange.mockClear();
+
+      act(() => {
+        result.current.navigateUp();
+      });
+
+      expect(mockOnChange).toHaveBeenCalledWith(userMessages[2], 'start');
+      expect(mockOnChange).not.toHaveBeenCalledWith(
+        'zombie draft',
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('checkpointCurrentInput and unsent draft restore', () => {
+    it('should persist trimmed-non-empty text to cache -1 for navigateUp when compose buffer is empty', () => {
+      const { result, rerender } = renderHook(
+        (props: { currentQuery: string; currentCursorOffset: number }) =>
+          useInputHistory({
+            userMessages: ['hist'],
+            onSubmit: mockOnSubmit,
+            isActive: true,
+            currentQuery: props.currentQuery,
+            currentCursorOffset: props.currentCursorOffset,
+            onChange: mockOnChange,
+          }),
+        {
+          initialProps: { currentQuery: 'typing', currentCursorOffset: 3 },
+        },
+      );
+
+      act(() => {
+        result.current.checkpointCurrentInput('saved draft', 4);
+      });
+      rerender({ currentQuery: '', currentCursorOffset: 0 });
+
+      act(() => {
+        result.current.navigateUp();
+      });
+
+      expect(mockOnChange).toHaveBeenCalledWith('saved draft', 4);
+    });
+
+    it('should not store checkpoint when text is empty after trim', () => {
+      const { result } = renderHook(
+        (props: { currentQuery: string; currentCursorOffset: number }) =>
+          useInputHistory({
+            userMessages: ['hist'],
+            onSubmit: mockOnSubmit,
+            isActive: true,
+            currentQuery: props.currentQuery,
+            currentCursorOffset: props.currentCursorOffset,
+            onChange: mockOnChange,
+          }),
+        {
+          initialProps: { currentQuery: '', currentCursorOffset: 0 },
+        },
+      );
+
+      act(() => {
+        result.current.checkpointCurrentInput('   ', 0);
+      });
+
+      act(() => {
+        result.current.navigateUp();
+      });
+
+      expect(mockOnChange).toHaveBeenCalledWith('hist', 'start');
+    });
+
+    it('should clear cache -1 after draft restore so the next navigateUp uses history', () => {
+      const { result, rerender } = renderHook(
+        (props: { currentQuery: string; currentCursorOffset: number }) =>
+          useInputHistory({
+            userMessages: ['h1', 'h2', 'h3'],
+            onSubmit: mockOnSubmit,
+            isActive: true,
+            currentQuery: props.currentQuery,
+            currentCursorOffset: props.currentCursorOffset,
+            onChange: mockOnChange,
+          }),
+        {
+          initialProps: { currentQuery: '', currentCursorOffset: 0 },
+        },
+      );
+
+      act(() => {
+        result.current.checkpointCurrentInput('draft', 2);
+      });
+
+      act(() => {
+        result.current.navigateUp();
+      });
+      expect(mockOnChange).toHaveBeenLastCalledWith('draft', 2);
+      mockOnChange.mockClear();
+
+      rerender({ currentQuery: 'draft', currentCursorOffset: 2 });
+
+      act(() => {
+        result.current.navigateUp();
+      });
+
+      expect(mockOnChange).toHaveBeenCalledWith('h3', 'start');
+    });
   });
 
   describe('navigateUp', () => {

--- a/packages/cli/src/ui/hooks/useInputHistory.ts
+++ b/packages/cli/src/ui/hooks/useInputHistory.ts
@@ -20,7 +20,7 @@ export interface UseInputHistoryReturn {
   handleSubmit: (value: string) => void;
   navigateUp: () => boolean;
   navigateDown: () => boolean;
-  saveDraft: (text: string, offset: number) => void;
+  checkpointCurrentInput: (text: string, offset: number) => void;
 }
 
 export function useInputHistory({
@@ -43,13 +43,10 @@ export function useInputHistory({
     Record<number, { text: string; offset: number }>
   >({});
 
-  const draftRef = useRef<{ text: string; offset: number } | null>(null);
-
   const resetHistoryNav = useCallback(() => {
     setHistoryIndex(-1);
     previousHistoryIndexRef.current = undefined;
     historyCacheRef.current = {};
-    draftRef.current = null;
   }, []);
 
   const handleSubmit = useCallback(
@@ -111,28 +108,30 @@ export function useInputHistory({
     [historyIndex, currentQuery, currentCursorOffset, userMessages, onChange],
   );
 
-  const saveDraft = useCallback((text: string, offset: number) => {
-    if (text.trim()) {
-      draftRef.current = { text, offset };
+  const checkpointCurrentInput = useCallback((text: string, offset: number) => {
+    if (!text.trim()) {
+      return;
     }
+    historyCacheRef.current[-1] = { text, offset };
   }, []);
 
   const navigateUp = useCallback(() => {
     if (!isActive) return false;
 
-    const shouldRestoreDraft =
-      historyIndex === -1 &&
-      draftRef.current &&
-      (!currentQuery.trim() || currentQuery === draftRef.current.text);
+    const cache = historyCacheRef.current;
+    const unsentDraft = cache[-1];
 
-    if (shouldRestoreDraft) {
-      const draft = draftRef.current;
-      if (!draft) {
-        return false;
+    if (historyIndex === -1 && unsentDraft !== undefined) {
+      const trimmedSaved = unsentDraft.text.trim();
+      if (trimmedSaved) {
+        const shouldRestoreDraft =
+          !currentQuery.trim() || currentQuery === unsentDraft.text;
+        if (shouldRestoreDraft) {
+          delete cache[-1];
+          onChange(unsentDraft.text, unsentDraft.offset);
+          return true;
+        }
       }
-      draftRef.current = null;
-      onChange(draft.text, draft.offset);
-      return true;
     }
 
     if (userMessages.length === 0) return false;
@@ -163,6 +162,6 @@ export function useInputHistory({
     handleSubmit,
     navigateUp,
     navigateDown,
-    saveDraft,
+    checkpointCurrentInput,
   };
 }

--- a/packages/cli/src/ui/hooks/useInputHistory.ts
+++ b/packages/cli/src/ui/hooks/useInputHistory.ts
@@ -20,6 +20,7 @@ export interface UseInputHistoryReturn {
   handleSubmit: (value: string) => void;
   navigateUp: () => boolean;
   navigateDown: () => boolean;
+  saveDraft: (text: string, offset: number) => void;
 }
 
 export function useInputHistory({
@@ -42,10 +43,13 @@ export function useInputHistory({
     Record<number, { text: string; offset: number }>
   >({});
 
+  const draftRef = useRef<{ text: string; offset: number } | null>(null);
+
   const resetHistoryNav = useCallback(() => {
     setHistoryIndex(-1);
     previousHistoryIndexRef.current = undefined;
     historyCacheRef.current = {};
+    draftRef.current = null;
   }, []);
 
   const handleSubmit = useCallback(
@@ -107,8 +111,22 @@ export function useInputHistory({
     [historyIndex, currentQuery, currentCursorOffset, userMessages, onChange],
   );
 
+  const saveDraft = useCallback((text: string, offset: number) => {
+    if (text.trim()) {
+      draftRef.current = { text, offset };
+    }
+  }, []);
+
   const navigateUp = useCallback(() => {
     if (!isActive) return false;
+
+    if (historyIndex === -1 && !currentQuery.trim() && draftRef.current) {
+      const draft = draftRef.current;
+      draftRef.current = null;
+      onChange(draft.text, draft.offset);
+      return true;
+    }
+
     if (userMessages.length === 0) return false;
 
     if (historyIndex < userMessages.length - 1) {
@@ -116,7 +134,14 @@ export function useInputHistory({
       return true;
     }
     return false;
-  }, [historyIndex, userMessages, isActive, navigateTo]);
+  }, [
+    historyIndex,
+    userMessages,
+    isActive,
+    navigateTo,
+    currentQuery,
+    onChange,
+  ]);
 
   const navigateDown = useCallback(() => {
     if (!isActive) return false;
@@ -130,5 +155,6 @@ export function useInputHistory({
     handleSubmit,
     navigateUp,
     navigateDown,
+    saveDraft,
   };
 }

--- a/packages/cli/src/ui/hooks/useInputHistory.ts
+++ b/packages/cli/src/ui/hooks/useInputHistory.ts
@@ -120,8 +120,16 @@ export function useInputHistory({
   const navigateUp = useCallback(() => {
     if (!isActive) return false;
 
-    if (historyIndex === -1 && !currentQuery.trim() && draftRef.current) {
+    const shouldRestoreDraft =
+      historyIndex === -1 &&
+      draftRef.current &&
+      (!currentQuery.trim() || currentQuery === draftRef.current.text);
+
+    if (shouldRestoreDraft) {
       const draft = draftRef.current;
+      if (!draft) {
+        return false;
+      }
       draftRef.current = null;
       onChange(draft.text, draft.offset);
       return true;


### PR DESCRIPTION
## Summary

- Add lightweight unsent-draft tracking to useInputHistory so accidental clears do not permanently lose in-progress input.
- Save the current buffer as a draft before destructive clear actions (Ctrl+C clear and double-Esc clear).
- Update Up Arrow behavior to restore the saved unsent draft first (when compose buffer is empty), then continue into normal sent-message history navigation.

## Related Issues

Fixes #20948

## How to Validate

- Ctrl+C clear -> Up Arrow now restores the last unsent draft first.
- Double-Esc clear -> Up Arrow now restores the last unsent draft first.
- After restoring the draft once, the next Up Arrow navigates sent history as usual.
- Submitting a message clears the saved draft state

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [X] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [X] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [X] Windows
    - [X] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
