### PR TITLE
feat(core): add trajectoryId to ConversationOffered telemetry

### DIFF
--- a/packages/core/src/code_assist/server.test.ts
+++ b/packages/core/src/code_assist/server.test.ts
@@ -208,6 +208,7 @@ describe('CodeAssistServer', () => {
               traceId: 'test-trace-id',
               status: ActionStatus.ACTION_STATUS_NO_ERROR,
               initiationMethod: InitiationMethod.COMMAND,
+              trajectoryId: 'test-session',
               streamingLatency: expect.objectContaining({
                 totalLatency: expect.stringMatching(/\d+s/),
                 firstMessageLatency: expect.stringMatching(/\d+s/),
@@ -277,6 +278,7 @@ describe('CodeAssistServer', () => {
             conversationOffered: expect.objectContaining({
               traceId: 'stream-trace-id',
               initiationMethod: InitiationMethod.COMMAND,
+              trajectoryId: 'test-session',
             }),
             timestamp: expect.stringMatching(
               /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/,

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -153,6 +153,7 @@ export class CodeAssistServer implements ContentGenerator {
           translatedResponse,
           streamingLatency,
           req.config?.abortSignal,
+          server.sessionId, // Use sessionId as trajectoryId
         );
 
         if (response.consumedCredits) {
@@ -223,6 +224,7 @@ export class CodeAssistServer implements ContentGenerator {
       translatedResponse,
       streamingLatency,
       req.config?.abortSignal,
+      this.sessionId, // Use sessionId as trajectoryId
     );
 
     if (response.remainingCredits) {

--- a/packages/core/src/code_assist/telemetry.test.ts
+++ b/packages/core/src/code_assist/telemetry.test.ts
@@ -92,6 +92,7 @@ describe('telemetry', () => {
         traceId,
         undefined,
         streamingLatency,
+        'trajectory-id',
       );
 
       expect(result).toEqual({
@@ -102,6 +103,7 @@ describe('telemetry', () => {
         streamingLatency,
         isAgentic: true,
         initiationMethod: InitiationMethod.COMMAND,
+        trajectoryId: 'trajectory-id',
       });
     });
 
@@ -124,6 +126,7 @@ describe('telemetry', () => {
         'trace-id',
         undefined,
         {},
+        'trajectory-id',
       );
       expect(result).toBeUndefined();
     });
@@ -140,6 +143,7 @@ describe('telemetry', () => {
         'trace-id',
         signal,
         {},
+        'trajectory-id',
       );
 
       expect(result?.status).toBe(ActionStatus.ACTION_STATUS_CANCELLED);
@@ -155,6 +159,7 @@ describe('telemetry', () => {
         'trace-id',
         undefined,
         {},
+        'trajectory-id',
       );
 
       expect(result?.status).toBe(ActionStatus.ACTION_STATUS_ERROR_UNKNOWN);
@@ -177,6 +182,7 @@ describe('telemetry', () => {
         'trace-id',
         undefined,
         {},
+        'trajectory-id',
       );
 
       expect(result?.status).toBe(ActionStatus.ACTION_STATUS_ERROR_UNKNOWN);
@@ -194,6 +200,7 @@ describe('telemetry', () => {
         'trace-id',
         undefined,
         {},
+        undefined,
       );
 
       expect(result?.status).toBe(ActionStatus.ACTION_STATUS_EMPTY);
@@ -214,7 +221,13 @@ describe('telemetry', () => {
         true,
         [{ name: 'replace', args: {} }],
       );
-      const result = createConversationOffered(response, 'id', undefined, {});
+      const result = createConversationOffered(
+        response,
+        'id',
+        undefined,
+        {},
+        undefined,
+      );
       expect(result?.includedCode).toBe(true);
     });
 
@@ -231,7 +244,13 @@ describe('telemetry', () => {
         true,
         [{ name: 'replace', args: {} }],
       );
-      const result = createConversationOffered(response, 'id', undefined, {});
+      const result = createConversationOffered(
+        response,
+        'id',
+        undefined,
+        {},
+        undefined,
+      );
       expect(result?.includedCode).toBe(false);
     });
   });
@@ -260,6 +279,7 @@ describe('telemetry', () => {
         response,
         streamingLatency,
         undefined,
+        undefined,
       );
 
       expect(serverMock.recordConversationOffered).toHaveBeenCalledWith(
@@ -282,6 +302,7 @@ describe('telemetry', () => {
         undefined,
         response,
         {},
+        undefined,
         undefined,
       );
 

--- a/packages/core/src/code_assist/telemetry.ts
+++ b/packages/core/src/code_assist/telemetry.ts
@@ -36,6 +36,7 @@ export async function recordConversationOffered(
   response: GenerateContentResponse,
   streamingLatency: StreamingLatency,
   abortSignal: AbortSignal | undefined,
+  trajectoryId: string | undefined,
 ): Promise<void> {
   try {
     if (traceId) {
@@ -44,6 +45,7 @@ export async function recordConversationOffered(
         traceId,
         abortSignal,
         streamingLatency,
+        trajectoryId,
       );
       if (offered) {
         await server.recordConversationOffered(offered);
@@ -87,6 +89,7 @@ export function createConversationOffered(
   traceId: string,
   signal: AbortSignal | undefined,
   streamingLatency: StreamingLatency,
+  trajectoryId: string | undefined,
 ): ConversationOffered | undefined {
   // Only send conversation offered events for responses that contain edit
   // function calls. Non-edit function calls don't represent file modifications.
@@ -107,6 +110,7 @@ export function createConversationOffered(
     streamingLatency,
     isAgentic: true,
     initiationMethod: InitiationMethod.COMMAND,
+    trajectoryId,
   };
 }
 

--- a/packages/core/src/code_assist/types.ts
+++ b/packages/core/src/code_assist/types.ts
@@ -315,6 +315,7 @@ export interface ConversationOffered {
   streamingLatency?: StreamingLatency;
   isAgentic?: boolean;
   initiationMethod?: InitiationMethod;
+  trajectoryId?: string;
 }
 
 export interface StreamingLatency {


### PR DESCRIPTION
## Summary
Passes the session ID as `trajectoryId` when recording conversation offered telemetry events in `CodeAssistServer`.

## Details
This ensures `trajectoryId` is present in the telemetry payload for `ConversationOffered` events, allowing better tracking of session trajectories.

## Related Issues
Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/1569

## How to Validate
Run `npm run test` or check if the telemetry payload includes the `trajectoryId` when the `ConversationOffered` event is dispatched in the `CodeAssistServer`.

## Pre-Merge Checklist
- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
