### PR TITLE
docs: change model desc

### DIFF
--- a/docs/cli/model.md
+++ b/docs/cli/model.md
@@ -21,7 +21,7 @@ Running this command will open a dialog with your options:
 
 | Option            | Description                                                    | Models                                       |
 | ----------------- | -------------------------------------------------------------- | -------------------------------------------- |
-| Auto (Gemini 3)   | Let the system choose the best Gemini 3 model for your task.   | gemini-3.1-pro, gemini-3-flash |
+| Auto (Gemini 3)   | Let the system choose the best Gemini 3 model for your task.   | gemini-3.1-pro-preview, gemini-3-flash-preview |
 | Auto (Gemini 2.5) | Let the system choose the best Gemini 2.5 model for your task. | gemini-2.5-pro, gemini-2.5-flash             |
 | Manual            | Select a specific model.                                       | Any available model.                         |
 

--- a/docs/cli/model.md
+++ b/docs/cli/model.md
@@ -21,7 +21,7 @@ Running this command will open a dialog with your options:
 
 | Option            | Description                                                    | Models                                       |
 | ----------------- | -------------------------------------------------------------- | -------------------------------------------- |
-| Auto (Gemini 3)   | Let the system choose the best Gemini 3 model for your task.   | gemini-3-pro-preview, gemini-3-flash-preview |
+| Auto (Gemini 3)   | Let the system choose the best Gemini 3 model for your task.   | gemini-3.1-pro, gemini-3-flash |
 | Auto (Gemini 2.5) | Let the system choose the best Gemini 2.5 model for your task. | gemini-2.5-pro, gemini-2.5-flash             |
 | Manual            | Select a specific model.                                       | Any available model.                         |
 

--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -1599,7 +1599,7 @@ function buildAvailableModels(
       value: PREVIEW_GEMINI_MODEL_AUTO,
       title: getDisplayString(PREVIEW_GEMINI_MODEL_AUTO),
       description: useGemini31
-        ? 'Let Gemini CLI decide the best model for the task: gemini-3.1-pro, gemini-3-flash'
+        ? 'Let Gemini CLI decide the best model for the task: gemini-3.1-pro-preview, gemini-3-flash-preview'
         : 'Let Gemini CLI decide the best model for the task: gemini-3-pro, gemini-3-flash',
     });
   }

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -106,7 +106,7 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
         value: PREVIEW_GEMINI_MODEL_AUTO,
         title: getDisplayString(PREVIEW_GEMINI_MODEL_AUTO),
         description: useGemini31
-          ? 'Let Gemini CLI decide the best model for the task: gemini-3.1-pro, gemini-3-flash'
+          ? 'Let Gemini CLI decide the best model for the task: gemini-3.1-pro-preview, gemini-3-flash-preview'
           : 'Let Gemini CLI decide the best model for the task: gemini-3-pro, gemini-3-flash',
         key: PREVIEW_GEMINI_MODEL_AUTO,
       });


### PR DESCRIPTION
## Summary

This PR updates the model descriptions in the `/model` documentation and CLI components. Specifically, it changes the reference from `gemini-3-pro` to `gemini-3.1-pro` (and includes the `-preview` suffix where applicable) to align with the current release versioning.

<img width="593" height="187" alt="Screenshot 2026-03-09 at 13 33 06" src="https://github.com/user-attachments/assets/0c769581-92d8-49b4-a43f-00452e493c39" />

## Details

- Updated `docs/cli/model.md` table to reflect `gemini-3.1-pro-preview`.
- Modified `acpClient.ts` and `ModelDialog.tsx` to ensure the CLI UI displays the correct model version string when the `useGemini31` flag is active.
- Ensures consistency between the technical documentation and the user-facing interface.

## Related Issues

Related to #21670

## How to Validate

1. **Verify Documentation:**
   - Open `docs/cli/model.md` and check that the "Auto (Gemini 3)" row now lists `gemini-3.1-pro-preview`.
2. **Verify CLI UI:**
   - Run the CLI locally: `npm run dev`.
   - Access the model selection menu (e.g., using the command to change models).
   - Confirm the description for the Gemini 3 Auto selection accurately mentions `gemini-3.1-pro-preview` and `gemini-3-flash-preview`.
3. **Build Check:**
   - Run `npm run build` to ensure no syntax errors were introduced in the TypeScript components.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker