### PR TITLE
docs: add FAQ entry for checking Gemini CLI version

### DIFF
--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -58,6 +58,19 @@ your total token usage using the `/stats` command in Gemini CLI.
 
 ## Installation and updates
 
+### How do I check which version of Gemini CLI I'm currently running?
+
+You can check your current Gemini CLI version using one of these methods:
+
+- Run `gemini --version` or `gemini -v` from your terminal
+- Check the globally installed version using your package manager:
+  - npm: `npm list -g @google/gemini-cli`
+  - pnpm: `pnpm list -g @google/gemini-cli`
+  - yarn: `yarn global list @google/gemini-cli`
+  - bun: `bun pm ls -g @google/gemini-cli`
+  - homebrew: `brew list --versions gemini-cli`
+- Inside an active Gemini CLI session, use the `/about` command
+
 ### How do I update Gemini CLI to the latest version?
 
 If you installed it globally via `npm`, update it using the command


### PR DESCRIPTION
Add a new FAQ entry explaining how users can check their current Gemini CLI version.

This addresses the common question about version checking by providing multiple methods:
- Using `gemini --version` or `gemini -v` command
- Checking via package managers (npm, pnpm, yarn, bun, homebrew)
- Using `/about` command within an active session

This is a clean FAQ-only PR as requested by @g-samroberts in #17666.

Fixes #17735
