### PR TITLE
fix(core): destroy PTY on kill() and exception to prevent fd leak

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -899,6 +899,48 @@ describe('ShellExecutionService', () => {
       expect(storedDestroySpy).toHaveBeenCalled();
       expect(ShellExecutionService['activePtys'].has(pid)).toBe(false);
     });
+
+    it('should destroy the PTY when an exception occurs after spawn in executeWithPty', async () => {
+      // Simulate: spawn succeeds, Promise executor runs fine (pid accesses 1-2),
+      // but the return statement `{ pid: ptyProcess.pid }` (access 3) throws.
+      // The catch block should call spawnedPty.destroy() to release the fd.
+      const destroySpy = vi.fn();
+      let pidAccessCount = 0;
+      const faultyPty = {
+        onData: vi.fn(),
+        onExit: vi.fn(),
+        write: vi.fn(),
+        kill: vi.fn(),
+        resize: vi.fn(),
+        destroy: destroySpy,
+        get pid() {
+          pidAccessCount++;
+          // Accesses 1-2 are inside the Promise executor (setup).
+          // Access 3 is at `return { pid: ptyProcess.pid, result }`,
+          // outside the Promise — caught by the outer try/catch.
+          if (pidAccessCount > 2) {
+            throw new Error('Simulated post-spawn failure on pid access');
+          }
+          return 77777;
+        },
+      };
+      mockPtySpawn.mockReturnValueOnce(faultyPty);
+
+      const handle = await ShellExecutionService.execute(
+        'will-fail-after-spawn',
+        '/test/dir',
+        onOutputEventMock,
+        new AbortController().signal,
+        true,
+        shellExecutionConfig,
+      );
+
+      const result = await handle.result;
+      expect(result.exitCode).toBe(1);
+      expect(result.error).toBeTruthy();
+      // The catch block must call destroy() on spawnedPty to prevent fd leak
+      expect(destroySpy).toHaveBeenCalled();
+    });
   });
 });
 

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -870,6 +870,35 @@ describe('ShellExecutionService', () => {
 
       expect(ShellExecutionService['activePtys'].size).toBe(0);
     });
+
+    it('should destroy the PTY when kill() is called', async () => {
+      // Execute a command to populate activePtys
+      const abortController = new AbortController();
+      await ShellExecutionService.execute(
+        'long-running',
+        '/test/dir',
+        onOutputEventMock,
+        abortController.signal,
+        true,
+        shellExecutionConfig,
+      );
+      await new Promise((resolve) => process.nextTick(resolve));
+
+      const pid = mockPtyProcess.pid;
+      const activePty = ShellExecutionService['activePtys'].get(pid);
+      expect(activePty).toBeTruthy();
+
+      // Spy on the actual stored object's destroy
+      const storedDestroySpy = vi.spyOn(
+        activePty!.ptyProcess as never as { destroy: () => void },
+        'destroy',
+      );
+
+      ShellExecutionService.kill(pid);
+
+      expect(storedDestroySpy).toHaveBeenCalled();
+      expect(ShellExecutionService['activePtys'].has(pid)).toBe(false);
+    });
   });
 });
 

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -552,6 +552,11 @@ export class ShellExecutionService {
       // This should not happen, but as a safeguard...
       throw new Error('PTY implementation not found');
     }
+    // Declared outside try so catch can destroy it if spawn succeeded
+    // but a later setup step threw.
+     
+    let spawnedPty: IPty | undefined;
+
     try {
       const cols = shellExecutionConfig.terminalWidth ?? 80;
       const rows = shellExecutionConfig.terminalHeight ?? 30;
@@ -585,6 +590,8 @@ export class ShellExecutionService {
         },
         handleFlowControl: true,
       });
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      spawnedPty = ptyProcess;
 
       const result = new Promise<ShellExecutionResult>((resolve) => {
         this.activeResolvers.set(ptyProcess.pid, resolve);
@@ -882,6 +889,19 @@ export class ShellExecutionService {
     } catch (e) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       const error = e as Error;
+
+      // FIX: If the PTY was spawned before the exception, destroy it to
+      // release the /dev/ptmx file descriptor and avoid exhausting
+      // macOS kern.tty.ptmx_max (511).
+      if (spawnedPty) {
+        try {
+           
+          (spawnedPty as IPty & { destroy?: () => void }).destroy?.();
+        } catch {
+          // Ignore errors during cleanup
+        }
+      }
+
       if (error.message.includes('posix_spawnp failed')) {
         onOutputEvent({
           type: 'data',
@@ -1008,6 +1028,15 @@ export class ShellExecutionService {
       this.activeChildProcesses.delete(pid);
     } else if (activePty) {
       killProcessGroup({ pid, pty: activePty.ptyProcess }).catch(() => {});
+      // FIX: Destroy the PTY to release the /dev/ptmx file descriptor.
+      // Without this, killed PTYs leak FDs and eventually exhaust
+      // the macOS kern.tty.ptmx_max limit (511).
+      try {
+         
+        (activePty.ptyProcess as IPty & { destroy?: () => void }).destroy?.();
+      } catch {
+        // Ignore errors during cleanup
+      }
       this.activePtys.delete(pid);
     }
 

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -554,7 +554,7 @@ export class ShellExecutionService {
     }
     // Declared outside try so catch can destroy it if spawn succeeded
     // but a later setup step threw.
-     
+
     let spawnedPty: IPty | undefined;
 
     try {
@@ -895,7 +895,6 @@ export class ShellExecutionService {
       // macOS kern.tty.ptmx_max (511).
       if (spawnedPty) {
         try {
-           
           (spawnedPty as IPty & { destroy?: () => void }).destroy?.();
         } catch {
           // Ignore errors during cleanup


### PR DESCRIPTION
Fixes #21692

## Summary

- **Add `destroy()` call in `kill()` method** — when a PTY process is killed (timeout, abort, user cancellation), `killProcessGroup()` was called but the PTY file descriptor was never released
- **Add `destroy()` in exception catch block** — if an error occurs after PTY spawn but before the `onExit` handler is registered, the PTY leaked
- Matches existing cleanup pattern already used in `onExit` and `background()` paths

## Problem

On macOS, each shell command spawns a PTY via `/dev/ptmx`. The kernel limits these to 511 (`kern.tty.ptmx_max`). The `destroy()` call was present in the `onExit` and `background()` paths but missing from `kill()` and the post-spawn exception handler.

In `--yolo` mode with many commands, leaked PTY file descriptors accumulate until the limit is hit. At that point, no new terminal tabs can be opened system-wide (iTerm2, Terminal.app, etc.) until the Gemini process exits.

Observed: 527 `/dev/ttys*` devices allocated (limit 511) with only 17 having open file handles. Killing old Gemini sessions immediately reclaimed ~480 PTYs.

## Test plan

- [x] All 53 existing `shellExecutionService.test.ts` tests pass
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Verified PTY reclamation: 527 → 48 `/dev/ttys*` after killing leaking sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)