### PR TITLE
fix(core): respect browser agent settings overrides from registry

### DIFF
--- a/packages/core/src/agents/browser/browserAgentFactory.ts
+++ b/packages/core/src/agents/browser/browserAgentFactory.ts
@@ -23,6 +23,7 @@ import type { AnyDeclarativeTool } from '../../tools/tools.js';
 import { BrowserManager } from './browserManager.js';
 import {
   BrowserAgentDefinition,
+  BROWSER_AGENT_NAME,
   type BrowserTaskResultSchema,
 } from './browserAgentDefinition.js';
 import { createMcpDeclarativeTools } from './mcpToolWrapper.js';
@@ -153,8 +154,28 @@ export async function createBrowserAgentDefinition(
   );
 
   // Create configured definition with tools
-  // BrowserAgentDefinition is a factory function - call it with config
-  const baseDefinition = BrowserAgentDefinition(config, !visionDisabledReason);
+  // Attempt to use the existing definition from the registry to preserve overrides
+  let baseDefinition:
+    | LocalAgentDefinition<typeof BrowserTaskResultSchema>
+    | undefined = undefined;
+
+  const registryDef = config
+    .getAgentRegistry()
+    ?.getDefinition(BROWSER_AGENT_NAME);
+
+  if (registryDef && registryDef.kind === 'local') {
+    // We know it's a LocalAgentDefinition, we can safely assume it has the right schema
+    // since we registered it as such.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    baseDefinition = registryDef as unknown as LocalAgentDefinition<
+      typeof BrowserTaskResultSchema
+    >;
+  }
+
+  if (!baseDefinition) {
+    baseDefinition = BrowserAgentDefinition(config, !visionDisabledReason);
+  }
+
   const definition: LocalAgentDefinition<typeof BrowserTaskResultSchema> = {
     ...baseDefinition,
     toolConfig: {


### PR DESCRIPTION
Fixes #22267

## What happened?
The Browser Agent completely ignored configuration overrides provided in global or project-level `settings.json` (e.g., `maxTurns`, `maxTimeMinutes`). The [browserAgentFactory.ts](cci:7://file:///d:/GSOC%2026/Gemini%20CLI/packages/core/src/agents/browser/browserAgentFactory.ts:0:0-0:0) recreated a raw definition with hardcoded defaults instead of retrieving the pre-merged definition from the [AgentRegistry](cci:2://file:///d:/GSOC%2026/Gemini%20CLI/packages/core/src/agents/registry.ts:40:0-568:1).

## Root Cause
In [createBrowserAgentDefinition()](cci:1://file:///d:/GSOC%2026/Gemini%20CLI/packages/core/src/agents/browser/browserAgentFactory.ts:32:0-163:1), the factory called [BrowserAgentDefinition(config, ...)](cci:1://file:///d:/GSOC%2026/Gemini%20CLI/packages/core/src/agents/browser/browserAgentFactory.ts:32:0-163:1) directly, which always returns hardcoded defaults. Meanwhile, the [AgentRegistry](cci:2://file:///d:/GSOC%2026/Gemini%20CLI/packages/core/src/agents/registry.ts:40:0-568:1) had already merged user overrides from `settings.json` during initialization — but this merged definition was never consulted.

## Fix
Modified [browserAgentFactory.ts](cci:7://file:///d:/GSOC%2026/Gemini%20CLI/packages/core/src/agents/browser/browserAgentFactory.ts:0:0-0:0) to first check for an existing definition in the [AgentRegistry](cci:2://file:///d:/GSOC%2026/Gemini%20CLI/packages/core/src/agents/registry.ts:40:0-568:1) via `config.getAgentRegistry()?.getDefinition(BROWSER_AGENT_NAME)`. If found, it uses that (preserving all user overrides). If not found, it falls back to the original behavior.

## Testing
- All existing [browserAgentFactory.test.ts](cci:7://file:///d:/GSOC%2026/Gemini%20CLI/packages/core/src/agents/browser/browserAgentFactory.test.ts:0:0-0:0) tests pass (13/13)
- Full test suite passes (`npm run test` — 5500+ tests)
- TypeScript type checking passes (`npm run typecheck`)