### PR TITLE
feat(evals): add debugging benchmark scenarios

### DIFF
--- a/evals/benchmarks/debugging/async-race-condition.eval.ts
+++ b/evals/benchmarks/debugging/async-race-condition.eval.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect } from 'vitest';
+import { evalTest } from '../../test-helper.js';
+
+describe('debugging/async-race-condition', () => {
+  evalTest('USUALLY_PASSES', {
+    name: 'should fix a race condition caused by two async writes to shared state',
+    category: 'debugging',
+    tags: ['async', 'concurrency', 'typescript'],
+    files: {
+      'src/counter.ts': `// BUG: concurrent increments lose updates due to read-modify-write race
+let counter = 0;
+
+export async function incrementAsync(): Promise<void> {
+  const current = counter;
+  await new Promise((r) => setTimeout(r, 0)); // simulate async work
+  counter = current + 1;
+}
+
+export function getCounter() {
+  return counter;
+}
+`,
+    },
+    prompt:
+      'src/counter.ts has a race condition: when incrementAsync is called concurrently, updates are lost because both reads happen before either write. Fix the race condition so concurrent calls each increment the counter exactly once.',
+    assert: async (rig) => {
+      const content = rig.readFile('src/counter.ts');
+      const hasProtection =
+        content.includes('++') ||
+        content.includes('queue') ||
+        content.includes('lock') ||
+        content.includes('mutex') ||
+        content.includes('Promise.all') ||
+        content.includes('sequential') ||
+        content.includes('counter +');
+      expect(
+        hasProtection,
+        'Expected race condition fix (atomic increment or serialization)',
+      ).toBe(true);
+    },
+  });
+});

--- a/evals/benchmarks/debugging/circular-dependency.eval.ts
+++ b/evals/benchmarks/debugging/circular-dependency.eval.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect } from 'vitest';
+import { evalTest } from '../../test-helper.js';
+
+describe('debugging/circular-dependency', () => {
+  evalTest('USUALLY_PASSES', {
+    name: 'should break a circular import between two modules',
+    category: 'debugging',
+    tags: ['typescript', 'modules', 'architecture'],
+    files: {
+      'src/a.ts': `import { greetB } from './b.js';
+
+export function greetA(): string {
+  return 'Hello from A, ' + greetB();
+}
+`,
+      'src/b.ts': `import { greetA } from './a.js'; // BUG: circular — a imports b, b imports a
+
+export function greetB(): string {
+  return 'Hello from B';
+}
+
+export function combined(): string {
+  return greetA() + ' and B';
+}
+`,
+      'src/index.ts': `export { greetA } from './a.js';
+export { greetB, combined } from './b.js';
+`,
+    },
+    prompt:
+      'src/a.ts and src/b.ts have a circular dependency: a imports greetB from b, and b imports greetA from a. This causes initialization issues. Break the cycle by introducing a shared src/shared.ts module or by restructuring the imports so neither module depends on the other.',
+    assert: async (rig) => {
+      const aContent = rig.readFile('src/a.ts');
+      const bContent = rig.readFile('src/b.ts');
+      // After fix, b.ts should not import from a.ts
+      const bStillCircular =
+        bContent.includes("from './a.js'") ||
+        bContent.includes('from "./a.js"');
+      expect(bStillCircular, 'b.ts should no longer import from a.ts').toBe(
+        false,
+      );
+      // And a.ts should still be valid (has some export or content)
+      expect(aContent.length).toBeGreaterThan(10);
+    },
+  });
+});

--- a/evals/benchmarks/debugging/cors-misconfiguration.eval.ts
+++ b/evals/benchmarks/debugging/cors-misconfiguration.eval.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect } from 'vitest';
+import { evalTest } from '../../test-helper.js';
+
+describe('debugging/cors-misconfiguration', () => {
+  evalTest('USUALLY_PASSES', {
+    name: 'should harden CORS from wildcard origin to a specific allowed origin',
+    category: 'debugging',
+    tags: ['security', 'cors', 'http', 'typescript'],
+    files: {
+      'src/server.ts': `import http from 'node:http';
+
+// BUG: Access-Control-Allow-Origin: * allows ANY domain to make credentialed
+// requests in production, which is a security risk.
+export function createServer() {
+  return http.createServer((req, res) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+    res.writeHead(200);
+    res.end('OK');
+  });
+}
+`,
+    },
+    prompt:
+      "src/server.ts sets Access-Control-Allow-Origin to '*' while also allowing credentials, which is rejected by browsers and is a security misconfiguration. Fix it to only allow the specific production origin 'https://app.example.com' instead of the wildcard.",
+    assert: async (rig) => {
+      const content = rig.readFile('src/server.ts');
+      expect(content).not.toContain("'*'");
+      const hasSpecificOrigin =
+        content.includes('example.com') ||
+        content.includes('ALLOWED_ORIGIN') ||
+        content.includes('allowedOrigin');
+      expect(
+        hasSpecificOrigin,
+        'Expected a specific origin instead of wildcard',
+      ).toBe(true);
+    },
+  });
+});

--- a/evals/benchmarks/debugging/env-variable-missing.eval.ts
+++ b/evals/benchmarks/debugging/env-variable-missing.eval.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect } from 'vitest';
+import { evalTest } from '../../test-helper.js';
+
+describe('debugging/env-variable-missing', () => {
+  evalTest('USUALLY_PASSES', {
+    name: 'should add a fallback or validation for a missing environment variable',
+    category: 'debugging',
+    tags: ['environment', 'config', 'typescript'],
+    files: {
+      'src/db.ts': `// BUG: process.env.DATABASE_URL is used directly without a fallback or check.
+// If the variable is not set, the driver will receive undefined and throw an
+// unhelpful error at connection time.
+export function getDatabaseUrl(): string {
+  return process.env['DATABASE_URL'] as string;
+}
+`,
+    },
+    prompt:
+      "src/db.ts returns process.env['DATABASE_URL'] cast to string without validating that it's actually set. If the env var is missing, the caller gets undefined masquerading as a string. Add a validation check that throws a descriptive error when DATABASE_URL is not set, or add a sensible fallback.",
+    assert: async (rig) => {
+      const content = rig.readFile('src/db.ts');
+      const hasValidation =
+        content.includes('throw') ||
+        content.includes('??') ||
+        content.includes('|| ') ||
+        content.includes('if (') ||
+        content.includes('!process.env');
+      expect(
+        hasValidation,
+        'Expected validation or fallback for missing env variable',
+      ).toBe(true);
+    },
+  });
+});

--- a/evals/benchmarks/debugging/incorrect-regex.eval.ts
+++ b/evals/benchmarks/debugging/incorrect-regex.eval.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect } from 'vitest';
+import { evalTest } from '../../test-helper.js';
+
+describe('debugging/incorrect-regex', () => {
+  evalTest('USUALLY_PASSES', {
+    name: 'should fix an incorrect regex that fails to validate email addresses',
+    category: 'debugging',
+    tags: ['regex', 'validation', 'typescript'],
+    files: {
+      'src/validate.ts': `// BUG: regex is too simple — accepts "a@b" (no TLD) and rejects valid emails with subdomains
+export function isValidEmail(email: string): boolean {
+  return /^[a-z]+@[a-z]+$/.test(email);
+}
+`,
+    },
+    prompt:
+      'src/validate.ts has an email validation regex that is far too restrictive: it only accepts lowercase letters, rejects dots, hyphens, digits, and multi-part domains. Fix the regex to correctly validate common email formats like user@example.com, first.last@sub.domain.org.',
+    assert: async (rig) => {
+      const content = rig.readFile('src/validate.ts');
+      // The broken regex was /^[a-z]+@[a-z]+$/ — fix should contain dots or more character classes
+      const hasImprovedRegex =
+        content.includes('\\.') ||
+        content.includes('[a-zA-Z0-9') ||
+        content.includes('[\\w') ||
+        content.includes('\\w') ||
+        content.includes('+\\.') ||
+        content.includes('[^@]');
+      expect(hasImprovedRegex, 'Expected improved email regex').toBe(true);
+    },
+  });
+});

--- a/evals/benchmarks/debugging/json-parse-error.eval.ts
+++ b/evals/benchmarks/debugging/json-parse-error.eval.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect } from 'vitest';
+import { evalTest } from '../../test-helper.js';
+
+describe('debugging/json-parse-error', () => {
+  evalTest('USUALLY_PASSES', {
+    name: 'should wrap JSON.parse in try/catch to handle malformed input',
+    category: 'debugging',
+    tags: ['json', 'error-handling', 'typescript'],
+    files: {
+      'src/config.ts': `// BUG: JSON.parse throws SyntaxError on malformed input, crashing the app
+export function loadConfig(raw: string): Record<string, unknown> {
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+`,
+    },
+    prompt:
+      'src/config.ts calls JSON.parse without any error handling. If the input is malformed JSON, the app crashes with an unhandled SyntaxError. Also, the direct type assertion is unsafe. Fix it: wrap JSON.parse in try/catch and return a safe fallback (empty object) on parse failure.',
+    assert: async (rig) => {
+      const content = rig.readFile('src/config.ts');
+      expect(content).toContain('try');
+      expect(content).toContain('catch');
+    },
+  });
+});

--- a/evals/benchmarks/debugging/memory-leak-event-listener.eval.ts
+++ b/evals/benchmarks/debugging/memory-leak-event-listener.eval.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect } from 'vitest';
+import { evalTest } from '../../test-helper.js';
+
+describe('debugging/memory-leak-event-listener', () => {
+  evalTest('USUALLY_PASSES', {
+    name: 'should add cleanup for an event listener that causes a memory leak',
+    category: 'debugging',
+    tags: ['typescript', 'memory', 'events', 'react'],
+    files: {
+      'src/useWindowSize.ts': `import { useState, useEffect } from 'react';
+
+// BUG: addEventListener is called on mount but removeEventListener is never called,
+// causing a memory leak when the component unmounts.
+export function useWindowSize() {
+  const [size, setSize] = useState({ width: window.innerWidth, height: window.innerHeight });
+
+  useEffect(() => {
+    function handleResize() {
+      setSize({ width: window.innerWidth, height: window.innerHeight });
+    }
+    window.addEventListener('resize', handleResize);
+    // Missing: return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return size;
+}
+`,
+    },
+    prompt:
+      'src/useWindowSize.ts leaks memory: addEventListener is called in useEffect but removeEventListener is never called on cleanup. Add the cleanup function so the event listener is removed when the component unmounts.',
+    assert: async (rig) => {
+      const content = rig.readFile('src/useWindowSize.ts');
+      expect(content).toContain('removeEventListener');
+    },
+  });
+});

--- a/evals/benchmarks/debugging/missing-import.eval.ts
+++ b/evals/benchmarks/debugging/missing-import.eval.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect } from 'vitest';
+import { evalTest } from '../../test-helper.js';
+
+describe('debugging/missing-import', () => {
+  evalTest('USUALLY_PASSES', {
+    name: 'should restore a missing import that causes a ReferenceError',
+    category: 'debugging',
+    tags: ['typescript', 'imports', 'modules'],
+    files: {
+      'src/utils.ts': `export function formatDate(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+`,
+      'src/report.ts': `// BUG: formatDate is used but never imported
+export function generateReport(date: Date): string {
+  return \`Report generated on: \${formatDate(date)}\`;
+}
+`,
+    },
+    prompt:
+      "src/report.ts calls formatDate but the import from './utils.js' is missing, which will cause a ReferenceError at runtime. Add the correct import statement.",
+    assert: async (rig) => {
+      const content = rig.readFile('src/report.ts');
+      expect(content).toMatch(/import.*formatDate.*from/);
+    },
+  });
+});

--- a/evals/benchmarks/debugging/null-reference.eval.ts
+++ b/evals/benchmarks/debugging/null-reference.eval.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect } from 'vitest';
+import { evalTest } from '../../test-helper.js';
+
+describe('debugging/null-reference', () => {
+  evalTest('USUALLY_PASSES', {
+    name: 'should identify and fix a null reference error in TypeScript',
+    category: 'debugging',
+    tags: ['typescript', 'null-safety'],
+    files: {
+      'src/user.ts': `export interface User { name: string; address?: { city: string } }
+export function getCity(user: User): string {
+  return user.address.city; // BUG: address may be undefined
+}
+`,
+      'src/user.test.ts': `import { getCity } from './user.js';
+import { describe, it, expect } from 'vitest';
+describe('getCity', () => {
+  it('returns city when address exists', () => {
+    expect(getCity({ name: 'Alice', address: { city: 'NYC' } })).toBe('NYC');
+  });
+  it('handles missing address gracefully', () => {
+    expect(getCity({ name: 'Bob' })).toBe('');
+  });
+});
+`,
+    },
+    prompt:
+      'There is a bug in src/user.ts. The getCity function crashes when address is undefined. Fix it so getCity returns an empty string when address is missing.',
+    assert: async (rig) => {
+      const content = rig.readFile('src/user.ts');
+      const hasGuard =
+        content.includes('?.') ||
+        content.includes('address &&') ||
+        content.includes('?? ') ||
+        content.includes('=== undefined') ||
+        content.includes('!address');
+      expect(hasGuard, 'Expected a null/undefined guard in fixed code').toBe(
+        true,
+      );
+    },
+  });
+});

--- a/evals/benchmarks/debugging/off-by-one.eval.ts
+++ b/evals/benchmarks/debugging/off-by-one.eval.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect } from 'vitest';
+import { evalTest } from '../../test-helper.js';
+
+describe('debugging/off-by-one', () => {
+  evalTest('USUALLY_PASSES', {
+    name: 'should fix an off-by-one error accessing the last array element',
+    category: 'debugging',
+    tags: ['javascript', 'arrays'],
+    files: {
+      'src/list.ts': `// BUG: array[array.length] is always undefined
+export function getLast<T>(items: T[]): T | undefined {
+  if (items.length === 0) return undefined;
+  return items[items.length]; // off-by-one: should be length - 1
+}
+`,
+    },
+    prompt:
+      'src/list.ts has an off-by-one bug in getLast. It returns undefined for non-empty arrays because it accesses index items.length instead of items.length - 1. Fix it.',
+    assert: async (rig) => {
+      const content = rig.readFile('src/list.ts');
+      const hasCorrectIndex =
+        content.includes('length - 1') ||
+        content.includes('.at(-1)') ||
+        content.includes('slice(-1)');
+      expect(
+        hasCorrectIndex,
+        'Expected corrected index (length - 1 or .at(-1))',
+      ).toBe(true);
+      expect(content).not.toMatch(/items\[items\.length\][^-]/);
+    },
+  });
+});

--- a/evals/benchmarks/debugging/stack-overflow-recursion.eval.ts
+++ b/evals/benchmarks/debugging/stack-overflow-recursion.eval.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect } from 'vitest';
+import { evalTest } from '../../test-helper.js';
+
+describe('debugging/stack-overflow-recursion', () => {
+  evalTest('USUALLY_PASSES', {
+    name: 'should add a base case to a recursive function missing one',
+    category: 'debugging',
+    tags: ['recursion', 'typescript', 'algorithms'],
+    files: {
+      'src/factorial.ts': `// BUG: missing base case — factorial(0) recurses forever causing a stack overflow
+export function factorial(n: number): number {
+  return n * factorial(n - 1); // no base case!
+}
+`,
+    },
+    prompt:
+      'src/factorial.ts is missing a base case. factorial(0) will recurse forever and crash with a stack overflow. Add the correct base case (factorial(0) = 1) and also guard against negative inputs.',
+    assert: async (rig) => {
+      const content = rig.readFile('src/factorial.ts');
+      const hasBaseCase =
+        content.includes('=== 0') ||
+        content.includes('=== 1') ||
+        content.includes('<= 0') ||
+        content.includes('<= 1') ||
+        content.includes('n === 0') ||
+        content.includes('n < 2');
+      expect(hasBaseCase, 'Expected a base case condition').toBe(true);
+      expect(content).toContain('return');
+    },
+  });
+});

--- a/evals/benchmarks/debugging/test-false-positive.eval.ts
+++ b/evals/benchmarks/debugging/test-false-positive.eval.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect } from 'vitest';
+import { evalTest } from '../../test-helper.js';
+
+describe('debugging/test-false-positive', () => {
+  evalTest('USUALLY_PASSES', {
+    name: 'should fix a test that always passes due to a bad mock returning wrong value',
+    category: 'debugging',
+    tags: ['testing', 'mocks', 'typescript', 'vitest'],
+    files: {
+      'src/emailService.ts': `export async function sendEmail(to: string, subject: string): Promise<boolean> {
+  // Real implementation would call an SMTP server
+  throw new Error('Not implemented in tests');
+}
+`,
+      'src/notifier.ts': `import { sendEmail } from './emailService.js';
+
+export async function notifyUser(email: string): Promise<string> {
+  const sent = await sendEmail(email, 'Welcome!');
+  if (sent) {
+    return 'Email sent successfully';
+  }
+  return 'Email failed';
+}
+`,
+      'src/notifier.test.ts': `import { describe, it, expect, vi } from 'vitest';
+import { notifyUser } from './notifier.js';
+
+// BUG: the mock always returns true regardless of the argument,
+// so the test never actually validates the failure path.
+vi.mock('./emailService.js', () => ({
+  sendEmail: vi.fn().mockResolvedValue(true), // always succeeds — failure branch never tested
+}));
+
+describe('notifyUser', () => {
+  it('returns success message when email is sent', async () => {
+    const result = await notifyUser('user@example.com');
+    expect(result).toBe('Email sent successfully');
+  });
+
+  it('returns failure message when email fails', async () => {
+    // BUG: mock still returns true here, so this test is a false positive
+    const result = await notifyUser('bad@example.com');
+    expect(result).toBe('Email sent successfully'); // wrong expectation!
+  });
+});
+`,
+    },
+    prompt:
+      "src/notifier.test.ts has a false-positive test: the failure case test expects 'Email sent successfully' because the mock always returns true and the expectation was never updated to test the actual failure path. Fix the test so it correctly mocks sendEmail returning false for the failure case and asserts 'Email failed'.",
+    assert: async (rig) => {
+      const content = rig.readFile('src/notifier.test.ts');
+      expect(content).toContain('Email failed');
+      const hasFalseMock =
+        content.includes('mockResolvedValue(false)') ||
+        content.includes('mockReturnValue(false)') ||
+        content.includes('mockResolvedValueOnce(false)');
+      expect(
+        hasFalseMock,
+        'Expected mock to return false for failure test case',
+      ).toBe(true);
+    },
+  });
+});

--- a/evals/benchmarks/debugging/type-mismatch.eval.ts
+++ b/evals/benchmarks/debugging/type-mismatch.eval.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect } from 'vitest';
+import { evalTest } from '../../test-helper.js';
+
+describe('debugging/type-mismatch', () => {
+  evalTest('USUALLY_PASSES', {
+    name: 'should fix a type mismatch where a string is passed where a number is expected',
+    category: 'debugging',
+    tags: ['typescript', 'types'],
+    files: {
+      'src/math.ts': `// BUG: price is coming in as string from query param, but used as number
+export function applyDiscount(price: string, discountPercent: number): number {
+  return price - (price * discountPercent) / 100;
+}
+`,
+    },
+    prompt:
+      'src/math.ts has a type bug: applyDiscount receives price as a string but performs arithmetic on it. In JavaScript this produces NaN for non-numeric strings. Fix the function to correctly convert and validate the price before computing the discount.',
+    assert: async (rig) => {
+      const content = rig.readFile('src/math.ts');
+      const hasConversion =
+        content.includes('Number(') ||
+        content.includes('parseFloat(') ||
+        content.includes('parseInt(') ||
+        content.includes(': number') ||
+        content.includes('isNaN');
+      expect(
+        hasConversion,
+        'Expected numeric conversion or type correction in fixed code',
+      ).toBe(true);
+    },
+  });
+});

--- a/evals/benchmarks/debugging/unhandled-promise-rejection.eval.ts
+++ b/evals/benchmarks/debugging/unhandled-promise-rejection.eval.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect } from 'vitest';
+import { evalTest } from '../../test-helper.js';
+
+describe('debugging/unhandled-promise-rejection', () => {
+  evalTest('USUALLY_PASSES', {
+    name: 'should add error handling to an async function missing catch',
+    category: 'debugging',
+    tags: ['async', 'error-handling', 'typescript'],
+    files: {
+      'src/fetcher.ts': `// BUG: no error handling — network failure causes unhandled rejection
+export async function fetchUser(id: number): Promise<{ name: string }> {
+  const response = await fetch(\`https://api.example.com/users/\${id}\`);
+  const data = await response.json();
+  return data as { name: string };
+}
+`,
+    },
+    prompt:
+      'src/fetcher.ts has no error handling. If the fetch fails or the server returns a non-OK status, the promise rejects silently or the caller gets unexpected data. Add proper error handling: check response.ok and wrap in try/catch, throwing a descriptive error on failure.',
+    assert: async (rig) => {
+      const content = rig.readFile('src/fetcher.ts');
+      const hasErrorHandling =
+        content.includes('try') ||
+        content.includes('.catch') ||
+        content.includes('response.ok') ||
+        content.includes('!response.ok') ||
+        content.includes('throw');
+      expect(
+        hasErrorHandling,
+        'Expected error handling (try/catch or response.ok check)',
+      ).toBe(true);
+    },
+  });
+});

--- a/evals/benchmarks/debugging/wrong-http-method.eval.ts
+++ b/evals/benchmarks/debugging/wrong-http-method.eval.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect } from 'vitest';
+import { evalTest } from '../../test-helper.js';
+
+describe('debugging/wrong-http-method', () => {
+  evalTest('USUALLY_PASSES', {
+    name: 'should fix a POST request that should be a GET',
+    category: 'debugging',
+    tags: ['http', 'api', 'typescript'],
+    files: {
+      'src/api.ts': `// BUG: fetching a resource with POST instead of GET
+export async function getUser(id: number): Promise<unknown> {
+  const response = await fetch(\`/api/users/\${id}\`, {
+    method: 'POST', // BUG: should be GET for a read-only fetch
+  });
+  return response.json();
+}
+`,
+    },
+    prompt:
+      "src/api.ts uses method: 'POST' in getUser, but this is a read operation that should use GET. Some servers reject POST for pure read endpoints. Fix the HTTP method.",
+    assert: async (rig) => {
+      const content = rig.readFile('src/api.ts');
+      expect(content).not.toContain("method: 'POST'");
+      expect(content).not.toContain('method: "POST"');
+      const hasGet =
+        content.includes("method: 'GET'") ||
+        content.includes('method: "GET"') ||
+        // simplest fix: remove the method entirely (defaults to GET)
+        !content.includes('method:');
+      expect(
+        hasGet,
+        'Expected GET method or no method property (defaults to GET)',
+      ).toBe(true);
+    },
+  });
+});

--- a/evals/categories.ts
+++ b/evals/categories.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The category of a behavioral evaluation scenario.
+ * Used for grouping results and computing per-category pass rates.
+ */
+export type EvalCategory =
+  | 'debugging'
+  | 'refactoring'
+  | 'new-feature'
+  | 'code-review'
+  | 'shell-tooling'
+  | 'memory'
+  | 'agent-delegation';
+
+/** Human-readable labels for each category. */
+export const CATEGORY_LABELS: Record<EvalCategory, string> = {
+  debugging: 'Debugging',
+  refactoring: 'Refactoring',
+  'new-feature': 'New Feature',
+  'code-review': 'Code Review',
+  'shell-tooling': 'Shell & Tooling',
+  memory: 'Memory',
+  'agent-delegation': 'Agent Delegation',
+};
+
+/** All defined category keys, derived from CATEGORY_LABELS to stay in sync. */
+export const ALL_CATEGORIES: EvalCategory[] = Object.keys(
+  CATEGORY_LABELS,
+) as EvalCategory[];

--- a/evals/scoring/global-setup.ts
+++ b/evals/scoring/global-setup.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Vitest global setup: clears the eval registry file before each run so that
+ * stale entries from previous runs do not pollute the current run's report.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export function setup() {
+  const registryPath = path.resolve(
+    process.cwd(),
+    'evals/logs/.eval-registry.ndjson',
+  );
+  // Ensure the logs dir exists and start with a clean registry.
+  fs.mkdirSync(path.dirname(registryPath), { recursive: true });
+  fs.writeFileSync(registryPath, '');
+}

--- a/evals/scoring/reporter.ts
+++ b/evals/scoring/reporter.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Custom Vitest reporter that generates a structured RunSummary JSON file
+ * after each evaluation run. It cross-references the Vitest task results
+ * with per-eval metadata (category, tags, policy) written to a registry
+ * file by the test-helper during test module initialisation.
+ */
+
+import type { Reporter, File, Task, Suite } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import type {
+  EvalRegistryEntry,
+  RunSummary,
+  ScenarioResult,
+  CategorySummary,
+} from './types.js';
+import { type EvalCategory, ALL_CATEGORIES } from '../categories.js';
+
+const REGISTRY_PATH = path.resolve(
+  process.cwd(),
+  'evals/logs/.eval-registry.ndjson',
+);
+
+function isRegistryEntry(v: unknown): v is EvalRegistryEntry {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    typeof (v as Record<string, unknown>)['name'] === 'string'
+  );
+}
+
+function loadRegistry(): Map<string, EvalRegistryEntry> {
+  const map = new Map<string, EvalRegistryEntry>();
+  if (!fs.existsSync(REGISTRY_PATH)) return map;
+  const raw = fs.readFileSync(REGISTRY_PATH, 'utf-8');
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (isRegistryEntry(parsed)) {
+        map.set(parsed.name, parsed);
+      }
+    } catch (e) {
+      console.warn(
+        `[eval-scorer] Could not parse registry line: "${trimmed}". Error: ${e}`,
+      );
+    }
+  }
+  return map;
+}
+
+function collectLeafTests(tasks: Task[]): Task[] {
+  const leaves: Task[] = [];
+  for (const task of tasks) {
+    if ('tasks' in task && Array.isArray((task as Suite).tasks)) {
+      leaves.push(...collectLeafTests((task as Suite).tasks));
+    } else {
+      leaves.push(task);
+    }
+  }
+  return leaves;
+}
+
+export default class EvalScoringReporter implements Reporter {
+  async onFinished(files: File[] = []) {
+    const registry = loadRegistry();
+    const scenarios: ScenarioResult[] = [];
+
+    for (const file of files) {
+      const leafTests = collectLeafTests(file.tasks);
+      for (const task of leafTests) {
+        const name = task.name;
+        const entry = registry.get(name);
+        const skipped =
+          task.mode === 'skip' ||
+          task.mode === 'todo' ||
+          task.result?.state === 'skip';
+        const passed = !skipped && task.result?.state === 'pass';
+        const durationMs = task.result?.duration ?? 0;
+
+        scenarios.push({
+          name,
+          category: (entry?.category ?? 'uncategorized') as
+            | EvalCategory
+            | 'uncategorized',
+          tags: entry?.tags ?? [],
+          policy: entry?.policy ?? 'USUALLY_PASSES',
+          passed,
+          skipped,
+          durationMs,
+        });
+      }
+    }
+
+    const byCategory: Record<string, CategorySummary> = {};
+    for (const category of [...ALL_CATEGORIES, 'uncategorized']) {
+      byCategory[category] = { pass: 0, fail: 0, skip: 0, passRate: 0 };
+    }
+    for (const s of scenarios) {
+      if (s.skipped) {
+        byCategory[s.category].skip++;
+      } else if (s.passed) {
+        byCategory[s.category].pass++;
+      } else {
+        byCategory[s.category].fail++;
+      }
+    }
+    for (const summary of Object.values(byCategory)) {
+      const ran = summary.pass + summary.fail;
+      summary.passRate = ran === 0 ? 0 : summary.pass / ran;
+    }
+
+    const totalPass = scenarios.filter((s) => s.passed).length;
+    const totalSkip = scenarios.filter((s) => s.skipped).length;
+    const totalFail = scenarios.length - totalPass - totalSkip;
+    const runId = `${new Date().toISOString().replace(/[:.]/g, '-')}-${crypto.randomBytes(3).toString('hex')}`;
+
+    const ran = scenarios.length - totalSkip;
+    const summary: RunSummary = {
+      runId,
+      timestamp: new Date().toISOString(),
+      totalPass,
+      totalFail,
+      totalSkip,
+      passRate: ran === 0 ? 0 : totalPass / ran,
+      byCategory,
+      scenarios,
+    };
+
+    const logsDir = path.resolve(process.cwd(), 'evals/logs');
+    fs.mkdirSync(logsDir, { recursive: true });
+    const outPath = path.join(logsDir, `run-${runId}.json`);
+    fs.writeFileSync(outPath, JSON.stringify(summary, null, 2));
+    console.log(`\n[eval-scorer] Run summary written to ${outPath}`);
+  }
+}

--- a/evals/scoring/types.ts
+++ b/evals/scoring/types.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { EvalCategory } from '../categories.js';
+import type { EvalPolicy } from '../test-helper.js';
+
+/** Metadata written to the registry file for each registered eval. */
+export interface EvalRegistryEntry {
+  name: string;
+  category: EvalCategory | 'uncategorized';
+  tags: string[];
+  policy: EvalPolicy;
+}
+
+/** Result record for a single scenario in one run. */
+export interface ScenarioResult {
+  name: string;
+  category: EvalCategory | 'uncategorized';
+  tags: string[];
+  policy: EvalPolicy;
+  passed: boolean;
+  skipped: boolean;
+  durationMs: number;
+}
+
+/** Pass/fail/skip counts for a single category. */
+export interface CategorySummary {
+  pass: number;
+  fail: number;
+  skip: number;
+  passRate: number;
+}
+
+/** Aggregated summary for a complete evaluation run. */
+export interface RunSummary {
+  runId: string;
+  timestamp: string;
+  totalPass: number;
+  totalFail: number;
+  totalSkip: number;
+  passRate: number;
+  byCategory: Record<string, CategorySummary>;
+  scenarios: ScenarioResult[];
+}

--- a/evals/test-helper.ts
+++ b/evals/test-helper.ts
@@ -14,8 +14,11 @@ import {
   createUnauthorizedToolError,
   parseAgentMarkdown,
 } from '@google/gemini-cli-core';
+import type { EvalCategory } from './categories.js';
+import type { EvalRegistryEntry } from './scoring/types.js';
 
 export * from '@google/gemini-cli-test-utils';
+export type { EvalCategory } from './categories.js';
 
 // Indicates the consistency expectation for this test.
 // - ALWAYS_PASSES - Means that the test is expected to pass 100% of the time. These
@@ -35,7 +38,27 @@ export * from '@google/gemini-cli-test-utils';
 //   This may take a really long time and is not recommended.
 export type EvalPolicy = 'ALWAYS_PASSES' | 'USUALLY_PASSES';
 
+const REGISTRY_PATH = path.resolve(
+  process.cwd(),
+  'evals/logs/.eval-registry.ndjson',
+);
+
+function writeRegistryEntry(entry: EvalRegistryEntry) {
+  try {
+    fs.mkdirSync(path.dirname(REGISTRY_PATH), { recursive: true });
+    fs.appendFileSync(REGISTRY_PATH, JSON.stringify(entry) + '\n');
+  } catch {
+    // Non-fatal: registry is best-effort for scoring purposes.
+  }
+}
+
 export function evalTest(policy: EvalPolicy, evalCase: EvalCase) {
+  writeRegistryEntry({
+    name: evalCase.name,
+    category: evalCase.category ?? 'uncategorized',
+    tags: evalCase.tags ?? [],
+    policy,
+  });
   const fn = async () => {
     const rig = new TestRig();
     const { logDir, sanitizedName } = await prepareLogDir(evalCase.name);
@@ -198,7 +221,11 @@ export function symlinkNodeModules(testDir: string) {
 
 export interface EvalCase {
   name: string;
-  params?: Record<string, any>;
+  /** Broad category used for grouping in run reports. */
+  category?: EvalCategory;
+  /** Free-form tags for finer-grained filtering (e.g. 'typescript', 'async'). */
+  tags?: string[];
+  params?: Record<string, unknown>;
   prompt: string;
   timeout?: number;
   files?: Record<string, string>;

--- a/evals/vitest.config.ts
+++ b/evals/vitest.config.ts
@@ -16,10 +16,15 @@ export default defineConfig({
   },
   test: {
     testTimeout: 300000, // 5 minutes
-    reporters: ['default', 'json'],
+    reporters: [
+      'default',
+      'json',
+      path.resolve(__dirname, './scoring/reporter.ts'),
+    ],
     outputFile: {
       json: 'evals/logs/report.json',
     },
+    globalSetup: [path.resolve(__dirname, './scoring/global-setup.ts')],
     include: ['**/*.eval.ts'],
     environment: 'node',
     globals: true,


### PR DESCRIPTION
## Summary

Adds 15 behavioral eval scenarios under `evals/benchmarks/debugging/`, each tagged with `category: 'debugging'` so they appear in per-category scoring reports.

Fixes #21249

**PR 2 of 8** in the behavioral evaluation framework series:
| # | PR | Status |
|---|---|---|
| 1 | feat(evals): add category tagging + scoring harness | [#21246](https://github.com/google-gemini/gemini-cli/pull/21246) ✅ |
| 2 | feat(evals): 15 debugging benchmarks | **this PR** |
| 3 | feat(evals): 15 refactoring benchmarks | coming next |
| 4 | feat(evals): 11 new-feature benchmarks | coming next |
| 5 | feat(evals): 10 code-review benchmarks | coming next |
| 6 | feat(evals): regression detection CI | coming next |
| 7 | feat(evals): eval report generator | coming next |
| 8 | feat(evals): docs + contributor guide | coming next |

## Before / After

**Before**
```
evals/benchmarks/   (directory did not exist)
```

**After**
```
evals/benchmarks/debugging/
  async-race-condition.eval.ts
  circular-dependency.eval.ts
  cors-misconfiguration.eval.ts
  env-variable-missing.eval.ts
  incorrect-regex.eval.ts
  json-parse-error.eval.ts
  memory-leak-event-listener.eval.ts
  missing-import.eval.ts
  null-reference.eval.ts
  off-by-one.eval.ts
  stack-overflow-recursion.eval.ts
  test-false-positive.eval.ts
  type-mismatch.eval.ts
  unhandled-promise-rejection.eval.ts
  wrong-http-method.eval.ts
```

Each scenario:
- Plants a realistic bug in 1–3 source files
- Issues a clear fix prompt
- Asserts against `rig.readFile()` content — not just LLM text output
- Tagged `category: 'debugging'` + relevant tags (typescript, async, regex, etc.)

## How to validate
1. `git checkout feat/eval-benchmarks-debugging`
2. `npm run build`
3. `export GEMINI_API_KEY=<key> RUN_EVALS=1`
4. `npx vitest run --config evals/vitest.config.ts --reporter=verbose evals/benchmarks/debugging/`
5. Check `evals/logs/run-*.json` — `byCategory.debugging` should show non-zero counts
6. Each test name appears in the scenarios array with `category: "debugging"`

## Screenshots
<!-- Attach 2-3 terminal screenshots showing the evals running -->