### PR TITLE
Docs: Update 'docs-writer' skill for relative links

### DIFF
--- a/.gemini/skills/docs-writer/SKILL.md
+++ b/.gemini/skills/docs-writer/SKILL.md
@@ -65,12 +65,19 @@ accessible.
 - **UI and code:** Use **bold** for UI elements and `code font` for filenames,
   snippets, commands, and API elements. Focus on the task when discussing
   interaction.
-- **Links:** Use descriptive anchor text; avoid "click here." Ensure the link
-  makes sense out of context.
 - **Accessibility:** Use semantic HTML elements correctly (headings, lists, 
   tables).
 - **Media:** Use lowercase hyphenated filenames. Provide descriptive alt text
   for all images.
+
+### Links
+- **Accessibility:** Use descriptive anchor text; avoid "click here."Ensure the
+  link makes sense out of context, such as when being read by a screen reader.
+- **Use relative links in docs:** Use relative links in documentation to
+ensure portability; avoid absolute URLs for links within the same repository. Do not
+  include the /docs/ section of a link.
+- **When changing headings, check for deep links:** If a user is changing a heading,
+check for deep links to that heading in other pages, and update accordingly.
 
 ### Structure
 - **BLUF:** Start with an introduction explaining what to expect.
@@ -125,7 +132,6 @@ documentation.
   sentences to make them easier for users to understand.
 - **Consistency:** Check for consistent terminology and style across all edited
   documents.
-
 
 ## Phase 4: Verification and finalization
 Perform a final quality check to ensure that all changes are correctly formatted

--- a/.gemini/skills/docs-writer/SKILL.md
+++ b/.gemini/skills/docs-writer/SKILL.md
@@ -73,10 +73,11 @@ accessible.
 ### Links
 - **Accessibility:** Use descriptive anchor text; avoid "click here." Ensure the
   link makes sense out of context, such as when being read by a screen reader.
-- **Use relative links in docs:** Use relative links in documentation to ensure
-  portability. Use paths relative to the current file's directory (for example,
-  `../tools/` from `docs/cli/`). Do not include the `/docs/` section of a path,
-  but do verify that the resulting relative link exists.
+- **Use relative links in docs:** Use relative links in documentation (`/docs/`)
+  to ensure portability. Use paths relative to the current file's directory
+  (for example, `../tools/` from `docs/cli/`). Do not include the `/docs/`
+  section of a path, but do verify that the resulting relative link exists. This
+  does not apply to meta files such as README.MD and CONTRIBUTING.MD.
 - **When changing headings, check for deep links:** If a user is changing a
   heading, check for deep links to that heading in other pages and update
   accordingly.

--- a/.gemini/skills/docs-writer/SKILL.md
+++ b/.gemini/skills/docs-writer/SKILL.md
@@ -71,13 +71,15 @@ accessible.
   for all images.
 
 ### Links
-- **Accessibility:** Use descriptive anchor text; avoid "click here."Ensure the
+- **Accessibility:** Use descriptive anchor text; avoid "click here." Ensure the
   link makes sense out of context, such as when being read by a screen reader.
-- **Use relative links in docs:** Use relative links in documentation to
-ensure portability; avoid absolute URLs for links within the same repository. Do not
-  include the /docs/ section of a link.
-- **When changing headings, check for deep links:** If a user is changing a heading,
-check for deep links to that heading in other pages, and update accordingly.
+- **Use relative links in docs:** Use relative links in documentation to ensure
+  portability. Use paths relative to the current file's directory (for example,
+  `../tools/` from `docs/cli/`). Do not include the `/docs/` section of a path,
+  but do verify that the resulting relative link exists.
+- **When changing headings, check for deep links:** If a user is changing a
+  heading, check for deep links to that heading in other pages and update
+  accordingly.
 
 ### Structure
 - **BLUF:** Start with an introduction explaining what to expect.


### PR DESCRIPTION
## Summary

Updates our 'docs-writer' skill to ensure relative links and double-check changes to deep links.

## Details

Relative links are required to ensure the consistency of the repo + website.

Additionally, deep links can break when headers are changed.

This update changes the docs-writer skill to check for these when writing documentation.

## Related Issues

Related to #21438

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
