### PR TITLE
fix(core): handle policy ALLOW for exit_plan_mode

### DIFF
--- a/packages/core/src/tools/exit-plan-mode.test.ts
+++ b/packages/core/src/tools/exit-plan-mode.test.ts
@@ -339,6 +339,26 @@ Ask the user for specific feedback on how to improve the plan.`,
     });
   });
 
+  describe('execute when shouldConfirmExecute is never called', () => {
+    it('should approve with DEFAULT mode when approvalPayload is null (policy ALLOW skips confirmation)', async () => {
+      const planRelativePath = createPlanFile('test.md', '# Content');
+      const invocation = tool.build({ plan_path: planRelativePath });
+
+      // Simulate the scheduler's policy ALLOW path: execute() is called
+      // directly without ever calling shouldConfirmExecute(), leaving
+      // approvalPayload null.
+      const result = await invocation.execute(new AbortController().signal);
+      const expectedPath = path.join(mockPlansDir, 'test.md');
+
+      expect(result.llmContent).toContain('Plan approved');
+      expect(result.returnDisplay).toContain('Plan approved');
+      expect(mockConfig.setApprovalMode).toHaveBeenCalledWith(
+        ApprovalMode.DEFAULT,
+      );
+      expect(mockConfig.setApprovedPlanPath).toHaveBeenCalledWith(expectedPath);
+    });
+  });
+
   describe('getApprovalModeDescription (internal)', () => {
     it('should handle all valid approval modes', async () => {
       const planRelativePath = createPlanFile('test.md', '# Content');

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -203,8 +203,16 @@ export class ExitPlanModeInvocation extends BaseToolInvocation<
       };
     }
 
-    const payload = this.approvalPayload;
-    if (payload?.approved) {
+    // When a user policy grants `allow` for exit_plan_mode, the scheduler
+    // skips the confirmation phase entirely and shouldConfirmExecute is never
+    // called, leaving approvalPayload null.  Treat that as an approval with
+    // the default mode — consistent with the ALLOW branch inside
+    // shouldConfirmExecute.
+    const payload = this.approvalPayload ?? {
+      approved: true,
+      approvalMode: ApprovalMode.DEFAULT,
+    };
+    if (payload.approved) {
       const newMode = payload.approvalMode ?? ApprovalMode.DEFAULT;
 
       if (newMode === ApprovalMode.PLAN || newMode === ApprovalMode.YOLO) {


### PR DESCRIPTION
Fixes #21806

## Problem

When a user policy grants `decision = "allow"` for `exit_plan_mode`, the scheduler correctly skips the confirmation phase. However, this means `shouldConfirmExecute()` is never called, so `approvalPayload` remains `null`. The tool then falls through to the rejection branch and returns **"Rejected (no feedback)"** — even though the policy explicitly allowed execution.

## Solution

Default `approvalPayload` to `{ approved: true, approvalMode: DEFAULT }` when `null`. This matches the existing behavior of the `ALLOW` branch inside `shouldConfirmExecute()` (line 149-157), which sets the same values when the message bus returns `ALLOW`.

## Test

Added a test that calls `execute()` directly without calling `shouldConfirmExecute()` first, simulating the scheduler's policy ALLOW path. Verifies the tool approves with DEFAULT mode and sets the approved plan path.

## Use case

User policies that auto-allow `exit_plan_mode` enable hook-driven plan approval workflows — e.g. routing plan review to a web UI via `BeforeTool` hooks (see [plannotator](https://github.com/backnotprop/plannotator)). Without this fix, the policy `allow` decision has no effect on this tool.