### PR TITLE
ci(contrib): enforce issue assignment as gate for PR creation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,11 @@ urgency. -->
 
 <!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
 only related to an issue or is a partial fix, simply reference the issue number
-without a keyword (Related to #123). -->
+without a keyword (Related to #123).
+
+IMPORTANT: You must be assigned to the linked issue before opening this PR.
+If you are not assigned, this PR will be automatically closed.
+To get assigned, comment /assign on the issue first (requires the 'help wanted' label). -->
 
 ## How to Validate
 

--- a/.github/workflows/gemini-self-assign-issue.yml
+++ b/.github/workflows/gemini-self-assign-issue.yml
@@ -107,7 +107,11 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
-              body: `👋 @${commenter}, you've been assigned to this issue! Thank you for taking the time to contribute. Make sure to check out our [contributing guidelines](https://github.com/google-gemini/gemini-cli/blob/main/CONTRIBUTING.md).`
+              body: `👋 @${commenter}, you've been assigned to issue #${issueNumber}!\n\n` +
+                `**Next step:** open a pull request and include \`Fixes #${issueNumber}\` in the PR body so it links back here.\n\n` +
+                `**Important:** PRs are automatically closed if the author is not assigned to the linked issue. ` +
+                `If you get unassigned before opening a PR, comment \`/assign\` here again.\n\n` +
+                `Check out the [contributing guidelines](https://github.com/google-gemini/gemini-cli/blob/main/CONTRIBUTING.md) before you start.`
             });
 
       - name: 'Unassign issue from user'

--- a/.github/workflows/pr-contribution-guidelines-notifier.yml
+++ b/.github/workflows/pr-contribution-guidelines-notifier.yml
@@ -1,17 +1,19 @@
 name: '🏷️ PR Contribution Guidelines Notifier'
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - 'opened'
+      - 'reopened'
 
 jobs:
-  notify-process-change:
+  enforce-contribution-guidelines:
     runs-on: 'ubuntu-latest'
     if: |-
       github.repository == 'google-gemini/gemini-cli' || github.repository == 'google-gemini/maintainers-gemini-cli'
     permissions:
       pull-requests: 'write'
+      issues: 'read'
     steps:
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
@@ -24,7 +26,7 @@ jobs:
           app-id: '${{ secrets.APP_ID }}'
           private-key: '${{ secrets.PRIVATE_KEY }}'
 
-      - name: 'Check membership and post comment'
+      - name: 'Enforce contribution guidelines'
         uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea'
         with:
           github-token: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
@@ -91,13 +93,32 @@ jobs:
               return;
             }
 
-            // 2. Check if the PR is already associated with an issue
+            // Helper: post a comment and close the PR
+            const closeWithComment = async (body) => {
+              await github.rest.issues.createComment({
+                owner: org,
+                repo: repo,
+                issue_number: pr_number,
+                body: body
+              });
+              await github.rest.pulls.update({
+                owner: org,
+                repo: repo,
+                pull_number: pr_number,
+                state: 'closed'
+              });
+            };
+
+            // 2. Check if the PR is linked to an existing issue
             const query = `
               query($owner:String!, $repo:String!, $number:Int!) {
                 repository(owner:$owner, name:$repo) {
                   pullRequest(number:$number) {
                     closingIssuesReferences(first: 1) {
                       totalCount
+                      nodes {
+                        number
+                      }
                     }
                   }
                 }
@@ -105,29 +126,45 @@ jobs:
             `;
             const variables = { owner: org, repo: repo, number: pr_number };
             const result = await github.graphql(query, variables);
-            const issueCount = result.repository.pullRequest.closingIssuesReferences.totalCount;
+            const refs = result.repository.pullRequest.closingIssuesReferences;
 
-            if (issueCount > 0) {
-              core.info(`PR #${pr_number} is already associated with an issue. No notification needed.`);
+            if (refs.totalCount === 0) {
+              core.info(`PR #${pr_number} has no linked issue. Closing.`);
+              await closeWithComment(
+                `Hi @${username}, this PR has been closed because it is not linked to an existing issue.\n\n` +
+                `Please follow these steps:\n` +
+                `1. Open an issue describing the change you want to make.\n` +
+                `2. Comment \`/assign\` on the issue to get assigned (only issues labelled \`help wanted\` are open for assignment).\n` +
+                `3. Open a new PR with \`Fixes #<issue_number>\` in the body.\n\n` +
+                `See our [contributing guidelines](https://github.com/google-gemini/gemini-cli/blob/main/CONTRIBUTING.md) for details.`
+              );
               return;
             }
 
-            // 3. Post the notification comment
-            core.info(`${username} is not a maintainer and PR #${pr_number} has no linked issue. Posting notification.`);
+            // 3. Check if the PR author is assigned to the linked issue
+            const linkedIssueNumber = refs.nodes[0].number;
+            core.info(`PR #${pr_number} is linked to issue #${linkedIssueNumber}. Checking assignment.`);
 
-            const comment = `
-            Hi @${username}, thank you so much for your contribution to Gemini CLI! We really appreciate the time and effort you've put into this.
-
-            We're making some updates to our contribution process to improve how we track and review changes. Please take a moment to review our recent discussion post: [Improving Our Contribution Process & Introducing New Guidelines](https://github.com/google-gemini/gemini-cli/discussions/16706).
-
-            Key Update: Starting **January 26, 2026**, the Gemini CLI project will require all pull requests to be associated with an existing issue. Any pull requests not linked to an issue by that date will be automatically closed.
-
-            Thank you for your understanding and for being a part of our community!
-            `.trim().replace(/^[ ]+/gm, '');
-
-            await github.rest.issues.createComment({
+            const { data: linkedIssue } = await github.rest.issues.get({
               owner: org,
               repo: repo,
-              issue_number: pr_number,
-              body: comment
+              issue_number: linkedIssueNumber
             });
+
+            const isAssigned = linkedIssue.assignees.some(
+              a => a.login.toLowerCase() === username.toLowerCase()
+            );
+
+            if (!isAssigned) {
+              core.info(`@${username} is not assigned to issue #${linkedIssueNumber}. Closing PR #${pr_number}.`);
+              await closeWithComment(
+                `Hi @${username}, this PR has been closed because you are not assigned to issue #${linkedIssueNumber}.\n\n` +
+                `To get assigned, comment \`/assign\` on [issue #${linkedIssueNumber}](https://github.com/${org}/${repo}/issues/${linkedIssueNumber}). ` +
+                `Once assigned, you can re-open this PR.\n\n` +
+                `Note: self-assignment is only available on issues labelled \`help wanted\`.`
+              );
+              return;
+            }
+
+            // 4. All checks passed
+            core.info(`@${username} is assigned to issue #${linkedIssueNumber}. PR #${pr_number} is compliant.`);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,18 +41,21 @@ This project follows
 
 The process for contributing code is as follows:
 
-1.  **Find an issue** that you want to work on. If an issue is tagged as
-    `🔒Maintainers only`, this means it is reserved for project maintainers. We
-    will not accept pull requests related to these issues. In the near future,
-    we will explicitly mark issues looking for contributions using the
-    `help-wanted` label. If you believe an issue is a good candidate for
-    community contribution, please leave a comment on the issue. A maintainer
-    will review it and apply the `help-wanted` label if appropriate. Only
-    maintainers should attempt to add the `help-wanted` label to an issue.
-2.  **Fork the repository** and create a new branch.
-3.  **Make your changes** in the `packages/` directory.
-4.  **Ensure all checks pass** by running `npm run preflight`.
-5.  **Open a pull request** with your changes.
+1.  **Find an issue** tagged `help wanted` that you want to work on. Issues
+    tagged `🔒Maintainers only` are reserved for project maintainers and do not
+    accept community pull requests. If you think an issue is a good candidate
+    for community contribution, leave a comment asking a maintainer to add the
+    `help wanted` label. Only maintainers can apply that label.
+2.  **Get assigned** by commenting `/assign` on the issue. You must be assigned
+    before opening a pull request. PRs from contributors who are not assigned to
+    the linked issue are automatically closed. See
+    [Self-assigning issues](#self-assigning-and-unassigning-issues) for limits
+    and conditions.
+3.  **Fork the repository** and create a new branch.
+4.  **Make your changes** in the `packages/` directory.
+5.  **Ensure all checks pass** by running `npm run preflight`.
+6.  **Open a pull request** that includes `Fixes #<issue_number>` in the
+    description to link it back to the issue.
 
 ### Code reviews
 
@@ -77,15 +80,17 @@ augment their manual review process.
 
 ### Self-assigning and unassigning issues
 
-To assign an issue to yourself, simply add a comment with the text `/assign`. To
-unassign yourself from an issue, add a comment with the text `/unassign`.
+To assign an issue to yourself, comment `/assign` on the issue. To unassign
+yourself, comment `/unassign`.
 
-The comment must contain only that text and nothing else. These commands will
-assign or unassign the issue as requested, provided the conditions are met
-(e.g., an issue must be unassigned to be assigned).
+The comment must contain only that text and nothing else. Assignment is only
+available on issues labelled `help wanted` and only when the issue has no
+existing assignee. You can have a maximum of 3 issues assigned to you at any
+given time.
 
-Please note that you can have a maximum of 3 issues assigned to you at any given
-time.
+**Assignment is required before opening a pull request.** If you open a PR
+linked to an issue you are not assigned to, the PR is automatically closed with
+instructions. Re-open the PR after getting assigned.
 
 ### Pull request guidelines
 
@@ -102,11 +107,15 @@ any code is written.
 - **For features:** The PR should be linked to the feature request or proposal
   issue that has been approved by a maintainer.
 
-If an issue for your change doesn't exist, we will automatically close your PR
-along with a comment reminding you to associate the PR with an issue. The ideal
-workflow starts with an issue that has been reviewed and approved by a
-maintainer. Please **open the issue first** and wait for feedback before you
-start coding.
+PRs that do not meet both conditions below are automatically closed:
+
+- The PR must be linked to an existing issue using `Fixes #<issue_number>` or
+  `Closes #<issue_number>` in the description.
+- The PR author must be assigned to that issue.
+
+The ideal workflow: open an issue, wait for a maintainer to add the
+`help wanted` label, comment `/assign` to get assigned, then open a PR with the
+issue linked.
 
 #### 2. Keep it small and focused
 


### PR DESCRIPTION
## Summary

The `pr-contribution-guidelines-notifier` workflow was added in #16707 as a soft warning with a January 26 2026 enforcement deadline. That date has passed. I upgraded the workflow to actually close non-compliant PRs, added an assignment check, and improved the self-assign success message so contributors know exactly what to do next. I also updated `CONTRIBUTING.md` to document the enforced workflow consistently.

## Details

Two checks now run on every external PR via `pull_request_target`:

1. PR must link to an existing issue (`Fixes #N`)
2. PR author must be assigned to that issue

`pull_request_target` is required (not `pull_request`) to close PRs from forks — same pattern already used by `pr-rate-limiter.yaml`. The self-assign success comment now tells contributors exactly what to do next.

## Related Issues

Fixes #21545

## Before / After

**Before**
```
Contributor opens PR without linked issue
  Bot posts comment: "Starting Jan 26 2026, PRs must be linked to an issue..."
  PR stays open — maintainer closes it manually

Contributor opens PR linked to issue but is not assigned
  No check at all — PR stays open

CONTRIBUTING.md step 1: "Find an issue"
  No mention of assignment requirement
  No mention of automatic closure
```

**After**
```
Contributor opens PR without linked issue
  Bot posts 3-step instructions and closes PR immediately

Contributor opens PR linked to issue but is not assigned
  Bot tells them to comment /assign and closes PR immediately

Contributor opens PR with valid linked issue + is assigned
  All checks pass — PR proceeds to review

CONTRIBUTING.md step 2 (new): "Get assigned by commenting /assign"
  Assignment requirement explicitly documented
  Enforcement behaviour explained
```

## Flow

```mermaid
flowchart TD
    A[PR opened or reopened] --> B{Is author a maintainer<br>or Googler?}
    B -- Yes --> C[Skip all checks]
    B -- No --> D{PR linked<br>to an issue?}
    D -- No --> E[Post instructions<br>Close PR]
    D -- Yes --> F{Author assigned<br>to that issue?}
    F -- No --> G[Post assignment instructions<br>Close PR]
    F -- Yes --> H[All checks pass<br>PR proceeds]
```

## How to Validate

1. Open a PR with no linked issue — bot closes it with 3-step instructions.
2. Open a PR with `Fixes #N` for an issue you are not assigned to — bot closes it and tells you to comment `/assign`.
3. Comment `/assign` on a `help wanted` issue, get assigned, open a PR with `Fixes #N` — PR stays open.
4. Open a PR as OWNER/MEMBER/COLLABORATOR — no checks run, PR stays open.

## Test Evidence

Two real test PRs were opened against this repo to validate the behaviour described above.

**Test case 1 — PR with no linked issue:** #21552
**Test case 2 — PR with linked issue but author not assigned:** #21554

Both test PRs triggered the `pr-contribution-guidelines-notifier` workflow. Result:

```
Old workflow (pull_request trigger)  → conclusion: action_required
                                       GitHub blocks fork PRs pending maintainer
                                       approval — the soft comment never fires reliably

pr-rate-limiter (pull_request_target) → conclusion: success
                                        Runs immediately on fork PRs with write access
```

This confirms two things:

1. The old `pull_request` trigger is broken for fork contributor PRs — the notifier never reliably fires, which is why the January 26 deadline had no practical effect.
2. Switching to `pull_request_target` (the change in this PR) is both necessary and correct. It is the same pattern `pr-rate-limiter.yaml` already uses successfully.

After this PR merges, test case 1 would receive this bot message and be closed:
```
Hi @contributor, this PR has been closed because it is not linked to an existing issue.

Please follow these steps:
1. Open an issue describing the change you want to make.
2. Comment /assign on the issue to get assigned.
3. Open a new PR with Fixes #<issue_number> in the body.
```

After this PR merges, test case 2 would receive this bot message and be closed:
```
Hi @contributor, this PR has been closed because you are not assigned to issue #21545.

To get assigned, comment /assign on issue #21545.
Once assigned, you can re-open this PR.
```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
  - [ ] Windows
    - [ ] npm run
  - [ ] Linux
    - [ ] npm run