### PR TITLE
chore: allow 'gemini-3.1' in sensitive keyword linter

### DIFF
--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -246,6 +246,7 @@ export function runSensitiveKeywordLinter() {
   console.log('\nRunning sensitive keyword linter...');
   const SENSITIVE_PATTERN = /gemini-\d+(\.\d+)?/g;
   const ALLOWED_KEYWORDS = new Set([
+    'gemini-3.1',
     'gemini-3',
     'gemini-3.0',
     'gemini-2.5',


### PR DESCRIPTION
allow 'gemini-3.1' in sensitive keyword linter

Fixes #22050