### PR TITLE
feat(voice): add VoiceWaveformVisualizer component for voice interaction feedback

### DIFF
--- a/packages/cli/src/ui/components/VoiceWaveformVisualizer.test.tsx
+++ b/packages/cli/src/ui/components/VoiceWaveformVisualizer.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { render } from '../../test-utils/render.js';
+import { VoiceWaveformVisualizer } from './VoiceWaveformVisualizer.js';
+import { describe, it, expect } from 'vitest';
+
+describe('VoiceWaveformVisualizer', () => {
+  it('renders nothing when idle', async () => {
+    const { lastFrame, waitUntilReady, unmount } = render(
+      <VoiceWaveformVisualizer state="idle" />,
+    );
+    await waitUntilReady();
+    expect(lastFrame({ allowEmpty: true })).toBe('');
+    unmount();
+  });
+
+  it('renders listening label', async () => {
+    const { lastFrame, waitUntilReady, unmount } = render(
+      <VoiceWaveformVisualizer state="listening" />,
+    );
+    await waitUntilReady();
+    expect(lastFrame()).toContain('Listening');
+    unmount();
+  });
+
+  it('renders processing label', async () => {
+    const { lastFrame, waitUntilReady, unmount } = render(
+      <VoiceWaveformVisualizer state="processing" />,
+    );
+    await waitUntilReady();
+    expect(lastFrame()).toContain('Processing');
+    unmount();
+  });
+
+  it('renders speaking label', async () => {
+    const { lastFrame, waitUntilReady, unmount } = render(
+      <VoiceWaveformVisualizer state="speaking" />,
+    );
+    await waitUntilReady();
+    expect(lastFrame()).toContain('Speaking');
+    unmount();
+  });
+});

--- a/packages/cli/src/ui/components/VoiceWaveformVisualizer.tsx
+++ b/packages/cli/src/ui/components/VoiceWaveformVisualizer.tsx
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type React from 'react';
+import { useEffect, useState } from 'react';
+import { Text, Box, useIsScreenReaderEnabled } from 'ink';
+import { theme } from '../semantic-colors.js';
+
+export type VoiceState = 'idle' | 'listening' | 'processing' | 'speaking';
+
+interface VoiceWaveformVisualizerProps {
+  state: VoiceState;
+}
+
+const BARS = 5;
+
+const STATE_LABELS: Record<VoiceState, string> = {
+  idle: '',
+  listening: 'Listening...',
+  processing: 'Processing...',
+  speaking: 'Speaking...',
+};
+
+const SCREEN_READER_LABELS: Record<VoiceState, string> = {
+  idle: '',
+  listening: 'Voice mode: listening',
+  processing: 'Voice mode: processing',
+  speaking: 'Voice mode: speaking',
+};
+
+function randomHeight(): number {
+  return Math.floor(Math.random() * 7) + 1;
+}
+
+export const VoiceWaveformVisualizer: React.FC<
+  VoiceWaveformVisualizerProps
+> = ({ state }) => {
+  const isScreenReaderEnabled = useIsScreenReaderEnabled();
+  const [heights, setHeights] = useState<number[]>(Array(BARS).fill(1));
+
+  useEffect(() => {
+    if (state !== 'listening' && state !== 'speaking') {
+      setHeights(Array(BARS).fill(1));
+      return;
+    }
+    const interval = setInterval(() => {
+      setHeights(Array.from({ length: BARS }, randomHeight));
+    }, 150);
+    return () => clearInterval(interval);
+  }, [state]);
+
+  if (state === 'idle') return null;
+
+  if (isScreenReaderEnabled) {
+    return <Text>{SCREEN_READER_LABELS[state]}</Text>;
+  }
+
+  const barColor =
+    state === 'listening'
+      ? theme.text.accent
+      : state === 'speaking'
+        ? theme.status.success
+        : theme.text.secondary;
+
+  return (
+    <Box flexDirection="row" alignItems="flex-end" gap={0}>
+      <Text color={barColor}>
+        {heights.map((h) => '█'.repeat(h) + ' ').join('')}
+      </Text>
+      <Text color={theme.text.secondary}> {STATE_LABELS[state]}</Text>
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/VoiceWaveformVisualizer.tsx
+++ b/packages/cli/src/ui/components/VoiceWaveformVisualizer.tsx
@@ -38,11 +38,11 @@ export const VoiceWaveformVisualizer: React.FC<
   VoiceWaveformVisualizerProps
 > = ({ state }) => {
   const isScreenReaderEnabled = useIsScreenReaderEnabled();
-  const [heights, setHeights] = useState<number[]>(Array(BARS).fill(1));
+  const [heights, setHeights] = useState<number[]>(STATIC_HEIGHTS);
 
   useEffect(() => {
     if (state !== 'listening' && state !== 'speaking') {
-      setHeights(Array(BARS).fill(1));
+      setHeights(STATIC_HEIGHTS);
       return;
     }
     const interval = setInterval(() => {


### PR DESCRIPTION
## Summary
Adds a VoiceWaveformVisualizer component that renders animated terminal feedback for voice interaction states: listening, processing and speaking. Returns null when idle. Includes screen reader support.

## Details
Adds a standalone VoiceWaveformVisualizer component as a foundation for voice UI feedback. The component handles four states (idle, listening, processing, speaking) with animated bar logic and screen reader support. Uses existing theme colors and follows the same patterns as other UI components.

This is a UI building block, integration with the voice input pipeline will follow in a subsequent PR.

## Related Issues
Related to #18067

## How to Validate
`cd packages/cli`
`npx vitest run src/ui/components/VoiceWaveformVisualizer.test.tsx`
All tests should pass.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
