### PR TITLE
docs: add quick CLI usage examples

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,28 @@ Gemini CLI brings the power of Gemini models directly into your terminal. Use it
 to understand code, automate tasks, and build workflows with your local project
 context.
 
+## Quick examples
+
+Here are a few common ways to use Gemini CLI in your terminal.
+
+### Explain a file
+
+```bash
+gemini explain src/app.js
+```
+
+### Debug a script
+
+```bash
+gemini debug script.py
+```
+
+### Generate documentation
+
+```bash
+gemini doc src/utils.ts
+```
+
 ## Install
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,19 +11,19 @@ Here are a few common ways to use Gemini CLI in your terminal.
 ### Explain a file
 
 ```bash
-gemini explain src/app.js
+gemini "explain src/app.js"
 ```
 
 ### Debug a script
 
 ```bash
-gemini debug script.py
+gemini "debug script.py"
 ```
 
 ### Generate documentation
 
 ```bash
-gemini doc src/utils.ts
+gemini "generate documentation for src/utils.ts"
 ```
 
 ## Install


### PR DESCRIPTION
Fixes #21442

## Summary
This PR adds a "Quick examples" section to the Gemini CLI documentation
homepage to help new users quickly understand common CLI workflows.

## Changes
- Added a "Quick examples" section to docs/index.md
- Included examples such as:
  - gemini explain src/app.js
  - gemini debug script.py
  - gemini doc src/utils.ts

## Motivation
This improves developer onboarding and makes it easier for new users
to understand how Gemini CLI commands are used in practice.