### PR TITLE
feat(core): enable dynamic approval mode switching

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -108,6 +108,7 @@ vi.mock('../core/client.js', () => ({
     initialize: vi.fn().mockResolvedValue(undefined),
     stripThoughtsFromHistory: vi.fn(),
     isInitialized: vi.fn().mockReturnValue(false),
+    setTools: vi.fn().mockResolvedValue(undefined),
   })),
 }));
 
@@ -839,6 +840,31 @@ describe('Server Config (config.ts)', () => {
       };
       const config = new Config(params);
       expect(config.getShellToolInactivityTimeout()).toBe(10000);
+    });
+  });
+
+  describe('Approval Mode and Non-Interactive Toggle', () => {
+    it('should support PLAN approval mode', () => {
+      const config = new Config(baseParams);
+      config.setApprovalMode(ApprovalMode.PLAN);
+      expect(config.getApprovalMode()).toBe(ApprovalMode.PLAN);
+    });
+
+    it('should allow toggling non-interactive mode', () => {
+      const config = new Config(baseParams);
+      config.setNonInteractive(true);
+      expect(config.getNonInteractive()).toBe(true);
+      config.setNonInteractive(false);
+      expect(config.getNonInteractive()).toBe(false);
+    });
+
+    it('should trigger tool refresh on approval mode switch', async () => {
+      const config = new Config(baseParams);
+      const geminiClient = config.getGeminiClient();
+      const setToolsSpy = vi.spyOn(geminiClient, 'setTools');
+
+      config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+      expect(setToolsSpy).toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1278,6 +1278,14 @@ export class Config {
     this.geminiMdFilePaths = paths;
   }
 
+  getNonInteractive(): boolean {
+    return this.policyEngine.getNonInteractive();
+  }
+
+  setNonInteractive(nonInteractive: boolean): void {
+    this.policyEngine.setNonInteractive(nonInteractive);
+  }
+
   getApprovalMode(): ApprovalMode {
     return this.policyEngine.getApprovalMode();
   }
@@ -1289,6 +1297,13 @@ export class Config {
       );
     }
     this.policyEngine.setApprovalMode(mode);
+    // Refresh tools to ensure mode switch takes effect immediately
+    void this.geminiClient?.setTools().catch((err) => {
+      debugLogger.error(
+        'Failed to update tools after approval mode change',
+        err,
+      );
+    });
   }
 
   isYoloModeDisabled(): boolean {

--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -262,6 +262,62 @@ describe('PolicyEngine', () => {
         PolicyDecision.ASK_USER,
       );
     });
+
+    it('should allow toggling non-interactive mode dynamically', async () => {
+      engine = new PolicyEngine({
+        nonInteractive: false,
+        rules: [{ toolName: 'test', decision: PolicyDecision.ASK_USER }],
+      });
+
+      // Initially interactive (ASK_USER)
+      expect((await engine.check({ name: 'test' }, undefined)).decision).toBe(
+        PolicyDecision.ASK_USER,
+      );
+
+      // Enable non-interactive
+      engine.setNonInteractive(true);
+      expect(engine.getNonInteractive()).toBe(true);
+      expect((await engine.check({ name: 'test' }, undefined)).decision).toBe(
+        PolicyDecision.DENY,
+      );
+
+      // Disable non-interactive
+      engine.setNonInteractive(false);
+      expect(engine.getNonInteractive()).toBe(false);
+      expect((await engine.check({ name: 'test' }, undefined)).decision).toBe(
+        PolicyDecision.ASK_USER,
+      );
+    });
+
+    it('should support PLAN mode', async () => {
+      const rules: PolicyRule[] = [
+        {
+          toolName: 'edit',
+          decision: PolicyDecision.ASK_USER,
+          priority: 10,
+        },
+        {
+          toolName: 'edit',
+          decision: PolicyDecision.ALLOW,
+          priority: 20,
+          modes: [ApprovalMode.PLAN],
+        },
+      ];
+
+      engine = new PolicyEngine({ rules });
+
+      // Default mode: priority 10 wins
+      expect((await engine.check({ name: 'edit' }, undefined)).decision).toBe(
+        PolicyDecision.ASK_USER,
+      );
+
+      // Switch to PLAN mode
+      engine.setApprovalMode(ApprovalMode.PLAN);
+      expect(engine.getApprovalMode()).toBe(ApprovalMode.PLAN);
+      expect((await engine.check({ name: 'edit' }, undefined)).decision).toBe(
+        PolicyDecision.ALLOW,
+      );
+    });
   });
 
   describe('addRule', () => {

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -105,7 +105,7 @@ export class PolicyEngine {
   private checkers: SafetyCheckerRule[];
   private hookCheckers: HookCheckerRule[];
   private readonly defaultDecision: PolicyDecision;
-  private readonly nonInteractive: boolean;
+  private nonInteractive: boolean;
   private readonly checkerRunner?: CheckerRunner;
   private readonly allowHooks: boolean;
   private approvalMode: ApprovalMode;
@@ -125,6 +125,20 @@ export class PolicyEngine {
     this.checkerRunner = checkerRunner;
     this.allowHooks = config.allowHooks ?? true;
     this.approvalMode = config.approvalMode ?? ApprovalMode.DEFAULT;
+  }
+
+  /**
+   * Update the non-interactive mode.
+   */
+  setNonInteractive(nonInteractive: boolean): void {
+    this.nonInteractive = nonInteractive;
+  }
+
+  /**
+   * Get the current non-interactive mode.
+   */
+  getNonInteractive(): boolean {
+    return this.nonInteractive;
   }
 
   /**

--- a/packages/core/src/policy/types.ts
+++ b/packages/core/src/policy/types.ts
@@ -46,6 +46,8 @@ export enum ApprovalMode {
   DEFAULT = 'default',
   AUTO_EDIT = 'autoEdit',
   YOLO = 'yolo',
+  PLAN = 'plan',
+  HEADLESS = 'headless',
 }
 
 /**


### PR DESCRIPTION
## Summary

Enables dynamic approval mode switching by making PolicyEngine's nonInteractive flag mutable and triggering tool syncs on mode change in Config. Part 1 of fixing #19776.

## Details

- Adds HEADLESS mode to ApprovalMode.
- Makes nonInteractive mutable in PolicyEngine.
- Triggers tool sync on mode change in Config to ensure tools evaluate correctly.

## Related Issues

Related to #19776

## How to Validate

Run `npm run test:ci` in packages/core.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)