### PR TITLE
test(cli): add integration tests for deprecated package spew (#20211)

### DIFF
--- a/integration-tests/deprecated-spew.test.ts
+++ b/integration-tests/deprecated-spew.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestRig } from './test-helper.js';
+
+describe('deprecated-spew', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = new TestRig();
+  });
+
+  afterEach(async () => {
+    await rig.cleanup();
+  });
+
+  const forbiddenPatterns = [
+    'DeprecationWarning',
+    'ExperimentalWarning',
+    'punycode',
+    'The `punycode` module is deprecated',
+  ];
+
+  it('should not contain any deprecated package spew in stderr when running --version', async () => {
+    rig.setup('deprecated-spew-version-test');
+
+    const { stderr, exitCode } = await rig.runWithStreams(['--version']);
+
+    expect(exitCode).toBe(0);
+
+    for (const pattern of forbiddenPatterns) {
+      expect(stderr).not.toContain(pattern);
+    }
+  });
+
+  it('should not contain any deprecated package spew in stderr when running a prompt', async () => {
+    rig.setup('deprecated-spew-prompt-test');
+
+    // Use a command that doesn't require API key if possible, or just ignore exit code
+    const output = await rig
+      .run({
+        args: ['-p', '/about'],
+      })
+      .catch((err) => err.message);
+
+    for (const pattern of forbiddenPatterns) {
+      expect(output).not.toContain(pattern);
+    }
+  });
+});

--- a/integration-tests/deprecated-spew.test.ts
+++ b/integration-tests/deprecated-spew.test.ts
@@ -40,12 +40,7 @@ describe('deprecated-spew', () => {
   it('should not contain any deprecated package spew in stderr when running a prompt', async () => {
     rig.setup('deprecated-spew-prompt-test');
 
-    // Use a command that doesn't require API key if possible, or just ignore exit code
-    const output = await rig
-      .run({
-        args: ['-p', '/about'],
-      })
-      .catch((err) => err.message);
+    const { stderr: output } = await rig.runWithStreams(['-p', '/about']);
 
     for (const pattern of forbiddenPatterns) {
       expect(output).not.toContain(pattern);


### PR DESCRIPTION
## Summary

Adds integration tests to ensure that `stderr` is free of deprecated package spew (e.g., `DeprecationWarning`, `ExperimentalWarning`) during CLI execution.

## Details

The new test file `integration-tests/deprecated-spew.test.ts` runs both `gemini --version` and a standard prompt (`gemini -p /about`) to verify that no forbidden warning patterns appear in the output. This addresses the concern raised in #20211 about preventing package spew from breaking user workflows or JSON parsing.

## Related Issues

Fixes #20211

## How to Validate

1. Build the project: `npm run build`
2. Run the new integration test: `npx vitest run integration-tests/deprecated-spew.test.ts`
3. Confirm the tests pass in the current environment.

Note: `npm run preflight` was executed; pre-existing timeouts in `modelSteering.test.tsx` and `AppRig.test.tsx` were confirmed to be present on the `main` branch and unrelated to these changes.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
  - [ ] Windows
  - [x] Linux
    - [x] npm run
