### PR TITLE
fix(core): preserve full path in workspace validation for non-existent segments

### DIFF
--- a/packages/core/src/utils/workspaceContext.test.ts
+++ b/packages/core/src/utils/workspaceContext.test.ts
@@ -162,6 +162,30 @@ describe('WorkspaceContext with real filesystem', () => {
       );
     });
 
+    it('should accept deeply nested non-existent paths within workspace', () => {
+      const workspaceContext = new WorkspaceContext(cwd);
+      const deepPath = path.join(
+        cwd,
+        'nonexistent',
+        'deeply',
+        'nested',
+        'file.txt',
+      );
+      expect(workspaceContext.isPathWithinWorkspace(deepPath)).toBe(true);
+    });
+
+    it('should reject deeply nested non-existent paths outside workspace', () => {
+      const workspaceContext = new WorkspaceContext(cwd);
+      const deepPath = path.join(
+        tempDir,
+        'outside',
+        'deeply',
+        'nested',
+        'file.txt',
+      );
+      expect(workspaceContext.isPathWithinWorkspace(deepPath)).toBe(false);
+    });
+
     describe.skipIf(os.platform() === 'win32')('with symbolic link', () => {
       describe('in the workspace', () => {
         let realDir: string;

--- a/packages/core/src/utils/workspaceContext.ts
+++ b/packages/core/src/utils/workspaceContext.ts
@@ -227,8 +227,9 @@ export class WorkspaceContext {
    * if it did exist.
    */
   private fullyResolvedPath(pathToCheck: string): string {
+    const fullPath = path.resolve(this.targetDir, pathToCheck);
     try {
-      return fs.realpathSync(path.resolve(this.targetDir, pathToCheck));
+      return fs.realpathSync(fullPath);
     } catch (e: unknown) {
       if (
         isNodeError(e) &&
@@ -238,8 +239,16 @@ export class WorkspaceContext {
         // non-existent files.
         !this.isFileSymlink(e.path)
       ) {
-        // If it doesn't exist, e.path contains the fully resolved path.
-        return e.path;
+        // e.path only contains the path up to the last existing segment,
+        // which truncates the rest on UNC paths (e.g. WSL \\wsl.localhost\...).
+        // Append the remaining non-existent segments from the original path
+        // to preserve the full intended path.
+        const resolvedPrefix = e.path;
+        const remainder = fullPath.substring(resolvedPrefix.length);
+        if (remainder) {
+          return resolvedPrefix + remainder;
+        }
+        return resolvedPrefix;
       }
       throw e;
     }

--- a/packages/core/src/utils/workspaceContext.ts
+++ b/packages/core/src/utils/workspaceContext.ts
@@ -243,10 +243,11 @@ export class WorkspaceContext {
         // which truncates the rest on UNC paths (e.g. WSL \\wsl.localhost\...).
         // Append the remaining non-existent segments from the original path
         // to preserve the full intended path.
+        // On case-insensitive filesystems (Windows), e.path may have different
+        // casing than fullPath, so use a case-insensitive prefix check.
         const resolvedPrefix = e.path;
-        const remainder = fullPath.substring(resolvedPrefix.length);
-        if (remainder) {
-          return resolvedPrefix + remainder;
+        if (fullPath.toLowerCase().startsWith(resolvedPrefix.toLowerCase())) {
+          return resolvedPrefix + fullPath.substring(resolvedPrefix.length);
         }
         return resolvedPrefix;
       }


### PR DESCRIPTION
## Summary

Fixes path validation failures on Windows when accessing non-existent files through UNC paths (e.g. WSL `\\wsl.localhost\...`).

**Root cause:** When `fs.realpathSync` fails with `ENOENT` on a non-existent path, Node's error object (`e.path`) only contains the resolved path up to the **last existing segment**, silently truncating the rest. For example:

```
Input:  \\wsl.localhost\Ubuntu\home\project\nonexistent\deep\file.txt
e.path: \\wsl.localhost\Ubuntu\home\project  (truncated!)
```

`fullyResolvedPath()` in `workspaceContext.ts` was returning this truncated `e.path` directly, causing downstream path comparisons to operate on incomplete paths. On regular Windows drive paths (`C:\...`) the truncation is less visible because `path.relative` still produces a valid sub-path, but on UNC paths (especially WSL paths accessed via MinGW) this leads to confusing "Path not in workspace" errors.

**Fix:** Compute the full resolved path before calling `realpathSync`, then on ENOENT append the remaining non-existent segments from the original path to `e.path`, preserving the full intended path for workspace boundary checks.

## Changes

- `packages/core/src/utils/workspaceContext.ts` — Fix `fullyResolvedPath()` to append remaining segments when `realpathSync` returns a truncated `e.path`
- `packages/core/src/utils/workspaceContext.test.ts` — Add tests for deeply nested non-existent paths (both inside and outside workspace)

## Reproduction

On Windows with WSL installed:

```js
const fs = require('fs');
try {
  fs.realpathSync('\\\\wsl.localhost\\Ubuntu\\home\\nonexistent\\deep\\file.txt');
} catch (e) {
  console.log(e.path);
  // \\wsl.localhost\Ubuntu\home\nonexistent  (truncated!)
}
```

## Test plan

- [x] Existing `workspaceContext.test.ts` tests pass (29 passed, 11 skipped on Windows)
- [x] New test: deeply nested non-existent path inside workspace → accepted
- [x] New test: deeply nested non-existent path outside workspace → rejected
- [x] ESLint + Prettier pass
- [x] Pre-commit hooks pass

Fixes #18594