### PR TITLE
fix(ui): increase scroll speed in alternate buffer mode

### DIFF
--- a/packages/cli/src/ui/contexts/ScrollProvider.test.tsx
+++ b/packages/cli/src/ui/contexts/ScrollProvider.test.tsx
@@ -276,9 +276,9 @@ describe('ScrollProvider', () => {
     // Advance timers to trigger the batched update
     await vi.runAllTimersAsync();
 
-    // Should have called scrollBy once with accumulated delta (3)
+    // Should have called scrollBy once with accumulated delta (9)
     expect(scrollBy).toHaveBeenCalledTimes(1);
-    expect(scrollBy).toHaveBeenCalledWith(3);
+    expect(scrollBy).toHaveBeenCalledWith(9);
   });
 
   it('handles mixed direction scroll events in batch', async () => {
@@ -299,7 +299,7 @@ describe('ScrollProvider', () => {
       </ScrollProvider>,
     );
 
-    // Simulate mixed scroll events: down (1), down (1), up (-1)
+    // Simulate mixed scroll events: down (3), down (3), up (-3)
     for (const callback of mockUseMouseCallbacks) {
       callback({
         name: 'scroll-down',
@@ -335,7 +335,7 @@ describe('ScrollProvider', () => {
     await vi.runAllTimersAsync();
 
     expect(scrollBy).toHaveBeenCalledTimes(1);
-    expect(scrollBy).toHaveBeenCalledWith(1); // 1 + 1 - 1 = 1
+    expect(scrollBy).toHaveBeenCalledWith(3); // 3 + 3 - 3 = 3
   });
 
   it('respects scroll limits during batching', async () => {
@@ -390,13 +390,9 @@ describe('ScrollProvider', () => {
 
     await vi.runAllTimersAsync();
 
-    // Should have accumulated only 1, because subsequent scrolls would be blocked
-    // Actually, the logic in ScrollProvider uses effectiveScrollTop to check bounds.
-    // scrollTop=89, max=90.
-    // 1st scroll: pending=1, effective=90. Allowed.
-    // 2nd scroll: pending=1, effective=90. canScrollDown checks effective < 90. 90 < 90 is false. Blocked.
+    // Should have accumulated only 3, because subsequent scrolls would be blocked
     expect(scrollBy).toHaveBeenCalledTimes(1);
-    expect(scrollBy).toHaveBeenCalledWith(1);
+    expect(scrollBy).toHaveBeenCalledWith(3);
   });
 
   it('calls scrollTo when dragging scrollbar thumb if available', async () => {

--- a/packages/cli/src/ui/contexts/ScrollProvider.tsx
+++ b/packages/cli/src/ui/contexts/ScrollProvider.tsx
@@ -126,7 +126,7 @@ export const ScrollProvider: React.FC<{ children: React.ReactNode }> = ({
   }, []);
 
   const handleScroll = (direction: 'up' | 'down', mouseEvent: MouseEvent) => {
-    const delta = direction === 'up' ? -1 : 1;
+    const delta = direction === 'up' ? -3 : 3;
     const candidates = findScrollableCandidates(
       mouseEvent,
       scrollablesRef.current,

--- a/packages/cli/src/ui/contexts/ScrollProvider.tsx
+++ b/packages/cli/src/ui/contexts/ScrollProvider.tsx
@@ -72,6 +72,8 @@ const findScrollableCandidates = (
   return candidates;
 };
 
+const MOUSE_SCROLL_DELTA = 3;
+
 export const ScrollProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
@@ -126,7 +128,7 @@ export const ScrollProvider: React.FC<{ children: React.ReactNode }> = ({
   }, []);
 
   const handleScroll = (direction: 'up' | 'down', mouseEvent: MouseEvent) => {
-    const delta = direction === 'up' ? -3 : 3;
+    const delta = direction === 'up' ? -MOUSE_SCROLL_DELTA : MOUSE_SCROLL_DELTA;
     const candidates = findScrollableCandidates(
       mouseEvent,
       scrollablesRef.current,


### PR DESCRIPTION
## Summary

Increase the scroll speed in alternate buffer mode from 1 to 3 lines per event. This makes scrolling more responsive and consistent with standard terminal behavior, especially on desktop mouse wheels and Termux touch gestures.

## Details

Modified `ScrollProvider.tsx` to use a delta of 3 for mouse wheel events. Updated `ScrollProvider.test.tsx` to match the new behavior. Keyboard scroll (Shift+Up/Down) remains at 1 line per event as it's more standard for keypresses (where repeats provide the desired speed).

## Related Issues

Fixes #22131

## How to Validate

1. Start Gemini CLI: `npm run start`
2. Enter a view that has scrolling (e.g. run `/help` or a long conversation).
3. Scroll with mouse wheel (Desktop) or touch swipe (Termux).
4. Observe that scrolling is faster and smoother.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
