### PR TITLE
fix(cli): serialize object settings as JSON for display and editing

### DIFF
--- a/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
@@ -392,7 +392,11 @@ export function BaseSettingsDialog({
             const rawVal = currentItem.rawValue;
             const initialValue =
               currentItem.editValue ??
-              (rawVal !== undefined ? String(rawVal) : '');
+              (rawVal !== undefined
+                ? typeof rawVal === 'object' && rawVal !== null
+                  ? JSON.stringify(rawVal)
+                  : String(rawVal)
+                : '');
             startEditing(currentItem.key, initialValue);
           }
           return true;

--- a/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
@@ -393,7 +393,9 @@ export function BaseSettingsDialog({
             const initialValue =
               currentItem.editValue ??
               (rawVal !== undefined
-                ? typeof rawVal === 'object' && rawVal !== null
+                ? typeof rawVal === 'object' &&
+                  rawVal !== null &&
+                  !Array.isArray(rawVal)
                   ? JSON.stringify(rawVal)
                   : String(rawVal)
                 : '');

--- a/packages/cli/src/utils/settingsUtils.test.ts
+++ b/packages/cli/src/utils/settingsUtils.test.ts
@@ -734,6 +734,88 @@ describe('SettingsUtils', () => {
         );
         expect(result).toBe('false');
       });
+
+      it('should stringify objects as JSON instead of [object Object]', () => {
+        vi.mocked(getSettingsSchema).mockReturnValue({
+          experimental: {
+            properties: {
+              gemmaModelRouter: {
+                type: 'object',
+                label: 'Gemma Model Router',
+                category: 'Experimental',
+                requiresRestart: true,
+                default: {},
+                showInDialog: false,
+              },
+            },
+          },
+        } as unknown as SettingsSchemaType);
+
+        const settings = makeMockSettings({
+          experimental: {
+            gemmaModelRouter: { enabled: true, foo: 'bar' },
+          },
+        });
+        const result = getDisplayValue(
+          'experimental.gemmaModelRouter',
+          settings,
+          makeMockSettings({}),
+        );
+        expect(result).toBe('{"enabled":true,"foo":"bar"}*');
+      });
+
+      it('should display empty objects as {} instead of [object Object]', () => {
+        vi.mocked(getSettingsSchema).mockReturnValue({
+          experimental: {
+            properties: {
+              gemmaModelRouter: {
+                type: 'object',
+                label: 'Gemma Model Router',
+                category: 'Experimental',
+                requiresRestart: true,
+                default: {},
+                showInDialog: false,
+              },
+            },
+          },
+        } as unknown as SettingsSchemaType);
+
+        const result = getDisplayValue(
+          'experimental.gemmaModelRouter',
+          makeMockSettings({}),
+          makeMockSettings({}),
+        );
+        expect(result).toBe('{}');
+      });
+
+      it('should display {}* when an empty object is explicitly in scope', () => {
+        vi.mocked(getSettingsSchema).mockReturnValue({
+          experimental: {
+            properties: {
+              gemmaModelRouter: {
+                type: 'object',
+                label: 'Gemma Model Router',
+                category: 'Experimental',
+                requiresRestart: true,
+                default: {},
+                showInDialog: false,
+              },
+            },
+          },
+        } as unknown as SettingsSchemaType);
+
+        const settings = makeMockSettings({
+          experimental: {
+            gemmaModelRouter: {},
+          },
+        });
+        const result = getDisplayValue(
+          'experimental.gemmaModelRouter',
+          settings,
+          makeMockSettings({}),
+        );
+        expect(result).toBe('{}*');
+      });
     });
 
     describe('getDisplayValue with units', () => {

--- a/packages/cli/src/utils/settingsUtils.ts
+++ b/packages/cli/src/utils/settingsUtils.ts
@@ -282,7 +282,10 @@ export function getDisplayValue(
     value = getDefaultValue(key);
   }
 
-  let valueString = String(value);
+  let valueString =
+    typeof value === 'object' && value !== null && !Array.isArray(value)
+      ? JSON.stringify(value)
+      : String(value);
 
   if (definition?.type === 'enum' && definition.options) {
     const option = definition.options?.find((option) => option.value === value);

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -608,10 +608,10 @@ export function formatTruncatedToolOutput(
   const tail = contentStr.slice(-tailChars);
   const omittedChars = contentStr.length - headChars - tailChars;
 
-  return `Output too large. Showing first ${headChars.toLocaleString()} and last ${tailChars.toLocaleString()} characters. For full output see: ${outputFile}
+  return `Output too large. Showing first ${headChars.toLocaleString('en-US')} and last ${tailChars.toLocaleString('en-US')} characters. For full output see: ${outputFile}
 ${head}
 
-... [${omittedChars.toLocaleString()} characters omitted] ...
+... [${omittedChars.toLocaleString('en-US')} characters omitted] ...
 
 ${tail}`;
 }

--- a/scripts/tests/patch-create-comment.test.js
+++ b/scripts/tests/patch-create-comment.test.js
@@ -18,6 +18,8 @@ function runPatchCreateComment(args, env = {}) {
   );
   const fullEnv = {
     ...process.env,
+    LANG: 'en_US.UTF-8',
+    LC_ALL: 'en_US.UTF-8',
     ...env,
   };
 


### PR DESCRIPTION
This change improves the display of complex settings in the CLI and ensures the settings dialog correctly initializes object-type fields. Also includes locale-agnostic number formatting fixes in packages/core and script tests to ensure preflight passes in non-English locales.

## Summary
This PR fixes the unhelpful [object Object] string displayed in the settings list and dialog when viewing/editing complex configuration objects. It also hardens the core utility and script tests against locale-specific formatting issues (e.g., German number separators or translated CLI error messages) to ensure consistent preflight behavior worldwide.

Fixes #21386 

## Details

- Object Serialization: Implemented JSON.stringify for object-type settings in getDisplayValue (display) and BaseSettingsDialog (edit mode initialization).
- Locale Hardening:
    - Updated fileUtils.ts to use .toLocaleString('en-US'), preventing tests from failing when system locales use . as a thousands separator.
    - Forced English locales (LANG/LC_ALL) in patch-create-comment.test.js to ensure Yargs error strings match test expectations.
- Test Coverage: Added unit tests to verify that both default empty objects ({}) and explicitly configured objects ({...}*) are rendered correctly.

## Related Issues

Related to [Wrong display of value of Gemma Model Router ([object Object]) #21386
](https://github.com/google-gemini/gemini-cli/issues/21386)

## How to Validate

1. Verify Display: Configure a complex setting (e.g., experimental.gemmaModelRouter) and run gemini --settings. Confirm it shows a JSON string.
2. Verify Editing: Edit an object setting in the dialog; it should be pre-populated with JSON, not [object Object].
3. Locale Independence: Run LANG=de_DE.UTF-8 npm run test --workspace=@google/gemini-cli-core. All tests should pass.
4. Full Suite: Run npm run preflight.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
