### PR TITLE
feat(core): simplify subagent success UI and improve early termination display

### DIFF
--- a/packages/core/src/agents/local-invocation.test.ts
+++ b/packages/core/src/agents/local-invocation.test.ts
@@ -202,8 +202,24 @@ describe('LocalSubagentInvocation', () => {
           ),
         },
       ]);
-      expect(result.returnDisplay).toContain('Result:\nAnalysis complete.');
-      expect(result.returnDisplay).toContain('Termination Reason:\n GOAL');
+      expect(result.returnDisplay).toBe('Analysis complete.');
+      expect(result.returnDisplay).not.toContain('Termination Reason');
+    });
+
+    it('should show detailed UI for non-goal terminations (e.g., TIMEOUT)', async () => {
+      const mockOutput = {
+        result: 'Partial progress...',
+        terminate_reason: AgentTerminateMode.TIMEOUT,
+      };
+      mockExecutorInstance.run.mockResolvedValue(mockOutput);
+
+      const result = await invocation.execute(signal, updateOutput);
+
+      expect(result.returnDisplay).toContain(
+        '### Subagent MockAgent Finished Early',
+      );
+      expect(result.returnDisplay).toContain('**Termination Reason:** TIMEOUT');
+      expect(result.returnDisplay).toContain('Partial progress...');
     });
 
     it('should stream THOUGHT_CHUNK activities from the executor', async () => {
@@ -291,7 +307,7 @@ describe('LocalSubagentInvocation', () => {
       // Execute without the optional callback
       const result = await invocation.execute(signal);
       expect(result.error).toBeUndefined();
-      expect(result.returnDisplay).toContain('Result:\nDone');
+      expect(result.returnDisplay).toBe('Done');
     });
 
     it('should handle executor run failure', async () => {

--- a/packages/core/src/agents/local-invocation.ts
+++ b/packages/core/src/agents/local-invocation.ts
@@ -253,12 +253,15 @@ Termination Reason: ${output.terminate_reason}
 Result:
 ${output.result}`;
 
-      const displayContent = `
-Subagent ${this.definition.name} Finished
+      const displayContent =
+        output.terminate_reason === AgentTerminateMode.GOAL
+          ? displayResult
+          : `
+### Subagent ${this.definition.name} Finished Early
 
-Termination Reason:\n ${output.terminate_reason}
+**Termination Reason:** ${output.terminate_reason}
 
-Result:
+**Result/Summary:**
 ${displayResult}
 `;
 


### PR DESCRIPTION
## Summary

Simplifies the subagent UI output (`returnDisplay`) to provide a cleaner experience for successful goals while maintaining descriptive context for early terminations.

## Details

- **Success (`GOAL`):** Omitted the redundant "Subagent Finished" and "Termination Reason: Goal" boilerplate. The UI now shows only the raw result.
- **Early Termination (`TIMEOUT`, `MAX_TURNS`, etc.):** Introduced a clearer "Finished Early" header with the specific termination reason and a breakdown of the partial result/summary.
- **Model Context:** Preserved the original `llmContent` structure to ensure the orchestrating model still has full context on the termination reason and results.
- **Tests:** Updated `packages/core/src/agents/local-invocation.test.ts` to verify both the simplified success output and the detailed failure display.

## Related Issues

N/A

## How to Validate

1. Run a subagent that succeeds (e.g., `@generalist What is the weather in London?`).
   - **Expectation:** The UI shows only the final summary from the subagent without "Subagent Finished" headers.
2. Run a subagent that hits a limit (e.g., `@codebase_investigator` with a very broad search and low turn limit).
   - **Expectation:** The UI shows `### Subagent [Name] Finished Early` followed by the termination reason and partial findings.
3. Run the unit tests:
   ```bash
   npm test packages/core/src/agents/local-invocation.test.ts
   ```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
