### PR TITLE
feat(cli): implement media visualizer for terminal image rendering

### DIFF
--- a/branch.diff
+++ b/branch.diff
@@ -1,0 +1,3493 @@
+diff --git a/package-lock.json b/package-lock.json
+index 8f7ed6be5..ac289a641 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -457,6 +457,15 @@
+         "node": ">=6.0.0"
+       }
+     },
++    "node_modules/@babel/runtime": {
++      "version": "7.28.6",
++      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
++      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=6.9.0"
++      }
++    },
+     "node_modules/@babel/template": {
+       "version": "7.27.2",
+       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+@@ -1662,184 +1671,1086 @@
+         "url": "https://github.com/sponsors/nzakas"
+       }
+     },
+-    "node_modules/@humanwhocodes/module-importer": {
+-      "version": "1.0.1",
+-      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+-      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+-      "dev": true,
+-      "license": "Apache-2.0",
+-      "engines": {
+-        "node": ">=12.22"
++    "node_modules/@humanwhocodes/module-importer": {
++      "version": "1.0.1",
++      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
++      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
++      "dev": true,
++      "license": "Apache-2.0",
++      "engines": {
++        "node": ">=12.22"
++      },
++      "funding": {
++        "type": "github",
++        "url": "https://github.com/sponsors/nzakas"
++      }
++    },
++    "node_modules/@humanwhocodes/retry": {
++      "version": "0.4.3",
++      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
++      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
++      "dev": true,
++      "license": "Apache-2.0",
++      "engines": {
++        "node": ">=18.18"
++      },
++      "funding": {
++        "type": "github",
++        "url": "https://github.com/sponsors/nzakas"
++      }
++    },
++    "node_modules/@iarna/toml": {
++      "version": "2.2.5",
++      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
++      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
++      "license": "ISC"
++    },
++    "node_modules/@inquirer/confirm": {
++      "version": "5.1.14",
++      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.14.tgz",
++      "integrity": "sha512-5yR4IBfe0kXe59r1YCTG8WXkUbl7Z35HK87Sw+WUyGD8wNUx7JvY7laahzeytyE1oLn74bQnL7hstctQxisQ8Q==",
++      "devOptional": true,
++      "license": "MIT",
++      "dependencies": {
++        "@inquirer/core": "^10.1.15",
++        "@inquirer/type": "^3.0.8"
++      },
++      "engines": {
++        "node": ">=18"
++      },
++      "peerDependencies": {
++        "@types/node": ">=18"
++      },
++      "peerDependenciesMeta": {
++        "@types/node": {
++          "optional": true
++        }
++      }
++    },
++    "node_modules/@inquirer/core": {
++      "version": "10.1.15",
++      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
++      "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
++      "devOptional": true,
++      "license": "MIT",
++      "dependencies": {
++        "@inquirer/figures": "^1.0.13",
++        "@inquirer/type": "^3.0.8",
++        "ansi-escapes": "^4.3.2",
++        "cli-width": "^4.1.0",
++        "mute-stream": "^2.0.0",
++        "signal-exit": "^4.1.0",
++        "wrap-ansi": "^6.2.0",
++        "yoctocolors-cjs": "^2.1.2"
++      },
++      "engines": {
++        "node": ">=18"
++      },
++      "peerDependencies": {
++        "@types/node": ">=18"
++      },
++      "peerDependenciesMeta": {
++        "@types/node": {
++          "optional": true
++        }
++      }
++    },
++    "node_modules/@inquirer/core/node_modules/ansi-escapes": {
++      "version": "4.3.2",
++      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
++      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
++      "devOptional": true,
++      "license": "MIT",
++      "dependencies": {
++        "type-fest": "^0.21.3"
++      },
++      "engines": {
++        "node": ">=8"
++      },
++      "funding": {
++        "url": "https://github.com/sponsors/sindresorhus"
++      }
++    },
++    "node_modules/@inquirer/core/node_modules/type-fest": {
++      "version": "0.21.3",
++      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
++      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
++      "devOptional": true,
++      "license": "(MIT OR CC0-1.0)",
++      "engines": {
++        "node": ">=10"
++      },
++      "funding": {
++        "url": "https://github.com/sponsors/sindresorhus"
++      }
++    },
++    "node_modules/@inquirer/figures": {
++      "version": "1.0.13",
++      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
++      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
++      "devOptional": true,
++      "license": "MIT",
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@inquirer/type": {
++      "version": "3.0.8",
++      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
++      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
++      "devOptional": true,
++      "license": "MIT",
++      "engines": {
++        "node": ">=18"
++      },
++      "peerDependencies": {
++        "@types/node": ">=18"
++      },
++      "peerDependenciesMeta": {
++        "@types/node": {
++          "optional": true
++        }
++      }
++    },
++    "node_modules/@isaacs/cliui": {
++      "version": "8.0.2",
++      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
++      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
++      "license": "ISC",
++      "dependencies": {
++        "string-width": "^5.1.2",
++        "string-width-cjs": "npm:string-width@^4.2.0",
++        "strip-ansi": "^7.0.1",
++        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
++        "wrap-ansi": "^8.1.0",
++        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
++      },
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@isaacs/fs-minipass": {
++      "version": "4.0.1",
++      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
++      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
++      "license": "ISC",
++      "dependencies": {
++        "minipass": "^7.0.4"
++      },
++      "engines": {
++        "node": ">=18.0.0"
++      }
++    },
++    "node_modules/@istanbuljs/schema": {
++      "version": "0.1.3",
++      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
++      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
++      "dev": true,
++      "license": "MIT",
++      "engines": {
++        "node": ">=8"
++      }
++    },
++    "node_modules/@jimp/core": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-1.6.0.tgz",
++      "integrity": "sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/file-ops": "1.6.0",
++        "@jimp/types": "1.6.0",
++        "@jimp/utils": "1.6.0",
++        "await-to-js": "^3.0.0",
++        "exif-parser": "^0.1.12",
++        "file-type": "^16.0.0",
++        "mime": "3"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/custom": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.14.0.tgz",
++      "integrity": "sha512-kQJMeH87+kWJdVw8F9GQhtsageqqxrvzg7yyOw3Tx/s7v5RToe8RnKyMM+kVtBJtNAG+Xyv/z01uYQ2jiZ3GwA==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/core": "^0.14.0"
++      }
++    },
++    "node_modules/@jimp/custom/node_modules/@jimp/core": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.14.0.tgz",
++      "integrity": "sha512-S62FcKdtLtj3yWsGfJRdFXSutjvHg7aQNiFogMbwq19RP4XJWqS2nOphu7ScB8KrSlyy5nPF2hkWNhLRLyD82w==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0",
++        "any-base": "^1.1.0",
++        "buffer": "^5.2.0",
++        "exif-parser": "^0.1.12",
++        "file-type": "^9.0.0",
++        "load-bmfont": "^1.3.1",
++        "mkdirp": "^0.5.1",
++        "phin": "^2.9.1",
++        "pixelmatch": "^4.0.2",
++        "tinycolor2": "^1.4.1"
++      }
++    },
++    "node_modules/@jimp/custom/node_modules/@jimp/utils": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
++      "integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "regenerator-runtime": "^0.13.3"
++      }
++    },
++    "node_modules/@jimp/custom/node_modules/buffer": {
++      "version": "5.7.1",
++      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
++      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
++      "funding": [
++        {
++          "type": "github",
++          "url": "https://github.com/sponsors/feross"
++        },
++        {
++          "type": "patreon",
++          "url": "https://www.patreon.com/feross"
++        },
++        {
++          "type": "consulting",
++          "url": "https://feross.org/support"
++        }
++      ],
++      "license": "MIT",
++      "dependencies": {
++        "base64-js": "^1.3.1",
++        "ieee754": "^1.1.13"
++      }
++    },
++    "node_modules/@jimp/custom/node_modules/file-type": {
++      "version": "9.0.0",
++      "resolved": "https://registry.npmjs.org/file-type/-/file-type-9.0.0.tgz",
++      "integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=6"
++      }
++    },
++    "node_modules/@jimp/custom/node_modules/mkdirp": {
++      "version": "0.5.6",
++      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
++      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
++      "license": "MIT",
++      "dependencies": {
++        "minimist": "^1.2.6"
++      },
++      "bin": {
++        "mkdirp": "bin/cmd.js"
++      }
++    },
++    "node_modules/@jimp/custom/node_modules/pixelmatch": {
++      "version": "4.0.2",
++      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
++      "integrity": "sha512-J8B6xqiO37sU/gkcMglv6h5Jbd9xNER7aHzpfRdNmV4IbQBzBpe4l9XmbG+xPF/znacgu2jfEw+wHffaq/YkXA==",
++      "license": "ISC",
++      "dependencies": {
++        "pngjs": "^3.0.0"
++      },
++      "bin": {
++        "pixelmatch": "bin/pixelmatch"
++      }
++    },
++    "node_modules/@jimp/custom/node_modules/pngjs": {
++      "version": "3.4.0",
++      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
++      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=4.0.0"
++      }
++    },
++    "node_modules/@jimp/diff": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/diff/-/diff-1.6.0.tgz",
++      "integrity": "sha512-+yUAQ5gvRC5D1WHYxjBHZI7JBRusGGSLf8AmPRPCenTzh4PA+wZ1xv2+cYqQwTfQHU5tXYOhA0xDytfHUf1Zyw==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/plugin-resize": "1.6.0",
++        "@jimp/types": "1.6.0",
++        "@jimp/utils": "1.6.0",
++        "pixelmatch": "^5.3.0"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/file-ops": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/file-ops/-/file-ops-1.6.0.tgz",
++      "integrity": "sha512-Dx/bVDmgnRe1AlniRpCKrGRm5YvGmUwbDzt+MAkgmLGf+jvBT75hmMEZ003n9HQI/aPnm/YKnXjg/hOpzNCpHQ==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/js-bmp": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/js-bmp/-/js-bmp-1.6.0.tgz",
++      "integrity": "sha512-FU6Q5PC/e3yzLyBDXupR3SnL3htU7S3KEs4e6rjDP6gNEOXRFsWs6YD3hXuXd50jd8ummy+q2WSwuGkr8wi+Gw==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/core": "1.6.0",
++        "@jimp/types": "1.6.0",
++        "@jimp/utils": "1.6.0",
++        "bmp-ts": "^1.0.9"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/js-gif": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/js-gif/-/js-gif-1.6.0.tgz",
++      "integrity": "sha512-N9CZPHOrJTsAUoWkWZstLPpwT5AwJ0wge+47+ix3++SdSL/H2QzyMqxbcDYNFe4MoI5MIhATfb0/dl/wmX221g==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/core": "1.6.0",
++        "@jimp/types": "1.6.0",
++        "gifwrap": "^0.10.1",
++        "omggif": "^1.0.10"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/js-jpeg": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/js-jpeg/-/js-jpeg-1.6.0.tgz",
++      "integrity": "sha512-6vgFDqeusblf5Pok6B2DUiMXplH8RhIKAryj1yn+007SIAQ0khM1Uptxmpku/0MfbClx2r7pnJv9gWpAEJdMVA==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/core": "1.6.0",
++        "@jimp/types": "1.6.0",
++        "jpeg-js": "^0.4.4"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/js-png": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/js-png/-/js-png-1.6.0.tgz",
++      "integrity": "sha512-AbQHScy3hDDgMRNfG0tPjL88AV6qKAILGReIa3ATpW5QFjBKpisvUaOqhzJ7Reic1oawx3Riyv152gaPfqsBVg==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/core": "1.6.0",
++        "@jimp/types": "1.6.0",
++        "pngjs": "^7.0.0"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/js-tiff": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/js-tiff/-/js-tiff-1.6.0.tgz",
++      "integrity": "sha512-zhReR8/7KO+adijj3h0ZQUOiun3mXUv79zYEAKvE0O+rP7EhgtKvWJOZfRzdZSNv0Pu1rKtgM72qgtwe2tFvyw==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/core": "1.6.0",
++        "@jimp/types": "1.6.0",
++        "utif2": "^4.1.0"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugin-blit": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-1.6.0.tgz",
++      "integrity": "sha512-M+uRWl1csi7qilnSK8uxK4RJMSuVeBiO1AY0+7APnfUbQNZm6hCe0CCFv1Iyw1D/Dhb8ph8fQgm5mwM0eSxgVA==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/types": "1.6.0",
++        "@jimp/utils": "1.6.0",
++        "zod": "^3.23.8"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugin-blur": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-1.6.0.tgz",
++      "integrity": "sha512-zrM7iic1OTwUCb0g/rN5y+UnmdEsT3IfuCXCJJNs8SZzP0MkZ1eTvuwK9ZidCuMo4+J3xkzCidRwYXB5CyGZTw==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/core": "1.6.0",
++        "@jimp/utils": "1.6.0"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugin-circle": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-1.6.0.tgz",
++      "integrity": "sha512-xt1Gp+LtdMKAXfDp3HNaG30SPZW6AQ7dtAtTnoRKorRi+5yCJjKqXRgkewS5bvj8DEh87Ko1ydJfzqS3P2tdWw==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/types": "1.6.0",
++        "zod": "^3.23.8"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugin-color": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-1.6.0.tgz",
++      "integrity": "sha512-J5q8IVCpkBsxIXM+45XOXTrsyfblyMZg3a9eAo0P7VPH4+CrvyNQwaYatbAIamSIN1YzxmO3DkIZXzRjFSz1SA==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/core": "1.6.0",
++        "@jimp/types": "1.6.0",
++        "@jimp/utils": "1.6.0",
++        "tinycolor2": "^1.6.0",
++        "zod": "^3.23.8"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugin-contain": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-1.6.0.tgz",
++      "integrity": "sha512-oN/n+Vdq/Qg9bB4yOBOxtY9IPAtEfES8J1n9Ddx+XhGBYT1/QTU/JYkGaAkIGoPnyYvmLEDqMz2SGihqlpqfzQ==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/core": "1.6.0",
++        "@jimp/plugin-blit": "1.6.0",
++        "@jimp/plugin-resize": "1.6.0",
++        "@jimp/types": "1.6.0",
++        "@jimp/utils": "1.6.0",
++        "zod": "^3.23.8"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugin-cover": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-1.6.0.tgz",
++      "integrity": "sha512-Iow0h6yqSC269YUJ8HC3Q/MpCi2V55sMlbkkTTx4zPvd8mWZlC0ykrNDeAy9IJegrQ7v5E99rJwmQu25lygKLA==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/core": "1.6.0",
++        "@jimp/plugin-crop": "1.6.0",
++        "@jimp/plugin-resize": "1.6.0",
++        "@jimp/types": "1.6.0",
++        "zod": "^3.23.8"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugin-crop": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-1.6.0.tgz",
++      "integrity": "sha512-KqZkEhvs+21USdySCUDI+GFa393eDIzbi1smBqkUPTE+pRwSWMAf01D5OC3ZWB+xZsNla93BDS9iCkLHA8wang==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/core": "1.6.0",
++        "@jimp/types": "1.6.0",
++        "@jimp/utils": "1.6.0",
++        "zod": "^3.23.8"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugin-displace": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-1.6.0.tgz",
++      "integrity": "sha512-4Y10X9qwr5F+Bo5ME356XSACEF55485j5nGdiyJ9hYzjQP9nGgxNJaZ4SAOqpd+k5sFaIeD7SQ0Occ26uIng5Q==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/types": "1.6.0",
++        "@jimp/utils": "1.6.0",
++        "zod": "^3.23.8"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugin-dither": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-1.6.0.tgz",
++      "integrity": "sha512-600d1RxY0pKwgyU0tgMahLNKsqEcxGdbgXadCiVCoGd6V6glyCvkNrnnwC0n5aJ56Htkj88PToSdF88tNVZEEQ==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/types": "1.6.0"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugin-fisheye": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-1.6.0.tgz",
++      "integrity": "sha512-E5QHKWSCBFtpgZarlmN3Q6+rTQxjirFqo44ohoTjzYVrDI6B6beXNnPIThJgPr0Y9GwfzgyarKvQuQuqCnnfbA==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/types": "1.6.0",
++        "@jimp/utils": "1.6.0",
++        "zod": "^3.23.8"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugin-flip": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-1.6.0.tgz",
++      "integrity": "sha512-/+rJVDuBIVOgwoyVkBjUFHtP+wmW0r+r5OQ2GpatQofToPVbJw1DdYWXlwviSx7hvixTWLKVgRWQ5Dw862emDg==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/types": "1.6.0",
++        "zod": "^3.23.8"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugin-gaussian": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.14.0.tgz",
++      "integrity": "sha512-uaLwQ0XAQoydDlF9tlfc7iD9drYPriFe+jgYnWm8fbw5cN+eOIcnneEX9XCOOzwgLPkNCxGox6Kxjn8zY6GxtQ==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
++      },
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5"
++      }
++    },
++    "node_modules/@jimp/plugin-gaussian/node_modules/@jimp/utils": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
++      "integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "regenerator-runtime": "^0.13.3"
++      }
++    },
++    "node_modules/@jimp/plugin-hash": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-hash/-/plugin-hash-1.6.0.tgz",
++      "integrity": "sha512-wWzl0kTpDJgYVbZdajTf+4NBSKvmI3bRI8q6EH9CVeIHps9VWVsUvEyb7rpbcwVLWYuzDtP2R0lTT6WeBNQH9Q==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/core": "1.6.0",
++        "@jimp/js-bmp": "1.6.0",
++        "@jimp/js-jpeg": "1.6.0",
++        "@jimp/js-png": "1.6.0",
++        "@jimp/js-tiff": "1.6.0",
++        "@jimp/plugin-color": "1.6.0",
++        "@jimp/plugin-resize": "1.6.0",
++        "@jimp/types": "1.6.0",
++        "@jimp/utils": "1.6.0",
++        "any-base": "^1.1.0"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugin-invert": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.14.0.tgz",
++      "integrity": "sha512-UaQW9X9vx8orQXYSjT5VcITkJPwDaHwrBbxxPoDG+F/Zgv4oV9fP+udDD6qmkgI9taU+44Fy+zm/J/gGcMWrdg==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
++      },
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5"
++      }
++    },
++    "node_modules/@jimp/plugin-invert/node_modules/@jimp/utils": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
++      "integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "regenerator-runtime": "^0.13.3"
++      }
++    },
++    "node_modules/@jimp/plugin-mask": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-1.6.0.tgz",
++      "integrity": "sha512-Cwy7ExSJMZszvkad8NV8o/Z92X2kFUFM8mcDAhNVxU0Q6tA0op2UKRJY51eoK8r6eds/qak3FQkXakvNabdLnA==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/types": "1.6.0",
++        "zod": "^3.23.8"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugin-normalize": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.14.0.tgz",
++      "integrity": "sha512-AfY8sqlsbbdVwFGcyIPy5JH/7fnBzlmuweb+Qtx2vn29okq6+HelLjw2b+VT2btgGUmWWHGEHd86oRGSoWGyEQ==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
++      },
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5"
++      }
++    },
++    "node_modules/@jimp/plugin-normalize/node_modules/@jimp/utils": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
++      "integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "regenerator-runtime": "^0.13.3"
++      }
++    },
++    "node_modules/@jimp/plugin-print": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-1.6.0.tgz",
++      "integrity": "sha512-zarTIJi8fjoGMSI/M3Xh5yY9T65p03XJmPsuNet19K/Q7mwRU6EV2pfj+28++2PV2NJ+htDF5uecAlnGyxFN2A==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/core": "1.6.0",
++        "@jimp/js-jpeg": "1.6.0",
++        "@jimp/js-png": "1.6.0",
++        "@jimp/plugin-blit": "1.6.0",
++        "@jimp/types": "1.6.0",
++        "parse-bmfont-ascii": "^1.0.6",
++        "parse-bmfont-binary": "^1.0.6",
++        "parse-bmfont-xml": "^1.1.6",
++        "simple-xml-to-json": "^1.2.2",
++        "zod": "^3.23.8"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugin-quantize": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-quantize/-/plugin-quantize-1.6.0.tgz",
++      "integrity": "sha512-EmzZ/s9StYQwbpG6rUGBCisc3f64JIhSH+ncTJd+iFGtGo0YvSeMdAd+zqgiHpfZoOL54dNavZNjF4otK+mvlg==",
++      "license": "MIT",
++      "dependencies": {
++        "image-q": "^4.0.0",
++        "zod": "^3.23.8"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugin-resize": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.0.tgz",
++      "integrity": "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/core": "1.6.0",
++        "@jimp/types": "1.6.0",
++        "zod": "^3.23.8"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugin-rotate": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-1.6.0.tgz",
++      "integrity": "sha512-JagdjBLnUZGSG4xjCLkIpQOZZ3Mjbg8aGCCi4G69qR+OjNpOeGI7N2EQlfK/WE8BEHOW5vdjSyglNqcYbQBWRw==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/core": "1.6.0",
++        "@jimp/plugin-crop": "1.6.0",
++        "@jimp/plugin-resize": "1.6.0",
++        "@jimp/types": "1.6.0",
++        "@jimp/utils": "1.6.0",
++        "zod": "^3.23.8"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugin-scale": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.14.0.tgz",
++      "integrity": "sha512-ZcJk0hxY5ZKZDDwflqQNHEGRblgaR+piePZm7dPwPUOSeYEH31P0AwZ1ziceR74zd8N80M0TMft+e3Td6KGBHw==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
++      },
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5",
++        "@jimp/plugin-resize": ">=0.3.5"
++      }
++    },
++    "node_modules/@jimp/plugin-scale/node_modules/@jimp/utils": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
++      "integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "regenerator-runtime": "^0.13.3"
++      }
++    },
++    "node_modules/@jimp/plugin-shadow": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.14.0.tgz",
++      "integrity": "sha512-p2igcEr/iGrLiTu0YePNHyby0WYAXM14c5cECZIVnq/UTOOIQ7xIcWZJ1lRbAEPxVVXPN1UibhZAbr3HAb5BjQ==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
++      },
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5",
++        "@jimp/plugin-blur": ">=0.3.5",
++        "@jimp/plugin-resize": ">=0.3.5"
++      }
++    },
++    "node_modules/@jimp/plugin-shadow/node_modules/@jimp/utils": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
++      "integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "regenerator-runtime": "^0.13.3"
++      }
++    },
++    "node_modules/@jimp/plugin-threshold": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-1.6.0.tgz",
++      "integrity": "sha512-M59m5dzLoHOVWdM41O8z9SyySzcDn43xHseOH0HavjsfQsT56GGCC4QzU1banJidbUrePhzoEdS42uFE8Fei8w==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/core": "1.6.0",
++        "@jimp/plugin-color": "1.6.0",
++        "@jimp/plugin-hash": "1.6.0",
++        "@jimp/types": "1.6.0",
++        "@jimp/utils": "1.6.0",
++        "zod": "^3.23.8"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@jimp/plugins": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.14.0.tgz",
++      "integrity": "sha512-vDO3XT/YQlFlFLq5TqNjQkISqjBHT8VMhpWhAfJVwuXIpilxz5Glu4IDLK6jp4IjPR6Yg2WO8TmRY/HI8vLrOw==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/plugin-blit": "^0.14.0",
++        "@jimp/plugin-blur": "^0.14.0",
++        "@jimp/plugin-circle": "^0.14.0",
++        "@jimp/plugin-color": "^0.14.0",
++        "@jimp/plugin-contain": "^0.14.0",
++        "@jimp/plugin-cover": "^0.14.0",
++        "@jimp/plugin-crop": "^0.14.0",
++        "@jimp/plugin-displace": "^0.14.0",
++        "@jimp/plugin-dither": "^0.14.0",
++        "@jimp/plugin-fisheye": "^0.14.0",
++        "@jimp/plugin-flip": "^0.14.0",
++        "@jimp/plugin-gaussian": "^0.14.0",
++        "@jimp/plugin-invert": "^0.14.0",
++        "@jimp/plugin-mask": "^0.14.0",
++        "@jimp/plugin-normalize": "^0.14.0",
++        "@jimp/plugin-print": "^0.14.0",
++        "@jimp/plugin-resize": "^0.14.0",
++        "@jimp/plugin-rotate": "^0.14.0",
++        "@jimp/plugin-scale": "^0.14.0",
++        "@jimp/plugin-shadow": "^0.14.0",
++        "@jimp/plugin-threshold": "^0.14.0",
++        "timm": "^1.6.1"
++      },
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5"
++      }
++    },
++    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-blit": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.14.0.tgz",
++      "integrity": "sha512-YoYOrnVHeX3InfgbJawAU601iTZMwEBZkyqcP1V/S33Qnz9uzH1Uj1NtC6fNgWzvX6I4XbCWwtr4RrGFb5CFrw==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
++      },
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5"
++      }
++    },
++    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-blur": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.14.0.tgz",
++      "integrity": "sha512-9WhZcofLrT0hgI7t0chf7iBQZib//0gJh9WcQMUt5+Q1Bk04dWs8vTgLNj61GBqZXgHSPzE4OpCrrLDBG8zlhQ==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
+       },
+-      "funding": {
+-        "type": "github",
+-        "url": "https://github.com/sponsors/nzakas"
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5"
+       }
+     },
+-    "node_modules/@humanwhocodes/retry": {
+-      "version": "0.4.3",
+-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+-      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+-      "dev": true,
+-      "license": "Apache-2.0",
+-      "engines": {
+-        "node": ">=18.18"
++    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-circle": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.14.0.tgz",
++      "integrity": "sha512-o5L+wf6QA44tvTum5HeLyLSc5eVfIUd5ZDVi5iRfO4o6GT/zux9AxuTSkKwnjhsG8bn1dDmywAOQGAx7BjrQVA==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
+       },
+-      "funding": {
+-        "type": "github",
+-        "url": "https://github.com/sponsors/nzakas"
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5"
+       }
+     },
+-    "node_modules/@iarna/toml": {
+-      "version": "2.2.5",
+-      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+-      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+-      "license": "ISC"
+-    },
+-    "node_modules/@inquirer/confirm": {
+-      "version": "5.1.14",
+-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.14.tgz",
+-      "integrity": "sha512-5yR4IBfe0kXe59r1YCTG8WXkUbl7Z35HK87Sw+WUyGD8wNUx7JvY7laahzeytyE1oLn74bQnL7hstctQxisQ8Q==",
+-      "devOptional": true,
++    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-color": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.14.0.tgz",
++      "integrity": "sha512-JJz512SAILYV0M5LzBb9sbOm/XEj2fGElMiHAxb7aLI6jx+n0agxtHpfpV/AePTLm1vzzDxx6AJxXbKv355hBQ==",
+       "license": "MIT",
+       "dependencies": {
+-        "@inquirer/core": "^10.1.15",
+-        "@inquirer/type": "^3.0.8"
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0",
++        "tinycolor2": "^1.4.1"
+       },
+-      "engines": {
+-        "node": ">=18"
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5"
++      }
++    },
++    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-contain": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.14.0.tgz",
++      "integrity": "sha512-RX2q233lGyaxiMY6kAgnm9ScmEkNSof0hdlaJAVDS1OgXphGAYAeSIAwzESZN4x3ORaWvkFefeVH9O9/698Evg==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
+       },
+       "peerDependencies": {
+-        "@types/node": ">=18"
++        "@jimp/custom": ">=0.3.5",
++        "@jimp/plugin-blit": ">=0.3.5",
++        "@jimp/plugin-resize": ">=0.3.5",
++        "@jimp/plugin-scale": ">=0.3.5"
++      }
++    },
++    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-cover": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.14.0.tgz",
++      "integrity": "sha512-0P/5XhzWES4uMdvbi3beUgfvhn4YuQ/ny8ijs5kkYIw6K8mHcl820HahuGpwWMx56DJLHRl1hFhJwo9CeTRJtQ==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
+       },
+-      "peerDependenciesMeta": {
+-        "@types/node": {
+-          "optional": true
+-        }
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5",
++        "@jimp/plugin-crop": ">=0.3.5",
++        "@jimp/plugin-resize": ">=0.3.5",
++        "@jimp/plugin-scale": ">=0.3.5"
+       }
+     },
+-    "node_modules/@inquirer/core": {
+-      "version": "10.1.15",
+-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
+-      "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
+-      "devOptional": true,
++    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-crop": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.14.0.tgz",
++      "integrity": "sha512-Ojtih+XIe6/XSGtpWtbAXBozhCdsDMmy+THUJAGu2x7ZgKrMS0JotN+vN2YC3nwDpYkM+yOJImQeptSfZb2Sug==",
+       "license": "MIT",
+       "dependencies": {
+-        "@inquirer/figures": "^1.0.13",
+-        "@inquirer/type": "^3.0.8",
+-        "ansi-escapes": "^4.3.2",
+-        "cli-width": "^4.1.0",
+-        "mute-stream": "^2.0.0",
+-        "signal-exit": "^4.1.0",
+-        "wrap-ansi": "^6.2.0",
+-        "yoctocolors-cjs": "^2.1.2"
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
+       },
+-      "engines": {
+-        "node": ">=18"
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5"
++      }
++    },
++    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-displace": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.14.0.tgz",
++      "integrity": "sha512-c75uQUzMgrHa8vegkgUvgRL/PRvD7paFbFJvzW0Ugs8Wl+CDMGIPYQ3j7IVaQkIS+cAxv+NJ3TIRBQyBrfVEOg==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
+       },
+       "peerDependencies": {
+-        "@types/node": ">=18"
++        "@jimp/custom": ">=0.3.5"
++      }
++    },
++    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-dither": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.14.0.tgz",
++      "integrity": "sha512-g8SJqFLyYexXQQsoh4dc1VP87TwyOgeTElBcxSXX2LaaMZezypmxQfLTzOFzZoK8m39NuaoH21Ou1Ftsq7LzVQ==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
+       },
+-      "peerDependenciesMeta": {
+-        "@types/node": {
+-          "optional": true
+-        }
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5"
+       }
+     },
+-    "node_modules/@inquirer/core/node_modules/ansi-escapes": {
+-      "version": "4.3.2",
+-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+-      "devOptional": true,
++    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-fisheye": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.14.0.tgz",
++      "integrity": "sha512-BFfUZ64EikCaABhCA6mR3bsltWhPpS321jpeIQfJyrILdpFsZ/OccNwCgpW1XlbldDHIoNtXTDGn3E+vCE7vDg==",
+       "license": "MIT",
+       "dependencies": {
+-        "type-fest": "^0.21.3"
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
+       },
+-      "engines": {
+-        "node": ">=8"
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5"
++      }
++    },
++    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-flip": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.14.0.tgz",
++      "integrity": "sha512-WtL1hj6ryqHhApih+9qZQYA6Ye8a4HAmdTzLbYdTMrrrSUgIzFdiZsD0WeDHpgS/+QMsWwF+NFmTZmxNWqKfXw==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
+       },
+-      "funding": {
+-        "url": "https://github.com/sponsors/sindresorhus"
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5",
++        "@jimp/plugin-rotate": ">=0.3.5"
+       }
+     },
+-    "node_modules/@inquirer/core/node_modules/type-fest": {
+-      "version": "0.21.3",
+-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+-      "devOptional": true,
+-      "license": "(MIT OR CC0-1.0)",
+-      "engines": {
+-        "node": ">=10"
++    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-mask": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.14.0.tgz",
++      "integrity": "sha512-tdiGM69OBaKtSPfYSQeflzFhEpoRZ+BvKfDEoivyTjauynbjpRiwB1CaiS8En1INTDwzLXTT0Be9SpI3LkJoEA==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
+       },
+-      "funding": {
+-        "url": "https://github.com/sponsors/sindresorhus"
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5"
+       }
+     },
+-    "node_modules/@inquirer/figures": {
+-      "version": "1.0.13",
+-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+-      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+-      "devOptional": true,
++    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-print": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.14.0.tgz",
++      "integrity": "sha512-MwP3sH+VS5AhhSTXk7pui+tEJFsxnTKFY3TraFJb8WFbA2Vo2qsRCZseEGwpTLhENB7p/JSsLvWoSSbpmxhFAQ==",
+       "license": "MIT",
+-      "engines": {
+-        "node": ">=18"
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0",
++        "load-bmfont": "^1.4.0"
++      },
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5",
++        "@jimp/plugin-blit": ">=0.3.5"
+       }
+     },
+-    "node_modules/@inquirer/type": {
+-      "version": "3.0.8",
+-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+-      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+-      "devOptional": true,
++    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-resize": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.14.0.tgz",
++      "integrity": "sha512-qFeMOyXE/Bk6QXN0GQo89+CB2dQcXqoxUcDb2Ah8wdYlKqpi53skABkgVy5pW3EpiprDnzNDboMltdvDslNgLQ==",
+       "license": "MIT",
+-      "engines": {
+-        "node": ">=18"
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
+       },
+       "peerDependencies": {
+-        "@types/node": ">=18"
++        "@jimp/custom": ">=0.3.5"
++      }
++    },
++    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-rotate": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.14.0.tgz",
++      "integrity": "sha512-aGaicts44bvpTcq5Dtf93/8TZFu5pMo/61lWWnYmwJJU1RqtQlxbCLEQpMyRhKDNSfPbuP8nyGmaqXlM/82J0Q==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
+       },
+-      "peerDependenciesMeta": {
+-        "@types/node": {
+-          "optional": true
+-        }
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5",
++        "@jimp/plugin-blit": ">=0.3.5",
++        "@jimp/plugin-crop": ">=0.3.5",
++        "@jimp/plugin-resize": ">=0.3.5"
+       }
+     },
+-    "node_modules/@isaacs/cliui": {
+-      "version": "8.0.2",
+-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+-      "license": "ISC",
++    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-threshold": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.14.0.tgz",
++      "integrity": "sha512-N4BlDgm/FoOMV/DQM2rSpzsgqAzkP0DXkWZoqaQrlRxQBo4zizQLzhEL00T/YCCMKnddzgEhnByaocgaaa0fKw==",
++      "license": "MIT",
+       "dependencies": {
+-        "string-width": "^5.1.2",
+-        "string-width-cjs": "npm:string-width@^4.2.0",
+-        "strip-ansi": "^7.0.1",
+-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+-        "wrap-ansi": "^8.1.0",
+-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0"
+       },
+-      "engines": {
+-        "node": ">=12"
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5",
++        "@jimp/plugin-color": ">=0.8.0",
++        "@jimp/plugin-resize": ">=0.8.0"
+       }
+     },
+-    "node_modules/@isaacs/fs-minipass": {
+-      "version": "4.0.1",
+-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+-      "license": "ISC",
++    "node_modules/@jimp/plugins/node_modules/@jimp/utils": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
++      "integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
++      "license": "MIT",
+       "dependencies": {
+-        "minipass": "^7.0.4"
++        "@babel/runtime": "^7.7.2",
++        "regenerator-runtime": "^0.13.3"
++      }
++    },
++    "node_modules/@jimp/types": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-1.6.0.tgz",
++      "integrity": "sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg==",
++      "license": "MIT",
++      "dependencies": {
++        "zod": "^3.23.8"
+       },
+       "engines": {
+-        "node": ">=18.0.0"
++        "node": ">=18"
+       }
+     },
+-    "node_modules/@istanbuljs/schema": {
+-      "version": "0.1.3",
+-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+-      "dev": true,
++    "node_modules/@jimp/utils": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-1.6.0.tgz",
++      "integrity": "sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA==",
+       "license": "MIT",
++      "dependencies": {
++        "@jimp/types": "1.6.0",
++        "tinycolor2": "^1.6.0"
++      },
+       "engines": {
+-        "node": ">=8"
++        "node": ">=18"
+       }
+     },
+     "node_modules/@joshua.litt/get-ripgrep": {
+@@ -3805,6 +4716,12 @@
+         "@textlint/ast-node-types": "15.2.2"
+       }
+     },
++    "node_modules/@tokenizer/token": {
++      "version": "0.3.0",
++      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
++      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
++      "license": "MIT"
++    },
+     "node_modules/@tootallnate/once": {
+       "version": "2.0.0",
+       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+@@ -5262,6 +6179,15 @@
+       "dev": true,
+       "license": "MIT"
+     },
++    "node_modules/@xmldom/xmldom": {
++      "version": "0.8.11",
++      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
++      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=10.0.0"
++      }
++    },
+     "node_modules/@xterm/headless": {
+       "version": "5.5.0",
+       "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-5.5.0.tgz",
+@@ -5379,56 +6305,148 @@
+         "require-from-string": "^2.0.2"
+       },
+       "funding": {
+-        "type": "github",
+-        "url": "https://github.com/sponsors/epoberezkin"
++        "type": "github",
++        "url": "https://github.com/sponsors/epoberezkin"
++      }
++    },
++    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
++      "version": "1.0.0",
++      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
++      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
++      "license": "MIT"
++    },
++    "node_modules/ansi-escapes": {
++      "version": "7.3.0",
++      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
++      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
++      "license": "MIT",
++      "dependencies": {
++        "environment": "^1.0.0"
++      },
++      "engines": {
++        "node": ">=18"
++      },
++      "funding": {
++        "url": "https://github.com/sponsors/sindresorhus"
++      }
++    },
++    "node_modules/ansi-regex": {
++      "version": "6.2.2",
++      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
++      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=12"
++      },
++      "funding": {
++        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
++      }
++    },
++    "node_modules/ansi-styles": {
++      "version": "4.3.0",
++      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
++      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
++      "license": "MIT",
++      "dependencies": {
++        "color-convert": "^2.0.1"
++      },
++      "engines": {
++        "node": ">=8"
++      },
++      "funding": {
++        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
++      }
++    },
++    "node_modules/any-base": {
++      "version": "1.1.0",
++      "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
++      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
++      "license": "MIT"
++    },
++    "node_modules/app-path": {
++      "version": "4.0.0",
++      "resolved": "https://registry.npmjs.org/app-path/-/app-path-4.0.0.tgz",
++      "integrity": "sha512-mgBO9PZJ3MpbKbwFTljTi36ZKBvG5X/fkVR1F85ANsVcVllEb+C0LGNdJfGUm84GpC4xxgN6HFkmkMU8VEO4mA==",
++      "license": "MIT",
++      "dependencies": {
++        "execa": "^5.0.0"
++      },
++      "engines": {
++        "node": ">=12"
++      },
++      "funding": {
++        "url": "https://github.com/sponsors/sindresorhus"
+       }
+     },
+-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+-      "version": "1.0.0",
+-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+-      "license": "MIT"
+-    },
+-    "node_modules/ansi-escapes": {
+-      "version": "7.3.0",
+-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+-      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
++    "node_modules/app-path/node_modules/execa": {
++      "version": "5.1.1",
++      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
++      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+       "license": "MIT",
+       "dependencies": {
+-        "environment": "^1.0.0"
++        "cross-spawn": "^7.0.3",
++        "get-stream": "^6.0.0",
++        "human-signals": "^2.1.0",
++        "is-stream": "^2.0.0",
++        "merge-stream": "^2.0.0",
++        "npm-run-path": "^4.0.1",
++        "onetime": "^5.1.2",
++        "signal-exit": "^3.0.3",
++        "strip-final-newline": "^2.0.0"
+       },
+       "engines": {
+-        "node": ">=18"
++        "node": ">=10"
+       },
+       "funding": {
+-        "url": "https://github.com/sponsors/sindresorhus"
++        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+       }
+     },
+-    "node_modules/ansi-regex": {
+-      "version": "6.2.2",
+-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
++    "node_modules/app-path/node_modules/get-stream": {
++      "version": "6.0.1",
++      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
++      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+       "license": "MIT",
+       "engines": {
+-        "node": ">=12"
++        "node": ">=10"
+       },
+       "funding": {
+-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
++        "url": "https://github.com/sponsors/sindresorhus"
+       }
+     },
+-    "node_modules/ansi-styles": {
+-      "version": "4.3.0",
+-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
++    "node_modules/app-path/node_modules/human-signals": {
++      "version": "2.1.0",
++      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
++      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
++      "license": "Apache-2.0",
++      "engines": {
++        "node": ">=10.17.0"
++      }
++    },
++    "node_modules/app-path/node_modules/npm-run-path": {
++      "version": "4.0.1",
++      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
++      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+       "license": "MIT",
+       "dependencies": {
+-        "color-convert": "^2.0.1"
++        "path-key": "^3.0.0"
+       },
+       "engines": {
+         "node": ">=8"
+-      },
+-      "funding": {
+-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
++      }
++    },
++    "node_modules/app-path/node_modules/signal-exit": {
++      "version": "3.0.7",
++      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
++      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
++      "license": "ISC"
++    },
++    "node_modules/app-path/node_modules/strip-final-newline": {
++      "version": "2.0.0",
++      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
++      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=6"
+       }
+     },
+     "node_modules/argparse": {
+@@ -5464,13 +6482,6 @@
+         "node": ">=8"
+       }
+     },
+-    "node_modules/array-flatten": {
+-      "version": "1.1.1",
+-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+-      "license": "MIT",
+-      "peer": true
+-    },
+     "node_modules/array-includes": {
+       "version": "3.1.9",
+       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+@@ -5494,6 +6505,12 @@
+         "url": "https://github.com/sponsors/ljharb"
+       }
+     },
++    "node_modules/array-range": {
++      "version": "1.0.1",
++      "resolved": "https://registry.npmjs.org/array-range/-/array-range-1.0.1.tgz",
++      "integrity": "sha512-shdaI1zT3CVNL2hnx9c0JMc0ZogGaxDs5e85akgHWKYa0yVbIyp06Ind3dVkTj/uuFrzaHBOyqFzo+VV6aXgtA==",
++      "license": "MIT"
++    },
+     "node_modules/array-timsort": {
+       "version": "1.0.3",
+       "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+@@ -5736,6 +6753,15 @@
+         "url": "https://github.com/sponsors/ljharb"
+       }
+     },
++    "node_modules/await-to-js": {
++      "version": "3.0.0",
++      "resolved": "https://registry.npmjs.org/await-to-js/-/await-to-js-3.0.0.tgz",
++      "integrity": "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=6.0.0"
++      }
++    },
+     "node_modules/azure-devops-node-api": {
+       "version": "12.5.0",
+       "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+@@ -5806,6 +6832,18 @@
+         "url": "https://bevry.me/fund"
+       }
+     },
++    "node_modules/bmp-js": {
++      "version": "0.1.0",
++      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
++      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
++      "license": "MIT"
++    },
++    "node_modules/bmp-ts": {
++      "version": "1.0.9",
++      "resolved": "https://registry.npmjs.org/bmp-ts/-/bmp-ts-1.0.9.tgz",
++      "integrity": "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==",
++      "license": "MIT"
++    },
+     "node_modules/body-parser": {
+       "version": "2.2.2",
+       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+@@ -5884,6 +6922,30 @@
+         "node": ">=8"
+       }
+     },
++    "node_modules/buffer": {
++      "version": "6.0.3",
++      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
++      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
++      "funding": [
++        {
++          "type": "github",
++          "url": "https://github.com/sponsors/feross"
++        },
++        {
++          "type": "patreon",
++          "url": "https://www.patreon.com/feross"
++        },
++        {
++          "type": "consulting",
++          "url": "https://feross.org/support"
++        }
++      ],
++      "license": "MIT",
++      "dependencies": {
++        "base64-js": "^1.3.1",
++        "ieee754": "^1.2.1"
++      }
++    },
+     "node_modules/buffer-crc32": {
+       "version": "0.2.13",
+       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+@@ -5893,6 +6955,15 @@
+         "node": "*"
+       }
+     },
++    "node_modules/buffer-equal": {
++      "version": "0.0.1",
++      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
++      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=0.4.0"
++      }
++    },
+     "node_modules/buffer-equal-constant-time": {
+       "version": "1.0.1",
+       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+@@ -6026,6 +7097,15 @@
+         "node": ">=6"
+       }
+     },
++    "node_modules/centra": {
++      "version": "2.7.0",
++      "resolved": "https://registry.npmjs.org/centra/-/centra-2.7.0.tgz",
++      "integrity": "sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg==",
++      "license": "MIT",
++      "dependencies": {
++        "follow-redirects": "^1.15.6"
++      }
++    },
+     "node_modules/chai": {
+       "version": "5.3.3",
+       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+@@ -6570,7 +7650,6 @@
+       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+       "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+       "license": "MIT",
+-      "peer": true,
+       "dependencies": {
+         "safe-buffer": "5.2.1"
+       },
+@@ -6604,6 +7683,7 @@
+       "version": "0.7.2",
+       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
++      "devOptional": true,
+       "license": "MIT",
+       "engines": {
+         "node": ">= 0.6"
+@@ -6777,6 +7857,18 @@
+       "devOptional": true,
+       "license": "MIT"
+     },
++    "node_modules/cycled": {
++      "version": "1.2.0",
++      "resolved": "https://registry.npmjs.org/cycled/-/cycled-1.2.0.tgz",
++      "integrity": "sha512-/BOOCEohSBflVHHtY/wUc1F6YDYPqyVs/A837gDoq4H1pm72nU/yChyGt91V4ML+MbbAmHs8uo2l1yJkkTIUdg==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=6"
++      },
++      "funding": {
++        "url": "https://github.com/sponsors/sindresorhus"
++      }
++    },
+     "node_modules/data-uri-to-buffer": {
+       "version": "4.0.1",
+       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+@@ -6857,6 +7949,19 @@
+         }
+       }
+     },
++    "node_modules/decode-gif": {
++      "version": "1.0.1",
++      "resolved": "https://registry.npmjs.org/decode-gif/-/decode-gif-1.0.1.tgz",
++      "integrity": "sha512-L0MT527mwlkil9TiN1xwnJXzUxCup55bUT91CPmQlc9zYejXJ8xp17d5EVnwM80JOIGImBUk1ptJQ+hDihyzwg==",
++      "license": "MIT",
++      "dependencies": {
++        "array-range": "^1.0.1",
++        "omggif": "^1.0.10"
++      },
++      "engines": {
++        "node": ">=10"
++      }
++    },
+     "node_modules/decompress-response": {
+       "version": "6.0.0",
+       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+@@ -7003,6 +8108,18 @@
+         "url": "https://github.com/sponsors/ljharb"
+       }
+     },
++    "node_modules/delay": {
++      "version": "4.4.1",
++      "resolved": "https://registry.npmjs.org/delay/-/delay-4.4.1.tgz",
++      "integrity": "sha512-aL3AhqtfhOlT/3ai6sWXeqwnw63ATNpnUiN4HL7x9q+My5QtHlO3OIkasmug9LKzpheLdmUKGRKnYXYAS7FQkQ==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=6"
++      },
++      "funding": {
++        "url": "https://github.com/sponsors/sindresorhus"
++      }
++    },
+     "node_modules/delayed-stream": {
+       "version": "1.0.0",
+       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+@@ -7348,6 +8465,11 @@
+         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+       }
+     },
++    "node_modules/dom-walk": {
++      "version": "0.1.2",
++      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
++      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
++    },
+     "node_modules/domelementtype": {
+       "version": "2.3.0",
+       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+@@ -8408,6 +9530,15 @@
+         "uuid": "dist/bin/uuid"
+       }
+     },
++    "node_modules/events": {
++      "version": "3.3.0",
++      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
++      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=0.8.x"
++      }
++    },
+     "node_modules/eventsource": {
+       "version": "3.0.7",
+       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+@@ -8467,6 +9598,11 @@
+         "url": "https://github.com/sponsors/sindresorhus"
+       }
+     },
++    "node_modules/exif-parser": {
++      "version": "0.1.12",
++      "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
++      "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
++    },
+     "node_modules/expand-tilde": {
+       "version": "2.0.2",
+       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+@@ -8555,7 +9691,6 @@
+       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+       "license": "MIT",
+-      "peer": true,
+       "engines": {
+         "node": ">= 0.6"
+       }
+@@ -8565,7 +9700,6 @@
+       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+       "license": "MIT",
+-      "peer": true,
+       "dependencies": {
+         "ms": "2.0.0"
+       }
+@@ -8575,7 +9709,6 @@
+       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+       "license": "MIT",
+-      "peer": true,
+       "engines": {
+         "node": ">= 0.8"
+       }
+@@ -8804,6 +9937,23 @@
+         "node": ">=16.0.0"
+       }
+     },
++    "node_modules/file-type": {
++      "version": "16.5.4",
++      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
++      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
++      "license": "MIT",
++      "dependencies": {
++        "readable-web-to-node-stream": "^3.0.0",
++        "strtok3": "^6.2.4",
++        "token-types": "^4.1.1"
++      },
++      "engines": {
++        "node": ">=10"
++      },
++      "funding": {
++        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
++      }
++    },
+     "node_modules/fill-range": {
+       "version": "7.1.1",
+       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+@@ -8839,7 +9989,6 @@
+       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+       "license": "MIT",
+-      "peer": true,
+       "dependencies": {
+         "ms": "2.0.0"
+       }
+@@ -8848,15 +9997,13 @@
+       "version": "2.0.0",
+       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+-      "license": "MIT",
+-      "peer": true
++      "license": "MIT"
+     },
+     "node_modules/finalhandler/node_modules/statuses": {
+       "version": "2.0.1",
+       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+       "license": "MIT",
+-      "peer": true,
+       "engines": {
+         "node": ">= 0.8"
+       }
+@@ -8933,6 +10080,26 @@
+       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+       "license": "MIT"
+     },
++    "node_modules/follow-redirects": {
++      "version": "1.15.11",
++      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
++      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
++      "funding": [
++        {
++          "type": "individual",
++          "url": "https://github.com/sponsors/RubenVerborgh"
++        }
++      ],
++      "license": "MIT",
++      "engines": {
++        "node": ">=4.0"
++      },
++      "peerDependenciesMeta": {
++        "debug": {
++          "optional": true
++        }
++      }
++    },
+     "node_modules/for-each": {
+       "version": "0.3.5",
+       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+@@ -9302,6 +10469,16 @@
+         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+       }
+     },
++    "node_modules/gifwrap": {
++      "version": "0.10.1",
++      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.10.1.tgz",
++      "integrity": "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==",
++      "license": "MIT",
++      "dependencies": {
++        "image-q": "^4.0.0",
++        "omggif": "^1.0.10"
++      }
++    },
+     "node_modules/glob": {
+       "version": "12.0.0",
+       "resolved": "https://registry.npmjs.org/glob/-/glob-12.0.0.tgz",
+@@ -9391,6 +10568,16 @@
+         "url": "https://github.com/sponsors/isaacs"
+       }
+     },
++    "node_modules/global": {
++      "version": "4.4.0",
++      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
++      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
++      "license": "MIT",
++      "dependencies": {
++        "min-document": "^2.19.0",
++        "process": "^0.11.10"
++      }
++    },
+     "node_modules/global-modules": {
+       "version": "1.0.0",
+       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+@@ -10029,6 +11216,26 @@
+         "node": ">=0.10.0"
+       }
+     },
++    "node_modules/ieee754": {
++      "version": "1.2.1",
++      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
++      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
++      "funding": [
++        {
++          "type": "github",
++          "url": "https://github.com/sponsors/feross"
++        },
++        {
++          "type": "patreon",
++          "url": "https://www.patreon.com/feross"
++        },
++        {
++          "type": "consulting",
++          "url": "https://feross.org/support"
++        }
++      ],
++      "license": "BSD-3-Clause"
++    },
+     "node_modules/ignore": {
+       "version": "5.3.2",
+       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+@@ -10039,6 +11246,36 @@
+         "node": ">= 4"
+       }
+     },
++    "node_modules/image-dimensions": {
++      "version": "2.5.0",
++      "resolved": "https://registry.npmjs.org/image-dimensions/-/image-dimensions-2.5.0.tgz",
++      "integrity": "sha512-CKZPHjAEtSg9lBV9eER0bhNn/yrY7cFEQEhkwjLhqLY+Na8lcP1pEyWsaGMGc8t2qbKWA/tuqbhFQpOKGN72Yw==",
++      "license": "MIT",
++      "bin": {
++        "image-dimensions": "cli.js"
++      },
++      "engines": {
++        "node": ">=18"
++      },
++      "funding": {
++        "url": "https://github.com/sponsors/sindresorhus"
++      }
++    },
++    "node_modules/image-q": {
++      "version": "4.0.0",
++      "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
++      "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
++      "license": "MIT",
++      "dependencies": {
++        "@types/node": "16.9.1"
++      }
++    },
++    "node_modules/image-q/node_modules/@types/node": {
++      "version": "16.9.1",
++      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
++      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
++      "license": "MIT"
++    },
+     "node_modules/import-fresh": {
+       "version": "3.3.1",
+       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+@@ -10485,6 +11722,12 @@
+         "node": ">=8"
+       }
+     },
++    "node_modules/is-function": {
++      "version": "1.0.2",
++      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
++      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
++      "license": "MIT"
++    },
+     "node_modules/is-generator-function": {
+       "version": "1.1.0",
+       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+@@ -10971,6 +12214,22 @@
+         "node": ">= 0.4"
+       }
+     },
++    "node_modules/iterm2-version": {
++      "version": "5.0.0",
++      "resolved": "https://registry.npmjs.org/iterm2-version/-/iterm2-version-5.0.0.tgz",
++      "integrity": "sha512-WdLXcMYvN3SXT6vEtuW78vnZs4pVWm2nBnb4VKjOPPXmdlR1xTHmBgqKacOzAe4RXOiY/V+0u/0zsU3LoGQoBg==",
++      "license": "MIT",
++      "dependencies": {
++        "app-path": "^4.0.0",
++        "plist": "^3.0.2"
++      },
++      "engines": {
++        "node": ">=12"
++      },
++      "funding": {
++        "url": "https://github.com/sponsors/sindresorhus"
++      }
++    },
+     "node_modules/jackspeak": {
+       "version": "4.1.1",
+       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+@@ -10986,6 +12245,44 @@
+         "url": "https://github.com/sponsors/isaacs"
+       }
+     },
++    "node_modules/jimp": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.0.tgz",
++      "integrity": "sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg==",
++      "license": "MIT",
++      "dependencies": {
++        "@jimp/core": "1.6.0",
++        "@jimp/diff": "1.6.0",
++        "@jimp/js-bmp": "1.6.0",
++        "@jimp/js-gif": "1.6.0",
++        "@jimp/js-jpeg": "1.6.0",
++        "@jimp/js-png": "1.6.0",
++        "@jimp/js-tiff": "1.6.0",
++        "@jimp/plugin-blit": "1.6.0",
++        "@jimp/plugin-blur": "1.6.0",
++        "@jimp/plugin-circle": "1.6.0",
++        "@jimp/plugin-color": "1.6.0",
++        "@jimp/plugin-contain": "1.6.0",
++        "@jimp/plugin-cover": "1.6.0",
++        "@jimp/plugin-crop": "1.6.0",
++        "@jimp/plugin-displace": "1.6.0",
++        "@jimp/plugin-dither": "1.6.0",
++        "@jimp/plugin-fisheye": "1.6.0",
++        "@jimp/plugin-flip": "1.6.0",
++        "@jimp/plugin-hash": "1.6.0",
++        "@jimp/plugin-mask": "1.6.0",
++        "@jimp/plugin-print": "1.6.0",
++        "@jimp/plugin-quantize": "1.6.0",
++        "@jimp/plugin-resize": "1.6.0",
++        "@jimp/plugin-rotate": "1.6.0",
++        "@jimp/plugin-threshold": "1.6.0",
++        "@jimp/types": "1.6.0",
++        "@jimp/utils": "1.6.0"
++      },
++      "engines": {
++        "node": ">=18"
++      }
++    },
+     "node_modules/jose": {
+       "version": "6.1.3",
+       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+@@ -10995,6 +12292,12 @@
+         "url": "https://github.com/sponsors/panva"
+       }
+     },
++    "node_modules/jpeg-js": {
++      "version": "0.4.4",
++      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
++      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
++      "license": "BSD-3-Clause"
++    },
+     "node_modules/js-tokens": {
+       "version": "9.0.1",
+       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+@@ -11464,6 +12767,47 @@
+         "url": "https://github.com/sponsors/sindresorhus"
+       }
+     },
++    "node_modules/load-bmfont": {
++      "version": "1.4.2",
++      "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.2.tgz",
++      "integrity": "sha512-qElWkmjW9Oq1F9EI5Gt7aD9zcdHb9spJCW1L/dmPf7KzCCEJxq8nhHz5eCgI9aMf7vrG/wyaCqdsI+Iy9ZTlog==",
++      "license": "MIT",
++      "dependencies": {
++        "buffer-equal": "0.0.1",
++        "mime": "^1.3.4",
++        "parse-bmfont-ascii": "^1.0.3",
++        "parse-bmfont-binary": "^1.0.5",
++        "parse-bmfont-xml": "^1.1.4",
++        "phin": "^3.7.1",
++        "xhr": "^2.0.1",
++        "xtend": "^4.0.0"
++      }
++    },
++    "node_modules/load-bmfont/node_modules/mime": {
++      "version": "1.6.0",
++      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
++      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
++      "license": "MIT",
++      "bin": {
++        "mime": "cli.js"
++      },
++      "engines": {
++        "node": ">=4"
++      }
++    },
++    "node_modules/load-bmfont/node_modules/phin": {
++      "version": "3.7.1",
++      "resolved": "https://registry.npmjs.org/phin/-/phin-3.7.1.tgz",
++      "integrity": "sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ==",
++      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
++      "license": "MIT",
++      "dependencies": {
++        "centra": "^2.7.0"
++      },
++      "engines": {
++        "node": ">= 8"
++      }
++    },
+     "node_modules/load-json-file": {
+       "version": "4.0.0",
+       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+@@ -11590,7 +12934,6 @@
+       "version": "6.1.0",
+       "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+       "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+-      "dev": true,
+       "license": "MIT",
+       "dependencies": {
+         "ansi-escapes": "^7.0.0",
+@@ -11610,7 +12953,6 @@
+       "version": "5.0.0",
+       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+       "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+-      "dev": true,
+       "license": "MIT",
+       "dependencies": {
+         "restore-cursor": "^5.0.0"
+@@ -11626,7 +12968,6 @@
+       "version": "7.0.0",
+       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+       "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+-      "dev": true,
+       "license": "MIT",
+       "dependencies": {
+         "mimic-function": "^5.0.0"
+@@ -11642,7 +12983,6 @@
+       "version": "5.1.0",
+       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+       "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+-      "dev": true,
+       "license": "MIT",
+       "dependencies": {
+         "onetime": "^7.0.0",
+@@ -11870,6 +13210,12 @@
+         "url": "https://github.com/sponsors/sindresorhus"
+       }
+     },
++    "node_modules/merge-stream": {
++      "version": "2.0.0",
++      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
++      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
++      "license": "MIT"
++    },
+     "node_modules/merge2": {
+       "version": "1.4.1",
+       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+@@ -11954,7 +13300,6 @@
+       "version": "5.0.1",
+       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+       "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+-      "dev": true,
+       "license": "MIT",
+       "engines": {
+         "node": ">=18"
+@@ -11975,6 +13320,15 @@
+         "url": "https://github.com/sponsors/sindresorhus"
+       }
+     },
++    "node_modules/min-document": {
++      "version": "2.19.2",
++      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.2.tgz",
++      "integrity": "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==",
++      "license": "MIT",
++      "dependencies": {
++        "dom-walk": "^0.1.0"
++      }
++    },
+     "node_modules/minimatch": {
+       "version": "3.1.3",
+       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+@@ -12849,6 +14203,12 @@
+       "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
+       "license": "MIT"
+     },
++    "node_modules/omggif": {
++      "version": "1.0.10",
++      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
++      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
++      "license": "MIT"
++    },
+     "node_modules/on-finished": {
+       "version": "2.4.1",
+       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+@@ -13047,6 +14407,12 @@
+       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+       "license": "BlueOak-1.0.0"
+     },
++    "node_modules/pako": {
++      "version": "1.0.11",
++      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
++      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
++      "license": "(MIT AND Zlib)"
++    },
+     "node_modules/parent-module": {
+       "version": "1.0.1",
+       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+@@ -13060,6 +14426,34 @@
+         "node": ">=6"
+       }
+     },
++    "node_modules/parse-bmfont-ascii": {
++      "version": "1.0.6",
++      "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
++      "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==",
++      "license": "MIT"
++    },
++    "node_modules/parse-bmfont-binary": {
++      "version": "1.0.6",
++      "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
++      "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==",
++      "license": "MIT"
++    },
++    "node_modules/parse-bmfont-xml": {
++      "version": "1.1.6",
++      "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
++      "integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
++      "license": "MIT",
++      "dependencies": {
++        "xml-parse-from-string": "^1.0.0",
++        "xml2js": "^0.5.0"
++      }
++    },
++    "node_modules/parse-headers": {
++      "version": "2.0.6",
++      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
++      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
++      "license": "MIT"
++    },
+     "node_modules/parse-json": {
+       "version": "8.3.0",
+       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+@@ -13305,12 +14699,32 @@
+         "url": "https://ko-fi.com/killymxi"
+       }
+     },
++    "node_modules/peek-readable": {
++      "version": "4.1.0",
++      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
++      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=8"
++      },
++      "funding": {
++        "type": "github",
++        "url": "https://github.com/sponsors/Borewit"
++      }
++    },
+     "node_modules/pend": {
+       "version": "1.2.0",
+       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+       "license": "MIT"
+     },
++    "node_modules/phin": {
++      "version": "2.9.3",
++      "resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
++      "integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==",
++      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
++      "license": "MIT"
++    },
+     "node_modules/picocolors": {
+       "version": "1.1.1",
+       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+@@ -13353,6 +14767,27 @@
+         "node": ">=4"
+       }
+     },
++    "node_modules/pixelmatch": {
++      "version": "5.3.0",
++      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
++      "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
++      "license": "ISC",
++      "dependencies": {
++        "pngjs": "^6.0.0"
++      },
++      "bin": {
++        "pixelmatch": "bin/pixelmatch"
++      }
++    },
++    "node_modules/pixelmatch/node_modules/pngjs": {
++      "version": "6.0.0",
++      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
++      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=12.13.0"
++      }
++    },
+     "node_modules/pkce-challenge": {
+       "version": "5.0.0",
+       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+@@ -13372,6 +14807,29 @@
+         "semver-compare": "^1.0.0"
+       }
+     },
++    "node_modules/plist": {
++      "version": "3.1.0",
++      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
++      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
++      "license": "MIT",
++      "dependencies": {
++        "@xmldom/xmldom": "^0.8.8",
++        "base64-js": "^1.5.1",
++        "xmlbuilder": "^15.1.1"
++      },
++      "engines": {
++        "node": ">=10.4.0"
++      }
++    },
++    "node_modules/plist/node_modules/xmlbuilder": {
++      "version": "15.1.1",
++      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
++      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=8.0"
++      }
++    },
+     "node_modules/pluralize": {
+       "version": "8.0.0",
+       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+@@ -13382,6 +14840,15 @@
+         "node": ">=4"
+       }
+     },
++    "node_modules/pngjs": {
++      "version": "7.0.0",
++      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
++      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=14.19.0"
++      }
++    },
+     "node_modules/possible-typed-array-names": {
+       "version": "1.1.0",
+       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+@@ -13461,6 +14928,15 @@
+         "url": "https://github.com/sponsors/sindresorhus"
+       }
+     },
++    "node_modules/process": {
++      "version": "0.11.10",
++      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
++      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
++      "license": "MIT",
++      "engines": {
++        "node": ">= 0.6.0"
++      }
++    },
+     "node_modules/prompts": {
+       "version": "2.4.2",
+       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+@@ -13931,6 +15407,38 @@
+         "node": ">= 6"
+       }
+     },
++    "node_modules/readable-web-to-node-stream": {
++      "version": "3.0.4",
++      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
++      "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
++      "license": "MIT",
++      "dependencies": {
++        "readable-stream": "^4.7.0"
++      },
++      "engines": {
++        "node": ">=8"
++      },
++      "funding": {
++        "type": "github",
++        "url": "https://github.com/sponsors/Borewit"
++      }
++    },
++    "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
++      "version": "4.7.0",
++      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
++      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
++      "license": "MIT",
++      "dependencies": {
++        "abort-controller": "^3.0.0",
++        "buffer": "^6.0.3",
++        "events": "^3.3.0",
++        "process": "^0.11.10",
++        "string_decoder": "^1.3.0"
++      },
++      "engines": {
++        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
++      }
++    },
+     "node_modules/readdirp": {
+       "version": "3.6.0",
+       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+@@ -13967,6 +15475,12 @@
+         "url": "https://github.com/sponsors/ljharb"
+       }
+     },
++    "node_modules/regenerator-runtime": {
++      "version": "0.13.11",
++      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
++      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
++      "license": "MIT"
++    },
+     "node_modules/regexp.prototype.flags": {
+       "version": "1.5.4",
+       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+@@ -14015,6 +15529,151 @@
+         "url": "https://github.com/sponsors/sindresorhus"
+       }
+     },
++    "node_modules/render-gif": {
++      "version": "2.0.4",
++      "resolved": "https://registry.npmjs.org/render-gif/-/render-gif-2.0.4.tgz",
++      "integrity": "sha512-l5X7EwbEvdflnvVAzjL7njizwZN8ATqJ0rdaQ5WwMJ55vyWXIXIUE9Ut7W6hm+KE+HMYn5C0a+7t0B6JjGfxQA==",
++      "license": "MIT",
++      "dependencies": {
++        "cycled": "^1.2.0",
++        "decode-gif": "^1.0.1",
++        "delay": "^4.3.0",
++        "jimp": "^0.14.0"
++      },
++      "engines": {
++        "node": ">=10"
++      }
++    },
++    "node_modules/render-gif/node_modules/@jimp/types": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.14.0.tgz",
++      "integrity": "sha512-hx3cXAW1KZm+b+XCrY3LXtdWy2U+hNtq0rPyJ7NuXCjU7lZR3vIkpz1DLJ3yDdS70hTi5QDXY3Cd9kd6DtloHQ==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/bmp": "^0.14.0",
++        "@jimp/gif": "^0.14.0",
++        "@jimp/jpeg": "^0.14.0",
++        "@jimp/png": "^0.14.0",
++        "@jimp/tiff": "^0.14.0",
++        "timm": "^1.6.1"
++      },
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5"
++      }
++    },
++    "node_modules/render-gif/node_modules/@jimp/types/node_modules/@jimp/bmp": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.14.0.tgz",
++      "integrity": "sha512-5RkX6tSS7K3K3xNEb2ygPuvyL9whjanhoaB/WmmXlJS6ub4DjTqrapu8j4qnIWmO4YYtFeTbDTXV6v9P1yMA5A==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0",
++        "bmp-js": "^0.1.0"
++      },
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5"
++      }
++    },
++    "node_modules/render-gif/node_modules/@jimp/types/node_modules/@jimp/gif": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.14.0.tgz",
++      "integrity": "sha512-DHjoOSfCaCz72+oGGEh8qH0zE6pUBaBxPxxmpYJjkNyDZP7RkbBkZJScIYeQ7BmJxmGN4/dZn+MxamoQlr+UYg==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0",
++        "gifwrap": "^0.9.2",
++        "omggif": "^1.0.9"
++      },
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5"
++      }
++    },
++    "node_modules/render-gif/node_modules/@jimp/types/node_modules/@jimp/jpeg": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.14.0.tgz",
++      "integrity": "sha512-561neGbr+87S/YVQYnZSTyjWTHBm9F6F1obYHiyU3wVmF+1CLbxY3FQzt4YolwyQHIBv36Bo0PY2KkkU8BEeeQ==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0",
++        "jpeg-js": "^0.4.0"
++      },
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5"
++      }
++    },
++    "node_modules/render-gif/node_modules/@jimp/types/node_modules/@jimp/png": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.14.0.tgz",
++      "integrity": "sha512-0RV/mEIDOrPCcNfXSPmPBqqSZYwGADNRVUTyMt47RuZh7sugbYdv/uvKmQSiqRdR0L1sfbCBMWUEa5G/8MSbdA==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/utils": "^0.14.0",
++        "pngjs": "^3.3.3"
++      },
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5"
++      }
++    },
++    "node_modules/render-gif/node_modules/@jimp/types/node_modules/@jimp/tiff": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.14.0.tgz",
++      "integrity": "sha512-zBYDTlutc7j88G/7FBCn3kmQwWr0rmm1e0FKB4C3uJ5oYfT8645lftUsvosKVUEfkdmOaMAnhrf4ekaHcb5gQw==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "utif": "^2.0.1"
++      },
++      "peerDependencies": {
++        "@jimp/custom": ">=0.3.5"
++      }
++    },
++    "node_modules/render-gif/node_modules/@jimp/utils": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
++      "integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "regenerator-runtime": "^0.13.3"
++      }
++    },
++    "node_modules/render-gif/node_modules/gifwrap": {
++      "version": "0.9.4",
++      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.4.tgz",
++      "integrity": "sha512-MDMwbhASQuVeD4JKd1fKgNgCRL3fGqMM4WaqpNhWO0JiMOAjbQdumbs4BbBZEy9/M00EHEjKN3HieVhCUlwjeQ==",
++      "license": "MIT",
++      "dependencies": {
++        "image-q": "^4.0.0",
++        "omggif": "^1.0.10"
++      }
++    },
++    "node_modules/render-gif/node_modules/jimp": {
++      "version": "0.14.0",
++      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.14.0.tgz",
++      "integrity": "sha512-8BXU+J8+SPmwwyq9ELihpSV4dWPTiOKBWCEgtkbnxxAVMjXdf3yGmyaLSshBfXc8sP/JQ9OZj5R8nZzz2wPXgA==",
++      "license": "MIT",
++      "dependencies": {
++        "@babel/runtime": "^7.7.2",
++        "@jimp/custom": "^0.14.0",
++        "@jimp/plugins": "^0.14.0",
++        "@jimp/types": "^0.14.0",
++        "regenerator-runtime": "^0.13.3"
++      }
++    },
++    "node_modules/render-gif/node_modules/pngjs": {
++      "version": "3.4.0",
++      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
++      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=4.0.0"
++      }
++    },
+     "node_modules/repeat-string": {
+       "version": "1.6.1",
+       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+@@ -14420,7 +16079,6 @@
+       "version": "1.4.1",
+       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+-      "dev": true,
+       "license": "ISC"
+     },
+     "node_modules/scheduler": {
+@@ -14735,6 +16393,15 @@
+       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+       "license": "MIT"
+     },
++    "node_modules/simple-xml-to-json": {
++      "version": "1.2.3",
++      "resolved": "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.3.tgz",
++      "integrity": "sha512-kWJDCr9EWtZ+/EYYM5MareWj2cRnZGF93YDNpH4jQiHB+hBIZnfPFSQiVMzZOdk+zXWqTZ/9fTeQNu2DqeiudA==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=20.12.2"
++      }
++    },
+     "node_modules/sisteransi": {
+       "version": "1.0.5",
+       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+@@ -15222,6 +16889,23 @@
+       ],
+       "license": "MIT"
+     },
++    "node_modules/strtok3": {
++      "version": "6.3.0",
++      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
++      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
++      "license": "MIT",
++      "dependencies": {
++        "@tokenizer/token": "^0.3.0",
++        "peek-readable": "^4.1.0"
++      },
++      "engines": {
++        "node": ">=10"
++      },
++      "funding": {
++        "type": "github",
++        "url": "https://github.com/sponsors/Borewit"
++      }
++    },
+     "node_modules/structured-source": {
+       "version": "4.0.0",
+       "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
+@@ -15352,6 +17036,18 @@
+         "url": "https://github.com/sponsors/ljharb"
+       }
+     },
++    "node_modules/supports-terminal-graphics": {
++      "version": "0.1.0",
++      "resolved": "https://registry.npmjs.org/supports-terminal-graphics/-/supports-terminal-graphics-0.1.0.tgz",
++      "integrity": "sha512-+KdfozhS0Fw8y5Sghw8kkZNGT8nWYzJ1EzcoIvVjxhl+26TJTs26y02yfBgvc1jh5AS/c8jcI3xtahhR95KRyQ==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=20"
++      },
++      "funding": {
++        "url": "https://github.com/sponsors/sindresorhus"
++      }
++    },
+     "node_modules/system-architecture": {
+       "version": "0.1.0",
+       "resolved": "https://registry.npmjs.org/system-architecture/-/system-architecture-0.1.0.tgz",
+@@ -15565,6 +17261,55 @@
+         "node": ">= 6"
+       }
+     },
++    "node_modules/term-img": {
++      "version": "7.1.0",
++      "resolved": "https://registry.npmjs.org/term-img/-/term-img-7.1.0.tgz",
++      "integrity": "sha512-au++khgSDly2KXNhC6BOU3mLi2v+Dk5mChYKDcpB5xYwhlwqYQtj0z59dIqFEmr+w7ndZaNqurHapkGc6/hprQ==",
++      "license": "MIT",
++      "dependencies": {
++        "ansi-escapes": "^7.1.1",
++        "iterm2-version": "^5.0.0"
++      },
++      "engines": {
++        "node": ">=18"
++      },
++      "funding": {
++        "url": "https://github.com/sponsors/sindresorhus"
++      }
++    },
++    "node_modules/terminal-image": {
++      "version": "4.2.0",
++      "resolved": "https://registry.npmjs.org/terminal-image/-/terminal-image-4.2.0.tgz",
++      "integrity": "sha512-KlK1fgS2AjAg9wmC998ys1uHNXyRb61hgBrSMWK/n+uthMIPejkhYhVcZfQ1ikI99BhiqP6Exr4ISfiNStGdkg==",
++      "license": "MIT",
++      "dependencies": {
++        "chalk": "^5.6.2",
++        "image-dimensions": "^2.5.0",
++        "jimp": "^1.6.0",
++        "log-update": "^6.1.0",
++        "render-gif": "^2.0.4",
++        "supports-terminal-graphics": "^0.1.0",
++        "term-img": "^7.0.0"
++      },
++      "engines": {
++        "node": ">=20"
++      },
++      "funding": {
++        "url": "https://github.com/sponsors/sindresorhus"
++      }
++    },
++    "node_modules/terminal-image/node_modules/chalk": {
++      "version": "5.6.2",
++      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
++      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
++      "license": "MIT",
++      "engines": {
++        "node": "^12.17.0 || ^14.13 || >=16.0.0"
++      },
++      "funding": {
++        "url": "https://github.com/chalk/chalk?sponsor=1"
++      }
++    },
+     "node_modules/terminal-link": {
+       "version": "4.0.0",
+       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-4.0.0.tgz",
+@@ -15682,6 +17427,12 @@
+         "tslib": "^2"
+       }
+     },
++    "node_modules/timm": {
++      "version": "1.7.1",
++      "resolved": "https://registry.npmjs.org/timm/-/timm-1.7.1.tgz",
++      "integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==",
++      "license": "MIT"
++    },
+     "node_modules/tinybench": {
+       "version": "2.9.0",
+       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+@@ -15814,6 +17565,23 @@
+         "node": ">=0.6"
+       }
+     },
++    "node_modules/token-types": {
++      "version": "4.2.1",
++      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
++      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
++      "license": "MIT",
++      "dependencies": {
++        "@tokenizer/token": "^0.3.0",
++        "ieee754": "^1.2.1"
++      },
++      "engines": {
++        "node": ">=10"
++      },
++      "funding": {
++        "type": "github",
++        "url": "https://github.com/sponsors/Borewit"
++      }
++    },
+     "node_modules/tree-dump": {
+       "version": "1.0.3",
+       "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.3.tgz",
+@@ -16280,22 +18048,30 @@
+       "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+       "license": "BSD"
+     },
++    "node_modules/utif": {
++      "version": "2.0.1",
++      "resolved": "https://registry.npmjs.org/utif/-/utif-2.0.1.tgz",
++      "integrity": "sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==",
++      "license": "MIT",
++      "dependencies": {
++        "pako": "^1.0.5"
++      }
++    },
++    "node_modules/utif2": {
++      "version": "4.1.0",
++      "resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
++      "integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
++      "license": "MIT",
++      "dependencies": {
++        "pako": "^1.0.11"
++      }
++    },
+     "node_modules/util-deprecate": {
+       "version": "1.0.2",
+       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+       "license": "MIT"
+     },
+-    "node_modules/utils-merge": {
+-      "version": "1.0.1",
+-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+-      "license": "MIT",
+-      "peer": true,
+-      "engines": {
+-        "node": ">= 0.4.0"
+-      }
+-    },
+     "node_modules/uuid": {
+       "version": "9.0.1",
+       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+@@ -16922,11 +18698,28 @@
+         "url": "https://github.com/sponsors/sindresorhus"
+       }
+     },
++    "node_modules/xhr": {
++      "version": "2.6.0",
++      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
++      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
++      "license": "MIT",
++      "dependencies": {
++        "global": "~4.4.0",
++        "is-function": "^1.0.1",
++        "parse-headers": "^2.0.0",
++        "xtend": "^4.0.0"
++      }
++    },
++    "node_modules/xml-parse-from-string": {
++      "version": "1.0.1",
++      "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
++      "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
++      "license": "MIT"
++    },
+     "node_modules/xml2js": {
+       "version": "0.5.0",
+       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+       "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+-      "dev": true,
+       "license": "MIT",
+       "dependencies": {
+         "sax": ">=0.6.0",
+@@ -16940,12 +18733,20 @@
+       "version": "11.0.1",
+       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+-      "dev": true,
+       "license": "MIT",
+       "engines": {
+         "node": ">=4.0"
+       }
+     },
++    "node_modules/xtend": {
++      "version": "4.0.2",
++      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
++      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=0.4"
++      }
++    },
+     "node_modules/y18n": {
+       "version": "5.0.8",
+       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+@@ -17226,6 +19027,7 @@
+         "strip-ansi": "^7.1.0",
+         "strip-json-comments": "^3.1.1",
+         "tar": "^7.5.8",
++        "terminal-image": "^4.2.0",
+         "tinygradient": "^1.1.5",
+         "undici": "^7.10.0",
+         "ws": "^8.16.0",
+diff --git a/packages/cli/package.json b/packages/cli/package.json
+index f4fd2f7bd..d4592da03 100644
+--- a/packages/cli/package.json
++++ b/packages/cli/package.json
+@@ -64,6 +64,7 @@
+     "strip-ansi": "^7.1.0",
+     "strip-json-comments": "^3.1.1",
+     "tar": "^7.5.8",
++    "terminal-image": "^4.2.0",
+     "tinygradient": "^1.1.5",
+     "undici": "^7.10.0",
+     "ws": "^8.16.0",
+diff --git a/packages/cli/src/ui/components/HistoryItemDisplay.tsx b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+index f40dcf9dc..5def8c32f 100644
+--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
++++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+@@ -36,6 +36,7 @@ import { ModelMessage } from './messages/ModelMessage.js';
+ import { ThinkingMessage } from './messages/ThinkingMessage.js';
+ import { HintMessage } from './messages/HintMessage.js';
+ import { getInlineThinkingMode } from '../utils/inlineThinkingMode.js';
++import { MediaVisualizer } from './MediaVisualizer.js';
+ import { useSettings } from '../contexts/SettingsContext.js';
+ 
+ interface HistoryItemDisplayProps {
+@@ -217,6 +218,13 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
+       {itemForDisplay.type === 'chat_list' && (
+         <ChatList chats={itemForDisplay.chats} />
+       )}
++      {itemForDisplay.type === 'media' && (
++        <MediaVisualizer
++          imagePath={itemForDisplay.imagePath}
++          imageBuffer={itemForDisplay.imageBuffer}
++          width={terminalWidth}
++        />
++      )}
+     </Box>
+   );
+ };
+diff --git a/packages/cli/src/ui/components/MediaVisualizer.test.tsx b/packages/cli/src/ui/components/MediaVisualizer.test.tsx
+new file mode 100644
+index 000000000..3ae8be41a
+--- /dev/null
++++ b/packages/cli/src/ui/components/MediaVisualizer.test.tsx
+@@ -0,0 +1,119 @@
++/**
++ * @license
++ * Copyright 2026 Google LLC
++ * SPDX-License-Identifier: Apache-2.0
++ */
++
++import { act } from 'react';
++import { renderWithProviders } from '../../test-utils/render.js';
++import { MediaVisualizer } from './MediaVisualizer.js';
++import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
++import terminalImage from 'terminal-image';
++
++vi.mock('terminal-image', () => ({
++  default: {
++    buffer: vi.fn() as unknown as typeof terminalImage.buffer,
++    file: vi.fn() as unknown as typeof terminalImage.file,
++  },
++}));
++
++describe('MediaVisualizer', () => {
++  beforeEach(() => {
++    vi.clearAllMocks();
++  });
++
++  it('renders loading state initially', async () => {
++    // Mock to never resolve
++    (terminalImage.file as Mock).mockReturnValue(new Promise(() => {}));
++
++    const { lastFrame, unmount, waitUntilReady } = renderWithProviders(
++      <MediaVisualizer imagePath="test.png" />,
++    );
++
++    await waitUntilReady();
++
++    expect(lastFrame()).toContain('Loading image...');
++    unmount();
++  });
++
++  it('renders rendered content from file', async () => {
++    let resolveImage!: (val: string) => void;
++    const promise = new Promise<string>((resolve) => {
++      resolveImage = resolve;
++    });
++    (terminalImage.file as Mock).mockReturnValue(promise);
++
++    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
++      <MediaVisualizer imagePath="test.png" />,
++    );
++
++    await waitUntilReady();
++    expect(lastFrame()).toContain('Loading image...');
++
++    await act(async () => {
++      resolveImage('MOCK_ANSI_IMAGE');
++    });
++
++    await waitUntilReady();
++
++    expect(lastFrame()).toContain('MOCK_ANSI_IMAGE');
++    expect(terminalImage.file).toHaveBeenCalledWith('test.png', {
++      width: undefined,
++      height: undefined,
++      preserveAspectRatio: true,
++    });
++    unmount();
++  });
++
++  it('renders rendered content from buffer', async () => {
++    let resolveImage!: (val: string) => void;
++    const promise = new Promise<string>((resolve) => {
++      resolveImage = resolve;
++    });
++    (terminalImage.buffer as Mock).mockReturnValue(promise);
++    const mockBuffer = Buffer.from('fake-image-data');
++
++    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
++      <MediaVisualizer imageBuffer={mockBuffer} />,
++    );
++
++    await waitUntilReady();
++
++    await act(async () => {
++      resolveImage('MOCK_ANSI_BUFFER');
++    });
++
++    await waitUntilReady();
++
++    expect(lastFrame()).toContain('MOCK_ANSI_BUFFER');
++    expect(terminalImage.buffer).toHaveBeenCalledWith(mockBuffer, {
++      width: undefined,
++      height: undefined,
++      preserveAspectRatio: true,
++    });
++    unmount();
++  });
++
++  it('renders error message on failure', async () => {
++    let rejectImage!: (err: Error) => void;
++    const promise = new Promise<string>((_, reject) => {
++      rejectImage = reject;
++    });
++    (terminalImage.file as Mock).mockReturnValue(promise);
++
++    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
++      <MediaVisualizer imagePath="error.png" />,
++    );
++
++    await waitUntilReady();
++
++    await act(async () => {
++      rejectImage(new Error('Failed to load'));
++    });
++
++    await waitUntilReady();
++
++    expect(lastFrame()).toContain('[Image Render Error: Failed to load]');
++    unmount();
++  });
++});
+diff --git a/packages/cli/src/ui/components/MediaVisualizer.tsx b/packages/cli/src/ui/components/MediaVisualizer.tsx
+new file mode 100644
+index 000000000..a8ff04a41
+--- /dev/null
++++ b/packages/cli/src/ui/components/MediaVisualizer.tsx
+@@ -0,0 +1,106 @@
++/**
++ * @license
++ * Copyright 2026 Google LLC
++ * SPDX-License-Identifier: Apache-2.0
++ */
++
++import type React from 'react';
++import { useEffect, useState } from 'react';
++import { Box, Text } from 'ink';
++import terminalImage from 'terminal-image';
++
++export interface MediaVisualizerProps {
++  /**
++   * Absolute or relative path to the image file.
++   */
++  imagePath?: string;
++  /**
++   * Image buffer (optional, takes precedence over imagePath).
++   */
++  imageBuffer?: Buffer;
++  /**
++   * Width of the rendered image. Defaults to standard terminal-image sizing.
++   */
++  width?: string | number;
++  /**
++   * Height of the rendered image.
++   */
++  height?: string | number;
++  /**
++   * If true, tries to maintain aspect ratio (default: true for terminal-image)
++   */
++  preserveAspectRatio?: boolean;
++}
++
++/**
++ * A fallback universal media visualizer that renders image content
++ * as ANSI block characters in the terminal using terminal-image.
++ */
++export const MediaVisualizer: React.FC<MediaVisualizerProps> = ({
++  imagePath,
++  imageBuffer,
++  width,
++  height,
++  preserveAspectRatio = true,
++}) => {
++  const [renderedContent, setRenderedContent] = useState<string | null>(null);
++  const [error, setError] = useState<string | null>(null);
++
++  useEffect(() => {
++    let isCancelled = false;
++
++    const renderImage = async () => {
++      try {
++        const options = { width, height, preserveAspectRatio };
++        let result = '';
++
++        if (imageBuffer) {
++          result = await terminalImage.buffer(imageBuffer, options);
++        } else if (imagePath) {
++          result = await terminalImage.file(imagePath, options);
++        } else {
++          return;
++        }
++
++        if (!isCancelled) {
++          setRenderedContent(result);
++          setError(null);
++        }
++      } catch (err: unknown) {
++        if (!isCancelled) {
++          const message = err instanceof Error ? err.message : String(err);
++          setError(`[Image Render Error: ${message}]`);
++        }
++      }
++    };
++
++    void renderImage();
++
++    return () => {
++      isCancelled = true;
++    };
++  }, [imagePath, imageBuffer, width, height, preserveAspectRatio]);
++
++  if (error) {
++    return (
++      <Box>
++        <Text color="red">{error}</Text>
++      </Box>
++    );
++  }
++
++  if (!renderedContent) {
++    return (
++      <Box>
++        <Text dimColor>Loading image...</Text>
++      </Box>
++    );
++  }
++
++  // terminal-image outputs VT100/ANSI color blocks
++  return (
++    <Box flexDirection="column">
++      <Text>{renderedContent}</Text>
++    </Box>
++  );
++};
+diff --git a/packages/cli/src/ui/components/messages/UserMessage.test.tsx b/packages/cli/src/ui/components/messages/UserMessage.test.tsx
+index a0071bf93..59b7f7b0c 100644
+--- a/packages/cli/src/ui/components/messages/UserMessage.test.tsx
++++ b/packages/cli/src/ui/components/messages/UserMessage.test.tsx
+@@ -4,15 +4,21 @@
+  * SPDX-License-Identifier: Apache-2.0
+  */
+ 
++import { type ReactElement } from 'react';
+ import { renderWithProviders } from '../../../test-utils/render.js';
+ import { UserMessage } from './UserMessage.js';
+ import { describe, it, expect, vi } from 'vitest';
++import { MediaVisualizer } from '../MediaVisualizer.js';
+ 
+ // Mock the commandUtils to control isSlashCommand behavior
+ vi.mock('../../utils/commandUtils.js', () => ({
+   isSlashCommand: vi.fn((text: string) => text.startsWith('/')),
+ }));
+ 
++// Mock MediaVisualizer to avoid running actual terminal-image in tests
++vi.mock('../MediaVisualizer.js');
++vi.mocked(MediaVisualizer).mockReturnValue(null as unknown as ReactElement);
++
+ describe('UserMessage', () => {
+   it('renders normal user message with correct prefix', async () => {
+     const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
+diff --git a/packages/cli/src/ui/components/messages/UserMessage.tsx b/packages/cli/src/ui/components/messages/UserMessage.tsx
+index 6453ab94c..cc3c96776 100644
+--- a/packages/cli/src/ui/components/messages/UserMessage.tsx
++++ b/packages/cli/src/ui/components/messages/UserMessage.tsx
+@@ -4,7 +4,7 @@
+  * SPDX-License-Identifier: Apache-2.0
+  */
+ 
+-import type React from 'react';
++import type { FC } from 'react';
+ import { useMemo } from 'react';
+ import { Text, Box } from 'ink';
+ import { theme } from '../../semantic-colors.js';
+@@ -14,6 +14,8 @@ import {
+   calculateTransformationsForLine,
+   calculateTransformedLine,
+ } from '../shared/text-buffer.js';
++import { unescapePath } from '@google/gemini-cli-core';
++import { MediaVisualizer } from '../MediaVisualizer.js';
+ import { HalfLinePaddedBox } from '../shared/HalfLinePaddedBox.js';
+ import { useConfig } from '../../contexts/ConfigContext.js';
+ 
+@@ -22,7 +24,7 @@ interface UserMessageProps {
+   width: number;
+ }
+ 
+-export const UserMessage: React.FC<UserMessageProps> = ({ text, width }) => {
++export const UserMessage: FC<UserMessageProps> = ({ text, width }) => {
+   const prefix = '> ';
+   const prefixWidth = prefix.length;
+   const isSlashCommand = checkIsSlashCommand(text);
+@@ -31,22 +33,32 @@ export const UserMessage: React.FC<UserMessageProps> = ({ text, width }) => {
+ 
+   const textColor = isSlashCommand ? theme.text.accent : theme.text.secondary;
+ 
+-  const displayText = useMemo(() => {
+-    if (!text) return text;
+-    return text
+-      .split('\n')
+-      .map((line) => {
+-        const transformations = calculateTransformationsForLine(line);
+-        // We pass a cursor position of [-1, -1] so that no transformations are expanded (e.g. images remain collapsed)
+-        const { transformedLine } = calculateTransformedLine(
+-          line,
+-          0, // line index doesn't matter since cursor is [-1, -1]
+-          [-1, -1],
+-          transformations,
+-        );
+-        return transformedLine;
+-      })
+-      .join('\n');
++  const { displayText, imagePaths } = useMemo(() => {
++    if (!text) return { displayText: text, imagePaths: [] };
++    const paths = new Set<string>();
++    const displayLines = text.split('\n').map((line) => {
++      const transformations = calculateTransformationsForLine(line);
++      for (const t of transformations) {
++        if (t.type === 'image') {
++          const withoutAt = t.logicalText.startsWith('@')
++            ? t.logicalText.slice(1)
++            : t.logicalText;
++          paths.add(unescapePath(withoutAt));
++        }
++      }
++      // We pass a cursor position of [-1, -1] so that no transformations are expanded (e.g. images remain collapsed)
++      const { transformedLine } = calculateTransformedLine(
++        line,
++        0, // line index doesn't matter since cursor is [-1, -1]
++        [-1, -1],
++        transformations,
++      );
++      return transformedLine;
++    });
++    return {
++      displayText: displayLines.join('\n'),
++      imagePaths: Array.from(paths),
++    };
+   }, [text]);
+ 
+   return (
+@@ -71,10 +83,19 @@ export const UserMessage: React.FC<UserMessageProps> = ({ text, width }) => {
+             {prefix}
+           </Text>
+         </Box>
+-        <Box flexGrow={1}>
++        <Box flexGrow={1} flexDirection="column">
+           <Text wrap="wrap" color={textColor}>
+             {displayText}
+           </Text>
++          {imagePaths.length > 0 && (
++            <Box flexDirection="column" marginTop={1}>
++              {imagePaths.map((imagePath, index) => (
++                <Box key={imagePath + index} marginBottom={1}>
++                  <MediaVisualizer imagePath={imagePath} />
++                </Box>
++              ))}
++            </Box>
++          )}
+         </Box>
+       </Box>
+     </HalfLinePaddedBox>
+diff --git a/packages/cli/src/ui/components/messages/__snapshots__/UserMessage.test.tsx.snap b/packages/cli/src/ui/components/messages/__snapshots__/UserMessage.test.tsx.snap
+index 679a5885d..c34571082 100644
+--- a/packages/cli/src/ui/components/messages/__snapshots__/UserMessage.test.tsx.snap
++++ b/packages/cli/src/ui/components/messages/__snapshots__/UserMessage.test.tsx.snap
+@@ -25,6 +25,8 @@ exports[`UserMessage > renders slash command message 1`] = `
+ exports[`UserMessage > transforms image paths in user message 1`] = `
+ "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  > Check out this image: [Image my-image.png]                                   
++                                                                                
++                                                                                
+ ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+ "
+ `;
+diff --git a/packages/cli/src/ui/types.ts b/packages/cli/src/ui/types.ts
+index c9910179a..21915e740 100644
+--- a/packages/cli/src/ui/types.ts
++++ b/packages/cli/src/ui/types.ts
+@@ -378,7 +378,14 @@ export type HistoryItemWithoutId =
+   | HistoryItemMcpStatus
+   | HistoryItemChatList
+   | HistoryItemThinking
+-  | HistoryItemHint;
++  | HistoryItemHint
++  | HistoryItemMedia;
++
++export type HistoryItemMedia = HistoryItemBase & {
++  type: 'media';
++  imagePath?: string;
++  imageBuffer?: Buffer;
++};
+ 
+ export type HistoryItem = HistoryItemWithoutId & { id: number };
+ 
+diff --git a/packages/cli/src/ui/utils/MarkdownDisplay.tsx b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+index 0200fbcb0..e66da952b 100644
+--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
++++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+@@ -4,7 +4,7 @@
+  * SPDX-License-Identifier: Apache-2.0
+  */
+ 
+-import React from 'react';
++import { type FC, memo, type ReactNode } from 'react';
+ import { Text, Box } from 'ink';
+ import { theme } from '../semantic-colors.js';
+ import { colorizeCode } from './CodeColorizer.js';
+@@ -12,6 +12,9 @@ import { TableRenderer } from './TableRenderer.js';
+ import { RenderInline } from './InlineMarkdownRenderer.js';
+ import { useSettings } from '../contexts/SettingsContext.js';
+ import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
++import { unescapePath } from '@google/gemini-cli-core';
++import { MediaVisualizer } from '../components/MediaVisualizer.js';
++import { calculateTransformationsForLine } from '../components/shared/text-buffer.js';
+ 
+ interface MarkdownDisplayProps {
+   text: string;
+@@ -28,7 +31,7 @@ const CODE_BLOCK_PREFIX_PADDING = 1;
+ const LIST_ITEM_PREFIX_PADDING = 1;
+ const LIST_ITEM_TEXT_FLEX_GROW = 1;
+ 
+-const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
++const MarkdownDisplayInternal: FC<MarkdownDisplayProps> = ({
+   text,
+   isPending,
+   availableTerminalHeight,
+@@ -68,7 +71,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
+   const tableRowRegex = /^\s*\|(.+)\|\s*$/;
+   const tableSeparatorRegex = /^\s*\|?\s*(:?-+:?)\s*(\|\s*(:?-+:?)\s*)+\|?\s*$/;
+ 
+-  const contentBlocks: React.ReactNode[] = [];
++  const contentBlocks: ReactNode[] = [];
+   let inCodeBlock = false;
+   let lastLineEmpty = true;
+   let codeBlockContent: string[] = [];
+@@ -196,7 +199,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
+     } else if (headerMatch) {
+       const level = headerMatch[1].length;
+       const headerText = headerMatch[2];
+-      let headerNode: React.ReactNode = null;
++      let headerNode: ReactNode = null;
+       switch (level) {
+         case 1:
+           headerNode = (
+@@ -273,11 +276,32 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
+           lastLineEmpty = true;
+         }
+       } else {
++        const transformations = calculateTransformationsForLine(line);
++        const imagePathsSet = new Set<string>();
++        for (const t of transformations) {
++          if (t.type === 'image') {
++            const withoutAt = t.logicalText.startsWith('@')
++              ? t.logicalText.slice(1)
++              : t.logicalText;
++            imagePathsSet.add(unescapePath(withoutAt));
++          }
++        }
++        const imagePaths = Array.from(imagePathsSet);
++
+         addContentBlock(
+-          <Box key={key}>
++          <Box key={key} flexDirection="column">
+             <Text wrap="wrap" color={responseColor}>
+               <RenderInline text={line} defaultColor={responseColor} />
+             </Text>
++            {imagePaths.length > 0 && (
++              <Box flexDirection="column" marginTop={1}>
++                {imagePaths.map((path, idx) => (
++                  <Box key={`${path}-${idx}`} marginBottom={1}>
++                    <MediaVisualizer imagePath={path} />
++                  </Box>
++                ))}
++              </Box>
++            )}
+           </Box>,
+         );
+       }
+@@ -324,7 +348,7 @@ interface RenderCodeBlockProps {
+   terminalWidth: number;
+ }
+ 
+-const RenderCodeBlockInternal: React.FC<RenderCodeBlockProps> = ({
++const RenderCodeBlockInternal: FC<RenderCodeBlockProps> = ({
+   content,
+   lang,
+   isPending,
+@@ -397,7 +421,7 @@ const RenderCodeBlockInternal: React.FC<RenderCodeBlockProps> = ({
+   );
+ };
+ 
+-const RenderCodeBlock = React.memo(RenderCodeBlockInternal);
++const RenderCodeBlock = memo(RenderCodeBlockInternal);
+ 
+ interface RenderListItemProps {
+   itemText: string;
+@@ -406,7 +430,7 @@ interface RenderListItemProps {
+   leadingWhitespace?: string;
+ }
+ 
+-const RenderListItemInternal: React.FC<RenderListItemProps> = ({
++const RenderListItemInternal: FC<RenderListItemProps> = ({
+   itemText,
+   type,
+   marker,
+@@ -434,7 +458,7 @@ const RenderListItemInternal: React.FC<RenderListItemProps> = ({
+   );
+ };
+ 
+-const RenderListItem = React.memo(RenderListItemInternal);
++const RenderListItem = memo(RenderListItemInternal);
+ 
+ interface RenderTableProps {
+   headers: string[];
+@@ -442,7 +466,7 @@ interface RenderTableProps {
+   terminalWidth: number;
+ }
+ 
+-const RenderTableInternal: React.FC<RenderTableProps> = ({
++const RenderTableInternal: FC<RenderTableProps> = ({
+   headers,
+   rows,
+   terminalWidth,
+@@ -450,6 +474,6 @@ const RenderTableInternal: React.FC<RenderTableProps> = ({
+   <TableRenderer headers={headers} rows={rows} terminalWidth={terminalWidth} />
+ );
+ 
+-const RenderTable = React.memo(RenderTableInternal);
++const RenderTable = memo(RenderTableInternal);
+ 
+-export const MarkdownDisplay = React.memo(MarkdownDisplayInternal);
++export const MarkdownDisplay = memo(MarkdownDisplayInternal);
+diff --git a/packages/cli/src/ui/utils/textUtils.ts b/packages/cli/src/ui/utils/textUtils.ts
+index a039a4399..23305d693 100644
+--- a/packages/cli/src/ui/utils/textUtils.ts
++++ b/packages/cli/src/ui/utils/textUtils.ts
+@@ -229,6 +229,11 @@ export function escapeAnsiCtrlCodes<T>(obj: T): T {
+     return obj;
+   }
+ 
++  // Skip Buffers properly to avoid iterating byte by byte
++  if (Buffer.isBuffer(obj) || obj instanceof Uint8Array) {
++    return obj;
++  }
++
+   if (Array.isArray(obj)) {
+     let newArr: unknown[] | null = null;
+ 
+diff --git a/packages/cli/test-setup.ts b/packages/cli/test-setup.ts
+index aee1c1345..d819b888e 100644
+--- a/packages/cli/test-setup.ts
++++ b/packages/cli/test-setup.ts
+@@ -9,6 +9,15 @@ import { format } from 'node:util';
+ import { coreEvents } from '@google/gemini-cli-core';
+ import { themeManager } from './src/ui/themes/theme-manager.js';
+ 
++// Mock terminal-image globally as it can cause test timeouts when UI 
++// components that import it are rendered (e.g. AppContainer, AppRig).
++vi.mock('terminal-image', () => ({
++  default: {
++    file: vi.fn().mockResolvedValue('MOCKED_TERMINAL_IMAGE'),
++    buffer: vi.fn().mockResolvedValue('MOCKED_TERMINAL_IMAGE'),
++  },
++}));
++
+ // Unset CI environment variable so that ink renders dynamically as it does in a real terminal
+ if (process.env.CI !== undefined) {
+   delete process.env.CI;
+diff --git a/packages/core/src/services/shellExecutionService.test.ts b/packages/core/src/services/shellExecutionService.test.ts
+index 61186c9eb..407b846b7 100644
+--- a/packages/core/src/services/shellExecutionService.test.ts
++++ b/packages/core/src/services/shellExecutionService.test.ts
+@@ -731,7 +731,11 @@ describe('ShellExecutionService', () => {
+ 
+       expect(mockPtySpawn).toHaveBeenCalledWith(
+         'powershell.exe',
+-        ['-NoProfile', '-Command', 'dir "foo bar"'],
++        [
++          '-NoProfile',
++          '-Command',
++          '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; dir "foo bar"',
++        ],
+         expect.any(Object),
+       );
+     });
+@@ -1250,7 +1254,11 @@ describe('ShellExecutionService child_process fallback', () => {
+ 
+       expect(mockCpSpawn).toHaveBeenCalledWith(
+         'powershell.exe',
+-        ['-NoProfile', '-Command', 'dir "foo bar"'],
++        [
++          '-NoProfile',
++          '-Command',
++          '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; dir "foo bar"',
++        ],
+         expect.objectContaining({
+           shell: false,
+           detached: false,
+diff --git a/packages/core/src/services/shellExecutionService.ts b/packages/core/src/services/shellExecutionService.ts
+index c21eeb113..9bca67e90 100644
+--- a/packages/core/src/services/shellExecutionService.ts
++++ b/packages/core/src/services/shellExecutionService.ts
+@@ -15,6 +15,7 @@ import { getCachedEncodingForBuffer } from '../utils/systemEncoding.js';
+ import {
+   getShellConfiguration,
+   resolveExecutable,
++  ensurePowerShellUtf8Encoding,
+   type ShellType,
+ } from '../utils/shell-utils.js';
+ import { isBinary } from '../utils/textUtils.js';
+@@ -303,7 +304,8 @@ export class ShellExecutionService {
+     try {
+       const isWindows = os.platform() === 'win32';
+       const { executable, argsPrefix, shell } = getShellConfiguration();
+-      const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
++      let guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
++      guardedCommand = ensurePowerShellUtf8Encoding(guardedCommand, shell);
+       const spawnArgs = [...argsPrefix, guardedCommand];
+ 
+       const child = cpSpawn(executable, spawnArgs, {
+@@ -565,7 +567,8 @@ export class ShellExecutionService {
+         );
+       }
+ 
+-      const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
++      let guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
++      guardedCommand = ensurePowerShellUtf8Encoding(guardedCommand, shell);
+       const args = [...argsPrefix, guardedCommand];
+ 
+       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+diff --git a/packages/core/src/utils/shell-utils.test.ts b/packages/core/src/utils/shell-utils.test.ts
+index 81b43abf5..63c40be7d 100644
+--- a/packages/core/src/utils/shell-utils.test.ts
++++ b/packages/core/src/utils/shell-utils.test.ts
+@@ -22,6 +22,7 @@ import {
+   stripShellWrapper,
+   hasRedirection,
+   resolveExecutable,
++  ensurePowerShellUtf8Encoding,
+ } from './shell-utils.js';
+ import path from 'node:path';
+ 
+@@ -339,6 +340,32 @@ describe('stripShellWrapper', () => {
+   });
+ });
+ 
++describe('ensurePowerShellUtf8Encoding', () => {
++  const utf8Prefix =
++    '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8;';
++
++  it('should not modify command for non-powershell shells', () => {
++    expect(ensurePowerShellUtf8Encoding('echo "test"', 'bash')).toEqual(
++      'echo "test"',
++    );
++    expect(ensurePowerShellUtf8Encoding('echo "test"', 'cmd')).toEqual(
++      'echo "test"',
++    );
++  });
++
++  it('should prepend utf8 configuration for powershell', () => {
++    expect(ensurePowerShellUtf8Encoding('echo "test"', 'powershell')).toEqual(
++      `${utf8Prefix} echo "test"`,
++    );
++  });
++
++  it('should not double-prepend if already present', () => {
++    expect(
++      ensurePowerShellUtf8Encoding(`${utf8Prefix} echo "test"`, 'powershell'),
++    ).toEqual(`${utf8Prefix} echo "test"`);
++  });
++});
++
+ describe('escapeShellArg', () => {
+   describe('POSIX (bash)', () => {
+     it('should use shell-quote for escaping', () => {
+diff --git a/packages/core/src/utils/shell-utils.ts b/packages/core/src/utils/shell-utils.ts
+index 6f92ec638..d49961d0e 100644
+--- a/packages/core/src/utils/shell-utils.ts
++++ b/packages/core/src/utils/shell-utils.ts
+@@ -604,6 +604,34 @@ export function escapeShellArg(arg: string, shell: ShellType): string {
+   }
+ }
+ 
++/**
++ * For PowerShell, we must explicitly configure the console output encoding to UTF-8
++ * to prevent Node.js from misinterpreting characters emitted by child processes,
++ * especially on Windows systems with different default code pages.
++ *
++ * @param command The command string to execute
++ * @param shell The type of shell being used
++ * @returns The command string, prefixed with the UTF-8 encoding configuration if PowerShell
++ */
++export function ensurePowerShellUtf8Encoding(
++  command: string,
++  shell: ShellType,
++): string {
++  if (shell !== 'powershell') {
++    return command;
++  }
++
++  const utf8Config =
++    '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8;';
++
++  const trimmed = command.trimStart();
++  if (trimmed.startsWith(utf8Config)) {
++    return command;
++  }
++
++  return `${utf8Config} ${command}`;
++}
++
+ /**
+  * Splits a shell command into a list of individual commands, respecting quotes.
+  * This is used to separate chained commands (e.g., using &&, ||, ;).

--- a/package-lock.json
+++ b/package-lock.json
@@ -457,6 +457,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -1840,6 +1849,908 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@jimp/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/file-ops": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "await-to-js": "^3.0.0",
+        "exif-parser": "^0.1.12",
+        "file-type": "^16.0.0",
+        "mime": "3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/custom": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.14.0.tgz",
+      "integrity": "sha512-kQJMeH87+kWJdVw8F9GQhtsageqqxrvzg7yyOw3Tx/s7v5RToe8RnKyMM+kVtBJtNAG+Xyv/z01uYQ2jiZ3GwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/core": "^0.14.0"
+      }
+    },
+    "node_modules/@jimp/custom/node_modules/@jimp/core": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-S62FcKdtLtj3yWsGfJRdFXSutjvHg7aQNiFogMbwq19RP4XJWqS2nOphu7ScB8KrSlyy5nPF2hkWNhLRLyD82w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0",
+        "any-base": "^1.1.0",
+        "buffer": "^5.2.0",
+        "exif-parser": "^0.1.12",
+        "file-type": "^9.0.0",
+        "load-bmfont": "^1.3.1",
+        "mkdirp": "^0.5.1",
+        "phin": "^2.9.1",
+        "pixelmatch": "^4.0.2",
+        "tinycolor2": "^1.4.1"
+      }
+    },
+    "node_modules/@jimp/custom/node_modules/@jimp/utils": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
+      "integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "regenerator-runtime": "^0.13.3"
+      }
+    },
+    "node_modules/@jimp/custom/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/@jimp/custom/node_modules/file-type": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-9.0.0.tgz",
+      "integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@jimp/custom/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/@jimp/custom/node_modules/pixelmatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
+      "integrity": "sha512-J8B6xqiO37sU/gkcMglv6h5Jbd9xNER7aHzpfRdNmV4IbQBzBpe4l9XmbG+xPF/znacgu2jfEw+wHffaq/YkXA==",
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^3.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/@jimp/custom/node_modules/pngjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@jimp/diff": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/diff/-/diff-1.6.0.tgz",
+      "integrity": "sha512-+yUAQ5gvRC5D1WHYxjBHZI7JBRusGGSLf8AmPRPCenTzh4PA+wZ1xv2+cYqQwTfQHU5tXYOhA0xDytfHUf1Zyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "pixelmatch": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/file-ops": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/file-ops/-/file-ops-1.6.0.tgz",
+      "integrity": "sha512-Dx/bVDmgnRe1AlniRpCKrGRm5YvGmUwbDzt+MAkgmLGf+jvBT75hmMEZ003n9HQI/aPnm/YKnXjg/hOpzNCpHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-bmp": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-bmp/-/js-bmp-1.6.0.tgz",
+      "integrity": "sha512-FU6Q5PC/e3yzLyBDXupR3SnL3htU7S3KEs4e6rjDP6gNEOXRFsWs6YD3hXuXd50jd8ummy+q2WSwuGkr8wi+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "bmp-ts": "^1.0.9"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-gif": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-gif/-/js-gif-1.6.0.tgz",
+      "integrity": "sha512-N9CZPHOrJTsAUoWkWZstLPpwT5AwJ0wge+47+ix3++SdSL/H2QzyMqxbcDYNFe4MoI5MIhATfb0/dl/wmX221g==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "gifwrap": "^0.10.1",
+        "omggif": "^1.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-jpeg": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-jpeg/-/js-jpeg-1.6.0.tgz",
+      "integrity": "sha512-6vgFDqeusblf5Pok6B2DUiMXplH8RhIKAryj1yn+007SIAQ0khM1Uptxmpku/0MfbClx2r7pnJv9gWpAEJdMVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "jpeg-js": "^0.4.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-png": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-png/-/js-png-1.6.0.tgz",
+      "integrity": "sha512-AbQHScy3hDDgMRNfG0tPjL88AV6qKAILGReIa3ATpW5QFjBKpisvUaOqhzJ7Reic1oawx3Riyv152gaPfqsBVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "pngjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-tiff": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-tiff/-/js-tiff-1.6.0.tgz",
+      "integrity": "sha512-zhReR8/7KO+adijj3h0ZQUOiun3mXUv79zYEAKvE0O+rP7EhgtKvWJOZfRzdZSNv0Pu1rKtgM72qgtwe2tFvyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "utif2": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-blit": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-1.6.0.tgz",
+      "integrity": "sha512-M+uRWl1csi7qilnSK8uxK4RJMSuVeBiO1AY0+7APnfUbQNZm6hCe0CCFv1Iyw1D/Dhb8ph8fQgm5mwM0eSxgVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-blur": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-1.6.0.tgz",
+      "integrity": "sha512-zrM7iic1OTwUCb0g/rN5y+UnmdEsT3IfuCXCJJNs8SZzP0MkZ1eTvuwK9ZidCuMo4+J3xkzCidRwYXB5CyGZTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/utils": "1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-circle": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-1.6.0.tgz",
+      "integrity": "sha512-xt1Gp+LtdMKAXfDp3HNaG30SPZW6AQ7dtAtTnoRKorRi+5yCJjKqXRgkewS5bvj8DEh87Ko1ydJfzqS3P2tdWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-color": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-1.6.0.tgz",
+      "integrity": "sha512-J5q8IVCpkBsxIXM+45XOXTrsyfblyMZg3a9eAo0P7VPH4+CrvyNQwaYatbAIamSIN1YzxmO3DkIZXzRjFSz1SA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "tinycolor2": "^1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-contain": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-1.6.0.tgz",
+      "integrity": "sha512-oN/n+Vdq/Qg9bB4yOBOxtY9IPAtEfES8J1n9Ddx+XhGBYT1/QTU/JYkGaAkIGoPnyYvmLEDqMz2SGihqlpqfzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/plugin-blit": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-cover": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-1.6.0.tgz",
+      "integrity": "sha512-Iow0h6yqSC269YUJ8HC3Q/MpCi2V55sMlbkkTTx4zPvd8mWZlC0ykrNDeAy9IJegrQ7v5E99rJwmQu25lygKLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/plugin-crop": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-crop": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-1.6.0.tgz",
+      "integrity": "sha512-KqZkEhvs+21USdySCUDI+GFa393eDIzbi1smBqkUPTE+pRwSWMAf01D5OC3ZWB+xZsNla93BDS9iCkLHA8wang==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-displace": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-1.6.0.tgz",
+      "integrity": "sha512-4Y10X9qwr5F+Bo5ME356XSACEF55485j5nGdiyJ9hYzjQP9nGgxNJaZ4SAOqpd+k5sFaIeD7SQ0Occ26uIng5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-dither": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-1.6.0.tgz",
+      "integrity": "sha512-600d1RxY0pKwgyU0tgMahLNKsqEcxGdbgXadCiVCoGd6V6glyCvkNrnnwC0n5aJ56Htkj88PToSdF88tNVZEEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-fisheye": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-1.6.0.tgz",
+      "integrity": "sha512-E5QHKWSCBFtpgZarlmN3Q6+rTQxjirFqo44ohoTjzYVrDI6B6beXNnPIThJgPr0Y9GwfzgyarKvQuQuqCnnfbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-flip": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-1.6.0.tgz",
+      "integrity": "sha512-/+rJVDuBIVOgwoyVkBjUFHtP+wmW0r+r5OQ2GpatQofToPVbJw1DdYWXlwviSx7hvixTWLKVgRWQ5Dw862emDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-gaussian": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.14.0.tgz",
+      "integrity": "sha512-uaLwQ0XAQoydDlF9tlfc7iD9drYPriFe+jgYnWm8fbw5cN+eOIcnneEX9XCOOzwgLPkNCxGox6Kxjn8zY6GxtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-gaussian/node_modules/@jimp/utils": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
+      "integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "regenerator-runtime": "^0.13.3"
+      }
+    },
+    "node_modules/@jimp/plugin-hash": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-hash/-/plugin-hash-1.6.0.tgz",
+      "integrity": "sha512-wWzl0kTpDJgYVbZdajTf+4NBSKvmI3bRI8q6EH9CVeIHps9VWVsUvEyb7rpbcwVLWYuzDtP2R0lTT6WeBNQH9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/js-bmp": "1.6.0",
+        "@jimp/js-jpeg": "1.6.0",
+        "@jimp/js-png": "1.6.0",
+        "@jimp/js-tiff": "1.6.0",
+        "@jimp/plugin-color": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "any-base": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-invert": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.14.0.tgz",
+      "integrity": "sha512-UaQW9X9vx8orQXYSjT5VcITkJPwDaHwrBbxxPoDG+F/Zgv4oV9fP+udDD6qmkgI9taU+44Fy+zm/J/gGcMWrdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-invert/node_modules/@jimp/utils": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
+      "integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "regenerator-runtime": "^0.13.3"
+      }
+    },
+    "node_modules/@jimp/plugin-mask": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-1.6.0.tgz",
+      "integrity": "sha512-Cwy7ExSJMZszvkad8NV8o/Z92X2kFUFM8mcDAhNVxU0Q6tA0op2UKRJY51eoK8r6eds/qak3FQkXakvNabdLnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-normalize": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.14.0.tgz",
+      "integrity": "sha512-AfY8sqlsbbdVwFGcyIPy5JH/7fnBzlmuweb+Qtx2vn29okq6+HelLjw2b+VT2btgGUmWWHGEHd86oRGSoWGyEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-normalize/node_modules/@jimp/utils": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
+      "integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "regenerator-runtime": "^0.13.3"
+      }
+    },
+    "node_modules/@jimp/plugin-print": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-1.6.0.tgz",
+      "integrity": "sha512-zarTIJi8fjoGMSI/M3Xh5yY9T65p03XJmPsuNet19K/Q7mwRU6EV2pfj+28++2PV2NJ+htDF5uecAlnGyxFN2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/js-jpeg": "1.6.0",
+        "@jimp/js-png": "1.6.0",
+        "@jimp/plugin-blit": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "parse-bmfont-ascii": "^1.0.6",
+        "parse-bmfont-binary": "^1.0.6",
+        "parse-bmfont-xml": "^1.1.6",
+        "simple-xml-to-json": "^1.2.2",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-quantize": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-quantize/-/plugin-quantize-1.6.0.tgz",
+      "integrity": "sha512-EmzZ/s9StYQwbpG6rUGBCisc3f64JIhSH+ncTJd+iFGtGo0YvSeMdAd+zqgiHpfZoOL54dNavZNjF4otK+mvlg==",
+      "license": "MIT",
+      "dependencies": {
+        "image-q": "^4.0.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-resize": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.0.tgz",
+      "integrity": "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-rotate": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-1.6.0.tgz",
+      "integrity": "sha512-JagdjBLnUZGSG4xjCLkIpQOZZ3Mjbg8aGCCi4G69qR+OjNpOeGI7N2EQlfK/WE8BEHOW5vdjSyglNqcYbQBWRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/plugin-crop": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-scale": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.14.0.tgz",
+      "integrity": "sha512-ZcJk0hxY5ZKZDDwflqQNHEGRblgaR+piePZm7dPwPUOSeYEH31P0AwZ1ziceR74zd8N80M0TMft+e3Td6KGBHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5",
+        "@jimp/plugin-resize": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-scale/node_modules/@jimp/utils": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
+      "integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "regenerator-runtime": "^0.13.3"
+      }
+    },
+    "node_modules/@jimp/plugin-shadow": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.14.0.tgz",
+      "integrity": "sha512-p2igcEr/iGrLiTu0YePNHyby0WYAXM14c5cECZIVnq/UTOOIQ7xIcWZJ1lRbAEPxVVXPN1UibhZAbr3HAb5BjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5",
+        "@jimp/plugin-blur": ">=0.3.5",
+        "@jimp/plugin-resize": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-shadow/node_modules/@jimp/utils": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
+      "integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "regenerator-runtime": "^0.13.3"
+      }
+    },
+    "node_modules/@jimp/plugin-threshold": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-1.6.0.tgz",
+      "integrity": "sha512-M59m5dzLoHOVWdM41O8z9SyySzcDn43xHseOH0HavjsfQsT56GGCC4QzU1banJidbUrePhzoEdS42uFE8Fei8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/plugin-color": "1.6.0",
+        "@jimp/plugin-hash": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugins": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.14.0.tgz",
+      "integrity": "sha512-vDO3XT/YQlFlFLq5TqNjQkISqjBHT8VMhpWhAfJVwuXIpilxz5Glu4IDLK6jp4IjPR6Yg2WO8TmRY/HI8vLrOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/plugin-blit": "^0.14.0",
+        "@jimp/plugin-blur": "^0.14.0",
+        "@jimp/plugin-circle": "^0.14.0",
+        "@jimp/plugin-color": "^0.14.0",
+        "@jimp/plugin-contain": "^0.14.0",
+        "@jimp/plugin-cover": "^0.14.0",
+        "@jimp/plugin-crop": "^0.14.0",
+        "@jimp/plugin-displace": "^0.14.0",
+        "@jimp/plugin-dither": "^0.14.0",
+        "@jimp/plugin-fisheye": "^0.14.0",
+        "@jimp/plugin-flip": "^0.14.0",
+        "@jimp/plugin-gaussian": "^0.14.0",
+        "@jimp/plugin-invert": "^0.14.0",
+        "@jimp/plugin-mask": "^0.14.0",
+        "@jimp/plugin-normalize": "^0.14.0",
+        "@jimp/plugin-print": "^0.14.0",
+        "@jimp/plugin-resize": "^0.14.0",
+        "@jimp/plugin-rotate": "^0.14.0",
+        "@jimp/plugin-scale": "^0.14.0",
+        "@jimp/plugin-shadow": "^0.14.0",
+        "@jimp/plugin-threshold": "^0.14.0",
+        "timm": "^1.6.1"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-blit": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.14.0.tgz",
+      "integrity": "sha512-YoYOrnVHeX3InfgbJawAU601iTZMwEBZkyqcP1V/S33Qnz9uzH1Uj1NtC6fNgWzvX6I4XbCWwtr4RrGFb5CFrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-blur": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.14.0.tgz",
+      "integrity": "sha512-9WhZcofLrT0hgI7t0chf7iBQZib//0gJh9WcQMUt5+Q1Bk04dWs8vTgLNj61GBqZXgHSPzE4OpCrrLDBG8zlhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-circle": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.14.0.tgz",
+      "integrity": "sha512-o5L+wf6QA44tvTum5HeLyLSc5eVfIUd5ZDVi5iRfO4o6GT/zux9AxuTSkKwnjhsG8bn1dDmywAOQGAx7BjrQVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-color": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.14.0.tgz",
+      "integrity": "sha512-JJz512SAILYV0M5LzBb9sbOm/XEj2fGElMiHAxb7aLI6jx+n0agxtHpfpV/AePTLm1vzzDxx6AJxXbKv355hBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0",
+        "tinycolor2": "^1.4.1"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-contain": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.14.0.tgz",
+      "integrity": "sha512-RX2q233lGyaxiMY6kAgnm9ScmEkNSof0hdlaJAVDS1OgXphGAYAeSIAwzESZN4x3ORaWvkFefeVH9O9/698Evg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5",
+        "@jimp/plugin-blit": ">=0.3.5",
+        "@jimp/plugin-resize": ">=0.3.5",
+        "@jimp/plugin-scale": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-cover": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.14.0.tgz",
+      "integrity": "sha512-0P/5XhzWES4uMdvbi3beUgfvhn4YuQ/ny8ijs5kkYIw6K8mHcl820HahuGpwWMx56DJLHRl1hFhJwo9CeTRJtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5",
+        "@jimp/plugin-crop": ">=0.3.5",
+        "@jimp/plugin-resize": ">=0.3.5",
+        "@jimp/plugin-scale": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-crop": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.14.0.tgz",
+      "integrity": "sha512-Ojtih+XIe6/XSGtpWtbAXBozhCdsDMmy+THUJAGu2x7ZgKrMS0JotN+vN2YC3nwDpYkM+yOJImQeptSfZb2Sug==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-displace": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.14.0.tgz",
+      "integrity": "sha512-c75uQUzMgrHa8vegkgUvgRL/PRvD7paFbFJvzW0Ugs8Wl+CDMGIPYQ3j7IVaQkIS+cAxv+NJ3TIRBQyBrfVEOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-dither": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.14.0.tgz",
+      "integrity": "sha512-g8SJqFLyYexXQQsoh4dc1VP87TwyOgeTElBcxSXX2LaaMZezypmxQfLTzOFzZoK8m39NuaoH21Ou1Ftsq7LzVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-fisheye": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.14.0.tgz",
+      "integrity": "sha512-BFfUZ64EikCaABhCA6mR3bsltWhPpS321jpeIQfJyrILdpFsZ/OccNwCgpW1XlbldDHIoNtXTDGn3E+vCE7vDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-flip": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.14.0.tgz",
+      "integrity": "sha512-WtL1hj6ryqHhApih+9qZQYA6Ye8a4HAmdTzLbYdTMrrrSUgIzFdiZsD0WeDHpgS/+QMsWwF+NFmTZmxNWqKfXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5",
+        "@jimp/plugin-rotate": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-mask": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.14.0.tgz",
+      "integrity": "sha512-tdiGM69OBaKtSPfYSQeflzFhEpoRZ+BvKfDEoivyTjauynbjpRiwB1CaiS8En1INTDwzLXTT0Be9SpI3LkJoEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-print": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.14.0.tgz",
+      "integrity": "sha512-MwP3sH+VS5AhhSTXk7pui+tEJFsxnTKFY3TraFJb8WFbA2Vo2qsRCZseEGwpTLhENB7p/JSsLvWoSSbpmxhFAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0",
+        "load-bmfont": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5",
+        "@jimp/plugin-blit": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-resize": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.14.0.tgz",
+      "integrity": "sha512-qFeMOyXE/Bk6QXN0GQo89+CB2dQcXqoxUcDb2Ah8wdYlKqpi53skABkgVy5pW3EpiprDnzNDboMltdvDslNgLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-rotate": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.14.0.tgz",
+      "integrity": "sha512-aGaicts44bvpTcq5Dtf93/8TZFu5pMo/61lWWnYmwJJU1RqtQlxbCLEQpMyRhKDNSfPbuP8nyGmaqXlM/82J0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5",
+        "@jimp/plugin-blit": ">=0.3.5",
+        "@jimp/plugin-crop": ">=0.3.5",
+        "@jimp/plugin-resize": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugins/node_modules/@jimp/plugin-threshold": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.14.0.tgz",
+      "integrity": "sha512-N4BlDgm/FoOMV/DQM2rSpzsgqAzkP0DXkWZoqaQrlRxQBo4zizQLzhEL00T/YCCMKnddzgEhnByaocgaaa0fKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5",
+        "@jimp/plugin-color": ">=0.8.0",
+        "@jimp/plugin-resize": ">=0.8.0"
+      }
+    },
+    "node_modules/@jimp/plugins/node_modules/@jimp/utils": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
+      "integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "regenerator-runtime": "^0.13.3"
+      }
+    },
+    "node_modules/@jimp/types": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-1.6.0.tgz",
+      "integrity": "sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/utils": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-1.6.0.tgz",
+      "integrity": "sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@joshua.litt/get-ripgrep": {
@@ -3805,6 +4716,12 @@
         "@textlint/ast-node-types": "15.2.2"
       }
     },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -5262,6 +6179,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@xterm/headless": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-5.5.0.tgz",
@@ -5431,6 +6357,98 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-base": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
+      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
+      "license": "MIT"
+    },
+    "node_modules/app-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/app-path/-/app-path-4.0.0.tgz",
+      "integrity": "sha512-mgBO9PZJ3MpbKbwFTljTi36ZKBvG5X/fkVR1F85ANsVcVllEb+C0LGNdJfGUm84GpC4xxgN6HFkmkMU8VEO4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/app-path/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/app-path/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/app-path/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/app-path/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/app-path/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/app-path/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -5464,13 +6482,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/array-includes": {
       "version": "3.1.9",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
@@ -5493,6 +6504,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/array-range": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-range/-/array-range-1.0.1.tgz",
+      "integrity": "sha512-shdaI1zT3CVNL2hnx9c0JMc0ZogGaxDs5e85akgHWKYa0yVbIyp06Ind3dVkTj/uuFrzaHBOyqFzo+VV6aXgtA==",
+      "license": "MIT"
     },
     "node_modules/array-timsort": {
       "version": "1.0.3",
@@ -5736,6 +6753,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/await-to-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/await-to-js/-/await-to-js-3.0.0.tgz",
+      "integrity": "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/azure-devops-node-api": {
       "version": "12.5.0",
       "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
@@ -5805,6 +6831,18 @@
       "funding": {
         "url": "https://bevry.me/fund"
       }
+    },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT"
+    },
+    "node_modules/bmp-ts": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bmp-ts/-/bmp-ts-1.0.9.tgz",
+      "integrity": "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -5884,6 +6922,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -5891,6 +6953,15 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/buffer-equal": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -6024,6 +7095,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/centra": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/centra/-/centra-2.7.0.tgz",
+      "integrity": "sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6"
       }
     },
     "node_modules/chai": {
@@ -6570,7 +7650,6 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
       "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -6604,6 +7683,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6777,6 +7857,18 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/cycled": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cycled/-/cycled-1.2.0.tgz",
+      "integrity": "sha512-/BOOCEohSBflVHHtY/wUc1F6YDYPqyVs/A837gDoq4H1pm72nU/yChyGt91V4ML+MbbAmHs8uo2l1yJkkTIUdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -6855,6 +7947,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-gif": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/decode-gif/-/decode-gif-1.0.1.tgz",
+      "integrity": "sha512-L0MT527mwlkil9TiN1xwnJXzUxCup55bUT91CPmQlc9zYejXJ8xp17d5EVnwM80JOIGImBUk1ptJQ+hDihyzwg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-range": "^1.0.1",
+        "omggif": "^1.0.10"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/decompress-response": {
@@ -7001,6 +8106,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delay": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.4.1.tgz",
+      "integrity": "sha512-aL3AhqtfhOlT/3ai6sWXeqwnw63ATNpnUiN4HL7x9q+My5QtHlO3OIkasmug9LKzpheLdmUKGRKnYXYAS7FQkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delayed-stream": {
@@ -7347,6 +8464,11 @@
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
+    },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "node_modules/domelementtype": {
       "version": "2.3.0",
@@ -8408,6 +9530,15 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -8466,6 +9597,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/exif-parser": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
+      "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
     },
     "node_modules/expand-tilde": {
       "version": "2.0.2",
@@ -8555,7 +9691,6 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8565,7 +9700,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -8575,7 +9709,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -8804,6 +9937,23 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-type": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -8839,7 +9989,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -8848,15 +9997,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/finalhandler/node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -8932,6 +10079,26 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -9302,6 +10469,16 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/gifwrap": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.10.1.tgz",
+      "integrity": "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==",
+      "license": "MIT",
+      "dependencies": {
+        "image-q": "^4.0.0",
+        "omggif": "^1.0.10"
+      }
+    },
     "node_modules/glob": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-12.0.0.tgz",
@@ -9389,6 +10566,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "license": "MIT",
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
       }
     },
     "node_modules/global-modules": {
@@ -10029,6 +11216,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -10038,6 +11245,36 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/image-dimensions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/image-dimensions/-/image-dimensions-2.5.0.tgz",
+      "integrity": "sha512-CKZPHjAEtSg9lBV9eER0bhNn/yrY7cFEQEhkwjLhqLY+Na8lcP1pEyWsaGMGc8t2qbKWA/tuqbhFQpOKGN72Yw==",
+      "license": "MIT",
+      "bin": {
+        "image-dimensions": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/image-q": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
+      "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "16.9.1"
+      }
+    },
+    "node_modules/image-q/node_modules/@types/node": {
+      "version": "16.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -10484,6 +11721,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
+      "license": "MIT"
     },
     "node_modules/is-generator-function": {
       "version": "1.1.0",
@@ -10971,6 +12214,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/iterm2-version": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/iterm2-version/-/iterm2-version-5.0.0.tgz",
+      "integrity": "sha512-WdLXcMYvN3SXT6vEtuW78vnZs4pVWm2nBnb4VKjOPPXmdlR1xTHmBgqKacOzAe4RXOiY/V+0u/0zsU3LoGQoBg==",
+      "license": "MIT",
+      "dependencies": {
+        "app-path": "^4.0.0",
+        "plist": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
@@ -10986,6 +12245,44 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/jimp": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.0.tgz",
+      "integrity": "sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/diff": "1.6.0",
+        "@jimp/js-bmp": "1.6.0",
+        "@jimp/js-gif": "1.6.0",
+        "@jimp/js-jpeg": "1.6.0",
+        "@jimp/js-png": "1.6.0",
+        "@jimp/js-tiff": "1.6.0",
+        "@jimp/plugin-blit": "1.6.0",
+        "@jimp/plugin-blur": "1.6.0",
+        "@jimp/plugin-circle": "1.6.0",
+        "@jimp/plugin-color": "1.6.0",
+        "@jimp/plugin-contain": "1.6.0",
+        "@jimp/plugin-cover": "1.6.0",
+        "@jimp/plugin-crop": "1.6.0",
+        "@jimp/plugin-displace": "1.6.0",
+        "@jimp/plugin-dither": "1.6.0",
+        "@jimp/plugin-fisheye": "1.6.0",
+        "@jimp/plugin-flip": "1.6.0",
+        "@jimp/plugin-hash": "1.6.0",
+        "@jimp/plugin-mask": "1.6.0",
+        "@jimp/plugin-print": "1.6.0",
+        "@jimp/plugin-quantize": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/plugin-rotate": "1.6.0",
+        "@jimp/plugin-threshold": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/jose": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
@@ -10994,6 +12291,12 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",
@@ -11464,6 +12767,47 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/load-bmfont": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.2.tgz",
+      "integrity": "sha512-qElWkmjW9Oq1F9EI5Gt7aD9zcdHb9spJCW1L/dmPf7KzCCEJxq8nhHz5eCgI9aMf7vrG/wyaCqdsI+Iy9ZTlog==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal": "0.0.1",
+        "mime": "^1.3.4",
+        "parse-bmfont-ascii": "^1.0.3",
+        "parse-bmfont-binary": "^1.0.5",
+        "parse-bmfont-xml": "^1.1.4",
+        "phin": "^3.7.1",
+        "xhr": "^2.0.1",
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/load-bmfont/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-bmfont/node_modules/phin": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/phin/-/phin-3.7.1.tgz",
+      "integrity": "sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "dependencies": {
+        "centra": "^2.7.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -11590,7 +12934,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
       "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^7.0.0",
@@ -11610,7 +12953,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
       "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^5.0.0"
@@ -11626,7 +12968,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
       "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-function": "^5.0.0"
@@ -11642,7 +12983,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
       "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "onetime": "^7.0.0",
@@ -11870,6 +13210,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -11954,7 +13300,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
       "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -11973,6 +13318,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-document": {
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.2.tgz",
+      "integrity": "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==",
+      "license": "MIT",
+      "dependencies": {
+        "dom-walk": "^0.1.0"
       }
     },
     "node_modules/minimatch": {
@@ -12849,6 +14203,12 @@
       "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
       "license": "MIT"
     },
+    "node_modules/omggif": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -13047,6 +14407,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -13059,6 +14425,34 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-bmfont-ascii": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
+      "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-bmfont-binary": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
+      "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-bmfont-xml": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
+      "integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-parse-from-string": "^1.0.0",
+        "xml2js": "^0.5.0"
+      }
+    },
+    "node_modules/parse-headers": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
+      "license": "MIT"
     },
     "node_modules/parse-json": {
       "version": "8.3.0",
@@ -13305,10 +14699,30 @@
         "url": "https://ko-fi.com/killymxi"
       }
     },
+    "node_modules/peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/phin": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
+      "integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -13353,6 +14767,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/pixelmatch": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
+      "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^6.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/pixelmatch/node_modules/pngjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
@@ -13372,6 +14807,29 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "node_modules/plist": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/plist/node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -13380,6 +14838,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -13459,6 +14926,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/prompts": {
@@ -13931,6 +15407,38 @@
         "node": ">= 6"
       }
     },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
+      "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -13966,6 +15474,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -14013,6 +15527,151 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/render-gif": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/render-gif/-/render-gif-2.0.4.tgz",
+      "integrity": "sha512-l5X7EwbEvdflnvVAzjL7njizwZN8ATqJ0rdaQ5WwMJ55vyWXIXIUE9Ut7W6hm+KE+HMYn5C0a+7t0B6JjGfxQA==",
+      "license": "MIT",
+      "dependencies": {
+        "cycled": "^1.2.0",
+        "decode-gif": "^1.0.1",
+        "delay": "^4.3.0",
+        "jimp": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/render-gif/node_modules/@jimp/types": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.14.0.tgz",
+      "integrity": "sha512-hx3cXAW1KZm+b+XCrY3LXtdWy2U+hNtq0rPyJ7NuXCjU7lZR3vIkpz1DLJ3yDdS70hTi5QDXY3Cd9kd6DtloHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/bmp": "^0.14.0",
+        "@jimp/gif": "^0.14.0",
+        "@jimp/jpeg": "^0.14.0",
+        "@jimp/png": "^0.14.0",
+        "@jimp/tiff": "^0.14.0",
+        "timm": "^1.6.1"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/render-gif/node_modules/@jimp/types/node_modules/@jimp/bmp": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.14.0.tgz",
+      "integrity": "sha512-5RkX6tSS7K3K3xNEb2ygPuvyL9whjanhoaB/WmmXlJS6ub4DjTqrapu8j4qnIWmO4YYtFeTbDTXV6v9P1yMA5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0",
+        "bmp-js": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/render-gif/node_modules/@jimp/types/node_modules/@jimp/gif": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.14.0.tgz",
+      "integrity": "sha512-DHjoOSfCaCz72+oGGEh8qH0zE6pUBaBxPxxmpYJjkNyDZP7RkbBkZJScIYeQ7BmJxmGN4/dZn+MxamoQlr+UYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0",
+        "gifwrap": "^0.9.2",
+        "omggif": "^1.0.9"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/render-gif/node_modules/@jimp/types/node_modules/@jimp/jpeg": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.14.0.tgz",
+      "integrity": "sha512-561neGbr+87S/YVQYnZSTyjWTHBm9F6F1obYHiyU3wVmF+1CLbxY3FQzt4YolwyQHIBv36Bo0PY2KkkU8BEeeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0",
+        "jpeg-js": "^0.4.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/render-gif/node_modules/@jimp/types/node_modules/@jimp/png": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.14.0.tgz",
+      "integrity": "sha512-0RV/mEIDOrPCcNfXSPmPBqqSZYwGADNRVUTyMt47RuZh7sugbYdv/uvKmQSiqRdR0L1sfbCBMWUEa5G/8MSbdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.14.0",
+        "pngjs": "^3.3.3"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/render-gif/node_modules/@jimp/types/node_modules/@jimp/tiff": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.14.0.tgz",
+      "integrity": "sha512-zBYDTlutc7j88G/7FBCn3kmQwWr0rmm1e0FKB4C3uJ5oYfT8645lftUsvosKVUEfkdmOaMAnhrf4ekaHcb5gQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "utif": "^2.0.1"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/render-gif/node_modules/@jimp/utils": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
+      "integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "regenerator-runtime": "^0.13.3"
+      }
+    },
+    "node_modules/render-gif/node_modules/gifwrap": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.4.tgz",
+      "integrity": "sha512-MDMwbhASQuVeD4JKd1fKgNgCRL3fGqMM4WaqpNhWO0JiMOAjbQdumbs4BbBZEy9/M00EHEjKN3HieVhCUlwjeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "image-q": "^4.0.0",
+        "omggif": "^1.0.10"
+      }
+    },
+    "node_modules/render-gif/node_modules/jimp": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.14.0.tgz",
+      "integrity": "sha512-8BXU+J8+SPmwwyq9ELihpSV4dWPTiOKBWCEgtkbnxxAVMjXdf3yGmyaLSshBfXc8sP/JQ9OZj5R8nZzz2wPXgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/custom": "^0.14.0",
+        "@jimp/plugins": "^0.14.0",
+        "@jimp/types": "^0.14.0",
+        "regenerator-runtime": "^0.13.3"
+      }
+    },
+    "node_modules/render-gif/node_modules/pngjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/repeat-string": {
@@ -14420,7 +16079,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/scheduler": {
@@ -14734,6 +16392,15 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "license": "MIT"
+    },
+    "node_modules/simple-xml-to-json": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.3.tgz",
+      "integrity": "sha512-kWJDCr9EWtZ+/EYYM5MareWj2cRnZGF93YDNpH4jQiHB+hBIZnfPFSQiVMzZOdk+zXWqTZ/9fTeQNu2DqeiudA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.12.2"
+      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -15222,6 +16889,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/structured-source": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
@@ -15350,6 +17034,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/supports-terminal-graphics": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/supports-terminal-graphics/-/supports-terminal-graphics-0.1.0.tgz",
+      "integrity": "sha512-+KdfozhS0Fw8y5Sghw8kkZNGT8nWYzJ1EzcoIvVjxhl+26TJTs26y02yfBgvc1jh5AS/c8jcI3xtahhR95KRyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/system-architecture": {
@@ -15565,6 +17261,55 @@
         "node": ">= 6"
       }
     },
+    "node_modules/term-img": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/term-img/-/term-img-7.1.0.tgz",
+      "integrity": "sha512-au++khgSDly2KXNhC6BOU3mLi2v+Dk5mChYKDcpB5xYwhlwqYQtj0z59dIqFEmr+w7ndZaNqurHapkGc6/hprQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.1.1",
+        "iterm2-version": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terminal-image": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/terminal-image/-/terminal-image-4.2.0.tgz",
+      "integrity": "sha512-KlK1fgS2AjAg9wmC998ys1uHNXyRb61hgBrSMWK/n+uthMIPejkhYhVcZfQ1ikI99BhiqP6Exr4ISfiNStGdkg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "image-dimensions": "^2.5.0",
+        "jimp": "^1.6.0",
+        "log-update": "^6.1.0",
+        "render-gif": "^2.0.4",
+        "supports-terminal-graphics": "^0.1.0",
+        "term-img": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terminal-image/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/terminal-link": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-4.0.0.tgz",
@@ -15681,6 +17426,12 @@
       "peerDependencies": {
         "tslib": "^2"
       }
+    },
+    "node_modules/timm": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/timm/-/timm-1.7.1.tgz",
+      "integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -15812,6 +17563,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/tree-dump": {
@@ -16280,21 +18048,29 @@
       "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
       "license": "BSD"
     },
+    "node_modules/utif": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/utif/-/utif-2.0.1.tgz",
+      "integrity": "sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.5"
+      }
+    },
+    "node_modules/utif2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
+      "integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.11"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.4.0"
-      }
     },
     "node_modules/uuid": {
       "version": "9.0.1",
@@ -16922,11 +18698,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/xhr": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
+      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
+      "license": "MIT",
+      "dependencies": {
+        "global": "~4.4.0",
+        "is-function": "^1.0.1",
+        "parse-headers": "^2.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/xml-parse-from-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
+      "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
+      "license": "MIT"
+    },
     "node_modules/xml2js": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
       "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
@@ -16940,10 +18733,18 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {
@@ -17226,6 +19027,7 @@
         "strip-ansi": "^7.1.0",
         "strip-json-comments": "^3.1.1",
         "tar": "^7.5.8",
+        "terminal-image": "^4.2.0",
         "tinygradient": "^1.1.5",
         "undici": "^7.10.0",
         "ws": "^8.16.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,6 +64,7 @@
     "strip-ansi": "^7.1.0",
     "strip-json-comments": "^3.1.1",
     "tar": "^7.5.8",
+    "terminal-image": "^4.2.0",
     "tinygradient": "^1.1.5",
     "undici": "^7.10.0",
     "ws": "^8.16.0",

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -36,6 +36,7 @@ import { ModelMessage } from './messages/ModelMessage.js';
 import { ThinkingMessage } from './messages/ThinkingMessage.js';
 import { HintMessage } from './messages/HintMessage.js';
 import { getInlineThinkingMode } from '../utils/inlineThinkingMode.js';
+import { MediaVisualizer } from './MediaVisualizer.js';
 import { useSettings } from '../contexts/SettingsContext.js';
 
 interface HistoryItemDisplayProps {
@@ -216,6 +217,13 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
       )}
       {itemForDisplay.type === 'chat_list' && (
         <ChatList chats={itemForDisplay.chats} />
+      )}
+      {itemForDisplay.type === 'media' && (
+        <MediaVisualizer
+          imagePath={itemForDisplay.imagePath}
+          imageBuffer={itemForDisplay.imageBuffer}
+          width={terminalWidth}
+        />
       )}
     </Box>
   );

--- a/packages/cli/src/ui/components/MediaVisualizer.test.tsx
+++ b/packages/cli/src/ui/components/MediaVisualizer.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act } from 'react';
+import { renderWithProviders } from '../../test-utils/render.js';
+import { MediaVisualizer } from './MediaVisualizer.js';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import terminalImage from 'terminal-image';
+
+vi.mock('terminal-image', () => ({
+  default: {
+    buffer: vi.fn() as unknown as typeof terminalImage.buffer,
+    file: vi.fn() as unknown as typeof terminalImage.file,
+  },
+}));
+
+describe('MediaVisualizer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders loading state initially', async () => {
+    // Mock to never resolve
+    (terminalImage.file as Mock).mockReturnValue(new Promise(() => {}));
+
+    const { lastFrame, unmount, waitUntilReady } = renderWithProviders(
+      <MediaVisualizer imagePath="test.png" />,
+    );
+
+    await waitUntilReady();
+
+    expect(lastFrame()).toContain('Loading image...');
+    unmount();
+  });
+
+  it('renders rendered content from file', async () => {
+    let resolveImage!: (val: string) => void;
+    const promise = new Promise<string>((resolve) => {
+      resolveImage = resolve;
+    });
+    (terminalImage.file as Mock).mockReturnValue(promise);
+
+    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
+      <MediaVisualizer imagePath="test.png" />,
+    );
+
+    await waitUntilReady();
+    expect(lastFrame()).toContain('Loading image...');
+
+    await act(async () => {
+      resolveImage('MOCK_ANSI_IMAGE');
+    });
+
+    await waitUntilReady();
+
+    expect(lastFrame()).toContain('MOCK_ANSI_IMAGE');
+    expect(terminalImage.file).toHaveBeenCalledWith('test.png', {
+      width: undefined,
+      height: undefined,
+      preserveAspectRatio: true,
+    });
+    unmount();
+  });
+
+  it('renders rendered content from buffer', async () => {
+    let resolveImage!: (val: string) => void;
+    const promise = new Promise<string>((resolve) => {
+      resolveImage = resolve;
+    });
+    (terminalImage.buffer as Mock).mockReturnValue(promise);
+    const mockBuffer = Buffer.from('fake-image-data');
+
+    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
+      <MediaVisualizer imageBuffer={mockBuffer} />,
+    );
+
+    await waitUntilReady();
+
+    await act(async () => {
+      resolveImage('MOCK_ANSI_BUFFER');
+    });
+
+    await waitUntilReady();
+
+    expect(lastFrame()).toContain('MOCK_ANSI_BUFFER');
+    expect(terminalImage.buffer).toHaveBeenCalledWith(mockBuffer, {
+      width: undefined,
+      height: undefined,
+      preserveAspectRatio: true,
+    });
+    unmount();
+  });
+
+  it('renders error message on failure', async () => {
+    let rejectImage!: (err: Error) => void;
+    const promise = new Promise<string>((_, reject) => {
+      rejectImage = reject;
+    });
+    (terminalImage.file as Mock).mockReturnValue(promise);
+
+    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
+      <MediaVisualizer imagePath="error.png" />,
+    );
+
+    await waitUntilReady();
+
+    await act(async () => {
+      rejectImage(new Error('Failed to load'));
+    });
+
+    await waitUntilReady();
+
+    expect(lastFrame()).toContain('[Image Render Error: Failed to load]');
+    unmount();
+  });
+});

--- a/packages/cli/src/ui/components/MediaVisualizer.test.tsx
+++ b/packages/cli/src/ui/components/MediaVisualizer.test.tsx
@@ -16,6 +16,24 @@ vi.mock('terminal-image', () => ({
     file: vi.fn() as unknown as typeof terminalImage.file,
   },
 }));
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      stat: vi.fn().mockResolvedValue({ isFile: () => true }),
+    },
+  };
+});
+
+vi.mock('node:path', async (importOriginal) => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    resolve: vi.fn((p: string) => `/mocked/path/to/${p}`),
+  };
+});
 
 describe('MediaVisualizer', () => {
   beforeEach(() => {
@@ -24,7 +42,7 @@ describe('MediaVisualizer', () => {
 
   it('renders loading state initially', async () => {
     // Mock to never resolve
-    (terminalImage.file as Mock).mockReturnValue(new Promise(() => {}));
+    (terminalImage.file as Mock).mockReturnValue(new Promise(() => { }));
 
     const { lastFrame, unmount, waitUntilReady } = renderWithProviders(
       <MediaVisualizer imagePath="test.png" />,
@@ -57,11 +75,14 @@ describe('MediaVisualizer', () => {
     await waitUntilReady();
 
     expect(lastFrame()).toContain('MOCK_ANSI_IMAGE');
-    expect(terminalImage.file).toHaveBeenCalledWith('test.png', {
-      width: undefined,
-      height: undefined,
-      preserveAspectRatio: true,
-    });
+    expect(terminalImage.file).toHaveBeenCalledWith(
+      '/mocked/path/to/test.png',
+      {
+        width: undefined,
+        height: undefined,
+        preserveAspectRatio: true,
+      },
+    );
     unmount();
   });
 

--- a/packages/cli/src/ui/components/MediaVisualizer.tsx
+++ b/packages/cli/src/ui/components/MediaVisualizer.tsx
@@ -57,7 +57,22 @@ export const MediaVisualizer: React.FC<MediaVisualizerProps> = ({
         if (imageBuffer) {
           result = await terminalImage.buffer(imageBuffer, options);
         } else if (imagePath) {
-          result = await terminalImage.file(imagePath, options);
+          // LFI / Path Traversal Remediation
+          const { promises: fs } = await import('node:fs');
+          const path = await import('node:path');
+
+          let resolvedPath: string;
+          try {
+            resolvedPath = path.resolve(imagePath);
+            const stats = await fs.stat(resolvedPath);
+            if (!stats.isFile()) {
+              throw new Error('Not a direct file');
+            }
+          } catch (e) {
+            throw new Error(`Invalid or inaccessible image path: ${imagePath}`);
+          }
+
+          result = await terminalImage.file(resolvedPath, options);
         } else {
           return;
         }

--- a/packages/cli/src/ui/components/MediaVisualizer.tsx
+++ b/packages/cli/src/ui/components/MediaVisualizer.tsx
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { useEffect, useState } from 'react';
+import { Box, Text } from 'ink';
+import terminalImage from 'terminal-image';
+
+export interface MediaVisualizerProps {
+  /**
+   * Absolute or relative path to the image file.
+   */
+  imagePath?: string;
+  /**
+   * Image buffer (optional, takes precedence over imagePath).
+   */
+  imageBuffer?: Buffer;
+  /**
+   * Width of the rendered image. Defaults to standard terminal-image sizing.
+   */
+  width?: string | number;
+  /**
+   * Height of the rendered image.
+   */
+  height?: string | number;
+  /**
+   * If true, tries to maintain aspect ratio (default: true for terminal-image)
+   */
+  preserveAspectRatio?: boolean;
+}
+
+/**
+ * A fallback universal media visualizer that renders image content
+ * as ANSI block characters in the terminal using terminal-image.
+ */
+export const MediaVisualizer: React.FC<MediaVisualizerProps> = ({
+  imagePath,
+  imageBuffer,
+  width,
+  height,
+  preserveAspectRatio = true,
+}) => {
+  const [renderedContent, setRenderedContent] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    const renderImage = async () => {
+      try {
+        const options = { width, height, preserveAspectRatio };
+        let result = '';
+
+        if (imageBuffer) {
+          result = await terminalImage.buffer(imageBuffer, options);
+        } else if (imagePath) {
+          result = await terminalImage.file(imagePath, options);
+        } else {
+          return;
+        }
+
+        if (!isCancelled) {
+          setRenderedContent(result);
+          setError(null);
+        }
+      } catch (err: unknown) {
+        if (!isCancelled) {
+          const message = err instanceof Error ? err.message : String(err);
+          setError(`[Image Render Error: ${message}]`);
+        }
+      }
+    };
+
+    void renderImage();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [imagePath, imageBuffer, width, height, preserveAspectRatio]);
+
+  if (error) {
+    return (
+      <Box>
+        <Text color="red">{error}</Text>
+      </Box>
+    );
+  }
+
+  if (!renderedContent) {
+    return (
+      <Box>
+        <Text dimColor>Loading image...</Text>
+      </Box>
+    );
+  }
+
+  // terminal-image outputs VT100/ANSI color blocks
+  return (
+    <Box flexDirection="column">
+      <Text>{renderedContent}</Text>
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/__snapshots__/ConfigInitDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ConfigInitDisplay.test.tsx.snap
@@ -23,3 +23,9 @@ exports[`ConfigInitDisplay > updates message on McpClientUpdate event 1`] = `
 Spinner Connecting to MCP servers... (1/2) - Waiting for: server2
 "
 `;
+
+exports[`ConfigInitDisplay > updates message on McpClientUpdate event 2`] = `
+"
+Spinner Connecting to MCP servers... (1/2) - Waiting for: server2
+"
+`;

--- a/packages/cli/src/ui/components/__snapshots__/ConfigInitDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ConfigInitDisplay.test.tsx.snap
@@ -23,9 +23,3 @@ exports[`ConfigInitDisplay > updates message on McpClientUpdate event 1`] = `
 Spinner Connecting to MCP servers... (1/2) - Waiting for: server2
 "
 `;
-
-exports[`ConfigInitDisplay > updates message on McpClientUpdate event 2`] = `
-"
-Spinner Connecting to MCP servers... (1/2) - Waiting for: server2
-"
-`;

--- a/packages/cli/src/ui/components/messages/UserMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/UserMessage.test.tsx
@@ -4,14 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { type ReactElement } from 'react';
 import { renderWithProviders } from '../../../test-utils/render.js';
 import { UserMessage } from './UserMessage.js';
 import { describe, it, expect, vi } from 'vitest';
+import { MediaVisualizer } from '../MediaVisualizer.js';
 
 // Mock the commandUtils to control isSlashCommand behavior
 vi.mock('../../utils/commandUtils.js', () => ({
   isSlashCommand: vi.fn((text: string) => text.startsWith('/')),
 }));
+
+// Mock MediaVisualizer to avoid running actual terminal-image in tests
+vi.mock('../MediaVisualizer.js');
+vi.mocked(MediaVisualizer).mockReturnValue(null as unknown as ReactElement);
 
 describe('UserMessage', () => {
   it('renders normal user message with correct prefix', async () => {

--- a/packages/cli/src/ui/components/messages/UserMessage.tsx
+++ b/packages/cli/src/ui/components/messages/UserMessage.tsx
@@ -43,7 +43,8 @@ export const UserMessage: FC<UserMessageProps> = ({ text, width }) => {
           const withoutAt = t.logicalText.startsWith('@')
             ? t.logicalText.slice(1)
             : t.logicalText;
-          paths.add(unescapePath(withoutAt));
+          const candidatePath = unescapePath(withoutAt);
+          paths.add(candidatePath);
         }
       }
       // We pass a cursor position of [-1, -1] so that no transformations are expanded (e.g. images remain collapsed)

--- a/packages/cli/src/ui/components/messages/UserMessage.tsx
+++ b/packages/cli/src/ui/components/messages/UserMessage.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type React from 'react';
+import type { FC } from 'react';
 import { useMemo } from 'react';
 import { Text, Box } from 'ink';
 import { theme } from '../../semantic-colors.js';
@@ -14,6 +14,8 @@ import {
   calculateTransformationsForLine,
   calculateTransformedLine,
 } from '../shared/text-buffer.js';
+import { unescapePath } from '@google/gemini-cli-core';
+import { MediaVisualizer } from '../MediaVisualizer.js';
 import { HalfLinePaddedBox } from '../shared/HalfLinePaddedBox.js';
 import { useConfig } from '../../contexts/ConfigContext.js';
 
@@ -22,7 +24,7 @@ interface UserMessageProps {
   width: number;
 }
 
-export const UserMessage: React.FC<UserMessageProps> = ({ text, width }) => {
+export const UserMessage: FC<UserMessageProps> = ({ text, width }) => {
   const prefix = '> ';
   const prefixWidth = prefix.length;
   const isSlashCommand = checkIsSlashCommand(text);
@@ -31,22 +33,32 @@ export const UserMessage: React.FC<UserMessageProps> = ({ text, width }) => {
 
   const textColor = isSlashCommand ? theme.text.accent : theme.text.secondary;
 
-  const displayText = useMemo(() => {
-    if (!text) return text;
-    return text
-      .split('\n')
-      .map((line) => {
-        const transformations = calculateTransformationsForLine(line);
-        // We pass a cursor position of [-1, -1] so that no transformations are expanded (e.g. images remain collapsed)
-        const { transformedLine } = calculateTransformedLine(
-          line,
-          0, // line index doesn't matter since cursor is [-1, -1]
-          [-1, -1],
-          transformations,
-        );
-        return transformedLine;
-      })
-      .join('\n');
+  const { displayText, imagePaths } = useMemo(() => {
+    if (!text) return { displayText: text, imagePaths: [] };
+    const paths = new Set<string>();
+    const displayLines = text.split('\n').map((line) => {
+      const transformations = calculateTransformationsForLine(line);
+      for (const t of transformations) {
+        if (t.type === 'image') {
+          const withoutAt = t.logicalText.startsWith('@')
+            ? t.logicalText.slice(1)
+            : t.logicalText;
+          paths.add(unescapePath(withoutAt));
+        }
+      }
+      // We pass a cursor position of [-1, -1] so that no transformations are expanded (e.g. images remain collapsed)
+      const { transformedLine } = calculateTransformedLine(
+        line,
+        0, // line index doesn't matter since cursor is [-1, -1]
+        [-1, -1],
+        transformations,
+      );
+      return transformedLine;
+    });
+    return {
+      displayText: displayLines.join('\n'),
+      imagePaths: Array.from(paths),
+    };
   }, [text]);
 
   return (
@@ -71,10 +83,19 @@ export const UserMessage: React.FC<UserMessageProps> = ({ text, width }) => {
             {prefix}
           </Text>
         </Box>
-        <Box flexGrow={1}>
+        <Box flexGrow={1} flexDirection="column">
           <Text wrap="wrap" color={textColor}>
             {displayText}
           </Text>
+          {imagePaths.length > 0 && (
+            <Box flexDirection="column" marginTop={1}>
+              {imagePaths.map((imagePath, index) => (
+                <Box key={imagePath + index} marginBottom={1}>
+                  <MediaVisualizer imagePath={imagePath} />
+                </Box>
+              ))}
+            </Box>
+          )}
         </Box>
       </Box>
     </HalfLinePaddedBox>

--- a/packages/cli/src/ui/components/messages/__snapshots__/UserMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/UserMessage.test.tsx.snap
@@ -25,6 +25,8 @@ exports[`UserMessage > renders slash command message 1`] = `
 exports[`UserMessage > transforms image paths in user message 1`] = `
 "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
  > Check out this image: [Image my-image.png]                                   
+                                                                                
+                                                                                
 ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
 "
 `;

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -378,7 +378,14 @@ export type HistoryItemWithoutId =
   | HistoryItemMcpStatus
   | HistoryItemChatList
   | HistoryItemThinking
-  | HistoryItemHint;
+  | HistoryItemHint
+  | HistoryItemMedia;
+
+export type HistoryItemMedia = HistoryItemBase & {
+  type: 'media';
+  imagePath?: string;
+  imageBuffer?: Buffer;
+};
 
 export type HistoryItem = HistoryItemWithoutId & { id: number };
 

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -12,9 +12,6 @@ import { TableRenderer } from './TableRenderer.js';
 import { RenderInline } from './InlineMarkdownRenderer.js';
 import { useSettings } from '../contexts/SettingsContext.js';
 import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
-import { unescapePath } from '@google/gemini-cli-core';
-import { MediaVisualizer } from '../components/MediaVisualizer.js';
-import { calculateTransformationsForLine } from '../components/shared/text-buffer.js';
 
 interface MarkdownDisplayProps {
   text: string;
@@ -276,32 +273,11 @@ const MarkdownDisplayInternal: FC<MarkdownDisplayProps> = ({
           lastLineEmpty = true;
         }
       } else {
-        const transformations = calculateTransformationsForLine(line);
-        const imagePathsSet = new Set<string>();
-        for (const t of transformations) {
-          if (t.type === 'image') {
-            const withoutAt = t.logicalText.startsWith('@')
-              ? t.logicalText.slice(1)
-              : t.logicalText;
-            imagePathsSet.add(unescapePath(withoutAt));
-          }
-        }
-        const imagePaths = Array.from(imagePathsSet);
-
         addContentBlock(
           <Box key={key} flexDirection="column">
             <Text wrap="wrap" color={responseColor}>
               <RenderInline text={line} defaultColor={responseColor} />
             </Text>
-            {imagePaths.length > 0 && (
-              <Box flexDirection="column" marginTop={1}>
-                {imagePaths.map((path, idx) => (
-                  <Box key={`${path}-${idx}`} marginBottom={1}>
-                    <MediaVisualizer imagePath={path} />
-                  </Box>
-                ))}
-              </Box>
-            )}
           </Box>,
         );
       }

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import { type FC, memo, type ReactNode } from 'react';
 import { Text, Box } from 'ink';
 import { theme } from '../semantic-colors.js';
 import { colorizeCode } from './CodeColorizer.js';
@@ -12,6 +12,9 @@ import { TableRenderer } from './TableRenderer.js';
 import { RenderInline } from './InlineMarkdownRenderer.js';
 import { useSettings } from '../contexts/SettingsContext.js';
 import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
+import { unescapePath } from '@google/gemini-cli-core';
+import { MediaVisualizer } from '../components/MediaVisualizer.js';
+import { calculateTransformationsForLine } from '../components/shared/text-buffer.js';
 
 interface MarkdownDisplayProps {
   text: string;
@@ -28,7 +31,7 @@ const CODE_BLOCK_PREFIX_PADDING = 1;
 const LIST_ITEM_PREFIX_PADDING = 1;
 const LIST_ITEM_TEXT_FLEX_GROW = 1;
 
-const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
+const MarkdownDisplayInternal: FC<MarkdownDisplayProps> = ({
   text,
   isPending,
   availableTerminalHeight,
@@ -68,7 +71,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   const tableRowRegex = /^\s*\|(.+)\|\s*$/;
   const tableSeparatorRegex = /^\s*\|?\s*(:?-+:?)\s*(\|\s*(:?-+:?)\s*)+\|?\s*$/;
 
-  const contentBlocks: React.ReactNode[] = [];
+  const contentBlocks: ReactNode[] = [];
   let inCodeBlock = false;
   let lastLineEmpty = true;
   let codeBlockContent: string[] = [];
@@ -196,7 +199,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
     } else if (headerMatch) {
       const level = headerMatch[1].length;
       const headerText = headerMatch[2];
-      let headerNode: React.ReactNode = null;
+      let headerNode: ReactNode = null;
       switch (level) {
         case 1:
           headerNode = (
@@ -273,11 +276,32 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
           lastLineEmpty = true;
         }
       } else {
+        const transformations = calculateTransformationsForLine(line);
+        const imagePathsSet = new Set<string>();
+        for (const t of transformations) {
+          if (t.type === 'image') {
+            const withoutAt = t.logicalText.startsWith('@')
+              ? t.logicalText.slice(1)
+              : t.logicalText;
+            imagePathsSet.add(unescapePath(withoutAt));
+          }
+        }
+        const imagePaths = Array.from(imagePathsSet);
+
         addContentBlock(
-          <Box key={key}>
+          <Box key={key} flexDirection="column">
             <Text wrap="wrap" color={responseColor}>
               <RenderInline text={line} defaultColor={responseColor} />
             </Text>
+            {imagePaths.length > 0 && (
+              <Box flexDirection="column" marginTop={1}>
+                {imagePaths.map((path, idx) => (
+                  <Box key={`${path}-${idx}`} marginBottom={1}>
+                    <MediaVisualizer imagePath={path} />
+                  </Box>
+                ))}
+              </Box>
+            )}
           </Box>,
         );
       }
@@ -324,7 +348,7 @@ interface RenderCodeBlockProps {
   terminalWidth: number;
 }
 
-const RenderCodeBlockInternal: React.FC<RenderCodeBlockProps> = ({
+const RenderCodeBlockInternal: FC<RenderCodeBlockProps> = ({
   content,
   lang,
   isPending,
@@ -397,7 +421,7 @@ const RenderCodeBlockInternal: React.FC<RenderCodeBlockProps> = ({
   );
 };
 
-const RenderCodeBlock = React.memo(RenderCodeBlockInternal);
+const RenderCodeBlock = memo(RenderCodeBlockInternal);
 
 interface RenderListItemProps {
   itemText: string;
@@ -406,7 +430,7 @@ interface RenderListItemProps {
   leadingWhitespace?: string;
 }
 
-const RenderListItemInternal: React.FC<RenderListItemProps> = ({
+const RenderListItemInternal: FC<RenderListItemProps> = ({
   itemText,
   type,
   marker,
@@ -434,7 +458,7 @@ const RenderListItemInternal: React.FC<RenderListItemProps> = ({
   );
 };
 
-const RenderListItem = React.memo(RenderListItemInternal);
+const RenderListItem = memo(RenderListItemInternal);
 
 interface RenderTableProps {
   headers: string[];
@@ -442,7 +466,7 @@ interface RenderTableProps {
   terminalWidth: number;
 }
 
-const RenderTableInternal: React.FC<RenderTableProps> = ({
+const RenderTableInternal: FC<RenderTableProps> = ({
   headers,
   rows,
   terminalWidth,
@@ -450,6 +474,6 @@ const RenderTableInternal: React.FC<RenderTableProps> = ({
   <TableRenderer headers={headers} rows={rows} terminalWidth={terminalWidth} />
 );
 
-const RenderTable = React.memo(RenderTableInternal);
+const RenderTable = memo(RenderTableInternal);
 
-export const MarkdownDisplay = React.memo(MarkdownDisplayInternal);
+export const MarkdownDisplay = memo(MarkdownDisplayInternal);

--- a/packages/cli/src/ui/utils/textUtils.ts
+++ b/packages/cli/src/ui/utils/textUtils.ts
@@ -229,6 +229,11 @@ export function escapeAnsiCtrlCodes<T>(obj: T): T {
     return obj;
   }
 
+  // Skip Buffers properly to avoid iterating byte by byte
+  if (Buffer.isBuffer(obj) || obj instanceof Uint8Array) {
+    return obj;
+  }
+
   if (Array.isArray(obj)) {
     let newArr: unknown[] | null = null;
 

--- a/packages/cli/test-setup.ts
+++ b/packages/cli/test-setup.ts
@@ -9,6 +9,15 @@ import { format } from 'node:util';
 import { coreEvents } from '@google/gemini-cli-core';
 import { themeManager } from './src/ui/themes/theme-manager.js';
 
+// Mock terminal-image globally as it can cause test timeouts when UI
+// components that import it are rendered (e.g. AppContainer, AppRig).
+vi.mock('terminal-image', () => ({
+  default: {
+    file: vi.fn().mockResolvedValue('MOCKED_TERMINAL_IMAGE'),
+    buffer: vi.fn().mockResolvedValue('MOCKED_TERMINAL_IMAGE'),
+  },
+}));
+
 // Unset CI environment variable so that ink renders dynamically as it does in a real terminal
 if (process.env.CI !== undefined) {
   delete process.env.CI;

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -731,7 +731,11 @@ describe('ShellExecutionService', () => {
 
       expect(mockPtySpawn).toHaveBeenCalledWith(
         'powershell.exe',
-        ['-NoProfile', '-Command', 'dir "foo bar"'],
+        [
+          '-NoProfile',
+          '-Command',
+          '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; dir "foo bar"',
+        ],
         expect.any(Object),
       );
     });
@@ -1250,7 +1254,11 @@ describe('ShellExecutionService child_process fallback', () => {
 
       expect(mockCpSpawn).toHaveBeenCalledWith(
         'powershell.exe',
-        ['-NoProfile', '-Command', 'dir "foo bar"'],
+        [
+          '-NoProfile',
+          '-Command',
+          '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; dir "foo bar"',
+        ],
         expect.objectContaining({
           shell: false,
           detached: false,

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -15,6 +15,7 @@ import { getCachedEncodingForBuffer } from '../utils/systemEncoding.js';
 import {
   getShellConfiguration,
   resolveExecutable,
+  ensurePowerShellUtf8Encoding,
   type ShellType,
 } from '../utils/shell-utils.js';
 import { isBinary } from '../utils/textUtils.js';
@@ -303,7 +304,8 @@ export class ShellExecutionService {
     try {
       const isWindows = os.platform() === 'win32';
       const { executable, argsPrefix, shell } = getShellConfiguration();
-      const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
+      let guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
+      guardedCommand = ensurePowerShellUtf8Encoding(guardedCommand, shell);
       const spawnArgs = [...argsPrefix, guardedCommand];
 
       const child = cpSpawn(executable, spawnArgs, {
@@ -565,7 +567,8 @@ export class ShellExecutionService {
         );
       }
 
-      const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
+      let guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
+      guardedCommand = ensurePowerShellUtf8Encoding(guardedCommand, shell);
       const args = [...argsPrefix, guardedCommand];
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -22,6 +22,7 @@ import {
   stripShellWrapper,
   hasRedirection,
   resolveExecutable,
+  ensurePowerShellUtf8Encoding,
 } from './shell-utils.js';
 import path from 'node:path';
 
@@ -336,6 +337,32 @@ describe('stripShellWrapper', () => {
 
   it('should not strip anything if no wrapper is present', () => {
     expect(stripShellWrapper('ls -l')).toEqual('ls -l');
+  });
+});
+
+describe('ensurePowerShellUtf8Encoding', () => {
+  const utf8Prefix =
+    '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8;';
+
+  it('should not modify command for non-powershell shells', () => {
+    expect(ensurePowerShellUtf8Encoding('echo "test"', 'bash')).toEqual(
+      'echo "test"',
+    );
+    expect(ensurePowerShellUtf8Encoding('echo "test"', 'cmd')).toEqual(
+      'echo "test"',
+    );
+  });
+
+  it('should prepend utf8 configuration for powershell', () => {
+    expect(ensurePowerShellUtf8Encoding('echo "test"', 'powershell')).toEqual(
+      `${utf8Prefix} echo "test"`,
+    );
+  });
+
+  it('should not double-prepend if already present', () => {
+    expect(
+      ensurePowerShellUtf8Encoding(`${utf8Prefix} echo "test"`, 'powershell'),
+    ).toEqual(`${utf8Prefix} echo "test"`);
   });
 });
 

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -605,6 +605,34 @@ export function escapeShellArg(arg: string, shell: ShellType): string {
 }
 
 /**
+ * For PowerShell, we must explicitly configure the console output encoding to UTF-8
+ * to prevent Node.js from misinterpreting characters emitted by child processes,
+ * especially on Windows systems with different default code pages.
+ *
+ * @param command The command string to execute
+ * @param shell The type of shell being used
+ * @returns The command string, prefixed with the UTF-8 encoding configuration if PowerShell
+ */
+export function ensurePowerShellUtf8Encoding(
+  command: string,
+  shell: ShellType,
+): string {
+  if (shell !== 'powershell') {
+    return command;
+  }
+
+  const utf8Config =
+    '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8;';
+
+  const trimmed = command.trimStart();
+  if (trimmed.startsWith(utf8Config)) {
+    return command;
+  }
+
+  return `${utf8Config} ${command}`;
+}
+
+/**
  * Splits a shell command into a list of individual commands, respecting quotes.
  * This is used to separate chained commands (e.g., using &&, ||, ;).
  * @param command The shell command string to parse


### PR DESCRIPTION
## Summary
This PR introduces the `MediaVisualizer` component to render images directly in the terminal, serving as a fallback for terminals that do not support native image protocols. It processes and displays inline image data from Gemini or file attachments using the `terminal-image` package.
Additionally, this PR fixes a critical performance issue in the `escapeAnsiCtrlCodes` utility. Previously, `escapeAnsiCtrlCodes` would deeply structure-iterate over `Buffer` and `Uint8Array` objects byte-by-byte, locking the UI thread and causing integration tests to timeout when rendering payloads with large `imageBuffer` attached. This has now been skipped for those object types.

## Details
- Created `<MediaVisualizer>` component leveraging `terminal-image` to construct ANSI block outputs.
- Embedded `<MediaVisualizer>` into generic chat interactions (`HistoryItemDisplay`, `MarkdownDisplay`, `UserMessage`).
- Added a global spy mock for `terminal-image` inside `test-setup.ts` to prevent UI tests hanging on unresolved promises.
- Skipped `Buffer` and `Uint8Array` processing in `escapeAnsiCtrlCodes` performance path.

## Related Issues
Closes the "Implementing Media Visualizer" task.

## How to Validate
1. Ask the model to describe an attached image: `What is in <image .png or .jpg>?`
2. You should see an ANSI block visualizer plotting the image in the chat interface.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run

Fixes #21343