### PR TITLE
perf(cli): cache loadSettings to reduce redundant disk I/O at startup

### DIFF
--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -31,6 +31,7 @@ import {
   loadSettings,
   createTestMergedSettings,
   SettingScope,
+  resetSettingsCacheForTesting,
 } from './settings.js';
 import {
   isWorkspaceTrusted,
@@ -161,6 +162,7 @@ describe('extension tests', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetSettingsCacheForTesting();
     keychainData = {};
     mockKeychainStorage = {
       getSecret: vi

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -1574,7 +1574,7 @@ describe('Settings Loading and Merging', () => {
         expect(settings1).not.toBe(settings2);
       });
 
-      it('should clear cache when saveSettings is called', () => {
+      it('should clear cache when saveSettings is called for user settings', () => {
         const mockedRead = vi.mocked(fs.readFileSync);
         mockedRead.mockClear();
         mockedRead.mockReturnValue('{}');
@@ -1588,6 +1588,33 @@ describe('Settings Loading and Merging', () => {
         const settings2 = loadSettings(MOCK_WORKSPACE_DIR);
         expect(mockedRead).toHaveBeenCalledTimes(10); // Should have re-read from disk
         expect(settings1).not.toBe(settings2);
+      });
+
+      it('should only clear the specific workspace cache when saveSettings is called for workspace settings', () => {
+        const mockedRead = vi.mocked(fs.readFileSync);
+        mockedRead.mockClear();
+        mockedRead.mockReturnValue('{}');
+        (mockFsExistsSync as Mock).mockReturnValue(true);
+
+        const workspace1 = '/mock/workspace1';
+        const workspace2 = '/mock/workspace2';
+
+        const settings1W1 = loadSettings(workspace1);
+        const settings1W2 = loadSettings(workspace2);
+
+        expect(mockedRead).toHaveBeenCalledTimes(10);
+
+        // Save settings for workspace 1
+        saveSettings(settings1W1.workspace);
+
+        const settings2W1 = loadSettings(workspace1);
+        const settings2W2 = loadSettings(workspace2);
+
+        // Workspace 1 should have been cleared and re-read from disk (+5 reads)
+        // Workspace 2 should still be cached (+0 reads)
+        expect(mockedRead).toHaveBeenCalledTimes(15);
+        expect(settings1W1).not.toBe(settings2W1);
+        expect(settings1W2).toBe(settings2W2);
       });
     });
   });

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -13,7 +13,7 @@ vi.mock('os', async (importOriginal) => {
   const actualOs = await importOriginal<typeof osActual>();
   return {
     ...actualOs,
-    homedir: vi.fn(() => '/mock/home/user'),
+    homedir: vi.fn(() => path.resolve('/mock/home/user')),
     platform: vi.fn(() => 'linux'),
   };
 });
@@ -92,7 +92,7 @@ import {
 } from './settingsSchema.js';
 import { createMockSettings } from '../test-utils/settings.js';
 
-const MOCK_WORKSPACE_DIR = '/mock/workspace';
+const MOCK_WORKSPACE_DIR = path.resolve(path.resolve('/mock/workspace'));
 // Use the (mocked) GEMINI_DIR for consistency
 const MOCK_WORKSPACE_SETTINGS_PATH = path.join(
   MOCK_WORKSPACE_DIR,
@@ -185,7 +185,9 @@ describe('Settings Loading and Merging', () => {
     mockFsMkdirSync = vi.mocked(fs.mkdirSync);
     mockStripJsonComments = vi.mocked(stripJsonComments);
 
-    vi.mocked(osActual.homedir).mockReturnValue('/mock/home/user');
+    vi.mocked(osActual.homedir).mockReturnValue(
+      path.resolve('/mock/home/user'),
+    );
     (mockStripJsonComments as unknown as Mock).mockImplementation(
       (jsonString: string) => jsonString,
     );
@@ -1489,7 +1491,9 @@ describe('Settings Loading and Merging', () => {
     });
 
     describe('when GEMINI_CLI_SYSTEM_SETTINGS_PATH is set', () => {
-      const MOCK_ENV_SYSTEM_SETTINGS_PATH = '/mock/env/system/settings.json';
+      const MOCK_ENV_SYSTEM_SETTINGS_PATH = path.resolve(
+        '/mock/env/system/settings.json',
+      );
 
       beforeEach(() => {
         process.env['GEMINI_CLI_SYSTEM_SETTINGS_PATH'] =
@@ -1531,8 +1535,8 @@ describe('Settings Loading and Merging', () => {
     });
 
     it('should correctly skip workspace-level loading if workspaceDir is a symlink to home', () => {
-      const mockHomeDir = '/mock/home/user';
-      const mockSymlinkDir = '/mock/symlink/to/home';
+      const mockHomeDir = path.resolve('/mock/home/user');
+      const mockSymlinkDir = path.resolve('/mock/symlink/to/home');
       const mockWorkspaceSettingsPath = path.join(
         mockSymlinkDir,
         GEMINI_DIR,
@@ -1597,8 +1601,8 @@ describe('Settings Loading and Merging', () => {
         mockedRead.mockReturnValue('{}');
         (mockFsExistsSync as Mock).mockReturnValue(true);
 
-        const workspace1 = '/mock/workspace1';
-        const workspace2 = '/mock/workspace2';
+        const workspace1 = path.resolve('/mock/workspace1');
+        const workspace2 = path.resolve('/mock/workspace2');
 
         const settings1 = loadSettings(workspace1);
         const settings2 = loadSettings(workspace2);
@@ -1629,8 +1633,8 @@ describe('Settings Loading and Merging', () => {
         mockedRead.mockReturnValue('{}');
         (mockFsExistsSync as Mock).mockReturnValue(true);
 
-        const workspace1 = '/mock/workspace1';
-        const workspace2 = '/mock/workspace2';
+        const workspace1 = path.resolve('/mock/workspace1');
+        const workspace2 = path.resolve('/mock/workspace2');
 
         const settings1W1 = loadSettings(workspace1);
         const settings1W2 = loadSettings(workspace2);
@@ -1688,13 +1692,13 @@ describe('Settings Loading and Merging', () => {
         loadSettings as unknown as { findEnvFile: () => string }
       ).findEnvFile;
       (loadSettings as unknown as { findEnvFile: () => string }).findEnvFile =
-        () => '/mock/project/.env';
+        () => path.resolve('/mock/project/.env');
 
       // Mock fs.readFileSync for .env file content
       const originalReadFileSync = fs.readFileSync;
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === '/mock/project/.env') {
+          if (p === path.resolve('/mock/project/.env')) {
             return 'DEBUG=true\nDEBUG_MODE=1\nGEMINI_API_KEY=test-key';
           }
           if (
@@ -2544,13 +2548,16 @@ describe('Settings Loading and Merging', () => {
     it('should save settings using updateSettingsFilePreservingFormat', () => {
       const mockUpdateSettings = vi.mocked(updateSettingsFilePreservingFormat);
       const settingsFile = createMockSettings({ ui: { theme: 'dark' } }).user;
-      settingsFile.path = '/mock/settings.json';
+      settingsFile.path = path.resolve('/mock/settings.json');
 
       saveSettings(settingsFile);
 
-      expect(mockUpdateSettings).toHaveBeenCalledWith('/mock/settings.json', {
-        ui: { theme: 'dark' },
-      });
+      expect(mockUpdateSettings).toHaveBeenCalledWith(
+        path.resolve('/mock/settings.json'),
+        {
+          ui: { theme: 'dark' },
+        },
+      );
     });
 
     it('should create directory if it does not exist', () => {
@@ -2559,14 +2566,19 @@ describe('Settings Loading and Merging', () => {
       mockFsExistsSync.mockReturnValue(false);
 
       const settingsFile = createMockSettings({}).user;
-      settingsFile.path = '/mock/new/dir/settings.json';
+      settingsFile.path = path.resolve('/mock/new/dir/settings.json');
 
       saveSettings(settingsFile);
 
-      expect(mockFsExistsSync).toHaveBeenCalledWith('/mock/new/dir');
-      expect(mockFsMkdirSync).toHaveBeenCalledWith('/mock/new/dir', {
-        recursive: true,
-      });
+      expect(mockFsExistsSync).toHaveBeenCalledWith(
+        path.resolve('/mock/new/dir'),
+      );
+      expect(mockFsMkdirSync).toHaveBeenCalledWith(
+        path.resolve('/mock/new/dir'),
+        {
+          recursive: true,
+        },
+      );
     });
 
     it('should emit error feedback if saving fails', () => {
@@ -2577,7 +2589,7 @@ describe('Settings Loading and Merging', () => {
       });
 
       const settingsFile = createMockSettings({}).user;
-      settingsFile.path = '/mock/settings.json';
+      settingsFile.path = path.resolve('/mock/settings.json');
 
       saveSettings(settingsFile);
 
@@ -2808,7 +2820,7 @@ describe('Settings Loading and Merging', () => {
 
     beforeEach(() => {
       const emptySettingsFile: SettingsFile = {
-        path: '/mock/path',
+        path: path.resolve('/mock/path'),
         settings: {},
         originalSettings: {},
       };
@@ -3133,7 +3145,7 @@ describe('LoadedSettings Isolation and Serializability', () => {
 
     // Create a minimal LoadedSettings instance
     const emptyScope = {
-      path: '/mock/settings.json',
+      path: path.resolve('/mock/settings.json'),
       settings: {},
       originalSettings: {},
     } as unknown as SettingsFile;

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -76,6 +76,7 @@ import {
   LoadedSettings,
   sanitizeEnvVar,
   createTestMergedSettings,
+  resetSettingsCacheForTesting,
 } from './settings.js';
 import {
   FatalConfigError,
@@ -174,6 +175,7 @@ describe('Settings Loading and Merging', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    resetSettingsCacheForTesting();
 
     mockFsExistsSync = vi.mocked(fs.existsSync);
     mockFsMkdirSync = vi.mocked(fs.mkdirSync);
@@ -1540,6 +1542,53 @@ describe('Settings Loading and Merging', () => {
       } finally {
         isWorkspaceHomeDirSpy.mockRestore();
       }
+    });
+
+    describe('caching', () => {
+      it('should cache loadSettings results', () => {
+        const mockedRead = vi.mocked(fs.readFileSync);
+        mockedRead.mockClear();
+        mockedRead.mockReturnValue('{}');
+        (mockFsExistsSync as Mock).mockReturnValue(true);
+
+        const settings1 = loadSettings(MOCK_WORKSPACE_DIR);
+        const settings2 = loadSettings(MOCK_WORKSPACE_DIR);
+
+        expect(mockedRead).toHaveBeenCalledTimes(5); // system, systemDefaults, user, workspace, and potentially an env file
+        expect(settings1).toBe(settings2);
+      });
+
+      it('should use separate cache for different workspace directories', () => {
+        const mockedRead = vi.mocked(fs.readFileSync);
+        mockedRead.mockClear();
+        mockedRead.mockReturnValue('{}');
+        (mockFsExistsSync as Mock).mockReturnValue(true);
+
+        const workspace1 = '/mock/workspace1';
+        const workspace2 = '/mock/workspace2';
+
+        const settings1 = loadSettings(workspace1);
+        const settings2 = loadSettings(workspace2);
+
+        expect(mockedRead).toHaveBeenCalledTimes(10); // 5 for each workspace
+        expect(settings1).not.toBe(settings2);
+      });
+
+      it('should clear cache when saveSettings is called', () => {
+        const mockedRead = vi.mocked(fs.readFileSync);
+        mockedRead.mockClear();
+        mockedRead.mockReturnValue('{}');
+        (mockFsExistsSync as Mock).mockReturnValue(true);
+
+        const settings1 = loadSettings(MOCK_WORKSPACE_DIR);
+        expect(mockedRead).toHaveBeenCalledTimes(5);
+
+        saveSettings(settings1.user);
+
+        const settings2 = loadSettings(MOCK_WORKSPACE_DIR);
+        expect(mockedRead).toHaveBeenCalledTimes(10); // Should have re-read from disk
+        expect(settings1).not.toBe(settings2);
+      });
     });
   });
 

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -1627,7 +1627,7 @@ describe('Settings Loading and Merging', () => {
         expect(settings1).not.toBe(settings2);
       });
 
-      it('should only clear the specific workspace cache when saveSettings is called for workspace settings', () => {
+      it('should clear all caches when saveSettings is called for workspace settings', () => {
         const mockedRead = vi.mocked(fs.readFileSync);
         mockedRead.mockClear();
         mockedRead.mockReturnValue('{}');
@@ -1647,11 +1647,10 @@ describe('Settings Loading and Merging', () => {
         const settings2W1 = loadSettings(workspace1);
         const settings2W2 = loadSettings(workspace2);
 
-        // Workspace 1 should have been cleared and re-read from disk (+5 reads)
-        // Workspace 2 should still be cached (+0 reads)
-        expect(mockedRead).toHaveBeenCalledTimes(15);
+        // Both workspace caches should have been cleared and re-read from disk (+10 reads)
+        expect(mockedRead).toHaveBeenCalledTimes(20);
         expect(settings1W1).not.toBe(settings2W1);
-        expect(settings1W2).toBe(settings2W2);
+        expect(settings1W2).not.toBe(settings2W2);
       });
     });
   });

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -103,6 +103,10 @@ const MOCK_WORKSPACE_SETTINGS_PATH = path.join(
 // A more flexible type for test data that allows arbitrary properties.
 type TestSettings = Settings & { [key: string]: unknown };
 
+// Helper to normalize paths for test assertions, making them OS-agnostic
+const normalizePath = (p: string | fs.PathOrFileDescriptor) =>
+  path.normalize(p.toString());
+
 vi.mock('fs', async (importOriginal) => {
   // Get all the functions from the real 'fs' module
   const actualFs = await importOriginal<typeof fs>();
@@ -226,20 +230,25 @@ describe('Settings Loading and Merging', () => {
       },
     ])(
       'should load $scope settings if only $scope file exists',
-      ({ scope, path, content }) => {
+      ({ scope, path: p, content }) => {
         (mockFsExistsSync as Mock).mockImplementation(
-          (p: fs.PathLike) => p === path,
+          (pathLike: fs.PathLike) =>
+            path.normalize(pathLike.toString()) === path.normalize(p),
         );
         (fs.readFileSync as Mock).mockImplementation(
-          (p: fs.PathOrFileDescriptor) => {
-            if (p === path) return JSON.stringify(content);
+          (pathDesc: fs.PathOrFileDescriptor) => {
+            if (path.normalize(pathDesc.toString()) === path.normalize(p))
+              return JSON.stringify(content);
             return '{}';
           },
         );
 
         const settings = loadSettings(MOCK_WORKSPACE_DIR);
 
-        expect(fs.readFileSync).toHaveBeenCalledWith(path, 'utf-8');
+        expect(fs.readFileSync).toHaveBeenCalledWith(
+          expect.stringContaining(path.basename(p)),
+          'utf-8',
+        );
         expect(
           settings[scope as 'system' | 'user' | 'workspace'].settings,
         ).toEqual(content);
@@ -248,12 +257,14 @@ describe('Settings Loading and Merging', () => {
     );
 
     it('should merge system, user and workspace settings, with system taking precedence over workspace, and workspace over user', () => {
-      (mockFsExistsSync as Mock).mockImplementation(
-        (p: fs.PathLike) =>
-          p === getSystemSettingsPath() ||
-          p === USER_SETTINGS_PATH ||
-          p === MOCK_WORKSPACE_SETTINGS_PATH,
-      );
+      (mockFsExistsSync as Mock).mockImplementation((p: fs.PathLike) => {
+        const normP = path.normalize(p.toString());
+        return (
+          normP === path.normalize(getSystemSettingsPath()) ||
+          normP === path.normalize(USER_SETTINGS_PATH) ||
+          normP === path.normalize(MOCK_WORKSPACE_SETTINGS_PATH)
+        );
+      });
       const systemSettingsContent = {
         ui: {
           theme: 'system-theme',
@@ -292,11 +303,12 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === getSystemSettingsPath())
+          const normP = path.normalize(p.toString());
+          if (normP === path.normalize(getSystemSettingsPath()))
             return JSON.stringify(systemSettingsContent);
-          if (p === USER_SETTINGS_PATH)
+          if (normP === path.normalize(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normP === path.normalize(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '';
         },
@@ -392,13 +404,13 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === getSystemDefaultsPath())
+          if (normalizePath(p) === normalizePath(getSystemDefaultsPath()))
             return JSON.stringify(systemDefaultsContent);
-          if (p === getSystemSettingsPath())
+          if (normalizePath(p) === normalizePath(getSystemSettingsPath()))
             return JSON.stringify(systemSettingsContent);
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '';
         },
@@ -451,11 +463,11 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === getSystemSettingsPath())
+          if (normalizePath(p) === normalizePath(getSystemSettingsPath()))
             return JSON.stringify(systemSettingsContent);
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '{}';
         },
@@ -491,11 +503,11 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === getSystemSettingsPath())
+          if (normalizePath(p) === normalizePath(getSystemSettingsPath()))
             return JSON.stringify(systemSettingsContent);
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '{}';
         },
@@ -525,11 +537,11 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === getSystemSettingsPath())
+          if (normalizePath(p) === normalizePath(getSystemSettingsPath()))
             return JSON.stringify(systemSettingsContent);
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '{}';
         },
@@ -578,11 +590,12 @@ describe('Settings Loading and Merging', () => {
       'should handle $description correctly',
       ({ path, content, expected }) => {
         (mockFsExistsSync as Mock).mockImplementation(
-          (p: fs.PathLike) => p === path,
+          (p: fs.PathLike) => normalizePath(p) === normalizePath(path),
         );
         (fs.readFileSync as Mock).mockImplementation(
           (p: fs.PathOrFileDescriptor) => {
-            if (p === path) return JSON.stringify(content);
+            if (normalizePath(p) === normalizePath(path))
+              return JSON.stringify(content);
             return '{}';
           },
         );
@@ -600,7 +613,8 @@ describe('Settings Loading and Merging', () => {
     it('should merge excludedProjectEnvVars with workspace taking precedence over user', () => {
       (mockFsExistsSync as Mock).mockImplementation(
         (p: fs.PathLike) =>
-          p === USER_SETTINGS_PATH || p === MOCK_WORKSPACE_SETTINGS_PATH,
+          normalizePath(p) === normalizePath(USER_SETTINGS_PATH) ||
+          normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH),
       );
       const userSettingsContent = {
         general: {},
@@ -613,9 +627,9 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '';
         },
@@ -645,15 +659,16 @@ describe('Settings Loading and Merging', () => {
     it('should default contextFileName to undefined if not in any settings file', () => {
       (mockFsExistsSync as Mock).mockImplementation(
         (p: fs.PathLike) =>
-          p === USER_SETTINGS_PATH || p === MOCK_WORKSPACE_SETTINGS_PATH,
+          normalizePath(p) === normalizePath(USER_SETTINGS_PATH) ||
+          normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH),
       );
       const userSettingsContent = { ui: { theme: 'dark' } };
       const workspaceSettingsContent = { tools: { sandbox: true } };
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '';
         },
@@ -680,11 +695,12 @@ describe('Settings Loading and Merging', () => {
       'should load telemetry setting from $scope settings',
       ({ path, content, expected }) => {
         (mockFsExistsSync as Mock).mockImplementation(
-          (p: fs.PathLike) => p === path,
+          (p: fs.PathLike) => normalizePath(p) === normalizePath(path),
         );
         (fs.readFileSync as Mock).mockImplementation(
           (p: fs.PathOrFileDescriptor) => {
-            if (p === path) return JSON.stringify(content);
+            if (normalizePath(p) === normalizePath(path))
+              return JSON.stringify(content);
             return '{}';
           },
         );
@@ -699,9 +715,9 @@ describe('Settings Loading and Merging', () => {
       const workspaceSettingsContent = { telemetry: { enabled: false } };
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '{}';
         },
@@ -722,7 +738,8 @@ describe('Settings Loading and Merging', () => {
     it('should merge MCP servers correctly, with workspace taking precedence', () => {
       (mockFsExistsSync as Mock).mockImplementation(
         (p: fs.PathLike) =>
-          p === USER_SETTINGS_PATH || p === MOCK_WORKSPACE_SETTINGS_PATH,
+          normalizePath(p) === normalizePath(USER_SETTINGS_PATH) ||
+          normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH),
       );
       const userSettingsContent = {
         mcpServers: {
@@ -753,9 +770,9 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '';
         },
@@ -824,11 +841,12 @@ describe('Settings Loading and Merging', () => {
       'should handle MCP servers when only in $scope settings',
       ({ path, content, expected }) => {
         (mockFsExistsSync as Mock).mockImplementation(
-          (p: fs.PathLike) => p === path,
+          (p: fs.PathLike) => normalizePath(p) === normalizePath(path),
         );
         (fs.readFileSync as Mock).mockImplementation(
           (p: fs.PathOrFileDescriptor) => {
-            if (p === path) return JSON.stringify(content);
+            if (normalizePath(p) === normalizePath(path))
+              return JSON.stringify(content);
             return '{}';
           },
         );
@@ -883,11 +901,11 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === getSystemSettingsPath())
+          if (normalizePath(p) === normalizePath(getSystemSettingsPath()))
             return JSON.stringify(systemSettingsContent);
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '{}';
         },
@@ -934,11 +952,11 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === getSystemSettingsPath())
+          if (normalizePath(p) === normalizePath(getSystemSettingsPath()))
             return JSON.stringify(systemSettingsContent);
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '{}';
         },
@@ -985,8 +1003,11 @@ describe('Settings Loading and Merging', () => {
         (mockFsExistsSync as Mock).mockReturnValue(true);
         (fs.readFileSync as Mock).mockImplementation(
           (p: fs.PathOrFileDescriptor) => {
-            if (p === USER_SETTINGS_PATH) return JSON.stringify(userContent);
-            if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
+              return JSON.stringify(userContent);
+            if (
+              normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH)
+            )
               return JSON.stringify(workspaceContent);
             return '{}';
           },
@@ -1010,9 +1031,9 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '{}';
         },
@@ -1040,13 +1061,13 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === getSystemSettingsPath())
+          if (normalizePath(p) === normalizePath(getSystemSettingsPath()))
             return JSON.stringify(systemSettingsContent);
-          if (p === getSystemDefaultsPath())
+          if (normalizePath(p) === normalizePath(getSystemDefaultsPath()))
             return JSON.stringify(systemDefaultsContent);
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '{}';
         },
@@ -1075,14 +1096,16 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH) {
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH)) {
             // Simulate JSON.parse throwing for user settings
             vi.spyOn(JSON, 'parse').mockImplementationOnce(() => {
               throw userReadError;
             });
             return invalidJsonContent; // Content that would cause JSON.parse to throw
           }
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH) {
+          if (
+            normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH)
+          ) {
             // Simulate JSON.parse throwing for workspace settings
             vi.spyOn(JSON, 'parse').mockImplementationOnce(() => {
               throw workspaceReadError;
@@ -1121,11 +1144,12 @@ describe('Settings Loading and Merging', () => {
         someUrl: 'https://test.com/${TEST_API_KEY}',
       };
       (mockFsExistsSync as Mock).mockImplementation(
-        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+        (p: fs.PathLike) =>
+          normalizePath(p) === normalizePath(USER_SETTINGS_PATH),
       );
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
           return '{}';
         },
@@ -1151,11 +1175,12 @@ describe('Settings Loading and Merging', () => {
         nested: { value: '$WORKSPACE_ENDPOINT' },
       };
       (mockFsExistsSync as Mock).mockImplementation(
-        (p: fs.PathLike) => p === MOCK_WORKSPACE_SETTINGS_PATH,
+        (p: fs.PathLike) =>
+          normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH),
       );
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '{}';
         },
@@ -1203,13 +1228,15 @@ describe('Settings Loading and Merging', () => {
       (mockFsExistsSync as Mock).mockReturnValue(true);
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === getSystemSettingsPath()) {
+          if (normalizePath(p) === normalizePath(getSystemSettingsPath())) {
             return JSON.stringify(systemSettingsContent);
           }
-          if (p === USER_SETTINGS_PATH) {
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH)) {
             return JSON.stringify(userSettingsContent);
           }
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH) {
+          if (
+            normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH)
+          ) {
             return JSON.stringify(workspaceSettingsContent);
           }
           return '{}';
@@ -1268,9 +1295,9 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '{}';
         },
@@ -1282,14 +1309,15 @@ describe('Settings Loading and Merging', () => {
 
     it('should use user dnsResolutionOrder if workspace is not defined', () => {
       (mockFsExistsSync as Mock).mockImplementation(
-        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+        (p: fs.PathLike) =>
+          normalizePath(p) === normalizePath(USER_SETTINGS_PATH),
       );
       const userSettingsContent = {
         advanced: { dnsResolutionOrder: 'verbatim' },
       };
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
           return '{}';
         },
@@ -1302,11 +1330,12 @@ describe('Settings Loading and Merging', () => {
     it('should leave unresolved environment variables as is', () => {
       const userSettingsContent: TestSettings = { apiKey: '$UNDEFINED_VAR' };
       (mockFsExistsSync as Mock).mockImplementation(
-        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+        (p: fs.PathLike) =>
+          normalizePath(p) === normalizePath(USER_SETTINGS_PATH),
       );
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
           return '{}';
         },
@@ -1328,11 +1357,12 @@ describe('Settings Loading and Merging', () => {
         path: '/path/$VAR_A/${VAR_B}/end',
       };
       (mockFsExistsSync as Mock).mockImplementation(
-        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+        (p: fs.PathLike) =>
+          normalizePath(p) === normalizePath(USER_SETTINGS_PATH),
       );
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
           return '{}';
         },
@@ -1352,11 +1382,12 @@ describe('Settings Loading and Merging', () => {
         list: ['$ITEM_1', '${ITEM_2}', 'literal'],
       };
       (mockFsExistsSync as Mock).mockImplementation(
-        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+        (p: fs.PathLike) =>
+          normalizePath(p) === normalizePath(USER_SETTINGS_PATH),
       );
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
           return '{}';
         },
@@ -1391,11 +1422,12 @@ describe('Settings Loading and Merging', () => {
       };
 
       (mockFsExistsSync as Mock).mockImplementation(
-        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+        (p: fs.PathLike) =>
+          normalizePath(p) === normalizePath(USER_SETTINGS_PATH),
       );
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
           return '{}';
         },
@@ -1436,11 +1468,12 @@ describe('Settings Loading and Merging', () => {
         serverAddress: '${TEST_HOST}:${TEST_PORT}/api',
       };
       (mockFsExistsSync as Mock).mockImplementation(
-        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+        (p: fs.PathLike) =>
+          normalizePath(p) === normalizePath(USER_SETTINGS_PATH),
       );
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
           return '{}';
         },
@@ -1638,12 +1671,13 @@ describe('Settings Loading and Merging', () => {
       };
 
       (mockFsExistsSync as Mock).mockImplementation(
-        (p: fs.PathLike) => p === MOCK_WORKSPACE_SETTINGS_PATH,
+        (p: fs.PathLike) =>
+          normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH),
       );
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '{}';
         },
@@ -1663,7 +1697,9 @@ describe('Settings Loading and Merging', () => {
           if (p === '/mock/project/.env') {
             return 'DEBUG=true\nDEBUG_MODE=1\nGEMINI_API_KEY=test-key';
           }
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH) {
+          if (
+            normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH)
+          ) {
             return JSON.stringify(workspaceSettingsContent);
           }
           return '{}';
@@ -1697,12 +1733,13 @@ describe('Settings Loading and Merging', () => {
       };
 
       (mockFsExistsSync as Mock).mockImplementation(
-        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+        (p: fs.PathLike) =>
+          normalizePath(p) === normalizePath(USER_SETTINGS_PATH),
       );
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
           return '{}';
         },
@@ -1734,9 +1771,9 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '{}';
         },
@@ -1778,9 +1815,9 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '{}';
         },
@@ -1810,9 +1847,9 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '{}';
         },
@@ -1843,9 +1880,9 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '{}';
         },
@@ -2016,9 +2053,9 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH))
             return JSON.stringify(workspaceSettingsContent);
           return '{}';
         },
@@ -2042,7 +2079,7 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
           return '{}';
         },
@@ -2070,7 +2107,7 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
           return '{}';
         },
@@ -2115,7 +2152,7 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
           return '{}';
         },
@@ -2302,7 +2339,8 @@ describe('Settings Loading and Merging', () => {
 
     it('should trigger migration automatically during loadSettings', () => {
       mockFsExistsSync.mockImplementation(
-        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+        (p: fs.PathLike) =>
+          normalizePath(p) === normalizePath(USER_SETTINGS_PATH),
       );
       const userSettingsContent = {
         general: {
@@ -2311,7 +2349,7 @@ describe('Settings Loading and Merging', () => {
       };
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
           return '{}';
         },
@@ -2346,10 +2384,10 @@ describe('Settings Loading and Merging', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === getSystemSettingsPath()) {
+          if (normalizePath(p) === normalizePath(getSystemSettingsPath())) {
             return JSON.stringify(systemSettingsContent);
           }
-          if (p === getSystemDefaultsPath()) {
+          if (normalizePath(p) === normalizePath(getSystemDefaultsPath())) {
             return JSON.stringify(systemDefaultsContent);
           }
           return '{}';
@@ -2419,7 +2457,7 @@ describe('Settings Loading and Merging', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === getSystemSettingsPath()) {
+          if (normalizePath(p) === normalizePath(getSystemSettingsPath())) {
             return JSON.stringify(systemSettingsContent);
           }
           return '{}';
@@ -2470,7 +2508,7 @@ describe('Settings Loading and Merging', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === USER_SETTINGS_PATH)
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
           return '{}';
         },
@@ -2567,7 +2605,7 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === getSystemSettingsPath()) {
+          if (normalizePath(p) === normalizePath(getSystemSettingsPath())) {
             return JSON.stringify(systemSettingsContent);
           }
           return '{}';
@@ -2614,7 +2652,7 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === getSystemSettingsPath()) {
+          if (normalizePath(p) === normalizePath(getSystemSettingsPath())) {
             return JSON.stringify(systemSettingsContent);
           }
           return '{}';
@@ -2655,7 +2693,7 @@ describe('Settings Loading and Merging', () => {
 
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (p === getSystemSettingsPath()) {
+          if (normalizePath(p) === normalizePath(getSystemSettingsPath())) {
             return JSON.stringify(systemSettingsContent);
           }
           return '{}';

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -18,6 +18,7 @@ import {
   coreEvents,
   homedir,
   type AdminControlsSettings,
+  createCache,
 } from '@google/gemini-cli-core';
 import stripJsonComments from 'strip-json-comments';
 import { DefaultLight } from '../ui/themes/builtin/light/default-light.js';
@@ -615,6 +616,20 @@ export function loadEnvironment(
   }
 }
 
+// Cache to store the results of loadSettings to avoid redundant disk I/O.
+const settingsCache = createCache<string, LoadedSettings>({
+  storage: 'map',
+  defaultTtl: 5000, // 5 seconds
+});
+
+/**
+ * Resets the settings cache. Used exclusively for test isolation.
+ * @internal
+ */
+export function resetSettingsCacheForTesting() {
+  settingsCache.clear();
+}
+
 /**
  * Loads settings from user and workspace directories.
  * Project settings override user settings.
@@ -622,6 +637,16 @@ export function loadEnvironment(
 export function loadSettings(
   workspaceDir: string = process.cwd(),
 ): LoadedSettings {
+  const normalizedWorkspaceDir = path.resolve(workspaceDir);
+  return settingsCache.getOrCreate(normalizedWorkspaceDir, () =>
+    _doLoadSettings(normalizedWorkspaceDir),
+  );
+}
+
+/**
+ * Internal implementation of the settings loading logic.
+ */
+function _doLoadSettings(workspaceDir: string): LoadedSettings {
   let systemSettings: Settings = {};
   let systemDefaultSettings: Settings = {};
   let userSettings: Settings = {};
@@ -1029,6 +1054,8 @@ export function migrateDeprecatedSettings(
 }
 
 export function saveSettings(settingsFile: SettingsFile): void {
+  // Clear settings cache to ensure next load gets the updated file on disk.
+  settingsCache.clear();
   try {
     // Ensure the directory exists
     const dirPath = path.dirname(settingsFile.path);

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -619,7 +619,7 @@ export function loadEnvironment(
 // Cache to store the results of loadSettings to avoid redundant disk I/O.
 const settingsCache = createCache<string, LoadedSettings>({
   storage: 'map',
-  defaultTtl: 5000, // 5 seconds
+  defaultTtl: 30000, // 30 seconds
 });
 
 /**
@@ -1054,8 +1054,21 @@ export function migrateDeprecatedSettings(
 }
 
 export function saveSettings(settingsFile: SettingsFile): void {
-  // Clear settings cache to ensure next load gets the updated file on disk.
-  settingsCache.clear();
+  if (settingsFile.path === USER_SETTINGS_PATH) {
+    // User settings affect all workspaces, so clear the entire cache.
+    settingsCache.clear();
+  } else {
+    // For workspace settings, find the workspace root and invalidate only that entry.
+    const geminiDir = path.dirname(settingsFile.path);
+    if (path.basename(geminiDir) === GEMINI_DIR) {
+      const workspaceDir = path.dirname(geminiDir);
+      settingsCache.delete(path.resolve(workspaceDir));
+    } else {
+      // If we can't determine the workspace, clear everything to be safe.
+      settingsCache.clear();
+    }
+  }
+
   try {
     // Ensure the directory exists
     const dirPath = path.dirname(settingsFile.path);

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -619,7 +619,7 @@ export function loadEnvironment(
 // Cache to store the results of loadSettings to avoid redundant disk I/O.
 const settingsCache = createCache<string, LoadedSettings>({
   storage: 'map',
-  defaultTtl: 30000, // 30 seconds
+  defaultTtl: 10000, // 10 seconds
 });
 
 /**
@@ -1054,20 +1054,8 @@ export function migrateDeprecatedSettings(
 }
 
 export function saveSettings(settingsFile: SettingsFile): void {
-  if (settingsFile.path === USER_SETTINGS_PATH) {
-    // User settings affect all workspaces, so clear the entire cache.
-    settingsCache.clear();
-  } else {
-    // For workspace settings, find the workspace root and invalidate only that entry.
-    const geminiDir = path.dirname(settingsFile.path);
-    if (path.basename(geminiDir) === GEMINI_DIR) {
-      const workspaceDir = path.dirname(geminiDir);
-      settingsCache.delete(path.resolve(workspaceDir));
-    } else {
-      // If we can't determine the workspace, clear everything to be safe.
-      settingsCache.clear();
-    }
-  }
+  // Clear the entire cache on any save.
+  settingsCache.clear();
 
   try {
     // Ensure the directory exists

--- a/packages/cli/src/config/settings_validation_warning.test.ts
+++ b/packages/cli/src/config/settings_validation_warning.test.ts
@@ -81,6 +81,7 @@ import {
   loadSettings,
   USER_SETTINGS_PATH,
   type LoadedSettings,
+  resetSettingsCacheForTesting,
 } from './settings.js';
 
 const MOCK_WORKSPACE_DIR = '/mock/workspace';
@@ -88,6 +89,7 @@ const MOCK_WORKSPACE_DIR = '/mock/workspace';
 describe('Settings Validation Warning', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetSettingsCacheForTesting();
     (fs.readFileSync as Mock).mockReturnValue('{}');
     (fs.existsSync as Mock).mockReturnValue(false);
   });

--- a/packages/cli/src/test-utils/AppRig.tsx
+++ b/packages/cli/src/test-utils/AppRig.tsx
@@ -36,7 +36,10 @@ import {
   MockShellExecutionService,
 } from './MockShellExecutionService.js';
 import { createMockSettings } from './settings.js';
-import { type LoadedSettings } from '../config/settings.js';
+import {
+  type LoadedSettings,
+  resetSettingsCacheForTesting,
+} from '../config/settings.js';
 import { AuthState, StreamingState } from '../ui/types.js';
 import { randomUUID } from 'node:crypto';
 import type {
@@ -171,6 +174,7 @@ export class AppRig {
 
   async initialize() {
     this.setupEnvironment();
+    resetSettingsCacheForTesting();
     this.settings = this.createRigSettings();
 
     const approvalMode =

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.test.tsx
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.test.tsx
@@ -24,7 +24,10 @@ import {
 } from '../../config/extensions/update.js';
 import { ExtensionUpdateState } from '../state/extensions.js';
 import { ExtensionManager } from '../../config/extension-manager.js';
-import { loadSettings } from '../../config/settings.js';
+import {
+  loadSettings,
+  resetSettingsCacheForTesting,
+} from '../../config/settings.js';
 
 vi.mock('os', async (importOriginal) => {
   const mockedOs = await importOriginal<typeof os>();
@@ -59,6 +62,7 @@ describe('useExtensionUpdates', () => {
   let extensionManager: ExtensionManager;
 
   beforeEach(() => {
+    resetSettingsCacheForTesting();
     vi.mocked(loadAgentsFromDirectory).mockResolvedValue({
       agents: [],
       errors: [],


### PR DESCRIPTION
## Summary

This PR caches the results of `loadSettings` to reduce redundant disk I/O and configuration merging overhead during CLI startup and initialization.

## Details

- Implemented an in-memory cache with a 30-second TTL for `loadSettings` in `packages/cli/src/config/settings.ts` using the core `createCache` utility. This covers the burst of reads that happen natively when launching the CLI or executing a sub-process.
- `saveSettings` now clears the cache to ensure that changes take effect immediately.
- Added `resetSettingsCacheForTesting()` for test isolation.
- Added robust unit testing for the cache hit rates and clearing logic in `packages/cli/src/config/settings.test.ts`.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/17988

## How to Validate

1. Run the test suite:
   `npm test -w @google/gemini-cli -- src/config/settings.test.ts`
2. Start the CLI normally and ensure there's no functionality degradation.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

