### PR TITLE
docs: add community guidelines for issue assignment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,19 @@ assign or unassign the issue as requested, provided the conditions are met
 Please note that you can have a maximum of 3 issues assigned to you at any given
 time.
 
+#### Community guidelines for issue assignment
+
+- **If you file an issue:** Please indicate in your issue whether you intend to
+  work on it once it receives the `help-wanted` label. This helps other
+  contributors know your plans.
+
+- **Look out for each other:** Before self-assigning an issue, check if someone
+  has already done significant work (e.g., detailed investigation, linked a
+  draft PR) or has clearly communicated their intent to contribute. If so,
+  please respect their effort and allow them the opportunity to complete the
+  work. Not everything needs a hard rule—we can show compassion and
+  understanding toward fellow contributors.
+
 ### Pull request guidelines
 
 To help us review and merge your PRs quickly, please follow these guidelines.


### PR DESCRIPTION
Fixes #21718

## Summary

Adds community guidelines to CONTRIBUTING.md for respectful issue assignment, addressing concerns about contributors trying to "game" the issue assignment system.

## Details

The update adds a new "Community guidelines for issue assignment" section with two key points:

1. **Issue authors** are encouraged to indicate whether they intend to work on an issue once it receives the `help-wanted` label
2. **All contributors** are reminded to check if someone has already done significant work or communicated their intent before self-assigning, and to show compassion and understanding toward fellow contributors

## Related Issues

Fixes #21718

## How to Validate

1. Open CONTRIBUTING.md
2. Navigate to the "Self-assigning and unassigning issues" section
3. Verify the new "Community guidelines for issue assignment" subsection is present
4. Confirm the two guidelines are clearly stated

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed) - N/A, documentation only
- [ ] Noted breaking changes (if any) - N/A
- [ ] Validated on required platforms/methods - N/A, documentation only

---

**Diff stats:**
```
CONTRIBUTING.md | 13 +++++++++++++
1 file changed, 13 insertions(+)
```