### PR TITLE
feat: add logging for model quota exhaustion in auto mode

### DIFF
--- a/packages/core/src/availability/policyHelpers.test.ts
+++ b/packages/core/src/availability/policyHelpers.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2026 Google LLC
+ * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/core/src/availability/policyHelpers.test.ts
+++ b/packages/core/src/availability/policyHelpers.test.ts
@@ -1,10 +1,10 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   resolvePolicyChain,
   buildFallbackPolicyContext,
@@ -22,11 +22,16 @@ import {
 import { AuthType } from '../core/contentGenerator.js';
 import { coreEvents } from '../utils/events.js';
 
-vi.mock('../utils/events.js', () => ({
-  coreEvents: {
-    emitFeedback: vi.fn(),
-  },
-}));
+vi.mock('../utils/events.js', async (importActual) => {
+  const actual = await importActual<typeof import('../utils/events.js')>();
+  return {
+    ...actual,
+    coreEvents: {
+      ...actual.coreEvents,
+      emitFeedback: vi.fn(),
+    },
+  };
+});
 
 const createMockConfig = (overrides: Partial<Config> = {}): Config => {
   const config = {
@@ -45,6 +50,10 @@ const createMockConfig = (overrides: Partial<Config> = {}): Config => {
 };
 
 describe('policyHelpers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe('resolvePolicyChain', () => {
     it('returns a single-model chain for a custom model', () => {
       const config = createMockConfig({

--- a/packages/core/src/availability/policyHelpers.test.ts
+++ b/packages/core/src/availability/policyHelpers.test.ts
@@ -9,6 +9,7 @@ import {
   resolvePolicyChain,
   buildFallbackPolicyContext,
   applyModelSelection,
+  applyAvailabilityTransition,
 } from './policyHelpers.js';
 import { createDefaultPolicy } from './policyCatalog.js';
 import type { Config } from '../config/config.js';
@@ -19,6 +20,13 @@ import {
   PREVIEW_GEMINI_3_1_MODEL,
 } from '../config/models.js';
 import { AuthType } from '../core/contentGenerator.js';
+import { coreEvents } from '../utils/events.js';
+
+vi.mock('../utils/events.js', () => ({
+  coreEvents: {
+    emitFeedback: vi.fn(),
+  },
+}));
 
 const createMockConfig = (overrides: Partial<Config> = {}): Config => {
   const config = {
@@ -359,6 +367,85 @@ describe('policyHelpers', () => {
       ).not.toHaveBeenCalled();
       expect(config.setActiveModel).toHaveBeenCalledWith('gemini-pro');
       expect(result.maxAttempts).toBe(1);
+    });
+  });
+
+  describe('applyAvailabilityTransition', () => {
+    it('emits feedback when transition is terminal, reason is quota and isAutoMode is true', () => {
+      const mockService = {
+        markTerminal: vi.fn(),
+      };
+      const context = {
+        service:
+          mockService as unknown as import('./modelAvailabilityService.js').ModelAvailabilityService,
+        policy: {
+          model: 'test-model',
+          stateTransitions: {
+            terminal: 'terminal',
+          },
+        } as unknown as import('./modelPolicy.js').ModelPolicy,
+      };
+
+      applyAvailabilityTransition(() => context, 'terminal', true);
+
+      expect(mockService.markTerminal).toHaveBeenCalledWith(
+        'test-model',
+        'quota',
+      );
+      expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+        'warning',
+        'Quota exhausted for test-model. Switching to a fallback model.',
+      );
+    });
+
+    it('does NOT emit feedback when isAutoMode is false', () => {
+      const mockService = {
+        markTerminal: vi.fn(),
+      };
+      const context = {
+        service:
+          mockService as unknown as import('./modelAvailabilityService.js').ModelAvailabilityService,
+        policy: {
+          model: 'test-model',
+          stateTransitions: {
+            terminal: 'terminal',
+          },
+        } as unknown as import('./modelPolicy.js').ModelPolicy,
+      };
+
+      vi.mocked(coreEvents.emitFeedback).mockClear();
+      applyAvailabilityTransition(() => context, 'terminal', false);
+
+      expect(mockService.markTerminal).toHaveBeenCalledWith(
+        'test-model',
+        'quota',
+      );
+      expect(coreEvents.emitFeedback).not.toHaveBeenCalled();
+    });
+
+    it('does NOT emit feedback when reason is capacity', () => {
+      const mockService = {
+        markTerminal: vi.fn(),
+      };
+      const context = {
+        service:
+          mockService as unknown as import('./modelAvailabilityService.js').ModelAvailabilityService,
+        policy: {
+          model: 'test-model',
+          stateTransitions: {
+            unknown: 'terminal',
+          },
+        } as unknown as import('./modelPolicy.js').ModelPolicy,
+      };
+
+      vi.mocked(coreEvents.emitFeedback).mockClear();
+      applyAvailabilityTransition(() => context, 'unknown', true);
+
+      expect(mockService.markTerminal).toHaveBeenCalledWith(
+        'test-model',
+        'capacity',
+      );
+      expect(coreEvents.emitFeedback).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/availability/policyHelpers.ts
+++ b/packages/core/src/availability/policyHelpers.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/core/src/availability/policyHelpers.ts
+++ b/packages/core/src/availability/policyHelpers.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2026 Google LLC
+ * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/core/src/availability/policyHelpers.ts
+++ b/packages/core/src/availability/policyHelpers.ts
@@ -29,6 +29,7 @@ import {
 } from '../config/models.js';
 import type { ModelSelectionResult } from './modelAvailabilityService.js';
 import type { ModelConfigKey } from '../services/modelConfigService.js';
+import { coreEvents } from '../utils/events.js';
 
 /**
  * Resolves the active policy chain for the given config, ensuring the
@@ -230,6 +231,7 @@ export function applyModelSelection(
 export function applyAvailabilityTransition(
   getContext: (() => RetryAvailabilityContext | undefined) | undefined,
   failureKind: FailureKind,
+  isAutoMode: boolean = false,
 ): void {
   const context = getContext?.();
   if (!context) return;
@@ -238,10 +240,15 @@ export function applyAvailabilityTransition(
   if (!transition) return;
 
   if (transition === 'terminal') {
-    context.service.markTerminal(
-      context.policy.model,
-      failureKind === 'terminal' ? 'quota' : 'capacity',
-    );
+    const reason = failureKind === 'terminal' ? 'quota' : 'capacity';
+    context.service.markTerminal(context.policy.model, reason);
+
+    if (isAutoMode && reason === 'quota') {
+      coreEvents.emitFeedback(
+        'warning',
+        `Quota exhausted for ${context.policy.model}. Switching to a fallback model.`,
+      );
+    }
   } else if (transition === 'sticky_retry') {
     context.service.markRetryOncePerTurn(context.policy.model);
   }

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2026 Google LLC
+ * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -36,6 +36,7 @@ import {
   RetryableQuotaError,
   TerminalQuotaError,
 } from '../utils/googleQuotaErrors.js';
+import { coreEvents } from '../utils/events.js';
 
 // Mock the telemetry logger and event class
 vi.mock('../telemetry/index.js', () => ({
@@ -45,6 +46,38 @@ vi.mock('../telemetry/index.js', () => ({
 vi.mock('../utils/secure-browser-launcher.js', () => ({
   openBrowserSecurely: vi.fn(),
   shouldLaunchBrowser: vi.fn().mockReturnValue(true),
+}));
+
+// Mock coreEvents
+vi.mock('../utils/events.js', () => ({
+  coreEvents: {
+    emitFeedback: vi.fn(),
+  },
+  CoreEvent: {
+    UserFeedback: 'user-feedback',
+    ModelChanged: 'model-changed',
+    ConsoleLog: 'console-log',
+    Output: 'output',
+    MemoryChanged: 'memory-changed',
+    ExternalEditorClosed: 'external-editor-closed',
+    McpClientUpdate: 'mcp-client-update',
+    OauthDisplayMessage: 'oauth-display-message',
+    SettingsChanged: 'settings-changed',
+    HookStart: 'hook-start',
+    HookEnd: 'hook-end',
+    AgentsRefreshed: 'agents-refreshed',
+    AdminSettingsChanged: 'admin-settings-changed',
+    RetryAttempt: 'retry-attempt',
+    ConsentRequest: 'consent-request',
+    McpProgress: 'mcp-progress',
+    AgentsDiscovered: 'agents-discovered',
+    RequestEditorSelection: 'request-editor-selection',
+    EditorSelected: 'editor-selected',
+    SlashCommandConflicts: 'slash-command-conflicts',
+    QuotaChanged: 'quota-changed',
+    TelemetryKeychainAvailability: 'telemetry-keychain-availability',
+    TelemetryTokenStorageType: 'telemetry-token-storage-type',
+  },
 }));
 
 // Mock debugLogger to prevent console pollution and allow spying
@@ -410,6 +443,51 @@ describe('handleFallback', () => {
 
       expect(result).toBe(true);
       expect(policyConfig.activateFallbackMode).not.toHaveBeenCalled();
+    });
+
+    it('emits feedback when quota is exhausted in auto mode', async () => {
+      vi.mocked(policyConfig.getModel).mockReturnValue(
+        DEFAULT_GEMINI_MODEL_AUTO,
+      );
+      policyHandler.mockResolvedValue('retry_always');
+
+      const terminalError = new TerminalQuotaError('Quota error', {
+        code: 429,
+        message: 'Quota exceeded',
+        details: [],
+      });
+
+      await handleFallback(
+        policyConfig,
+        MOCK_PRO_MODEL,
+        AUTH_OAUTH,
+        terminalError,
+      );
+
+      expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+        'warning',
+        `Quota exhausted for ${MOCK_PRO_MODEL}. Switching to a fallback model.`,
+      );
+    });
+
+    it('does NOT emit feedback when quota is exhausted in manual mode', async () => {
+      vi.mocked(policyConfig.getModel).mockReturnValue(MOCK_PRO_MODEL);
+      policyHandler.mockResolvedValue('retry_always');
+
+      const terminalError = new TerminalQuotaError('Quota error', {
+        code: 429,
+        message: 'Quota exceeded',
+        details: [],
+      });
+
+      await handleFallback(
+        policyConfig,
+        MOCK_PRO_MODEL,
+        AUTH_OAUTH,
+        terminalError,
+      );
+
+      expect(coreEvents.emitFeedback).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -53,31 +53,6 @@ vi.mock('../utils/events.js', () => ({
   coreEvents: {
     emitFeedback: vi.fn(),
   },
-  CoreEvent: {
-    UserFeedback: 'user-feedback',
-    ModelChanged: 'model-changed',
-    ConsoleLog: 'console-log',
-    Output: 'output',
-    MemoryChanged: 'memory-changed',
-    ExternalEditorClosed: 'external-editor-closed',
-    McpClientUpdate: 'mcp-client-update',
-    OauthDisplayMessage: 'oauth-display-message',
-    SettingsChanged: 'settings-changed',
-    HookStart: 'hook-start',
-    HookEnd: 'hook-end',
-    AgentsRefreshed: 'agents-refreshed',
-    AdminSettingsChanged: 'admin-settings-changed',
-    RetryAttempt: 'retry-attempt',
-    ConsentRequest: 'consent-request',
-    McpProgress: 'mcp-progress',
-    AgentsDiscovered: 'agents-discovered',
-    RequestEditorSelection: 'request-editor-selection',
-    EditorSelected: 'editor-selected',
-    SlashCommandConflicts: 'slash-command-conflicts',
-    QuotaChanged: 'quota-changed',
-    TelemetryKeychainAvailability: 'telemetry-keychain-availability',
-    TelemetryTokenStorageType: 'telemetry-token-storage-type',
-  },
 }));
 
 // Mock debugLogger to prevent console pollution and allow spying

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2026 Google LLC
+ * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -13,6 +13,7 @@ import { debugLogger } from '../utils/debugLogger.js';
 import { getErrorMessage } from '../utils/errors.js';
 import type { FallbackIntent, FallbackRecommendation } from './types.js';
 import { classifyFailureKind } from '../availability/errorClassification.js';
+import { isAutoModel } from '../config/models.js';
 import {
   buildFallbackPolicyContext,
   resolvePolicyChain,
@@ -40,6 +41,8 @@ export async function handleFallback(
     if (!failedPolicy) return undefined;
     return { service: availability, policy: failedPolicy };
   };
+
+  const isAutoMode = isAutoModel(config.getModel());
 
   let fallbackModel: string;
   if (!candidates.length) {
@@ -70,7 +73,11 @@ export async function handleFallback(
     const action = resolvePolicyAction(failureKind, selectedPolicy);
 
     if (action === 'silent') {
-      applyAvailabilityTransition(getAvailabilityContext, failureKind);
+      applyAvailabilityTransition(
+        getAvailabilityContext,
+        failureKind,
+        isAutoMode,
+      );
       return processIntent(config, 'retry_always', fallbackModel);
     }
 
@@ -99,7 +106,11 @@ export async function handleFallback(
     // We DO NOT apply it if the user chose 'stop' or 'retry_later', allowing
     // them to try again later with the same model state.
     if (intent === 'retry_always' || intent === 'retry_once') {
-      applyAvailabilityTransition(getAvailabilityContext, failureKind);
+      applyAvailabilityTransition(
+        getAvailabilityContext,
+        failureKind,
+        isAutoMode,
+      );
     }
 
     return await processIntent(config, intent, fallbackModel);


### PR DESCRIPTION
## Summary

This PR adds explicit user-facing logging when a model's quota is exhausted while operating in "auto" mode. This provides transparency into which specific model (e.g., `gemini-3-pro-preview`) has had its quota exhausted before the system automatically switches to a fallback model.

## Details

- Modified `applyAvailabilityTransition` in `policyHelpers.ts` to accept an `isAutoMode` flag and emit a warning feedback message via `coreEvents` when a `terminal` quota error occurs.
- Updated `handleFallback` in `handler.ts` to calculate `isAutoMode` based on the configured model and pass it to the transition logic.
- Added comprehensive unit tests in `policyHelpers.test.ts` and `handler.test.ts` to verify that feedback is emitted only in auto mode and only for quota-related terminal failures.
- Fixed linting issues regarding `explicit-any` in the new test cases.

## Related Issues

Related to #22107 

## How to Validate

1. Run the new unit tests to ensure the logic correctly identifies auto mode and quota failures:
   ```bash
   npm test -w @google/gemini-cli-core -- src/fallback/handler.test.ts src/availability/policyHelpers.test.ts
   ```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
