### PR TITLE
build(ci): fix false positive evals trigger on merge commits

### DIFF
--- a/scripts/changed_prompt.js
+++ b/scripts/changed_prompt.js
@@ -14,18 +14,17 @@ const EVALS_FILE_PREFIXES = [
 function main() {
   const targetBranch = process.env.GITHUB_BASE_REF || 'main';
   try {
-    // Fetch target branch from origin.
-    execSync(`git fetch origin ${targetBranch}`, {
+    const remoteUrl = process.env.GITHUB_REPOSITORY
+      ? `https://github.com/${process.env.GITHUB_REPOSITORY}.git`
+      : 'origin';
+
+    // Fetch target branch from the remote.
+    execSync(`git fetch ${remoteUrl} ${targetBranch}`, {
       stdio: 'ignore',
     });
 
-    // Find the merge base with the target branch.
-    const mergeBase = execSync('git merge-base HEAD FETCH_HEAD', {
-      encoding: 'utf-8',
-    }).trim();
-
-    // Get changed files
-    const changedFiles = execSync(`git diff --name-only ${mergeBase} HEAD`, {
+    // Get changed files using the triple-dot syntax which correctly handles merge commits
+    const changedFiles = execSync(`git diff --name-only FETCH_HEAD...HEAD`, {
       encoding: 'utf-8',
     })
       .split('\n')


### PR DESCRIPTION
## Summary

Fixes false positives in the chained E2E workflow where `scripts/changed_prompt.js` incorrectly triggers E2E evaluation tests on PRs with merge commits.

## Details

Previously, the script manually computed the merge base against `origin/main` (which, on forks, could be outdated) or got confused by multiple merge bases during criss-cross merges. By changing the script to fetch the upstream repository directly and comparing the changes with Git's `FETCH_HEAD...HEAD` triple-dot syntax, Git accurately identifies the changes actually introduced by the PR branch, eliminating false positives caused by merge commits from `main`.

## Related Issues

<!-- -->

## How to Validate

1. Verify the script correctly detects changed files.
2. The GitHub Action test run for this PR should not trigger the always passing evals job, but another test run with a dummy prompt change should.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
