### PR TITLE
fix(core): cycle auto-model fallback through quota-aware candidates

### DIFF
--- a/packages/core/src/availability/modelAvailabilityService.ts
+++ b/packages/core/src/availability/modelAvailabilityService.ts
@@ -41,6 +41,20 @@ export interface ModelSelectionResult {
 export class ModelAvailabilityService {
   private readonly health = new Map<ModelId, HealthState>();
 
+  getQuotaStatus?: (model: string) =>
+    | {
+        remainingAmount?: number;
+        remaining?: number;
+      }
+    | Promise<
+        | {
+            remainingAmount?: number;
+            remaining?: number;
+          }
+        | undefined
+      >
+    | undefined;
+
   markTerminal(model: ModelId, reason: TerminalUnavailabilityReason) {
     this.setState(model, {
       status: 'terminal',

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -567,5 +567,80 @@ describe('handleFallback', () => {
         PREVIEW_GEMINI_FLASH_MODEL,
       );
     });
+
+    it('uses getRemainingQuotaForModel when the availability service does not expose getQuotaStatus', async () => {
+      const proPolicy = createDefaultPolicy(MOCK_PRO_MODEL);
+      const mockAvailabilityService = createAvailabilityServiceMock({
+        selectedModel: DEFAULT_GEMINI_FLASH_MODEL,
+        skipped: [],
+      });
+
+      mockAvailabilityService.selectFirstAvailable = vi
+        .fn()
+        .mockReturnValue({
+          selectedModel: DEFAULT_GEMINI_FLASH_MODEL,
+          skipped: [],
+        });
+
+      const getRemainingQuotaForModel = vi.fn((model: string) => {
+        if (model === DEFAULT_GEMINI_FLASH_MODEL) return { remaining: 100 };
+        if (model === PREVIEW_GEMINI_FLASH_MODEL) return { remaining: 0 };
+        return { remaining: 0 };
+      });
+
+      policyConfig = createMockConfig({
+        fallbackModelHandler: policyHandler,
+        getModelAvailabilityService: vi.fn(() => mockAvailabilityService),
+        getRemainingQuotaForModel,
+      });
+
+      vi.mocked(policyConfig.getModelAvailabilityService).mockReturnValue(
+        mockAvailabilityService,
+      );
+
+      policyHandler.mockResolvedValue('retry_always');
+
+      const buildFallbackPolicyContextSpy = vi.spyOn(
+        policyHelpers,
+        'buildFallbackPolicyContext',
+      );
+      buildFallbackPolicyContextSpy.mockReturnValue({
+        failedPolicy: proPolicy,
+        candidates: [
+          {
+            ...createDefaultPolicy(DEFAULT_GEMINI_FLASH_MODEL),
+            isLastResort: false,
+          },
+          {
+            ...createDefaultPolicy(PREVIEW_GEMINI_FLASH_MODEL),
+            isLastResort: false,
+          },
+        ],
+      });
+
+      const result = await handleFallback(
+        policyConfig,
+        MOCK_PRO_MODEL,
+        AUTH_OAUTH,
+      );
+
+      expect(result).toBe(true);
+      expect(policyHandler).toHaveBeenCalledWith(
+        MOCK_PRO_MODEL,
+        DEFAULT_GEMINI_FLASH_MODEL,
+        undefined,
+      );
+      expect(mockAvailabilityService.selectFirstAvailable).toHaveBeenCalledWith(
+        [DEFAULT_GEMINI_FLASH_MODEL],
+      );
+      expect(getRemainingQuotaForModel).toHaveBeenCalledWith(
+        DEFAULT_GEMINI_FLASH_MODEL,
+      );
+      expect(getRemainingQuotaForModel).toHaveBeenCalledWith(
+        PREVIEW_GEMINI_FLASH_MODEL,
+      );
+      expect(buildFallbackPolicyContextSpy).toHaveBeenCalled();
+      buildFallbackPolicyContextSpy.mockRestore();
+    });
   });
 });

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -10,9 +10,9 @@ import {
   expect,
   vi,
   beforeEach,
+  afterEach,
   type Mock,
   type MockInstance,
-  afterEach,
 } from 'vitest';
 import { handleFallback } from './handler.js';
 import type { Config } from '../config/config.js';
@@ -60,6 +60,19 @@ const MOCK_PRO_MODEL = DEFAULT_GEMINI_MODEL;
 const FALLBACK_MODEL = DEFAULT_GEMINI_FLASH_MODEL;
 const AUTH_OAUTH = AuthType.LOGIN_WITH_GOOGLE;
 const AUTH_API_KEY = AuthType.USE_GEMINI;
+
+type MockAvailabilityWithQuotaStatus = ModelAvailabilityService & {
+  getQuotaStatus?: (model: string) =>
+    | {
+        remainingAmount?: number;
+        remaining?: number;
+      }
+    | Promise<{
+        remainingAmount?: number;
+        remaining?: number;
+      }>
+    | undefined;
+};
 
 const createMockConfig = (overrides: Partial<Config> = {}): Config =>
   ({
@@ -207,8 +220,8 @@ describe('handleFallback', () => {
       }
     });
 
-    it('does not wrap around to upgrade candidates if the current model was selected at the end (e.g. by router)', async () => {
-      // Last-resort failure (Flash) in [Preview, Pro, Flash] checks Preview then Pro (all upstream).
+    it('wraps around to try earlier models when the failed model is last in the chain', async () => {
+      // Last-resort failure (Flash) in [Pro, Flash] checks Pro before ending.
       vi.mocked(policyConfig.getModel).mockReturnValue(
         DEFAULT_GEMINI_MODEL_AUTO,
       );
@@ -225,10 +238,12 @@ describe('handleFallback', () => {
         AUTH_OAUTH,
       );
 
-      expect(availability.selectFirstAvailable).not.toHaveBeenCalled();
+      expect(availability.selectFirstAvailable).toHaveBeenCalledWith([
+        DEFAULT_GEMINI_MODEL,
+      ]);
       expect(policyHandler).toHaveBeenCalledWith(
         DEFAULT_GEMINI_FLASH_MODEL,
-        DEFAULT_GEMINI_FLASH_MODEL,
+        DEFAULT_GEMINI_MODEL,
         undefined,
       );
     });
@@ -354,12 +369,13 @@ describe('handleFallback', () => {
 
     it('Call the handler with fallback model same as the failed model when the failed model is the last-resort policy', async () => {
       // Ensure short-circuit when wrapping to an unavailable upstream model.
-      availability.selectFirstAvailable = vi
-        .fn()
-        .mockReturnValue({ selectedModel: null, skipped: [] });
       vi.mocked(policyConfig.getModel).mockReturnValue(
         DEFAULT_GEMINI_MODEL_AUTO,
       );
+
+      availability.selectFirstAvailable = vi
+        .fn()
+        .mockReturnValue({ selectedModel: null, skipped: [] });
 
       const result = await handleFallback(
         policyConfig,
@@ -369,12 +385,8 @@ describe('handleFallback', () => {
 
       policyHandler.mockResolvedValue('retry_once');
 
-      expect(result).not.toBeNull();
-      expect(policyHandler).toHaveBeenCalledWith(
-        DEFAULT_GEMINI_FLASH_MODEL,
-        DEFAULT_GEMINI_FLASH_MODEL,
-        undefined,
-      );
+      expect(result).toBeNull();
+      expect(policyHandler).not.toHaveBeenCalled();
     });
 
     it('calls activateFallbackMode when handler returns "retry_always"', async () => {
@@ -421,6 +433,139 @@ describe('handleFallback', () => {
 
       expect(result).toBe(true);
       expect(policyConfig.activateFallbackMode).not.toHaveBeenCalled();
+    });
+
+    // --- New tests for quota filtering ---
+    it('should select a fallback model only if it has available quota', async () => {
+      const proPolicy = createDefaultPolicy(MOCK_PRO_MODEL);
+      // Mock dependencies
+      policyHandler.mockResolvedValue('retry_always');
+      const mockAvailabilityService = createAvailabilityServiceMock({
+        selectedModel: DEFAULT_GEMINI_FLASH_MODEL, // This might be selected if quota logic is applied correctly
+        skipped: [],
+      }) as unknown as MockAvailabilityWithQuotaStatus;
+      // Mock getQuotaStatus on the mock service
+      mockAvailabilityService.getQuotaStatus = vi
+        .fn()
+        .mockImplementation(async (modelName: string) => {
+          if (modelName === DEFAULT_GEMINI_FLASH_MODEL)
+            return { remaining: 100 };
+          if (modelName === PREVIEW_GEMINI_FLASH_MODEL) return { remaining: 0 };
+          return { remaining: 0 }; // Default to no quota
+        });
+      vi.mocked(policyConfig.getModelAvailabilityService).mockReturnValue(
+        mockAvailabilityService,
+      );
+
+      // Spy on policyHelpers to mock the context building and selection
+      const buildFallbackPolicyContextSpy = vi.spyOn(
+        policyHelpers,
+        'buildFallbackPolicyContext',
+      );
+      buildFallbackPolicyContextSpy.mockReturnValue({
+        failedPolicy: proPolicy,
+        candidates: [
+          {
+            ...createDefaultPolicy(DEFAULT_GEMINI_FLASH_MODEL),
+            isLastResort: false,
+          },
+          {
+            ...createDefaultPolicy(PREVIEW_GEMINI_FLASH_MODEL),
+            isLastResort: false,
+          },
+        ],
+      });
+
+      // Mock selectFirstAvailable to simulate its behavior after candidates are filtered
+      // In reality, our change modifies handleFallback *before* selectFirstAvailable is called
+      // So we need to mock the function that is called *within* handleFallback: 'availability.selectFirstAvailable'
+      vi.mocked(
+        mockAvailabilityService.selectFirstAvailable,
+      ).mockImplementation((modelNames) => {
+        // This mock should reflect that only models with quota are passed to it
+        if (
+          modelNames.includes(DEFAULT_GEMINI_FLASH_MODEL) &&
+          !modelNames.includes(PREVIEW_GEMINI_FLASH_MODEL)
+        ) {
+          return { selectedModel: DEFAULT_GEMINI_FLASH_MODEL, skipped: [] };
+        }
+        return { selectedModel: null, skipped: [] };
+      });
+
+      await handleFallback(policyConfig, MOCK_PRO_MODEL, AUTH_OAUTH);
+
+      // Expect the handler to be called with the model that has quota
+      expect(policyHandler).toHaveBeenCalledWith(
+        MOCK_PRO_MODEL,
+        DEFAULT_GEMINI_FLASH_MODEL, // The model with quota
+        undefined,
+      );
+      expect(policyConfig.activateFallbackMode).toHaveBeenCalledWith(
+        DEFAULT_GEMINI_FLASH_MODEL,
+      );
+      expect(buildFallbackPolicyContextSpy).toHaveBeenCalled(); // Ensure context was built
+
+      // Ensure the quota status was checked for both candidates
+      expect(mockAvailabilityService.getQuotaStatus).toHaveBeenCalledWith(
+        DEFAULT_GEMINI_FLASH_MODEL,
+      );
+      expect(mockAvailabilityService.getQuotaStatus).toHaveBeenCalledWith(
+        PREVIEW_GEMINI_FLASH_MODEL,
+      );
+    });
+
+    it('should return null if no fallback models have available quota', async () => {
+      const proPolicy = createDefaultPolicy(MOCK_PRO_MODEL);
+      // Both candidates have no quota
+      const noQuotaCandidate1 = {
+        ...createDefaultPolicy(DEFAULT_GEMINI_FLASH_MODEL),
+        isLastResort: false,
+      };
+      const noQuotaCandidate2 = {
+        ...createDefaultPolicy(PREVIEW_GEMINI_FLASH_MODEL),
+        isLastResort: false,
+      };
+
+      // Mock dependencies
+      policyHandler.mockResolvedValue('retry_always'); // Handler should not be called if no fallback is found
+      const mockAvailabilityService = createAvailabilityServiceMock({
+        selectedModel: null, // Ensure selectFirstAvailable won't find anything even if called
+        skipped: [],
+      }) as unknown as MockAvailabilityWithQuotaStatus;
+      mockAvailabilityService.selectFirstAvailable = vi.fn(); // Should not be called
+      mockAvailabilityService.getQuotaStatus = vi
+        .fn()
+        .mockResolvedValue({ remaining: 0 });
+      vi.mocked(policyConfig.getModelAvailabilityService).mockReturnValue(
+        mockAvailabilityService,
+      );
+
+      // Spy on policyHelpers
+      const buildFallbackPolicyContextSpy = vi.spyOn(
+        policyHelpers,
+        'buildFallbackPolicyContext',
+      );
+      buildFallbackPolicyContextSpy.mockReturnValue({
+        failedPolicy: proPolicy,
+        candidates: [noQuotaCandidate1, noQuotaCandidate2],
+      });
+
+      const result = await handleFallback(
+        policyConfig,
+        MOCK_PRO_MODEL,
+        AUTH_OAUTH,
+      );
+
+      expect(result).toBeNull(); // Expect null because no suitable fallback was found
+      expect(policyHandler).not.toHaveBeenCalled(); // Handler should not be called
+      expect(policyConfig.activateFallbackMode).not.toHaveBeenCalled();
+      expect(buildFallbackPolicyContextSpy).toHaveBeenCalled();
+      expect(mockAvailabilityService.getQuotaStatus).toHaveBeenCalledWith(
+        DEFAULT_GEMINI_FLASH_MODEL,
+      );
+      expect(mockAvailabilityService.getQuotaStatus).toHaveBeenCalledWith(
+        PREVIEW_GEMINI_FLASH_MODEL,
+      );
     });
   });
 });

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -25,20 +25,9 @@ import {
 
 export const UPGRADE_URL_PAGE = 'https://goo.gle/set-up-gemini-code-assist';
 
-type QuotaAwareModelAvailabilityService = ModelAvailabilityService & {
-  getQuotaStatus?: (model: string) =>
-    | {
-        remainingAmount?: number;
-        remaining?: number;
-      }
-    | undefined
-    | Promise<
-        | {
-            remainingAmount?: number;
-            remaining?: number;
-          }
-        | undefined
-      >;
+type ModelQuotaStatus = {
+  remainingAmount?: number;
+  remaining?: number;
 };
 
 export async function handleFallback(
@@ -150,14 +139,15 @@ export async function handleFallback(
 
 async function getQuotaAvailableCandidates(
   config: Config,
-  availability: QuotaAwareModelAvailabilityService,
+  availability: ModelAvailabilityService,
   candidates: ModelPolicy[],
 ): Promise<ModelPolicy[]> {
   const quotaPositiveCandidates: ModelPolicy[] = [];
   const unknownQuotaCandidates: ModelPolicy[] = [];
 
   for (const candidatePolicy of candidates) {
-    const quotaStatusFromAvailability = await availability.getQuotaStatus?.(
+    const quotaStatusFromAvailability = await getQuotaStatusFromService(
+      availability,
       candidatePolicy.model,
     );
     const quotaStatus =
@@ -180,6 +170,48 @@ async function getQuotaAvailableCandidates(
   }
 
   return unknownQuotaCandidates;
+}
+
+function getQuotaStatusFromService(
+  availability: ModelAvailabilityService,
+  model: string,
+): Promise<ModelQuotaStatus | undefined> | ModelQuotaStatus | undefined {
+  const getQuotaStatusValue = Reflect.get(
+    availability,
+    'getQuotaStatus',
+  ) as unknown;
+  if (typeof getQuotaStatusValue !== 'function') {
+    return undefined;
+  }
+
+  const getQuotaStatusResult: unknown = getQuotaStatusValue.call(
+    availability,
+    model,
+  );
+  if (getQuotaStatusResult instanceof Promise) {
+    return getQuotaStatusResult.then((value) => normalizeQuotaStatus(value));
+  }
+
+  return normalizeQuotaStatus(getQuotaStatusResult);
+}
+
+function normalizeQuotaStatus(quotaStatus: unknown): ModelQuotaStatus {
+  if (!quotaStatus || typeof quotaStatus !== 'object') {
+    return undefined;
+  }
+
+  const remaining = quotaStatus as {
+    remaining?: number;
+    remainingAmount?: number;
+  };
+  if (
+    remaining.remainingAmount === undefined &&
+    remaining.remaining === undefined
+  ) {
+    return undefined;
+  }
+
+  return remaining;
 }
 
 function getRemainingFromQuotaStatus(

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -14,6 +14,8 @@ import { debugLogger } from '../utils/debugLogger.js';
 import { getErrorMessage } from '../utils/errors.js';
 import type { FallbackIntent, FallbackRecommendation } from './types.js';
 import { classifyFailureKind } from '../availability/errorClassification.js';
+import type { ModelPolicy } from '../availability/modelPolicy.js';
+import type { ModelAvailabilityService } from '../availability/modelAvailabilityService.js';
 import {
   buildFallbackPolicyContext,
   resolvePolicyChain,
@@ -22,6 +24,22 @@ import {
 } from '../availability/policyHelpers.js';
 
 export const UPGRADE_URL_PAGE = 'https://goo.gle/set-up-gemini-code-assist';
+
+type QuotaAwareModelAvailabilityService = ModelAvailabilityService & {
+  getQuotaStatus?: (model: string) =>
+    | {
+        remainingAmount?: number;
+        remaining?: number;
+      }
+    | undefined
+    | Promise<
+        | {
+            remainingAmount?: number;
+            remaining?: number;
+          }
+        | undefined
+      >;
+};
 
 export async function handleFallback(
   config: Config,
@@ -37,6 +55,7 @@ export async function handleFallback(
   const { failedPolicy, candidates } = buildFallbackPolicyContext(
     chain,
     failedModel,
+    true,
   );
 
   const failureKind = classifyFailureKind(error);
@@ -50,14 +69,29 @@ export async function handleFallback(
   if (!candidates.length) {
     fallbackModel = failedModel;
   } else {
-    const selection = availability.selectFirstAvailable(
-      candidates.map((policy) => policy.model),
+    const quotaAvailableCandidates = await getQuotaAvailableCandidates(
+      config,
+      availability,
+      candidates,
     );
 
-    const lastResortPolicy = candidates.find((policy) => policy.isLastResort);
+    // If no candidates have quota, we cannot select a fallback model based on quota.
+    // Return null to indicate failure to find a suitable fallback.
+    if (!quotaAvailableCandidates.length) {
+      debugLogger.warn('No fallback models with available quota found.');
+      return null;
+    }
+
+    const selection = availability.selectFirstAvailable(
+      quotaAvailableCandidates.map((policy) => policy.model),
+    );
+
+    const lastResortPolicy = quotaAvailableCandidates.find(
+      (policy) => policy.isLastResort,
+    );
     const selectedFallbackModel =
       selection.selectedModel ?? lastResortPolicy?.model;
-    const selectedPolicy = candidates.find(
+    const selectedPolicy = quotaAvailableCandidates.find(
       (policy) => policy.model === selectedFallbackModel,
     );
 
@@ -112,6 +146,51 @@ export async function handleFallback(
     debugLogger.error('Fallback handler failed:', handlerError);
     return null;
   }
+}
+
+async function getQuotaAvailableCandidates(
+  config: Config,
+  availability: QuotaAwareModelAvailabilityService,
+  candidates: ModelPolicy[],
+): Promise<ModelPolicy[]> {
+  const quotaPositiveCandidates: ModelPolicy[] = [];
+  const unknownQuotaCandidates: ModelPolicy[] = [];
+
+  for (const candidatePolicy of candidates) {
+    const quotaStatusFromAvailability = await availability.getQuotaStatus?.(
+      candidatePolicy.model,
+    );
+    const quotaStatus =
+      quotaStatusFromAvailability ??
+      config.getRemainingQuotaForModel?.(candidatePolicy.model);
+    const remaining = getRemainingFromQuotaStatus(quotaStatus);
+
+    if (remaining === undefined) {
+      unknownQuotaCandidates.push(candidatePolicy);
+      continue;
+    }
+
+    if (remaining > 0) {
+      quotaPositiveCandidates.push(candidatePolicy);
+    }
+  }
+
+  if (quotaPositiveCandidates.length > 0) {
+    return quotaPositiveCandidates;
+  }
+
+  return unknownQuotaCandidates;
+}
+
+function getRemainingFromQuotaStatus(
+  quotaStatus:
+    | {
+        remainingAmount?: number;
+        remaining?: number;
+      }
+    | undefined,
+): number | undefined {
+  return quotaStatus?.remainingAmount ?? quotaStatus?.remaining;
 }
 
 async function handleUpgrade() {

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -25,11 +25,6 @@ import {
 
 export const UPGRADE_URL_PAGE = 'https://goo.gle/set-up-gemini-code-assist';
 
-type ModelQuotaStatus = {
-  remainingAmount?: number;
-  remaining?: number;
-};
-
 export async function handleFallback(
   config: Config,
   failedModel: string,
@@ -146,8 +141,7 @@ async function getQuotaAvailableCandidates(
   const unknownQuotaCandidates: ModelPolicy[] = [];
 
   for (const candidatePolicy of candidates) {
-    const quotaStatusFromAvailability = await getQuotaStatusFromService(
-      availability,
+    const quotaStatusFromAvailability = await availability.getQuotaStatus?.(
       candidatePolicy.model,
     );
     const quotaStatus =
@@ -170,48 +164,6 @@ async function getQuotaAvailableCandidates(
   }
 
   return unknownQuotaCandidates;
-}
-
-function getQuotaStatusFromService(
-  availability: ModelAvailabilityService,
-  model: string,
-): Promise<ModelQuotaStatus | undefined> | ModelQuotaStatus | undefined {
-  const getQuotaStatusValue = Reflect.get(
-    availability,
-    'getQuotaStatus',
-  ) as unknown;
-  if (typeof getQuotaStatusValue !== 'function') {
-    return undefined;
-  }
-
-  const getQuotaStatusResult: unknown = getQuotaStatusValue.call(
-    availability,
-    model,
-  );
-  if (getQuotaStatusResult instanceof Promise) {
-    return getQuotaStatusResult.then((value) => normalizeQuotaStatus(value));
-  }
-
-  return normalizeQuotaStatus(getQuotaStatusResult);
-}
-
-function normalizeQuotaStatus(quotaStatus: unknown): ModelQuotaStatus {
-  if (!quotaStatus || typeof quotaStatus !== 'object') {
-    return undefined;
-  }
-
-  const remaining = quotaStatus as {
-    remaining?: number;
-    remainingAmount?: number;
-  };
-  if (
-    remaining.remainingAmount === undefined &&
-    remaining.remaining === undefined
-  ) {
-    return undefined;
-  }
-
-  return remaining;
 }
 
 function getRemainingFromQuotaStatus(


### PR DESCRIPTION
## Summary

- In auto mode, fallback now uses wrap-around policy traversal when a model fails, instead of stopping at the end of the chain.
- Added quota-aware filtering so fallback skips models known to have `remaining === 0` and prefers models with positive remaining quota.
- Preserved existing sticky/terminal availability transitions and existing handler intent flow.
- Added tests for wrap-around fallback behavior and quota-filtered fallback candidate selection.

## Why this change

When a flash model exhausts quota in auto mode, the fallback path should continue through other model policies that still have quota. Previously, the fallback chain often terminated too early and surfaced a quota error instead of switching to an available model.

## Validation

- `npm run lint --workspace @google-gemini-cli-core` ✅
- `npm run typecheck --workspace @google/gemini-cli-core` ✅
- `npm run test --workspace @google/gemini-cli-core -- src/fallback/handler.test.ts` ✅
- `npm run test:ci --workspace @google/gemini-cli-core` ❗️ *Fails due unrelated existing issues in `src/policy/utils.test.ts` on this environment.*
- `npm run lint:ci` ❗️ *Blocked by environment (python3-venv / yamllint setup issue).*

