### PR TITLE
refactor(core): improve API response error logging when retry

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1154,7 +1154,7 @@ describe('GeminiChat', () => {
         1,
       );
       expect(mockLogContentRetry).not.toHaveBeenCalled();
-      expect(mockLogContentRetryFailure).not.toHaveBeenCalled();
+      expect(mockLogContentRetryFailure).toHaveBeenCalledTimes(1);
     });
 
     it('should yield a RETRY event when an invalid stream is encountered', async () => {

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1154,6 +1154,7 @@ describe('GeminiChat', () => {
         1,
       );
       expect(mockLogContentRetry).not.toHaveBeenCalled();
+      expect(mockLogContentRetryFailure).not.toHaveBeenCalled();
     });
 
     it('should yield a RETRY event when an invalid stream is encountered', async () => {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -412,6 +412,7 @@ export class GeminiChat {
             }
 
             const isContentError = error instanceof InvalidStreamError;
+            const errorType = isContentError ? error.type : 'NETWORK_ERROR';
 
             if (
               (isContentError && isGemini2Model(model)) ||
@@ -420,11 +421,10 @@ export class GeminiChat {
               // Check if we have more attempts left.
               if (attempt < maxAttempts - 1) {
                 const delayMs = INVALID_CONTENT_RETRY_OPTIONS.initialDelayMs;
-                const retryType = isContentError ? error.type : 'NETWORK_ERROR';
 
                 logContentRetry(
                   this.config,
-                  new ContentRetryEvent(attempt, retryType, delayMs, model),
+                  new ContentRetryEvent(attempt, errorType, delayMs, model),
                 );
                 coreEvents.emitRetryAttempt({
                   attempt: attempt + 1,
@@ -440,12 +440,16 @@ export class GeminiChat {
               }
             }
 
-            if (error instanceof InvalidStreamError && isGemini2Model(model)) {
-              logContentRetryFailure(
-                this.config,
-                new ContentRetryFailureEvent(maxAttempts, error.type, model),
-              );
+            // If we've aborted, we throw without logging a failure.
+            if (signal.aborted) {
+              throw error;
             }
+
+            logContentRetryFailure(
+              this.config,
+              new ContentRetryFailureEvent(attempt + 1, errorType, model),
+            );
+
             throw error;
           }
         }

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -344,8 +344,6 @@ export class GeminiChat {
       this: GeminiChat,
     ): AsyncGenerator<StreamEvent, void, void> {
       try {
-        let lastError: unknown = new Error('Request failed after all retries.');
-
         const maxAttempts = INVALID_CONTENT_RETRY_OPTIONS.maxAttempts;
 
         for (let attempt = 0; attempt < maxAttempts; attempt++) {
@@ -374,15 +372,13 @@ export class GeminiChat {
               yield { type: StreamEventType.CHUNK, value: chunk };
             }
 
-            lastError = null;
-            break;
+            return;
           } catch (error) {
             if (error instanceof AgentExecutionStoppedError) {
               yield {
                 type: StreamEventType.AGENT_EXECUTION_STOPPED,
                 reason: error.reason,
               };
-              lastError = null; // Clear error as this is an expected stop
               return; // Stop the generator
             }
 
@@ -397,7 +393,6 @@ export class GeminiChat {
                   value: error.syntheticResponse,
                 };
               }
-              lastError = null; // Clear error as this is an expected stop
               return; // Stop the generator
             }
 
@@ -415,7 +410,7 @@ export class GeminiChat {
               }
               // Fall through to retry logic for retryable connection errors
             }
-            lastError = error;
+
             const isContentError = error instanceof InvalidStreamError;
 
             if (
@@ -444,21 +439,15 @@ export class GeminiChat {
                 continue;
               }
             }
-            break;
-          }
-        }
 
-        if (lastError) {
-          if (
-            lastError instanceof InvalidStreamError &&
-            isGemini2Model(model)
-          ) {
-            logContentRetryFailure(
-              this.config,
-              new ContentRetryFailureEvent(maxAttempts, lastError.type, model),
-            );
+            if (error instanceof InvalidStreamError && isGemini2Model(model)) {
+              logContentRetryFailure(
+                this.config,
+                new ContentRetryFailureEvent(maxAttempts, error.type, model),
+              );
+            }
+            throw error;
           }
-          throw lastError;
         }
       } finally {
         streamDoneResolver!();

--- a/packages/core/src/core/geminiChat_network_retry.test.ts
+++ b/packages/core/src/core/geminiChat_network_retry.test.ts
@@ -401,6 +401,7 @@ describe('GeminiChat Network Retries', () => {
 
     // Should only be called once (no retry)
     expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(1);
+    expect(mockLogContentRetryFailure).not.toHaveBeenCalled();
   });
 
   it('should retry on SSL error during stream iteration (mid-stream failure)', async () => {


### PR DESCRIPTION
## Summary

This PR refactors the API response error handling and retry logic to improve the accuracy of our telemetry and error logging.

## Details
- **Enhanced Failure Logging:** Previously, `logContentRetryFailure` only captured `InvalidStreamError` for Gemini 2 models, missing terminal network failures. Now, it consistently logs `ContentRetryFailureEvent` for all exhausted retryable errors (content and network), with the correct attempt number.
- **Refactored Retry Logic:** Simplifies the stream retry loop in `GeminiChat` by removing the `lastError` tracking variable in favor of immediate throwing within the catch block. 

## Related Issues

Fixes #20189

## How to Validate

Review the code changes and run `npm run test -w @google/gemini-cli-core`. The tests will ensure that retry counts are accurately reported and the logging behaves as expected for both eligible and non-eligible models.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker