### PR TITLE
feat(ui): rename ToDo to Tasks in the list tray component

### DIFF
--- a/packages/cli/src/ui/components/messages/Todo.tsx
+++ b/packages/cli/src/ui/components/messages/Todo.tsx
@@ -54,7 +54,7 @@ export const TodoTray: React.FC = () => {
 
   return (
     <Checklist
-      title="Todo"
+      title="Tasks"
       items={checklistItems}
       isExpanded={uiState.showFullTodos}
       toggleHint={`${formatCommand(Command.SHOW_FULL_TODOS)} to toggle`}

--- a/packages/cli/src/ui/components/messages/__snapshots__/Todo.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/Todo.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<TodoTray /> (showFullTodos: false) > renders a todo list with long descriptions that wrap when full view is on 1`] = `
 "──────────────────────────────────────────────────
- Todo  1/2 completed (Ctrl+T to toggle) » This i…
+ Tasks  1/2 completed (Ctrl+T to toggle) » This …
 "
 `;
 
@@ -14,25 +14,25 @@ exports[`<TodoTray /> (showFullTodos: false) > renders null when todo list is em
 
 exports[`<TodoTray /> (showFullTodos: false) > renders the most recent todo list when multiple write_todos calls are in history 1`] = `
 "────────────────────────────────────────────────────────────────────────────────────────────────────
- Todo  0/2 completed (Ctrl+T to toggle) » Newer Task 2
+ Tasks  0/2 completed (Ctrl+T to toggle) » Newer Task 2
 "
 `;
 
 exports[`<TodoTray /> (showFullTodos: false) > renders when todos exist and one is in progress 1`] = `
 "────────────────────────────────────────────────────────────────────────────────────────────────────
- Todo  1/3 completed (Ctrl+T to toggle) » Task 2
+ Tasks  1/3 completed (Ctrl+T to toggle) » Task 2
 "
 `;
 
 exports[`<TodoTray /> (showFullTodos: false) > renders when todos exist but none are in progress 1`] = `
 "────────────────────────────────────────────────────────────────────────────────────────────────────
- Todo  1/2 completed (Ctrl+T to toggle)
+ Tasks  1/2 completed (Ctrl+T to toggle)
 "
 `;
 
 exports[`<TodoTray /> (showFullTodos: true) > renders a todo list with long descriptions that wrap when full view is on 1`] = `
 "──────────────────────────────────────────────────
- Todo  1/2 completed (Ctrl+T to toggle)
+ Tasks  1/2 completed (Ctrl+T to toggle)
 
  » This is a very long description for a pending
    task that should wrap around multiple lines
@@ -44,7 +44,7 @@ exports[`<TodoTray /> (showFullTodos: true) > renders a todo list with long desc
 
 exports[`<TodoTray /> (showFullTodos: true) > renders full list when all todos are inactive 1`] = `
 "────────────────────────────────────────────────────────────────────────────────────────────────────
- Todo  1/1 completed (Ctrl+T to toggle)
+ Tasks  1/1 completed (Ctrl+T to toggle)
 
  ✓ Task 1
  ✗ Task 2
@@ -57,7 +57,7 @@ exports[`<TodoTray /> (showFullTodos: true) > renders null when todo list is emp
 
 exports[`<TodoTray /> (showFullTodos: true) > renders the most recent todo list when multiple write_todos calls are in history 1`] = `
 "────────────────────────────────────────────────────────────────────────────────────────────────────
- Todo  0/2 completed (Ctrl+T to toggle)
+ Tasks  0/2 completed (Ctrl+T to toggle)
 
  ☐ Newer Task 1
  » Newer Task 2
@@ -66,7 +66,7 @@ exports[`<TodoTray /> (showFullTodos: true) > renders the most recent todo list 
 
 exports[`<TodoTray /> (showFullTodos: true) > renders when todos exist and one is in progress 1`] = `
 "────────────────────────────────────────────────────────────────────────────────────────────────────
- Todo  1/3 completed (Ctrl+T to toggle)
+ Tasks  1/3 completed (Ctrl+T to toggle)
 
  ☐ Pending Task
  » Task 2
@@ -77,7 +77,7 @@ exports[`<TodoTray /> (showFullTodos: true) > renders when todos exist and one i
 
 exports[`<TodoTray /> (showFullTodos: true) > renders when todos exist but none are in progress 1`] = `
 "────────────────────────────────────────────────────────────────────────────────────────────────────
- Todo  1/2 completed (Ctrl+T to toggle)
+ Tasks  1/2 completed (Ctrl+T to toggle)
 
  ☐ Pending Task
  ✗ In Progress Task


### PR DESCRIPTION
Fixes #22203

### Description
This PR updates the UI of the list tray component to rename the title from \Todo\ to \Tasks\.

### Changes
- Changed the \	itle\ prop of the \Checklist\ component in \packages/cli/src/ui/components/messages/Todo.tsx\ from \Todo\ to \Tasks\.
- Updated the associated snapshot tests in \Todo.test.tsx\ to reflect the new label.