### PR TITLE
fix(partUtils): display media type and size for inline data parts

### DIFF
--- a/packages/core/src/utils/partUtils.test.ts
+++ b/packages/core/src/utils/partUtils.test.ts
@@ -123,7 +123,19 @@ describe('partUtils', () => {
 
     it('should return descriptive string for inlineData part', () => {
       const part = { inlineData: { mimeType: 'image/png', data: '' } } as Part;
-      expect(partToString(part, verboseOptions)).toBe('<image/png>');
+      expect(partToString(part, verboseOptions)).toBe(
+        '[Image: image/png, 0.0 KB]',
+      );
+    });
+
+    it('should show size for inlineData with non-empty base64 data', () => {
+      // 4 base64 chars → ceil(4*3/4) = 3 bytes → 3/1024 ≈ 0.0 KB
+      const part = {
+        inlineData: { mimeType: 'audio/mp3', data: 'AAAA' },
+      } as Part;
+      expect(partToString(part, verboseOptions)).toBe(
+        '[Audio: audio/mp3, 0.0 KB]',
+      );
     });
 
     it('should return an empty string for an unknown part type', () => {
@@ -142,7 +154,7 @@ describe('partUtils', () => {
         ],
       ];
       expect(partToString(parts as Part, verboseOptions)).toBe(
-        'start middle[Function Call: func1] end<audio/mp3>',
+        'start middle[Function Call: func1] end[Audio: audio/mp3, 0.0 KB]',
       );
     });
   });

--- a/packages/core/src/utils/partUtils.ts
+++ b/packages/core/src/utils/partUtils.ts
@@ -63,7 +63,18 @@ export function partToString(
       return `[Function Response: ${part.functionResponse.name}]`;
     }
     if (part.inlineData !== undefined) {
-      return `<${part.inlineData.mimeType}>`;
+      const mimeType = part.inlineData.mimeType ?? 'unknown';
+      const data = part.inlineData.data ?? '';
+      const bytes = Math.ceil((data.length * 3) / 4);
+      const kb = (bytes / 1024).toFixed(1);
+      const category = mimeType.startsWith('audio/')
+        ? 'Audio'
+        : mimeType.startsWith('video/')
+          ? 'Video'
+          : mimeType.startsWith('image/')
+            ? 'Image'
+            : 'Media';
+      return `[${category}: ${mimeType}, ${kb} KB]`;
     }
   }
 


### PR DESCRIPTION
Noticed inline data parts render as minimal output when using the CLI with multimodal responses.

## What

When the Gemini API returns inline data (images, audio, video) in a response, the CLI shows only `<mime/type>` in verbose mode. Users can't tell the media category or how large the payload is.

## How I found this

Was testing image generation through the CLI and the verbose response looked unhelpful even though the API was returning valid image data. Looked at `partToString` in `partUtils.ts` and found the `inlineData` branch only emitted the bare MIME type with no size info.

## Fix

The `inlineData` branch in `partToString` now emits a richer label:

```
[Image: image/png, 45.2 KB]
[Audio: audio/mp3, 12.8 KB]
[Video: video/mp4, 1024.0 KB]
```

- Media category derived from the MIME type prefix (`image/`, `audio/`, `video/`, fallback `Media`)
- Approximate byte size derived from base64 length: `ceil(base64.length * 3 / 4)`
- Formatted as KB to one decimal place

Updated the two existing tests that expected the old `<mime/type>` format and added a new test covering non-empty base64 data and the audio category.

Fixes #20656