### PR TITLE
feat(core): prefer PowerShell 7 (pwsh) over Windows PowerShell on Windows

### DIFF
--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -471,10 +471,26 @@ describe('getShellConfiguration', () => {
       expect(config.shell).toBe('powershell');
     });
 
-    it('should return PowerShell configuration if ComSpec points to powershell.exe', () => {
+    it('should prefer pwsh.exe in PATH even if ComSpec points to powershell.exe', () => {
+      const psPath = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
+      const pwshPath = path.resolve('C:\\pwsh', 'pwsh.exe');
+      process.env['ComSpec'] = psPath;
+      process.env['PATH'] = 'C:\\pwsh';
+
+      mockExistsSync.mockImplementation((p: string) => p === pwshPath);
+
+      const config = getShellConfiguration();
+      expect(config.executable).toBe(pwshPath);
+      expect(config.shell).toBe('powershell');
+    });
+
+    it('should return PowerShell configuration if ComSpec points to powershell.exe and pwsh.exe is NOT in PATH', () => {
       const psPath =
         'C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
       process.env['ComSpec'] = psPath;
+      process.env['PATH'] = ''; // Ensure pwsh is not found
+      mockExistsSync.mockReturnValue(false);
+
       const config = getShellConfiguration();
       expect(config.executable).toBe(psPath);
       expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -37,6 +37,7 @@ vi.mock('os', () => ({
   homedir: mockHomedir,
 }));
 
+const mockAccess = vi.hoisted(() => vi.fn());
 const mockAccessSync = vi.hoisted(() => vi.fn());
 const mockExistsSync = vi.hoisted(() => vi.fn());
 const mockRealpathSync = vi.hoisted(() => vi.fn());

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -430,6 +430,10 @@ describe('getShellConfiguration', () => {
       const expectedPath = path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
       
       mockExistsSync.mockImplementation((p: string) => p === expectedPath);
+      mockAccessSync.mockImplementation((p: string) => {
+        if (p === expectedPath) return; // success
+        throw new Error('ENOENT');
+      });
 
       const config = getShellConfiguration();
       expect(config.executable).toBe(expectedPath);

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -39,6 +39,7 @@ vi.mock('os', () => ({
 
 const mockAccess = vi.hoisted(() => vi.fn());
 const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockRealpathSync = vi.hoisted(() => vi.fn());
 vi.mock('node:fs', () => ({
   default: {
     promises: {
@@ -46,12 +47,14 @@ vi.mock('node:fs', () => ({
     },
     constants: { X_OK: 1 },
     existsSync: mockExistsSync,
+    realpathSync: mockRealpathSync,
   },
   promises: {
     access: mockAccess,
   },
   constants: { X_OK: 1 },
   existsSync: mockExistsSync,
+  realpathSync: mockRealpathSync,
 }));
 
 const mockSpawnSync = vi.hoisted(() => vi.fn());
@@ -95,6 +98,7 @@ beforeEach(() => {
     error: undefined,
   });
   mockExistsSync.mockReturnValue(false);
+  mockRealpathSync.mockImplementation((p: string) => p);
   resetShellConfiguration();
 });
 

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -287,7 +287,7 @@ describe('hasRedirection', () => {
 describeWindowsOnly('PowerShell integration', () => {
   beforeEach(() => {
     mockPlatform.mockReturnValue('win32');
-    const systemRoot = process.env['SystemRoot'] || 'C:\\\\Windows';
+    const systemRoot = 'C:\\\\Windows';
     vi.stubEnv('ComSpec', `${systemRoot}\\\\System32\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe`);
   });
 

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -102,7 +102,10 @@ beforeEach(() => {
   });
   mockExistsSync.mockReturnValue(false);
   mockRealpathSync.mockImplementation((p: string) => p);
-  mockAccessSync.mockReturnValue(undefined); // Success by default
+  mockAccessSync.mockImplementation((p: string) => {
+    if (mockExistsSync(p)) return;
+    throw new Error(`ENOENT: no such file or directory, access '${p}'`);
+  });
   resetShellConfiguration();
 });
 
@@ -430,10 +433,6 @@ describe('getShellConfiguration', () => {
       const expectedPath = path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
       
       mockExistsSync.mockImplementation((p: string) => p === expectedPath);
-      mockAccessSync.mockImplementation((p: string) => {
-        if (p === expectedPath) return; // success
-        throw new Error('ENOENT');
-      });
 
       const config = getShellConfiguration();
       expect(config.executable).toBe(expectedPath);

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -37,7 +37,7 @@ vi.mock('os', () => ({
   homedir: mockHomedir,
 }));
 
-const mockAccess = vi.hoisted(() => vi.fn());
+const mockAccessSync = vi.hoisted(() => vi.fn());
 const mockExistsSync = vi.hoisted(() => vi.fn());
 const mockRealpathSync = vi.hoisted(() => vi.fn());
 vi.mock('node:fs', () => ({
@@ -48,6 +48,7 @@ vi.mock('node:fs', () => ({
     constants: { X_OK: 1 },
     existsSync: mockExistsSync,
     realpathSync: mockRealpathSync,
+    accessSync: mockAccessSync,
   },
   promises: {
     access: mockAccess,
@@ -55,6 +56,7 @@ vi.mock('node:fs', () => ({
   constants: { X_OK: 1 },
   existsSync: mockExistsSync,
   realpathSync: mockRealpathSync,
+  accessSync: mockAccessSync,
 }));
 
 const mockSpawnSync = vi.hoisted(() => vi.fn());
@@ -99,6 +101,7 @@ beforeEach(() => {
   });
   mockExistsSync.mockReturnValue(false);
   mockRealpathSync.mockImplementation((p: string) => p);
+  mockAccessSync.mockReturnValue(undefined); // Success by default
   resetShellConfiguration();
 });
 
@@ -435,27 +438,42 @@ describe('getShellConfiguration', () => {
       mockPlatform.mockReturnValue('win32');
     });
 
-    it('should return PowerShell configuration by default (powershell.exe)', () => {
+    it('should return PowerShell configuration by default (powershell.exe) with absolute path', () => {
       delete process.env['ComSpec'];
+      const systemRoot = 'C:\\Windows';
+      process.env['SystemRoot'] = systemRoot;
+      const expectedPath = path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+      
+      mockExistsSync.mockImplementation((p: string) => p === expectedPath);
+
       const config = getShellConfiguration();
-      expect(config.executable).toBe('powershell.exe');
+      expect(config.executable).toBe(expectedPath);
       expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
       expect(config.shell).toBe('powershell');
     });
 
-    it('should prefer pwsh.exe if available in PATH', () => {
+    it('should prefer pwsh.exe if available in PATH with absolute directory', () => {
       delete process.env['ComSpec'];
-      const pwshDir = 'C:\\Program Files\\PowerShell\\7';
+      const pwshDir = path.resolve('C:\\Program Files\\PowerShell\\7');
       const pwshPath = path.join(pwshDir, 'pwsh.exe');
       process.env['PATH'] = pwshDir;
 
       mockExistsSync.mockImplementation((p: string) => p === pwshPath);
 
       const config = getShellConfiguration();
-      // On non-Windows tests, path.join(pwshDir, 'pwsh.exe') might use forward slashes for the last part
-      // but the mock is set to return true for exactly that.
       expect(config.executable).toBe(pwshPath);
       expect(config.shell).toBe('powershell');
+    });
+
+    it('should ignore relative paths in PATH for security', () => {
+      delete process.env['ComSpec'];
+      process.env['PATH'] = 'relative_path;C:\\Windows';
+      mockExistsSync.mockReturnValue(false);
+
+      const config = getShellConfiguration();
+      // Should fall back to absolute powershell.exe, not search in 'relative_path'
+      expect(config.executable).toContain('powershell.exe');
+      expect(config.executable).toContain('C:');
     });
 
     it('should ignore ComSpec when pointing to cmd.exe and prefer pwsh.exe in PATH', () => {

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -22,6 +22,7 @@ import {
   stripShellWrapper,
   hasRedirection,
   resolveExecutable,
+  resetShellConfiguration,
 } from './shell-utils.js';
 import path from 'node:path';
 
@@ -37,17 +38,20 @@ vi.mock('os', () => ({
 }));
 
 const mockAccess = vi.hoisted(() => vi.fn());
+const mockExistsSync = vi.hoisted(() => vi.fn());
 vi.mock('node:fs', () => ({
   default: {
     promises: {
       access: mockAccess,
     },
     constants: { X_OK: 1 },
+    existsSync: mockExistsSync,
   },
   promises: {
     access: mockAccess,
   },
   constants: { X_OK: 1 },
+  existsSync: mockExistsSync,
 }));
 
 const mockSpawnSync = vi.hoisted(() => vi.fn());
@@ -90,6 +94,8 @@ beforeEach(() => {
     status: 0,
     error: undefined,
   });
+  mockExistsSync.mockReturnValue(false);
+  resetShellConfiguration();
 });
 
 afterEach(() => {
@@ -425,7 +431,7 @@ describe('getShellConfiguration', () => {
       mockPlatform.mockReturnValue('win32');
     });
 
-    it('should return PowerShell configuration by default', () => {
+    it('should return PowerShell configuration by default (powershell.exe)', () => {
       delete process.env['ComSpec'];
       const config = getShellConfiguration();
       expect(config.executable).toBe('powershell.exe');
@@ -433,12 +439,31 @@ describe('getShellConfiguration', () => {
       expect(config.shell).toBe('powershell');
     });
 
-    it('should ignore ComSpec when pointing to cmd.exe', () => {
+    it('should prefer pwsh.exe if available in PATH', () => {
+      delete process.env['ComSpec'];
+      const pwshDir = 'C:\\Program Files\\PowerShell\\7';
+      const pwshPath = path.join(pwshDir, 'pwsh.exe');
+      process.env['PATH'] = pwshDir;
+
+      mockExistsSync.mockImplementation((p: string) => p === pwshPath);
+
+      const config = getShellConfiguration();
+      // On non-Windows tests, path.join(pwshDir, 'pwsh.exe') might use forward slashes for the last part
+      // but the mock is set to return true for exactly that.
+      expect(config.executable).toBe(pwshPath);
+      expect(config.shell).toBe('powershell');
+    });
+
+    it('should ignore ComSpec when pointing to cmd.exe and prefer pwsh.exe in PATH', () => {
       const cmdPath = 'C:\\WINDOWS\\system32\\cmd.exe';
       process.env['ComSpec'] = cmdPath;
+      const pwshPath = path.join('C:\\pwsh', 'pwsh.exe');
+      process.env['PATH'] = 'C:\\pwsh';
+
+      mockExistsSync.mockImplementation((p: string) => p === pwshPath);
+
       const config = getShellConfiguration();
-      expect(config.executable).toBe('powershell.exe');
-      expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
+      expect(config.executable).toBe(pwshPath);
       expect(config.shell).toBe('powershell');
     });
 

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -108,6 +108,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks();
+  vi.unstubAllEnvs();
 });
 
 const mockPowerShellResult = (
@@ -284,21 +285,10 @@ describe('hasRedirection', () => {
 });
 
 describeWindowsOnly('PowerShell integration', () => {
-  const originalComSpec = process.env['ComSpec'];
-
   beforeEach(() => {
     mockPlatform.mockReturnValue('win32');
     const systemRoot = process.env['SystemRoot'] || 'C:\\\\Windows';
-    process.env['ComSpec'] =
-      `${systemRoot}\\\\System32\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe`;
-  });
-
-  afterEach(() => {
-    if (originalComSpec === undefined) {
-      delete process.env['ComSpec'];
-    } else {
-      process.env['ComSpec'] = originalComSpec;
-    }
+    vi.stubEnv('ComSpec', `${systemRoot}\\\\System32\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe`);
   });
 
   it('should return command roots using PowerShell AST output', () => {
@@ -412,12 +402,6 @@ describe('escapeShellArg', () => {
 });
 
 describe('getShellConfiguration', () => {
-  const originalEnv = { ...process.env };
-
-  afterEach(() => {
-    process.env = originalEnv;
-  });
-
   it('should return bash configuration on Linux', () => {
     mockPlatform.mockReturnValue('linux');
     const config = getShellConfiguration();
@@ -440,9 +424,9 @@ describe('getShellConfiguration', () => {
     });
 
     it('should return PowerShell configuration by default (powershell.exe) with absolute path', () => {
-      delete process.env['ComSpec'];
+      vi.stubEnv('ComSpec', '');
       const systemRoot = 'C:\\Windows';
-      process.env['SystemRoot'] = systemRoot;
+      vi.stubEnv('SystemRoot', systemRoot);
       const expectedPath = path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
       
       mockExistsSync.mockImplementation((p: string) => p === expectedPath);
@@ -454,10 +438,10 @@ describe('getShellConfiguration', () => {
     });
 
     it('should prefer pwsh.exe if available in PATH with absolute directory', () => {
-      delete process.env['ComSpec'];
+      vi.stubEnv('ComSpec', '');
       const pwshDir = path.resolve('C:\\Program Files\\PowerShell\\7');
       const pwshPath = path.join(pwshDir, 'pwsh.exe');
-      process.env['PATH'] = pwshDir;
+      vi.stubEnv('PATH', pwshDir);
 
       mockExistsSync.mockImplementation((p: string) => p === pwshPath);
 
@@ -467,8 +451,8 @@ describe('getShellConfiguration', () => {
     });
 
     it('should ignore relative paths in PATH for security', () => {
-      delete process.env['ComSpec'];
-      process.env['PATH'] = 'relative_path;C:\\Windows';
+      vi.stubEnv('ComSpec', '');
+      vi.stubEnv('PATH', `relative_path${path.delimiter}C:\\Windows`);
       mockExistsSync.mockReturnValue(false);
 
       const config = getShellConfiguration();
@@ -479,9 +463,9 @@ describe('getShellConfiguration', () => {
 
     it('should ignore ComSpec when pointing to cmd.exe and prefer pwsh.exe in PATH', () => {
       const cmdPath = 'C:\\WINDOWS\\system32\\cmd.exe';
-      process.env['ComSpec'] = cmdPath;
+      vi.stubEnv('ComSpec', cmdPath);
       const pwshPath = path.join('C:\\pwsh', 'pwsh.exe');
-      process.env['PATH'] = 'C:\\pwsh';
+      vi.stubEnv('PATH', 'C:\\pwsh');
 
       mockExistsSync.mockImplementation((p: string) => p === pwshPath);
 
@@ -493,8 +477,8 @@ describe('getShellConfiguration', () => {
     it('should prefer pwsh.exe in PATH even if ComSpec points to powershell.exe', () => {
       const psPath = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
       const pwshPath = path.resolve('C:\\pwsh', 'pwsh.exe');
-      process.env['ComSpec'] = psPath;
-      process.env['PATH'] = 'C:\\pwsh';
+      vi.stubEnv('ComSpec', psPath);
+      vi.stubEnv('PATH', 'C:\\pwsh');
 
       mockExistsSync.mockImplementation((p: string) => p === pwshPath);
 
@@ -506,8 +490,8 @@ describe('getShellConfiguration', () => {
     it('should return PowerShell configuration if ComSpec points to powershell.exe and pwsh.exe is NOT in PATH', () => {
       const psPath =
         'C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
-      process.env['ComSpec'] = psPath;
-      process.env['PATH'] = ''; // Ensure pwsh is not found
+      vi.stubEnv('ComSpec', psPath);
+      vi.stubEnv('PATH', ''); // Ensure pwsh is not found
       mockExistsSync.mockReturnValue(false);
 
       const config = getShellConfiguration();
@@ -518,7 +502,7 @@ describe('getShellConfiguration', () => {
 
     it('should return PowerShell configuration if ComSpec points to pwsh.exe', () => {
       const pwshPath = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe';
-      process.env['ComSpec'] = pwshPath;
+      vi.stubEnv('ComSpec', pwshPath);
       const config = getShellConfiguration();
       expect(config.executable).toBe(pwshPath);
       expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
@@ -526,7 +510,7 @@ describe('getShellConfiguration', () => {
     });
 
     it('should be case-insensitive when checking ComSpec', () => {
-      process.env['ComSpec'] = 'C:\\Path\\To\\POWERSHELL.EXE';
+      vi.stubEnv('ComSpec', 'C:\\Path\\To\\POWERSHELL.EXE');
       const config = getShellConfiguration();
       expect(config.executable).toBe('C:\\Path\\To\\POWERSHELL.EXE');
       expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
@@ -538,7 +522,7 @@ describe('getShellConfiguration', () => {
 describe('hasRedirection (PowerShell via mock)', () => {
   beforeEach(() => {
     mockPlatform.mockReturnValue('win32');
-    process.env['ComSpec'] = 'powershell.exe';
+    vi.stubEnv('ComSpec', 'powershell.exe');
   });
 
   it('should return true when PowerShell parser detects redirection', () => {
@@ -570,15 +554,8 @@ describe('hasRedirection (PowerShell via mock)', () => {
 });
 
 describe('resolveExecutable', () => {
-  const originalEnv = process.env;
-
   beforeEach(() => {
-    process.env = { ...originalEnv };
     mockAccess.mockReset();
-  });
-
-  afterEach(() => {
-    process.env = originalEnv;
   });
 
   it('should return the absolute path if it exists and is executable', async () => {
@@ -597,7 +574,7 @@ describe('resolveExecutable', () => {
   it('should resolve executable in PATH', async () => {
     const binDir = path.resolve('/bin');
     const usrBinDir = path.resolve('/usr/bin');
-    process.env['PATH'] = `${binDir}${path.delimiter}${usrBinDir}`;
+    vi.stubEnv('PATH', `${binDir}${path.delimiter}${usrBinDir}`);
     mockPlatform.mockReturnValue('linux');
 
     const targetPath = path.join(usrBinDir, 'ls');
@@ -611,7 +588,7 @@ describe('resolveExecutable', () => {
 
   it('should try extensions on Windows', async () => {
     const sys32 = path.resolve('C:\\Windows\\System32');
-    process.env['PATH'] = sys32;
+    vi.stubEnv('PATH', sys32);
     mockPlatform.mockReturnValue('win32');
     mockAccess.mockImplementation(async (p: string) => {
       // Use includes because on Windows path separators might differ
@@ -623,7 +600,7 @@ describe('resolveExecutable', () => {
   });
 
   it('should return undefined if not found in PATH', async () => {
-    process.env['PATH'] = path.resolve('/bin');
+    vi.stubEnv('PATH', path.resolve('/bin'));
     mockPlatform.mockReturnValue('linux');
     mockAccess.mockRejectedValue(new Error('ENOENT'));
 

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -534,6 +534,8 @@ export function parseCommandDetails(
   return null;
 }
 
+let cachedShellConfiguration: ShellConfiguration | null = null;
+
 /**
  * Determines the appropriate shell configuration for the current platform.
  *
@@ -543,6 +545,10 @@ export function parseCommandDetails(
  * @returns The ShellConfiguration for the current environment.
  */
 export function getShellConfiguration(): ShellConfiguration {
+  if (cachedShellConfiguration) {
+    return cachedShellConfiguration;
+  }
+
   if (isWindows()) {
     const comSpec = process.env['ComSpec'];
     if (comSpec) {
@@ -551,24 +557,58 @@ export function getShellConfiguration(): ShellConfiguration {
         executable.endsWith('powershell.exe') ||
         executable.endsWith('pwsh.exe')
       ) {
-        return {
+        cachedShellConfiguration = {
           executable: comSpec,
           argsPrefix: ['-NoProfile', '-Command'],
           shell: 'powershell',
         };
+        return cachedShellConfiguration;
       }
     }
 
-    // Default to PowerShell for all other Windows configurations.
-    return {
+    // Prefer pwsh.exe (PowerShell 7+) if available in PATH
+    const pathDelimiter = os.platform() === 'win32' ? ';' : path.delimiter;
+    const paths = (process.env['PATH'] || '').split(pathDelimiter);
+    for (const p of paths) {
+      const fullPath = path.join(p, 'pwsh.exe');
+      try {
+        if (fs.existsSync(fullPath)) {
+          cachedShellConfiguration = {
+            executable: fullPath,
+            argsPrefix: ['-NoProfile', '-Command'],
+            shell: 'powershell',
+          };
+          return cachedShellConfiguration;
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    // Default to Windows PowerShell (powershell.exe)
+    cachedShellConfiguration = {
       executable: 'powershell.exe',
       argsPrefix: ['-NoProfile', '-Command'],
       shell: 'powershell',
     };
+    return cachedShellConfiguration;
   }
 
   // Unix-like systems (Linux, macOS)
-  return { executable: 'bash', argsPrefix: ['-c'], shell: 'bash' };
+  cachedShellConfiguration = {
+    executable: 'bash',
+    argsPrefix: ['-c'],
+    shell: 'bash',
+  };
+  return cachedShellConfiguration;
+}
+
+/**
+ * Resets the cached shell configuration.
+ * Used for testing purposes when environment variables change.
+ */
+export function resetShellConfiguration(): void {
+  cachedShellConfiguration = null;
 }
 
 /**

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -620,10 +620,10 @@ export function getShellConfiguration(): ShellConfiguration {
       return cachedShellConfiguration;
     }
 
-    // Last resort fallback, but still trying to be absolute if possible
+    // Last resort fallback, strictly absolute
     const fallbackPsPath = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
     cachedShellConfiguration = {
-      executable: fs.existsSync(fallbackPsPath) ? fallbackPsPath : 'powershell.exe', // if all else fails, we might still have to use the name, but this is rare
+      executable: fallbackPsPath,
       argsPrefix: ['-NoProfile', '-Command'],
       shell: 'powershell',
     };

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -555,13 +555,22 @@ export function getShellConfiguration(): ShellConfiguration {
     const pathDelimiter = os.platform() === 'win32' ? ';' : path.delimiter;
     const paths = (process.env['PATH'] || '').split(pathDelimiter);
     for (const p of paths) {
-      if (!p || !path.isAbsolute(p)) continue; // Security: ignore relative paths in PATH
+      if (!p) continue;
+      // Security: ignore relative paths in PATH
+      if (!path.isAbsolute(p)) {
+        debugLogger.debug(`Ignoring relative path in PATH: ${p}`);
+        continue;
+      }
       const fullPath = path.resolve(p, 'pwsh.exe');
       try {
         if (path.isAbsolute(fullPath) && fs.existsSync(fullPath)) {
           // Security: check if the file is actually executable
           fs.accessSync(fullPath, fs.constants.X_OK);
           const canonicalPath = fs.realpathSync(fullPath);
+          if (!path.isAbsolute(canonicalPath)) {
+            debugLogger.debug(`Ignoring non-absolute canonical path: ${canonicalPath}`);
+            continue;
+          }
           cachedShellConfiguration = {
             executable: canonicalPath,
             argsPrefix: ['-NoProfile', '-Command'],
@@ -606,8 +615,19 @@ export function getShellConfiguration(): ShellConfiguration {
     // Default to Windows PowerShell (powershell.exe) with absolute path
     const systemRoot = process.env['SystemRoot'] || 'C:\\Windows';
     const defaultPsPath = path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+    if (fs.existsSync(defaultPsPath)) {
+      cachedShellConfiguration = {
+        executable: defaultPsPath,
+        argsPrefix: ['-NoProfile', '-Command'],
+        shell: 'powershell',
+      };
+      return cachedShellConfiguration;
+    }
+
+    // Last resort fallback, but still trying to be absolute if possible
+    const fallbackPsPath = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
     cachedShellConfiguration = {
-      executable: fs.existsSync(defaultPsPath) ? defaultPsPath : 'powershell.exe',
+      executable: fs.existsSync(fallbackPsPath) ? fallbackPsPath : 'powershell.exe', // if all else fails, we might still have to use the name, but this is rare
       argsPrefix: ['-NoProfile', '-Command'],
       shell: 'powershell',
     };

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -630,16 +630,19 @@ export function getShellConfiguration(): ShellConfiguration {
     const fallbackPsPath = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
     try {
       fs.accessSync(fallbackPsPath, fs.constants.X_OK);
+      cachedShellConfiguration = {
+        executable: fallbackPsPath,
+        argsPrefix: ['-NoProfile', '-Command'],
+        shell: 'powershell',
+      };
+      return cachedShellConfiguration;
     } catch {
-      debugLogger.warn('Could not find a valid PowerShell executable on Windows.');
+      debugLogger.error('Could not find a valid PowerShell executable on Windows.');
+      throw new Error(
+        'Could not find a valid PowerShell executable (pwsh.exe or powershell.exe) on Windows. ' +
+          'Please ensure PowerShell is installed and available in your PATH or SystemRoot.',
+      );
     }
-
-    cachedShellConfiguration = {
-      executable: fallbackPsPath,
-      argsPrefix: ['-NoProfile', '-Command'],
-      shell: 'powershell',
-    };
-    return cachedShellConfiguration;
   }
 
   // Unix-like systems (Linux, macOS)

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -513,7 +513,8 @@ function parsePowerShellCommandDetails(
       hasError: details.length === 0,
       hasRedirection: parsed.hasRedirection,
     };
-  } catch {
+  } catch (e) {
+    debugLogger.debug('PowerShell command parsing error:', e);
     return null;
   }
 }
@@ -551,18 +552,28 @@ export function getShellConfiguration(): ShellConfiguration {
 
   if (isWindows()) {
     const comSpec = process.env['ComSpec'];
-    if (comSpec) {
-      const executable = comSpec.toLowerCase();
-      if (
-        executable.endsWith('powershell.exe') ||
-        executable.endsWith('pwsh.exe')
-      ) {
-        cachedShellConfiguration = {
-          executable: comSpec,
-          argsPrefix: ['-NoProfile', '-Command'],
-          shell: 'powershell',
-        };
-        return cachedShellConfiguration;
+    if (comSpec && path.isAbsolute(comSpec)) {
+      // Basic security check: ensure no redirection or command chaining characters in ComSpec
+      if (/[;&|<>%]/.test(comSpec)) {
+        debugLogger.warn(`Unsafe ComSpec detected: ${comSpec}`);
+      } else {
+        const executable = comSpec.toLowerCase();
+        if (
+          executable.endsWith('powershell.exe') ||
+          executable.endsWith('pwsh.exe')
+        ) {
+          try {
+            const canonicalPath = fs.realpathSync(comSpec);
+            cachedShellConfiguration = {
+              executable: canonicalPath,
+              argsPrefix: ['-NoProfile', '-Command'],
+              shell: 'powershell',
+            };
+            return cachedShellConfiguration;
+          } catch (e) {
+            debugLogger.debug(`Error resolving canonical path for ComSpec: ${comSpec}`, e);
+          }
+        }
       }
     }
 
@@ -570,17 +581,20 @@ export function getShellConfiguration(): ShellConfiguration {
     const pathDelimiter = os.platform() === 'win32' ? ';' : path.delimiter;
     const paths = (process.env['PATH'] || '').split(pathDelimiter);
     for (const p of paths) {
-      const fullPath = path.join(p, 'pwsh.exe');
+      if (!p) continue;
+      const fullPath = path.resolve(p, 'pwsh.exe');
       try {
-        if (fs.existsSync(fullPath)) {
+        if (path.isAbsolute(fullPath) && fs.existsSync(fullPath)) {
+          const canonicalPath = fs.realpathSync(fullPath);
           cachedShellConfiguration = {
-            executable: fullPath,
+            executable: canonicalPath,
             argsPrefix: ['-NoProfile', '-Command'],
             shell: 'powershell',
           };
           return cachedShellConfiguration;
         }
-      } catch {
+      } catch (e) {
+        debugLogger.debug(`Error checking for pwsh.exe in ${p}:`, e);
         continue;
       }
     }

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -563,14 +563,10 @@ export function getShellConfiguration(): ShellConfiguration {
       }
       const fullPath = path.resolve(p, 'pwsh.exe');
       try {
-        if (path.isAbsolute(fullPath) && fs.existsSync(fullPath)) {
-          // Security: check if the file is actually executable
+        if (path.isAbsolute(fullPath)) {
+          // Security: fs.accessSync throws if file doesn't exist or isn't executable
           fs.accessSync(fullPath, fs.constants.X_OK);
           const canonicalPath = fs.realpathSync(fullPath);
-          if (!path.isAbsolute(canonicalPath)) {
-            debugLogger.debug(`Ignoring non-absolute canonical path: ${canonicalPath}`);
-            continue;
-          }
           cachedShellConfiguration = {
             executable: canonicalPath,
             argsPrefix: ['-NoProfile', '-Command'],
@@ -596,7 +592,7 @@ export function getShellConfiguration(): ShellConfiguration {
           executable.endsWith('pwsh.exe')
         ) {
           try {
-            // Security: check if the file is actually executable
+            // Security: fs.accessSync throws if file doesn't exist or isn't executable
             fs.accessSync(comSpec, fs.constants.X_OK);
             const canonicalPath = fs.realpathSync(comSpec);
             cachedShellConfiguration = {

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -609,27 +609,37 @@ export function getShellConfiguration(): ShellConfiguration {
     }
 
     // Default to Windows PowerShell (powershell.exe) with absolute path
-    const systemRoot = process.env['SystemRoot'] || 'C:\\Windows';
-    const defaultPsPath = path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
-    try {
-      // Security: use accessSync(X_OK) for consistency with other checks
-      fs.accessSync(defaultPsPath, fs.constants.X_OK);
-      cachedShellConfiguration = {
-        executable: defaultPsPath,
-        argsPrefix: ['-NoProfile', '-Command'],
-        shell: 'powershell',
-      };
-      return cachedShellConfiguration;
-    } catch {
-      // If default path fails, fall back to a hardcoded absolute path
-      const fallbackPsPath = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
-      cachedShellConfiguration = {
-        executable: fallbackPsPath,
-        argsPrefix: ['-NoProfile', '-Command'],
-        shell: 'powershell',
-      };
-      return cachedShellConfiguration;
+    const systemRoot = process.env['SystemRoot'];
+    if (systemRoot && path.isAbsolute(systemRoot)) {
+      const defaultPsPath = path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+      try {
+        // Security: use accessSync(X_OK) for consistency with other checks
+        fs.accessSync(defaultPsPath, fs.constants.X_OK);
+        cachedShellConfiguration = {
+          executable: defaultPsPath,
+          argsPrefix: ['-NoProfile', '-Command'],
+          shell: 'powershell',
+        };
+        return cachedShellConfiguration;
+      } catch (e) {
+        debugLogger.debug(`Error checking for default powershell.exe in ${defaultPsPath}:`, e);
+      }
     }
+
+    // Last resort fallback, strictly absolute to well-known system location
+    const fallbackPsPath = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
+    try {
+      fs.accessSync(fallbackPsPath, fs.constants.X_OK);
+    } catch {
+      debugLogger.warn('Could not find a valid PowerShell executable on Windows.');
+    }
+
+    cachedShellConfiguration = {
+      executable: fallbackPsPath,
+      argsPrefix: ['-NoProfile', '-Command'],
+      shell: 'powershell',
+    };
+    return cachedShellConfiguration;
   }
 
   // Unix-like systems (Linux, macOS)

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -611,23 +611,25 @@ export function getShellConfiguration(): ShellConfiguration {
     // Default to Windows PowerShell (powershell.exe) with absolute path
     const systemRoot = process.env['SystemRoot'] || 'C:\\Windows';
     const defaultPsPath = path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
-    if (fs.existsSync(defaultPsPath)) {
+    try {
+      // Security: use accessSync(X_OK) for consistency with other checks
+      fs.accessSync(defaultPsPath, fs.constants.X_OK);
       cachedShellConfiguration = {
         executable: defaultPsPath,
         argsPrefix: ['-NoProfile', '-Command'],
         shell: 'powershell',
       };
       return cachedShellConfiguration;
+    } catch {
+      // If default path fails, fall back to a hardcoded absolute path
+      const fallbackPsPath = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
+      cachedShellConfiguration = {
+        executable: fallbackPsPath,
+        argsPrefix: ['-NoProfile', '-Command'],
+        shell: 'powershell',
+      };
+      return cachedShellConfiguration;
     }
-
-    // Last resort fallback, strictly absolute
-    const fallbackPsPath = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
-    cachedShellConfiguration = {
-      executable: fallbackPsPath,
-      argsPrefix: ['-NoProfile', '-Command'],
-      shell: 'powershell',
-    };
-    return cachedShellConfiguration;
   }
 
   // Unix-like systems (Linux, macOS)

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -555,10 +555,12 @@ export function getShellConfiguration(): ShellConfiguration {
     const pathDelimiter = os.platform() === 'win32' ? ';' : path.delimiter;
     const paths = (process.env['PATH'] || '').split(pathDelimiter);
     for (const p of paths) {
-      if (!p) continue;
+      if (!p || !path.isAbsolute(p)) continue; // Security: ignore relative paths in PATH
       const fullPath = path.resolve(p, 'pwsh.exe');
       try {
         if (path.isAbsolute(fullPath) && fs.existsSync(fullPath)) {
+          // Security: check if the file is actually executable
+          fs.accessSync(fullPath, fs.constants.X_OK);
           const canonicalPath = fs.realpathSync(fullPath);
           cachedShellConfiguration = {
             executable: canonicalPath,
@@ -585,6 +587,8 @@ export function getShellConfiguration(): ShellConfiguration {
           executable.endsWith('pwsh.exe')
         ) {
           try {
+            // Security: check if the file is actually executable
+            fs.accessSync(comSpec, fs.constants.X_OK);
             const canonicalPath = fs.realpathSync(comSpec);
             cachedShellConfiguration = {
               executable: canonicalPath,
@@ -593,15 +597,17 @@ export function getShellConfiguration(): ShellConfiguration {
             };
             return cachedShellConfiguration;
           } catch (e) {
-            debugLogger.debug(`Error resolving canonical path for ComSpec: ${comSpec}`, e);
+            debugLogger.debug(`Error resolving canonical path or checking execution permission for ComSpec: ${comSpec}`, e);
           }
         }
       }
     }
 
-    // Default to Windows PowerShell (powershell.exe)
+    // Default to Windows PowerShell (powershell.exe) with absolute path
+    const systemRoot = process.env['SystemRoot'] || 'C:\\Windows';
+    const defaultPsPath = path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
     cachedShellConfiguration = {
-      executable: 'powershell.exe',
+      executable: fs.existsSync(defaultPsPath) ? defaultPsPath : 'powershell.exe',
       argsPrefix: ['-NoProfile', '-Command'],
       shell: 'powershell',
     };

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -551,6 +551,28 @@ export function getShellConfiguration(): ShellConfiguration {
   }
 
   if (isWindows()) {
+    // Prefer pwsh.exe (PowerShell 7+) if available in PATH
+    const pathDelimiter = os.platform() === 'win32' ? ';' : path.delimiter;
+    const paths = (process.env['PATH'] || '').split(pathDelimiter);
+    for (const p of paths) {
+      if (!p) continue;
+      const fullPath = path.resolve(p, 'pwsh.exe');
+      try {
+        if (path.isAbsolute(fullPath) && fs.existsSync(fullPath)) {
+          const canonicalPath = fs.realpathSync(fullPath);
+          cachedShellConfiguration = {
+            executable: canonicalPath,
+            argsPrefix: ['-NoProfile', '-Command'],
+            shell: 'powershell',
+          };
+          return cachedShellConfiguration;
+        }
+      } catch (e) {
+        debugLogger.debug(`Error checking for pwsh.exe in ${p}:`, e);
+        continue;
+      }
+    }
+
     const comSpec = process.env['ComSpec'];
     if (comSpec && path.isAbsolute(comSpec)) {
       // Basic security check: ensure no redirection or command chaining characters in ComSpec
@@ -574,28 +596,6 @@ export function getShellConfiguration(): ShellConfiguration {
             debugLogger.debug(`Error resolving canonical path for ComSpec: ${comSpec}`, e);
           }
         }
-      }
-    }
-
-    // Prefer pwsh.exe (PowerShell 7+) if available in PATH
-    const pathDelimiter = os.platform() === 'win32' ? ';' : path.delimiter;
-    const paths = (process.env['PATH'] || '').split(pathDelimiter);
-    for (const p of paths) {
-      if (!p) continue;
-      const fullPath = path.resolve(p, 'pwsh.exe');
-      try {
-        if (path.isAbsolute(fullPath) && fs.existsSync(fullPath)) {
-          const canonicalPath = fs.realpathSync(fullPath);
-          cachedShellConfiguration = {
-            executable: canonicalPath,
-            argsPrefix: ['-NoProfile', '-Command'],
-            shell: 'powershell',
-          };
-          return cachedShellConfiguration;
-        }
-      } catch (e) {
-        debugLogger.debug(`Error checking for pwsh.exe in ${p}:`, e);
-        continue;
       }
     }
 

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -586,11 +586,8 @@ export function getShellConfiguration(): ShellConfiguration {
       if (/[;&|<>%]/.test(comSpec)) {
         debugLogger.warn(`Unsafe ComSpec detected: ${comSpec}`);
       } else {
-        const executable = comSpec.toLowerCase();
-        if (
-          executable.endsWith('powershell.exe') ||
-          executable.endsWith('pwsh.exe')
-        ) {
+        const fileName = path.basename(comSpec).toLowerCase();
+        if (fileName === 'powershell.exe' || fileName === 'pwsh.exe') {
           try {
             // Security: fs.accessSync throws if file doesn't exist or isn't executable
             fs.accessSync(comSpec, fs.constants.X_OK);


### PR DESCRIPTION
## Summary
This PR updates the default shell selection logic on Windows to prefer PowerShell 7 (`pwsh.exe`) over Windows PowerShell (`powershell.exe`) if available in the system's `PATH`.

## Details
- Introduced `getShellConfiguration` caching to avoid repeated file system checks.
- Added a security-hardened fallback mechanism:
  1. Search for `pwsh.exe` in `PATH` (absolute paths only).
  2. Check `ComSpec` environment variable (absolute paths only, security-checked).
  3. Fall back to absolute path for `powershell.exe` via `SystemRoot`.
- All PowerShell versions continue to use `-NoProfile -Command` for consistent execution.
- Added file executability checks and improved error logging.

## Related Issues
Fixes #15493

## How to Validate
- On Windows with PowerShell 7 installed, run a shell command tool and verify it uses `pwsh.exe`.
- On Windows without PowerShell 7, verify it correctly falls back to `powershell.exe`.
- Run `npm test -w @google/gemini-cli-core -- src/utils/shell-utils.test.ts`.

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] Linux (Unit tests)