### PR TITLE
(core): add missing JSDoc to core utility functions

### DIFF
--- a/packages/core/src/utils/httpErrors.ts
+++ b/packages/core/src/utils/httpErrors.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * Represents an HTTP error with an optional status code.
+ */
 export interface HttpError extends Error {
   status?: number;
 }
@@ -36,6 +39,9 @@ export function getErrorStatus(error: unknown): number | undefined {
   return undefined;
 }
 
+/**
+ * Error thrown when the requested model is not found (HTTP 404).
+ */
 export class ModelNotFoundError extends Error {
   code: number;
   constructor(message: string, code?: number) {

--- a/packages/core/src/utils/messageInspectors.ts
+++ b/packages/core/src/utils/messageInspectors.ts
@@ -6,6 +6,13 @@
 
 import type { Content } from '@google/genai';
 
+/**
+ * Returns true if the given content represents a function response turn.
+ * A function response is a user-role message where every part is a
+ * `functionResponse` (i.e. the result of a previously invoked tool).
+ * @param content The conversation content to inspect.
+ * @returns `true` when all parts of the content are function responses.
+ */
 export function isFunctionResponse(content: Content): boolean {
   return (
     content.role === 'user' &&
@@ -14,6 +21,13 @@ export function isFunctionResponse(content: Content): boolean {
   );
 }
 
+/**
+ * Returns true if the given content represents a function call turn.
+ * A function call is a model-role message where every part is a
+ * `functionCall` (i.e. a request to invoke a tool).
+ * @param content The conversation content to inspect.
+ * @returns `true` when all parts of the content are function calls.
+ */
 export function isFunctionCall(content: Content): boolean {
   return (
     content.role === 'model' &&

--- a/packages/core/src/utils/nextSpeakerChecker.ts
+++ b/packages/core/src/utils/nextSpeakerChecker.ts
@@ -35,11 +35,27 @@ const RESPONSE_SCHEMA: Record<string, unknown> = {
   required: ['reasoning', 'next_speaker'],
 };
 
+/**
+ * Structured response from the next-speaker check LLM call.
+ */
 export interface NextSpeakerResponse {
   reasoning: string;
   next_speaker: 'user' | 'model';
 }
 
+/**
+ * Determines who should speak next in the conversation by asking the model
+ * to analyze its own last response.
+ *
+ * Returns `null` when the next speaker cannot be determined (e.g. empty
+ * history, last turn was not from the model, or the LLM call fails).
+ *
+ * @param chat - The current {@link GeminiChat} session providing conversation history.
+ * @param baseLlmClient - LLM client used to make the next-speaker check request.
+ * @param abortSignal - Signal used to cancel the underlying LLM request.
+ * @param promptId - Identifier for the originating prompt, used for telemetry.
+ * @returns A {@link NextSpeakerResponse} indicating who speaks next, or `null`.
+ */
 export async function checkNextSpeaker(
   chat: GeminiChat,
   baseLlmClient: BaseLlmClient,

--- a/packages/core/src/utils/version.ts
+++ b/packages/core/src/utils/version.ts
@@ -13,6 +13,13 @@ const __dirname = path.dirname(__filename);
 
 let versionPromise: Promise<string> | undefined;
 
+/**
+ * Resolves the current CLI version string.
+ * Reads the version from `package.json` in the package directory, falling back
+ * to the `CLI_VERSION` environment variable, then `'unknown'`.
+ * The result is cached after the first call.
+ * @returns A promise that resolves to the version string.
+ */
 export function getVersion(): Promise<string> {
   if (versionPromise) {
     return versionPromise;


### PR DESCRIPTION
## Summary

Add JSDoc comments to exported functions and types in `packages/core/src/utils/` that previously had none, improving IDE hover documentation and contributor experience.

## Changes

### `packages/core/src/utils/messageInspectors.ts`
- Added JSDoc to `isFunctionResponse()`
- Added JSDoc to `isFunctionCall()`

### `packages/core/src/utils/version.ts`
- Added JSDoc to `getVersion()`

### `packages/core/src/utils/httpErrors.ts`
- Added JSDoc to `HttpError` interface
- Added JSDoc to `ModelNotFoundError` class

### `packages/core/src/utils/nextSpeakerChecker.ts`
- Added JSDoc to `NextSpeakerResponse` interface
- Added JSDoc to `checkNextSpeaker()`

## Notes

No logic changes — documentation only.

Fixes #21264