### PR TITLE
Updates the documentation link.

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -24,7 +24,7 @@ More information can be found about these systems in the
 
 ## Release cadence and tags
 
-We will follow https://semver.org/ as closely as possible but will call out when
+We will follow [Semantic Versioning](https://semver.org/) as closely as possible but will call out when
 or if we have to deviate from it. Our weekly releases will be minor version
 increments and any bug or hotfixes between releases will go out as patch
 versions on the most recent release.


### PR DESCRIPTION
## Summary

Updates the documentation to fix a broken link for Semantic Versioning. This ensures that users can correctly navigate to the official SemVer specification from the README.

## Details

Modified the plain text "Semantic Versioning" in the README to a standard Markdown link: `[Semantic Versioning](https://semver.org/)`. No code or logic changes were made.

## Related Issues

Closes #22233

## How to Validate

1. Go to the `README.md` file in the GitHub web interface.
2. Scroll to the section mentioning Semantic Versioning.
3. Hover over the link to verify it points to `https://semver.org/`.
4. Click the link to confirm it opens the correct website.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Web (GitHub Preview)