### PR TITLE
fix(core): handle partial llm_request in BeforeModel hook override

### DIFF
--- a/packages/core/src/hooks/hookTranslator.test.ts
+++ b/packages/core/src/hooks/hookTranslator.test.ts
@@ -121,6 +121,56 @@ describe('HookTranslator', () => {
         },
       ]);
     });
+
+    it('should apply model override when hook returns only model field', () => {
+      const baseRequest: GenerateContentParameters = {
+        model: 'gemini-2.5-flash-lite',
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: 'Hello' }],
+          },
+        ],
+      } as unknown as GenerateContentParameters;
+
+      // Simulate a hook that only overrides the model — no messages field
+      const hookRequest = {
+        model: 'gemini-2.5-flash',
+      } as unknown as LLMRequest;
+
+      const sdkRequest = translator.fromHookLLMRequest(
+        hookRequest,
+        baseRequest,
+      );
+
+      // Model should be overridden
+      expect(sdkRequest.model).toBe('gemini-2.5-flash');
+      // Original conversation contents should be preserved
+      expect(sdkRequest.contents).toEqual(baseRequest.contents);
+    });
+
+    it('should preserve base request contents when hook messages is undefined', () => {
+      const baseRequest: GenerateContentParameters = {
+        model: 'gemini-1.5-flash',
+        contents: [
+          { role: 'user', parts: [{ text: 'original message' }] },
+          { role: 'model', parts: [{ text: 'original reply' }] },
+        ],
+      } as unknown as GenerateContentParameters;
+
+      const hookRequest = {
+        model: 'gemini-1.5-pro',
+        // messages intentionally omitted
+      } as unknown as LLMRequest;
+
+      const sdkRequest = translator.fromHookLLMRequest(
+        hookRequest,
+        baseRequest,
+      );
+
+      expect(sdkRequest.model).toBe('gemini-1.5-pro');
+      expect(sdkRequest.contents).toEqual(baseRequest.contents);
+    });
   });
 
   describe('LLM Response Translation', () => {

--- a/packages/core/src/hooks/hookTranslator.ts
+++ b/packages/core/src/hooks/hookTranslator.ts
@@ -225,23 +225,30 @@ export class HookTranslatorGenAIv1 extends HookTranslator {
     hookRequest: LLMRequest,
     baseRequest?: GenerateContentParameters,
   ): GenerateContentParameters {
-    // Convert hook messages back to SDK Content format
-    const contents = hookRequest.messages.map((message) => ({
-      role: message.role === 'model' ? 'model' : message.role,
-      parts: [
-        {
-          text:
-            typeof message.content === 'string'
-              ? message.content
-              : String(message.content),
-        },
-      ],
-    }));
+    // Convert hook messages back to SDK Content format.
+    // If the hook returned a partial request without messages (e.g. only
+    // overriding `model`), fall back to the base request's contents so the
+    // conversation is preserved.
+    const contents = hookRequest.messages
+      ? hookRequest.messages.map((message) => ({
+          role: message.role === 'model' ? 'model' : message.role,
+          parts: [
+            {
+              text:
+                typeof message.content === 'string'
+                  ? message.content
+                  : String(message.content),
+            },
+          ],
+        }))
+      : (baseRequest?.contents ?? []);
 
-    // Build the result with proper typing
+    // Build the result with proper typing.
+    // Use nullish coalescing so a hook that only sets `model` still works --
+    // fall back to the base request's model rather than overwriting with undefined.
     const result: GenerateContentParameters = {
       ...baseRequest,
-      model: hookRequest.model,
+      model: hookRequest.model ?? baseRequest?.model ?? '',
       contents,
     };
 


### PR DESCRIPTION
## Summary
`fromHookLLMRequest` crashed with `TypeError: Cannot read properties of undefined (reading 'map')` when a `BeforeModel` hook returned a partial `llm_request` containing only a `model` override (no `messages`). The model override never applied because the crash happened first.

## Details
Two targeted guards added to `fromHookLLMRequest` in `HookTranslatorGenAIv1`:

1. **messages guard**: Check `hookRequest.messages` before calling `.map()`. If absent, fall back to `baseRequest?.contents` so the existing conversation is preserved.
2. **model guard**: Use `hookRequest.model ?? baseRequest?.model ?? ''` so a hook returning only `{ model: '...' }` correctly overrides the model without clobbering it with `undefined`.

No changes to the public hook API, hooks that already return full `llm_request` objects are unaffected.

## Related Issues
Fixes #21847

## How to Validate
1. Add a `BeforeModel` hook that returns only `{ hookSpecificOutput: { hookEventName: "BeforeModel", llm_request: { model: "gemini-2.5-flash" } } }`
2. Set active model to `gemini-2.5-flash-lite` via `/model set gemini-2.5-flash-lite`
3. Send a message, previously crashed, now correctly routes to `gemini-2.5-flash`
4. Run unit tests: `npx vitest run packages/core/src/hooks/hookTranslator.test.ts`

## Pre-Merge Checklist
- [x] Added/updated tests (2 new unit tests covering the exact failing case)
- [x] No breaking changes, existing hooks with full `messages` are unaffected
- [ ] Updated relevant documentation and README (not needed)