### PR TITLE
feat: add explicit auto-gemini-3.1 model path

### DIFF
--- a/packages/cli/src/acp/acpClient.test.ts
+++ b/packages/cli/src/acp/acpClient.test.ts
@@ -99,6 +99,13 @@ vi.mock(
     const actual = await importOriginal();
     return {
       ...actual,
+      PREVIEW_GEMINI_3_1_MODEL_AUTO: 'auto-gemini-3.1',
+      getDisplayString: vi.fn((model: string) => {
+        if (model === 'auto-gemini-3.1') {
+          return 'Auto (Gemini 3.1)';
+        }
+        return actual.getDisplayString(model);
+      }),
       ReadManyFilesTool: vi.fn().mockImplementation(() => ({
         name: 'read_many_files',
         kind: 'read',
@@ -383,6 +390,10 @@ describe('GeminiAgent', () => {
         expect.objectContaining({
           modelId: 'auto-gemini-3',
           name: expect.stringContaining('Auto'),
+        }),
+        expect.objectContaining({
+          modelId: 'auto-gemini-3.1',
+          name: 'Auto (Gemini 3.1)',
         }),
         expect.objectContaining({
           modelId: 'gemini-3.1-pro-preview',

--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -43,6 +43,7 @@ import {
   PREVIEW_GEMINI_MODEL,
   PREVIEW_GEMINI_3_1_MODEL,
   PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL,
+  PREVIEW_GEMINI_3_1_MODEL_AUTO,
   PREVIEW_GEMINI_FLASH_MODEL,
   DEFAULT_GEMINI_MODEL_AUTO,
   PREVIEW_GEMINI_MODEL_AUTO,
@@ -1595,13 +1596,21 @@ function buildAvailableModels(
   ];
 
   if (shouldShowPreviewModels) {
-    mainOptions.unshift({
-      value: PREVIEW_GEMINI_MODEL_AUTO,
-      title: getDisplayString(PREVIEW_GEMINI_MODEL_AUTO),
-      description: useGemini31
-        ? 'Let Gemini CLI decide the best model for the task: gemini-3.1-pro, gemini-3-flash'
-        : 'Let Gemini CLI decide the best model for the task: gemini-3-pro, gemini-3-flash',
-    });
+    mainOptions.unshift(
+      {
+        value: PREVIEW_GEMINI_3_1_MODEL_AUTO,
+        title: getDisplayString(PREVIEW_GEMINI_3_1_MODEL_AUTO),
+        description:
+          'Let Gemini CLI decide the best model for the task: gemini-3.1-pro, gemini-3-flash',
+      },
+      {
+        value: PREVIEW_GEMINI_MODEL_AUTO,
+        title: getDisplayString(PREVIEW_GEMINI_MODEL_AUTO),
+        description: useGemini31
+          ? 'Let Gemini CLI decide the best model for the task: gemini-3.1-pro, gemini-3-flash'
+          : 'Let Gemini CLI decide the best model for the task: gemini-3-pro, gemini-3-flash',
+      },
+    );
   }
 
   const manualOptions = [

--- a/packages/core/src/availability/policyHelpers.test.ts
+++ b/packages/core/src/availability/policyHelpers.test.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_GEMINI_FLASH_LITE_MODEL,
   DEFAULT_GEMINI_MODEL_AUTO,
   PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL,
+  PREVIEW_GEMINI_3_1_MODEL_AUTO,
   PREVIEW_GEMINI_3_1_MODEL,
 } from '../config/models.js';
 import { AuthType } from '../core/contentGenerator.js';
@@ -141,10 +142,31 @@ describe('policyHelpers', () => {
       expect(chain[1]?.model).toBe('gemini-2.5-flash');
     });
 
+    it('proactively returns Gemini 2.5 chain if auto-gemini-3.1 is requested but user lacks access', () => {
+      const config = createMockConfig({
+        getModel: () => PREVIEW_GEMINI_3_1_MODEL_AUTO,
+        getHasAccessToPreviewModel: () => false,
+      });
+      const chain = resolvePolicyChain(config);
+
+      expect(chain).toHaveLength(2);
+      expect(chain[0]?.model).toBe('gemini-2.5-pro');
+      expect(chain[1]?.model).toBe('gemini-2.5-flash');
+    });
+
     it('returns Gemini 3.1 Pro chain when launched and auto-gemini-3 requested', () => {
       const config = createMockConfig({
         getModel: () => 'auto-gemini-3',
         getGemini31LaunchedSync: () => true,
+      });
+      const chain = resolvePolicyChain(config);
+      expect(chain[0]?.model).toBe(PREVIEW_GEMINI_3_1_MODEL);
+      expect(chain[1]?.model).toBe('gemini-3-flash-preview');
+    });
+
+    it('returns Gemini 3.1 Pro chain when auto-gemini-3.1 is requested even if launch flag is false', () => {
+      const config = createMockConfig({
+        getModel: () => PREVIEW_GEMINI_3_1_MODEL_AUTO,
       });
       const chain = resolvePolicyChain(config);
       expect(chain[0]?.model).toBe(PREVIEW_GEMINI_3_1_MODEL);

--- a/packages/core/src/availability/policyHelpers.ts
+++ b/packages/core/src/availability/policyHelpers.ts
@@ -22,6 +22,9 @@ import {
 import {
   DEFAULT_GEMINI_FLASH_LITE_MODEL,
   DEFAULT_GEMINI_MODEL,
+  PREVIEW_GEMINI_3_1_MODEL,
+  PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL,
+  PREVIEW_GEMINI_3_1_MODEL_AUTO,
   PREVIEW_GEMINI_MODEL_AUTO,
   isAutoModel,
   isGemini3Model,
@@ -54,6 +57,12 @@ export function resolvePolicyChain(
     useCustomToolModel,
     hasAccessToPreview,
   );
+  const isExplicit31AutoRequest =
+    modelFromConfig === PREVIEW_GEMINI_3_1_MODEL_AUTO;
+  const shouldUseGemini31ForRequest =
+    isExplicit31AutoRequest ||
+    resolvedModel === PREVIEW_GEMINI_3_1_MODEL ||
+    resolvedModel === PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL;
   const isAutoPreferred = preferredModel ? isAutoModel(preferredModel) : false;
   const isAutoConfigured = isAutoModel(configuredModel);
 
@@ -72,7 +81,7 @@ export function resolvePolicyChain(
       chain = getModelPolicyChain({
         previewEnabled,
         userTier: config.getUserTier(),
-        useGemini31,
+        useGemini31: useGemini31 || shouldUseGemini31ForRequest,
         useCustomToolModel,
       });
     } else {

--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -28,6 +28,7 @@ import {
   isActiveModel,
   PREVIEW_GEMINI_3_1_MODEL,
   PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL,
+  PREVIEW_GEMINI_3_1_MODEL_AUTO,
   isPreviewModel,
   isProModel,
 } from './models.js';
@@ -39,6 +40,7 @@ describe('isPreviewModel', () => {
     expect(isPreviewModel(PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL)).toBe(true);
     expect(isPreviewModel(PREVIEW_GEMINI_FLASH_MODEL)).toBe(true);
     expect(isPreviewModel(PREVIEW_GEMINI_MODEL_AUTO)).toBe(true);
+    expect(isPreviewModel(PREVIEW_GEMINI_3_1_MODEL_AUTO)).toBe(true);
   });
 
   it('should return false for non-preview models', () => {
@@ -115,6 +117,7 @@ describe('isGemini3Model', () => {
     expect(isGemini3Model(GEMINI_MODEL_ALIAS_AUTO)).toBe(true);
     expect(isGemini3Model(GEMINI_MODEL_ALIAS_PRO)).toBe(true);
     expect(isGemini3Model(PREVIEW_GEMINI_MODEL_AUTO)).toBe(true);
+    expect(isGemini3Model(PREVIEW_GEMINI_3_1_MODEL_AUTO)).toBe(true);
   });
 
   it('should return false for Gemini 2 models', () => {
@@ -131,6 +134,12 @@ describe('isGemini3Model', () => {
 describe('getDisplayString', () => {
   it('should return Auto (Gemini 3) for preview auto model', () => {
     expect(getDisplayString(PREVIEW_GEMINI_MODEL_AUTO)).toBe('Auto (Gemini 3)');
+  });
+
+  it('should return Auto (Gemini 3.1) for explicit Gemini 3.1 auto model', () => {
+    expect(getDisplayString(PREVIEW_GEMINI_3_1_MODEL_AUTO)).toBe(
+      'Auto (Gemini 3.1)',
+    );
   });
 
   it('should return Auto (Gemini 2.5) for default auto model', () => {
@@ -184,6 +193,16 @@ describe('resolveModel', () => {
     it('should return the Preview Pro model when auto-gemini-3 is requested', () => {
       const model = resolveModel(PREVIEW_GEMINI_MODEL_AUTO);
       expect(model).toBe(PREVIEW_GEMINI_MODEL);
+    });
+
+    it('should return Gemini 3.1 Pro when auto-gemini-3.1 is requested', () => {
+      const model = resolveModel(PREVIEW_GEMINI_3_1_MODEL_AUTO);
+      expect(model).toBe(PREVIEW_GEMINI_3_1_MODEL);
+    });
+
+    it('should return Gemini 3.1 Pro Custom Tools when auto-gemini-3.1 is requested and useCustomToolModel is true', () => {
+      const model = resolveModel(PREVIEW_GEMINI_3_1_MODEL_AUTO, false, true);
+      expect(model).toBe(PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL);
     });
 
     it('should return Gemini 3.1 Pro when auto-gemini-3 is requested and useGemini3_1 is true', () => {
@@ -248,6 +267,12 @@ describe('resolveModel', () => {
         DEFAULT_GEMINI_MODEL,
       );
     });
+
+    it('should return default model when access to preview is false and auto-gemini-3.1 is requested', () => {
+      expect(
+        resolveModel(PREVIEW_GEMINI_3_1_MODEL_AUTO, false, false, false),
+      ).toBe(DEFAULT_GEMINI_MODEL);
+    });
   });
 });
 
@@ -284,6 +309,10 @@ describe('isAutoModel', () => {
 
   it('should return true for "auto-gemini-3"', () => {
     expect(isAutoModel(PREVIEW_GEMINI_MODEL_AUTO)).toBe(true);
+  });
+
+  it('should return true for "auto-gemini-3.1"', () => {
+    expect(isAutoModel(PREVIEW_GEMINI_3_1_MODEL_AUTO)).toBe(true);
   });
 
   it('should return true for "auto-gemini-2.5"', () => {

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -9,6 +9,7 @@ export const PREVIEW_GEMINI_3_1_MODEL = 'gemini-3.1-pro-preview';
 export const PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL =
   'gemini-3.1-pro-preview-customtools';
 export const PREVIEW_GEMINI_FLASH_MODEL = 'gemini-3-flash-preview';
+export const PREVIEW_GEMINI_3_1_MODEL_AUTO = 'auto-gemini-3.1';
 export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro';
 export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash';
 export const DEFAULT_GEMINI_FLASH_LITE_MODEL = 'gemini-2.5-flash-lite';
@@ -55,10 +56,15 @@ export function resolveModel(
   let resolved: string;
   switch (requestedModel) {
     case PREVIEW_GEMINI_MODEL:
+    case PREVIEW_GEMINI_3_1_MODEL_AUTO:
     case PREVIEW_GEMINI_MODEL_AUTO:
     case GEMINI_MODEL_ALIAS_AUTO:
     case GEMINI_MODEL_ALIAS_PRO: {
       if (useGemini3_1) {
+        resolved = useCustomToolModel
+          ? PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL
+          : PREVIEW_GEMINI_3_1_MODEL;
+      } else if (requestedModel === PREVIEW_GEMINI_3_1_MODEL_AUTO) {
         resolved = useCustomToolModel
           ? PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL
           : PREVIEW_GEMINI_3_1_MODEL;
@@ -143,6 +149,8 @@ export function getDisplayString(model: string) {
   switch (model) {
     case PREVIEW_GEMINI_MODEL_AUTO:
       return 'Auto (Gemini 3)';
+    case PREVIEW_GEMINI_3_1_MODEL_AUTO:
+      return 'Auto (Gemini 3.1)';
     case DEFAULT_GEMINI_MODEL_AUTO:
       return 'Auto (Gemini 2.5)';
     case GEMINI_MODEL_ALIAS_PRO:
@@ -168,6 +176,7 @@ export function isPreviewModel(model: string): boolean {
     model === PREVIEW_GEMINI_3_1_MODEL ||
     model === PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL ||
     model === PREVIEW_GEMINI_FLASH_MODEL ||
+    model === PREVIEW_GEMINI_3_1_MODEL_AUTO ||
     model === PREVIEW_GEMINI_MODEL_AUTO ||
     model === GEMINI_MODEL_ALIAS_AUTO
   );
@@ -237,6 +246,7 @@ export function isAutoModel(model: string): boolean {
   return (
     model === GEMINI_MODEL_ALIAS_AUTO ||
     model === PREVIEW_GEMINI_MODEL_AUTO ||
+    model === PREVIEW_GEMINI_3_1_MODEL_AUTO ||
     model === DEFAULT_GEMINI_MODEL_AUTO
   );
 }


### PR DESCRIPTION
## Summary
- Add explicit model alias `auto-gemini-3.1` for explicit opt-in to Gemini 3.1 routing in auto mode.
- Resolve `auto-gemini-3.1` to the Gemini 3.1 Pro model independently of launch-flag state.
- Keep `auto-gemini-3` behavior unchanged while introducing a `auto-gemini-3.1` preference in policy model chains.
- Expose the new option in ACP as an auto model choice with updated descriptions and labels.
- Add regression coverage in core and ACP for opt-in resolution, policy-chain selection, and model list availability.

## How to use
- Select `auto-gemini-3.1` (or equivalent auto Gemini 3.1 option) in model selection when you explicitly want Gemini 3.1 preference.

## Testing
- `npm run test:ci`
- `npm run test --workspace packages/core -- src/config/models.test.ts src/availability/policyHelpers.test.ts`
- `npm run test --workspace packages/cli -- src/acp/acpClient.test.ts`
