### PR TITLE
feat(core/cli): expose model thinking events in --output-format stream-json

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1558,7 +1558,10 @@ for that specific session.
   - **Values:**
     - `text`: (Default) The standard human-readable output.
     - `json`: A machine-readable JSON output.
-    - `stream-json`: A streaming JSON output that emits real-time events.
+    - `stream-json`: A streaming JSON output that emits real-time JSONL events.
+      Event types include: `init`, `message`, `thinking`, `tool_use`,
+      `tool_result`, `error`, and `result`. The `thinking` event exposes model
+      reasoning from thinking-capable models (for example, Gemini 2.5 Pro).
   - **Note:** For structured output and scripting, use the
     `--output-format json` or `--output-format stream-json` flag.
 - **`--sandbox`** (**`-s`**):

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -316,14 +316,19 @@ export async function runNonInteractive({
 
           if (event.type === GeminiEventType.Thought) {
             if (streamFormatter) {
-              const text = event.value.subject
-                ? `**${event.value.subject}** ${event.value.description}`
-                : event.value.description;
+              const isRaw =
+                config.getRawOutput() || config.getAcceptRawOutputRisk();
+              const subject = isRaw
+                ? event.value.subject || undefined
+                : stripAnsi(event.value.subject) || undefined;
+              const description = isRaw
+                ? event.value.description
+                : stripAnsi(event.value.description);
               streamFormatter.emitEvent({
                 type: JsonStreamEventType.THINKING,
                 timestamp: new Date().toISOString(),
-                content: text,
-                subject: event.value.subject || undefined,
+                description,
+                subject,
               });
             }
           } else if (event.type === GeminiEventType.Content) {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -314,7 +314,19 @@ export async function runNonInteractive({
             handleCancellationError(config);
           }
 
-          if (event.type === GeminiEventType.Content) {
+          if (event.type === GeminiEventType.Thought) {
+            if (streamFormatter) {
+              const text = event.value.subject
+                ? `**${event.value.subject}** ${event.value.description}`
+                : event.value.description;
+              streamFormatter.emitEvent({
+                type: JsonStreamEventType.THINKING,
+                timestamp: new Date().toISOString(),
+                content: text,
+                subject: event.value.subject || undefined,
+              });
+            }
+          } else if (event.type === GeminiEventType.Content) {
             const isRaw =
               config.getRawOutput() || config.getAcceptRawOutputRisk();
             const output = isRaw ? event.value : stripAnsi(event.value);

--- a/packages/core/src/output/types.ts
+++ b/packages/core/src/output/types.ts
@@ -56,7 +56,7 @@ export interface MessageEvent extends BaseJsonStreamEvent {
 
 export interface ThinkingEvent extends BaseJsonStreamEvent {
   type: JsonStreamEventType.THINKING;
-  content: string;
+  description: string;
   subject?: string;
 }
 

--- a/packages/core/src/output/types.ts
+++ b/packages/core/src/output/types.ts
@@ -29,6 +29,7 @@ export interface JsonOutput {
 export enum JsonStreamEventType {
   INIT = 'init',
   MESSAGE = 'message',
+  THINKING = 'thinking',
   TOOL_USE = 'tool_use',
   TOOL_RESULT = 'tool_result',
   ERROR = 'error',
@@ -51,6 +52,12 @@ export interface MessageEvent extends BaseJsonStreamEvent {
   role: 'user' | 'assistant';
   content: string;
   delta?: boolean;
+}
+
+export interface ThinkingEvent extends BaseJsonStreamEvent {
+  type: JsonStreamEventType.THINKING;
+  content: string;
+  subject?: string;
 }
 
 export interface ToolUseEvent extends BaseJsonStreamEvent {
@@ -110,6 +117,7 @@ export interface ResultEvent extends BaseJsonStreamEvent {
 export type JsonStreamEvent =
   | InitEvent
   | MessageEvent
+  | ThinkingEvent
   | ToolUseEvent
   | ToolResultEvent
   | ErrorEvent


### PR DESCRIPTION
## Summary

Fixes #22083

When using `--output-format stream-json` with a thinking-capable model (e.g. Gemini 2.5 Pro), model `Thought` events were silently dropped. The interactive UI already handles thinking via `useGeminiStream`, but the non-interactive stream-json path had no corresponding support.

- Add `THINKING = 'thinking'` to `JsonStreamEventType` enum in `packages/core/src/output/types.ts`
- Add `ThinkingEvent` interface (`content: string`, `subject?: string`) to the `JsonStreamEvent` union
- Handle `GeminiEventType.Thought` in `nonInteractiveCli.ts` to emit structured `thinking` events in stream-json mode
- Update `docs/reference/configuration.md` to document all stream-json event types including `thinking`

Example stream-json output with thinking:
```jsonl
{"type":"thinking","timestamp":"2025-...","content":"**Analysis** Let me think through this...","subject":"Analysis"}
```

## Test plan

- [ ] Run `gemini -p "solve step by step: what is 15% of 240" --output-format stream-json` with a thinking-capable model and verify `thinking` events appear in the output
- [ ] Run `npm run preflight` — all checks pass (2 pre-existing flaky UI integration test timeouts unrelated to this change)
- [ ] Verify non-thinking models are unaffected (no `thinking` events emitted when none are produced)