### PR TITLE
fix(cli): detect workspace policy roots in Mercurial repositories

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -53,6 +53,7 @@ import { RESUME_LATEST } from '../utils/sessionUtils.js';
 import { isWorkspaceTrusted } from './trustedFolders.js';
 import {
   createPolicyEngineConfig,
+  findWorkspaceRoot,
   resolveWorkspacePolicyState,
 } from './policy.js';
 import { ExtensionManager } from './extension-manager.js';
@@ -635,10 +636,15 @@ export async function loadCliConfig(
     policyPaths: argv.policy,
   };
 
+  const workspaceRoot = findWorkspaceRoot(cwd);
+  const workspaceRootTrusted =
+    isWorkspaceTrusted(settings, workspaceRoot).isTrusted ?? false;
+
   const { workspacePoliciesDir, policyUpdateConfirmationRequest } =
     await resolveWorkspacePolicyState({
       cwd,
       trustedFolder,
+      workspaceRootTrusted,
       interactive,
     });
 

--- a/packages/cli/src/config/policy.test.ts
+++ b/packages/cli/src/config/policy.test.ts
@@ -238,6 +238,55 @@ describe('resolveWorkspacePolicyState', () => {
     expect(result.policyUpdateConfirmationRequest).toBeUndefined();
   });
 
+  it('should not load workspace policies when the workspace root is not trusted', async () => {
+    const repoRoot = path.join(tempDir, 'hg-repo');
+    const nestedDir = path.join(repoRoot, 'src', 'nested');
+    const repoPoliciesDir = path.join(repoRoot, '.gemini', 'policies');
+
+    fs.mkdirSync(path.join(repoRoot, '.hg'), { recursive: true });
+    fs.mkdirSync(nestedDir, { recursive: true });
+    fs.mkdirSync(repoPoliciesDir, { recursive: true });
+    fs.writeFileSync(path.join(repoPoliciesDir, 'policy.toml'), 'rules = []');
+
+    const result = await resolveWorkspacePolicyState({
+      cwd: nestedDir,
+      trustedFolder: true,
+      workspaceRootTrusted: false,
+      interactive: true,
+    });
+
+    expect(result).toEqual({
+      workspacePoliciesDir: undefined,
+      policyUpdateConfirmationRequest: undefined,
+    });
+  });
+
+  it('should resolve symlinked directories before finding the workspace root', async () => {
+    const repoRoot = path.join(tempDir, 'hg-repo');
+    const nestedDir = path.join(repoRoot, 'src', 'nested');
+    const symlinkDir = path.join(tempDir, 'linked-nested');
+    const repoPoliciesDir = path.join(repoRoot, '.gemini', 'policies');
+
+    fs.mkdirSync(path.join(repoRoot, '.hg'), { recursive: true });
+    fs.mkdirSync(nestedDir, { recursive: true });
+    fs.mkdirSync(repoPoliciesDir, { recursive: true });
+    fs.writeFileSync(path.join(repoPoliciesDir, 'policy.toml'), 'rules = []');
+    fs.symlinkSync(nestedDir, symlinkDir, 'dir');
+
+    try {
+      const result = await resolveWorkspacePolicyState({
+        cwd: symlinkDir,
+        trustedFolder: true,
+        interactive: true,
+      });
+
+      expect(result.workspacePoliciesDir).toBe(repoPoliciesDir);
+      expect(result.policyUpdateConfirmationRequest).toBeUndefined();
+    } finally {
+      fs.rmSync(symlinkDir, { force: true });
+    }
+  });
+
   it('should return empty state if cwd is a symlink to the home directory', async () => {
     const policiesDir = path.join(tempDir, '.gemini', 'policies');
     fs.mkdirSync(policiesDir, { recursive: true });

--- a/packages/cli/src/config/policy.test.ts
+++ b/packages/cli/src/config/policy.test.ts
@@ -218,6 +218,26 @@ describe('resolveWorkspacePolicyState', () => {
     });
   });
 
+  it('should load workspace policies from the repository root in Mercurial repositories', async () => {
+    const repoRoot = path.join(tempDir, 'hg-repo');
+    const nestedDir = path.join(repoRoot, 'src', 'nested');
+    const repoPoliciesDir = path.join(repoRoot, '.gemini', 'policies');
+
+    fs.mkdirSync(path.join(repoRoot, '.hg'), { recursive: true });
+    fs.mkdirSync(nestedDir, { recursive: true });
+    fs.mkdirSync(repoPoliciesDir, { recursive: true });
+    fs.writeFileSync(path.join(repoPoliciesDir, 'policy.toml'), 'rules = []');
+
+    const result = await resolveWorkspacePolicyState({
+      cwd: nestedDir,
+      trustedFolder: true,
+      interactive: true,
+    });
+
+    expect(result.workspacePoliciesDir).toBe(repoPoliciesDir);
+    expect(result.policyUpdateConfirmationRequest).toBeUndefined();
+  });
+
   it('should return empty state if cwd is a symlink to the home directory', async () => {
     const policiesDir = path.join(tempDir, '.gemini', 'policies');
     fs.mkdirSync(policiesDir, { recursive: true });

--- a/packages/cli/src/config/policy.ts
+++ b/packages/cli/src/config/policy.ts
@@ -19,6 +19,8 @@ import {
   writeToStderr,
   debugLogger,
 } from '@google/gemini-cli-core';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { type Settings } from './settings.js';
 
 /**
@@ -80,6 +82,27 @@ export interface WorkspacePolicyState {
   policyUpdateConfirmationRequest?: PolicyUpdateConfirmationRequest;
 }
 
+const WORKSPACE_ROOT_MARKERS = ['.git', '.hg', '.svn'];
+
+function findWorkspaceRoot(startDir: string): string {
+  let currentDir = path.resolve(startDir);
+
+  while (true) {
+    for (const marker of WORKSPACE_ROOT_MARKERS) {
+      if (fs.existsSync(path.join(currentDir, marker))) {
+        return currentDir;
+      }
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      return path.resolve(startDir);
+    }
+
+    currentDir = parentDir;
+  }
+}
+
 /**
  * Resolves the workspace policy state by checking folder trust and policy integrity.
  */
@@ -89,6 +112,7 @@ export async function resolveWorkspacePolicyState(options: {
   interactive: boolean;
 }): Promise<WorkspacePolicyState> {
   const { cwd, trustedFolder, interactive } = options;
+  const workspaceRoot = findWorkspaceRoot(cwd);
 
   let workspacePoliciesDir: string | undefined;
   let policyUpdateConfirmationRequest:
@@ -96,7 +120,7 @@ export async function resolveWorkspacePolicyState(options: {
     | undefined;
 
   if (trustedFolder && !disableWorkspacePolicies) {
-    const storage = new Storage(cwd);
+    const storage = new Storage(workspaceRoot);
 
     // If we are in the home directory (or rather, our target Gemini dir is the global one),
     // don't treat it as a workspace to avoid loading global policies twice.
@@ -108,7 +132,7 @@ export async function resolveWorkspacePolicyState(options: {
     const integrityManager = new PolicyIntegrityManager();
     const integrityResult = await integrityManager.checkIntegrity(
       'workspace',
-      cwd,
+      workspaceRoot,
       potentialWorkspacePoliciesDir,
     );
 
@@ -124,7 +148,7 @@ export async function resolveWorkspacePolicyState(options: {
       // Policies changed or are new, and we are in interactive mode and auto-accept is disabled
       policyUpdateConfirmationRequest = {
         scope: 'workspace',
-        identifier: cwd,
+        identifier: workspaceRoot,
         policyDir: potentialWorkspacePoliciesDir,
         newHash: integrityResult.hash,
       };
@@ -132,7 +156,7 @@ export async function resolveWorkspacePolicyState(options: {
       // Non-interactive mode or auto-accept is enabled: automatically accept/load
       await integrityManager.acceptIntegrity(
         'workspace',
-        cwd,
+        workspaceRoot,
         integrityResult.hash,
       );
       workspacePoliciesDir = potentialWorkspacePoliciesDir;

--- a/packages/cli/src/config/policy.ts
+++ b/packages/cli/src/config/policy.ts
@@ -23,6 +23,8 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { type Settings } from './settings.js';
 
+export const WORKSPACE_ROOT_MARKERS = ['.git', '.hg', '.svn'];
+
 /**
  * Temporary flag to automatically accept workspace policies to reduce friction.
  * Exported as 'let' to allow monkey patching in tests via the setter.
@@ -82,10 +84,16 @@ export interface WorkspacePolicyState {
   policyUpdateConfirmationRequest?: PolicyUpdateConfirmationRequest;
 }
 
-const WORKSPACE_ROOT_MARKERS = ['.git', '.hg', '.svn'];
+export function findWorkspaceRoot(startDir: string): string {
+  let resolvedStartDir = path.resolve(startDir);
 
-function findWorkspaceRoot(startDir: string): string {
-  let currentDir = path.resolve(startDir);
+  try {
+    resolvedStartDir = fs.realpathSync(resolvedStartDir);
+  } catch {
+    // Fall back to the resolved path when the real path cannot be determined.
+  }
+
+  let currentDir = resolvedStartDir;
 
   while (true) {
     for (const marker of WORKSPACE_ROOT_MARKERS) {
@@ -96,7 +104,7 @@ function findWorkspaceRoot(startDir: string): string {
 
     const parentDir = path.dirname(currentDir);
     if (parentDir === currentDir) {
-      return path.resolve(startDir);
+      return resolvedStartDir;
     }
 
     currentDir = parentDir;
@@ -109,17 +117,20 @@ function findWorkspaceRoot(startDir: string): string {
 export async function resolveWorkspacePolicyState(options: {
   cwd: string;
   trustedFolder: boolean;
+  workspaceRootTrusted?: boolean;
   interactive: boolean;
 }): Promise<WorkspacePolicyState> {
-  const { cwd, trustedFolder, interactive } = options;
+  const { cwd, trustedFolder, workspaceRootTrusted, interactive } = options;
   const workspaceRoot = findWorkspaceRoot(cwd);
+  const shouldLoadWorkspacePolicies =
+    trustedFolder && (workspaceRootTrusted ?? trustedFolder);
 
   let workspacePoliciesDir: string | undefined;
   let policyUpdateConfirmationRequest:
     | PolicyUpdateConfirmationRequest
     | undefined;
 
-  if (trustedFolder && !disableWorkspacePolicies) {
+  if (shouldLoadWorkspacePolicies && !disableWorkspacePolicies) {
     const storage = new Storage(workspaceRoot);
 
     // If we are in the home directory (or rather, our target Gemini dir is the global one),

--- a/packages/cli/src/config/workspace-policy-cli.test.ts
+++ b/packages/cli/src/config/workspace-policy-cli.test.ts
@@ -63,6 +63,10 @@ describe('Workspace-Level Policy CLI Integration', () => {
       fileCount: 1,
     });
     vi.mocked(ServerConfig.isHeadlessMode).mockReturnValue(false);
+    vi.mocked(isWorkspaceTrusted).mockReturnValue({
+      isTrusted: true,
+      source: 'file',
+    });
   });
 
   it('should have getWorkspacePoliciesDir on Storage class', () => {
@@ -97,6 +101,25 @@ describe('Workspace-Level Policy CLI Integration', () => {
       isTrusted: false,
       source: 'file',
     });
+
+    const settings = createTestMergedSettings();
+    const argv = { query: 'test' } as unknown as CliArgs;
+
+    await loadCliConfig(settings, 'test-session', argv, { cwd: MOCK_CWD });
+
+    expect(ServerConfig.createPolicyEngineConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspacePoliciesDir: undefined,
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('should NOT load workspace policies when the workspace root is not trusted', async () => {
+    vi.mocked(isWorkspaceTrusted).mockImplementation((_, workspaceDir) => ({
+      isTrusted: workspaceDir === MOCK_WORKSPACE_ROOT ? false : true,
+      source: 'file',
+    }));
 
     const settings = createTestMergedSettings();
     const argv = { query: 'test' } as unknown as CliArgs;

--- a/packages/cli/src/config/workspace-policy-cli.test.ts
+++ b/packages/cli/src/config/workspace-policy-cli.test.ts
@@ -51,6 +51,7 @@ vi.mock('@google/gemini-cli-core', async () => {
 
 describe('Workspace-Level Policy CLI Integration', () => {
   const MOCK_CWD = process.cwd();
+  const MOCK_WORKSPACE_ROOT = path.resolve(MOCK_CWD, '..', '..');
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -153,7 +154,7 @@ describe('Workspace-Level Policy CLI Integration', () => {
 
     expect(mockAcceptIntegrity).toHaveBeenCalledWith(
       'workspace',
-      MOCK_CWD,
+      MOCK_WORKSPACE_ROOT,
       'new-hash',
     );
     expect(ServerConfig.createPolicyEngineConfig).toHaveBeenCalledWith(
@@ -191,7 +192,7 @@ describe('Workspace-Level Policy CLI Integration', () => {
     expect(config.getPolicyUpdateConfirmationRequest()).toBeUndefined();
     expect(mockAcceptIntegrity).toHaveBeenCalledWith(
       'workspace',
-      MOCK_CWD,
+      MOCK_WORKSPACE_ROOT,
       'new-hash',
     );
     expect(ServerConfig.createPolicyEngineConfig).toHaveBeenCalledWith(
@@ -226,7 +227,7 @@ describe('Workspace-Level Policy CLI Integration', () => {
     expect(config.getPolicyUpdateConfirmationRequest()).toBeUndefined();
     expect(mockAcceptIntegrity).toHaveBeenCalledWith(
       'workspace',
-      MOCK_CWD,
+      MOCK_WORKSPACE_ROOT,
       'new-hash',
     );
 
@@ -269,7 +270,7 @@ describe('Workspace-Level Policy CLI Integration', () => {
 
       expect(config.getPolicyUpdateConfirmationRequest()).toEqual({
         scope: 'workspace',
-        identifier: MOCK_CWD,
+        identifier: MOCK_WORKSPACE_ROOT,
         policyDir: expect.stringContaining(path.join('.gemini', 'policies')),
         newHash: 'new-hash',
       });


### PR DESCRIPTION
This fixes workspace policy discovery when Gemini CLI is launched inside a nested directory of a Mercurial repository.

What was happening
- Workspace policies were anchored to `cwd`.
- In practice, that meant `.gemini/policies` was only discovered when it existed under the current working directory.
- Repositories without a `.git` root marker (for example `.hg`) could silently miss workspace policies even when other project-level config was being picked up.

What changed
- Added workspace root detection for `.git`, `.hg`, and `.svn`.
- Resolved workspace policy storage/integrity using the detected workspace root instead of the raw `cwd`.
- Added a regression test covering nested execution inside a Mercurial repository.
- Updated CLI integration tests to assert integrity bookkeeping against the resolved workspace root.

Validation
- `npm test --workspace @google/gemini-cli -- src/config/policy.test.ts`
- `npm test --workspace @google/gemini-cli -- src/config/workspace-policy-cli.test.ts`
