### PR TITLE
fix(core): preserve command paths in normalization for accurate policy matching

### DIFF
--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -119,8 +119,10 @@ describe('getCommandRoots', () => {
     expect(getCommandRoots('ls -l')).toEqual(['ls']);
   });
 
-  it('should handle paths and return the binary name', () => {
-    expect(getCommandRoots('/usr/local/bin/node script.js')).toEqual(['node']);
+  it('should handle paths and NOT return only the binary name (for policy matching)', () => {
+    expect(getCommandRoots('/usr/local/bin/node script.js')).toEqual([
+      '/usr/local/bin/node',
+    ]);
   });
 
   it('should return an empty array for an empty string', () => {

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -262,11 +262,7 @@ function normalizeCommandName(raw: string): string {
       return raw.slice(1, -1);
     }
   }
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return trimmed;
-  }
-  return trimmed.split(/[\\/]/).pop() ?? trimmed;
+  return raw.trim();
 }
 
 function extractNameFromNode(node: Node): string | null {


### PR DESCRIPTION
## Summary

Fixes the issue where `./gradlew` (and other path-prefixed commands) would repeatedly prompt for permission even after being allowed "forever."

## Details

The root cause was in `normalizeCommandName` within `shell-utils.ts`, which was stripping the path from command names (e.g., `./gradlew` became `gradlew`). This caused a mismatch:
1. User approves `./gradlew build` "forever."
2. System saves permission for `gradlew`.
3. Next time, system checks `./gradlew build` against `gradlew`, fails to match, and prompts again.

Updated `normalizeCommandName` to preserve the full command name (including paths) while still handling quotes and whitespace. This ensures that approved path-prefixed commands are correctly matched and improves security by making permissions path-specific.

## Related Issues

This should resolve [this issue](https://github.com/google-gemini/gemini-cli/issues/17953).

## How to Validate

1. Run a command with a relative path: `./gradlew --version` (or any dummy script like `./test.sh`).
2. When prompted, select **Proceed Always**.
3. Run the same command again.
4. **Expected:** It should execute without prompting.

Verified with:
- `npm run test -w @google/gemini-cli-core -- src/utils/shell-utils.test.ts`
- Manual reproduction logic in a temporary test (now removed).

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
  - [ ] Linux

