### PR TITLE
Unmarshall update

### DIFF
--- a/packages/cli/src/config/extensions/variables.test.ts
+++ b/packages/cli/src/config/extensions/variables.test.ts
@@ -124,4 +124,30 @@ describe('recursivelyHydrateStrings', () => {
     const result = recursivelyHydrateStrings(obj, context);
     expect(result).toEqual(obj);
   });
+
+  it('should not allow prototype pollution via __proto__', () => {
+    const payload = JSON.parse('{"__proto__": {"polluted": "yes"}}');
+    const result = recursivelyHydrateStrings(payload, context);
+
+    expect(result.polluted).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(result, 'polluted')).toBe(
+      false,
+    );
+  });
+
+  it('should not allow prototype pollution via constructor', () => {
+    const payload = JSON.parse(
+      '{"constructor": {"prototype": {"polluted": "yes"}}}',
+    );
+    const result = recursivelyHydrateStrings(payload, context);
+
+    expect(result.polluted).toBeUndefined();
+  });
+
+  it('should not allow prototype pollution via prototype', () => {
+    const payload = JSON.parse('{"prototype": {"polluted": "yes"}}');
+    const result = recursivelyHydrateStrings(payload, context);
+
+    expect(result.polluted).toBeUndefined();
+  });
 });

--- a/packages/cli/src/config/extensions/variables.ts
+++ b/packages/cli/src/config/extensions/variables.ts
@@ -65,7 +65,12 @@ export function recursivelyHydrateStrings<T>(
   if (typeof obj === 'object' && obj !== null) {
     const newObj: Record<string, unknown> = {};
     for (const key in obj) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      if (
+        key !== '__proto__' &&
+        key !== 'constructor' &&
+        key !== 'prototype' &&
+        Object.prototype.hasOwnProperty.call(obj, key)
+      ) {
         newObj[key] = recursivelyHydrateStrings(
           // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
           (obj as Record<string, unknown>)[key],

--- a/packages/cli/src/config/extensions/variables.ts
+++ b/packages/cli/src/config/extensions/variables.ts
@@ -9,7 +9,7 @@ import { type VariableSchema, VARIABLE_SCHEMA } from './variableSchema.js';
 import { GEMINI_DIR } from '@google/gemini-cli-core';
 
 /**
- * Respresents a set of keys that will be considered invalid while umarshalling
+ * Represents a set of keys that will be considered invalid while unmarshalling
  * JSON in recursivelyHydrateStrings.
  */
 const UNMARSHALL_KEY_IGNORE_LIST: Set<string> = new Set<string>([

--- a/packages/cli/src/config/extensions/variables.ts
+++ b/packages/cli/src/config/extensions/variables.ts
@@ -8,6 +8,16 @@ import * as path from 'node:path';
 import { type VariableSchema, VARIABLE_SCHEMA } from './variableSchema.js';
 import { GEMINI_DIR } from '@google/gemini-cli-core';
 
+/**
+ * Respresents a set of keys that will be considered invalid while umarshalling
+ * JSON in recursivelyHydrateStrings.
+ */
+const UNMARSHALL_KEY_IGNORE_LIST: Set<string> = new Set<string>([
+  '__proto__',
+  'constructor',
+  'prototype',
+]);
+
 export const EXTENSIONS_DIRECTORY_NAME = path.join(GEMINI_DIR, 'extensions');
 export const EXTENSIONS_CONFIG_FILENAME = 'gemini-extension.json';
 export const INSTALL_METADATA_FILENAME = '.gemini-extension-install.json';
@@ -66,9 +76,7 @@ export function recursivelyHydrateStrings<T>(
     const newObj: Record<string, unknown> = {};
     for (const key in obj) {
       if (
-        key !== '__proto__' &&
-        key !== 'constructor' &&
-        key !== 'prototype' &&
+        !UNMARSHALL_KEY_IGNORE_LIST.has(key) &&
         Object.prototype.hasOwnProperty.call(obj, key)
       ) {
         newObj[key] = recursivelyHydrateStrings(


### PR DESCRIPTION
## Summary

Added an ignore list for object keys when unmarshalling JSON in recursivelyHydrateStrings.

## Details

The recursivelyHydrateStrings function now sanitizes object keys by skipping __proto__, constructor, and prototype.
Added tests to verify this.

## Related Issues

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/1499