### PR TITLE
fix(sandbox): clean up leftover proxy container before starting new session

### DIFF
--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -669,6 +669,18 @@ export async function start_sandbox(
     let sandboxProcess: ChildProcess | undefined = undefined;
 
     if (proxyCommand) {
+      // Clean up any leftover proxy container from a previously crashed session.
+      // The stopProxy exit handler normally removes the container, but if the
+      // previous process was killed with SIGKILL or crashed hard (OOM, host
+      // reboot), the handler never fires and the container remains with the
+      // same fixed name, causing "name already in use" errors on next start.
+      try {
+        execSync(`${config.command} rm -f ${SANDBOX_PROXY_NAME}`, {
+          stdio: 'ignore',
+        });
+      } catch {
+        // Container does not exist — expected on clean starts.
+      }
       // run proxyCommand in its own container
       // build args array to prevent command injection
       const proxyContainerArgs = [


### PR DESCRIPTION
Fixes #21619
## Problem

The proxy container uses a fixed name (`gemini-cli-sandbox-proxy`). If the previous session was killed with SIGKILL, the exit handlers never fire and the container remains. The next `gemini -s` fails with either "name already in use" or a silent 30s health check timeout.

## Fix

Add `docker rm -f gemini-cli-sandbox-proxy` (with `stdio: 'ignore'`) before starting the proxy container. This is a no-op on clean starts and removes stale containers from crashed sessions.

## How to test

1. Start `gemini -s` with `GEMINI_SANDBOX_PROXY_COMMAND` set
2. Kill the process with `kill -9`
3. Verify the proxy container is still running: `docker ps -a | grep sandbox-proxy`
4. Start `gemini -s` again — with this fix, it starts cleanly instead of failing