### PR TITLE
fix(core): exclude `?` from nested quantifier ReDoS heuristic

### DIFF
--- a/packages/core/src/policy/utils.test.ts
+++ b/packages/core/src/policy/utils.test.ts
@@ -59,6 +59,14 @@ describe('policy/utils', () => {
       expect(isSafeRegExp('([a-z]+)+')).toBe(false);
       expect(isSafeRegExp('(.*)+')).toBe(false);
     });
+
+    it('should return true for optional groups with inner quantifiers', () => {
+      // '?' as an outer quantifier allows only 0 or 1 match, so no
+      // exponential backtracking is possible.
+      expect(isSafeRegExp('(a+)?')).toBe(true);
+      expect(isSafeRegExp('(.*)?')).toBe(true);
+      expect(isSafeRegExp('(?:(.*?)\\s+)?')).toBe(true);
+    });
   });
 
   describe('buildArgsPatterns', () => {

--- a/packages/core/src/policy/utils.ts
+++ b/packages/core/src/policy/utils.ts
@@ -34,7 +34,9 @@ export function isSafeRegExp(pattern: string): boolean {
   // where the group itself contains a quantifier.
   // This matches a '(' followed by some content including a quantifier, then ')',
   // followed by another quantifier.
-  const nestedQuantifierPattern = /\([^)]*[*+?{].*\)[*+?{]/;
+  // Note: '?' as an outer quantifier is excluded because it only allows 0 or 1
+  // match of the group, which cannot cause exponential backtracking.
+  const nestedQuantifierPattern = /\([^)]*[*+?{].*\)[*+{]/;
   if (nestedQuantifierPattern.test(pattern)) {
     return false;
   }


### PR DESCRIPTION
## Summary

The `isSafeRegExp()` heuristic in `packages/core/src/policy/utils.ts` incorrectly rejects patterns where a group with an inner quantifier is followed by `?`. For example, `(?:(.*?)\s+)?` is flagged as unsafe even though `?` (0 or 1) cannot cause exponential backtracking — only unbounded quantifiers (`+`, `*`, `{n,}`) can.

This makes it impossible to write practical `commandRegex` policies for CLI tools that need optional capture groups (e.g. `blaze\s+(?:(.*?)\s+)?(build)\s+(.*)`), as reported in #21415.

## Changes

- **`packages/core/src/policy/utils.ts`**: Remove `?` from the outer quantifier character class in the nested quantifier heuristic (`[*+?{]` → `[*+{]`)
- **`packages/core/src/policy/utils.test.ts`**: Add test cases for `(a+)?`, `(.*)?`, and `(?:(.*?)\s+)?` confirming they are accepted as safe

## Test plan

- [x] All 20 existing + new `isSafeRegExp` tests pass
- [x] Pre-commit hooks (prettier, eslint) pass

Fixes #21415