### PR TITLE
fix(core): ensure chat compression summary persists across session resumes

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -661,6 +661,7 @@ describe('Gemini Client (client.ts)', () => {
           conversation: mockConversation,
           filePath: mockFilePath,
         },
+        true, // overwriteHistory
       );
     });
   });

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -335,6 +335,7 @@ export class GeminiClient {
   async startChat(
     extraHistory?: Content[],
     resumedSessionData?: ResumedSessionData,
+    overwriteHistory: boolean = false,
   ): Promise<GeminiChat> {
     this.forceFullIdeContext = true;
     this.hasFailedCompressionAttempt = false;
@@ -362,6 +363,8 @@ export class GeminiClient {
             toolRegistry.getFunctionDeclarations(modelId);
           return [{ functionDeclarations: toolDeclarations }];
         },
+        'main',
+        overwriteHistory,
       );
     } catch (error) {
       await reportError(
@@ -1136,7 +1139,7 @@ export class GeminiClient {
           resumedData = { conversation, filePath };
         }
 
-        this.chat = await this.startChat(newHistory, resumedData);
+        this.chat = await this.startChat(newHistory, resumedData, true);
         this.updateTelemetryTokenCount();
         this.forceFullIdeContext = true;
       }

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -255,7 +255,7 @@ export class GeminiChat {
   ) {
     validateHistory(history);
     this.chatRecordingService = new ChatRecordingService(config);
-    this.chatRecordingService.initialize(resumedSessionData, kind);
+    this.chatRecordingService.initialize(resumedSessionData, kind, history);
     this.lastPromptTokenCount = estimateTokenCountSync(
       this.history.flatMap((c) => c.parts || []),
     );

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -252,10 +252,16 @@ export class GeminiChat {
     resumedSessionData?: ResumedSessionData,
     private readonly onModelChanged?: (modelId: string) => Promise<Tool[]>,
     kind: 'main' | 'subagent' = 'main',
+    overwriteHistory: boolean = false,
   ) {
     validateHistory(history);
     this.chatRecordingService = new ChatRecordingService(config);
-    this.chatRecordingService.initialize(resumedSessionData, kind, history);
+    this.chatRecordingService.initialize(
+      resumedSessionData,
+      kind,
+      history,
+      overwriteHistory,
+    );
     this.lastPromptTokenCount = estimateTokenCountSync(
       this.history.flatMap((c) => c.parts || []),
     );

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -122,6 +122,50 @@ describe('ChatRecordingService', () => {
       const conversation = JSON.parse(fs.readFileSync(sessionFile, 'utf8'));
       expect(conversation.sessionId).toBe('old-session-id');
     });
+
+    it('should overwrite existing messages if initialHistory is provided', () => {
+      const chatsDir = path.join(testTempDir, 'chats');
+      fs.mkdirSync(chatsDir, { recursive: true });
+      const sessionFile = path.join(chatsDir, 'session-overwrite.json');
+      const initialData = {
+        sessionId: 'test-session-id',
+        projectHash: 'test-project-hash',
+        messages: [
+          {
+            id: 'msg-1',
+            type: 'user',
+            content: 'Old Message',
+            timestamp: new Date().toISOString(),
+          },
+        ],
+      };
+      fs.writeFileSync(sessionFile, JSON.stringify(initialData));
+
+      const newHistory: Content[] = [
+        {
+          role: 'user',
+          parts: [{ text: 'Compressed Summary' }],
+        },
+      ];
+
+      chatRecordingService.initialize(
+        {
+          filePath: sessionFile,
+          conversation: initialData as ConversationRecord,
+        },
+        'main',
+        newHistory,
+      );
+
+      const conversation = JSON.parse(
+        fs.readFileSync(sessionFile, 'utf8'),
+      ) as ConversationRecord;
+      expect(conversation.messages).toHaveLength(1);
+      expect(conversation.messages[0].content).toEqual([
+        { text: 'Compressed Summary' },
+      ]);
+      expect(conversation.messages[0].type).toBe('user');
+    });
   });
 
   describe('recordMessage', () => {

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -123,7 +123,7 @@ describe('ChatRecordingService', () => {
       expect(conversation.sessionId).toBe('old-session-id');
     });
 
-    it('should overwrite existing messages if initialHistory is provided', () => {
+    it('should overwrite existing messages if overwriteHistory is true', () => {
       const chatsDir = path.join(testTempDir, 'chats');
       fs.mkdirSync(chatsDir, { recursive: true });
       const sessionFile = path.join(chatsDir, 'session-overwrite.json');
@@ -155,6 +155,7 @@ describe('ChatRecordingService', () => {
         },
         'main',
         newHistory,
+        true, // overwriteHistory = true
       );
 
       const conversation = JSON.parse(
@@ -165,6 +166,49 @@ describe('ChatRecordingService', () => {
         { text: 'Compressed Summary' },
       ]);
       expect(conversation.messages[0].type).toBe('user');
+    });
+
+    it('should NOT overwrite existing messages if overwriteHistory is false', () => {
+      const chatsDir = path.join(testTempDir, 'chats');
+      fs.mkdirSync(chatsDir, { recursive: true });
+      const sessionFile = path.join(chatsDir, 'session-no-overwrite.json');
+      const initialData = {
+        sessionId: 'test-session-id',
+        projectHash: 'test-project-hash',
+        messages: [
+          {
+            id: 'msg-1',
+            type: 'user',
+            content: 'Old Message',
+            timestamp: new Date().toISOString(),
+          },
+        ],
+      };
+      fs.writeFileSync(sessionFile, JSON.stringify(initialData));
+
+      const newHistory: Content[] = [
+        {
+          role: 'user',
+          parts: [{ text: 'Some New Context' }],
+        },
+      ];
+
+      chatRecordingService.initialize(
+        {
+          filePath: sessionFile,
+          conversation: initialData as ConversationRecord,
+        },
+        'main',
+        newHistory,
+        false, // overwriteHistory = false
+      );
+
+      const conversation = JSON.parse(
+        fs.readFileSync(sessionFile, 'utf8'),
+      ) as ConversationRecord;
+      expect(conversation.messages).toHaveLength(1);
+      expect(conversation.messages[0].content).toBe('Old Message');
+      expect(conversation.messages[0].id).toBe('msg-1');
     });
   });
 

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -147,10 +147,14 @@ export class ChatRecordingService {
    *
    * @param resumedSessionData Data from a previous session to resume from.
    * @param kind The kind of conversation (main or subagent).
+   * @param initialHistory The starting history for this session. If provided when resuming an
+   * existing session (e.g., after chat compression), this will overwrite the messages currently
+   * stored on disk to ensure the file reflects the new session state.
    */
   initialize(
     resumedSessionData?: ResumedSessionData,
     kind?: 'main' | 'subagent',
+    initialHistory?: Content[],
   ): void {
     try {
       this.kind = kind;
@@ -163,6 +167,10 @@ export class ChatRecordingService {
         // Update the session ID in the existing file
         this.updateConversation((conversation) => {
           conversation.sessionId = this.sessionId;
+          if (initialHistory) {
+            conversation.messages =
+              this.apiContentToMessageRecords(initialHistory);
+          }
         });
 
         // Clear any cached data to force fresh reads
@@ -190,7 +198,7 @@ export class ChatRecordingService {
           projectHash: this.projectHash,
           startTime: new Date().toISOString(),
           lastUpdated: new Date().toISOString(),
-          messages: [],
+          messages: this.apiContentToMessageRecords(initialHistory || []),
           kind: this.kind,
         });
       }
@@ -213,6 +221,24 @@ export class ChatRecordingService {
       debugLogger.error('Error initializing chat recording service:', error);
       throw error;
     }
+  }
+
+  /**
+   * Converts API Content array to storage-compatible MessageRecord array.
+   */
+  private apiContentToMessageRecords(history: Content[]): MessageRecord[] {
+    return history.map((content) => {
+      const type = content.role === 'model' ? 'gemini' : 'user';
+      const record = {
+        id: randomUUID(),
+        timestamp: new Date().toISOString(),
+        type,
+        content: content.parts,
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      return record as MessageRecord;
+    });
   }
 
   private getLastMessage(

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -147,14 +147,16 @@ export class ChatRecordingService {
    *
    * @param resumedSessionData Data from a previous session to resume from.
    * @param kind The kind of conversation (main or subagent).
-   * @param initialHistory The starting history for this session. If provided when resuming an
-   * existing session (e.g., after chat compression), this will overwrite the messages currently
-   * stored on disk to ensure the file reflects the new session state.
+   * @param initialHistory The starting history for this session.
+   * @param overwriteHistory If true and resuming an existing session, the messages on disk will
+   * be overwritten with initialHistory. Use with caution as this destroys original message
+   * IDs and timestamps.
    */
   initialize(
     resumedSessionData?: ResumedSessionData,
     kind?: 'main' | 'subagent',
     initialHistory?: Content[],
+    overwriteHistory: boolean = false,
   ): void {
     try {
       this.kind = kind;
@@ -167,7 +169,7 @@ export class ChatRecordingService {
         // Update the session ID in the existing file
         this.updateConversation((conversation) => {
           conversation.sessionId = this.sessionId;
-          if (initialHistory) {
+          if (overwriteHistory && initialHistory) {
             conversation.messages =
               this.apiContentToMessageRecords(initialHistory);
           }
@@ -225,6 +227,8 @@ export class ChatRecordingService {
 
   /**
    * Converts API Content array to storage-compatible MessageRecord array.
+   * WARNING: Generates new IDs and timestamps. Use only for brand new content
+   * or when explicitly overwriting history (e.g. after compression).
    */
   private apiContentToMessageRecords(history: Content[]): MessageRecord[] {
     return history.map((content): MessageRecord => {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -227,17 +227,22 @@ export class ChatRecordingService {
    * Converts API Content array to storage-compatible MessageRecord array.
    */
   private apiContentToMessageRecords(history: Content[]): MessageRecord[] {
-    return history.map((content) => {
-      const type = content.role === 'model' ? 'gemini' : 'user';
-      const record = {
-        id: randomUUID(),
-        timestamp: new Date().toISOString(),
-        type,
-        content: content.parts,
-      };
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      return record as MessageRecord;
+    return history.map((content): MessageRecord => {
+      if (content.role === 'model') {
+        return {
+          id: randomUUID(),
+          timestamp: new Date().toISOString(),
+          type: 'gemini',
+          content: content.parts || [],
+        };
+      } else {
+        return {
+          id: randomUUID(),
+          timestamp: new Date().toISOString(),
+          type: 'user',
+          content: content.parts || [],
+        };
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

This PR fixes a bug where the `/compress` command's summary was not persistent across session exits and resumes. 

## Details

The issue was that while `/compress` updated the in-memory chat history, it failed to sync this change to the session file on disk during the transition to a new chat session.

Key changes:
- **`ChatRecordingService.initialize`**: Updated to accept an optional `initialHistory` parameter. When provided during session resumption (which happens internally after compression), it overwrites the `messages` array in the session file with the new history.
- **`GeminiChat` Constructor**: Updated to pass its `history` to the `ChatRecordingService.initialize` call, ensuring immediate persistence of the starting history (e.g., the compression summary).
- **`apiContentToMessageRecords`**: Added a private helper in `ChatRecordingService` to convert API `Content` objects into storage-compatible `MessageRecord` objects.
- **Type Safety**: Addressed a lint error regarding an unsafe type assertion in the new helper.

## Related Issues

Fixes #21335

## How to Validate

1. Start a chat with `gemini`.
2. Build up some history with several messages.
3. Run `/compress` and wait for the "Chat history compressed" message.
4. Exit the CLI (`ctrl+d` or `/exit`).
5. Resume the session with `gemini --resume latest`.
6. Verify that the history correctly starts with the **Chat summary**.

Alternatively, run the new unit test:
`npm test -w @google/gemini-cli-core -- src/services/chatRecordingService.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
