### PR TITLE
fix(core): update @a2a-js/sdk to 0.3.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,9 +84,9 @@
       }
     },
     "node_modules/@a2a-js/sdk": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.10.tgz",
-      "integrity": "sha512-t6w5ctnwJkSOMRl6M9rn95C1FTHCPqixxMR0yWXtzhZXEnF6mF1NAK0CfKlG3cz+tcwTxkmn287QZC3t9XPgrA==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.11.tgz",
+      "integrity": "sha512-pXjjlL0ZYHgAxObov1J+W3ylfQV0rOrDBB8Eo4a9eCunqs7iNW5OIfMcV8YnZQdzeVSRomj8jHeudVz0zc4RNw==",
       "license": "Apache-2.0",
       "dependencies": {
         "uuid": "^11.1.0"
@@ -17337,7 +17337,7 @@
       "name": "@google/gemini-cli-a2a-server",
       "version": "0.34.0-nightly.20260304.28af4e127",
       "dependencies": {
-        "@a2a-js/sdk": "^0.3.8",
+        "@a2a-js/sdk": "0.3.11",
         "@google-cloud/storage": "^7.16.0",
         "@google/gemini-cli-core": "file:../core",
         "express": "^5.1.0",
@@ -17479,7 +17479,7 @@
       "version": "0.34.0-nightly.20260304.28af4e127",
       "license": "Apache-2.0",
       "dependencies": {
-        "@a2a-js/sdk": "^0.3.10",
+        "@a2a-js/sdk": "0.3.11",
         "@bufbuild/protobuf": "^2.11.0",
         "@google-cloud/logging": "^11.2.1",
         "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",

--- a/packages/a2a-server/package.json
+++ b/packages/a2a-server/package.json
@@ -25,7 +25,7 @@
     "dist"
   ],
   "dependencies": {
-    "@a2a-js/sdk": "^0.3.8",
+    "@a2a-js/sdk": "0.3.11",
     "@google-cloud/storage": "^7.16.0",
     "@google/gemini-cli-core": "file:../core",
     "express": "^5.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
     "dist"
   ],
   "dependencies": {
-    "@a2a-js/sdk": "^0.3.10",
+    "@a2a-js/sdk": "0.3.11",
     "@bufbuild/protobuf": "^2.11.0",
     "@google-cloud/logging": "^11.2.1",
     "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",


### PR DESCRIPTION
## Summary

Update `@a2a-js/sdk` to version `0.3.11` in `packages/core` and `packages/a2a-server`.

## Details

This update ensures compatibility with the latest features and fixes in the `@a2a-js/sdk`. During the update, the `package-lock.json` was also cleaned of redundant `"peer": true` entries by running a clean install with Node 22 (though `.nvmrc` was not updated in this commit as per user request).

## Related Issues

https://github.com/google-gemini/gemini-cli/issues/18199

## How to Validate

1. Run `npm install` to ensure dependencies are correctly resolved.
2. Verify the version in `package-lock.json`:
   ```bash
   grep -C 5 '"@a2a-js/sdk"' package-lock.json
   ```
3. Run existing tests to ensure no regressions:
   ```bash
   npm run test --workspace=@google/gemini-cli-core
   npm run test --workspace=@google/gemini-cli-a2a-server
   ```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
