### PR TITLE
fix(cli): avoid event-loop stalls when sanitizing binary payloads

### DIFF
--- a/packages/cli/src/ui/utils/textUtils.test.ts
+++ b/packages/cli/src/ui/utils/textUtils.test.ts
@@ -521,6 +521,28 @@ describe('textUtils', () => {
         expect(sanitized.g).toBe(null);
         expect(sanitized.h()).toBe('\u001b[35mpurple\u001b[0m');
       });
+
+      it('should not recurse into large Uint8Array payloads', () => {
+        const bytes = new Uint8Array(2_000_000);
+        bytes.fill(65);
+        const details = {
+          payload: bytes,
+          title: '\u001b[31mimage\u001b[0m',
+        };
+
+        const sanitized = escapeAnsiCtrlCodes(details);
+
+        expect(sanitized).not.toBe(details);
+        expect(sanitized.payload).toBe(bytes);
+        expect(sanitized.title).toBe('\\u001b[31mimage\\u001b[0m');
+      });
+
+      it('should preserve Buffer payload references', () => {
+        const binary = Buffer.from([0x1b, 0x5b, 0x33, 0x31, 0x6d]);
+        const sanitized = escapeAnsiCtrlCodes({ payload: binary });
+
+        expect(sanitized.payload).toBe(binary);
+      });
     });
   });
 });

--- a/packages/cli/src/ui/utils/textUtils.ts
+++ b/packages/cli/src/ui/utils/textUtils.ts
@@ -229,6 +229,12 @@ export function escapeAnsiCtrlCodes<T>(obj: T): T {
     return obj;
   }
 
+  // Avoid iterating over every byte index for binary payloads (Buffer/Uint8Array),
+  // which can block the event loop for large inlineData blobs.
+  if (obj instanceof Uint8Array) {
+    return obj;
+  }
+
   if (Array.isArray(obj)) {
     let newArr: unknown[] | null = null;
 


### PR DESCRIPTION
## Summary
- short-circuit `escapeAnsiCtrlCodes` for `Uint8Array`/`Buffer` values before recursive traversal
- prevent byte-by-byte object-key traversal on large `inlineData` payloads
- add regression tests to ensure binary payload references are preserved while strings are still sanitized

## Testing
- npm run test --workspace @google/gemini-cli -- src/ui/utils/textUtils.test.ts

Fixes #21343
