### PR TITLE
fix: remove duplicate VERTEX_API_ENABLED telemetry entries

### DIFF
--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -638,18 +638,8 @@ export class ClearcutLogger {
         value: event.debug_enabled.toString(),
       },
       {
-        gemini_cli_key:
-          EventMetadataKey.GEMINI_CLI_START_SESSION_VERTEX_API_ENABLED,
-        value: event.vertex_ai_enabled.toString(),
-      },
-      {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_START_SESSION_MCP_SERVERS,
         value: event.mcp_servers,
-      },
-      {
-        gemini_cli_key:
-          EventMetadataKey.GEMINI_CLI_START_SESSION_VERTEX_API_ENABLED,
-        value: event.vertex_ai_enabled.toString(),
       },
       {
         gemini_cli_key:


### PR DESCRIPTION
Removes two duplicate `GEMINI_CLI_START_SESSION_VERTEX_API_ENABLED` metadata entries from the start session telemetry event builder. Only one entry is needed.

Closes #22318