### PR TITLE
fix: handle null fallback intent without throwing

### DIFF
--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -158,6 +158,9 @@ async function processIntent(
       await handleUpgrade();
       return false;
 
+    case null:
+      return false;
+
     default:
       throw new Error(
         `Unexpected fallback intent received from fallbackModelHandler: "${intent}"`,


### PR DESCRIPTION
Adds a `null` case to the `processIntent` switch statement in `handler.ts`. The function's type signature already accepts `FallbackIntent | null`, but null was falling through to the default case and throwing a spurious error.

Now returns `false` for null intents, which is consistent with the "no action taken" semantics.

Closes #22317