### PR TITLE
 Show extension name in /hooks panel UI

### DIFF
--- a/packages/cli/src/ui/components/HooksDialog.tsx
+++ b/packages/cli/src/ui/components/HooksDialog.tsx
@@ -211,7 +211,7 @@ export const HooksDialog: React.FC<HooksDialogProps> = ({
                     )}
                     <Text color={theme.text.secondary} wrap="wrap">
                       Source: {hook.source}
-                      {hook.extensionName && ` (${hook.extensionName})`}
+{hook.extensionName && ` (${hook.extensionName.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')})`}
                       {hook.config.name &&
                         hook.config.command &&
                         ` | Command: ${hook.config.command}`}

--- a/packages/cli/src/ui/components/HooksDialog.tsx
+++ b/packages/cli/src/ui/components/HooksDialog.tsx
@@ -23,6 +23,7 @@ export interface HookEntry {
     timeout?: number;
   };
   source: string;
+  extensionName?: string;
   eventName: string;
   matcher?: string;
   sequential?: boolean;
@@ -210,6 +211,7 @@ export const HooksDialog: React.FC<HooksDialogProps> = ({
                     )}
                     <Text color={theme.text.secondary} wrap="wrap">
                       Source: {hook.source}
+                      {hook.extensionName && ` (${hook.extensionName})`}
                       {hook.config.name &&
                         hook.config.command &&
                         ` | Command: ${hook.config.command}`}

--- a/packages/core/src/hooks/hookRegistry.test.ts
+++ b/packages/core/src/hooks/hookRegistry.test.ts
@@ -284,6 +284,36 @@ describe('HookRegistry', () => {
         hookRegistry.getHooksForEvent(HookEventName.BeforeTool),
       ).toHaveLength(0);
     });
+
+    it('should set extensionName when hooks come from an extension', async () => {
+      const extensionHooks = {
+        BeforeTool: [
+          {
+            hooks: [
+              {
+                type: 'command',
+                command: './hooks/ext-hook.sh',
+              },
+            ],
+          },
+        ],
+      };
+
+      vi.mocked(mockConfig.getExtensions).mockReturnValue([
+        {
+          name: 'my-test-extension',
+          isActive: true,
+          hooks: extensionHooks,
+        },
+      ] as unknown as ReturnType<typeof mockConfig.getExtensions>);
+
+      await hookRegistry.initialize();
+
+      const hooks = hookRegistry.getAllHooks();
+      expect(hooks).toHaveLength(1);
+      expect(hooks[0].extensionName).toBe('my-test-extension');
+      expect(hooks[0].source).toBe(ConfigSource.Extensions);
+    });
   });
 
   describe('getHooksForEvent', () => {

--- a/packages/core/src/hooks/hookRegistry.ts
+++ b/packages/core/src/hooks/hookRegistry.ts
@@ -22,6 +22,7 @@ import { coreEvents } from '../utils/events.js';
 export interface HookRegistryEntry {
   config: HookConfig;
   source: ConfigSource;
+  extensionName?: string;
   eventName: HookEventName;
   matcher?: string;
   sequential?: boolean;
@@ -193,6 +194,7 @@ please review the project settings (.gemini/settings.json) and remove them.`;
         this.processHooksConfiguration(
           extension.hooks,
           ConfigSource.Extensions,
+          extension.name,
         );
       }
     }
@@ -204,6 +206,7 @@ please review the project settings (.gemini/settings.json) and remove them.`;
   private processHooksConfiguration(
     hooksConfig: { [K in HookEventName]?: HookDefinition[] },
     source: ConfigSource,
+    extensionName?: string,
   ): void {
     for (const [eventName, definitions] of Object.entries(hooksConfig)) {
       if (HOOKS_CONFIG_FIELDS.includes(eventName)) {
@@ -228,7 +231,12 @@ please review the project settings (.gemini/settings.json) and remove them.`;
       }
 
       for (const definition of definitions) {
-        this.processHookDefinition(definition, typedEventName, source);
+        this.processHookDefinition(
+          definition,
+          typedEventName,
+          source,
+          extensionName,
+        );
       }
     }
   }
@@ -240,6 +248,7 @@ please review the project settings (.gemini/settings.json) and remove them.`;
     definition: HookDefinition,
     eventName: HookEventName,
     source: ConfigSource,
+    extensionName?: string,
   ): void {
     if (
       !definition ||
@@ -275,6 +284,7 @@ please review the project settings (.gemini/settings.json) and remove them.`;
         this.entries.push({
           config: hookConfig,
           source,
+          extensionName,
           eventName,
           matcher: definition.matcher,
           sequential: definition.sequential,


### PR DESCRIPTION
## Summary
When looking at the "/hooks panel", the source of the hook from an extension will now include the extension's name, rather than just the source (e.g., "Source: extensions (my-extension-name)" versus "Source: extensions").

## Details
Adds an `extensionName` field to the `HookRegistryEntry` class. The source of the hook will now include the extension's name when the hook is loaded from an extension.

## Related Issues
#18133

## How to Validate
1. Install an extension that has hooks configured
2. Run the CLI: "npm run start"
3. Type "/hooks panel"
4. Verify the source line shows the extension name, e.g.:
   "Source: extensions (my-extension-name)"
   instead of the old:
   "Source: extensions"
   
   To validate via unit tests:
   cd packages/core
   npx vitest run src/hooks/hookRegistry
   
All 25 tests should pass, including "should set extensionName when hooks come from an extension" test.

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
