### PR TITLE
refactor(cli): consolidate getErrorMessage utility to core

### DIFF
--- a/packages/cli/src/acp/commands/extensions.ts
+++ b/packages/cli/src/acp/commands/extensions.ts
@@ -4,13 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { listExtensions, type Config } from '@google/gemini-cli-core';
+import {
+  listExtensions,
+  type Config,
+  getErrorMessage,
+} from '@google/gemini-cli-core';
 import { SettingScope } from '../../config/settings.js';
 import {
   ExtensionManager,
   inferInstallMetadata,
 } from '../../config/extension-manager.js';
-import { getErrorMessage } from '../../utils/errors.js';
 import { McpServerEnablementManager } from '../../config/mcp/mcpServerEnablement.js';
 import { stat } from 'node:fs/promises';
 import type {

--- a/packages/cli/src/commands/extensions/disable.test.ts
+++ b/packages/cli/src/commands/extensions/disable.test.ts
@@ -22,7 +22,7 @@ import {
   SettingScope,
   type LoadedSettings,
 } from '../../config/settings.js';
-import { getErrorMessage } from '../../utils/errors.js';
+import { getErrorMessage } from '@google/gemini-cli-core';
 
 // Mock dependencies
 const emitConsoleLog = vi.hoisted(() => vi.fn());
@@ -44,12 +44,12 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
       emitConsoleLog,
     },
     debugLogger,
+    getErrorMessage: vi.fn(),
   };
 });
 
 vi.mock('../../config/extension-manager.js');
 vi.mock('../../config/settings.js');
-vi.mock('../../utils/errors.js');
 vi.mock('../../config/extensions/consent.js', () => ({
   requestConsentNonInteractive: vi.fn(),
 }));

--- a/packages/cli/src/commands/extensions/disable.ts
+++ b/packages/cli/src/commands/extensions/disable.ts
@@ -6,8 +6,7 @@
 
 import { type CommandModule } from 'yargs';
 import { loadSettings, SettingScope } from '../../config/settings.js';
-import { getErrorMessage } from '../../utils/errors.js';
-import { debugLogger } from '@google/gemini-cli-core';
+import { debugLogger, getErrorMessage } from '@google/gemini-cli-core';
 import { ExtensionManager } from '../../config/extension-manager.js';
 import { requestConsentNonInteractive } from '../../config/extensions/consent.js';
 import { promptForSetting } from '../../config/extensions/extensionSettings.js';

--- a/packages/cli/src/commands/extensions/install.ts
+++ b/packages/cli/src/commands/extensions/install.ts
@@ -11,8 +11,8 @@ import {
   debugLogger,
   FolderTrustDiscoveryService,
   getRealPath,
+  getErrorMessage,
 } from '@google/gemini-cli-core';
-import { getErrorMessage } from '../../utils/errors.js';
 import {
   INSTALL_WARNING_MESSAGE,
   promptForConsentNonInteractive,

--- a/packages/cli/src/commands/extensions/link.test.ts
+++ b/packages/cli/src/commands/extensions/link.test.ts
@@ -13,26 +13,24 @@ import {
   afterEach,
   type Mock,
 } from 'vitest';
-import { coreEvents } from '@google/gemini-cli-core';
+import { coreEvents, getErrorMessage } from '@google/gemini-cli-core';
 import { type Argv } from 'yargs';
 import { handleLink, linkCommand } from './link.js';
 import { ExtensionManager } from '../../config/extension-manager.js';
 import { loadSettings, type LoadedSettings } from '../../config/settings.js';
-import { getErrorMessage } from '../../utils/errors.js';
 
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const { mockCoreDebugLogger } = await import(
     '../../test-utils/mockDebugLogger.js'
   );
-  return mockCoreDebugLogger(
-    await importOriginal<typeof import('@google/gemini-cli-core')>(),
-    { stripAnsi: true },
-  );
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  const mocked = mockCoreDebugLogger(actual, { stripAnsi: true });
+  return { ...mocked, getErrorMessage: vi.fn() };
 });
 
 vi.mock('../../config/extension-manager.js');
 vi.mock('../../config/settings.js');
-vi.mock('../../utils/errors.js');
 vi.mock('../../config/extensions/consent.js', () => ({
   requestConsentNonInteractive: vi.fn(),
 }));

--- a/packages/cli/src/commands/extensions/link.ts
+++ b/packages/cli/src/commands/extensions/link.ts
@@ -8,10 +8,10 @@ import type { CommandModule } from 'yargs';
 import chalk from 'chalk';
 import {
   debugLogger,
+  getErrorMessage,
   type ExtensionInstallMetadata,
 } from '@google/gemini-cli-core';
 
-import { getErrorMessage } from '../../utils/errors.js';
 import {
   INSTALL_WARNING_MESSAGE,
   requestConsentNonInteractive,

--- a/packages/cli/src/commands/extensions/list.test.ts
+++ b/packages/cli/src/commands/extensions/list.test.ts
@@ -5,27 +5,23 @@
  */
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { coreEvents } from '@google/gemini-cli-core';
+import { coreEvents, getErrorMessage } from '@google/gemini-cli-core';
 import { handleList, listCommand } from './list.js';
 import { ExtensionManager } from '../../config/extension-manager.js';
 import { loadSettings, type LoadedSettings } from '../../config/settings.js';
-import { getErrorMessage } from '../../utils/errors.js';
 
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const { mockCoreDebugLogger } = await import(
     '../../test-utils/mockDebugLogger.js'
   );
-  return mockCoreDebugLogger(
-    await importOriginal<typeof import('@google/gemini-cli-core')>(),
-    {
-      stripAnsi: false,
-    },
-  );
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  const mocked = mockCoreDebugLogger(actual, { stripAnsi: false });
+  return { ...mocked, getErrorMessage: vi.fn() };
 });
 
 vi.mock('../../config/extension-manager.js');
 vi.mock('../../config/settings.js');
-vi.mock('../../utils/errors.js');
 vi.mock('../../config/extensions/consent.js', () => ({
   requestConsentNonInteractive: vi.fn(),
 }));

--- a/packages/cli/src/commands/extensions/list.ts
+++ b/packages/cli/src/commands/extensions/list.ts
@@ -5,8 +5,7 @@
  */
 
 import type { CommandModule } from 'yargs';
-import { getErrorMessage } from '../../utils/errors.js';
-import { debugLogger } from '@google/gemini-cli-core';
+import { debugLogger, getErrorMessage } from '@google/gemini-cli-core';
 import { ExtensionManager } from '../../config/extension-manager.js';
 import { requestConsentNonInteractive } from '../../config/extensions/consent.js';
 import { loadSettings } from '../../config/settings.js';

--- a/packages/cli/src/commands/extensions/uninstall.test.ts
+++ b/packages/cli/src/commands/extensions/uninstall.test.ts
@@ -18,7 +18,7 @@ import { type Argv } from 'yargs';
 import { handleUninstall, uninstallCommand } from './uninstall.js';
 import { ExtensionManager } from '../../config/extension-manager.js';
 import { loadSettings, type LoadedSettings } from '../../config/settings.js';
-import { getErrorMessage } from '../../utils/errors.js';
+import { getErrorMessage } from '@google/gemini-cli-core';
 
 // NOTE: This file uses vi.hoisted() mocks to enable testing of sequential
 // mock behaviors (mockResolvedValueOnce/mockRejectedValueOnce chaining).
@@ -66,11 +66,11 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
       emitConsoleLog,
     },
     debugLogger,
+    getErrorMessage: vi.fn(),
   };
 });
 
 vi.mock('../../config/settings.js');
-vi.mock('../../utils/errors.js');
 vi.mock('../../config/extensions/consent.js', () => ({
   requestConsentNonInteractive: vi.fn(),
 }));

--- a/packages/cli/src/commands/extensions/uninstall.ts
+++ b/packages/cli/src/commands/extensions/uninstall.ts
@@ -5,8 +5,7 @@
  */
 
 import type { CommandModule } from 'yargs';
-import { getErrorMessage } from '../../utils/errors.js';
-import { debugLogger } from '@google/gemini-cli-core';
+import { debugLogger, getErrorMessage } from '@google/gemini-cli-core';
 import { requestConsentNonInteractive } from '../../config/extensions/consent.js';
 import { ExtensionManager } from '../../config/extension-manager.js';
 import { loadSettings } from '../../config/settings.js';

--- a/packages/cli/src/commands/extensions/update.ts
+++ b/packages/cli/src/commands/extensions/update.ts
@@ -12,9 +12,12 @@ import {
   updateExtension,
 } from '../../config/extensions/update.js';
 import { checkForExtensionUpdate } from '../../config/extensions/github.js';
-import { getErrorMessage } from '../../utils/errors.js';
 import { ExtensionUpdateState } from '../../ui/state/extensions.js';
-import { coreEvents, debugLogger } from '@google/gemini-cli-core';
+import {
+  coreEvents,
+  debugLogger,
+  getErrorMessage,
+} from '@google/gemini-cli-core';
 import { ExtensionManager } from '../../config/extension-manager.js';
 import { requestConsentNonInteractive } from '../../config/extensions/consent.js';
 import { loadSettings } from '../../config/settings.js';

--- a/packages/cli/src/commands/extensions/validate.ts
+++ b/packages/cli/src/commands/extensions/validate.ts
@@ -5,11 +5,10 @@
  */
 
 import type { CommandModule } from 'yargs';
-import { debugLogger } from '@google/gemini-cli-core';
+import { debugLogger, getErrorMessage } from '@google/gemini-cli-core';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import semver from 'semver';
-import { getErrorMessage } from '../../utils/errors.js';
 import type { ExtensionConfig } from '../../config/extension.js';
 import { ExtensionManager } from '../../config/extension-manager.js';
 import { requestConsentNonInteractive } from '../../config/extensions/consent.js';

--- a/packages/cli/src/commands/skills/install.test.ts
+++ b/packages/cli/src/commands/skills/install.test.ts
@@ -28,6 +28,9 @@ const { debugLogger, emitConsoleLog } = await vi.hoisted(async () => {
 
 vi.mock('@google/gemini-cli-core', () => ({
   debugLogger,
+  getErrorMessage: vi.fn((e: unknown) =>
+    e instanceof Error ? e.message : String(e),
+  ),
 }));
 
 import { handleInstall, installCommand } from './install.js';

--- a/packages/cli/src/commands/skills/install.ts
+++ b/packages/cli/src/commands/skills/install.ts
@@ -5,8 +5,11 @@
  */
 
 import type { CommandModule } from 'yargs';
-import { debugLogger, type SkillDefinition } from '@google/gemini-cli-core';
-import { getErrorMessage } from '../../utils/errors.js';
+import {
+  debugLogger,
+  type SkillDefinition,
+  getErrorMessage,
+} from '@google/gemini-cli-core';
 import { exitCli } from '../utils.js';
 import { installSkill } from '../../utils/skillUtils.js';
 import chalk from 'chalk';

--- a/packages/cli/src/commands/skills/link.test.ts
+++ b/packages/cli/src/commands/skills/link.test.ts
@@ -24,6 +24,9 @@ const { debugLogger } = await vi.hoisted(async () => {
 
 vi.mock('@google/gemini-cli-core', () => ({
   debugLogger,
+  getErrorMessage: vi.fn((e: unknown) =>
+    e instanceof Error ? e.message : String(e),
+  ),
 }));
 
 vi.mock('../../config/extensions/consent.js', () => ({

--- a/packages/cli/src/commands/skills/link.ts
+++ b/packages/cli/src/commands/skills/link.ts
@@ -5,10 +5,9 @@
  */
 
 import type { CommandModule } from 'yargs';
-import { debugLogger } from '@google/gemini-cli-core';
+import { debugLogger, getErrorMessage } from '@google/gemini-cli-core';
 import chalk from 'chalk';
 
-import { getErrorMessage } from '../../utils/errors.js';
 import { exitCli } from '../utils.js';
 import {
   requestConsentNonInteractive,

--- a/packages/cli/src/commands/skills/uninstall.test.ts
+++ b/packages/cli/src/commands/skills/uninstall.test.ts
@@ -21,6 +21,9 @@ const { debugLogger, emitConsoleLog } = await vi.hoisted(async () => {
 
 vi.mock('@google/gemini-cli-core', () => ({
   debugLogger,
+  getErrorMessage: vi.fn((e: unknown) =>
+    e instanceof Error ? e.message : String(e),
+  ),
 }));
 
 import { handleUninstall, uninstallCommand } from './uninstall.js';

--- a/packages/cli/src/commands/skills/uninstall.ts
+++ b/packages/cli/src/commands/skills/uninstall.ts
@@ -5,8 +5,7 @@
  */
 
 import type { CommandModule } from 'yargs';
-import { debugLogger } from '@google/gemini-cli-core';
-import { getErrorMessage } from '../../utils/errors.js';
+import { debugLogger, getErrorMessage } from '@google/gemini-cli-core';
 import { exitCli } from '../utils.js';
 import { uninstallSkill } from '../../utils/skillUtils.js';
 import chalk from 'chalk';

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -5,9 +5,9 @@
  */
 
 import { simpleGit } from 'simple-git';
-import { getErrorMessage } from '../../utils/errors.js';
 import {
   debugLogger,
+  getErrorMessage,
   type ExtensionInstallMetadata,
   type GeminiCLIExtension,
 } from '@google/gemini-cli-core';

--- a/packages/cli/src/config/extensions/update.ts
+++ b/packages/cli/src/config/extensions/update.ts
@@ -11,9 +11,12 @@ import {
 } from '../../ui/state/extensions.js';
 import { loadInstallMetadata } from '../extension.js';
 import { checkForExtensionUpdate } from './github.js';
-import { debugLogger, type GeminiCLIExtension } from '@google/gemini-cli-core';
+import {
+  debugLogger,
+  getErrorMessage,
+  type GeminiCLIExtension,
+} from '@google/gemini-cli-core';
 import * as fs from 'node:fs';
-import { getErrorMessage } from '../../utils/errors.js';
 import { copyExtension, type ExtensionManager } from '../extension-manager.js';
 import { ExtensionStorage } from './storage.js';
 

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -7,10 +7,10 @@
 import {
   debugLogger,
   listExtensions,
+  getErrorMessage,
   type ExtensionInstallMetadata,
 } from '@google/gemini-cli-core';
 import type { ExtensionUpdateInfo } from '../../config/extension.js';
-import { getErrorMessage } from '../../utils/errors.js';
 import {
   emptyIcon,
   MessageType,

--- a/packages/cli/src/ui/commands/skillsCommand.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.ts
@@ -16,9 +16,8 @@ import {
   MessageType,
 } from '../types.js';
 import { disableSkill, enableSkill } from '../../utils/skillSettings.js';
-import { getErrorMessage } from '../../utils/errors.js';
 
-import { getAdminErrorMessage } from '@google/gemini-cli-core';
+import { getAdminErrorMessage, getErrorMessage } from '@google/gemini-cli-core';
 import {
   linkSkill,
   renderSkillActionFeedback,

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -7,9 +7,9 @@
 import {
   debugLogger,
   checkExhaustive,
+  getErrorMessage,
   type GeminiCLIExtension,
 } from '@google/gemini-cli-core';
-import { getErrorMessage } from '../../utils/errors.js';
 import {
   ExtensionUpdateState,
   extensionUpdatesReducer,

--- a/packages/cli/src/utils/errors.test.ts
+++ b/packages/cli/src/utils/errors.test.ts
@@ -21,7 +21,6 @@ import {
   coreEvents,
 } from '@google/gemini-cli-core';
 import {
-  getErrorMessage,
   handleError,
   handleToolError,
   handleCancellationError,
@@ -150,25 +149,6 @@ describe('errors', () => {
     debugLoggerErrorSpy.mockRestore();
     debugLoggerWarnSpy.mockRestore();
     processExitSpy.mockRestore();
-  });
-
-  describe('getErrorMessage', () => {
-    it('should return error message for Error instances', () => {
-      const error = new Error('Test error message');
-      expect(getErrorMessage(error)).toBe('Test error message');
-    });
-
-    it('should convert non-Error values to strings', () => {
-      expect(getErrorMessage('string error')).toBe('string error');
-      expect(getErrorMessage(123)).toBe('123');
-      expect(getErrorMessage(null)).toBe('null');
-      expect(getErrorMessage(undefined)).toBe('undefined');
-    });
-
-    it('should handle objects', () => {
-      const obj = { message: 'test' };
-      expect(getErrorMessage(obj)).toBe('[object Object]');
-    });
   });
 
   describe('handleError', () => {

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -18,15 +18,9 @@ import {
   isFatalToolError,
   debugLogger,
   coreEvents,
+  getErrorMessage,
 } from '@google/gemini-cli-core';
 import { runSyncCleanup } from './cleanup.js';
-
-export function getErrorMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
-  return String(error);
-}
 
 interface ErrorWithCode extends Error {
   exitCode?: number;


### PR DESCRIPTION
## Summary

Consolidates the duplicate `getErrorMessage` utility functions from `packages/cli` into a single, smarter implementation in `@google/gemini-cli-core`. This ensures consistent error messaging (including API error transformations like 403 to `AccountSuspendedError`) across the application and removes redundant code.

## Details

- Removed `getErrorMessage` from `packages/cli/src/utils/errors.ts`.
- Updated approximately 20 files in `packages/cli` to import `getErrorMessage` directly from `@google/gemini-cli-core`.
- Removed duplicate tests for `getErrorMessage` in `packages/cli/src/utils/errors.test.ts`, as they are already comprehensively covered in the core package's test suite.
- Fixed a lingering mock issue in the `skills` test files where `getErrorMessage` was not being correctly exported by `vi.mock('@google/gemini-cli-core')`.

## Related Issues

Fixes #17139

## How to Validate

1. Run `npm run test:ci` to ensure all tests (specifically in `packages/cli` and `packages/core`) pass.
2. Run `npm run preflight` to confirm the build and linting rules are fully satisfied. 

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
