### PR TITLE
fix(core): implement deterministic default intent pattern for fallback (#22317)

### DIFF
--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -411,5 +411,33 @@ describe('handleFallback', () => {
       expect(result).toBe(true);
       expect(policyConfig.activateFallbackMode).not.toHaveBeenCalled();
     });
+
+    it('defaults to "stop" when handler returns null (Deterministic Default Intent)', async () => {
+      policyHandler.mockResolvedValue(null);
+
+      const result = await handleFallback(
+        policyConfig,
+        MOCK_PRO_MODEL,
+        AUTH_OAUTH,
+      );
+
+      expect(result).toBe(false);
+      expect(policyConfig.activateFallbackMode).not.toHaveBeenCalled();
+    });
+
+    it('defaults to "stop" when handler returns an unknown intent (Deterministic Default Intent)', async () => {
+      policyHandler.mockResolvedValue(
+        'invalid-intent' as unknown as FallbackIntent,
+      );
+
+      const result = await handleFallback(
+        policyConfig,
+        MOCK_PRO_MODEL,
+        AUTH_OAUTH,
+      );
+
+      expect(result).toBe(false);
+      expect(policyConfig.activateFallbackMode).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -131,7 +131,8 @@ async function processIntent(
   intent: FallbackIntent | null,
   fallbackModel: string,
 ): Promise<boolean> {
-  switch (intent) {
+  const effectiveIntent = intent ?? 'stop';
+  switch (effectiveIntent) {
     case 'retry_always':
       // TODO(telemetry): Implement generic fallback event logging. Existing
       // logFlashFallback is specific to a single Model.
@@ -159,8 +160,9 @@ async function processIntent(
       return false;
 
     default:
-      throw new Error(
-        `Unexpected fallback intent received from fallbackModelHandler: "${intent}"`,
+      debugLogger.warn(
+        `Unexpected fallback intent received from fallbackModelHandler: "${intent}". Defaulting to "stop".`,
       );
+      return false;
   }
 }


### PR DESCRIPTION
## Summary

This PR implements a **Deterministic Default Intent** pattern in the core fallback handler to resolve issue #22317. It ensures that if the UI layer returns a `null` or unrecognized intent during a fallback sequence, the agent loop gracefully defaults to a safe 'stop' state instead of throwing an internal error.

## Details

- **Robustness**: Modified `processIntent` in `packages/core/src/fallback/handler.ts` to provide a safe, predictable default ('stop') for any invalid or missing intent.
- **Error Handling**: Replaced a `throw new Error` with a `debugLogger.warn` and a safe return of `false`, preventing upstream crashes in the agent's brain logic.
- **Predictability**: The agent now reaches a "Safe State" even if classification fails or UI interaction returns unexpected data.

## Related Issues

Fixes #22317

## How to Validate

1. Run the new unit tests specifically designed for this edge case:
   ```bash
   npm test -w @google/gemini-cli-core -- src/fallback/handler.test.ts
   ```
2. Verify that the two new test cases ("defaults to 'stop' when handler returns null" and "defaults to 'stop' when handler returns an unknown intent") both pass.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
