### PR TITLE
fix(a2a): add missing return after 501 in /tasks/metadata endpoint

### DIFF
--- a/packages/a2a-server/src/http/app.ts
+++ b/packages/a2a-server/src/http/app.ts
@@ -326,6 +326,7 @@ export async function createApp() {
           error:
             'Listing all task metadata is only supported when using InMemoryTaskStore.',
         });
+        return;
       }
       try {
         const wrappers = agentExecutor.getAllTasks();


### PR DESCRIPTION
## Summary

Adds a missing `return` statement after `res.status(501).send(...)` in the `GET /tasks/metadata` endpoint.

Without the return, when a non-InMemory task store (e.g., `GCSTaskStore`) is used, the handler falls through into the `try` block and attempts to send a second response, crashing the server with `ERR_HTTP_HEADERS_SENT`.

### Changes

- `packages/a2a-server/src/http/app.ts`: Added `return;` after the 501 response

Fixes #21729

This contribution was developed with AI assistance (Claude Code).