### PR TITLE
Prevent negative token count in context window overflow message

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -2293,14 +2293,14 @@ describe('useGeminiStream', () => {
           requestTokens: 20,
           remainingTokens: 80,
           expectedMessage:
-            'Sending this message (20 tokens) might exceed the context window limit (80 tokens left).',
+            'Sending this message (20 tokens) might exceed the remaining context window limit (80 tokens).',
         },
         {
           name: 'with suggestion when remaining tokens are < 75% of limit',
           requestTokens: 30,
           remainingTokens: 70,
           expectedMessage:
-            'Sending this message (30 tokens) might exceed the context window limit (70 tokens left). Please try reducing the size of your message or use the `/compress` command to compress the chat history.',
+            'Sending this message (30 tokens) might exceed the remaining context window limit (70 tokens). Please try reducing the size of your message or use the `/compress` command to compress the chat history.',
         },
       ])(
         'should add message $name',

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1110,7 +1110,8 @@ export const useGeminiStream = (
       const isMoreThan25PercentUsed =
         limit > 0 && remainingTokenCount < limit * 0.75;
 
-      let text = `Sending this message (${estimatedRequestTokenCount} tokens) might exceed the context window limit (${remainingTokenCount.toLocaleString()} tokens left).`;
+      const displayRemaining = Math.max(0, remainingTokenCount);
+      let text = `Sending this message (${estimatedRequestTokenCount} tokens) might exceed the remaining context window limit (${displayRemaining.toLocaleString()} tokens).`;
 
       if (isMoreThan25PercentUsed) {
         text +=


### PR DESCRIPTION
## Summary
Resolves an issue with the warning about the context window overflowing, showing a negative token count after resuming a session that already exceeds the model's token limit.

## Details
In a resumed session, the remaining token count could potentially be negative after exceeding the model's token limit. The warning message now shows a non-negative number by using Math.max(0, remainingTokenCount).

## Related Issues
#16488

## How to Validate
1. Create or resume a session with a large history that exceeds the model's token limit
2. Send a message. The warning should now show "0 tokens" instead of a negative number

To validate via unit tests:
cd packages/cli
npx vitest run src/ui/hooks/useGeminiStream

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker