### PR TITLE
feat(a2a): implement secure acknowledgment and core registry improvements

### DIFF
--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -110,6 +110,7 @@ export async function loadConfig(
     interactive: !isHeadlessMode(),
     enableInteractiveShell: !isHeadlessMode(),
     ptyInfo: 'auto',
+    enableAgents: settings.experimental?.enableAgents ?? false,
   };
 
   const fileService = new FileDiscoveryService(workspaceDir, {

--- a/packages/a2a-server/src/config/settings.ts
+++ b/packages/a2a-server/src/config/settings.ts
@@ -48,6 +48,9 @@ export interface Settings {
     enableRecursiveFileSearch?: boolean;
     customIgnoreFilePaths?: string[];
   };
+  experimental?: {
+    enableAgents?: boolean;
+  };
 }
 
 export interface SettingsError {

--- a/packages/core/src/agents/a2a-client-manager.test.ts
+++ b/packages/core/src/agents/a2a-client-manager.test.ts
@@ -186,17 +186,6 @@ describe('A2AClientManager', () => {
     });
 
     it('should configure ClientFactory with REST, JSON-RPC, and gRPC transports', async () => {
-<<<<<<< HEAD
-      await manager.loadAgent('TestAgent', 'http://test.agent/card');
-      expect(ClientFactoryOptions.createFrom).toHaveBeenCalled();
-    });
-
-    it('should throw an error if an agent with the same name is already loaded', async () => {
-      await manager.loadAgent('TestAgent', 'http://test.agent/card');
-      await expect(
-        manager.loadAgent('TestAgent', 'http://test.agent/card'),
-      ).rejects.toThrow("Agent with name 'TestAgent' is already loaded.");
-=======
       await manager.loadAgent('TestAgent', 'http://test.agent/card');
       expect(ClientFactoryOptions.createFrom).toHaveBeenCalled();
     });
@@ -212,7 +201,6 @@ describe('A2AClientManager', () => {
       );
       expect(card1).toBe(card2);
       expect(vi.mocked(DefaultAgentCardResolver)).toHaveBeenCalledTimes(1);
->>>>>>> 7af0b4745
     });
 
     it('should use native fetch by default', async () => {

--- a/packages/core/src/agents/a2a-client-manager.test.ts
+++ b/packages/core/src/agents/a2a-client-manager.test.ts
@@ -186,6 +186,7 @@ describe('A2AClientManager', () => {
     });
 
     it('should configure ClientFactory with REST, JSON-RPC, and gRPC transports', async () => {
+<<<<<<< HEAD
       await manager.loadAgent('TestAgent', 'http://test.agent/card');
       expect(ClientFactoryOptions.createFrom).toHaveBeenCalled();
     });
@@ -195,6 +196,23 @@ describe('A2AClientManager', () => {
       await expect(
         manager.loadAgent('TestAgent', 'http://test.agent/card'),
       ).rejects.toThrow("Agent with name 'TestAgent' is already loaded.");
+=======
+      await manager.loadAgent('TestAgent', 'http://test.agent/card');
+      expect(ClientFactoryOptions.createFrom).toHaveBeenCalled();
+    });
+
+    it('should return the cached card if an agent with the same name is already loaded (idempotent)', async () => {
+      const card1 = await manager.loadAgent(
+        'TestAgent',
+        'http://test.agent/card',
+      );
+      const card2 = await manager.loadAgent(
+        'TestAgent',
+        'http://test.agent/card',
+      );
+      expect(card1).toBe(card2);
+      expect(vi.mocked(DefaultAgentCardResolver)).toHaveBeenCalledTimes(1);
+>>>>>>> 7af0b4745
     });
 
     it('should use native fetch by default', async () => {

--- a/packages/core/src/agents/a2a-client-manager.ts
+++ b/packages/core/src/agents/a2a-client-manager.ts
@@ -109,8 +109,9 @@ export class A2AClientManager {
     agentCardUrl: string,
     authHandler?: AuthenticationHandler,
   ): Promise<AgentCard> {
-    if (this.clients.has(name) && this.agentCards.has(name)) {
-      throw new Error(`Agent with name '${name}' is already loaded.`);
+    const existingCard = this.agentCards.get(name);
+    if (existingCard) {
+      return existingCard;
     }
 
     // Authenticated fetch for API calls (transports).

--- a/packages/core/src/agents/acknowledgedAgents.test.ts
+++ b/packages/core/src/agents/acknowledgedAgents.test.ts
@@ -63,6 +63,17 @@ describe('AcknowledgedAgentsService', () => {
     );
   });
 
+  it('should return true for acknowledged agent via isAcknowledgedSync', async () => {
+    const service = new AcknowledgedAgentsService();
+
+    await service.acknowledge('/project', 'AgentA', 'hash1');
+
+    expect(service.isAcknowledgedSync('/project', 'AgentA', 'hash1')).toBe(true);
+    expect(service.isAcknowledgedSync('/project', 'AgentA', 'hash2')).toBe(
+      false,
+    );
+  });
+
   it('should load acknowledged agents from disk', async () => {
     const ackPath = Storage.getAcknowledgedAgentsPath();
     const data = {

--- a/packages/core/src/agents/acknowledgedAgents.test.ts
+++ b/packages/core/src/agents/acknowledgedAgents.test.ts
@@ -68,7 +68,9 @@ describe('AcknowledgedAgentsService', () => {
 
     await service.acknowledge('/project', 'AgentA', 'hash1');
 
-    expect(service.isAcknowledgedSync('/project', 'AgentA', 'hash1')).toBe(true);
+    expect(service.isAcknowledgedSync('/project', 'AgentA', 'hash1')).toBe(
+      true,
+    );
     expect(service.isAcknowledgedSync('/project', 'AgentA', 'hash2')).toBe(
       false,
     );

--- a/packages/core/src/agents/acknowledgedAgents.ts
+++ b/packages/core/src/agents/acknowledgedAgents.ts
@@ -66,6 +66,18 @@ export class AcknowledgedAgentsService {
     hash: string,
   ): Promise<boolean> {
     await this.load();
+    return this.isAcknowledgedSync(projectPath, agentName, hash);
+  }
+
+  /**
+   * Synchronous check for acknowledgment.
+   * Note: Assumes load() has already been called and awaited (e.g. during registry init).
+   */
+  isAcknowledgedSync(
+    projectPath: string,
+    agentName: string,
+    hash: string,
+  ): boolean {
     const projectAgents = this.acknowledgedAgents[projectPath];
     if (!projectAgents) return false;
     return projectAgents[agentName] === hash;

--- a/packages/core/src/agents/registry.test.ts
+++ b/packages/core/src/agents/registry.test.ts
@@ -29,7 +29,7 @@ import { SimpleExtensionLoader } from '../utils/extensionLoader.js';
 import type { ToolRegistry } from '../tools/tool-registry.js';
 import { ThinkingLevel } from '@google/genai';
 import type { AcknowledgedAgentsService } from './acknowledgedAgents.js';
-import { PolicyDecision } from '../policy/types.js';
+import { PolicyDecision, ApprovalMode } from '../policy/types.js';
 import { A2AAuthProviderFactory } from './auth-provider/factory.js';
 import type { A2AAuthProvider } from './auth-provider/types.js';
 
@@ -1168,6 +1168,37 @@ describe('AgentRegistry', () => {
         expect.objectContaining({
           toolName: 'OverwrittenAgent',
           decision: PolicyDecision.ASK_USER,
+        }),
+      );
+    });
+
+    it('should register remote agents with ALLOW decision in YOLO mode', async () => {
+      const remoteAgent: AgentDefinition = {
+        kind: 'remote',
+        name: 'YoloAgent',
+        description: 'A remote agent in YOLO mode',
+        agentCardUrl: 'https://example.com/card',
+        inputConfig: { inputSchema: { type: 'object' } },
+      };
+
+      vi.mocked(A2AClientManager.getInstance).mockReturnValue({
+        loadAgent: vi.fn().mockResolvedValue({ name: 'YoloAgent' }),
+      } as unknown as A2AClientManager);
+
+      const policyEngine = mockConfig.getPolicyEngine();
+      vi.spyOn(mockConfig, 'getApprovalMode').mockReturnValue(
+        ApprovalMode.YOLO,
+      );
+      const addRuleSpy = vi.spyOn(policyEngine, 'addRule');
+
+      await registry.testRegisterAgent(remoteAgent);
+
+      // In YOLO mode, even remote agents should be registered with ALLOW.
+      expect(addRuleSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          toolName: 'YoloAgent',
+          decision: PolicyDecision.ALLOW,
+          source: 'AgentRegistry (Dynamic)',
         }),
       );
     });

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -23,7 +23,11 @@ import {
   type ModelConfig,
   ModelConfigService,
 } from '../services/modelConfigService.js';
-import { PolicyDecision, PRIORITY_SUBAGENT_TOOL } from '../policy/types.js';
+import {
+  PolicyDecision,
+  PRIORITY_SUBAGENT_TOOL,
+  ApprovalMode,
+} from '../policy/types.js';
 import { A2AAgentError, AgentAuthConfigMissingError } from './a2a-errors.js';
 
 /**
@@ -176,9 +180,8 @@ export class AgentRegistry {
           agent.metadata.hash,
         );
 
-        if (isAcknowledged) {
-          agentsToRegister.push(agent);
-        } else {
+        agentsToRegister.push(agent);
+        if (!isAcknowledged) {
           unacknowledgedAgents.push(agent);
         }
       }
@@ -340,10 +343,23 @@ export class AgentRegistry {
     policyEngine.removeRulesForTool(definition.name, 'AgentRegistry (Dynamic)');
 
     // Add the new dynamic policy
+    const isYolo = this.config.getApprovalMode() === ApprovalMode.YOLO;
+    const isAcknowledged =
+      definition.kind === 'local' &&
+      (!definition.metadata?.hash ||
+        (this.config.getProjectRoot() &&
+          this.config
+            .getAcknowledgedAgentsService()
+            ?.isAcknowledgedSync?.(
+              this.config.getProjectRoot(),
+              definition.name,
+              definition.metadata.hash,
+            )));
+
     policyEngine.addRule({
       toolName: definition.name,
       decision:
-        definition.kind === 'local'
+        isAcknowledged || isYolo
           ? PolicyDecision.ALLOW
           : PolicyDecision.ASK_USER,
       priority: PRIORITY_SUBAGENT_TOOL,

--- a/packages/core/src/agents/registry_acknowledgement.test.ts
+++ b/packages/core/src/agents/registry_acknowledgement.test.ts
@@ -12,6 +12,7 @@ import { coreEvents } from '../utils/events.js';
 import * as tomlLoader from './agentLoader.js';
 import { type Config } from '../config/config.js';
 import { AcknowledgedAgentsService } from './acknowledgedAgents.js';
+import { PolicyDecision } from '../policy/types.js';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -103,13 +104,22 @@ describe('AgentRegistry Acknowledgement', () => {
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
-  it('should not register unacknowledged project agents and emit event', async () => {
+  it('should register unacknowledged project agents and emit event', async () => {
     const emitSpy = vi.spyOn(coreEvents, 'emitAgentsDiscovered');
 
     await registry.initialize();
 
-    expect(registry.getDefinition('ProjectAgent')).toBeUndefined();
+    // Now unacknowledged agents ARE registered (but with ASK_USER policy)
+    expect(registry.getDefinition('ProjectAgent')).toBeDefined();
     expect(emitSpy).toHaveBeenCalledWith([MOCK_AGENT_WITH_HASH]);
+
+    // Verify policy
+    const policyEngine = config.getPolicyEngine();
+    expect(
+      await policyEngine?.check({ name: 'ProjectAgent', args: {} }, undefined),
+    ).toMatchObject({
+      decision: PolicyDecision.ASK_USER,
+    });
   });
 
   it('should register acknowledged project agents', async () => {
@@ -134,6 +144,14 @@ describe('AgentRegistry Acknowledgement', () => {
 
     expect(registry.getDefinition('ProjectAgent')).toBeDefined();
     expect(emitSpy).not.toHaveBeenCalled();
+
+    // Verify policy is ALLOW for acknowledged agent
+    const policyEngine = config.getPolicyEngine();
+    expect(
+      await policyEngine?.check({ name: 'ProjectAgent', args: {} }, undefined),
+    ).toMatchObject({
+      decision: PolicyDecision.ALLOW,
+    });
   });
 
   it('should register agents without hash (legacy/safe?)', async () => {


### PR DESCRIPTION
## Summary

Building on the recently submitted Branch 3 infrastructure, this PR enhances the A2A and general agent discovery systems with robust trust validation, improved registry policies, and idempotent client management.

## File-based Changes

### `packages/core/src/agents/`

#### `acknowledgedAgents.ts`
- **Change:** Added `isAcknowledgedSync` method.
- **Purpose:** Enables synchronous trust validation by looking up cached agent hashes. This is needed to prevent startup race conditions where the registry initialization (which is synchronous) might finish before the asynchronous disk-based trust load completes.

#### `registry.ts`
- **Change:** 
  1. Updated `loadAgents` to register **all** discovered agents, regardless of trust status.
  2. Implemented `ASK_USER` policy for unacknowledged agents using `isAcknowledgedSync`.
  3. Added `GEMINI_YOLO_MODE` (ApprovalMode.YOLO) check.
- **Purpose:** Prevents trusted agents from being incorrectly flagged during startup. Registers untrusted agents as "visible but restricted" (ASK_USER) instead of ignoring them, improving discoverability. YOLO mode allows for automated testing/development by defaulting all policies to `ALLOW`.

#### `a2a-client-manager.ts`
- **Change:** Made `loadAgent` idempotent.
- **Purpose:** Instead of throwing an error if an agent is already loaded, it now returns the existing cached card. This is critical for architectures (like the experimental A2A server) that frequently re-initialize their registries but share a single singleton manager. Without this, subsequent tasks within the same server lifecycle would fail to load the agent tool.

---

### `packages/a2a-server/src/config/`

#### `settings.ts`
- **Change:** Added `experimental.enableAgents` to the `Settings` interface.
- **Purpose:** Allows the A2A server to recognize and parse the agent discovery flag from `.gemini/settings.json`.

#### `config.ts`
- **Change:** Updated `loadConfig` to propagate the `enableAgents` flag from settings to the core registry.
- **Purpose:** Enables the experimental A2A server to discover and host custom agents defined in the `.gemini/agents` directory, rather than being restricted to its internal Coder Agent.

---

## Testing

### Automated Tests
- **`acknowledgedAgents.test.ts`**: Added tests for `isAcknowledgedSync` functionality.
- **`registry_acknowledgement.test.ts`**: Verified that unacknowledged agents are registered with `ASK_USER` and transitioned to `ALLOW` once trusted.
- **`a2a-client-manager.test.ts`**: Updated tests to verify that `loadAgent` is idempotent and correctly returns cached instances.
- **`registry.test.ts`**: Added verification for remote agent registration in YOLO mode.

### Manual Test (gRPC V0 Compatibility)
1. **Prepare the Go Server (a2a-go repo)**
   - Switch to V0 Handler in `examples/helloworld/server/grpc/main.go`.
   - Set protocol Version to `"0.1"` in `a2a/core.go`.
   - Run: `go run examples/helloworld/server/grpc/main.go` (listens on port 9001).

2. **Prepare the Gemini CLI**
   - Create `.gemini/agents/grpc-test-agent.md` with URL: `http://localhost:9001/.well-known/agent-card.json`.
   - Ensure `"enableAgents": true` in the `experimental` block of `.gemini/settings.json`.

3. **Verify**
   - Start server:
     ```bash
     export CODER_AGENT_WORKSPACE_PATH="/path/to/your/workspace" && DEBUG=true GEMINI_YOLO_MODE=true npm run start -w @google/gemini-cli-a2a-server
     ```
   - Trigger call:
     ```bash
     curl -N -X POST http://localhost:PORT/ \
       -H "Content-Type: application/json" \
       -d '{
         "jsonrpc": "2.0",
         "id": "1",
         "method": "message/stream",
         "params": {
           "message": {
             "kind": "message",
             "role": "user",
             "parts": [{ "kind": "text", "text": "Hello, call the grpc-test-agent tool and say hi" }],
             "messageId": "test-final-attempt"
           }
         }
       }'
     ```

## Related Issues
Closes #22199
