### PR TITLE
docs: fix broken docs/architecture.md references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -365,7 +365,7 @@ npm run lint
 - `docs/`: Contains all project documentation.
 - `scripts/`: Utility scripts for building, testing, and development tasks.
 
-For more detailed architecture, see `docs/architecture.md`.
+For more detailed architecture, see `docs/core/index.md`.
 
 ### Debugging
 

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ gemini
 
 - [**Headless Mode (Scripting)**](./docs/cli/headless.md) - Use Gemini CLI in
   automated workflows.
-- [**Architecture Overview**](./docs/architecture.md) - How Gemini CLI works.
+- [**Architecture Overview**](./docs/core/index.md) - How Gemini CLI works.
 - [**IDE Integration**](./docs/ide-integration/index.md) - VS Code companion.
 - [**Sandboxing & Security**](./docs/cli/sandbox.md) - Safe execution
   environments.


### PR DESCRIPTION
## Summary\n- replace stale \docs/architecture.md\ links with \docs/core/index.md\\n- update both \README.md\ and \CONTRIBUTING.md\\n\n## Why\nIssue #22150 reports that \docs/architecture.md\ does not exist, causing broken links in contributor docs.\n\nCloses #22150