### PR TITLE
docs: fix typo `allowslisted` → `allowlisted` in mcp-server.md

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -372,7 +372,7 @@ To authenticate with a server using Service Account Impersonation, you must set
 the `authProviderType` to `service_account_impersonation` and provide the
 following properties:
 
-- **`targetAudience`** (string): The OAuth Client ID allowslisted on the
+- **`targetAudience`** (string): The OAuth Client ID allowlisted on the
   IAP-protected application you are trying to access.
 - **`targetServiceAccount`** (string): The email address of the Google Cloud
   Service Account to impersonate.


### PR DESCRIPTION
## Summary

Fixes a typo in the **Service account impersonation** section of `docs/tools/mcp-server.md`.

`allowslisted` → `allowlisted`

## Details

The `targetAudience` property description under the **Service account impersonation** section used the incorrect word `allowslisted`. The same property is correctly documented as `allowlisted` earlier in the same file (under **Configuration properties → Optional**), and `allowlisted` is the consistent spelling used throughout the rest of the repository.

Fixes #21634