### PR TITLE
feat(ui): add token budget warning banner

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -166,6 +166,10 @@ import { parseSlashCommand } from '../utils/commands.js';
 import { useTerminalTheme } from './hooks/useTerminalTheme.js';
 import { useTimedMessage } from './hooks/useTimedMessage.js';
 import { useIsHelpDismissKey } from './utils/shortcutsHelp.js';
+import {
+  getContextUsagePercentage,
+  TOKEN_BUDGET_WARNING_THRESHOLD,
+} from './utils/contextUsage.js';
 import { useSuspend } from './hooks/useSuspend.js';
 import { useRunEventNotifications } from './hooks/useRunEventNotifications.js';
 import { isNotificationsEnabled } from '../utils/terminalNotifications.js';
@@ -303,6 +307,7 @@ export const AppContainer = (props: AppContainerProps) => {
   const [defaultBannerText, setDefaultBannerText] = useState('');
   const [warningBannerText, setWarningBannerText] = useState('');
   const [bannerVisible, setBannerVisible] = useState(true);
+  const [hasWarnedTokenBudget, setHasWarnedTokenBudget] = useState(false);
 
   const bannerData = useMemo(
     () => ({
@@ -415,6 +420,34 @@ export const AppContainer = (props: AppContainerProps) => {
   // Additional hooks moved from App.tsx
   const { stats: sessionStats } = useSessionStats();
   const branchName = useGitBranchName(config.getTargetDir());
+
+  useEffect(() => {
+    const usagePercentage = getContextUsagePercentage(
+      sessionStats.lastPromptTokenCount,
+      typeof currentModel === 'string' ? currentModel : undefined,
+    );
+
+    if (usagePercentage >= TOKEN_BUDGET_WARNING_THRESHOLD) {
+      if (!hasWarnedTokenBudget) {
+        setWarningBannerText(
+          'Token budget exceeds 80%. Context will be truncated soon.',
+        );
+        setBannerVisible(true);
+        setHasWarnedTokenBudget(true); // Only warn once per crossing
+      }
+    } else {
+      // If it drops back below, reset so we can warn again if it climbs
+      if (hasWarnedTokenBudget) {
+        setHasWarnedTokenBudget(false);
+      }
+    }
+  }, [
+    sessionStats.lastPromptTokenCount,
+    currentModel,
+    hasWarnedTokenBudget,
+    setWarningBannerText,
+    setBannerVisible,
+  ]);
 
   // Layout measurements
   const mainControlsRef = useRef<DOMElement>(null);

--- a/packages/cli/src/ui/utils/contextUsage.ts
+++ b/packages/cli/src/ui/utils/contextUsage.ts
@@ -6,6 +6,8 @@
 
 import { tokenLimit } from '@google/gemini-cli-core';
 
+export const TOKEN_BUDGET_WARNING_THRESHOLD = 0.8;
+
 export function getContextUsagePercentage(
   promptTokenCount: number,
   model: string | undefined,


### PR DESCRIPTION
## Summary

Adds a **Token Budget Warning** that shows a dismissible banner when prompt context usage exceeds **80% of the model’s token budget**. This helps users anticipate context truncation during long sessions.

## Details

This PR introduces a lightweight threshold-based warning in the CLI UI.

### Changes

- Added `TOKEN_BUDGET_WARNING_THRESHOLD = 0.8` in  
  `packages/cli/src/ui/utils/contextUsage.ts`.

- Updated `packages/cli/src/ui/AppContainer.tsx` to monitor context usage using `getContextUsagePercentage`.

- When usage crosses the threshold, the CLI displays a banner:


Token budget exceeds 80%. Context will be truncated soon.


- Introduced `hasWarnedTokenBudget` state to ensure the banner appears **only once per threshold crossing**.

- If usage later drops below the threshold (e.g., context compression or window rollover), the warning state resets so it can trigger again.

### Dismiss Behavior

The banner uses existing UI logic and is dismissed when:

- a new prompt is submitted
- `Ctrl + C` is pressed

This relies on existing behavior in `InputPrompt.tsx` which calls `setBannerVisible(false)`.

### Validation


npm run typecheck
npm run lint


Both pass cleanly across workspaces.

## Related Issues

Closes the proposed feature request for **Token Budget Warning when context usage exceeds 80%**.

## How to Validate

1. Run the CLI:

```
npm run dev
```
2. Generate prompts until the **context usage approaches ~80%**.

3. Expected behavior:

- Warning banner appears:


Token budget exceeds 80%. Context will be truncated soon.


4. Verify:

- Banner appears **once per threshold crossing**
- Sending a new prompt **dismisses the banner**
- If usage drops below 80% and rises again, the banner **reappears**

## Pre-Merge Checklist

- [x] Updated relevant documentation (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (none)

### Validated Platforms

- [x] MacOS
  - [x] npm run
  - [ ] npx
  - [ ] Docker

- [ ] Windows
- [ ] Linux