### PR TITLE
fix: remove duplicate VERTEX_API_ENABLED telemetry entries

### DIFF
--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -638,18 +638,8 @@ export class ClearcutLogger {
         value: event.debug_enabled.toString(),
       },
       {
-        gemini_cli_key:
-          EventMetadataKey.GEMINI_CLI_START_SESSION_VERTEX_API_ENABLED,
-        value: event.vertex_ai_enabled.toString(),
-      },
-      {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_START_SESSION_MCP_SERVERS,
         value: event.mcp_servers,
-      },
-      {
-        gemini_cli_key:
-          EventMetadataKey.GEMINI_CLI_START_SESSION_VERTEX_API_ENABLED,
-        value: event.vertex_ai_enabled.toString(),
       },
       {
         gemini_cli_key:


### PR DESCRIPTION
hey, i noticed there were duplicate VERTEX_API_ENABLED entries being pushed to the start session telemetry event. 

found 3 copies at lines 630, 640, and 649 in clearcut-logger.ts. removed the 2 duplicates and kept the first one.

this was bloating every start session payload with redundant data. should be clean now.

let me know if you need anything else!