### PR TITLE
refactor(cli): pass keyMatchers directly to handlers to remove global state

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -99,6 +99,7 @@ import { mergeSettings, type LoadedSettings } from '../config/settings.js';
 import type { InitializationResult } from '../core/initializer.js';
 import { useQuotaAndFallback } from './hooks/useQuotaAndFallback.js';
 import { StreamingState } from './types.js';
+import { defaultKeyMatchers, type KeyMatchers } from './keyMatchers.js';
 import { UIStateContext, type UIState } from './contexts/UIStateContext.js';
 import {
   UIActionsContext,
@@ -2529,7 +2530,7 @@ describe('AppContainer State Management', () => {
   });
 
   describe('Shortcuts Help Visibility', () => {
-    let handleGlobalKeypress: (key: Key) => boolean;
+    let handleGlobalKeypress: (key: Key, matchers: KeyMatchers) => boolean;
     let mockedUseKeypress: Mock;
     let rerender: () => void;
     let unmount: () => void;
@@ -2545,16 +2546,19 @@ describe('AppContainer State Management', () => {
 
     const pressKey = (key: Partial<Key>) => {
       act(() => {
-        handleGlobalKeypress({
-          name: 'r',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: false,
-          sequence: '',
-          ...key,
-        } as Key);
+        handleGlobalKeypress(
+          {
+            name: 'r',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: false,
+            sequence: '',
+            ...key,
+          } as Key,
+          defaultKeyMatchers,
+        );
       });
       rerender();
     };
@@ -2562,7 +2566,10 @@ describe('AppContainer State Management', () => {
     beforeEach(() => {
       mockedUseKeypress = vi.spyOn(useKeypressModule, 'useKeypress') as Mock;
       mockedUseKeypress.mockImplementation(
-        (callback: (key: Key) => boolean, options: { isActive: boolean }) => {
+        (
+          callback: (key: Key, matchers: KeyMatchers) => boolean,
+          options: { isActive: boolean },
+        ) => {
           // AppContainer registers multiple keypress handlers; capture only
           // active handlers so inactive copy-mode handler doesn't override.
           if (options?.isActive) {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -119,7 +119,7 @@ import { type InitializationResult } from '../core/initializer.js';
 import { useFocus } from './hooks/useFocus.js';
 import { useKeypress, type Key } from './hooks/useKeypress.js';
 import { KeypressPriority } from './contexts/KeypressContext.js';
-import { keyMatchers, Command } from './keyMatchers.js';
+import { Command, type KeyMatchers } from './keyMatchers.js';
 import { useLoadingIndicator } from './hooks/useLoadingIndicator.js';
 import { useShellInactivityStatus } from './hooks/useShellInactivityStatus.js';
 import { useFolderTrust } from './hooks/useFolderTrust.js';
@@ -1648,36 +1648,39 @@ Logging in with Google... Restarting Gemini CLI to continue.
   });
 
   const handleGlobalKeypress = useCallback(
-    (key: Key): boolean => {
+    (key: Key, matchers: KeyMatchers): boolean => {
       // Debug log keystrokes if enabled
       if (settings.merged.general.debugKeystrokeLogging) {
         debugLogger.log('[DEBUG] Keystroke:', JSON.stringify(key));
       }
 
-      if (shortcutsHelpVisible && shouldDismissShortcutsHelpOnHotkey(key)) {
+      if (
+        shortcutsHelpVisible &&
+        shouldDismissShortcutsHelpOnHotkey(key, matchers)
+      ) {
         setShortcutsHelpVisible(false);
       }
 
-      if (isAlternateBuffer && keyMatchers[Command.TOGGLE_COPY_MODE](key)) {
+      if (isAlternateBuffer && matchers[Command.TOGGLE_COPY_MODE](key)) {
         setCopyModeEnabled(true);
         disableMouseEvents();
         return true;
       }
 
-      if (keyMatchers[Command.QUIT](key)) {
+      if (matchers[Command.QUIT](key)) {
         // If the user presses Ctrl+C, we want to cancel any ongoing requests.
         // This should happen regardless of the count.
         cancelOngoingRequest?.();
 
         handleCtrlCPress();
         return true;
-      } else if (keyMatchers[Command.EXIT](key)) {
+      } else if (matchers[Command.EXIT](key)) {
         handleCtrlDPress();
         return true;
-      } else if (keyMatchers[Command.SUSPEND_APP](key)) {
+      } else if (matchers[Command.SUSPEND_APP](key)) {
         handleSuspend();
       } else if (
-        keyMatchers[Command.TOGGLE_COPY_MODE](key) &&
+        matchers[Command.TOGGLE_COPY_MODE](key) &&
         !isAlternateBuffer
       ) {
         showTransientMessage({
@@ -1691,7 +1694,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       if (!constrainHeight) {
         enteringConstrainHeightMode = true;
         setConstrainHeight(true);
-        if (keyMatchers[Command.SHOW_MORE_LINES](key)) {
+        if (matchers[Command.SHOW_MORE_LINES](key)) {
           // If the user manually collapses the view, show the hint and reset the x-second timer.
           triggerExpandHint(true);
         }
@@ -1700,7 +1703,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
         }
       }
 
-      if (keyMatchers[Command.SHOW_ERROR_DETAILS](key)) {
+      if (matchers[Command.SHOW_ERROR_DETAILS](key)) {
         if (settings.merged.general.devtools) {
           void (async () => {
             const { toggleDevToolsPanel } = await import(
@@ -1717,10 +1720,10 @@ Logging in with Google... Restarting Gemini CLI to continue.
           setShowErrorDetails((prev) => !prev);
         }
         return true;
-      } else if (keyMatchers[Command.SHOW_FULL_TODOS](key)) {
+      } else if (matchers[Command.SHOW_FULL_TODOS](key)) {
         setShowFullTodos((prev) => !prev);
         return true;
-      } else if (keyMatchers[Command.TOGGLE_MARKDOWN](key)) {
+      } else if (matchers[Command.TOGGLE_MARKDOWN](key)) {
         setRenderMarkdown((prev) => {
           const newValue = !prev;
           // Force re-render of static content
@@ -1729,7 +1732,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
         });
         return true;
       } else if (
-        keyMatchers[Command.SHOW_IDE_CONTEXT_DETAIL](key) &&
+        matchers[Command.SHOW_IDE_CONTEXT_DETAIL](key) &&
         config.getIdeMode() &&
         ideContextState
       ) {
@@ -1737,7 +1740,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
         handleSlashCommand('/ide status');
         return true;
       } else if (
-        keyMatchers[Command.SHOW_MORE_LINES](key) &&
+        matchers[Command.SHOW_MORE_LINES](key) &&
         !enteringConstrainHeightMode
       ) {
         setConstrainHeight(false);
@@ -1748,8 +1751,8 @@ Logging in with Google... Restarting Gemini CLI to continue.
         }
         return true;
       } else if (
-        (keyMatchers[Command.FOCUS_SHELL_INPUT](key) ||
-          keyMatchers[Command.UNFOCUS_BACKGROUND_SHELL_LIST](key)) &&
+        (matchers[Command.FOCUS_SHELL_INPUT](key) ||
+          matchers[Command.UNFOCUS_BACKGROUND_SHELL_LIST](key)) &&
         (activePtyId || (isBackgroundShellVisible && backgroundShells.size > 0))
       ) {
         if (embeddedShellFocused) {
@@ -1783,15 +1786,15 @@ Logging in with Google... Restarting Gemini CLI to continue.
         setEmbeddedShellFocused(true);
         return true;
       } else if (
-        keyMatchers[Command.UNFOCUS_SHELL_INPUT](key) ||
-        keyMatchers[Command.UNFOCUS_BACKGROUND_SHELL](key)
+        matchers[Command.UNFOCUS_SHELL_INPUT](key) ||
+        matchers[Command.UNFOCUS_BACKGROUND_SHELL](key)
       ) {
         if (embeddedShellFocused) {
           setEmbeddedShellFocused(false);
           return true;
         }
         return false;
-      } else if (keyMatchers[Command.TOGGLE_BACKGROUND_SHELL](key)) {
+      } else if (matchers[Command.TOGGLE_BACKGROUND_SHELL](key)) {
         if (activePtyId) {
           backgroundCurrentShell();
           // After backgrounding, we explicitly do NOT show or focus the background UI.
@@ -1808,7 +1811,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
           }
         }
         return true;
-      } else if (keyMatchers[Command.TOGGLE_BACKGROUND_SHELL_LIST](key)) {
+      } else if (matchers[Command.TOGGLE_BACKGROUND_SHELL_LIST](key)) {
         if (backgroundShells.size > 0 && isBackgroundShellVisible) {
           if (!embeddedShellFocused) {
             setEmbeddedShellFocused(true);
@@ -1851,7 +1854,10 @@ Logging in with Google... Restarting Gemini CLI to continue.
     ],
   );
 
-  useKeypress(handleGlobalKeypress, { isActive: true, priority: true });
+  useKeypress((key, matchers) => handleGlobalKeypress(key, matchers), {
+    isActive: true,
+    priority: true,
+  });
 
   useKeypress(
     () => {

--- a/packages/cli/src/ui/auth/ApiAuthDialog.test.tsx
+++ b/packages/cli/src/ui/auth/ApiAuthDialog.test.tsx
@@ -9,6 +9,7 @@ import { waitFor } from '../../test-utils/async.js';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { ApiAuthDialog } from './ApiAuthDialog.js';
 import { useKeypress } from '../hooks/useKeypress.js';
+import { defaultKeyMatchers } from '../keyMatchers.js';
 import {
   useTextBuffer,
   type TextBuffer,
@@ -121,14 +122,17 @@ describe('ApiAuthDialog', () => {
       // calls[1] is the TextInput's useKeypress (typing handler)
       const keypressHandler = mockedUseKeypress.mock.calls[1][0];
 
-      keypressHandler({
-        name: keyName,
-        shift: false,
-        alt: false,
-        ctrl: false,
-        cmd: false,
-        sequence,
-      });
+      keypressHandler(
+        {
+          name: keyName,
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+          sequence,
+        },
+        defaultKeyMatchers,
+      );
 
       expect(expectedCall).toHaveBeenCalledWith(...args);
       unmount();
@@ -158,12 +162,15 @@ describe('ApiAuthDialog', () => {
     // Call 1 is TextInput (isActive: true, priority: true)
     const keypressHandler = mockedUseKeypress.mock.calls[0][0];
 
-    keypressHandler({
-      name: 'c',
-      shift: false,
-      ctrl: true,
-      cmd: false,
-    });
+    keypressHandler(
+      {
+        name: 'c',
+        shift: false,
+        ctrl: true,
+        cmd: false,
+      },
+      defaultKeyMatchers,
+    );
 
     await waitFor(() => {
       expect(clearApiKey).toHaveBeenCalled();

--- a/packages/cli/src/ui/auth/ApiAuthDialog.tsx
+++ b/packages/cli/src/ui/auth/ApiAuthDialog.tsx
@@ -13,7 +13,7 @@ import { useTextBuffer } from '../components/shared/text-buffer.js';
 import { useUIState } from '../contexts/UIStateContext.js';
 import { clearApiKey, debugLogger } from '@google/gemini-cli-core';
 import { useKeypress } from '../hooks/useKeypress.js';
-import { keyMatchers, Command } from '../keyMatchers.js';
+import { Command } from '../keyMatchers.js';
 
 interface ApiAuthDialogProps {
   onSubmit: (apiKey: string) => void;
@@ -85,8 +85,8 @@ export function ApiAuthDialog({
   };
 
   useKeypress(
-    (key) => {
-      if (keyMatchers[Command.CLEAR_INPUT](key)) {
+    (key, matchers) => {
+      if (matchers[Command.CLEAR_INPUT](key)) {
         void handleClear();
         return true;
       }

--- a/packages/cli/src/ui/auth/AuthInProgress.test.tsx
+++ b/packages/cli/src/ui/auth/AuthInProgress.test.tsx
@@ -9,6 +9,7 @@ import { render } from '../../test-utils/render.js';
 import { act } from 'react';
 import { AuthInProgress } from './AuthInProgress.js';
 import { useKeypress, type Key } from '../hooks/useKeypress.js';
+import { defaultKeyMatchers } from '../keyMatchers.js';
 import { debugLogger } from '@google/gemini-cli-core';
 
 // Mock dependencies
@@ -72,7 +73,7 @@ describe('AuthInProgress', () => {
     const keypressHandler = vi.mocked(useKeypress).mock.calls[0][0];
 
     await act(async () => {
-      keypressHandler({ name: 'escape' } as unknown as Key);
+      keypressHandler({ name: 'escape' } as unknown as Key, defaultKeyMatchers);
     });
     // Escape key has a 50ms timeout in KeypressContext, so we need to wrap waitUntilReady in act
     await act(async () => {
@@ -91,7 +92,10 @@ describe('AuthInProgress', () => {
     const keypressHandler = vi.mocked(useKeypress).mock.calls[0][0];
 
     await act(async () => {
-      keypressHandler({ name: 'c', ctrl: true } as unknown as Key);
+      keypressHandler(
+        { name: 'c', ctrl: true } as unknown as Key,
+        defaultKeyMatchers,
+      );
     });
     await waitUntilReady();
 

--- a/packages/cli/src/ui/components/AdminSettingsChangedDialog.tsx
+++ b/packages/cli/src/ui/components/AdminSettingsChangedDialog.tsx
@@ -8,14 +8,14 @@ import { Box, Text } from 'ink';
 import { theme } from '../semantic-colors.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { useUIActions } from '../contexts/UIActionsContext.js';
-import { Command, keyMatchers } from '../keyMatchers.js';
+import { Command } from '../keyMatchers.js';
 
 export const AdminSettingsChangedDialog = () => {
   const { handleRestart } = useUIActions();
 
   useKeypress(
-    (key) => {
-      if (keyMatchers[Command.RESTART_APP](key)) {
+    (key, matchers) => {
+      if (matchers[Command.RESTART_APP](key)) {
         handleRestart();
         return true;
       }

--- a/packages/cli/src/ui/components/AskUserDialog.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.tsx
@@ -20,7 +20,7 @@ import { BaseSelectionList } from './shared/BaseSelectionList.js';
 import type { SelectionListItem } from '../hooks/useSelectionList.js';
 import { TabHeader, type Tab } from './shared/TabHeader.js';
 import { useKeypress, type Key } from '../hooks/useKeypress.js';
-import { keyMatchers, Command } from '../keyMatchers.js';
+import { Command, type KeyMatchers } from '../keyMatchers.js';
 import { checkExhaustive } from '@google/gemini-cli-core';
 import { TextInput } from './shared/TextInput.js';
 import { formatCommand } from '../utils/keybindingUtils.js';
@@ -213,8 +213,8 @@ const ReviewView: React.FC<ReviewViewProps> = ({
 
   // Handle Enter to submit
   useKeypress(
-    (key: Key) => {
-      if (keyMatchers[Command.RETURN](key)) {
+    (key, matchers) => {
+      if (matchers[Command.RETURN](key)) {
         onSubmit();
         return true;
       }
@@ -315,8 +315,8 @@ const TextQuestionView: React.FC<TextQuestionViewProps> = ({
 
   // Handle Ctrl+C to clear all text
   const handleExtraKeys = useCallback(
-    (key: Key) => {
-      if (keyMatchers[Command.QUIT](key)) {
+    (key: Key, matchers: KeyMatchers) => {
+      if (matchers[Command.QUIT](key)) {
         if (textValue === '') {
           return false;
         }
@@ -627,9 +627,9 @@ const ChoiceQuestionView: React.FC<ChoiceQuestionViewProps> = ({
 
   // Handle "Type-to-Jump" and Ctrl+C for custom buffer
   const handleExtraKeys = useCallback(
-    (key: Key) => {
+    (key: Key, matchers: KeyMatchers) => {
       // If focusing custom option, handle Ctrl+C
-      if (isCustomOptionFocused && keyMatchers[Command.QUIT](key)) {
+      if (isCustomOptionFocused && matchers[Command.QUIT](key)) {
         if (customOptionText === '') {
           return false;
         }
@@ -639,15 +639,15 @@ const ChoiceQuestionView: React.FC<ChoiceQuestionViewProps> = ({
 
       // Don't jump if a navigation or selection key is pressed
       if (
-        keyMatchers[Command.DIALOG_NAVIGATION_UP](key) ||
-        keyMatchers[Command.DIALOG_NAVIGATION_DOWN](key) ||
-        keyMatchers[Command.DIALOG_NEXT](key) ||
-        keyMatchers[Command.DIALOG_PREV](key) ||
-        keyMatchers[Command.MOVE_LEFT](key) ||
-        keyMatchers[Command.MOVE_RIGHT](key) ||
-        keyMatchers[Command.RETURN](key) ||
-        keyMatchers[Command.ESCAPE](key) ||
-        keyMatchers[Command.QUIT](key)
+        matchers[Command.DIALOG_NAVIGATION_UP](key) ||
+        matchers[Command.DIALOG_NAVIGATION_DOWN](key) ||
+        matchers[Command.DIALOG_NEXT](key) ||
+        matchers[Command.DIALOG_PREV](key) ||
+        matchers[Command.MOVE_LEFT](key) ||
+        matchers[Command.MOVE_RIGHT](key) ||
+        matchers[Command.RETURN](key) ||
+        matchers[Command.ESCAPE](key) ||
+        matchers[Command.QUIT](key)
       ) {
         return false;
       }
@@ -985,12 +985,12 @@ export const AskUserDialog: React.FC<AskUserDialogProps> = ({
   }, [isEditingCustomOption, onActiveTextInputChange]);
 
   const handleCancel = useCallback(
-    (key: Key) => {
+    (key: Key, matchers: KeyMatchers) => {
       if (submitted) return false;
-      if (keyMatchers[Command.ESCAPE](key)) {
+      if (matchers[Command.ESCAPE](key)) {
         onCancel();
         return true;
-      } else if (keyMatchers[Command.QUIT](key)) {
+      } else if (matchers[Command.QUIT](key)) {
         if (!isEditingCustomOption) {
           onCancel();
         }
@@ -1002,21 +1002,21 @@ export const AskUserDialog: React.FC<AskUserDialogProps> = ({
     [onCancel, submitted, isEditingCustomOption],
   );
 
-  useKeypress(handleCancel, {
+  useKeypress((key, matchers) => handleCancel(key, matchers), {
     isActive: !submitted,
   });
 
   const isOnReviewTab = currentQuestionIndex === reviewTabIndex;
 
   const handleNavigation = useCallback(
-    (key: Key) => {
+    (key: Key, matchers: KeyMatchers) => {
       if (submitted || questions.length <= 1) return false;
 
-      const isNextKey = keyMatchers[Command.DIALOG_NEXT](key);
-      const isPrevKey = keyMatchers[Command.DIALOG_PREV](key);
+      const isNextKey = matchers[Command.DIALOG_NEXT](key);
+      const isPrevKey = matchers[Command.DIALOG_PREV](key);
 
-      const isRight = keyMatchers[Command.MOVE_RIGHT](key);
-      const isLeft = keyMatchers[Command.MOVE_LEFT](key);
+      const isRight = matchers[Command.MOVE_RIGHT](key);
+      const isLeft = matchers[Command.MOVE_LEFT](key);
 
       // Tab keys always trigger navigation.
       // Arrows trigger navigation if NOT in a text input OR if the input bubbles the event (already at edge).
@@ -1035,7 +1035,7 @@ export const AskUserDialog: React.FC<AskUserDialogProps> = ({
     [questions.length, submitted, goToNextTab, goToPrevTab],
   );
 
-  useKeypress(handleNavigation, {
+  useKeypress((key, matchers) => handleNavigation(key, matchers), {
     isActive: questions.length > 1 && !submitted,
   });
 

--- a/packages/cli/src/ui/components/BackgroundShellDisplay.test.tsx
+++ b/packages/cli/src/ui/components/BackgroundShellDisplay.test.tsx
@@ -7,6 +7,7 @@
 import { render } from '../../test-utils/render.js';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { BackgroundShellDisplay } from './BackgroundShellDisplay.js';
+import { defaultKeyMatchers } from '../keyMatchers.js';
 import { type BackgroundShell } from '../hooks/shellCommandProcessor.js';
 import { ShellExecutionService } from '@google/gemini-cli-core';
 import { act } from 'react';
@@ -61,7 +62,7 @@ const simulateKey = (key: Partial<Key>) => {
   const fullKey: Key = createMockKey(key);
   keypressHandlers.forEach(({ handler, isActive }) => {
     if (isActive) {
-      handler(fullKey);
+      handler(fullKey, defaultKeyMatchers);
     }
   });
 };

--- a/packages/cli/src/ui/components/BackgroundShellDisplay.tsx
+++ b/packages/cli/src/ui/components/BackgroundShellDisplay.tsx
@@ -16,7 +16,7 @@ import {
 } from '@google/gemini-cli-core';
 import { cpLen, cpSlice, getCachedStringWidth } from '../utils/textUtils.js';
 import { type BackgroundShell } from '../hooks/shellCommandProcessor.js';
-import { Command, keyMatchers } from '../keyMatchers.js';
+import { Command } from '../keyMatchers.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { formatCommand } from '../utils/keybindingUtils.js';
 import {
@@ -133,7 +133,7 @@ export const BackgroundShellDisplay = ({
   }, [isListOpenProp, activePid]);
 
   useKeypress(
-    (key) => {
+    (key, matchers) => {
       if (!activeShell) return;
 
       if (isListOpenProp) {
@@ -141,12 +141,12 @@ export const BackgroundShellDisplay = ({
         // We only handle special keys not consumed by RadioButtonSelect or overriding them if needed
         // RadioButtonSelect handles Enter -> onSelect
 
-        if (keyMatchers[Command.BACKGROUND_SHELL_ESCAPE](key)) {
+        if (matchers[Command.BACKGROUND_SHELL_ESCAPE](key)) {
           setIsBackgroundShellListOpen(false);
           return true;
         }
 
-        if (keyMatchers[Command.KILL_BACKGROUND_SHELL](key)) {
+        if (matchers[Command.KILL_BACKGROUND_SHELL](key)) {
           if (highlightedPid) {
             dismissBackgroundShell(highlightedPid);
             // If we killed the active one, the list might update via props
@@ -154,7 +154,7 @@ export const BackgroundShellDisplay = ({
           return true;
         }
 
-        if (keyMatchers[Command.TOGGLE_BACKGROUND_SHELL_LIST](key)) {
+        if (matchers[Command.TOGGLE_BACKGROUND_SHELL_LIST](key)) {
           if (highlightedPid) {
             setActiveBackgroundShellPid(highlightedPid);
           }
@@ -164,24 +164,24 @@ export const BackgroundShellDisplay = ({
         return false;
       }
 
-      if (keyMatchers[Command.TOGGLE_BACKGROUND_SHELL](key)) {
+      if (matchers[Command.TOGGLE_BACKGROUND_SHELL](key)) {
         return false;
       }
 
-      if (keyMatchers[Command.KILL_BACKGROUND_SHELL](key)) {
+      if (matchers[Command.KILL_BACKGROUND_SHELL](key)) {
         dismissBackgroundShell(activeShell.pid);
         return true;
       }
 
-      if (keyMatchers[Command.TOGGLE_BACKGROUND_SHELL_LIST](key)) {
+      if (matchers[Command.TOGGLE_BACKGROUND_SHELL_LIST](key)) {
         setIsBackgroundShellListOpen(true);
         return true;
       }
 
-      if (keyMatchers[Command.BACKGROUND_SHELL_SELECT](key)) {
+      if (matchers[Command.BACKGROUND_SHELL_SELECT](key)) {
         ShellExecutionService.writeToPty(activeShell.pid, '\r');
         return true;
-      } else if (keyMatchers[Command.DELETE_CHAR_LEFT](key)) {
+      } else if (matchers[Command.DELETE_CHAR_LEFT](key)) {
         ShellExecutionService.writeToPty(activeShell.pid, '\b');
         return true;
       } else if (key.sequence) {

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
@@ -10,7 +10,7 @@ import { renderWithProviders } from '../../test-utils/render.js';
 import { waitFor } from '../../test-utils/async.js';
 import { ExitPlanModeDialog } from './ExitPlanModeDialog.js';
 import { useKeypress } from '../hooks/useKeypress.js';
-import { keyMatchers, Command } from '../keyMatchers.js';
+import { defaultKeyMatchers, Command } from '../keyMatchers.js';
 import {
   ApprovalMode,
   validatePlanContent,
@@ -404,7 +404,7 @@ Implement a comprehensive authentication system with multiple providers.
         }) => {
           useKeypress(
             (key) => {
-              if (keyMatchers[Command.QUIT](key)) {
+              if (defaultKeyMatchers[Command.QUIT](key)) {
                 onBubbledQuit();
               }
               return false;

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
@@ -22,7 +22,7 @@ import { useConfig } from '../contexts/ConfigContext.js';
 import { AskUserDialog } from './AskUserDialog.js';
 import { openFileInEditor } from '../utils/editorUtils.js';
 import { useKeypress } from '../hooks/useKeypress.js';
-import { keyMatchers, Command } from '../keyMatchers.js';
+import { Command } from '../keyMatchers.js';
 import { formatCommand } from '../utils/keybindingUtils.js';
 
 export interface ExitPlanModeDialogProps {
@@ -167,8 +167,8 @@ export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
   }, [planPath, stdin, setRawMode, getPreferredEditor, refresh, onFeedback]);
 
   useKeypress(
-    (key) => {
-      if (keyMatchers[Command.OPEN_EXTERNAL_EDITOR](key)) {
+    (key, matchers) => {
+      if (matchers[Command.OPEN_EXTERNAL_EDITOR](key)) {
         void handleOpenEditor();
         return true;
       }

--- a/packages/cli/src/ui/components/FooterConfigDialog.tsx
+++ b/packages/cli/src/ui/components/FooterConfigDialog.tsx
@@ -10,8 +10,8 @@ import { Box, Text } from 'ink';
 import { theme } from '../semantic-colors.js';
 import { useSettingsStore } from '../contexts/SettingsContext.js';
 import { useUIState } from '../contexts/UIStateContext.js';
-import { useKeypress, type Key } from '../hooks/useKeypress.js';
-import { keyMatchers, Command } from '../keyMatchers.js';
+import { useKeypress, type Key as _Key } from '../hooks/useKeypress.js';
+import { Command } from '../keyMatchers.js';
 import { FooterRow, type FooterRowItem } from './Footer.js';
 import { ALL_ITEMS, resolveFooterState } from '../../config/footerItems.js';
 import { SettingScope } from '../../config/settings.js';
@@ -177,20 +177,20 @@ export const FooterConfigDialog: React.FC<FooterConfigDialogProps> = ({
   }, []);
 
   useKeypress(
-    (key: Key) => {
-      if (keyMatchers[Command.ESCAPE](key)) {
+    (key, matchers) => {
+      if (matchers[Command.ESCAPE](key)) {
         handleSaveAndClose();
         return true;
       }
 
-      if (keyMatchers[Command.MOVE_LEFT](key)) {
+      if (matchers[Command.MOVE_LEFT](key)) {
         if (focusKey && orderedIds.includes(focusKey)) {
           dispatch({ type: 'MOVE_ITEM', id: focusKey, direction: -1 });
           return true;
         }
       }
 
-      if (keyMatchers[Command.MOVE_RIGHT](key)) {
+      if (matchers[Command.MOVE_RIGHT](key)) {
         if (focusKey && orderedIds.includes(focusKey)) {
           dispatch({ type: 'MOVE_ITEM', id: focusKey, direction: 1 });
           return true;

--- a/packages/cli/src/ui/components/HooksDialog.tsx
+++ b/packages/cli/src/ui/components/HooksDialog.tsx
@@ -9,7 +9,7 @@ import { useState, useMemo } from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../semantic-colors.js';
 import { useKeypress } from '../hooks/useKeypress.js';
-import { keyMatchers, Command } from '../keyMatchers.js';
+import { Command } from '../keyMatchers.js';
 
 /**
  * Hook entry type matching HookRegistryEntry from core
@@ -88,19 +88,19 @@ export const HooksDialog: React.FC<HooksDialogProps> = ({
 
   // Handle keyboard navigation
   useKeypress(
-    (key) => {
-      if (keyMatchers[Command.ESCAPE](key)) {
+    (key, matchers) => {
+      if (matchers[Command.ESCAPE](key)) {
         onClose();
         return true;
       }
 
       // Scroll navigation
       if (needsScrolling) {
-        if (keyMatchers[Command.DIALOG_NAVIGATION_UP](key)) {
+        if (matchers[Command.DIALOG_NAVIGATION_UP](key)) {
           setScrollOffset((prev) => Math.max(0, prev - 1));
           return true;
         }
-        if (keyMatchers[Command.DIALOG_NAVIGATION_DOWN](key)) {
+        if (matchers[Command.DIALOG_NAVIGATION_DOWN](key)) {
           setScrollOffset((prev) => Math.min(maxScrollOffset, prev + 1));
           return true;
         }

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -44,7 +44,7 @@ import { terminalCapabilityManager } from '../utils/terminalCapabilityManager.js
 import type { UIState } from '../contexts/UIStateContext.js';
 import { isLowColorDepth } from '../utils/terminalUtils.js';
 import { cpLen } from '../utils/textUtils.js';
-import { keyMatchers, Command } from '../keyMatchers.js';
+import { defaultKeyMatchers, Command } from '../keyMatchers.js';
 import type { Key } from '../hooks/useKeypress.js';
 import {
   appEvents,
@@ -197,7 +197,7 @@ describe('InputPrompt', () => {
       visualCursor: [0, 0],
       visualScrollRow: 0,
       handleInput: vi.fn((key: Key) => {
-        if (keyMatchers[Command.CLEAR_INPUT](key)) {
+        if (defaultKeyMatchers[Command.CLEAR_INPUT](key)) {
           if (mockBuffer.text.length > 0) {
             mockBuffer.setText('');
             return true;
@@ -1980,6 +1980,7 @@ describe('InputPrompt', () => {
             name: 'paste',
             sequence: 'pasted text',
           }),
+          expect.anything(),
         );
       });
       unmount();
@@ -2248,6 +2249,7 @@ describe('InputPrompt', () => {
             name: 'paste',
             sequence: pastedText,
           }),
+          expect.anything(),
         );
       });
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -36,7 +36,7 @@ import {
 } from '../hooks/useCommandCompletion.js';
 import type { Key } from '../hooks/useKeypress.js';
 import { useKeypress } from '../hooks/useKeypress.js';
-import { keyMatchers, Command } from '../keyMatchers.js';
+import { Command, type KeyMatchers } from '../keyMatchers.js';
 import { formatCommand } from '../utils/keybindingUtils.js';
 import type { CommandContext, SlashCommand } from '../commands/types.js';
 import type { Config } from '@google/gemini-cli-core';
@@ -106,7 +106,7 @@ export interface InputPromptProps {
   approvalMode: ApprovalMode;
   onEscapePromptChange?: (showPrompt: boolean) => void;
   onSuggestionsVisibilityChange?: (visible: boolean) => void;
-  vimHandleInput?: (key: Key) => boolean;
+  vimHandleInput?: (key: Key, matchers: KeyMatchers) => boolean;
   isEmbeddedShellFocused?: boolean;
   setQueueErrorMessage: (message: string | null) => void;
   streamingState: StreamingState;
@@ -590,46 +590,46 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   );
 
   const handleInput = useCallback(
-    (key: Key) => {
+    (key: Key, matchers: KeyMatchers) => {
       // Determine if this keypress is a history navigation command
       const isHistoryUp =
         !shellModeActive &&
-        (keyMatchers[Command.HISTORY_UP](key) ||
-          (keyMatchers[Command.NAVIGATION_UP](key) &&
+        (matchers[Command.HISTORY_UP](key) ||
+          (matchers[Command.NAVIGATION_UP](key) &&
             (buffer.allVisualLines.length === 1 ||
               (buffer.visualCursor[0] === 0 && buffer.visualScrollRow === 0))));
       const isHistoryDown =
         !shellModeActive &&
-        (keyMatchers[Command.HISTORY_DOWN](key) ||
-          (keyMatchers[Command.NAVIGATION_DOWN](key) &&
+        (matchers[Command.HISTORY_DOWN](key) ||
+          (matchers[Command.NAVIGATION_DOWN](key) &&
             (buffer.allVisualLines.length === 1 ||
               buffer.visualCursor[0] === buffer.allVisualLines.length - 1)));
 
       const isHistoryNav = isHistoryUp || isHistoryDown;
       const isCursorMovement =
-        keyMatchers[Command.MOVE_LEFT](key) ||
-        keyMatchers[Command.MOVE_RIGHT](key) ||
-        keyMatchers[Command.MOVE_UP](key) ||
-        keyMatchers[Command.MOVE_DOWN](key) ||
-        keyMatchers[Command.MOVE_WORD_LEFT](key) ||
-        keyMatchers[Command.MOVE_WORD_RIGHT](key) ||
-        keyMatchers[Command.HOME](key) ||
-        keyMatchers[Command.END](key);
+        matchers[Command.MOVE_LEFT](key) ||
+        matchers[Command.MOVE_RIGHT](key) ||
+        matchers[Command.MOVE_UP](key) ||
+        matchers[Command.MOVE_DOWN](key) ||
+        matchers[Command.MOVE_WORD_LEFT](key) ||
+        matchers[Command.MOVE_WORD_RIGHT](key) ||
+        matchers[Command.HOME](key) ||
+        matchers[Command.END](key);
 
       const isSuggestionsNav =
         shouldShowSuggestions &&
-        (keyMatchers[Command.COMPLETION_UP](key) ||
-          keyMatchers[Command.COMPLETION_DOWN](key) ||
-          keyMatchers[Command.EXPAND_SUGGESTION](key) ||
-          keyMatchers[Command.COLLAPSE_SUGGESTION](key) ||
-          keyMatchers[Command.ACCEPT_SUGGESTION](key));
+        (matchers[Command.COMPLETION_UP](key) ||
+          matchers[Command.COMPLETION_DOWN](key) ||
+          matchers[Command.EXPAND_SUGGESTION](key) ||
+          matchers[Command.COLLAPSE_SUGGESTION](key) ||
+          matchers[Command.ACCEPT_SUGGESTION](key));
 
       // Reset completion suppression if the user performs any action other than
       // history navigation or cursor movement.
       // We explicitly skip this if we are currently navigating suggestions.
       if (!isSuggestionsNav) {
         setSuppressCompletion(
-          isHistoryNav || isCursorMovement || keyMatchers[Command.ESCAPE](key),
+          isHistoryNav || isCursorMovement || matchers[Command.ESCAPE](key),
         );
         hasUserNavigatedSuggestions.current = false;
 
@@ -727,7 +727,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           }, 40);
         }
         // Ensure we never accidentally interpret paste as regular input.
-        buffer.handleInput(key);
+        buffer.handleInput(key, matchers);
         if (key.sequence && isLargePaste(key.sequence)) {
           appEvents.emit(AppEvent.TransientMessage, {
             message: `Press ${formatCommand(Command.EXPAND_PASTE)} to expand pasted text`,
@@ -737,14 +737,17 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         return true;
       }
 
-      if (shortcutsHelpVisible && shouldDismissShortcutsHelpOnHotkey(key)) {
+      if (
+        shortcutsHelpVisible &&
+        shouldDismissShortcutsHelpOnHotkey(key, matchers)
+      ) {
         setShortcutsHelpVisible(false);
       }
 
       if (shortcutsHelpVisible) {
         if (key.sequence === '?' && key.insertable) {
           setShortcutsHelpVisible(false);
-          buffer.handleInput(key);
+          buffer.handleInput(key, matchers);
           return true;
         }
         // Escape is handled earlier to ensure it closes the panel before
@@ -768,7 +771,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         return true;
       }
 
-      if (vimHandleInput && vimHandleInput(key)) {
+      if (vimHandleInput && vimHandleInput(key, matchers)) {
         return true;
       }
 
@@ -778,7 +781,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
 
       // Ctrl+O to expand/collapse paste placeholders
-      if (keyMatchers[Command.EXPAND_PASTE](key)) {
+      if (matchers[Command.EXPAND_PASTE](key)) {
         const handled = tryTogglePasteExpansion(buffer);
         if (handled) return true;
       }
@@ -793,7 +796,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         return true;
       }
 
-      if (keyMatchers[Command.ESCAPE](key)) {
+      if (matchers[Command.ESCAPE](key)) {
         const cancelSearch = (
           setActive: (active: boolean) => void,
           resetCompletion: () => void,
@@ -842,13 +845,13 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         return true;
       }
 
-      if (keyMatchers[Command.CLEAR_SCREEN](key)) {
+      if (matchers[Command.CLEAR_SCREEN](key)) {
         setBannerVisible(false);
         onClearScreen();
         return true;
       }
 
-      if (shellModeActive && keyMatchers[Command.REVERSE_SEARCH](key)) {
+      if (shellModeActive && matchers[Command.REVERSE_SEARCH](key)) {
         setReverseSearchActive(true);
         setTextBeforeReverseSearch(buffer.text);
         setCursorPosition(buffer.cursor);
@@ -875,27 +878,27 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         const resetState = sc.resetCompletionState;
 
         if (showSuggestions) {
-          if (keyMatchers[Command.NAVIGATION_UP](key)) {
+          if (matchers[Command.NAVIGATION_UP](key)) {
             navigateUp();
             return true;
           }
-          if (keyMatchers[Command.NAVIGATION_DOWN](key)) {
+          if (matchers[Command.NAVIGATION_DOWN](key)) {
             navigateDown();
             return true;
           }
-          if (keyMatchers[Command.COLLAPSE_SUGGESTION](key)) {
+          if (matchers[Command.COLLAPSE_SUGGESTION](key)) {
             if (suggestions[activeSuggestionIndex].value.length >= MAX_WIDTH) {
               setExpandedSuggestionIndex(-1);
               return true;
             }
           }
-          if (keyMatchers[Command.EXPAND_SUGGESTION](key)) {
+          if (matchers[Command.EXPAND_SUGGESTION](key)) {
             if (suggestions[activeSuggestionIndex].value.length >= MAX_WIDTH) {
               setExpandedSuggestionIndex(activeSuggestionIndex);
               return true;
             }
           }
-          if (keyMatchers[Command.ACCEPT_SUGGESTION_REVERSE_SEARCH](key)) {
+          if (matchers[Command.ACCEPT_SUGGESTION_REVERSE_SEARCH](key)) {
             sc.handleAutocomplete(activeSuggestionIndex);
             resetState();
             setActive(false);
@@ -903,7 +906,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           }
         }
 
-        if (keyMatchers[Command.SUBMIT_REVERSE_SEARCH](key)) {
+        if (matchers[Command.SUBMIT_REVERSE_SEARCH](key)) {
           const textToSubmit =
             showSuggestions && activeSuggestionIndex > -1
               ? suggestions[activeSuggestionIndex].value
@@ -916,8 +919,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
         // Prevent up/down from falling through to regular history navigation
         if (
-          keyMatchers[Command.NAVIGATION_UP](key) ||
-          keyMatchers[Command.NAVIGATION_DOWN](key)
+          matchers[Command.NAVIGATION_UP](key) ||
+          matchers[Command.NAVIGATION_DOWN](key)
         ) {
           return true;
         }
@@ -927,7 +930,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       // We prioritize execution unless the user is explicitly selecting a different suggestion.
       if (
         completion.isPerfectMatch &&
-        keyMatchers[Command.SUBMIT](key) &&
+        matchers[Command.SUBMIT](key) &&
         recentUnsafePasteTime === null &&
         (!(completion.showSuggestions && isShellSuggestionsVisible) ||
           (completion.activeSuggestionIndex <= 0 &&
@@ -938,20 +941,20 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
 
       // Newline insertion
-      if (keyMatchers[Command.NEWLINE](key)) {
+      if (matchers[Command.NEWLINE](key)) {
         buffer.newline();
         return true;
       }
 
       if (completion.showSuggestions && isShellSuggestionsVisible) {
         if (completion.suggestions.length > 1) {
-          if (keyMatchers[Command.COMPLETION_UP](key)) {
+          if (matchers[Command.COMPLETION_UP](key)) {
             completion.navigateUp();
             hasUserNavigatedSuggestions.current = true;
             setExpandedSuggestionIndex(-1); // Reset expansion when navigating
             return true;
           }
-          if (keyMatchers[Command.COMPLETION_DOWN](key)) {
+          if (matchers[Command.COMPLETION_DOWN](key)) {
             completion.navigateDown();
             hasUserNavigatedSuggestions.current = true;
             setExpandedSuggestionIndex(-1); // Reset expansion when navigating
@@ -959,7 +962,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           }
         }
 
-        if (keyMatchers[Command.ACCEPT_SUGGESTION](key)) {
+        if (matchers[Command.ACCEPT_SUGGESTION](key)) {
           if (completion.suggestions.length > 0) {
             const targetIndex =
               completion.activeSuggestionIndex === -1
@@ -1055,7 +1058,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
 
       if (!shellModeActive) {
-        if (keyMatchers[Command.REVERSE_SEARCH](key)) {
+        if (matchers[Command.REVERSE_SEARCH](key)) {
           setCommandSearchActive(true);
           setTextBeforeReverseSearch(buffer.text);
           setCursorPosition(buffer.cursor);
@@ -1064,7 +1067,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
         if (isHistoryUp) {
           if (
-            keyMatchers[Command.NAVIGATION_UP](key) &&
+            matchers[Command.NAVIGATION_UP](key) &&
             buffer.visualCursor[1] > 0
           ) {
             buffer.move('home');
@@ -1081,7 +1084,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
         if (isHistoryDown) {
           if (
-            keyMatchers[Command.NAVIGATION_DOWN](key) &&
+            matchers[Command.NAVIGATION_DOWN](key) &&
             buffer.visualCursor[1] <
               cpLen(buffer.allVisualLines[buffer.visualCursor[0]] || '')
           ) {
@@ -1093,7 +1096,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
       } else {
         // Shell History Navigation
-        if (keyMatchers[Command.NAVIGATION_UP](key)) {
+        if (matchers[Command.NAVIGATION_UP](key)) {
           if (
             (buffer.allVisualLines.length === 1 ||
               (buffer.visualCursor[0] === 0 && buffer.visualScrollRow === 0)) &&
@@ -1106,7 +1109,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           if (prevCommand !== null) buffer.setText(prevCommand);
           return true;
         }
-        if (keyMatchers[Command.NAVIGATION_DOWN](key)) {
+        if (matchers[Command.NAVIGATION_DOWN](key)) {
           if (
             (buffer.allVisualLines.length === 1 ||
               buffer.visualCursor[0] === buffer.allVisualLines.length - 1) &&
@@ -1122,7 +1125,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
       }
 
-      if (keyMatchers[Command.SUBMIT](key)) {
+      if (matchers[Command.SUBMIT](key)) {
         if (buffer.text.trim()) {
           // Check if a paste operation occurred recently to prevent accidental auto-submission
           if (recentUnsafePasteTime !== null) {
@@ -1150,49 +1153,49 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
 
       // Ctrl+A (Home) / Ctrl+E (End)
-      if (keyMatchers[Command.HOME](key)) {
+      if (matchers[Command.HOME](key)) {
         buffer.move('home');
         return true;
       }
-      if (keyMatchers[Command.END](key)) {
+      if (matchers[Command.END](key)) {
         buffer.move('end');
         return true;
       }
 
       // Kill line commands
-      if (keyMatchers[Command.KILL_LINE_RIGHT](key)) {
+      if (matchers[Command.KILL_LINE_RIGHT](key)) {
         buffer.killLineRight();
         return true;
       }
-      if (keyMatchers[Command.KILL_LINE_LEFT](key)) {
+      if (matchers[Command.KILL_LINE_LEFT](key)) {
         buffer.killLineLeft();
         return true;
       }
 
-      if (keyMatchers[Command.DELETE_WORD_BACKWARD](key)) {
+      if (matchers[Command.DELETE_WORD_BACKWARD](key)) {
         buffer.deleteWordLeft();
         return true;
       }
 
       // External editor
-      if (keyMatchers[Command.OPEN_EXTERNAL_EDITOR](key)) {
+      if (matchers[Command.OPEN_EXTERNAL_EDITOR](key)) {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         buffer.openInExternalEditor();
         return true;
       }
 
       // Ctrl+V for clipboard paste
-      if (keyMatchers[Command.PASTE_CLIPBOARD](key)) {
+      if (matchers[Command.PASTE_CLIPBOARD](key)) {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         handleClipboardPaste();
         return true;
       }
 
-      if (keyMatchers[Command.TOGGLE_BACKGROUND_SHELL](key)) {
+      if (matchers[Command.TOGGLE_BACKGROUND_SHELL](key)) {
         return false;
       }
 
-      if (keyMatchers[Command.FOCUS_SHELL_INPUT](key)) {
+      if (matchers[Command.FOCUS_SHELL_INPUT](key)) {
         if (
           activePtyId ||
           (backgroundShells.size > 0 && backgroundShellHeight > 0)
@@ -1204,10 +1207,10 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
 
       // Fall back to the text buffer's default input handling for all other keys
-      const handled = buffer.handleInput(key);
+      const handled = buffer.handleInput(key, matchers);
 
       if (handled) {
-        if (keyMatchers[Command.CLEAR_INPUT](key)) {
+        if (matchers[Command.CLEAR_INPUT](key)) {
           resetCompletionState();
         }
 
@@ -1268,7 +1271,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     ],
   );
 
-  useKeypress(handleInput, {
+  useKeypress((key, matchers) => handleInput(key, matchers), {
     isActive: !isEmbeddedShellFocused,
     priority: true,
   });

--- a/packages/cli/src/ui/components/MultiFolderTrustDialog.test.tsx
+++ b/packages/cli/src/ui/components/MultiFolderTrustDialog.test.tsx
@@ -21,6 +21,7 @@ import * as directoryUtils from '../utils/directoryUtils.js';
 import type { Config } from '@google/gemini-cli-core';
 import { MessageType } from '../types.js';
 import { useKeypress } from '../hooks/useKeypress.js';
+import { defaultKeyMatchers } from '../keyMatchers.js';
 import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
 import * as path from 'node:path';
 
@@ -95,15 +96,18 @@ describe('MultiFolderTrustDialog', () => {
 
     const keypressCallback = mockedUseKeypress.mock.calls[0][0];
     await act(async () => {
-      keypressCallback({
-        name: 'escape',
-        shift: false,
-        alt: false,
-        ctrl: false,
-        cmd: false,
-        sequence: '',
-        insertable: false,
-      });
+      keypressCallback(
+        {
+          name: 'escape',
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+          sequence: '',
+          insertable: false,
+        },
+        defaultKeyMatchers,
+      );
     });
     await waitUntilReady();
 

--- a/packages/cli/src/ui/components/PolicyUpdateDialog.tsx
+++ b/packages/cli/src/ui/components/PolicyUpdateDialog.tsx
@@ -16,7 +16,7 @@ import { theme } from '../semantic-colors.js';
 import type { RadioSelectItem } from './shared/RadioButtonSelect.js';
 import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
 import { useKeypress } from '../hooks/useKeypress.js';
-import { keyMatchers, Command } from '../keyMatchers.js';
+import { Command } from '../keyMatchers.js';
 
 export enum PolicyUpdateChoice {
   ACCEPT = 'accept',
@@ -62,8 +62,8 @@ export const PolicyUpdateDialog: React.FC<PolicyUpdateDialogProps> = ({
   );
 
   useKeypress(
-    (key) => {
-      if (keyMatchers[Command.ESCAPE](key)) {
+    (key, matchers) => {
+      if (matchers[Command.ESCAPE](key)) {
         onClose();
         return true;
       }

--- a/packages/cli/src/ui/components/RewindConfirmation.tsx
+++ b/packages/cli/src/ui/components/RewindConfirmation.tsx
@@ -13,7 +13,7 @@ import type { RadioSelectItem } from './shared/RadioButtonSelect.js';
 import type { FileChangeStats } from '../utils/rewindFileOps.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { formatTimeAgo } from '../utils/formatters.js';
-import { keyMatchers, Command } from '../keyMatchers.js';
+import { Command } from '../keyMatchers.js';
 
 export enum RewindOutcome {
   RewindAndRevert = 'rewind_and_revert',
@@ -60,8 +60,8 @@ export const RewindConfirmation: React.FC<RewindConfirmationProps> = ({
 }) => {
   const isScreenReaderEnabled = useIsScreenReaderEnabled();
   useKeypress(
-    (key) => {
-      if (keyMatchers[Command.ESCAPE](key)) {
+    (key, matchers) => {
+      if (matchers[Command.ESCAPE](key)) {
         onConfirm(RewindOutcome.Cancel);
         return true;
       }

--- a/packages/cli/src/ui/components/RewindViewer.tsx
+++ b/packages/cli/src/ui/components/RewindViewer.tsx
@@ -19,7 +19,7 @@ import { useKeypress } from '../hooks/useKeypress.js';
 import { useRewind } from '../hooks/useRewind.js';
 import { RewindConfirmation, RewindOutcome } from './RewindConfirmation.js';
 import { stripReferenceContent } from '../utils/formatters.js';
-import { keyMatchers, Command } from '../keyMatchers.js';
+import { Command } from '../keyMatchers.js';
 import { CliSpinner } from './CliSpinner.js';
 import { ExpandableText } from './shared/ExpandableText.js';
 
@@ -95,13 +95,13 @@ export const RewindViewer: React.FC<RewindViewerProps> = ({
   }, [interactions]);
 
   useKeypress(
-    (key) => {
+    (key, matchers) => {
       if (!selectedMessageId) {
-        if (keyMatchers[Command.ESCAPE](key)) {
+        if (matchers[Command.ESCAPE](key)) {
           onExit();
           return true;
         }
-        if (keyMatchers[Command.EXPAND_SUGGESTION](key)) {
+        if (matchers[Command.EXPAND_SUGGESTION](key)) {
           if (
             highlightedMessageId &&
             highlightedMessageId !== 'current-position'
@@ -110,7 +110,7 @@ export const RewindViewer: React.FC<RewindViewerProps> = ({
             return true;
           }
         }
-        if (keyMatchers[Command.COLLAPSE_SUGGESTION](key)) {
+        if (matchers[Command.COLLAPSE_SUGGESTION](key)) {
           setExpandedMessageId(null);
           return true;
         }

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -40,6 +40,7 @@ import {
   BaseSettingsDialog,
   type SettingsDialogItem,
 } from './shared/BaseSettingsDialog.js';
+import { type KeyMatchers } from '../keyMatchers.js';
 
 interface FzfResult {
   item: string;
@@ -335,7 +336,11 @@ export function SettingsDialog({
 
   // Custom key handler for restart key
   const handleKeyPress = useCallback(
-    (key: Key, _currentItem: SettingsDialogItem | undefined): boolean => {
+    (
+      key: Key,
+      _matchers: KeyMatchers,
+      _currentItem: SettingsDialogItem | undefined,
+    ): boolean => {
       // 'r' key for restart
       if (showRestartPrompt && key.sequence === 'r') {
         if (onRestartRequest) onRestartRequest();

--- a/packages/cli/src/ui/components/ShellInputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/ShellInputPrompt.test.tsx
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act } from 'react';
 import { ShellExecutionService } from '@google/gemini-cli-core';
 import { useUIActions, type UIActions } from '../contexts/UIActionsContext.js';
+import { defaultKeyMatchers } from '../keyMatchers.js';
 
 // Mock useUIActions
 vi.mock('../contexts/UIActionsContext.js', () => ({
@@ -65,14 +66,17 @@ describe('ShellInputPrompt', () => {
     const handler = mockUseKeypress.mock.calls[0][0];
 
     await act(async () => {
-      handler({
-        name: 'tab',
-        shift: false,
-        alt: false,
-        ctrl: false,
-        cmd: false,
-        sequence: '\t',
-      });
+      handler(
+        {
+          name: 'tab',
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+          sequence: '\t',
+        },
+        defaultKeyMatchers,
+      );
     });
     await waitUntilReady();
 
@@ -94,14 +98,17 @@ describe('ShellInputPrompt', () => {
 
     // Simulate keypress
     await act(async () => {
-      handler({
-        name,
-        shift: false,
-        alt: false,
-        ctrl: false,
-        cmd: false,
-        sequence,
-      });
+      handler(
+        {
+          name,
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+          sequence,
+        },
+        defaultKeyMatchers,
+      );
     });
     await waitUntilReady();
 
@@ -121,7 +128,10 @@ describe('ShellInputPrompt', () => {
     const handler = mockUseKeypress.mock.calls[0][0];
 
     await act(async () => {
-      handler({ name: key, shift: true, alt: false, ctrl: false, cmd: false });
+      handler(
+        { name: key, shift: true, alt: false, ctrl: false, cmd: false },
+        defaultKeyMatchers,
+      );
     });
     await waitUntilReady();
 
@@ -143,13 +153,16 @@ describe('ShellInputPrompt', () => {
       const handler = mockUseKeypress.mock.calls[0][0];
 
       await act(async () => {
-        handler({
-          name: key,
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-        });
+        handler(
+          {
+            name: key,
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+          },
+          defaultKeyMatchers,
+        );
       });
       await waitUntilReady();
 
@@ -172,26 +185,32 @@ describe('ShellInputPrompt', () => {
 
     // PageDown
     await act(async () => {
-      handler({
-        name: 'pagedown',
-        shift: false,
-        alt: false,
-        ctrl: false,
-        cmd: false,
-      });
+      handler(
+        {
+          name: 'pagedown',
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+        },
+        defaultKeyMatchers,
+      );
     });
     await waitUntilReady();
     expect(mockScrollPty).toHaveBeenCalledWith(1, 10);
 
     // PageUp
     await act(async () => {
-      handler({
-        name: 'pageup',
-        shift: false,
-        alt: false,
-        ctrl: false,
-        cmd: false,
-      });
+      handler(
+        {
+          name: 'pageup',
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+        },
+        defaultKeyMatchers,
+      );
     });
     await waitUntilReady();
     expect(mockScrollPty).toHaveBeenCalledWith(1, -10);
@@ -207,14 +226,17 @@ describe('ShellInputPrompt', () => {
     const handler = mockUseKeypress.mock.calls[0][0];
 
     await act(async () => {
-      handler({
-        name: 'a',
-        shift: false,
-        alt: false,
-        ctrl: false,
-        cmd: false,
-        sequence: 'a',
-      });
+      handler(
+        {
+          name: 'a',
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+          sequence: 'a',
+        },
+        defaultKeyMatchers,
+      );
     });
     await waitUntilReady();
 
@@ -231,14 +253,17 @@ describe('ShellInputPrompt', () => {
     const handler = mockUseKeypress.mock.calls[0][0];
 
     await act(async () => {
-      handler({
-        name: 'a',
-        shift: false,
-        alt: false,
-        ctrl: false,
-        cmd: false,
-        sequence: 'a',
-      });
+      handler(
+        {
+          name: 'a',
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+          sequence: 'a',
+        },
+        defaultKeyMatchers,
+      );
     });
     await waitUntilReady();
 
@@ -256,13 +281,16 @@ describe('ShellInputPrompt', () => {
 
     let result: boolean | undefined;
     await act(async () => {
-      result = handler({
-        name: 'tab',
-        shift: true,
-        alt: false,
-        ctrl: false,
-        cmd: false,
-      });
+      result = handler(
+        {
+          name: 'tab',
+          shift: true,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+        },
+        defaultKeyMatchers,
+      );
     });
     await waitUntilReady();
 

--- a/packages/cli/src/ui/components/ShellInputPrompt.tsx
+++ b/packages/cli/src/ui/components/ShellInputPrompt.tsx
@@ -10,7 +10,7 @@ import { useKeypress } from '../hooks/useKeypress.js';
 import { ShellExecutionService } from '@google/gemini-cli-core';
 import { keyToAnsi, type Key } from '../hooks/keyToAnsi.js';
 import { ACTIVE_SHELL_MAX_LINES } from '../constants.js';
-import { Command, keyMatchers } from '../keyMatchers.js';
+import { Command, type KeyMatchers } from '../keyMatchers.js';
 
 export interface ShellInputPromptProps {
   activeShellPtyId: number | null;
@@ -33,34 +33,34 @@ export const ShellInputPrompt: React.FC<ShellInputPromptProps> = ({
   );
 
   const handleInput = useCallback(
-    (key: Key) => {
+    (key: Key, matchers: KeyMatchers) => {
       if (!focus || !activeShellPtyId) {
         return false;
       }
       // Allow background shell toggle to bubble up
-      if (keyMatchers[Command.TOGGLE_BACKGROUND_SHELL](key)) {
+      if (matchers[Command.TOGGLE_BACKGROUND_SHELL](key)) {
         return false;
       }
 
       // Allow Shift+Tab to bubble up for focus navigation
-      if (keyMatchers[Command.UNFOCUS_SHELL_INPUT](key)) {
+      if (matchers[Command.UNFOCUS_SHELL_INPUT](key)) {
         return false;
       }
 
-      if (keyMatchers[Command.SCROLL_UP](key)) {
+      if (matchers[Command.SCROLL_UP](key)) {
         ShellExecutionService.scrollPty(activeShellPtyId, -1);
         return true;
       }
-      if (keyMatchers[Command.SCROLL_DOWN](key)) {
+      if (matchers[Command.SCROLL_DOWN](key)) {
         ShellExecutionService.scrollPty(activeShellPtyId, 1);
         return true;
       }
       // TODO: Check pty service actually scrolls (request)[https://github.com/google-gemini/gemini-cli/pull/17438/changes/c9fdaf8967da0036bfef43592fcab5a69537df35#r2776479023].
-      if (keyMatchers[Command.PAGE_UP](key)) {
+      if (matchers[Command.PAGE_UP](key)) {
         ShellExecutionService.scrollPty(activeShellPtyId, -scrollPageSize);
         return true;
       }
-      if (keyMatchers[Command.PAGE_DOWN](key)) {
+      if (matchers[Command.PAGE_DOWN](key)) {
         ShellExecutionService.scrollPty(activeShellPtyId, scrollPageSize);
         return true;
       }
@@ -76,7 +76,9 @@ export const ShellInputPrompt: React.FC<ShellInputPromptProps> = ({
     [focus, handleShellInputSubmit, activeShellPtyId, scrollPageSize],
   );
 
-  useKeypress(handleInput, { isActive: focus });
+  useKeypress((key, matchers) => handleInput(key, matchers), {
+    isActive: focus,
+  });
 
   return null;
 };

--- a/packages/cli/src/ui/components/ValidationDialog.test.tsx
+++ b/packages/cli/src/ui/components/ValidationDialog.test.tsx
@@ -18,6 +18,7 @@ import {
 import { ValidationDialog } from './ValidationDialog.js';
 import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
 import type { Key } from '../hooks/useKeypress.js';
+import { defaultKeyMatchers, type KeyMatchers } from '../keyMatchers.js';
 
 // Mock the child components and utilities
 vi.mock('./shared/RadioButtonSelect.js', () => ({
@@ -43,14 +44,16 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
 });
 
 // Capture keypress handler to test it
-let mockKeypressHandler: (key: Key) => void;
+let mockKeypressHandler: (key: Key, matchers: KeyMatchers) => void;
 let mockKeypressOptions: { isActive: boolean };
 
 vi.mock('../hooks/useKeypress.js', () => ({
-  useKeypress: vi.fn((handler, options) => {
-    mockKeypressHandler = handler;
-    mockKeypressOptions = options;
-  }),
+  useKeypress: vi.fn(
+    (handler: (key: Key, matchers: KeyMatchers) => void, options) => {
+      mockKeypressHandler = handler;
+      mockKeypressOptions = options;
+    },
+  ),
 }));
 
 describe('ValidationDialog', () => {
@@ -121,15 +124,18 @@ describe('ValidationDialog', () => {
 
       // Simulate ESCAPE key press
       await act(async () => {
-        mockKeypressHandler({
-          name: 'escape',
-          ctrl: false,
-          shift: false,
-          alt: false,
-          cmd: false,
-          insertable: false,
-          sequence: '\x1b',
-        });
+        mockKeypressHandler(
+          {
+            name: 'escape',
+            ctrl: false,
+            shift: false,
+            alt: false,
+            cmd: false,
+            insertable: false,
+            sequence: '\x1b',
+          },
+          defaultKeyMatchers,
+        );
       });
       // Escape key has a 50ms timeout in KeypressContext, so we need to wrap waitUntilReady in act
       await act(async () => {

--- a/packages/cli/src/ui/components/ValidationDialog.tsx
+++ b/packages/cli/src/ui/components/ValidationDialog.tsx
@@ -16,7 +16,7 @@ import {
   type ValidationIntent,
 } from '@google/gemini-cli-core';
 import { useKeypress } from '../hooks/useKeypress.js';
-import { keyMatchers, Command } from '../keyMatchers.js';
+import { Command } from '../keyMatchers.js';
 
 interface ValidationDialogProps {
   validationLink?: string;
@@ -50,11 +50,11 @@ export function ValidationDialog({
 
   // Handle keypresses globally for cancellation, and specific logic for waiting state
   useKeypress(
-    (key) => {
-      if (keyMatchers[Command.ESCAPE](key) || keyMatchers[Command.QUIT](key)) {
+    (key, matchers) => {
+      if (matchers[Command.ESCAPE](key) || matchers[Command.QUIT](key)) {
         onChoice('cancel');
         return true;
-      } else if (state === 'waiting' && keyMatchers[Command.RETURN](key)) {
+      } else if (state === 'waiting' && matchers[Command.RETURN](key)) {
         // User confirmed verification is complete - transition to 'complete' state
         setState('complete');
         return true;

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -29,7 +29,7 @@ import {
 import { useKeypress } from '../../hooks/useKeypress.js';
 import { theme } from '../../semantic-colors.js';
 import { useSettings } from '../../contexts/SettingsContext.js';
-import { keyMatchers, Command } from '../../keyMatchers.js';
+import { Command } from '../../keyMatchers.js';
 import { formatCommand } from '../../utils/keybindingUtils.js';
 import { AskUserDialog } from '../AskUserDialog.js';
 import { ExitPlanModeDialog } from '../ExitPlanModeDialog.js';
@@ -163,12 +163,12 @@ export const ToolConfirmationMessage: React.FC<
   const expandDetailsHintKey = formatCommand(Command.SHOW_MORE_LINES);
 
   useKeypress(
-    (key) => {
+    (key, matchers) => {
       if (!isFocused) return false;
       if (
         confirmationDetails.type === 'mcp' &&
         hasMcpToolDetails &&
-        keyMatchers[Command.SHOW_MORE_LINES](key)
+        matchers[Command.SHOW_MORE_LINES](key)
       ) {
         setMcpDetailsExpansionState({
           callId,
@@ -176,11 +176,11 @@ export const ToolConfirmationMessage: React.FC<
         });
         return true;
       }
-      if (keyMatchers[Command.ESCAPE](key)) {
+      if (matchers[Command.ESCAPE](key)) {
         handleConfirm(ToolConfirmationOutcome.Cancel);
         return true;
       }
-      if (keyMatchers[Command.QUIT](key)) {
+      if (matchers[Command.QUIT](key)) {
         // Return false to let ctrl-C bubble up to AppContainer for exit flow.
         // AppContainer will call cancelOngoingRequest which will cancel the tool.
         return false;

--- a/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
@@ -24,7 +24,7 @@ import {
   cpIndexToOffset,
 } from '../../utils/textUtils.js';
 import { useKeypress, type Key } from '../../hooks/useKeypress.js';
-import { keyMatchers, Command } from '../../keyMatchers.js';
+import { Command, type KeyMatchers } from '../../keyMatchers.js';
 import { formatCommand } from '../../utils/keybindingUtils.js';
 
 /**
@@ -103,6 +103,7 @@ export interface BaseSettingsDialogProps {
   /** Optional custom key handler for parent-specific keys. Return true if handled. */
   onKeyPress?: (
     key: Key,
+    matchers: KeyMatchers,
     currentItem: SettingsDialogItem | undefined,
   ) => boolean;
 
@@ -247,9 +248,9 @@ export function BaseSettingsDialog({
 
   // Keyboard handling
   useKeypress(
-    (key: Key) => {
+    (key, matchers) => {
       // Let parent handle custom keys first
-      if (onKeyPress?.(key, currentItem)) {
+      if (onKeyPress?.(key, matchers, currentItem)) {
         return;
       }
 
@@ -259,25 +260,25 @@ export function BaseSettingsDialog({
         const type = item?.type ?? 'string';
 
         // Navigation within edit buffer
-        if (keyMatchers[Command.MOVE_LEFT](key)) {
+        if (matchers[Command.MOVE_LEFT](key)) {
           setEditCursorPos((p) => Math.max(0, p - 1));
           return;
         }
-        if (keyMatchers[Command.MOVE_RIGHT](key)) {
+        if (matchers[Command.MOVE_RIGHT](key)) {
           setEditCursorPos((p) => Math.min(cpLen(editBuffer), p + 1));
           return;
         }
-        if (keyMatchers[Command.HOME](key)) {
+        if (matchers[Command.HOME](key)) {
           setEditCursorPos(0);
           return;
         }
-        if (keyMatchers[Command.END](key)) {
+        if (matchers[Command.END](key)) {
           setEditCursorPos(cpLen(editBuffer));
           return;
         }
 
         // Backspace
-        if (keyMatchers[Command.DELETE_CHAR_LEFT](key)) {
+        if (matchers[Command.DELETE_CHAR_LEFT](key)) {
           if (editCursorPos > 0) {
             setEditBuffer((b) => {
               const before = cpSlice(b, 0, editCursorPos - 1);
@@ -290,7 +291,7 @@ export function BaseSettingsDialog({
         }
 
         // Delete
-        if (keyMatchers[Command.DELETE_CHAR_RIGHT](key)) {
+        if (matchers[Command.DELETE_CHAR_RIGHT](key)) {
           if (editCursorPos < cpLen(editBuffer)) {
             setEditBuffer((b) => {
               const before = cpSlice(b, 0, editCursorPos);
@@ -302,19 +303,19 @@ export function BaseSettingsDialog({
         }
 
         // Escape in edit mode - commit (consistent with SettingsDialog)
-        if (keyMatchers[Command.ESCAPE](key)) {
+        if (matchers[Command.ESCAPE](key)) {
           commitEdit();
           return;
         }
 
         // Enter in edit mode - commit
-        if (keyMatchers[Command.RETURN](key)) {
+        if (matchers[Command.RETURN](key)) {
           commitEdit();
           return;
         }
 
         // Up/Down in edit mode - commit and navigate
-        if (keyMatchers[Command.DIALOG_NAVIGATION_UP](key)) {
+        if (matchers[Command.DIALOG_NAVIGATION_UP](key)) {
           commitEdit();
           const newIndex = activeIndex > 0 ? activeIndex - 1 : items.length - 1;
           setActiveIndex(newIndex);
@@ -325,7 +326,7 @@ export function BaseSettingsDialog({
           }
           return;
         }
-        if (keyMatchers[Command.DIALOG_NAVIGATION_DOWN](key)) {
+        if (matchers[Command.DIALOG_NAVIGATION_DOWN](key)) {
           commitEdit();
           const newIndex = activeIndex < items.length - 1 ? activeIndex + 1 : 0;
           setActiveIndex(newIndex);
@@ -362,7 +363,7 @@ export function BaseSettingsDialog({
       // Not in edit mode - handle navigation and actions
       if (focusSection === 'settings') {
         // Up/Down navigation with wrap-around
-        if (keyMatchers[Command.DIALOG_NAVIGATION_UP](key)) {
+        if (matchers[Command.DIALOG_NAVIGATION_UP](key)) {
           const newIndex = activeIndex > 0 ? activeIndex - 1 : items.length - 1;
           setActiveIndex(newIndex);
           if (newIndex === items.length - 1) {
@@ -372,7 +373,7 @@ export function BaseSettingsDialog({
           }
           return true;
         }
-        if (keyMatchers[Command.DIALOG_NAVIGATION_DOWN](key)) {
+        if (matchers[Command.DIALOG_NAVIGATION_DOWN](key)) {
           const newIndex = activeIndex < items.length - 1 ? activeIndex + 1 : 0;
           setActiveIndex(newIndex);
           if (newIndex === 0) {
@@ -384,7 +385,7 @@ export function BaseSettingsDialog({
         }
 
         // Enter - toggle or start edit
-        if (keyMatchers[Command.RETURN](key) && currentItem) {
+        if (matchers[Command.RETURN](key) && currentItem) {
           if (currentItem.type === 'boolean' || currentItem.type === 'enum') {
             onItemToggle(currentItem.key, currentItem);
           } else {
@@ -399,7 +400,7 @@ export function BaseSettingsDialog({
         }
 
         // Ctrl+L - clear/reset to default (using only Ctrl+L to avoid Ctrl+C exit conflict)
-        if (keyMatchers[Command.CLEAR_SCREEN](key) && currentItem) {
+        if (matchers[Command.CLEAR_SCREEN](key) && currentItem) {
           onItemClear(currentItem.key, currentItem);
           return true;
         }
@@ -418,7 +419,7 @@ export function BaseSettingsDialog({
       }
 
       // Escape - close dialog
-      if (keyMatchers[Command.ESCAPE](key)) {
+      if (matchers[Command.ESCAPE](key)) {
         onClose();
         return;
       }

--- a/packages/cli/src/ui/components/shared/Scrollable.tsx
+++ b/packages/cli/src/ui/components/shared/Scrollable.tsx
@@ -15,12 +15,12 @@ import {
   useId,
 } from 'react';
 import { Box, ResizeObserver, type DOMElement } from 'ink';
-import { useKeypress, type Key } from '../../hooks/useKeypress.js';
+import { useKeypress } from '../../hooks/useKeypress.js';
 import { useScrollable } from '../../contexts/ScrollProvider.js';
 import { useAnimatedScrollbar } from '../../hooks/useAnimatedScrollbar.js';
 import { useBatchedScroll } from '../../hooks/useBatchedScroll.js';
-import { keyMatchers, Command } from '../../keyMatchers.js';
 import { useOverflowActions } from '../../contexts/OverflowContext.js';
+import { Command } from '../../keyMatchers.js';
 
 interface ScrollableProps {
   children?: React.ReactNode;
@@ -170,7 +170,7 @@ export const Scrollable: React.FC<ScrollableProps> = ({
     useAnimatedScrollbar(hasFocus, scrollBy);
 
   useKeypress(
-    (key: Key) => {
+    (key, matchers) => {
       const { scrollHeight, innerHeight } = sizeRef.current;
       const scrollTop = getScrollTop();
       const maxScroll = Math.max(0, scrollHeight - innerHeight);
@@ -179,11 +179,11 @@ export const Scrollable: React.FC<ScrollableProps> = ({
       // Only capture scroll-up events if there's room;
       // otherwise allow events to bubble.
       if (actualScrollTop > 0) {
-        if (keyMatchers[Command.PAGE_UP](key)) {
+        if (matchers[Command.PAGE_UP](key)) {
           scrollByWithAnimation(-innerHeight);
           return true;
         }
-        if (keyMatchers[Command.SCROLL_UP](key)) {
+        if (matchers[Command.SCROLL_UP](key)) {
           scrollByWithAnimation(-1);
           return true;
         }
@@ -192,11 +192,11 @@ export const Scrollable: React.FC<ScrollableProps> = ({
       // Only capture scroll-down events if there's room;
       // otherwise allow events to bubble.
       if (actualScrollTop < maxScroll) {
-        if (keyMatchers[Command.PAGE_DOWN](key)) {
+        if (matchers[Command.PAGE_DOWN](key)) {
           scrollByWithAnimation(innerHeight);
           return true;
         }
-        if (keyMatchers[Command.SCROLL_DOWN](key)) {
+        if (matchers[Command.SCROLL_DOWN](key)) {
           scrollByWithAnimation(1);
           return true;
         }

--- a/packages/cli/src/ui/components/shared/ScrollableList.tsx
+++ b/packages/cli/src/ui/components/shared/ScrollableList.tsx
@@ -21,8 +21,8 @@ import {
 import { useScrollable } from '../../contexts/ScrollProvider.js';
 import { Box, type DOMElement } from 'ink';
 import { useAnimatedScrollbar } from '../../hooks/useAnimatedScrollbar.js';
-import { useKeypress, type Key } from '../../hooks/useKeypress.js';
-import { keyMatchers, Command } from '../../keyMatchers.js';
+import { useKeypress } from '../../hooks/useKeypress.js';
+import { Command } from '../../keyMatchers.js';
 
 const ANIMATION_FRAME_DURATION_MS = 33;
 
@@ -195,20 +195,20 @@ function ScrollableList<T>(
   );
 
   useKeypress(
-    (key: Key) => {
-      if (keyMatchers[Command.SCROLL_UP](key)) {
+    (key, matchers) => {
+      if (matchers[Command.SCROLL_UP](key)) {
         stopSmoothScroll();
         scrollByWithAnimation(-1);
         return true;
-      } else if (keyMatchers[Command.SCROLL_DOWN](key)) {
+      } else if (matchers[Command.SCROLL_DOWN](key)) {
         stopSmoothScroll();
         scrollByWithAnimation(1);
         return true;
       } else if (
-        keyMatchers[Command.PAGE_UP](key) ||
-        keyMatchers[Command.PAGE_DOWN](key)
+        matchers[Command.PAGE_UP](key) ||
+        matchers[Command.PAGE_DOWN](key)
       ) {
-        const direction = keyMatchers[Command.PAGE_UP](key) ? -1 : 1;
+        const direction = matchers[Command.PAGE_UP](key) ? -1 : 1;
         const scrollState = getScrollState();
         const maxScroll = Math.max(
           0,
@@ -220,10 +220,10 @@ function ScrollableList<T>(
         const innerHeight = scrollState.innerHeight;
         smoothScrollTo(current + direction * innerHeight);
         return true;
-      } else if (keyMatchers[Command.SCROLL_HOME](key)) {
+      } else if (matchers[Command.SCROLL_HOME](key)) {
         smoothScrollTo(0);
         return true;
-      } else if (keyMatchers[Command.SCROLL_END](key)) {
+      } else if (matchers[Command.SCROLL_END](key)) {
         smoothScrollTo(SCROLL_TO_ITEM_END);
         return true;
       }

--- a/packages/cli/src/ui/components/shared/SearchableList.tsx
+++ b/packages/cli/src/ui/components/shared/SearchableList.tsx
@@ -11,7 +11,7 @@ import { useSelectionList } from '../../hooks/useSelectionList.js';
 import { TextInput } from './TextInput.js';
 import type { TextBuffer } from './text-buffer.js';
 import { useKeypress } from '../../hooks/useKeypress.js';
-import { keyMatchers, Command } from '../../keyMatchers.js';
+import { Command } from '../../keyMatchers.js';
 
 /**
  * Generic interface for items in a searchable list.
@@ -148,8 +148,8 @@ export function SearchableList<T extends GenericListItem>({
 
   // Handle global Escape key to close the list
   useKeypress(
-    (key) => {
-      if (keyMatchers[Command.ESCAPE](key)) {
+    (key, matchers) => {
+      if (matchers[Command.ESCAPE](key)) {
         onClose();
         return true;
       }

--- a/packages/cli/src/ui/components/shared/TextInput.test.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.test.tsx
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { act } from 'react';
 import { TextInput } from './TextInput.js';
 import { useKeypress } from '../../hooks/useKeypress.js';
+import { defaultKeyMatchers, type KeyMatchers } from '../../keyMatchers.js';
 import { useTextBuffer, type TextBuffer } from './text-buffer.js';
 
 // Mocks
@@ -25,7 +26,7 @@ vi.mock('./text-buffer.js', async (importOriginal) => {
     cursor: [0, 0],
     visualCursor: [0, 0],
     viewportVisualLines: [''],
-    handleInput: vi.fn((key) => {
+    handleInput: vi.fn((key, _matchers: KeyMatchers) => {
       // Simulate basic input for testing
       if (key.sequence) {
         mockTextBuffer.text += key.sequence;
@@ -85,7 +86,7 @@ describe('TextInput', () => {
       visualCursor: [0, 0],
       viewportVisualLines: [''],
       pastedContent: {} as Record<string, string>,
-      handleInput: vi.fn((key) => {
+      handleInput: vi.fn((key, _matchers: KeyMatchers) => {
         if (key.sequence) {
           buffer.text += key.sequence;
           buffer.viewportVisualLines = [buffer.text];
@@ -172,25 +173,31 @@ describe('TextInput', () => {
     const keypressHandler = mockedUseKeypress.mock.calls[0][0];
 
     await act(async () => {
-      keypressHandler({
+      keypressHandler(
+        {
+          name: 'a',
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+          sequence: 'a',
+        },
+        defaultKeyMatchers,
+      );
+    });
+    await waitUntilReady();
+
+    expect(mockBuffer.handleInput).toHaveBeenCalledWith(
+      {
         name: 'a',
         shift: false,
         alt: false,
         ctrl: false,
         cmd: false,
         sequence: 'a',
-      });
-    });
-    await waitUntilReady();
-
-    expect(mockBuffer.handleInput).toHaveBeenCalledWith({
-      name: 'a',
-      shift: false,
-      alt: false,
-      ctrl: false,
-      cmd: false,
-      sequence: 'a',
-    });
+      },
+      expect.anything(),
+    );
     expect(mockBuffer.text).toBe('a');
     unmount();
   });
@@ -204,25 +211,31 @@ describe('TextInput', () => {
     const keypressHandler = mockedUseKeypress.mock.calls[0][0];
 
     await act(async () => {
-      keypressHandler({
+      keypressHandler(
+        {
+          name: 'backspace',
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+          sequence: '',
+        },
+        defaultKeyMatchers,
+      );
+    });
+    await waitUntilReady();
+
+    expect(mockBuffer.handleInput).toHaveBeenCalledWith(
+      {
         name: 'backspace',
         shift: false,
         alt: false,
         ctrl: false,
         cmd: false,
         sequence: '',
-      });
-    });
-    await waitUntilReady();
-
-    expect(mockBuffer.handleInput).toHaveBeenCalledWith({
-      name: 'backspace',
-      shift: false,
-      alt: false,
-      ctrl: false,
-      cmd: false,
-      sequence: '',
-    });
+      },
+      expect.anything(),
+    );
     expect(mockBuffer.text).toBe('tes');
     unmount();
   });
@@ -236,14 +249,17 @@ describe('TextInput', () => {
     const keypressHandler = mockedUseKeypress.mock.calls[0][0];
 
     await act(async () => {
-      keypressHandler({
-        name: 'left',
-        shift: false,
-        alt: false,
-        ctrl: false,
-        cmd: false,
-        sequence: '',
-      });
+      keypressHandler(
+        {
+          name: 'left',
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+          sequence: '',
+        },
+        defaultKeyMatchers,
+      );
     });
     await waitUntilReady();
 
@@ -262,14 +278,17 @@ describe('TextInput', () => {
     const keypressHandler = mockedUseKeypress.mock.calls[0][0];
 
     await act(async () => {
-      keypressHandler({
-        name: 'right',
-        shift: false,
-        alt: false,
-        ctrl: false,
-        cmd: false,
-        sequence: '',
-      });
+      keypressHandler(
+        {
+          name: 'right',
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+          sequence: '',
+        },
+        defaultKeyMatchers,
+      );
     });
     await waitUntilReady();
 
@@ -286,14 +305,17 @@ describe('TextInput', () => {
     const keypressHandler = mockedUseKeypress.mock.calls[0][0];
 
     await act(async () => {
-      keypressHandler({
-        name: 'return',
-        shift: false,
-        alt: false,
-        ctrl: false,
-        cmd: false,
-        sequence: '',
-      });
+      keypressHandler(
+        {
+          name: 'return',
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+          sequence: '',
+        },
+        defaultKeyMatchers,
+      );
     });
     await waitUntilReady();
 
@@ -313,14 +335,17 @@ describe('TextInput', () => {
     const keypressHandler = mockedUseKeypress.mock.calls[0][0];
 
     await act(async () => {
-      keypressHandler({
-        name: 'return',
-        shift: false,
-        alt: false,
-        ctrl: false,
-        cmd: false,
-        sequence: '',
-      });
+      keypressHandler(
+        {
+          name: 'return',
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+          sequence: '',
+        },
+        defaultKeyMatchers,
+      );
     });
     await waitUntilReady();
 
@@ -338,14 +363,17 @@ describe('TextInput', () => {
     const keypressHandler = mockedUseKeypress.mock.calls[0][0];
 
     await act(async () => {
-      keypressHandler({
-        name: 'return',
-        shift: false,
-        alt: false,
-        ctrl: false,
-        cmd: false,
-        sequence: '',
-      });
+      keypressHandler(
+        {
+          name: 'return',
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+          sequence: '',
+        },
+        defaultKeyMatchers,
+      );
     });
     await waitUntilReady();
 
@@ -362,14 +390,17 @@ describe('TextInput', () => {
     const keypressHandler = mockedUseKeypress.mock.calls[0][0];
 
     await act(async () => {
-      keypressHandler({
-        name: 'escape',
-        shift: false,
-        alt: false,
-        ctrl: false,
-        cmd: false,
-        sequence: '',
-      });
+      keypressHandler(
+        {
+          name: 'escape',
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+          sequence: '',
+        },
+        defaultKeyMatchers,
+      );
     });
     // Escape key has a 50ms timeout in KeypressContext, so we need to wrap waitUntilReady in act
     await act(async () => {

--- a/packages/cli/src/ui/components/shared/TextInput.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.tsx
@@ -14,7 +14,7 @@ import { theme } from '../../semantic-colors.js';
 import type { TextBuffer } from './text-buffer.js';
 import { expandPastePlaceholders } from './text-buffer.js';
 import { cpSlice, cpIndexToOffset } from '../../utils/textUtils.js';
-import { keyMatchers, Command } from '../../keyMatchers.js';
+import { Command, type KeyMatchers } from '../../keyMatchers.js';
 
 export interface TextInputProps {
   buffer: TextBuffer;
@@ -41,24 +41,27 @@ export function TextInput({
   const [cursorVisualRowAbsolute, cursorVisualColAbsolute] = visualCursor;
 
   const handleKeyPress = useCallback(
-    (key: Key) => {
+    (key: Key, matchers: KeyMatchers) => {
       if (key.name === 'escape' && onCancel) {
         onCancel();
         return true;
       }
 
-      if (keyMatchers[Command.SUBMIT](key) && onSubmit) {
+      if (matchers[Command.SUBMIT](key) && onSubmit) {
         onSubmit(expandPastePlaceholders(text, buffer.pastedContent));
         return true;
       }
 
-      const handled = handleInput(key);
+      const handled = handleInput(key, matchers);
       return handled;
     },
     [handleInput, onCancel, onSubmit, text, buffer.pastedContent],
   );
 
-  useKeypress(handleKeyPress, { isActive: focus, priority: true });
+  useKeypress((key, matchers) => handleKeyPress(key, matchers), {
+    isActive: focus,
+    priority: true,
+  });
 
   const showPlaceholder = text.length === 0 && placeholder;
 

--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -41,6 +41,7 @@ import {
   getTransformedImagePath,
 } from './text-buffer.js';
 import { cpLen } from '../../utils/textUtils.js';
+import { defaultKeyMatchers } from '../../keyMatchers.js';
 import { escapePath } from '@google/gemini-cli-core';
 
 const defaultVisualLayout: VisualLayout = {
@@ -1442,15 +1443,18 @@ describe('useTextBuffer', () => {
       // This currently fails because handleInput returns false if cursorRow === 0
       let handledUp = false;
       act(() => {
-        handledUp = result.current.handleInput({
-          name: 'up',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: false,
-          sequence: '\x1b[A',
-        });
+        handledUp = result.current.handleInput(
+          {
+            name: 'up',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: false,
+            sequence: '\x1b[A',
+          },
+          defaultKeyMatchers,
+        );
       });
       expect(handledUp).toBe(true);
       expect(getBufferState(result).visualCursor[0]).toBe(0);
@@ -1459,15 +1463,18 @@ describe('useTextBuffer', () => {
       // This would also fail if cursorRow is the last logical row
       let handledDown = false;
       act(() => {
-        handledDown = result.current.handleInput({
-          name: 'down',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: false,
-          sequence: '\x1b[B',
-        });
+        handledDown = result.current.handleInput(
+          {
+            name: 'down',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: false,
+            sequence: '\x1b[B',
+          },
+          defaultKeyMatchers,
+        );
       });
       expect(handledDown).toBe(true);
       expect(getBufferState(result).visualCursor[0]).toBe(1);
@@ -1505,26 +1512,32 @@ describe('useTextBuffer', () => {
     it('should insert printable characters', () => {
       const { result } = renderHook(() => useTextBuffer({ viewport }));
       act(() => {
-        result.current.handleInput({
-          name: 'h',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: true,
-          sequence: 'h',
-        });
+        result.current.handleInput(
+          {
+            name: 'h',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: true,
+            sequence: 'h',
+          },
+          defaultKeyMatchers,
+        );
       });
       void act(() =>
-        result.current.handleInput({
-          name: 'i',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: true,
-          sequence: 'i',
-        }),
+        result.current.handleInput(
+          {
+            name: 'i',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: true,
+            sequence: 'i',
+          },
+          defaultKeyMatchers,
+        ),
       );
       expect(getBufferState(result).text).toBe('hi');
     });
@@ -1532,15 +1545,18 @@ describe('useTextBuffer', () => {
     it('should handle "Enter" key as newline', () => {
       const { result } = renderHook(() => useTextBuffer({ viewport }));
       act(() => {
-        result.current.handleInput({
-          name: 'return',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: true,
-          sequence: '\r',
-        });
+        result.current.handleInput(
+          {
+            name: 'return',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: true,
+            sequence: '\r',
+          },
+          defaultKeyMatchers,
+        );
       });
       expect(getBufferState(result).lines).toEqual(['', '']);
     });
@@ -1548,15 +1564,18 @@ describe('useTextBuffer', () => {
     it('should handle Ctrl+J as newline', () => {
       const { result } = renderHook(() => useTextBuffer({ viewport }));
       act(() => {
-        result.current.handleInput({
-          name: 'j',
-          shift: false,
-          alt: false,
-          ctrl: true,
-          cmd: false,
-          insertable: false,
-          sequence: '\n',
-        });
+        result.current.handleInput(
+          {
+            name: 'j',
+            shift: false,
+            alt: false,
+            ctrl: true,
+            cmd: false,
+            insertable: false,
+            sequence: '\n',
+          },
+          defaultKeyMatchers,
+        );
       });
       expect(getBufferState(result).lines).toEqual(['', '']);
     });
@@ -1564,15 +1583,18 @@ describe('useTextBuffer', () => {
     it('should do nothing for a tab key press', () => {
       const { result } = renderHook(() => useTextBuffer({ viewport }));
       act(() => {
-        result.current.handleInput({
-          name: 'tab',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: false,
-          sequence: '\t',
-        });
+        result.current.handleInput(
+          {
+            name: 'tab',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: false,
+            sequence: '\t',
+          },
+          defaultKeyMatchers,
+        );
       });
       expect(getBufferState(result).text).toBe('');
     });
@@ -1580,15 +1602,18 @@ describe('useTextBuffer', () => {
     it('should do nothing for a shift tab key press', () => {
       const { result } = renderHook(() => useTextBuffer({ viewport }));
       act(() => {
-        result.current.handleInput({
-          name: 'tab',
-          shift: true,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: false,
-          sequence: '\u001b[9;2u',
-        });
+        result.current.handleInput(
+          {
+            name: 'tab',
+            shift: true,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: false,
+            sequence: '\u001b[9;2u',
+          },
+          defaultKeyMatchers,
+        );
       });
       expect(getBufferState(result).text).toBe('');
     });
@@ -1603,15 +1628,18 @@ describe('useTextBuffer', () => {
       expect(getBufferState(result).text).toBe('hello');
       let handled = false;
       act(() => {
-        handled = result.current.handleInput({
-          name: 'c',
-          shift: false,
-          alt: false,
-          ctrl: true,
-          cmd: false,
-          insertable: false,
-          sequence: '\u0003',
-        });
+        handled = result.current.handleInput(
+          {
+            name: 'c',
+            shift: false,
+            alt: false,
+            ctrl: true,
+            cmd: false,
+            insertable: false,
+            sequence: '\u0003',
+          },
+          defaultKeyMatchers,
+        );
       });
       expect(handled).toBe(true);
       expect(getBufferState(result).text).toBe('');
@@ -1621,15 +1649,18 @@ describe('useTextBuffer', () => {
       const { result } = renderHook(() => useTextBuffer({ viewport }));
       let handled = true;
       act(() => {
-        handled = result.current.handleInput({
-          name: 'c',
-          shift: false,
-          alt: false,
-          ctrl: true,
-          cmd: false,
-          insertable: false,
-          sequence: '\u0003',
-        });
+        handled = result.current.handleInput(
+          {
+            name: 'c',
+            shift: false,
+            alt: false,
+            ctrl: true,
+            cmd: false,
+            insertable: false,
+            sequence: '\u0003',
+          },
+          defaultKeyMatchers,
+        );
       });
       expect(handled).toBe(false);
     });
@@ -1643,15 +1674,18 @@ describe('useTextBuffer', () => {
       );
       act(() => result.current.move('end'));
       act(() => {
-        result.current.handleInput({
-          name: 'backspace',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: false,
-          sequence: '\x7f',
-        });
+        result.current.handleInput(
+          {
+            name: 'backspace',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: false,
+            sequence: '\x7f',
+          },
+          defaultKeyMatchers,
+        );
       });
       expect(getBufferState(result).text).toBe('');
     });
@@ -1667,33 +1701,42 @@ describe('useTextBuffer', () => {
       expect(getBufferState(result).cursor).toEqual([0, 5]);
 
       act(() => {
-        result.current.handleInput({
-          name: 'backspace',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: false,
-          sequence: '\x7f',
-        });
-        result.current.handleInput({
-          name: 'backspace',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: false,
-          sequence: '\x7f',
-        });
-        result.current.handleInput({
-          name: 'backspace',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: false,
-          sequence: '\x7f',
-        });
+        result.current.handleInput(
+          {
+            name: 'backspace',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: false,
+            sequence: '\x7f',
+          },
+          defaultKeyMatchers,
+        );
+        result.current.handleInput(
+          {
+            name: 'backspace',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: false,
+            sequence: '\x7f',
+          },
+          defaultKeyMatchers,
+        );
+        result.current.handleInput(
+          {
+            name: 'backspace',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: false,
+            sequence: '\x7f',
+          },
+          defaultKeyMatchers,
+        );
       });
       expect(getBufferState(result).text).toBe('ab');
       expect(getBufferState(result).cursor).toEqual([0, 2]);
@@ -1742,27 +1785,33 @@ describe('useTextBuffer', () => {
       );
       act(() => result.current.move('end')); // cursor [0,2]
       act(() => {
-        result.current.handleInput({
-          name: 'left',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: false,
-          sequence: '\x1b[D',
-        });
+        result.current.handleInput(
+          {
+            name: 'left',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: false,
+            sequence: '\x1b[D',
+          },
+          defaultKeyMatchers,
+        );
       });
       expect(getBufferState(result).cursor).toEqual([0, 1]);
       act(() => {
-        result.current.handleInput({
-          name: 'right',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: false,
-          sequence: '\x1b[C',
-        });
+        result.current.handleInput(
+          {
+            name: 'right',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: false,
+            sequence: '\x1b[C',
+          },
+          defaultKeyMatchers,
+        );
       });
       expect(getBufferState(result).cursor).toEqual([0, 2]);
     });
@@ -1772,15 +1821,18 @@ describe('useTextBuffer', () => {
       const textWithAnsi = '\x1B[31mHello\x1B[0m \x1B[32mWorld\x1B[0m';
       // Simulate pasting by calling handleInput with a string longer than 1 char
       act(() => {
-        result.current.handleInput({
-          name: '',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: true,
-          sequence: textWithAnsi,
-        });
+        result.current.handleInput(
+          {
+            name: '',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: true,
+            sequence: textWithAnsi,
+          },
+          defaultKeyMatchers,
+        );
       });
       expect(getBufferState(result).text).toBe('Hello World');
     });
@@ -1788,15 +1840,18 @@ describe('useTextBuffer', () => {
     it('should handle VSCode terminal Shift+Enter as newline', () => {
       const { result } = renderHook(() => useTextBuffer({ viewport }));
       act(() => {
-        result.current.handleInput({
-          name: 'return',
-          shift: true,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: true,
-          sequence: '\r',
-        });
+        result.current.handleInput(
+          {
+            name: 'return',
+            shift: true,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: true,
+            sequence: '\r',
+          },
+          defaultKeyMatchers,
+        );
       }); // Simulates Shift+Enter in VSCode terminal
       expect(getBufferState(result).lines).toEqual(['', '']);
     });
@@ -2024,7 +2079,7 @@ Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots 
     ])('should strip $desc from input', ({ input, expected }) => {
       const { result } = renderHook(() => useTextBuffer({ viewport }));
       act(() => {
-        result.current.handleInput(createInput(input));
+        result.current.handleInput(createInput(input), defaultKeyMatchers);
       });
       expect(getBufferState(result).text).toBe(expected);
     });
@@ -2033,7 +2088,7 @@ Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots 
       const { result } = renderHook(() => useTextBuffer({ viewport }));
       const validText = 'Hello World\nThis is a test.';
       act(() => {
-        result.current.handleInput(createInput(validText));
+        result.current.handleInput(createInput(validText), defaultKeyMatchers);
       });
       expect(getBufferState(result).text).toBe(validText);
     });
@@ -2047,15 +2102,18 @@ Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots 
       expect(largeTextWithUnsafe.length).toBeGreaterThan(5000);
 
       act(() => {
-        result.current.handleInput({
-          name: '',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: true,
-          sequence: largeTextWithUnsafe,
-        });
+        result.current.handleInput(
+          {
+            name: '',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: true,
+            sequence: largeTextWithUnsafe,
+          },
+          defaultKeyMatchers,
+        );
       });
 
       const resultText = getBufferState(result).text;
@@ -2080,15 +2138,18 @@ Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots 
       expect(largeTextWithAnsi.length).toBeGreaterThan(5000);
 
       act(() => {
-        result.current.handleInput({
-          name: '',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: true,
-          sequence: largeTextWithAnsi,
-        });
+        result.current.handleInput(
+          {
+            name: '',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: true,
+            sequence: largeTextWithAnsi,
+          },
+          defaultKeyMatchers,
+        );
       });
 
       const resultText = getBufferState(result).text;
@@ -2103,15 +2164,18 @@ Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots 
       const { result } = renderHook(() => useTextBuffer({ viewport }));
       const emojis = '🐍🐳🦀🦄';
       act(() => {
-        result.current.handleInput({
-          name: '',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: true,
-          sequence: emojis,
-        });
+        result.current.handleInput(
+          {
+            name: '',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: true,
+            sequence: emojis,
+          },
+          defaultKeyMatchers,
+        );
       });
       expect(getBufferState(result).text).toBe(emojis);
     });
@@ -2289,15 +2353,18 @@ Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots 
         }),
       );
       act(() => {
-        result.current.handleInput({
-          name: 'return',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: true,
-          sequence: '\r',
-        });
+        result.current.handleInput(
+          {
+            name: 'return',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: true,
+            sequence: '\r',
+          },
+          defaultKeyMatchers,
+        );
       });
       expect(getBufferState(result).lines).toEqual(['']);
     });
@@ -2311,15 +2378,18 @@ Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots 
         }),
       );
       act(() => {
-        result.current.handleInput({
-          name: 'f1',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: false,
-          sequence: '\u001bOP',
-        });
+        result.current.handleInput(
+          {
+            name: 'f1',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: false,
+            sequence: '\u001bOP',
+          },
+          defaultKeyMatchers,
+        );
       });
       expect(getBufferState(result).lines).toEqual(['']);
     });

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -25,7 +25,7 @@ import {
 } from '../../utils/textUtils.js';
 import { parsePastedPaths } from '../../utils/clipboardUtils.js';
 import type { Key } from '../../contexts/KeypressContext.js';
-import { keyMatchers, Command } from '../../keyMatchers.js';
+import { Command, type KeyMatchers } from '../../keyMatchers.js';
 import type { VimAction } from './vim-buffer-actions.js';
 import { handleVimAction } from './vim-buffer-actions.js';
 import { LRU_BUFFER_PERF_CACHE_LIMIT } from '../../constants.js';
@@ -3145,33 +3145,33 @@ export function useTextBuffer({
   }, [text, pastedContent, stdin, setRawMode, getPreferredEditor]);
 
   const handleInput = useCallback(
-    (key: Key): boolean => {
+    (key: Key, matchers: KeyMatchers): boolean => {
       const { sequence: input } = key;
 
       if (key.name === 'paste') {
         insert(input, { paste: true });
         return true;
       }
-      if (keyMatchers[Command.RETURN](key)) {
+      if (matchers[Command.RETURN](key)) {
         if (singleLine) {
           return false;
         }
         newline();
         return true;
       }
-      if (keyMatchers[Command.NEWLINE](key)) {
+      if (matchers[Command.NEWLINE](key)) {
         if (singleLine) {
           return false;
         }
         newline();
         return true;
       }
-      if (keyMatchers[Command.MOVE_LEFT](key)) {
+      if (matchers[Command.MOVE_LEFT](key)) {
         if (cursorRow === 0 && cursorCol === 0) return false;
         move('left');
         return true;
       }
-      if (keyMatchers[Command.MOVE_RIGHT](key)) {
+      if (matchers[Command.MOVE_RIGHT](key)) {
         const lastLineIdx = lines.length - 1;
         if (
           cursorRow === lastLineIdx &&
@@ -3182,52 +3182,52 @@ export function useTextBuffer({
         move('right');
         return true;
       }
-      if (keyMatchers[Command.MOVE_UP](key)) {
+      if (matchers[Command.MOVE_UP](key)) {
         if (visualCursor[0] === 0) return false;
         move('up');
         return true;
       }
-      if (keyMatchers[Command.MOVE_DOWN](key)) {
+      if (matchers[Command.MOVE_DOWN](key)) {
         if (visualCursor[0] === visualLines.length - 1) return false;
         move('down');
         return true;
       }
-      if (keyMatchers[Command.MOVE_WORD_LEFT](key)) {
+      if (matchers[Command.MOVE_WORD_LEFT](key)) {
         move('wordLeft');
         return true;
       }
-      if (keyMatchers[Command.MOVE_WORD_RIGHT](key)) {
+      if (matchers[Command.MOVE_WORD_RIGHT](key)) {
         move('wordRight');
         return true;
       }
-      if (keyMatchers[Command.HOME](key)) {
+      if (matchers[Command.HOME](key)) {
         move('home');
         return true;
       }
-      if (keyMatchers[Command.END](key)) {
+      if (matchers[Command.END](key)) {
         move('end');
         return true;
       }
-      if (keyMatchers[Command.CLEAR_INPUT](key)) {
+      if (matchers[Command.CLEAR_INPUT](key)) {
         if (text.length > 0) {
           setText('');
           return true;
         }
         return false;
       }
-      if (keyMatchers[Command.DELETE_WORD_BACKWARD](key)) {
+      if (matchers[Command.DELETE_WORD_BACKWARD](key)) {
         deleteWordLeft();
         return true;
       }
-      if (keyMatchers[Command.DELETE_WORD_FORWARD](key)) {
+      if (matchers[Command.DELETE_WORD_FORWARD](key)) {
         deleteWordRight();
         return true;
       }
-      if (keyMatchers[Command.DELETE_CHAR_LEFT](key)) {
+      if (matchers[Command.DELETE_CHAR_LEFT](key)) {
         backspace();
         return true;
       }
-      if (keyMatchers[Command.DELETE_CHAR_RIGHT](key)) {
+      if (matchers[Command.DELETE_CHAR_RIGHT](key)) {
         const lastLineIdx = lines.length - 1;
         if (
           cursorRow === lastLineIdx &&
@@ -3238,11 +3238,11 @@ export function useTextBuffer({
         del();
         return true;
       }
-      if (keyMatchers[Command.UNDO](key)) {
+      if (matchers[Command.UNDO](key)) {
         undo();
         return true;
       }
-      if (keyMatchers[Command.REDO](key)) {
+      if (matchers[Command.REDO](key)) {
         redo();
         return true;
       }
@@ -3745,7 +3745,7 @@ export interface TextBuffer {
   /**
    * High level "handleInput" – receives what Ink gives us.
    */
-  handleInput: (key: Key) => boolean;
+  handleInput: (key: Key, matchers: KeyMatchers) => boolean;
   /**
    * Opens the current buffer contents in the user's preferred terminal text
    * editor ($VISUAL or $EDITOR, falling back to "vi").  The method blocks

--- a/packages/cli/src/ui/components/triage/TriageDuplicates.tsx
+++ b/packages/cli/src/ui/components/triage/TriageDuplicates.tsx
@@ -10,7 +10,7 @@ import Spinner from 'ink-spinner';
 import type { Config } from '@google/gemini-cli-core';
 import { debugLogger, spawnAsync, LlmRole } from '@google/gemini-cli-core';
 import { useKeypress } from '../../hooks/useKeypress.js';
-import { keyMatchers, Command } from '../../keyMatchers.js';
+import { Command } from '../../keyMatchers.js';
 
 interface Issue {
   number: number;
@@ -574,7 +574,7 @@ Return a JSON object with:
   };
 
   useKeypress(
-    (key) => {
+    (key, matchers) => {
       const input = key.sequence;
 
       // History Toggle
@@ -584,11 +584,7 @@ Return a JSON object with:
       }
 
       if (showHistory) {
-        if (
-          keyMatchers[Command.ESCAPE](key) ||
-          input === 'h' ||
-          input === 'q'
-        ) {
+        if (matchers[Command.ESCAPE](key) || input === 'h' || input === 'q') {
           setShowHistory(false);
         }
         return;
@@ -596,7 +592,7 @@ Return a JSON object with:
 
       // Global Quit/Cancel
       if (
-        keyMatchers[Command.ESCAPE](key) ||
+        matchers[Command.ESCAPE](key) ||
         (input === 'q' && focusSection !== 'candidate_detail')
       ) {
         if (focusSection === 'candidate_detail') {
@@ -614,7 +610,7 @@ Return a JSON object with:
       const isInteraction = state.status === 'interaction';
 
       // Priority 1: Action Confirmation (Enter)
-      if (keyMatchers[Command.RETURN](key) && inputAction) {
+      if (matchers[Command.RETURN](key) && inputAction) {
         if (inputAction === 's') {
           setProcessedHistory((prev) => [
             ...prev,
@@ -668,7 +664,7 @@ Return a JSON object with:
           setTargetExpanded((prev) => !prev);
           setTargetScrollOffset(0);
         }
-        if (keyMatchers[Command.NAVIGATION_DOWN](key)) {
+        if (matchers[Command.NAVIGATION_DOWN](key)) {
           const targetBody = state.currentIssue?.body || '';
           const targetLines = targetBody.split('\n');
           const visibleLines = targetExpanded
@@ -677,21 +673,21 @@ Return a JSON object with:
           const maxScroll = Math.max(0, targetLines.length - visibleLines);
           setTargetScrollOffset((prev) => Math.min(prev + 1, maxScroll));
         }
-        if (keyMatchers[Command.NAVIGATION_UP](key)) {
+        if (matchers[Command.NAVIGATION_UP](key)) {
           setTargetScrollOffset((prev) => Math.max(0, prev - 1));
         }
       } else if (focusSection === 'candidates') {
-        if (keyMatchers[Command.NAVIGATION_DOWN](key)) {
+        if (matchers[Command.NAVIGATION_DOWN](key)) {
           setSelectedCandidateIndex((prev) =>
             Math.min((state.candidates?.length || 1) - 1, prev + 1),
           );
         }
-        if (keyMatchers[Command.NAVIGATION_UP](key)) {
+        if (matchers[Command.NAVIGATION_UP](key)) {
           setSelectedCandidateIndex((prev) => Math.max(0, prev - 1));
         }
         if (
-          keyMatchers[Command.MOVE_RIGHT](key) ||
-          (keyMatchers[Command.RETURN](key) && !inputAction)
+          matchers[Command.MOVE_RIGHT](key) ||
+          (matchers[Command.RETURN](key) && !inputAction)
         ) {
           setFocusSection('candidate_detail');
           setCandidateScrollOffset(0);
@@ -702,13 +698,13 @@ Return a JSON object with:
         const candLines = candBody.split('\n');
         const maxScroll = Math.max(0, candLines.length - VISIBLE_LINES_DETAIL);
 
-        if (keyMatchers[Command.MOVE_LEFT](key)) {
+        if (matchers[Command.MOVE_LEFT](key)) {
           setFocusSection('candidates');
         }
-        if (keyMatchers[Command.NAVIGATION_DOWN](key)) {
+        if (matchers[Command.NAVIGATION_DOWN](key)) {
           setCandidateScrollOffset((prev) => Math.min(prev + 1, maxScroll));
         }
-        if (keyMatchers[Command.NAVIGATION_UP](key)) {
+        if (matchers[Command.NAVIGATION_UP](key)) {
           setCandidateScrollOffset((prev) => Math.max(0, prev - 1));
         }
       }

--- a/packages/cli/src/ui/components/triage/TriageIssues.tsx
+++ b/packages/cli/src/ui/components/triage/TriageIssues.tsx
@@ -10,7 +10,7 @@ import Spinner from 'ink-spinner';
 import type { Config } from '@google/gemini-cli-core';
 import { debugLogger, spawnAsync, LlmRole } from '@google/gemini-cli-core';
 import { useKeypress } from '../../hooks/useKeypress.js';
-import { keyMatchers, Command } from '../../keyMatchers.js';
+import { Command } from '../../keyMatchers.js';
 import { TextInput } from '../shared/TextInput.js';
 import { useTextBuffer } from '../shared/text-buffer.js';
 
@@ -366,11 +366,11 @@ Return a JSON object with:
   };
 
   useKeypress(
-    (key) => {
+    (key, matchers) => {
       const input = key.sequence;
 
       if (isEditingComment) {
-        if (keyMatchers[Command.ESCAPE](key)) {
+        if (matchers[Command.ESCAPE](key)) {
           setIsEditingComment(false);
           return;
         }
@@ -383,17 +383,13 @@ Return a JSON object with:
       }
 
       if (showHistory) {
-        if (
-          keyMatchers[Command.ESCAPE](key) ||
-          input === 'h' ||
-          input === 'q'
-        ) {
+        if (matchers[Command.ESCAPE](key) || input === 'h' || input === 'q') {
           setShowHistory(false);
         }
         return;
       }
 
-      if (keyMatchers[Command.ESCAPE](key) || input === 'q') {
+      if (matchers[Command.ESCAPE](key) || input === 'q') {
         onExit();
         return;
       }
@@ -424,7 +420,7 @@ Return a JSON object with:
         return;
       }
 
-      if (keyMatchers[Command.NAVIGATION_DOWN](key)) {
+      if (matchers[Command.NAVIGATION_DOWN](key)) {
         const targetLines = currentIssue.body.split('\n');
         const visibleLines = targetExpanded
           ? VISIBLE_LINES_EXPANDED
@@ -432,7 +428,7 @@ Return a JSON object with:
         const maxScroll = Math.max(0, targetLines.length - visibleLines);
         setTargetScrollOffset((prev) => Math.min(prev + 1, maxScroll));
       }
-      if (keyMatchers[Command.NAVIGATION_UP](key)) {
+      if (matchers[Command.NAVIGATION_UP](key)) {
         setTargetScrollOffset((prev) => Math.max(0, prev - 1));
       }
     },

--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -105,6 +105,7 @@ describe('KeypressContext', () => {
           ctrl: false,
           cmd: false,
         }),
+        expect.anything(),
       );
     });
 
@@ -120,6 +121,7 @@ describe('KeypressContext', () => {
           ctrl: false,
           cmd: false,
         }),
+        expect.anything(),
       );
     });
 
@@ -151,6 +153,7 @@ describe('KeypressContext', () => {
             name: 'return',
             ...expected,
           }),
+          expect.anything(),
         );
       },
     );
@@ -167,6 +170,7 @@ describe('KeypressContext', () => {
           ctrl: true,
           cmd: false,
         }),
+        expect.anything(),
       );
     });
 
@@ -183,6 +187,7 @@ describe('KeypressContext', () => {
           ctrl: false,
           cmd: false,
         }),
+        expect.anything(),
       );
     });
   });
@@ -210,6 +215,7 @@ describe('KeypressContext', () => {
           ctrl: false,
           cmd: false,
         }),
+        expect.anything(),
       );
 
       act(() => stdin.write('\r'));
@@ -224,6 +230,7 @@ describe('KeypressContext', () => {
           ctrl: false,
           cmd: false,
         }),
+        expect.anything(),
       );
     });
 
@@ -244,6 +251,7 @@ describe('KeypressContext', () => {
           ctrl: false,
           cmd: false,
         }),
+        expect.anything(),
       );
     });
   });
@@ -265,6 +273,7 @@ describe('KeypressContext', () => {
           ctrl: false,
           cmd: false,
         }),
+        expect.anything(),
       );
     });
 
@@ -291,6 +300,7 @@ describe('KeypressContext', () => {
             alt: false,
             cmd: false,
           }),
+          expect.anything(),
         );
         expect(keyHandler).toHaveBeenNthCalledWith(
           2,
@@ -300,6 +310,7 @@ describe('KeypressContext', () => {
             alt: false,
             cmd: false,
           }),
+          expect.anything(),
         );
       });
     });
@@ -329,6 +340,7 @@ describe('KeypressContext', () => {
             alt: false,
             cmd: false,
           }),
+          expect.anything(),
         );
       });
     });
@@ -394,6 +406,7 @@ describe('KeypressContext', () => {
           expect.objectContaining({
             ...expected,
           }),
+          expect.anything(),
         );
       },
     );
@@ -448,6 +461,7 @@ describe('KeypressContext', () => {
           name: 'paste',
           sequence: pastedText,
         }),
+        expect.anything(),
       );
     });
 
@@ -468,6 +482,7 @@ describe('KeypressContext', () => {
             name: 'paste',
             sequence: 'Hello OSC 52',
           }),
+          expect.anything(),
         );
       });
     });
@@ -494,6 +509,7 @@ describe('KeypressContext', () => {
             name: 'paste',
             sequence: 'Split Paste',
           }),
+          expect.anything(),
         );
       });
     });
@@ -515,6 +531,7 @@ describe('KeypressContext', () => {
             name: 'paste',
             sequence: 'Terminated by ST',
           }),
+          expect.anything(),
         );
       });
     });
@@ -753,6 +770,7 @@ describe('KeypressContext', () => {
 
         expect(keyHandler).toHaveBeenCalledWith(
           expect.objectContaining(expected),
+          expect.anything(),
         );
       },
     );
@@ -827,6 +845,7 @@ describe('KeypressContext', () => {
         act(() => stdin.write(sequence));
         expect(keyHandler).toHaveBeenCalledWith(
           expect.objectContaining(expected),
+          expect.anything(),
         );
       },
     );
@@ -848,6 +867,7 @@ describe('KeypressContext', () => {
           ctrl: false,
           cmd: false,
         }),
+        expect.anything(),
       );
       expect(keyHandler).toHaveBeenNthCalledWith(
         2,
@@ -858,6 +878,7 @@ describe('KeypressContext', () => {
           ctrl: false,
           cmd: false,
         }),
+        expect.anything(),
       );
     });
 
@@ -868,9 +889,11 @@ describe('KeypressContext', () => {
 
       expect(keyHandler).toHaveBeenCalledWith(
         expect.objectContaining({ name: 'delete' }),
+        expect.anything(),
       );
       expect(keyHandler).toHaveBeenCalledWith(
         expect.objectContaining({ name: 'pageup' }),
+        expect.anything(),
       );
     });
   });
@@ -979,6 +1002,7 @@ describe('KeypressContext', () => {
 
         expect(keyHandler).toHaveBeenCalledWith(
           expect.objectContaining(expected),
+          expect.anything(),
         );
       },
     );
@@ -1003,6 +1027,7 @@ describe('KeypressContext', () => {
           ctrl: false,
           cmd: false,
         }),
+        expect.anything(),
       );
     });
   });
@@ -1039,6 +1064,7 @@ describe('KeypressContext', () => {
         ctrl: false,
         cmd: false,
       }),
+      expect.anything(),
     );
   });
 
@@ -1061,6 +1087,7 @@ describe('KeypressContext', () => {
         ctrl: false,
         cmd: false,
       }),
+      expect.anything(),
     );
   });
 
@@ -1079,6 +1106,7 @@ describe('KeypressContext', () => {
         name: 'a',
         ctrl: true,
       }),
+      expect.anything(),
     );
   });
 
@@ -1099,6 +1127,7 @@ describe('KeypressContext', () => {
         name: 'a',
         ctrl: true,
       }),
+      expect.anything(),
     );
     expect(keyHandler).toHaveBeenNthCalledWith(
       2,
@@ -1106,6 +1135,7 @@ describe('KeypressContext', () => {
         name: 'b',
         ctrl: true,
       }),
+      expect.anything(),
     );
   });
 
@@ -1126,12 +1156,14 @@ describe('KeypressContext', () => {
       expect.objectContaining({
         name: 'return',
       }),
+      expect.anything(),
     );
     expect(keyHandler).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
         sequence: '\x1b[!',
       }),
+      expect.anything(),
     );
   });
 
@@ -1156,6 +1188,7 @@ describe('KeypressContext', () => {
           expect.objectContaining({
             name: 'escape',
           }),
+          expect.anything(),
         );
       });
     },
@@ -1192,6 +1225,7 @@ describe('KeypressContext', () => {
       expect.objectContaining({
         name: 'a',
       }),
+      expect.anything(),
     );
   });
 
@@ -1237,6 +1271,7 @@ describe('KeypressContext', () => {
           ctrl: false,
           cmd: false,
         }),
+        expect.anything(),
       );
     });
 
@@ -1292,10 +1327,12 @@ describe('KeypressContext', () => {
       expect(keyHandler).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({ name: 'h', sequence: 'H', shift: true }),
+        expect.anything(),
       );
       expect(keyHandler).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({ name: 'i', sequence: 'I', shift: true }),
+        expect.anything(),
       );
     });
   });
@@ -1330,10 +1367,12 @@ describe('KeypressContext', () => {
       expect(keyHandler).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({ name: 'h', sequence: 'H', shift: true }),
+        expect.anything(),
       );
       expect(keyHandler).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({ name: 'i', sequence: 'I', shift: true }),
+        expect.anything(),
       );
     });
 
@@ -1358,6 +1397,7 @@ describe('KeypressContext', () => {
           ctrl: false,
           cmd: false,
         }),
+        expect.anything(),
       );
     });
   });
@@ -1380,6 +1420,7 @@ describe('KeypressContext', () => {
       for (const char of inputString) {
         expect(keyHandler).toHaveBeenCalledWith(
           expect.objectContaining({ sequence: char }),
+          expect.anything(),
         );
       }
     });
@@ -1433,6 +1474,7 @@ describe('KeypressContext', () => {
             ...expected,
             sequence: char,
           }),
+          expect.anything(),
         );
       },
     );

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -21,6 +21,7 @@ import { parseMouseEvent } from '../utils/mouse.js';
 import { FOCUS_IN, FOCUS_OUT } from '../hooks/useFocus.js';
 import { appEvents, AppEvent } from '../../utils/events.js';
 import { terminalCapabilityManager } from '../utils/terminalCapabilityManager.js';
+import { defaultKeyMatchers, type KeyMatchers } from '../keyMatchers.js';
 
 export const BACKSLASH_ENTER_TIMEOUT = 5;
 export const ESC_TIMEOUT = 50;
@@ -166,13 +167,13 @@ const MAC_ALT_KEY_CHARACTER_MAP: Record<string, string> = {
 function nonKeyboardEventFilter(
   keypressHandler: KeypressHandler,
 ): KeypressHandler {
-  return (key: Key) => {
+  return (key: Key, matchers: KeyMatchers) => {
     if (
       !parseMouseEvent(key.sequence) &&
       key.sequence !== FOCUS_IN &&
       key.sequence !== FOCUS_OUT
     ) {
-      keypressHandler(key);
+      keypressHandler(key, matchers);
     }
   };
 }
@@ -184,21 +185,24 @@ function nonKeyboardEventFilter(
  */
 function bufferFastReturn(keypressHandler: KeypressHandler): KeypressHandler {
   let lastKeyTime = 0;
-  return (key: Key) => {
+  return (key: Key, matchers: KeyMatchers) => {
     const now = Date.now();
     if (key.name === 'return' && now - lastKeyTime <= FAST_RETURN_TIMEOUT) {
-      keypressHandler({
-        ...key,
-        name: 'return',
-        shift: true, // to make it a newline, not a submission
-        alt: false,
-        ctrl: false,
-        cmd: false,
-        sequence: '\r',
-        insertable: true,
-      });
+      keypressHandler(
+        {
+          ...key,
+          name: 'return',
+          shift: true, // to make it a newline, not a submission
+          alt: false,
+          ctrl: false,
+          cmd: false,
+          sequence: '\r',
+          insertable: true,
+        },
+        matchers,
+      );
     } else {
-      keypressHandler(key);
+      keypressHandler(key, matchers);
     }
     lastKeyTime = key.insertable ? now : 0;
   };
@@ -212,14 +216,21 @@ function bufferFastReturn(keypressHandler: KeypressHandler): KeypressHandler {
 function bufferBackslashEnter(
   keypressHandler: KeypressHandler,
 ): KeypressHandler {
-  const bufferer = (function* (): Generator<void, void, Key | null> {
+  const bufferer = (function* (): Generator<
+    void,
+    void,
+    { key: Key; matchers: KeyMatchers } | null
+  > {
     while (true) {
-      const key = yield;
+      const input = yield;
 
-      if (key == null) {
+      if (input == null) {
         continue;
-      } else if (key.sequence !== '\\') {
-        keypressHandler(key);
+      }
+      const { key, matchers } = input;
+
+      if (key.sequence !== '\\') {
+        keypressHandler(key, matchers);
         continue;
       }
 
@@ -227,28 +238,31 @@ function bufferBackslashEnter(
         () => bufferer.next(null),
         BACKSLASH_ENTER_TIMEOUT,
       );
-      const nextKey = yield;
+      const nextInput = yield;
       clearTimeout(timeoutId);
 
-      if (nextKey === null) {
-        keypressHandler(key);
-      } else if (nextKey.name === 'return') {
-        keypressHandler({
-          ...nextKey,
-          shift: true,
-          sequence: '\r', // Corrected escaping for newline
-        });
+      if (nextInput === null) {
+        keypressHandler(key, matchers);
+      } else if (nextInput.key.name === 'return') {
+        keypressHandler(
+          {
+            ...nextInput.key,
+            shift: true,
+            sequence: '\r', // Corrected escaping for newline
+          },
+          matchers,
+        );
       } else {
-        keypressHandler(key);
-        keypressHandler(nextKey);
+        keypressHandler(key, matchers);
+        keypressHandler(nextInput.key, nextInput.matchers);
       }
     }
   })();
 
   bufferer.next(); // prime the generator so it starts listening.
 
-  return (key: Key) => {
-    bufferer.next(key);
+  return (key: Key, matchers: KeyMatchers) => {
+    bufferer.next({ key, matchers });
   };
 }
 
@@ -258,27 +272,37 @@ function bufferBackslashEnter(
  * when a null key is received.
  */
 function bufferPaste(keypressHandler: KeypressHandler): KeypressHandler {
-  const bufferer = (function* (): Generator<void, void, Key | null> {
+  const bufferer = (function* (): Generator<
+    void,
+    void,
+    { key: Key; matchers: KeyMatchers } | null
+  > {
     while (true) {
-      let key = yield;
+      let input = yield;
 
-      if (key === null) {
+      if (input === null) {
         continue;
-      } else if (key.name !== 'paste-start') {
-        keypressHandler(key);
+      }
+      let { key, matchers } = input;
+
+      if (key.name !== 'paste-start') {
+        keypressHandler(key, matchers);
         continue;
       }
 
       let buffer = '';
       while (true) {
         const timeoutId = setTimeout(() => bufferer.next(null), PASTE_TIMEOUT);
-        key = yield;
+        input = yield;
         clearTimeout(timeoutId);
 
-        if (key === null) {
+        if (input === null) {
           appEvents.emit(AppEvent.PasteTimeout);
           break;
         }
+
+        key = input.key;
+        matchers = input.matchers;
 
         if (key.name === 'paste-end') {
           break;
@@ -287,22 +311,25 @@ function bufferPaste(keypressHandler: KeypressHandler): KeypressHandler {
       }
 
       if (buffer.length > 0) {
-        keypressHandler({
-          name: 'paste',
-          shift: false,
-          alt: false,
-          ctrl: false,
-          cmd: false,
-          insertable: true,
-          sequence: buffer,
-        });
+        keypressHandler(
+          {
+            name: 'paste',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            insertable: true,
+            sequence: buffer,
+          },
+          matchers,
+        );
       }
     }
   })();
   bufferer.next(); // prime the generator so it starts listening.
 
-  return (key: Key) => {
-    bufferer.next(key);
+  return (key: Key, matchers: KeyMatchers) => {
+    bufferer.next({ key, matchers });
   };
 }
 
@@ -311,8 +338,11 @@ function bufferPaste(keypressHandler: KeypressHandler): KeypressHandler {
  * Buffers escape sequences until a full sequence is received or
  * until a timeout occurs.
  */
-function createDataListener(keypressHandler: KeypressHandler) {
-  const parser = emitKeys(keypressHandler);
+function createDataListener(
+  keypressHandler: KeypressHandler,
+  matchers: KeyMatchers,
+) {
+  const parser = emitKeys(keypressHandler, matchers);
   parser.next(); // prime the generator so it starts listening.
 
   let timeoutId: NodeJS.Timeout;
@@ -334,6 +364,7 @@ function createDataListener(keypressHandler: KeypressHandler) {
  */
 function* emitKeys(
   keypressHandler: KeypressHandler,
+  matchers: KeyMatchers,
 ): Generator<void, void, string> {
   const lang = process.env['LANG'] || '';
   const lcAll = process.env['LC_ALL'] || '';
@@ -397,15 +428,18 @@ function* emitKeys(
           try {
             const base64Data = match[1];
             const decoded = Buffer.from(base64Data, 'base64').toString('utf-8');
-            keypressHandler({
-              name: 'paste',
-              shift: false,
-              alt: false,
-              ctrl: false,
-              cmd: false,
-              insertable: true,
-              sequence: decoded,
-            });
+            keypressHandler(
+              {
+                name: 'paste',
+                shift: false,
+                alt: false,
+                ctrl: false,
+                cmd: false,
+                insertable: true,
+                sequence: decoded,
+              },
+              matchers,
+            );
           } catch (_e) {
             debugLogger.log('Failed to decode OSC 52 clipboard data');
           }
@@ -632,15 +666,18 @@ function* emitKeys(
       alt = false;
 
       // Emit first escape key here, then continue processing
-      keypressHandler({
-        name: 'escape',
-        shift,
-        alt,
-        ctrl,
-        cmd,
-        insertable: false,
-        sequence: ESC,
-      });
+      keypressHandler(
+        {
+          name: 'escape',
+          shift,
+          alt,
+          ctrl,
+          cmd,
+          insertable: false,
+          sequence: ESC,
+        },
+        matchers,
+      );
     } else if (escaped) {
       // Escape sequence timeout
       name = ch.length ? undefined : 'escape';
@@ -654,15 +691,18 @@ function* emitKeys(
       (sequence.length !== 0 && (name !== undefined || escaped)) ||
       charLengthAt(sequence, 0) === sequence.length
     ) {
-      keypressHandler({
-        name: name || '',
-        shift,
-        alt,
-        ctrl,
-        cmd,
-        insertable,
-        sequence,
-      });
+      keypressHandler(
+        {
+          name: name || '',
+          shift,
+          alt,
+          ctrl,
+          cmd,
+          insertable,
+          sequence,
+        },
+        matchers,
+      );
     }
     // Unrecognized or broken escape sequence, don't emit anything
   }
@@ -678,7 +718,10 @@ export interface Key {
   sequence: string;
 }
 
-export type KeypressHandler = (key: Key) => boolean | void;
+export type KeypressHandler = (
+  key: Key,
+  matchers: KeyMatchers,
+) => boolean | void;
 
 interface KeypressContextValue {
   subscribe: (
@@ -766,7 +809,7 @@ export function KeypressProvider({
   );
 
   const broadcast = useCallback(
-    (key: Key) => {
+    (key: Key, matchers: KeyMatchers) => {
       // Use cached sorted priorities to avoid sorting on every keypress
       for (const p of sortedPriorities.current) {
         const set = subscribers.get(p);
@@ -775,7 +818,7 @@ export function KeypressProvider({
         // Within a priority level, use stack behavior (last subscribed is first to handle)
         const handlers = Array.from(set).reverse();
         for (const handler of handlers) {
-          if (handler(key) === true) {
+          if (handler(key, matchers) === true) {
             return;
           }
         }
@@ -800,7 +843,7 @@ export function KeypressProvider({
     }
     processor = bufferBackslashEnter(processor);
     processor = bufferPaste(processor);
-    let dataListener = createDataListener(processor);
+    let dataListener = createDataListener(processor, defaultKeyMatchers);
 
     if (debugKeystrokeLogging) {
       const old = dataListener;

--- a/packages/cli/src/ui/contexts/UIActionsContext.tsx
+++ b/packages/cli/src/ui/contexts/UIActionsContext.tsx
@@ -6,6 +6,7 @@
 
 import { createContext, useContext } from 'react';
 import { type Key } from '../hooks/useKeypress.js';
+import { type KeyMatchers } from '../keyMatchers.js';
 import { type IdeIntegrationNudgeResult } from '../IdeIntegrationNudge.js';
 import { type FolderTrustChoice } from '../components/FolderTrustDialog.js';
 import {
@@ -50,7 +51,7 @@ export interface UIActions {
   openPermissionsDialog: (props?: PermissionsDialogProps) => void;
   closePermissionsDialog: () => void;
   setShellModeActive: (value: boolean) => void;
-  vimHandleInput: (key: Key) => boolean;
+  vimHandleInput: (key: Key, matchers: KeyMatchers) => boolean;
   handleIdePromptComplete: (result: IdeIntegrationNudgeResult) => void;
   handleFolderTrustSelect: (choice: FolderTrustChoice) => void;
   setIsPolicyUpdateDialogOpen: (value: boolean) => void;

--- a/packages/cli/src/ui/hooks/useApprovalModeIndicator.test.ts
+++ b/packages/cli/src/ui/hooks/useApprovalModeIndicator.test.ts
@@ -21,6 +21,7 @@ import { Config, ApprovalMode } from '@google/gemini-cli-core';
 import type { Config as ActualConfigType } from '@google/gemini-cli-core';
 import type { Key } from './useKeypress.js';
 import { useKeypress } from './useKeypress.js';
+import { defaultKeyMatchers, type KeyMatchers } from '../keyMatchers.js';
 import { MessageType } from '../types.js';
 
 vi.mock('./useKeypress.js');
@@ -60,7 +61,7 @@ interface MockConfigInstanceShape {
   >;
 }
 
-type UseKeypressHandler = (key: Key) => void;
+type UseKeypressHandler = (key: Key, matchers: KeyMatchers) => void;
 
 describe('useApprovalModeIndicator', () => {
   let mockConfigInstance: MockConfigInstanceShape;
@@ -184,10 +185,13 @@ describe('useApprovalModeIndicator', () => {
 
     // Shift+Tab cycles to AUTO_EDIT
     act(() => {
-      capturedUseKeypressHandler({
-        name: 'tab',
-        shift: true,
-      } as Key);
+      capturedUseKeypressHandler(
+        {
+          name: 'tab',
+          shift: true,
+        } as Key,
+        defaultKeyMatchers,
+      );
     });
     expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
       ApprovalMode.AUTO_EDIT,
@@ -195,7 +199,10 @@ describe('useApprovalModeIndicator', () => {
     expect(result.current).toBe(ApprovalMode.AUTO_EDIT);
 
     act(() => {
-      capturedUseKeypressHandler({ name: 'y', ctrl: true } as Key);
+      capturedUseKeypressHandler(
+        { name: 'y', ctrl: true } as Key,
+        defaultKeyMatchers,
+      );
     });
     expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
       ApprovalMode.YOLO,
@@ -204,10 +211,13 @@ describe('useApprovalModeIndicator', () => {
 
     // Shift+Tab cycles back to AUTO_EDIT (from YOLO)
     act(() => {
-      capturedUseKeypressHandler({
-        name: 'tab',
-        shift: true,
-      } as Key);
+      capturedUseKeypressHandler(
+        {
+          name: 'tab',
+          shift: true,
+        } as Key,
+        defaultKeyMatchers,
+      );
     });
     expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
       ApprovalMode.AUTO_EDIT,
@@ -216,7 +226,10 @@ describe('useApprovalModeIndicator', () => {
 
     // Ctrl+Y toggles YOLO
     act(() => {
-      capturedUseKeypressHandler({ name: 'y', ctrl: true } as Key);
+      capturedUseKeypressHandler(
+        { name: 'y', ctrl: true } as Key,
+        defaultKeyMatchers,
+      );
     });
     expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
       ApprovalMode.YOLO,
@@ -225,10 +238,13 @@ describe('useApprovalModeIndicator', () => {
 
     // Shift+Tab from YOLO jumps to AUTO_EDIT
     act(() => {
-      capturedUseKeypressHandler({
-        name: 'tab',
-        shift: true,
-      } as Key);
+      capturedUseKeypressHandler(
+        {
+          name: 'tab',
+          shift: true,
+        } as Key,
+        defaultKeyMatchers,
+      );
     });
     expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
       ApprovalMode.AUTO_EDIT,
@@ -246,51 +262,72 @@ describe('useApprovalModeIndicator', () => {
     );
 
     act(() => {
-      capturedUseKeypressHandler({
-        name: 'tab',
-        shift: false,
-      } as Key);
+      capturedUseKeypressHandler(
+        {
+          name: 'tab',
+          shift: false,
+        } as Key,
+        defaultKeyMatchers,
+      );
     });
     expect(mockConfigInstance.setApprovalMode).not.toHaveBeenCalled();
 
     act(() => {
-      capturedUseKeypressHandler({
-        name: 'unknown',
-        shift: true,
-      } as Key);
+      capturedUseKeypressHandler(
+        {
+          name: 'unknown',
+          shift: true,
+        } as Key,
+        defaultKeyMatchers,
+      );
     });
     expect(mockConfigInstance.setApprovalMode).not.toHaveBeenCalled();
 
     act(() => {
-      capturedUseKeypressHandler({
-        name: 'a',
-        shift: false,
-        ctrl: false,
-      } as Key);
+      capturedUseKeypressHandler(
+        {
+          name: 'a',
+          shift: false,
+          ctrl: false,
+        } as Key,
+        defaultKeyMatchers,
+      );
     });
     expect(mockConfigInstance.setApprovalMode).not.toHaveBeenCalled();
 
     act(() => {
-      capturedUseKeypressHandler({ name: 'y', ctrl: false } as Key);
+      capturedUseKeypressHandler(
+        { name: 'y', ctrl: false } as Key,
+        defaultKeyMatchers,
+      );
     });
     expect(mockConfigInstance.setApprovalMode).not.toHaveBeenCalled();
 
     act(() => {
-      capturedUseKeypressHandler({ name: 'a', ctrl: true } as Key);
+      capturedUseKeypressHandler(
+        { name: 'a', ctrl: true } as Key,
+        defaultKeyMatchers,
+      );
     });
     expect(mockConfigInstance.setApprovalMode).not.toHaveBeenCalled();
 
     act(() => {
-      capturedUseKeypressHandler({ name: 'y', shift: true } as Key);
+      capturedUseKeypressHandler(
+        { name: 'y', shift: true } as Key,
+        defaultKeyMatchers,
+      );
     });
     expect(mockConfigInstance.setApprovalMode).not.toHaveBeenCalled();
 
     act(() => {
-      capturedUseKeypressHandler({
-        name: 'a',
-        shift: true,
-        ctrl: true,
-      } as Key);
+      capturedUseKeypressHandler(
+        {
+          name: 'a',
+          shift: true,
+          ctrl: true,
+        } as Key,
+        defaultKeyMatchers,
+      );
     });
     expect(mockConfigInstance.setApprovalMode).not.toHaveBeenCalled();
   });
@@ -342,7 +379,10 @@ describe('useApprovalModeIndicator', () => {
       expect(result.current).toBe(ApprovalMode.DEFAULT);
 
       act(() => {
-        capturedUseKeypressHandler({ name: 'y', ctrl: true } as Key);
+        capturedUseKeypressHandler(
+          { name: 'y', ctrl: true } as Key,
+          defaultKeyMatchers,
+        );
       });
 
       // We expect setApprovalMode to be called, and the error to be caught.
@@ -372,10 +412,13 @@ describe('useApprovalModeIndicator', () => {
       expect(result.current).toBe(ApprovalMode.DEFAULT);
 
       act(() => {
-        capturedUseKeypressHandler({
-          name: 'tab',
-          shift: true,
-        } as Key);
+        capturedUseKeypressHandler(
+          {
+            name: 'tab',
+            shift: true,
+          } as Key,
+          defaultKeyMatchers,
+        );
       });
 
       // We expect setApprovalMode to be called, and the error to be caught.
@@ -398,7 +441,10 @@ describe('useApprovalModeIndicator', () => {
       );
 
       act(() => {
-        capturedUseKeypressHandler({ name: 'y', ctrl: true } as Key);
+        capturedUseKeypressHandler(
+          { name: 'y', ctrl: true } as Key,
+          defaultKeyMatchers,
+        );
       });
 
       expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
@@ -420,10 +466,13 @@ describe('useApprovalModeIndicator', () => {
       );
 
       act(() => {
-        capturedUseKeypressHandler({
-          name: 'tab',
-          shift: true,
-        } as Key);
+        capturedUseKeypressHandler(
+          {
+            name: 'tab',
+            shift: true,
+          } as Key,
+          defaultKeyMatchers,
+        );
       });
 
       expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
@@ -450,7 +499,10 @@ describe('useApprovalModeIndicator', () => {
 
       // Try to enable YOLO mode
       act(() => {
-        capturedUseKeypressHandler({ name: 'y', ctrl: true } as Key);
+        capturedUseKeypressHandler(
+          { name: 'y', ctrl: true } as Key,
+          defaultKeyMatchers,
+        );
       });
 
       expect(mockAddItem).toHaveBeenCalledWith(
@@ -463,10 +515,13 @@ describe('useApprovalModeIndicator', () => {
 
       // Try to enable AUTO_EDIT mode
       act(() => {
-        capturedUseKeypressHandler({
-          name: 'tab',
-          shift: true,
-        } as Key);
+        capturedUseKeypressHandler(
+          {
+            name: 'tab',
+            shift: true,
+          } as Key,
+          defaultKeyMatchers,
+        );
       });
 
       expect(mockAddItem).toHaveBeenCalledWith(
@@ -505,7 +560,10 @@ describe('useApprovalModeIndicator', () => {
       expect(result.current).toBe(ApprovalMode.DEFAULT);
 
       act(() => {
-        capturedUseKeypressHandler({ name: 'y', ctrl: true } as Key);
+        capturedUseKeypressHandler(
+          { name: 'y', ctrl: true } as Key,
+          defaultKeyMatchers,
+        );
       });
 
       // setApprovalMode should not be called because the check should return early
@@ -537,7 +595,10 @@ describe('useApprovalModeIndicator', () => {
       );
 
       act(() => {
-        capturedUseKeypressHandler({ name: 'y', ctrl: true } as Key);
+        capturedUseKeypressHandler(
+          { name: 'y', ctrl: true } as Key,
+          defaultKeyMatchers,
+        );
       });
 
       expect(mockAddItem).toHaveBeenCalledWith(
@@ -562,7 +623,10 @@ describe('useApprovalModeIndicator', () => {
       );
 
       act(() => {
-        capturedUseKeypressHandler({ name: 'y', ctrl: true } as Key);
+        capturedUseKeypressHandler(
+          { name: 'y', ctrl: true } as Key,
+          defaultKeyMatchers,
+        );
       });
 
       expect(mockAddItem).toHaveBeenCalledWith(
@@ -588,7 +652,10 @@ describe('useApprovalModeIndicator', () => {
     );
 
     act(() => {
-      capturedUseKeypressHandler({ name: 'y', ctrl: true } as Key);
+      capturedUseKeypressHandler(
+        { name: 'y', ctrl: true } as Key,
+        defaultKeyMatchers,
+      );
     });
 
     expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
@@ -610,7 +677,10 @@ describe('useApprovalModeIndicator', () => {
     );
 
     act(() => {
-      capturedUseKeypressHandler({ name: 'tab', shift: true } as Key);
+      capturedUseKeypressHandler(
+        { name: 'tab', shift: true } as Key,
+        defaultKeyMatchers,
+      );
     });
 
     expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
@@ -634,7 +704,10 @@ describe('useApprovalModeIndicator', () => {
     );
 
     act(() => {
-      capturedUseKeypressHandler({ name: 'y', ctrl: true } as Key); // This should toggle from YOLO to DEFAULT
+      capturedUseKeypressHandler(
+        { name: 'y', ctrl: true } as Key,
+        defaultKeyMatchers,
+      ); // This should toggle from YOLO to DEFAULT
     });
 
     expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
@@ -653,7 +726,10 @@ describe('useApprovalModeIndicator', () => {
     );
 
     act(() => {
-      capturedUseKeypressHandler({ name: 'y', ctrl: true } as Key);
+      capturedUseKeypressHandler(
+        { name: 'y', ctrl: true } as Key,
+        defaultKeyMatchers,
+      );
     });
 
     expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
@@ -676,12 +752,18 @@ describe('useApprovalModeIndicator', () => {
 
     // Switch to YOLO
     act(() => {
-      capturedUseKeypressHandler({ name: 'y', ctrl: true } as Key);
+      capturedUseKeypressHandler(
+        { name: 'y', ctrl: true } as Key,
+        defaultKeyMatchers,
+      );
     });
 
     // Switch to AUTO_EDIT
     act(() => {
-      capturedUseKeypressHandler({ name: 'tab', shift: true } as Key);
+      capturedUseKeypressHandler(
+        { name: 'tab', shift: true } as Key,
+        defaultKeyMatchers,
+      );
     });
 
     expect(mockOnApprovalModeChange).toHaveBeenCalledTimes(2);
@@ -708,7 +790,10 @@ describe('useApprovalModeIndicator', () => {
 
     // AUTO_EDIT -> PLAN
     act(() => {
-      capturedUseKeypressHandler({ name: 'tab', shift: true } as Key);
+      capturedUseKeypressHandler(
+        { name: 'tab', shift: true } as Key,
+        defaultKeyMatchers,
+      );
     });
     expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
       ApprovalMode.PLAN,
@@ -728,7 +813,10 @@ describe('useApprovalModeIndicator', () => {
 
     // AUTO_EDIT -> DEFAULT
     act(() => {
-      capturedUseKeypressHandler({ name: 'tab', shift: true } as Key);
+      capturedUseKeypressHandler(
+        { name: 'tab', shift: true } as Key,
+        defaultKeyMatchers,
+      );
     });
     expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
       ApprovalMode.DEFAULT,

--- a/packages/cli/src/ui/hooks/useApprovalModeIndicator.ts
+++ b/packages/cli/src/ui/hooks/useApprovalModeIndicator.ts
@@ -11,7 +11,7 @@ import {
   getAdminErrorMessage,
 } from '@google/gemini-cli-core';
 import { useKeypress } from './useKeypress.js';
-import { keyMatchers, Command } from '../keyMatchers.js';
+import { Command } from '../keyMatchers.js';
 import type { HistoryItemWithoutId } from '../types.js';
 import { MessageType } from '../types.js';
 
@@ -38,10 +38,10 @@ export function useApprovalModeIndicator({
   }, [currentConfigValue]);
 
   useKeypress(
-    (key) => {
+    (key, matchers) => {
       let nextApprovalMode: ApprovalMode | undefined;
 
-      if (keyMatchers[Command.TOGGLE_YOLO](key)) {
+      if (matchers[Command.TOGGLE_YOLO](key)) {
         if (
           config.isYoloModeDisabled() &&
           config.getApprovalMode() !== ApprovalMode.YOLO
@@ -70,7 +70,7 @@ export function useApprovalModeIndicator({
           config.getApprovalMode() === ApprovalMode.YOLO
             ? ApprovalMode.DEFAULT
             : ApprovalMode.YOLO;
-      } else if (keyMatchers[Command.CYCLE_APPROVAL_MODE](key)) {
+      } else if (matchers[Command.CYCLE_APPROVAL_MODE](key)) {
         const currentMode = config.getApprovalMode();
         switch (currentMode) {
           case ApprovalMode.DEFAULT:

--- a/packages/cli/src/ui/hooks/useKeypress.test.tsx
+++ b/packages/cli/src/ui/hooks/useKeypress.test.tsx
@@ -92,7 +92,10 @@ describe(`useKeypress`, () => {
   ])('should listen for keypress when active for key $key.name', ({ key }) => {
     renderKeypressHook(true);
     act(() => stdin.write(key.sequence));
-    expect(onKeypress).toHaveBeenCalledWith(expect.objectContaining(key));
+    expect(onKeypress).toHaveBeenCalledWith(
+      expect.objectContaining(key),
+      expect.anything(),
+    );
   });
 
   it('should set and release raw mode', () => {
@@ -121,6 +124,7 @@ describe(`useKeypress`, () => {
         ctrl: false,
         cmd: false,
       }),
+      expect.anything(),
     );
   });
 
@@ -144,15 +148,18 @@ describe(`useKeypress`, () => {
       act(() => stdin.write(PASTE_START + pasteText + PASTE_END));
 
       expect(onKeypress).toHaveBeenCalledTimes(1);
-      expect(onKeypress).toHaveBeenCalledWith({
-        name: 'paste',
-        shift: false,
-        alt: false,
-        ctrl: false,
-        cmd: false,
-        insertable: true,
-        sequence: pasteText,
-      });
+      expect(onKeypress).toHaveBeenCalledWith(
+        {
+          name: 'paste',
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+          insertable: true,
+          sequence: pasteText,
+        },
+        expect.anything(),
+      );
     });
 
     it('should handle keypress interspersed with pastes', () => {
@@ -162,18 +169,21 @@ describe(`useKeypress`, () => {
       act(() => stdin.write('a'));
       expect(onKeypress).toHaveBeenCalledWith(
         expect.objectContaining({ ...keyA }),
+        expect.anything(),
       );
 
       const pasteText = 'pasted';
       act(() => stdin.write(PASTE_START + pasteText + PASTE_END));
       expect(onKeypress).toHaveBeenCalledWith(
         expect.objectContaining({ name: 'paste', sequence: pasteText }),
+        expect.anything(),
       );
 
       const keyB = { name: 'b', sequence: 'b' };
       act(() => stdin.write('b'));
       expect(onKeypress).toHaveBeenCalledWith(
         expect.objectContaining({ ...keyB }),
+        expect.anything(),
       );
 
       expect(onKeypress).toHaveBeenCalledTimes(3);
@@ -190,6 +200,7 @@ describe(`useKeypress`, () => {
       });
       expect(onKeypress).toHaveBeenCalledWith(
         expect.objectContaining({ name: 'paste', sequence: pasteText }),
+        expect.anything(),
       );
     });
 
@@ -203,9 +214,11 @@ describe(`useKeypress`, () => {
 
       expect(onKeypress).toHaveBeenCalledWith(
         expect.objectContaining({ sequence: '\x1B[200d' }),
+        expect.anything(),
       );
       expect(onKeypress).toHaveBeenCalledWith(
         expect.objectContaining({ sequence: 'o' }),
+        expect.anything(),
       );
       expect(onKeypress).toHaveBeenCalledTimes(2);
     });
@@ -227,9 +240,11 @@ describe(`useKeypress`, () => {
       });
       expect(onKeypress).toHaveBeenCalledWith(
         expect.objectContaining({ name: 'paste', sequence: pasteText1 }),
+        expect.anything(),
       );
       expect(onKeypress).toHaveBeenCalledWith(
         expect.objectContaining({ name: 'paste', sequence: pasteText2 }),
+        expect.anything(),
       );
 
       expect(onKeypress).toHaveBeenCalledTimes(2);
@@ -242,6 +257,7 @@ describe(`useKeypress`, () => {
       act(() => stdin.write('a'));
       expect(onKeypress).toHaveBeenCalledWith(
         expect.objectContaining({ ...keyA }),
+        expect.anything(),
       );
 
       const pasteText = 'pasted';
@@ -256,12 +272,14 @@ describe(`useKeypress`, () => {
       });
       expect(onKeypress).toHaveBeenCalledWith(
         expect.objectContaining({ name: 'paste', sequence: pasteText }),
+        expect.anything(),
       );
 
       const keyB = { name: 'b', sequence: 'b' };
       act(() => stdin.write('b'));
       expect(onKeypress).toHaveBeenCalledWith(
         expect.objectContaining({ ...keyB }),
+        expect.anything(),
       );
 
       expect(onKeypress).toHaveBeenCalledTimes(3);

--- a/packages/cli/src/ui/hooks/useSelectionList.test.tsx
+++ b/packages/cli/src/ui/hooks/useSelectionList.test.tsx
@@ -13,6 +13,7 @@ import {
   type SelectionListItem,
 } from './useSelectionList.js';
 import { useKeypress } from './useKeypress.js';
+import { defaultKeyMatchers } from '../keyMatchers.js';
 
 import type { KeypressHandler, Key } from '../contexts/KeypressContext.js';
 
@@ -64,7 +65,7 @@ describe('useSelectionList', () => {
           shift: options.shift ?? false,
           insertable: false,
         };
-        activeKeypressHandler(key);
+        activeKeypressHandler(key, defaultKeyMatchers);
       } else {
         throw new Error(
           `Test attempted to press key (${name}) but the keypress handler is not active. Ensure the hook is focused (isFocused=true) and the list is not empty.`,
@@ -400,7 +401,7 @@ describe('useSelectionList', () => {
           shift: false,
           insertable: true,
         };
-        handler(key);
+        handler(key, defaultKeyMatchers);
       };
 
       // 1. Press Down. Should move 0 (A) -> 2 (C).
@@ -453,7 +454,7 @@ describe('useSelectionList', () => {
             shift: false,
             insertable: false,
           };
-          handler(key);
+          handler(key, defaultKeyMatchers);
         };
 
         // All presses happen in same render cycle - React batches the state updates

--- a/packages/cli/src/ui/hooks/useSelectionList.ts
+++ b/packages/cli/src/ui/hooks/useSelectionList.ts
@@ -6,7 +6,7 @@
 
 import { useReducer, useRef, useEffect, useCallback } from 'react';
 import { useKeypress, type Key } from './useKeypress.js';
-import { keyMatchers, Command } from '../keyMatchers.js';
+import { Command, type KeyMatchers } from '../keyMatchers.js';
 import { debugLogger } from '@google/gemini-cli-core';
 
 export interface SelectionListItem<T> {
@@ -386,7 +386,7 @@ export function useSelectionList<T>({
 
   const itemsLength = items.length;
   const handleKeypress = useCallback(
-    (key: Key) => {
+    (key: Key, matchers: KeyMatchers) => {
       const { sequence } = key;
       const isNumeric = showNumbers && /^[0-9]$/.test(sequence);
 
@@ -396,17 +396,17 @@ export function useSelectionList<T>({
         numberInputRef.current = '';
       }
 
-      if (keyMatchers[Command.DIALOG_NAVIGATION_UP](key)) {
+      if (matchers[Command.DIALOG_NAVIGATION_UP](key)) {
         dispatch({ type: 'MOVE_UP' });
         return true;
       }
 
-      if (keyMatchers[Command.DIALOG_NAVIGATION_DOWN](key)) {
+      if (matchers[Command.DIALOG_NAVIGATION_DOWN](key)) {
         dispatch({ type: 'MOVE_DOWN' });
         return true;
       }
 
-      if (keyMatchers[Command.RETURN](key)) {
+      if (matchers[Command.RETURN](key)) {
         dispatch({ type: 'SELECT_CURRENT' });
         return true;
       }
@@ -463,7 +463,7 @@ export function useSelectionList<T>({
     [dispatch, itemsLength, showNumbers],
   );
 
-  useKeypress(handleKeypress, {
+  useKeypress((key, matchers) => handleKeypress(key, matchers), {
     isActive: !!(isFocused && itemsLength > 0),
     priority,
   });

--- a/packages/cli/src/ui/hooks/useTabbedNavigation.test.ts
+++ b/packages/cli/src/ui/hooks/useTabbedNavigation.test.ts
@@ -27,7 +27,7 @@ const createKey = (partial: Partial<Key>): Key => ({
 });
 
 vi.mock('../keyMatchers.js', () => ({
-  keyMatchers: {
+  defaultKeyMatchers: {
     'cursor.left': vi.fn((key) => key.name === 'left'),
     'cursor.right': vi.fn((key) => key.name === 'right'),
     'dialog.next': vi.fn((key) => key.name === 'tab' && !key.shift),
@@ -40,6 +40,8 @@ vi.mock('../keyMatchers.js', () => ({
     DIALOG_PREV: 'dialog.previous',
   },
 }));
+
+import { defaultKeyMatchers } from '../keyMatchers.js';
 
 describe('useTabbedNavigation', () => {
   let capturedHandler: KeypressHandler;
@@ -61,7 +63,7 @@ describe('useTabbedNavigation', () => {
       );
 
       act(() => {
-        capturedHandler(createKey({ name: 'right' }));
+        capturedHandler(createKey({ name: 'right' }), defaultKeyMatchers);
       });
 
       expect(result.current.currentIndex).toBe(1);
@@ -77,7 +79,7 @@ describe('useTabbedNavigation', () => {
       );
 
       act(() => {
-        capturedHandler(createKey({ name: 'left' }));
+        capturedHandler(createKey({ name: 'left' }), defaultKeyMatchers);
       });
 
       expect(result.current.currentIndex).toBe(0);
@@ -89,7 +91,10 @@ describe('useTabbedNavigation', () => {
       );
 
       act(() => {
-        capturedHandler(createKey({ name: 'tab', shift: false }));
+        capturedHandler(
+          createKey({ name: 'tab', shift: false }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(result.current.currentIndex).toBe(1);
@@ -105,7 +110,10 @@ describe('useTabbedNavigation', () => {
       );
 
       act(() => {
-        capturedHandler(createKey({ name: 'tab', shift: true }));
+        capturedHandler(
+          createKey({ name: 'tab', shift: true }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(result.current.currentIndex).toBe(0);
@@ -121,7 +129,7 @@ describe('useTabbedNavigation', () => {
       );
 
       act(() => {
-        capturedHandler(createKey({ name: 'right' }));
+        capturedHandler(createKey({ name: 'right' }), defaultKeyMatchers);
       });
 
       expect(result.current.currentIndex).toBe(0);

--- a/packages/cli/src/ui/hooks/useTabbedNavigation.ts
+++ b/packages/cli/src/ui/hooks/useTabbedNavigation.ts
@@ -6,7 +6,7 @@
 
 import { useReducer, useCallback, useEffect, useRef } from 'react';
 import { useKeypress, type Key } from './useKeypress.js';
-import { keyMatchers, Command } from '../keyMatchers.js';
+import { Command, type KeyMatchers } from '../keyMatchers.js';
 
 /**
  * Options for the useTabbedNavigation hook.
@@ -200,26 +200,26 @@ export function useTabbedNavigation({
   );
 
   const handleKeypress = useCallback(
-    (key: Key) => {
+    (key: Key, matchers: KeyMatchers) => {
       if (isNavigationBlocked?.()) return;
 
       if (enableArrowNavigation) {
-        if (keyMatchers[Command.MOVE_RIGHT](key)) {
+        if (matchers[Command.MOVE_RIGHT](key)) {
           goToNextTab();
           return;
         }
-        if (keyMatchers[Command.MOVE_LEFT](key)) {
+        if (matchers[Command.MOVE_LEFT](key)) {
           goToPrevTab();
           return;
         }
       }
 
       if (enableTabKey) {
-        if (keyMatchers[Command.DIALOG_NEXT](key)) {
+        if (matchers[Command.DIALOG_NEXT](key)) {
           goToNextTab();
           return;
         }
-        if (keyMatchers[Command.DIALOG_PREV](key)) {
+        if (matchers[Command.DIALOG_PREV](key)) {
           goToPrevTab();
           return;
         }
@@ -234,7 +234,9 @@ export function useTabbedNavigation({
     ],
   );
 
-  useKeypress(handleKeypress, { isActive: isActive && tabCount > 1 });
+  useKeypress((key, matchers) => handleKeypress(key, matchers), {
+    isActive: isActive && tabCount > 1,
+  });
 
   return {
     currentIndex: state.currentIndex,

--- a/packages/cli/src/ui/hooks/vim-passthrough.test.tsx
+++ b/packages/cli/src/ui/hooks/vim-passthrough.test.tsx
@@ -11,6 +11,7 @@ import { useVim } from './vim.js';
 import type { VimMode } from './vim.js';
 import type { TextBuffer } from '../components/shared/text-buffer.js';
 import type { Key } from './useKeypress.js';
+import { defaultKeyMatchers } from '../keyMatchers.js';
 
 // Mock the VimModeContext
 const mockVimContext = {
@@ -77,7 +78,7 @@ describe('useVim passthrough', () => {
 
     let handled = true;
     act(() => {
-      handled = result.current.handleInput(key);
+      handled = result.current.handleInput(key, defaultKeyMatchers);
     });
 
     expect(handled).toBe(false);

--- a/packages/cli/src/ui/hooks/vim.test.tsx
+++ b/packages/cli/src/ui/hooks/vim.test.tsx
@@ -18,6 +18,7 @@ import type {
   TextBufferAction,
 } from '../components/shared/text-buffer.js';
 import { textBufferReducer } from '../components/shared/text-buffer.js';
+import { defaultKeyMatchers, type KeyMatchers } from '../keyMatchers.js';
 
 // Mock the VimModeContext
 const mockVimContext = {
@@ -205,11 +206,11 @@ describe('useVim hook', () => {
 
   const exitInsertMode = (result: {
     current: {
-      handleInput: (key: Key) => boolean;
+      handleInput: (key: Key, matchers: KeyMatchers) => boolean;
     };
   }) => {
     act(() => {
-      result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+      result.current.handleInput(TEST_SEQUENCES.ESCAPE, defaultKeyMatchers);
     });
   };
 
@@ -237,7 +238,7 @@ describe('useVim hook', () => {
       expect(result.current.mode).toBe('NORMAL');
 
       act(() => {
-        result.current.handleInput(TEST_SEQUENCES.INSERT);
+        result.current.handleInput(TEST_SEQUENCES.INSERT, defaultKeyMatchers);
       });
 
       expect(result.current.mode).toBe('INSERT');
@@ -248,7 +249,7 @@ describe('useVim hook', () => {
       const { result } = renderVimHook();
 
       act(() => {
-        result.current.handleInput(TEST_SEQUENCES.INSERT);
+        result.current.handleInput(TEST_SEQUENCES.INSERT, defaultKeyMatchers);
       });
       expect(result.current.mode).toBe('INSERT');
 
@@ -261,7 +262,10 @@ describe('useVim hook', () => {
       const { result } = renderVimHook(testBuffer);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'i' }));
+        result.current.handleInput(
+          createKey({ sequence: 'i' }),
+          defaultKeyMatchers,
+        );
       });
       expect(result.current.mode).toBe('INSERT');
 
@@ -271,7 +275,10 @@ describe('useVim hook', () => {
       expect(result.current.mode).toBe('NORMAL');
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'b' }));
+        result.current.handleInput(
+          createKey({ sequence: 'b' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimMoveWordBackward).toHaveBeenCalledWith(1);
@@ -284,7 +291,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'h' }));
+        result.current.handleInput(
+          createKey({ sequence: 'h' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(mockBuffer.vimMoveLeft).toHaveBeenCalledWith(1);
@@ -295,7 +305,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'l' }));
+        result.current.handleInput(
+          createKey({ sequence: 'l' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(mockBuffer.vimMoveRight).toHaveBeenCalledWith(1);
@@ -307,7 +320,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'j' }));
+        result.current.handleInput(
+          createKey({ sequence: 'j' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimMoveDown).toHaveBeenCalledWith(1);
@@ -319,7 +335,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'k' }));
+        result.current.handleInput(
+          createKey({ sequence: 'k' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimMoveUp).toHaveBeenCalledWith(1);
@@ -330,7 +349,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: '0' }));
+        result.current.handleInput(
+          createKey({ sequence: '0' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(mockBuffer.vimMoveToLineStart).toHaveBeenCalled();
@@ -341,7 +363,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: '$' }));
+        result.current.handleInput(
+          createKey({ sequence: '$' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(mockBuffer.vimMoveToLineEnd).toHaveBeenCalled();
@@ -354,7 +379,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'a' }));
+        result.current.handleInput(
+          createKey({ sequence: 'a' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(mockBuffer.vimAppendAtCursor).toHaveBeenCalled();
@@ -366,7 +394,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'A' }));
+        result.current.handleInput(
+          createKey({ sequence: 'A' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(mockBuffer.vimAppendAtLineEnd).toHaveBeenCalled();
@@ -378,7 +409,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'o' }));
+        result.current.handleInput(
+          createKey({ sequence: 'o' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(mockBuffer.vimOpenLineBelow).toHaveBeenCalled();
@@ -390,7 +424,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'O' }));
+        result.current.handleInput(
+          createKey({ sequence: 'O' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(mockBuffer.vimOpenLineAbove).toHaveBeenCalled();
@@ -405,7 +442,10 @@ describe('useVim hook', () => {
       vi.clearAllMocks();
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'x' }));
+        result.current.handleInput(
+          createKey({ sequence: 'x' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(mockBuffer.vimDeleteChar).toHaveBeenCalledWith(1);
@@ -417,7 +457,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'x' }));
+        result.current.handleInput(
+          createKey({ sequence: 'x' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimDeleteChar).toHaveBeenCalledWith(1);
@@ -428,7 +471,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'd' }));
+        result.current.handleInput(
+          createKey({ sequence: 'd' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(mockBuffer.replaceRangeByOffset).not.toHaveBeenCalled();
@@ -443,6 +489,7 @@ describe('useVim hook', () => {
       act(() => {
         const handled = result.current.handleInput(
           createKey({ sequence: '3' }),
+          defaultKeyMatchers,
         );
         expect(handled).toBe(true);
       });
@@ -450,6 +497,7 @@ describe('useVim hook', () => {
       act(() => {
         const handled = result.current.handleInput(
           createKey({ sequence: 'h' }),
+          defaultKeyMatchers,
         );
         expect(handled).toBe(true);
       });
@@ -463,7 +511,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'x' }));
+        result.current.handleInput(
+          createKey({ sequence: 'x' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimDeleteChar).toHaveBeenCalledWith(1);
@@ -500,7 +551,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'w' }));
+        result.current.handleInput(
+          createKey({ sequence: 'w' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimMoveWordForward).toHaveBeenCalledWith(1);
@@ -512,7 +566,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'b' }));
+        result.current.handleInput(
+          createKey({ sequence: 'b' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimMoveWordBackward).toHaveBeenCalledWith(1);
@@ -524,7 +581,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'e' }));
+        result.current.handleInput(
+          createKey({ sequence: 'e' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimMoveWordEnd).toHaveBeenCalledWith(1);
@@ -536,7 +596,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'w' }));
+        result.current.handleInput(
+          createKey({ sequence: 'w' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimMoveWordForward).toHaveBeenCalledWith(1);
@@ -547,7 +610,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'c' }));
+        result.current.handleInput(
+          createKey({ sequence: 'c' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(result.current.mode).toBe('NORMAL');
@@ -558,8 +624,14 @@ describe('useVim hook', () => {
       const { result } = renderVimHook();
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'd' }));
-        result.current.handleInput(createKey({ sequence: 'f' }));
+        result.current.handleInput(
+          createKey({ sequence: 'd' }),
+          defaultKeyMatchers,
+        );
+        result.current.handleInput(
+          createKey({ sequence: 'f' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(mockBuffer.replaceRangeByOffset).not.toHaveBeenCalled();
@@ -570,7 +642,10 @@ describe('useVim hook', () => {
       const { result } = renderVimHook();
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'd' }));
+        result.current.handleInput(
+          createKey({ sequence: 'd' }),
+          defaultKeyMatchers,
+        );
       });
 
       exitInsertMode(result);
@@ -586,7 +661,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'W' }));
+        result.current.handleInput(
+          createKey({ sequence: 'W' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimMoveBigWordForward).toHaveBeenCalledWith(1);
@@ -598,7 +676,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'B' }));
+        result.current.handleInput(
+          createKey({ sequence: 'B' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimMoveBigWordBackward).toHaveBeenCalledWith(1);
@@ -610,7 +691,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'E' }));
+        result.current.handleInput(
+          createKey({ sequence: 'E' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimMoveBigWordEnd).toHaveBeenCalledWith(1);
@@ -622,10 +706,16 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'd' }));
+        result.current.handleInput(
+          createKey({ sequence: 'd' }),
+          defaultKeyMatchers,
+        );
       });
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'W' }));
+        result.current.handleInput(
+          createKey({ sequence: 'W' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimDeleteBigWordForward).toHaveBeenCalledWith(1);
@@ -637,10 +727,16 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'c' }));
+        result.current.handleInput(
+          createKey({ sequence: 'c' }),
+          defaultKeyMatchers,
+        );
       });
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'W' }));
+        result.current.handleInput(
+          createKey({ sequence: 'W' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimChangeBigWordForward).toHaveBeenCalledWith(1);
@@ -653,10 +749,16 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'd' }));
+        result.current.handleInput(
+          createKey({ sequence: 'd' }),
+          defaultKeyMatchers,
+        );
       });
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'B' }));
+        result.current.handleInput(
+          createKey({ sequence: 'B' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimDeleteBigWordBackward).toHaveBeenCalledWith(1);
@@ -668,10 +770,16 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'd' }));
+        result.current.handleInput(
+          createKey({ sequence: 'd' }),
+          defaultKeyMatchers,
+        );
       });
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'E' }));
+        result.current.handleInput(
+          createKey({ sequence: 'E' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimDeleteBigWordEnd).toHaveBeenCalledWith(1);
@@ -684,7 +792,10 @@ describe('useVim hook', () => {
       const { result } = renderVimHook(mockBuffer);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'h' }));
+        result.current.handleInput(
+          createKey({ sequence: 'h' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(mockBuffer.move).not.toHaveBeenCalled();
@@ -700,14 +811,20 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'x' }));
+        result.current.handleInput(
+          createKey({ sequence: 'x' }),
+          defaultKeyMatchers,
+        );
       });
       expect(testBuffer.vimDeleteChar).toHaveBeenCalledWith(1);
 
       testBuffer.cursor = [1, 2];
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: '.' }));
+        result.current.handleInput(
+          createKey({ sequence: '.' }),
+          defaultKeyMatchers,
+        );
       });
       expect(testBuffer.vimDeleteChar).toHaveBeenCalledWith(1);
     });
@@ -718,17 +835,26 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'd' }));
+        result.current.handleInput(
+          createKey({ sequence: 'd' }),
+          defaultKeyMatchers,
+        );
       });
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'd' }));
+        result.current.handleInput(
+          createKey({ sequence: 'd' }),
+          defaultKeyMatchers,
+        );
       });
       expect(testBuffer.vimDeleteLine).toHaveBeenCalledTimes(1);
 
       testBuffer.cursor = [0, 0];
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: '.' }));
+        result.current.handleInput(
+          createKey({ sequence: '.' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimDeleteLine).toHaveBeenCalledTimes(2);
@@ -740,10 +866,16 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'c' }));
+        result.current.handleInput(
+          createKey({ sequence: 'c' }),
+          defaultKeyMatchers,
+        );
       });
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'e' }));
+        result.current.handleInput(
+          createKey({ sequence: 'e' }),
+          defaultKeyMatchers,
+        );
       });
       expect(testBuffer.vimChangeWordEnd).toHaveBeenCalledTimes(1);
 
@@ -753,7 +885,10 @@ describe('useVim hook', () => {
       testBuffer.cursor = [0, 2];
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: '.' }));
+        result.current.handleInput(
+          createKey({ sequence: '.' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimChangeWordEnd).toHaveBeenCalledTimes(2);
@@ -765,10 +900,16 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'c' }));
+        result.current.handleInput(
+          createKey({ sequence: 'c' }),
+          defaultKeyMatchers,
+        );
       });
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'c' }));
+        result.current.handleInput(
+          createKey({ sequence: 'c' }),
+          defaultKeyMatchers,
+        );
       });
       expect(testBuffer.vimChangeLine).toHaveBeenCalledTimes(1);
 
@@ -778,7 +919,10 @@ describe('useVim hook', () => {
       testBuffer.cursor = [0, 1];
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: '.' }));
+        result.current.handleInput(
+          createKey({ sequence: '.' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimChangeLine).toHaveBeenCalledTimes(2);
@@ -790,10 +934,16 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'c' }));
+        result.current.handleInput(
+          createKey({ sequence: 'c' }),
+          defaultKeyMatchers,
+        );
       });
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'w' }));
+        result.current.handleInput(
+          createKey({ sequence: 'w' }),
+          defaultKeyMatchers,
+        );
       });
       expect(testBuffer.vimChangeWordForward).toHaveBeenCalledTimes(1);
 
@@ -803,7 +953,10 @@ describe('useVim hook', () => {
       testBuffer.cursor = [0, 0];
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: '.' }));
+        result.current.handleInput(
+          createKey({ sequence: '.' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimChangeWordForward).toHaveBeenCalledTimes(2);
@@ -815,7 +968,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'D' }));
+        result.current.handleInput(
+          createKey({ sequence: 'D' }),
+          defaultKeyMatchers,
+        );
       });
       expect(testBuffer.vimDeleteToEndOfLine).toHaveBeenCalledTimes(1);
 
@@ -823,7 +979,10 @@ describe('useVim hook', () => {
       vi.clearAllMocks(); // Clear all mocks instead of just one method
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: '.' }));
+        result.current.handleInput(
+          createKey({ sequence: '.' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimDeleteToEndOfLine).toHaveBeenCalledTimes(1);
@@ -835,7 +994,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'C' }));
+        result.current.handleInput(
+          createKey({ sequence: 'C' }),
+          defaultKeyMatchers,
+        );
       });
       expect(testBuffer.vimChangeToEndOfLine).toHaveBeenCalledTimes(1);
 
@@ -845,7 +1007,10 @@ describe('useVim hook', () => {
       testBuffer.cursor = [0, 2];
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: '.' }));
+        result.current.handleInput(
+          createKey({ sequence: '.' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimChangeToEndOfLine).toHaveBeenCalledTimes(2);
@@ -857,14 +1022,20 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'x' }));
+        result.current.handleInput(
+          createKey({ sequence: 'x' }),
+          defaultKeyMatchers,
+        );
       });
       expect(testBuffer.vimDeleteChar).toHaveBeenCalledWith(1);
 
       testBuffer.cursor = [0, 2];
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: '.' }));
+        result.current.handleInput(
+          createKey({ sequence: '.' }),
+          defaultKeyMatchers,
+        );
       });
       expect(testBuffer.vimDeleteChar).toHaveBeenCalledWith(1);
     });
@@ -876,7 +1047,10 @@ describe('useVim hook', () => {
       expect(testBuffer.cursor).toEqual([0, 10]);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'a' }));
+        result.current.handleInput(
+          createKey({ sequence: 'a' }),
+          defaultKeyMatchers,
+        );
       });
       expect(result.current.mode).toBe('INSERT');
       expect(testBuffer.cursor).toEqual([0, 11]);
@@ -894,7 +1068,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: '^' }));
+        result.current.handleInput(
+          createKey({ sequence: '^' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimMoveToFirstNonWhitespace).toHaveBeenCalled();
@@ -906,7 +1083,10 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'G' }));
+        result.current.handleInput(
+          createKey({ sequence: 'G' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimMoveToLastLine).toHaveBeenCalled();
@@ -919,12 +1099,18 @@ describe('useVim hook', () => {
 
       // First 'g' sets pending state
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'g' }));
+        result.current.handleInput(
+          createKey({ sequence: 'g' }),
+          defaultKeyMatchers,
+        );
       });
 
       // Second 'g' executes the command
       act(() => {
-        result.current.handleInput(createKey({ sequence: 'g' }));
+        result.current.handleInput(
+          createKey({ sequence: 'g' }),
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimMoveToFirstLine).toHaveBeenCalled();
@@ -936,11 +1122,17 @@ describe('useVim hook', () => {
       exitInsertMode(result);
 
       act(() => {
-        result.current.handleInput(createKey({ sequence: '3' }));
+        result.current.handleInput(
+          createKey({ sequence: '3' }),
+          defaultKeyMatchers,
+        );
       });
 
       act(() => {
-        result.current.handleInput(TEST_SEQUENCES.WORD_FORWARD);
+        result.current.handleInput(
+          TEST_SEQUENCES.WORD_FORWARD,
+          defaultKeyMatchers,
+        );
       });
 
       expect(testBuffer.vimMoveWordForward).toHaveBeenCalledWith(3);
@@ -955,10 +1147,16 @@ describe('useVim hook', () => {
         exitInsertMode(result);
 
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'd' }));
+          result.current.handleInput(
+            createKey({ sequence: 'd' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'w' }));
+          result.current.handleInput(
+            createKey({ sequence: 'w' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimDeleteWordForward).toHaveBeenCalledWith(1);
@@ -1040,13 +1238,22 @@ describe('useVim hook', () => {
         exitInsertMode(result);
 
         act(() => {
-          result.current.handleInput(createKey({ sequence: '2' }));
+          result.current.handleInput(
+            createKey({ sequence: '2' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'd' }));
+          result.current.handleInput(
+            createKey({ sequence: 'd' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'w' }));
+          result.current.handleInput(
+            createKey({ sequence: 'w' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimDeleteWordForward).toHaveBeenCalledWith(2);
@@ -1059,17 +1266,26 @@ describe('useVim hook', () => {
 
         // Execute dw
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'd' }));
+          result.current.handleInput(
+            createKey({ sequence: 'd' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'w' }));
+          result.current.handleInput(
+            createKey({ sequence: 'w' }),
+            defaultKeyMatchers,
+          );
         });
 
         vi.clearAllMocks();
 
         // Execute dot repeat
         act(() => {
-          result.current.handleInput(createKey({ sequence: '.' }));
+          result.current.handleInput(
+            createKey({ sequence: '.' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimDeleteWordForward).toHaveBeenCalledWith(1);
@@ -1083,10 +1299,16 @@ describe('useVim hook', () => {
         exitInsertMode(result);
 
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'd' }));
+          result.current.handleInput(
+            createKey({ sequence: 'd' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'e' }));
+          result.current.handleInput(
+            createKey({ sequence: 'e' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimDeleteWordEnd).toHaveBeenCalledWith(1);
@@ -1098,13 +1320,22 @@ describe('useVim hook', () => {
         exitInsertMode(result);
 
         act(() => {
-          result.current.handleInput(createKey({ sequence: '3' }));
+          result.current.handleInput(
+            createKey({ sequence: '3' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'd' }));
+          result.current.handleInput(
+            createKey({ sequence: 'd' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'e' }));
+          result.current.handleInput(
+            createKey({ sequence: 'e' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimDeleteWordEnd).toHaveBeenCalledWith(3);
@@ -1118,10 +1349,16 @@ describe('useVim hook', () => {
         exitInsertMode(result);
 
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'c' }));
+          result.current.handleInput(
+            createKey({ sequence: 'c' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'w' }));
+          result.current.handleInput(
+            createKey({ sequence: 'w' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimChangeWordForward).toHaveBeenCalledWith(1);
@@ -1135,13 +1372,22 @@ describe('useVim hook', () => {
         exitInsertMode(result);
 
         act(() => {
-          result.current.handleInput(createKey({ sequence: '2' }));
+          result.current.handleInput(
+            createKey({ sequence: '2' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'c' }));
+          result.current.handleInput(
+            createKey({ sequence: 'c' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'w' }));
+          result.current.handleInput(
+            createKey({ sequence: 'w' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimChangeWordForward).toHaveBeenCalledWith(2);
@@ -1155,10 +1401,16 @@ describe('useVim hook', () => {
 
         // Execute cw
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'c' }));
+          result.current.handleInput(
+            createKey({ sequence: 'c' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'w' }));
+          result.current.handleInput(
+            createKey({ sequence: 'w' }),
+            defaultKeyMatchers,
+          );
         });
 
         // Exit INSERT mode
@@ -1169,7 +1421,10 @@ describe('useVim hook', () => {
 
         // Execute dot repeat
         act(() => {
-          result.current.handleInput(createKey({ sequence: '.' }));
+          result.current.handleInput(
+            createKey({ sequence: '.' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimChangeWordForward).toHaveBeenCalledWith(1);
@@ -1184,10 +1439,16 @@ describe('useVim hook', () => {
         exitInsertMode(result);
 
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'c' }));
+          result.current.handleInput(
+            createKey({ sequence: 'c' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'e' }));
+          result.current.handleInput(
+            createKey({ sequence: 'e' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimChangeWordEnd).toHaveBeenCalledWith(1);
@@ -1200,13 +1461,22 @@ describe('useVim hook', () => {
         exitInsertMode(result);
 
         act(() => {
-          result.current.handleInput(createKey({ sequence: '2' }));
+          result.current.handleInput(
+            createKey({ sequence: '2' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'c' }));
+          result.current.handleInput(
+            createKey({ sequence: 'c' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'e' }));
+          result.current.handleInput(
+            createKey({ sequence: 'e' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimChangeWordEnd).toHaveBeenCalledWith(2);
@@ -1221,10 +1491,16 @@ describe('useVim hook', () => {
         exitInsertMode(result);
 
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'c' }));
+          result.current.handleInput(
+            createKey({ sequence: 'c' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'c' }));
+          result.current.handleInput(
+            createKey({ sequence: 'c' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimChangeLine).toHaveBeenCalledWith(1);
@@ -1240,13 +1516,22 @@ describe('useVim hook', () => {
         exitInsertMode(result);
 
         act(() => {
-          result.current.handleInput(createKey({ sequence: '3' }));
+          result.current.handleInput(
+            createKey({ sequence: '3' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'c' }));
+          result.current.handleInput(
+            createKey({ sequence: 'c' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'c' }));
+          result.current.handleInput(
+            createKey({ sequence: 'c' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimChangeLine).toHaveBeenCalledWith(3);
@@ -1260,10 +1545,16 @@ describe('useVim hook', () => {
 
         // Execute cc
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'c' }));
+          result.current.handleInput(
+            createKey({ sequence: 'c' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'c' }));
+          result.current.handleInput(
+            createKey({ sequence: 'c' }),
+            defaultKeyMatchers,
+          );
         });
 
         // Exit INSERT mode
@@ -1274,7 +1565,10 @@ describe('useVim hook', () => {
 
         // Execute dot repeat
         act(() => {
-          result.current.handleInput(createKey({ sequence: '.' }));
+          result.current.handleInput(
+            createKey({ sequence: '.' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimChangeLine).toHaveBeenCalledWith(1);
@@ -1289,10 +1583,16 @@ describe('useVim hook', () => {
         exitInsertMode(result);
 
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'd' }));
+          result.current.handleInput(
+            createKey({ sequence: 'd' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'b' }));
+          result.current.handleInput(
+            createKey({ sequence: 'b' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimDeleteWordBackward).toHaveBeenCalledWith(1);
@@ -1304,13 +1604,22 @@ describe('useVim hook', () => {
         exitInsertMode(result);
 
         act(() => {
-          result.current.handleInput(createKey({ sequence: '2' }));
+          result.current.handleInput(
+            createKey({ sequence: '2' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'd' }));
+          result.current.handleInput(
+            createKey({ sequence: 'd' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'b' }));
+          result.current.handleInput(
+            createKey({ sequence: 'b' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimDeleteWordBackward).toHaveBeenCalledWith(2);
@@ -1324,10 +1633,16 @@ describe('useVim hook', () => {
         exitInsertMode(result);
 
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'c' }));
+          result.current.handleInput(
+            createKey({ sequence: 'c' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'b' }));
+          result.current.handleInput(
+            createKey({ sequence: 'b' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimChangeWordBackward).toHaveBeenCalledWith(1);
@@ -1340,13 +1655,22 @@ describe('useVim hook', () => {
         exitInsertMode(result);
 
         act(() => {
-          result.current.handleInput(createKey({ sequence: '3' }));
+          result.current.handleInput(
+            createKey({ sequence: '3' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'c' }));
+          result.current.handleInput(
+            createKey({ sequence: 'c' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'b' }));
+          result.current.handleInput(
+            createKey({ sequence: 'b' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimChangeWordBackward).toHaveBeenCalledWith(3);
@@ -1362,22 +1686,34 @@ describe('useVim hook', () => {
 
         // Press 'd' to enter pending delete state
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'd' }));
+          result.current.handleInput(
+            createKey({ sequence: 'd' }),
+            defaultKeyMatchers,
+          );
         });
 
         // Complete with 'w'
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'w' }));
+          result.current.handleInput(
+            createKey({ sequence: 'w' }),
+            defaultKeyMatchers,
+          );
         });
 
         // Next 'd' should start a new pending state, not continue the previous one
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'd' }));
+          result.current.handleInput(
+            createKey({ sequence: 'd' }),
+            defaultKeyMatchers,
+          );
         });
 
         // This should trigger dd (delete line), not an error
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'd' }));
+          result.current.handleInput(
+            createKey({ sequence: 'd' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimDeleteLine).toHaveBeenCalledWith(1);
@@ -1390,10 +1726,16 @@ describe('useVim hook', () => {
 
         // Execute cw
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'c' }));
+          result.current.handleInput(
+            createKey({ sequence: 'c' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'w' }));
+          result.current.handleInput(
+            createKey({ sequence: 'w' }),
+            defaultKeyMatchers,
+          );
         });
 
         // Exit INSERT mode
@@ -1401,10 +1743,16 @@ describe('useVim hook', () => {
 
         // Next 'c' should start a new pending state
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'c' }));
+          result.current.handleInput(
+            createKey({ sequence: 'c' }),
+            defaultKeyMatchers,
+          );
         });
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'c' }));
+          result.current.handleInput(
+            createKey({ sequence: 'c' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimChangeLine).toHaveBeenCalledWith(1);
@@ -1417,17 +1765,26 @@ describe('useVim hook', () => {
 
         // Enter pending delete state
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'd' }));
+          result.current.handleInput(
+            createKey({ sequence: 'd' }),
+            defaultKeyMatchers,
+          );
         });
 
         // Press escape to clear pending state
         act(() => {
-          result.current.handleInput(createKey({ name: 'escape' }));
+          result.current.handleInput(
+            createKey({ name: 'escape' }),
+            defaultKeyMatchers,
+          );
         });
 
         // Now 'w' should just move cursor, not delete
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'w' }));
+          result.current.handleInput(
+            createKey({ sequence: 'w' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(testBuffer.vimDeleteWordForward).not.toHaveBeenCalled();
@@ -1443,6 +1800,7 @@ describe('useVim hook', () => {
 
         const handled = result.current.handleInput(
           createKey({ name: 'escape' }),
+          defaultKeyMatchers,
         );
 
         expect(handled).toBe(false);
@@ -1453,12 +1811,18 @@ describe('useVim hook', () => {
         const { result } = renderVimHook();
 
         act(() => {
-          result.current.handleInput(createKey({ sequence: 'd' }));
+          result.current.handleInput(
+            createKey({ sequence: 'd' }),
+            defaultKeyMatchers,
+          );
         });
 
         let handled: boolean | undefined;
         act(() => {
-          handled = result.current.handleInput(createKey({ name: 'escape' }));
+          handled = result.current.handleInput(
+            createKey({ name: 'escape' }),
+            defaultKeyMatchers,
+          );
         });
 
         expect(handled).toBe(true);
@@ -1477,6 +1841,7 @@ describe('useVim hook', () => {
 
       const handled = result.current.handleInput(
         createKey({ name: 'r', ctrl: true }),
+        defaultKeyMatchers,
       );
 
       expect(handled).toBe(false);
@@ -1491,7 +1856,10 @@ describe('useVim hook', () => {
         expect(result.current.mode).toBe('INSERT');
       });
 
-      const handled = result.current.handleInput(createKey({ sequence: '!' }));
+      const handled = result.current.handleInput(
+        createKey({ sequence: '!' }),
+        defaultKeyMatchers,
+      );
 
       expect(handled).toBe(false);
     });
@@ -1508,11 +1876,12 @@ describe('useVim hook', () => {
       const key = createKey({ sequence: '!', name: '!' });
 
       act(() => {
-        result.current.handleInput(key);
+        result.current.handleInput(key, defaultKeyMatchers);
       });
 
       expect(nonEmptyBuffer.handleInput).toHaveBeenCalledWith(
         expect.objectContaining(key),
+        defaultKeyMatchers,
       );
     });
   });
@@ -1815,13 +2184,19 @@ describe('useVim hook', () => {
       // First escape - should pass through (return false)
       let handled: boolean;
       await act(async () => {
-        handled = result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+        handled = result.current.handleInput(
+          TEST_SEQUENCES.ESCAPE,
+          defaultKeyMatchers,
+        );
       });
       expect(handled!).toBe(false);
 
       // Second escape within timeout - should clear buffer (return true)
       await act(async () => {
-        handled = result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+        handled = result.current.handleInput(
+          TEST_SEQUENCES.ESCAPE,
+          defaultKeyMatchers,
+        );
       });
       expect(handled!).toBe(true);
       expect(mockBuffer.setText).toHaveBeenCalledWith('');
@@ -1835,14 +2210,20 @@ describe('useVim hook', () => {
       // First escape - switches to NORMAL mode
       let handled: boolean;
       await act(async () => {
-        handled = result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+        handled = result.current.handleInput(
+          TEST_SEQUENCES.ESCAPE,
+          defaultKeyMatchers,
+        );
       });
       expect(handled!).toBe(true);
       expect(mockBuffer.vimEscapeInsertMode).toHaveBeenCalled();
 
       // Second escape within timeout - should clear buffer
       await act(async () => {
-        handled = result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+        handled = result.current.handleInput(
+          TEST_SEQUENCES.ESCAPE,
+          defaultKeyMatchers,
+        );
       });
       expect(handled!).toBe(true);
       expect(mockBuffer.setText).toHaveBeenCalledWith('');
@@ -1860,7 +2241,7 @@ describe('useVim hook', () => {
 
       // First escape
       await act(async () => {
-        result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+        result.current.handleInput(TEST_SEQUENCES.ESCAPE, defaultKeyMatchers);
       });
 
       // Wait longer than timeout (500ms)
@@ -1871,7 +2252,10 @@ describe('useVim hook', () => {
       // Second escape - should NOT clear buffer because timeout expired
       let handled: boolean;
       await act(async () => {
-        handled = result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+        handled = result.current.handleInput(
+          TEST_SEQUENCES.ESCAPE,
+          defaultKeyMatchers,
+        );
       });
       // First escape of new sequence, passes through
       expect(handled!).toBe(false);
@@ -1890,23 +2274,26 @@ describe('useVim hook', () => {
 
       // First escape
       await act(async () => {
-        result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+        result.current.handleInput(TEST_SEQUENCES.ESCAPE, defaultKeyMatchers);
       });
 
       // Type 'd' to set pending operator
       await act(async () => {
-        result.current.handleInput(TEST_SEQUENCES.DELETE);
+        result.current.handleInput(TEST_SEQUENCES.DELETE, defaultKeyMatchers);
       });
 
       // Escape to clear pending operator
       await act(async () => {
-        result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+        result.current.handleInput(TEST_SEQUENCES.ESCAPE, defaultKeyMatchers);
       });
 
       // Another escape - should NOT clear buffer (history was reset)
       let handled: boolean;
       await act(async () => {
-        handled = result.current.handleInput(TEST_SEQUENCES.ESCAPE);
+        handled = result.current.handleInput(
+          TEST_SEQUENCES.ESCAPE,
+          defaultKeyMatchers,
+        );
       });
       expect(handled!).toBe(false);
       expect(mockBuffer.setText).not.toHaveBeenCalled();
@@ -1920,7 +2307,10 @@ describe('useVim hook', () => {
 
       let handled: boolean;
       await act(async () => {
-        handled = result.current.handleInput(TEST_SEQUENCES.CTRL_C);
+        handled = result.current.handleInput(
+          TEST_SEQUENCES.CTRL_C,
+          defaultKeyMatchers,
+        );
       });
       // Should return false to let InputPrompt handle it
       expect(handled!).toBe(false);
@@ -1933,7 +2323,10 @@ describe('useVim hook', () => {
 
       let handled: boolean;
       await act(async () => {
-        handled = result.current.handleInput(TEST_SEQUENCES.CTRL_C);
+        handled = result.current.handleInput(
+          TEST_SEQUENCES.CTRL_C,
+          defaultKeyMatchers,
+        );
       });
       // Should return false to let InputPrompt handle it
       expect(handled!).toBe(false);

--- a/packages/cli/src/ui/hooks/vim.ts
+++ b/packages/cli/src/ui/hooks/vim.ts
@@ -9,7 +9,7 @@ import type { Key } from './useKeypress.js';
 import type { TextBuffer } from '../components/shared/text-buffer.js';
 import { useVimMode } from '../contexts/VimModeContext.js';
 import { debugLogger } from '@google/gemini-cli-core';
-import { keyMatchers, Command } from '../keyMatchers.js';
+import { Command, type KeyMatchers } from '../keyMatchers.js';
 
 export type VimMode = 'NORMAL' | 'INSERT';
 
@@ -381,8 +381,8 @@ export function useVim(buffer: TextBuffer, onSubmit?: (value: string) => void) {
    * @returns boolean indicating if the key was handled
    */
   const handleInsertModeInput = useCallback(
-    (normalizedKey: Key): boolean => {
-      if (keyMatchers[Command.ESCAPE](normalizedKey)) {
+    (normalizedKey: Key, matchers: KeyMatchers): boolean => {
+      if (matchers[Command.ESCAPE](normalizedKey)) {
         // Record for double-escape detection (clearing happens in NORMAL mode)
         checkDoubleEscape();
         buffer.vimEscapeInsertMode();
@@ -437,7 +437,7 @@ export function useVim(buffer: TextBuffer, onSubmit?: (value: string) => void) {
         return true; // Handled by vim (even if no onSubmit callback)
       }
 
-      return buffer.handleInput(normalizedKey);
+      return buffer.handleInput(normalizedKey, matchers);
     },
     [buffer, dispatch, updateMode, onSubmit, checkDoubleEscape],
   );
@@ -568,7 +568,7 @@ export function useVim(buffer: TextBuffer, onSubmit?: (value: string) => void) {
   );
 
   const handleInput = useCallback(
-    (key: Key): boolean => {
+    (key: Key, matchers: KeyMatchers): boolean => {
       if (!vimEnabled) {
         return false; // Let InputPrompt handle it
       }
@@ -583,18 +583,18 @@ export function useVim(buffer: TextBuffer, onSubmit?: (value: string) => void) {
       }
 
       // Let InputPrompt handle Ctrl+C for clearing input (works in all modes)
-      if (keyMatchers[Command.CLEAR_INPUT](normalizedKey)) {
+      if (matchers[Command.CLEAR_INPUT](normalizedKey)) {
         return false;
       }
 
       // Handle INSERT mode
       if (state.mode === 'INSERT') {
-        return handleInsertModeInput(normalizedKey);
+        return handleInsertModeInput(normalizedKey, matchers);
       }
 
       // Handle NORMAL mode
       if (state.mode === 'NORMAL') {
-        if (keyMatchers[Command.ESCAPE](normalizedKey)) {
+        if (matchers[Command.ESCAPE](normalizedKey)) {
           if (state.pendingOperator) {
             dispatch({ type: 'CLEAR_PENDING_STATES' });
             lastEscapeTimestampRef.current = 0;

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { keyMatchers, Command, createKeyMatchers } from './keyMatchers.js';
+import {
+  defaultKeyMatchers,
+  Command,
+  createKeyMatchers,
+} from './keyMatchers.js';
 import type { KeyBindingConfig } from '../config/keyBindings.js';
 import { defaultKeyBindings } from '../config/keyBindings.js';
 import type { Key } from './hooks/useKeypress.js';
@@ -422,14 +426,14 @@ describe('keyMatchers', () => {
       it(`should match ${command} correctly`, () => {
         positive.forEach((key) => {
           expect(
-            keyMatchers[command](key),
+            defaultKeyMatchers[command](key),
             `Expected ${command} to match ${JSON.stringify(key)}`,
           ).toBe(true);
         });
 
         negative.forEach((key) => {
           expect(
-            keyMatchers[command](key),
+            defaultKeyMatchers[command](key),
             `Expected ${command} to NOT match ${JSON.stringify(key)}`,
           ).toBe(false);
         });

--- a/packages/cli/src/ui/keyMatchers.ts
+++ b/packages/cli/src/ui/keyMatchers.ts
@@ -68,7 +68,8 @@ export function createKeyMatchers(
 /**
  * Default key binding matchers using the default configuration
  */
-export const keyMatchers: KeyMatchers = createKeyMatchers(defaultKeyBindings);
+export const defaultKeyMatchers: KeyMatchers =
+  createKeyMatchers(defaultKeyBindings);
 
 // Re-export Command for convenience
 export { Command };

--- a/packages/cli/src/ui/utils/shortcutsHelp.ts
+++ b/packages/cli/src/ui/utils/shortcutsHelp.ts
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Command, keyMatchers } from '../keyMatchers.js';
+import { Command, type KeyMatchers } from '../keyMatchers.js';
 import type { Key } from '../hooks/useKeypress.js';
 
-export function shouldDismissShortcutsHelpOnHotkey(key: Key): boolean {
-  return Object.values(Command).some((command) => keyMatchers[command](key));
+export function shouldDismissShortcutsHelpOnHotkey(
+  key: Key,
+  matchers: KeyMatchers,
+): boolean {
+  return Object.values(Command).some((command) => matchers[command](key));
 }


### PR DESCRIPTION
## Summary

Refactors the keypress handling system to explicitly pass `keyMatchers` as an argument to `KeypressHandler` instances rather than relying on a globally imported instance.

## Details

We need to make this change because once we support configurable key bindings, we can't rely on a single hardcoded global variable.

## Related Issues

For #21294

## How to Validate

Use various keybindings and verify that they still work.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
