### PR TITLE
perf(core): cache loadApiKey to reduce redundant keychain access

### DIFF
--- a/packages/core/src/core/apiKeyCredentialStorage.test.ts
+++ b/packages/core/src/core/apiKeyCredentialStorage.test.ts
@@ -117,4 +117,28 @@ describe('ApiKeyCredentialStorage', () => {
     await loadApiKey();
     expect(getCredentialsMock).toHaveBeenCalledTimes(2); // Should have fetched again
   });
+
+  it('should clear an API key and cache when saving empty key', async () => {
+    await saveApiKey('');
+    expect(deleteCredentialsMock).toHaveBeenCalledWith('default-api-key');
+    expect(setCredentialsMock).not.toHaveBeenCalled();
+  });
+
+  it('should clear an API key and cache when saving null key', async () => {
+    await saveApiKey(null);
+    expect(deleteCredentialsMock).toHaveBeenCalledWith('default-api-key');
+    expect(setCredentialsMock).not.toHaveBeenCalled();
+  });
+
+  it('should not throw when clearing an API key fails during saveApiKey', async () => {
+    deleteCredentialsMock.mockRejectedValueOnce(new Error('Failed to delete'));
+    await expect(saveApiKey('')).resolves.not.toThrow();
+    expect(deleteCredentialsMock).toHaveBeenCalledWith('default-api-key');
+  });
+
+  it('should not throw when clearing an API key fails during clearApiKey', async () => {
+    deleteCredentialsMock.mockRejectedValueOnce(new Error('Failed to delete'));
+    await expect(clearApiKey()).resolves.not.toThrow();
+    expect(deleteCredentialsMock).toHaveBeenCalledWith('default-api-key');
+  });
 });

--- a/packages/core/src/core/apiKeyCredentialStorage.test.ts
+++ b/packages/core/src/core/apiKeyCredentialStorage.test.ts
@@ -9,6 +9,7 @@ import {
   loadApiKey,
   saveApiKey,
   clearApiKey,
+  resetApiKeyCacheForTesting,
 } from './apiKeyCredentialStorage.js';
 
 const getCredentialsMock = vi.hoisted(() => vi.fn());
@@ -26,9 +27,10 @@ vi.mock('../mcp/token-storage/hybrid-token-storage.js', () => ({
 describe('ApiKeyCredentialStorage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetApiKeyCacheForTesting();
   });
 
-  it('should load an API key', async () => {
+  it('should load an API key and cache it', async () => {
     getCredentialsMock.mockResolvedValue({
       serverName: 'default-api-key',
       token: {
@@ -38,19 +40,39 @@ describe('ApiKeyCredentialStorage', () => {
       updatedAt: Date.now(),
     });
 
-    const apiKey = await loadApiKey();
-    expect(apiKey).toBe('test-key');
-    expect(getCredentialsMock).toHaveBeenCalledWith('default-api-key');
+    const apiKey1 = await loadApiKey();
+    expect(apiKey1).toBe('test-key');
+    expect(getCredentialsMock).toHaveBeenCalledTimes(1);
+
+    const apiKey2 = await loadApiKey();
+    expect(apiKey2).toBe('test-key');
+    expect(getCredentialsMock).toHaveBeenCalledTimes(1); // Should be cached
   });
 
-  it('should return null if no API key is stored', async () => {
+  it('should return null if no API key is stored and cache it', async () => {
     getCredentialsMock.mockResolvedValue(null);
-    const apiKey = await loadApiKey();
-    expect(apiKey).toBeNull();
-    expect(getCredentialsMock).toHaveBeenCalledWith('default-api-key');
+    const apiKey1 = await loadApiKey();
+    expect(apiKey1).toBeNull();
+    expect(getCredentialsMock).toHaveBeenCalledTimes(1);
+
+    const apiKey2 = await loadApiKey();
+    expect(apiKey2).toBeNull();
+    expect(getCredentialsMock).toHaveBeenCalledTimes(1); // Should be cached
   });
 
-  it('should save an API key', async () => {
+  it('should save an API key and clear cache', async () => {
+    getCredentialsMock.mockResolvedValue({
+      serverName: 'default-api-key',
+      token: {
+        accessToken: 'old-key',
+        tokenType: 'ApiKey',
+      },
+      updatedAt: Date.now(),
+    });
+
+    await loadApiKey();
+    expect(getCredentialsMock).toHaveBeenCalledTimes(1);
+
     await saveApiKey('new-key');
     expect(setCredentialsMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -61,28 +83,38 @@ describe('ApiKeyCredentialStorage', () => {
         }),
       }),
     );
+
+    getCredentialsMock.mockResolvedValue({
+      serverName: 'default-api-key',
+      token: {
+        accessToken: 'new-key',
+        tokenType: 'ApiKey',
+      },
+      updatedAt: Date.now(),
+    });
+
+    await loadApiKey();
+    expect(getCredentialsMock).toHaveBeenCalledTimes(2); // Should have fetched again
   });
 
-  it('should clear an API key when saving empty key', async () => {
-    await saveApiKey('');
-    expect(deleteCredentialsMock).toHaveBeenCalledWith('default-api-key');
-    expect(setCredentialsMock).not.toHaveBeenCalled();
-  });
+  it('should clear an API key and clear cache', async () => {
+    getCredentialsMock.mockResolvedValue({
+      serverName: 'default-api-key',
+      token: {
+        accessToken: 'old-key',
+        tokenType: 'ApiKey',
+      },
+      updatedAt: Date.now(),
+    });
 
-  it('should clear an API key when saving null key', async () => {
-    await saveApiKey(null);
-    expect(deleteCredentialsMock).toHaveBeenCalledWith('default-api-key');
-    expect(setCredentialsMock).not.toHaveBeenCalled();
-  });
+    await loadApiKey();
+    expect(getCredentialsMock).toHaveBeenCalledTimes(1);
 
-  it('should clear an API key', async () => {
     await clearApiKey();
     expect(deleteCredentialsMock).toHaveBeenCalledWith('default-api-key');
-  });
 
-  it('should not throw when clearing an API key fails', async () => {
-    deleteCredentialsMock.mockRejectedValueOnce(new Error('Failed to delete'));
-    await expect(saveApiKey('')).resolves.not.toThrow();
-    expect(deleteCredentialsMock).toHaveBeenCalledWith('default-api-key');
+    getCredentialsMock.mockResolvedValue(null);
+    await loadApiKey();
+    expect(getCredentialsMock).toHaveBeenCalledTimes(2); // Should have fetched again
   });
 });

--- a/packages/core/src/core/apiKeyCredentialStorage.ts
+++ b/packages/core/src/core/apiKeyCredentialStorage.ts
@@ -7,29 +7,49 @@
 import { HybridTokenStorage } from '../mcp/token-storage/hybrid-token-storage.js';
 import type { OAuthCredentials } from '../mcp/token-storage/types.js';
 import { debugLogger } from '../utils/debugLogger.js';
+import { createCache } from '../utils/cache.js';
 
 const KEYCHAIN_SERVICE_NAME = 'gemini-cli-api-key';
 const DEFAULT_API_KEY_ENTRY = 'default-api-key';
 
 const storage = new HybridTokenStorage(KEYCHAIN_SERVICE_NAME);
 
+// Cache to store the results of loadApiKey to avoid redundant keychain access.
+let apiKeyCache = createCache<string, Promise<string | null>>({
+  storage: 'map',
+  defaultTtl: 30000, // 30 seconds
+});
+
+/**
+ * Resets the API key cache. Used exclusively for test isolation.
+ * @internal
+ */
+export function resetApiKeyCacheForTesting() {
+  apiKeyCache = createCache<string, Promise<string | null>>({
+    storage: 'map',
+    defaultTtl: 30000,
+  });
+}
+
 /**
  * Load cached API key
  */
 export async function loadApiKey(): Promise<string | null> {
-  try {
-    const credentials = await storage.getCredentials(DEFAULT_API_KEY_ENTRY);
+  return apiKeyCache.getOrCreate(DEFAULT_API_KEY_ENTRY, async () => {
+    try {
+      const credentials = await storage.getCredentials(DEFAULT_API_KEY_ENTRY);
 
-    if (credentials?.token?.accessToken) {
-      return credentials.token.accessToken;
+      if (credentials?.token?.accessToken) {
+        return credentials.token.accessToken;
+      }
+
+      return null;
+    } catch (error: unknown) {
+      // Log other errors but don't crash, just return null so user can re-enter key
+      debugLogger.error('Failed to load API key from storage:', error);
+      return null;
     }
-
-    return null;
-  } catch (error: unknown) {
-    // Log other errors but don't crash, just return null so user can re-enter key
-    debugLogger.error('Failed to load API key from storage:', error);
-    return null;
-  }
+  });
 }
 
 /**
@@ -38,6 +58,7 @@ export async function loadApiKey(): Promise<string | null> {
 export async function saveApiKey(
   apiKey: string | null | undefined,
 ): Promise<void> {
+  apiKeyCache.delete(DEFAULT_API_KEY_ENTRY);
   if (!apiKey || apiKey.trim() === '') {
     try {
       await storage.deleteCredentials(DEFAULT_API_KEY_ENTRY);
@@ -65,6 +86,7 @@ export async function saveApiKey(
  * Clear cached API key
  */
 export async function clearApiKey(): Promise<void> {
+  apiKeyCache.delete(DEFAULT_API_KEY_ENTRY);
   try {
     await storage.deleteCredentials(DEFAULT_API_KEY_ENTRY);
   } catch (error: unknown) {

--- a/packages/core/src/core/apiKeyCredentialStorage.ts
+++ b/packages/core/src/core/apiKeyCredentialStorage.ts
@@ -15,7 +15,7 @@ const DEFAULT_API_KEY_ENTRY = 'default-api-key';
 const storage = new HybridTokenStorage(KEYCHAIN_SERVICE_NAME);
 
 // Cache to store the results of loadApiKey to avoid redundant keychain access.
-let apiKeyCache = createCache<string, Promise<string | null>>({
+const apiKeyCache = createCache<string, Promise<string | null>>({
   storage: 'map',
   defaultTtl: 30000, // 30 seconds
 });
@@ -25,10 +25,7 @@ let apiKeyCache = createCache<string, Promise<string | null>>({
  * @internal
  */
 export function resetApiKeyCacheForTesting() {
-  apiKeyCache = createCache<string, Promise<string | null>>({
-    storage: 'map',
-    defaultTtl: 30000,
-  });
+  apiKeyCache.clear();
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR caches the results of `loadApiKey` to avoid redundant keychain access during CLI startup and context refreshes. Accessing the system keychain involves IPC overhead, so caching this for a short duration (30 seconds) improves startup performance while still allowing for near-instant updates if the key is changed interactively.

## Details

- Implemented an in-memory cache with a 30-second TTL for `loadApiKey` in `packages/core/src/core/apiKeyCredentialStorage.ts` using the core `createCache` utility.
- Added `resetApiKeyCacheForTesting` to allow proper test isolation.
- Updated `saveApiKey` and `clearApiKey` to explicitly delete the cached entry to ensure changes take effect instantly.
- Updated tests in `apiKeyCredentialStorage.test.ts` to assert that `fs` and storage read methods are only called the expected number of times, validating the cache behavior.

## Related Issues

Related to #21519

## How to Validate

1. Run the core tests for `apiKeyCredentialStorage`:
   `npm test -w @google/gemini-cli-core -- src/core/apiKeyCredentialStorage.test.ts`
2. Start the CLI normally and ensure there are no keychain prompts or delays. The API key should be correctly loaded and utilized.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

