### PR TITLE
Add issue for automated changelogs

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -95,6 +95,8 @@ jobs:
             This PR contains the auto-generated changelog for the ${{ steps.release_info.outputs.VERSION }} release.
 
             Please review and merge.
+
+            Related to #18505
           branch: 'changelog-${{ steps.release_info.outputs.VERSION }}'
           base: 'main'
           team-reviewers: 'gemini-cli-docs, gemini-cli-maintainers'


### PR DESCRIPTION
## Summary

Add issue for automated changelogs, so they show up on our project board. Currently automatically generated changelog PRs don't have an issue tied to them, and can get lost in the PR mix. 

With this change, changelogs will link to https://github.com/google-gemini/gemini-cli/issues/18505. This way the auto triage both will transitively apply the area/documentation label and put the PR in Technical Writer project, so it appears on our PR review list. This is the main changelog issue, this also serves to put all changelog PRs under one issue for easier search/development.

Note that this is different from the issue that engineering might use to track the release that results in the changelog.

Related to #18505