### PR TITLE
fix(acp): pass isChatModel to sendMessageStream for proper model config resolution

### DIFF
--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -714,7 +714,7 @@ export class Session {
           (await this.config.getGemini31Launched?.()) ?? false,
         );
         const responseStream = await chat.sendMessageStream(
-          { model },
+          { model, isChatModel: true },
           nextMessage?.parts ?? [],
           promptId,
           pendingSend.signal,


### PR DESCRIPTION
## Summary

Add missing `isChatModel: true` to the `ModelConfigKey` passed to `sendMessageStream` in ACP mode, aligning it with the interactive CLI path.

## Details

When using ACP mode (`--experimental-acp`) with a model that doesn't have an explicit alias in `defaultModelConfigs.ts` (e.g., `gemini-3.1-pro-preview`), the model config — including `thinkingConfig` — was not applied at all.

**Root cause:** In `zedIntegration.ts`, `sendMessageStream` was called with `{ model }` instead of `{ model, isChatModel: true }`. Without this flag, `ModelConfigService.resolveAliasChain()` skips the `chat-base` fallback for unrecognized models, resulting in an empty config where `thinkingConfig` is `undefined`.

**Impact:**
- No thinking/thought chunks were sent via ACP for models without explicit aliases
- Other `chat-base` defaults (`temperature`, `topP`, `topK`) were also missing
- The interactive CLI path (`client.ts` line 665) already passes `isChatModel: true` and works correctly

**Debugging steps taken:**
1. Observed that `gemini-3.1-pro-preview` produces thoughts in interactive mode but not via ACP
2. Added debug logging to `geminiChat.ts` at the API call site — confirmed `thinkingConfig` was `undefined` in ACP mode
3. Traced config resolution: `gemini-3.1-pro-preview` has no alias in `defaultModelConfigs.ts`, so it depends on the `chat-base` fallback
4. The fallback only triggers when `isChatModel === true` (`modelConfigService.ts` line 215)
5. Found that `zedIntegration.ts` line 663 passes `{ model }` without `isChatModel`, while `client.ts` line 665 passes `{ model, isChatModel: true }`

This bug was not visible with models that have explicit aliases (e.g., `gemini-3-pro-preview` → `chat-base-3`) since they resolve directly without needing the fallback.

## Related Issues

Fixes #21411

## How to Validate

1. Run gemini-cli with `--experimental-acp` and `--model gemini-3.1-pro-preview` (or any model without an explicit alias in `defaultModelConfigs.ts`)
2. Send a prompt that would trigger thinking
3. **Before fix:** No `agent_thought_chunk` updates are sent; `thinkingConfig` is `undefined`
4. **After fix:** `agent_thought_chunk` updates are sent correctly; `thinkingConfig` includes `{ includeThoughts: true }`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) — N/A, no user-facing doc change
- [ ] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) — None
- [ ] Validated on required platforms/methods:
  - [ ] Linux
    - [x] npm run