### PR TITLE
fix(core): preserve ask_user payload in CoreToolScheduler

### DIFF
--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -804,6 +804,81 @@ describe('CoreToolScheduler with payload', () => {
       newContent: 'final version',
     });
   });
+
+  it('should forward ask_user payload through wrapped onConfirm', async () => {
+    const originalOnConfirm = vi.fn().mockResolvedValue(undefined);
+    const mockTool = new MockTool({
+      name: 'mockTool',
+      shouldConfirmExecute: async () => ({
+        type: 'ask_user',
+        title: 'Ask User',
+        questions: [],
+        onConfirm: originalOnConfirm,
+      }),
+    });
+
+    const mockToolRegistry = {
+      getTool: () => mockTool,
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {},
+      registerTool: () => {},
+      getToolByName: () => mockTool,
+      getToolByDisplayName: () => mockTool,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => [],
+      getToolsByServer: () => [],
+    } as unknown as ToolRegistry;
+
+    const onToolCallsUpdate = vi.fn();
+    const mockConfig = createMockConfig({
+      getToolRegistry: () => mockToolRegistry,
+    });
+    const mockMessageBus = createMockMessageBus();
+    mockConfig.getMessageBus = vi.fn().mockReturnValue(mockMessageBus);
+    mockConfig.getEnableHooks = vi.fn().mockReturnValue(false);
+    mockConfig.getHookSystem = vi
+      .fn()
+      .mockReturnValue(new HookSystem(mockConfig));
+
+    const scheduler = new CoreToolScheduler({
+      config: mockConfig,
+      onToolCallsUpdate,
+      getPreferredEditor: () => 'vscode',
+    });
+
+    await scheduler.schedule(
+      [
+        {
+          callId: 'ask-user-call',
+          name: 'mockTool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-id-1',
+        },
+      ],
+      new AbortController().signal,
+    );
+
+    const waitingCall = (await waitForStatus(
+      onToolCallsUpdate,
+      CoreToolCallStatus.AwaitingApproval,
+    )) as WaitingToolCall;
+
+    const payload: ToolConfirmationPayload = {
+      answers: { '0': 'Test answer from user' },
+    };
+
+    await (
+      waitingCall.confirmationDetails as ToolCallConfirmationDetails
+    ).onConfirm(ToolConfirmationOutcome.ProceedOnce, payload);
+
+    expect(originalOnConfirm).toHaveBeenCalledWith(
+      ToolConfirmationOutcome.ProceedOnce,
+      payload,
+    );
+  });
 });
 
 class MockEditToolInvocation extends BaseToolInvocation<

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -787,7 +787,10 @@ export class CoreToolScheduler {
 
   async handleConfirmationResponse(
     callId: string,
-    originalOnConfirm: (outcome: ToolConfirmationOutcome) => Promise<void>,
+    originalOnConfirm: (
+      outcome: ToolConfirmationOutcome,
+      payload?: ToolConfirmationPayload,
+    ) => Promise<void>,
     outcome: ToolConfirmationOutcome,
     signal: AbortSignal,
     payload?: ToolConfirmationPayload,
@@ -799,7 +802,7 @@ export class CoreToolScheduler {
     );
 
     if (toolCall && toolCall.status === CoreToolCallStatus.AwaitingApproval) {
-      await originalOnConfirm(outcome);
+      await originalOnConfirm(outcome, payload);
     }
 
     this.setToolCallOutcome(callId, outcome);


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Fixes a regression in `CoreToolScheduler.handleConfirmationResponse()` where confirmation payloads were not forwarded to the wrapped `onConfirm` callback. This caused `ask_user` answers to be dropped for non-TUI integrations.


## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
Forward the optional `payload` argument to `originalOnConfirm()` inside `handleConfirmationResponse()`.

Add a regression test covering the `ask_user` confirmation path through the scheduler's wrapped `onConfirm` callback so submitted answers are preserved.


## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes #22120

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
Run:

```bash
npm run test --workspace @google/gemini-cli-core -- src/core/coreToolScheduler.test.ts src/tools/ask-user.test.ts
```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
