### PR TITLE
fix(cli): defer auto-update on Windows to avoid file-locking errors

### DIFF
--- a/packages/cli/src/utils/handleAutoUpdate.test.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.test.ts
@@ -377,20 +377,39 @@ describe('handleAutoUpdate', () => {
 });
 
 describe('buildWindowsDeferredUpdateCommand', () => {
-  it('should include Wait-Process with the parent PID', () => {
+  function decodeEncodedCommand(command: string): string {
+    const match = command.match(/-EncodedCommand\s+(\S+)/);
+    if (!match) return '';
+    return Buffer.from(match[1], 'base64').toString('utf16le');
+  }
+
+  it('should use -EncodedCommand with a Base64 payload', () => {
     const command = buildWindowsDeferredUpdateCommand(
       'npm install -g @google/gemini-cli@2.0.0',
       12345,
     );
-    expect(command).toContain('Wait-Process -Id 12345');
+    expect(command).toContain('-EncodedCommand');
+    // The encoded payload should decode back to a valid PowerShell script
+    const decoded = decodeEncodedCommand(command);
+    expect(decoded).toBeTruthy();
   });
 
-  it('should include the update command in the PowerShell script', () => {
+  it('should include Wait-Process with the parent PID in the decoded script', () => {
     const command = buildWindowsDeferredUpdateCommand(
       'npm install -g @google/gemini-cli@2.0.0',
       12345,
     );
-    expect(command).toContain('npm install -g @google/gemini-cli@2.0.0');
+    const decoded = decodeEncodedCommand(command);
+    expect(decoded).toContain('Wait-Process -Id 12345');
+  });
+
+  it('should include the update command in the decoded script', () => {
+    const command = buildWindowsDeferredUpdateCommand(
+      'npm install -g @google/gemini-cli@2.0.0',
+      12345,
+    );
+    const decoded = decodeEncodedCommand(command);
+    expect(decoded).toContain('npm install -g @google/gemini-cli@2.0.0');
   });
 
   it('should use hidden window style', () => {
@@ -401,12 +420,13 @@ describe('buildWindowsDeferredUpdateCommand', () => {
     expect(command).toContain('-WindowStyle Hidden');
   });
 
-  it('should include a startup delay', () => {
+  it('should include a startup delay in the decoded script', () => {
     const command = buildWindowsDeferredUpdateCommand(
       'npm install -g @google/gemini-cli@2.0.0',
       1,
     );
-    expect(command).toContain('Start-Sleep -Seconds 2');
+    const decoded = decodeEncodedCommand(command);
+    expect(decoded).toContain('Start-Sleep -Seconds 2');
   });
 });
 
@@ -486,8 +506,13 @@ describe('handleAutoUpdate on Windows', () => {
     expect(mockSpawn).toHaveBeenCalledOnce();
     const spawnedCommand = mockSpawn.mock.calls[0][0] as string;
     expect(spawnedCommand).toContain('powershell.exe');
-    expect(spawnedCommand).toContain('Wait-Process');
-    expect(spawnedCommand).toContain('npm install -g @google/gemini-cli@2.0.0');
+    expect(spawnedCommand).toContain('-EncodedCommand');
+    // Decode the Base64 payload and verify it contains the update command
+    const match = spawnedCommand.match(/-EncodedCommand\s+(\S+)/);
+    expect(match).toBeTruthy();
+    const decoded = Buffer.from(match![1], 'base64').toString('utf16le');
+    expect(decoded).toContain('npm install -g @google/gemini-cli@2.0.0');
+    expect(decoded).toContain('Wait-Process');
   });
 
   it('should use windowsHide option on Windows', () => {

--- a/packages/cli/src/utils/handleAutoUpdate.test.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.test.ts
@@ -18,6 +18,7 @@ import {
   isUpdateInProgress,
   waitForUpdateCompletion,
   _setUpdateStateForTesting,
+  buildWindowsDeferredUpdateCommand,
 } from './handleAutoUpdate.js';
 import { MessageType } from '../ui/types.js';
 
@@ -36,6 +37,7 @@ vi.mock('./updateEventEmitter.js', async (importOriginal) =>
 const mockGetInstallationInfo = vi.mocked(getInstallationInfo);
 
 describe('handleAutoUpdate', () => {
+  const originalPlatform = process.platform;
   let mockSpawn: Mock;
   let mockUpdateInfo: UpdateObject;
   let mockSettings: LoadedSettings;
@@ -44,6 +46,13 @@ describe('handleAutoUpdate', () => {
   beforeEach(() => {
     vi.stubEnv('GEMINI_SANDBOX', '');
     vi.stubEnv('SANDBOX', '');
+    // Use a non-Windows platform so the existing tests exercise the
+    // standard (non-deferred) update path. Windows-specific behavior
+    // is covered in a dedicated describe block.
+    Object.defineProperty(process, 'platform', {
+      value: 'linux',
+      configurable: true,
+    });
     mockSpawn = vi.fn();
     vi.clearAllMocks();
     vi.spyOn(updateEventEmitter, 'emit');
@@ -83,6 +92,10 @@ describe('handleAutoUpdate', () => {
   });
 
   afterEach(() => {
+    Object.defineProperty(process, 'platform', {
+      value: originalPlatform,
+      configurable: true,
+    });
     vi.unstubAllEnvs();
     vi.clearAllMocks();
     _setUpdateStateForTesting(false);
@@ -359,6 +372,163 @@ describe('handleAutoUpdate', () => {
     expect(updateEventEmitter.emit).toHaveBeenCalledWith('update-success', {
       message:
         'Update successful! The new version will be used on your next run.',
+    });
+  });
+});
+
+describe('buildWindowsDeferredUpdateCommand', () => {
+  it('should include Wait-Process with the parent PID', () => {
+    const command = buildWindowsDeferredUpdateCommand(
+      'npm install -g @google/gemini-cli@2.0.0',
+      12345,
+    );
+    expect(command).toContain('Wait-Process -Id 12345');
+  });
+
+  it('should include the update command in the PowerShell script', () => {
+    const command = buildWindowsDeferredUpdateCommand(
+      'npm install -g @google/gemini-cli@2.0.0',
+      12345,
+    );
+    expect(command).toContain('npm install -g @google/gemini-cli@2.0.0');
+  });
+
+  it('should use hidden window style', () => {
+    const command = buildWindowsDeferredUpdateCommand(
+      'npm install -g @google/gemini-cli@2.0.0',
+      1,
+    );
+    expect(command).toContain('-WindowStyle Hidden');
+  });
+
+  it('should include a startup delay', () => {
+    const command = buildWindowsDeferredUpdateCommand(
+      'npm install -g @google/gemini-cli@2.0.0',
+      1,
+    );
+    expect(command).toContain('Start-Sleep -Seconds 2');
+  });
+});
+
+describe('handleAutoUpdate on Windows', () => {
+  const originalPlatform = process.platform;
+  let mockSpawn: Mock;
+  let mockSettings: LoadedSettings;
+  let mockChildProcess: ChildProcess;
+  let mockUpdateInfo: UpdateObject;
+
+  beforeEach(() => {
+    vi.stubEnv('GEMINI_SANDBOX', '');
+    vi.stubEnv('SANDBOX', '');
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+      configurable: true,
+    });
+    mockSpawn = vi.fn();
+    vi.clearAllMocks();
+    vi.spyOn(updateEventEmitter, 'emit');
+
+    mockUpdateInfo = {
+      update: {
+        latest: '2.0.0',
+        current: '1.0.0',
+        type: 'major',
+        name: '@google/gemini-cli',
+      },
+      message: 'An update is available!',
+    };
+
+    mockSettings = {
+      merged: {
+        general: {
+          enableAutoUpdate: true,
+          enableAutoUpdateNotification: true,
+        },
+        tools: {
+          sandbox: false,
+        },
+      },
+    } as LoadedSettings;
+
+    mockChildProcess = Object.assign(new EventEmitter(), {
+      stdin: Object.assign(new EventEmitter(), {
+        write: vi.fn(),
+        end: vi.fn(),
+      }),
+      unref: vi.fn(),
+    }) as unknown as ChildProcess;
+
+    mockSpawn.mockReturnValue(
+      mockChildProcess as unknown as ReturnType<typeof mockSpawn>,
+    );
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', {
+      value: originalPlatform,
+      configurable: true,
+    });
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+    _setUpdateStateForTesting(false);
+  });
+
+  it('should spawn a deferred PowerShell command on Windows', () => {
+    mockGetInstallationInfo.mockReturnValue({
+      updateCommand: 'npm install -g @google/gemini-cli@latest',
+      updateMessage: 'Attempting to update...',
+      isGlobal: true,
+      packageManager: PackageManager.NPM,
+    });
+
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+
+    expect(mockSpawn).toHaveBeenCalledOnce();
+    const spawnedCommand = mockSpawn.mock.calls[0][0] as string;
+    expect(spawnedCommand).toContain('powershell.exe');
+    expect(spawnedCommand).toContain('Wait-Process');
+    expect(spawnedCommand).toContain('npm install -g @google/gemini-cli@2.0.0');
+  });
+
+  it('should use windowsHide option on Windows', () => {
+    mockGetInstallationInfo.mockReturnValue({
+      updateCommand: 'npm install -g @google/gemini-cli@latest',
+      updateMessage: 'Attempting to update...',
+      isGlobal: true,
+      packageManager: PackageManager.NPM,
+    });
+
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+
+    const spawnOptions = mockSpawn.mock.calls[0][1];
+    expect(spawnOptions.windowsHide).toBe(true);
+  });
+
+  it('should not mark update as in-progress on Windows', () => {
+    mockGetInstallationInfo.mockReturnValue({
+      updateCommand: 'npm install -g @google/gemini-cli@latest',
+      updateMessage: 'Attempting to update...',
+      isGlobal: true,
+      packageManager: PackageManager.NPM,
+    });
+
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+
+    expect(isUpdateInProgress()).toBe(false);
+  });
+
+  it('should emit update-info with deferred message on Windows', () => {
+    mockGetInstallationInfo.mockReturnValue({
+      updateCommand: 'npm install -g @google/gemini-cli@latest',
+      updateMessage: 'Attempting to update...',
+      isGlobal: true,
+      packageManager: PackageManager.NPM,
+    });
+
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+
+    expect(updateEventEmitter.emit).toHaveBeenCalledWith('update-info', {
+      message: expect.stringContaining('deferred'),
     });
   });
 });

--- a/packages/cli/src/utils/handleAutoUpdate.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.ts
@@ -25,15 +25,15 @@ export function buildWindowsDeferredUpdateCommand(
   updateCommand: string,
   parentPid: number,
 ): string {
-  // Use PowerShell to: wait for the parent process to exit, then run the
-  // update. -ErrorAction SilentlyContinue handles the case where the
-  // process has already exited before Wait-Process runs.
-  return (
-    `powershell.exe -NoProfile -WindowStyle Hidden -Command "` +
+  // Use PowerShell's -EncodedCommand to pass the script as a Base64 string.
+  // This avoids all quoting and special character issues that could arise
+  // from embedding the update command directly in a -Command string.
+  const psScript =
     `Start-Sleep -Seconds 2; ` +
     `try { Wait-Process -Id ${parentPid} -Timeout 60 -ErrorAction SilentlyContinue } catch {}; ` +
-    `${updateCommand}"`
-  );
+    updateCommand;
+  const encodedScript = Buffer.from(psScript, 'utf16le').toString('base64');
+  return `powershell.exe -NoProfile -WindowStyle Hidden -EncodedCommand ${encodedScript}`;
 }
 
 /** @internal */

--- a/packages/cli/src/utils/handleAutoUpdate.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.ts
@@ -16,6 +16,26 @@ import { debugLogger } from '@google/gemini-cli-core';
 
 let _updateInProgress = false;
 
+/**
+ * Builds a PowerShell command that waits for the given process to exit
+ * before running the update command. This avoids file-locking errors on
+ * Windows where the running CLI executable cannot be overwritten.
+ */
+export function buildWindowsDeferredUpdateCommand(
+  updateCommand: string,
+  parentPid: number,
+): string {
+  // Use PowerShell to: wait for the parent process to exit, then run the
+  // update. -ErrorAction SilentlyContinue handles the case where the
+  // process has already exited before Wait-Process runs.
+  return (
+    `powershell.exe -NoProfile -WindowStyle Hidden -Command "` +
+    `Start-Sleep -Seconds 2; ` +
+    `try { Wait-Process -Id ${parentPid} -Timeout 60 -ErrorAction SilentlyContinue } catch {}; ` +
+    `${updateCommand}"`
+  );
+}
+
 /** @internal */
 export function _setUpdateStateForTesting(value: boolean) {
   _updateInProgress = value;
@@ -121,6 +141,33 @@ export function handleAutoUpdate(
     '@latest',
     isNightly ? '@nightly' : `@${info.update.latest}`,
   );
+
+  if (process.platform === 'win32') {
+    // On Windows, the CLI executable is locked while the process is running.
+    // Running npm install -g in the background will fail because it cannot
+    // overwrite the locked files. Instead, spawn a detached PowerShell
+    // process that waits for this process to exit before running the update.
+    const deferredCommand = buildWindowsDeferredUpdateCommand(
+      updateCommand,
+      process.pid,
+    );
+    const updateProcess = spawnFn(deferredCommand, {
+      stdio: 'ignore',
+      shell: true,
+      detached: true,
+      windowsHide: true,
+    });
+    updateProcess.unref();
+
+    // The actual update happens after exit, so we cannot track its progress.
+    // Notify the user that the update will be applied on next launch.
+    updateEventEmitter.emit('update-info', {
+      message:
+        'Update will be applied after you exit the CLI (deferred to avoid Windows file locking).',
+    });
+    return updateProcess;
+  }
+
   const updateProcess = spawnFn(updateCommand, {
     stdio: 'ignore',
     shell: true,


### PR DESCRIPTION
## Summary

On Windows, the CLI executable and its dependencies are locked by the OS while the process is running. The current auto-update mechanism spawns `npm install -g` in the background, which fails silently because it cannot overwrite the locked files — leaving the installation corrupted and requiring a manual `npm install -g @google/gemini-cli@latest` to recover.

This PR fixes the issue by detecting Windows (`process.platform === "win32"`) and deferring the update to a detached PowerShell process that:
1. Waits for the parent CLI process (by PID) to exit
2. Then runs the actual update command

On non-Windows platforms, behavior is completely unchanged.

### Changes
- Added `buildWindowsDeferredUpdateCommand()` that generates a PowerShell one-liner to wait for the parent PID and then run the update
- Modified `handleAutoUpdate()` to use the deferred path on Windows with `windowsHide: true`
- On Windows, the update is not marked as "in progress" since it runs post-exit — the user gets an info message instead
- Added tests for the Windows deferred command builder and the Windows-specific update flow
- Existing non-Windows tests are unaffected (platform is mocked to `linux` in those tests)

### Why PowerShell?
PowerShell is guaranteed to be available on all supported Windows versions (10+). The `Wait-Process` cmdlet provides clean PID-based synchronization. The `-WindowStyle Hidden` flag ensures the update runs invisibly in the background.

Fixes #18899

## Test plan
- [x] All 33 existing + new tests pass
- [x] ESLint + Prettier clean
- [ ] Manual test on Windows: enable auto-update, verify update applies after CLI exit
- [ ] Verify non-Windows behavior is unchanged