### PR TITLE
docs: remove experimental badge from plan mode in sidebar

### DIFF
--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -111,7 +111,7 @@
             "badge": "🔬",
             "slug": "docs/cli/notifications"
           },
-          { "label": "Plan mode", "badge": "🔬", "slug": "docs/cli/plan-mode" },
+          { "label": "Plan mode", "slug": "docs/cli/plan-mode" },
           {
             "label": "Subagents",
             "badge": "🔬",


### PR DESCRIPTION
Plan mode is no longer an experimental feature. This commit updates the documentation sidebar to remove the experimental badge from the Plan mode entry.

<img width="551" height="61" alt="image" src="https://github.com/user-attachments/assets/ea9f68c3-68a1-44f5-9e08-03805a1cc9fd" />


Part of #20909
