### PR TITLE
fix(core): resolve duplicate import errors in CLI package

### DIFF
--- a/packages/cli/src/acp/acpResume.test.ts
+++ b/packages/cli/src/acp/acpResume.test.ts
@@ -20,13 +20,13 @@ import {
   AuthType,
   type Config,
   CoreToolCallStatus,
+  convertSessionToClientHistory,
 } from '@google/gemini-cli-core';
 import { loadCliConfig, type CliArgs } from '../config/config.js';
 import {
   SessionSelector,
   convertSessionToHistoryFormats,
 } from '../utils/sessionUtils.js';
-import { convertSessionToClientHistory } from '@google/gemini-cli-core';
 import type { LoadedSettings } from '../config/settings.js';
 
 vi.mock('../config/config.js', () => ({

--- a/packages/cli/src/test-utils/render.tsx
+++ b/packages/cli/src/test-utils/render.tsx
@@ -8,9 +8,9 @@ import {
   render as inkRenderDirect,
   type Instance as InkInstance,
   type RenderOptions,
+  Box,
 } from 'ink';
 import { EventEmitter } from 'node:events';
-import { Box } from 'ink';
 import type React from 'react';
 import { Terminal } from '@xterm/headless';
 import { vi } from 'vitest';

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -31,6 +31,10 @@ import {
   AuthType,
   type AgentDefinition,
   CoreToolCallStatus,
+  ShellExecutionService,
+  writeToStdout,
+  enableMouseEvents,
+  disableMouseEvents,
 } from '@google/gemini-cli-core';
 
 // Mock coreEvents
@@ -105,8 +109,8 @@ import {
   type UIActions,
 } from './contexts/UIActionsContext.js';
 import { KeypressProvider } from './contexts/KeypressContext.js';
-import { OverflowProvider } from './contexts/OverflowContext.js';
 import {
+  OverflowProvider,
   useOverflowActions,
   type OverflowActions,
 } from './contexts/OverflowContext.js';
@@ -234,12 +238,6 @@ import * as useKeypressModule from './hooks/useKeypress.js';
 import { useSuspend } from './hooks/useSuspend.js';
 import { measureElement } from 'ink';
 import { useTerminalSize } from './hooks/useTerminalSize.js';
-import {
-  ShellExecutionService,
-  writeToStdout,
-  enableMouseEvents,
-  disableMouseEvents,
-} from '@google/gemini-cli-core';
 import { type ExtensionManager } from '../config/extension-manager.js';
 import {
   WARNING_PROMPT_DURATION_MS,

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -36,9 +36,10 @@ import {
   type ConfirmationRequest,
   type PermissionConfirmationRequest,
   type QuotaStats,
+  MessageType,
+  StreamingState,
 } from './types.js';
 import { checkPermissions } from './hooks/atCommandProcessor.js';
-import { MessageType, StreamingState } from './types.js';
 import { ToolActionsProvider } from './contexts/ToolActionsContext.js';
 import {
   type StartupWarning,

--- a/packages/cli/src/ui/auth/useAuth.ts
+++ b/packages/cli/src/ui/auth/useAuth.ts
@@ -13,8 +13,8 @@ import {
   debugLogger,
   isAccountSuspendedError,
   ProjectIdRequiredError,
+  getErrorMessage,
 } from '@google/gemini-cli-core';
-import { getErrorMessage } from '@google/gemini-cli-core';
 import { AuthState } from '../types.js';
 import { validateAuthMethod } from '../../config/auth.js';
 

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -18,6 +18,7 @@ import {
   decodeTagName,
   type MessageActionReturn,
   INITIAL_HISTORY_LENGTH,
+  convertToRestPayload,
 } from '@google/gemini-cli-core';
 import path from 'node:path';
 import type {
@@ -27,7 +28,6 @@ import type {
 } from '../types.js';
 import { MessageType } from '../types.js';
 import { exportHistoryToFile } from '../utils/historyExportUtils.js';
-import { convertToRestPayload } from '@google/gemini-cli-core';
 
 const getSavedChatTags = async (
   context: CommandContext,

--- a/packages/cli/src/ui/commands/ideCommand.ts
+++ b/packages/cli/src/ui/commands/ideCommand.ts
@@ -11,8 +11,6 @@ import {
   logIdeConnection,
   IdeConnectionEvent,
   IdeConnectionType,
-} from '@google/gemini-cli-core';
-import {
   getIdeInstaller,
   IDEConnectionStatus,
   ideContextStore,

--- a/packages/cli/src/ui/components/EditorSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/EditorSettingsDialog.tsx
@@ -22,9 +22,9 @@ import {
   type EditorType,
   isEditorAvailable,
   EDITOR_DISPLAY_NAMES,
+  coreEvents,
 } from '@google/gemini-cli-core';
 import { useKeypress } from '../hooks/useKeypress.js';
-import { coreEvents } from '@google/gemini-cli-core';
 
 interface EditorDialogProps {
   onSelect: (

--- a/packages/cli/src/ui/contexts/SessionContext.test.tsx
+++ b/packages/cli/src/ui/contexts/SessionContext.test.tsx
@@ -4,10 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type MutableRefObject, Component, type ReactNode } from 'react';
+import { type MutableRefObject, Component, type ReactNode, act } from 'react';
 import { render } from '../../test-utils/render.js';
-
-import { act } from 'react';
 import type { SessionMetrics } from './SessionContext.js';
 import { SessionStatsProvider, useSessionStats } from './SessionContext.js';
 import { describe, it, expect, vi } from 'vitest';

--- a/packages/cli/src/ui/contexts/SettingsContext.test.tsx
+++ b/packages/cli/src/ui/contexts/SettingsContext.test.tsx
@@ -5,9 +5,8 @@
  */
 
 import type React from 'react';
-import { Component, type ReactNode } from 'react';
+import { Component, type ReactNode, act } from 'react';
 import { renderHook, render } from '../../test-utils/render.js';
-import { act } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SettingsContext, useSettingsStore } from './SettingsContext.js';
 import {

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { debugLogger, type GeminiCLIExtension } from '@google/gemini-cli-core';
+import {
+  debugLogger,
+  type GeminiCLIExtension,
+  checkExhaustive,
+} from '@google/gemini-cli-core';
 import { getErrorMessage } from '../../utils/errors.js';
 import {
   ExtensionUpdateState,
@@ -19,7 +23,6 @@ import {
   updateExtension,
 } from '../../config/extensions/update.js';
 import { type ExtensionUpdateInfo } from '../../config/extension.js';
-import { checkExhaustive } from '@google/gemini-cli-core';
 import type { ExtensionManager } from '../../config/extension-manager.js';
 
 type ConfirmationRequestWrapper = {

--- a/packages/cli/src/ui/hooks/useSessionBrowser.test.ts
+++ b/packages/cli/src/ui/hooks/useSessionBrowser.test.ts
@@ -19,8 +19,6 @@ import {
   type ConversationRecord,
   type MessageRecord,
   CoreToolCallStatus,
-} from '@google/gemini-cli-core';
-import {
   coreEvents,
   convertSessionToClientHistory,
 } from '@google/gemini-cli-core';


### PR DESCRIPTION
## Summary

Merged duplicate imports across 12 files to comply with the `import/no-duplicates` ESLint rule. This includes merging imports from `@google/gemini-cli-core`, `react`, `ink`, and `./types.js` in various test and source files.

## Details

The changes fix duplicate import errors that were causing ESLint failures. Each file had multiple imports from the same package that have been consolidated into single import statements.

## Related Issues

<!-- Link to any related issues here -->

## How to Validate

1. Run `npm run build` to verify the build passes
2. Run `npm run lint` to verify no ESLint errors
3. All tests should continue to pass

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (N/A - internal refactor)
- [x] Added/updated tests (N/A - existing tests cover the changes)
- [x] Noted breaking changes (None)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run