### PR TITLE
feat(cli): support udocker as sandbox backend

### DIFF
--- a/packages/cli/src/config/sandboxConfig.ts
+++ b/packages/cli/src/config/sandboxConfig.ts
@@ -28,6 +28,7 @@ const VALID_SANDBOX_COMMANDS: ReadonlyArray<SandboxConfig['command']> = [
   'podman',
   'sandbox-exec',
   'lxc',
+  'udocker',
 ];
 
 function isSandboxCommand(value: string): value is SandboxConfig['command'] {
@@ -81,6 +82,8 @@ function getSandboxCommand(
     return 'docker';
   } else if (commandExists.sync('podman') && sandbox === true) {
     return 'podman';
+  } else if (commandExists.sync('udocker') && sandbox === true) {
+    return 'udocker';
   }
 
   // throw an error if user requested sandbox but no command was found

--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -494,6 +494,49 @@ describe('sandbox', () => {
       expect(entrypointCmd).toContain('su -p gemini');
     });
 
+    it('should normalize udocker long flags before image token', async () => {
+      const config: SandboxConfig = {
+        command: 'udocker',
+        image: 'gemini-cli-sandbox:latest',
+      };
+      process.env['SANDBOX_FLAGS'] = '--device /dev/fuse --privileged';
+
+      interface MockProcessWithStdout extends EventEmitter {
+        stdout: EventEmitter;
+      }
+      const mockImageCheckProcess = new EventEmitter() as MockProcessWithStdout;
+      mockImageCheckProcess.stdout = new EventEmitter();
+      vi.mocked(spawn).mockImplementationOnce(() => {
+        setTimeout(() => {
+          mockImageCheckProcess.stdout.emit(
+            'data',
+            Buffer.from('REPOSITORY TAG\n gemini-cli-sandbox latest\n'),
+          );
+          mockImageCheckProcess.emit('close', 0);
+        }, 1);
+        return mockImageCheckProcess as unknown as ReturnType<typeof spawn>;
+      });
+
+      const mockRunProcess = new EventEmitter() as unknown as ReturnType<
+        typeof spawn
+      >;
+      mockRunProcess.on = vi.fn().mockImplementation((event, cb) => {
+        if (event === 'close') {
+          setTimeout(() => cb(0), 10);
+        }
+        return mockRunProcess;
+      });
+      vi.mocked(spawn).mockImplementationOnce(() => mockRunProcess);
+
+      await start_sandbox(config);
+
+      const runArgs = vi.mocked(spawn).mock.calls[1][1] as string[];
+      expect(runArgs).toContain('--device=/dev/fuse');
+      expect(runArgs).toContain('--privileged');
+      expect(runArgs).toContain('gemini-cli-sandbox:latest');
+      expect(runArgs).not.toContain('--privileged=gemini-cli-sandbox:latest');
+    });
+
     describe('LXC sandbox', () => {
       const LXC_RUNNING = JSON.stringify([
         { name: 'gemini-sandbox', status: 'Running' },

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -721,6 +721,7 @@ export async function start_sandbox(
 
       if (config.command === 'udocker') {
         // udocker doesn't support --init or --network
+        proxyContainerArgs.push(`--name=${SANDBOX_PROXY_NAME}`);
         proxyContainerArgs.push(`--publish=8877:8877`);
         proxyContainerArgs.push(`--volume=${process.cwd()}:${workdir}`);
         proxyContainerArgs.push(`--workdir=${workdir}`);
@@ -742,7 +743,11 @@ export async function start_sandbox(
       // install handlers to stop proxy on exit/signal
       const stopProxy = () => {
         debugLogger.log('stopping proxy container ...');
-        execFileSync(config.command, ['rm', '-f', SANDBOX_PROXY_NAME]);
+        const removeArgs =
+          config.command === 'udocker'
+            ? ['rm', SANDBOX_PROXY_NAME]
+            : ['rm', '-f', SANDBOX_PROXY_NAME];
+        execFileSync(config.command, removeArgs);
       };
 
       cleanupProxyHandlers = setupProcessExitHandlers(stopProxy);

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -48,6 +48,7 @@ export async function start_sandbox(
   nodeArgs: string[] = [],
   cliConfig?: Config,
   cliArgs: string[] = [],
+  isDirectCommand = false,
 ): Promise<number> {
   const patcher = new ConsolePatcher({
     debugMode: cliConfig?.getDebugMode() || !!process.env['DEBUG'],
@@ -141,6 +142,7 @@ export async function start_sandbox(
       const proxyCommand = process.env['GEMINI_SANDBOX_PROXY_COMMAND'];
       let proxyProcess: ChildProcess | undefined = undefined;
       let sandboxProcess: ChildProcess | undefined = undefined;
+      let cleanupProxyHandlers: (() => void) | undefined = undefined;
       const sandboxEnv = { ...process.env };
       if (proxyCommand) {
         const proxy =
@@ -170,11 +172,15 @@ export async function start_sandbox(
             process.kill(-proxyProcess.pid, 'SIGTERM');
           }
         };
-        process.off('exit', stopProxy);
+
+        cleanupProxyHandlers = () => {
+          process.off('exit', stopProxy);
+          process.off('SIGINT', stopProxy);
+          process.off('SIGTERM', stopProxy);
+        };
+
         process.on('exit', stopProxy);
-        process.off('SIGINT', stopProxy);
         process.on('SIGINT', stopProxy);
-        process.off('SIGTERM', stopProxy);
         process.on('SIGTERM', stopProxy);
 
         // commented out as it disrupts ink rendering
@@ -185,6 +191,9 @@ export async function start_sandbox(
           debugLogger.debug(`[PROXY STDERR]: ${data.toString().trim()}`);
         });
         proxyProcess.on('close', (code, signal) => {
+          if (typeof cleanupProxyHandlers === 'function') {
+            cleanupProxyHandlers();
+          }
           if (sandboxProcess?.pid) {
             process.kill(-sandboxProcess.pid, 'SIGTERM');
           }
@@ -203,8 +212,16 @@ export async function start_sandbox(
         stdio: 'inherit',
       });
       return await new Promise((resolve, reject) => {
-        sandboxProcess?.on('error', reject);
+        sandboxProcess?.on('error', (err) => {
+          if (typeof cleanupProxyHandlers === 'function') {
+            cleanupProxyHandlers();
+          }
+          reject(err);
+        });
         sandboxProcess?.on('close', (code) => {
+          if (typeof cleanupProxyHandlers === 'function') {
+            cleanupProxyHandlers();
+          }
           process.stdin.resume();
           resolve(code ?? 1);
         });
@@ -280,7 +297,10 @@ export async function start_sandbox(
 
     // use interactive mode and auto-remove container on exit
     // run init binary inside container to forward signals & reap zombies
-    const args = ['run', '-i', '--rm', '--init', '--workdir', containerWorkdir];
+    const args = ['run', '-i', '--rm', '--workdir', containerWorkdir];
+    if (config.command !== 'udocker') {
+      args.push('--init');
+    }
 
     // add custom flags from SANDBOX_FLAGS
     if (process.env['SANDBOX_FLAGS']) {
@@ -291,12 +311,14 @@ export async function start_sandbox(
     }
 
     // add TTY only if stdin is TTY as well, i.e. for piped input don't init TTY in container
-    if (process.stdin.isTTY) {
+    if (process.stdin.isTTY && config.command !== 'udocker') {
       args.push('-t');
     }
 
-    // allow access to host.docker.internal
-    args.push('--add-host', 'host.docker.internal:host-gateway');
+    // allow access to host.docker.internal (not supported by udocker)
+    if (config.command !== 'udocker') {
+      args.push('--add-host', 'host.docker.internal:host-gateway');
+    }
 
     // mount current directory as working directory in sandbox (set via --workdir)
     args.push('--volume', `${workdir}:${containerWorkdir}`);
@@ -419,8 +441,8 @@ export async function start_sandbox(
         args.push('--env', `no_proxy=${noProxy}`);
       }
 
-      // if using proxy, switch to internal networking through proxy
-      if (proxy) {
+      // if using proxy, switch to internal networking through proxy (not supported by udocker natively)
+      if (proxy && config.command !== 'udocker') {
         execSync(
           `${config.command} network inspect ${SANDBOX_NETWORK_NAME} || ${config.command} network create --internal ${SANDBOX_NETWORK_NAME}`,
         );
@@ -441,10 +463,10 @@ export async function start_sandbox(
     const isIntegrationTest =
       process.env['GEMINI_CLI_INTEGRATION_TEST'] === 'true';
     let containerName;
-    if (isIntegrationTest) {
-      containerName = `gemini-cli-integration-test-${randomBytes(4).toString(
-        'hex',
-      )}`;
+    if (isIntegrationTest || config.command === 'udocker') {
+      containerName = `gemini-cli-${
+        isIntegrationTest ? 'integration-test' : 'sandbox'
+      }-${randomBytes(4).toString('hex')}`;
       debugLogger.log(`ContainerName: ${containerName}`);
     } else {
       let index = 0;
@@ -457,7 +479,9 @@ export async function start_sandbox(
       containerName = `${imageName}-${index}`;
       debugLogger.log(`ContainerName (regular): ${containerName}`);
     }
-    args.push('--name', containerName, '--hostname', containerName);
+    if (config.command !== 'udocker') {
+      args.push('--name', containerName, '--hostname', containerName);
+    }
 
     // copy GEMINI_CLI_TEST_VAR for integration tests
     if (process.env['GEMINI_CLI_TEST_VAR']) {
@@ -608,7 +632,7 @@ export async function start_sandbox(
     // Determine if the current user's UID/GID should be passed to the sandbox.
     // See shouldUseCurrentUserInSandbox for more details.
     let userFlag = '';
-    const finalEntrypoint = entrypoint(workdir, cliArgs);
+    const finalEntrypoint = entrypoint(workdir, cliArgs, isDirectCommand);
 
     if (process.env['GEMINI_CLI_INTEGRATION_TEST'] === 'true') {
       args.push('--user', 'root');
@@ -660,10 +684,15 @@ export async function start_sandbox(
     // start and set up proxy if GEMINI_SANDBOX_PROXY_COMMAND is set
     let proxyProcess: ChildProcess | undefined = undefined;
     let sandboxProcess: ChildProcess | undefined = undefined;
+    let cleanupProxyHandlers: (() => void) | undefined = undefined;
 
     if (proxyCommand) {
       // run proxyCommand in its own container
-      const proxyContainerCommand = `${config.command} run --rm --init ${userFlag} --name ${SANDBOX_PROXY_NAME} --network ${SANDBOX_PROXY_NAME} -p 8877:8877 -v ${process.cwd()}:${workdir} --workdir ${workdir} ${image} ${proxyCommand}`;
+      let proxyContainerCommand = `${config.command} run --rm --init ${userFlag} --name ${SANDBOX_PROXY_NAME} --network ${SANDBOX_PROXY_NAME} -p 8877:8877 -v ${process.cwd()}:${workdir} --workdir ${workdir} ${image} ${proxyCommand}`;
+      if (config.command === 'udocker') {
+        // udocker doesn't support --init or --network
+        proxyContainerCommand = `${config.command} run --rm ${userFlag} -p 8877:8877 -v ${process.cwd()}:${workdir} --workdir ${workdir} ${image} ${proxyCommand}`;
+      }
       proxyProcess = spawn(proxyContainerCommand, {
         stdio: ['ignore', 'pipe', 'pipe'],
         shell: true,
@@ -674,11 +703,15 @@ export async function start_sandbox(
         debugLogger.log('stopping proxy container ...');
         execSync(`${config.command} rm -f ${SANDBOX_PROXY_NAME}`);
       };
-      process.off('exit', stopProxy);
+
+      cleanupProxyHandlers = () => {
+        process.off('exit', stopProxy);
+        process.off('SIGINT', stopProxy);
+        process.off('SIGTERM', stopProxy);
+      };
+
       process.on('exit', stopProxy);
-      process.off('SIGINT', stopProxy);
       process.on('SIGINT', stopProxy);
-      process.off('SIGTERM', stopProxy);
       process.on('SIGTERM', stopProxy);
 
       // commented out as it disrupts ink rendering
@@ -689,6 +722,9 @@ export async function start_sandbox(
         debugLogger.debug(`[PROXY STDERR]: ${data.toString().trim()}`);
       });
       proxyProcess.on('close', (code, signal) => {
+        if (typeof cleanupProxyHandlers === 'function') {
+          cleanupProxyHandlers();
+        }
         if (sandboxProcess?.pid) {
           process.kill(-sandboxProcess.pid, 'SIGTERM');
         }
@@ -707,19 +743,43 @@ export async function start_sandbox(
       );
     }
 
+    // udocker's parser fails on space-separated flags like `--volume /src:/dst`. Combine them into `--volume=/src:/dst`
+    if (config.command === 'udocker') {
+      const combinedArgs: string[] = [];
+      for (let i = 0; i < args.length; i++) {
+        if (
+          ['--workdir', '--volume', '--env', '--user'].includes(args[i]) &&
+          i + 1 < args.length
+        ) {
+          combinedArgs.push(`${args[i]}=${args[i + 1]}`);
+          i++;
+        } else {
+          combinedArgs.push(args[i]);
+        }
+      }
+      args.splice(0, args.length, ...combinedArgs);
+    }
+
     // spawn child and let it inherit stdio
     process.stdin.pause();
+    debugLogger.log(`Executing ${config.command} ` + args.join(' '));
     sandboxProcess = spawn(config.command, args, {
       stdio: 'inherit',
     });
 
     return await new Promise<number>((resolve, reject) => {
       sandboxProcess.on('error', (err) => {
+        if (typeof cleanupProxyHandlers === 'function') {
+          cleanupProxyHandlers();
+        }
         coreEvents.emitFeedback('error', 'Sandbox process error', err);
         reject(err);
       });
 
       sandboxProcess?.on('close', (code, signal) => {
+        if (typeof cleanupProxyHandlers === 'function') {
+          cleanupProxyHandlers();
+        }
         process.stdin.resume();
         if (code !== 0 && code !== null) {
           debugLogger.log(
@@ -939,7 +999,7 @@ async function start_lxc_sandbox(
 // Helper functions to ensure sandbox image is present
 async function imageExists(sandbox: string, image: string): Promise<boolean> {
   return new Promise((resolve) => {
-    const args = ['images', '-q', image];
+    const args = sandbox === 'udocker' ? ['images'] : ['images', '-q', image];
     const checkProcess = spawn(sandbox, args);
 
     let stdoutData = '';
@@ -962,7 +1022,11 @@ async function imageExists(sandbox: string, image: string): Promise<boolean> {
       if (code !== 0) {
         // console.warn(`'${sandbox} images -q ${image}' exited with code ${code}.`);
       }
-      resolve(stdoutData.trim() !== '');
+      if (sandbox === 'udocker') {
+        resolve(stdoutData.includes(image));
+      } else {
+        resolve(stdoutData.trim() !== '');
+      }
     });
   });
 }

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -783,21 +783,26 @@ export async function start_sandbox(
       }
     }
 
-    // udocker's parser fails on space-separated flags like `--volume /src:/dst`. Combine them into `--volume=/src:/dst`
+    // udocker's parser fails on space-separated flags like `--volume /src:/dst`.
+    // Normalize long flags to `--flag=value` for all option args before the image token.
     if (config.command === 'udocker') {
       const combinedArgs: string[] = [];
+      const imageIndex = args.indexOf(image);
       for (let i = 0; i < args.length; i++) {
-        if (
-          ['--workdir', '--volume', '--env', '--user', '--publish'].includes(
-            args[i],
-          ) &&
-          i + 1 < args.length &&
-          !args[i + 1].startsWith('-')
-        ) {
-          combinedArgs.push(`${args[i]}=${args[i + 1]}`);
+        const currentArg = args[i];
+        const nextArg = args[i + 1];
+        const canCombine =
+          currentArg.startsWith('--') &&
+          nextArg &&
+          !nextArg.startsWith('-') &&
+          imageIndex !== -1 &&
+          i + 1 < imageIndex;
+
+        if (canCombine) {
+          combinedArgs.push(`${currentArg}=${nextArg}`);
           i++;
         } else {
-          combinedArgs.push(args[i]);
+          combinedArgs.push(currentArg);
         }
       }
       args.splice(0, args.length, ...combinedArgs);

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -173,9 +173,17 @@ export async function start_sandbox(
           sandboxEnv['NO_PROXY'] = noProxy;
           sandboxEnv['no_proxy'] = noProxy;
         }
-        proxyProcess = spawn(proxyCommand, {
+        const parsedProxyCommand = parse(proxyCommand, process.env).filter(
+          (token): token is string => typeof token === 'string',
+        );
+        if (parsedProxyCommand.length === 0) {
+          throw new FatalSandboxError(
+            'GEMINI_SANDBOX_PROXY_COMMAND is empty or invalid',
+          );
+        }
+        const [proxyCmd, ...proxyCmdArgs] = parsedProxyCommand;
+        proxyProcess = spawn(proxyCmd, proxyCmdArgs, {
           stdio: ['ignore', 'pipe', 'pipe'],
-          shell: true,
           detached: true,
         });
         // install handlers to stop proxy on exit/signal

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -32,6 +32,7 @@ import {
   getContainerPath,
   shouldUseCurrentUserInSandbox,
   parseImageName,
+  splitImageTag,
   ports,
   sanitizeDebugPort,
   entrypoint,
@@ -1070,8 +1071,8 @@ async function imageExists(sandbox: string, image: string): Promise<boolean> {
         // console.warn(`'${sandbox} images -q ${image}' exited with code ${code}.`);
       }
       if (sandbox === 'udocker') {
-        const [targetRepo, targetTag = 'latest'] = image.split(':');
-        const targetImage = `${targetRepo}:${targetTag}`;
+        const [targetRepo, targetTag] = splitImageTag(image);
+        const targetImage = `${targetRepo}:${targetTag ?? 'latest'}`;
         const lines = stdoutData
           .trim()
           .split('\n')

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -33,6 +33,7 @@ import {
   shouldUseCurrentUserInSandbox,
   parseImageName,
   ports,
+  sanitizeDebugPort,
   entrypoint,
   LOCAL_DEV_SANDBOX_IMAGE_NAME,
   SANDBOX_NETWORK_NAME,
@@ -416,7 +417,7 @@ export async function start_sandbox(
 
     // if DEBUG is set, expose debugging port
     if (process.env['DEBUG']) {
-      const debugPort = process.env['DEBUG_PORT'] || '9229';
+      const debugPort = sanitizeDebugPort(process.env['DEBUG_PORT']);
       args.push(`--publish`, `${debugPort}:${debugPort}`);
     }
 
@@ -695,7 +696,7 @@ export async function start_sandbox(
       let proxyContainerCommand = `${config.command} run --rm --init ${userFlag} --name ${SANDBOX_PROXY_NAME} --network ${SANDBOX_PROXY_NAME} -p 8877:8877 -v ${process.cwd()}:${workdir} --workdir ${workdir} ${image} ${proxyCommand}`;
       if (config.command === 'udocker') {
         // udocker doesn't support --init or --network
-        proxyContainerCommand = `${config.command} run --rm ${userFlag} -p 8877:8877 -v ${process.cwd()}:${workdir} --workdir ${workdir} ${image} ${proxyCommand}`;
+        proxyContainerCommand = `${config.command} run --rm ${userFlag} --publish=8877:8877 --volume=${process.cwd()}:${workdir} --workdir=${workdir} ${image} ${proxyCommand}`;
       }
       proxyProcess = spawn(proxyContainerCommand, {
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -744,7 +745,9 @@ export async function start_sandbox(
       const combinedArgs: string[] = [];
       for (let i = 0; i < args.length; i++) {
         if (
-          ['--workdir', '--volume', '--env', '--user'].includes(args[i]) &&
+          ['--workdir', '--volume', '--env', '--user', '--publish'].includes(
+            args[i],
+          ) &&
           i + 1 < args.length
         ) {
           combinedArgs.push(`${args[i]}=${args[i + 1]}`);
@@ -758,7 +761,6 @@ export async function start_sandbox(
 
     // spawn child and let it inherit stdio
     process.stdin.pause();
-    debugLogger.log(`Executing ${config.command} ` + args.join(' '));
     sandboxProcess = spawn(config.command, args, {
       stdio: 'inherit',
     });

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -43,6 +43,18 @@ import {
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 
+function setupProcessExitHandlers(stopFn: () => void): () => void {
+  process.on('exit', stopFn);
+  process.on('SIGINT', stopFn);
+  process.on('SIGTERM', stopFn);
+
+  return () => {
+    process.off('exit', stopFn);
+    process.off('SIGINT', stopFn);
+    process.off('SIGTERM', stopFn);
+  };
+}
+
 export async function start_sandbox(
   config: SandboxConfig,
   nodeArgs: string[] = [],
@@ -173,15 +185,7 @@ export async function start_sandbox(
           }
         };
 
-        cleanupProxyHandlers = () => {
-          process.off('exit', stopProxy);
-          process.off('SIGINT', stopProxy);
-          process.off('SIGTERM', stopProxy);
-        };
-
-        process.on('exit', stopProxy);
-        process.on('SIGINT', stopProxy);
-        process.on('SIGTERM', stopProxy);
+        cleanupProxyHandlers = setupProcessExitHandlers(stopProxy);
 
         // commented out as it disrupts ink rendering
         // proxyProcess.stdout?.on('data', (data) => {
@@ -704,15 +708,7 @@ export async function start_sandbox(
         execSync(`${config.command} rm -f ${SANDBOX_PROXY_NAME}`);
       };
 
-      cleanupProxyHandlers = () => {
-        process.off('exit', stopProxy);
-        process.off('SIGINT', stopProxy);
-        process.off('SIGTERM', stopProxy);
-      };
-
-      process.on('exit', stopProxy);
-      process.on('SIGINT', stopProxy);
-      process.on('SIGTERM', stopProxy);
+      cleanupProxyHandlers = setupProcessExitHandlers(stopProxy);
 
       // commented out as it disrupts ink rendering
       // proxyProcess.stdout?.on('data', (data) => {

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -692,21 +692,49 @@ export async function start_sandbox(
     let cleanupProxyHandlers: (() => void) | undefined = undefined;
 
     if (proxyCommand) {
-      // run proxyCommand in its own container
-      let proxyContainerCommand = `${config.command} run --rm --init ${userFlag} --name ${SANDBOX_PROXY_NAME} --network ${SANDBOX_PROXY_NAME} -p 8877:8877 -v ${process.cwd()}:${workdir} --workdir ${workdir} ${image} ${proxyCommand}`;
+      const parsedProxyCommand = parse(proxyCommand, process.env).filter(
+        (token): token is string => typeof token === 'string',
+      );
+      if (parsedProxyCommand.length === 0) {
+        throw new FatalSandboxError(
+          'GEMINI_SANDBOX_PROXY_COMMAND is empty or invalid',
+        );
+      }
+
+      const proxyContainerArgs = ['run', '--rm'];
+      const proxyUser = userFlag.replace(/^--user\s+/, '').trim();
+      if (proxyUser) {
+        if (config.command === 'udocker') {
+          proxyContainerArgs.push(`--user=${proxyUser}`);
+        } else {
+          proxyContainerArgs.push('--user', proxyUser);
+        }
+      }
+
       if (config.command === 'udocker') {
         // udocker doesn't support --init or --network
-        proxyContainerCommand = `${config.command} run --rm ${userFlag} --publish=8877:8877 --volume=${process.cwd()}:${workdir} --workdir=${workdir} ${image} ${proxyCommand}`;
+        proxyContainerArgs.push(`--publish=8877:8877`);
+        proxyContainerArgs.push(`--volume=${process.cwd()}:${workdir}`);
+        proxyContainerArgs.push(`--workdir=${workdir}`);
+      } else {
+        proxyContainerArgs.push('--init');
+        proxyContainerArgs.push('--name', SANDBOX_PROXY_NAME);
+        proxyContainerArgs.push('--network', SANDBOX_PROXY_NAME);
+        proxyContainerArgs.push('-p', '8877:8877');
+        proxyContainerArgs.push('-v', `${process.cwd()}:${workdir}`);
+        proxyContainerArgs.push('--workdir', workdir);
       }
-      proxyProcess = spawn(proxyContainerCommand, {
+
+      proxyContainerArgs.push(image, ...parsedProxyCommand);
+
+      proxyProcess = spawn(config.command, proxyContainerArgs, {
         stdio: ['ignore', 'pipe', 'pipe'],
-        shell: true,
         detached: true,
       });
       // install handlers to stop proxy on exit/signal
       const stopProxy = () => {
         debugLogger.log('stopping proxy container ...');
-        execSync(`${config.command} rm -f ${SANDBOX_PROXY_NAME}`);
+        execFileSync(config.command, ['rm', '-f', SANDBOX_PROXY_NAME]);
       };
 
       cleanupProxyHandlers = setupProcessExitHandlers(stopProxy);
@@ -726,7 +754,7 @@ export async function start_sandbox(
           process.kill(-sandboxProcess.pid, 'SIGTERM');
         }
         throw new FatalSandboxError(
-          `Proxy container command '${proxyContainerCommand}' exited with code ${code}, signal ${signal}`,
+          `Proxy container command exited with code ${code}, signal ${signal}`,
         );
       });
       debugLogger.log('waiting for proxy to start ...');
@@ -735,9 +763,11 @@ export async function start_sandbox(
       );
       // connect proxy container to sandbox network
       // (workaround for older versions of docker that don't support multiple --network args)
-      await execAsync(
-        `${config.command} network connect ${SANDBOX_NETWORK_NAME} ${SANDBOX_PROXY_NAME}`,
-      );
+      if (config.command !== 'udocker') {
+        await execAsync(
+          `${config.command} network connect ${SANDBOX_NETWORK_NAME} ${SANDBOX_PROXY_NAME}`,
+        );
+      }
     }
 
     // udocker's parser fails on space-separated flags like `--volume /src:/dst`. Combine them into `--volume=/src:/dst`
@@ -748,7 +778,8 @@ export async function start_sandbox(
           ['--workdir', '--volume', '--env', '--user', '--publish'].includes(
             args[i],
           ) &&
-          i + 1 < args.length
+          i + 1 < args.length &&
+          !args[i + 1].startsWith('-')
         ) {
           combinedArgs.push(`${args[i]}=${args[i + 1]}`);
           i++;
@@ -1021,7 +1052,28 @@ async function imageExists(sandbox: string, image: string): Promise<boolean> {
         // console.warn(`'${sandbox} images -q ${image}' exited with code ${code}.`);
       }
       if (sandbox === 'udocker') {
-        resolve(stdoutData.includes(image));
+        const [targetRepo, targetTag = 'latest'] = image.split(':');
+        const targetImage = `${targetRepo}:${targetTag}`;
+        const lines = stdoutData
+          .trim()
+          .split('\n')
+          .map((line) => line.trim())
+          .filter(Boolean);
+
+        const imageFound = lines.some((line) => {
+          if (line.toLowerCase().startsWith('repository')) {
+            return false;
+          }
+          const parts = line.split(/\s+/);
+          if (parts.length === 1) {
+            return parts[0] === image || parts[0] === targetImage;
+          }
+          const repo = parts[0];
+          const tag = parts[1] || 'latest';
+          return `${repo}:${tag}` === targetImage;
+        });
+
+        resolve(imageFound);
       } else {
         resolve(stdoutData.trim() !== '');
       }

--- a/packages/cli/src/utils/sandboxUtils.test.ts
+++ b/packages/cli/src/utils/sandboxUtils.test.ts
@@ -12,6 +12,7 @@ import {
   getContainerPath,
   parseImageName,
   ports,
+  sanitizeDebugPort,
   entrypoint,
   shouldUseCurrentUserInSandbox,
 } from './sandboxUtils.js';
@@ -84,6 +85,26 @@ describe('sandboxUtils', () => {
     it('should parse comma-separated ports', () => {
       process.env['SANDBOX_PORTS'] = '8080, 3000 , 9000';
       expect(ports()).toEqual(['8080', '3000', '9000']);
+    });
+
+    it('should ignore invalid ports', () => {
+      process.env['SANDBOX_PORTS'] = '8080, abc, 70000, -1, 9000';
+      expect(ports()).toEqual(['8080', '9000']);
+    });
+  });
+
+  describe('sanitizeDebugPort', () => {
+    it('should return default for invalid values', () => {
+      expect(sanitizeDebugPort(undefined)).toBe('9229');
+      expect(sanitizeDebugPort('')).toBe('9229');
+      expect(sanitizeDebugPort('9229; touch /tmp/pwned')).toBe('9229');
+      expect(sanitizeDebugPort('70000')).toBe('9229');
+      expect(sanitizeDebugPort('-1')).toBe('9229');
+    });
+
+    it('should return valid debug port', () => {
+      expect(sanitizeDebugPort('9229')).toBe('9229');
+      expect(sanitizeDebugPort(' 3000 ')).toBe('3000');
     });
   });
 

--- a/packages/cli/src/utils/sandboxUtils.test.ts
+++ b/packages/cli/src/utils/sandboxUtils.test.ts
@@ -11,6 +11,7 @@ import { readFile } from 'node:fs/promises';
 import {
   getContainerPath,
   parseImageName,
+  splitImageTag,
   ports,
   sanitizeDebugPort,
   entrypoint,
@@ -73,6 +74,54 @@ describe('sandboxUtils', () => {
       expect(parseImageName('gcr.io/my-project/my-image:v1')).toBe(
         'my-image-v1',
       );
+    });
+
+    it('should handle registry with port', () => {
+      expect(parseImageName('localhost:5000/sandbox:latest')).toBe(
+        'sandbox-latest',
+      );
+    });
+
+    it('should handle registry with port and no tag', () => {
+      expect(parseImageName('localhost:5000/sandbox')).toBe('sandbox');
+    });
+  });
+
+  describe('splitImageTag', () => {
+    it('should split standard image:tag', () => {
+      expect(splitImageTag('ubuntu:latest')).toEqual(['ubuntu', 'latest']);
+    });
+
+    it('should handle image with no tag', () => {
+      expect(splitImageTag('ubuntu')).toEqual(['ubuntu', undefined]);
+    });
+
+    it('should handle registry path with tag', () => {
+      expect(splitImageTag('gcr.io/my-project/my-image:v1')).toEqual([
+        'gcr.io/my-project/my-image',
+        'v1',
+      ]);
+    });
+
+    it('should handle registry with port and tag', () => {
+      expect(splitImageTag('localhost:5000/sandbox:latest')).toEqual([
+        'localhost:5000/sandbox',
+        'latest',
+      ]);
+    });
+
+    it('should handle registry with port and no tag', () => {
+      expect(splitImageTag('localhost:5000/sandbox')).toEqual([
+        'localhost:5000/sandbox',
+        undefined,
+      ]);
+    });
+
+    it('should handle registry with port, nested path, and tag', () => {
+      expect(splitImageTag('myregistry.io:5000/org/my-image:v2.1')).toEqual([
+        'myregistry.io:5000/org/my-image',
+        'v2.1',
+      ]);
     });
   });
 

--- a/packages/cli/src/utils/sandboxUtils.ts
+++ b/packages/cli/src/utils/sandboxUtils.ts
@@ -77,11 +77,20 @@ export function parseImageName(image: string): string {
   return tag ? `${name}-${tag}` : name;
 }
 
+function sanitizePort(value: string): string | undefined {
+  const trimmedValue = value.trim();
+  if (!/^\d{1,5}$/.test(trimmedValue)) {
+    return undefined;
+  }
+  const port = Number(trimmedValue);
+  return port >= 1 && port <= 65535 ? trimmedValue : undefined;
+}
+
 export function ports(): string[] {
   return (process.env['SANDBOX_PORTS'] ?? '')
     .split(',')
-    .filter((p) => p.trim())
-    .map((p) => p.trim());
+    .map((port) => sanitizePort(port))
+    .filter((port): port is string => Boolean(port));
 }
 
 export function sanitizeDebugPort(value: string | undefined): string {

--- a/packages/cli/src/utils/sandboxUtils.ts
+++ b/packages/cli/src/utils/sandboxUtils.ts
@@ -71,8 +71,41 @@ export async function shouldUseCurrentUserInSandbox(): Promise<boolean> {
   return false; // Default to false if no other condition is met
 }
 
+/**
+ * Splits a Docker image reference into its repository and tag parts.
+ *
+ * Uses `lastIndexOf(':')` to find the tag separator, but guards against
+ * interpreting a port number as a tag by checking whether the substring
+ * after the last colon contains a `/` (which would indicate it is part
+ * of the registry path, not a tag).
+ *
+ * Examples:
+ *   'ubuntu:latest'                  → ['ubuntu', 'latest']
+ *   'localhost:5000/sandbox:latest'  → ['localhost:5000/sandbox', 'latest']
+ *   'localhost:5000/sandbox'         → ['localhost:5000/sandbox', undefined]
+ *   'ubuntu'                         → ['ubuntu', undefined]
+ */
+export function splitImageTag(
+  image: string,
+): [repo: string, tag: string | undefined] {
+  const lastColon = image.lastIndexOf(':');
+  if (lastColon === -1) {
+    return [image, undefined];
+  }
+
+  const possibleTag = image.slice(lastColon + 1);
+
+  // If the part after the last colon contains a '/', it's not a tag
+  // (e.g. 'localhost:5000/sandbox' → port, not tag).
+  if (possibleTag.includes('/')) {
+    return [image, undefined];
+  }
+
+  return [image.slice(0, lastColon), possibleTag];
+}
+
 export function parseImageName(image: string): string {
-  const [fullName, tag] = image.split(':');
+  const [fullName, tag] = splitImageTag(image);
   const name = fullName.split('/').at(-1) ?? 'unknown-image';
   return tag ? `${name}-${tag}` : name;
 }

--- a/packages/cli/src/utils/sandboxUtils.ts
+++ b/packages/cli/src/utils/sandboxUtils.ts
@@ -84,6 +84,20 @@ export function ports(): string[] {
     .map((p) => p.trim());
 }
 
+export function sanitizeDebugPort(value: string | undefined): string {
+  if (!value) {
+    return '9229';
+  }
+
+  const trimmedValue = value.trim();
+  if (!/^\d{1,5}$/.test(trimmedValue)) {
+    return '9229';
+  }
+
+  const port = Number(trimmedValue);
+  return port >= 1 && port <= 65535 ? trimmedValue : '9229';
+}
+
 export function entrypoint(
   workdir: string,
   cliArgs: string[],
@@ -149,7 +163,7 @@ export function entrypoint(
         ? 'npm run debug --'
         : 'npm rebuild && npm run start --'
       : isDebugMode
-        ? `node --inspect-brk=0.0.0.0:${process.env['DEBUG_PORT'] || '9229'} $(which gemini)`
+        ? `node --inspect-brk=0.0.0.0:${sanitizeDebugPort(process.env['DEBUG_PORT'])} $(which gemini)`
         : 'gemini';
 
   const args = [...shellCmds, cliCmd, ...quotedCliArgs].filter(Boolean);

--- a/packages/cli/src/utils/sandboxUtils.ts
+++ b/packages/cli/src/utils/sandboxUtils.ts
@@ -84,7 +84,11 @@ export function ports(): string[] {
     .map((p) => p.trim());
 }
 
-export function entrypoint(workdir: string, cliArgs: string[]): string[] {
+export function entrypoint(
+  workdir: string,
+  cliArgs: string[],
+  isDirectCommand = false,
+): string[] {
   const isWindows = os.platform() === 'win32';
   const containerWorkdir = getContainerPath(workdir);
   const shellCmds = [];
@@ -133,11 +137,14 @@ export function entrypoint(workdir: string, cliArgs: string[]): string[] {
     ),
   );
 
-  const quotedCliArgs = cliArgs.slice(2).map((arg) => quote([arg]));
+  const quotedCliArgs = (isDirectCommand ? cliArgs : cliArgs.slice(2)).map(
+    (arg) => quote([arg]),
+  );
   const isDebugMode =
     process.env['DEBUG'] === 'true' || process.env['DEBUG'] === '1';
-  const cliCmd =
-    process.env['NODE_ENV'] === 'development'
+  const cliCmd = isDirectCommand
+    ? ''
+    : process.env['NODE_ENV'] === 'development'
       ? isDebugMode
         ? 'npm run debug --'
         : 'npm rebuild && npm run start --'
@@ -145,6 +152,6 @@ export function entrypoint(workdir: string, cliArgs: string[]): string[] {
         ? `node --inspect-brk=0.0.0.0:${process.env['DEBUG_PORT'] || '9229'} $(which gemini)`
         : 'gemini';
 
-  const args = [...shellCmds, cliCmd, ...quotedCliArgs];
+  const args = [...shellCmds, cliCmd, ...quotedCliArgs].filter(Boolean);
   return ['bash', '-c', args.join(' ')];
 }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -446,7 +446,7 @@ export enum AuthProviderType {
 }
 
 export interface SandboxConfig {
-  command: 'docker' | 'podman' | 'sandbox-exec' | 'lxc';
+  command: 'docker' | 'podman' | 'sandbox-exec' | 'lxc' | 'udocker';
   image: string;
 }
 

--- a/scripts/build_sandbox.js
+++ b/scripts/build_sandbox.js
@@ -130,6 +130,12 @@ const isWindows = os.platform() === 'win32';
 const shellToUse = isWindows ? 'powershell.exe' : '/bin/bash';
 
 function buildImage(imageName, dockerfile) {
+  if (sandboxCommand === 'udocker') {
+    console.log(
+      `Skipping build for udocker. Please pull the image manually using 'udocker pull <image>'.`,
+    );
+    return;
+  }
   console.log(`building ${imageName} ... (can be slow first time)`);
 
   let buildCommandArgs = '';

--- a/scripts/sandbox_command.js
+++ b/scripts/sandbox_command.js
@@ -96,9 +96,11 @@ if (['1', 'true'].includes(geminiSandbox)) {
     command = 'docker';
   } else if (commandExists('podman')) {
     command = 'podman';
+  } else if (commandExists('udocker')) {
+    command = 'udocker';
   } else {
     console.error(
-      'ERROR: install docker or podman or specify command in GEMINI_SANDBOX',
+      'ERROR: install docker, podman, udocker, or specify command in GEMINI_SANDBOX',
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Summary

Add `udocker` as a supported sandbox backend so sandboxing can work in environments where Docker/Podman are unavailable (for example, some Android setups).

## Changes

- Add `udocker` as a valid sandbox command in CLI/core sandbox config types.
- Add `udocker` fallback detection in `scripts/sandbox_command.js`.
- Update `scripts/build_sandbox.js` to skip image build for `udocker` and instruct manual pull.
- Update sandbox runtime behavior in `packages/cli/src/utils/sandbox.ts` for `udocker` compatibility:
  - skip unsupported flags (`--init`, `-t`, `--add-host`, hostname/name handling)
  - adjust proxy/network handling
  - normalize arg formatting for udocker parser
  - handle image existence checks via `udocker images` output parsing
- Update entrypoint handling in `packages/cli/src/utils/sandboxUtils.ts` to support direct command mode.

## Validation

- Ran targeted sandbox tests for this change:
  - `npm run test --workspace @google/gemini-cli -- src/config/sandboxConfig.test.ts src/utils/sandboxUtils.test.ts src/utils/sandbox.test.ts`
- Also ran broader CONTRIBUTING-recommended checks previously (`npm run test` / preflight-oriented validation) during development.

Fixes #15888
