### PR TITLE
Enhance CLI with human-readable summaries for shell commands

### DIFF
--- a/packages/cli/src/ui/components/messages/ShellToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ShellToolMessage.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { Box, type DOMElement } from 'ink';
+import { Box, Text, type DOMElement } from 'ink';
 import { ShellInputPrompt } from '../ShellInputPrompt.js';
 import { StickyHeader } from '../StickyHeader.js';
 import { useUIActions } from '../../contexts/UIActionsContext.js';
@@ -26,6 +26,8 @@ import { useAlternateBuffer } from '../../hooks/useAlternateBuffer.js';
 import { useUIState } from '../../contexts/UIStateContext.js';
 import { type Config } from '@google/gemini-cli-core';
 import { calculateShellMaxLines } from '../../utils/toolLayoutUtils.js';
+import { useCommandSummary } from '../../hooks/useCommandSummary.js';
+import { theme } from '../../semantic-colors.js';
 
 export interface ShellToolMessageProps extends ToolMessageProps {
   config?: Config;
@@ -62,6 +64,9 @@ export const ShellToolMessage: React.FC<ShellToolMessageProps> = ({
   isExpandable,
 
   originalRequestName,
+
+  commandSummary: modelSummary,
+  rawCommand,
 }) => {
   const {
     activePtyId: activeShellPtyId,
@@ -69,6 +74,8 @@ export const ShellToolMessage: React.FC<ShellToolMessageProps> = ({
     constrainHeight,
   } = useUIState();
   const isAlternateBuffer = useAlternateBuffer();
+
+  const commandSummary = useCommandSummary(config, rawCommand, modelSummary);
 
   const isThisShellFocused = checkIsShellFocused(
     name,
@@ -96,8 +103,6 @@ export const ShellToolMessage: React.FC<ShellToolMessageProps> = ({
 
   const contentRef = React.useRef<DOMElement>(null);
 
-  // The shell is focusable if it's the shell command, it's executing, and the interactive shell is enabled.
-
   const isThisShellFocusable = checkIsShellFocusable(name, status, config);
 
   const handleFocus = () => {
@@ -115,6 +120,8 @@ export const ShellToolMessage: React.FC<ShellToolMessageProps> = ({
     isThisShellFocused,
     resultDisplay,
   );
+
+  const showCollapsedCommand = !!commandSummary && !!rawCommand;
 
   return (
     <>
@@ -137,6 +144,7 @@ export const ShellToolMessage: React.FC<ShellToolMessageProps> = ({
           description={description}
           emphasis={emphasis}
           originalRequestName={originalRequestName}
+          commandSummary={commandSummary}
         />
 
         <FocusHint
@@ -160,6 +168,14 @@ export const ShellToolMessage: React.FC<ShellToolMessageProps> = ({
         paddingX={1}
         flexDirection="column"
       >
+        {showCollapsedCommand && (
+          <Box>
+            <Text dimColor color={theme.text.secondary} wrap="truncate">
+              {'$ '}
+              {rawCommand}
+            </Text>
+          </Box>
+        )}
         <ToolResultDisplay
           resultDisplay={resultDisplay}
           availableTerminalHeight={availableTerminalHeight}

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -60,6 +60,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
   originalRequestName,
   progress,
   progressTotal,
+  commandSummary,
 }) => {
   const isThisShellFocused = checkIsShellFocused(
     name,
@@ -99,6 +100,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
           description={description}
           emphasis={emphasis}
           originalRequestName={originalRequestName}
+          commandSummary={commandSummary}
         />
         <FocusHint
           shouldShowFocusHint={shouldShowFocusHint}

--- a/packages/cli/src/ui/components/messages/ToolShared.tsx
+++ b/packages/cli/src/ui/components/messages/ToolShared.tsx
@@ -193,6 +193,8 @@ type ToolInfoProps = {
   status: CoreToolCallStatus;
   emphasis: TextEmphasis;
   originalRequestName?: string;
+  /** Human-readable summary of what the command does (shown instead of raw description). */
+  commandSummary?: string;
 };
 
 export const ToolInfo: React.FC<ToolInfoProps> = ({
@@ -201,6 +203,7 @@ export const ToolInfo: React.FC<ToolInfoProps> = ({
   status: coreStatus,
   emphasis,
   originalRequestName,
+  commandSummary,
 }) => {
   const status = mapCoreStatusToDisplayStatus(coreStatus);
   const nameColor = React.useMemo<string>(() => {
@@ -221,6 +224,8 @@ export const ToolInfo: React.FC<ToolInfoProps> = ({
   // Hide description for completed Ask User tools (the result display speaks for itself)
   const isCompletedAskUser = isCompletedAskUserTool(name, status);
 
+  const displayDescription = commandSummary || description;
+
   return (
     <Box overflow="hidden" height={1} flexGrow={1} flexShrink={1}>
       <Text strikethrough={status === ToolCallStatus.Canceled} wrap="truncate">
@@ -236,7 +241,11 @@ export const ToolInfo: React.FC<ToolInfoProps> = ({
         {!isCompletedAskUser && (
           <>
             {' '}
-            <Text color={theme.text.secondary}>{description}</Text>
+            <Text
+              color={commandSummary ? theme.text.primary : theme.text.secondary}
+            >
+              {displayDescription}
+            </Text>
           </>
         )}
       </Text>

--- a/packages/cli/src/ui/hooks/toolMapping.test.ts
+++ b/packages/cli/src/ui/hooks/toolMapping.test.ts
@@ -353,5 +353,82 @@ describe('toolMapping', () => {
       expect(result.tools[0].isClientInitiated).toBe(true);
       expect(result.tools[1].isClientInitiated).toBe(false);
     });
+
+    describe('shell tool command summary', () => {
+      const shellTool = {
+        name: 'run_shell_command',
+        displayName: 'Shell',
+        isOutputMarkdown: false,
+      } as unknown as AnyDeclarativeTool;
+
+      const shellInvocation = {
+        getDescription: () => 'ls -la [in /home/user]',
+      } as unknown as AnyToolInvocation;
+
+      it('extracts rawCommand and commandSummary for shell tools with description', () => {
+        const toolCall: ScheduledToolCall = {
+          status: CoreToolCallStatus.Scheduled,
+          request: {
+            callId: 'shell-1',
+            name: 'run_shell_command',
+            args: {
+              command: 'ls -la',
+              description: 'List all files in current directory',
+              dir_path: '/home/user',
+            },
+            isClientInitiated: false,
+            prompt_id: 'p1',
+          },
+          tool: shellTool,
+          invocation: shellInvocation,
+        };
+
+        const result = mapToDisplay(toolCall);
+        const displayTool = result.tools[0];
+
+        expect(displayTool.rawCommand).toBe('ls -la [in /home/user]');
+        expect(displayTool.commandSummary).toBe(
+          'List all files in current directory',
+        );
+      });
+
+      it('extracts rawCommand without dir_path', () => {
+        const toolCall: ScheduledToolCall = {
+          status: CoreToolCallStatus.Scheduled,
+          request: {
+            callId: 'shell-2',
+            name: 'run_shell_command',
+            args: {
+              command: 'git status',
+            },
+            isClientInitiated: false,
+            prompt_id: 'p1',
+          },
+          tool: shellTool,
+          invocation: shellInvocation,
+        };
+
+        const result = mapToDisplay(toolCall);
+        const displayTool = result.tools[0];
+
+        expect(displayTool.rawCommand).toBe('git status');
+        expect(displayTool.commandSummary).toBeUndefined();
+      });
+
+      it('does not set commandSummary or rawCommand for non-shell tools', () => {
+        const toolCall: ScheduledToolCall = {
+          status: CoreToolCallStatus.Scheduled,
+          request: mockRequest,
+          tool: mockTool,
+          invocation: mockInvocation,
+        };
+
+        const result = mapToDisplay(toolCall);
+        const displayTool = result.tools[0];
+
+        expect(displayTool.rawCommand).toBeUndefined();
+        expect(displayTool.commandSummary).toBeUndefined();
+      });
+    });
   });
 });

--- a/packages/cli/src/ui/hooks/toolMapping.ts
+++ b/packages/cli/src/ui/hooks/toolMapping.ts
@@ -10,11 +10,46 @@ import {
   type ToolResultDisplay,
   debugLogger,
   CoreToolCallStatus,
+  SHELL_TOOL_NAME,
 } from '@google/gemini-cli-core';
 import {
   type HistoryItemToolGroup,
   type IndividualToolCallDisplay,
 } from '../types.js';
+import { SHELL_COMMAND_NAME, SHELL_NAME } from '../constants.js';
+
+function isShellToolName(name: string): boolean {
+  return (
+    name === SHELL_COMMAND_NAME ||
+    name === SHELL_NAME ||
+    name === SHELL_TOOL_NAME
+  );
+}
+
+/**
+ * Extracts the raw command and model-provided summary from shell tool args.
+ */
+function extractShellCommandInfo(args: Record<string, unknown>): {
+  rawCommand: string | undefined;
+  commandSummary: string | undefined;
+} {
+  const command =
+    typeof args['command'] === 'string' ? args['command'] : undefined;
+  const description =
+    typeof args['description'] === 'string' ? args['description'] : undefined;
+  const dirPath =
+    typeof args['dir_path'] === 'string' ? args['dir_path'] : undefined;
+
+  let rawCommand = command;
+  if (rawCommand && dirPath) {
+    rawCommand = `${rawCommand} [in ${dirPath}]`;
+  }
+
+  return {
+    rawCommand,
+    commandSummary: description || undefined,
+  };
+}
 
 /**
  * Transforms `ToolCall` objects into `HistoryItemToolGroup` objects for UI
@@ -46,12 +81,23 @@ export function mapToDisplay(
       renderOutputAsMarkdown = call.tool.isOutputMarkdown;
     }
 
+    let commandSummary: string | undefined = undefined;
+    let rawCommand: string | undefined = undefined;
+
+    if (isShellToolName(displayName) || isShellToolName(call.request.name)) {
+      const shellInfo = extractShellCommandInfo(call.request.args);
+      rawCommand = shellInfo.rawCommand;
+      commandSummary = shellInfo.commandSummary;
+    }
+
     const baseDisplayProperties = {
       callId: call.request.callId,
       parentCallId: call.request.parentCallId,
       name: displayName,
       description,
       renderOutputAsMarkdown,
+      commandSummary,
+      rawCommand,
     };
 
     let resultDisplay: ToolResultDisplay | undefined = undefined;

--- a/packages/cli/src/ui/hooks/useCommandSummary.ts
+++ b/packages/cli/src/ui/hooks/useCommandSummary.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, useEffect, useRef } from 'react';
+import { summarizeCommand, type Config } from '@google/gemini-cli-core';
+
+/**
+ * Hook that provides a human-readable summary for a shell command.
+ *
+ * When a model-provided summary is available, it's used directly.
+ * Otherwise, Flash Lite is called asynchronously to generate one.
+ *
+ * @param config The application config (for Gemini client access).
+ * @param rawCommand The raw shell command string.
+ * @param modelProvidedSummary Optional summary provided by the model.
+ * @returns The best available summary, or undefined while loading.
+ */
+export function useCommandSummary(
+  config: Config | undefined,
+  rawCommand: string | undefined,
+  modelProvidedSummary: string | undefined,
+): string | undefined {
+  const [flashLiteSummary, setFlashLiteSummary] = useState<string | undefined>(
+    undefined,
+  );
+  const requestedCommandRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (modelProvidedSummary || !rawCommand || !config) {
+      return;
+    }
+
+    if (requestedCommandRef.current === rawCommand) {
+      return;
+    }
+    requestedCommandRef.current = rawCommand;
+
+    const controller = new AbortController();
+
+    summarizeCommand(
+      config,
+      rawCommand,
+      config.getGeminiClient(),
+      controller.signal,
+    )
+      .then((summary) => {
+        if (!controller.signal.aborted && summary !== rawCommand) {
+          setFlashLiteSummary(summary);
+        }
+      })
+      .catch(() => {
+        // Silently ignore failures; the raw command remains visible.
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [config, rawCommand, modelProvidedSummary]);
+
+  if (modelProvidedSummary) {
+    return modelProvidedSummary;
+  }
+  return flashLiteSummary;
+}

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -115,6 +115,10 @@ export interface IndividualToolCallDisplay {
   originalRequestName?: string;
   progress?: number;
   progressTotal?: number;
+  /** Human-readable summary of what the tool command does (e.g. from model or Flash Lite). */
+  commandSummary?: string;
+  /** The raw shell command string, shown collapsed when a summary is available. */
+  rawCommand?: string;
 }
 
 export interface CompressionProps {

--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -169,6 +169,18 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
         },
       },
     },
+    'command-summarizer': {
+      extends: 'base',
+      modelConfig: {
+        model: 'gemini-2.5-flash-lite',
+        generateContentConfig: {
+          maxOutputTokens: 100,
+          thinkingConfig: {
+            thinkingBudget: 0,
+          },
+        },
+      },
+    },
     'web-search': {
       extends: 'gemini-3-flash-base',
       modelConfig: {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,6 +112,7 @@ export * from './utils/apiConversionUtils.js';
 export * from './utils/channel.js';
 export * from './utils/constants.js';
 export * from './utils/sessionUtils.js';
+export * from './utils/commandSummarizer.js';
 
 // Export services
 export * from './services/fileDiscoveryService.js';

--- a/packages/core/src/utils/commandSummarizer.ts
+++ b/packages/core/src/utils/commandSummarizer.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Content } from '@google/genai';
+import type { GeminiClient } from '../core/client.js';
+import { getResponseText } from './partUtils.js';
+import { debugLogger } from './debugLogger.js';
+import type { Config } from '../config/config.js';
+import { LlmRole } from '../telemetry/llmRole.js';
+
+const COMMAND_SUMMARY_PROMPT = `Summarize what the following shell command does in a single short sentence (max 10 words). Focus on WHAT it does, not HOW. Use plain language a non-technical person could understand. Do not include the command itself in the summary. Do not use backticks or code formatting.
+
+Examples:
+- "cat foo.txt | head -n 5" → "Read first 5 lines of foo.txt"
+- "find . -name '*.ts' -exec grep -l 'import' {} +" → "Find TypeScript files containing imports"
+- "git log --oneline -10" → "Show last 10 commits"
+- "npm install && npm run build" → "Install dependencies and build project"
+- "sed -i 's/foo/bar/g' file.ts utils.ts" → "Rename foo to bar in file.ts and utils.ts"
+- "mkdir -p src/components && touch src/components/index.ts" → "Create components directory with index file"
+- "docker compose up -d" → "Start Docker services in background"
+- "curl -s https://api.example.com/health" → "Check API health endpoint"
+
+Command: "{command}"
+Summary:`;
+
+/**
+ * Summarizes a shell command into a human-readable description using Flash Lite.
+ *
+ * @param config The application config.
+ * @param command The raw shell command to summarize.
+ * @param geminiClient The Gemini client for API calls.
+ * @param signal Abort signal for cancellation.
+ * @returns A human-readable summary of what the command does.
+ */
+export async function summarizeCommand(
+  config: Config,
+  command: string,
+  geminiClient: GeminiClient,
+  signal: AbortSignal,
+): Promise<string> {
+  if (!command || command.trim().length === 0) {
+    return command;
+  }
+
+  const prompt = COMMAND_SUMMARY_PROMPT.replace('{command}', command);
+  const contents: Content[] = [{ role: 'user', parts: [{ text: prompt }] }];
+
+  try {
+    const response = await geminiClient.generateContent(
+      { model: 'command-summarizer' },
+      contents,
+      signal,
+      LlmRole.UTILITY_SUMMARIZER,
+    );
+    const summary = getResponseText(response)?.trim();
+    if (summary && summary.length > 0 && summary.length < 200) {
+      return summary;
+    }
+    return command;
+  } catch (error) {
+    debugLogger.warn('Failed to summarize command.', error);
+    return command;
+  }
+}


### PR DESCRIPTION
Surface a concise human-readable summary of what each shell command does in the tool header, with the raw command shown dimmed in the body. Uses the model-provided description parameter when available, and falls back to Flash Lite (gemini-2.5-flash-lite) for async summarization when not.

## Summary

- Show a short, human-readable summary of what each shell command does (e.g. “List all files in current directory”) in the tool header instead of the raw command string.
- Display the raw shell command dimmed with a `$` prefix in the tool body as a collapsed view.
- Prefer the model-provided `description` parameter when available, and fall back to a lightweight Flash Lite model (`gemini-2.5-flash-lite`) to summarize commands when `description` is missing.

## Details

- Added a core `commandSummarizer` utility that uses a few-shot prompt on `gemini-2.5-flash-lite` to turn shell commands into short, plain-language summaries.
- Introduced a `useCommandSummary` hook in the CLI UI that:
  - Immediately uses the model-provided `description` if present.
  - Otherwise asynchronously calls the Flash Lite summarizer and updates the header once the summary is available.
- Extended `IndividualToolCallDisplay` with `commandSummary` and `rawCommand` and populated these for shell tools in `toolMapping`.
- Updated `ToolInfo` so it prefers `commandSummary` as the primary text (with stronger coloring), falling back to the existing `description` when no summary exists.
- Updated `ShellToolMessage` to render the raw command dimmed in the body (collapsed view) while the header focuses on the summary.
- Added tests around tool mapping to ensure shell command summaries and raw commands are wired correctly and that non-shell tools are unaffected.

## Related Issues

#21192

## How to Validate

1. **Install dependencies**
   - From repo root: `npm install`
2. **Run core and CLI tests**
   - `cd packages/core && npx tsc --noEmit`
   - `cd ../cli && npx vitest run src/ui/hooks/toolMapping.test.ts`
   - `npx vitest run src/ui/components/messages/ShellToolMessage.test.tsx src/ui/components/messages/ToolMessage.test.tsx src/ui/components/messages/ToolGroupMessage.test.tsx`
3. **Manual CLI validation (shell summaries)**
   - Run the CLI in interactive mode (same way you normally invoke `gemini-cli`).
   - Ask the model to run a few shell commands via the shell tool, e.g.:
     - `ls -la`
     - `cat README.md | head -n 5`
     - `git status`
   - Verify that:
     - The **header** shows a short, descriptive sentence (e.g. “List all files in current directory”).
     - The **body** shows the raw command dimmed with a `$` prefix.
4. **Flash Lite fallback behavior**
   - Prompt the model in a way that it is unlikely to provide an explicit `description` (e.g. “Run this exact shell command: `<complex command>`”).
   - Confirm that the header eventually updates with a human-readable summary, indicating the Flash Lite summarizer path was used.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (tool mapping + component tests)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run (via `npx vitest` / `tsc`)
    - [ ] npx (end-to-end CLI run)
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker