### PR TITLE
fix(core): ensure AgentLoopContext getters are preserved in updatePolicy

### DIFF
--- a/packages/core/src/scheduler/policy.ts
+++ b/packages/core/src/scheduler/policy.ts
@@ -116,7 +116,11 @@ export async function updatePolicy(
   context: AgentLoopContext,
   toolInvocation?: AnyToolInvocation,
 ): Promise<void> {
-  const deps = { ...context, toolInvocation };
+  const deps = {
+    config: context.config,
+    messageBus: context.messageBus,
+    toolInvocation,
+  };
 
   // Mode Transitions (AUTO_EDIT)
   if (isAutoEditTransition(tool, outcome)) {


### PR DESCRIPTION
## Summary

This PR fixes a regression where selecting "Always Allow" on a tool confirmation would cause a crash with `"Cannot read properties of undefined (reading 'publish')"`.

## Details

The bug was in `packages/core/src/scheduler/policy.ts`. The code was using the spread operator `{ ...context }` on an object implementing `AgentLoopContext` (typically a `Config` instance). In JavaScript, the spread operator only copies own enumerable properties and does not copy prototype getters. Since `messageBus` and `config` are defined as getters on the class prototype, they were missing from the resulting `deps` object, leading to `undefined` access.

Fix:
- Explicitly map `config` and `messageBus` from the context instead of using the spread operator.

## Related Issues

Closes #21982

## How to Validate

1. Run any tool that requires confirmation (e.g., `shell`).
2. Select "Always allow" or "Always allow and save".
3. Verify that the policy update succeeds without a crash.
4. Run policy tests: `npm test -w @google/gemini-cli-core -- src/scheduler/policy.test.ts`.
