### PR TITLE
feat(core): include available sessions in --resume error message

### DIFF
--- a/packages/cli/src/utils/sessionUtils.test.ts
+++ b/packages/cli/src/utils/sessionUtils.test.ts
@@ -341,6 +341,117 @@ describe('SessionSelector', () => {
     );
   });
 
+  it('should include available sessions in INVALID_SESSION_IDENTIFIER error', async () => {
+    // Create 3 test sessions with different timestamps
+    const sessionId1 = randomUUID();
+    const sessionId2 = randomUUID();
+    const sessionId3 = randomUUID();
+
+    const chatsDir = path.join(tmpDir, 'chats');
+    await fs.mkdir(chatsDir, { recursive: true });
+
+    // Session 1: 2 days ago
+    const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+    const session1 = {
+      sessionId: sessionId1,
+      projectHash: 'test-hash',
+      startTime: twoDaysAgo.toISOString(),
+      lastUpdated: twoDaysAgo.toISOString(),
+      messages: [
+        {
+          type: 'user',
+          content: 'Fix bug in auth',
+          id: 'msg1',
+          timestamp: twoDaysAgo.toISOString(),
+        },
+      ],
+    };
+
+    // Session 2: 5 hours ago
+    const fiveHoursAgo = new Date(Date.now() - 5 * 60 * 60 * 1000);
+    const session2 = {
+      sessionId: sessionId2,
+      projectHash: 'test-hash',
+      startTime: fiveHoursAgo.toISOString(),
+      lastUpdated: fiveHoursAgo.toISOString(),
+      messages: [
+        {
+          type: 'user',
+          content: 'Refactor database schema',
+          id: 'msg2',
+          timestamp: fiveHoursAgo.toISOString(),
+        },
+      ],
+    };
+
+    // Session 3: 2 minutes ago (very recent)
+    const twoMinutesAgo = new Date(Date.now() - 2 * 60 * 1000);
+    const session3 = {
+      sessionId: sessionId3,
+      projectHash: 'test-hash',
+      startTime: twoMinutesAgo.toISOString(),
+      lastUpdated: twoMinutesAgo.toISOString(),
+      messages: [
+        {
+          type: 'user',
+          content: 'Update documentation',
+          id: 'msg3',
+          timestamp: twoMinutesAgo.toISOString(),
+        },
+      ],
+    };
+
+    // Write session files with proper timestamps in filenames
+    await fs.writeFile(
+      path.join(
+        chatsDir,
+        `${SESSION_FILE_PREFIX}${twoDaysAgo.toISOString().slice(0, 10)}T${twoDaysAgo.toISOString().slice(11, 16).replace(':', '-')}-${sessionId1.slice(0, 8)}.json`,
+      ),
+      JSON.stringify(session1, null, 2),
+    );
+
+    await fs.writeFile(
+      path.join(
+        chatsDir,
+        `${SESSION_FILE_PREFIX}${fiveHoursAgo.toISOString().slice(0, 10)}T${fiveHoursAgo.toISOString().slice(11, 16).replace(':', '-')}-${sessionId2.slice(0, 8)}.json`,
+      ),
+      JSON.stringify(session2, null, 2),
+    );
+
+    await fs.writeFile(
+      path.join(
+        chatsDir,
+        `${SESSION_FILE_PREFIX}${twoMinutesAgo.toISOString().slice(0, 10)}T${twoMinutesAgo.toISOString().slice(11, 16).replace(':', '-')}-${sessionId3.slice(0, 8)}.json`,
+      ),
+      JSON.stringify(session3, null, 2),
+    );
+
+    const sessionSelector = new SessionSelector(config);
+
+    // Test that error includes formatted sessions
+    await expect(sessionSelector.resolveSession('99')).rejects.toSatisfy(
+      (error) => {
+        expect(error).toBeInstanceOf(SessionError);
+        expect((error as SessionError).code).toBe('INVALID_SESSION_IDENTIFIER');
+        const errorMessage = (error as SessionError).message;
+
+        // Verify error message structure
+        expect(errorMessage).toContain('Invalid session identifier "99"');
+        expect(errorMessage).toContain('Available sessions for this project:');
+        expect(errorMessage).toContain('Fix bug in auth');
+        expect(errorMessage).toContain('Refactor database schema');
+        expect(errorMessage).toContain('Update documentation');
+
+        // Verify it includes the resume instructions
+        expect(errorMessage).toMatch(
+          /Use --resume 1, 2, 3, or --resume latest/,
+        );
+
+        return true;
+      },
+    );
+  });
+
   it('should throw SessionError with NO_SESSIONS_FOUND when resolving latest with no sessions', async () => {
     // Empty chats directory — no session files
     const chatsDir = path.join(tmpDir, 'chats');

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -57,11 +57,40 @@ export class SessionError extends Error {
   /**
    * Creates an error for when a session identifier is invalid.
    */
-  static invalidSessionIdentifier(identifier: string): SessionError {
-    return new SessionError(
-      'INVALID_SESSION_IDENTIFIER',
-      `Invalid session identifier "${identifier}".\n  Use --list-sessions to see available sessions, then use --resume {number}, --resume {uuid}, or --resume latest.`,
-    );
+  static invalidSessionIdentifier(
+    identifier: string,
+    availableSessions?: SessionInfo[],
+  ): SessionError {
+    let message = `Invalid session identifier "${identifier}".`;
+
+    if (availableSessions && availableSessions.length > 0) {
+      // Limit to at most 10 sessions to avoid flooding the terminal
+      const sessionsToShow = availableSessions.slice(0, 10);
+      const hasMore = availableSessions.length > 10;
+
+      message += '\n\nAvailable sessions for this project:\n';
+      sessionsToShow.forEach((session) => {
+        const time = formatRelativeTime(session.lastUpdated);
+        const title =
+          session.displayName.length > 60
+            ? session.displayName.slice(0, 57) + '...'
+            : session.displayName;
+        message += `  ${session.index}. ${title} (${time})\n`;
+      });
+
+      if (hasMore) {
+        message += `\n  Run --list-sessions to see all ${availableSessions.length} sessions.\n`;
+      } else {
+        const indices = availableSessions.map((s) => s.index).join(', ');
+        message += `\nUse --resume ${indices}, or --resume latest.\n`;
+      }
+    } else {
+      // Fallback message when sessions list not available
+      message +=
+        '\n  Use --list-sessions to see available sessions, then use --resume {number}, --resume {uuid}, or --resume latest.';
+    }
+
+    return new SessionError('INVALID_SESSION_IDENTIFIER', message);
   }
 }
 
@@ -447,7 +476,7 @@ export class SessionSelector {
       return sortedSessions[index - 1];
     }
 
-    throw SessionError.invalidSessionIdentifier(identifier);
+    throw SessionError.invalidSessionIdentifier(identifier, sessions);
   }
 
   /**


### PR DESCRIPTION
## Summary

Enhances the error message when `--resume` receives an invalid session identifier by displaying available sessions directly in the error output, eliminating the need for users to run a separate `--list-sessions` command.

## Changes

### Modified Files

1. **`packages/cli/src/utils/sessionUtils.ts`**
   - Updated `SessionError.invalidSessionIdentifier()` to accept optional `availableSessions` parameter
   - Formats sessions into error message (limit to 10, truncate titles to 60 chars)
   - Maintains backward compatibility when sessions list is not provided

2. **`packages/cli/src/utils/sessionUtils.ts`** (line ~450)
   - Updated `SessionSelector.findSession()` to pass sessions array when throwing error

3. **`packages/cli/src/utils/sessionUtils.test.ts`**
   - Added comprehensive unit test for enhanced error message
   - Verifies error includes formatted session list and proper instructions

## Example Output

**Before:**
```
Error resuming session: Invalid session identifier "99".
Use --list-sessions to see available sessions, then use --resume {number}, --resume {uuid}, or --resume latest.
```

**After:**
```
Error resuming session: Invalid session identifier "99".

Available sessions for this project:
  1. Fix bug in auth (2 days ago)
  2. Refactor database schema (5 hours ago)
  3. Update documentation (Just now)

Use --resume 1, 2, 3, or --resume latest.
```

## Test Results

✅ All 23 unit tests pass in `sessionUtils.test.ts`
✅ New test specifically validates enhanced error message
✅ Backward compatible with existing error handling

## Implementation Details

- Reuses existing `formatRelativeTime()` utility for time formatting
- Limits display to 10 sessions to prevent terminal flooding
- Truncates long titles (60-char limit vs 100 in `listSessions`)
- Uses same display format as `listSessions()` for consistency
- No performance impact - only formats sessions when error occurs

Fixes #21764