### PR TITLE
feat(cli): add foundational configuration schema for multimodal voice mode

### DIFF
--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -161,4 +161,13 @@ they appear in the UI.
 | Enable Hooks       | `hooksConfig.enabled`       | Canonical toggle for the hooks system. When disabled, no hooks will be executed. | `true`  |
 | Hook Notifications | `hooksConfig.notifications` | Show visual indicators when hooks are executing.                                 | `true`  |
 
+### Voice
+
+| UI Label          | Setting                | Description                                              | Default     |
+| ----------------- | ---------------------- | -------------------------------------------------------- | ----------- |
+| Enable Voice Mode | `voice.enabled`        | Enable the real-time, bidirectional voice interface.     | `false`     |
+| Microphone Device | `voice.inputDevice`    | The name or ID of the microphone to use for voice input. | `"default"` |
+| VAD Sensitivity   | `voice.vadSensitivity` | Sensitivity for Voice Activity Detection (0.0 to 1.0).   | `0.5`       |
+| Agent Voice       | `voice.ttsVoice`       | The voice used by Gemini for audio responses.            | `"Puck"`    |
+
 <!-- SETTINGS-AUTOGEN:END -->

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1143,6 +1143,27 @@ their corresponding top-level category object in your `settings.json` file.
     prioritize available tools dynamically.
   - **Default:** `[]`
 
+#### `voice`
+
+- **`voice.enabled`** (boolean):
+  - **Description:** Enable the real-time, bidirectional voice interface.
+  - **Default:** `false`
+  - **Requires restart:** Yes
+
+- **`voice.inputDevice`** (string):
+  - **Description:** The name or ID of the microphone to use for voice input.
+  - **Default:** `"default"`
+  - **Requires restart:** Yes
+
+- **`voice.vadSensitivity`** (number):
+  - **Description:** Sensitivity for Voice Activity Detection (0.0 to 1.0).
+  - **Default:** `0.5`
+
+- **`voice.ttsVoice`** (enum):
+  - **Description:** The voice used by Gemini for audio responses.
+  - **Default:** `"Puck"`
+  - **Values:** `"Puck"`, `"Charon"`, `"Kore"`, `"Fenrir"`
+
 #### `admin`
 
 - **`admin.secureModeEnabled`** (boolean):

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -2174,6 +2174,61 @@ const SETTINGS_SCHEMA = {
     },
   },
 
+  voice: {
+    type: 'object',
+    label: 'Voice Mode',
+    category: 'Experimental',
+    requiresRestart: false,
+    default: {},
+    description:
+      'Settings for the Hands-Free Multimodal Voice Mode (GSoC 2026).',
+    showInDialog: true,
+    properties: {
+      enabled: {
+        type: 'boolean',
+        label: 'Enable Voice Mode',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: false,
+        description: 'Enable the real-time, bidirectional voice interface.',
+        showInDialog: true,
+      },
+      inputDevice: {
+        type: 'string',
+        label: 'Microphone Device',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: 'default',
+        description: 'The name or ID of the microphone to use for voice input.',
+        showInDialog: true,
+      },
+      vadSensitivity: {
+        type: 'number',
+        label: 'VAD Sensitivity',
+        category: 'Experimental',
+        requiresRestart: false,
+        default: 0.5,
+        description: 'Sensitivity for Voice Activity Detection (0.0 to 1.0).',
+        showInDialog: true,
+      },
+      ttsVoice: {
+        type: 'enum',
+        label: 'Agent Voice',
+        category: 'Experimental',
+        requiresRestart: false,
+        default: 'Puck',
+        description: 'The voice used by Gemini for audio responses.',
+        showInDialog: true,
+        options: [
+          { value: 'Puck', label: 'Puck (Default)' },
+          { value: 'Charon', label: 'Charon' },
+          { value: 'Kore', label: 'Kore' },
+          { value: 'Fenrir', label: 'Fenrir' },
+        ],
+      },
+    },
+  },
+
   admin: {
     type: 'object',
     label: 'Admin',

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1963,6 +1963,45 @@
         "items": {}
       }
     },
+    "voice": {
+      "title": "Voice Mode",
+      "description": "Settings for the Hands-Free Multimodal Voice Mode (GSoC 2026).",
+      "markdownDescription": "Settings for the Hands-Free Multimodal Voice Mode (GSoC 2026).\n\n- Category: `Experimental`\n- Requires restart: `no`\n- Default: `{}`",
+      "default": {},
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enable Voice Mode",
+          "description": "Enable the real-time, bidirectional voice interface.",
+          "markdownDescription": "Enable the real-time, bidirectional voice interface.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
+          "default": false,
+          "type": "boolean"
+        },
+        "inputDevice": {
+          "title": "Microphone Device",
+          "description": "The name or ID of the microphone to use for voice input.",
+          "markdownDescription": "The name or ID of the microphone to use for voice input.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `default`",
+          "default": "default",
+          "type": "string"
+        },
+        "vadSensitivity": {
+          "title": "VAD Sensitivity",
+          "description": "Sensitivity for Voice Activity Detection (0.0 to 1.0).",
+          "markdownDescription": "Sensitivity for Voice Activity Detection (0.0 to 1.0).\n\n- Category: `Experimental`\n- Requires restart: `no`\n- Default: `0.5`",
+          "default": 0.5,
+          "type": "number"
+        },
+        "ttsVoice": {
+          "title": "Agent Voice",
+          "description": "The voice used by Gemini for audio responses.",
+          "markdownDescription": "The voice used by Gemini for audio responses.\n\n- Category: `Experimental`\n- Requires restart: `no`\n- Default: `Puck`",
+          "default": "Puck",
+          "type": "string",
+          "enum": ["Puck", "Charon", "Kore", "Fenrir"]
+        }
+      },
+      "additionalProperties": false
+    },
     "admin": {
       "title": "Admin",
       "description": "Settings configured remotely by enterprise admins.",


### PR DESCRIPTION
### Description
This PR introduces the foundational configuration schema for the Hands-Free Multimodal Voice Mode (GSoC 2026 Idea 11).

By integrating these settings into the core `settingsSchema.ts`, the CLI can now persistently store user preferences for voice interaction without impacting current text-based workflows. This follows the project's monorepo architecture and leverages the existing deep-merge logic for User and Workspace settings.

### Changes
- [x] Added `voice `configuration block to `SETTINGS_SCHEMA` in `packages/cli/src/config/settingsSchema.ts`.
- [x] Defined properties: `enabled` (boolean), `inputDevice` (string), `vadSensitivity` (number), and `ttsVoice` (enum).
- [x] Updated auto-generated JSON schemas in `schemas/settings.schema.json`.
- [x] Regenerated documentation via `npm run docs:settings`.

### Testing Done
Verified build via `npm run build`.

Confirmed schema inference in the configuration engine.

Ran` npm run docs:settings` to ensure documentation consistency across the monorepo.

### Related Issue
Fixes #21649 