### PR TITLE
fix(acp): preserve explicit CLI approval mode when IDE companion connects

### DIFF
--- a/packages/cli/src/acp/acpClient.approvalMode.test.ts
+++ b/packages/cli/src/acp/acpClient.approvalMode.test.ts
@@ -23,6 +23,7 @@ function makeSession(opts: {
   const config = {
     isPlanEnabled: vi.fn().mockReturnValue(false),
     isApprovalModeExplicit: vi.fn().mockReturnValue(opts.approvalModeExplicit),
+    isYoloModeDisabled: vi.fn().mockReturnValue(false),
     setApprovalMode,
     getApprovalMode: vi.fn().mockReturnValue(opts.currentMode),
   } as unknown as Config;
@@ -123,6 +124,28 @@ describe('Session.setMode — CLI approval mode precedence', () => {
       expect(() => s2.setMode('not_a_mode' as acp.SessionModeId)).toThrow(
         'Invalid or unavailable mode',
       );
+    });
+  });
+
+  describe('when YOLO mode is disabled by security policy', () => {
+    it('does NOT apply IDE-pushed yolo when isYoloModeDisabled is true', () => {
+      const setApprovalMode = vi.fn();
+      const config = {
+        isPlanEnabled: vi.fn().mockReturnValue(false),
+        isApprovalModeExplicit: vi.fn().mockReturnValue(false),
+        isYoloModeDisabled: vi.fn().mockReturnValue(true),
+        setApprovalMode,
+        getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
+      } as unknown as Config;
+      const session = new Session(
+        'test-session-id',
+        {} as never,
+        config,
+        {} as never,
+        {} as unknown as LoadedSettings,
+      );
+      session.setMode(ApprovalMode.YOLO as unknown as acp.SessionModeId);
+      expect(setApprovalMode).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/cli/src/acp/acpClient.approvalMode.test.ts
+++ b/packages/cli/src/acp/acpClient.approvalMode.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { Session } from './acpClient.js';
+import { ApprovalMode, type Config } from '@google/gemini-cli-core';
+import type * as acp from '@agentclientprotocol/sdk';
+import type { LoadedSettings } from '../config/settings.js';
+
+/**
+ * Builds a minimal Session for testing setMode() in isolation.
+ * All constructor args except `config` are stubbed out — they are not
+ * exercised by the paths under test.
+ */
+function makeSession(opts: {
+  approvalModeExplicit: boolean;
+  currentMode: ApprovalMode;
+}) {
+  const setApprovalMode = vi.fn();
+  const config = {
+    isPlanEnabled: vi.fn().mockReturnValue(false),
+    isApprovalModeExplicit: vi.fn().mockReturnValue(opts.approvalModeExplicit),
+    setApprovalMode,
+    getApprovalMode: vi.fn().mockReturnValue(opts.currentMode),
+  } as unknown as Config;
+
+  const session = new Session(
+    'test-session-id',
+    {} as never,
+    config,
+    {} as never,
+    {} as unknown as LoadedSettings,
+  );
+
+  return { session, setApprovalMode, config };
+}
+
+describe('Session.setMode — CLI approval mode precedence', () => {
+  describe('when no CLI flag was set (approvalModeExplicit = false)', () => {
+    it('applies the IDE-pushed yolo mode', () => {
+      const { session, setApprovalMode } = makeSession({
+        approvalModeExplicit: false,
+        currentMode: ApprovalMode.DEFAULT,
+      });
+
+      session.setMode(ApprovalMode.YOLO as unknown as acp.SessionModeId);
+
+      expect(setApprovalMode).toHaveBeenCalledWith(ApprovalMode.YOLO);
+    });
+
+    it('applies auto_edit mode from IDE', () => {
+      const { session, setApprovalMode } = makeSession({
+        approvalModeExplicit: false,
+        currentMode: ApprovalMode.DEFAULT,
+      });
+
+      session.setMode(ApprovalMode.AUTO_EDIT as unknown as acp.SessionModeId);
+
+      expect(setApprovalMode).toHaveBeenCalledWith(ApprovalMode.AUTO_EDIT);
+    });
+  });
+
+  describe('when CLI flag was explicitly set (approvalModeExplicit = true)', () => {
+    it('does NOT apply IDE-pushed default when --yolo was passed', () => {
+      const { session, setApprovalMode } = makeSession({
+        approvalModeExplicit: true,
+        currentMode: ApprovalMode.YOLO,
+      });
+
+      // VS Code companion sends its stored default on connect — must be ignored
+      session.setMode(ApprovalMode.DEFAULT as unknown as acp.SessionModeId);
+
+      expect(setApprovalMode).not.toHaveBeenCalled();
+    });
+
+    it('does NOT apply any IDE mode when --approval-mode was passed', () => {
+      const { session, setApprovalMode } = makeSession({
+        approvalModeExplicit: true,
+        currentMode: ApprovalMode.AUTO_EDIT,
+      });
+
+      session.setMode(ApprovalMode.DEFAULT as unknown as acp.SessionModeId);
+
+      expect(setApprovalMode).not.toHaveBeenCalled();
+    });
+
+    it('returns empty response object in both code paths', () => {
+      const { session: s1 } = makeSession({
+        approvalModeExplicit: false,
+        currentMode: ApprovalMode.DEFAULT,
+      });
+      const { session: s2 } = makeSession({
+        approvalModeExplicit: true,
+        currentMode: ApprovalMode.YOLO,
+      });
+
+      expect(
+        s1.setMode(ApprovalMode.YOLO as unknown as acp.SessionModeId),
+      ).toEqual({});
+      expect(
+        s2.setMode(ApprovalMode.DEFAULT as unknown as acp.SessionModeId),
+      ).toEqual({});
+    });
+  });
+
+  describe('invalid mode', () => {
+    it('throws for an unrecognised mode id regardless of CLI flag', () => {
+      const { session: s1 } = makeSession({
+        approvalModeExplicit: false,
+        currentMode: ApprovalMode.DEFAULT,
+      });
+      const { session: s2 } = makeSession({
+        approvalModeExplicit: true,
+        currentMode: ApprovalMode.YOLO,
+      });
+
+      expect(() => s1.setMode('not_a_mode' as acp.SessionModeId)).toThrow(
+        'Invalid or unavailable mode',
+      );
+      expect(() => s2.setMode('not_a_mode' as acp.SessionModeId)).toThrow(
+        'Invalid or unavailable mode',
+      );
+    });
+  });
+});

--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -560,6 +560,13 @@ export class Session {
     if (!mode) {
       throw new Error(`Invalid or unavailable mode: ${modeId}`);
     }
+    // Do not allow the IDE companion to override an approval mode that was
+    // explicitly set via a CLI flag (e.g. --yolo, --approval-mode).
+    // The CLI flag represents explicit user intent that takes precedence
+    // over the IDE's stored default mode. See: github.com/google-gemini/gemini-cli/issues/18816
+    if (this.config.isApprovalModeExplicit()) {
+      return {};
+    }
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     this.context.config.setApprovalMode(mode.id as ApprovalMode);
     return {};

--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -564,7 +564,10 @@ export class Session {
     // explicitly set via a CLI flag (e.g. --yolo, --approval-mode).
     // The CLI flag represents explicit user intent that takes precedence
     // over the IDE's stored default mode. See: github.com/google-gemini/gemini-cli/issues/18816
-    if (this.config.isApprovalModeExplicit()) {
+    if (
+      this.config.isApprovalModeExplicit() ||
+      (mode.id === ApprovalMode.YOLO && this.config.isYoloModeDisabled())
+    ) {
       return {};
     }
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -892,6 +892,7 @@ export async function loadCliConfig(
     geminiMdFileCount: fileCount,
     geminiMdFilePaths: filePaths,
     approvalMode,
+    approvalModeExplicit: !!(argv.approvalMode || argv.yolo),
     disableYoloMode:
       settings.security?.disableYoloMode || settings.admin?.secureModeEnabled,
     disableAlwaysAllow:

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -668,6 +668,7 @@ export interface ConfigParameters {
     adminSkillsEnabled?: boolean;
     agents?: AgentSettings;
   }>;
+  approvalModeExplicit?: boolean;
   enableConseca?: boolean;
   billing?: {
     overageStrategy?: OverageStrategy;
@@ -891,6 +892,7 @@ export class Config implements McpContext, AgentLoopContext {
   private lastModeSwitchTime: number = performance.now();
   readonly injectionService: InjectionService;
   private approvedPlanPath: string | undefined;
+  private readonly approvalModeFromCli: boolean;
 
   constructor(params: ConfigParameters) {
     this._sessionId = params.sessionId;
@@ -1079,6 +1081,7 @@ export class Config implements McpContext, AgentLoopContext {
     };
     this.maxSessionTurns = params.maxSessionTurns ?? -1;
     this.acpMode = params.acpMode ?? false;
+    this.approvalModeFromCli = params.approvalModeExplicit ?? false;
     this.listSessions = params.listSessions ?? false;
     this.deleteSession = params.deleteSession;
     this.listExtensions = params.listExtensions ?? false;
@@ -2375,6 +2378,15 @@ export class Config implements McpContext, AgentLoopContext {
 
   getDisableAlwaysAllow(): boolean {
     return this.disableAlwaysAllow;
+  }
+
+  /**
+   * Returns true if the approval mode was explicitly set via a CLI flag
+   * (e.g. --yolo, --approval-mode). When true, IDE-pushed mode changes
+   * should not overwrite the user's explicit intent.
+   */
+  isApprovalModeExplicit(): boolean {
+    return this.approvalModeFromCli;
   }
 
   getRawOutput(): boolean {


### PR DESCRIPTION
## Problem

Fixes #18816

When a user starts `gemini --yolo` or `gemini --approval-mode=yolo`, the VS Code IDE companion silently overwrites that mode on every connection via the ACP handshake. The result: YOLO mode reverts to the IDE's stored default and every tool call requires manual confirmation, defeating the purpose of the flag entirely.

Reproduced consistently on v0.28.0–v0.29.5 across multiple users in the issue thread.

## Root Cause

`Session.setMode()` in `packages/cli/src/acp/acpClient.ts` called `config.setApprovalMode()` unconditionally whenever the IDE sent a `setSessionMode` RPC. VS Code sends this on every handshake with its own stored default mode. There was no mechanism to distinguish "user set this via CLI flag" from "IDE runtime sync".

## Fix

**`packages/core/src/config/config.ts`**
- Add `approvalModeExplicit?: boolean` to `ConfigParameters`
- Add `private readonly approvalModeFromCli: boolean` field
- Add `isApprovalModeExplicit(): boolean` getter

**`packages/cli/src/config/config.ts`**
- Pass `approvalModeExplicit: !!(argv.approvalMode || argv.yolo)` into the `Config` constructor

**`packages/cli/src/acp/acpClient.ts`**
- In `Session.setMode()`, return early (no-op) when `config.isApprovalModeExplicit()` is true

**`packages/cli/src/acp/acpClient.approvalMode.test.ts`** *(new)*
- 6 tests covering: IDE mode applied when no CLI flag set, IDE mode blocked when `--yolo` passed, IDE mode blocked when `--approval-mode` passed, return value correctness in both paths, invalid mode rejection

The guard is placed exclusively in the ACP path. All other callers of `setApprovalMode()` - slash commands (`/yolo`, `/mode`), the policy engine, UI interactions, are completely unaffected.

## How to Validate
```bash
# Run the new tests
npx vitest run packages/cli/src/acp/acpClient.approvalMode.test.ts
# Expected: 6 passed

# Manual: start with --yolo and connect VS Code companion
gemini --yolo
# Expected: zero confirmation prompts regardless of IDE connection
```

## Alternatives Considered

- **Guard inside `Config.setApprovalMode()`** - rejected: that method is general-purpose and used by slash commands and the policy engine. Guarding it there would break legitimate runtime mode changes.
- **Guard only on first IDE connect** - rejected: can't reliably distinguish "initial IDE sync" from "user clicked a mode in the IDE UI" without protocol changes.