### PR TITLE
fix(core): use CLI version in IDE client connections

### DIFF
--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -22,6 +22,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { IDE_REQUEST_TIMEOUT_MS } from './constants.js';
 import { debugLogger } from '../utils/debugLogger.js';
+import { getVersion } from '../utils/version.js';
 import {
   getConnectionConfigFromFile,
   getIdeServerHost,
@@ -588,8 +589,7 @@ export class IdeClient {
       logger.debug(`Server URL: ${serverUrl}`);
       this.client = new Client({
         name: 'streamable-http-client',
-        // TODO(#3487): use the CLI version here.
-        version: '1.0.0',
+        version: await getVersion(),
       });
       transport = new StreamableHTTPClientTransport(new URL(serverUrl), {
         fetch: await createProxyAwareFetch(ideServerHost),
@@ -623,8 +623,7 @@ export class IdeClient {
       logger.debug('Attempting to connect to IDE via stdio');
       this.client = new Client({
         name: 'stdio-client',
-        // TODO(#3487): use the CLI version here.
-        version: '1.0.0',
+        version: await getVersion(),
       });
 
       transport = new StdioClientTransport({


### PR DESCRIPTION
## Summary
Fixes #3487

Uses the actual CLI version instead of hardcoded `'1.0.0'` in IDE client connections.

## Changes
- Import `getVersion()` from `../utils/version.js`
- Replace hardcoded version in `establishHttpConnection()`
- Replace hardcoded version in `establishStdioConnection()`

## Testing
- [x] Changes compile without errors
- [x] Ran `npm run preflight`