### PR TITLE
fix: detect Linuxbrew installations in getInstallationInfo

### DIFF
--- a/packages/cli/src/utils/installationInfo.test.ts
+++ b/packages/cli/src/utils/installationInfo.test.ts
@@ -168,6 +168,42 @@ describe('getInstallationInfo', () => {
     );
   });
 
+  it('should detect Linuxbrew installation on Linux', () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'linux',
+    });
+    const cliPath =
+      '/home/linuxbrew/.linuxbrew/Cellar/gemini-cli/1.0.0/bin/gemini';
+    process.argv[1] = cliPath;
+
+    mockedExecSync.mockImplementation((cmd) => {
+      if (typeof cmd === 'string' && cmd.includes('brew --prefix gemini-cli')) {
+        return '/home/linuxbrew/.linuxbrew/opt/gemini-cli';
+      }
+      throw new Error(`Command failed: ${cmd}`);
+    });
+
+    mockedRealPathSync.mockImplementation((p) => {
+      if (p === cliPath) return cliPath;
+      if (p === '/home/linuxbrew/.linuxbrew/opt/gemini-cli') {
+        return '/home/linuxbrew/.linuxbrew/Cellar/gemini-cli/1.0.0';
+      }
+      return String(p);
+    });
+
+    const info = getInstallationInfo(projectRoot, true);
+
+    expect(mockedExecSync).toHaveBeenCalledWith(
+      expect.stringContaining('brew --prefix gemini-cli'),
+      expect.anything(),
+    );
+    expect(info.packageManager).toBe(PackageManager.HOMEBREW);
+    expect(info.isGlobal).toBe(true);
+    expect(info.updateMessage).toBe(
+      'Installed via Homebrew. Please update with "brew upgrade gemini-cli".',
+    );
+  });
+
   it('should fall through if brew command fails', () => {
     Object.defineProperty(process, 'platform', {
       value: 'darwin',

--- a/packages/cli/src/utils/installationInfo.ts
+++ b/packages/cli/src/utils/installationInfo.ts
@@ -80,8 +80,8 @@ export function getInstallationInfo(
       };
     }
 
-    // Check for Homebrew
-    if (process.platform === 'darwin') {
+    // Check for Homebrew (macOS and Linuxbrew)
+    if (process.platform === 'darwin' || process.platform === 'linux') {
       try {
         const brewPrefix = childProcess
           .execSync('brew --prefix gemini-cli', {


### PR DESCRIPTION
## Summary

Fixes #21370

`getInstallationInfo` only checked `process.platform === "darwin"` before resolving Homebrew installations, so Linux and WSL users with Linuxbrew received incorrect npm-based update instructions instead of `brew upgrade gemini-cli`.

- Include `"linux"` in the platform check alongside `"darwin"` to support Linuxbrew
- Add test case for Linuxbrew detection on Linux

## Test plan

- [x] `npx vitest run packages/cli/src/utils/installationInfo.test.ts` — all 18 tests pass
- [x] Prettier and ESLint pass (pre-commit hooks ran successfully)
- [ ] Manual: on a Linux machine with Linuxbrew-installed gemini-cli, verify `getInstallationInfo` returns `HOMEBREW` package manager