### PR TITLE
Fix crash when vim editor is not found in PATH on Windows

### DIFF
--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -302,6 +302,10 @@ export async function openDiff(
 
   if (isTerminalEditor(editor)) {
     try {
+      if (!commandExists(diffCommand.command)) {
+        throw new Error(`Editor command not found: ${diffCommand.command}`);
+      }
+
       const result = spawnSync(diffCommand.command, diffCommand.args, {
         stdio: 'inherit',
       });


### PR DESCRIPTION
Fixes #16492

## Summary
Prevents the CLI from crashing when vim is not available in PATH on Windows.

## Details
Adds a check to verify that the editor command exists before calling spawnSync.
Without this validation, Node throws ENOENT which causes the CLI to crash.

## How to Validate
1. Configure vim as the editor
2. Remove vim from PATH
3. Trigger the diff editor
4. CLI should show a clear error instead of crashing