### PR TITLE
feat(evals): add category tagging and per-run scoring harness

### DIFF
--- a/evals/categories.ts
+++ b/evals/categories.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The category of a behavioral evaluation scenario.
+ * Used for grouping results and computing per-category pass rates.
+ */
+export type EvalCategory =
+  | 'debugging'
+  | 'refactoring'
+  | 'new-feature'
+  | 'code-review'
+  | 'shell-tooling'
+  | 'memory'
+  | 'agent-delegation';
+
+/** Human-readable labels for each category. */
+export const CATEGORY_LABELS: Record<EvalCategory, string> = {
+  debugging: 'Debugging',
+  refactoring: 'Refactoring',
+  'new-feature': 'New Feature',
+  'code-review': 'Code Review',
+  'shell-tooling': 'Shell & Tooling',
+  memory: 'Memory',
+  'agent-delegation': 'Agent Delegation',
+};
+
+/** All defined category keys, derived from CATEGORY_LABELS to stay in sync. */
+export const ALL_CATEGORIES: EvalCategory[] = Object.keys(
+  CATEGORY_LABELS,
+) as EvalCategory[];

--- a/evals/scoring/global-setup.ts
+++ b/evals/scoring/global-setup.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Vitest global setup: clears the eval registry file before each run so that
+ * stale entries from previous runs do not pollute the current run's report.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export function setup() {
+  const registryPath = path.resolve(
+    process.cwd(),
+    'evals/logs/.eval-registry.ndjson',
+  );
+  // Ensure the logs dir exists and start with a clean registry.
+  fs.mkdirSync(path.dirname(registryPath), { recursive: true });
+  fs.writeFileSync(registryPath, '');
+}

--- a/evals/scoring/reporter.ts
+++ b/evals/scoring/reporter.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Custom Vitest reporter that generates a structured RunSummary JSON file
+ * after each evaluation run. It cross-references the Vitest task results
+ * with per-eval metadata (category, tags, policy) written to a registry
+ * file by the test-helper during test module initialisation.
+ */
+
+import type { Reporter, File, Task, Suite } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import type {
+  EvalRegistryEntry,
+  RunSummary,
+  ScenarioResult,
+  CategorySummary,
+} from './types.js';
+import { type EvalCategory, ALL_CATEGORIES } from '../categories.js';
+
+const REGISTRY_PATH = path.resolve(
+  process.cwd(),
+  'evals/logs/.eval-registry.ndjson',
+);
+
+function isRegistryEntry(v: unknown): v is EvalRegistryEntry {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    typeof (v as Record<string, unknown>)['name'] === 'string'
+  );
+}
+
+function loadRegistry(): Map<string, EvalRegistryEntry> {
+  const map = new Map<string, EvalRegistryEntry>();
+  if (!fs.existsSync(REGISTRY_PATH)) return map;
+  const raw = fs.readFileSync(REGISTRY_PATH, 'utf-8');
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (isRegistryEntry(parsed)) {
+        map.set(parsed.name, parsed);
+      }
+    } catch (e) {
+      console.warn(
+        `[eval-scorer] Could not parse registry line: "${trimmed}". Error: ${e}`,
+      );
+    }
+  }
+  return map;
+}
+
+function collectLeafTests(tasks: Task[]): Task[] {
+  const leaves: Task[] = [];
+  for (const task of tasks) {
+    if ('tasks' in task && Array.isArray((task as Suite).tasks)) {
+      leaves.push(...collectLeafTests((task as Suite).tasks));
+    } else {
+      leaves.push(task);
+    }
+  }
+  return leaves;
+}
+
+export default class EvalScoringReporter implements Reporter {
+  async onFinished(files: File[] = []) {
+    const registry = loadRegistry();
+    const scenarios: ScenarioResult[] = [];
+
+    for (const file of files) {
+      const leafTests = collectLeafTests(file.tasks);
+      for (const task of leafTests) {
+        const name = task.name;
+        const entry = registry.get(name);
+        const skipped =
+          task.mode === 'skip' ||
+          task.mode === 'todo' ||
+          task.result?.state === 'skip';
+        const passed = !skipped && task.result?.state === 'pass';
+        const durationMs = task.result?.duration ?? 0;
+
+        scenarios.push({
+          name,
+          category: (entry?.category ?? 'uncategorized') as
+            | EvalCategory
+            | 'uncategorized',
+          tags: entry?.tags ?? [],
+          policy: entry?.policy ?? 'USUALLY_PASSES',
+          passed,
+          skipped,
+          durationMs,
+        });
+      }
+    }
+
+    const byCategory: Record<string, CategorySummary> = {};
+    for (const category of [...ALL_CATEGORIES, 'uncategorized']) {
+      byCategory[category] = { pass: 0, fail: 0, skip: 0, passRate: 0 };
+    }
+    for (const s of scenarios) {
+      if (s.skipped) {
+        byCategory[s.category].skip++;
+      } else if (s.passed) {
+        byCategory[s.category].pass++;
+      } else {
+        byCategory[s.category].fail++;
+      }
+    }
+    for (const summary of Object.values(byCategory)) {
+      const ran = summary.pass + summary.fail;
+      summary.passRate = ran === 0 ? 0 : summary.pass / ran;
+    }
+
+    const totalPass = scenarios.filter((s) => s.passed).length;
+    const totalSkip = scenarios.filter((s) => s.skipped).length;
+    const totalFail = scenarios.length - totalPass - totalSkip;
+    const runId = `${new Date().toISOString().replace(/[:.]/g, '-')}-${crypto.randomBytes(3).toString('hex')}`;
+
+    const ran = scenarios.length - totalSkip;
+    const summary: RunSummary = {
+      runId,
+      timestamp: new Date().toISOString(),
+      totalPass,
+      totalFail,
+      totalSkip,
+      passRate: ran === 0 ? 0 : totalPass / ran,
+      byCategory,
+      scenarios,
+    };
+
+    const logsDir = path.resolve(process.cwd(), 'evals/logs');
+    fs.mkdirSync(logsDir, { recursive: true });
+    const outPath = path.join(logsDir, `run-${runId}.json`);
+    fs.writeFileSync(outPath, JSON.stringify(summary, null, 2));
+    console.log(`\n[eval-scorer] Run summary written to ${outPath}`);
+  }
+}

--- a/evals/scoring/types.ts
+++ b/evals/scoring/types.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { EvalCategory } from '../categories.js';
+import type { EvalPolicy } from '../test-helper.js';
+
+/** Metadata written to the registry file for each registered eval. */
+export interface EvalRegistryEntry {
+  name: string;
+  category: EvalCategory | 'uncategorized';
+  tags: string[];
+  policy: EvalPolicy;
+}
+
+/** Result record for a single scenario in one run. */
+export interface ScenarioResult {
+  name: string;
+  category: EvalCategory | 'uncategorized';
+  tags: string[];
+  policy: EvalPolicy;
+  passed: boolean;
+  skipped: boolean;
+  durationMs: number;
+}
+
+/** Pass/fail/skip counts for a single category. */
+export interface CategorySummary {
+  pass: number;
+  fail: number;
+  skip: number;
+  passRate: number;
+}
+
+/** Aggregated summary for a complete evaluation run. */
+export interface RunSummary {
+  runId: string;
+  timestamp: string;
+  totalPass: number;
+  totalFail: number;
+  totalSkip: number;
+  passRate: number;
+  byCategory: Record<string, CategorySummary>;
+  scenarios: ScenarioResult[];
+}

--- a/evals/test-helper.ts
+++ b/evals/test-helper.ts
@@ -14,8 +14,11 @@ import {
   createUnauthorizedToolError,
   parseAgentMarkdown,
 } from '@google/gemini-cli-core';
+import type { EvalCategory } from './categories.js';
+import type { EvalRegistryEntry } from './scoring/types.js';
 
 export * from '@google/gemini-cli-test-utils';
+export type { EvalCategory } from './categories.js';
 
 // Indicates the consistency expectation for this test.
 // - ALWAYS_PASSES - Means that the test is expected to pass 100% of the time. These
@@ -35,7 +38,27 @@ export * from '@google/gemini-cli-test-utils';
 //   This may take a really long time and is not recommended.
 export type EvalPolicy = 'ALWAYS_PASSES' | 'USUALLY_PASSES';
 
+const REGISTRY_PATH = path.resolve(
+  process.cwd(),
+  'evals/logs/.eval-registry.ndjson',
+);
+
+function writeRegistryEntry(entry: EvalRegistryEntry) {
+  try {
+    fs.mkdirSync(path.dirname(REGISTRY_PATH), { recursive: true });
+    fs.appendFileSync(REGISTRY_PATH, JSON.stringify(entry) + '\n');
+  } catch {
+    // Non-fatal: registry is best-effort for scoring purposes.
+  }
+}
+
 export function evalTest(policy: EvalPolicy, evalCase: EvalCase) {
+  writeRegistryEntry({
+    name: evalCase.name,
+    category: evalCase.category ?? 'uncategorized',
+    tags: evalCase.tags ?? [],
+    policy,
+  });
   const fn = async () => {
     const rig = new TestRig();
     const { logDir, sanitizedName } = await prepareLogDir(evalCase.name);
@@ -198,7 +221,11 @@ export function symlinkNodeModules(testDir: string) {
 
 export interface EvalCase {
   name: string;
-  params?: Record<string, any>;
+  /** Broad category used for grouping in run reports. */
+  category?: EvalCategory;
+  /** Free-form tags for finer-grained filtering (e.g. 'typescript', 'async'). */
+  tags?: string[];
+  params?: Record<string, unknown>;
   prompt: string;
   timeout?: number;
   files?: Record<string, string>;

--- a/evals/vitest.config.ts
+++ b/evals/vitest.config.ts
@@ -16,10 +16,15 @@ export default defineConfig({
   },
   test: {
     testTimeout: 300000, // 5 minutes
-    reporters: ['default', 'json'],
+    reporters: [
+      'default',
+      'json',
+      path.resolve(__dirname, './scoring/reporter.ts'),
+    ],
     outputFile: {
       json: 'evals/logs/report.json',
     },
+    globalSetup: [path.resolve(__dirname, './scoring/global-setup.ts')],
     include: ['**/*.eval.ts'],
     environment: 'node',
     globals: true,


### PR DESCRIPTION
Fixes #21244

The evals runner currently gives one aggregate pass/fail number. This PR adds the foundation for tracking pass rates by task category so regressions are easier to locate.

## What changed

1. `evals/categories.ts` — defines the `EvalCategory` type (`debugging`, `refactoring`, `new-feature`, `code-review`, `shell-tooling`, `memory`, `agent-delegation`) and a labels map.
2. `evals/test-helper.ts` — `EvalCase` now has optional `category` and `tags` fields. When `evalTest` is called, it writes a one-line JSON entry to `evals/logs/.eval-registry.ndjson` so the reporter can look up metadata for each test.
3. `evals/scoring/types.ts` — shared types for `EvalRegistryEntry`, `ScenarioResult`, `CategorySummary`, and `RunSummary`.
4. `evals/scoring/reporter.ts` — custom Vitest reporter. On `onFinished` it reads the registry file, joins with Vitest task results, and writes `evals/logs/run-<id>.json` with per-category pass rates.
5. `evals/scoring/global-setup.ts` — Vitest global setup that clears the registry file at the start of each run so stale entries from a previous run do not pollute results.
6. `evals/vitest.config.ts` — wires up the new reporter and global setup using absolute paths (required because Vitest resolves reporter paths from the working directory, not the config file location).

All existing evals are unaffected. `category` and `tags` default to `uncategorized` when not set.

## Before / After

**Before**

Running `npm run test:always_passing_evals` produced only Vitest's default console output and `evals/logs/report.json` (raw Vitest JSON). No per-category breakdown existed.

**After**

The same command now also writes `evals/logs/run-<timestamp>-<hash>.json`:

```json
{
  "runId": "2025-06-01T12-00-00-000Z-a1b2c3",
  "timestamp": "2025-06-01T12:00:00.000Z",
  "totalPass": 12,
  "totalFail": 0,
  "passRate": 1,
  "byCategory": {
    "uncategorized": { "pass": 12, "fail": 0, "passRate": 1 },
    "debugging":     { "pass": 0,  "fail": 0, "passRate": 0 }
  },
  "scenarios": [...]
}
```

Once benchmark scenarios land in later PRs, `byCategory` will show real per-type pass rates.

## How to validate

1. `npm run build && npm run bundle`
2. `npm run test:always_passing_evals`
3. `ls evals/logs/run-*.json` — confirm a new timestamped file was created
4. Open it and confirm `byCategory` contains all 7 category keys (all zeros) plus `uncategorized` with real counts, and `scenarios` lists each test
5. Optional: add `category: 'debugging'` to any existing eval, rerun, and confirm that eval moves from `uncategorized` to `debugging` in the report

## Screenshots

<!-- Attach 2-3 terminal screenshots: the test run output and the contents of the generated run-*.json file -->