### PR TITLE
fix(core): prioritize currentTier over paidTier to fix Enterprise entitlement routing

### DIFF
--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -189,10 +189,10 @@ async function _doSetupUser(
         return {
           projectId,
           userTier:
-            loadRes.paidTier?.id ??
             loadRes.currentTier.id ??
+            loadRes.paidTier?.id ??
             UserTierId.STANDARD,
-          userTierName: loadRes.paidTier?.name ?? loadRes.currentTier.name,
+          userTierName: loadRes.currentTier.name ?? loadRes.paidTier?.name,
           paidTier: loadRes.paidTier ?? undefined,
         };
       }
@@ -203,8 +203,8 @@ async function _doSetupUser(
     return {
       projectId: loadRes.cloudaicompanionProject,
       userTier:
-        loadRes.paidTier?.id ?? loadRes.currentTier.id ?? UserTierId.STANDARD,
-      userTierName: loadRes.paidTier?.name ?? loadRes.currentTier.name,
+        loadRes.currentTier.id ?? loadRes.paidTier?.id ?? UserTierId.STANDARD,
+      userTierName: loadRes.currentTier.name ?? loadRes.paidTier?.name,
       paidTier: loadRes.paidTier ?? undefined,
     };
   }


### PR DESCRIPTION
## Summary

Fixes a critical entitlement routing bug where a user's `currentTier` (e.g.,
Enterprise Gemini Code Assist Standard) is incorrectly overwritten by their
`paidTier` (e.g., consumer Google One AI Pro). This change ensures the CLI
prioritizes the authoritative `currentTier` assigned by the backend, preserving
proprietary IP guarantees for Enterprise users while still functioning correctly
for users on standard consumer or free tiers.

## Details

In `packages/core/src/code_assist/setup.ts`, the logic for determining the
`userTier` and `userTierName` mistakenly used the nullish coalescing operator to
prioritize `loadRes.paidTier` over `loadRes.currentTier`. The `paidTier` field
serves as a metadata container (e.g., for available credits), whereas
`currentTier` is the actual active entitlement for the session as determined by
the backend. When an account has an Enterprise license (which becomes the
`currentTier`) but also has a Google One subscription (which populates the
`paidTier`), the CLI would incorrectly force the user into the consumer tier.
This PR simply swaps the prioritization order to
`loadRes.currentTier.id ?? loadRes.paidTier?.id` to respect the server's
assignment.

## Related Issues

Fixes #19970

## How to Validate

1. **Enterprise + Google One User (Bug Reproduction):**
   - Use an account with a GCP Enterprise license and a Google One AI Pro
     subscription.
   - Run the CLI and authenticate.
   - Run `/about`. The Tier should be listed as "Gemini Code Assist" (the
     Enterprise tier), not the Google One consumer tier.
2. **Google One AI Pro Only User:**
   - Authenticate with an account having only a Google One AI Pro subscription.
   - Run `/about`. The Tier should still correctly reflect the Google One AI Pro
     tier (as it will be present in both `currentTier` and `paidTier`).
3. **Free Tier User:**
   - Authenticate with a free tier account.
   - Run `/about`. The Tier should correctly show the free tier.
4. **Automated Tests:**
   - Ensure `vitest run src/code_assist/setup.test.ts` passes successfully (all
     17 tests), confirming no regressions in other fallback scenarios.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
