### PR TITLE
feat(cli): allow disabling startup prompt context in one-shot mode

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -3671,3 +3671,99 @@ describe('loadCliConfig acpMode and clientName', () => {
     expect(config.getClientName()).toBeUndefined();
   });
 });
+
+describe('non-interactive prompt context controls', () => {
+  it('should parse --no-prompt-context', async () => {
+    process.argv = [
+      'node',
+      'script.js',
+      '--prompt',
+      'test',
+      '--no-prompt-context',
+    ];
+
+    const argv = await parseArguments(createTestMergedSettings());
+
+    expect(argv.promptContext).toBe(false);
+  });
+
+  it('should disable startup context in non-interactive mode when --no-prompt-context is used', async () => {
+    process.argv = [
+      'node',
+      'script.js',
+      '--prompt',
+      'test',
+      '--no-prompt-context',
+    ];
+
+    const argv = await parseArguments(createTestMergedSettings());
+    const config = await loadCliConfig(
+      createTestMergedSettings(),
+      'test-session-id',
+      argv,
+    );
+
+    expect(config.getIncludeEnvironmentContext()).toBe(false);
+    expect(config.getIncludeSystemPrompt()).toBe(false);
+  });
+
+  it('should skip memory discovery in non-interactive mode when prompt context is disabled', async () => {
+    process.argv = [
+      'node',
+      'script.js',
+      '--prompt',
+      'test',
+      '--no-prompt-context',
+    ];
+
+    const argv = await parseArguments(createTestMergedSettings());
+    await loadCliConfig(createTestMergedSettings(), 'test-session-id', argv);
+
+    expect(ServerConfig.loadServerHierarchicalMemory).not.toHaveBeenCalled();
+  });
+
+  it('should disable startup context in non-interactive mode when config disables it', async () => {
+    process.argv = ['node', 'script.js', '--prompt', 'test'];
+
+    const settings = createTestMergedSettings({
+      context: { includePromptContextInNonInteractive: false },
+    });
+    const argv = await parseArguments(settings);
+    const config = await loadCliConfig(settings, 'test-session-id', argv);
+
+    expect(config.getIncludeEnvironmentContext()).toBe(false);
+    expect(config.getIncludeSystemPrompt()).toBe(false);
+  });
+
+  it('should allow CLI flag to re-enable startup context when config disables it', async () => {
+    process.argv = [
+      'node',
+      'script.js',
+      '--prompt',
+      'test',
+      '--prompt-context',
+    ];
+
+    const settings = createTestMergedSettings({
+      context: { includePromptContextInNonInteractive: false },
+    });
+    const argv = await parseArguments(settings);
+    const config = await loadCliConfig(settings, 'test-session-id', argv);
+
+    expect(config.getIncludeEnvironmentContext()).toBe(true);
+    expect(config.getIncludeSystemPrompt()).toBe(true);
+  });
+
+  it('should keep startup context in interactive mode even when context setting is false', async () => {
+    process.argv = ['node', 'script.js', '--prompt-interactive', 'test'];
+
+    const settings = createTestMergedSettings({
+      context: { includePromptContextInNonInteractive: false },
+    });
+    const argv = await parseArguments(settings);
+    const config = await loadCliConfig(settings, 'test-session-id', argv);
+
+    expect(config.getIncludeEnvironmentContext()).toBe(true);
+    expect(config.getIncludeSystemPrompt()).toBe(true);
+  });
+});

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -75,6 +75,7 @@ export interface CliArgs {
   debug: boolean | undefined;
   prompt: string | undefined;
   promptInteractive: string | undefined;
+  promptContext: boolean | undefined;
 
   yolo: boolean | undefined;
   approvalMode: string | undefined;
@@ -158,6 +159,11 @@ export async function parseArguments(
           nargs: 1,
           description:
             'Execute the provided prompt and continue in interactive mode',
+        })
+        .option('prompt-context', {
+          type: 'boolean',
+          description:
+            'Include startup context (system prompt and workspace context) in non-interactive mode. Use --no-prompt-context to disable.',
         })
         .option('sandbox', {
           alias: 's',
@@ -439,6 +445,10 @@ export async function loadCliConfig(
 
   const memoryImportFormat = settings.context?.importFormat || 'tree';
   const includeDirectoryTree = settings.context?.includeDirectoryTree ?? true;
+  const includePromptContextInNonInteractive =
+    argv.promptContext ??
+    settings.context?.includePromptContextInNonInteractive ??
+    true;
 
   const ideMode = settings.ide?.enabled ?? false;
 
@@ -495,6 +505,17 @@ export async function loadCliConfig(
   const extensionPlanSettings = extensionManager
     .getExtensions()
     .find((ext) => ext.isActive && ext.plan?.directory)?.plan;
+  // -p/--prompt forces non-interactive (headless) mode
+  // -i/--prompt-interactive forces interactive mode with an initial prompt
+  const interactive =
+    !!argv.promptInteractive ||
+    !!argv.acp ||
+    !!argv.experimentalAcp ||
+    (!isHeadlessMode({ prompt: argv.prompt, query: argv.query }) &&
+      !argv.isCommand);
+
+  const includePromptContext =
+    interactive || includePromptContextInNonInteractive;
 
   const experimentalJitContext = settings.experimental?.jitContext ?? false;
 
@@ -511,7 +532,7 @@ export async function loadCliConfig(
   let fileCount = 0;
   let filePaths: string[] = [];
 
-  if (!experimentalJitContext) {
+  if (!experimentalJitContext && includePromptContext) {
     // Call the (now wrapper) loadHierarchicalGeminiMemory which calls the server's version
     const result = await loadServerHierarchicalMemory(
       cwd,
@@ -616,15 +637,6 @@ export async function loadCliConfig(
     }
     throw err;
   }
-
-  // -p/--prompt forces non-interactive (headless) mode
-  // -i/--prompt-interactive forces interactive mode with an initial prompt
-  const interactive =
-    !!argv.promptInteractive ||
-    !!argv.acp ||
-    !!argv.experimentalAcp ||
-    (!isHeadlessMode({ prompt: argv.prompt, query: argv.query }) &&
-      !argv.isCommand);
 
   const allowedTools = argv.allowedTools || settings.tools?.allowed || [];
 
@@ -746,6 +758,8 @@ export async function loadCliConfig(
     sandbox: sandboxConfig,
     targetDir: cwd,
     includeDirectoryTree,
+    includeEnvironmentContext: includePromptContext,
+    includeSystemPrompt: includePromptContext,
     includeDirectories,
     loadMemoryFromIncludeDirectories:
       settings.context?.loadMemoryFromIncludeDirectories || false,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1171,6 +1171,16 @@ const SETTINGS_SCHEMA = {
           'Whether to include the directory tree of the current working directory in the initial request to the model.',
         showInDialog: false,
       },
+      includePromptContextInNonInteractive: {
+        type: 'boolean',
+        label: 'Include Prompt Context In Non-Interactive',
+        category: 'Context',
+        requiresRestart: false,
+        default: true,
+        description:
+          'Whether non-interactive mode should include startup context (system prompt and workspace context).',
+        showInDialog: false,
+      },
       discoveryMaxDirs: {
         type: 'number',
         label: 'Memory Discovery Max Dirs',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -567,6 +567,8 @@ export interface ConfigParameters {
   ideMode?: boolean;
   loadMemoryFromIncludeDirectories?: boolean;
   includeDirectoryTree?: boolean;
+  includeEnvironmentContext?: boolean;
+  includeSystemPrompt?: boolean;
   importFormat?: 'tree' | 'flat';
   discoveryMaxDirs?: number;
   compressionThreshold?: number;
@@ -754,6 +756,8 @@ export class Config implements McpContext, AgentLoopContext {
   private readonly acpMode: boolean = false;
   private readonly loadMemoryFromIncludeDirectories: boolean = false;
   private readonly includeDirectoryTree: boolean = true;
+  private readonly includeEnvironmentContext: boolean = true;
+  private readonly includeSystemPrompt: boolean = true;
   private readonly importFormat: 'tree' | 'flat';
   private readonly discoveryMaxDirs: number;
   private readonly compressionThreshold: number | undefined;
@@ -963,6 +967,8 @@ export class Config implements McpContext, AgentLoopContext {
     this.folderTrust = params.folderTrust ?? false;
     this.ideMode = params.ideMode ?? false;
     this.includeDirectoryTree = params.includeDirectoryTree ?? true;
+    this.includeEnvironmentContext = params.includeEnvironmentContext ?? true;
+    this.includeSystemPrompt = params.includeSystemPrompt ?? true;
     this.loadMemoryFromIncludeDirectories =
       params.loadMemoryFromIncludeDirectories ?? false;
     this.importFormat = params.importFormat ?? 'tree';
@@ -1463,6 +1469,14 @@ export class Config implements McpContext, AgentLoopContext {
 
   getIncludeDirectoryTree(): boolean {
     return this.includeDirectoryTree;
+  }
+
+  getIncludeEnvironmentContext(): boolean {
+    return this.includeEnvironmentContext;
+  }
+
+  getIncludeSystemPrompt(): boolean {
+    return this.includeSystemPrompt;
   }
 
   getImportFormat(): 'tree' | 'flat' {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -339,14 +339,24 @@ export class GeminiClient {
     });
   }
 
+  private getSystemInstruction(): string {
+    if (
+      typeof this.config.getIncludeSystemPrompt === 'function' &&
+      !this.config.getIncludeSystemPrompt()
+    ) {
+      return '';
+    }
+
+    const systemMemory = this.config.getUserMemory();
+    return getCoreSystemPrompt(this.config, systemMemory);
+  }
+
   updateSystemInstruction(): void {
     if (!this.isInitialized()) {
       return;
     }
 
-    const systemMemory = this.config.getUserMemory();
-    const systemInstruction = getCoreSystemPrompt(this.config, systemMemory);
-    this.getChat().setSystemInstruction(systemInstruction);
+    this.getChat().setSystemInstruction(this.getSystemInstruction());
   }
 
   async startChat(
@@ -364,11 +374,9 @@ export class GeminiClient {
     const history = await getInitialChatHistory(this.config, extraHistory);
 
     try {
-      const systemMemory = this.config.getUserMemory();
-      const systemInstruction = getCoreSystemPrompt(this.config, systemMemory);
       return new GeminiChat(
         this.config,
-        systemInstruction,
+        this.getSystemInstruction(),
         tools,
         history,
         resumedSessionData,
@@ -1027,8 +1035,7 @@ export class GeminiClient {
     } = desiredModelConfig;
 
     try {
-      const userMemory = this.config.getUserMemory();
-      const systemInstruction = getCoreSystemPrompt(this.config, userMemory);
+      const systemInstruction = this.getSystemInstruction();
       const {
         model,
         config: newConfig,

--- a/packages/core/src/utils/environmentContext.test.ts
+++ b/packages/core/src/utils/environmentContext.test.ts
@@ -16,6 +16,7 @@ import {
 import {
   getEnvironmentContext,
   getDirectoryContextString,
+  getInitialChatHistory,
 } from './environmentContext.js';
 import type { Config } from '../config/config.js';
 import type { Storage } from '../config/storage.js';
@@ -184,5 +185,27 @@ describe('getEnvironmentContext', () => {
     const parts = await getEnvironmentContext(mockConfig as Config);
 
     expect(parts.length).toBe(1); // No extra part added
+  });
+});
+
+describe('getInitialChatHistory', () => {
+  it('should omit environment context when disabled', async () => {
+    const history = await getInitialChatHistory({
+      getIncludeEnvironmentContext: vi.fn().mockReturnValue(false),
+    } as unknown as Config);
+
+    expect(history).toEqual([]);
+  });
+
+  it('should include extra history when environment context is disabled', async () => {
+    const extraHistory = [{ role: 'user', parts: [{ text: 'hello' }] }];
+    const history = await getInitialChatHistory(
+      {
+        getIncludeEnvironmentContext: vi.fn().mockReturnValue(false),
+      } as unknown as Config,
+      extraHistory,
+    );
+
+    expect(history).toEqual(extraHistory);
   });
 });

--- a/packages/core/src/utils/environmentContext.ts
+++ b/packages/core/src/utils/environmentContext.ts
@@ -79,6 +79,13 @@ export async function getInitialChatHistory(
   config: Config,
   extraHistory?: Content[],
 ): Promise<Content[]> {
+  if (
+    typeof config.getIncludeEnvironmentContext === 'function' &&
+    !config.getIncludeEnvironmentContext()
+  ) {
+    return [...(extraHistory ?? [])];
+  }
+
   const envParts = await getEnvironmentContext(config);
   const envContextString = envParts.map((part) => part.text || '').join('\n\n');
 


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Adds support for disabling startup prompt context in non-interactive (one-shot) mode to reduce startup latency when workspace context is not needed.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
- Added --prompt-context / --no-prompt-context CLI flags.
- Added context.includePromptContextInNonInteractive config option.
- When disabled:
   - workspace/environment context is skipped
   - system prompt injection is skipped
   - hierarchical memory loading is skipped
   - Interactive mode behavior remains unchanged.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Closes #16335

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
