### PR TITLE
fix(browser): fix duplicate function declaration error in browser agent

### DIFF
--- a/packages/core/src/agents/local-executor.test.ts
+++ b/packages/core/src/agents/local-executor.test.ts
@@ -2495,4 +2495,337 @@ describe('LocalAgentExecutor', () => {
       expect(mockSetHistory).toHaveBeenCalledWith(compressedHistory);
     });
   });
+
+  describe('DeclarativeTool instance tools (browser agent pattern)', () => {
+    /**
+     * The browser agent passes DeclarativeTool instances (not string names) in
+     * toolConfig.tools.  These tests ensure that prepareToolsList() and
+     * create() handle that pattern correctly — in particular, that each tool
+     * appears exactly once in the function declarations sent to the model.
+     */
+
+    /**
+     * Helper that creates a definition using MockTool *instances* in
+     * toolConfig.tools — the same pattern the browser agent uses.
+     */
+    const createInstanceToolDefinition = (
+      instanceTools: MockTool[],
+      outputConfigMode: 'default' | 'none' = 'default',
+    ): LocalAgentDefinition => {
+      const outputConfig =
+        outputConfigMode === 'default'
+          ? {
+              outputName: 'finalResult',
+              description: 'The final result.',
+              schema: z.string(),
+            }
+          : undefined;
+
+      return {
+        kind: 'local',
+        name: 'BrowserLikeAgent',
+        description: 'An agent using instance tools.',
+        inputConfig: {
+          inputSchema: {
+            type: 'object',
+            properties: {
+              goal: { type: 'string', description: 'goal' },
+            },
+            required: ['goal'],
+          },
+        },
+        modelConfig: {
+          model: 'gemini-test-model',
+          generateContentConfig: { temperature: 0, topP: 1 },
+        },
+        runConfig: { maxTimeMinutes: 5, maxTurns: 5 },
+        promptConfig: { systemPrompt: 'Achieve: ${goal}.' },
+        toolConfig: {
+          // Cast required because the type expects AnyDeclarativeTool |
+          // string | FunctionDeclaration; MockTool satisfies the first.
+          tools: instanceTools as unknown as AnyDeclarativeTool[],
+        },
+        outputConfig,
+      } as unknown as LocalAgentDefinition;
+    };
+
+    /**
+     * Helper to extract the functionDeclarations sent to GeminiChat.
+     */
+    const getSentFunctionDeclarations = () => {
+      const chatCtorArgs = MockedGeminiChat.mock.calls[0];
+      const toolsArg = chatCtorArgs[2] as Tool[];
+      return toolsArg[0].functionDeclarations ?? [];
+    };
+
+    it('should produce NO duplicate function declarations when tools are DeclarativeTool instances', async () => {
+      const clickTool = new MockTool({ name: 'click' });
+      const fillTool = new MockTool({ name: 'fill' });
+      const snapshotTool = new MockTool({ name: 'take_snapshot' });
+
+      const definition = createInstanceToolDefinition([
+        clickTool,
+        fillTool,
+        snapshotTool,
+      ]);
+
+      mockModelResponse([
+        {
+          name: TASK_COMPLETE_TOOL_NAME,
+          args: { finalResult: 'done' },
+          id: 'c1',
+        },
+      ]);
+
+      const executor = await LocalAgentExecutor.create(
+        definition,
+        mockConfig,
+        onActivity,
+      );
+      await executor.run({ goal: 'Test' }, signal);
+
+      const declarations = getSentFunctionDeclarations();
+      const names = declarations.map((d) => d.name);
+
+      // Each tool must appear exactly once
+      expect(names.filter((n) => n === 'click')).toHaveLength(1);
+      expect(names.filter((n) => n === 'fill')).toHaveLength(1);
+      expect(names.filter((n) => n === 'take_snapshot')).toHaveLength(1);
+
+      // Total = 3 tools + complete_task
+      expect(declarations).toHaveLength(4);
+    });
+
+    it('should register DeclarativeTool instances in the isolated tool registry', async () => {
+      const clickTool = new MockTool({ name: 'click' });
+      const navTool = new MockTool({ name: 'navigate_page' });
+
+      const definition = createInstanceToolDefinition([clickTool, navTool]);
+
+      const executor = await LocalAgentExecutor.create(
+        definition,
+        mockConfig,
+        onActivity,
+      );
+
+      const registry = executor['toolRegistry'];
+      expect(registry.getTool('click')).toBeDefined();
+      expect(registry.getTool('navigate_page')).toBeDefined();
+      // Should NOT have tools that were not passed
+      expect(registry.getTool(LS_TOOL_NAME)).toBeUndefined();
+    });
+
+    it('should handle mixed string + DeclarativeTool instances without duplicates', async () => {
+      const instanceTool = new MockTool({ name: 'fill' });
+
+      const definition: LocalAgentDefinition = {
+        kind: 'local',
+        name: 'MixedAgent',
+        description: 'Uses both patterns.',
+        inputConfig: {
+          inputSchema: {
+            type: 'object',
+            properties: { goal: { type: 'string', description: 'goal' } },
+          },
+        },
+        modelConfig: {
+          model: 'gemini-test-model',
+          generateContentConfig: { temperature: 0, topP: 1 },
+        },
+        runConfig: { maxTimeMinutes: 5, maxTurns: 5 },
+        promptConfig: { systemPrompt: 'Achieve: ${goal}.' },
+        toolConfig: {
+          tools: [
+            LS_TOOL_NAME, // string reference
+            instanceTool as unknown as AnyDeclarativeTool, // instance
+          ],
+        },
+        outputConfig: {
+          outputName: 'finalResult',
+          description: 'result',
+          schema: z.string(),
+        },
+      } as unknown as LocalAgentDefinition;
+
+      mockModelResponse([
+        {
+          name: TASK_COMPLETE_TOOL_NAME,
+          args: { finalResult: 'ok' },
+          id: 'c1',
+        },
+      ]);
+
+      const executor = await LocalAgentExecutor.create(
+        definition,
+        mockConfig,
+        onActivity,
+      );
+      await executor.run({ goal: 'Mixed' }, signal);
+
+      const declarations = getSentFunctionDeclarations();
+      const names = declarations.map((d) => d.name);
+
+      expect(names.filter((n) => n === LS_TOOL_NAME)).toHaveLength(1);
+      expect(names.filter((n) => n === 'fill')).toHaveLength(1);
+      expect(names.filter((n) => n === TASK_COMPLETE_TOOL_NAME)).toHaveLength(
+        1,
+      );
+      // Total = ls + fill + complete_task
+      expect(declarations).toHaveLength(3);
+    });
+
+    it('should correctly execute tools passed as DeclarativeTool instances', async () => {
+      const executeFn = vi.fn().mockResolvedValue({
+        llmContent: 'Clicked successfully.',
+        returnDisplay: 'Clicked successfully.',
+      });
+      const clickTool = new MockTool({ name: 'click', execute: executeFn });
+
+      const definition = createInstanceToolDefinition([clickTool]);
+
+      // Turn 1: Model calls click
+      mockModelResponse([
+        { name: 'click', args: { uid: '42' }, id: 'call-click' },
+      ]);
+      mockScheduleAgentTools.mockResolvedValueOnce([
+        {
+          status: 'success',
+          request: {
+            callId: 'call-click',
+            name: 'click',
+            args: { uid: '42' },
+            isClientInitiated: false,
+            prompt_id: 'test',
+          },
+          tool: {} as AnyDeclarativeTool,
+          invocation: {} as AnyToolInvocation,
+          response: {
+            callId: 'call-click',
+            resultDisplay: 'Clicked',
+            responseParts: [
+              {
+                functionResponse: {
+                  name: 'click',
+                  response: { result: 'Clicked' },
+                  id: 'call-click',
+                },
+              },
+            ],
+            error: undefined,
+            errorType: undefined,
+            contentLength: undefined,
+          },
+        },
+      ]);
+
+      // Turn 2: Model completes
+      mockModelResponse([
+        {
+          name: TASK_COMPLETE_TOOL_NAME,
+          args: { finalResult: 'done' },
+          id: 'call-done',
+        },
+      ]);
+
+      const executor = await LocalAgentExecutor.create(
+        definition,
+        mockConfig,
+        onActivity,
+      );
+      const output = await executor.run({ goal: 'Click test' }, signal);
+
+      // The scheduler should have received the click tool call
+      expect(mockScheduleAgentTools).toHaveBeenCalled();
+      const scheduledRequests = mockScheduleAgentTools.mock
+        .calls[0][1] as ToolCallRequestInfo[];
+      expect(scheduledRequests).toHaveLength(1);
+      expect(scheduledRequests[0].name).toBe('click');
+
+      expect(output.terminate_reason).toBe(AgentTerminateMode.GOAL);
+    });
+
+    it('should always include complete_task even when all tools are instances', async () => {
+      const definition = createInstanceToolDefinition(
+        [new MockTool({ name: 'take_snapshot' })],
+        'none',
+      );
+
+      mockModelResponse([
+        {
+          name: TASK_COMPLETE_TOOL_NAME,
+          args: { result: 'done' },
+          id: 'c1',
+        },
+      ]);
+
+      const executor = await LocalAgentExecutor.create(
+        definition,
+        mockConfig,
+        onActivity,
+      );
+      await executor.run({ goal: 'Test' }, signal);
+
+      const declarations = getSentFunctionDeclarations();
+      const names = declarations.map((d) => d.name);
+
+      expect(names).toContain(TASK_COMPLETE_TOOL_NAME);
+      expect(names).toContain('take_snapshot');
+      expect(declarations).toHaveLength(2);
+    });
+
+    it('should produce unique declarations for many instance tools (browser agent scale)', async () => {
+      // Simulates the full set of tools the browser agent typically registers
+      const browserToolNames = [
+        'click',
+        'click_at',
+        'fill',
+        'fill_form',
+        'hover',
+        'drag',
+        'press_key',
+        'take_snapshot',
+        'navigate_page',
+        'new_page',
+        'close_page',
+        'select_page',
+        'evaluate_script',
+        'type_text',
+      ];
+      const instanceTools = browserToolNames.map(
+        (name) => new MockTool({ name }),
+      );
+
+      const definition = createInstanceToolDefinition(instanceTools);
+
+      mockModelResponse([
+        {
+          name: TASK_COMPLETE_TOOL_NAME,
+          args: { finalResult: 'done' },
+          id: 'c1',
+        },
+      ]);
+
+      const executor = await LocalAgentExecutor.create(
+        definition,
+        mockConfig,
+        onActivity,
+      );
+      await executor.run({ goal: 'Scale test' }, signal);
+
+      const declarations = getSentFunctionDeclarations();
+      const names = declarations.map((d) => d.name);
+
+      // Every tool name must appear exactly once
+      for (const toolName of browserToolNames) {
+        const count = names.filter((n) => n === toolName).length;
+        expect(count).toBe(1);
+      }
+      // Plus complete_task
+      expect(declarations).toHaveLength(browserToolNames.length + 1);
+
+      // Verify the complete set of names has no duplicates
+      const uniqueNames = new Set(names);
+      expect(uniqueNames.size).toBe(names.length);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fix "Duplicate function declaration found: click" error in the browser agent by preventing `prepareToolsList()` from adding `DeclarativeTool` schemas twice to the function declarations sent to the Gemini API.

## Details

### Root Cause
`prepareToolsList()` in `local-executor.ts` had two independent code paths that both emit schemas for the same tool:

1. The `toolConfig.tools` loop's `'schema' in toolRef` branch — directly pushes `toolRef.schema`
2. `this.toolRegistry.getFunctionDeclarations()` — pushes schemas from all registered tools

These two paths are designed for different tool reference types but **overlap** for `DeclarativeTool` instances (which have both `schema` AND are registered in the registry). The browser agent is the only agent that passes `DeclarativeTool` instances directly in `toolConfig.tools` (all other agents use string-based references), which is why the bug only manifested there.

### Fix
Added a guard to the `schema` extraction branch: skip tool instances that have `name` and `build` properties (i.e., registered `DeclarativeTool` instances), since their schemas are already included via `getFunctionDeclarations()`.

### Tests
Added 6 new tests in a `"DeclarativeTool instance tools (browser agent pattern)"` describe block that exercise this exact code path:

- **No duplicate declarations** — the direct regression test
- **Registry registration** — verifies instance tools are in the isolated registry
- **Mixed string + instance tools** — guards against cross-pattern duplication
- **Tool execution via scheduler** — confirms instance tools can be called and dispatched
- **complete_task injection** — ensures completion tool always appears
- **Browser-agent-scale test (14 tools)** — simulates the real browser agent's full tool set

## Related Issues

<!-- No specific issue tracked for this bug -->

## How to Validate

1. Run the new tests:
   ```bash
   npm test -w @google/gemini-cli-core -- src/agents/local-executor.test.ts
   ```
   All 46 tests should pass (40 existing + 6 new).

2. Run the full core test suite:
   ```bash
   npm test -w @google/gemini-cli-core
   ```
   All 5919 tests should pass.

3. Run lint and typecheck:
   ```bash
   npm run lint -w @google/gemini-cli-core
   npm run typecheck -w @google/gemini-cli-core
   ```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
