### PR TITLE
docs: document tool exclusion from memory via deny policy

### DIFF
--- a/docs/reference/policy-engine.md
+++ b/docs/reference/policy-engine.md
@@ -98,7 +98,7 @@ There are three possible decisions a rule can enforce:
 - `ask_user`: The user is prompted to approve or deny the tool call. (In
   non-interactive mode, this is treated as `deny`.)
 
-> [!NOTE] The `deny` decision is the recommended way to exclude tools. The
+> **Note:** The `deny` decision is the recommended way to exclude tools. The
 > legacy `tools.exclude` setting in `settings.json` is deprecated in favor of
 > policy rules with a `deny` decision.
 

--- a/docs/reference/policy-engine.md
+++ b/docs/reference/policy-engine.md
@@ -91,9 +91,16 @@ the arguments don't match the pattern, the rule does not apply.
 There are three possible decisions a rule can enforce:
 
 - `allow`: The tool call is executed automatically without user interaction.
-- `deny`: The tool call is blocked and is not executed.
+- `deny`: The tool call is blocked and is not executed. For global rules (those
+  without an `argsPattern`), tools that are denied are **completely excluded
+  from the model's memory**. This means the model will not even see the tool as
+  an option, which is more secure and saves context window space.
 - `ask_user`: The user is prompted to approve or deny the tool call. (In
   non-interactive mode, this is treated as `deny`.)
+
+> [!NOTE] The `deny` decision is the recommended way to exclude tools. The
+> legacy `excludeTools` setting in `settings.json` is deprecated in favor of
+> policy rules with a `deny` decision.
 
 ### Priority system and tiers
 

--- a/docs/reference/policy-engine.md
+++ b/docs/reference/policy-engine.md
@@ -99,7 +99,7 @@ There are three possible decisions a rule can enforce:
   non-interactive mode, this is treated as `deny`.)
 
 > [!NOTE] The `deny` decision is the recommended way to exclude tools. The
-> legacy `excludeTools` setting in `settings.json` is deprecated in favor of
+> legacy `tools.exclude` setting in `settings.json` is deprecated in favor of
 > policy rules with a `deny` decision.
 
 ### Priority system and tiers


### PR DESCRIPTION
## Summary

This PR updates the policy engine documentation to explain that global `deny` rules exclude tools from the model's memory (function declarations). It also notes the deprecation of the legacy `excludeTools` setting.

## Details

- Added clarification to `docs/reference/policy-engine.md` about how `deny` decisions impact tool visibility for the model.
- Documented that `excludeTools` in `settings.json` is deprecated in favor of the Policy Engine's `deny` rules.
- Verified in `packages/core/src/tools/tool-registry.ts` that `getActiveTools` correctly filters these tools.

## Related Issues

Closes #21427

## How to Validate

1. View the changes in `docs/reference/policy-engine.md`.
2. Verify that the explanation for `deny` decisions correctly describes the memory exclusion behavior.
3. Confirm the deprecation note for `excludeTools` is clear.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
