### PR TITLE
test(core): add stableStringify coverage

### DIFF
--- a/packages/core/src/policy/stable-stringify.test.ts
+++ b/packages/core/src/policy/stable-stringify.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { stableStringify } from './stable-stringify.js';
+
+describe('stableStringify', () => {
+  it('should stringify primitive values', () => {
+    expect(stableStringify('test')).toBe('"test"');
+    expect(stableStringify(42)).toBe('42');
+    expect(stableStringify(true)).toBe('true');
+    expect(stableStringify(null)).toBe('null');
+  });
+
+  it('should sort object keys deterministically', () => {
+    expect(
+      stableStringify({
+        b: 2,
+        a: 1,
+        nested: {
+          d: 4,
+          c: 3,
+        },
+      }),
+    ).toBe('{"a":1,"b":2,"nested":{"c":3,"d":4}}');
+  });
+
+  it('should handle arrays using JSON.stringify-compatible null conversions', () => {
+    expect(
+      stableStringify([
+        1,
+        undefined,
+        () => 'ignored',
+        {
+          b: 2,
+          a: 1,
+        },
+        null,
+      ]),
+    ).toBe('[1,null,null,{"a":1,"b":2},null]');
+  });
+
+  it('should replace circular references with [Circular]', () => {
+    const circular: Record<string, unknown> = { a: 1 };
+    circular.self = circular;
+
+    expect(stableStringify(circular)).toBe('{"a":1,"self":"[Circular]"}');
+  });
+
+  it('should serialize repeated non-circular references normally', () => {
+    const shared = { value: 1 };
+
+    expect(
+      stableStringify({
+        first: shared,
+        second: shared,
+      }),
+    ).toBe('{"first":{"value":1},"second":{"value":1}}');
+  });
+
+  it('should respect toJSON results', () => {
+    const withToJson = {
+      hidden: 'secret',
+      toJSON: () => ({
+        b: 2,
+        a: 1,
+      }),
+    };
+
+    expect(stableStringify(withToJson)).toBe('{"a":1,"b":2}');
+  });
+
+  it('should fall back to regular object serialization when toJSON throws', () => {
+    const withThrowingToJson = {
+      z: 1,
+      a: 2,
+      toJSON: () => {
+        throw new Error('boom');
+      },
+    };
+
+    expect(stableStringify(withThrowingToJson)).toBe('{"a":2,"z":1}');
+  });
+});


### PR DESCRIPTION
## What?
Add a dedicated `stableStringify` unit test file in `packages/core/src/policy`.

## Why?
Issue #21701 points out that this security-critical utility had no direct unit coverage despite documented behavior that should be verified independently of `policy-engine.test.ts`.

## How?
- add a focused `stable-stringify.test.ts`
- cover primitive serialization
- verify deterministic key sorting for nested objects
- verify JSON-compatible array null coercion
- verify circular reference replacement
- verify repeated non-circular references are preserved
- verify `toJSON` handling and fallback when `toJSON` throws

## Testing
- `npm run test --workspace @google/gemini-cli-core -- src/policy/stable-stringify.test.ts`

Closes #21701