### PR TITLE
docs(cli): clarify that /clear resets active context

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -79,9 +79,11 @@ Slash commands provide meta-level control over the CLI itself.
 ### `/clear`
 
 - **Description:** Clear the terminal screen, including the visible session
-  history and scrollback within the CLI. The underlying session data (for
-  history recall) might be preserved depending on the exact implementation, but
-  the visual display is cleared.
+  history and scrollback within the CLI. This also resets the active
+  conversation context so you can start a fresh thread without prior context
+  affecting future responses. Underlying session data used for history recall
+  might still be preserved depending on the exact implementation, even though
+  the visible display is cleared.
 - **Keyboard shortcut:** Press **Ctrl+L** at any time to perform a clear action.
 
 ### `/commands`

--- a/packages/cli/src/ui/commands/clearCommand.ts
+++ b/packages/cli/src/ui/commands/clearCommand.ts
@@ -17,7 +17,7 @@ import { randomUUID } from 'node:crypto';
 
 export const clearCommand: SlashCommand = {
   name: 'clear',
-  description: 'Clear the screen and conversation history',
+  description: 'Clear the screen and reset the active conversation context',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
   action: async (context, _args) => {


### PR DESCRIPTION
## Summary
- clarify the `/clear` command reference so it explicitly states that the active conversation context is reset
- update the built-in slash command description to match the documented behavior
- keep the change small and focused on issue scope

Fixes #19239

## Validation
- `npm run test -w packages/cli -- src/ui/commands/clearCommand.test.ts` *(currently fails on the existing `@google/gemini-cli-core` partial mock missing `createCache` export in the upstream test setup)*
- `npm run build` *(currently fails on pre-existing workspace type errors in `packages/a2a-server`, unrelated to this change)*