### PR TITLE
feat(triage): add area/documentation to issue triage

### DIFF
--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -121,6 +121,7 @@ jobs:
               'area/security',
               'area/platform',
               'area/extensions',
+              'area/documentation',
               'area/unknown'
             ];
             const labelNames = labels.map(label => label.name).filter(name => allowedLabels.includes(name));
@@ -254,6 +255,14 @@ jobs:
               "Bugs related to the extension marketplace website."
               "Issues with a specific extension."
               "Feature request for the extension ecosystem."
+
+            area/documentation
+            - Description: Issues related to user-facing documentation and other content on the documentation website.
+            - Example Issues:
+              "A typo in a README file."
+              "DOCS: A command is not working as described in the documentation."
+              "A request for a new documentation page."
+              "Instructions missing for skills feature"
 
             area/unknown
             - Description: Issues that do not clearly fit into any other defined area/ category, or where information is too limited to make a determination. Use this when no other area is appropriate.

--- a/.github/workflows/gemini-scheduled-issue-triage.yml
+++ b/.github/workflows/gemini-scheduled-issue-triage.yml
@@ -63,7 +63,7 @@ jobs:
 
           echo '🔍 Finding issues missing area labels...'
           NO_AREA_ISSUES="$(gh issue list --repo "${GITHUB_REPOSITORY}" \
-            --search 'is:open is:issue -label:area/core -label:area/agent -label:area/enterprise -label:area/non-interactive -label:area/security -label:area/platform -label:area/extensions -label:area/unknown' --limit 100 --json number,title,body)"
+            --search 'is:open is:issue -label:area/core -label:area/agent -label:area/enterprise -label:area/non-interactive -label:area/security -label:area/platform -label:area/extensions -label:area/documentation -label:area/unknown' --limit 100 --json number,title,body)"
 
           echo '🔍 Finding issues missing kind labels...'
           NO_KIND_ISSUES="$(gh issue list --repo "${GITHUB_REPOSITORY}" \
@@ -204,6 +204,7 @@ jobs:
             Categorization Guidelines (Area):
             area/agent: Core Agent, Tools, Memory, Sub-Agents, Hooks, Agent Quality
             area/core: User Interface, OS Support, Core Functionality
+            area/documentation: End-user and contributor-facing documentation, website-related
             area/enterprise: Telemetry, Policy, Quota / Licensing
             area/extensions: Gemini CLI extensions capability
             area/non-interactive: GitHub Actions, SDK, 3P Integrations, Shell Scripting, Command line automation


### PR DESCRIPTION
## Summary

Adds details on the 'area/documentation' label to the automated and scheduled issue triage workflows.

This ensures that issues related to documentation are correctly labeled, improving the organization of the issue tracker.

Fixes google-gemini/maintainers-gemini-cli#1483
