### PR TITLE
fix(core): deduplicate command names in Action Required UI

### DIFF
--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -124,9 +124,9 @@ export class ShellToolInvocation extends BaseToolInvocation<
         rootCommandDisplay += ', redirection';
       }
     } else {
-      rootCommandDisplay = parsed.details
-        .map((detail) => detail.name)
-        .join(', ');
+      rootCommandDisplay = Array.from(
+        new Set(parsed.details.map((detail) => detail.name)),
+      ).join(', ');
     }
 
     const rootCommands = [...new Set(getCommandRoots(command))];


### PR DESCRIPTION
Fixes #19768. Deduplicates identical tool calls when constructing the prompt header for action requirements.