### PR TITLE
feat(cli): add /compact alias for /compress command

### DIFF
--- a/packages/cli/src/ui/commands/compressCommand.test.ts
+++ b/packages/cli/src/ui/commands/compressCommand.test.ts
@@ -131,4 +131,12 @@ describe('compressCommand', () => {
     await compressCommand.action!(context, '');
     expect(context.ui.setPendingItem).toHaveBeenCalledWith(null);
   });
+
+  describe('metadata', () => {
+    it('should have the correct name and aliases', () => {
+      expect(compressCommand.name).toBe('compress');
+      expect(compressCommand.altNames).toContain('summarize');
+      expect(compressCommand.altNames).toContain('compact');
+    });
+  });
 });

--- a/packages/cli/src/ui/commands/compressCommand.ts
+++ b/packages/cli/src/ui/commands/compressCommand.ts
@@ -11,7 +11,7 @@ import { CommandKind } from './types.js';
 
 export const compressCommand: SlashCommand = {
   name: 'compress',
-  altNames: ['summarize'],
+  altNames: ['summarize', 'compact'],
   description: 'Compresses the context by replacing it with a summary',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,


### PR DESCRIPTION
## Summary
Adds the `/compact` alias for the `/compress` command to allow users to use `/compact` as a more familiar alternative to `/compress` or `/summarize`.

## Details
- Added `'compact'` to the `altNames` array in `packages/cli/src/ui/commands/compressCommand.ts`.
- Added a metadata test suite in `packages/cli/src/ui/commands/compressCommand.test.ts` to verify the command name and aliases (`summarize` and `compact`).

## Related Issues
N/A

## How to Validate
1. Run `npm test -w @google/gemini-cli -- src/ui/commands/compressCommand.test.ts`
2. Run the CLI and type `/compact` followed by enter to compress the context.

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker