### PR TITLE
fix(cli): hide redundant parent gemmaModelRouter setting (#21201)

### DIFF
--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -461,7 +461,7 @@ describe('SettingsSchema', () => {
       expect(gemmaModelRouter.category).toBe('Experimental');
       expect(gemmaModelRouter.default).toEqual({});
       expect(gemmaModelRouter.requiresRestart).toBe(true);
-      expect(gemmaModelRouter.showInDialog).toBe(true);
+      expect(gemmaModelRouter.showInDialog).toBe(false);
       expect(gemmaModelRouter.description).toBe(
         'Enable Gemma model router (experimental).',
       );

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1863,7 +1863,7 @@ const SETTINGS_SCHEMA = {
         requiresRestart: true,
         default: {},
         description: 'Enable Gemma model router (experimental).',
-        showInDialog: true,
+        showInDialog: false,
         properties: {
           enabled: {
             type: 'boolean',


### PR DESCRIPTION
## Summary

Hides the redundant parent `gemmaModelRouter` setting from the CLI settings dialog to resolve duplication.

## Details

Both the `gemmaModelRouter` object and its child `enabled` property were previously marked with `showInDialog: true`, causing the setting to appear twice in the UI. Setting `showInDialog: false` on the parent object ensures that only the relevant child toggle is displayed.

## Related Issues

Fixes #21201

## How to Validate

1. Run the CLI.
2. Open the settings dialog (`/settings`).
3. Observe that "Gemma Model Router" only appears once.
4. Run unit tests: `npm test -w @google/gemini-cli -- src/config/settingsSchema.test.ts`

Note: `npm run preflight` was executed; timeouts in `modelSteering.test.tsx` and `AppRig.test.tsx` were observed but confirmed to be pre-existing on the `main` branch.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
  - [ ] Windows
  - [x] Linux
    - [x] npm run
