### PR TITLE
Fix the enforced authentication method config example in the enterprise docs

### DIFF
--- a/docs/cli/enterprise.md
+++ b/docs/cli/enterprise.md
@@ -500,15 +500,19 @@ avoid collecting potentially sensitive information from user prompts.
 ## Authentication
 
 You can enforce a specific authentication method for all users by setting the
-`enforcedAuthType` in the system-level `settings.json` file. This prevents users
-from choosing a different authentication method. See the
+`security.auth.enforcedType` in the system-level `settings.json` file. This
+prevents users from choosing a different authentication method. See the
 [Authentication docs](../get-started/authentication.md) for more details.
 
 **Example:** Enforce the use of Google login for all users.
 
 ```json
 {
-  "enforcedAuthType": "oauth-personal"
+  "security": {
+    "auth": {
+      "enforcedType": "oauth-personal"
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary

The documented `enforcedAuthType` field does not work; the right field is `security.auth.enforcedType`

Fixes #22783

## How to Validate

Add the config snippet to `settings.json`, run `/auth`, see only the "Login with Google" option

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
