### PR TITLE
fix(cli): make extension relink idempotent for same path

### DIFF
--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -191,7 +191,7 @@ export class ExtensionManager extends ExtensionLoader {
       );
     }
 
-    const isUpdate = !!previousExtensionConfig;
+    let isUpdate = !!previousExtensionConfig;
     let newExtensionConfig: ExtensionConfig | null = null;
     let localSourcePath: string | undefined;
     let extension: GeminiCLIExtension | null;
@@ -280,6 +280,20 @@ Would you like to attempt to install via "git clone" instead?`,
         const previous = this.getExtensions().find(
           (installed) => installed.name === previousName,
         );
+        const isSameLinkRelink =
+          !isUpdate &&
+          installMetadata.type === 'link' &&
+          previous?.installMetadata?.type === 'link' &&
+          getRealPath(previous.installMetadata.source) ===
+            getRealPath(installMetadata.source);
+
+        if (isSameLinkRelink) {
+          isUpdate = true;
+          previousExtensionConfig = await this.loadExtensionConfig(
+            previous.path,
+          );
+        }
+
         const nameConflict = this.getExtensions().find(
           (installed) =>
             installed.name === newExtensionName &&
@@ -435,7 +449,7 @@ Would you like to attempt to install via "git clone" instead?`,
               hashValue(newExtensionConfig.name),
               getExtensionId(newExtensionConfig, installMetadata),
               newExtensionConfig.version,
-              previousExtensionConfig.version,
+              previousExtensionConfig!.version,
               installMetadata.type,
               CoreToolCallStatus.Success,
             ),
@@ -497,7 +511,7 @@ Would you like to attempt to install via "git clone" instead?`,
             hashValue(config?.name ?? ''),
             extensionId ?? '',
             newExtensionConfig?.version ?? '',
-            previousExtensionConfig.version,
+            previousExtensionConfig!.version,
             installMetadata.type,
             CoreToolCallStatus.Error,
           ),

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -1176,6 +1176,63 @@ name = "yolo-checker"
       );
     });
 
+    it('should allow relinking an extension from the same path', async () => {
+      const sourceExtDir = createExtension({
+        extensionsDir: tempHomeDir,
+        name: 'my-linked-extension',
+        version: '1.0.0',
+      });
+
+      await extensionManager.loadExtensions();
+      await extensionManager.installOrUpdateExtension({
+        source: sourceExtDir,
+        type: 'link',
+      });
+
+      await expect(
+        extensionManager.installOrUpdateExtension({
+          source: sourceExtDir,
+          type: 'link',
+        }),
+      ).resolves.toMatchObject({
+        name: 'my-linked-extension',
+        installMetadata: {
+          source: sourceExtDir,
+          type: 'link',
+        },
+      });
+    });
+
+    it('should still reject relinking an extension from a different path with the same name', async () => {
+      const originalSourceExtDir = createExtension({
+        extensionsDir: tempHomeDir,
+        name: 'my-linked-extension',
+        version: '1.0.0',
+      });
+      const secondSourceExtDir = createExtension({
+        extensionsDir: fs.mkdtempSync(
+          path.join(tempHomeDir, 'other-ext-root-'),
+        ),
+        name: 'my-linked-extension',
+        version: '1.0.0',
+      });
+
+      await extensionManager.loadExtensions();
+      await extensionManager.installOrUpdateExtension({
+        source: originalSourceExtDir,
+        type: 'link',
+      });
+
+      await expect(
+        extensionManager.installOrUpdateExtension({
+          source: secondSourceExtDir,
+          type: 'link',
+        }),
+      ).rejects.toThrow(
+        'Extension "my-linked-extension" is already installed. Please uninstall it first.',
+      );
+    });
+
     it('should throw an error and cleanup if gemini-extension.json is missing', async () => {
       const sourceExtDir = getRealPath(path.join(tempHomeDir, 'bad-extension'));
       fs.mkdirSync(sourceExtDir, { recursive: true });


### PR DESCRIPTION
## Summary

Make `gemini extensions link <path>` idempotent when the same extension is relinked from the same local path.

## Details

`ExtensionManager.installOrUpdateExtension()` previously treated every repeated `link` call as a fresh install and rejected it with an `already installed` error.

This change detects the narrow same-path relink case and treats it as an update instead, while preserving the existing error for a different path that happens to produce the same extension name.

I also added focused tests for both cases.

## Related Issues

Fixes #22125

## How to Validate

1. Run `npm run build --workspace @google/gemini-cli-core --workspace @google/gemini-cli`
2. Run `npm exec --workspace @google/gemini-cli vitest run src/config/extension.test.ts src/commands/extensions/link.test.ts`
3. Verify same-path relink behavior manually or with a small `ExtensionManager` repro:
   - first `installOrUpdateExtension({ source, type: 'link' })` succeeds
   - second call with the same `source` also succeeds
   - relinking from a different path with the same extension name still throws `already installed`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
