### PR TITLE
fix(core): improve editor detection on Windows

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -10,7 +10,16 @@ import { act } from 'react';
 import { renderHook } from '../../test-utils/render.js';
 import { waitFor } from '../../test-utils/async.js';
 import type { Mock } from 'vitest';
-import { vi, afterAll, beforeAll } from 'vitest';
+import {
+  vi,
+  afterAll,
+  beforeAll,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from 'vitest';
 import type { Key } from './KeypressContext.js';
 import {
   KeypressProvider,
@@ -397,6 +406,60 @@ describe('KeypressContext', () => {
         );
       },
     );
+  });
+
+  describe('Windows Terminal Backspace handling', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('should NOT treat \\b as ctrl when WT_SESSION is NOT present', async () => {
+      vi.stubEnv('WT_SESSION', '');
+      const { keyHandler } = setupKeypressTest();
+
+      act(() => {
+        stdin.write('\b');
+      });
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'backspace',
+          ctrl: false,
+        }),
+      );
+    });
+
+    it('should treat \\b as ctrl when WT_SESSION IS present', async () => {
+      vi.stubEnv('WT_SESSION', 'some-id');
+      const { keyHandler } = setupKeypressTest();
+
+      act(() => {
+        stdin.write('\b');
+      });
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'backspace',
+          ctrl: true,
+        }),
+      );
+    });
+
+    it('should treat \\x7f as regular backspace regardless of WT_SESSION', async () => {
+      vi.stubEnv('WT_SESSION', 'some-id');
+      const { keyHandler } = setupKeypressTest();
+
+      act(() => {
+        stdin.write('\x7f');
+      });
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'backspace',
+          ctrl: false,
+        }),
+      );
+    });
   });
 
   describe('paste mode', () => {

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -593,9 +593,13 @@ function* emitKeys(
       name = 'tab';
       alt = escaped;
     } else if (ch === '\b') {
-      // ctrl+h or ctrl+backspace (windows terminals send \x08 for ctrl+backspace)
+      // ctrl+h / ctrl+backspace (windows terminals send \x08 for ctrl+backspace)
       name = 'backspace';
-      ctrl = true;
+      // In Windows Terminal, \b can be sent for Ctrl+Backspace.
+      // We scope this behavior to avoid breaking other terminals where \b is a plain backspace.
+      if (typeof process !== 'undefined' && !!process.env?.['WT_SESSION']) {
+        ctrl = true;
+      }
       alt = escaped;
     } else if (ch === '\x7f') {
       // backspace

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -592,8 +592,13 @@ function* emitKeys(
       // tab
       name = 'tab';
       alt = escaped;
-    } else if (ch === '\b' || ch === '\x7f') {
-      // backspace or ctrl+h
+    } else if (ch === '\b') {
+      // ctrl+h or ctrl+backspace (windows terminals send \x08 for ctrl+backspace)
+      name = 'backspace';
+      ctrl = true;
+      alt = escaped;
+    } else if (ch === '\x7f') {
+      // backspace
       name = 'backspace';
       alt = escaped;
     } else if (ch === ESC) {

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -35,6 +35,12 @@ vi.mock('child_process', () => ({
   spawnSync: vi.fn(() => ({ error: null, status: 0 })),
 }));
 
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+}));
+
+import { existsSync } from 'node:fs';
+
 const originalPlatform = process.platform;
 
 describe('editor utils', () => {
@@ -45,6 +51,10 @@ describe('editor utils', () => {
       value: originalPlatform,
       writable: true,
     });
+    vi.stubEnv('LOCALAPPDATA', 'C:\\LOCALAPPDATA');
+    vi.stubEnv('ProgramFiles', 'C:\\Program Files');
+    vi.stubEnv('APPDATA', 'C:\\APPDATA');
+    vi.stubEnv('ANTIGRAVITY_CLI_ALIAS', 'agy');
   });
 
   afterEach(() => {
@@ -62,26 +72,60 @@ describe('editor utils', () => {
       commands: string[];
       win32Commands: string[];
     }> = [
-      { editor: 'vscode', commands: ['code'], win32Commands: ['code.cmd'] },
+      {
+        editor: 'vscode',
+        commands: ['code'],
+        win32Commands: [
+          'code.cmd',
+          'code',
+          'C:\\LOCALAPPDATA\\Programs\\Microsoft VS Code\\bin\\code.cmd',
+          'C:\\Program Files\\Microsoft VS Code\\bin\\code.cmd',
+        ],
+      },
       {
         editor: 'vscodium',
         commands: ['codium'],
-        win32Commands: ['codium.cmd'],
+        win32Commands: [
+          'codium.cmd',
+          'codium',
+          'C:\\LOCALAPPDATA\\Programs\\VSCodium\\bin\\codium.cmd',
+          'C:\\Program Files\\VSCodium\\bin\\codium.cmd',
+        ],
       },
       {
         editor: 'windsurf',
         commands: ['windsurf'],
         win32Commands: ['windsurf'],
       },
-      { editor: 'cursor', commands: ['cursor'], win32Commands: ['cursor'] },
+      {
+        editor: 'cursor',
+        commands: ['cursor'],
+        win32Commands: [
+          'cursor',
+          'C:\\LOCALAPPDATA\\Programs\\cursor\\resources\\app\\bin\\cursor.cmd',
+          'C:\\Program Files\\cursor\\resources\\app\\bin\\cursor.cmd',
+        ],
+      },
       { editor: 'vim', commands: ['vim'], win32Commands: ['vim'] },
       { editor: 'neovim', commands: ['nvim'], win32Commands: ['nvim'] },
       { editor: 'zed', commands: ['zed', 'zeditor'], win32Commands: ['zed'] },
-      { editor: 'emacs', commands: ['emacs'], win32Commands: ['emacs.exe'] },
+      {
+        editor: 'emacs',
+        commands: ['emacs'],
+        win32Commands: ['emacs.exe', 'emacs'],
+      },
       {
         editor: 'antigravity',
-        commands: ['agy', 'antigravity'],
-        win32Commands: ['agy.cmd', 'antigravity.cmd', 'antigravity'],
+        commands: ['gemini', 'agy', 'antigravity'],
+        win32Commands: [
+          'gemini.cmd',
+          'gemini',
+          'agy.cmd',
+          'agy',
+          'antigravity.cmd',
+          'antigravity',
+          'C:\\APPDATA\\npm\\agy.cmd',
+        ],
       },
       { editor: 'hx', commands: ['hx'], win32Commands: ['hx'] },
     ];
@@ -125,30 +169,55 @@ describe('editor utils', () => {
         // Windows tests
         it(`should return true if first command "${win32Commands[0]}" exists on windows`, () => {
           Object.defineProperty(process, 'platform', { value: 'win32' });
-          (execSync as Mock).mockReturnValue(
-            Buffer.from(`C:\\Program Files\\...\\${win32Commands[0]}`),
-          );
-          expect(hasValidEditorCommand(editor)).toBe(true);
-          expect(execSync).toHaveBeenCalledWith(
-            `where.exe ${win32Commands[0]}`,
-            {
-              stdio: 'ignore',
-            },
-          );
+          if (
+            win32Commands[0].includes('\\') ||
+            win32Commands[0].includes('/')
+          ) {
+            (existsSync as Mock).mockReturnValue(true);
+            expect(hasValidEditorCommand(editor)).toBe(true);
+            expect(existsSync).toHaveBeenCalledWith(win32Commands[0]);
+          } else {
+            (execSync as Mock).mockReturnValue(
+              Buffer.from(`C:\\Program Files\\...\\${win32Commands[0]}`),
+            );
+            expect(hasValidEditorCommand(editor)).toBe(true);
+            expect(execSync).toHaveBeenCalledWith(
+              `where.exe ${win32Commands[0]}`,
+              {
+                stdio: 'ignore',
+              },
+            );
+          }
         });
 
         if (win32Commands.length > 1) {
           it(`should return true if first command doesn't exist but second command "${win32Commands[1]}" exists on windows`, () => {
             Object.defineProperty(process, 'platform', { value: 'win32' });
-            (execSync as Mock)
-              .mockImplementationOnce(() => {
-                throw new Error(); // first command not found
-              })
-              .mockReturnValueOnce(
-                Buffer.from(`C:\\Program Files\\...\\${win32Commands[1]}`),
-              ); // second command found
+
+            const mockCommand = (cmd: string, exists: boolean) => {
+              if (cmd.includes('\\') || cmd.includes('/')) {
+                if (exists) {
+                  (existsSync as Mock).mockReturnValueOnce(true);
+                } else {
+                  (existsSync as Mock).mockReturnValueOnce(false);
+                }
+              } else {
+                if (exists) {
+                  (execSync as Mock).mockReturnValueOnce(
+                    Buffer.from(`C:\\Program Files\\...\\${cmd}`),
+                  );
+                } else {
+                  (execSync as Mock).mockImplementationOnce(() => {
+                    throw new Error();
+                  });
+                }
+              }
+            };
+
+            mockCommand(win32Commands[0], false);
+            mockCommand(win32Commands[1], true);
+
             expect(hasValidEditorCommand(editor)).toBe(true);
-            expect(execSync).toHaveBeenCalledTimes(2);
           });
         }
 
@@ -157,8 +226,9 @@ describe('editor utils', () => {
           (execSync as Mock).mockImplementation(() => {
             throw new Error(); // all commands not found
           });
+          (existsSync as Mock).mockReturnValue(false);
+
           expect(hasValidEditorCommand(editor)).toBe(false);
-          expect(execSync).toHaveBeenCalledTimes(win32Commands.length);
         });
       });
     }
@@ -170,23 +240,53 @@ describe('editor utils', () => {
       commands: string[];
       win32Commands: string[];
     }> = [
-      { editor: 'vscode', commands: ['code'], win32Commands: ['code.cmd'] },
+      {
+        editor: 'vscode',
+        commands: ['code'],
+        win32Commands: [
+          'code.cmd',
+          'code',
+          'C:\\LOCALAPPDATA\\Programs\\Microsoft VS Code\\bin\\code.cmd',
+          'C:\\Program Files\\Microsoft VS Code\\bin\\code.cmd',
+        ],
+      },
       {
         editor: 'vscodium',
         commands: ['codium'],
-        win32Commands: ['codium.cmd'],
+        win32Commands: [
+          'codium.cmd',
+          'codium',
+          'C:\\LOCALAPPDATA\\Programs\\VSCodium\\bin\\codium.cmd',
+          'C:\\Program Files\\VSCodium\\bin\\codium.cmd',
+        ],
       },
       {
         editor: 'windsurf',
         commands: ['windsurf'],
         win32Commands: ['windsurf'],
       },
-      { editor: 'cursor', commands: ['cursor'], win32Commands: ['cursor'] },
+      {
+        editor: 'cursor',
+        commands: ['cursor'],
+        win32Commands: [
+          'cursor',
+          'C:\\LOCALAPPDATA\\Programs\\cursor\\resources\\app\\bin\\cursor.cmd',
+          'C:\\Program Files\\cursor\\resources\\app\\bin\\cursor.cmd',
+        ],
+      },
       { editor: 'zed', commands: ['zed', 'zeditor'], win32Commands: ['zed'] },
       {
         editor: 'antigravity',
-        commands: ['agy', 'antigravity'],
-        win32Commands: ['agy.cmd', 'antigravity.cmd', 'antigravity'],
+        commands: ['gemini', 'agy', 'antigravity'],
+        win32Commands: [
+          'gemini.cmd',
+          'gemini',
+          'agy.cmd',
+          'agy',
+          'antigravity.cmd',
+          'antigravity',
+          'C:\\APPDATA\\npm\\agy.cmd',
+        ],
       },
     ];
 
@@ -235,11 +335,30 @@ describe('editor utils', () => {
       });
 
       // Windows tests
+      const mockCommand = (cmd: string, exists: boolean) => {
+        if (cmd.includes('\\') || cmd.includes('/')) {
+          if (exists) {
+            (existsSync as Mock).mockReturnValueOnce(true);
+          } else {
+            (existsSync as Mock).mockReturnValueOnce(false);
+          }
+        } else {
+          if (exists) {
+            (execSync as Mock).mockReturnValueOnce(
+              Buffer.from(`C:\\Program Files\\...\\${cmd}`),
+            );
+          } else {
+            (execSync as Mock).mockImplementationOnce(() => {
+              throw new Error();
+            });
+          }
+        }
+      };
+
       it(`should use first command "${win32Commands[0]}" when it exists on windows`, () => {
         Object.defineProperty(process, 'platform', { value: 'win32' });
-        (execSync as Mock).mockReturnValue(
-          Buffer.from(`C:\\Program Files\\...\\${win32Commands[0]}`),
-        );
+        mockCommand(win32Commands[0], true);
+
         const diffCommand = getDiffCommand('old.txt', 'new.txt', editor);
         expect(diffCommand).toEqual({
           command: win32Commands[0],
@@ -250,13 +369,8 @@ describe('editor utils', () => {
       if (win32Commands.length > 1) {
         it(`should use second command "${win32Commands[1]}" when first doesn't exist on windows`, () => {
           Object.defineProperty(process, 'platform', { value: 'win32' });
-          (execSync as Mock)
-            .mockImplementationOnce(() => {
-              throw new Error(); // first command not found
-            })
-            .mockReturnValueOnce(
-              Buffer.from(`C:\\Program Files\\...\\${win32Commands[1]}`),
-            ); // second command found
+          mockCommand(win32Commands[0], false);
+          mockCommand(win32Commands[1], true);
 
           const diffCommand = getDiffCommand('old.txt', 'new.txt', editor);
           expect(diffCommand).toEqual({
@@ -266,11 +380,11 @@ describe('editor utils', () => {
         });
       }
 
-      it(`should fall back to last command "${win32Commands[win32Commands.length - 1]}" when none exist on windows`, () => {
+      it(`should fall back to last command "${
+        win32Commands[win32Commands.length - 1]
+      }" when none exist on windows`, () => {
         Object.defineProperty(process, 'platform', { value: 'win32' });
-        (execSync as Mock).mockImplementation(() => {
-          throw new Error(); // all commands not found
-        });
+        win32Commands.slice(0, -1).forEach((cmd) => mockCommand(cmd, false));
 
         const diffCommand = getDiffCommand('old.txt', 'new.txt', editor);
         expect(diffCommand).toEqual({

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -5,6 +5,7 @@
  */
 
 import { exec, execSync, spawn, spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { promisify } from 'node:util';
 import { once } from 'node:events';
 import { debugLogger } from './debugLogger.js';
@@ -87,6 +88,9 @@ function getCommandExistsCmd(cmd: string): string {
 }
 
 function commandExists(cmd: string): boolean {
+  if (cmd.includes('\\') || cmd.includes('/')) {
+    return existsSync(cmd);
+  }
   try {
     execSync(getCommandExistsCmd(cmd), { stdio: 'ignore' });
     return true;
@@ -96,6 +100,9 @@ function commandExists(cmd: string): boolean {
 }
 
 async function commandExistsAsync(cmd: string): Promise<boolean> {
+  if (cmd.includes('\\') || cmd.includes('/')) {
+    return existsSync(cmd);
+  }
   try {
     await execAsync(getCommandExistsCmd(cmd));
     return true;
@@ -108,27 +115,109 @@ async function commandExistsAsync(cmd: string): Promise<boolean> {
  * Editor command configurations for different platforms.
  * Each editor can have multiple possible command names, listed in order of preference.
  */
-const editorCommands: Record<
-  EditorType,
-  { win32: string[]; default: string[] }
-> = {
-  vscode: { win32: ['code.cmd'], default: ['code'] },
-  vscodium: { win32: ['codium.cmd'], default: ['codium'] },
-  windsurf: { win32: ['windsurf'], default: ['windsurf'] },
-  cursor: { win32: ['cursor'], default: ['cursor'] },
-  vim: { win32: ['vim'], default: ['vim'] },
-  neovim: { win32: ['nvim'], default: ['nvim'] },
-  zed: { win32: ['zed'], default: ['zed', 'zeditor'] },
-  emacs: { win32: ['emacs.exe'], default: ['emacs'] },
-  antigravity: {
-    win32: ['agy.cmd', 'antigravity.cmd', 'antigravity'],
-    default: ['agy', 'antigravity'],
-  },
-  hx: { win32: ['hx'], default: ['hx'] },
-};
+function getEditorConfig(editor: EditorType): {
+  win32: string[];
+  default: string[];
+} {
+  switch (editor) {
+    case 'vscode':
+      return {
+        win32: [
+          'code.cmd',
+          'code',
+          ...(process.env['LOCALAPPDATA']
+            ? [
+                `${process.env['LOCALAPPDATA']}\\Programs\\Microsoft VS Code\\bin\\code.cmd`,
+              ]
+            : []),
+          ...(process.env['ProgramFiles']
+            ? [
+                `${process.env['ProgramFiles']}\\Microsoft VS Code\\bin\\code.cmd`,
+              ]
+            : []),
+        ],
+        default: ['code'],
+      };
+    case 'vscodium':
+      return {
+        win32: [
+          'codium.cmd',
+          'codium',
+          ...(process.env['LOCALAPPDATA']
+            ? [
+                `${process.env['LOCALAPPDATA']}\\Programs\\VSCodium\\bin\\codium.cmd`,
+              ]
+            : []),
+          ...(process.env['ProgramFiles']
+            ? [`${process.env['ProgramFiles']}\\VSCodium\\bin\\codium.cmd`]
+            : []),
+        ],
+        default: ['codium'],
+      };
+    case 'windsurf':
+      return { win32: ['windsurf'], default: ['windsurf'] };
+    case 'cursor':
+      return {
+        win32: [
+          'cursor',
+          ...(process.env['LOCALAPPDATA']
+            ? [
+                `${process.env['LOCALAPPDATA']}\\Programs\\cursor\\resources\\app\\bin\\cursor.cmd`,
+              ]
+            : []),
+          ...(process.env['ProgramFiles']
+            ? [
+                `${process.env['ProgramFiles']}\\cursor\\resources\\app\\bin\\cursor.cmd`,
+              ]
+            : []),
+        ],
+        default: ['cursor'],
+      };
+    case 'vim':
+      return { win32: ['vim'], default: ['vim'] };
+    case 'neovim':
+      return { win32: ['nvim'], default: ['nvim'] };
+    case 'zed':
+      return { win32: ['zed'], default: ['zed', 'zeditor'] };
+    case 'emacs':
+      return { win32: ['emacs.exe', 'emacs'], default: ['emacs'] };
+    case 'antigravity': {
+      const alias = process.env['ANTIGRAVITY_CLI_ALIAS'];
+      const win32 = [
+        'gemini.cmd',
+        'gemini',
+        'agy.cmd',
+        'agy',
+        'antigravity.cmd',
+        'antigravity',
+      ];
+      if (alias) {
+        win32.push(`${alias}.cmd`, alias);
+      }
+      if (process.env['APPDATA']) {
+        win32.push(`${process.env['APPDATA']}\\npm\\agy.cmd`);
+      }
+
+      const defaultList = ['gemini', 'agy', 'antigravity'];
+      if (alias) {
+        defaultList.push(alias);
+      }
+
+      return {
+        // Use Set to remove duplicates
+        win32: [...new Set(win32)],
+        default: [...new Set(defaultList)],
+      };
+    }
+    case 'hx':
+      return { win32: ['hx'], default: ['hx'] };
+    default:
+      return { win32: [], default: [] };
+  }
+}
 
 function getEditorCommands(editor: EditorType): string[] {
-  const commandConfig = editorCommands[editor];
+  const commandConfig = getEditorConfig(editor);
   return process.platform === 'win32'
     ? commandConfig.win32
     : commandConfig.default;


### PR DESCRIPTION
## Summary

Improves editor detection on Windows by resolving common installation paths and refactoring command resolution to be dynamic. This ensures that VS Code and Antigravity (detected as `gemini` or `agy`) are correctly identified even when they are not in the system `PATH`.

## Details

- **Dynamic Config**: Refactored `editorCommands` to a function-based resolution to ensure environment variables like `LOCALAPPDATA` and `ProgramFiles` are resolved at runtime.
- **Enhanced Search**: Added explicit file existence checks for common Windows installation paths for VS Code, VSCodium, and Cursor in both System and User directories.
- **Antigravity Detection**: Added `gemini` and `gemini.cmd` to the detection list for the Antigravity editor, ensuring it's found across different install methods.
- **Improved Performance**: Implemented direct `fs.existsSync` checks for absolute paths, avoiding unnecessary and potentially slow `where.exe` calls.
- **Updated Tests**: Refactored unit tests to verify the new dynamic logic and ensure consistent cross-platform behavior. 

## Related Issues

Fixes #21571 

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

1. Run the updated unit tests to ensure no regressions:
   `npm test -w @google/gemini-cli-core -- src/utils/editor.test.ts`
   (All 147 tests should pass). 

 2. Manual verification:
   - Open Gemini CLI on a Windows machine where VS Code is installed but not in PATH.
   - Run the `/editor` command.
- **Expected**: editors should be listed as "Installed".

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
