### PR TITLE
fix(core): prevent infinite recursion in symlink resolution

### DIFF
--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -542,6 +542,24 @@ describe('resolveToRealPath', () => {
 
     expect(resolveToRealPath(childPath)).toBe(expectedPath);
   });
+
+  it('should prevent infinite recursion on malicious symlink structures', () => {
+    const maliciousPath = path.resolve('malicious', 'symlink');
+
+    vi.spyOn(fs, 'realpathSync').mockImplementation(() => {
+      const err = new Error('ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    });
+
+    vi.spyOn(fs, 'lstatSync').mockImplementation(() => ({ isSymbolicLink: () => true } as fs.Stats));
+
+    vi.spyOn(fs, 'readlinkSync').mockImplementation(() => ['..', 'malicious', 'symlink'].join(path.sep));
+
+    expect(() => resolveToRealPath(maliciousPath)).toThrow(
+      /Infinite recursion detected/,
+    );
+  });
 });
 
 describe('normalizePath', () => {

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -552,9 +552,13 @@ describe('resolveToRealPath', () => {
       throw err;
     });
 
-    vi.spyOn(fs, 'lstatSync').mockImplementation(() => ({ isSymbolicLink: () => true } as fs.Stats));
+    vi.spyOn(fs, 'lstatSync').mockImplementation(
+      () => ({ isSymbolicLink: () => true }) as fs.Stats,
+    );
 
-    vi.spyOn(fs, 'readlinkSync').mockImplementation(() => ['..', 'malicious', 'symlink'].join(path.sep));
+    vi.spyOn(fs, 'readlinkSync').mockImplementation(() =>
+      ['..', 'malicious', 'symlink'].join(path.sep),
+    );
 
     expect(() => resolveToRealPath(maliciousPath)).toThrow(
       /Infinite recursion detected/,

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -484,6 +484,10 @@ describe('shortenPath', () => {
 });
 
 describe('resolveToRealPath', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it.each([
     {
       description:

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -376,10 +376,11 @@ export function resolveToRealPath(pathStr: string): string {
 }
 
 function robustRealpath(p: string, visited = new Set<string>()): string {
-  if (visited.has(p)) {
+  const key = process.platform === 'win32' ? p.toLowerCase() : p;
+  if (visited.has(key)) {
     throw new Error(`Infinite recursion detected in robustRealpath: ${p}`);
   }
-  visited.add(p);
+  visited.add(key);
   try {
     return fs.realpathSync(p);
   } catch (e: unknown) {

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -375,7 +375,11 @@ export function resolveToRealPath(pathStr: string): string {
   return robustRealpath(path.resolve(resolvedPath));
 }
 
-function robustRealpath(p: string): string {
+function robustRealpath(p: string, visited = new Set<string>()): string {
+  if (visited.has(p)) {
+    throw new Error(`Infinite recursion detected in robustRealpath: ${p}`);
+  }
+  visited.add(p);
   try {
     return fs.realpathSync(p);
   } catch (e: unknown) {
@@ -385,14 +389,25 @@ function robustRealpath(p: string): string {
         if (stat.isSymbolicLink()) {
           const target = fs.readlinkSync(p);
           const resolvedTarget = path.resolve(path.dirname(p), target);
-          return robustRealpath(resolvedTarget);
+          return robustRealpath(resolvedTarget, visited);
         }
-      } catch {
-        // Not a symlink, or lstat failed. Just resolve parent.
+      } catch (lstatError: unknown) {
+        // Not a symlink, or lstat failed. Re-throw if it's not an expected
+        // ENOENT (e.g., a permissions error), otherwise resolve parent.
+        if (
+          !(
+            lstatError &&
+            typeof lstatError === 'object' &&
+            'code' in lstatError &&
+            lstatError.code === 'ENOENT'
+          )
+        ) {
+          throw lstatError;
+        }
       }
       const parent = path.dirname(p);
       if (parent === p) return p;
-      return path.join(robustRealpath(parent), path.basename(p));
+      return path.join(robustRealpath(parent, visited), path.basename(p));
     }
     throw e;
   }


### PR DESCRIPTION
## Summary

This PR adds infinite recursion protection to the `resolveToRealPath` utility. It prevents the process from hanging or crashing when encountering malicious or circular symlink structures that `fs.realpathSync` might not handle robustly in all environments.

## Details

- Modified `robustRealpath` to track visited paths using a `Set`.
- If a path is encountered more than once during the resolution of a single symlink chain, an `Error` is thrown with a descriptive message.
- Added a new unit test in `packages/core/src/utils/paths.test.ts` that mocks a malicious symlink structure to verify the recursion detection.

## Related Issues

Fixes a security vulnerability related to symlink path validation.
#21489 
## How to Validate

1. Run the new unit test:
   ```bash
   npm test -w @google/gemini-cli-core -- src/utils/paths.test.ts
   ```
2. Verify that the test `should prevent infinite recursion on malicious symlink structures` passes.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
