### PR TITLE
fix(telemetry): remove duplicate start_session VERTEX_API_KEY metadata entries

### DIFF
--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -638,18 +638,8 @@ export class ClearcutLogger {
         value: event.debug_enabled.toString(),
       },
       {
-        gemini_cli_key:
-          EventMetadataKey.GEMINI_CLI_START_SESSION_VERTEX_API_ENABLED,
-        value: event.vertex_ai_enabled.toString(),
-      },
-      {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_START_SESSION_MCP_SERVERS,
         value: event.mcp_servers,
-      },
-      {
-        gemini_cli_key:
-          EventMetadataKey.GEMINI_CLI_START_SESSION_VERTEX_API_ENABLED,
-        value: event.vertex_ai_enabled.toString(),
       },
       {
         gemini_cli_key:


### PR DESCRIPTION
## Summary

This PR fixes a telemetry issue in the start session event by removing duplicate entries of the VERTEX_API_KEY metadata key. The event now emits this field once, which keeps the payload aligned with the metadata schema and improves data quality for analytics.

## Details

This PR fixes a Clearcut logging issue where GEMINI_CLI_START_SESSION_VERTEX_API_ENABLED was appended multiple times in the start session payload.
The implementation now emits a single entry for that key, aligning event metadata with the expected schema and preventing redundant values in downstream analytics.

Only one entry should be emitted for this key, so the duplicate entries were removed.

## Related Issues

Fixes #22318

## How to Validate

Go to  `packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts` and search for VERTEX_API_KEY, you will find a single entry. 

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
