### PR TITLE
feat(core): phase 2 - add interactive task tree visualization (WIP)

### DIFF
--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -97,6 +97,11 @@ export enum Command {
   CLEAR_SCREEN = 'app.clearScreen',
   RESTART_APP = 'app.restart',
   SUSPEND_APP = 'app.suspend',
+
+  // Task tree collapse/expand
+  TOGGLE_COLLAPSE = 'tree.toggleCollapse',
+  COLLAPSE_ALL = 'tree.collapseAll',
+  EXPAND_ALL = 'tree.expandAll',
 }
 
 /**
@@ -257,6 +262,11 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.CLEAR_SCREEN]: [{ key: 'l', ctrl: true }],
   [Command.RESTART_APP]: [{ key: 'r' }, { key: 'r', shift: true }],
   [Command.SUSPEND_APP]: [{ key: 'z', ctrl: true }],
+
+  // Task tree collapse/expand
+  [Command.TOGGLE_COLLAPSE]: [{ key: 'right' }, { key: 'left' }],
+  [Command.COLLAPSE_ALL]: [{ key: '[', ctrl: true }],
+  [Command.EXPAND_ALL]: [{ key: ']', ctrl: true }],
 };
 
 interface CommandCategory {
@@ -379,6 +389,14 @@ export const commandCategories: readonly CommandCategory[] = [
       Command.SUSPEND_APP,
     ],
   },
+  {
+    title: 'Task Tree',
+    commands: [
+      Command.TOGGLE_COLLAPSE,
+      Command.COLLAPSE_ALL,
+      Command.EXPAND_ALL,
+    ],
+  },
 ];
 
 /**
@@ -485,4 +503,10 @@ export const commandDescriptions: Readonly<Record<Command, string>> = {
   [Command.CLEAR_SCREEN]: 'Clear the terminal screen and redraw the UI.',
   [Command.RESTART_APP]: 'Restart the application.',
   [Command.SUSPEND_APP]: 'Suspend the CLI and move it to the background.',
+
+  // Task tree collapse/expand
+  [Command.TOGGLE_COLLAPSE]:
+    'Toggle the expanded/collapsed state of the focused task tree node.',
+  [Command.COLLAPSE_ALL]: 'Collapse all tool output sections in the task tree.',
+  [Command.EXPAND_ALL]: 'Expand all tool output sections in the task tree.',
 };

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -48,6 +48,12 @@ interface HistoryItemDisplayProps {
   isExpandable?: boolean;
   isFirstThinking?: boolean;
   isFirstAfterThinking?: boolean;
+  /**
+   * When true and item is tool_group, render nothing. Used so the task tree
+   * can be the single source of truth for the most recent tool run (no duplicate
+   * linear "thought box" above the tree).
+   */
+  suppressToolGroup?: boolean;
 }
 
 export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
@@ -60,6 +66,7 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
   isExpandable,
   isFirstThinking = false,
   isFirstAfterThinking = false,
+  suppressToolGroup = false,
 }) => {
   const settings = useSettings();
   const inlineThinkingMode = getInlineThinkingMode(settings);
@@ -67,6 +74,11 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
 
   const needsTopMarginAfterThinking =
     isFirstAfterThinking && inlineThinkingMode !== 'off';
+
+  // Task tree shows the most recent tool run; avoid duplicate linear box.
+  if (itemForDisplay.type === 'tool_group' && suppressToolGroup) {
+    return <Box key={itemForDisplay.id} width={terminalWidth} />;
+  }
 
   return (
     <Box

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -19,6 +19,9 @@ import { useMemo, memo, useCallback, useEffect, useRef } from 'react';
 import { MAX_GEMINI_MESSAGE_LINES } from '../constants.js';
 import { useConfirmingTool } from '../hooks/useConfirmingTool.js';
 import { ToolConfirmationQueue } from './ToolConfirmationQueue.js';
+import { TaskTree } from './TaskTree.js';
+import { useTaskTree } from '../hooks/useTaskTree.js';
+import type { IndividualToolCallDisplay } from '../types.js';
 
 const MemoizedHistoryItemDisplay = memo(HistoryItemDisplay);
 const MemoizedAppHeader = memo(AppHeader);
@@ -36,22 +39,8 @@ export const MainContent = () => {
   const showConfirmationQueue = confirmingTool !== null;
   const confirmingToolCallId = confirmingTool?.tool.callId;
 
-  const scrollableListRef = useRef<VirtualizedListRef<unknown>>(null);
-
-  useEffect(() => {
-    if (showConfirmationQueue) {
-      scrollableListRef.current?.scrollToEnd();
-    }
-  }, [showConfirmationQueue, confirmingToolCallId]);
-
-  const {
-    pendingHistoryItems,
-    mainAreaWidth,
-    staticAreaMaxItemHeight,
-    cleanUiDetailsVisible,
-  } = uiState;
-  const showHeaderDetails = cleanUiDetailsVisible;
-
+  // Accumulate all tool calls for the current agent turn so the tree persists
+  // across round-trips
   const lastUserPromptIndex = useMemo(() => {
     for (let i = uiState.history.length - 1; i >= 0; i--) {
       const type = uiState.history[i].type;
@@ -61,6 +50,38 @@ export const MainContent = () => {
     }
     return -1;
   }, [uiState.history]);
+
+  const allCurrentTurnToolCalls = useMemo<IndividualToolCallDisplay[]>(() => {
+    const calls: IndividualToolCallDisplay[] = [];
+    // Completed batches already committed to history for this turn
+    for (let i = lastUserPromptIndex + 1; i < uiState.history.length; i++) {
+      const item = uiState.history[i];
+      if (item.type === 'tool_group') {
+        calls.push(...item.tools);
+      }
+    }
+    // Live batch still pending
+    for (const item of uiState.pendingHistoryItems) {
+      if (item.type === 'tool_group') {
+        calls.push(...item.tools);
+      }
+    }
+    return calls;
+  }, [uiState.history, uiState.pendingHistoryItems, lastUserPromptIndex]);
+
+  const taskTree = useTaskTree(allCurrentTurnToolCalls);
+
+  const scrollableListRef = useRef<VirtualizedListRef<unknown>>(null);
+
+  useEffect(() => {
+    if (showConfirmationQueue) {
+      scrollableListRef.current?.scrollToEnd();
+    }
+  }, [showConfirmationQueue, confirmingToolCallId]);
+
+  const { mainAreaWidth, staticAreaMaxItemHeight, cleanUiDetailsVisible } =
+    uiState;
+  const showHeaderDetails = cleanUiDetailsVisible;
 
   const augmentedHistory = useMemo(
     () =>
@@ -72,21 +93,34 @@ export const MainContent = () => {
           item.type === 'thinking' && prevType !== 'thinking';
         const isFirstAfterThinking =
           item.type !== 'thinking' && prevType === 'thinking';
+        // Suppress all tool_group items from the current turn when the task tree
+        // is active — the tree is the single source of truth for the full turn.
+        const suppressToolGroup =
+          item.type === 'tool_group' &&
+          index > lastUserPromptIndex &&
+          taskTree.hasHierarchy;
 
         return {
           item,
           isExpandable,
           isFirstThinking,
           isFirstAfterThinking,
+          suppressToolGroup,
         };
       }),
-    [uiState.history, lastUserPromptIndex],
+    [uiState.history, lastUserPromptIndex, taskTree.hasHierarchy],
   );
 
   const historyItems = useMemo(
     () =>
       augmentedHistory.map(
-        ({ item, isExpandable, isFirstThinking, isFirstAfterThinking }) => (
+        ({
+          item,
+          isExpandable,
+          isFirstThinking,
+          isFirstAfterThinking,
+          suppressToolGroup,
+        }) => (
           <MemoizedHistoryItemDisplay
             terminalWidth={mainAreaWidth}
             availableTerminalHeight={
@@ -102,6 +136,7 @@ export const MainContent = () => {
             isExpandable={isExpandable}
             isFirstThinking={isFirstThinking}
             isFirstAfterThinking={isFirstAfterThinking}
+            suppressToolGroup={suppressToolGroup}
           />
         ),
       ),
@@ -127,44 +162,25 @@ export const MainContent = () => {
   const pendingItems = useMemo(
     () => (
       <Box flexDirection="column">
-        {pendingHistoryItems.map((item, i) => {
-          const prevType =
-            i === 0
-              ? uiState.history.at(-1)?.type
-              : pendingHistoryItems[i - 1]?.type;
-          const isFirstThinking =
-            item.type === 'thinking' && prevType !== 'thinking';
-          const isFirstAfterThinking =
-            item.type !== 'thinking' && prevType === 'thinking';
-
-          return (
-            <HistoryItemDisplay
-              key={i}
-              availableTerminalHeight={
-                uiState.constrainHeight ? staticAreaMaxItemHeight : undefined
-              }
-              terminalWidth={mainAreaWidth}
-              item={{ ...item, id: 0 }}
-              isPending={true}
-              isExpandable={true}
-              isFirstThinking={isFirstThinking}
-              isFirstAfterThinking={isFirstAfterThinking}
-            />
-          );
-        })}
+        {/* display task tree */}
+        {taskTree.hasHierarchy && (
+          <TaskTree
+            {...taskTree}
+            terminalWidth={mainAreaWidth}
+            isFocused={!uiState.embeddedShellFocused}
+          />
+        )}
         {showConfirmationQueue && confirmingTool && (
           <ToolConfirmationQueue confirmingTool={confirmingTool} />
         )}
       </Box>
     ),
     [
-      pendingHistoryItems,
-      uiState.constrainHeight,
-      staticAreaMaxItemHeight,
+      uiState.embeddedShellFocused,
       mainAreaWidth,
       showConfirmationQueue,
       confirmingTool,
-      uiState.history,
+      taskTree,
     ],
   );
 
@@ -172,12 +188,19 @@ export const MainContent = () => {
     () => [
       { type: 'header' as const },
       ...augmentedHistory.map(
-        ({ item, isExpandable, isFirstThinking, isFirstAfterThinking }) => ({
+        ({
+          item,
+          isExpandable,
+          isFirstThinking,
+          isFirstAfterThinking,
+          suppressToolGroup,
+        }) => ({
           type: 'history' as const,
           item,
           isExpandable,
           isFirstThinking,
           isFirstAfterThinking,
+          suppressToolGroup,
         }),
       ),
       { type: 'pending' as const },
@@ -212,6 +235,7 @@ export const MainContent = () => {
             isExpandable={item.isExpandable}
             isFirstThinking={item.isFirstThinking}
             isFirstAfterThinking={item.isFirstAfterThinking}
+            suppressToolGroup={item.suppressToolGroup}
           />
         );
       } else {

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -22,6 +22,7 @@ import { ToolConfirmationQueue } from './ToolConfirmationQueue.js';
 import { TaskTree } from './TaskTree.js';
 import { useTaskTree } from '../hooks/useTaskTree.js';
 import type { IndividualToolCallDisplay } from '../types.js';
+import { escapeAnsiCtrlCodes } from '../utils/textUtils.js';
 
 const MemoizedHistoryItemDisplay = memo(HistoryItemDisplay);
 const MemoizedAppHeader = memo(AppHeader);
@@ -57,13 +58,13 @@ export const MainContent = () => {
     for (let i = lastUserPromptIndex + 1; i < uiState.history.length; i++) {
       const item = uiState.history[i];
       if (item.type === 'tool_group') {
-        calls.push(...item.tools);
+        calls.push(...item.tools.map(escapeAnsiCtrlCodes));
       }
     }
     // Live batch still pending
     for (const item of uiState.pendingHistoryItems) {
       if (item.type === 'tool_group') {
-        calls.push(...item.tools);
+        calls.push(...item.tools.map(escapeAnsiCtrlCodes));
       }
     }
     return calls;

--- a/packages/cli/src/ui/components/TaskNode.tsx
+++ b/packages/cli/src/ui/components/TaskNode.tsx
@@ -1,0 +1,182 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box, Text } from 'ink';
+import { CoreToolCallStatus } from '@google/gemini-cli-core';
+import { CliSpinner } from './CliSpinner.js';
+import { ToolResultDisplay } from './messages/ToolResultDisplay.js';
+import { theme } from '../semantic-colors.js';
+import type { TaskTreeNode } from '../types.js';
+
+// ── Tree-drawing characters ─────────────────────────────────────
+const BRANCH = '├─ ';
+const LAST = '└─ ';
+const PIPE = '│   ';
+const BLANK = '    ';
+/** Min width for tool name column so descriptions align. */
+const TOOL_NAME_WIDTH = 14;
+
+// ── Status glyphs (spec: ✓ ● ◷ ◌) ───────────────────────────────────────────
+function statusGlyph(status: CoreToolCallStatus): {
+  text: string;
+  color: string;
+} {
+  switch (status) {
+    case CoreToolCallStatus.Success:
+      return { text: '✓', color: theme.status.success };
+    case CoreToolCallStatus.Error:
+      return { text: '✗', color: theme.status.error };
+    case CoreToolCallStatus.Cancelled:
+      return { text: '⊘', color: theme.text.secondary };
+    case CoreToolCallStatus.Executing:
+      return { text: '●', color: theme.status.warning };
+    case CoreToolCallStatus.AwaitingApproval:
+      return { text: '?', color: theme.status.warning };
+    case CoreToolCallStatus.Scheduled:
+      return { text: '◷', color: theme.text.secondary };
+    case CoreToolCallStatus.Validating:
+    default:
+      return { text: '◌', color: theme.text.secondary };
+  }
+}
+
+/** Status suffix for row: [0.3s], [running…], [pending], [queued]. No duration in data so we use [done] for success. */
+function statusSuffix(status: CoreToolCallStatus): string {
+  switch (status) {
+    case CoreToolCallStatus.Success:
+      return '[done]';
+    case CoreToolCallStatus.Executing:
+      return '[running…]';
+    case CoreToolCallStatus.Scheduled:
+      return '[pending]';
+    case CoreToolCallStatus.AwaitingApproval:
+      return '[pending]';
+    case CoreToolCallStatus.Error:
+    case CoreToolCallStatus.Cancelled:
+      return '[done]';
+    case CoreToolCallStatus.Validating:
+    default:
+      return '[queued]';
+  }
+}
+
+interface TaskNodeProps {
+  node: TaskTreeNode;
+  /** Characters to prepend that come from ancestor nodes (pipe/blank). */
+  prefix: string;
+  /** True when this is the last sibling at its level. */
+  isLast: boolean;
+  terminalWidth: number;
+}
+
+/**
+ * Renders a single row in the task tree, including its branch connector,
+ * status icon, tool name, description, and — when expanded — the tool's
+ * output and its children.
+ */
+export const TaskNode: React.FC<TaskNodeProps> = ({
+  node,
+  prefix,
+  isLast,
+  terminalWidth,
+}) => {
+  const { toolCall, children, isCollapsed, isFocused } = node;
+  const glyph = statusGlyph(toolCall.status);
+  const isRunning = toolCall.status === CoreToolCallStatus.Executing;
+  const hasChildren = children.length > 0;
+  const hasOutput =
+    toolCall.resultDisplay !== undefined && toolCall.resultDisplay !== '';
+
+  // Connector and prefix for children (spec: ├─ └─ │   )
+  const connector = isLast ? LAST : BRANCH;
+  const childPrefix = prefix + (isLast ? BLANK : PIPE);
+
+  // Spec row: ├─ ✓ read_file       src/auth.ts              [0.3s]
+  const namePadded = toolCall.name.padEnd(TOOL_NAME_WIDTH);
+  const suffix = statusSuffix(toolCall.status);
+
+  // Collapse hint when focused
+  const collapseToggle =
+    hasChildren || hasOutput ? (isCollapsed ? ' [+]' : ' [-]') : '';
+  const collapseHintColor = isFocused
+    ? theme.text.accent
+    : theme.text.secondary;
+
+  return (
+    <Box flexDirection="column">
+      {/* Single-line row per spec */}
+      <Box flexDirection="row" flexShrink={0}>
+        <Text color={theme.text.secondary}>{prefix}</Text>
+        <Text color={theme.text.secondary}>{connector}</Text>
+        <Box minWidth={2} flexShrink={0}>
+          {isRunning ? (
+            <Text color={glyph.color}>
+              <CliSpinner type="toggle" />
+            </Text>
+          ) : (
+            <Text color={glyph.color}>{glyph.text}</Text>
+          )}
+          <Text> </Text>
+        </Box>
+        <Text
+          color={
+            toolCall.status === CoreToolCallStatus.Cancelled
+              ? theme.text.secondary
+              : theme.text.primary
+          }
+          bold
+          strikethrough={toolCall.status === CoreToolCallStatus.Cancelled}
+          wrap="truncate"
+        >
+          {namePadded}
+        </Text>
+        {toolCall.description ? (
+          <Text color={theme.text.secondary} wrap="truncate">
+            {' '}
+            {toolCall.description}
+          </Text>
+        ) : null}
+        <Text color={theme.text.secondary}> {suffix}</Text>
+        {collapseToggle ? (
+          <Text color={collapseHintColor}>{collapseToggle}</Text>
+        ) : null}
+      </Box>
+
+      {/* ── Inline output (shown when not collapsed) ── */}
+      {!isCollapsed && hasOutput && (
+        <Box flexDirection="row">
+          {/* Continuation pipe from this node */}
+          <Text color={theme.text.secondary}>
+            {childPrefix}
+            {'   '}
+          </Text>
+          <Box flexDirection="column" flexShrink={1} flexGrow={1}>
+            <ToolResultDisplay
+              resultDisplay={toolCall.resultDisplay}
+              terminalWidth={
+                terminalWidth - (childPrefix.length + 3) /* indent */
+              }
+              renderOutputAsMarkdown={toolCall.renderOutputAsMarkdown}
+            />
+          </Box>
+        </Box>
+      )}
+
+      {/* ── Children (shown when not collapsed) ── */}
+      {!isCollapsed &&
+        children.map((child, idx) => (
+          <TaskNode
+            key={child.toolCall.callId}
+            node={child}
+            prefix={childPrefix}
+            isLast={idx === children.length - 1}
+            terminalWidth={terminalWidth}
+          />
+        ))}
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/TaskNode.tsx
+++ b/packages/cli/src/ui/components/TaskNode.tsx
@@ -44,20 +44,21 @@ function statusGlyph(status: CoreToolCallStatus): {
   }
 }
 
-/** Status suffix for row: [0.3s], [running…], [pending], [queued]. No duration in data so we use [done] for success. */
-function statusSuffix(status: CoreToolCallStatus): string {
+/** Status suffix for row: [0.3s], [running…], [pending], [queued]. */
+function statusSuffix(status: CoreToolCallStatus, durationMs?: number): string {
+  if (durationMs !== undefined) {
+    return `[${(durationMs / 1000).toFixed(1)}s]`;
+  }
   switch (status) {
     case CoreToolCallStatus.Success:
+    case CoreToolCallStatus.Error:
+    case CoreToolCallStatus.Cancelled:
       return '[done]';
     case CoreToolCallStatus.Executing:
       return '[running…]';
     case CoreToolCallStatus.Scheduled:
-      return '[pending]';
     case CoreToolCallStatus.AwaitingApproval:
       return '[pending]';
-    case CoreToolCallStatus.Error:
-    case CoreToolCallStatus.Cancelled:
-      return '[done]';
     case CoreToolCallStatus.Validating:
     default:
       return '[queued]';
@@ -97,7 +98,7 @@ export const TaskNode: React.FC<TaskNodeProps> = ({
 
   // Spec row: ├─ ✓ read_file       src/auth.ts              [0.3s]
   const namePadded = toolCall.name.padEnd(TOOL_NAME_WIDTH);
-  const suffix = statusSuffix(toolCall.status);
+  const suffix = statusSuffix(toolCall.status, node.durationMs);
 
   // Collapse hint when focused
   const collapseToggle =
@@ -161,6 +162,7 @@ export const TaskNode: React.FC<TaskNodeProps> = ({
                 terminalWidth - (childPrefix.length + 3) /* indent */
               }
               renderOutputAsMarkdown={toolCall.renderOutputAsMarkdown}
+              maxLines={15}
             />
           </Box>
         </Box>

--- a/packages/cli/src/ui/components/TaskTree.tsx
+++ b/packages/cli/src/ui/components/TaskTree.tsx
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box, Text } from 'ink';
+import { theme } from '../semantic-colors.js';
+import { TaskNode } from './TaskNode.js';
+import { useKeypress } from '../hooks/useKeypress.js';
+import { keyMatchers, Command } from '../keyMatchers.js';
+import type { TaskTreeNode } from '../types.js';
+import type { UseTaskTreeResult } from '../hooks/useTaskTree.js';
+
+interface TaskTreeProps
+  extends Omit<UseTaskTreeResult, 'isHoldingAfterCompletion'> {
+  terminalWidth: number;
+  /** Whether the tree should capture key events. */
+  isFocused?: boolean;
+  /**
+   * When true the tool calls have all finished and we are in the post-completion
+   * hold window — show a "done" badge instead of the live navigation hint.
+   */
+  isHoldingAfterCompletion?: boolean;
+}
+
+/**
+ * Renders the hierarchical task tree for all active tool calls.
+ *
+ * Shows each tool call as a tree row with its status icon, name, description,
+ * and — when expanded — its output and child calls.  Keyboard navigation
+ * (arrow keys) and collapse/expand commands are handled here.
+ */
+export const TaskTree: React.FC<TaskTreeProps> = ({
+  nodes,
+  terminalWidth,
+  isFocused = true,
+  isHoldingAfterCompletion = false,
+  toggleCollapse,
+  collapseAll,
+  expandAll,
+  focusNext,
+  focusPrev,
+  focusedId,
+}) => {
+  // Keyboard navigation for the tree.
+  useKeypress(
+    (key) => {
+      if (keyMatchers[Command.NAVIGATION_DOWN](key)) {
+        focusNext();
+        return;
+      }
+      if (keyMatchers[Command.NAVIGATION_UP](key)) {
+        focusPrev();
+        return;
+      }
+      if (keyMatchers[Command.TOGGLE_COLLAPSE](key)) {
+        if (focusedId) toggleCollapse(focusedId);
+        return;
+      }
+      if (keyMatchers[Command.COLLAPSE_ALL](key)) {
+        collapseAll();
+        return;
+      }
+      if (keyMatchers[Command.EXPAND_ALL](key)) {
+        expandAll();
+        return;
+      }
+    },
+    { isActive: isFocused },
+  );
+
+  if (nodes.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      width={terminalWidth}
+      paddingX={1}
+      marginBottom={1}
+    >
+      {/* Header — marginBottom separates the tree from the Composer/Thinking area below */}
+      <Box marginBottom={0}>
+        <Text color={theme.text.secondary} bold>
+          Task Tree
+        </Text>
+        {isHoldingAfterCompletion ? (
+          // tree stays visible until the next tool run.
+          <Text color={theme.status.success}>{'  ✓ completed'}</Text>
+        ) : (
+          <Text color={theme.text.secondary}>
+            {
+              '  ↑↓ navigate  →/← expand/collapse  Ctrl+] expand all  Ctrl+[ collapse all'
+            }
+          </Text>
+        )}
+      </Box>
+
+      {/* Tree rows */}
+      {nodes.map((node, idx) => (
+        <TaskNode
+          key={node.toolCall.callId}
+          node={node}
+          prefix=""
+          isLast={idx === nodes.length - 1}
+          terminalWidth={terminalWidth}
+        />
+      ))}
+    </Box>
+  );
+};
+
+/** Flattens a tree to a plain string for accessibility / screen-reader mode. */
+export function taskTreeToText(nodes: TaskTreeNode[]): string {
+  const lines: string[] = [];
+  function visit(node: TaskTreeNode, indent: number) {
+    const pad = '  '.repeat(indent);
+    lines.push(
+      `${pad}${node.toolCall.name}  ${node.toolCall.description ?? ''}  [${node.toolCall.status}]`,
+    );
+    if (!node.isCollapsed) {
+      node.children.forEach((c) => visit(c, indent + 1));
+    }
+  }
+  nodes.forEach((n) => visit(n, 0));
+  return lines.join('\n');
+}

--- a/packages/cli/src/ui/hooks/useTaskTree.test.ts
+++ b/packages/cli/src/ui/hooks/useTaskTree.test.ts
@@ -1,0 +1,233 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { act } from 'react';
+import { renderHook } from '../../test-utils/render.js';
+import { useTaskTree, flattenVisibleNodes } from './useTaskTree.js';
+import type { IndividualToolCallDisplay } from '../types.js';
+import { CoreToolCallStatus } from '@google/gemini-cli-core';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/** Create a minimal IndividualToolCallDisplay for test fixtures. */
+function makeTool(
+  callId: string,
+  name: string,
+  opts: Partial<IndividualToolCallDisplay> = {},
+): IndividualToolCallDisplay {
+  return {
+    callId,
+    name,
+    description: `args for ${name}`,
+    status: CoreToolCallStatus.Success,
+    resultDisplay: undefined,
+    confirmationDetails: undefined,
+    approvalMode: undefined,
+    isClientInitiated: false,
+    ...opts,
+  };
+}
+
+// ── buildTree / useTaskTree ───────────────────────────────────────────────────
+
+describe('useTaskTree – flat list', () => {
+  it('returns hasHierarchy=true when there are tool calls', () => {
+    const tools = [makeTool('a', 'read_file'), makeTool('b', 'write_file')];
+    const { result } = renderHook(() => useTaskTree(tools));
+
+    expect(result.current.hasHierarchy).toBe(true);
+  });
+
+  it('returns hasHierarchy=false when list is empty', () => {
+    const { result } = renderHook(() => useTaskTree([]));
+    expect(result.current.hasHierarchy).toBe(false);
+  });
+
+  it('builds two root nodes from a flat list', () => {
+    const tools = [makeTool('a', 'read_file'), makeTool('b', 'write_file')];
+    const { result } = renderHook(() => useTaskTree(tools));
+
+    expect(result.current.nodes).toHaveLength(2);
+    expect(result.current.nodes[0].toolCall.callId).toBe('a');
+    expect(result.current.nodes[1].toolCall.callId).toBe('b');
+    expect(result.current.nodes[0].depth).toBe(0);
+  });
+
+  it('all root nodes start expanded (isCollapsed=false)', () => {
+    const tools = [makeTool('a', 'read_file'), makeTool('b', 'write_file')];
+    const { result } = renderHook(() => useTaskTree(tools));
+
+    result.current.nodes.forEach((n) => expect(n.isCollapsed).toBe(false));
+  });
+});
+
+describe('useTaskTree – hierarchy', () => {
+  it('nests a child under its parent via parentCallId', () => {
+    const tools = [
+      makeTool('parent', 'agent'),
+      makeTool('child', 'read_file', { parentCallId: 'parent' }),
+    ];
+    const { result } = renderHook(() => useTaskTree(tools));
+
+    // Only the parent is a root
+    expect(result.current.nodes).toHaveLength(1);
+    const parent = result.current.nodes[0];
+    expect(parent.children).toHaveLength(1);
+    expect(parent.children[0].toolCall.callId).toBe('child');
+    expect(parent.children[0].depth).toBe(1);
+  });
+
+  it('promotes orphan (unknown parentCallId) to root', () => {
+    const tools = [makeTool('orphan', 'read_file', { parentCallId: 'ghost' })];
+    const { result } = renderHook(() => useTaskTree(tools));
+
+    expect(result.current.nodes).toHaveLength(1);
+    expect(result.current.nodes[0].toolCall.callId).toBe('orphan');
+    expect(result.current.nodes[0].depth).toBe(0);
+  });
+
+  it('supports two levels of nesting', () => {
+    const tools = [
+      makeTool('root', 'agent'),
+      makeTool('child', 'sub_agent', { parentCallId: 'root' }),
+      makeTool('grandchild', 'read_file', { parentCallId: 'child' }),
+    ];
+    const { result } = renderHook(() => useTaskTree(tools));
+
+    const root = result.current.nodes[0];
+    expect(root.depth).toBe(0);
+    expect(root.children[0].depth).toBe(1);
+    expect(root.children[0].children[0].depth).toBe(2);
+    expect(root.children[0].children[0].toolCall.callId).toBe('grandchild');
+  });
+});
+
+describe('useTaskTree – collapse/expand', () => {
+  it('toggleCollapse collapses a node', () => {
+    const tools = [makeTool('a', 'read_file')];
+    const { result } = renderHook(() => useTaskTree(tools));
+
+    act(() => {
+      result.current.toggleCollapse('a');
+    });
+
+    expect(result.current.nodes[0].isCollapsed).toBe(true);
+  });
+
+  it('toggleCollapse expands a collapsed node', () => {
+    const tools = [makeTool('a', 'read_file')];
+    const { result } = renderHook(() => useTaskTree(tools));
+
+    act(() => {
+      result.current.toggleCollapse('a');
+    });
+    act(() => {
+      result.current.toggleCollapse('a');
+    });
+
+    expect(result.current.nodes[0].isCollapsed).toBe(false);
+  });
+
+  it('collapseAll marks every node collapsed', () => {
+    const tools = [makeTool('a', 'read_file'), makeTool('b', 'write_file')];
+    const { result } = renderHook(() => useTaskTree(tools));
+
+    act(() => {
+      result.current.collapseAll();
+    });
+
+    result.current.nodes.forEach((n) => expect(n.isCollapsed).toBe(true));
+  });
+
+  it('expandAll clears all collapsed state', () => {
+    const tools = [makeTool('a', 'read_file'), makeTool('b', 'write_file')];
+    const { result } = renderHook(() => useTaskTree(tools));
+
+    act(() => {
+      result.current.collapseAll();
+    });
+    act(() => {
+      result.current.expandAll();
+    });
+
+    result.current.nodes.forEach((n) => expect(n.isCollapsed).toBe(false));
+  });
+});
+
+describe('useTaskTree – keyboard focus', () => {
+  it('focusNext advances focus through visible nodes', () => {
+    const tools = [makeTool('a', 'read_file'), makeTool('b', 'write_file')];
+    const { result } = renderHook(() => useTaskTree(tools));
+
+    act(() => result.current.focusNext());
+    expect(result.current.focusedId).toBe('a');
+
+    act(() => result.current.focusNext());
+    expect(result.current.focusedId).toBe('b');
+  });
+
+  it('focusPrev wraps around to the last node', () => {
+    const tools = [makeTool('a', 'read_file'), makeTool('b', 'write_file')];
+    const { result } = renderHook(() => useTaskTree(tools));
+
+    // Start unfocused → focusPrev → lands on last
+    act(() => result.current.focusPrev());
+    expect(result.current.focusedId).toBe('b');
+  });
+
+  it('focused node has isFocused=true', () => {
+    const tools = [makeTool('a', 'read_file'), makeTool('b', 'write_file')];
+    const { result } = renderHook(() => useTaskTree(tools));
+
+    act(() => result.current.focusNext());
+
+    const focused = result.current.nodes.find((n) => n.isFocused);
+    expect(focused?.toolCall.callId).toBe('a');
+  });
+
+  it('collapsed nodes hide their children from focusNext traversal', () => {
+    const tools = [
+      makeTool('parent', 'agent'),
+      makeTool('child', 'read_file', { parentCallId: 'parent' }),
+      makeTool('sibling', 'write_file'),
+    ];
+    const { result } = renderHook(() => useTaskTree(tools));
+
+    // Collapse the parent — child should be skipped by focusNext
+    act(() => result.current.toggleCollapse('parent'));
+    act(() => result.current.focusNext()); // → parent
+    act(() => result.current.focusNext()); // → sibling (child skipped)
+
+    expect(result.current.focusedId).toBe('sibling');
+  });
+});
+
+describe('flattenVisibleNodes', () => {
+  it('returns all nodes when nothing is collapsed', () => {
+    const tools = [
+      makeTool('root', 'agent'),
+      makeTool('child', 'read_file', { parentCallId: 'root' }),
+    ];
+    const { result } = renderHook(() => useTaskTree(tools));
+    const flat = flattenVisibleNodes(result.current.nodes);
+
+    expect(flat.map((n) => n.toolCall.callId)).toEqual(['root', 'child']);
+  });
+
+  it('excludes children of collapsed nodes', () => {
+    const tools = [
+      makeTool('root', 'agent'),
+      makeTool('child', 'read_file', { parentCallId: 'root' }),
+    ];
+    const { result } = renderHook(() => useTaskTree(tools));
+
+    act(() => result.current.toggleCollapse('root'));
+
+    const flat = flattenVisibleNodes(result.current.nodes);
+    expect(flat.map((n) => n.toolCall.callId)).toEqual(['root']);
+  });
+});

--- a/packages/cli/src/ui/hooks/useTaskTree.ts
+++ b/packages/cli/src/ui/hooks/useTaskTree.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, useCallback, useMemo, useEffect } from 'react';
+import type { IndividualToolCallDisplay, TaskTreeNode } from '../types.js';
+
+/**
+ * Builds a TaskTreeNode hierarchy from a flat list of tool calls.
+ *
+ * Root nodes are calls with no parentCallId.  Every call whose parentCallId
+ * matches an existing callId becomes a child of that node.  Calls whose
+ * parentCallId references an unknown id are promoted to roots so nothing is
+ * silently dropped.
+ */
+function buildTree(
+  toolCalls: IndividualToolCallDisplay[],
+  collapsedIds: Set<string>,
+  focusedId: string | null,
+): TaskTreeNode[] {
+  const childrenMap = new Map<string, IndividualToolCallDisplay[]>();
+  const roots: IndividualToolCallDisplay[] = [];
+  const knownIds = new Set(toolCalls.map((t) => t.callId));
+
+  for (const tool of toolCalls) {
+    if (tool.parentCallId && knownIds.has(tool.parentCallId)) {
+      const siblings = childrenMap.get(tool.parentCallId) ?? [];
+      siblings.push(tool);
+      childrenMap.set(tool.parentCallId, siblings);
+    } else {
+      roots.push(tool);
+    }
+  }
+
+  function buildNode(
+    tool: IndividualToolCallDisplay,
+    depth: number,
+  ): TaskTreeNode {
+    const childCalls = childrenMap.get(tool.callId) ?? [];
+    return {
+      toolCall: tool,
+      children: childCalls.map((c) => buildNode(c, depth + 1)),
+      depth,
+      isCollapsed: collapsedIds.has(tool.callId),
+      isFocused: tool.callId === focusedId,
+    };
+  }
+
+  return roots.map((r) => buildNode(r, 0));
+}
+
+/**
+ * Returns a flat, pre-order traversal of a tree, skipping collapsed subtrees.
+ * Useful for keyboard navigation.
+ */
+export function flattenVisibleNodes(nodes: TaskTreeNode[]): TaskTreeNode[] {
+  const result: TaskTreeNode[] = [];
+  function visit(node: TaskTreeNode) {
+    result.push(node);
+    if (!node.isCollapsed) {
+      node.children.forEach(visit);
+    }
+  }
+  nodes.forEach(visit);
+  return result;
+}
+
+export interface UseTaskTreeResult {
+  /** The hierarchical tree nodes ready to render. */
+  nodes: TaskTreeNode[];
+  /** Whether there is actually a hierarchy to show (any tool has a parentCallId). */
+  hasHierarchy: boolean;
+  /**
+   * True when all tool calls have finished and the tree is showing the last
+   * completed snapshot (stays visible until the next tool run).
+   */
+  isHoldingAfterCompletion: boolean;
+  /** Toggle the collapsed state of a specific node. */
+  toggleCollapse: (callId: string) => void;
+  /** Collapse all nodes. */
+  collapseAll: () => void;
+  /** Expand all nodes. */
+  expandAll: () => void;
+  /** Move keyboard focus to the next visible node. */
+  focusNext: () => void;
+  /** Move keyboard focus to the previous visible node. */
+  focusPrev: () => void;
+  /** The callId that currently has keyboard focus, or null. */
+  focusedId: string | null;
+}
+
+/**
+ * Manages the task tree state derived from a flat list of tool calls.
+ *
+ * @param toolCalls - All tool calls from all active tool_group history items.
+ */
+export function useTaskTree(
+  toolCalls: IndividualToolCallDisplay[],
+): UseTaskTreeResult {
+  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
+  const [focusedId, setFocusedId] = useState<string | null>(null);
+
+  // When tool calls complete, keep the last snapshot visible until the next
+  // tool run so the user can always see the full completed tree.
+  const [heldNodes, setHeldNodes] = useState<TaskTreeNode[]>([]);
+  const [isHeld, setIsHeld] = useState(false);
+
+  const liveNodes = useMemo(
+    () => buildTree(toolCalls, collapsedIds, focusedId),
+    [toolCalls, collapsedIds, focusedId],
+  );
+
+  // Persist completed tree: while there are live calls, keep updating the
+  // snapshot; when they drain to empty, show that snapshot until next run.
+  useEffect(() => {
+    if (toolCalls.length > 0) {
+      setHeldNodes(liveNodes);
+      setIsHeld(false);
+    } else if (heldNodes.length > 0) {
+      setIsHeld(true);
+    }
+  }, [toolCalls.length, liveNodes, heldNodes.length]);
+
+  // Expose live nodes during execution; held (frozen) nodes after completion.
+  const nodes = useMemo(
+    () => (toolCalls.length > 0 ? liveNodes : isHeld ? heldNodes : []),
+    [toolCalls.length, liveNodes, isHeld, heldNodes],
+  );
+
+  // Show the tree whenever there are active calls or a completed snapshot.
+  const hasHierarchy = toolCalls.length > 0 || isHeld;
+
+  const toggleCollapse = useCallback((callId: string) => {
+    setCollapsedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(callId)) {
+        next.delete(callId);
+      } else {
+        next.add(callId);
+      }
+      return next;
+    });
+  }, []);
+
+  const collapseAll = useCallback(() => {
+    // Flatten the currently visible nodes (live or held) to collect all callIds.
+    const allCallIds = flattenVisibleNodes(nodes).map((n) => n.toolCall.callId);
+    setCollapsedIds(new Set(allCallIds));
+  }, [nodes]);
+
+  const expandAll = useCallback(() => {
+    setCollapsedIds(new Set());
+  }, []);
+
+  const focusNext = useCallback(() => {
+    const visible = flattenVisibleNodes(nodes);
+    if (visible.length === 0) return;
+    const idx = visible.findIndex((n) => n.toolCall.callId === focusedId);
+    const next = visible[(idx + 1) % visible.length];
+    setFocusedId(next.toolCall.callId);
+  }, [nodes, focusedId]);
+
+  const focusPrev = useCallback(() => {
+    const visible = flattenVisibleNodes(nodes);
+    if (visible.length === 0) return;
+    const idx = visible.findIndex((n) => n.toolCall.callId === focusedId);
+    // When nothing is focused (idx === -1), jump to the last visible node.
+    const prevIdx =
+      idx === -1
+        ? visible.length - 1
+        : (idx - 1 + visible.length) % visible.length;
+    setFocusedId(visible[prevIdx].toolCall.callId);
+  }, [nodes, focusedId]);
+
+  return {
+    nodes,
+    hasHierarchy,
+    isHoldingAfterCompletion: isHeld,
+    toggleCollapse,
+    collapseAll,
+    expandAll,
+    focusNext,
+    focusPrev,
+    focusedId,
+  };
+}

--- a/packages/cli/src/ui/hooks/useTaskTree.ts
+++ b/packages/cli/src/ui/hooks/useTaskTree.ts
@@ -4,8 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useCallback, useMemo, useEffect } from 'react';
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import { CoreToolCallStatus } from '@google/gemini-cli-core';
 import type { IndividualToolCallDisplay, TaskTreeNode } from '../types.js';
+
+type CallTiming = { start: number; end?: number };
 
 /**
  * Builds a TaskTreeNode hierarchy from a flat list of tool calls.
@@ -19,6 +22,7 @@ function buildTree(
   toolCalls: IndividualToolCallDisplay[],
   collapsedIds: Set<string>,
   focusedId: string | null,
+  callTimes: Map<string, CallTiming>,
 ): TaskTreeNode[] {
   const childrenMap = new Map<string, IndividualToolCallDisplay[]>();
   const roots: IndividualToolCallDisplay[] = [];
@@ -39,12 +43,18 @@ function buildTree(
     depth: number,
   ): TaskTreeNode {
     const childCalls = childrenMap.get(tool.callId) ?? [];
+    const timing = callTimes.get(tool.callId);
+    const durationMs =
+      timing?.start !== undefined && timing?.end !== undefined
+        ? timing.end - timing.start
+        : undefined;
     return {
       toolCall: tool,
       children: childCalls.map((c) => buildNode(c, depth + 1)),
       depth,
       isCollapsed: collapsedIds.has(tool.callId),
       isFocused: tool.callId === focusedId,
+      durationMs,
     };
   }
 
@@ -102,14 +112,45 @@ export function useTaskTree(
   const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
   const [focusedId, setFocusedId] = useState<string | null>(null);
 
+  // Track wall-clock start/end times per callId.  Stored in a ref so mutations
+  // don't themselves cause re-renders; timingVersion state bumps to trigger the
+  // liveNodes memo when new timing data is recorded.
+  const callTimesRef = useRef<Map<string, CallTiming>>(new Map());
+  const [timingVersion, setTimingVersion] = useState(0);
+
+  useEffect(() => {
+    let changed = false;
+    for (const tc of toolCalls) {
+      const existing = callTimesRef.current.get(tc.callId);
+      if (tc.status === CoreToolCallStatus.Executing && !existing) {
+        callTimesRef.current.set(tc.callId, { start: Date.now() });
+        changed = true;
+      }
+      const isTerminal =
+        tc.status === CoreToolCallStatus.Success ||
+        tc.status === CoreToolCallStatus.Error ||
+        tc.status === CoreToolCallStatus.Cancelled;
+      if (
+        isTerminal &&
+        existing?.start !== undefined &&
+        existing.end === undefined
+      ) {
+        callTimesRef.current.set(tc.callId, { ...existing, end: Date.now() });
+        changed = true;
+      }
+    }
+    if (changed) setTimingVersion((v) => v + 1);
+  }, [toolCalls]);
+
   // When tool calls complete, keep the last snapshot visible until the next
   // tool run so the user can always see the full completed tree.
   const [heldNodes, setHeldNodes] = useState<TaskTreeNode[]>([]);
   const [isHeld, setIsHeld] = useState(false);
 
   const liveNodes = useMemo(
-    () => buildTree(toolCalls, collapsedIds, focusedId),
-    [toolCalls, collapsedIds, focusedId],
+    () => buildTree(toolCalls, collapsedIds, focusedId, callTimesRef.current),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [toolCalls, collapsedIds, focusedId, timingVersion],
   );
 
   // Persist completed tree: while there are live calls, keep updating the

--- a/packages/cli/src/ui/hooks/useTaskTree.ts
+++ b/packages/cli/src/ui/hooks/useTaskTree.ts
@@ -145,8 +145,12 @@ export function useTaskTree(
   }, []);
 
   const collapseAll = useCallback(() => {
-    // Flatten the currently visible nodes (live or held) to collect all callIds.
-    const allCallIds = flattenVisibleNodes(nodes).map((n) => n.toolCall.callId);
+    const allCallIds: string[] = [];
+    function visit(node: TaskTreeNode) {
+      allCallIds.push(node.toolCall.callId);
+      node.children.forEach(visit);
+    }
+    nodes.forEach(visit);
     setCollapsedIds(new Set(allCallIds));
   }, [nodes]);
 

--- a/packages/cli/src/ui/hooks/useTaskTree.ts
+++ b/packages/cli/src/ui/hooks/useTaskTree.ts
@@ -117,8 +117,15 @@ export function useTaskTree(
   // liveNodes memo when new timing data is recorded.
   const callTimesRef = useRef<Map<string, CallTiming>>(new Map());
   const [timingVersion, setTimingVersion] = useState(0);
+  const wasPreviouslyEmpty = useRef(true);
 
   useEffect(() => {
+    //if starting new turn (tool calls appeared after being empty), clear old timing
+    if (toolCalls.length > 0 && wasPreviouslyEmpty.current) {
+      callTimesRef.current.clear();
+    }
+    wasPreviouslyEmpty.current = toolCalls.length === 0;
+
     let changed = false;
     for (const tc of toolCalls) {
       const existing = callTimesRef.current.get(tc.callId);

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -507,3 +507,21 @@ export interface ActiveHook {
   index?: number;
   total?: number;
 }
+
+/**
+ * A single node in the interactive task tree visualization.
+ * Built by useTaskTree from the flat IndividualToolCallDisplay list using
+ * parentCallId relationships.
+ */
+export interface TaskTreeNode {
+  /** The underlying tool call data. */
+  toolCall: IndividualToolCallDisplay;
+  /** Nested child calls (e.g. tools invoked by a subagent). */
+  children: TaskTreeNode[];
+  /** Nesting depth, 0 = top-level. */
+  depth: number;
+  /** When true, this node's output and children are collapsed. */
+  isCollapsed: boolean;
+  /** When true, this node has keyboard focus for expand/collapse. */
+  isFocused: boolean;
+}

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -524,4 +524,6 @@ export interface TaskTreeNode {
   isCollapsed: boolean;
   /** When true, this node has keyboard focus for expand/collapse. */
   isFocused: boolean;
+  /** Wall-clock duration in ms from Executing → terminal state. Undefined while pending/queued. */
+  durationMs?: number;
 }


### PR DESCRIPTION
## Summary

Creates task tree visualization for tool/sub-agent calls

Closes Phase 2 of #21484

<img width="1257" height="768" alt="image" src="https://github.com/user-attachments/assets/5bfeb522-9ae0-4e82-b4ce-e373f0eb973b" />


- Add TaskTreeNode interface to ui/types.ts (wraps IndividualToolCallDisplay with children[], depth, isCollapsed, isFocused)
- Implement useTaskTree hook: builds parent-child hierarchy from IndividualToolCallDisplay[] via parentCallId; promotes orphan children to roots; manages collapse/expand state (Set<string>) and keyboard focus; holds last completed snapshot visible briefly after tool calls drain
- Accumulate tool calls across entire agent turn: allCurrentTurnToolCalls reads from both uiState.history (completed batches) and uiState.pendingHistoryItems (live batch) so the tree persists across multi-round-trip tool sequences
- Add TaskNode component: branch connectors (├─ / └─ / │), status glyphs (✓ ● ✗ ) + spinner, padded tool name, inline ToolResultDisplay, recursive children
- capped tree branch lines to 15 and shows a +N more lines indicator for long outputs.
- Add TaskTree component: wires TOGGLE_COLLAPSE, COLLAPSE_ALL, EXPAND_ALL keyboard commands; shows completion badge during hold window
- Wire TaskTree into MainContent; suppress all current-turn tool_group history items when tree is active (index > lastUserPromptIndex)
- Add TOGGLE_COLLAPSE / COLLAPSE_ALL / EXPAND_ALL keybindings (→/←, Ctrl+[, Ctrl+])
- Add useTaskTree unit tests (17 tests)
- WIP: display logic and hold-timer still being refined

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
Prevously, in MainContent.tsx:43-51 — allPendingToolCalls is built only from pendingHistoryItems. When a batch of tool calls completes, those items are committed to uiState.history and removed from pendingHistoryItems. The tree then only sees the new (empty) pending batch → resets.
- **New Design**: pull tool_group items from uiState.history that belong to the current turn (everything after
  lastUserPromptIndex), and combine them with the pending batch of tool calls. Suppressed all current-turn
  history tool_group items (not just the last one), since the tree now renders them.


  ## Pre-Merge Checklist

  ### Build & Quality
  - [ ] `npm run build` passes
  - [ ] `npm run lint` passes
  - [ ] `npm run typecheck` passes
  - [ ] `npm test` passes (useTaskTree — 17 tests)

  ### Visual / Manual
  - [ ] Tree renders for a single tool call
  - [ ] Tree renders for multiple parallel tool calls (flat list with ├─ / └─)
  - [ ] Tree persists across multi-round-trip sequences (model calls tools → gets results → calls more tools → tree accumulates, doesn't
  restart)
  - [ ] Tree with nested parent/child calls (subagent with parentCallId)
  - [ ] No duplicate flat ToolGroupMessage boxes visible while tree is active
  - [ ] Running calls show spinner, completed show ✓, errors show ✗, cancelled show ⊘ with strikethrough
  - [ ] Inline output renders correctly when node is expanded
  - [ ] 3s hold window shows "✓ completed" badge, then tree clears

  ### Keyboard Navigation
  - [ ] ↑/↓ moves focus between nodes
  - [ ] →/← toggles collapse on the focused node
  - [ ] Ctrl+[ collapses all nodes
  - [ ] Ctrl+] expands all nodes

  ### Platform
  - [ ] macOS (`npm run start -w packages/cli`)
  - [ ] Linux