### PR TITLE
fix(core): display actual graph output in tracker_visualize tool

### DIFF
--- a/packages/core/src/tools/trackerTools.ts
+++ b/packages/core/src/tools/trackerTools.ts
@@ -566,7 +566,7 @@ class TrackerVisualizeInvocation extends BaseToolInvocation<
 
     return {
       llmContent: output,
-      returnDisplay: 'Graph rendered.',
+      returnDisplay: output,
     };
   }
 }


### PR DESCRIPTION
## Summary

Fixes the `tracker_visualize` tool so that the generated task dependency graph is returned for user display, instead of the hardcoded string "Graph rendered."

## Details

Previously, the `TrackerVisualizeInvocation` returned the graph correctly to the LLM via `llmContent`, but masked the output in the UI using `returnDisplay: 'Graph rendered.'`. This changes the `returnDisplay` value to the actual `output` string so the user can see the graph structure in their terminal.

## Related Issues

Fixes #21456

## How to Validate

1. Start the CLI with a task tracker enabled.
2. Create a few tasks and dependencies.
3. Run the `tracker_visualize` tool or ask the agent to visualize the tracker.
4. Confirm that the terminal displays the rendered graph (tree structure) rather than just the text "Graph rendered."

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed) - *Existing tests cover the output content.*
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker