### PR TITLE
feat(cli): add update command to auto-upgrade based on package manager

### DIFF
--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'node:child_process';
+import { coreEvents } from '@google/gemini-cli-core';
+import { updateCommand } from './update.js';
+import {
+  getInstallationInfo,
+  PackageManager,
+} from '../utils/installationInfo.js';
+import { runExitCleanup } from '../utils/cleanup.js';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+vi.mock('../utils/installationInfo.js', () => ({
+  getInstallationInfo: vi.fn(),
+  PackageManager: {
+    NPM: 'npm',
+    HOMEBREW: 'homebrew',
+    UNKNOWN: 'unknown',
+  },
+}));
+
+vi.mock('@google/gemini-cli-core', () => ({
+  coreEvents: {
+    emitFeedback: vi.fn(),
+  },
+}));
+
+vi.mock('../utils/cleanup.js', () => ({
+  runExitCleanup: vi.fn(),
+}));
+
+vi.mock('../gemini.js', () => ({
+  initializeOutputListenersAndFlush: vi.fn(),
+}));
+
+describe('updateCommand', () => {
+  const originalProcessExit = process.exit;
+
+  beforeEach(() => {
+    // @ts-expect-error - Mocking process.exit
+    process.exit = vi.fn();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.exit = originalProcessExit;
+  });
+
+  it('should have the correct command signature', () => {
+    expect(updateCommand.command).toBe('update');
+    expect(updateCommand.describe).toBe(
+      'Updates the Gemini CLI to the latest version.',
+    );
+  });
+
+  it('should exit with error if installation is not global', async () => {
+    // Mock a local project installation (e.g., cloned repo)
+    vi.mocked(getInstallationInfo).mockReturnValue({
+      packageManager: PackageManager.UNKNOWN,
+      isGlobal: false,
+      updateMessage: 'Running from a local git clone.',
+    });
+
+    // @ts-expect-error - testing the handler
+    await updateCommand.handler({});
+
+    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+      'info',
+      'Checking installation method...',
+    );
+    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+      'error',
+      'Running from a local git clone.',
+    );
+    expect(runExitCleanup).toHaveBeenCalled();
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(execSync).not.toHaveBeenCalled();
+  });
+
+  it('should execute the update command for a global npm installation', async () => {
+    // Mock a standard global npm installation
+    vi.mocked(getInstallationInfo).mockReturnValue({
+      packageManager: PackageManager.NPM,
+      isGlobal: true,
+      updateCommand: 'npm install -g @google/gemini-cli@latest',
+    });
+
+    // @ts-expect-error - testing the handler
+    await updateCommand.handler({});
+
+    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+      'info',
+      expect.stringContaining('npm'),
+    );
+    expect(execSync).toHaveBeenCalledWith(
+      'npm install -g @google/gemini-cli@latest',
+      { stdio: 'inherit' },
+    );
+    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+      'info',
+      expect.stringContaining('successfully updated'),
+    );
+    expect(runExitCleanup).toHaveBeenCalled();
+    expect(process.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('should handle EACCES permission errors gracefully', async () => {
+    // Force execSync to throw a permission error
+    vi.mocked(getInstallationInfo).mockReturnValue({
+      packageManager: PackageManager.NPM,
+      isGlobal: true,
+      updateCommand: 'npm install -g @google/gemini-cli@latest',
+    });
+
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    // @ts-expect-error - testing the handler
+    await updateCommand.handler({});
+
+    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+      'error',
+      expect.stringContaining('Permission denied'),
+    );
+    expect(runExitCleanup).toHaveBeenCalled();
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -52,10 +52,11 @@ export const updateCommand: CommandModule = {
       process.exit(0);
     } catch (error) {
       if (error instanceof Error && error.message.includes('EACCES')) {
-        coreEvents.emitFeedback(
-          'error',
-          `Permission denied. Try running the command with sudo: sudo ${installInfo.updateCommand}`,
-        );
+        const isWindows = process.platform === 'win32';
+        const suggestion = isWindows
+          ? 'Try running this command in a terminal with Administrator privileges.'
+          : `Try running the command with sudo: sudo ${installInfo.updateCommand}`;
+        coreEvents.emitFeedback('error', `Permission denied. ${suggestion}`);
       } else {
         coreEvents.emitFeedback(
           'error',

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -23,20 +23,20 @@ export const updateCommand: CommandModule = {
   handler: async () => {
     coreEvents.emitFeedback('info', 'Checking installation method...');
 
+    const installInfo = getInstallationInfo(process.cwd(), true);
+
+    if (!installInfo.isGlobal || !installInfo.updateCommand) {
+      coreEvents.emitFeedback(
+        'error',
+        installInfo.updateMessage ||
+          'Could not determine a global installation method. Please update manually.',
+      );
+      await runExitCleanup();
+      process.exit(1);
+      return; // For tests
+    }
+
     try {
-      const installInfo = getInstallationInfo(process.cwd(), true);
-
-      if (!installInfo.isGlobal || !installInfo.updateCommand) {
-        coreEvents.emitFeedback(
-          'error',
-          installInfo.updateMessage ||
-            'Could not determine a global installation method. Please update manually.',
-        );
-        await runExitCleanup();
-        process.exit(1);
-        return; // For tests
-      }
-
       coreEvents.emitFeedback(
         'info',
         `Detected global installation via: ${installInfo.packageManager}. Upgrading...`,
@@ -54,7 +54,7 @@ export const updateCommand: CommandModule = {
       if (error instanceof Error && error.message.includes('EACCES')) {
         coreEvents.emitFeedback(
           'error',
-          'Permission denied. Try running the command with sudo: sudo gemini update',
+          `Permission denied. Try running the command with sudo: sudo ${installInfo.updateCommand}`,
         );
       } else {
         coreEvents.emitFeedback(

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule } from 'yargs';
+import { execSync } from 'node:child_process';
+import process from 'node:process';
+import { coreEvents } from '@google/gemini-cli-core';
+import { getInstallationInfo } from '../utils/installationInfo.js';
+import { initializeOutputListenersAndFlush } from '../gemini.js';
+import { runExitCleanup } from '../utils/cleanup.js';
+
+export const updateCommand: CommandModule = {
+  command: 'update',
+  describe: 'Updates the Gemini CLI to the latest version.',
+  builder: (yargs) =>
+    yargs.middleware((argv) => {
+      initializeOutputListenersAndFlush();
+      argv['isCommand'] = true;
+    }),
+  handler: async () => {
+    coreEvents.emitFeedback('info', 'Checking installation method...');
+
+    try {
+      const installInfo = getInstallationInfo(process.cwd(), true);
+
+      if (!installInfo.isGlobal || !installInfo.updateCommand) {
+        coreEvents.emitFeedback(
+          'error',
+          installInfo.updateMessage ||
+            'Could not determine a global installation method. Please update manually.',
+        );
+        await runExitCleanup();
+        process.exit(1);
+        return; // For tests
+      }
+
+      coreEvents.emitFeedback(
+        'info',
+        `Detected global installation via: ${installInfo.packageManager}. Upgrading...`,
+      );
+      coreEvents.emitFeedback(
+        'info',
+        `Executing: ${installInfo.updateCommand}`,
+      );
+      execSync(installInfo.updateCommand, { stdio: 'inherit' });
+
+      coreEvents.emitFeedback('info', 'Gemini CLI successfully updated!');
+      await runExitCleanup();
+      process.exit(0);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('EACCES')) {
+        coreEvents.emitFeedback(
+          'error',
+          'Permission denied. Try running the command with sudo: sudo gemini update',
+        );
+      } else {
+        coreEvents.emitFeedback(
+          'error',
+          `Update failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      await runExitCleanup();
+      process.exit(1);
+    }
+  },
+};

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -10,6 +10,7 @@ import process from 'node:process';
 import * as path from 'node:path';
 import { execa } from 'execa';
 import { mcpCommand } from '../commands/mcp.js';
+import { updateCommand } from '../commands/update.js';
 import { extensionsCommand } from '../commands/extensions.js';
 import { skillsCommand } from '../commands/skills.js';
 import { hooksCommand } from '../commands/hooks.js';
@@ -181,6 +182,7 @@ export async function parseArguments(
         extensionsCommand,
         skillsCommand,
         hooksCommand,
+        updateCommand,
       ];
 
       const subcommands = commandModules.flatMap((mod) => {
@@ -260,6 +262,7 @@ export async function parseArguments(
   yargsInstance.command(extensionsCommand);
   yargsInstance.command(skillsCommand);
   yargsInstance.command(hooksCommand);
+  yargsInstance.command(updateCommand);
 
   yargsInstance
     .command('$0 [query..]', 'Launch Gemini CLI', (yargsInstance) =>


### PR DESCRIPTION
## Summary

Introduces a new `gemini update` subcommand that automatically detects the CLI's installation package manager (npm, brew, yarn, bun, pnpm) and executes the corresponding upgrade command. This reduces friction for users who frequently switch between package managers and eliminates the need to remember their original installation method.

## Details

- Wires `updateCommand` into the main Yargs router (`config.ts`).

- Uses the existing `getInstallationInfo` utility to find the package manager, safely aborts for local/npx environments, and runs `execSync` with `stdio: 'inherit'`

- Bypasses the interactive UI (`argv['isCommand'] = true`) and pipes logs through `coreEvents.emitFeedback`

- **Testing:** Adds `update.test.ts` to mock `child_process` and verify execution paths

## Related Issues

Fixes #21400 

## How to Validate

- Run `npm run build:all` and link the binary locally.
- Run `gemini update`
- Observe the correct package manager detection (e.g., "Detected global installation via: npm...").
- Verify the native upgrade command executes and completes successfully.
- Run the test suite.
- Verify edge case: run from a local git clone and ensure it gracefully prints "Running from a local git clone. Please update with 'git pull'." and exits with code 1.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
