### PR TITLE
fix(core): preserve refresh tokens on save, tolerate missing on delete

### DIFF
--- a/packages/core/src/code_assist/oauth-credential-storage.ts
+++ b/packages/core/src/code_assist/oauth-credential-storage.ts
@@ -66,12 +66,26 @@ export class OAuthCredentialStorage {
       throw new Error('Attempted to save credentials without an access token.');
     }
 
-    // Convert Google Credentials to OAuthCredentials format
+    // When Google refreshes an access token, the tokens event only contains
+    // the new access_token — the refresh_token is NOT resent. Preserve the
+    // existing refresh token so we can continue refreshing after this one
+    // expires.
+    let refreshToken = credentials.refresh_token || undefined;
+    if (!refreshToken) {
+      try {
+        const existing = await this.storage.getCredentials(MAIN_ACCOUNT_KEY);
+        refreshToken = existing?.token?.refreshToken;
+      } catch {
+        // If we can't read existing creds, proceed without — the caller
+        // may be saving a fresh full credential set.
+      }
+    }
+
     const mcpCredentials: OAuthCredentials = {
       serverName: MAIN_ACCOUNT_KEY,
       token: {
         accessToken: credentials.access_token,
-        refreshToken: credentials.refresh_token || undefined,
+        refreshToken,
         tokenType: credentials.token_type || 'Bearer',
         scope: credentials.scope || undefined,
         expiresAt: credentials.expiry_date || undefined,

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -408,6 +408,7 @@ async function authWithUserCode(client: OAuth2Client): Promise<boolean> {
     const authUrl: string = client.generateAuthUrl({
       redirect_uri: redirectUri,
       access_type: 'offline',
+      prompt: 'consent',
       scope: OAUTH_SCOPE,
       code_challenge_method: CodeChallengeMethod.S256,
       code_challenge: codeVerifier.codeChallenge,
@@ -497,6 +498,7 @@ async function authWithWeb(client: OAuth2Client): Promise<OauthWebLogin> {
   const authUrl = client.generateAuthUrl({
     redirect_uri: redirectUri,
     access_type: 'offline',
+    prompt: 'consent',
     scope: OAUTH_SCOPE,
     state,
   });
@@ -736,7 +738,23 @@ async function cacheCredentials(credentials: Credentials) {
   const filePath = Storage.getOAuthCredsPath();
   await fs.mkdir(path.dirname(filePath), { recursive: true });
 
-  const credString = JSON.stringify(credentials, null, 2);
+  // Preserve existing refresh_token when Google only sends a new access_token
+  // during token refresh (refresh_token is only included on initial auth).
+  let merged = credentials;
+  if (!credentials.refresh_token) {
+    try {
+      const existing = await fs.readFile(filePath, 'utf-8');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      const parsed = JSON.parse(existing) as Credentials;
+      if (parsed.refresh_token) {
+        merged = { ...credentials, refresh_token: parsed.refresh_token };
+      }
+    } catch {
+      // No existing file or parse error — proceed with what we have
+    }
+  }
+
+  const credString = JSON.stringify(merged, null, 2);
   await fs.writeFile(filePath, credString, { mode: 0o600 });
   try {
     await fs.chmod(filePath, 0o600);

--- a/packages/core/src/mcp/token-storage/base-token-storage.ts
+++ b/packages/core/src/mcp/token-storage/base-token-storage.ts
@@ -39,6 +39,13 @@ export abstract class BaseTokenStorage implements TokenStorage {
     if (!credentials.token.expiresAt) {
       return false;
     }
+    // If a refresh token exists, the caller (e.g. OAuth2Client) can silently
+    // refresh the access token.  Discarding the credentials here would lose
+    // the refresh token and force an interactive re-auth — which is fatal in
+    // non-interactive / headless sessions (swarms, CI, -p flag).
+    if (credentials.token.refreshToken) {
+      return false;
+    }
     const bufferMs = 5 * 60 * 1000;
     return Date.now() > credentials.token.expiresAt - bufferMs;
   }


### PR DESCRIPTION
Fixes #21691

## Summary
- `saveCredentials`: merge with existing stored refresh token when Google only sends a new access_token during token refresh (both encrypted and file-based paths)
- `isExpired`: don't discard credentials that have a refresh token — the caller can silently refresh the access token
- Add `prompt: 'consent'` to OAuth flows to ensure Google always returns a refresh token

## Test plan
- [x] Manual: authenticate, wait >1 hour, verify refresh works without re-auth
- [x] Verified refresh token preserved across token refresh events