### PR TITLE
Change to using absolute paths for shell command policy enforcement

### DIFF
--- a/docs/reference/policy-engine.md
+++ b/docs/reference/policy-engine.md
@@ -167,7 +167,13 @@ A rule matches a tool call if all of its conditions are met:
     - **Wildcards**: You can use wildcards like `*`, `server__*`, or
       `*__toolName` to match multiple tools. See [Tool Name](#tool-name) for
       details.
-2.  **Arguments pattern**: If `argsPattern` is specified, the tool's arguments
+2.  **Canonical Shell Commands**: For `run_shell_command`, the engine
+    automatically resolves commands to their canonical (absolute) paths (e.g.,
+    resolving `ls` to `/usr/bin/ls`) before matching. Rules are checked against
+    **both** the raw command and its canonical path. This provides enhanced
+    security by preventing path-based bypasses while maintaining backward
+    compatibility with rules that use raw command names.
+3.  **Arguments pattern**: If `argsPattern` is specified, the tool's arguments
     are converted to a stable JSON string, which is then tested against the
     provided regular expression. If the arguments don't match the pattern, the
     rule does not apply.

--- a/docs/tools/shell.md
+++ b/docs/tools/shell.md
@@ -141,9 +141,15 @@ The validation logic is designed to be secure and flexible:
 1.  **Command chaining disabled**: The tool automatically splits commands
     chained with `&&`, `||`, or `;` and validates each part separately. If any
     part of the chain is disallowed, the entire command is blocked.
-2.  **Prefix matching**: The tool uses prefix matching. For example, if you
-    allow `git`, you can run `git status` or `git log`.
-3.  **Blocklist precedence**: The `tools.exclude` list is always checked first.
+2.  **Canonical path matching**: For enhanced security, the tool resolves
+    commands to their absolute canonical paths (e.g., resolving `ls` to
+    `/usr/bin/ls`) before matching against policies. This prevents bypasses
+    using different relative paths or missing absolute paths for the same
+    executable.
+3.  **Prefix matching**: The tool uses prefix matching against both the raw
+    command and its canonical path. For example, if you allow `git`, you can run
+    `git status` or `git log`.
+4.  **Blocklist precedence**: The `tools.exclude` list is always checked first.
     If a command matches a blocked prefix, it will be denied, even if it also
     matches an allowed prefix in `tools.core`.
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -987,6 +987,7 @@ export class Config implements McpContext, AgentLoopContext {
     this.policyEngine = new PolicyEngine(
       {
         ...params.policyEngineConfig,
+        targetDir: this.targetDir,
         approvalMode:
           params.approvalMode ?? params.policyEngineConfig?.approvalMode,
       },

--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -41,6 +41,11 @@ vi.mock('../utils/shell-utils.js', async (importOriginal) => {
         // Simple mock: true if '>' is present, unless it looks like "-> arrow"
         command.includes('>') && !command.includes('-> arrow'),
     ),
+    getCanonicalCommand: vi.fn().mockImplementation((command: string) => {
+      if (command === 'ls') return '/usr/bin/ls';
+      if (command === 'git status') return '/usr/bin/git status';
+      return command;
+    }),
   };
 });
 
@@ -1255,12 +1260,59 @@ describe('PolicyEngine', () => {
 
       engine = new PolicyEngine({ rules });
 
-      // "git status && ls" matches the catch-all ASK_USER rule initially.
       // But since both parts are explicitly ALLOWed, the result should be upgraded to ALLOW.
       const result = await engine.check(
         {
           name: 'run_shell_command',
           args: { command: 'git status && ls' },
+        },
+        undefined,
+      );
+
+      expect(result.decision).toBe(PolicyDecision.ALLOW);
+    });
+
+    it('should match canonical command path if rule uses it', async () => {
+      const rules: PolicyRule[] = [
+        {
+          toolName: 'run_shell_command',
+          // Rule uses absolute path
+          argsPattern: /"command":"\/usr\/bin\/ls/,
+          decision: PolicyDecision.ALLOW,
+        },
+      ];
+
+      engine = new PolicyEngine({ rules });
+
+      // Call uses raw command "ls".
+      // Our mock getCanonicalCommand returns "/usr/bin/ls" for "ls".
+      const result = await engine.check(
+        {
+          name: 'run_shell_command',
+          args: { command: 'ls' },
+        },
+        undefined,
+      );
+
+      expect(result.decision).toBe(PolicyDecision.ALLOW);
+    });
+
+    it('should match raw command if rule uses it (backward compatibility)', async () => {
+      const rules: PolicyRule[] = [
+        {
+          toolName: 'run_shell_command',
+          // Rule uses raw prefix
+          argsPattern: /"command":"ls/,
+          decision: PolicyDecision.ALLOW,
+        },
+      ];
+
+      engine = new PolicyEngine({ rules });
+
+      const result = await engine.check(
+        {
+          name: 'run_shell_command',
+          args: { command: 'ls' },
         },
         undefined,
       );

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -5,6 +5,7 @@
  */
 
 import { type FunctionCall } from '@google/genai';
+import path from 'node:path';
 import {
   PolicyDecision,
   type PolicyEngineConfig,
@@ -23,6 +24,7 @@ import {
   initializeShellParsers,
   splitCommands,
   hasRedirection,
+  getCanonicalCommand,
 } from '../utils/shell-utils.js';
 import { getToolAliases } from '../tools/tool-names.js';
 import {
@@ -156,6 +158,7 @@ export class PolicyEngine {
   private readonly nonInteractive: boolean;
   private readonly checkerRunner?: CheckerRunner;
   private approvalMode: ApprovalMode;
+  private readonly targetDir?: string;
 
   constructor(config: PolicyEngineConfig = {}, checkerRunner?: CheckerRunner) {
     this.rules = (config.rules ?? []).sort(
@@ -171,6 +174,7 @@ export class PolicyEngine {
     this.nonInteractive = config.nonInteractive ?? false;
     this.checkerRunner = checkerRunner;
     this.approvalMode = config.approvalMode ?? ApprovalMode.DEFAULT;
+    this.targetDir = config.targetDir;
   }
 
   /**
@@ -380,18 +384,8 @@ export class PolicyEngine {
       }
     }
 
-    let stringifiedArgs: string | undefined;
-    // Compute stringified args once before the loop
-    if (
-      toolCall.args &&
-      (this.rules.some((rule) => rule.argsPattern) ||
-        this.checkers.some((checker) => checker.argsPattern))
-    ) {
-      stringifiedArgs = stableStringify(toolCall.args);
-    }
-
     debugLogger.debug(
-      `[PolicyEngine.check] toolCall.name: ${toolCall.name}, stringifiedArgs: ${stringifiedArgs}`,
+      `[PolicyEngine.check] toolCall.name: ${toolCall.name}`,
     );
 
     // Check for shell commands upfront to handle splitting
@@ -409,24 +403,64 @@ export class PolicyEngine {
       shellDirPath = args?.dir_path;
     }
 
+    // Resolve effective directory for shell tools to aid canonicalization.
+    let resolvedShellCwd: string | undefined;
+    if (isShellCommand) {
+      if (this.targetDir) {
+        resolvedShellCwd = shellDirPath
+          ? path.resolve(this.targetDir, shellDirPath)
+          : this.targetDir;
+      } else {
+        resolvedShellCwd = shellDirPath
+          ? path.resolve(process.cwd(), shellDirPath)
+          : process.cwd();
+      }
+    }
+
+    const canonicalCommand =
+      isShellCommand && command
+        ? await getCanonicalCommand(command, resolvedShellCwd)
+        : undefined;
+
+    // Prepare variations of the tool call to try against rules.
+    // For shell tools, we try both the raw command and its canonical path version.
+    const toolNamesToTry = toolCall.name ? getToolAliases(toolCall.name) : [];
+    const variations: Array<{ tc: FunctionCall; argsStr: string | undefined }> =
+      [];
+
+    const needsArgsString =
+      this.rules.some((rule) => rule.argsPattern) ||
+      this.checkers.some((checker) => checker.argsPattern);
+
+    for (const name of toolNamesToTry) {
+      const tc = { ...toolCall, name };
+      variations.push({
+        tc,
+        argsStr: needsArgsString ? stableStringify(tc.args) : undefined,
+      });
+
+      if (canonicalCommand && canonicalCommand !== command) {
+        const canonicalTc = {
+          ...tc,
+          args: { ...tc.args, command: canonicalCommand },
+        };
+        variations.push({
+          tc: canonicalTc,
+          argsStr: stableStringify(canonicalTc.args),
+        });
+      }
+    }
+
     // Find the first matching rule (already sorted by priority)
     let matchedRule: PolicyRule | undefined;
     let decision: PolicyDecision | undefined;
 
-    // We also want to check legacy aliases for the tool name.
-    const toolNamesToTry = toolCall.name ? getToolAliases(toolCall.name) : [];
-
-    const toolCallsToTry: FunctionCall[] = [];
-    for (const name of toolNamesToTry) {
-      toolCallsToTry.push({ ...toolCall, name });
-    }
-
     for (const rule of this.rules) {
-      const match = toolCallsToTry.some((tc) =>
+      const match = variations.find((v) =>
         ruleMatches(
           rule,
-          tc,
-          stringifiedArgs,
+          v.tc,
+          v.argsStr,
           serverName,
           this.approvalMode,
           toolAnnotations,
@@ -491,23 +525,25 @@ export class PolicyEngine {
     // Safety checks
     if (decision !== PolicyDecision.DENY && this.checkerRunner) {
       for (const checkerRule of this.checkers) {
-        if (
+        const match = variations.find((v) =>
           ruleMatches(
             checkerRule,
-            toolCall,
-            stringifiedArgs,
+            v.tc,
+            v.argsStr,
             serverName,
             this.approvalMode,
             toolAnnotations,
             subagent,
-          )
-        ) {
+          ),
+        );
+
+        if (match) {
           debugLogger.debug(
             `[PolicyEngine.check] Running safety checker: ${checkerRule.checker.name}`,
           );
           try {
             const result = await this.checkerRunner.runChecker(
-              toolCall,
+              match.tc,
               checkerRule.checker,
             );
             if (result.decision === SafetyCheckDecision.DENY) {

--- a/packages/core/src/policy/types.ts
+++ b/packages/core/src/policy/types.ts
@@ -259,6 +259,11 @@ export interface HookCheckerRule {
 
 export interface PolicyEngineConfig {
   /**
+   * Base directory for path resolution (e.g. for shell tools).
+   */
+  targetDir?: string;
+
+  /**
    * List of policy rules to apply.
    */
   rules?: PolicyRule[];

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -40,8 +40,23 @@ vi.mock('node:os', async (importOriginal) => {
 });
 vi.mock('crypto');
 vi.mock('../utils/summarizer.js');
+vi.mock('../utils/shell-utils.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../utils/shell-utils.js')>();
+  return {
+    ...actual,
+    initializeShellParsers: vi.fn().mockResolvedValue(undefined),
+    getCanonicalCommandRoots: vi.fn().mockImplementation((cmd) => {
+      if (cmd === 'ls') return ['/usr/bin/ls'];
+      return [cmd];
+    }),
+  };
+});
 
-import { initializeShellParsers } from '../utils/shell-utils.js';
+import {
+  initializeShellParsers,
+  getCanonicalCommandRoots,
+} from '../utils/shell-utils.js';
 import { ShellTool, OUTPUT_UPDATE_INTERVAL_MS } from './shell.js';
 import { debugLogger } from '../index.js';
 import { type Config } from '../config/config.js';
@@ -821,6 +836,20 @@ describe('ShellTool', () => {
       if (details && details.type === 'exec') {
         expect(details.rootCommand).toBe('ls, grep');
       }
+    });
+
+    it('should propose canonical paths for permanent policies', async () => {
+      const bus = createMockMessageBus();
+      const shellTool = new ShellTool(mockConfig, bus);
+      const command = 'ls';
+      const invocation = shellTool.build({ command });
+
+      // Mock getCanonicalCommandRoots is already set up to return ['/usr/bin/ls'] for 'ls'
+      // @ts-expect-error - getPolicyUpdateOptions is protected
+      const options = await invocation.getPolicyUpdateOptions(ToolConfirmationOutcome.ProceedAlwaysAndSave);
+
+      expect(options).toEqual({ commandPrefix: ['/usr/bin/ls'] });
+      expect(getCanonicalCommandRoots).toHaveBeenCalledWith('ls', tempRootDir);
     });
   });
 

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -35,6 +35,7 @@ import { formatBytes } from '../utils/formatters.js';
 import type { AnsiOutput } from '../utils/terminalSerializer.js';
 import {
   getCommandRoots,
+  getCanonicalCommandRoots,
   initializeShellParsers,
   stripShellWrapper,
   parseCommandDetails,
@@ -90,15 +91,20 @@ export class ShellToolInvocation extends BaseToolInvocation<
     return description;
   }
 
-  protected override getPolicyUpdateOptions(
+  protected override async getPolicyUpdateOptions(
     outcome: ToolConfirmationOutcome,
-  ): PolicyUpdateOptions | undefined {
+  ): Promise<PolicyUpdateOptions | undefined> {
     if (
       outcome === ToolConfirmationOutcome.ProceedAlwaysAndSave ||
       outcome === ToolConfirmationOutcome.ProceedAlways
     ) {
       const command = stripShellWrapper(this.params.command);
-      const rootCommands = [...new Set(getCommandRoots(command))];
+
+      const cwd = this.params.dir_path
+        ? path.resolve(this.config.getTargetDir(), this.params.dir_path)
+        : this.config.getTargetDir();
+
+      const rootCommands = [...new Set(await getCanonicalCommandRoots(command, cwd))];
       if (rootCommands.length > 0) {
         return { commandPrefix: rootCommands };
       }

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -132,7 +132,7 @@ export abstract class BaseToolInvocation<
    */
   protected getPolicyUpdateOptions(
     _outcome: ToolConfirmationOutcome,
-  ): PolicyUpdateOptions | undefined {
+  ): Promise<PolicyUpdateOptions | undefined> | PolicyUpdateOptions | undefined {
     return undefined;
   }
 
@@ -148,7 +148,7 @@ export abstract class BaseToolInvocation<
       outcome === ToolConfirmationOutcome.ProceedAlwaysAndSave
     ) {
       if (this._toolName) {
-        const options = this.getPolicyUpdateOptions(outcome);
+        const options = await this.getPolicyUpdateOptions(outcome);
         void this.messageBus.publish({
           type: MessageBusType.UPDATE_POLICY,
           toolName: this._toolName,

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -565,4 +565,79 @@ describe('resolveExecutable', () => {
 
     expect(await resolveExecutable('unknown')).toBeUndefined();
   });
+
+  it('should resolve relative path with cwd', async () => {
+    const cwd = path.resolve('/my/project');
+    const relativeExe = './scripts/test.sh';
+    const absoluteExe = path.join(cwd, relativeExe);
+
+    mockAccess.mockImplementation(async (p: string) => {
+      if (p === absoluteExe) return undefined;
+      throw new Error('ENOENT');
+    });
+
+    expect(await resolveExecutable(relativeExe, cwd)).toBe(absoluteExe);
+  });
+});
+
+describe('getCanonicalCommand and getCanonicalCommandRoots', () => {
+  beforeEach(() => {
+    mockPlatform.mockReturnValue('linux');
+    mockAccess.mockReset();
+  });
+
+  it('should canonicalize simple command', async () => {
+    const usrBin = path.resolve('/usr/bin');
+    const gitPath = path.join(usrBin, 'git');
+    process.env['PATH'] = usrBin;
+
+    mockAccess.mockImplementation(async (p: string) => {
+      if (p === gitPath) return undefined;
+      throw new Error('ENOENT');
+    });
+
+    expect(await getCanonicalCommand('git status')).toBe(`${gitPath} status`);
+    expect(await getCanonicalCommandRoots('git status')).toEqual([gitPath]);
+  });
+
+  it('should canonicalize relative path command', async () => {
+    const cwd = path.resolve('/my/project');
+    const relativeExe = './bin/foo';
+    const absoluteExe = path.join(cwd, relativeExe);
+
+    mockAccess.mockImplementation(async (p: string) => {
+      if (p === absoluteExe) return undefined;
+      throw new Error('ENOENT');
+    });
+
+    expect(await getCanonicalCommand(relativeExe + ' --help', cwd)).toBe(
+      `${absoluteExe} --help`,
+    );
+    expect(await getCanonicalCommandRoots(relativeExe, cwd)).toEqual([
+      absoluteExe,
+    ]);
+  });
+
+  it('should return raw roots if resolution fails', async () => {
+    mockAccess.mockRejectedValue(new Error('ENOENT'));
+    expect(await getCanonicalCommandRoots('unknown --cmd')).toEqual(['unknown']);
+  });
+
+  it('should canonicalize roots in complex command', async () => {
+    const bin = path.resolve('/bin');
+    const catPath = path.join(bin, 'cat');
+    const grepPath = path.join(bin, 'grep');
+    process.env['PATH'] = bin;
+
+    mockAccess.mockImplementation(async (p: string) => {
+      if (p === catPath || p === grepPath) return undefined;
+      throw new Error('ENOENT');
+    });
+
+    // Note: getCanonicalCommandRoots returns all unique executables
+    const roots = await getCanonicalCommandRoots('cat file.txt | grep foo');
+    expect(roots).toContain(catPath);
+    expect(roots).toContain(grepPath);
+    expect(roots.length).toBe(2);
+  });
 });

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -41,15 +41,30 @@ export interface ShellConfiguration {
 
 export async function resolveExecutable(
   exe: string,
+  cwd?: string,
 ): Promise<string | undefined> {
+  // If it's already an absolute path, normalize it and check access.
   if (path.isAbsolute(exe)) {
     try {
-      await fs.promises.access(exe, fs.constants.X_OK);
-      return exe;
+      const normalized = path.resolve(exe);
+      await fs.promises.access(normalized, fs.constants.X_OK);
+      return normalized;
     } catch {
       return undefined;
     }
   }
+
+  // If it contains a directory separator, resolve it relative to cwd.
+  if (exe.includes(path.sep) || (isWindows() && exe.includes('/'))) {
+    try {
+      const resolved = path.resolve(cwd ?? process.cwd(), exe);
+      await fs.promises.access(resolved, fs.constants.X_OK);
+      return resolved;
+    } catch {
+      // Fall through to PATH search just in case, though unlikely for relative paths with separators.
+    }
+  }
+
   const paths = (process.env['PATH'] || '').split(path.delimiter);
   const extensions =
     os.platform() === 'win32' ? ['.exe', '.cmd', '.bat', ''] : [''];
@@ -59,7 +74,7 @@ export async function resolveExecutable(
       const fullPath = path.join(p, exe + ext);
       try {
         await fs.promises.access(fullPath, fs.constants.X_OK);
-        return fullPath;
+        return path.resolve(fullPath);
       } catch {
         continue;
       }
@@ -139,8 +154,13 @@ export async function initializeShellParsers(): Promise<void> {
 }
 
 export interface ParsedCommandDetail {
+  /** The normalized command name (e.g. "git" from "/usr/bin/git" or "./foo/git"). */
   name: string;
+  /** The raw command name as it appears in the shell string (e.g. "/usr/bin/git"). */
+  rawName: string;
+  /** The full command string (e.g. "git status"). */
   text: string;
+  /** The starting index of the command within the original shell string. */
   startIndex: number;
 }
 
@@ -183,6 +203,7 @@ foreach ($commandAst in $commandAsts) {
   }
   $commandObjects += [PSCustomObject]@{
     name = $name
+    rawName = $name
     text = $commandAst.Extent.Text.Trim()
   }
 }
@@ -269,14 +290,19 @@ function normalizeCommandName(raw: string): string {
   return trimmed.split(/[\\/]/).pop() ?? trimmed;
 }
 
-function extractNameFromNode(node: Node): string | null {
+function extractNameFromNode(
+  node: Node,
+): { name: string; rawName: string } | null {
   switch (node.type) {
     case 'command': {
       const nameNode = node.childForFieldName('name');
       if (!nameNode) {
         return null;
       }
-      return normalizeCommandName(nameNode.text);
+      return {
+        name: normalizeCommandName(nameNode.text),
+        rawName: nameNode.text,
+      };
     }
     case 'declaration_command':
     case 'unset_command':
@@ -285,7 +311,10 @@ function extractNameFromNode(node: Node): string | null {
       if (!firstChild) {
         return null;
       }
-      return normalizeCommandName(firstChild.text);
+      return {
+        name: normalizeCommandName(firstChild.text),
+        rawName: firstChild.text,
+      };
     }
     case 'file_redirect': {
       // The first child might be a file descriptor (e.g., '2>').
@@ -293,18 +322,18 @@ function extractNameFromNode(node: Node): string | null {
       for (let i = 0; i < node.childCount; i++) {
         const child = node.child(i);
         if (child && child.text.includes('<')) {
-          return 'redirection (<)';
+          return { name: 'redirection (<)', rawName: child.text };
         }
         if (child && child.text.includes('>')) {
-          return 'redirection (>)';
+          return { name: 'redirection (>)', rawName: child.text };
         }
       }
-      return 'redirection (>)';
+      return { name: 'redirection (>)', rawName: '>' };
     }
     case 'heredoc_redirect':
-      return 'heredoc (<<)';
+      return { name: 'heredoc (<<)', rawName: '<<' };
     case 'herestring_redirect':
-      return 'herestring (<<<)';
+      return { name: 'herestring (<<<)', rawName: '<<<' };
     default:
       return null;
   }
@@ -320,10 +349,12 @@ function collectCommandDetails(
   while (stack.length > 0) {
     const current = stack.pop()!;
 
-    const name = extractNameFromNode(current);
-    if (name) {
+    const result = extractNameFromNode(current);
+    if (result) {
+      const { name, rawName } = result;
       details.push({
         name,
+        rawName,
         text: source.slice(current.startIndex, current.endIndex).trim(),
         startIndex: current.startIndex,
       });
@@ -495,6 +526,10 @@ function parsePowerShellCommandDetails(
         }
 
         const name = normalizeCommandName(commandDetail.name);
+        const rawName =
+          typeof commandDetail.rawName === 'string'
+            ? commandDetail.rawName
+            : commandDetail.name;
         const text =
           typeof commandDetail.text === 'string'
             ? commandDetail.text.trim()
@@ -502,6 +537,7 @@ function parsePowerShellCommandDetails(
 
         return {
           name,
+          rawName,
           text,
           startIndex: 0,
         };
@@ -699,6 +735,72 @@ export function getCommandRoots(command: string): string[] {
     .map((detail) => detail.name)
     .filter((name) => !REDIRECTION_NAMES.has(name))
     .filter(Boolean);
+}
+
+/**
+ * Returns the canonical (absolute) paths of all commands in a shell string.
+ * This is used for policy enforcement to ensure consistent representation.
+ */
+export async function getCanonicalCommandRoots(
+  command: string,
+  cwd?: string,
+): Promise<string[]> {
+  if (!command) {
+    return [];
+  }
+
+  const parsed = parseCommandDetails(command);
+  if (!parsed || parsed.hasError) {
+    return [];
+  }
+
+  const roots = await Promise.all(
+    parsed.details
+      .filter((detail) => !REDIRECTION_NAMES.has(detail.name))
+      .map(async (detail) => {
+        // Use rawName to resolve the executable accurately.
+        const rawExe = normalizeCommandName(detail.rawName);
+        const resolved = await resolveExecutable(rawExe, cwd);
+        // Fallback to normalized name if resolution fails.
+        return resolved ?? detail.name;
+      }),
+  );
+
+  return roots.filter(Boolean);
+}
+
+/**
+ * Transforms a command string into its canonical form by replacing the primary executable
+ * with its absolute path.
+ */
+export async function getCanonicalCommand(
+  command: string,
+  cwd?: string,
+): Promise<string> {
+  const parsed = parseCommandDetails(command);
+  if (!parsed || parsed.hasError || parsed.details.length === 0) {
+    return command;
+  }
+
+  // We only canonicalize the primary command of the string.
+  // If it's a complex string with pipes/&&, the PolicyEngine will split it and call this recursively.
+  const detail = parsed.details[0];
+  if (!detail || REDIRECTION_NAMES.has(detail.name)) {
+    return command;
+  }
+
+  const rawExe = normalizeCommandName(detail.rawName);
+  const resolved = await resolveExecutable(rawExe, cwd);
+
+  if (!resolved) {
+    return command;
+  }
+
+  // Replace the raw command name in the original text with the resolved path.
+  // We use the start index from the parser to be precise.
+  const before = command.substring(0, detail.startIndex);
+  const after = command.substring(detail.startIndex + detail.rawName.length);
+  return `${before}${resolved}${after}`;
 }
 
 export function stripShellWrapper(command: string): string {


### PR DESCRIPTION
## Summary

Change policy enforcement for shell commands to use absolute paths.

## Details

Ensure that shell commands are compared and stored using their canonical (absolute) paths. This prevents bypasses where different relative paths or missing absolute paths refer to the same executable. This change *should* be backwards compatible with existing configs, as it uses the existing command matching if the config specifies a non-absolute path.

### Enhance Shell Utilities (`packages/core/src/utils/shell-utils.ts`)
- **Modify `resolveExecutable(exe: string, cwd?: string)`**:
  - Update to handle relative paths by resolving them against `cwd` (defaulting to `process.cwd()`).
  - Ensure it returns an absolute, normalized path if the executable exists and is accessible.
- **Update `ParsedCommandDetail` interface**:
  - Add `rawName: string` to store the un-normalized command name as it appears in the shell string.
- **Modify `collectCommandDetails`**:
  - Populate `rawName` by extracting the raw text from the name node before normalization.
- **Add `getCanonicalCommand(command: string, cwd?: string): Promise<string>`**:
  - Parses a sub-command string, resolves its primary executable to a canonical path, and returns the reconstructed command string.
- **Add `getCanonicalCommandRoots(command: string, cwd?: string): Promise<string[]>`**:
  - Similar to `getCommandRoots`, but resolves each extracted command to its canonical path using `resolveExecutable`.

### Update Policy Engine Types (`packages/core/src/policy/types.ts`)
- Add `targetDir?: string` to `PolicyEngineConfig` to provide a base directory for path resolution.

### Update Policy Engine Logic (`packages/core/src/policy/policy-engine.ts`)
- Initialize `targetDir` in the `PolicyEngine` constructor.
- **Modify `check(toolCall, ...)`**:
  - If the tool is a shell tool, asynchronously generate a canonical version of the command using `getCanonicalCommand`.
  - Resolve the `dir_path` from arguments against the `targetDir`.
  - Add the canonicalized `FunctionCall` to `toolCallsToTry`. This allows the engine to match against rules defined for either the raw command or its canonical path, ensuring both backward compatibility and support for new canonical rules.

### Update Shell Tool (`packages/core/src/tools/shell.ts`)
- In `ShellToolInvocation.getPolicyUpdateOptions`:
  - Resolve the effective `cwd` using `this.params.dir_path` and `this.config.getTargetDir()`.
  - Use `await getCanonicalCommandRoots(command, cwd)` to determine the `commandPrefix` for permanent approval. This ensures that newly saved rules use absolute canonical paths.

### Config Integration (`packages/core/src/config/config.ts`)
- Pass `this.targetDir` to the `PolicyEngine` constructor.

### Update Documentation
- Update `docs/tools/shell.md` and `docs/reference/policy-engine.md` to describe the new behavior.

## Related Issues

This Fixes #16970.

## How to Validate

Get Gemini to try to run commands with a relative path. Choose allow for session or allow permanently. Verify that the command does not prompt the next time Gemini tries to run it.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [* ] Updated relevant documentation and README (if needed)
- [ *] Added/updated tests (if needed)
- [* ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
