### PR TITLE
fix(policy): restrict skill activation permissions to specific skill names

### DIFF
--- a/packages/core/src/confirmation-bus/types.ts
+++ b/packages/core/src/confirmation-bus/types.ts
@@ -121,6 +121,7 @@ export interface UpdatePolicy {
   argsPattern?: string;
   commandPrefix?: string | string[];
   mcpName?: string;
+  skillName?: string;
 }
 
 export interface ToolPolicyRejection {

--- a/packages/core/src/policy/config.ts
+++ b/packages/core/src/policy/config.ts
@@ -489,7 +489,26 @@ export function createPolicyUpdater(
     async (message: UpdatePolicy) => {
       const toolName = message.toolName;
 
-      if (message.commandPrefix) {
+      if (message.skillName) {
+        // Convert skillName to argsPattern for in-memory rules
+        const patterns = buildArgsPatterns(
+          undefined,
+          undefined,
+          undefined,
+          message.skillName,
+        );
+        for (const pattern of patterns) {
+          if (pattern) {
+            policyEngine.addRule({
+              toolName,
+              decision: PolicyDecision.ALLOW,
+              priority: ALWAYS_ALLOW_PRIORITY,
+              argsPattern: new RegExp(pattern),
+              source: 'Dynamic (Confirmed)',
+            });
+          }
+        }
+      } else if (message.commandPrefix) {
         // Convert commandPrefix(es) to argsPatterns for in-memory rules
         const patterns = buildArgsPatterns(undefined, message.commandPrefix);
         for (const pattern of patterns) {
@@ -571,6 +590,19 @@ export function createPolicyUpdater(
               newRule.toolName = simpleToolName;
               newRule.decision = 'allow';
               newRule.priority = 200;
+            } else if (message.skillName) {
+              newRule.toolName = toolName;
+              newRule.decision = 'allow';
+              newRule.priority = 100;
+              const patterns = buildArgsPatterns(
+                undefined,
+                undefined,
+                undefined,
+                message.skillName,
+              );
+              if (patterns[0]) {
+                newRule.argsPattern = patterns[0];
+              }
             } else {
               newRule.toolName = toolName;
               newRule.decision = 'allow';

--- a/packages/core/src/policy/utils.ts
+++ b/packages/core/src/policy/utils.ts
@@ -57,7 +57,12 @@ export function buildArgsPatterns(
   argsPattern?: string,
   commandPrefix?: string | string[],
   commandRegex?: string,
+  skillName?: string,
 ): Array<string | undefined> {
+  if (skillName) {
+    return [`"name":"${escapeRegex(skillName)}"`];
+  }
+
   if (commandPrefix) {
     const prefixes = Array.isArray(commandPrefix)
       ? commandPrefix

--- a/packages/core/src/tools/activate-skill.ts
+++ b/packages/core/src/tools/activate-skill.ts
@@ -15,6 +15,7 @@ import {
   type ToolCallConfirmationDetails,
   type ToolInvocation,
   type ToolConfirmationOutcome,
+  type PolicyUpdateOptions,
 } from './tools.js';
 import type { Config } from '../config/config.js';
 import { ACTIVATE_SKILL_TOOL_NAME } from './tool-names.js';
@@ -46,6 +47,12 @@ class ActivateSkillToolInvocation extends BaseToolInvocation<
     _toolDisplayName?: string,
   ) {
     super(params, messageBus, _toolName, _toolDisplayName);
+  }
+
+  protected override getPolicyUpdateOptions(
+    _outcome: ToolConfirmationOutcome,
+  ): PolicyUpdateOptions | undefined {
+    return { skillName: this.params.name };
   }
 
   getDescription(): string {

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -76,6 +76,7 @@ export interface ToolInvocation<
 export interface PolicyUpdateOptions {
   commandPrefix?: string | string[];
   mcpName?: string;
+  skillName?: string;
 }
 
 /**


### PR DESCRIPTION
Fixes #19583

Currently, the policy engine uses broad permissions for skill activation.
When a user chooses "always allow," the decision applies globally to all skills.
This change implements granular permissions that restrict "always allow" 
decisions to specific skill names.

### Changes
- Add `skillName` to [UpdatePolicy](cci:2://file:///d:/GSOC%2026/Gemini%20CLI/packages/core/src/confirmation-bus/types.ts:116:0-124:1) and [PolicyUpdateOptions](cci:2://file:///d:/GSOC%2026/Gemini%20CLI/packages/core/src/tools/tools.ts:75:0-79:1) interfaces
- Override [getPolicyUpdateOptions](cci:1://file:///d:/GSOC%2026/Gemini%20CLI/packages/core/src/tools/activate-skill.ts:51:2-55:3) in [ActivateSkillToolInvocation](cci:2://file:///d:/GSOC%2026/Gemini%20CLI/packages/core/src/tools/activate-skill.ts:35:0-160:1)
- Extend [buildArgsPatterns](cci:1://file:///d:/GSOC%2026/Gemini%20CLI/packages/core/src/policy/utils.ts:44:0-88:1) to generate skill-specific regex patterns
- Update [createPolicyUpdater](cci:1://file:///d:/GSOC%2026/Gemini%20CLI/packages/core/src/policy/config.ts:478:0-652:1) for in-memory rules and TOML persistence