### PR TITLE
fix(acp): send tool_call session update before request_permission

### DIFF
--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -886,6 +886,16 @@ export class Session {
         await invocation.shouldConfirmExecute(abortSignal);
 
       if (confirmationDetails) {
+        await this.sendUpdate({
+          sessionUpdate: 'tool_call',
+          toolCallId: callId,
+          status: 'pending',
+          title: invocation.getDescription(),
+          content: [],
+          locations: invocation.toolLocations(),
+          kind: toAcpToolKind(tool.kind),
+        });
+
         const content: acp.ToolCallContent[] = [];
 
         if (confirmationDetails.type === 'edit') {

--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -885,15 +885,19 @@ export class Session {
       const confirmationDetails =
         await invocation.shouldConfirmExecute(abortSignal);
 
+      const baseToolCall = {
+        toolCallId: callId,
+        title: invocation.getDescription(),
+        locations: invocation.toolLocations(),
+        kind: toAcpToolKind(tool.kind),
+      };
+
       if (confirmationDetails) {
         await this.sendUpdate({
           sessionUpdate: 'tool_call',
-          toolCallId: callId,
-          status: 'pending',
-          title: invocation.getDescription(),
+          ...baseToolCall,
+          status: 'pending' as const,
           content: [],
-          locations: invocation.toolLocations(),
-          kind: toAcpToolKind(tool.kind),
         });
 
         const content: acp.ToolCallContent[] = [];
@@ -918,12 +922,9 @@ export class Session {
           sessionId: this.id,
           options: toPermissionOptions(confirmationDetails),
           toolCall: {
-            toolCallId: callId,
+            ...baseToolCall,
             status: 'pending',
-            title: invocation.getDescription(),
             content,
-            locations: invocation.toolLocations(),
-            kind: toAcpToolKind(tool.kind),
           },
         };
 
@@ -958,12 +959,9 @@ export class Session {
       } else {
         await this.sendUpdate({
           sessionUpdate: 'tool_call',
-          toolCallId: callId,
-          status: 'in_progress',
-          title: invocation.getDescription(),
+          ...baseToolCall,
+          status: 'in_progress' as const,
           content: [],
-          locations: invocation.toolLocations(),
-          kind: toAcpToolKind(tool.kind),
         });
       }
 


### PR DESCRIPTION
## Summary

In ACP mode, when a tool requires confirmation, `runTool()` sends `session/request_permission` but never sends a preceding `tool_call` session update. The if/else in `runTool` treats them as mutually exclusive:

- If `confirmationDetails` is truthy: sends `request_permission` only (no `tool_call`)
- If `confirmationDetails` is falsy: sends `tool_call` only

ACP clients expect to receive a `tool_call` update before `request_permission`.

### Changes

- `packages/cli/src/acp/acpClient.ts`: Added `this.sendUpdate()` with `sessionUpdate: 'tool_call'` and `status: 'pending'` before the `request_permission` call in the confirmation branch

The new update mirrors the structure of the existing `tool_call` update in the no-confirmation path but uses `status: 'pending'` since the tool hasn't started executing yet.

Fixes #21783

This contribution was developed with AI assistance (Claude Code).