### PR TITLE
fix broken extension link in hooks guide

### DIFF
--- a/docs/hooks/writing-hooks.md
+++ b/docs/hooks/writing-hooks.md
@@ -470,5 +470,5 @@ console.error('Consolidating memories for session end...');
 
 While project-level hooks are great for specific repositories, you can share
 your hooks across multiple projects by packaging them as a
-[Gemini CLI extension](../extensions/index.md).
-This provides version control, easy distribution, and centralized management.
+[Gemini CLI extension](../extensions/index.md). This provides version control,
+easy distribution, and centralized management.

--- a/docs/hooks/writing-hooks.md
+++ b/docs/hooks/writing-hooks.md
@@ -470,5 +470,5 @@ console.error('Consolidating memories for session end...');
 
 While project-level hooks are great for specific repositories, you can share
 your hooks across multiple projects by packaging them as a
-[Gemini CLI extension](https://www.google.com/search?q=../extensions/index.md).
+[Gemini CLI extension](../extensions/index.md).
 This provides version control, easy distribution, and centralized management.


### PR DESCRIPTION

## Summary

Fixes a broken documentation link in the hooks guide that incorrectly sends users to a Google search instead of the local extensions docs page. This makes the “Packaging as an extension” section navigable and consistent with the rest of the docs.

Fixes #21712

## Details

- Updates the “Gemini CLI extension” link in docs/hooks/writing-hooks.md to use a relative path: `../extensions/index.md`.
- No behavior change; docs-only fix.

## Related Issues

- Related to #(add-issue-number-if-one-exists)

## How to Validate

1. Open docs/hooks/writing-hooks.md.
2. Scroll to “## Packaging as an extension”.
3. Click “Gemini CLI extension”.
4. Confirm it navigates to the extensions index page (and does not go to a Google search).

Optional CLI check:
- Run `grep -n "google.com/search?q=../extensions/index.md" -R docs/` and confirm no matches.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ x] Validated on required platforms/methods:
  - [x ] MacOS
    - [ x] npm run
    - [ x] npx
    - [ x] Docker
    - [ x] Podman
    - [ x] Seatbelt
  - [ x] Windows
    - [ x] npm run
    - [ x] npx
    - [ x] Docker
  - [x] Linux
    - [ x] npm run
    - [ x] npx
    - [ x] Docker