### PR TITLE
docs(cli): add --prompt flag to headless mode examples

### DIFF
--- a/docs/changelogs/index.md
+++ b/docs/changelogs/index.md
@@ -533,7 +533,7 @@ on GitHub.
   [pr](https://github.com/google-gemini/gemini-cli/pull/11284) by
   [@abhipatel12](https://github.com/abhipatel12))
 - **Non-interactive MCP commands:** Users can now run MCP slash commands in
-  non-interactive mode `gemini "/some-mcp-prompt"`.
+  non-interactive mode `gemini -p "/some-mcp-prompt"`.
   ([pr](https://github.com/google-gemini/gemini-cli/pull/10194) by
   [@capachino](https://github.com/capachino))
 - **Removal of deprecated flags:** We’ve finally removed a number of deprecated
@@ -658,7 +658,7 @@ on GitHub.
   ([pr](https://github.com/google-gemini/gemini-cli/pull/8570) by
   [@scidomino](https://github.com/scidomino))
 - **Custom commands in Headless Mode:** Run custom slash commands directly from
-  the command line in non-interactive mode: `gemini "/joke Chuck Norris"`
+  the command line in non-interactive mode: `gemini -p "/joke Chuck Norris"`
   ([pr](https://github.com/google-gemini/gemini-cli/pull/8305) by
   [@capachino](https://github.com/capachino))
 - **Small features, polish, reliability & bug fixes:** A large amount of
@@ -754,9 +754,8 @@ on GitHub.
   [@jackwotherspoon](https://github.com/jackwotherspoon)**)**
   - Getting started:
     [https://gofastmcp.com/integrations/gemini-cli](https://gofastmcp.com/integrations/gemini-cli)
-- **Positional Prompt for Non-Interactive:** Seamlessly invoke Gemini CLI
-  headlessly via `gemini "Hello"`. Synonymous with passing `-p`.
-  ([gif](https://imgur.com/a/hcBznpB),
+- **Prompt Flag for Non-Interactive:** Seamlessly invoke Gemini CLI headlessly
+  via `gemini -p "Hello"`. ([gif](https://imgur.com/a/hcBznpB),
   [pr](https://github.com/google-gemini/gemini-cli/pull/7668) by
   [@allenhutchison](https://github.com/allenhutchison))
 - **Experimental Tool output truncation:** Enable truncating shell tool outputs

--- a/docs/cli/cli-reference.md
+++ b/docs/cli/cli-reference.md
@@ -8,7 +8,7 @@ and parameters.
 | Command                            | Description                        | Example                                                      |
 | ---------------------------------- | ---------------------------------- | ------------------------------------------------------------ |
 | `gemini`                           | Start interactive REPL             | `gemini`                                                     |
-| `gemini "query"`                   | Query non-interactively, then exit | `gemini "explain this project"`                              |
+| `gemini -p "query"`                | Query non-interactively, then exit | `gemini -p "explain this project"`                           |
 | `cat file \| gemini`               | Process piped content              | `cat logs.txt \| gemini`<br>`Get-Content logs.txt \| gemini` |
 | `gemini -i "query"`                | Execute and continue interactively | `gemini -i "What is the purpose of this project?"`           |
 | `gemini -r "latest"`               | Continue most recent session       | `gemini -r "latest"`                                         |

--- a/docs/cli/cli-reference.md
+++ b/docs/cli/cli-reference.md
@@ -20,9 +20,9 @@ and parameters.
 
 ### Positional arguments
 
-| Argument | Type              | Description                                                                                                        |
-| -------- | ----------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `query`  | string (variadic) | Positional prompt. Defaults to one-shot mode. Use `-i/--prompt-interactive` to execute and continue interactively. |
+| Argument | Type              | Description                                                                                                                                                                     |
+| -------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `query`  | string (variadic) | Positional prompt argument. Supported for compatibility; prefer `-p/--prompt` for non-interactive prompts. Use `-i/--prompt-interactive` to execute and continue interactively. |
 
 ## CLI Options
 
@@ -32,7 +32,7 @@ and parameters.
 | `--version`                      | `-v`  | -       | -         | Show CLI version number and exit                                                                                                                                       |
 | `--help`                         | `-h`  | -       | -         | Show help information                                                                                                                                                  |
 | `--model`                        | `-m`  | string  | `auto`    | Model to use. See [Model Selection](#model-selection) for available values.                                                                                            |
-| `--prompt`                       | `-p`  | string  | -         | Prompt text. Appended to stdin input if provided. **Deprecated:** Use positional arguments instead.                                                                    |
+| `--prompt`                       | `-p`  | string  | -         | Prompt text for non-interactive mode. Appended to stdin input if provided.                                                                                             |
 | `--prompt-interactive`           | `-i`  | string  | -         | Execute prompt and continue in interactive mode                                                                                                                        |
 | `--sandbox`                      | `-s`  | boolean | `false`   | Run in a sandboxed environment for safer execution                                                                                                                     |
 | `--approval-mode`                | -     | string  | `default` | Approval mode for tool execution. Choices: `default`, `auto_edit`, `yolo`                                                                                              |

--- a/docs/cli/tutorials/automation.md
+++ b/docs/cli/tutorials/automation.md
@@ -19,14 +19,14 @@ Headless mode runs Gemini CLI once and exits. It's perfect for:
 
 ## How to use headless mode
 
-Run Gemini CLI in headless mode by providing a prompt as a positional argument.
-This bypasses the interactive chat interface and prints the response to standard
-output (stdout).
+Run Gemini CLI in headless mode by providing a prompt with the `-p` / `--prompt`
+flag. This bypasses the interactive chat interface and prints the response to
+standard output (stdout).
 
 Run a single command:
 
 ```bash
-gemini "Write a poem about TypeScript"
+gemini -p "Write a poem about TypeScript"
 ```
 
 ## How to pipe input to Gemini CLI
@@ -40,19 +40,19 @@ Pipe a file:
 **macOS/Linux**
 
 ```bash
-cat error.log | gemini "Explain why this failed"
+cat error.log | gemini -p "Explain why this failed"
 ```
 
 **Windows (PowerShell)**
 
 ```powershell
-Get-Content error.log | gemini "Explain why this failed"
+Get-Content error.log | gemini -p "Explain why this failed"
 ```
 
 Pipe a command:
 
 ```bash
-git diff | gemini "Write a commit message for these changes"
+git diff | gemini -p "Write a commit message for these changes"
 ```
 
 ## Use Gemini CLI output in scripts
@@ -78,7 +78,7 @@ one.
       echo "Generating docs for $file..."
 
       # Ask Gemini CLI to generate the documentation and print it to stdout
-      gemini "Generate a Markdown documentation summary for @$file. Print the
+      gemini -p "Generate a Markdown documentation summary for @$file. Print the
       result to standard output." > "${file%.py}.md"
     done
     ```
@@ -92,7 +92,7 @@ one.
 
       $newName = $_.Name -replace '\.py$', '.md'
       # Ask Gemini CLI to generate the documentation and print it to stdout
-      gemini "Generate a Markdown documentation summary for @$($_.Name). Print the result to standard output." | Out-File -FilePath $newName -Encoding utf8
+      gemini -p "Generate a Markdown documentation summary for @$($_.Name). Print the result to standard output." | Out-File -FilePath $newName -Encoding utf8
     }
     ```
 
@@ -137,7 +137,7 @@ like `jq`. To get pure JSON data from the model, combine the
     fi
 
     # Extract data
-    gemini --output-format json "Return a raw JSON object with keys 'version' and 'deps' from @package.json" | jq -r '.response' > data.json
+    gemini --output-format json -p "Return a raw JSON object with keys 'version' and 'deps' from @package.json" | jq -r '.response' > data.json
     ```
 
     **Windows PowerShell (`generate_json.ps1`)**
@@ -150,7 +150,7 @@ like `jq`. To get pure JSON data from the model, combine the
     }
 
     # Extract data (requires jq installed, or you can use ConvertFrom-Json)
-    $output = gemini --output-format json "Return a raw JSON object with keys 'version' and 'deps' from @package.json" | ConvertFrom-Json
+    $output = gemini --output-format json -p "Return a raw JSON object with keys 'version' and 'deps' from @package.json" | ConvertFrom-Json
     $output.response | Out-File -FilePath data.json -Encoding utf8
     ```
 
@@ -214,7 +214,7 @@ wrapper that writes the message for you.
 
       # Ask Gemini to write the message
       echo "Generating commit message..."
-      msg=$(echo "$diff" | gemini "Write a concise Conventional Commit message for this diff. Output ONLY the message.")
+      msg=$(echo "$diff" | gemini -p "Write a concise Conventional Commit message for this diff. Output ONLY the message.")
 
       # Commit with the generated message
       git commit -m "$msg"
@@ -251,7 +251,7 @@ wrapper that writes the message for you.
 
       # Ask Gemini to write the message
       Write-Host "Generating commit message..."
-      $msg = $diff | gemini "Write a concise Conventional Commit message for this diff. Output ONLY the message."
+      $msg = $diff | gemini -p "Write a concise Conventional Commit message for this diff. Output ONLY the message."
 
       # Commit with the generated message
       git commit -m "$msg"

--- a/docs/release-confidence.md
+++ b/docs/release-confidence.md
@@ -85,7 +85,7 @@ manually run through this checklist.
     - [ ] Vertex AI
 
 - **Basic prompting:**
-  - [ ] Run `gemini "Tell me a joke"` and verify a sensible response.
+  - [ ] Run `gemini -p "Tell me a joke"` and verify a sensible response.
   - [ ] Run in interactive mode: `gemini`. Ask a follow-up question to test
         context.
 


### PR DESCRIPTION
## Summary
- update headless tutorial examples to use `-p/--prompt`
- fix non-interactive command example in the CLI cheatsheet
- align release/changelog command snippets with explicit prompt-flag usage

## Files updated
- docs/cli/tutorials/automation.md
- docs/cli/cli-reference.md
- docs/release-confidence.md
- docs/changelogs/index.md

Fixes #21111
