### PR TITLE
fix(cli): allow --prompt and --prompt-interactive to be empty (#22369)

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -279,9 +279,26 @@ describe('parseArguments', () => {
 
   it.each([
     {
-      description: 'should allow --prompt without --prompt-interactive',
-      argv: ['node', 'script.js', '--prompt', 'test prompt'],
-      expected: { prompt: 'test prompt', promptInteractive: undefined },
+      description: 'should allow --prompt without value',
+      argv: ['node', 'script.js', '--prompt'],
+      expected: { prompt: '', promptInteractive: undefined },
+    },
+    {
+      description: 'should allow -p without value',
+      argv: ['node', 'script.js', '-p'],
+      expected: { prompt: '', promptInteractive: undefined },
+    },
+    {
+      description: 'should allow -i without value',
+      argv: ['node', 'script.js', '-i'],
+      expected: { prompt: undefined, promptInteractive: '' },
+    },
+    {
+      description:
+        'should throw error when using -p without value and a positional prompt',
+      argv: ['node', 'script.js', '-p', '--', 'my query'],
+      shouldThrow:
+        'Cannot use both a positional prompt and the --prompt (-p) flag together',
     },
     {
       description: 'should allow --prompt-interactive without --prompt',
@@ -293,11 +310,36 @@ describe('parseArguments', () => {
       argv: ['node', 'script.js', '-i', 'interactive prompt'],
       expected: { prompt: undefined, promptInteractive: 'interactive prompt' },
     },
-  ])('$description', async ({ argv, expected }) => {
+  ])('$description', async ({ argv, expected, shouldThrow }) => {
     process.argv = argv;
+
+    if (shouldThrow) {
+      const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit called');
+      });
+      const mockConsoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(parseArguments(createTestMergedSettings())).rejects.toThrow(
+        'process.exit called',
+      );
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(shouldThrow),
+      );
+
+      mockExit.mockRestore();
+      mockConsoleError.mockRestore();
+      return;
+    }
+
     const parsedArgs = await parseArguments(createTestMergedSettings());
-    expect(parsedArgs.prompt).toBe(expected.prompt);
-    expect(parsedArgs.promptInteractive).toBe(expected.promptInteractive);
+    expect(parsedArgs.prompt).toBe(expected!.prompt);
+    expect(parsedArgs.promptInteractive).toBe(expected!.promptInteractive);
+    if ('query' in expected!) {
+      expect(parsedArgs.query).toBe(expected.query);
+    }
   });
 
   describe('positional arguments and @commands', () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -148,16 +148,30 @@ export async function parseArguments(
         .option('prompt', {
           alias: 'p',
           type: 'string',
-          nargs: 1,
+          requiresArg: false,
           description:
             'Run in non-interactive (headless) mode with the given prompt. Appended to input on stdin (if any).',
+          coerce: (value: string | boolean): string => {
+            if (value === true) {
+              return '';
+            }
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+            return value as string;
+          },
         })
         .option('prompt-interactive', {
           alias: 'i',
           type: 'string',
-          nargs: 1,
+          requiresArg: false,
           description:
             'Execute the provided prompt and continue in interactive mode',
+          coerce: (value: string | boolean): string => {
+            if (value === true) {
+              return '';
+            }
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+            return value as string;
+          },
         })
         .option('sandbox', {
           alias: 's',
@@ -385,8 +399,13 @@ export async function parseArguments(
     : queryArg;
 
   // -p/--prompt forces non-interactive mode; positional args default to interactive in TTY
-  if (q && !result['prompt']) {
-    if (!isHeadlessMode()) {
+  if (q && result['prompt'] === undefined) {
+    if (
+      !isHeadlessMode({
+        prompt: result['prompt'] as string | undefined,
+        query: q,
+      })
+    ) {
       startupMessages.push(
         'Positional arguments now default to interactive mode. To run in non-interactive mode, use the --prompt (-p) flag.',
       );


### PR DESCRIPTION
## Summary

This PR allows the `--prompt` (`-p`) and `--prompt-interactive` (`-i`) flags to be used without an explicit value, resolving issue #22369. This is useful for triggering specific modes (like headless mode) without necessarily providing a query on the command line (e.g., when expecting input from stdin).

## Details

- **Argument Parsing**: Replaced `nargs: 1` with `requiresArg: false` for the prompt flags in `packages/cli/src/config/config.ts`.
- **Value Coercion**: Added a `coerce` function to convert the boolean `true` (returned by yargs when a flag is present but empty) into an empty string.
- **Normalization Fix**: Refined the argument normalization logic to prevent positional arguments from overwriting an explicitly provided empty prompt.
- **Testing**: Added comprehensive unit tests in `packages/cli/src/config/config.test.ts` to cover various combinations of empty flags and positional arguments.

## Related Issues

Fixes #22369

## How to Validate

1. Run the updated unit tests:
   ```bash
   npm test -w @google/gemini-cli -- src/config/config.test.ts
   ```
2. Manually verify the behavior with the compiled CLI:
   ```bash
   # Should not error out about missing argument
   node packages/cli/dist/src/gemini.js --prompt
   ```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
