### PR TITLE
test: clean up temp directories in afterEach hooks

### DIFF
--- a/packages/cli/src/commands/extensions/configure.test.ts
+++ b/packages/cli/src/commands/extensions/configure.test.ts
@@ -95,6 +95,7 @@ describe('extensions configure command', () => {
   });
 
   afterEach(() => {
+    fs.rmSync(tempWorkspaceDir, { recursive: true, force: true });
     vi.restoreAllMocks();
   });
 

--- a/packages/cli/src/config/extension-manager-scope.test.ts
+++ b/packages/cli/src/config/extension-manager-scope.test.ts
@@ -88,7 +88,8 @@ describe('ExtensionManager Settings Scope', () => {
   });
 
   afterEach(() => {
-    // Clean up files if needed, or rely on temp dir cleanup
+    fs.rmSync(currentTempHome, { recursive: true, force: true });
+    fs.rmSync(tempWorkspace, { recursive: true, force: true });
     vi.clearAllMocks();
   });
 

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -102,6 +102,7 @@ describe('mcp-client', () => {
   });
 
   afterEach(() => {
+    fs.rmSync(testWorkspace, { recursive: true, force: true });
     vi.restoreAllMocks();
     vi.useRealTimers();
   });


### PR DESCRIPTION
## Summary
Three test files created temporary directories via mkdtempSync in beforeEach but never removed them in afterEach, causing temp dirs to accumulate in the OS temp folder after every test run. This adds the missing fs.rmSync(..., { recursive: true, force: true }) calls to clean them up.

## Details
Only 3 of the 4 files flagged in the issue needed changes:

- mcp-client.test.ts : testWorkspace was never deleted
- extension-manager-scope.test.ts : currentTempHome and tempWorkspace were never deleted (the existing comment said "rely on temp dir cleanup" which never actually happened)
- configure.test.ts : tempWorkspaceDir was never deleted

#### extension-manager.test.ts is already correct, its tempWorkspaceDir is nested inside tempHomeDir, which is deleted recursively in the existing afterEach.

### Related Issues
Fixes #22032

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [x] Docker
 