### PR TITLE
fix(core): prevent agent from asking and immediately acting

### DIFF
--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -555,7 +555,7 @@ An approved plan is available for this task at \`${approvedPlanPath}\`.
 
 function mandateConfirm(interactive: boolean): string {
   return interactive
-    ? "**Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If the user implies a change (e.g., reports a bug) without explicitly asking for a fix, **ask for confirmation first**. If asked *how* to do something, explain first, don't just do it."
+    ? "**Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If the user implies a change (e.g., reports a bug) without explicitly asking for a fix, **ask for confirmation first**. If asked *how* to do something, explain first, don't just do it. When executing a multi-step plan, if you ask the user whether to proceed to the next step, you MUST stop and wait for their reply before taking any action — do not ask and immediately act in the same turn."
     : '**Handle Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request. If the user implies a change (e.g., reports a bug) without explicitly asking for a fix, do not perform it automatically.';
 }
 


### PR DESCRIPTION
## Summary

Adds an explicit instruction to the interactive system prompt preventing the agent from asking a checkpoint question (e.g. "Shall I proceed?") and immediately acting on it in the same turn, a pattern reported to cause repeated trust breakdowns in multi-step sessions.

## Details

The [`mandateConfirm`](https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/prompts/snippets.ts#L556-L560) rule in [`snippets.ts`](https://github.com/google/gemini-cli/blob/main/packages/core/src/prompts/snippets.ts) only gated ambiguous or scope-expanding actions. It had no instruction covering the specific case where the agent verbally requests a go-ahead and then proceeds without waiting for a reply. A single sentence was appended to the interactive variant of that mandate making the required behavior explicit: ask → stop → wait.

No runtime or scheduler changes are needed; the prompt layer is the correct place to close this gap.

## Related Issues

Fixes #21818

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [x] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
