### PR TITLE
Fix issue where config was undefined.

### DIFF
--- a/packages/core/src/agents/agent-scheduler.test.ts
+++ b/packages/core/src/agents/agent-scheduler.test.ts
@@ -120,4 +120,25 @@ describe('agent-scheduler', () => {
     expect(schedulerConfig.toolRegistry).toBe(agentRegistry);
     expect(schedulerConfig.toolRegistry).not.toBe(mainRegistry);
   });
+
+  it('should create an AgentLoopContext that has a defined .config property', async () => {
+    const mockConfig = {
+      messageBus: mockMessageBus,
+      toolRegistry: mockToolRegistry,
+      promptId: 'test-prompt',
+    } as unknown as Mocked<Config>;
+
+    const options = {
+      schedulerId: 'subagent-1',
+      toolRegistry: mockToolRegistry as unknown as ToolRegistry,
+      signal: new AbortController().signal,
+    };
+
+    await scheduleAgentTools(mockConfig as unknown as Config, [], options);
+
+    const schedulerContext = vi.mocked(Scheduler).mock.calls[0][0].context;
+    expect(schedulerContext.config).toBeDefined();
+    expect(schedulerContext.config.promptId).toBe('test-prompt');
+    expect(schedulerContext.toolRegistry).toBe(mockToolRegistry);
+  });
 });

--- a/packages/core/src/agents/agent-scheduler.ts
+++ b/packages/core/src/agents/agent-scheduler.ts
@@ -67,8 +67,17 @@ export async function scheduleAgentTools(
     configurable: true,
   });
 
+  const schedulerContext = {
+    config: agentConfig,
+    promptId: config.promptId,
+    toolRegistry,
+    messageBus: toolRegistry.messageBus,
+    geminiClient: config.geminiClient,
+    sandboxManager: config.sandboxManager,
+  };
+
   const scheduler = new Scheduler({
-    context: agentConfig,
+    context: schedulerContext,
     messageBus: toolRegistry.messageBus,
     getPreferredEditor: getPreferredEditor ?? (() => undefined),
     schedulerId,

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -133,7 +133,7 @@ export class CoreToolScheduler {
     this.onAllToolCallsComplete = options.onAllToolCallsComplete;
     this.onToolCallsUpdate = options.onToolCallsUpdate;
     this.getPreferredEditor = options.getPreferredEditor;
-    this.toolExecutor = new ToolExecutor(this.context.config);
+    this.toolExecutor = new ToolExecutor(this.context);
     this.toolModifier = new ToolModificationHandler();
 
     // Subscribe to message bus for ASK_USER policy decisions


### PR DESCRIPTION
## Summary

Fixes an issue introduced by https://github.com/google-gemini/gemini-cli/pull/22115 which caused the config property to be undefined.

The bulk of the change is correct however it fell afoul of a usage of `Object.create()` which performs an unsafe replication of the underlying type with only a subset of the properties declared on the type.

Going forward we should take care to never introduce code that creates objects that are inconsistent with their typings. I will follow up with additional PRs to disallow this.