### PR TITLE
fix(cli): remove leading space from selection list option descriptions

### DIFF
--- a/packages/cli/src/ui/components/AskUserDialog.test.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.test.tsx
@@ -1348,6 +1348,40 @@ describe('AskUserDialog', () => {
     });
   });
 
+  it('aligns wrapped description lines consistently (regression #21590)', async () => {
+    // Before the fix, a {' '} prefix on the description caused the first line
+    // to be indented one extra space compared to continuation lines when text
+    // wrapped. This snapshot captures correct, consistent alignment.
+    const questions: Question[] = [
+      {
+        question: 'Pick one:',
+        header: 'Wrap',
+        type: QuestionType.CHOICE,
+        options: [
+          {
+            label: 'Alpha',
+            description:
+              'This is a long description that should wrap to multiple lines to verify alignment',
+          },
+        ],
+        multiSelect: false,
+      },
+    ];
+
+    const { lastFrame, waitUntilReady } = renderWithProviders(
+      <AskUserDialog
+        questions={questions}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+        width={40}
+      />,
+      { width: 40 },
+    );
+
+    await waitUntilReady();
+    expect(lastFrame()).toMatchSnapshot();
+  });
+
   it('expands paste placeholders in multi-select custom option via Done', async () => {
     const questions: Question[] = [
       {

--- a/packages/cli/src/ui/components/AskUserDialog.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.tsx
@@ -925,7 +925,6 @@ const ChoiceQuestionView: React.FC<ChoiceQuestionViewProps> = ({
               </Box>
               {optionItem.description && (
                 <Text color={theme.text.secondary} wrap="wrap">
-                  {' '}
                   <RenderInline
                     text={optionItem.description}
                     defaultColor={theme.text.secondary}

--- a/packages/cli/src/ui/components/__snapshots__/AskUserDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/AskUserDialog.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`AskUserDialog > Choice question placeholder > uses default placeholder 
 
   1.  TypeScript
   2.  JavaScript
-● 3.  Enter a custom value                                                      
+● 3.  Enter a custom value
 
 Enter to submit · Esc to cancel
 "
@@ -16,7 +16,7 @@ exports[`AskUserDialog > Choice question placeholder > uses placeholder for "Oth
 
   1.  TypeScript
   2.  JavaScript
-● 3.  Type another language...                                                  
+● 3.  Type another language...
 
 Enter to submit · Esc to cancel
 "
@@ -26,10 +26,10 @@ exports[`AskUserDialog > Scroll Arrows (useAlternateBuffer: false) > shows scrol
 "Choose an option
 
 ▲
-●  1.  Option 1                                                                 
-       Description 1                                                            
+●  1.  Option 1
+      Description 1
    2.  Option 2
-       Description 2
+      Description 2
 ▼
 
 Enter to select · ↑/↓ to navigate · Esc to cancel
@@ -39,36 +39,36 @@ Enter to select · ↑/↓ to navigate · Esc to cancel
 exports[`AskUserDialog > Scroll Arrows (useAlternateBuffer: true) > shows scroll arrows correctly when useAlternateBuffer is true 1`] = `
 "Choose an option
 
-●  1.  Option 1                                                                 
-       Description 1                                                            
+●  1.  Option 1
+      Description 1
    2.  Option 2
-       Description 2
+      Description 2
    3.  Option 3
-       Description 3
+      Description 3
    4.  Option 4
-       Description 4
+      Description 4
    5.  Option 5
-       Description 5
+      Description 5
    6.  Option 6
-       Description 6
+      Description 6
    7.  Option 7
-       Description 7
+      Description 7
    8.  Option 8
-       Description 8
+      Description 8
    9.  Option 9
-       Description 9
+      Description 9
   10.  Option 10
-       Description 10
+      Description 10
   11.  Option 11
-       Description 11
+      Description 11
   12.  Option 12
-       Description 12
+      Description 12
   13.  Option 13
-       Description 13
+      Description 13
   14.  Option 14
-       Description 14
+      Description 14
   15.  Option 15
-       Description 15
+      Description 15
   16.  Enter a custom value
 
 Enter to select · ↑/↓ to navigate · Esc to cancel
@@ -105,6 +105,20 @@ Enter to submit · Esc to cancel
 "
 `;
 
+exports[`AskUserDialog > aligns wrapped description lines consistently (regression #21590) 1`] = `
+"Pick one:
+
+● 1.  Alpha
+     This is a long description that
+     should wrap to multiple lines to
+     verify alignment
+  2.  Enter a custom value
+
+Enter to select · ↑/↓ to navigate · Esc
+to cancel
+"
+`;
+
 exports[`AskUserDialog > allows navigating to Review tab and back 1`] = `
 "← □ Tests │ □ Docs │ ≡ Review →
 
@@ -122,10 +136,10 @@ Enter to submit · Tab/Shift+Tab to edit answers · Esc to cancel
 exports[`AskUserDialog > hides progress header for single question 1`] = `
 "Which authentication method should we use?
 
-● 1.  OAuth 2.0                                                                                                         
-      Industry standard, supports SSO                                                                                   
+● 1.  OAuth 2.0
+     Industry standard, supports SSO
   2.  JWT tokens
-      Stateless, good for APIs
+     Stateless, good for APIs
   3.  Enter a custom value
 
 Enter to select · ↑/↓ to navigate · Esc to cancel
@@ -135,10 +149,10 @@ Enter to select · ↑/↓ to navigate · Esc to cancel
 exports[`AskUserDialog > renders question and options 1`] = `
 "Which authentication method should we use?
 
-● 1.  OAuth 2.0                                                                                                         
-      Industry standard, supports SSO                                                                                   
+● 1.  OAuth 2.0
+     Industry standard, supports SSO
   2.  JWT tokens
-      Stateless, good for APIs
+     Stateless, good for APIs
   3.  Enter a custom value
 
 Enter to select · ↑/↓ to navigate · Esc to cancel
@@ -150,10 +164,10 @@ exports[`AskUserDialog > shows Review tab in progress header for multiple questi
 
 Which framework?
 
-● 1.  React                                                                                                             
-      Component library                                                                                                 
+● 1.  React
+     Component library
   2.  Vue
-      Progressive framework
+     Progressive framework
   3.  Enter a custom value
 
 Enter to select · ←/→ to switch questions · Esc to cancel
@@ -163,10 +177,10 @@ Enter to select · ←/→ to switch questions · Esc to cancel
 exports[`AskUserDialog > shows keyboard hints 1`] = `
 "Which authentication method should we use?
 
-● 1.  OAuth 2.0                                                                                                         
-      Industry standard, supports SSO                                                                                   
+● 1.  OAuth 2.0
+     Industry standard, supports SSO
   2.  JWT tokens
-      Stateless, good for APIs
+     Stateless, good for APIs
   3.  Enter a custom value
 
 Enter to select · ↑/↓ to navigate · Esc to cancel
@@ -178,10 +192,10 @@ exports[`AskUserDialog > shows progress header for multiple questions 1`] = `
 
 Which database should we use?
 
-● 1.  PostgreSQL                                                                                                        
-      Relational database                                                                                               
+● 1.  PostgreSQL
+     Relational database
   2.  MongoDB
-      Document database
+     Document database
   3.  Enter a custom value
 
 Enter to select · ←/→ to switch questions · Esc to cancel


### PR DESCRIPTION
## Summary

Remove the extraneous `{' '}` space prefix before the description text in selection list options within `AskUserDialog.tsx`.

## Problem

In the `ChoiceQuestionView` render function, option descriptions were prefixed with a `{' '}` JSX expression that added a leading space character. When description text wrapped to the next line, the continuation did not carry this space, resulting in inconsistent indentation between the first line and wrapped lines of the description.

## Fix

Removed the `{' '}` from the description `<Text>` element so the description text starts flush with the content column, ensuring consistent alignment when text wraps.

Fixes #21590