### PR TITLE
Broken link in "Packaging as an extension" section

### DIFF
--- a/docs/hooks/writing-hooks.md
+++ b/docs/hooks/writing-hooks.md
@@ -470,5 +470,5 @@ console.error('Consolidating memories for session end...');
 
 While project-level hooks are great for specific repositories, you can share
 your hooks across multiple projects by packaging them as a
-[Gemini CLI extension](https://www.google.com/search?q=../extensions/index.md).
+[Gemini CLI extension](https://geminicli.com/docs/extensions/)
 This provides version control, easy distribution, and centralized management.


### PR DESCRIPTION
Fix broken link in the "Packaging as an extension" section.

Previously the link redirected to a Google search instead of the
Gemini CLI extensions documentation.

