### PR TITLE
build(release): restrict npm bundling to non-stable tags

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -193,7 +193,7 @@ runs:
         INPUTS_A2A_PACKAGE_NAME: '${{ inputs.a2a-package-name }}'
 
     - name: '📦 Prepare bundled CLI for npm release'
-      if: "inputs.npm-registry-url != 'https://npm.pkg.github.com/'"
+      if: "inputs.npm-registry-url != 'https://npm.pkg.github.com/' && inputs.npm-tag != 'latest'"
       working-directory: '${{ inputs.working-directory }}'
       shell: 'bash'
       run: |


### PR DESCRIPTION
## Summary
This PR restricts the new NPM release bundling step to pre-releases (`preview`, `nightly`, etc.) so that we can fully test the bundled CLI artifacts before applying this change to stable (`latest`) releases.

## Details
The GitHub Action `publish-release` now explicitly excludes `latest` from running the `prepare-npm-release.js` bundling script. This ensures `latest` deployments remain unchanged for now.

## Related Issues
Closes #21820

## How to Validate
- Confirm `scripts/prepare-npm-release.js` is not run during a stable release publish action.
- Confirm it is run for a preview release action.

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods: