### PR TITLE
feat(ui): Do not show Ultra users /upgrade hint (#22154)

### DIFF
--- a/packages/cli/src/ui/commands/upgradeCommand.test.ts
+++ b/packages/cli/src/ui/commands/upgradeCommand.test.ts
@@ -37,6 +37,7 @@ describe('upgradeCommand', () => {
           getContentGeneratorConfig: vi.fn().mockReturnValue({
             authType: AuthType.LOGIN_WITH_GOOGLE,
           }),
+          getUserTierName: vi.fn().mockReturnValue(undefined),
         },
       },
     } as unknown as CommandContext);
@@ -112,6 +113,25 @@ describe('upgradeCommand', () => {
       type: 'message',
       messageType: 'info',
       content: `Please open this URL in a browser: ${UPGRADE_URL_PAGE}`,
+    });
+    expect(openBrowserSecurely).not.toHaveBeenCalled();
+  });
+
+  it('should return info message for ultra tiers', async () => {
+    vi.mocked(mockContext.services.config!.getUserTierName).mockReturnValue(
+      'Advanced Ultra',
+    );
+
+    if (!upgradeCommand.action) {
+      throw new Error('The upgrade command must have an action.');
+    }
+
+    const result = await upgradeCommand.action(mockContext, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'You are already on the highest tier: Advanced Ultra.',
     });
     expect(openBrowserSecurely).not.toHaveBeenCalled();
   });

--- a/packages/cli/src/ui/commands/upgradeCommand.ts
+++ b/packages/cli/src/ui/commands/upgradeCommand.ts
@@ -35,6 +35,15 @@ export const upgradeCommand: SlashCommand = {
       };
     }
 
+    const tierName = context.services.config?.getUserTierName();
+    if (tierName?.toLowerCase().includes('ultra')) {
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: `You are already on the highest tier: ${tierName}.`,
+      };
+    }
+
     if (!shouldLaunchBrowser()) {
       return {
         type: 'message',

--- a/packages/cli/src/ui/commands/upgradeCommand.ts
+++ b/packages/cli/src/ui/commands/upgradeCommand.ts
@@ -10,6 +10,7 @@ import {
   shouldLaunchBrowser,
   UPGRADE_URL_PAGE,
 } from '@google/gemini-cli-core';
+import { isUltraTier } from '../../utils/tierUtils.js';
 import { CommandKind, type SlashCommand } from './types.js';
 
 /**
@@ -36,7 +37,7 @@ export const upgradeCommand: SlashCommand = {
     }
 
     const tierName = context.services.config?.getUserTierName();
-    if (tierName?.toLowerCase().includes('ultra')) {
+    if (isUltraTier(tierName)) {
       return {
         type: 'message',
         messageType: 'info',

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -87,6 +87,7 @@ export const DialogManager = ({
           !!uiState.quota.proQuotaRequest.isModelNotFoundError
         }
         authType={uiState.quota.proQuotaRequest.authType}
+        tierName={config?.getUserTierName()}
         onChoice={uiActions.handleProQuotaChoice}
       />
     );

--- a/packages/cli/src/ui/components/ProQuotaDialog.test.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.test.tsx
@@ -202,6 +202,40 @@ describe('ProQuotaDialog', () => {
         );
         unmount();
       });
+
+      it('should NOT render upgrade option for LOGIN_WITH_GOOGLE if tier is Ultra', () => {
+        const { unmount } = render(
+          <ProQuotaDialog
+            failedModel="gemini-2.5-pro"
+            fallbackModel="gemini-2.5-flash"
+            message="free tier quota error"
+            isTerminalQuotaError={true}
+            isModelNotFoundError={false}
+            authType={AuthType.LOGIN_WITH_GOOGLE}
+            tierName="Gemini Advanced Ultra"
+            onChoice={mockOnChoice}
+          />,
+        );
+
+        expect(RadioButtonSelect).toHaveBeenCalledWith(
+          expect.objectContaining({
+            items: [
+              {
+                label: 'Switch to gemini-2.5-flash',
+                value: 'retry_always',
+                key: 'retry_always',
+              },
+              {
+                label: 'Stop',
+                value: 'retry_later',
+                key: 'retry_later',
+              },
+            ],
+          }),
+          undefined,
+        );
+        unmount();
+      });
     });
 
     describe('when it is a capacity error', () => {

--- a/packages/cli/src/ui/components/ProQuotaDialog.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.tsx
@@ -17,6 +17,7 @@ interface ProQuotaDialogProps {
   isTerminalQuotaError: boolean;
   isModelNotFoundError?: boolean;
   authType?: AuthType;
+  tierName?: string;
   onChoice: (
     choice: 'retry_later' | 'retry_once' | 'retry_always' | 'upgrade',
   ) => void;
@@ -29,6 +30,7 @@ export function ProQuotaDialog({
   isTerminalQuotaError,
   isModelNotFoundError,
   authType,
+  tierName,
   onChoice,
 }: ProQuotaDialogProps): React.JSX.Element {
   let items;
@@ -47,6 +49,8 @@ export function ProQuotaDialog({
       },
     ];
   } else if (isModelNotFoundError || isTerminalQuotaError) {
+    const isUltra = tierName?.toLowerCase().includes('ultra');
+
     // free users and out of quota users on G1 pro and Cloud Console gets an option to upgrade
     items = [
       {
@@ -54,7 +58,7 @@ export function ProQuotaDialog({
         value: 'retry_always' as const,
         key: 'retry_always',
       },
-      ...(authType === AuthType.LOGIN_WITH_GOOGLE
+      ...(authType === AuthType.LOGIN_WITH_GOOGLE && !isUltra
         ? [
             {
               label: 'Upgrade for higher limits',

--- a/packages/cli/src/ui/components/ProQuotaDialog.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.tsx
@@ -9,6 +9,7 @@ import { Box, Text } from 'ink';
 import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
 import { theme } from '../semantic-colors.js';
 import { AuthType } from '@google/gemini-cli-core';
+import { isUltraTier } from '../../utils/tierUtils.js';
 
 interface ProQuotaDialogProps {
   failedModel: string;
@@ -49,7 +50,7 @@ export function ProQuotaDialog({
       },
     ];
   } else if (isModelNotFoundError || isTerminalQuotaError) {
-    const isUltra = tierName?.toLowerCase().includes('ultra');
+    const isUltra = isUltraTier(tierName);
 
     // free users and out of quota users on G1 pro and Cloud Console gets an option to upgrade
     items = [

--- a/packages/cli/src/ui/components/UserIdentity.test.tsx
+++ b/packages/cli/src/ui/components/UserIdentity.test.tsx
@@ -182,4 +182,23 @@ describe('<UserIdentity />', () => {
     expect(output).toContain('/upgrade');
     unmount();
   });
+
+  it('should not render /upgrade indicator for ultra tiers', async () => {
+    const mockConfig = makeFakeConfig();
+    vi.spyOn(mockConfig, 'getContentGeneratorConfig').mockReturnValue({
+      authType: AuthType.LOGIN_WITH_GOOGLE,
+      model: 'gemini-pro',
+    } as unknown as ContentGeneratorConfig);
+    vi.spyOn(mockConfig, 'getUserTierName').mockReturnValue('Advanced Ultra');
+
+    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
+      <UserIdentity config={mockConfig} />,
+    );
+    await waitUntilReady();
+
+    const output = lastFrame();
+    expect(output).toContain('Plan: Advanced Ultra');
+    expect(output).not.toContain('/upgrade');
+    unmount();
+  });
 });

--- a/packages/cli/src/ui/components/UserIdentity.tsx
+++ b/packages/cli/src/ui/components/UserIdentity.tsx
@@ -13,6 +13,7 @@ import {
   UserAccountManager,
   AuthType,
 } from '@google/gemini-cli-core';
+import { isUltraTier } from '../../utils/tierUtils.js';
 
 interface UserIdentityProps {
   config: Config;
@@ -33,10 +34,7 @@ export const UserIdentity: React.FC<UserIdentityProps> = ({ config }) => {
     [config, authType],
   );
 
-  const isUltra = useMemo(
-    () => tierName?.toLowerCase().includes('ultra'),
-    [tierName],
-  );
+  const isUltra = useMemo(() => isUltraTier(tierName), [tierName]);
 
   if (!authType) {
     return null;

--- a/packages/cli/src/ui/components/UserIdentity.tsx
+++ b/packages/cli/src/ui/components/UserIdentity.tsx
@@ -33,6 +33,11 @@ export const UserIdentity: React.FC<UserIdentityProps> = ({ config }) => {
     [config, authType],
   );
 
+  const isUltra = useMemo(
+    () => tierName?.toLowerCase().includes('ultra'),
+    [tierName],
+  );
+
   if (!authType) {
     return null;
   }
@@ -60,7 +65,7 @@ export const UserIdentity: React.FC<UserIdentityProps> = ({ config }) => {
           <Text color={theme.text.primary} wrap="truncate-end">
             <Text bold>Plan:</Text> {tierName}
           </Text>
-          <Text color={theme.text.secondary}> /upgrade</Text>
+          {!isUltra && <Text color={theme.text.secondary}> /upgrade</Text>}
         </Box>
       )}
     </Box>

--- a/packages/cli/src/utils/tierUtils.test.ts
+++ b/packages/cli/src/utils/tierUtils.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isUltraTier } from './tierUtils.js';
+
+describe('tierUtils', () => {
+  describe('isUltraTier', () => {
+    it('should return true if tier name contains "ultra" (case-insensitive)', () => {
+      expect(isUltraTier('Advanced Ultra')).toBe(true);
+      expect(isUltraTier('gemini ultra')).toBe(true);
+      expect(isUltraTier('ULTRA')).toBe(true);
+    });
+
+    it('should return false if tier name does not contain "ultra"', () => {
+      expect(isUltraTier('Free')).toBe(false);
+      expect(isUltraTier('Pro')).toBe(false);
+      expect(isUltraTier('Standard')).toBe(false);
+    });
+
+    it('should return false if tier name is undefined', () => {
+      expect(isUltraTier(undefined)).toBe(false);
+    });
+  });
+});

--- a/packages/cli/src/utils/tierUtils.ts
+++ b/packages/cli/src/utils/tierUtils.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Checks if the given tier name corresponds to an "Ultra" tier.
+ *
+ * @param tierName The name of the user's tier.
+ * @returns True if the tier is an "Ultra" tier, false otherwise.
+ */
+export function isUltraTier(tierName?: string): boolean {
+  return !!tierName?.toLowerCase().includes('ultra');
+}


### PR DESCRIPTION
## Summary

Correctly identify users on "Ultra" tiers (e.g., Gemini Advanced Ultra) and adjust the UI accordingly. This includes hiding the `/upgrade` command hint, showing the correct plan name, and removing the "Upgrade" option from quota dialogs.

## Details

- Updated `upgradeCommand.ts` to show an info message for ultra tiers instead of opening the upgrade URL.
- Updated `UserIdentity.tsx` to hide the `/upgrade` hint when the user is on an ultra tier.
- Updated `ProQuotaDialog.tsx` to remove the "Upgrade" option when the user is on an ultra tier.
- Added tests for all updated components and commands to verify behavior for both ultra and non-ultra tiers.

## Related Issues

Fixes #22154

## How to Validate

1. Mock a user tier containing "Ultra" (e.g., "Advanced Ultra").
2. Observe that `/upgrade` hint is hidden in the prompt.
3. Run `/upgrade` command and confirm it returns: `You are already on the highest tier: Advanced Ultra.`
4. Trigger a quota error and confirm the "Upgrade" option is missing from the dialog.
5. Run tests: `npm test -w @google/gemini-cli -- src/ui/commands/upgradeCommand.test.ts src/ui/components/ProQuotaDialog.test.tsx src/ui/components/UserIdentity.test.tsx`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
