### PR TITLE
fix(core): whitelist TERM and COLORTERM in environment sanitization

### DIFF
--- a/packages/core/src/services/environmentSanitization.test.ts
+++ b/packages/core/src/services/environmentSanitization.test.ts
@@ -32,6 +32,28 @@ describe('sanitizeEnvironment', () => {
     expect(sanitized).toEqual(env);
   });
 
+  it('should allow TERM and COLORTERM environment variables', () => {
+    const env = {
+      TERM: 'xterm-256color',
+      COLORTERM: 'truecolor',
+    };
+    const sanitized = sanitizeEnvironment(env, EMPTY_OPTIONS);
+    expect(sanitized).toEqual(env);
+  });
+
+  it('should preserve TERM and COLORTERM even in strict sanitization mode', () => {
+    const env = {
+      GITHUB_SHA: 'abc123',
+      TERM: 'xterm-256color',
+      COLORTERM: 'truecolor',
+      SOME_OTHER_VAR: 'value',
+    };
+    const sanitized = sanitizeEnvironment(env, EMPTY_OPTIONS);
+    expect(sanitized['TERM']).toBe('xterm-256color');
+    expect(sanitized['COLORTERM']).toBe('truecolor');
+    expect(sanitized['SOME_OTHER_VAR']).toBeUndefined();
+  });
+
   it('should allow variables prefixed with GEMINI_CLI_', () => {
     const env = {
       GEMINI_CLI_FOO: 'bar',

--- a/packages/core/src/services/environmentSanitization.ts
+++ b/packages/core/src/services/environmentSanitization.ts
@@ -69,6 +69,10 @@ export const ALWAYS_ALLOWED_ENVIRONMENT_VARIABLES: ReadonlySet<string> =
     'TMPDIR',
     'USER',
     'LOGNAME',
+    // Terminal capability variables (needed by editors like vim/emacs and
+    // interactive commands like top)
+    'TERM',
+    'COLORTERM',
     // GitHub Action-related variables
     'ADDITIONAL_CONTEXT',
     'AVAILABLE_LABELS',


### PR DESCRIPTION
**[original author - @deadsmash07  - from PR - 20514]**


## Summary

- Added `TERM` and `COLORTERM` to `ALWAYS_ALLOWED_ENVIRONMENT_VARIABLES` in the environment sanitization service
- These variables describe terminal capabilities and are safe to pass through — they're needed by terminal editors (vim, emacs) and interactive commands (top)
- The sandbox path already preserves these variables (see `sandbox.ts`), so this aligns the sanitization behavior

## Details

Terminal-based editors fail to initialize ("Terminal type not defined") and interactive commands default to no-color mode because `TERM` and `COLORTERM` are stripped during environment sanitization. This change simply whitelists them so they pass through to spawned processes unchanged — no fallback values are introduced.

## Related Issues

Fixes #20444

## How to Validate

1. Set `EDITOR=vim` or `EDITOR=emacs`
2. Run Gemini CLI with environment variable redaction enabled
3. Trigger an editor operation (e.g., edit a plan)
4. Verify the editor starts correctly without "Terminal type not defined" errors
5. Run `top` via shell command and verify color support works

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) — N/A
- [x] Added/updated tests (if needed) — Two new tests covering normal and strict sanitization modes
- [x] Noted breaking changes (if any) — None
- [x] Validated on required platforms/methods:
  - [x] Linux `npm run`