### PR TITLE
docs: Add vi mode shortcuts and clarify custom sandbox requirements

### DIFF
--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -239,7 +239,7 @@ $env:SANDBOX_SET_UID_GID="false"  # Disable UID/GID mapping
 
 **Missing commands**
 
-- Add to custom Dockerfile.
+- Add to custom Dockerfile (requires running from source code; not available when installed via npm).
 - Install via `sandbox.bashrc`.
 
 **Network issues**

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1745,6 +1745,12 @@ sandbox image:
 BUILD_SANDBOX=1 gemini -s
 ```
 
+**Note:** Building custom sandboxes from a Dockerfile is only supported when
+running Gemini CLI from source code. If you installed the CLI via npm
+(`npm install -g @google/gemini-cli`), the `BUILD_SANDBOX` feature is not
+available. To use custom sandboxes with the npm package, you need to build your
+Docker image separately and reference it via configuration.
+
 ## Usage statistics
 
 To help us improve the Gemini CLI, we collect anonymized usage statistics. This


### PR DESCRIPTION
## Summary

This PR adds documentation for the new **Vi mode keyboard shortcuts** and clarifies that building custom sandboxes via a Dockerfile requires running the CLI from **source code** (it is not available via the npm package). It also resolves significant merge conflicts by migrating these updates to the project's new documentation structure.

## Details

- **Vi Mode**: Added a comprehensive list of modal editing shortcuts (Normal/Insert mode, navigation, and editing commands) to `docs/reference/keyboard-shortcuts.md`.
- **Sandbox**: Added a note to `docs/cli/sandbox.md` and `docs/reference/configuration.md` explaining that the `BUILD_SANDBOX` feature is limited to source-based installations.
- **Maintenance**: 
    - Resolved conflicts with `origin/main` by migrating docs to their new directory locations.
    - Removed the deprecated `docs/get-started/configuration-v1.md` as requested by reviewers.
    - Fixed commit authorship to match the signed Google CLA email.

## Related Issues

Related to #19243
Closes #17381
Closes #15141

## How to Validate

1.  Open `docs/reference/keyboard-shortcuts.md` and verify the "Vi Mode Shortcuts" section appears correctly at the end.
2.  Open `docs/reference/configuration.md` and search for "BUILD_SANDBOX" to see the added note.
3.  Confirm that `docs/get-started/configuration-v1.md` is no longer in the file tree.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
  - [x] Windows
  - [x] Linux
