### PR TITLE
fix(core): remove unsafe type assertion in httpErrors

### DIFF
--- a/packages/core/src/utils/httpErrors.test.ts
+++ b/packages/core/src/utils/httpErrors.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getErrorStatus, ModelNotFoundError } from './httpErrors.js';
+
+describe('httpErrors', () => {
+  describe('getErrorStatus', () => {
+    it('returns status from a direct status property', () => {
+      expect(getErrorStatus({ status: 404 })).toBe(404);
+    });
+
+    it('returns status from an Error with status', () => {
+      const error = Object.assign(new Error('fail'), { status: 500 });
+      expect(getErrorStatus(error)).toBe(500);
+    });
+
+    it('returns status from error.response.status (axios-style)', () => {
+      const error = { response: { status: 429 } };
+      expect(getErrorStatus(error)).toBe(429);
+    });
+
+    it('returns status from nested response with extra headers', () => {
+      const error = {
+        response: { status: 503, headers: { 'retry-after': '30' } },
+      };
+      expect(getErrorStatus(error)).toBe(503);
+    });
+
+    it('returns undefined for null', () => {
+      expect(getErrorStatus(null)).toBeUndefined();
+    });
+
+    it('returns undefined for undefined', () => {
+      expect(getErrorStatus(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for a string', () => {
+      expect(getErrorStatus('error')).toBeUndefined();
+    });
+
+    it('returns undefined for a number', () => {
+      expect(getErrorStatus(42)).toBeUndefined();
+    });
+
+    it('returns undefined for an empty object', () => {
+      expect(getErrorStatus({})).toBeUndefined();
+    });
+
+    it('returns undefined when status is not a number', () => {
+      expect(getErrorStatus({ status: '404' })).toBeUndefined();
+    });
+
+    it('returns undefined when response is not an object', () => {
+      expect(getErrorStatus({ response: 'not an object' })).toBeUndefined();
+    });
+
+    it('returns undefined when response is null', () => {
+      expect(getErrorStatus({ response: null })).toBeUndefined();
+    });
+
+    it('returns undefined when response has no status', () => {
+      expect(getErrorStatus({ response: { headers: {} } })).toBeUndefined();
+    });
+
+    it('returns undefined when response.status is not a number', () => {
+      expect(getErrorStatus({ response: { status: 'bad' } })).toBeUndefined();
+    });
+
+    it('prefers direct status over response.status', () => {
+      const error = { status: 400, response: { status: 500 } };
+      expect(getErrorStatus(error)).toBe(400);
+    });
+  });
+
+  describe('ModelNotFoundError', () => {
+    it('creates error with default 404 code', () => {
+      const error = new ModelNotFoundError('model not found');
+      expect(error.message).toBe('model not found');
+      expect(error.code).toBe(404);
+      expect(error.name).toBe('ModelNotFoundError');
+      expect(error).toBeInstanceOf(Error);
+    });
+
+    it('creates error with custom code', () => {
+      const error = new ModelNotFoundError('gone', 410);
+      expect(error.code).toBe(410);
+    });
+  });
+});

--- a/packages/core/src/utils/httpErrors.ts
+++ b/packages/core/src/utils/httpErrors.ts
@@ -19,17 +19,12 @@ export function getErrorStatus(error: unknown): number | undefined {
       return error.status;
     }
     // Check for error.response.status (common in axios errors)
-    if (
-      'response' in error &&
-      typeof (error as { response?: unknown }).response === 'object' &&
-      (error as { response?: unknown }).response !== null
-    ) {
-      const response =
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        (error as { response: { status?: unknown; headers?: unknown } })
-          .response;
-      if ('status' in response && typeof response.status === 'number') {
-        return response.status;
+    if ('response' in error) {
+      const resp: unknown = error.response;
+      if (typeof resp === 'object' && resp !== null) {
+        if ('status' in resp && typeof resp.status === 'number') {
+          return resp.status;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Remove the `@typescript-eslint/no-unsafe-type-assertion` eslint-disable suppression in `getErrorStatus()` by replacing the unsafe `as` cast with safe runtime type narrowing.

## Changes

### `httpErrors.ts`

The original code used `(error as { response?: unknown }).response` twice then cast the result with a complex inline type assertion. After `'response' in error`, the value is now extracted into a local `unknown` variable and narrowed step-by-step with `typeof` and `in` checks — no `as` casts needed.

### `httpErrors.test.ts` (new)

Adds **17 tests** covering:
- `getErrorStatus()`: direct status, axios-style `response.status`, nested response with headers
- Edge cases: null, undefined, strings, numbers, empty objects
- Non-numeric status, null response, missing `response.status`
- Priority check: direct `status` preferred over `response.status`
- `ModelNotFoundError`: default 404 code, custom code, `instanceof Error`

## Verification

- `npx tsc --noEmit` — zero errors
- `npx eslint` — zero errors on modified file, no remaining suppressions
- `npx vitest run` — 17/17 tests pass
- Pre-commit hooks pass