### PR TITLE
fix(cli): prevent unmapped keys in Vim Normal mode from inserting text 

### DIFF
--- a/packages/cli/src/ui/hooks/vim.test.tsx
+++ b/packages/cli/src/ui/hooks/vim.test.tsx
@@ -2248,6 +2248,80 @@ describe('useVim hook', () => {
     });
   });
 
+  describe('should handle unmapped keys in Normal mode', () => {
+    type UnmappedKeyCase = {
+      char: string;
+      insertable: boolean;
+    };
+    it.each<UnmappedKeyCase>([
+      { char: 'm', insertable: true },
+      { char: 'n', insertable: true },
+      { char: 'p', insertable: true },
+      { char: 'q', insertable: true },
+      { char: 's', insertable: true },
+      { char: 'v', insertable: true },
+      { char: 'y', insertable: true },
+      { char: 'z', insertable: true },
+      { char: 'H', insertable: true },
+      { char: 'J', insertable: true },
+      { char: 'K', insertable: true },
+      { char: 'L', insertable: true },
+      { char: 'M', insertable: true },
+      { char: 'N', insertable: true },
+      { char: 'P', insertable: true },
+      { char: 'Q', insertable: true },
+      { char: 'R', insertable: true },
+      { char: 'S', insertable: true },
+      { char: 'U', insertable: true },
+      { char: 'V', insertable: true },
+      { char: 'Y', insertable: true },
+      { char: 'Z', insertable: true },
+      { char: '/', insertable: true },
+      { char: '#', insertable: true },
+      { char: '%', insertable: true },
+      { char: '&', insertable: true },
+      { char: "'", insertable: true },
+      { char: '(', insertable: true },
+      { char: ')', insertable: true },
+      { char: '*', insertable: true },
+      { char: '+', insertable: true },
+      { char: '-', insertable: true },
+      { char: '/', insertable: true },
+      { char: ':', insertable: true },
+      { char: '<', insertable: true },
+      { char: '=', insertable: true },
+      { char: '>', insertable: true },
+      { char: '@', insertable: true },
+      { char: '[', insertable: true },
+      { char: '\\', insertable: true },
+      { char: ']', insertable: true },
+      { char: '_', insertable: true },
+      { char: '`', insertable: true },
+      { char: '{', insertable: true },
+      { char: '|', insertable: true },
+      { char: '}', insertable: true },
+    ])(
+      '$sequence: should be swallowed and do nothing in Normal mode',
+      ({ char, insertable }) => {
+        const { result } = renderVimHook();
+        exitInsertMode(result);
+
+        let handled = false;
+        act(() => {
+          handled = result.current.handleInput(
+            createKey({ sequence: char, name: char, insertable }),
+          );
+        });
+
+        expect(handled).toBe(true);
+        expect(mockVimContext.setVimMode).not.toHaveBeenCalledWith('INSERT');
+
+        expect(mockBuffer.vimFindCharForward).not.toHaveBeenCalled();
+        expect(mockBuffer.vimFindCharBackward).not.toHaveBeenCalled();
+      },
+    );
+  });
+
   describe('Operator + find motions (df, dt, dF, dT, cf, ct, cF, cT)', () => {
     it('df{char}: executes delete-to-char, not a dangling operator', () => {
       const { result } = renderVimHook();

--- a/packages/cli/src/ui/hooks/vim.ts
+++ b/packages/cli/src/ui/hooks/vim.ts
@@ -1330,7 +1330,12 @@ export function useVim(buffer: TextBuffer, onSubmit?: (value: string) => void) {
             // Unknown command, clear count and pending states
             dispatch({ type: 'CLEAR_PENDING_STATES' });
 
-            // Not handled by vim so allow other handlers to process it.
+            // Ignore any insertable key in Normal Mode
+            if (normalizedKey.insertable) {
+              return true;
+            }
+
+            // Not handled by vim so allow other handlers to process it
             return false;
           }
         }


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Fixes a bug where pressing unmapped keys in Vim Normal mode would insert characters into input buffer. This change ensures that unhandled keys are ignored, aligning the CLI's behavior with standard Vim mechanics where text is only inserted during Insert mode.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

In the Vim hook, unmapped keys in `NORMAL` mode were inserted into the buffer. This fix intercepts those unmapped keys and prevents them from modifying the input. I have added tests cases to ensure unmapped keys are ignored and don't change the input buffer.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes #21686

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

1. Launch `gemini-cli` locally.
2. Enable Vim Mode
3. Enter Vim **NORMAL** mode by pressing `Esc`.
4. Type unmapped keys such as `H`, `M`, `Q`, `m`, `[` or `/`.
5. **Expected Result:** The keys are ignored and do not appear in the text prompt.
6. Enter **INSERT** mode by pressing `i` or `a` and verify that typing works normally.
7. Run the tests `npm run test` to verify the new Vim normal mode tests pass successfully.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [X] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [X] Linux
    - [X] npm run
    - [ ] npx
    - [ ] Docker
