### PR TITLE
fix(core): use session-specific temp directory for task tracker

### DIFF
--- a/packages/core/src/config/storage.test.ts
+++ b/packages/core/src/config/storage.test.ts
@@ -180,6 +180,25 @@ describe('Storage – additional helpers', () => {
     expect(storageWithSession.getProjectTempPlansDir()).toBe(expected);
   });
 
+  it('getProjectTempTrackerDir returns ~/.gemini/tmp/<identifier>/tracker when no sessionId is provided', async () => {
+    await storage.initialize();
+    const tempDir = storage.getProjectTempDir();
+    const expected = path.join(tempDir, 'tracker');
+    expect(storage.getProjectTempTrackerDir()).toBe(expected);
+  });
+
+  it('getProjectTempTrackerDir returns ~/.gemini/tmp/<identifier>/<sessionId>/tracker when sessionId is provided', async () => {
+    const sessionId = 'test-session-id';
+    const storageWithSession = new Storage(projectRoot, sessionId);
+    ProjectRegistry.prototype.getShortId = vi
+      .fn()
+      .mockReturnValue(PROJECT_SLUG);
+    await storageWithSession.initialize();
+    const tempDir = storageWithSession.getProjectTempDir();
+    const expected = path.join(tempDir, sessionId, 'tracker');
+    expect(storageWithSession.getProjectTempTrackerDir()).toBe(expected);
+  });
+
   describe('Session and JSON Loading', () => {
     beforeEach(async () => {
       await storage.initialize();

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -302,6 +302,9 @@ export class Storage {
   }
 
   getProjectTempTrackerDir(): string {
+    if (this.sessionId) {
+      return path.join(this.getProjectTempDir(), this.sessionId, 'tracker');
+    }
     return path.join(this.getProjectTempDir(), 'tracker');
   }
 


### PR DESCRIPTION
## Summary
Fixes #22198.

Updates `getProjectTempTrackerDir` in `Storage` to use a session-specific path when `sessionId` is available, which avoids collisions across multiple concurrent sessions.

## Details
- Added a check for `this.sessionId` in `getProjectTempTrackerDir`.
- Added corresponding unit tests in `storage.test.ts`.

## Related Issues
Fixes #22198

## How to Validate
Run `npm run test -w @google/gemini-cli-core -- src/config/storage.test.ts`

## Pre-Merge Checklist
[ ] Updated relevant documentation and README (if needed)
[x] Added/updated tests (if needed)
[ ] Noted breaking changes (if any)
[ ] Validated on required platforms/methods:
  [ ] MacOS
    [ ] npm run
    [ ] npx
    [ ] Docker
    [ ] Podman
    [ ] Seatbelt
  [ ] Windows
    [ ] npm run
    [ ] npx
    [ ] Docker
  [ ] Linux
    [ ] npm run
    [ ] npx
    [ ] Docker
