### PR TITLE
Fix slash commands not working in non-interactive mode

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -247,9 +247,18 @@ export async function runNonInteractive({
           settings,
         );
         // If a slash command is found and returns a prompt, use it.
-        // Otherwise, slashCommandResult falls through to the default prompt
-        // handling.
+        // If it returns an empty array, the command was handled (e.g., /about, /help)
+        // and we should exit early without sending to the model.
+        // Otherwise, slashCommandResult falls through to the default prompt handling.
         if (slashCommandResult) {
+          // Check if command was handled (empty array means command executed but returned void)
+          if (
+            Array.isArray(slashCommandResult) &&
+            slashCommandResult.length === 0
+          ) {
+            // Command was handled (e.g., /about, /help), exit early
+            return;
+          }
           // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
           query = slashCommandResult as Part[];
         }

--- a/packages/cli/src/nonInteractiveCliCommands.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.ts
@@ -105,6 +105,10 @@ export const handleSlashCommand = async (
               'Exiting due to command result that is not supported in non-interactive mode.',
             );
         }
+      } else {
+        // Command executed successfully but returned void (e.g., /about, /help).
+        // Return empty array to indicate command was handled and we should exit early.
+        return [];
       }
     }
   }

--- a/packages/cli/src/ui/noninteractive/nonInteractiveUi.ts
+++ b/packages/cli/src/ui/noninteractive/nonInteractiveUi.ts
@@ -6,6 +6,18 @@
 
 import type { CommandContext } from '../commands/types.js';
 import type { ExtensionUpdateAction } from '../state/extensions.js';
+import type { HistoryItemAbout, HistoryItemWithoutId } from '../types.js';
+import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
+import { getDisplayString } from '@google/gemini-cli-core';
+
+/**
+ * Type guard to check if an item is a HistoryItemAbout
+ */
+function isHistoryItemAbout(
+  item: HistoryItemWithoutId,
+): item is HistoryItemAbout {
+  return item.type === 'about';
+}
 
 /**
  * Creates a UI context object with no-op functions.
@@ -23,6 +35,51 @@ export function createNonInteractiveUI(): CommandContext['ui'] {
         } else if (item.type === 'info') {
           process.stdout.write(`${item.text}\n`);
         }
+      } else if (isHistoryItemAbout(item)) {
+        // Format ABOUT items for console output
+        const aboutItem = item;
+        const lines: string[] = [];
+        lines.push('About Gemini CLI');
+        lines.push('');
+        lines.push(
+          `CLI Version${' '.repeat(60 - 'CLI Version'.length)}${aboutItem.cliVersion}`,
+        );
+        if (GIT_COMMIT_INFO && !['N/A'].includes(GIT_COMMIT_INFO)) {
+          lines.push(
+            `Git Commit${' '.repeat(60 - 'Git Commit'.length)}${GIT_COMMIT_INFO}`,
+          );
+        }
+        lines.push(
+          `Model${' '.repeat(60 - 'Model'.length)}${getDisplayString(aboutItem.modelVersion)}`,
+        );
+        lines.push(
+          `Sandbox${' '.repeat(60 - 'Sandbox'.length)}${aboutItem.sandboxEnv}`,
+        );
+        lines.push(`OS${' '.repeat(60 - 'OS'.length)}${aboutItem.osVersion}`);
+        if (aboutItem.selectedAuthType) {
+          const authDisplay =
+            aboutItem.selectedAuthType.startsWith('oauth') &&
+            aboutItem.userEmail
+              ? `Logged in with Google (${aboutItem.userEmail})`
+              : aboutItem.selectedAuthType;
+          lines.push(
+            `Auth Method${' '.repeat(60 - 'Auth Method'.length)}${authDisplay}`,
+          );
+        }
+        if (aboutItem.tier) {
+          lines.push(`Tier${' '.repeat(60 - 'Tier'.length)}${aboutItem.tier}`);
+        }
+        if (aboutItem.gcpProject) {
+          lines.push(
+            `GCP Project${' '.repeat(60 - 'GCP Project'.length)}${aboutItem.gcpProject}`,
+          );
+        }
+        if (aboutItem.ideClient) {
+          lines.push(
+            `IDE Client${' '.repeat(60 - 'IDE Client'.length)}${aboutItem.ideClient}`,
+          );
+        }
+        process.stdout.write(lines.join('\n') + '\n');
       }
       return 0;
     },


### PR DESCRIPTION
Fixes #21430

## Summary

Fixes a regression where slash commands (e.g., `/about`, `/help`) were not recognized when provided via command line with `-p` or `--prompt` flag. Previously, these commands were being sent to the model as regular prompts instead of being executed as commands.

## Details

The issue occurred because:
1. Slash commands that return `void` (like `/about`) were executing successfully but `handleSlashCommand` returned `undefined`
2. The non-interactive UI's `addItem` function only handled items with a `text` property, so ABOUT items (which have structured properties like `cliVersion`, `osVersion`, etc.) were silently ignored
3. When `handleSlashCommand` returned `undefined`, the code fell through to treating the input as a regular prompt, sending it to the model

**Changes made:**
- **nonInteractiveUi.ts**: Added formatting logic for ABOUT items to display them properly in console output (matching the interactive UI format)
- **nonInteractiveCliCommands.ts**: Modified to return an empty array `[]` when a command executes successfully but returns `void`, signaling that the command was handled
- **nonInteractiveCli.ts**: Added check to detect empty array result and exit early, preventing the command from being sent to the model

## Related Issues

Fixes #21430

## How to Validate

1. **Test `/about` command:**
   ```bash
   npm run start -- -p "/about" -y
   ```
   Expected: Should display formatted "About Gemini CLI" output and exit immediately (not send to model)

2. **Test `/help` command:**
   ```bash
   npm run start -- -p "/help" -y
   ```
   Expected: Should display help information and exit immediately

3. **Test custom slash commands** (if you have any in `.gemini/commands`):
   ```bash
   npm run start -- -p "/your-custom-command" -y
   ```
   Expected: Should execute the custom command and exit immediately

4. **Verify regular prompts still work:**
   ```bash
   npm run start -- -p "what is the version" -y
   ```
   Expected: Should send to model and get a response (this should still work normally)

5. **Compare behavior:**
   - Slash commands should execute and exit immediately
   - Regular text prompts should still send to the model

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
