### PR TITLE
fix(core): resolve MCP tool FQN validation, schema export, and wildcards in subagents

### DIFF
--- a/packages/core/src/agents/agentLoader.ts
+++ b/packages/core/src/agents/agentLoader.ts
@@ -107,9 +107,11 @@ const localAgentSchema = z
     display_name: z.string().optional(),
     tools: z
       .array(
-        z.string().refine((val) => isValidToolName(val), {
-          message: 'Invalid tool name',
-        }),
+        z
+          .string()
+          .refine((val) => isValidToolName(val, { allowWildcards: true }), {
+            message: 'Invalid tool name',
+          }),
       )
       .optional(),
     model: z.string().optional(),

--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -17,7 +17,13 @@ import {
   type Schema,
 } from '@google/genai';
 import { ToolRegistry } from '../tools/tool-registry.js';
-import { DiscoveredMCPTool } from '../tools/mcp-tool.js';
+import { type AnyDeclarativeTool } from '../tools/tools.js';
+import {
+  DiscoveredMCPTool,
+  isMcpToolName,
+  parseMcpToolName,
+  MCP_TOOL_PREFIX,
+} from '../tools/mcp-tool.js';
 import { CompressionStatus } from '../core/turn.js';
 import { type ToolCallRequestInfo } from '../scheduler/types.js';
 import { type Message } from '../confirmation-bus/types.js';
@@ -146,28 +152,62 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
       context.config.getAgentRegistry().getAllAgentNames(),
     );
 
-    const registerToolByName = (toolName: string) => {
+    const registerToolInstance = (tool: AnyDeclarativeTool) => {
       // Check if the tool is a subagent to prevent recursion.
       // We do not allow agents to call other agents.
-      if (allAgentNames.has(toolName)) {
+      if (allAgentNames.has(tool.name)) {
         debugLogger.warn(
-          `[LocalAgentExecutor] Skipping subagent tool '${toolName}' for agent '${definition.name}' to prevent recursion.`,
+          `[LocalAgentExecutor] Skipping subagent tool '${tool.name}' for agent '${definition.name}' to prevent recursion.`,
         );
         return;
+      }
+
+      if (tool instanceof DiscoveredMCPTool) {
+        // Subagents MUST use fully qualified names for MCP tools to ensure
+        // unambiguous tool calls and to comply with policy requirements.
+        // We automatically "upgrade" any MCP tool to its qualified version.
+        agentToolRegistry.registerTool(tool.asFullyQualifiedTool());
+      } else {
+        agentToolRegistry.registerTool(tool);
+      }
+    };
+
+    const registerToolByName = (toolName: string) => {
+      // Handle global wildcard
+      if (toolName === '*') {
+        for (const tool of parentToolRegistry.getAllTools()) {
+          registerToolInstance(tool);
+        }
+        return;
+      }
+
+      // Handle MCP wildcards
+      if (isMcpToolName(toolName)) {
+        if (toolName === `${MCP_TOOL_PREFIX}*`) {
+          for (const tool of parentToolRegistry.getAllTools()) {
+            if (tool instanceof DiscoveredMCPTool) {
+              registerToolInstance(tool);
+            }
+          }
+          return;
+        }
+
+        const parsed = parseMcpToolName(toolName);
+        if (parsed.serverName && parsed.toolName === '*') {
+          for (const tool of parentToolRegistry.getToolsByServer(
+            parsed.serverName,
+          )) {
+            registerToolInstance(tool);
+          }
+          return;
+        }
       }
 
       // If the tool is referenced by name, retrieve it from the parent
       // registry and register it with the agent's isolated registry.
       const tool = parentToolRegistry.getTool(toolName);
       if (tool) {
-        if (tool instanceof DiscoveredMCPTool) {
-          // Subagents MUST use fully qualified names for MCP tools to ensure
-          // unambiguous tool calls and to comply with policy requirements.
-          // We automatically "upgrade" any MCP tool to its qualified version.
-          agentToolRegistry.registerTool(tool.asFullyQualifiedTool());
-        } else {
-          agentToolRegistry.registerTool(tool);
-        }
+        registerToolInstance(tool);
       }
     };
 
@@ -1175,10 +1215,9 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
     const { toolConfig, outputConfig } = this.definition;
 
     if (toolConfig) {
-      const toolNamesToLoad: string[] = [];
       for (const toolRef of toolConfig.tools) {
         if (typeof toolRef === 'string') {
-          toolNamesToLoad.push(toolRef);
+          // The names were already expanded and loaded into the registry during creation.
         } else if (typeof toolRef === 'object' && 'schema' in toolRef) {
           // Tool instance with an explicit schema property.
           toolsList.push(toolRef.schema);
@@ -1187,10 +1226,8 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
           toolsList.push(toolRef);
         }
       }
-      // Add schemas from tools that were registered by name.
-      toolsList.push(
-        ...this.toolRegistry.getFunctionDeclarationsFiltered(toolNamesToLoad),
-      );
+      // Add schemas from tools that were explicitly registered by name or wildcard.
+      toolsList.push(...this.toolRegistry.getFunctionDeclarations());
     }
 
     // Always inject complete_task.

--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -162,14 +162,7 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
         return;
       }
 
-      if (tool instanceof DiscoveredMCPTool) {
-        // Subagents MUST use fully qualified names for MCP tools to ensure
-        // unambiguous tool calls and to comply with policy requirements.
-        // We automatically "upgrade" any MCP tool to its qualified version.
-        agentToolRegistry.registerTool(tool.asFullyQualifiedTool());
-      } else {
-        agentToolRegistry.registerTool(tool);
-      }
+      agentToolRegistry.registerTool(tool);
     };
 
     const registerToolByName = (toolName: string) => {

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -58,6 +58,7 @@ export function parseMcpToolName(name: string): {
   // Remove the prefix
   const withoutPrefix = name.slice(MCP_TOOL_PREFIX.length);
   // The first segment is the server name, the rest is the tool name
+  // Must be strictly `server_tool` where neither are empty
   const match = withoutPrefix.match(/^([^_]+)_(.+)$/);
   if (match) {
     return {

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -391,25 +391,6 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
       `${this.serverName}${MCP_QUALIFIED_NAME_SEPARATOR}${this.serverToolName}`,
     );
   }
-
-  asFullyQualifiedTool(): DiscoveredMCPTool {
-    return new DiscoveredMCPTool(
-      this.mcpTool,
-      this.serverName,
-      this.serverToolName,
-      this.description,
-      this.parameterSchema,
-      this.messageBus,
-      this.trust,
-      this.isReadOnly,
-      this.getFullyQualifiedName(),
-      this.cliConfig,
-      this.extensionName,
-      this.extensionId,
-      this._toolAnnotations,
-    );
-  }
-
   protected createInvocation(
     params: ToolParams,
     messageBus: MessageBus,

--- a/packages/core/src/tools/tool-names.test.ts
+++ b/packages/core/src/tools/tool-names.test.ts
@@ -25,7 +25,8 @@ vi.mock('./tool-names.js', async (importOriginal) => {
     ...actual,
     TOOL_LEGACY_ALIASES: mockedAliases,
     isValidToolName: vi.fn().mockImplementation((name: string, options) => {
-      if (mockedAliases[name]) return true;
+      if (Object.prototype.hasOwnProperty.call(mockedAliases, name))
+        return true;
       return actual.isValidToolName(name, options);
     }),
     getToolAliases: vi.fn().mockImplementation((name: string) => {
@@ -55,11 +56,9 @@ describe('tool-names', () => {
       expect(isValidToolName(`${DISCOVERED_TOOL_PREFIX}my_tool`)).toBe(true);
     });
 
-    it('should validate MCP tool names (server__tool)', () => {
-      expect(isValidToolName('server__tool')).toBe(true);
-      expect(isValidToolName('my-server__my-tool')).toBe(true);
-      expect(isValidToolName('my.server__my:tool')).toBe(true);
-      expect(isValidToolName('my-server...truncated__tool')).toBe(true);
+    it('should validate modern MCP FQNs (mcp_server_tool)', () => {
+      expect(isValidToolName('mcp_server_tool')).toBe(true);
+      expect(isValidToolName('mcp_my-server_my-tool')).toBe(true);
     });
 
     it('should validate legacy tool aliases', async () => {
@@ -69,28 +68,33 @@ describe('tool-names', () => {
       }
     });
 
-    it('should reject invalid tool names', () => {
-      expect(isValidToolName('')).toBe(false);
-      expect(isValidToolName('invalid-name')).toBe(false);
-      expect(isValidToolName('server__')).toBe(false);
-      expect(isValidToolName('__tool')).toBe(false);
-      expect(isValidToolName('server__tool__extra')).toBe(false);
+    it('should return false for invalid tool names', () => {
+      expect(isValidToolName('invalid-tool-name')).toBe(false);
+      expect(isValidToolName('mcp_server')).toBe(false);
+      expect(isValidToolName('mcp__tool')).toBe(false);
+      expect(isValidToolName('mcp_invalid server_tool')).toBe(false);
+      expect(isValidToolName('mcp_server_invalid tool')).toBe(false);
+      expect(isValidToolName('mcp_server_')).toBe(false);
     });
 
     it('should handle wildcards when allowed', () => {
       // Default: not allowed
       expect(isValidToolName('*')).toBe(false);
-      expect(isValidToolName('server__*')).toBe(false);
+      expect(isValidToolName('mcp_*')).toBe(false);
+      expect(isValidToolName('mcp_server_*')).toBe(false);
 
       // Explicitly allowed
       expect(isValidToolName('*', { allowWildcards: true })).toBe(true);
-      expect(isValidToolName('server__*', { allowWildcards: true })).toBe(true);
+      expect(isValidToolName('mcp_*', { allowWildcards: true })).toBe(true);
+      expect(isValidToolName('mcp_server_*', { allowWildcards: true })).toBe(
+        true,
+      );
 
       // Invalid wildcards
-      expect(isValidToolName('__*', { allowWildcards: true })).toBe(false);
-      expect(isValidToolName('server__tool*', { allowWildcards: true })).toBe(
-        false,
-      );
+      expect(isValidToolName('mcp__*', { allowWildcards: true })).toBe(false);
+      expect(
+        isValidToolName('mcp_server_tool*', { allowWildcards: true }),
+      ).toBe(false);
     });
   });
 

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -221,6 +221,12 @@ export const DISCOVERED_TOOL_PREFIX = 'discovered_tool_';
 /**
  * List of all built-in tool names.
  */
+import {
+  isMcpToolName,
+  parseMcpToolName,
+  MCP_TOOL_PREFIX,
+} from './mcp-tool.js';
+
 export const ALL_BUILTIN_TOOL_NAMES = [
   GLOB_TOOL_NAME,
   WRITE_TODOS_TOOL_NAME,
@@ -290,25 +296,44 @@ export function isValidToolName(
     return true;
   }
 
-  // MCP tools (format: server__tool)
-  if (name.includes('__')) {
-    const parts = name.split('__');
-    if (parts.length !== 2 || parts[0].length === 0 || parts[1].length === 0) {
+  // Handle standard MCP FQNs (mcp_server_tool or wildcards mcp_*, mcp_server_*)
+  if (isMcpToolName(name)) {
+    // Global wildcard: mcp_*
+    if (name === `${MCP_TOOL_PREFIX}*` && options.allowWildcards) {
+      return true;
+    }
+
+    // Explicitly reject names with empty server component (e.g. mcp__tool)
+    if (name.startsWith(`${MCP_TOOL_PREFIX}_`)) {
       return false;
     }
 
-    const server = parts[0];
-    const tool = parts[1];
+    const parsed = parseMcpToolName(name);
+    // Ensure that both components are populated. parseMcpToolName splits at the second _,
+    // so `mcp__tool` has serverName="", toolName="tool"
+    if (parsed.serverName && parsed.toolName) {
+      // Basic slug validation for server and tool names.
+      // We allow dots (.) and colons (:) as they are valid in function names and
+      // used for truncation markers.
+      const slugRegex = /^[a-z0-9_.:-]+$/i;
 
-    if (tool === '*') {
-      return !!options.allowWildcards;
+      if (!slugRegex.test(parsed.serverName)) {
+        return false;
+      }
+
+      if (parsed.toolName === '*') {
+        return options.allowWildcards === true;
+      }
+
+      // A tool name consisting only of underscores is invalid.
+      if (/^_*$/.test(parsed.toolName)) {
+        return false;
+      }
+
+      return slugRegex.test(parsed.toolName);
     }
 
-    // Basic slug validation for server and tool names.
-    // We allow dots (.) and colons (:) as they are valid in function names and
-    // used for truncation markers.
-    const slugRegex = /^[a-z0-9_.:-]+$/i;
-    return slugRegex.test(server) && slugRegex.test(tool);
+    return false;
   }
 
   return false;

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -310,13 +310,13 @@ describe('ToolRegistry', () => {
         excludedTools: ['tool-a'],
       },
       {
-        name: 'should match simple MCP tool names, when qualified or unqualified',
-        tools: [mcpTool, mcpTool.asFullyQualifiedTool()],
+        name: 'should match simple MCP tool names',
+        tools: [mcpTool],
         excludedTools: [mcpTool.name],
       },
       {
-        name: 'should match qualified MCP tool names when qualified or unqualified',
-        tools: [mcpTool, mcpTool.asFullyQualifiedTool()],
+        name: 'should match qualified MCP tool names',
+        tools: [mcpTool],
         excludedTools: [mcpTool.name],
       },
       {
@@ -414,9 +414,9 @@ describe('ToolRegistry', () => {
       const toolName = 'my-tool';
       const mcpTool = createMCPTool(serverName, toolName, 'desc');
 
-      // Register same MCP tool twice (one as alias, one as qualified)
+      // Register same MCP tool twice
       toolRegistry.registerTool(mcpTool);
-      toolRegistry.registerTool(mcpTool.asFullyQualifiedTool());
+      toolRegistry.registerTool(mcpTool);
 
       const toolNames = toolRegistry.getAllToolNames();
       expect(toolNames).toEqual([`mcp_${serverName}_${toolName}`]);
@@ -698,9 +698,8 @@ describe('ToolRegistry', () => {
       const toolName = 'my-tool';
       const mcpTool = createMCPTool(serverName, toolName, 'description');
 
-      // Register both alias and qualified
       toolRegistry.registerTool(mcpTool);
-      toolRegistry.registerTool(mcpTool.asFullyQualifiedTool());
+      toolRegistry.registerTool(mcpTool);
 
       const declarations = toolRegistry.getFunctionDeclarations();
       expect(declarations).toHaveLength(1);

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -594,7 +594,17 @@ export class ToolRegistry {
     for (const name of toolNames) {
       const tool = this.getTool(name);
       if (tool) {
-        declarations.push(tool.getSchema(modelId));
+        let schema = tool.getSchema(modelId);
+
+        // Ensure the schema name matches the qualified name for MCP tools
+        if (tool instanceof DiscoveredMCPTool) {
+          schema = {
+            ...schema,
+            name: tool.getFullyQualifiedName(),
+          };
+        }
+
+        declarations.push(schema);
       }
     }
     return declarations;
@@ -667,17 +677,6 @@ export class ToolRegistry {
         debugLogger.debug(
           `Resolved legacy tool name "${name}" to current name "${currentName}"`,
         );
-      }
-    }
-
-    if (!tool && name.includes('__')) {
-      for (const t of this.allKnownTools.values()) {
-        if (t instanceof DiscoveredMCPTool) {
-          if (t.getFullyQualifiedName() === name) {
-            tool = t;
-            break;
-          }
-        }
       }
     }
 

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -222,14 +222,10 @@ export class ToolRegistry {
    */
   registerTool(tool: AnyDeclarativeTool): void {
     if (this.allKnownTools.has(tool.name)) {
-      if (tool instanceof DiscoveredMCPTool) {
-        tool = tool.asFullyQualifiedTool();
-      } else {
-        // Decide on behavior: throw error, log warning, or allow overwrite
-        debugLogger.warn(
-          `Tool with name "${tool.name}" is already registered. Overwriting.`,
-        );
-      }
+      // Decide on behavior: throw error, log warning, or allow overwrite
+      debugLogger.warn(
+        `Tool with name "${tool.name}" is already registered. Overwriting.`,
+      );
     }
     this.allKnownTools.set(tool.name, tool);
   }


### PR DESCRIPTION
## Summary

Fixes an issue where subagents rejected standard `mcp_{serverName}_{toolName}` Fully Qualified Names (FQNs) due to outdated validation logic that incorrectly permitted only the deprecated `server__tool` legacy format. It additionally adds internal support for resolving generic and MCP wildcards during subagent tool loads.

## Details

* The `isValidToolName` logic in `tool-names.ts` now securely validates `mcp_` names by strictly adhering to the parsing constraints given by `mcp-tool.ts`.
* Explicitly removed the dead fallback block for parsing `__` inside `tool-registry.ts`, as the Policy Engine normalizes structure to `mcp_` before `getTool(name)` executes.
* Cleaned up legacy checks and false-positive wildcard tests inside `tool-names.test.ts`.
* Updated the `agentLoader.ts` Zod schema to allow wildcards when parsing the `tools` array of a subagent configuration file (by supplying `{ allowWildcards: true }` to `isValidToolName`).
* Implemented generic wildcard (`*`) and MCP wildcard (`mcp_*`, `mcp_server_*`) resolution natively inside `local-executor.ts` since subagents lacked the ability to expand tools organically.
* **Bug Fix:** Removed the unnecessary duplicate tool filtering inside `local-executor.ts` `prepareToolsList`, and updated `ToolRegistry.getFunctionDeclarationsFiltered` (used by subagents) to properly rewrite the tool schema `name` to the Fully Qualified Name (e.g. `mcp_server_tool`) just like `getFunctionDeclarations` does. This ensures the model executes authorized tools instead of hallucinating stripped bare names.

## Related Issues

N/A

## How to Validate

1. Configure an MCP server in your `settings.json`.
2. Define a subagent using the new standard FQN pattern (e.g. `mcp_serverName_*`).
3. Observe that it successfully validates and resolves to all the tools in the registry, and correctly outputs the delegated tool responses.
4. Validate unit tests via `npm run test` across `@google/gemini-cli-core`.
5. Run full validations via `npm run preflight`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
