### PR TITLE
Fix up telemetry monitoring image paths for website

### DIFF
--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -256,11 +256,11 @@ visualize your telemetry.
 This dashboard can be found under **Google Cloud Monitoring Dashboard
 Templates** as "**Gemini CLI Monitoring**".
 
-![Gemini CLI Monitoring Dashboard Overview](../assets/monitoring-dashboard-overview.png)
+![Gemini CLI Monitoring Dashboard Overview](/assets/monitoring-dashboard-overview.png)
 
-![Gemini CLI Monitoring Dashboard Metrics](../assets/monitoring-dashboard-metrics.png)
+![Gemini CLI Monitoring Dashboard Metrics](/assets/monitoring-dashboard-metrics.png)
 
-![Gemini CLI Monitoring Dashboard Logs](../assets/monitoring-dashboard-logs.png)
+![Gemini CLI Monitoring Dashboard Logs](/assets/monitoring-dashboard-logs.png)
 
 To learn more, check out this blog post:
 [Instant insights: Gemini CLI’s new pre-configured monitoring dashboards](https://cloud.google.com/blog/topics/developers-practitioners/instant-insights-gemini-clis-new-pre-configured-monitoring-dashboards/).

--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -256,11 +256,11 @@ visualize your telemetry.
 This dashboard can be found under **Google Cloud Monitoring Dashboard
 Templates** as "**Gemini CLI Monitoring**".
 
-![Gemini CLI Monitoring Dashboard Overview](/docs/assets/monitoring-dashboard-overview.png)
+![Gemini CLI Monitoring Dashboard Overview](/assets/monitoring-dashboard-overview.png)
 
-![Gemini CLI Monitoring Dashboard Metrics](/docs/assets/monitoring-dashboard-metrics.png)
+![Gemini CLI Monitoring Dashboard Metrics](/assets/monitoring-dashboard-metrics.png)
 
-![Gemini CLI Monitoring Dashboard Logs](/docs/assets/monitoring-dashboard-logs.png)
+![Gemini CLI Monitoring Dashboard Logs](/assets/monitoring-dashboard-logs.png)
 
 To learn more, check out this blog post:
 [Instant insights: Gemini CLI’s new pre-configured monitoring dashboards](https://cloud.google.com/blog/topics/developers-practitioners/instant-insights-gemini-clis-new-pre-configured-monitoring-dashboards/).

--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -256,11 +256,11 @@ visualize your telemetry.
 This dashboard can be found under **Google Cloud Monitoring Dashboard
 Templates** as "**Gemini CLI Monitoring**".
 
-![Gemini CLI Monitoring Dashboard Overview](/assets/monitoring-dashboard-overview.png)
+![Gemini CLI Monitoring Dashboard Overview](../assets/monitoring-dashboard-overview.png)
 
-![Gemini CLI Monitoring Dashboard Metrics](/assets/monitoring-dashboard-metrics.png)
+![Gemini CLI Monitoring Dashboard Metrics](../assets/monitoring-dashboard-metrics.png)
 
-![Gemini CLI Monitoring Dashboard Logs](/assets/monitoring-dashboard-logs.png)
+![Gemini CLI Monitoring Dashboard Logs](../assets/monitoring-dashboard-logs.png)
 
 To learn more, check out this blog post:
 [Instant insights: Gemini CLI’s new pre-configured monitoring dashboards](https://cloud.google.com/blog/topics/developers-practitioners/instant-insights-gemini-clis-new-pre-configured-monitoring-dashboards/).


### PR DESCRIPTION
## Summary

Fix up telemetry monitoring image paths so that they work on the Gemini CLI website.

## Details

Currently, image paths starting with /docs/assets/ work on GitHub but not on the website. This patch prioritizes fixing the images on the site over GitHub. When applied, it'll fix the broken images on the site but cause the images to not show on GitHub. A more comprehensive fix for images is next.

Fixes maintainers-gemini-cli#1505

## How to Validate

Run the site as a local server and check in /docs/cli/telemetry/#monitoring-dashboards

## Pre-Merge Checklist

- [ X ] Noted breaking changes (if any)
