### PR TITLE
feat(core): support selecting Jetbrains IDEs as preferred editor

### DIFF
--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -84,6 +84,57 @@ describe('editor utils', () => {
         win32Commands: ['agy.cmd', 'antigravity.cmd', 'antigravity'],
       },
       { editor: 'hx', commands: ['hx'], win32Commands: ['hx'] },
+      // JetBrains IDEs
+      {
+        editor: 'intellij',
+        commands: ['idea', 'idea.sh'],
+        win32Commands: ['idea64.exe'],
+      },
+      {
+        editor: 'webstorm',
+        commands: ['webstorm', 'webstorm.sh'],
+        win32Commands: ['webstorm64.exe'],
+      },
+      {
+        editor: 'pycharm',
+        commands: ['pycharm', 'pycharm.sh'],
+        win32Commands: ['pycharm64.exe'],
+      },
+      {
+        editor: 'goland',
+        commands: ['goland', 'goland.sh'],
+        win32Commands: ['goland64.exe'],
+      },
+      {
+        editor: 'androidstudio',
+        commands: ['studio', 'studio.sh'],
+        win32Commands: ['studio64.exe'],
+      },
+      {
+        editor: 'clion',
+        commands: ['clion', 'clion.sh'],
+        win32Commands: ['clion64.exe'],
+      },
+      {
+        editor: 'rustrover',
+        commands: ['rustrover', 'rustrover.sh'],
+        win32Commands: ['rustrover64.exe'],
+      },
+      {
+        editor: 'datagrip',
+        commands: ['datagrip', 'datagrip.sh'],
+        win32Commands: ['datagrip64.exe'],
+      },
+      {
+        editor: 'phpstorm',
+        commands: ['phpstorm', 'phpstorm.sh'],
+        win32Commands: ['phpstorm64.exe'],
+      },
+      {
+        editor: 'rubymine',
+        commands: ['rubymine', 'rubymine.sh'],
+        win32Commands: ['rubymine64.exe'],
+      },
     ];
 
     for (const { editor, commands, win32Commands } of testCases) {
@@ -188,9 +239,77 @@ describe('editor utils', () => {
         commands: ['agy', 'antigravity'],
         win32Commands: ['agy.cmd', 'antigravity.cmd', 'antigravity'],
       },
+      // JetBrains IDEs - note: these use different diff arguments
+      {
+        editor: 'intellij',
+        commands: ['idea', 'idea.sh'],
+        win32Commands: ['idea64.exe'],
+      },
+      {
+        editor: 'webstorm',
+        commands: ['webstorm', 'webstorm.sh'],
+        win32Commands: ['webstorm64.exe'],
+      },
+      {
+        editor: 'pycharm',
+        commands: ['pycharm', 'pycharm.sh'],
+        win32Commands: ['pycharm64.exe'],
+      },
+      {
+        editor: 'goland',
+        commands: ['goland', 'goland.sh'],
+        win32Commands: ['goland64.exe'],
+      },
+      {
+        editor: 'androidstudio',
+        commands: ['studio', 'studio.sh'],
+        win32Commands: ['studio64.exe'],
+      },
+      {
+        editor: 'clion',
+        commands: ['clion', 'clion.sh'],
+        win32Commands: ['clion64.exe'],
+      },
+      {
+        editor: 'rustrover',
+        commands: ['rustrover', 'rustrover.sh'],
+        win32Commands: ['rustrover64.exe'],
+      },
+      {
+        editor: 'datagrip',
+        commands: ['datagrip', 'datagrip.sh'],
+        win32Commands: ['datagrip64.exe'],
+      },
+      {
+        editor: 'phpstorm',
+        commands: ['phpstorm', 'phpstorm.sh'],
+        win32Commands: ['phpstorm64.exe'],
+      },
+      {
+        editor: 'rubymine',
+        commands: ['rubymine', 'rubymine.sh'],
+        win32Commands: ['rubymine64.exe'],
+      },
     ];
 
     for (const { editor, commands, win32Commands } of guiEditors) {
+      // Helper function to determine if editor is a JetBrains IDE
+      const isJetBrainsIde = (editor: EditorType): boolean => {
+        const jetbrainsEditors = [
+          'intellij',
+          'webstorm',
+          'pycharm',
+          'goland',
+          'androidstudio',
+          'clion',
+          'rustrover',
+          'datagrip',
+          'phpstorm',
+          'rubymine',
+        ];
+        return jetbrainsEditors.includes(editor);
+      };
+
       // Non-windows tests
       it(`should use first command "${commands[0]}" when it exists on non-windows`, () => {
         Object.defineProperty(process, 'platform', { value: 'linux' });
@@ -198,9 +317,15 @@ describe('editor utils', () => {
           Buffer.from(`/usr/bin/${commands[0]}`),
         );
         const diffCommand = getDiffCommand('old.txt', 'new.txt', editor);
+
+        // JetBrains IDEs use different diff arguments
+        const expectedArgs = isJetBrainsIde(editor)
+          ? ['diff', 'old.txt', 'new.txt']
+          : ['--wait', '--diff', 'old.txt', 'new.txt'];
+
         expect(diffCommand).toEqual({
           command: commands[0],
-          args: ['--wait', '--diff', 'old.txt', 'new.txt'],
+          args: expectedArgs,
         });
       });
 
@@ -214,9 +339,15 @@ describe('editor utils', () => {
             .mockReturnValueOnce(Buffer.from(`/usr/bin/${commands[1]}`)); // second command found
 
           const diffCommand = getDiffCommand('old.txt', 'new.txt', editor);
+
+          // JetBrains IDEs use different diff arguments
+          const expectedArgs = isJetBrainsIde(editor)
+            ? ['diff', 'old.txt', 'new.txt']
+            : ['--wait', '--diff', 'old.txt', 'new.txt'];
+
           expect(diffCommand).toEqual({
             command: commands[1],
-            args: ['--wait', '--diff', 'old.txt', 'new.txt'],
+            args: expectedArgs,
           });
         });
       }
@@ -228,9 +359,15 @@ describe('editor utils', () => {
         });
 
         const diffCommand = getDiffCommand('old.txt', 'new.txt', editor);
+
+        // JetBrains IDEs use different diff arguments
+        const expectedArgs = isJetBrainsIde(editor)
+          ? ['diff', 'old.txt', 'new.txt']
+          : ['--wait', '--diff', 'old.txt', 'new.txt'];
+
         expect(diffCommand).toEqual({
           command: commands[commands.length - 1],
-          args: ['--wait', '--diff', 'old.txt', 'new.txt'],
+          args: expectedArgs,
         });
       });
 
@@ -241,9 +378,15 @@ describe('editor utils', () => {
           Buffer.from(`C:\\Program Files\\...\\${win32Commands[0]}`),
         );
         const diffCommand = getDiffCommand('old.txt', 'new.txt', editor);
+
+        // JetBrains IDEs use different diff arguments
+        const expectedArgs = isJetBrainsIde(editor)
+          ? ['diff', 'old.txt', 'new.txt']
+          : ['--wait', '--diff', 'old.txt', 'new.txt'];
+
         expect(diffCommand).toEqual({
           command: win32Commands[0],
-          args: ['--wait', '--diff', 'old.txt', 'new.txt'],
+          args: expectedArgs,
         });
       });
 
@@ -259,9 +402,15 @@ describe('editor utils', () => {
             ); // second command found
 
           const diffCommand = getDiffCommand('old.txt', 'new.txt', editor);
+
+          // JetBrains IDEs use different diff arguments
+          const expectedArgs = isJetBrainsIde(editor)
+            ? ['diff', 'old.txt', 'new.txt']
+            : ['--wait', '--diff', 'old.txt', 'new.txt'];
+
           expect(diffCommand).toEqual({
             command: win32Commands[1],
-            args: ['--wait', '--diff', 'old.txt', 'new.txt'],
+            args: expectedArgs,
           });
         });
       }
@@ -273,9 +422,15 @@ describe('editor utils', () => {
         });
 
         const diffCommand = getDiffCommand('old.txt', 'new.txt', editor);
+
+        // JetBrains IDEs use different diff arguments
+        const expectedArgs = isJetBrainsIde(editor)
+          ? ['diff', 'old.txt', 'new.txt']
+          : ['--wait', '--diff', 'old.txt', 'new.txt'];
+
         expect(diffCommand).toEqual({
           command: win32Commands[win32Commands.length - 1],
-          args: ['--wait', '--diff', 'old.txt', 'new.txt'],
+          args: expectedArgs,
         });
       });
     }
@@ -344,6 +499,53 @@ describe('editor utils', () => {
       const command = getDiffCommand('old.txt', 'new.txt', 'foobar');
       expect(command).toBeNull();
     });
+
+    // JetBrains IDE specific diff command tests
+    describe('JetBrains IDE diff commands', () => {
+      const jetbrainsEditors: Array<{ editor: EditorType; command: string }> = [
+        { editor: 'intellij', command: 'idea' },
+        { editor: 'webstorm', command: 'webstorm' },
+        { editor: 'pycharm', command: 'pycharm' },
+        { editor: 'goland', command: 'goland' },
+        { editor: 'androidstudio', command: 'studio' },
+        { editor: 'clion', command: 'clion' },
+        { editor: 'rustrover', command: 'rustrover' },
+        { editor: 'datagrip', command: 'datagrip' },
+        { editor: 'phpstorm', command: 'phpstorm' },
+        { editor: 'rubymine', command: 'rubymine' },
+      ];
+
+      for (const { editor, command: expectedCommand } of jetbrainsEditors) {
+        it(`should return correct diff command for ${editor}`, () => {
+          // Mock that the command exists
+          (execSync as Mock).mockReturnValue(
+            Buffer.from(`/usr/bin/${expectedCommand}`),
+          );
+
+          const diffCommand = getDiffCommand('old.txt', 'new.txt', editor);
+          expect(diffCommand).toEqual({
+            command: expectedCommand,
+            args: ['diff', 'old.txt', 'new.txt'],
+          });
+        });
+
+        it(`should handle paths with spaces for ${editor}`, () => {
+          (execSync as Mock).mockReturnValue(
+            Buffer.from(`/usr/bin/${expectedCommand}`),
+          );
+
+          const diffCommand = getDiffCommand(
+            'old file.txt',
+            'new file.txt',
+            editor,
+          );
+          expect(diffCommand).toEqual({
+            command: expectedCommand,
+            args: ['diff', 'old file.txt', 'new file.txt'],
+          });
+        });
+      }
+    });
   });
 
   describe('openDiff', () => {
@@ -353,6 +555,18 @@ describe('editor utils', () => {
       'windsurf',
       'cursor',
       'zed',
+      'antigravity',
+      // JetBrains IDEs
+      'intellij',
+      'webstorm',
+      'pycharm',
+      'goland',
+      'androidstudio',
+      'clion',
+      'rustrover',
+      'datagrip',
+      'phpstorm',
+      'rubymine',
     ];
 
     for (const editor of guiEditors) {
@@ -544,6 +758,18 @@ describe('editor utils', () => {
       'windsurf',
       'cursor',
       'zed',
+      'antigravity',
+      // JetBrains IDEs
+      'intellij',
+      'webstorm',
+      'pycharm',
+      'goland',
+      'androidstudio',
+      'clion',
+      'rustrover',
+      'datagrip',
+      'phpstorm',
+      'rubymine',
     ];
     for (const editor of guiEditors) {
       it(`should not allow ${editor} in sandbox mode`, () => {

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -28,6 +28,33 @@ import { coreEvents, CoreEvent } from './events.js';
 import { exec, execSync, spawn, spawnSync } from 'node:child_process';
 import { debugLogger } from './debugLogger.js';
 
+const JETBRAINS_EDITORS: EditorType[] = [
+  'intellij',
+  'webstorm',
+  'pycharm',
+  'goland',
+  'androidstudio',
+  'clion',
+  'rustrover',
+  'datagrip',
+  'phpstorm',
+  'rubymine',
+];
+
+const GUI_EDITORS: EditorType[] = [
+  'vscode',
+  'vscodium',
+  'windsurf',
+  'cursor',
+  'zed',
+  'antigravity',
+  ...JETBRAINS_EDITORS,
+];
+
+// Helper function to determine if editor is a JetBrains IDE
+const isJetBrainsIde = (editor: EditorType): boolean =>
+  JETBRAINS_EDITORS.includes(editor);
+
 vi.mock('child_process', () => ({
   exec: vi.fn(),
   execSync: vi.fn(),
@@ -293,23 +320,6 @@ describe('editor utils', () => {
     ];
 
     for (const { editor, commands, win32Commands } of guiEditors) {
-      // Helper function to determine if editor is a JetBrains IDE
-      const isJetBrainsIde = (editor: EditorType): boolean => {
-        const jetbrainsEditors = [
-          'intellij',
-          'webstorm',
-          'pycharm',
-          'goland',
-          'androidstudio',
-          'clion',
-          'rustrover',
-          'datagrip',
-          'phpstorm',
-          'rubymine',
-        ];
-        return jetbrainsEditors.includes(editor);
-      };
-
       // Non-windows tests
       it(`should use first command "${commands[0]}" when it exists on non-windows`, () => {
         Object.defineProperty(process, 'platform', { value: 'linux' });
@@ -499,77 +509,10 @@ describe('editor utils', () => {
       const command = getDiffCommand('old.txt', 'new.txt', 'foobar');
       expect(command).toBeNull();
     });
-
-    // JetBrains IDE specific diff command tests
-    describe('JetBrains IDE diff commands', () => {
-      const jetbrainsEditors: Array<{ editor: EditorType; command: string }> = [
-        { editor: 'intellij', command: 'idea' },
-        { editor: 'webstorm', command: 'webstorm' },
-        { editor: 'pycharm', command: 'pycharm' },
-        { editor: 'goland', command: 'goland' },
-        { editor: 'androidstudio', command: 'studio' },
-        { editor: 'clion', command: 'clion' },
-        { editor: 'rustrover', command: 'rustrover' },
-        { editor: 'datagrip', command: 'datagrip' },
-        { editor: 'phpstorm', command: 'phpstorm' },
-        { editor: 'rubymine', command: 'rubymine' },
-      ];
-
-      for (const { editor, command: expectedCommand } of jetbrainsEditors) {
-        it(`should return correct diff command for ${editor}`, () => {
-          // Mock that the command exists
-          (execSync as Mock).mockReturnValue(
-            Buffer.from(`/usr/bin/${expectedCommand}`),
-          );
-
-          const diffCommand = getDiffCommand('old.txt', 'new.txt', editor);
-          expect(diffCommand).toEqual({
-            command: expectedCommand,
-            args: ['diff', 'old.txt', 'new.txt'],
-          });
-        });
-
-        it(`should handle paths with spaces for ${editor}`, () => {
-          (execSync as Mock).mockReturnValue(
-            Buffer.from(`/usr/bin/${expectedCommand}`),
-          );
-
-          const diffCommand = getDiffCommand(
-            'old file.txt',
-            'new file.txt',
-            editor,
-          );
-          expect(diffCommand).toEqual({
-            command: expectedCommand,
-            args: ['diff', 'old file.txt', 'new file.txt'],
-          });
-        });
-      }
-    });
   });
 
   describe('openDiff', () => {
-    const guiEditors: EditorType[] = [
-      'vscode',
-      'vscodium',
-      'windsurf',
-      'cursor',
-      'zed',
-      'antigravity',
-      // JetBrains IDEs
-      'intellij',
-      'webstorm',
-      'pycharm',
-      'goland',
-      'androidstudio',
-      'clion',
-      'rustrover',
-      'datagrip',
-      'phpstorm',
-      'rubymine',
-    ];
-
-    for (const editor of guiEditors) {
+    for (const editor of GUI_EDITORS) {
       it(`should call spawn for ${editor}`, async () => {
         const mockSpawnOn = vi.fn((event, cb) => {
           if (event === 'close') {
@@ -752,26 +695,7 @@ describe('editor utils', () => {
       expect(allowEditorTypeInSandbox('hx')).toBe(true);
     });
 
-    const guiEditors: EditorType[] = [
-      'vscode',
-      'vscodium',
-      'windsurf',
-      'cursor',
-      'zed',
-      'antigravity',
-      // JetBrains IDEs
-      'intellij',
-      'webstorm',
-      'pycharm',
-      'goland',
-      'androidstudio',
-      'clion',
-      'rustrover',
-      'datagrip',
-      'phpstorm',
-      'rubymine',
-    ];
-    for (const editor of guiEditors) {
+    for (const editor of GUI_EDITORS) {
       it(`should not allow ${editor} in sandbox mode`, () => {
         vi.stubEnv('SANDBOX', 'sandbox');
         expect(allowEditorTypeInSandbox(editor)).toBe(false);

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -17,6 +17,16 @@ const GUI_EDITORS = [
   'cursor',
   'zed',
   'antigravity',
+  'intellij',
+  'webstorm',
+  'pycharm',
+  'goland',
+  'androidstudio',
+  'clion',
+  'rustrover',
+  'datagrip',
+  'phpstorm',
+  'rubymine',
 ] as const;
 const TERMINAL_EDITORS = ['vim', 'neovim', 'emacs', 'hx'] as const;
 const EDITORS = [...GUI_EDITORS, ...TERMINAL_EDITORS] as const;
@@ -55,6 +65,16 @@ export const EDITOR_DISPLAY_NAMES: Record<EditorType, string> = {
   emacs: 'Emacs',
   antigravity: 'Antigravity',
   hx: 'Helix',
+  intellij: 'IntelliJ IDEA',
+  webstorm: 'WebStorm',
+  pycharm: 'PyCharm',
+  goland: 'GoLand',
+  androidstudio: 'Android Studio',
+  clion: 'CLion',
+  rustrover: 'RustRover',
+  datagrip: 'DataGrip',
+  phpstorm: 'PhpStorm',
+  rubymine: 'RubyMine',
 };
 
 export function getEditorDisplayName(editor: EditorType): string {
@@ -125,6 +145,19 @@ const editorCommands: Record<
     default: ['agy', 'antigravity'],
   },
   hx: { win32: ['hx'], default: ['hx'] },
+  intellij: { win32: ['idea64.exe'], default: ['idea', 'idea.sh'] },
+  webstorm: { win32: ['webstorm64.exe'], default: ['webstorm', 'webstorm.sh'] },
+  pycharm: { win32: ['pycharm64.exe'], default: ['pycharm', 'pycharm.sh'] },
+  goland: { win32: ['goland64.exe'], default: ['goland', 'goland.sh'] },
+  androidstudio: { win32: ['studio64.exe'], default: ['studio', 'studio.sh'] },
+  clion: { win32: ['clion64.exe'], default: ['clion', 'clion.sh'] },
+  rustrover: {
+    win32: ['rustrover64.exe'],
+    default: ['rustrover', 'rustrover.sh'],
+  },
+  datagrip: { win32: ['datagrip64.exe'], default: ['datagrip', 'datagrip.sh'] },
+  phpstorm: { win32: ['phpstorm64.exe'], default: ['phpstorm', 'phpstorm.sh'] },
+  rubymine: { win32: ['rubymine64.exe'], default: ['rubymine', 'rubymine.sh'] },
 };
 
 function getEditorCommands(editor: EditorType): string[] {
@@ -279,6 +312,17 @@ export function getDiffCommand(
         command: 'hx',
         args: ['--vsplit', '--', oldPath, newPath],
       };
+    case 'intellij':
+    case 'webstorm':
+    case 'pycharm':
+    case 'goland':
+    case 'androidstudio':
+    case 'clion':
+    case 'rustrover':
+    case 'datagrip':
+    case 'phpstorm':
+    case 'rubymine':
+      return { command, args: ['diff', oldPath, newPath] };
     default:
       return null;
   }


### PR DESCRIPTION
## Summary

make a series of JetBrains IDE(IntelliiJ, WebStorm, PyCharm, GoLand, Android Studio, CLion, DataGrip, PhpStorm, RubyMine) as preferred editor option. How it looks like in Terminal:

<img width="1915" height="727" alt="image" src="https://github.com/user-attachments/assets/8298e502-b86d-4b70-8935-84d12d4963d6" />


## Details

This helps all **Gemini CLI x JetBrains IDE** users keep all code displaying on tools they're familiar with. How it looks like in integrated terminal window of an IDE:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/33d2b119-3495-4000-b55e-25c584afaf39" />

However, It seems JetBrains IDE's cmd is not created by default. A way to enable it via Settings in ToolBox App:
<img width="440" height="700" alt="image" src="https://github.com/user-attachments/assets/e08ba933-5c1c-4d19-a934-9f68f6ae6176" />

## Related Issues

#21389 

## How to Validate

1. install a local built version of gemini including this PR.
2. install at least one JetBrains IDE mentioned above.
3. set switch on Shell Script in ToolBox App Settings. 
4. run `gemini` in terminal.
5. run `/editor` in gemini, editor options should be shown like pic above at Summary sec.
7. select the one you like like pic above at Details sec.
8. make a change request to gemini in *Plan Mode*.
9. press **Ctrl + X** when gemini asks for exiting Plan Mode, IDE selected in step 7 would be opened (, in lightEdit mode though), like pic above at Details sec.


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker