### PR TITLE
fix: Adjust ToolGroupMessage filtering to hide Confirming and show Canceled tool calls.

### DIFF
--- a/packages/cli/src/ui/components/__snapshots__/AlternateBufferQuittingDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/AlternateBufferQuittingDisplay.test.tsx.snap
@@ -13,10 +13,6 @@ Tips for getting started:
 2. /help for more information
 3. Ask coding questions, edit code or run commands
 4. Be specific for the best results
-╭──────────────────────────────────────────────────────────────────────────╮
-│ ?  confirming_tool Confirming tool description                           │
-│                                                                          │
-╰──────────────────────────────────────────────────────────────────────────╯
 
 Action Required (was prompted):
 

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -118,10 +118,30 @@ describe('<ToolGroupMessage />', () => {
         { config: baseMockConfig, settings: fullVerbositySettings },
       );
 
-      // Should now render confirming tools
+      // Should now hide confirming tools (to avoid duplication with Global Queue)
+      await waitUntilReady();
+      expect(lastFrame({ allowEmpty: true })).toBe('');
+      unmount();
+    });
+
+    it('renders canceled tool calls', async () => {
+      const toolCalls = [
+        createToolCall({
+          callId: 'canceled-tool',
+          name: 'canceled-tool',
+          status: CoreToolCallStatus.Cancelled,
+        }),
+      ];
+      const item = createItem(toolCalls);
+
+      const { lastFrame, unmount, waitUntilReady } = renderWithProviders(
+        <ToolGroupMessage {...baseProps} item={item} toolCalls={toolCalls} />,
+        { config: baseMockConfig, settings: fullVerbositySettings },
+      );
+
       await waitUntilReady();
       const output = lastFrame();
-      expect(output).toContain('test-tool');
+      expect(output).toMatchSnapshot('canceled_tool');
       unmount();
     });
 
@@ -842,7 +862,7 @@ describe('<ToolGroupMessage />', () => {
       );
 
       await waitUntilReady();
-      expect(lastFrame({ allowEmpty: true })).not.toBe('');
+      expect(lastFrame({ allowEmpty: true })).toBe('');
       unmount();
     });
 

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -110,11 +110,12 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
     () =>
       toolCalls.filter((t) => {
         const displayStatus = mapCoreStatusToDisplayStatus(t.status);
-        // We used to filter out Pending and Confirming statuses here to avoid
-        // duplication with the Global Queue, but this causes tools to appear to
-        // "vanish" from the context after approval.
-        // We now allow them to be visible here as well.
-        return displayStatus !== ToolCallStatus.Canceled;
+        // We hide Confirming tools from the history log because they are
+        // currently being rendered in the interactive ToolConfirmationQueue.
+        // We show everything else, including Pending (waiting to run) and
+        // Canceled (rejected by user), to ensure the history is complete
+        // and to avoid tools "vanishing" after approval.
+        return displayStatus !== ToolCallStatus.Confirming;
       }),
 
     [toolCalls],

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
@@ -49,6 +49,15 @@ exports[`<ToolGroupMessage /> > Border Color Logic > uses yellow border for shel
 "
 `;
 
+exports[`<ToolGroupMessage /> > Golden Snapshots > renders canceled tool calls > canceled_tool 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────╮
+│ -  canceled-tool A tool for testing                                      │
+│                                                                          │
+│ Test result                                                              │
+╰──────────────────────────────────────────────────────────────────────────╯
+"
+`;
+
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders empty tool calls array 1`] = `""`;
 
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders header when scrolled 1`] = `


### PR DESCRIPTION
## Summary

Fix duplicate rendering of tool outputs and respect user cancel cascade for parallel tool calls and sequential tool calls alike..

## Details

**UI Fixes**: Fix ToolGroupMessage.tsx so that rejected tools (status Canceled) remain visible in the history, and tools currently awaiting confirmation (Confirming) are hidden from the history log to avoid duplication with the interactive queue.

**Duplication UX Fixed**
<img width="1364" height="736" alt="image" src="https://github.com/user-attachments/assets/38fc5d08-2281-4055-a296-f56ea071f5ad" />


## Related Issues

Fixes #22221 

## How to Validate

The buggy behavior of duplicate overlapping confirmation boxes as shown below should not be there for tool calls :

<img width="1750" height="630" alt="image" src="https://github.com/user-attachments/assets/41eb62a0-99ee-4c87-9702-6b0ab9b51e34" />



## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [✅] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [✅] Validated on required platforms/methods:
  - [✅] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
