### PR TITLE
feat(core): include initiationMethod in conversation interaction telemetry

### DIFF
--- a/packages/core/src/code_assist/server.test.ts
+++ b/packages/core/src/code_assist/server.test.ts
@@ -10,6 +10,7 @@ import { OAuth2Client } from 'google-auth-library';
 import {
   UserTierId,
   ActionStatus,
+  InitiationMethod,
   type LoadCodeAssistResponse,
   type GeminiUserTier,
   type SetCodeAssistGlobalUserSettingRequest,
@@ -206,6 +207,7 @@ describe('CodeAssistServer', () => {
             conversationOffered: expect.objectContaining({
               traceId: 'test-trace-id',
               status: ActionStatus.ACTION_STATUS_NO_ERROR,
+              initiationMethod: InitiationMethod.COMMAND,
               streamingLatency: expect.objectContaining({
                 totalLatency: expect.stringMatching(/\d+s/),
                 firstMessageLatency: expect.stringMatching(/\d+s/),
@@ -274,6 +276,7 @@ describe('CodeAssistServer', () => {
           expect.objectContaining({
             conversationOffered: expect.objectContaining({
               traceId: 'stream-trace-id',
+              initiationMethod: InitiationMethod.COMMAND,
             }),
             timestamp: expect.stringMatching(
               /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/,

--- a/packages/core/src/code_assist/telemetry.test.ts
+++ b/packages/core/src/code_assist/telemetry.test.ts
@@ -339,6 +339,7 @@ describe('telemetry', () => {
           acceptedLines: '8',
           removedLines: '3',
           isAgentic: true,
+          initiationMethod: InitiationMethod.COMMAND,
         }),
       );
     });

--- a/packages/core/src/code_assist/telemetry.ts
+++ b/packages/core/src/code_assist/telemetry.ts
@@ -204,6 +204,7 @@ function createConversationInteraction(
     removedLines,
     language,
     isAgentic: true,
+    initiationMethod: InitiationMethod.COMMAND,
   };
 }
 

--- a/packages/core/src/code_assist/types.ts
+++ b/packages/core/src/code_assist/types.ts
@@ -330,6 +330,7 @@ export interface ConversationInteraction {
   removedLines?: string;
   language?: string;
   isAgentic?: boolean;
+  initiationMethod?: InitiationMethod;
 }
 
 export interface FetchAdminControlsRequest {


### PR DESCRIPTION
## Summary

This PR adds the `initiationMethod` field to the conversation interaction telemetry for Code Assist. It ensures that telemetry metrics correctly reflect the method used to initiate the interaction.

## Details

- Added `initiationMethod?: InitiationMethod` to `ConversationInteraction` in `types.ts`.
- Included `initiationMethod: InitiationMethod.COMMAND` when creating conversation interactions in `telemetry.ts`.
- Updated tests in `server.test.ts` and `telemetry.test.ts` to assert that `initiationMethod` is correctly captured and set to `COMMAND`.

## Related Issues

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/1510

## How to Validate

Run the core package tests to verify the updated behavior:
`npm run test -w @google/gemini-cli-core`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
