### PR TITLE
fix(core): skip missing includeDirectories during init

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -346,6 +346,42 @@ describe('Server Config (config.ts)', () => {
       expect(storageSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('should skip missing includeDirectories without failing initialization', async () => {
+      const existingDir = '/existing-shared-rules';
+      const missingDir = '/missing-shared-rules';
+      const existsSyncMock = vi.mocked(fs.existsSync);
+      const warnSpy = vi.spyOn(debugLogger, 'warn').mockImplementation(() => {
+        // expected warning path for skipped directory
+      });
+
+      existsSyncMock.mockImplementation(
+        (checkedPath) => checkedPath.toString() !== missingDir,
+      );
+
+      try {
+        const config = new Config({
+          ...baseParams,
+          checkpointing: false,
+          includeDirectories: [existingDir, missingDir],
+        });
+
+        await expect(config.initialize()).resolves.toBeUndefined();
+
+        const directories = config.getWorkspaceContext().getDirectories();
+        expect(directories).toContain(path.resolve(baseParams.targetDir));
+        expect(directories).toContain(existingDir);
+        expect(directories).not.toContain(missingDir);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            `[WARN] Skipping unreadable directory: ${missingDir}`,
+          ),
+        );
+      } finally {
+        existsSyncMock.mockReturnValue(true);
+        warnSpy.mockRestore();
+      }
+    });
+
     it('should await MCP initialization in non-interactive mode', async () => {
       const config = new Config({
         ...baseParams,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1110,10 +1110,9 @@ export class Config implements McpContext {
   private async _initialize(): Promise<void> {
     await this.storage.initialize();
 
-    // Add pending directories to workspace context
-    for (const dir of this.pendingIncludeDirectories) {
-      this.workspaceContext.addDirectory(dir);
-    }
+    // Add pending include directories to workspace context.
+    // Missing/unreadable paths are skipped by WorkspaceContext with warnings.
+    this.workspaceContext.addDirectories(this.pendingIncludeDirectories);
 
     // Add plans directory to workspace context for plan file storage
     if (this.planEnabled) {


### PR DESCRIPTION
## Summary
Fix startup failure when includeDirectories contains a missing path.

## Details
Config initialization now uses WorkspaceContext.addDirectories for pending includeDirectories. Missing or unreadable directories are skipped with warnings instead of aborting initialization. Added a regression test that verifies initialization succeeds when includeDirectories contains both existing and missing paths.

## Related Issues
Fixes #18368

## How to Validate
1. Run `npm test --workspace @google/gemini-cli-core -- src/config/config.test.ts -t "should skip missing includeDirectories without failing initialization"`
2. Run `npm run lint --workspace @google/gemini-cli-core`
3. Run `npm run build --workspace @google/gemini-cli-core`
4. Confirm all commands pass.

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added or updated tests
- [ ] Noted breaking changes (if any)
- [x] Validated on Linux with npm run/test/lint/build
