### PR TITLE
Fix build issue

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1063,6 +1063,9 @@ export const useGeminiStream = (
           'Response stopped due to prohibited image content.',
         [FinishReason.NO_IMAGE]:
           'Response stopped because no image was generated.',
+        [FinishReason.IMAGE_RECITATION]:
+          'Response stopped due to image recitation policy.',
+        [FinishReason.IMAGE_OTHER]: 'Response stopped for other image reasons.',
       };
 
       const message = finishReasonMessages[finishReason];

--- a/packages/core/src/telemetry/semantic.ts
+++ b/packages/core/src/telemetry/semantic.ts
@@ -351,6 +351,14 @@ function toOTelFinishReason(finishReason?: string): OTelFinishReason {
       return OTelFinishReason.ERROR;
     case FinishReason.IMAGE_SAFETY:
       return OTelFinishReason.CONTENT_FILTER;
+    case FinishReason.IMAGE_RECITATION:
+      return OTelFinishReason.CONTENT_FILTER;
+    case FinishReason.IMAGE_PROHIBITED_CONTENT:
+      return OTelFinishReason.CONTENT_FILTER;
+    case FinishReason.IMAGE_OTHER:
+      return OTelFinishReason.CONTENT_FILTER;
+    case FinishReason.NO_IMAGE:
+      return OTelFinishReason.STOP;
     case FinishReason.UNEXPECTED_TOOL_CALL:
       return OTelFinishReason.ERROR;
     default:


### PR DESCRIPTION
## Summary

updated  FinishReason values in the @google/genai library.

## Details

Added mappings for IMAGE_RECITATION and IMAGE_OTHER to finishReasonMessages.
This ensures that the Record<FinishReason, string | undefined> is complete and the build succeeds.

## Related Issues

Fixes #22096 



## How to Validate

`npm run build` succeeds without regressing any tests.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [NA] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [✅] Validated on required platforms/methods:
  - [✅] MacOS
    - [✅] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
