### PR TITLE
refactor: remove agent_card_requires_auth config flag

### DIFF
--- a/packages/core/src/agents/agentLoader.test.ts
+++ b/packages/core/src/agents/agentLoader.test.ts
@@ -557,26 +557,6 @@ auth:
       });
     });
 
-    it('should parse auth with agent_card_requires_auth flag', async () => {
-      const filePath = await writeAgentMarkdown(`---
-kind: remote
-name: protected-card-agent
-agent_card_url: https://example.com/card
-auth:
-  type: apiKey
-  key: $MY_API_KEY
-  agent_card_requires_auth: true
----
-`);
-      const result = await parseAgentMarkdown(filePath);
-      expect(result[0]).toMatchObject({
-        auth: {
-          type: 'apiKey',
-          agent_card_requires_auth: true,
-        },
-      });
-    });
-
     it('should parse remote agent with oauth2 auth', async () => {
       const filePath = await writeAgentMarkdown(`---
 kind: remote

--- a/packages/core/src/agents/agentLoader.ts
+++ b/packages/core/src/agents/agentLoader.ts
@@ -45,7 +45,6 @@ interface FrontmatterLocalAgentDefinition
  */
 interface FrontmatterAuthConfig {
   type: 'apiKey' | 'http' | 'oauth2';
-  agent_card_requires_auth?: boolean;
   // API Key
   key?: string;
   name?: string;
@@ -123,9 +122,7 @@ const localAgentSchema = z
 /**
  * Base fields shared by all auth configs.
  */
-const baseAuthFields = {
-  agent_card_requires_auth: z.boolean().optional(),
-};
+const baseAuthFields = {};
 
 /**
  * API Key auth schema.
@@ -356,9 +353,7 @@ export async function parseAgentMarkdown(
 function convertFrontmatterAuthToConfig(
   frontmatter: FrontmatterAuthConfig,
 ): A2AAuthConfig {
-  const base = {
-    agent_card_requires_auth: frontmatter.agent_card_requires_auth,
-  };
+  const base = {};
 
   switch (frontmatter.type) {
     case 'apiKey':

--- a/packages/core/src/agents/auth-provider/types.ts
+++ b/packages/core/src/agents/auth-provider/types.ts
@@ -24,9 +24,8 @@ export interface A2AAuthProvider extends AuthenticationHandler {
   initialize?(): Promise<void>;
 }
 
-export interface BaseAuthConfig {
-  agent_card_requires_auth?: boolean;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface BaseAuthConfig {}
 
 /** Client config for google-credentials (not in A2A spec, Gemini-specific). */
 export interface GoogleCredentialsAuthConfig extends BaseAuthConfig {


### PR DESCRIPTION
## Summary

Removes the deprecated `agent_card_requires_auth` flag from the agent configuration, as the system now natively intercepts 401/403s when fetching the Agent Card and retries with the provided `A2AAuthConfig`.

## Details

- Removed `agent_card_requires_auth` from `BaseAuthConfig` and `FrontmatterAuthConfig`.
- `BaseAuthConfig` has been kept as a marker interface (with an eslint override) for all A2A authentication configs.

## Related Issues

Relates to https://github.com/google-gemini/gemini-cli/issues/17607

## How to Validate

1. Run `npm test -w @google/gemini-cli-core -- src/agents/agentLoader.test.ts`
2. Run `npm run typecheck`
3. Run `npm run lint`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
