### PR TITLE
fix(cli): restore Ctrl+B cursor navigation and remap background shells

### DIFF
--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -23,7 +23,7 @@ available combinations.
 | Move the cursor to the end of the line.     | `Ctrl + E`<br />`End (no Shift, Ctrl)`                       |
 | Move the cursor up one line.                | `Up Arrow (no Shift, Alt, Ctrl, Cmd)`                        |
 | Move the cursor down one line.              | `Down Arrow (no Shift, Alt, Ctrl, Cmd)`                      |
-| Move the cursor one character to the left.  | `Left Arrow (no Shift, Alt, Ctrl, Cmd)`                      |
+| Move the cursor one character to the left.  | `Left Arrow (no Shift, Alt, Ctrl, Cmd)`<br />`Ctrl + B`      |
 | Move the cursor one character to the right. | `Right Arrow (no Shift, Alt, Ctrl, Cmd)`<br />`Ctrl + F`     |
 | Move the cursor one word to the left.       | `Ctrl + Left Arrow`<br />`Alt + Left Arrow`<br />`Alt + B`   |
 | Move the cursor one word to the right.      | `Ctrl + Right Arrow`<br />`Alt + Right Arrow`<br />`Alt + F` |
@@ -107,7 +107,7 @@ available combinations.
 | Cycle through approval modes: default (prompt), auto_edit (auto-approve edits), and plan (read-only). Plan mode is skipped when the agent is busy. | `Shift + Tab`    |
 | Expand and collapse blocks of content when not in alternate buffer mode.                                                                           | `Ctrl + O`       |
 | Expand or collapse a paste placeholder when cursor is over placeholder.                                                                            | `Ctrl + O`       |
-| Toggle current background shell visibility.                                                                                                        | `Ctrl + B`       |
+| Toggle current background shell visibility.                                                                                                        | `Ctrl + Q`       |
 | Toggle background shell list.                                                                                                                      | `Ctrl + L`       |
 | Kill the active background shell.                                                                                                                  | `Ctrl + K`       |
 | Confirm selection in background shell list.                                                                                                        | `Enter`          |

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -150,6 +150,7 @@ export const defaultKeyBindings: KeyBindingConfig = {
   ],
   [Command.MOVE_LEFT]: [
     { key: 'left', shift: false, alt: false, ctrl: false, cmd: false },
+    { key: 'b', ctrl: true },
   ],
   [Command.MOVE_RIGHT]: [
     { key: 'right', shift: false, alt: false, ctrl: false, cmd: false },
@@ -279,7 +280,7 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.TOGGLE_COPY_MODE]: [{ key: 's', ctrl: true }],
   [Command.TOGGLE_YOLO]: [{ key: 'y', ctrl: true }],
   [Command.CYCLE_APPROVAL_MODE]: [{ key: 'tab', shift: true }],
-  [Command.TOGGLE_BACKGROUND_SHELL]: [{ key: 'b', ctrl: true }],
+  [Command.TOGGLE_BACKGROUND_SHELL]: [{ key: 'q', ctrl: true }],
   [Command.TOGGLE_BACKGROUND_SHELL_LIST]: [{ key: 'l', ctrl: true }],
   [Command.KILL_BACKGROUND_SHELL]: [{ key: 'k', ctrl: true }],
   [Command.UNFOCUS_BACKGROUND_SHELL]: [{ key: 'tab', shift: true }],

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -2486,8 +2486,8 @@ describe('AppContainer State Management', () => {
       });
     });
 
-    describe('Background Shell Toggling (CTRL+B)', () => {
-      it('should toggle background shell on Ctrl+B even if visible but not focused', async () => {
+    describe('Background Shell Toggling (CTRL+Q)', () => {
+      it('should toggle background shell on Ctrl+Q even if visible but not focused', async () => {
         const mockToggleBackgroundShell = vi.fn();
         mockedUseGeminiStream.mockReturnValue({
           ...DEFAULT_GEMINI_STREAM_MOCK,
@@ -2502,8 +2502,8 @@ describe('AppContainer State Management', () => {
         // Initially not focused, but visible
         expect(capturedUIState.embeddedShellFocused).toBe(false);
 
-        // Press Ctrl+B
-        pressKey('\x02');
+        // Press Ctrl+Q
+        pressKey('\x11');
 
         // Should have toggled (closed) the shell
         expect(mockToggleBackgroundShell).toHaveBeenCalled();
@@ -2513,7 +2513,7 @@ describe('AppContainer State Management', () => {
         unmount();
       });
 
-      it('should show and focus background shell on Ctrl+B if hidden', async () => {
+      it('should show and focus background shell on Ctrl+Q if hidden', async () => {
         const mockToggleBackgroundShell = vi.fn();
         const geminiStreamMock = {
           ...DEFAULT_GEMINI_STREAM_MOCK,
@@ -2531,8 +2531,8 @@ describe('AppContainer State Management', () => {
           geminiStreamMock.isBackgroundShellVisible = true;
         });
 
-        // Press Ctrl+B
-        pressKey('\x02');
+        // Press Ctrl+Q
+        pressKey('\x11');
 
         // Should have toggled (shown) the shell
         expect(mockToggleBackgroundShell).toHaveBeenCalled();

--- a/packages/cli/src/ui/constants/tips.ts
+++ b/packages/cli/src/ui/constants/tips.ts
@@ -115,7 +115,7 @@ export const INFORMATIVE_TIPS = [
   'In menus, move up/down with k/j or the arrow keys…',
   'In menus, select an item by typing its number…',
   "If you're using an IDE, see the context with Ctrl+G…",
-  'Toggle background shells with Ctrl+B or /shells...',
+  'Toggle background shells with Ctrl+Q or /shells...',
   'Toggle the background shell process list with Ctrl+L...',
   // Keyboard shortcut tips end here
   // Command tips start here

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -460,7 +460,7 @@ export const useShellCommandProcessor = (
             finalOutput = `Command was cancelled.\n${finalOutput}`;
           } else if (result.backgrounded) {
             finalStatus = CoreToolCallStatus.Success;
-            finalOutput = `Command moved to background (PID: ${result.pid}). Output hidden. Press Ctrl+B to view.`;
+            finalOutput = `Command moved to background (PID: ${result.pid}). Output hidden. Press Ctrl+Q or /shells to view.`;
           } else if (result.signal) {
             finalStatus = CoreToolCallStatus.Error;
             finalOutput = `Command terminated by signal: ${result.signal}.\n${finalOutput}`;

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -59,11 +59,11 @@ describe('keyMatchers', () => {
     },
     {
       command: Command.MOVE_LEFT,
-      positive: [createKey('left')],
+      positive: [createKey('left'), createKey('b', { ctrl: true })],
       negative: [
         createKey('left', { ctrl: true }),
         createKey('b'),
-        createKey('b', { ctrl: true }),
+        createKey('f', { ctrl: true }),
       ],
     },
     {
@@ -385,8 +385,12 @@ describe('keyMatchers', () => {
     },
     {
       command: Command.TOGGLE_BACKGROUND_SHELL,
-      positive: [createKey('b', { ctrl: true })],
-      negative: [createKey('f10'), createKey('b')],
+      positive: [createKey('q', { ctrl: true })],
+      negative: [
+        createKey('f10'),
+        createKey('b'),
+        createKey('b', { ctrl: true }),
+      ],
     },
     {
       command: Command.TOGGLE_BACKGROUND_SHELL_LIST,

--- a/packages/cli/src/ui/utils/keybindingUtils.test.ts
+++ b/packages/cli/src/ui/utils/keybindingUtils.test.ts
@@ -43,7 +43,7 @@ describe('keybindingUtils', () => {
     it('formats default commands', () => {
       expect(formatCommand(Command.QUIT)).toBe('Ctrl+C');
       expect(formatCommand(Command.SUBMIT)).toBe('Enter');
-      expect(formatCommand(Command.TOGGLE_BACKGROUND_SHELL)).toBe('Ctrl+B');
+      expect(formatCommand(Command.TOGGLE_BACKGROUND_SHELL)).toBe('Ctrl+Q');
     });
 
     it('returns empty string for unknown commands', () => {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -345,7 +345,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
           llmContent += ' There was no output before it was cancelled.';
         }
       } else if (this.params.is_background || result.backgrounded) {
-        llmContent = `Command moved to background (PID: ${result.pid}). Output hidden. Press Ctrl+B to view.`;
+        llmContent = `Command moved to background (PID: ${result.pid}). Output hidden. Press Ctrl+Q or /shells to view.`;
         data = {
           pid: result.pid,
           command: this.params.command,
@@ -386,7 +386,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
         returnDisplayMessage = llmContent;
       } else {
         if (this.params.is_background || result.backgrounded) {
-          returnDisplayMessage = `Command moved to background (PID: ${result.pid}). Output hidden. Press Ctrl+B to view.`;
+          returnDisplayMessage = `Command moved to background (PID: ${result.pid}). Output hidden. Press Ctrl+Q or /shells to view.`;
         } else if (result.output.trim()) {
           returnDisplayMessage = result.output;
         } else {


### PR DESCRIPTION
## Summary

Fixes #21368.

This change removes the conflict between Gemini CLI's background shell shortcut and standard Unix/readline navigation keys.

## What changed

- restored `Ctrl+B` as cursor-left navigation
- remapped background shell toggle from `Ctrl+B` to `Ctrl+Q`
- updated user-facing shortcut text and background-shell messaging
- updated shortcut docs and related tests

## Why

On macOS and Linux terminals, `Ctrl+B` is a common navigation key for moving one character left. Using it to open background shell UI made normal prompt editing inconsistent with expected terminal behavior.

## Validation

- updated focused unit tests for key matching and app shortcut behavior
- test result: 168 passed, 0 failed