### PR TITLE
docs(cli): mention per-model token usage in stream-json result event

### DIFF
--- a/docs/cli/headless.md
+++ b/docs/cli/headless.md
@@ -31,7 +31,8 @@ Returns a stream of newline-delimited JSON (JSONL) events.
   - `tool_use`: Tool call requests with arguments.
   - `tool_result`: Output from executed tools.
   - `error`: Non-fatal warnings and system errors.
-  - `result`: Final outcome with aggregated statistics.
+  - `result`: Final outcome with aggregated statistics and per-model token usage
+    breakdowns.
 
 ## Exit codes
 


### PR DESCRIPTION
## Summary

Updates the `docs/cli/headless.md` to reflect that the `stream-json` `result` event now includes per-model token usage breakdowns alongside aggregated statistics.

## Details

- Updated the `result` event description in the Streaming JSON output section to mention per-model token usage breakdowns, matching the change introduced in #21839.

## Related Issues

Related to #21839 

## How to Validate

1. Review the change in `docs/cli/headless.md` and confirm the `result` event description accurately reflects the current `StreamStats` schema.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker