### PR TITLE
fix: register themes on extension load not start

### DIFF
--- a/packages/cli/src/config/extension-manager.test.ts
+++ b/packages/cli/src/config/extension-manager.test.ts
@@ -515,7 +515,6 @@ describe('ExtensionManager', () => {
 
       await extensionManager.loadExtensions();
 
-      expect(themeManager.hasExtensionThemes('themed-ext')).toBe(true);
       expect(themeManager.getCustomThemeNames()).toContain(
         'MyTheme (themed-ext)',
       );
@@ -540,7 +539,9 @@ describe('ExtensionManager', () => {
 
       await manager.loadExtensions();
 
-      expect(themeManager.hasExtensionThemes('disabled-ext')).toBe(false);
+      expect(themeManager.getCustomThemeNames()).not.toContain(
+        'MyTheme (disabled-ext)',
+      );
     });
   });
 });

--- a/packages/cli/src/config/extension-manager.test.ts
+++ b/packages/cli/src/config/extension-manager.test.ts
@@ -42,18 +42,21 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
 const testTheme: CustomTheme = {
   type: 'custom',
   name: 'MyTheme',
-  Background: '#000000',
-  Foreground: '#ffffff',
-  LightBlue: '#89BDCD',
-  AccentBlue: '#3B82F6',
-  AccentPurple: '#8B5CF6',
-  AccentCyan: '#06B6D4',
-  AccentGreen: '#3CA84B',
-  AccentYellow: 'yellow',
-  AccentRed: 'red',
-  DiffAdded: 'green',
-  DiffRemoved: 'red',
-  Gray: 'gray',
+  background: {
+    primary: '#282828',
+    diff: { added: '#2b3312', removed: '#341212' },
+  },
+  text: {
+    primary: '#ebdbb2',
+    secondary: '#a89984',
+    link: '#83a598',
+    accent: '#d3869b',
+  },
+  status: {
+    success: '#b8bb26',
+    warning: '#fabd2f',
+    error: '#fb4934',
+  },
 };
 
 describe('ExtensionManager', () => {

--- a/packages/cli/src/config/extension-manager.test.ts
+++ b/packages/cli/src/config/extension-manager.test.ts
@@ -12,12 +12,13 @@ import { ExtensionManager } from './extension-manager.js';
 import { createTestMergedSettings, type MergedSettings } from './settings.js';
 import { createExtension } from '../test-utils/createExtension.js';
 import { EXTENSIONS_DIRECTORY_NAME } from './extensions/variables.js';
+import { themeManager } from '../ui/themes/theme-manager.js';
 import {
   TrustLevel,
   loadTrustedFolders,
   isWorkspaceTrusted,
 } from './trustedFolders.js';
-import { getRealPath } from '@google/gemini-cli-core';
+import { getRealPath, type CustomTheme } from '@google/gemini-cli-core';
 
 const mockHomedir = vi.hoisted(() => vi.fn(() => '/tmp/mock-home'));
 
@@ -37,6 +38,23 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     homedir: mockHomedir,
   };
 });
+
+const testTheme: CustomTheme = {
+  type: 'custom',
+  name: 'MyTheme',
+  Background: '#000000',
+  Foreground: '#ffffff',
+  LightBlue: '#89BDCD',
+  AccentBlue: '#3B82F6',
+  AccentPurple: '#8B5CF6',
+  AccentCyan: '#06B6D4',
+  AccentGreen: '#3CA84B',
+  AccentYellow: 'yellow',
+  AccentRed: 'red',
+  DiffAdded: 'green',
+  DiffRemoved: 'red',
+  Gray: 'gray',
+};
 
 describe('ExtensionManager', () => {
   let tempHomeDir: string;
@@ -65,6 +83,7 @@ describe('ExtensionManager', () => {
   });
 
   afterEach(() => {
+    themeManager.clearExtensionThemes();
     try {
       fs.rmSync(tempHomeDir, { recursive: true, force: true });
     } catch (_e) {
@@ -482,6 +501,46 @@ describe('ExtensionManager', () => {
           { name: 'ext1', version: '1.0.0' },
         ),
       ).rejects.toThrow(/already installed/);
+    });
+  });
+
+  describe('early theme registration', () => {
+    it('should register themes with ThemeManager during loadExtensions for active extensions', async () => {
+      createExtension({
+        extensionsDir: userExtensionsDir,
+        name: 'themed-ext',
+        version: '1.0.0',
+        themes: [testTheme],
+      });
+
+      await extensionManager.loadExtensions();
+
+      expect(themeManager.hasExtensionThemes('themed-ext')).toBe(true);
+      expect(themeManager.getCustomThemeNames()).toContain(
+        'MyTheme (themed-ext)',
+      );
+    });
+
+    it('should not register themes for inactive extensions', async () => {
+      createExtension({
+        extensionsDir: userExtensionsDir,
+        name: 'disabled-ext',
+        version: '1.0.0',
+        themes: [testTheme],
+      });
+
+      // Disable the extension by creating an enablement override
+      const manager = new ExtensionManager({
+        enabledExtensionOverrides: ['none'],
+        settings: createTestMergedSettings(),
+        workspaceDir: tempWorkspaceDir,
+        requestConsent: vi.fn().mockResolvedValue(true),
+        requestSetting: null,
+      });
+
+      await manager.loadExtensions();
+
+      expect(themeManager.hasExtensionThemes('disabled-ext')).toBe(false);
     });
   });
 });

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -624,9 +624,7 @@ Would you like to attempt to install via "git clone" instead?`,
 
         this.loadedExtensions = builtExtensions;
 
-        // Register extension themes early so they're available before
-        // config.initialize() calls startExtension(). Themes are purely
-        // declarative data and don't depend on MCP server initialization.
+        // Register extension themes early so they're available at startup.
         for (const ext of this.loadedExtensions) {
           if (ext.isActive && ext.themes) {
             themeManager.registerExtensionThemes(ext.name, ext.themes);
@@ -674,12 +672,6 @@ Would you like to attempt to install via "git clone" instead?`,
     }
 
     this.loadedExtensions = [...this.loadedExtensions, extension];
-
-    // Register themes early for dynamically loaded extensions too
-    if (extension.isActive && extension.themes) {
-      themeManager.registerExtensionThemes(extension.name, extension.themes);
-    }
-
     await this.maybeStartExtension(extension);
     return extension;
   }

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -564,7 +564,7 @@ Would you like to attempt to install via "git clone" instead?`,
 
   protected override async startExtension(extension: GeminiCLIExtension) {
     await super.startExtension(extension);
-    if (extension.themes) {
+    if (extension.themes && !themeManager.hasExtensionThemes(extension.name)) {
       themeManager.registerExtensionThemes(extension.name, extension.themes);
     }
   }
@@ -624,6 +624,15 @@ Would you like to attempt to install via "git clone" instead?`,
 
         this.loadedExtensions = builtExtensions;
 
+        // Register extension themes early so they're available before
+        // config.initialize() calls startExtension(). Themes are purely
+        // declarative data and don't depend on MCP server initialization.
+        for (const ext of this.loadedExtensions) {
+          if (ext.isActive && ext.themes) {
+            themeManager.registerExtensionThemes(ext.name, ext.themes);
+          }
+        }
+
         await Promise.all(
           this.loadedExtensions.map((ext) => this.maybeStartExtension(ext)),
         );
@@ -665,6 +674,12 @@ Would you like to attempt to install via "git clone" instead?`,
     }
 
     this.loadedExtensions = [...this.loadedExtensions, extension];
+
+    // Register themes early for dynamically loaded extensions too
+    if (extension.isActive && extension.themes) {
+      themeManager.registerExtensionThemes(extension.name, extension.themes);
+    }
+
     await this.maybeStartExtension(extension);
     return extension;
   }

--- a/packages/cli/src/ui/themes/theme-manager.test.ts
+++ b/packages/cli/src/ui/themes/theme-manager.test.ts
@@ -238,22 +238,6 @@ describe('ThemeManager', () => {
       expect(themeManager.isCustomTheme('ExtensionTheme (Ext)')).toBe(true);
       expect(themeManager.isCustomTheme('SettingsTheme')).toBe(true);
     });
-
-    it('should check if extension themes are registered via hasExtensionThemes', () => {
-      const extTheme: CustomTheme = {
-        ...validCustomTheme,
-        name: 'ExtensionTheme',
-      };
-
-      expect(themeManager.hasExtensionThemes('test-ext')).toBe(false);
-
-      themeManager.registerExtensionThemes('test-ext', [extTheme]);
-      expect(themeManager.hasExtensionThemes('test-ext')).toBe(true);
-      expect(themeManager.hasExtensionThemes('other-ext')).toBe(false);
-
-      themeManager.unregisterExtensionThemes('test-ext', [extTheme]);
-      expect(themeManager.hasExtensionThemes('test-ext')).toBe(false);
-    });
   });
 
   describe('terminalBackground override', () => {

--- a/packages/cli/src/ui/themes/theme-manager.test.ts
+++ b/packages/cli/src/ui/themes/theme-manager.test.ts
@@ -238,6 +238,22 @@ describe('ThemeManager', () => {
       expect(themeManager.isCustomTheme('ExtensionTheme (Ext)')).toBe(true);
       expect(themeManager.isCustomTheme('SettingsTheme')).toBe(true);
     });
+
+    it('should check if extension themes are registered via hasExtensionThemes', () => {
+      const extTheme: CustomTheme = {
+        ...validCustomTheme,
+        name: 'ExtensionTheme',
+      };
+
+      expect(themeManager.hasExtensionThemes('test-ext')).toBe(false);
+
+      themeManager.registerExtensionThemes('test-ext', [extTheme]);
+      expect(themeManager.hasExtensionThemes('test-ext')).toBe(true);
+      expect(themeManager.hasExtensionThemes('other-ext')).toBe(false);
+
+      themeManager.unregisterExtensionThemes('test-ext', [extTheme]);
+      expect(themeManager.hasExtensionThemes('test-ext')).toBe(false);
+    });
   });
 
   describe('terminalBackground override', () => {

--- a/packages/cli/src/ui/themes/theme-manager.ts
+++ b/packages/cli/src/ui/themes/theme-manager.ts
@@ -241,6 +241,17 @@ class ThemeManager {
   }
 
   /**
+   * Checks if themes for a given extension are already registered.
+   * @param extensionName The name of the extension.
+   * @returns True if any themes from the extension are registered.
+   */
+  hasExtensionThemes(extensionName: string): boolean {
+    return Array.from(this.extensionThemes.keys()).some((name) =>
+      name.endsWith(`(${extensionName})`),
+    );
+  }
+
+  /**
    * Clears all registered extension themes.
    * This is primarily for testing purposes to reset state between tests.
    */


### PR DESCRIPTION
## Summary

   This PR fixes an issue where extension-provided themes could not be used on launch, causing errors when a user had previously selected a custom extension theme in a previous session. 

<img width="600" height="2094" alt="image" src="https://github.com/user-attachments/assets/557472d5-57b9-4e8d-9eb9-77bd1247a372" />

By registering themes earlier in the extension loading lifecycle, we ensure they are available before the application's configuration is fully initialized.

   ## Details

   - **Early Registration:** Modified `ExtensionManager.loadExtensions()` and `loadExtension()` to register declarative
   theme data immediately after extensions are loaded. This decouples theme availability from MCP server initialization in
   `startExtension()`.
   - **Deduplication:** Added `ThemeManager.hasExtensionThemes()` to track and prevent redundant theme registrations.

   ## Related Issues

   ## How to Validate

   1. Install or create an extension that provides a custom theme.
   2. Select that theme in your settings.
   3. Restart the CLI and verify it launches without errors and correctly applies the theme.
   4. Run the updated tests:
      ```bash
      npm test -w @google/gemini-cli -- src/config/extension-manager.test.ts src/ui/themes/theme-manager.test.ts
      ```

   ## Pre-Merge Checklist

   - [ ] Updated relevant documentation and README (if needed)
   - [x] Added/updated tests (if needed)
   - [ ] Noted breaking changes (if any)
   - [ ] Validated on required platforms/methods:
     - [x] MacOS
       - [x] npm run
       - [ ] npx
       - [ ] Docker
       - [ ] Podman
       - [ ] Seatbelt
     - [ ] Windows
       - [ ] npm run
       - [ ] npx
       - [ ] Docker
     - [ ] Linux
       - [ ] npm run
       - [ ] npx
       - [ ] Docker