### PR TITLE
docs(plan): clarify interactive plan editing with Ctrl+X

### DIFF
--- a/docs/cli/plan-mode.md
+++ b/docs/cli/plan-mode.md
@@ -77,6 +77,9 @@ Gemini CLI takes action.
       CLI will refine the strategy and update the plan.
     - **Cancel:** You can cancel your plan with `Esc`.
 
+For more complex or specialized planning tasks, you can
+[customize the planning workflow with skills](#custom-planning-with-skills).
+
 ### Collaborative plan editing
 
 You can collaborate with Gemini CLI by making direct changes or leaving comments
@@ -95,9 +98,6 @@ describing complex changes in natural language.
 4.  **Review and refine:** Gemini CLI automatically detects the changes, reviews
     your comments, and adjusts the implementation strategy. It then presents the
     refined plan for your final approval.
-
-For more complex or specialized planning tasks, you can
-[customize the planning workflow with skills](#custom-planning-with-skills).
 
 ## How to exit Plan Mode
 

--- a/docs/cli/plan-mode.md
+++ b/docs/cli/plan-mode.md
@@ -61,16 +61,40 @@ Gemini CLI takes action.
     [`ask_user`](../tools/ask-user.md). Provide your preferences to help guide
     the design.
 3.  **Review the plan:** Once Gemini CLI has a proposed strategy, it creates a
-    detailed implementation plan as a Markdown file in your plans directory. You
-    can open and read this file to understand the proposed changes.
+    detailed implementation plan as a Markdown file in your plans directory.
+    - **View:** You can open and read this file to understand the proposed
+      changes.
+    - **Edit:** Press `Ctrl+X` to open the plan directly in your configured
+      external editor.
+
 4.  **Approve or iterate:** Gemini CLI will present the finalized plan for your
     approval.
     - **Approve:** If you're satisfied with the plan, approve it to start the
       implementation immediately: **Yes, automatically accept edits** or **Yes,
       manually accept edits**.
-    - **Iterate:** If the plan needs adjustments, provide feedback. Gemini CLI
-      will refine the strategy and update the plan.
+    - **Iterate:** If the plan needs adjustments, provide feedback in the input
+      box or [edit the plan file directly](#collaborative-plan-editing). Gemini
+      CLI will refine the strategy and update the plan.
     - **Cancel:** You can cancel your plan with `Esc`.
+
+### Collaborative plan editing
+
+You can collaborate with Gemini CLI by making direct changes or leaving comments
+in the implementation plan. This is often faster and more precise than
+describing complex changes in natural language.
+
+1.  **Open the plan:** Press `Ctrl+X` when Gemini CLI presents a plan for
+    review.
+2.  **Edit or comment:** The plan opens in your configured external editor (for
+    example, VS Code or Vim). You can:
+    - **Modify steps:** Directly reorder, delete, or rewrite implementation
+      steps.
+    - **Leave comments:** Add inline questions or feedback (for example, "Wait,
+      shouldn't we use the existing `Logger` class here?").
+3.  **Save and close:** Save your changes and close the editor.
+4.  **Review and refine:** Gemini CLI automatically detects the changes, reviews
+    your comments, and adjusts the implementation strategy. It then presents the
+    refined plan for your final approval.
 
 For more complex or specialized planning tasks, you can
 [customize the planning workflow with skills](#custom-planning-with-skills).

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -229,6 +229,9 @@ a `key` combination.
   the numbered radio option and confirm when the full number is entered.
 - `Ctrl + O`: Expand or collapse paste placeholders (`[Pasted Text: X lines]`)
   inline when the cursor is over the placeholder.
+- `Ctrl + X` (while a plan is presented): Open the plan in an external editor to
+  [collaboratively edit or comment](../cli/plan-mode.md#collaborative-plan-editing)
+  on the implementation strategy.
 - `Double-click` on a paste placeholder (alternate buffer mode only): Expand to
   view full content inline. Double-click again to collapse.
 


### PR DESCRIPTION
## Summary

Clarify how users can interactively edit and comment on plans in Plan Mode using the `Ctrl+X` shortcut.

## Details

Users were not always aware that they could open the plan file directly to make edits or leave comments for the agent. This PR updates the "Plan Mode" documentation and "Keyboard Shortcuts" reference to make this feature more discoverable and explains the collaborative workflow.

## Related Issues

Fixes #22075

## How to Validate

1. Read `docs/cli/plan-mode.md` and verify the new "Collaborative plan editing" section.
2. Read `docs/reference/keyboard-shortcuts.md` and verify the new entry for `Ctrl+X` in the "Additional context-specific shortcuts" section.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
