### PR TITLE
fix(core): handle null fallback intent in processIntent (#22317)

### DIFF
--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -411,5 +411,18 @@ describe('handleFallback', () => {
       expect(result).toBe(true);
       expect(policyConfig.activateFallbackMode).not.toHaveBeenCalled();
     });
+
+    it('returns false without throwing when handler returns null', async () => {
+      policyHandler.mockResolvedValue(null);
+
+      const result = await handleFallback(
+        policyConfig,
+        MOCK_PRO_MODEL,
+        AUTH_OAUTH,
+      );
+
+      expect(result).toBe(false);
+      expect(policyConfig.activateFallbackMode).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -158,6 +158,9 @@ async function processIntent(
       await handleUpgrade();
       return false;
 
+    case null:
+      return false;
+
     default:
       throw new Error(
         `Unexpected fallback intent received from fallbackModelHandler: "${intent}"`,


### PR DESCRIPTION
## Summary

Fixes #22317. `processIntent` accepts `FallbackIntent | null` but the switch statement had no `null` case, so a valid null response from the fallback model handler fell through to `default` and threw a misleading error.

## Root cause

`FallbackModelHandler` returns `Promise<FallbackIntent | null>`, and this null flows into `processIntent` at line 105. The switch covers all `FallbackIntent` variants but not `null`, so it hits the `default` throw.

## Fix

Added `case null: return false;` to the switch — consistent with the `stop` / `retry_later` behavior (do nothing, no model switch).

## Test

Added `returns false without throwing when handler returns null` — handler resolves null, asserts result is `false` and `activateFallbackMode` is not called.

```
 ✓ returns false without throwing when handler returns null 0ms
 Test Files  1 passed (1)
      Tests  14 passed (14)
```