### PR TITLE
fix(cli): support linuxbrew in package manager detection

### DIFF
--- a/packages/cli/src/utils/installationInfo.test.ts
+++ b/packages/cli/src/utils/installationInfo.test.ts
@@ -12,11 +12,16 @@ import * as childProcess from 'node:child_process';
 import { isGitRepository, debugLogger } from '@google/gemini-cli-core';
 
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  const actual = await importOriginal<any>();
   return {
     ...actual,
     isGitRepository: vi.fn(),
+    debugLogger: {
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
   };
 });
 
@@ -51,7 +56,6 @@ describe('getInstallationInfo', () => {
     originalArgv = [...process.argv];
     // Mock process.cwd() for isGitRepository
     vi.spyOn(process, 'cwd').mockReturnValue(projectRoot);
-    vi.spyOn(debugLogger, 'log').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -151,6 +155,42 @@ describe('getInstallationInfo', () => {
       if (p === cliPath) return cliPath;
       if (p === '/opt/homebrew/opt/gemini-cli') {
         return '/opt/homebrew/Cellar/gemini-cli/1.0.0';
+      }
+      return String(p);
+    });
+
+    const info = getInstallationInfo(projectRoot, true);
+
+    expect(mockedExecSync).toHaveBeenCalledWith(
+      expect.stringContaining('brew --prefix gemini-cli'),
+      expect.anything(),
+    );
+    expect(info.packageManager).toBe(PackageManager.HOMEBREW);
+    expect(info.isGlobal).toBe(true);
+    expect(info.updateMessage).toBe(
+      'Installed via Homebrew. Please update with "brew upgrade gemini-cli".',
+    );
+  });
+
+  it('should detect Homebrew installation on Linux', () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'linux',
+    });
+    // Path for Linuxbrew
+    const cliPath = '/home/linuxbrew/.linuxbrew/Cellar/gemini-cli/1.0.0/bin/gemini';
+    process.argv[1] = cliPath;
+
+    mockedExecSync.mockImplementation((cmd) => {
+      if (typeof cmd === 'string' && cmd.includes('brew --prefix gemini-cli')) {
+        return '/home/linuxbrew/.linuxbrew/opt/gemini-cli';
+      }
+      throw new Error(`Command failed: ${cmd}`);
+    });
+
+    mockedRealPathSync.mockImplementation((p) => {
+      if (p === cliPath) return cliPath;
+      if (p === '/home/linuxbrew/.linuxbrew/opt/gemini-cli') {
+        return '/home/linuxbrew/.linuxbrew/Cellar/gemini-cli/1.0.0';
       }
       return String(p);
     });

--- a/packages/cli/src/utils/installationInfo.ts
+++ b/packages/cli/src/utils/installationInfo.ts
@@ -81,7 +81,7 @@ export function getInstallationInfo(
     }
 
     // Check for Homebrew
-    if (process.platform === 'darwin') {
+    if (process.platform === 'darwin' || process.platform === 'linux') {
       try {
         const brewPrefix = childProcess
           .execSync('brew --prefix gemini-cli', {


### PR DESCRIPTION
## Summary

Currently, `getInstallationInfo` strictly checks `process.platform === 'darwin'` before attempting to resolve a Homebrew installation. This ignores Linux and WSL users who install via Linuxbrew, causing the CLI to fallback to incorrect update instructions (like `npm install -g`).

This PR expands the check to include `linux`, ensuring Linuxbrew users get the correct update message: "Installed via Homebrew. Please update with 'brew upgrade gemini-cli'."

## Details

- Modified `packages/cli/src/utils/installationInfo.ts` to check for `darwin` or `linux` before calling `brew --prefix`.
- Updated `packages/cli/src/utils/installationInfo.test.ts` with a new test case for Linuxbrew detection.
- Fixed a minor issue in the test mock for `@google/gemini-cli-core` where `debugLogger` was not correctly mocked, causing Vitest failures in the local environment.

Note on Platform Architecture:
While auditing this for the fix, I noticed a broader pattern of `process.platform` branching scattered across the CLI (specifically regarding the sandbox-exec vs Docker implementations). I am currently architecting the Unified Sandbox Driver (GSoC Idea 10) to abstract these OS-level conditionals into a clean plugin interface.

## Related Issues

Fixes #21370

## How to Validate

1. Run the unit tests specifically for installation info:
   ```bash
   npx vitest run packages/cli/src/utils/installationInfo.test.ts
   ```
2. Verify that the new test case "should detect Homebrew installation on Linux" passes.
3. (Manual) On a Linux system with Linuxbrew installed, run the CLI and verify that it correctly identifies the installation as Homebrew.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] Linux
    - [x] npm run (via unit tests)
