### PR TITLE
fix(core): fix startup stats to use int values for timestamps and durations

### DIFF
--- a/packages/core/src/telemetry/startupProfiler.test.ts
+++ b/packages/core/src/telemetry/startupProfiler.test.ts
@@ -388,5 +388,32 @@ describe('StartupProfiler', () => {
         }),
       );
     });
+
+    it('should log startup stats timestamps as rounded integers', () => {
+      const handle = profiler.start('test_phase');
+      handle?.end();
+
+      profiler.flush(mockConfig);
+
+      const statsEvent = logStartupStats.mock.calls[0][1];
+      const phase = statsEvent.phases[0];
+
+      // Verify they are integers
+      expect(Number.isInteger(phase.start_time_usec)).toBe(true);
+      expect(Number.isInteger(phase.end_time_usec)).toBe(true);
+    });
+
+    it('should log startup stats duration as rounded integers', () => {
+      const handle = profiler.start('test_phase');
+      handle?.end();
+
+      profiler.flush(mockConfig);
+
+      const statsEvent = logStartupStats.mock.calls[0][1];
+      const phase = statsEvent.phases[0];
+
+      // Verify they are integers
+      expect(Number.isInteger(phase.duration_ms)).toBe(true);
+    });
   });
 });

--- a/packages/core/src/telemetry/startupProfiler.ts
+++ b/packages/core/src/telemetry/startupProfiler.ts
@@ -207,13 +207,16 @@ export class StartupProfiler {
       if (measure && phase.cpuUsage) {
         startupPhases.push({
           name: phase.name,
-          duration_ms: measure.duration,
+          duration_ms: Math.round(measure.duration),
           cpu_usage_user_usec: phase.cpuUsage.user,
           cpu_usage_system_usec: phase.cpuUsage.system,
-          start_time_usec: (performance.timeOrigin + measure.startTime) * 1000,
-          end_time_usec:
+          start_time_usec: Math.round(
+            (performance.timeOrigin + measure.startTime) * 1000,
+          ),
+          end_time_usec: Math.round(
             (performance.timeOrigin + measure.startTime + measure.duration) *
-            1000,
+              1000,
+          ),
         });
       }
     }


### PR DESCRIPTION
## Summary

Ensures that startup stats timestamps and duration values are correctly formatted as integers in `StartupProfiler`.

## Details

Applied `Math.round()` to `duration_ms`, `start_time_usec`, and `end_time_usec` before adding them to the telemetry startup phases. This fixes schema compliance issues related to telemetry logging where floating-point numbers were being emitted instead of integers. Added unit tests to verify the integer outputs.

## Related Issues

Related to #21161
Related to https://github.com/google-gemini/maintainers-gemini-cli/issues/1513

## How to Validate

- Run the unit tests for telemetry: `npm test -w @google/gemini-cli-core -- src/telemetry/startupProfiler.test.ts`
- Check the logged telemetry payload on startup and confirm the types are integers for phase timing.

## Pre-Merge Checklist

- [x] Added/updated tests (if needed)
