### PR TITLE
docs: fix stale tier numbers in policy-engine docs and toml-loader comments

### DIFF
--- a/docs/reference/policy-engine.md
+++ b/docs/reference/policy-engine.md
@@ -112,7 +112,7 @@ The policy engine uses a sophisticated priority system to resolve conflicts when
 multiple rules match a single tool call. The core principle is simple: **the
 rule with the highest priority wins**.
 
-To provide a clear hierarchy, policies are organized into three tiers. Each tier
+To provide a clear hierarchy, policies are organized into five tiers. Each tier
 has a designated number that forms the base of the final priority calculation.
 
 | Tier      | Base | Description                                                                |
@@ -138,9 +138,9 @@ This system guarantees that:
 For example:
 
 - A `priority: 50` rule in a Default policy file becomes `1.050`.
-- A `priority: 10` rule in a Workspace policy policy file becomes `2.010`.
-- A `priority: 100` rule in a User policy file becomes `3.100`.
-- A `priority: 20` rule in an Admin policy file becomes `4.020`.
+- A `priority: 10` rule in a Workspace policy file becomes `3.010`.
+- A `priority: 100` rule in a User policy file becomes `4.100`.
+- A `priority: 20` rule in an Admin policy file becomes `5.020`.
 
 ### Approval modes
 
@@ -191,7 +191,7 @@ User, and (if configured) Admin directories.
 
 #### System-wide policies (Admin)
 
-Administrators can enforce system-wide policies (Tier 3) that override all user
+Administrators can enforce system-wide policies (Tier 5) that override all user
 and default settings. These policies must be placed in specific, secure
 directories:
 

--- a/packages/core/src/policy/toml-loader.ts
+++ b/packages/core/src/policy/toml-loader.ts
@@ -47,8 +47,10 @@ const PolicyRuleSchema = z.object({
   // Priority must be in range [0, 999] to prevent tier overflow.
   // With tier transformation (tier + priority/1000), this ensures:
   // - Tier 1 (default): range [1.000, 1.999]
-  // - Tier 2 (user): range [2.000, 2.999]
-  // - Tier 3 (admin): range [3.000, 3.999]
+  // - Tier 2 (extension): range [2.000, 2.999]
+  // - Tier 3 (workspace): range [3.000, 3.999]
+  // - Tier 4 (user): range [4.000, 4.999]
+  // - Tier 5 (admin): range [5.000, 5.999]
   priority: z
     .number({
       required_error: 'priority is required',
@@ -297,7 +299,7 @@ function validateToolName(name: string, ruleIndex: number): string | null {
  * Formula: tier + priority/1000
  *
  * @param priority The priority value from the TOML file
- * @param tier The tier (1=default, 2=user, 3=admin)
+ * @param tier The tier (1=default, 2=extension, 3=workspace, 4=user, 5=admin)
  * @returns The transformed priority
  */
 function transformPriority(priority: number, tier: number): number {
@@ -314,7 +316,7 @@ function transformPriority(priority: number, tier: number): number {
  * 4. Collects detailed error information for any failures
  *
  * @param policyPaths Array of paths (directories or files) to scan for policy files
- * @param getPolicyTier Function to determine tier (1-4) for a path
+ * @param getPolicyTier Function to determine tier (1-5) for a path
  * @returns Object containing successfully parsed rules and any errors encountered
  */
 export async function loadPoliciesFromToml(


### PR DESCRIPTION
## Summary

Fixes stale tier numbers in `docs/reference/policy-engine.md` and `packages/core/src/policy/toml-loader.ts` that were left over when Extension (tier 2) and Workspace (tier 3) tiers were added, shifting User from 2→4 and Admin from 3→5.

### Changes

**`docs/reference/policy-engine.md`:**
- Fixed "three tiers" → "five tiers"
- Fixed duplicate word "policy policy" → "policy"
- Corrected tier number examples (Workspace 3.010, User 4.100, Admin 5.020)
- Fixed Admin tier reference from "Tier 3" to "Tier 5"

**`packages/core/src/policy/toml-loader.ts`:**
- Updated priority range comments to show all 5 tiers
- Updated `@param tier` JSDoc to `(1=default, 2=extension, 3=workspace, 4=user, 5=admin)`
- Updated `getPolicyTier` JSDoc range from `(1-4)` to `(1-5)`

Fixes #21681

This contribution was developed with AI assistance (Claude Code).