### PR TITLE
docs(links): update docs-writer skill and fix broken link

### DIFF
--- a/.gemini/skills/docs-writer/SKILL.md
+++ b/.gemini/skills/docs-writer/SKILL.md
@@ -118,6 +118,8 @@ documentation.
   reflects existing code.
 - **Structure:** Apply "Structure (New Docs)" rules (BLUF, headings, etc.) when 
   adding new sections to existing pages.
+- **Headers**: If you change a header, you must check for links that lead to
+  that header and update them.
 - **Tone:** Ensure the tone is active and engaging. Use "you" and contractions.
 - **Clarity:** Correct awkward wording, spelling, and grammar. Rephrase
   sentences to make them easier for users to understand.
@@ -133,7 +135,8 @@ and that all links are functional.
   technical behavior.
 2.  **Self-review:** Re-read changes for formatting, correctness, and flow.
 3.  **Link check:** Verify all new and existing links leading to or from modified
-    pages.
+    pages. If you changed a header, ensure that any links that lead to it are
+    updated.
 4.  **Format:** Once all changes are complete, ask to execute `npm run format`
     to ensure consistent formatting across the project. If the user confirms,
     execute the command.

--- a/docs/cli/plan-mode.md
+++ b/docs/cli/plan-mode.md
@@ -369,7 +369,7 @@ those files are not automatically deleted and must be managed manually.
 [model routing]: /docs/cli/telemetry.md#model-routing
 [preferred external editor]: /docs/reference/configuration.md#general
 [session retention]: /docs/cli/session-management.md#session-retention
-[extensions]: /docs/extensions/index.md
+[extensions]: /docs/extensions/
 [Conductor]: https://github.com/gemini-cli-extensions/conductor
 [open an issue]: https://github.com/google-gemini/gemini-cli/issues
 [Agent Skills]: /docs/cli/skills.md


### PR DESCRIPTION
## Summary

- Updated the 'docs-writer' skill to require checking for broken links to headers when a header is changed.

- Fixed a broken link in 'docs/cli/plan-mode.md' that was pointing to the extensions index page.

Related #21301 

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [X] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
