### PR TITLE
docs: fix broken link in writing-hooks documentation (#21712)

### DIFF
--- a/docs/hooks/writing-hooks.md
+++ b/docs/hooks/writing-hooks.md
@@ -470,5 +470,5 @@ console.error('Consolidating memories for session end...');
 
 While project-level hooks are great for specific repositories, you can share
 your hooks across multiple projects by packaging them as a
-[Gemini CLI extension](https://www.google.com/search?q=../extensions/index.md).
+[Gemini CLI extension](../extensions/index.md).
 This provides version control, easy distribution, and centralized management.


### PR DESCRIPTION
Corrected the link to the Gemini CLI extension documentation for better accessibility.

## Summary

Updated a faulty link in the "Packaging as an Extension" section of the hooks documentation. The previous link was incorrectly formatted, hindering navigation to the extension-specific guides.

## Details

Refactored the link in docs/hooks/writing-hooks.md to use the correct relative path (../extensions/index.md).

Verified that the target file exists and the path resolves correctly within the documentation hierarchy.

This is a non-functional change intended to improve the documentation's usability.

## Related Issues

Closes #21712

## How to Validate

Navigate to the writing-hooks.md file in the docs directory.

Locate the link labeled "Gemini CLI extension" under the packaging header.

Verify that the link now leads directly to the extensions documentation instead of a search results page or a 404.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [x] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
