### PR TITLE
feat(core): add per-model token usage to stream-json output

### DIFF
--- a/packages/cli/src/__snapshots__/nonInteractiveCli.test.ts.snap
+++ b/packages/cli/src/__snapshots__/nonInteractiveCli.test.ts.snap
@@ -4,7 +4,7 @@ exports[`runNonInteractive > should emit appropriate error event in streaming JS
 "{"type":"init","timestamp":"<TIMESTAMP>","session_id":"test-session-id","model":"test-model"}
 {"type":"message","timestamp":"<TIMESTAMP>","role":"user","content":"Loop test"}
 {"type":"error","timestamp":"<TIMESTAMP>","severity":"warning","message":"Loop detected, stopping execution"}
-{"type":"result","timestamp":"<TIMESTAMP>","status":"success","stats":{"total_tokens":0,"input_tokens":0,"output_tokens":0,"cached":0,"input":0,"duration_ms":<DURATION>,"tool_calls":0}}
+{"type":"result","timestamp":"<TIMESTAMP>","status":"success","stats":{"total_tokens":0,"input_tokens":0,"output_tokens":0,"cached":0,"input":0,"duration_ms":<DURATION>,"tool_calls":0,"models":{}}}
 "
 `;
 
@@ -12,7 +12,7 @@ exports[`runNonInteractive > should emit appropriate error event in streaming JS
 "{"type":"init","timestamp":"<TIMESTAMP>","session_id":"test-session-id","model":"test-model"}
 {"type":"message","timestamp":"<TIMESTAMP>","role":"user","content":"Max turns test"}
 {"type":"error","timestamp":"<TIMESTAMP>","severity":"error","message":"Maximum session turns exceeded"}
-{"type":"result","timestamp":"<TIMESTAMP>","status":"success","stats":{"total_tokens":0,"input_tokens":0,"output_tokens":0,"cached":0,"input":0,"duration_ms":<DURATION>,"tool_calls":0}}
+{"type":"result","timestamp":"<TIMESTAMP>","status":"success","stats":{"total_tokens":0,"input_tokens":0,"output_tokens":0,"cached":0,"input":0,"duration_ms":<DURATION>,"tool_calls":0,"models":{}}}
 "
 `;
 
@@ -23,7 +23,7 @@ exports[`runNonInteractive > should emit appropriate events for streaming JSON o
 {"type":"tool_use","timestamp":"<TIMESTAMP>","tool_name":"testTool","tool_id":"tool-1","parameters":{"arg1":"value1"}}
 {"type":"tool_result","timestamp":"<TIMESTAMP>","tool_id":"tool-1","status":"success","output":"Tool executed successfully"}
 {"type":"message","timestamp":"<TIMESTAMP>","role":"assistant","content":"Final answer","delta":true}
-{"type":"result","timestamp":"<TIMESTAMP>","status":"success","stats":{"total_tokens":0,"input_tokens":0,"output_tokens":0,"cached":0,"input":0,"duration_ms":<DURATION>,"tool_calls":0}}
+{"type":"result","timestamp":"<TIMESTAMP>","status":"success","stats":{"total_tokens":0,"input_tokens":0,"output_tokens":0,"cached":0,"input":0,"duration_ms":<DURATION>,"tool_calls":0,"models":{}}}
 "
 `;
 

--- a/packages/cli/src/utils/errors.test.ts
+++ b/packages/cli/src/utils/errors.test.ts
@@ -74,6 +74,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
         input: 0,
         duration_ms: 0,
         tool_calls: 0,
+        models: {},
       }),
     })),
     uiTelemetryService: {

--- a/packages/core/src/output/stream-json-formatter.test.ts
+++ b/packages/core/src/output/stream-json-formatter.test.ts
@@ -154,6 +154,7 @@ describe('StreamJsonFormatter', () => {
           input: 50,
           duration_ms: 1200,
           tool_calls: 2,
+          models: {},
         },
       };
 
@@ -180,6 +181,7 @@ describe('StreamJsonFormatter', () => {
           input: 50,
           duration_ms: 1200,
           tool_calls: 0,
+          models: {},
         },
       };
 
@@ -304,6 +306,15 @@ describe('StreamJsonFormatter', () => {
         input: 50,
         duration_ms: 1200,
         tool_calls: 2,
+        models: {
+          'gemini-2.0-flash': {
+            total_tokens: 80,
+            input_tokens: 50,
+            output_tokens: 30,
+            cached: 0,
+            input: 50,
+          },
+        },
       });
     });
 
@@ -347,6 +358,22 @@ describe('StreamJsonFormatter', () => {
         input: 150,
         duration_ms: 3000,
         tool_calls: 5,
+        models: {
+          'gemini-pro': {
+            total_tokens: 80,
+            input_tokens: 50,
+            output_tokens: 30,
+            cached: 0,
+            input: 50,
+          },
+          'gemini-ultra': {
+            total_tokens: 170,
+            input_tokens: 100,
+            output_tokens: 70,
+            cached: 0,
+            input: 100,
+          },
+        },
       });
     });
 
@@ -376,6 +403,15 @@ describe('StreamJsonFormatter', () => {
         input: 20,
         duration_ms: 1200,
         tool_calls: 0,
+        models: {
+          'gemini-pro': {
+            total_tokens: 80,
+            input_tokens: 50,
+            output_tokens: 30,
+            cached: 30,
+            input: 20,
+          },
+        },
       });
     });
 
@@ -392,6 +428,7 @@ describe('StreamJsonFormatter', () => {
         input: 0,
         duration_ms: 100,
         tool_calls: 0,
+        models: {},
       });
     });
 
@@ -521,6 +558,7 @@ describe('StreamJsonFormatter', () => {
             input: 0,
             duration_ms: 0,
             tool_calls: 0,
+            models: {},
           },
         } as ResultEvent,
       ];
@@ -544,6 +582,7 @@ describe('StreamJsonFormatter', () => {
           input: 50,
           duration_ms: 1200,
           tool_calls: 2,
+          models: {},
         },
       };
 

--- a/packages/core/src/output/stream-json-formatter.ts
+++ b/packages/core/src/output/stream-json-formatter.ts
@@ -44,41 +44,35 @@ export class StreamJsonFormatter {
     metrics: SessionMetrics,
     durationMs: number,
   ): StreamStats {
-    const {
-      totalTokens,
-      inputTokens,
-      outputTokens,
-      cached,
-      input,
-      models,
-    } = Object.entries(metrics.models).reduce(
-      (acc, [modelName, modelMetrics]) => {
-        const modelStats: ModelStreamStats = {
-          total_tokens: modelMetrics.tokens.total,
-          input_tokens: modelMetrics.tokens.prompt,
-          output_tokens: modelMetrics.tokens.candidates,
-          cached: modelMetrics.tokens.cached,
-          input: modelMetrics.tokens.input,
-        };
+    const { totalTokens, inputTokens, outputTokens, cached, input, models } =
+      Object.entries(metrics.models).reduce(
+        (acc, [modelName, modelMetrics]) => {
+          const modelStats: ModelStreamStats = {
+            total_tokens: modelMetrics.tokens.total,
+            input_tokens: modelMetrics.tokens.prompt,
+            output_tokens: modelMetrics.tokens.candidates,
+            cached: modelMetrics.tokens.cached,
+            input: modelMetrics.tokens.input,
+          };
 
-        acc.models[modelName] = modelStats;
-        acc.totalTokens += modelStats.total_tokens;
-        acc.inputTokens += modelStats.input_tokens;
-        acc.outputTokens += modelStats.output_tokens;
-        acc.cached += modelStats.cached;
-        acc.input += modelStats.input;
+          acc.models[modelName] = modelStats;
+          acc.totalTokens += modelStats.total_tokens;
+          acc.inputTokens += modelStats.input_tokens;
+          acc.outputTokens += modelStats.output_tokens;
+          acc.cached += modelStats.cached;
+          acc.input += modelStats.input;
 
-        return acc;
-      },
-      {
-        totalTokens: 0,
-        inputTokens: 0,
-        outputTokens: 0,
-        cached: 0,
-        input: 0,
-        models: {} as Record<string, ModelStreamStats>,
-      },
-    );
+          return acc;
+        },
+        {
+          totalTokens: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          cached: 0,
+          input: 0,
+          models: {} as Record<string, ModelStreamStats>,
+        },
+      );
 
     return {
       total_tokens: totalTokens,

--- a/packages/core/src/output/stream-json-formatter.ts
+++ b/packages/core/src/output/stream-json-formatter.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JsonStreamEvent, StreamStats } from './types.js';
+import type {
+  JsonStreamEvent,
+  ModelStreamStats,
+  StreamStats,
+} from './types.js';
 import type { SessionMetrics } from '../telemetry/uiTelemetry.js';
 
 /**
@@ -31,7 +35,7 @@ export class StreamJsonFormatter {
 
   /**
    * Converts SessionMetrics to simplified StreamStats format.
-   * Aggregates token counts across all models.
+   * Includes per-model token breakdowns and aggregated totals.
    * @param metrics - The session metrics from telemetry
    * @param durationMs - The session duration in milliseconds
    * @returns Simplified stats for streaming output
@@ -40,20 +44,41 @@ export class StreamJsonFormatter {
     metrics: SessionMetrics,
     durationMs: number,
   ): StreamStats {
-    let totalTokens = 0;
-    let inputTokens = 0;
-    let outputTokens = 0;
-    let cached = 0;
-    let input = 0;
+    const {
+      totalTokens,
+      inputTokens,
+      outputTokens,
+      cached,
+      input,
+      models,
+    } = Object.entries(metrics.models).reduce(
+      (acc, [modelName, modelMetrics]) => {
+        const modelStats: ModelStreamStats = {
+          total_tokens: modelMetrics.tokens.total,
+          input_tokens: modelMetrics.tokens.prompt,
+          output_tokens: modelMetrics.tokens.candidates,
+          cached: modelMetrics.tokens.cached,
+          input: modelMetrics.tokens.input,
+        };
 
-    // Aggregate token counts across all models
-    for (const modelMetrics of Object.values(metrics.models)) {
-      totalTokens += modelMetrics.tokens.total;
-      inputTokens += modelMetrics.tokens.prompt;
-      outputTokens += modelMetrics.tokens.candidates;
-      cached += modelMetrics.tokens.cached;
-      input += modelMetrics.tokens.input;
-    }
+        acc.models[modelName] = modelStats;
+        acc.totalTokens += modelStats.total_tokens;
+        acc.inputTokens += modelStats.input_tokens;
+        acc.outputTokens += modelStats.output_tokens;
+        acc.cached += modelStats.cached;
+        acc.input += modelStats.input;
+
+        return acc;
+      },
+      {
+        totalTokens: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cached: 0,
+        input: 0,
+        models: {} as Record<string, ModelStreamStats>,
+      },
+    );
 
     return {
       total_tokens: totalTokens,
@@ -63,6 +88,7 @@ export class StreamJsonFormatter {
       input,
       duration_ms: durationMs,
       tool_calls: metrics.tools.totalCalls,
+      models,
     };
   }
 }

--- a/packages/core/src/output/types.ts
+++ b/packages/core/src/output/types.ts
@@ -77,6 +77,14 @@ export interface ErrorEvent extends BaseJsonStreamEvent {
   message: string;
 }
 
+export interface ModelStreamStats {
+  total_tokens: number;
+  input_tokens: number;
+  output_tokens: number;
+  cached: number;
+  input: number;
+}
+
 export interface StreamStats {
   total_tokens: number;
   input_tokens: number;
@@ -86,6 +94,7 @@ export interface StreamStats {
   input: number;
   duration_ms: number;
   tool_calls: number;
+  models: Record<string, ModelStreamStats>;
 }
 
 export interface ResultEvent extends BaseJsonStreamEvent {


### PR DESCRIPTION
Add a `models` field to `StreamStats` with per-model token breakdowns, bringing stream-json output to parity with json output format. Aggregated totals are derived from per-model stats to avoid duplicate logic.

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
The `stream-json` output format aggregates token usage into a single flat `stats` object, losing per-model granularity that `json` output provides. This PR adds a `models` field to the `result` event's `StreamStats` with per-model token breakdowns. Existing aggregated fields are unchanged, making this a backward-compatible addition.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
- Added `ModelStreamStats` interface with per-model token fields (`total_tokens`, `input_tokens`, `output_tokens`, `cached`, `input`).
- Added `models: Record<string, ModelStreamStats>` to `StreamStats`.
- Refactored `convertToStreamStats()` to build per-model stats first, then derive aggregated totals from them to avoid duplicate logic.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
https://github.com/google-gemini/gemini-cli/issues/21833

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
1. Run with stream-json output and verify the `result` event includes per-model stats:
   ```bash
   NODE_ENV=development node scripts/start.js -p "hello" --output-format stream-json 2>/dev/null | grep '"type":"result"' | python3 -m json.tool
   ```
2. Run unit tests:
   ```bash
   npx vitest run --coverage.enabled=false packages/core/src/output/stream-json-formatter.test.ts
   ```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
