### PR TITLE
docs: fix typo 'allowslisted' -> 'allowlisted' in mcp-server.md

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -372,7 +372,7 @@ To authenticate with a server using Service Account Impersonation, you must set
 the `authProviderType` to `service_account_impersonation` and provide the
 following properties:
 
-- **`targetAudience`** (string): The OAuth Client ID allowslisted on the
+- **`targetAudience`** (string): The OAuth Client ID allowlisted on the
   IAP-protected application you are trying to access.
 - **`targetServiceAccount`** (string): The email address of the Google Cloud
   Service Account to impersonate.


### PR DESCRIPTION
## Summary

Fixes a typo in the MCP server documentation where `allowslisted` should be `allowlisted`.

## Changes

- Changed `allowslisted` to `allowlisted` in the Service Account Impersonation section of `docs/tools/mcp-server.md`

## Location

File: `docs/tools/mcp-server.md`  
Section: **OAuth support for remote MCP servers → Service account impersonation**

Fixes #21634