### PR TITLE
fix(billing): fix overage strategy lifecycle and settings integration

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -798,6 +798,7 @@ export async function loadCliConfig(
     fakeResponses: argv.fakeResponses,
     recordResponses: argv.recordResponses,
     retryFetchErrors: settings.general?.retryFetchErrors,
+    billing: settings.billing,
     maxAttempts: settings.general?.maxAttempts,
     ptyInfo: ptyInfo?.name,
     disableLLMCorrection: settings.tools?.disableLLMCorrection,

--- a/packages/cli/src/ui/hooks/creditsFlowHandler.ts
+++ b/packages/cli/src/ui/hooks/creditsFlowHandler.ts
@@ -110,7 +110,6 @@ async function handleOverageMenu(
     isDialogPending,
     setOverageMenuRequest,
     setModelSwitchedFromQuotaError,
-    historyManager,
   } = args;
 
   logBillingEvent(
@@ -155,13 +154,6 @@ async function handleOverageMenu(
       setModelSwitchedFromQuotaError(false);
       config.setQuotaErrorOccurred(false);
       config.setOverageStrategy('always');
-      historyManager.addItem(
-        {
-          type: MessageType.INFO,
-          text: `Using AI Credits for this request.`,
-        },
-        Date.now(),
-      );
       return 'retry_with_credits';
 
     case 'use_fallback':

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -271,6 +271,7 @@ describe('useGeminiStream', () => {
     addHistory: vi.fn(),
     getSessionId: vi.fn(() => 'test-session-id'),
     setQuotaErrorOccurred: vi.fn(),
+    resetBillingTurnState: vi.fn(),
     getQuotaErrorOccurred: vi.fn(() => false),
     getModel: vi.fn(() => 'gemini-2.5-pro'),
     getContentGeneratorConfig: vi.fn(() => ({

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1376,6 +1376,9 @@ export const useGeminiStream = (
           if (!options?.isContinuation) {
             setModelSwitchedFromQuotaError(false);
             config.setQuotaErrorOccurred(false);
+            config.resetBillingTurnState(
+              settings.merged.billing?.overageStrategy,
+            );
             suppressedToolErrorCountRef.current = 0;
             suppressedToolErrorNoteShownRef.current = false;
             lowVerbosityFailureNoteShownRef.current = false;
@@ -1536,6 +1539,7 @@ export const useGeminiStream = (
       setThought,
       maybeAddSuppressedToolErrorNote,
       maybeAddLowVerbosityFailureNote,
+      settings.merged.billing?.overageStrategy,
     ],
   );
 
@@ -1799,7 +1803,6 @@ export const useGeminiStream = (
       addItem,
       registerBackgroundShell,
       consumeUserHint,
-      config,
       isLowErrorVerbosity,
       maybeAddSuppressedToolErrorNote,
       maybeAddLowVerbosityFailureNote,

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -67,14 +67,6 @@ export function useQuotaAndFallback({
   const isDialogPending = useRef(false);
   const isValidationPending = useRef(false);
 
-  // Initial overage strategy from settings; runtime value read from config at call time.
-  const initialOverageStrategy =
-    (settings.merged.billing?.overageStrategy as
-      | 'ask'
-      | 'always'
-      | 'never'
-      | undefined) ?? 'ask';
-
   // Set up Flash fallback handler
   useEffect(() => {
     const fallbackHandler: FallbackModelHandler = async (
@@ -109,9 +101,7 @@ export function useQuotaAndFallback({
             ? getResetTimeMessage(error.retryDelayMs)
             : undefined;
 
-          const overageStrategy =
-            config.getBillingSettings().overageStrategy ??
-            initialOverageStrategy;
+          const overageStrategy = config.getBillingSettings().overageStrategy;
 
           const creditsResult = await handleCreditsFlow({
             config,
@@ -209,7 +199,6 @@ export function useQuotaAndFallback({
     userTier,
     paidTier,
     settings,
-    initialOverageStrategy,
     setModelSwitchedFromQuotaError,
     onShowAuthSelection,
     errorVerbosity,

--- a/packages/core/src/billing/billing.test.ts
+++ b/packages/core/src/billing/billing.test.ts
@@ -229,14 +229,14 @@ describe('billing', () => {
       expect(isOverageEligibleModel('gemini-3.1-pro-preview')).toBe(true);
     });
 
-    it('should return true for gemini-3.1-pro-preview-customtools', () => {
+    it('should return false for gemini-3.1-pro-preview-customtools', () => {
       expect(isOverageEligibleModel('gemini-3.1-pro-preview-customtools')).toBe(
         false,
       );
     });
 
-    it('should return false for gemini-3-flash-preview', () => {
-      expect(isOverageEligibleModel('gemini-3-flash-preview')).toBe(false);
+    it('should return true for gemini-3-flash-preview', () => {
+      expect(isOverageEligibleModel('gemini-3-flash-preview')).toBe(true);
     });
 
     it('should return false for gemini-2.5-pro', () => {

--- a/packages/core/src/billing/billing.ts
+++ b/packages/core/src/billing/billing.ts
@@ -12,6 +12,7 @@ import type {
 import {
   PREVIEW_GEMINI_MODEL,
   PREVIEW_GEMINI_3_1_MODEL,
+  PREVIEW_GEMINI_FLASH_MODEL,
 } from '../config/models.js';
 
 /**
@@ -32,6 +33,7 @@ export const G1_CREDIT_TYPE: CreditType = 'GOOGLE_ONE_AI';
 export const OVERAGE_ELIGIBLE_MODELS = new Set([
   PREVIEW_GEMINI_MODEL,
   PREVIEW_GEMINI_3_1_MODEL,
+  PREVIEW_GEMINI_FLASH_MODEL,
 ]);
 
 /**

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -86,8 +86,6 @@ export class CodeAssistServer implements ContentGenerator {
     readonly config?: Config,
   ) {}
 
-  private lastCreditsNotificationPromptId: string | null = null;
-
   async generateContentStream(
     req: GenerateContentParameters,
     userPromptId: string,
@@ -103,11 +101,8 @@ export class CodeAssistServer implements ContentGenerator {
     const modelIsEligible = isOverageEligibleModel(req.model);
     const shouldEnableCredits = modelIsEligible && autoUse;
 
-    if (
-      shouldEnableCredits &&
-      this.lastCreditsNotificationPromptId !== userPromptId
-    ) {
-      this.lastCreditsNotificationPromptId = userPromptId;
+    if (shouldEnableCredits && !this.config?.getCreditsNotificationShown()) {
+      this.config?.setCreditsNotificationShown(true);
       coreEvents.emitFeedback('info', 'Using AI Credits for this request.');
     }
 

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -48,6 +48,7 @@ import {
   shouldAutoUseCredits,
 } from '../billing/billing.js';
 import { logBillingEvent, logInvalidChunk } from '../telemetry/loggers.js';
+import { coreEvents } from '../utils/events.js';
 import { CreditsUsedEvent } from '../telemetry/billingEvents.js';
 import {
   fromCountTokenResponse,
@@ -85,6 +86,8 @@ export class CodeAssistServer implements ContentGenerator {
     readonly config?: Config,
   ) {}
 
+  private lastCreditsNotificationPromptId: string | null = null;
+
   async generateContentStream(
     req: GenerateContentParameters,
     userPromptId: string,
@@ -99,6 +102,14 @@ export class CodeAssistServer implements ContentGenerator {
       : false;
     const modelIsEligible = isOverageEligibleModel(req.model);
     const shouldEnableCredits = modelIsEligible && autoUse;
+
+    if (
+      shouldEnableCredits &&
+      this.lastCreditsNotificationPromptId !== userPromptId
+    ) {
+      this.lastCreditsNotificationPromptId = userPromptId;
+      coreEvents.emitFeedback('info', 'Using AI Credits for this request.');
+    }
 
     const enabledCreditTypes = shouldEnableCredits
       ? ([G1_CREDIT_TYPE] as string[])

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -2424,6 +2424,65 @@ describe('Availability Service Integration', () => {
     config.resetTurn();
     expect(spy).toHaveBeenCalled();
   });
+
+  it('resetTurn does NOT reset billing state', () => {
+    const config = new Config({
+      ...baseParams,
+      billing: { overageStrategy: 'ask' },
+    });
+
+    // Simulate accepting credits mid-turn
+    config.setOverageStrategy('always');
+    config.setCreditsNotificationShown(true);
+
+    // resetTurn should leave billing state intact
+    config.resetTurn();
+    expect(config.getBillingSettings().overageStrategy).toBe('always');
+    expect(config.getCreditsNotificationShown()).toBe(true);
+  });
+
+  it('resetBillingTurnState resets overageStrategy to configured value', () => {
+    const config = new Config({
+      ...baseParams,
+      billing: { overageStrategy: 'ask' },
+    });
+
+    config.setOverageStrategy('always');
+    expect(config.getBillingSettings().overageStrategy).toBe('always');
+
+    config.resetBillingTurnState('ask');
+    expect(config.getBillingSettings().overageStrategy).toBe('ask');
+  });
+
+  it('resetBillingTurnState preserves overageStrategy when configured as always', () => {
+    const config = new Config({
+      ...baseParams,
+      billing: { overageStrategy: 'always' },
+    });
+
+    config.resetBillingTurnState('always');
+    expect(config.getBillingSettings().overageStrategy).toBe('always');
+  });
+
+  it('resetBillingTurnState defaults to ask when no strategy provided', () => {
+    const config = new Config({
+      ...baseParams,
+      billing: { overageStrategy: 'always' },
+    });
+
+    config.resetBillingTurnState();
+    expect(config.getBillingSettings().overageStrategy).toBe('ask');
+  });
+
+  it('resetBillingTurnState resets creditsNotificationShown', () => {
+    const config = new Config(baseParams);
+
+    config.setCreditsNotificationShown(true);
+    expect(config.getCreditsNotificationShown()).toBe(true);
+
+    config.resetBillingTurnState();
+    expect(config.getCreditsNotificationShown()).toBe(false);
+  });
 });
 
 describe('Hooks configuration', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -685,6 +685,7 @@ export class Config implements McpContext {
   fallbackModelHandler?: FallbackModelHandler;
   validationHandler?: ValidationHandler;
   private quotaErrorOccurred: boolean = false;
+  private creditsNotificationShown: boolean = false;
   private modelQuotas: Map<
     string,
     { remaining: number; limit: number; resetTime?: string }
@@ -1448,6 +1449,12 @@ export class Config implements McpContext {
     this.modelAvailabilityService.resetTurn();
   }
 
+  /** Resets billing state (overageStrategy, creditsNotificationShown) once per user prompt. */
+  resetBillingTurnState(overageStrategy?: OverageStrategy): void {
+    this.creditsNotificationShown = false;
+    this.billing.overageStrategy = overageStrategy ?? 'ask';
+  }
+
   getMaxSessionTurns(): number {
     return this.maxSessionTurns;
   }
@@ -1458,6 +1465,14 @@ export class Config implements McpContext {
 
   getQuotaErrorOccurred(): boolean {
     return this.quotaErrorOccurred;
+  }
+
+  setCreditsNotificationShown(value: boolean): void {
+    this.creditsNotificationShown = value;
+  }
+
+  getCreditsNotificationShown(): boolean {
+    return this.creditsNotificationShown;
   }
 
   setQuota(


### PR DESCRIPTION
## Summary

Fixes three issues with the AI credits billing feature:

1. **Overage strategy reset per turn**: When `overageStrategy` is `ask`, accepting credits on one turn permanently mutated the strategy to `always` for the rest of the session. Now the strategy resets on each new user prompt.

2. **Billing settings not forwarded**: `billing.overageStrategy` from `settings.json` was never passed to the `Config` constructor, so the setting had no effect. Fixed by passing `settings.billing` through.

3. **In-process setting changes ignored**: `configuredOverageStrategy` was a stale snapshot from Config construction. Replaced with live settings read — `resetBillingTurnState()` now accepts the current value from `settings.merged.billing.overageStrategy`, so changes via `/settings` take effect on the next prompt.

Also includes two supporting commits: adding Flash model to the credits allowlist and deduplicating the "Using AI Credits" banner to show once per turn.

## Changes

### Commit 1: Add Flash model to credits allowlist

- `billing.ts` — Add `gemini-2.5-flash` to `OVERAGE_ELIGIBLE_MODELS`

### Commit 2: Deduplicate "Using AI Credits" banner

- `server.ts` — Gate notification on `Config.creditsNotificationShown`
- `config.ts` — Add `creditsNotificationShown` flag
- `creditsFlowHandler.ts` — Remove dead `initialOverageStrategy` listener code

### Commit 3: Fix overage strategy lifecycle

- `config.ts` — Split billing resets from `resetTurn()` into `resetBillingTurnState(overageStrategy?)`, removed stale `configuredOverageStrategy` field
- `config.ts` (CLI) — Pass `billing: settings.billing` to Config constructor
- `useGeminiStream.ts` — Call `config.resetBillingTurnState(settings.merged.billing?.overageStrategy)` in the `!isContinuation` guard; fixed pre-existing unnecessary `config` dep in useCallback
- `useQuotaAndFallback.ts` — Remove dead `initialOverageStrategy` code
- `useGeminiStream.test.tsx` — Add `resetBillingTurnState` mock
- `config.test.ts` — Tests for `resetTurn` not resetting billing, `resetBillingTurnState` with/without args

## How to Validate

Integration testing instructions at go/gemini-cli-x-ai-credits-integration-testing

## Pre-Merge Checklist

- [x] Added/updated tests
- [x] `npm run preflight` passes
- [x] Validated on MacOS (npm run)
