### PR TITLE
fix(core): handle missing credentials gracefully in deleteCredentials

### DIFF
--- a/packages/core/src/mcp/token-storage/file-token-storage.test.ts
+++ b/packages/core/src/mcp/token-storage/file-token-storage.test.ts
@@ -212,12 +212,12 @@ describe('FileTokenStorage', () => {
   });
 
   describe('deleteCredentials', () => {
-    it('should throw when credentials do not exist', async () => {
+    it('should not throw when credentials do not exist', async () => {
       mockFs.readFile.mockRejectedValue({ code: 'ENOENT' });
 
-      await expect(storage.deleteCredentials('test-server')).rejects.toThrow(
-        'No credentials found for test-server',
-      );
+      await expect(
+        storage.deleteCredentials('test-server'),
+      ).resolves.not.toThrow();
     });
 
     it('should delete file when last credential is removed', async () => {

--- a/packages/core/src/mcp/token-storage/file-token-storage.ts
+++ b/packages/core/src/mcp/token-storage/file-token-storage.ts
@@ -142,7 +142,7 @@ export class FileTokenStorage extends BaseTokenStorage {
     const tokens = await this.loadTokens();
 
     if (!tokens.has(serverName)) {
-      throw new Error(`No credentials found for ${serverName}`);
+      return;
     }
 
     tokens.delete(serverName);

--- a/packages/core/src/mcp/token-storage/keychain-token-storage.test.ts
+++ b/packages/core/src/mcp/token-storage/keychain-token-storage.test.ts
@@ -125,15 +125,16 @@ describe('KeychainTokenStorage', () => {
       await expect(storage.clearAll()).rejects.toThrow(
         /Failed to clear some credentials: system fail/,
       );
+    });
 
-      // Aggregating a 'not found' error (returns false)
-      vi.spyOn(KeychainService.prototype, 'deletePassword')
-        .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(false);
-
-      await expect(storage.clearAll()).rejects.toThrow(
-        /Failed to clear some credentials: No credentials found/,
+    it('should not throw when deleteCredentials called on missing entry', async () => {
+      vi.spyOn(KeychainService.prototype, 'deletePassword').mockResolvedValue(
+        false,
       );
+
+      await expect(
+        storage.deleteCredentials('nonexistent'),
+      ).resolves.not.toThrow();
     });
 
     it('should manage secrets with prefix independently', async () => {

--- a/packages/core/src/mcp/token-storage/keychain-token-storage.ts
+++ b/packages/core/src/mcp/token-storage/keychain-token-storage.ts
@@ -64,11 +64,7 @@ export class KeychainTokenStorage
 
   async deleteCredentials(serverName: string): Promise<void> {
     const sanitizedName = this.sanitizeServerName(serverName);
-    const deleted = await this.keychainService.deletePassword(sanitizedName);
-
-    if (!deleted) {
-      throw new Error(`No credentials found for ${serverName}`);
-    }
+    await this.keychainService.deletePassword(sanitizedName);
   }
 
   async listServers(): Promise<string[]> {


### PR DESCRIPTION
## Summary

`KeychainTokenStorage.deleteCredentials()` and `FileTokenStorage.deleteCredentials()` throw errors when the credential doesn't exist, causing cascading "Failed to clear OAuth credentials" errors during re-auth flows.

### Changes

**`packages/core/src/mcp/token-storage/keychain-token-storage.ts`:**
- Removed the `if (!deleted) throw` check - now silently succeeds when entry doesn't exist

**`packages/core/src/mcp/token-storage/file-token-storage.ts`:**
- Changed to return early when server name not found in token map instead of throwing

**Tests updated:**
- `keychain-token-storage.test.ts`: Added test for deleting non-existent credentials
- `file-token-storage.test.ts`: Changed "should throw" test to "should not throw"

### Scenarios fixed
- Double logout (`/auth logout` twice)
- Auth-switch without prior login
- Token refresh race conditions

Fixes #21768

This contribution was developed with AI assistance (Claude Code).