### PR TITLE
fix(plan): keep approved plan during chat compression

### DIFF
--- a/packages/core/src/prompts/promptProvider.test.ts
+++ b/packages/core/src/prompts/promptProvider.test.ts
@@ -176,4 +176,41 @@ describe('PromptProvider', () => {
       expect(prompt).toContain('/tmp/project-temp/plans/');
     });
   });
+
+  describe('getCompressionPrompt', () => {
+    it('should include plan preservation instructions when an approved plan path is provided', () => {
+      const planPath = '/path/to/plan.md';
+      (
+        mockConfig.getApprovedPlanPath as ReturnType<typeof vi.fn>
+      ).mockReturnValue(planPath);
+
+      const provider = new PromptProvider();
+      const prompt = provider.getCompressionPrompt(mockConfig);
+
+      expect(prompt).toContain('### APPROVED PLAN PRESERVATION');
+      expect(prompt).toContain(planPath);
+
+      // Verify it's BEFORE the structure example
+      const structureMarker = 'The structure MUST be as follows:';
+      const planPreservationMarker = '### APPROVED PLAN PRESERVATION';
+
+      const structureIndex = prompt.indexOf(structureMarker);
+      const planPreservationIndex = prompt.indexOf(planPreservationMarker);
+
+      expect(planPreservationIndex).toBeGreaterThan(-1);
+      expect(structureIndex).toBeGreaterThan(-1);
+      expect(planPreservationIndex).toBeLessThan(structureIndex);
+    });
+
+    it('should NOT include plan preservation instructions when no approved plan path is provided', () => {
+      (
+        mockConfig.getApprovedPlanPath as ReturnType<typeof vi.fn>
+      ).mockReturnValue(undefined);
+
+      const provider = new PromptProvider();
+      const prompt = provider.getCompressionPrompt(mockConfig);
+
+      expect(prompt).not.toContain('### APPROVED PLAN PRESERVATION');
+    });
+  });
 });

--- a/packages/core/src/prompts/promptProvider.ts
+++ b/packages/core/src/prompts/promptProvider.ts
@@ -231,7 +231,7 @@ export class PromptProvider {
     );
     const isModernModel = supportsModernFeatures(desiredModel);
     const activeSnippets = isModernModel ? snippets : legacySnippets;
-    return activeSnippets.getCompressionPrompt();
+    return activeSnippets.getCompressionPrompt(config.getApprovedPlanPath());
   }
 
   private withSection<T>(

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -702,7 +702,17 @@ function formatToolName(name: string): string {
 /**
  * Provides the system prompt for history compression.
  */
-export function getCompressionPrompt(): string {
+export function getCompressionPrompt(approvedPlanPath?: string): string {
+  const planPreservation = approvedPlanPath
+    ? `
+
+### APPROVED PLAN PRESERVATION
+An approved implementation plan exists at ${approvedPlanPath}. You MUST preserve the following in your snapshot:
+- The plan's file path in <key_knowledge>
+- Completion status of each plan step in <task_state> (mark as [DONE], [IN PROGRESS], or [TODO])
+- Any user feedback or modifications to the plan in <active_constraints>`
+    : '';
+
   return `
 You are a specialized system component responsible for distilling chat history into a structured XML <state_snapshot>.
 
@@ -718,7 +728,7 @@ When the conversation history grows too large, you will be invoked to distill th
 
 First, you will think through the entire history in a private <scratchpad>. Review the user's overall goal, the agent's actions, tool outputs, file modifications, and any unresolved questions. Identify every piece of information for future actions.
 
-After your reasoning is complete, generate the final <state_snapshot> XML object. Be incredibly dense with information. Omit any irrelevant conversational filler.
+After your reasoning is complete, generate the final <state_snapshot> XML object. Be incredibly dense with information. Omit any irrelevant conversational filler.${planPreservation}
 
 The structure MUST be as follows:
 

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -10,7 +10,7 @@ import {
   findCompressSplitPoint,
   modelStringToModelConfigAlias,
 } from './chatCompressionService.js';
-import type { Content, GenerateContentResponse } from '@google/genai';
+import type { Content, GenerateContentResponse, Part } from '@google/genai';
 import { CompressionStatus } from '../core/turn.js';
 import type { BaseLlmClient } from '../core/baseLlmClient.js';
 import type { GeminiChat } from '../core/geminiChat.js';
@@ -189,6 +189,7 @@ describe('ChatCompressionService', () => {
       storage: {
         getProjectTempDir: vi.fn().mockReturnValue(testTempDir),
       },
+      getApprovedPlanPath: vi.fn().mockReturnValue('/path/to/plan.md'),
     } as unknown as Config;
 
     vi.mocked(getInitialChatHistory).mockImplementation(
@@ -353,6 +354,63 @@ describe('ChatCompressionService', () => {
     expect(lastContent?.parts?.[0].text).toContain(
       'A previous <state_snapshot> exists',
     );
+  });
+
+  it('should include the approved plan path in the system instruction', async () => {
+    const planPath = '/custom/plan/path.md';
+    vi.mocked(mockConfig.getApprovedPlanPath).mockReturnValue(planPath);
+    vi.mocked(mockConfig.getActiveModel).mockReturnValue(
+      'gemini-3.1-pro-preview',
+    );
+
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'msg1' }] },
+      { role: 'model', parts: [{ text: 'msg2' }] },
+    ];
+    vi.mocked(mockChat.getHistory).mockReturnValue(history);
+    vi.mocked(mockChat.getLastPromptTokenCount).mockReturnValue(600000);
+
+    await service.compress(
+      mockChat,
+      mockPromptId,
+      false,
+      mockModel,
+      mockConfig,
+      false,
+    );
+
+    const firstCallText = (
+      vi.mocked(mockConfig.getBaseLlmClient().generateContent).mock.calls[0][0]
+        .systemInstruction as Part
+    ).text;
+    expect(firstCallText).toContain('### APPROVED PLAN PRESERVATION');
+    expect(firstCallText).toContain(planPath);
+  });
+
+  it('should not include the approved plan section if no approved plan path exists', async () => {
+    vi.mocked(mockConfig.getApprovedPlanPath).mockReturnValue(undefined);
+
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'msg1' }] },
+      { role: 'model', parts: [{ text: 'msg2' }] },
+    ];
+    vi.mocked(mockChat.getHistory).mockReturnValue(history);
+    vi.mocked(mockChat.getLastPromptTokenCount).mockReturnValue(600000);
+
+    await service.compress(
+      mockChat,
+      mockPromptId,
+      false,
+      mockModel,
+      mockConfig,
+      false,
+    );
+
+    const firstCallText = (
+      vi.mocked(mockConfig.getBaseLlmClient().generateContent).mock.calls[0][0]
+        .systemInstruction as Part
+    ).text;
+    expect(firstCallText).not.toContain('### APPROVED PLAN PRESERVATION');
   });
 
   it('should force compress even if under threshold', async () => {


### PR DESCRIPTION
## Summary

This PR ensures that approved implementation plans are preserved during chat history compression. When the conversation history grows too large and needs to be distilled into a `<state_snapshot>`, the model is now explicitly instructed to keep the plan's file path, step completion status, and any relevant user feedback.

## Details

- Updated `PromptProvider` to retrieve and pass the approved plan path (if any) to the history compression prompt.
- Modified both modern (`snippets.ts`) and legacy (`snippets.legacy.ts`) compression prompts to include a new `### APPROVED PLAN PRESERVATION` section when a plan is active.
- This prevents the agent from "forgetting" its current progress on a plan after a compression event, which previously led to redundant work or lost context on the overall goal.


## Related Issues

Fixes #17796

## How to Validate

1. Start a session that generates an approved plan.
2. Force or wait for history compression (simulated via tests).
3. Verify that the compression prompt now includes the `### APPROVED PLAN PRESERVATION` section.
4. Run the new tests: `npm test -w @google/gemini-cli-core -- src/prompts/promptProvider.test.ts`

## Pre-Merge Checklist


- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
