### PR TITLE
fix(core): deduplicate project memory when JIT context is enabled

### DIFF
--- a/packages/core/src/utils/environmentContext.test.ts
+++ b/packages/core/src/utils/environmentContext.test.ts
@@ -165,6 +165,29 @@ describe('getEnvironmentContext', () => {
     expect(getFolderStructure).not.toHaveBeenCalled();
   });
 
+  it('should exclude environment memory when JIT context is enabled', async () => {
+    (mockConfig as Record<string, unknown>)['isJitContextEnabled'] = vi
+      .fn()
+      .mockReturnValue(true);
+
+    const parts = await getEnvironmentContext(mockConfig as Config);
+
+    const context = parts[0].text;
+    expect(context).not.toContain('Mock Environment Memory');
+    expect(mockConfig.getEnvironmentMemory).not.toHaveBeenCalled();
+  });
+
+  it('should include environment memory when JIT context is disabled', async () => {
+    (mockConfig as Record<string, unknown>)['isJitContextEnabled'] = vi
+      .fn()
+      .mockReturnValue(false);
+
+    const parts = await getEnvironmentContext(mockConfig as Config);
+
+    const context = parts[0].text;
+    expect(context).toContain('Mock Environment Memory');
+  });
+
   it('should handle read_many_files returning no content', async () => {
     const mockReadManyFilesTool = {
       build: vi.fn().mockReturnValue({

--- a/packages/core/src/utils/environmentContext.ts
+++ b/packages/core/src/utils/environmentContext.ts
@@ -57,7 +57,12 @@ export async function getEnvironmentContext(config: Config): Promise<Part[]> {
     ? await getDirectoryContextString(config)
     : '';
   const tempDir = config.storage.getProjectTempDir();
-  const environmentMemory = config.getEnvironmentMemory();
+  // When JIT context is enabled, project memory is already included in the
+  // system instruction via renderUserMemory(). Skip it here to avoid sending
+  // the same GEMINI.md content twice.
+  const environmentMemory = config.isJitContextEnabled?.()
+    ? ''
+    : config.getEnvironmentMemory();
 
   const context = `
 <session_context>


### PR DESCRIPTION
## Summary

Fixes duplicate project memory (GEMINI.md content) being sent to the model when JIT context is enabled — once in the system instruction and again in the first user message.

## Details

When `experimental.jitContext` is `true`, `renderUserMemory()` already includes project memory in the system instruction via `config.getUserMemory().project`. However, `getEnvironmentContext()` also calls `config.getEnvironmentMemory()` and injects the same content into the first user message's `<session_context>`.

This fix skips `getEnvironmentMemory()` in `getEnvironmentContext()` when JIT context is enabled, since the content is already present in the system instruction. This avoids wasting context window tokens on duplicated content.

When JIT is disabled, behavior is unchanged — project memory continues to be included in the first user message as before.

## Related Issues

Related to #22057
Related to #11488

## How to Validate

1. Enable JIT context: `"experimental": { "jitContext": true }` in `~/.gemini/settings.json`
2. Start the CLI in a project with a `GEMINI.md` file
3. **Before fix**: The same GEMINI.md content appears both in `<project_context>` (system instruction) and in `<session_context>` (first user message)
4. **After fix**: GEMINI.md content appears only in `<project_context>` (system instruction); `<session_context>` no longer contains it
5. Disable JIT (`jitContext: false`) — GEMINI.md content should still appear in `<session_context>` as before

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
