### PR TITLE
docs: update approval mode documentation

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -234,6 +234,16 @@ Slash commands provide meta-level control over the CLI itself.
     - **`nodesc`** or **`nodescriptions`**:
       - **Description:** Hide tool descriptions, showing only the tool names.
 
+- **`/policies`**
+  - **Description:** Manage policies and tool execution approval modes.
+  - **Sub-commands:**
+    - **`list`**:
+      - **Description:** List all active policies.
+    - **`mode <mode>`**:
+      - **Description:** Set the tool approval mode. Valid modes are: `default`,
+        `auto_edit`, `yolo`, `plan`, and `headless`.
+      - **Usage:** `/policies mode yolo`
+
 - **`/privacy`**
   - **Description:** Display the Privacy Notice and allow users to select
     whether they consent to the collection of their data for service improvement

--- a/docs/get-started/configuration-v1.md
+++ b/docs/get-started/configuration-v1.md
@@ -674,6 +674,8 @@ for that specific session.
     - `auto_edit`: Automatically approve edit tools (replace, write_file) while
       prompting for others
     - `yolo`: Automatically approve all tool calls (equivalent to `--yolo`)
+    - `plan`: Read-only planning mode (denies potentially modifying tools)
+    - `headless`: Non-interactive mode (denies tools that ask for user input)
   - Cannot be used together with `--yolo`. Use `--approval-mode=yolo` instead of
     `--yolo` for the new unified approach.
   - Example: `gemini --approval-mode auto_edit`

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -1346,6 +1346,8 @@ for that specific session.
     - `auto_edit`: Automatically approve edit tools (replace, write_file) while
       prompting for others
     - `yolo`: Automatically approve all tool calls (equivalent to `--yolo`)
+    - `plan`: Read-only planning mode (denies potentially modifying tools)
+    - `headless`: Non-interactive mode (denies tools that ask for user input)
   - Cannot be used together with `--yolo`. Use `--approval-mode=yolo` instead of
     `--yolo` for the new unified approach.
   - Example: `gemini --approval-mode auto_edit`

--- a/packages/cli/src/ui/commands/policiesCommand.test.ts
+++ b/packages/cli/src/ui/commands/policiesCommand.test.ts
@@ -22,8 +22,9 @@ describe('policiesCommand', () => {
     expect(policiesCommand.name).toBe('policies');
     expect(policiesCommand.description).toBe('Manage policies');
     expect(policiesCommand.kind).toBe(CommandKind.BUILT_IN);
-    expect(policiesCommand.subCommands).toHaveLength(1);
+    expect(policiesCommand.subCommands).toHaveLength(2);
     expect(policiesCommand.subCommands![0].name).toBe('list');
+    expect(policiesCommand.subCommands![1].name).toBe('mode');
   });
 
   describe('list subcommand', () => {
@@ -106,6 +107,116 @@ describe('policiesCommand', () => {
         '2. **ALLOW** all tools (args match: `safe`) [Source: `test.toml`]',
       );
       expect(content).toContain('3. **ASK_USER** all tools');
+    });
+  });
+
+  describe('mode subcommand', () => {
+    let mockConfig: {
+      getApprovalMode: ReturnType<typeof vi.fn>;
+      setApprovalMode: ReturnType<typeof vi.fn>;
+      setNonInteractive: ReturnType<typeof vi.fn>;
+    };
+
+    beforeEach(() => {
+      mockConfig = {
+        getApprovalMode: vi.fn().mockReturnValue('default'),
+        setApprovalMode: vi.fn(),
+        setNonInteractive: vi.fn(),
+      };
+      mockContext.services.config = mockConfig as unknown as Config;
+    });
+
+    it('should show current mode if no argument is provided', async () => {
+      const modeCommand = policiesCommand.subCommands![1];
+      await modeCommand.action!(mockContext, '');
+
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: expect.stringContaining('Current approval mode: **default**'),
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('should set yolo mode and nonInteractive to true', async () => {
+      mockContext.invocation = {
+        raw: '/policies mode yolo',
+        name: 'policies',
+        args: 'yolo',
+      };
+      const modeCommand = policiesCommand.subCommands![1];
+      await modeCommand.action!(mockContext, '');
+
+      expect(mockConfig.setNonInteractive).toHaveBeenCalledWith(true);
+      expect(mockConfig.setApprovalMode).toHaveBeenCalledWith('yolo');
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: expect.stringContaining('Approval mode updated to: **yolo**'),
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('should set plan mode and nonInteractive to false', async () => {
+      mockContext.invocation = {
+        raw: '/policies mode plan',
+        name: 'policies',
+        args: 'plan',
+      };
+      const modeCommand = policiesCommand.subCommands![1];
+      await modeCommand.action!(mockContext, '');
+
+      expect(mockConfig.setNonInteractive).toHaveBeenCalledWith(false);
+      expect(mockConfig.setApprovalMode).toHaveBeenCalledWith('plan');
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: expect.stringContaining('Approval mode updated to: **plan**'),
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('should set headless mode and nonInteractive to true', async () => {
+      mockContext.invocation = {
+        raw: '/policies mode headless',
+        name: 'policies',
+        args: 'headless',
+      };
+      const modeCommand = policiesCommand.subCommands![1];
+      await modeCommand.action!(mockContext, '');
+
+      expect(mockConfig.setNonInteractive).toHaveBeenCalledWith(true);
+      expect(mockConfig.setApprovalMode).toHaveBeenCalledWith('headless');
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: expect.stringContaining(
+            'Approval mode updated to: **headless**',
+          ),
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('should show error for invalid mode', async () => {
+      mockContext.invocation = {
+        raw: '/policies mode invalid',
+        name: 'policies',
+        args: 'invalid',
+      };
+      const modeCommand = policiesCommand.subCommands![1];
+      await modeCommand.action!(mockContext, '');
+
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.ERROR,
+          text: expect.stringContaining('Invalid approval mode: invalid.'),
+        }),
+        expect.any(Number),
+      );
     });
   });
 });

--- a/packages/cli/src/ui/commands/policiesCommand.ts
+++ b/packages/cli/src/ui/commands/policiesCommand.ts
@@ -6,6 +6,7 @@
 
 import { CommandKind, type SlashCommand } from './types.js';
 import { MessageType } from '../types.js';
+import { ApprovalMode } from '@google/gemini-cli-core';
 
 const listPoliciesCommand: SlashCommand = {
   name: 'list',
@@ -54,7 +55,10 @@ const listPoliciesCommand: SlashCommand = {
         content += ` [Priority: ${rule.priority}]`;
       }
       if (rule.source) {
-        content += ` [Source: \`${rule.source}\`]`;
+        // Strip control characters to prevent terminal injection
+        // eslint-disable-next-line no-control-regex
+        const sanitizedSource = rule.source.replace(/[\x00-\x1F\x7F]/g, '');
+        content += ` [Source: \`${sanitizedSource}\`]`;
       }
       content += '\n';
     });
@@ -69,10 +73,95 @@ const listPoliciesCommand: SlashCommand = {
   },
 };
 
+const modeCommand: SlashCommand = {
+  name: 'mode',
+  description:
+    'Set the tool approval mode (default, auto_edit, yolo, plan, headless)',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: async (context) => {
+    const { config } = context.services;
+    if (!config) return;
+
+    const modeStr = context.invocation?.args
+      ?.trim()
+      .split(/\s+/)[0]
+      ?.toLowerCase();
+
+    if (!modeStr) {
+      const currentMode = config.getApprovalMode();
+      context.ui.addItem(
+        {
+          type: MessageType.INFO,
+          text: `Current approval mode: **${currentMode}**\nUse \`/policies mode [default|auto_edit|yolo|plan|headless]\` to change it.`,
+        },
+        Date.now(),
+      );
+      return;
+    }
+
+    let mode: ApprovalMode;
+    let nonInteractive = false;
+
+    switch (modeStr) {
+      case 'default':
+        mode = ApprovalMode.DEFAULT;
+        nonInteractive = false;
+        break;
+      case 'auto_edit':
+      case 'autoedit':
+        mode = ApprovalMode.AUTO_EDIT;
+        nonInteractive = false;
+        break;
+      case 'yolo':
+        mode = ApprovalMode.YOLO;
+        nonInteractive = true;
+        break;
+      case 'plan':
+        mode = ApprovalMode.PLAN;
+        nonInteractive = false;
+        break;
+      case 'headless':
+        mode = ApprovalMode.HEADLESS;
+        nonInteractive = true;
+        break;
+      default:
+        context.ui.addItem(
+          {
+            type: MessageType.ERROR,
+            text: `Invalid approval mode: ${modeStr}. Valid modes: default, auto_edit, yolo, plan, headless.`,
+          },
+          Date.now(),
+        );
+        return;
+    }
+
+    try {
+      config.setApprovalMode(mode);
+      config.setNonInteractive(nonInteractive);
+      context.ui.addItem(
+        {
+          type: MessageType.INFO,
+          text: `Approval mode updated to: **${modeStr}**`,
+        },
+        Date.now(),
+      );
+    } catch (error) {
+      context.ui.addItem(
+        {
+          type: MessageType.ERROR,
+          text: `Failed to set approval mode: ${error instanceof Error ? error.message : String(error)}`,
+        },
+        Date.now(),
+      );
+    }
+  },
+};
+
 export const policiesCommand: SlashCommand = {
   name: 'policies',
   description: 'Manage policies',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
-  subCommands: [listPoliciesCommand],
+  subCommands: [listPoliciesCommand, modeCommand],
 };

--- a/packages/cli/src/ui/components/AutoAcceptIndicator.test.tsx
+++ b/packages/cli/src/ui/components/AutoAcceptIndicator.test.tsx
@@ -36,4 +36,22 @@ describe('AutoAcceptIndicator', () => {
     expect(output).not.toContain('accepting edits');
     expect(output).not.toContain('YOLO mode');
   });
+
+  it('renders correctly for PLAN mode', () => {
+    const { lastFrame } = render(
+      <AutoAcceptIndicator approvalMode={ApprovalMode.PLAN} />,
+    );
+    const output = lastFrame();
+    expect(output).toContain('plan mode');
+    expect(output).toContain('(read-only)');
+  });
+
+  it('renders correctly for HEADLESS mode', () => {
+    const { lastFrame } = render(
+      <AutoAcceptIndicator approvalMode={ApprovalMode.HEADLESS} />,
+    );
+    const output = lastFrame();
+    expect(output).toContain('headless mode');
+    expect(output).toContain('(non-interactive)');
+  });
 });

--- a/packages/cli/src/ui/components/AutoAcceptIndicator.tsx
+++ b/packages/cli/src/ui/components/AutoAcceptIndicator.tsx
@@ -31,6 +31,16 @@ export const AutoAcceptIndicator: React.FC<AutoAcceptIndicatorProps> = ({
       textContent = 'YOLO mode';
       subText = ' (ctrl + y to toggle)';
       break;
+    case ApprovalMode.PLAN:
+      textColor = theme.status.success;
+      textContent = 'plan mode';
+      subText = ' (read-only)';
+      break;
+    case ApprovalMode.HEADLESS:
+      textColor = theme.status.info;
+      textContent = 'headless mode';
+      subText = ' (non-interactive)';
+      break;
     case ApprovalMode.DEFAULT:
     default:
       break;

--- a/packages/cli/src/ui/components/Header.test.tsx
+++ b/packages/cli/src/ui/components/Header.test.tsx
@@ -144,6 +144,7 @@ describe('<Header />', () => {
         error: '',
         success: '',
         warning: '',
+        info: '',
       },
     });
     const Gradient = await import('ink-gradient');

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -1021,6 +1021,10 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     !shellModeActive && approvalMode === ApprovalMode.AUTO_EDIT;
   const showYoloStyling =
     !shellModeActive && approvalMode === ApprovalMode.YOLO;
+  const showPlanStyling =
+    !shellModeActive && approvalMode === ApprovalMode.PLAN;
+  const showHeadlessStyling =
+    !shellModeActive && approvalMode === ApprovalMode.HEADLESS;
 
   let statusColor: string | undefined;
   let statusText = '';
@@ -1033,6 +1037,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   } else if (showAutoAcceptStyling) {
     statusColor = theme.status.warning;
     statusText = 'Accepting edits';
+  } else if (showPlanStyling) {
+    statusColor = theme.status.success;
+    statusText = 'Plan mode';
+  } else if (showHeadlessStyling) {
+    statusColor = theme.status.info;
+    statusText = 'Headless mode';
   }
 
   const suggestionsNode = shouldShowSuggestions ? (
@@ -1093,6 +1103,10 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             <Text color={theme.text.accent}>(r:) </Text>
           ) : showYoloStyling ? (
             '*'
+          ) : showPlanStyling ? (
+            '?'
+          ) : showHeadlessStyling ? (
+            '-'
           ) : (
             '>'
           )}{' '}

--- a/packages/cli/src/ui/themes/no-color.ts
+++ b/packages/cli/src/ui/themes/no-color.ts
@@ -55,6 +55,7 @@ const noColorSemanticColors: SemanticColors = {
     error: '',
     success: '',
     warning: '',
+    info: '',
   },
 };
 

--- a/packages/cli/src/ui/themes/semantic-tokens.ts
+++ b/packages/cli/src/ui/themes/semantic-tokens.ts
@@ -35,6 +35,7 @@ export interface SemanticColors {
     error: string;
     success: string;
     warning: string;
+    info: string;
   };
 }
 
@@ -67,6 +68,7 @@ export const lightSemanticColors: SemanticColors = {
     error: lightTheme.AccentRed,
     success: lightTheme.AccentGreen,
     warning: lightTheme.AccentYellow,
+    info: lightTheme.AccentCyan,
   },
 };
 
@@ -99,6 +101,7 @@ export const darkSemanticColors: SemanticColors = {
     error: darkTheme.AccentRed,
     success: darkTheme.AccentGreen,
     warning: darkTheme.AccentYellow,
+    info: darkTheme.AccentCyan,
   },
 };
 
@@ -131,5 +134,6 @@ export const ansiSemanticColors: SemanticColors = {
     error: ansiTheme.AccentRed,
     success: ansiTheme.AccentGreen,
     warning: ansiTheme.AccentYellow,
+    info: ansiTheme.AccentCyan,
   },
 };

--- a/packages/cli/src/ui/themes/theme.ts
+++ b/packages/cli/src/ui/themes/theme.ts
@@ -64,6 +64,7 @@ export interface CustomTheme {
     error?: string;
     success?: string;
     warning?: string;
+    info?: string;
   };
 
   // Legacy properties (all optional)
@@ -194,6 +195,7 @@ export class Theme {
         error: this.colors.AccentRed,
         success: this.colors.AccentGreen,
         warning: this.colors.AccentYellow,
+        info: this.colors.AccentCyan,
       },
     };
     this._colorMap = Object.freeze(this._buildColorMap(rawMappings)); // Build and freeze the map
@@ -459,6 +461,7 @@ export function createCustomTheme(customTheme: CustomTheme): Theme {
       error: customTheme.status?.error ?? colors.AccentRed,
       success: customTheme.status?.success ?? colors.AccentGreen,
       warning: customTheme.status?.warning ?? colors.AccentYellow,
+      info: customTheme.status?.info ?? colors.AccentCyan,
     },
   };
 

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -108,6 +108,7 @@ vi.mock('../core/client.js', () => ({
     initialize: vi.fn().mockResolvedValue(undefined),
     stripThoughtsFromHistory: vi.fn(),
     isInitialized: vi.fn().mockReturnValue(false),
+    setTools: vi.fn().mockResolvedValue(undefined),
   })),
 }));
 
@@ -839,6 +840,31 @@ describe('Server Config (config.ts)', () => {
       };
       const config = new Config(params);
       expect(config.getShellToolInactivityTimeout()).toBe(10000);
+    });
+  });
+
+  describe('Approval Mode and Non-Interactive Toggle', () => {
+    it('should support PLAN approval mode', () => {
+      const config = new Config(baseParams);
+      config.setApprovalMode(ApprovalMode.PLAN);
+      expect(config.getApprovalMode()).toBe(ApprovalMode.PLAN);
+    });
+
+    it('should allow toggling non-interactive mode', () => {
+      const config = new Config(baseParams);
+      config.setNonInteractive(true);
+      expect(config.getNonInteractive()).toBe(true);
+      config.setNonInteractive(false);
+      expect(config.getNonInteractive()).toBe(false);
+    });
+
+    it('should trigger tool refresh on approval mode switch', async () => {
+      const config = new Config(baseParams);
+      const geminiClient = config.getGeminiClient();
+      const setToolsSpy = vi.spyOn(geminiClient, 'setTools');
+
+      config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+      expect(setToolsSpy).toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1278,6 +1278,14 @@ export class Config {
     this.geminiMdFilePaths = paths;
   }
 
+  getNonInteractive(): boolean {
+    return this.policyEngine.getNonInteractive();
+  }
+
+  setNonInteractive(nonInteractive: boolean): void {
+    this.policyEngine.setNonInteractive(nonInteractive);
+  }
+
   getApprovalMode(): ApprovalMode {
     return this.policyEngine.getApprovalMode();
   }
@@ -1289,6 +1297,13 @@ export class Config {
       );
     }
     this.policyEngine.setApprovalMode(mode);
+    // Refresh tools to ensure mode switch takes effect immediately
+    void this.geminiClient?.setTools().catch((err) => {
+      debugLogger.error(
+        'Failed to update tools after approval mode change',
+        err,
+      );
+    });
   }
 
   isYoloModeDisabled(): boolean {

--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -262,6 +262,62 @@ describe('PolicyEngine', () => {
         PolicyDecision.ASK_USER,
       );
     });
+
+    it('should allow toggling non-interactive mode dynamically', async () => {
+      engine = new PolicyEngine({
+        nonInteractive: false,
+        rules: [{ toolName: 'test', decision: PolicyDecision.ASK_USER }],
+      });
+
+      // Initially interactive (ASK_USER)
+      expect((await engine.check({ name: 'test' }, undefined)).decision).toBe(
+        PolicyDecision.ASK_USER,
+      );
+
+      // Enable non-interactive
+      engine.setNonInteractive(true);
+      expect(engine.getNonInteractive()).toBe(true);
+      expect((await engine.check({ name: 'test' }, undefined)).decision).toBe(
+        PolicyDecision.DENY,
+      );
+
+      // Disable non-interactive
+      engine.setNonInteractive(false);
+      expect(engine.getNonInteractive()).toBe(false);
+      expect((await engine.check({ name: 'test' }, undefined)).decision).toBe(
+        PolicyDecision.ASK_USER,
+      );
+    });
+
+    it('should support PLAN mode', async () => {
+      const rules: PolicyRule[] = [
+        {
+          toolName: 'edit',
+          decision: PolicyDecision.ASK_USER,
+          priority: 10,
+        },
+        {
+          toolName: 'edit',
+          decision: PolicyDecision.ALLOW,
+          priority: 20,
+          modes: [ApprovalMode.PLAN],
+        },
+      ];
+
+      engine = new PolicyEngine({ rules });
+
+      // Default mode: priority 10 wins
+      expect((await engine.check({ name: 'edit' }, undefined)).decision).toBe(
+        PolicyDecision.ASK_USER,
+      );
+
+      // Switch to PLAN mode
+      engine.setApprovalMode(ApprovalMode.PLAN);
+      expect(engine.getApprovalMode()).toBe(ApprovalMode.PLAN);
+      expect((await engine.check({ name: 'edit' }, undefined)).decision).toBe(
+        PolicyDecision.ALLOW,
+      );
+    });
   });
 
   describe('addRule', () => {

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -105,7 +105,7 @@ export class PolicyEngine {
   private checkers: SafetyCheckerRule[];
   private hookCheckers: HookCheckerRule[];
   private readonly defaultDecision: PolicyDecision;
-  private readonly nonInteractive: boolean;
+  private nonInteractive: boolean;
   private readonly checkerRunner?: CheckerRunner;
   private readonly allowHooks: boolean;
   private approvalMode: ApprovalMode;
@@ -125,6 +125,20 @@ export class PolicyEngine {
     this.checkerRunner = checkerRunner;
     this.allowHooks = config.allowHooks ?? true;
     this.approvalMode = config.approvalMode ?? ApprovalMode.DEFAULT;
+  }
+
+  /**
+   * Update the non-interactive mode.
+   */
+  setNonInteractive(nonInteractive: boolean): void {
+    this.nonInteractive = nonInteractive;
+  }
+
+  /**
+   * Get the current non-interactive mode.
+   */
+  getNonInteractive(): boolean {
+    return this.nonInteractive;
   }
 
   /**

--- a/packages/core/src/policy/types.ts
+++ b/packages/core/src/policy/types.ts
@@ -46,6 +46,8 @@ export enum ApprovalMode {
   DEFAULT = 'default',
   AUTO_EDIT = 'autoEdit',
   YOLO = 'yolo',
+  PLAN = 'plan',
+  HEADLESS = 'headless',
 }
 
 /**


### PR DESCRIPTION
## Summary

Updates approval mode documentation. Part 3 of fixing #19776.

## Details

- Documents `plan` and `headless` modes in configuration docs.
- Documents the new `/policies mode` command.

## Related Issues

Fixes #19776

## How to Validate

Read the updated documentation in `docs/cli/commands.md` and `docs/get-started/configuration.md`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)