### PR TITLE
feat(core): add custom editor support via VISUAL/EDITOR env vars

### DIFF
--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -22,6 +22,7 @@ import {
   isEditorAvailable,
   isEditorAvailableAsync,
   resolveEditorAsync,
+  resolveCustomEditorCommand,
   type EditorType,
 } from './editor.js';
 import { coreEvents, CoreEvent } from './events.js';
@@ -775,6 +776,162 @@ describe('editor utils', () => {
       const result = await resolvePromise;
       expect(result).toBe('vim');
       expect(emitSpy).toHaveBeenCalledWith(CoreEvent.RequestEditorSelection);
+    });
+  });
+
+  describe('resolveCustomEditorCommand', () => {
+    it('should return $VISUAL when set', () => {
+      vi.stubEnv('VISUAL', '/usr/local/bin/code');
+      vi.stubEnv('EDITOR', 'vim');
+      expect(resolveCustomEditorCommand()).toBe('/usr/local/bin/code');
+    });
+
+    it('should return $EDITOR when $VISUAL is not set', () => {
+      vi.stubEnv('VISUAL', '');
+      vi.stubEnv('EDITOR', 'vim');
+      expect(resolveCustomEditorCommand()).toBe('vim');
+    });
+
+    it('should return undefined when neither variable is set', () => {
+      vi.stubEnv('VISUAL', '');
+      vi.stubEnv('EDITOR', '');
+      expect(resolveCustomEditorCommand()).toBeUndefined();
+    });
+
+    it('should trim whitespace from $VISUAL', () => {
+      vi.stubEnv('VISUAL', '  /usr/local/bin/code  ');
+      expect(resolveCustomEditorCommand()).toBe('/usr/local/bin/code');
+    });
+
+    it('should trim whitespace from $EDITOR', () => {
+      vi.stubEnv('VISUAL', '');
+      vi.stubEnv('EDITOR', '  vim  ');
+      expect(resolveCustomEditorCommand()).toBe('vim');
+    });
+  });
+
+  describe('custom editor type', () => {
+    describe('hasValidEditorCommand', () => {
+      it('should return true when $VISUAL points to an installed command', () => {
+        vi.stubEnv('VISUAL', '/usr/local/bin/code');
+        (execSync as Mock).mockReturnValue(Buffer.from('/usr/local/bin/code'));
+        expect(hasValidEditorCommand('custom')).toBe(true);
+      });
+
+      it('should return false when no env vars are set', () => {
+        vi.stubEnv('VISUAL', '');
+        vi.stubEnv('EDITOR', '');
+        expect(hasValidEditorCommand('custom')).toBe(false);
+      });
+
+      it('should return false when $EDITOR command is not installed', () => {
+        vi.stubEnv('VISUAL', '');
+        vi.stubEnv('EDITOR', 'my-editor');
+        (execSync as Mock).mockImplementation(() => {
+          throw new Error();
+        });
+        expect(hasValidEditorCommand('custom')).toBe(false);
+      });
+    });
+
+    describe('hasValidEditorCommandAsync', () => {
+      it('should return true when $VISUAL points to an installed command', async () => {
+        vi.stubEnv('VISUAL', '/usr/local/bin/code');
+        mockExecAsync((cmd) => cmd.includes('/usr/local/bin/code'));
+        expect(await hasValidEditorCommandAsync('custom')).toBe(true);
+      });
+
+      it('should return false when no env vars are set', async () => {
+        vi.stubEnv('VISUAL', '');
+        vi.stubEnv('EDITOR', '');
+        expect(await hasValidEditorCommandAsync('custom')).toBe(false);
+      });
+    });
+
+    describe('getDiffCommand', () => {
+      it('should reuse vscode diff args when $VISUAL is code', () => {
+        vi.stubEnv('VISUAL', '/usr/local/bin/code');
+        const result = getDiffCommand('old.txt', 'new.txt', 'custom');
+        expect(result).toEqual({
+          command: '/usr/local/bin/code',
+          args: ['--wait', '--diff', 'old.txt', 'new.txt'],
+        });
+      });
+
+      it('should reuse vim diff args when $EDITOR is vim', () => {
+        vi.stubEnv('VISUAL', '');
+        vi.stubEnv('EDITOR', '/usr/bin/vim');
+        const result = getDiffCommand('old.txt', 'new.txt', 'custom');
+        expect(result).not.toBeNull();
+        expect(result!.command).toBe('/usr/bin/vim');
+        expect(result!.args[0]).toBe('-d');
+      });
+
+      it('should reuse zed diff args when $VISUAL is zeditor', () => {
+        vi.stubEnv('VISUAL', '/usr/local/bin/zeditor');
+        const result = getDiffCommand('old.txt', 'new.txt', 'custom');
+        expect(result).toEqual({
+          command: '/usr/local/bin/zeditor',
+          args: ['--wait', '--diff', 'old.txt', 'new.txt'],
+        });
+      });
+
+      it('should open only the new file for an unrecognized editor', () => {
+        vi.stubEnv('VISUAL', '/usr/local/bin/my-editor');
+        const result = getDiffCommand('old.txt', 'new.txt', 'custom');
+        expect(result).toEqual({
+          command: '/usr/local/bin/my-editor',
+          args: ['new.txt'],
+        });
+      });
+
+      it('should return null when no env var is set', () => {
+        vi.stubEnv('VISUAL', '');
+        vi.stubEnv('EDITOR', '');
+        const result = getDiffCommand('old.txt', 'new.txt', 'custom');
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('allowEditorTypeInSandbox', () => {
+      it('should block custom editor in sandbox when it maps to a GUI editor', () => {
+        vi.stubEnv('VISUAL', '/usr/local/bin/code');
+        vi.stubEnv('SANDBOX', 'sandbox');
+        expect(allowEditorTypeInSandbox('custom')).toBe(false);
+      });
+
+      it('should allow custom editor in sandbox when it maps to a terminal editor', () => {
+        vi.stubEnv('VISUAL', '/usr/bin/vim');
+        vi.stubEnv('SANDBOX', 'sandbox');
+        expect(allowEditorTypeInSandbox('custom')).toBe(true);
+      });
+
+      it('should allow custom editor in sandbox when it is unrecognized', () => {
+        vi.stubEnv('VISUAL', '/usr/local/bin/my-editor');
+        vi.stubEnv('SANDBOX', 'sandbox');
+        expect(allowEditorTypeInSandbox('custom')).toBe(true);
+      });
+
+      it('should allow custom editor outside sandbox regardless of type', () => {
+        vi.stubEnv('VISUAL', '/usr/local/bin/code');
+        vi.stubEnv('SANDBOX', '');
+        expect(allowEditorTypeInSandbox('custom')).toBe(true);
+      });
+    });
+
+    describe('isEditorAvailable', () => {
+      it('should return true when $VISUAL is set and command exists', () => {
+        vi.stubEnv('VISUAL', '/usr/local/bin/code');
+        vi.stubEnv('SANDBOX', '');
+        (execSync as Mock).mockReturnValue(Buffer.from('/usr/local/bin/code'));
+        expect(isEditorAvailable('custom')).toBe(true);
+      });
+
+      it('should return false when no env var is set', () => {
+        vi.stubEnv('VISUAL', '');
+        vi.stubEnv('EDITOR', '');
+        expect(isEditorAvailable('custom')).toBe(false);
+      });
     });
   });
 });

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -93,7 +93,8 @@ const COMMAND_TO_EDITOR: Record<string, BuiltinEditorType> = {
   nvim: 'neovim',
   emacs: 'emacs',
   'emacs.exe': 'emacs',
-  nano: 'vim', // nano lacks diff mode; fall back to opening new file
+  // nano intentionally omitted: it lacks diff mode, so the custom editor
+  // fallback path will open only the new file, which is the safest behavior.
   hx: 'hx',
   zed: 'zed',
   zeditor: 'zed',

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -19,7 +19,8 @@ const GUI_EDITORS = [
   'antigravity',
 ] as const;
 const TERMINAL_EDITORS = ['vim', 'neovim', 'emacs', 'hx'] as const;
-const EDITORS = [...GUI_EDITORS, ...TERMINAL_EDITORS] as const;
+const BUILTIN_EDITORS = [...GUI_EDITORS, ...TERMINAL_EDITORS] as const;
+const EDITORS = [...BUILTIN_EDITORS, 'custom'] as const;
 
 const GUI_EDITORS_SET = new Set<string>(GUI_EDITORS);
 const TERMINAL_EDITORS_SET = new Set<string>(TERMINAL_EDITORS);
@@ -32,6 +33,7 @@ export const DEFAULT_GUI_EDITOR: GuiEditorType = 'vscode';
 
 export type GuiEditorType = (typeof GUI_EDITORS)[number];
 export type TerminalEditorType = (typeof TERMINAL_EDITORS)[number];
+export type BuiltinEditorType = (typeof BUILTIN_EDITORS)[number];
 export type EditorType = (typeof EDITORS)[number];
 
 export function isGuiEditor(editor: EditorType): editor is GuiEditorType {
@@ -55,6 +57,7 @@ export const EDITOR_DISPLAY_NAMES: Record<EditorType, string> = {
   emacs: 'Emacs',
   antigravity: 'Antigravity',
   hx: 'Helix',
+  custom: 'Custom ($VISUAL / $EDITOR)',
 };
 
 export function getEditorDisplayName(editor: EditorType): string {
@@ -71,6 +74,58 @@ function isValidEditorType(editor: string): editor is EditorType {
  */
 function escapeELispString(str: string): string {
   return `"${str.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Maps the basename of a command to a known built-in editor type so that
+ * custom editor commands (from $VISUAL / $EDITOR) can reuse the diff
+ * arguments and execution strategy of a recognized editor.
+ */
+const COMMAND_TO_EDITOR: Record<string, BuiltinEditorType> = {
+  code: 'vscode',
+  codium: 'vscodium',
+  'code.cmd': 'vscode',
+  'codium.cmd': 'vscodium',
+  windsurf: 'windsurf',
+  cursor: 'cursor',
+  vim: 'vim',
+  vi: 'vim',
+  nvim: 'neovim',
+  emacs: 'emacs',
+  'emacs.exe': 'emacs',
+  nano: 'vim', // nano lacks diff mode; fall back to opening new file
+  hx: 'hx',
+  zed: 'zed',
+  zeditor: 'zed',
+  agy: 'antigravity',
+  antigravity: 'antigravity',
+};
+
+/**
+ * Resolves the editor command from the $VISUAL and $EDITOR environment
+ * variables, following the POSIX convention of preferring $VISUAL.
+ * Returns undefined when neither variable is set to a non-empty value.
+ */
+export function resolveCustomEditorCommand(): string | undefined {
+  const visual = process.env['VISUAL']?.trim();
+  if (visual) {
+    return visual;
+  }
+  const editor = process.env['EDITOR']?.trim();
+  if (editor) {
+    return editor;
+  }
+  return undefined;
+}
+
+/**
+ * Given a command string (potentially a full path), extracts the basename
+ * and returns the matching built-in editor type, or undefined if no match.
+ */
+function detectEditorFlavor(command: string): BuiltinEditorType | undefined {
+  const parts = command.split(/[\\/]/);
+  const basename = parts[parts.length - 1];
+  return COMMAND_TO_EDITOR[basename];
 }
 
 interface DiffCommand {
@@ -109,7 +164,7 @@ async function commandExistsAsync(cmd: string): Promise<boolean> {
  * Each editor can have multiple possible command names, listed in order of preference.
  */
 const editorCommands: Record<
-  EditorType,
+  BuiltinEditorType,
   { win32: string[]; default: string[] }
 > = {
   vscode: { win32: ['code.cmd'], default: ['code'] },
@@ -128,6 +183,10 @@ const editorCommands: Record<
 };
 
 function getEditorCommands(editor: EditorType): string[] {
+  if (editor === 'custom') {
+    const cmd = resolveCustomEditorCommand();
+    return cmd ? [cmd] : [];
+  }
   const commandConfig = editorCommands[editor];
   return process.platform === 'win32'
     ? commandConfig.win32
@@ -135,12 +194,20 @@ function getEditorCommands(editor: EditorType): string[] {
 }
 
 export function hasValidEditorCommand(editor: EditorType): boolean {
+  if (editor === 'custom') {
+    const cmd = resolveCustomEditorCommand();
+    return !!cmd && commandExists(cmd);
+  }
   return getEditorCommands(editor).some((cmd) => commandExists(cmd));
 }
 
 export async function hasValidEditorCommandAsync(
   editor: EditorType,
 ): Promise<boolean> {
+  if (editor === 'custom') {
+    const cmd = resolveCustomEditorCommand();
+    return !!cmd && commandExistsAsync(cmd);
+  }
   return Promise.any(
     getEditorCommands(editor).map((cmd) =>
       commandExistsAsync(cmd).then((exists) => exists || Promise.reject()),
@@ -149,6 +216,9 @@ export async function hasValidEditorCommandAsync(
 }
 
 export function getEditorCommand(editor: EditorType): string {
+  if (editor === 'custom') {
+    return resolveCustomEditorCommand() || '';
+  }
   const commands = getEditorCommands(editor);
   return (
     commands.slice(0, -1).find((cmd) => commandExists(cmd)) ||
@@ -158,6 +228,18 @@ export function getEditorCommand(editor: EditorType): string {
 
 export function allowEditorTypeInSandbox(editor: EditorType): boolean {
   const notUsingSandbox = !process.env['SANDBOX'];
+  if (editor === 'custom') {
+    // For custom editors, check what the resolved command maps to.
+    // If it maps to a GUI editor, block in sandbox; otherwise allow.
+    const cmd = resolveCustomEditorCommand();
+    if (cmd) {
+      const flavor = detectEditorFlavor(cmd);
+      if (flavor && isGuiEditor(flavor)) {
+        return notUsingSandbox;
+      }
+    }
+    return true;
+  }
   if (isGuiEditor(editor)) {
     return notUsingSandbox;
   }
@@ -227,6 +309,26 @@ export function getDiffCommand(
   if (!isValidEditorType(editor)) {
     return null;
   }
+
+  // For custom editors, resolve the command from env vars and delegate
+  // to the matching built-in editor's diff args when possible.
+  if (editor === 'custom') {
+    const command = resolveCustomEditorCommand();
+    if (!command) {
+      return null;
+    }
+    const flavor = detectEditorFlavor(command);
+    if (flavor) {
+      // Reuse the built-in editor's diff arguments with the custom command
+      const builtinDiff = getDiffCommand(oldPath, newPath, flavor);
+      if (builtinDiff) {
+        return { command, args: builtinDiff.args };
+      }
+    }
+    // Unknown editor: just open the new file for editing
+    return { command, args: [newPath] };
+  }
+
   const command = getEditorCommand(editor);
 
   switch (editor) {


### PR DESCRIPTION
## Summary
- Adds a `custom` editor type that resolves the user's preferred editor from the standard `$VISUAL` and `$EDITOR` environment variables (POSIX convention, `$VISUAL` takes precedence)
- When the resolved command maps to a known built-in editor (e.g. `code` -> VS Code, `nvim` -> Neovim), its diff arguments are reused automatically
- Unrecognized editors fall back to opening the new file directly

## Changes
- `packages/core/src/utils/editor.ts`: Added `custom` to `EditorType`, added `resolveCustomEditorCommand()`, `detectEditorFlavor()`, and updated all editor functions to handle the new type
- `packages/core/src/utils/editor.test.ts`: Added 20 new tests covering env var resolution, flavor detection, diff commands, sandbox behavior, and availability checks

## Test plan
- [x] All 181 editor tests pass (`npx vitest run packages/core/src/utils/editor.test.ts`)
- [x] EditorSettingsDialog tests pass (5/5)
- [x] TypeScript build succeeds (`npx tsc --build`)
- [x] Lint passes (`npm run lint:ci`)
- [x] Format passes (`npm run format`)
- [ ] Manual: Set `$VISUAL=code` and verify `/editor` shows "Custom ($VISUAL / $EDITOR)" option
- [ ] Manual: Select custom editor and confirm diff opens in VS Code with `--wait --diff` args
- [ ] Manual: Set `$EDITOR=my-unknown-editor` and confirm it falls back to opening the new file only

Closes #1698