### PR TITLE
feat(cli): make extension installation idempotent

### DIFF
--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -291,9 +291,7 @@ Would you like to attempt to install via "git clone" instead?`,
             `Extension "${previousName}" was not already installed, cannot update it.`,
           );
         } else if (!isUpdate && previous) {
-          throw new Error(
-            `Extension "${newExtensionName}" is already installed. Please uninstall it first.`,
-          );
+          return previous;
         } else if (isUpdate && nameConflict) {
           throw new Error(
             `Cannot update to "${newExtensionName}" because an extension with that name is already installed.`,

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -1155,25 +1155,22 @@ name = "yolo-checker"
       fs.rmSync(targetExtDir, { recursive: true, force: true });
     });
 
-    it('should throw an error if the extension already exists', async () => {
+    it('should be idempotent and not throw an error if the extension already exists', async () => {
       const sourceExtDir = createExtension({
         extensionsDir: tempHomeDir,
         name: 'my-local-extension',
         version: '1.0.0',
       });
       await extensionManager.loadExtensions();
-      await extensionManager.installOrUpdateExtension({
+      const first = await extensionManager.installOrUpdateExtension({
         source: sourceExtDir,
         type: 'local',
       });
-      await expect(
-        extensionManager.installOrUpdateExtension({
-          source: sourceExtDir,
-          type: 'local',
-        }),
-      ).rejects.toThrow(
-        'Extension "my-local-extension" is already installed. Please uninstall it first.',
-      );
+      const second = await extensionManager.installOrUpdateExtension({
+        source: sourceExtDir,
+        type: 'local',
+      });
+      expect(first).toBe(second);
     });
 
     it('should throw an error and cleanup if gemini-extension.json is missing', async () => {


### PR DESCRIPTION
## Summary

Make extension installation idempotent by returning the existing extension instead of throwing an error when it is already installed.

## Details

Modified `ExtensionManager.installOrUpdateExtension` in `packages/cli/src/config/extension-manager.ts` to return the `previous` extension instance when it's already installed and not an update. This makes the installation process idempotent, allowing users or scripts to run installation commands without checking for existence first or handling "already installed" errors.

## Related Issues
Fixes #22125

## How to Validate

   1. Run the specific test file: `npm test packages/cli/src/config/extension.test.ts`
   2. Confirm the test case `"should be idempotent and not throw an error if the extension already exists"` passes.
   3. Verify that manual installation attempts of existing extensions succeed silently.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
