### PR TITLE
fix(agents): record tool calls in sub-agent session logs

### DIFF
--- a/packages/core/src/agents/local-executor.test.ts
+++ b/packages/core/src/agents/local-executor.test.ts
@@ -101,6 +101,7 @@ vi.mock('../core/geminiChat.js', async (importOriginal) => {
       getHistory: vi.fn((_curated?: boolean) => [...mockChatHistory]),
       setHistory: mockSetHistory,
       setSystemInstruction: mockSetSystemInstruction,
+      recordCompletedToolCalls: vi.fn(),
     })),
   };
 });
@@ -301,6 +302,7 @@ describe('LocalAgentExecutor', () => {
           getHistory: vi.fn((_curated?: boolean) => [...mockChatHistory]),
           getLastPromptTokenCount: vi.fn(() => 100),
           setHistory: mockSetHistory,
+          recordCompletedToolCalls: vi.fn(),
         }) as unknown as GeminiChat,
     );
 

--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -258,8 +258,10 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
 
     await this.tryCompressChat(chat, promptId);
 
-    const { functionCalls } = await promptIdContext.run(promptId, async () =>
-      this.callModel(chat, currentMessage, combinedSignal, promptId),
+    const { functionCalls, model } = await promptIdContext.run(
+      promptId,
+      async () =>
+        this.callModel(chat, currentMessage, combinedSignal, promptId),
     );
 
     if (combinedSignal.aborted) {
@@ -288,6 +290,8 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
 
     const { nextMessage, submittedOutput, taskCompleted, aborted } =
       await this.processFunctionCalls(
+        chat,
+        model,
         functionCalls,
         combinedSignal,
         promptId,
@@ -735,7 +739,11 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
     message: Content,
     signal: AbortSignal,
     promptId: string,
-  ): Promise<{ functionCalls: FunctionCall[]; textResponse: string }> {
+  ): Promise<{
+    functionCalls: FunctionCall[];
+    textResponse: string;
+    model: string;
+  }> {
     const modelConfigAlias = getModelConfigAlias(this.definition);
 
     // Resolve the model config early to get the concrete model string (which may be `auto`).
@@ -819,7 +827,7 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
       }
     }
 
-    return { functionCalls, textResponse };
+    return { functionCalls, textResponse, model: modelToUse };
   }
 
   /** Initializes a `GeminiChat` instance for the agent run. */
@@ -873,6 +881,8 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
    * @returns A new `Content` object for history, any submitted output, and completion status.
    */
   private async processFunctionCalls(
+    chat: GeminiChat,
+    model: string,
     functionCalls: FunctionCall[],
     signal: AbortSignal,
     promptId: string,
@@ -1106,6 +1116,9 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
           onWaitingForConfirmation,
         },
       );
+
+      // Record completed tool calls in the session log
+      chat.recordCompletedToolCalls(model, completedCalls);
 
       for (const call of completedCalls) {
         const toolName =


### PR DESCRIPTION
## Summary

Sub-agent session log files have missing `toolCalls` entries because `LocalAgentExecutor.processFunctionCalls()` never calls `chat.recordCompletedToolCalls()` after tool execution completes.

This adds the missing `recordCompletedToolCalls` call, aligning sub-agent behavior with all main agent execution paths.

## Details

All main agent execution paths (`useGeminiStream.ts`, `nonInteractiveCli.ts`, `zedIntegration.ts`) call `chat.recordCompletedToolCalls()` after tool execution, but the sub-agent loop in `LocalAgentExecutor` was missing this call.

**Changes:**
- Pass `chat` and `model` to `processFunctionCalls()` so it can call `chat.recordCompletedToolCalls(model, completedCalls)` after `scheduleAgentTools` returns
- Expand `callModel` return type to include the resolved `model` string
- Add `recordCompletedToolCalls` mock to test file to prevent test crashes

## Related Issues

Fixes #21667

## How to Validate

1. Run Gemini CLI with a sub-agent (e.g., generalist agent)
2. Check the session log file in `~/.gemini/tmp/*/chats/`
3. Verify that sub-agent turns now include `toolCalls` data instead of being empty

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker