### PR TITLE
fix(hooks): fix BeforeAgent/AfterAgent inconsistencies (#18514)

### DIFF
--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -30,12 +30,6 @@ import { getCoreSystemPrompt } from './prompts.js';
 import { checkNextSpeaker } from '../utils/nextSpeakerChecker.js';
 import { reportError } from '../utils/errorReporting.js';
 import { GeminiChat } from './geminiChat.js';
-import { coreEvents, CoreEvent } from '../utils/events.js';
-import {
-  getDisplayString,
-  resolveModel,
-  isGemini2Model,
-} from '../config/models.js';
 import {
   retryWithBackoff,
   type RetryAvailabilityContext,
@@ -76,7 +70,13 @@ import {
   applyModelSelection,
   createAvailabilityContextProvider,
 } from '../availability/policyHelpers.js';
+import {
+  getDisplayString,
+  resolveModel,
+  isGemini2Model,
+} from '../config/models.js';
 import { partToString } from '../utils/partUtils.js';
+import { coreEvents, CoreEvent } from '../utils/events.js';
 
 const MAX_TURNS = 100;
 
@@ -907,6 +907,7 @@ export class GeminiClient {
 
     const boundedTurns = Math.min(turns, MAX_TURNS);
     let turn = new Turn(this.getChat(), prompt_id);
+    let continuationHandled = false;
 
     try {
       turn = yield* this.processTurn(
@@ -963,7 +964,15 @@ export class GeminiClient {
             await this.resetChat();
           }
           const continueRequest = [{ text: continueReason }];
-          yield* this.sendMessageStream(
+          // Reset hook state so the continuation fires BeforeAgent fresh
+          // and fireAfterAgentHookSafe sees activeCalls=1, not 2.
+          const contHookState = this.hookStateMap.get(prompt_id);
+          if (contHookState) {
+            contHookState.hasFiredBeforeAgent = false;
+            contHookState.activeCalls--;
+          }
+          continuationHandled = true;
+          turn = yield* this.sendMessageStream(
             continueRequest,
             signal,
             prompt_id,
@@ -981,16 +990,18 @@ export class GeminiClient {
       }
       throw error;
     } finally {
-      const hookState = this.hookStateMap.get(prompt_id);
-      if (hookState) {
-        hookState.activeCalls--;
-        const isPendingTools =
-          turn?.pendingToolCalls && turn.pendingToolCalls.length > 0;
-        const isAborted = signal?.aborted;
+      if (!continuationHandled) {
+        const hookState = this.hookStateMap.get(prompt_id);
+        if (hookState) {
+          hookState.activeCalls--;
+          const isPendingTools =
+            turn?.pendingToolCalls && turn.pendingToolCalls.length > 0;
+          const isAborted = signal?.aborted;
 
-        if (hookState.activeCalls <= 0) {
-          if (!isPendingTools || isAborted) {
-            this.hookStateMap.delete(prompt_id);
+          if (hookState.activeCalls <= 0) {
+            if (!isPendingTools || isAborted) {
+              this.hookStateMap.delete(prompt_id);
+            }
           }
         }
       }


### PR DESCRIPTION
Fixes #18514

## Root Cause

All three bugs trace to hook state management in `sendMessageStream` in `packages/core/src/core/client.ts`.

When `isBlockingDecision()` fires and triggers a recursive `sendMessageStream` call with the same `prompt_id`:

1. **BeforeAgent not firing on injected prompt**, `hasFiredBeforeAgent` is still `true` from the prior turn. The guard at `fireBeforeAgentHookSafe` returns early, silently skipping BeforeAgent for the injected prompt.

2. **AfterAgent not firing after text-only continuation**, the recursive call increments `activeCalls` to 2. `fireAfterAgentHookSafe` guards on `activeCalls !== 1` and returns `undefined`, so AfterAgent never fires for that turn.

3. **BeforeAgent firing spuriously after first tool call** — the `finally` block checks `pendingToolCalls` on the *outer* turn (not the continuation turn), which can prematurely delete the hookState mid-sequence. The next call creates a fresh hookState with `hasFiredBeforeAgent=false`, causing an unexpected BeforeAgent fire.

## Fix

Three surgical changes, all in `sendMessageStream`:

- Before the recursive `sendMessageStream` call in the `isBlockingDecision` branch: reset `hasFiredBeforeAgent = false` and decrement `activeCalls` on the hookState, so the continuation is treated as a fresh outermost turn.
- Set a `continuationHandled` flag to prevent the `finally` block from double-decrementing `activeCalls` when the continuation has already managed its own state.

## Testing

- All 71 existing tests pass (`npx vitest run packages/core/src/core/client.test.ts`)
- Full preflight passes (`npm run preflight`) - 0 errors
- The fix specifically covers the exact event sequences described in the issue: hook injection via exit code 2, text-only responses, and tool call sequences