### PR TITLE
Initialize persist toggle from saved model setting in /model dialog

### DIFF
--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -370,4 +370,20 @@ describe('<ModelDialog />', () => {
       unmount();
     });
   });
+  it('initializes persistMode to true when a model is already saved in settings', async () => {
+    const settings = createMockSettings({
+      merged: {
+        model: { name: DEFAULT_GEMINI_MODEL },
+      },
+    });
+    const result = renderWithProviders(<ModelDialog onClose={mockOnClose} />, {
+      config: mockConfig as Config,
+      settings,
+    });
+    await result.waitUntilReady();
+    expect(result.lastFrame()).toContain(
+      'Remember model for future sessions: true',
+    );
+    result.unmount();
+  });
 });

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -36,7 +36,9 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
   const config = useContext(ConfigContext);
   const settings = useSettings();
   const [view, setView] = useState<'main' | 'manual'>('main');
-  const [persistMode, setPersistMode] = useState(false);
+  const [persistMode, setPersistMode] = useState(
+    () => !!settings.merged.model?.name,
+  );
 
   // Determine the Preferred Model (read once when the dialog opens).
   const preferredModel = config?.getModel() || DEFAULT_GEMINI_MODEL_AUTO;


### PR DESCRIPTION
## Summary
Fixes the "Remember model for future sessions" toggle in the /model dialog from always showing False on open, even if a model was previously saved. The toggle now uses the saved settings.

## Details
The persistMode state in the ModelDialog class has been hardcoded to false during initialization. It now reads from settings.merged.model?.name to determine if the model has been persisted, and initializes the toggle appropriately.

## Related Issues
#19054

## How to Validate
1. Run the CLI: "npm run start"
2. Type "/model" and select any model with "Remember model for future sessions" toggled to true
3. Close and reopen the /model dialog
4. The toggle should now show true instead of reverting to false

To validate via unit tests:
cd packages/cli
npx vitest run src/ui/components/ModelDialog

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker