### PR TITLE
feat(core): enable retryFetchErrors by default and add user notifications

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1013,7 +1013,7 @@ export class Config implements McpContext {
           params.gemmaModelRouter?.classifier?.model ?? 'gemma3-1b-gpu-custom',
       },
     };
-    this.retryFetchErrors = params.retryFetchErrors ?? false;
+    this.retryFetchErrors = params.retryFetchErrors ?? true;
     this.maxAttempts = Math.min(
       params.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
       DEFAULT_MAX_ATTEMPTS,

--- a/packages/core/src/core/baseLlmClient.test.ts
+++ b/packages/core/src/core/baseLlmClient.test.ts
@@ -118,6 +118,8 @@ describe('BaseLlmClient', () => {
         .mockReturnValue(createAvailabilityServiceMock()),
       setActiveModel: vi.fn(),
       getUserTier: vi.fn().mockReturnValue(undefined),
+      getRetryFetchErrors: vi.fn().mockReturnValue(true),
+      getMaxAttempts: vi.fn().mockReturnValue(3),
       getModel: vi.fn().mockReturnValue('test-model'),
       getActiveModel: vi.fn().mockReturnValue('test-model'),
     } as unknown as Mocked<Config>;

--- a/packages/core/src/core/baseLlmClient.ts
+++ b/packages/core/src/core/baseLlmClient.ts
@@ -21,6 +21,8 @@ import { getErrorMessage } from '../utils/errors.js';
 import { logMalformedJsonResponse } from '../telemetry/loggers.js';
 import { MalformedJsonResponseEvent, LlmRole } from '../telemetry/types.js';
 import { retryWithBackoff } from '../utils/retry.js';
+import { coreEvents } from '../utils/events.js';
+import { getDisplayString } from '../config/models.js';
 import type { ModelConfigKey } from '../services/modelConfigService.js';
 import {
   applyModelSelection,
@@ -327,6 +329,17 @@ export class BaseLlmClient {
           : undefined,
         authType:
           this.authType ?? this.config.getContentGeneratorConfig()?.authType,
+        retryFetchErrors: this.config.getRetryFetchErrors(),
+        onRetry: (attempt, error, delayMs) => {
+          coreEvents.emitRetryAttempt({
+            attempt,
+            maxAttempts:
+              availabilityMaxAttempts ?? maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+            delayMs,
+            error: error instanceof Error ? error.message : String(error),
+            model: getDisplayString(currentModel),
+          });
+        },
       });
     } catch (error) {
       if (abortSignal?.aborted) {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -233,6 +233,8 @@ describe('Gemini Client (client.ts)', () => {
         getDirectories: vi.fn().mockReturnValue(['/test/dir']),
       }),
       getGeminiClient: vi.fn(),
+      getRetryFetchErrors: vi.fn().mockReturnValue(true),
+      getMaxAttempts: vi.fn().mockReturnValue(3),
       getModelRouterService: vi
         .fn()
         .mockReturnValue(mockRouterService as unknown as ModelRouterService),

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -29,6 +29,8 @@ import { getCoreSystemPrompt } from './prompts.js';
 import { checkNextSpeaker } from '../utils/nextSpeakerChecker.js';
 import { reportError } from '../utils/errorReporting.js';
 import { GeminiChat } from './geminiChat.js';
+import { coreEvents, CoreEvent } from '../utils/events.js';
+import { getDisplayString , resolveModel, isGemini2Model } from '../config/models.js';
 import {
   retryWithBackoff,
   type RetryAvailabilityContext,
@@ -69,9 +71,7 @@ import {
   applyModelSelection,
   createAvailabilityContextProvider,
 } from '../availability/policyHelpers.js';
-import { resolveModel, isGemini2Model } from '../config/models.js';
 import { partToString } from '../utils/partUtils.js';
-import { coreEvents, CoreEvent } from '../utils/events.js';
 
 const MAX_TURNS = 100;
 
@@ -1062,7 +1062,18 @@ export class GeminiClient {
         onValidationRequired: onValidationRequiredCallback,
         authType: this.config.getContentGeneratorConfig()?.authType,
         maxAttempts: availabilityMaxAttempts,
+        retryFetchErrors: this.config.getRetryFetchErrors(),
         getAvailabilityContext,
+        onRetry: (attempt, error, delayMs) => {
+          coreEvents.emitRetryAttempt({
+            attempt,
+            maxAttempts:
+              availabilityMaxAttempts ?? this.config.getMaxAttempts(),
+            delayMs,
+            error: error instanceof Error ? error.message : String(error),
+            model: getDisplayString(currentAttemptModel),
+          });
+        },
       });
 
       return result;

--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -248,6 +248,7 @@ describe('WebFetchTool', () => {
       getProxy: vi.fn(),
       getGeminiClient: mockGetGeminiClient,
       getRetryFetchErrors: vi.fn().mockReturnValue(false),
+      getMaxAttempts: vi.fn().mockReturnValue(3),
       getDirectWebFetch: vi.fn().mockReturnValue(false),
       modelConfigService: {
         getResolvedConfig: vi.fn().mockImplementation(({ model }) => ({

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -29,6 +29,7 @@ import {
 import { LlmRole } from '../telemetry/llmRole.js';
 import { WEB_FETCH_TOOL_NAME } from './tool-names.js';
 import { debugLogger } from '../utils/debugLogger.js';
+import { coreEvents } from '../utils/events.js';
 import { retryWithBackoff } from '../utils/retry.js';
 import { WEB_FETCH_DEFINITION } from './definitions/coreTools.js';
 import { resolveToolDeclaration } from './definitions/resolver.js';
@@ -212,6 +213,15 @@ class WebFetchToolInvocation extends BaseToolInvocation<
         },
         {
           retryFetchErrors: this.config.getRetryFetchErrors(),
+          onRetry: (attempt, error, delayMs) => {
+            coreEvents.emitRetryAttempt({
+              attempt,
+              maxAttempts: this.config.getMaxAttempts(),
+              delayMs,
+              error: error instanceof Error ? error.message : String(error),
+              model: 'Web Fetch',
+            });
+          },
         },
       );
 
@@ -405,6 +415,15 @@ ${textContent}
         },
         {
           retryFetchErrors: this.config.getRetryFetchErrors(),
+          onRetry: (attempt, error, delayMs) => {
+            coreEvents.emitRetryAttempt({
+              attempt,
+              maxAttempts: this.config.getMaxAttempts(),
+              delayMs,
+              error: error instanceof Error ? error.message : String(error),
+              model: 'Web Fetch',
+            });
+          },
         },
       );
 


### PR DESCRIPTION
## Summary

Enable `retryFetchErrors` by default in the Gemini CLI and ensure that users are notified whenever a retry attempt occurs. This brings consistency to how network errors and 429 quota errors are handled.

## Details

- Updated `packages/core/src/config/config.ts` to set `retryFetchErrors` to `true` by default.
- Integrated `onRetry` callbacks into `BaseLlmClient`, `Client`, and the `WebFetch` tool.
- Each `onRetry` callback emits a `CoreEvent.RetryAttempt` via the `coreEvents` message bus.
- The CLI UI already handles these events to show a retry message (e.g., "Trying to reach [Model] (Attempt X/Y)").
- Fixed `Config` mocks in `baseLlmClient.test.ts`, `client.test.ts`, and `web-fetch.test.ts` to include missing methods required by the changes.

## Related Issue 
Related to #21809 
Related to enabling better transient error recovery and user awareness.

## How to Validate

1. Run `npm run start` with a configuration that triggers a retryable fetch error or model error.
2. Observe the loading indicator showing the retry attempt and count.
3. Verify all core tests pass: `npm test -w @google/gemini-cli-core -- src/config/config.test.ts src/tools/web-fetch.test.ts src/core/geminiChat_network_retry.test.ts src/core/baseLlmClient.test.ts src/core/client.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
