### PR TITLE
fix(mcp): resolve API validation errors and malformed function calls

### DIFF
--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -292,7 +292,10 @@ export class GeminiClient {
 
     const toolRegistry = this.context.toolRegistry;
     const toolDeclarations = toolRegistry.getFunctionDeclarations(modelId);
-    const tools: Tool[] = [{ functionDeclarations: toolDeclarations }];
+    const tools: Tool[] =
+      toolDeclarations.length > 0
+        ? [{ functionDeclarations: toolDeclarations }]
+        : [];
     this.getChat().setTools(tools);
   }
 
@@ -356,7 +359,10 @@ export class GeminiClient {
 
     const toolRegistry = this.context.toolRegistry;
     const toolDeclarations = toolRegistry.getFunctionDeclarations();
-    const tools: Tool[] = [{ functionDeclarations: toolDeclarations }];
+    const tools: Tool[] =
+      toolDeclarations.length > 0
+        ? [{ functionDeclarations: toolDeclarations }]
+        : [];
 
     const history = await getInitialChatHistory(this.config, extraHistory);
 
@@ -374,7 +380,9 @@ export class GeminiClient {
           const toolRegistry = this.context.toolRegistry;
           const toolDeclarations =
             toolRegistry.getFunctionDeclarations(modelId);
-          return [{ functionDeclarations: toolDeclarations }];
+          return toolDeclarations.length > 0
+            ? [{ functionDeclarations: toolDeclarations }]
+            : [];
         },
       );
     } catch (error) {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -29,6 +29,7 @@ import type { Config } from '../config/config.js';
 import {
   resolveModel,
   isGemini2Model,
+  isGemini3Model,
   supportsModernFeatures,
 } from '../config/models.js';
 import { hasCycleInSchema } from '../tools/tools.js';
@@ -421,7 +422,8 @@ export class GeminiChat {
               : getRetryErrorType(error);
 
             if (
-              (isContentError && isGemini2Model(model)) ||
+              (isContentError &&
+                (isGemini2Model(model) || isGemini3Model(model))) ||
               (isRetryable && !signal.aborted)
             ) {
               // The issue requests exactly 3 retries (4 attempts) for API errors during stream iteration.

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -749,15 +749,7 @@ describe('mcp-client', () => {
       expect(registeredTool.schema.parametersJsonSchema).toEqual({
         type: 'object',
         properties: {
-          param1: {
-            $ref: '#/$defs/MyType',
-          },
-        },
-        $defs: {
-          MyType: {
-            type: 'string',
-            description: 'A defined type',
-          },
+          param1: {},
         },
       });
     });

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -1082,7 +1082,8 @@ class LenientJsonSchemaValidator implements jsonSchemaValidator {
     } catch (error) {
       debugLogger.warn(
         `Failed to compile MCP tool output schema (${
-          (schema as Record<string, unknown>)?.['$id'] ?? '<no $id>'
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          (schema as McpTool['inputSchema'])?.['$id'] ?? '<no $id>'
         }): ${error instanceof Error ? error.message : String(error)}. ` +
           'Skipping output validation for this tool.',
       );
@@ -1205,6 +1206,48 @@ export async function connectAndDiscover(
 }
 
 /**
+ * Sanitizes an MCP tool's JSON schema to ensure compatibility with the Gemini API.
+ * The Gemini API does not fully support certain JSON Schema features like $defs, $ref,
+ * additionalProperties, and complex union types (anyOf, allOf, oneOf).
+ * This recursively removes those unsupported keys.
+ */
+function sanitizeMcpSchema(schema: unknown): unknown {
+  if (Array.isArray(schema)) {
+    return schema.map(sanitizeMcpSchema);
+  }
+  if (schema !== null && typeof schema === 'object') {
+    const sanitized: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(schema)) {
+      // Skip unsupported JSON schema keys
+      if (
+        [
+          '$defs',
+          'definitions',
+          '$ref',
+          'anyOf',
+          'allOf',
+          'oneOf',
+          'additionalProperties',
+          'default',
+        ].includes(key)
+      ) {
+        continue;
+      }
+      sanitized[key] = sanitizeMcpSchema(value);
+    }
+
+    // If the schema is an object but has no properties, some APIs reject it.
+    // Ensure minimal valid structure if properties were stripped.
+    if (sanitized['type'] === 'object' && !sanitized['properties']) {
+      sanitized['properties'] = {};
+    }
+
+    return sanitized;
+  }
+  return schema;
+}
+
+/**
  * Discovers and sanitizes tools from a connected MCP client.
  * It retrieves function declarations from the client, filters out disabled tools,
  * generates valid names for them, and wraps them in `DiscoveredMCPTool` instances.
@@ -1241,23 +1284,34 @@ export async function discoverTools(
           continue;
         }
 
+        // Sanitize the input schema to remove unsupported Gemini API JSON schema features
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        const sanitizedSchema = sanitizeMcpSchema(
+          toolDef.inputSchema,
+        ) as McpTool['inputSchema'];
+        // Use the sanitized schema instead of the original
+        const safeToolDef = {
+          ...toolDef,
+          inputSchema: sanitizedSchema ?? { type: 'object', properties: {} },
+        };
+
         const mcpCallableTool = new McpCallableTool(
           mcpClient,
-          toolDef,
+          safeToolDef,
           mcpServerConfig.timeout ?? MCP_DEFAULT_TIMEOUT_MSEC,
           options?.progressReporter,
         );
 
         // Extract annotations from the tool definition
-        const annotations = toolDef.annotations;
+        const annotations = safeToolDef.annotations;
         const isReadOnly = annotations?.readOnlyHint === true;
 
         const tool = new DiscoveredMCPTool(
           mcpCallableTool,
           mcpServerName,
-          toolDef.name,
-          toolDef.description ?? '',
-          toolDef.inputSchema ?? { type: 'object', properties: {} },
+          safeToolDef.name,
+          safeToolDef.description ?? '',
+          safeToolDef.inputSchema,
           messageBus,
           mcpServerConfig.trust,
           isReadOnly,
@@ -1265,7 +1319,8 @@ export async function discoverTools(
           cliConfig,
           mcpServerConfig.extension?.name,
           mcpServerConfig.extension?.id,
-          annotations as Record<string, unknown> | undefined,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          annotations as McpTool['inputSchema'] | undefined,
         );
 
         discoveredTools.push(tool);
@@ -1341,7 +1396,7 @@ class McpCallableTool implements CallableTool {
         {
           name: call.name!,
           // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          arguments: call.args as Record<string, unknown>,
+          arguments: call.args as McpTool['inputSchema'],
           _meta: { progressToken },
         },
         undefined,

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -1319,8 +1319,7 @@ export async function discoverTools(
           cliConfig,
           mcpServerConfig.extension?.name,
           mcpServerConfig.extension?.id,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          annotations as McpTool['inputSchema'] | undefined,
+          annotations,
         );
 
         discoveredTools.push(tool);


### PR DESCRIPTION
Summary
Fix MCP integration failures with 400 INVALID_ARGUMENT and MALFORMED_FUNCTION_CALL errors that occur when Yolo mode is disabled.

Details
Three distinct issues were identified and fixed:

Schema Sanitization (

mcp-client.ts
): MCP servers (e.g., Atlassian) return tool schemas with JSON Schema extensions ($defs, $ref, anyOf, allOf, additionalProperties, default) that the Gemini API does not support in functionDeclarations. Added a 

sanitizeMcpSchema()
 function that recursively strips unsupported keys before tool registration, preventing the API from returning MALFORMED_FUNCTION_CALL.

Retry Logic for Gemini 3 (

geminiChat.ts
): The existing retry logic for MALFORMED_FUNCTION_CALL / 

InvalidStreamError
 was gated behind isGemini2Model(). Extended the condition to also include isGemini3Model().

Empty Tool Declarations (

client.ts
): When no MCP tools pass filtering, getFunctionDeclarations() returns []. Sending [{ functionDeclarations: [] }] to the API causes a 400 error. Added a guard: only include tools when toolDeclarations.length > 0.

Related Issues
Fixes #22179

How to Validate
Configure an MCP server with complex schemas (e.g., Atlassian MCP Server).
Run gemini CLI without Yolo mode enabled.
Invoke an MCP tool — it should succeed without 400 or MALFORMED_FUNCTION_CALL errors.
Run unit tests: npm run test -w @google/gemini-cli-core -- src/tools/mcp-client.test.ts and npm run test -w @google/gemini-cli-core -- src/core/geminiChat.test.ts — all should pass.