### PR TITLE
fix(cli): prevent gemmaModelRouter parent from showing in settings dialog

### DIFF
--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -461,7 +461,7 @@ describe('SettingsSchema', () => {
       expect(gemmaModelRouter.category).toBe('Experimental');
       expect(gemmaModelRouter.default).toEqual({});
       expect(gemmaModelRouter.requiresRestart).toBe(true);
-      expect(gemmaModelRouter.showInDialog).toBe(true);
+      expect(gemmaModelRouter.showInDialog).toBe(false);
       expect(gemmaModelRouter.description).toBe(
         'Enable Gemma model router (experimental).',
       );

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1863,7 +1863,7 @@ const SETTINGS_SCHEMA = {
         requiresRestart: true,
         default: {},
         description: 'Enable Gemma model router (experimental).',
-        showInDialog: true,
+        showInDialog: false,
         properties: {
           enabled: {
             type: 'boolean',


### PR DESCRIPTION
## Summary

Fixes a bug where the `gemmaModelRouter` parent container was appearing twice in the settings dialog - once as the parent object and again through its child properties.

## Details

- Changed `showInDialog: true` to `showInDialog: false` for the `gemmaModelRouter` parent container in `settingsSchema.ts`
- Updated corresponding test expectation in `settingsSchema.test.ts`

## Related Issues
Fixes #21201 

## Pre-Merge Checklist

   - [x] Updated relevant documentation and README (if needed)
   - [x] Added/updated tests (if needed)
   - [ ] Noted breaking changes (if any)
   - [x] Validated on required platforms/methods:
     - [x] MacOS
       - [x] npm run
       - [ ] npx
       - [ ] Docker
       - [ ] Podman
       - [ ] Seatbelt
     - [ ] Windows
     - [ ] Linux
