### PR TITLE
fix(core): separate sub-agent thought headers with comma and space

### DIFF
--- a/packages/core/src/agents/local-invocation.test.ts
+++ b/packages/core/src/agents/local-invocation.test.ts
@@ -234,7 +234,45 @@ describe('LocalSubagentInvocation', () => {
       expect(lastCall.recentActivity).toContainEqual(
         expect.objectContaining({
           type: 'thought',
-          content: 'Analyzing... Still thinking.',
+          content: 'Analyzing...,  Still thinking.',
+        }),
+      );
+    });
+
+    it('should correctly handle growing thought headers without duplication', async () => {
+      mockExecutorInstance.run.mockImplementation(async () => {
+        const onActivity = MockLocalAgentExecutor.create.mock.calls[0][2];
+
+        if (onActivity) {
+          onActivity({
+            isSubagentActivityEvent: true,
+            agentName: 'MockAgent',
+            type: 'THOUGHT_CHUNK',
+            data: { text: 'Analy' },
+          } as SubagentActivityEvent);
+          onActivity({
+            isSubagentActivityEvent: true,
+            agentName: 'MockAgent',
+            type: 'THOUGHT_CHUNK',
+            data: { text: 'Analyzing' },
+          } as SubagentActivityEvent);
+          onActivity({
+            isSubagentActivityEvent: true,
+            agentName: 'MockAgent',
+            type: 'THOUGHT_CHUNK',
+            data: { text: 'Searching' },
+          } as SubagentActivityEvent);
+        }
+        return { result: 'Done', terminate_reason: AgentTerminateMode.GOAL };
+      });
+
+      await invocation.execute(signal, updateOutput);
+
+      const lastCall = updateOutput.mock.calls[3][0] as SubagentProgress;
+      expect(lastCall.recentActivity).toContainEqual(
+        expect.objectContaining({
+          type: 'thought',
+          content: 'Analyzing, Searching',
         }),
       );
     });

--- a/packages/core/src/agents/local-invocation.ts
+++ b/packages/core/src/agents/local-invocation.ts
@@ -120,7 +120,14 @@ export class LocalSubagentInvocation extends BaseToolInvocation<
               lastItem.type === 'thought' &&
               lastItem.status === 'running'
             ) {
-              lastItem.content += text;
+              if (
+                text.startsWith(lastItem.content) &&
+                lastItem.content.length > 0
+              ) {
+                lastItem.content = text;
+              } else if (!lastItem.content.includes(text)) {
+                lastItem.content += (lastItem.content ? ', ' : '') + text;
+              }
             } else {
               recentActivity.push({
                 id: randomUUID(),


### PR DESCRIPTION
## Summary

Fixes the issue where sub-agent thought headers in the TUI were concatenated into a single string without spaces (e.g., `Analyzing...Searching...`). They are now separated by a comma and a space (`Analyzing..., Searching...`).

## Details

- Modified `packages/core/src/agents/local-invocation.ts` to handle `THOUGHT_CHUNK` events more intelligently.
- Implemented a "growth" check: if a new thought header starts with the current content, it's treated as a continuation (incremental streaming) and replaces the old content.
- If it's a new distinct thought, it's appended using `, ` as a separator.
- Added a check to skip exact duplicates.
- Updated existing tests and added a new test case for incremental growth.

## Related Issues

Fixes #21688

## How to Validate

1. Run any sub-agent (e.g., Generalist) that performs multiple steps.
2. Observe the status line next to the 💭 icon.
3. Multiple thought headers should now be clearly separated by commas.

Alternatively, run the updated tests:
```bash
npm test -w @google/gemini-cli-core -- src/agents/local-invocation.test.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
  - [ ] Windows
  - [x] Linux
    - [x] npm run
