### PR TITLE
fix(ui): handle headless execution in credits and upgrade dialogs

### DIFF
--- a/packages/cli/src/ui/commands/upgradeCommand.test.ts
+++ b/packages/cli/src/ui/commands/upgradeCommand.test.ts
@@ -11,6 +11,7 @@ import { createMockCommandContext } from '../../test-utils/mockCommandContext.js
 import {
   AuthType,
   openBrowserSecurely,
+  shouldLaunchBrowser,
   UPGRADE_URL_PAGE,
 } from '@google/gemini-cli-core';
 
@@ -20,6 +21,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   return {
     ...actual,
     openBrowserSecurely: vi.fn(),
+    shouldLaunchBrowser: vi.fn().mockReturnValue(true),
     UPGRADE_URL_PAGE: 'https://goo.gle/set-up-gemini-code-assist',
   };
 });
@@ -95,5 +97,22 @@ describe('upgradeCommand', () => {
       messageType: 'error',
       content: 'Failed to open upgrade page: Failed to open',
     });
+  });
+
+  it('should return URL message when shouldLaunchBrowser returns false', async () => {
+    vi.mocked(shouldLaunchBrowser).mockReturnValue(false);
+
+    if (!upgradeCommand.action) {
+      throw new Error('The upgrade command must have an action.');
+    }
+
+    const result = await upgradeCommand.action(mockContext, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: `Please open this URL in a browser: ${UPGRADE_URL_PAGE}`,
+    });
+    expect(openBrowserSecurely).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/ui/commands/upgradeCommand.ts
+++ b/packages/cli/src/ui/commands/upgradeCommand.ts
@@ -7,6 +7,7 @@
 import {
   AuthType,
   openBrowserSecurely,
+  shouldLaunchBrowser,
   UPGRADE_URL_PAGE,
 } from '@google/gemini-cli-core';
 import type { SlashCommand } from './types.js';
@@ -32,6 +33,14 @@ export const upgradeCommand: SlashCommand = {
         messageType: 'error',
         content:
           'The /upgrade command is only available when logged in with Google.',
+      };
+    }
+
+    if (!shouldLaunchBrowser()) {
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: `Please open this URL in a browser: ${UPGRADE_URL_PAGE}`,
       };
     }
 

--- a/packages/cli/src/ui/components/__snapshots__/ConfigInitDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ConfigInitDisplay.test.tsx.snap
@@ -18,6 +18,12 @@ Spinner Connecting to MCP servers... (0/5) - Waiting for: s1, s2, s3, +2 more
 "
 `;
 
+exports[`ConfigInitDisplay > truncates list of waiting servers if too many 2`] = `
+"
+Spinner Connecting to MCP servers... (0/5) - Waiting for: s1, s2, s3, +2 more
+"
+`;
+
 exports[`ConfigInitDisplay > updates message on McpClientUpdate event 1`] = `
 "
 Spinner Connecting to MCP servers... (1/2) - Waiting for: server2

--- a/packages/cli/src/ui/hooks/creditsFlowHandler.test.ts
+++ b/packages/cli/src/ui/hooks/creditsFlowHandler.test.ts
@@ -15,6 +15,7 @@ import {
   shouldAutoUseCredits,
   shouldShowOverageMenu,
   shouldShowEmptyWalletMenu,
+  shouldLaunchBrowser,
   logBillingEvent,
   G1_CREDIT_TYPE,
   UserTierId,
@@ -32,6 +33,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     shouldShowEmptyWalletMenu: vi.fn(),
     logBillingEvent: vi.fn(),
     openBrowserSecurely: vi.fn(),
+    shouldLaunchBrowser: vi.fn().mockReturnValue(true),
   };
 });
 
@@ -236,5 +238,50 @@ describe('handleCreditsFlow', () => {
 
     expect(isDialogPending.current).toBe(false);
     expect(mockSetEmptyWalletRequest).toHaveBeenCalledWith(null);
+  });
+
+  describe('headless mode (shouldLaunchBrowser=false)', () => {
+    beforeEach(() => {
+      vi.mocked(shouldLaunchBrowser).mockReturnValue(false);
+    });
+
+    it('should show manage URL in history when manage selected in headless mode', async () => {
+      vi.mocked(shouldShowOverageMenu).mockReturnValue(true);
+
+      const flowPromise = handleCreditsFlow(makeArgs());
+      const request = mockSetOverageMenuRequest.mock.calls[0][0];
+      request.resolve('manage');
+      const result = await flowPromise;
+
+      expect(result).toBe('stop');
+      expect(mockHistoryManager.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: expect.stringContaining('Please open this URL in a browser:'),
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('should show credits URL in history when get_credits selected in headless mode', async () => {
+      vi.mocked(shouldShowEmptyWalletMenu).mockReturnValue(true);
+
+      const flowPromise = handleCreditsFlow(makeArgs());
+      const request = mockSetEmptyWalletRequest.mock.calls[0][0];
+
+      // Trigger onGetCredits callback and wait for it
+      await request.onGetCredits();
+
+      expect(mockHistoryManager.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: expect.stringContaining('Please open this URL in a browser:'),
+        }),
+        expect.any(Number),
+      );
+
+      request.resolve('get_credits');
+      await flowPromise;
+    });
   });
 });

--- a/packages/cli/src/ui/hooks/creditsFlowHandler.ts
+++ b/packages/cli/src/ui/hooks/creditsFlowHandler.ts
@@ -14,6 +14,7 @@ import {
   shouldShowOverageMenu,
   shouldShowEmptyWalletMenu,
   openBrowserSecurely,
+  shouldLaunchBrowser,
   logBillingEvent,
   OverageMenuShownEvent,
   OverageOptionSelectedEvent,
@@ -159,10 +160,23 @@ async function handleOverageMenu(
     case 'use_fallback':
       return 'retry_always';
 
-    case 'manage':
+    case 'manage': {
       logCreditPurchaseClick(config, 'manage', usageLimitReachedModel);
-      await openG1Url('activity', G1_UTM_CAMPAIGNS.MANAGE_ACTIVITY);
+      const manageUrl = await openG1Url(
+        'activity',
+        G1_UTM_CAMPAIGNS.MANAGE_ACTIVITY,
+      );
+      if (manageUrl) {
+        args.historyManager.addItem(
+          {
+            type: MessageType.INFO,
+            text: `Please open this URL in a browser: ${manageUrl}`,
+          },
+          Date.now(),
+        );
+      }
       return 'stop';
+    }
 
     case 'stop':
     default:
@@ -205,13 +219,25 @@ async function handleEmptyWalletMenu(
       failedModel: usageLimitReachedModel,
       fallbackModel,
       resetTime,
-      onGetCredits: () => {
+      onGetCredits: async () => {
         logCreditPurchaseClick(
           config,
           'empty_wallet_menu',
           usageLimitReachedModel,
         );
-        void openG1Url('credits', G1_UTM_CAMPAIGNS.EMPTY_WALLET_ADD_CREDITS);
+        const creditsUrl = await openG1Url(
+          'credits',
+          G1_UTM_CAMPAIGNS.EMPTY_WALLET_ADD_CREDITS,
+        );
+        if (creditsUrl) {
+          args.historyManager.addItem(
+            {
+              type: MessageType.INFO,
+              text: `Please open this URL in a browser: ${creditsUrl}`,
+            },
+            Date.now(),
+          );
+        }
       },
       resolve,
     });
@@ -272,11 +298,16 @@ function logCreditPurchaseClick(
 async function openG1Url(
   path: 'activity' | 'credits',
   campaign: string,
-): Promise<void> {
+): Promise<string | undefined> {
   try {
     const userEmail = new UserAccountManager().getCachedGoogleAccount() ?? '';
-    await openBrowserSecurely(buildG1Url(path, userEmail, campaign));
+    const url = buildG1Url(path, userEmail, campaign);
+    if (!shouldLaunchBrowser()) {
+      return url;
+    }
+    await openBrowserSecurely(url);
   } catch {
     // Ignore browser open errors
   }
+  return undefined;
 }

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -44,6 +44,7 @@ vi.mock('../telemetry/index.js', () => ({
 }));
 vi.mock('../utils/secure-browser-launcher.js', () => ({
   openBrowserSecurely: vi.fn(),
+  shouldLaunchBrowser: vi.fn().mockReturnValue(true),
 }));
 
 // Mock debugLogger to prevent console pollution and allow spying

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -6,7 +6,10 @@
 
 import type { Config } from '../config/config.js';
 import { AuthType } from '../core/contentGenerator.js';
-import { openBrowserSecurely } from '../utils/secure-browser-launcher.js';
+import {
+  openBrowserSecurely,
+  shouldLaunchBrowser,
+} from '../utils/secure-browser-launcher.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { getErrorMessage } from '../utils/errors.js';
 import type { FallbackIntent, FallbackRecommendation } from './types.js';
@@ -112,6 +115,12 @@ export async function handleFallback(
 }
 
 async function handleUpgrade() {
+  if (!shouldLaunchBrowser()) {
+    debugLogger.log(
+      `Cannot open browser in this environment. Please visit: ${UPGRADE_URL_PAGE}`,
+    );
+    return;
+  }
   try {
     await openBrowserSecurely(UPGRADE_URL_PAGE);
   } catch (error) {


### PR DESCRIPTION
## Summary

Fix headless execution handling in AI credits integration dialogs and the `/upgrade` command. When `shouldLaunchBrowser()` returns `false` (CI, SSH, headless environments), the credits "Manage" and "Get Credits" options, as well as the `/upgrade` command and core `handleUpgrade()` fallback, now print the URL to the user instead of silently failing.

## Details

Three places called `openBrowserSecurely()` without checking `shouldLaunchBrowser()` first:

1. **`creditsFlowHandler.ts` `openG1Url()`** — Used by "Manage" (overage menu) and "Get Credits" (empty wallet menu). Changed return type to `Promise<string | undefined>` so callers can surface the URL as an info message in chat history.
2. **`upgradeCommand.ts`** — The `/upgrade` slash command now returns an info message with the URL when browser can't launch.
3. **`handler.ts` `handleUpgrade()`** — Core-level handler logs the URL via `debugLogger.log()` since it has no UI access.

This follows the patterns already established in `ValidationDialog.tsx` and `BannedAccountDialog.tsx`.

## Related Issues

N/A

## How to Validate

1. Run the affected test suites:
   ```bash
   npm test -w @google/gemini-cli -- src/ui/hooks/creditsFlowHandler.test.ts
   npm test -w @google/gemini-cli -- src/ui/commands/upgradeCommand.test.ts
   npm test -w @google/gemini-cli-core -- src/fallback/handler.test.ts
   ```
2. Set `CI=1` in your environment and trigger a quota error to see the overage/empty wallet dialogs print URLs instead of trying to open a browser.
3. With `CI=1`, run `/upgrade` and verify it returns the URL as an info message.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
