### PR TITLE
fix: resolve symlinks in @import path validation to prevent traversal

### DIFF
--- a/packages/core/src/utils/memoryImportProcessor.test.ts
+++ b/packages/core/src/utils/memoryImportProcessor.test.ts
@@ -923,5 +923,29 @@ describe('memoryImportProcessor', () => {
         fsSync.rmSync(tmpDir, { recursive: true, force: true });
       }
     });
+
+    it('should allow imports when allowedDir is accessed via a symlink', () => {
+      // Regression test: if the project root itself is reached through a
+      // symlink (e.g., /tmp → /private/tmp on macOS), both the import target
+      // and the allowedDir must be canonicalized for isSubpath to match.
+      const tmpDir = fsSync.realpathSync(
+        fsSync.mkdtempSync(path.join(os.tmpdir(), 'gemini-import-test-')),
+      );
+      const realRoot = path.join(tmpDir, 'real-root');
+      const symlinkRoot = path.join(tmpDir, 'link-root');
+
+      try {
+        fsSync.mkdirSync(realRoot, { recursive: true });
+        fsSync.writeFileSync(path.join(realRoot, 'file.md'), 'hello');
+        fsSync.symlinkSync(realRoot, symlinkRoot);
+
+        // allowedDir is the symlink path; import resolves canonically
+        expect(validateImportPath('file.md', symlinkRoot, [symlinkRoot])).toBe(
+          true,
+        );
+      } finally {
+        fsSync.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/packages/core/src/utils/memoryImportProcessor.test.ts
+++ b/packages/core/src/utils/memoryImportProcessor.test.ts
@@ -6,7 +6,9 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs/promises';
+import * as fsSync from 'node:fs';
 import * as path from 'node:path';
+import * as os from 'node:os';
 import { marked } from 'marked';
 import { processImports, validateImportPath } from './memoryImportProcessor.js';
 import { debugLogger } from './debugLogger.js';
@@ -866,6 +868,60 @@ describe('memoryImportProcessor', () => {
         'file.md',
       );
       expect(validateImportPath(dotPath, basePath, [allowedPath])).toBe(true);
+    });
+
+    it('should reject symlinks that point outside allowed directories', () => {
+      // Use sync fs (not mocked) to create real temp directory structure
+      const tmpDir = fsSync.mkdtempSync(
+        path.join(os.tmpdir(), 'gemini-import-test-'),
+      );
+      const projectDir = path.join(tmpDir, 'project');
+      const secretDir = path.join(tmpDir, 'secrets');
+
+      try {
+        fsSync.mkdirSync(projectDir, { recursive: true });
+        fsSync.mkdirSync(secretDir, { recursive: true });
+        fsSync.writeFileSync(path.join(secretDir, 'key.pem'), 'SECRET_KEY');
+
+        // Create a symlink inside the project that points to the secret file
+        const symlinkPath = path.join(projectDir, 'innocent-ref');
+        fsSync.symlinkSync(path.join(secretDir, 'key.pem'), symlinkPath);
+
+        // The symlink lexically resolves inside the project, but its real
+        // target is outside — validateImportPath must reject it.
+        expect(
+          validateImportPath('innocent-ref', projectDir, [projectDir]),
+        ).toBe(false);
+      } finally {
+        fsSync.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should allow symlinks that point within allowed directories', () => {
+      const tmpDir = fsSync.mkdtempSync(
+        path.join(os.tmpdir(), 'gemini-import-test-'),
+      );
+      const projectDir = path.join(tmpDir, 'project');
+      const docsDir = path.join(projectDir, 'docs');
+      const srcDir = path.join(projectDir, 'src');
+
+      try {
+        fsSync.mkdirSync(docsDir, { recursive: true });
+        fsSync.mkdirSync(srcDir, { recursive: true });
+        fsSync.writeFileSync(path.join(srcDir, 'README.md'), 'hello');
+
+        // Symlink within the project directory — should be allowed
+        fsSync.symlinkSync(
+          path.join(srcDir, 'README.md'),
+          path.join(docsDir, 'link.md'),
+        );
+
+        expect(
+          validateImportPath('docs/link.md', projectDir, [projectDir]),
+        ).toBe(true);
+      } finally {
+        fsSync.rmSync(tmpDir, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/packages/core/src/utils/memoryImportProcessor.ts
+++ b/packages/core/src/utils/memoryImportProcessor.ts
@@ -5,6 +5,7 @@
  */
 
 import * as fs from 'node:fs/promises';
+import * as fsSync from 'node:fs';
 import * as path from 'node:path';
 import { isSubpath } from './paths.js';
 import { debugLogger } from './debugLogger.js';
@@ -384,7 +385,20 @@ export function validateImportPath(
 
   const resolvedPath = path.resolve(basePath, importPath);
 
+  // Resolve symlinks to prevent symlink-based path traversal.
+  // Without this, a symlink inside the project pointing outside (e.g.,
+  // docs/ref -> ~/.ssh/id_rsa) passes the lexical isSubpath check but
+  // fs.readFile follows the symlink to read the target file.
+  let realPath: string;
+  try {
+    realPath = fsSync.realpathSync(resolvedPath);
+  } catch {
+    // File does not exist — fall back to lexical check.
+    // The subsequent fs.readFile will also fail, so this is safe.
+    realPath = resolvedPath;
+  }
+
   return allowedDirectories.some((allowedDir) =>
-    isSubpath(allowedDir, resolvedPath),
+    isSubpath(allowedDir, realPath),
   );
 }

--- a/packages/core/src/utils/memoryImportProcessor.ts
+++ b/packages/core/src/utils/memoryImportProcessor.ts
@@ -385,40 +385,22 @@ export function validateImportPath(
 
   const resolvedPath = path.resolve(basePath, importPath);
 
-  // Resolve symlinks to prevent symlink-based path traversal.
-  // Without this, a symlink inside the project pointing outside (e.g.,
-  // docs/ref -> ~/.ssh/id_rsa) passes the lexical isSubpath check but
-  // fs.readFile follows the symlink to read the target file.
+  // Resolve symlinks so a symlink inside the project pointing outside
+  // cannot bypass the directory check.
   let realPath: string;
   try {
     realPath = fsSync.realpathSync(resolvedPath);
-  } catch (e: unknown) {
-    if (
-      e &&
-      typeof e === 'object' &&
-      'code' in e &&
-      (e as { code: unknown }).code === 'ENOENT'
-    ) {
-      // File does not exist — fall back to lexical check.
-      // The subsequent fs.readFile will also fail, so this is safe.
-      realPath = resolvedPath;
-    } else {
-      // EACCES, ELOOP, etc. — deny access rather than bypassing the check.
-      return false;
-    }
+  } catch {
+    realPath = resolvedPath;
   }
 
-  // Canonicalize allowedDirectories too, so that both sides of the
-  // isSubpath comparison use the same path form. Without this, a project
-  // accessed via a symlinked path (e.g., /tmp → /private/tmp on macOS)
-  // would fail the check because one side is canonical and the other is not.
+  // Canonicalize allowedDirectories too to avoid mismatches when the
+  // project root is itself accessed via a symlink.
   return allowedDirectories.some((allowedDir) => {
-    let realAllowedDir: string;
     try {
-      realAllowedDir = fsSync.realpathSync(allowedDir);
+      return isSubpath(fsSync.realpathSync(allowedDir), realPath);
     } catch {
-      realAllowedDir = allowedDir;
+      return isSubpath(allowedDir, realPath);
     }
-    return isSubpath(realAllowedDir, realPath);
   });
 }

--- a/packages/core/src/utils/memoryImportProcessor.ts
+++ b/packages/core/src/utils/memoryImportProcessor.ts
@@ -392,13 +392,33 @@ export function validateImportPath(
   let realPath: string;
   try {
     realPath = fsSync.realpathSync(resolvedPath);
-  } catch {
-    // File does not exist — fall back to lexical check.
-    // The subsequent fs.readFile will also fail, so this is safe.
-    realPath = resolvedPath;
+  } catch (e: unknown) {
+    if (
+      e &&
+      typeof e === 'object' &&
+      'code' in e &&
+      (e as { code: unknown }).code === 'ENOENT'
+    ) {
+      // File does not exist — fall back to lexical check.
+      // The subsequent fs.readFile will also fail, so this is safe.
+      realPath = resolvedPath;
+    } else {
+      // EACCES, ELOOP, etc. — deny access rather than bypassing the check.
+      return false;
+    }
   }
 
-  return allowedDirectories.some((allowedDir) =>
-    isSubpath(allowedDir, realPath),
-  );
+  // Canonicalize allowedDirectories too, so that both sides of the
+  // isSubpath comparison use the same path form. Without this, a project
+  // accessed via a symlinked path (e.g., /tmp → /private/tmp on macOS)
+  // would fail the check because one side is canonical and the other is not.
+  return allowedDirectories.some((allowedDir) => {
+    let realAllowedDir: string;
+    try {
+      realAllowedDir = fsSync.realpathSync(allowedDir);
+    } catch {
+      realAllowedDir = allowedDir;
+    }
+    return isSubpath(realAllowedDir, realPath);
+  });
 }


### PR DESCRIPTION
## Summary

`validateImportPath` in `memoryImportProcessor.ts` uses `path.resolve()` (lexical only) to check whether a `GEMINI.md` `@import` target is within allowed directories. Since `fs.readFile` follows symlinks, a symlink placed inside the project tree that points outside it bypasses the path validation, and the target file content is read into the system prompt.

This is the **only** path validation in the codebase that doesn't resolve symlinks — all other file operations (`read_file`, `write_file`, `edit`, `ls`, `glob`, `grep`, `@`-commands) use `resolveToRealPath()` → `fs.realpathSync()`.

### Changes

- Add `fs.realpathSync()` call in `validateImportPath` before the `isSubpath` check, consistent with the rest of the codebase
- Fall back to lexical resolution when the file doesn't exist (the subsequent `fs.readFile` will also fail, so this is safe)
- Add two test cases: symlink pointing outside allowed dirs (rejected) and symlink pointing within (allowed)

### Example attack scenario

A malicious repository contains:
```
project/docs/ref  →  ~/.ssh/id_rsa   (symlink)
GEMINI.md:  @docs/ref
```

Before this fix: validation passes (lexical path is inside project) → `fs.readFile` follows symlink → private key content injected into LLM context.

After this fix: `realpathSync` resolves the symlink target → `isSubpath` rejects it.

## Test plan

- [x] Existing 25 `validateImportPath` tests pass (no regression)
- [x] New test: symlink to outside directory → correctly **rejected**
- [x] New test: symlink within project directory → correctly **allowed**
- [ ] Manual: create a repo with a symlink in `GEMINI.md` `@import` and verify rejection