### PR TITLE
fix(scripts): make lint.js OS-agnostic for Windows compatibility

### DIFF
--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -188,10 +188,11 @@ const LINTERS = {
   shellcheck: {
     check: shellcheckCheck,
     installer: shellcheckInstaller,
-    // If Linux/Mac, keep the original "smart" command. If Windows, use JS-filtered version.
+    // If Linux/Mac, keep the original "smart" command (sed masks the exit code).
+    // If Windows, use JS-filtered version with || exit 0 to match Linux's behavior.
     run: !isWindows
       ? `git ls-files | grep -E '^([^.]+|.*\\.(sh|zsh|bash))' | xargs file --mime-type | grep "text/x-shellscript" | awk '{ print substr($1, 1, length($1)-1) }' | xargs shellcheck --check-sourced --enable=all --exclude=SC2002,SC2129,SC2310 --severity=style --format=gcc --color=never | sed -e 's/note:/warning:/g' -e 's/style:/warning:/g'`
-      : `shellcheck --check-sourced --enable=all --exclude=SC2002,SC2129,SC2310 --severity=style --format=gcc --color=never ${getShellFiles()}`,
+      : `shellcheck --check-sourced --enable=all --exclude=SC2002,SC2129,SC2310 --severity=style --format=gcc --color=never ${getShellFiles()} || exit 0`,
   },
   yamllint: {
     check: yamllintCheck,

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -59,6 +59,58 @@ const platformArch = getPlatformArch();
 
 const PYTHON_VENV_PATH = join(TEMP_DIR, 'python_venv');
 
+/**
+ * Gets a list of files from git and filters them by a regex.
+ * This replaces the "git ls-files | grep" shell command with an
+ * OS-agnostic Node.js implementation.
+ */
+function getFilesByPattern(pattern) {
+  try {
+    const output = execSync('git ls-files', { encoding: 'utf-8' });
+    return output
+      .split('\n')
+      .filter((file) => file && pattern.test(file))
+      .join(' ');
+  } catch (e) {
+    console.error('Error fetching file list from git:', e.message);
+    return '';
+  }
+}
+
+/**
+ * Gets shell script files using a shebang-based check for extension-less files.
+ * This is the OS-agnostic equivalent of the Linux pipeline:
+ *   git ls-files | grep ... | xargs file --mime-type | grep "text/x-shellscript"
+ */
+function getShellFiles() {
+  const shellExtensions = /\.(sh|zsh|bash)$/;
+  const shellShebang = /^#!.*\b(sh|bash|zsh|dash|ksh)\b/;
+  try {
+    const output = execSync('git ls-files', { encoding: 'utf-8' });
+    return output
+      .split('\n')
+      .filter((file) => {
+        if (!file) return false;
+        // Files with shell extensions are always included
+        if (shellExtensions.test(file)) return true;
+        // For extension-less files, check the shebang line
+        if (!file.includes('.')) {
+          try {
+            const firstLine = readFileSync(file, 'utf-8').split('\n')[0];
+            return shellShebang.test(firstLine);
+          } catch (_e) {
+            return false;
+          }
+        }
+        return false;
+      })
+      .join(' ');
+  } catch (e) {
+    console.error('Error fetching file list from git:', e.message);
+    return '';
+  }
+}
+
 const pythonVenvPythonPath = join(
   PYTHON_VENV_PATH,
   process.platform === 'win32' ? 'Scripts' : 'bin',
@@ -127,34 +179,25 @@ const LINTERS = {
   actionlint: {
     check: actionlintCheck,
     installer: actionlintInstaller,
-    run: `
-      actionlint \
-        -color \
-        -ignore 'SC2002:' \
-        -ignore 'SC2016:' \
-        -ignore 'SC2129:' \
-        -ignore 'label ".+" is unknown'
-    `,
+    // On Windows, cmd.exe doesn't recognize single quotes as grouping characters,
+    // so we use double quotes and a simplified regex to avoid nested-quote issues.
+    run: isWindows
+      ? `actionlint -color -ignore "SC2002:" -ignore "SC2016:" -ignore "SC2129:" -ignore "label .+ is unknown"`
+      : `actionlint -color -ignore 'SC2002:' -ignore 'SC2016:' -ignore 'SC2129:' -ignore 'label ".+" is unknown'`,
   },
   shellcheck: {
     check: shellcheckCheck,
     installer: shellcheckInstaller,
-    run: `
-      git ls-files | grep -E '^([^.]+|.*\\.(sh|zsh|bash))' | xargs file --mime-type \
-        | grep "text/x-shellscript" | awk '{ print substr($1, 1, length($1)-1) }' \
-        | xargs shellcheck \
-          --check-sourced \
-          --enable=all \
-          --exclude=SC2002,SC2129,SC2310 \
-          --severity=style \
-          --format=gcc \
-          --color=never | sed -e 's/note:/warning:/g' -e 's/style:/warning:/g'
-    `,
+    // If Linux/Mac, keep the original "smart" command. If Windows, use JS-filtered version.
+    run: !isWindows
+      ? `git ls-files | grep -E '^([^.]+|.*\\.(sh|zsh|bash))' | xargs file --mime-type | grep "text/x-shellscript" | awk '{ print substr($1, 1, length($1)-1) }' | xargs shellcheck --check-sourced --enable=all --exclude=SC2002,SC2129,SC2310 --severity=style --format=gcc --color=never | sed -e 's/note:/warning:/g' -e 's/style:/warning:/g'`
+      : `shellcheck --check-sourced --enable=all --exclude=SC2002,SC2129,SC2310 --severity=style --format=gcc --color=never ${getShellFiles()}`,
   },
   yamllint: {
     check: yamllintCheck,
     installer: yamllintInstaller,
-    run: "git ls-files | grep -E '\\.(yaml|yml)' | xargs yamllint --format github",
+    // Unified: use JS filtering for both platforms — simple and fast
+    run: `yamllint --format github ${getFilesByPattern(/\.(yaml|yml)$/)}`,
   },
 };
 
@@ -175,6 +218,10 @@ function runCommand(command, stdio = 'inherit') {
       pythonBin,
       env[pathKey],
     ].join(sep);
+    // Force Python to use UTF-8 on Windows (default cp1252 can't handle some files)
+    if (isWindows) {
+      env.PYTHONUTF8 = '1';
+    }
     execSync(command, { stdio, env, shell: true });
     return true;
   } catch (_e) {


### PR DESCRIPTION
## Summary

This PR fixes a critical developer experience blocker on Windows where npm run preflight hard-crashes during the linting phase. The setup script previously relied on Unix-specific shell dependencies (grep, sed, single-quote escaping), which completely prevented native Windows contributors from setting up and verifying the repository without WSL. This makes scripts/lint.js completely OS-agnostic.

## Details

-Cross-Platform File Filtering
Replaced the grep/awk pipelines with a native Node.js regex filter using execSync('git ls-files').

-Windows Quote Escaping
Leveraged the existing isWindows flag to supply cmd.exe-friendly double-quotes for actionlint on Windows (retaining the exact original single-quotes for Linux/Mac).

-Encoding Fix
Passed PYTHONUTF8=1 into the environment variables so the Python virtual environment running yamllint no longer crashes on Windows' default cp1252 encoding.

-Exit Code Parity
Appended || exit 0 to the native Windows shellcheck command. This ensures it doesn't crash the script prematurely on standard stylistic warnings, perfectly matching the current Linux CI behavior where piping to sed inherently swallows the exit code.

## Related Issues

Fixes #22149

## How to Validate

1. Clone or checkout this branch on a native Windows machine (using PowerShell or CMD, not WSL).

2. Run npm ci to install dependencies.

3. Run npm run preflight (or node scripts/lint.js directly).

4. Verify that the setup script downloads the linters, successfully parses the files, and completes without throwing 'grep' is not recognized errors. It should finish with "All linting checks passed!".

## Pre-Merge Checklist


- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x ] Windows
    - [x ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
