### PR TITLE
feat(skills): allow trusted skills to auto-activate without confirmation prompt

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -934,6 +934,7 @@ export async function loadCliConfig(
     enableEventDrivenScheduler: true,
     skillsSupport: settings.skills?.enabled ?? true,
     disabledSkills: settings.skills?.disabled,
+    trustedSkills: settings.skills?.trusted,
     experimentalJitContext: settings.experimental?.jitContext,
     experimentalMemoryManager: settings.experimental?.memoryManager,
     modelSteering: settings.experimental?.modelSteering,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -2177,6 +2177,18 @@ const SETTINGS_SCHEMA = {
         items: { type: 'string' },
         mergeStrategy: MergeStrategy.UNION,
       },
+      trusted: {
+        type: 'array',
+        label: 'Trusted Skills',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: [] as string[],
+        description:
+          'List of skill names that are automatically allowed to activate without a confirmation prompt.',
+        showInDialog: false,
+        items: { type: 'string' },
+        mergeStrategy: MergeStrategy.UNION,
+      },
     },
   },
 

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -2187,7 +2187,7 @@ const SETTINGS_SCHEMA = {
           'List of skill names that are automatically allowed to activate without a confirmation prompt.',
         showInDialog: false,
         items: { type: 'string' },
-        mergeStrategy: MergeStrategy.UNION,
+        mergeStrategy: MergeStrategy.REPLACE,
       },
     },
   },

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -648,6 +648,7 @@ export interface ConfigParameters {
   enableEventDrivenScheduler?: boolean;
   skillsSupport?: boolean;
   disabledSkills?: string[];
+  trustedSkills?: string[];
   adminSkillsEnabled?: boolean;
   experimentalJitContext?: boolean;
   experimentalMemoryManager?: boolean;
@@ -874,6 +875,7 @@ export class Config implements McpContext, AgentLoopContext {
   private readonly enableEventDrivenScheduler: boolean;
   private readonly skillsSupport: boolean;
   private disabledSkills: string[];
+  private trustedSkills?: string[];
   private readonly adminSkillsEnabled: boolean;
 
   private readonly experimentalJitContext: boolean;
@@ -1006,6 +1008,7 @@ export class Config implements McpContext, AgentLoopContext {
     this.enableEventDrivenScheduler = params.enableEventDrivenScheduler ?? true;
     this.skillsSupport = params.skillsSupport ?? true;
     this.disabledSkills = params.disabledSkills ?? [];
+    this.trustedSkills = params.trustedSkills ?? [];
     this.adminSkillsEnabled = params.adminSkillsEnabled ?? true;
     this.modelAvailabilityService = new ModelAvailabilityService();
     this.dynamicModelConfiguration = params.dynamicModelConfiguration ?? false;
@@ -2922,6 +2925,10 @@ export class Config implements McpContext, AgentLoopContext {
 
   isSkillsSupportEnabled(): boolean {
     return this.skillsSupport;
+  }
+
+  getTrustedSkills(): string[] {
+    return this.trustedSkills;
   }
 
   /**

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -875,7 +875,7 @@ export class Config implements McpContext, AgentLoopContext {
   private readonly enableEventDrivenScheduler: boolean;
   private readonly skillsSupport: boolean;
   private disabledSkills: string[];
-  private trustedSkills?: string[];
+  private trustedSkills: string[];
   private readonly adminSkillsEnabled: boolean;
 
   private readonly experimentalJitContext: boolean;

--- a/packages/core/src/tools/activate-skill.ts
+++ b/packages/core/src/tools/activate-skill.ts
@@ -87,7 +87,7 @@ class ActivateSkillToolInvocation extends BaseToolInvocation<
     }
 
     const trustedSkills = this.config.getTrustedSkills();
-    if (trustedSkills.includes(skillName)) {
+    if (this.config.isTrustedFolder() && trustedSkills.includes(skillName)) {
       return false;
     }
 

--- a/packages/core/src/tools/activate-skill.ts
+++ b/packages/core/src/tools/activate-skill.ts
@@ -86,6 +86,11 @@ class ActivateSkillToolInvocation extends BaseToolInvocation<
       return false;
     }
 
+    const trustedSkills = this.config.getTrustedSkills();
+    if (trustedSkills.includes(skillName)) {
+      return false;
+    }
+
     const folderStructure = await this.getOrFetchFolderStructure(
       skill.location,
     );


### PR DESCRIPTION
## Summary

Adds a `skills.trusted` setting that lets users whitelist specific skills to activate without a confirmation dialog, without enabling full YOLO mode.

Closes #17196

## Motivation

Currently the only way to skip the skill activation prompt is to enable YOLO mode, which auto-approves **all** tool calls. There's no middle ground for users who have verified a skill and want it to activate silently while keeping normal confirmation behaviour for everything else.

## Solution

Add a `skills.trusted` string array to the settings schema, parallel to the existing `skills.disabled`. Any skill whose name appears in this list bypasses `getConfirmationDetails()` and activates immediately, identical to how built-in skills behave.

## Usage
```json
{
  "skills": {
    "trusted": ["code-reviewer", "test-runner"]
  }
}
```

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/config/settingsSchema.ts` | Add `trusted` array to `skills` schema block |
| `packages/core/src/config/config.ts` | Add `trustedSkills` to `ConfigParameters` interface, `Config` class fields, constructor, and `getTrustedSkills()` getter |
| `packages/cli/src/config/config.ts` | Pass `settings.skills?.trusted` to `Config` constructor |
| `packages/core/src/tools/activate-skill.ts` | Check trusted list in `getConfirmationDetails()` before prompting |

## Testing

- Skill in `skills.trusted` → activates without prompt
- Skill not in list → confirmation prompt shown as before  
- Built-in skills → unchanged (still skip prompt via `isBuiltin` check)