### PR TITLE
fix(agents): codebase_investigator times out on large codebases before returning any output

### DIFF
--- a/packages/core/src/agents/codebase-investigator.test.ts
+++ b/packages/core/src/agents/codebase-investigator.test.ts
@@ -77,4 +77,22 @@ describe('CodebaseInvestigatorAgent', () => {
     const agent = CodebaseInvestigatorAgent(config);
     expect(agent.promptConfig.systemPrompt).toContain('`ls -R`');
   });
+
+  it('should use default runConfig values when env vars are not set', () => {
+    delete process.env['GEMINI_CBI_TIMEOUT_MINUTES'];
+    delete process.env['GEMINI_CBI_MAX_TURNS'];
+    const agent = CodebaseInvestigatorAgent(config);
+    expect(agent.runConfig.maxTimeMinutes).toBe(10);
+    expect(agent.runConfig.maxTurns).toBe(25);
+  });
+
+  it('should respect GEMINI_CBI_TIMEOUT_MINUTES and GEMINI_CBI_MAX_TURNS env vars', () => {
+    process.env['GEMINI_CBI_TIMEOUT_MINUTES'] = '20';
+    process.env['GEMINI_CBI_MAX_TURNS'] = '50';
+    const agent = CodebaseInvestigatorAgent(config);
+    expect(agent.runConfig.maxTimeMinutes).toBe(20);
+    expect(agent.runConfig.maxTurns).toBe(50);
+    delete process.env['GEMINI_CBI_TIMEOUT_MINUTES'];
+    delete process.env['GEMINI_CBI_MAX_TURNS'];
+  });
 });

--- a/packages/core/src/agents/codebase-investigator.test.ts
+++ b/packages/core/src/agents/codebase-investigator.test.ts
@@ -20,6 +20,7 @@ describe('CodebaseInvestigatorAgent', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   const mockPlatform = (platform: string) => {
@@ -79,20 +80,18 @@ describe('CodebaseInvestigatorAgent', () => {
   });
 
   it('should use default runConfig values when env vars are not set', () => {
-    delete process.env['GEMINI_CBI_TIMEOUT_MINUTES'];
-    delete process.env['GEMINI_CBI_MAX_TURNS'];
+    vi.stubEnv('GEMINI_CBI_TIMEOUT_MINUTES', '');
+    vi.stubEnv('GEMINI_CBI_MAX_TURNS', '');
     const agent = CodebaseInvestigatorAgent(config);
     expect(agent.runConfig.maxTimeMinutes).toBe(10);
     expect(agent.runConfig.maxTurns).toBe(25);
   });
 
   it('should respect GEMINI_CBI_TIMEOUT_MINUTES and GEMINI_CBI_MAX_TURNS env vars', () => {
-    process.env['GEMINI_CBI_TIMEOUT_MINUTES'] = '20';
-    process.env['GEMINI_CBI_MAX_TURNS'] = '50';
+    vi.stubEnv('GEMINI_CBI_TIMEOUT_MINUTES', '20');
+    vi.stubEnv('GEMINI_CBI_MAX_TURNS', '50');
     const agent = CodebaseInvestigatorAgent(config);
     expect(agent.runConfig.maxTimeMinutes).toBe(20);
     expect(agent.runConfig.maxTurns).toBe(50);
-    delete process.env['GEMINI_CBI_TIMEOUT_MINUTES'];
-    delete process.env['GEMINI_CBI_MAX_TURNS'];
   });
 });

--- a/packages/core/src/agents/codebase-investigator.ts
+++ b/packages/core/src/agents/codebase-investigator.ts
@@ -109,8 +109,9 @@ export const CodebaseInvestigatorAgent = (
     },
 
     runConfig: {
-      maxTimeMinutes: 3,
-      maxTurns: 10,
+      maxTimeMinutes:
+        parseInt(process.env['GEMINI_CBI_TIMEOUT_MINUTES'] ?? '', 10) || 10,
+      maxTurns: parseInt(process.env['GEMINI_CBI_MAX_TURNS'] ?? '', 10) || 25,
     },
 
     toolConfig: {


### PR DESCRIPTION
Fixes #16928
Related: #13589

## Problem
The `codebase_investigator` agent consistently timed out on moderately-sized codebases without returning any output. Users reported this happening every single time the agent was invoked for comprehensive reviews.

## Root Cause
`codebase-investigator.ts` had hardcoded `maxTimeMinutes: 3` and `maxTurns: 10` in its `runConfig`. These values fed directly into `DeadlineTimer` in `local-executor.ts`, giving the agent only 3 minutes and 10 turns regardless
of codebase size or task complexity. A full codebase review, which requires recursive directory listing, reading multiple files, and cross-referencing symbols, cannot realistically complete within these limits.

## Fix
- Raised default `maxTimeMinutes` from 3 → 10
- Raised default `maxTurns` from 10 → 25  
- Both values are now user-configurable via environment variables, with no breaking changes to existing behaviour:
  - `GEMINI_CBI_TIMEOUT_MINUTES` (default: 10)
  - `GEMINI_CBI_MAX_TURNS` (default: 25)

## Testing
Added 2 unit tests to `codebase-investigator.test.ts`:
- Verifies default values of 10 minutes and 25 turns when env vars are unset
- Verifies env vars correctly override both limits

All 6 tests pass.