### PR TITLE
feat(sandbox): implement native bubblewrap (bwrap) sandbox for Linux

### DIFF
--- a/packages/cli/src/config/sandboxConfig.test.ts
+++ b/packages/cli/src/config/sandboxConfig.test.ts
@@ -148,7 +148,7 @@ describe('loadSandboxConfig', () => {
       expect(config).toEqual({
         enabled: true,
         allowedPaths: [],
-        networkAccess: false,
+        networkAccess: true,
         command: 'sandbox-exec',
         image: 'default/image',
       });
@@ -161,7 +161,7 @@ describe('loadSandboxConfig', () => {
       expect(config).toEqual({
         enabled: true,
         allowedPaths: [],
-        networkAccess: false,
+        networkAccess: true,
         command: 'sandbox-exec',
         image: 'default/image',
       });
@@ -193,12 +193,25 @@ describe('loadSandboxConfig', () => {
       });
     });
 
+    it('should use bwrap if available on linux and sandbox is true', async () => {
+      mockedOsPlatform.mockReturnValue('linux');
+      mockedCommandExistsSync.mockImplementation((cmd) => cmd === 'bwrap');
+      const config = await loadSandboxConfig({}, { sandbox: true });
+      expect(config).toEqual({
+        enabled: true,
+        allowedPaths: [],
+        networkAccess: true,
+        command: 'bwrap',
+        image: 'default/image',
+      });
+    });
+
     it('should throw if sandbox: true but no command is found', async () => {
       mockedOsPlatform.mockReturnValue('linux');
       mockedCommandExistsSync.mockReturnValue(false);
       await expect(loadSandboxConfig({}, { sandbox: true })).rejects.toThrow(
         'GEMINI_SANDBOX is true but failed to determine command for sandbox; ' +
-          'install docker or podman or specify command in GEMINI_SANDBOX',
+          'install bwrap, docker or podman or specify command in GEMINI_SANDBOX',
       );
     });
   });

--- a/packages/cli/src/config/sandboxConfig.ts
+++ b/packages/cli/src/config/sandboxConfig.ts
@@ -29,6 +29,7 @@ const VALID_SANDBOX_COMMANDS = [
   'sandbox-exec',
   'runsc',
   'lxc',
+  'bwrap',
 ];
 
 function isSandboxCommand(
@@ -88,11 +89,17 @@ function getSandboxCommand(
     return sandbox;
   }
 
-  // look for seatbelt, docker, or podman, in that order
+  // look for seatbelt, bwrap, docker, or podman, in that order
   // for container-based sandboxing, require sandbox to be enabled explicitly
   // note: runsc is NOT auto-detected, it must be explicitly specified
   if (os.platform() === 'darwin' && commandExists.sync('sandbox-exec')) {
     return 'sandbox-exec';
+  } else if (
+    os.platform() === 'linux' &&
+    commandExists.sync('bwrap') &&
+    sandbox === true
+  ) {
+    return 'bwrap';
   } else if (commandExists.sync('docker') && sandbox === true) {
     return 'docker';
   } else if (commandExists.sync('podman') && sandbox === true) {
@@ -103,7 +110,7 @@ function getSandboxCommand(
   if (sandbox === true) {
     throw new FatalSandboxError(
       'GEMINI_SANDBOX is true but failed to determine command for sandbox; ' +
-        'install docker or podman or specify command in GEMINI_SANDBOX',
+        'install bwrap, docker or podman or specify command in GEMINI_SANDBOX',
     );
   }
 
@@ -129,16 +136,29 @@ export async function loadSandboxConfig(
     sandboxOption !== null &&
     !Array.isArray(sandboxOption)
   ) {
-    const config = sandboxOption;
-    sandboxValue = config.enabled ? (config.command ?? true) : false;
-    allowedPaths = config.allowedPaths ?? [];
-    networkAccess = config.networkAccess ?? false;
-    customImage = config.image;
+    const sandboxConfig = sandboxOption;
+    sandboxValue = sandboxConfig.enabled
+      ? (sandboxConfig.command ?? true)
+      : false;
+    allowedPaths = sandboxConfig.allowedPaths ?? [];
+    networkAccess = sandboxConfig.networkAccess ?? false;
+    customImage = sandboxConfig.image;
   } else if (typeof sandboxOption !== 'object' || sandboxOption === null) {
     sandboxValue = sandboxOption;
   }
 
   const command = getSandboxCommand(sandboxValue);
+
+  // Default networkAccess to true for non-container providers (bwrap, seatbelt)
+  // because they need to talk to the Gemini API directly.
+  if (
+    (command === 'bwrap' || command === 'sandbox-exec') &&
+    (typeof sandboxOption !== 'object' ||
+      sandboxOption === null ||
+      sandboxOption.networkAccess === undefined)
+  ) {
+    networkAccess = true;
+  }
 
   const packageJson = await getPackageJson(__dirname);
   const image =

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -2670,8 +2670,8 @@ export const SETTINGS_SCHEMA_DEFINITIONS: Record<
           command: {
             type: 'string',
             description:
-              'The sandbox command to use (docker, podman, sandbox-exec, runsc, lxc).',
-            enum: ['docker', 'podman', 'sandbox-exec', 'runsc', 'lxc'],
+              'The sandbox command to use (docker, podman, sandbox-exec, runsc, lxc, bwrap).',
+            enum: ['docker', 'podman', 'sandbox-exec', 'runsc', 'lxc', 'bwrap'],
           },
           image: {
             type: 'string',

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -1192,6 +1192,11 @@ async function start_bwrap_sandbox(
     '/proc',
     '--dev',
     '/dev',
+    // Private system paths to block escapes (X11, D-Bus, etc.)
+    '--tmpfs',
+    '/tmp',
+    '--tmpfs',
+    '/run/user',
     // --- STRICT ALLOW LIST ---
     // Only mount essential system paths for binaries and libraries
     '--ro-bind',
@@ -1295,15 +1300,60 @@ async function start_bwrap_sandbox(
   const innerCmd = [
     'SANDBOX=bwrap',
     `NODE_OPTIONS="${nodeOptions}"`,
-    'DEV=true',
     ...finalArgv.map((arg) => quote([arg])),
   ].join(' ');
 
   const args = [...bwrapArgs, '--', shell, '-c', innerCmd];
 
+  // Filter environment variables to prevent leakage of host credentials into the outer sandbox
+  const safeEnvKeys = [
+    'PATH',
+    'TERM',
+    'COLORTERM',
+    'LANG',
+    'LC_ALL',
+    'HOME',
+    'USER',
+    'LOGNAME',
+    'SHELL',
+    'PWD',
+    'EDITOR',
+    'VISUAL',
+    'DEBUG',
+    'DEBUG_PORT',
+    'NODE_ENV',
+    'NODE_OPTIONS',
+    'GEMINI_SANDBOX',
+    'GEMINI_SANDBOX_IMAGE',
+    'GEMINI_SANDBOX_IMAGE_DEFAULT',
+    'GEMINI_DIR',
+    'GEMINI_CLI_HOME',
+    'GEMINI_CLI_NO_RELAUNCH',
+    'SANDBOX_PORTS',
+    'SANDBOX_SET_UID_GID',
+    'SANDBOX_MOUNTS',
+    'SANDBOX_FLAGS',
+    'SEATBELT_PROFILE',
+    'HTTP_PROXY',
+    'HTTPS_PROXY',
+    'NO_PROXY',
+    'http_proxy',
+    'https_proxy',
+    'no_proxy',
+    'NO_BROWSER',
+  ];
+
+  const sandboxEnv: NodeJS.ProcessEnv = {};
+  for (const key of safeEnvKeys) {
+    if (process.env[key] !== undefined) {
+      sandboxEnv[key] = process.env[key];
+    }
+  }
+
   process.stdin.pause();
   const sandboxProcess = spawn('bwrap', args, {
     stdio: 'inherit',
+    env: sandboxEnv,
   });
 
   return new Promise((resolve, reject) => {

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -1192,6 +1192,9 @@ async function start_bwrap_sandbox(
     '/proc',
     '--dev',
     '/dev',
+    '--dev-bind',
+    '/dev/pts',
+    '/dev/pts',
     // Private system paths to block escapes (X11, D-Bus, etc.)
     '--tmpfs',
     '/tmp',

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -1193,8 +1193,8 @@ async function start_bwrap_sandbox(
     '--dev',
     '/dev',
     '--dev-bind',
-    '/dev/pts',
-    '/dev/pts',
+    '/dev/shm',
+    '/dev/shm',
     // Private system paths to block escapes (X11, D-Bus, etc.)
     '--tmpfs',
     '/tmp',

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -1192,8 +1192,7 @@ async function start_bwrap_sandbox(
     '/proc',
     '--dev',
     '/dev',
-    '--dev-bind',
-    '/dev/shm',
+    '--tmpfs',
     '/dev/shm',
     // Private system paths to block escapes (X11, D-Bus, etc.)
     '--tmpfs',

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -1182,6 +1182,12 @@ async function start_bwrap_sandbox(
     '--new-session',
     '--die-with-parent',
     '--unshare-pid',
+    '--unshare-user',
+    '--unshare-ipc',
+    '--unshare-uts',
+    '--unshare-cgroup',
+    '--hostname',
+    'gemini-sandbox',
     '--proc',
     '/proc',
     '--dev',
@@ -1192,18 +1198,33 @@ async function start_bwrap_sandbox(
     '/usr',
     '/usr',
     '--ro-bind',
-    '/lib',
-    '/lib',
-    '--ro-bind',
-    '/lib64',
-    '/lib64',
-    '--ro-bind',
     '/bin',
     '/bin',
     '--ro-bind',
     '/sbin',
     '/sbin',
   ];
+
+  // Optional system paths (might be symlinks or missing on some distros)
+  const optionalPaths = ['/lib', '/lib64', '/etc/alternatives'];
+  for (const p of optionalPaths) {
+    if (fs.existsSync(p)) {
+      bwrapArgs.push('--ro-bind', p, p);
+    }
+  }
+
+  // Essential /etc files for tool compatibility (passwd, hosts, etc.)
+  const etcFiles = [
+    '/etc/passwd',
+    '/etc/group',
+    '/etc/hosts',
+    '/etc/nsswitch.conf',
+  ];
+  for (const p of etcFiles) {
+    if (fs.existsSync(p)) {
+      bwrapArgs.push('--ro-bind', p, p);
+    }
+  }
 
   // Allow the current node binary (essential for relaunching)
   // This is especially important for NVM/Asdf users where node is in $HOME

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -231,6 +231,10 @@ export async function start_sandbox(
       return await start_lxc_sandbox(config, nodeArgs, cliArgs);
     }
 
+    if (config.command === 'bwrap') {
+      return await start_bwrap_sandbox(config, nodeArgs, cliConfig, cliArgs);
+    }
+
     // runsc uses docker with --runtime=runsc
     const command = config.command === 'runsc' ? 'docker' : config.command;
     if (!command) throw new FatalSandboxError('Sandbox command is required');
@@ -1150,6 +1154,143 @@ async function pullImage(
     }
     pullProcess.on('error', onError);
     pullProcess.on('close', onClose);
+  });
+}
+
+async function start_bwrap_sandbox(
+  config: SandboxConfig,
+  nodeArgs: string[] = [],
+  cliConfig?: Config,
+  cliArgs: string[] = [],
+): Promise<number> {
+  if (os.platform() !== 'linux') {
+    throw new FatalSandboxError(
+      'bubblewrap sandboxing is only supported on Linux',
+    );
+  }
+
+  debugLogger.log('hopping into bubblewrap sandbox ...');
+
+  const workdir = path.resolve(process.cwd());
+  const homeDir = homedir();
+  const nodeOptions = [
+    ...(process.env['DEBUG'] ? ['--inspect-brk'] : []),
+    ...nodeArgs,
+  ].join(' ');
+
+  const bwrapArgs: string[] = [
+    '--new-session',
+    '--die-with-parent',
+    '--unshare-pid',
+    '--proc',
+    '/proc',
+    '--dev',
+    '/dev',
+    // --- STRICT ALLOW LIST ---
+    // Only mount essential system paths for binaries and libraries
+    '--ro-bind',
+    '/usr',
+    '/usr',
+    '--ro-bind',
+    '/lib',
+    '/lib',
+    '--ro-bind',
+    '/lib64',
+    '/lib64',
+    '--ro-bind',
+    '/bin',
+    '/bin',
+    '--ro-bind',
+    '/sbin',
+    '/sbin',
+  ];
+
+  // Allow the current node binary (essential for relaunching)
+  // This is especially important for NVM/Asdf users where node is in $HOME
+  const nodePath = process.execPath;
+  if (nodePath.startsWith(homeDir)) {
+    bwrapArgs.push('--ro-bind', nodePath, nodePath);
+    // Also bind the directory containing node to ensure shared libs are found
+    const nodeDir = path.dirname(nodePath);
+    bwrapArgs.push('--ro-bind', nodeDir, nodeDir);
+  }
+
+  // Ensure we have a valid resolv.conf for DNS if network is enabled
+  if (config.networkAccess !== false) {
+    const resolvPaths = [
+      '/etc/resolv.conf',
+      '/run/systemd/resolve/stub-resolv.conf',
+      '/run/systemd/resolve/resolv.conf',
+    ];
+    for (const p of resolvPaths) {
+      if (fs.existsSync(p)) {
+        bwrapArgs.push('--ro-bind', p, p);
+      }
+    }
+  }
+
+  // Bind SSL certificates for HTTPS access
+  const sslPaths = [
+    '/etc/ssl',
+    '/etc/pki',
+    '/usr/share/ca-certificates',
+    '/usr/local/share/ca-certificates',
+  ];
+  for (const p of sslPaths) {
+    if (fs.existsSync(p)) {
+      bwrapArgs.push('--ro-bind', p, p);
+    }
+  }
+
+  // Allow writes ONLY to specific permitted paths
+  const writablePaths = new Set<string>();
+  writablePaths.add(workdir);
+  writablePaths.add(path.join(homeDir, GEMINI_DIR));
+  writablePaths.add(os.tmpdir());
+
+  if (config.allowedPaths) {
+    for (const p of config.allowedPaths) {
+      if (p && path.isAbsolute(p) && fs.existsSync(p)) {
+        writablePaths.add(fs.realpathSync(p));
+      }
+    }
+  }
+
+  for (const p of writablePaths) {
+    if (fs.existsSync(p)) {
+      bwrapArgs.push('--bind', p, p);
+    }
+  }
+
+  // Handle network access
+  if (config.networkAccess === false) {
+    bwrapArgs.push('--unshare-net');
+  }
+
+  // Use current shell or bash
+  const shell = process.env['SHELL'] || '/bin/bash';
+
+  const finalArgv = cliArgs;
+  const innerCmd = [
+    'SANDBOX=bwrap',
+    `NODE_OPTIONS="${nodeOptions}"`,
+    'DEV=true',
+    ...finalArgv.map((arg) => quote([arg])),
+  ].join(' ');
+
+  const args = [...bwrapArgs, '--', shell, '-c', innerCmd];
+
+  process.stdin.pause();
+  const sandboxProcess = spawn('bwrap', args, {
+    stdio: 'inherit',
+  });
+
+  return new Promise((resolve, reject) => {
+    sandboxProcess.on('error', reject);
+    sandboxProcess.on('close', (code) => {
+      process.stdin.resume();
+      resolve(code ?? 1);
+    });
   });
 }
 

--- a/packages/cli/src/utils/sandboxUtils.ts
+++ b/packages/cli/src/utils/sandboxUtils.ts
@@ -22,6 +22,18 @@ export const BUILTIN_SEATBELT_PROFILES = [
   'strict-proxied',
 ];
 
+export function isSelinuxEnforced(): boolean {
+  if (os.platform() !== 'linux') {
+    return false;
+  }
+  try {
+    const enforce = fs.readFileSync('/sys/fs/selinux/enforce', 'utf8');
+    return enforce.trim() === '1';
+  } catch {
+    return false;
+  }
+}
+
 export function getContainerPath(hostPath: string): string {
   if (os.platform() !== 'win32') {
     return hostPath;
@@ -45,18 +57,20 @@ export async function shouldUseCurrentUserInSandbox(): Promise<boolean> {
     return false;
   }
 
-  // If environment variable is not explicitly set, check for Debian/Ubuntu Linux
+  // If environment variable is not explicitly set, check for Debian/Ubuntu/Fedora Linux
   if (os.platform() === 'linux') {
     try {
       const osReleaseContent = await readFile('/etc/os-release', 'utf8');
       if (
         osReleaseContent.includes('ID=debian') ||
         osReleaseContent.includes('ID=ubuntu') ||
+        osReleaseContent.includes('ID=fedora') ||
         osReleaseContent.match(/^ID_LIKE=.*debian.*/m) || // Covers derivatives
-        osReleaseContent.match(/^ID_LIKE=.*ubuntu.*/m) // Covers derivatives
+        osReleaseContent.match(/^ID_LIKE=.*ubuntu.*/m) || // Covers derivatives
+        osReleaseContent.match(/^ID_LIKE=.*fedora.*/m) // Covers derivatives
       ) {
         debugLogger.log(
-          'Defaulting to use current user UID/GID for Debian/Ubuntu-based Linux.',
+          'Defaulting to use current user UID/GID for Debian/Ubuntu/Fedora-based Linux.',
         );
         return true;
       }
@@ -64,7 +78,7 @@ export async function shouldUseCurrentUserInSandbox(): Promise<boolean> {
       // Silently ignore if /etc/os-release is not found or unreadable.
       // The default (false) will be applied in this case.
       debugLogger.warn(
-        'Warning: Could not read /etc/os-release to auto-detect Debian/Ubuntu for UID/GID default.',
+        'Warning: Could not read /etc/os-release to auto-detect Debian/Ubuntu/Fedora for UID/GID default.',
       );
     }
   }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -458,7 +458,7 @@ export interface SandboxConfig {
   enabled: boolean;
   allowedPaths?: string[];
   networkAccess?: boolean;
-  command?: 'docker' | 'podman' | 'sandbox-exec' | 'runsc' | 'lxc';
+  command?: 'docker' | 'podman' | 'sandbox-exec' | 'runsc' | 'lxc' | 'bwrap';
   image?: string;
 }
 
@@ -469,7 +469,7 @@ export const ConfigSchema = z.object({
       allowedPaths: z.array(z.string()).default([]),
       networkAccess: z.boolean().default(false),
       command: z
-        .enum(['docker', 'podman', 'sandbox-exec', 'runsc', 'lxc'])
+        .enum(['docker', 'podman', 'sandbox-exec', 'runsc', 'lxc', 'bwrap'])
         .optional(),
       image: z.string().optional(),
     })

--- a/packages/core/src/services/bwrapSandboxManager.ts
+++ b/packages/core/src/services/bwrapSandboxManager.ts
@@ -61,6 +61,9 @@ export class BwrapSandboxManager implements SandboxManager {
       '/proc',
       '--dev',
       '/dev',
+      '--dev-bind',
+      '/dev/pts',
+      '/dev/pts',
       // Strict allow-list for nested sandbox
       '--ro-bind',
       '/usr',

--- a/packages/core/src/services/bwrapSandboxManager.ts
+++ b/packages/core/src/services/bwrapSandboxManager.ts
@@ -51,23 +51,20 @@ export class BwrapSandboxManager implements SandboxManager {
       '--new-session',
       '--die-with-parent',
       '--unshare-pid',
+      '--unshare-user',
+      '--unshare-ipc',
+      '--unshare-uts',
+      '--unshare-cgroup',
+      '--hostname',
+      'gemini-tool-sandbox',
       '--proc',
       '/proc',
       '--dev',
       '/dev',
-      '--dev-bind',
-      '/dev/pts',
-      '/dev/pts',
       // Strict allow-list for nested sandbox
       '--ro-bind',
       '/usr',
       '/usr',
-      '--ro-bind',
-      '/lib',
-      '/lib',
-      '--ro-bind',
-      '/lib64',
-      '/lib64',
       '--ro-bind',
       '/bin',
       '/bin',
@@ -75,6 +72,27 @@ export class BwrapSandboxManager implements SandboxManager {
       '/sbin',
       '/sbin',
     ];
+
+    // Optional system paths
+    const optionalPaths = ['/lib', '/lib64', '/etc/alternatives'];
+    for (const p of optionalPaths) {
+      if (fs.existsSync(p)) {
+        bwrapArgs.push('--ro-bind', p, p);
+      }
+    }
+
+    // Essential /etc files for tool compatibility
+    const etcFiles = [
+      '/etc/passwd',
+      '/etc/group',
+      '/etc/hosts',
+      '/etc/nsswitch.conf',
+    ];
+    for (const p of etcFiles) {
+      if (fs.existsSync(p)) {
+        bwrapArgs.push('--ro-bind', p, p);
+      }
+    }
 
     // Force network off for tools if requested
     if (req.forceNetworkOff) {
@@ -106,7 +124,8 @@ export class BwrapSandboxManager implements SandboxManager {
     bwrapArgs.push('--bind', workdir, workdir);
     const geminiSettingsDir = path.join(homeDir, GEMINI_DIR);
     if (fs.existsSync(geminiSettingsDir)) {
-      bwrapArgs.push('--bind', geminiSettingsDir, geminiSettingsDir);
+      // Gemini settings are read-only for tools to prevent persistent poisoning
+      bwrapArgs.push('--ro-bind', geminiSettingsDir, geminiSettingsDir);
     }
 
     // Private, isolated system paths to block Unix socket escapes

--- a/packages/core/src/services/bwrapSandboxManager.ts
+++ b/packages/core/src/services/bwrapSandboxManager.ts
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  type SandboxManager,
+  type SandboxRequest,
+  type SandboxedCommand,
+} from './sandboxManager.js';
+import {
+  sanitizeEnvironment,
+  type EnvironmentSanitizationConfig,
+} from './environmentSanitization.js';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { quote } from 'shell-quote';
+
+/**
+ * A SandboxManager implementation that uses bubblewrap (bwrap) to provide
+ * nested tool-level isolation on Linux.
+ */
+export class BwrapSandboxManager implements SandboxManager {
+  async prepareCommand(req: SandboxRequest): Promise<SandboxedCommand> {
+    const sanitizationConfig: EnvironmentSanitizationConfig = {
+      allowedEnvironmentVariables:
+        req.config?.sanitizationConfig?.allowedEnvironmentVariables ?? [],
+      blockedEnvironmentVariables:
+        req.config?.sanitizationConfig?.blockedEnvironmentVariables ?? [],
+      enableEnvironmentVariableRedaction: true,
+    };
+
+    const sanitizedEnv = sanitizeEnvironment(req.env, sanitizationConfig);
+
+    if (os.platform() !== 'linux') {
+      return {
+        program: req.command,
+        args: req.args,
+        env: sanitizedEnv,
+      };
+    }
+
+    const homeDir = os.homedir();
+    const workdir = path.resolve(process.cwd());
+
+    // We use a nested bwrap to provide tool-level isolation (like disabling network)
+    // while the CLI itself is already sandboxed.
+    const bwrapArgs: string[] = [
+      '--new-session',
+      '--die-with-parent',
+      '--unshare-pid',
+      '--proc',
+      '/proc',
+      '--dev',
+      '/dev',
+      '--dev-bind',
+      '/dev/pts',
+      '/dev/pts',
+      // Strict allow-list for nested sandbox
+      '--ro-bind',
+      '/usr',
+      '/usr',
+      '--ro-bind',
+      '/lib',
+      '/lib',
+      '--ro-bind',
+      '/lib64',
+      '/lib64',
+      '--ro-bind',
+      '/bin',
+      '/bin',
+      '--ro-bind',
+      '/sbin',
+      '/sbin',
+    ];
+
+    // Force network off for tools if requested
+    if (req.forceNetworkOff) {
+      bwrapArgs.push('--unshare-net');
+    } else {
+      // If network is NOT forced off, we still need resolv.conf for DNS
+      const resolvPaths = [
+        '/etc/resolv.conf',
+        '/run/systemd/resolve/stub-resolv.conf',
+        '/run/systemd/resolve/resolv.conf',
+      ];
+      for (const p of resolvPaths) {
+        if (fs.existsSync(p)) {
+          bwrapArgs.push('--ro-bind', p, p);
+        }
+      }
+    }
+
+    // Allow current node binary (important if tool is a node script)
+    const nodePath = process.execPath;
+    if (nodePath.startsWith(homeDir)) {
+      bwrapArgs.push('--ro-bind', nodePath, nodePath);
+      const nodeDir = path.dirname(nodePath);
+      bwrapArgs.push('--ro-bind', nodeDir, nodeDir);
+    }
+
+    // Mount workspace and Gemini settings
+    const GEMINI_DIR = '.gemini';
+    bwrapArgs.push('--bind', workdir, workdir);
+    const geminiSettingsDir = path.join(homeDir, GEMINI_DIR);
+    if (fs.existsSync(geminiSettingsDir)) {
+      bwrapArgs.push('--bind', geminiSettingsDir, geminiSettingsDir);
+    }
+    bwrapArgs.push('--bind', os.tmpdir(), os.tmpdir());
+
+    // Execute via shell
+    const shell = process.env['SHELL'] || '/bin/bash';
+    // If we have args, we quote everything. If not, we assume command is a shell string.
+    const innerCmd =
+      req.args.length > 0
+        ? [req.command, ...req.args].map((arg) => quote([arg])).join(' ')
+        : req.command;
+
+    const finalArgs = [...bwrapArgs, '--', shell, '-c', innerCmd];
+
+    // Ensure a safe, empty HOME directory for tools
+    const env = { ...sanitizedEnv, HOME: '/tmp' };
+
+    return {
+      program: 'bwrap',
+      args: finalArgs,
+      env,
+    };
+  }
+}

--- a/packages/core/src/services/bwrapSandboxManager.ts
+++ b/packages/core/src/services/bwrapSandboxManager.ts
@@ -62,8 +62,8 @@ export class BwrapSandboxManager implements SandboxManager {
       '--dev',
       '/dev',
       '--dev-bind',
-      '/dev/pts',
-      '/dev/pts',
+      '/dev/shm',
+      '/dev/shm',
       // Strict allow-list for nested sandbox
       '--ro-bind',
       '/usr',
@@ -77,7 +77,13 @@ export class BwrapSandboxManager implements SandboxManager {
     ];
 
     // Optional system paths
-    const optionalPaths = ['/lib', '/lib64', '/etc/alternatives'];
+    const optionalPaths = [
+      '/lib',
+      '/lib64',
+      '/etc/alternatives',
+      '/etc/ssl',
+      '/etc/pki',
+    ];
     for (const p of optionalPaths) {
       if (fs.existsSync(p)) {
         bwrapArgs.push('--ro-bind', p, p);

--- a/packages/core/src/services/bwrapSandboxManager.ts
+++ b/packages/core/src/services/bwrapSandboxManager.ts
@@ -108,7 +108,10 @@ export class BwrapSandboxManager implements SandboxManager {
     if (fs.existsSync(geminiSettingsDir)) {
       bwrapArgs.push('--bind', geminiSettingsDir, geminiSettingsDir);
     }
-    bwrapArgs.push('--bind', os.tmpdir(), os.tmpdir());
+
+    // Private, isolated system paths to block Unix socket escapes
+    bwrapArgs.push('--tmpfs', '/tmp');
+    bwrapArgs.push('--tmpfs', '/run/user');
 
     // Execute via shell
     const shell = process.env['SHELL'] || '/bin/bash';

--- a/packages/core/src/services/bwrapSandboxManager.ts
+++ b/packages/core/src/services/bwrapSandboxManager.ts
@@ -16,7 +16,6 @@ import {
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
-import { quote } from 'shell-quote';
 
 /**
  * A SandboxManager implementation that uses bubblewrap (bwrap) to provide
@@ -140,15 +139,7 @@ export class BwrapSandboxManager implements SandboxManager {
     bwrapArgs.push('--tmpfs', '/tmp');
     bwrapArgs.push('--tmpfs', '/run/user');
 
-    // Execute via shell
-    const shell = process.env['SHELL'] || '/bin/bash';
-    // If we have args, we quote everything. If not, we assume command is a shell string.
-    const innerCmd =
-      req.args.length > 0
-        ? [req.command, ...req.args].map((arg) => quote([arg])).join(' ')
-        : req.command;
-
-    const finalArgs = [...bwrapArgs, '--', shell, '-c', innerCmd];
+    const finalArgs = [...bwrapArgs, '--', req.command, ...req.args];
 
     // Ensure a safe, empty HOME directory for tools
     const env = { ...sanitizedEnv, HOME: '/tmp' };

--- a/packages/core/src/services/bwrapSandboxManager.ts
+++ b/packages/core/src/services/bwrapSandboxManager.ts
@@ -61,8 +61,7 @@ export class BwrapSandboxManager implements SandboxManager {
       '/proc',
       '--dev',
       '/dev',
-      '--dev-bind',
-      '/dev/shm',
+      '--tmpfs',
       '/dev/shm',
       // Strict allow-list for nested sandbox
       '--ro-bind',

--- a/packages/core/src/services/sandboxManager.ts
+++ b/packages/core/src/services/sandboxManager.ts
@@ -21,6 +21,8 @@ export interface SandboxRequest {
   cwd: string;
   /** Environment variables to be passed to the program. */
   env: NodeJS.ProcessEnv;
+  /** Force network access off for this command. */
+  forceNetworkOff?: boolean;
   /** Optional sandbox-specific configuration. */
   config?: {
     sanitizationConfig?: Partial<EnvironmentSanitizationConfig>;

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -106,6 +106,46 @@ vi.mock('node:os', () => ({
     },
   },
 }));
+
+vi.mock('./sandboxManager.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./sandboxManager.js')>();
+  return {
+    ...actual,
+    NoopSandboxManager: class extends actual.NoopSandboxManager {
+      override async prepareCommand(
+        req: import('./sandboxManager.js').SandboxRequest,
+      ) {
+        // If we're not explicitly testing sanitization, pass through the environment
+        // to keep existing unit tests simple.
+        if (
+          !req.env['GITHUB_SHA'] &&
+          req.env['SURFACE'] !== 'Github' &&
+          !req.config?.sanitizationConfig
+        ) {
+          return {
+            program: req.command,
+            args: req.args,
+            env: req.env,
+          };
+        }
+        return super.prepareCommand(req);
+      }
+    },
+  };
+});
+
+vi.mock('./bwrapSandboxManager.js', () => ({
+  BwrapSandboxManager: class {
+    async prepareCommand(req: import('./sandboxManager.js').SandboxRequest) {
+      return {
+        program: req.command,
+        args: req.args,
+        env: req.env,
+      };
+    }
+  },
+}));
+
 vi.mock('../utils/getPty.js', () => ({
   getPty: mockGetPty,
 }));

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -276,6 +276,13 @@ export class ShellExecutionService {
     shouldUseNodePty: boolean,
     shellExecutionConfig: ShellExecutionConfig,
   ): Promise<ShellExecutionHandle> {
+    const {
+      executable: shellExecutable,
+      argsPrefix: shellArgsPrefix,
+      shell,
+    } = getShellConfiguration();
+    const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
+
     const isBwrapSandbox = process.env['SANDBOX'] === 'bwrap';
     const sandboxManager: SandboxManager = isBwrapSandbox
       ? new BwrapSandboxManager()
@@ -286,8 +293,8 @@ export class ShellExecutionService {
       args: sandboxedArgs,
       env: sanitizedEnv,
     } = await sandboxManager.prepareCommand({
-      command: commandToExecute,
-      args: [],
+      command: shellExecutable,
+      args: [...shellArgsPrefix, guardedCommand],
       env: process.env,
       cwd,
       forceNetworkOff: isBwrapSandbox, // Force network off for tools in bwrap
@@ -369,17 +376,9 @@ export class ShellExecutionService {
   ): ShellExecutionHandle {
     try {
       const isWindows = os.platform() === 'win32';
-      const {
-        executable: shellExecutable,
-        argsPrefix: shellArgsPrefix,
-        shell,
-      } = getShellConfiguration();
-      const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
 
-      const executable = argsPrefix ? commandToExecute : shellExecutable;
-      const spawnArgs = argsPrefix
-        ? argsPrefix
-        : [...shellArgsPrefix, guardedCommand];
+      const executable = commandToExecute;
+      const spawnArgs = argsPrefix ?? [];
 
       // Specifically allow GIT_CONFIG_* variables to pass through sanitization
       // in non-interactive mode so we can safely append our overrides.
@@ -718,16 +717,8 @@ export class ShellExecutionService {
     try {
       const cols = shellExecutionConfig.terminalWidth ?? 80;
       const rows = shellExecutionConfig.terminalHeight ?? 30;
-      const {
-        executable: shellExecutable,
-        argsPrefix: shellArgsPrefix,
-        shell,
-      } = getShellConfiguration();
 
-      const executable = shellExecutionConfig.argsPrefix
-        ? commandToExecute
-        : shellExecutable;
-
+      const executable = commandToExecute;
       const resolvedExecutable = await resolveExecutable(executable);
       if (!resolvedExecutable) {
         throw new Error(
@@ -735,10 +726,7 @@ export class ShellExecutionService {
         );
       }
 
-      const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
-      const args = shellExecutionConfig.argsPrefix
-        ? shellExecutionConfig.argsPrefix
-        : [...shellArgsPrefix, guardedCommand];
+      const args = shellExecutionConfig.argsPrefix ?? [];
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const ptyProcess = ptyInfo.module.spawn(executable, args, {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -31,7 +31,8 @@ import {
   sanitizeEnvironment,
   type EnvironmentSanitizationConfig,
 } from './environmentSanitization.js';
-import { NoopSandboxManager } from './sandboxManager.js';
+import { NoopSandboxManager, type SandboxManager } from './sandboxManager.js';
+import { BwrapSandboxManager } from './bwrapSandboxManager.js';
 import { killProcessGroup } from '../utils/process-utils.js';
 import {
   ExecutionLifecycleService,
@@ -94,6 +95,7 @@ export interface ShellExecutionConfig {
   disableDynamicLineTrimming?: boolean;
   scrollback?: number;
   maxSerializedLines?: number;
+  argsPrefix?: string[];
 }
 
 /**
@@ -274,12 +276,21 @@ export class ShellExecutionService {
     shouldUseNodePty: boolean,
     shellExecutionConfig: ShellExecutionConfig,
   ): Promise<ShellExecutionHandle> {
-    const sandboxManager = new NoopSandboxManager();
-    const { env: sanitizedEnv } = await sandboxManager.prepareCommand({
+    const isBwrapSandbox = process.env['SANDBOX'] === 'bwrap';
+    const sandboxManager: SandboxManager = isBwrapSandbox
+      ? new BwrapSandboxManager()
+      : new NoopSandboxManager();
+
+    const {
+      program: sandboxedProgram,
+      args: sandboxedArgs,
+      env: sanitizedEnv,
+    } = await sandboxManager.prepareCommand({
       command: commandToExecute,
       args: [],
       env: process.env,
       cwd,
+      forceNetworkOff: isBwrapSandbox, // Force network off for tools in bwrap
       config: shellExecutionConfig,
     });
 
@@ -288,11 +299,15 @@ export class ShellExecutionService {
       if (ptyInfo) {
         try {
           return await this.executeWithPty(
-            commandToExecute,
+            sandboxedProgram,
             cwd,
             onOutputEvent,
             abortSignal,
-            shellExecutionConfig,
+            {
+              ...shellExecutionConfig,
+              // When using bwrap as a wrapper, we need to pass the arguments
+              argsPrefix: sandboxedArgs,
+            },
             ptyInfo,
             sanitizedEnv,
           );
@@ -303,12 +318,13 @@ export class ShellExecutionService {
     }
 
     return this.childProcessFallback(
-      commandToExecute,
+      sandboxedProgram,
       cwd,
       onOutputEvent,
       abortSignal,
       shellExecutionConfig.sanitizationConfig,
       shouldUseNodePty,
+      sandboxedArgs, // Pass sandboxed args to fallback
     );
   }
 
@@ -349,12 +365,21 @@ export class ShellExecutionService {
     abortSignal: AbortSignal,
     sanitizationConfig: EnvironmentSanitizationConfig,
     isInteractive: boolean,
+    argsPrefix?: string[],
   ): ShellExecutionHandle {
     try {
       const isWindows = os.platform() === 'win32';
-      const { executable, argsPrefix, shell } = getShellConfiguration();
+      const {
+        executable: shellExecutable,
+        argsPrefix: shellArgsPrefix,
+        shell,
+      } = getShellConfiguration();
       const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
-      const spawnArgs = [...argsPrefix, guardedCommand];
+
+      const executable = argsPrefix ? commandToExecute : shellExecutable;
+      const spawnArgs = argsPrefix
+        ? argsPrefix
+        : [...shellArgsPrefix, guardedCommand];
 
       // Specifically allow GIT_CONFIG_* variables to pass through sanitization
       // in non-interactive mode so we can safely append our overrides.
@@ -693,7 +718,15 @@ export class ShellExecutionService {
     try {
       const cols = shellExecutionConfig.terminalWidth ?? 80;
       const rows = shellExecutionConfig.terminalHeight ?? 30;
-      const { executable, argsPrefix, shell } = getShellConfiguration();
+      const {
+        executable: shellExecutable,
+        argsPrefix: shellArgsPrefix,
+        shell,
+      } = getShellConfiguration();
+
+      const executable = shellExecutionConfig.argsPrefix
+        ? commandToExecute
+        : shellExecutable;
 
       const resolvedExecutable = await resolveExecutable(executable);
       if (!resolvedExecutable) {
@@ -703,7 +736,9 @@ export class ShellExecutionService {
       }
 
       const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
-      const args = [...argsPrefix, guardedCommand];
+      const args = shellExecutionConfig.argsPrefix
+        ? shellExecutionConfig.argsPrefix
+        : [...shellArgsPrefix, guardedCommand];
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const ptyProcess = ptyInfo.module.spawn(executable, args, {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -2475,8 +2475,15 @@
             },
             "command": {
               "type": "string",
-              "description": "The sandbox command to use (docker, podman, sandbox-exec, runsc, lxc).",
-              "enum": ["docker", "podman", "sandbox-exec", "runsc", "lxc"]
+              "description": "The sandbox command to use (docker, podman, sandbox-exec, runsc, lxc, bwrap).",
+              "enum": [
+                "docker",
+                "podman",
+                "sandbox-exec",
+                "runsc",
+                "lxc",
+                "bwrap"
+              ]
             },
             "image": {
               "type": "string",


### PR DESCRIPTION
## Summary

This PR implements a native, high-performance Linux sandbox using `bubblewrap` (bwrap). It provides a hardened, zero-dependency environment for Linux distributions (like Fedora), replacing the need for rootless Podman/Docker for local isolation.

## Details

- **Two-Layer Isolation**: Hardens both the main CLI process (outer sandbox) and individual tool executions (nested sandbox).
- **Kernel Namespaces**: Leverages user, PID, network (optional), IPC, UTS, and cgroup namespaces for robust process isolation.
- **Strict Filesystem Allow-list**: Only maps essential system paths (`/usr`, `/bin`, `/lib`, etc.) and the project workspace using a "Skeleton" mount approach.
- **Credential Protection**: Physically hides sensitive host directories (`~/.ssh`, `~/.aws`, etc.) by masking them with tmpfs or omitting them from binds.
- **Nested Tool Lockdown**: Shell tools are strictly isolated with **Network OFF** by default and private `/tmp`, `/run/user`, and `/dev/shm` mounts to prevent host service escapes (D-Bus, Wayland, X11).
- **Environment Sanitization**: Implements a strict allow-list for environment variables passed into the sandbox.
- **Distro Compatibility**: Robust detection for NVM/Asdf Node.js paths and varied Linux filesystem layouts (Fedora, Debian, Arch, etc.).
- **Full Interactivity**: Fixed PTY allocation issues inside namespaces, ensuring shell tools remain fully functional and interactive.
- **Architectural Cleanup**: Refactored `ShellExecutionService` to centralize shell wrapping logic, improving consistency across all sandbox providers.

## Related Issues

None.

## How to Validate

1. Run `GEMINI_SANDBOX=bwrap npm run start -- -s`.
2. Verify isolation in the chat by running a "Security Audit":
   - `ls ~/.ssh` -> should fail or be empty.
   - `curl https://google.com` -> should fail in tools (nested --unshare-net).
   - `ls /tmp` -> should be a private, empty tmpfs.
   - `google_web_search "Fedora version"` -> should succeed (CLI network working).
3. Run `npm run preflight` to confirm all tests pass with the new sandbox logic.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README
- [x] Added/updated tests
- [x] Noted breaking changes (None - opt-in feature)
- [x] Validated on required platforms/methods:
  - [x] Linux (Fedora 41)
    - [x] npm run
