### PR TITLE
refactor(sdk): introduce Logger interface to replace ad-hoc console logging

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -5,6 +5,7 @@
  */
 
 export * from './agent.js';
+export * from './logger.js';
 export * from './session.js';
 export * from './tool.js';
 export * from './skills.js';

--- a/packages/sdk/src/logger.test.ts
+++ b/packages/sdk/src/logger.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ConsoleLogger, NoopLogger, LogLevel } from './logger.js';
+import type { Logger } from './logger.js';
+
+describe('Logger', () => {
+  describe('ConsoleLogger', () => {
+    let consoleSpy: {
+      debug: ReturnType<typeof vi.spyOn>;
+      info: ReturnType<typeof vi.spyOn>;
+      warn: ReturnType<typeof vi.spyOn>;
+      error: ReturnType<typeof vi.spyOn>;
+    };
+
+    beforeEach(() => {
+      consoleSpy = {
+        debug: vi.spyOn(console, 'debug').mockImplementation(() => {}),
+        info: vi.spyOn(console, 'info').mockImplementation(() => {}),
+        warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+        error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+      };
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should log at INFO level by default', () => {
+      const logger = new ConsoleLogger();
+
+      logger.debug('debug message');
+      logger.info('info message');
+      logger.warn('warn message');
+      logger.error('error message');
+
+      expect(consoleSpy.debug).not.toHaveBeenCalled();
+      expect(consoleSpy.info).toHaveBeenCalledWith('[INFO] info message');
+      expect(consoleSpy.warn).toHaveBeenCalledWith('[WARN] warn message');
+      expect(consoleSpy.error).toHaveBeenCalledWith('[ERROR] error message');
+    });
+
+    it('should log all levels when set to DEBUG', () => {
+      const logger = new ConsoleLogger(LogLevel.DEBUG);
+
+      logger.debug('debug message');
+      logger.info('info message');
+      logger.warn('warn message');
+      logger.error('error message');
+
+      expect(consoleSpy.debug).toHaveBeenCalledOnce();
+      expect(consoleSpy.info).toHaveBeenCalledOnce();
+      expect(consoleSpy.warn).toHaveBeenCalledOnce();
+      expect(consoleSpy.error).toHaveBeenCalledOnce();
+    });
+
+    it('should only log errors when set to ERROR', () => {
+      const logger = new ConsoleLogger(LogLevel.ERROR);
+
+      logger.debug('debug message');
+      logger.info('info message');
+      logger.warn('warn message');
+      logger.error('error message');
+
+      expect(consoleSpy.debug).not.toHaveBeenCalled();
+      expect(consoleSpy.info).not.toHaveBeenCalled();
+      expect(consoleSpy.warn).not.toHaveBeenCalled();
+      expect(consoleSpy.error).toHaveBeenCalledOnce();
+    });
+
+    it('should log nothing when set to SILENT', () => {
+      const logger = new ConsoleLogger(LogLevel.SILENT);
+
+      logger.debug('debug message');
+      logger.info('info message');
+      logger.warn('warn message');
+      logger.error('error message');
+
+      expect(consoleSpy.debug).not.toHaveBeenCalled();
+      expect(consoleSpy.info).not.toHaveBeenCalled();
+      expect(consoleSpy.warn).not.toHaveBeenCalled();
+      expect(consoleSpy.error).not.toHaveBeenCalled();
+    });
+
+    it('should include metadata when provided', () => {
+      const logger = new ConsoleLogger(LogLevel.DEBUG);
+      const metadata = { key: 'value', count: 42 };
+
+      logger.info('test message', metadata);
+
+      expect(consoleSpy.info).toHaveBeenCalledWith(
+        '[INFO] test message',
+        metadata,
+      );
+    });
+
+    it('should not include metadata argument when not provided', () => {
+      const logger = new ConsoleLogger(LogLevel.DEBUG);
+
+      logger.info('test message');
+
+      expect(consoleSpy.info).toHaveBeenCalledWith('[INFO] test message');
+    });
+  });
+
+  describe('NoopLogger', () => {
+    it('should not call console methods', () => {
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const logger = new NoopLogger();
+
+      logger.debug('debug');
+      logger.info('info');
+      logger.warn('warn');
+      logger.error('error');
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+      vi.restoreAllMocks();
+    });
+
+    it('should implement the Logger interface', () => {
+      const logger: Logger = new NoopLogger();
+
+      // Should not throw
+      logger.debug('test', { key: 'value' });
+      logger.info('test', { key: 'value' });
+      logger.warn('test', { key: 'value' });
+      logger.error('test', { key: 'value' });
+    });
+  });
+
+  describe('Logger interface', () => {
+    it('should allow custom logger implementations', () => {
+      const messages: Array<{
+        level: string;
+        message: string;
+        metadata?: Record<string, unknown>;
+      }> = [];
+
+      const customLogger: Logger = {
+        debug(message, metadata) {
+          messages.push({ level: 'debug', message, metadata });
+        },
+        info(message, metadata) {
+          messages.push({ level: 'info', message, metadata });
+        },
+        warn(message, metadata) {
+          messages.push({ level: 'warn', message, metadata });
+        },
+        error(message, metadata) {
+          messages.push({ level: 'error', message, metadata });
+        },
+      };
+
+      customLogger.info('test message', { sessionId: 'abc-123' });
+      customLogger.error('something failed', { code: 500 });
+
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toEqual({
+        level: 'info',
+        message: 'test message',
+        metadata: { sessionId: 'abc-123' },
+      });
+      expect(messages[1]).toEqual({
+        level: 'error',
+        message: 'something failed',
+        metadata: { code: 500 },
+      });
+    });
+  });
+});

--- a/packages/sdk/src/logger.ts
+++ b/packages/sdk/src/logger.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Standardized logger interface for the Gemini CLI SDK.
+ *
+ * All modules should use this interface for consistent logging behavior.
+ * The logger is injectable to allow different implementations
+ * (console, telemetry, file, no-op for testing).
+ */
+export interface Logger {
+  debug(message: string, metadata?: Record<string, unknown>): void;
+  info(message: string, metadata?: Record<string, unknown>): void;
+  warn(message: string, metadata?: Record<string, unknown>): void;
+  error(message: string, metadata?: Record<string, unknown>): void;
+}
+
+/**
+ * Log severity levels, ordered from most verbose to least verbose.
+ */
+export enum LogLevel {
+  DEBUG = 0,
+  INFO = 1,
+  WARN = 2,
+  ERROR = 3,
+  SILENT = 4,
+}
+
+/**
+ * Default logger implementation that writes to the console.
+ * Supports configurable log levels to filter output.
+ */
+export class ConsoleLogger implements Logger {
+  private readonly level: LogLevel;
+
+  constructor(level: LogLevel = LogLevel.INFO) {
+    this.level = level;
+  }
+
+  private log(
+    level: LogLevel,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    logFn: (...data: any[]) => void,
+    prefix: string,
+    message: string,
+    metadata?: Record<string, unknown>,
+  ): void {
+    if (this.level <= level) {
+      const logMessage = `[${prefix}] ${message}`;
+      if (metadata) {
+         
+        logFn(logMessage, metadata);
+      } else {
+         
+        logFn(logMessage);
+      }
+    }
+  }
+
+  debug(message: string, metadata?: Record<string, unknown>): void {
+    // eslint-disable-next-line no-console
+    this.log(LogLevel.DEBUG, console.debug, 'DEBUG', message, metadata);
+  }
+
+  info(message: string, metadata?: Record<string, unknown>): void {
+    // eslint-disable-next-line no-console
+    this.log(LogLevel.INFO, console.info, 'INFO', message, metadata);
+  }
+
+  warn(message: string, metadata?: Record<string, unknown>): void {
+    // eslint-disable-next-line no-console
+    this.log(LogLevel.WARN, console.warn, 'WARN', message, metadata);
+  }
+
+  error(message: string, metadata?: Record<string, unknown>): void {
+    // eslint-disable-next-line no-console
+    this.log(LogLevel.ERROR, console.error, 'ERROR', message, metadata);
+  }
+}
+
+/**
+ * A no-op logger that silently discards all log messages.
+ * Useful for unit testing or when logging should be completely disabled.
+ */
+export class NoopLogger implements Logger {
+  debug(_message: string, _metadata?: Record<string, unknown>): void {}
+  info(_message: string, _metadata?: Record<string, unknown>): void {}
+  warn(_message: string, _metadata?: Record<string, unknown>): void {}
+  error(_message: string, _metadata?: Record<string, unknown>): void {}
+}

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -26,6 +26,7 @@ import {
 import { type Tool, SdkTool } from './tool.js';
 import { SdkAgentFilesystem } from './fs.js';
 import { SdkAgentShell } from './shell.js';
+import { ConsoleLogger, type Logger } from './logger.js';
 import type {
   SessionContext,
   GeminiCliAgentOptions,
@@ -40,6 +41,7 @@ export class GeminiCliSession {
   private readonly tools: Array<Tool<any>>;
   private readonly skillRefs: SkillReference[];
   private readonly instructions: SystemInstructions | undefined;
+  private readonly logger: Logger;
   private client: GeminiClient | undefined;
   private initialized = false;
 
@@ -50,6 +52,7 @@ export class GeminiCliSession {
     private readonly resumedData?: ResumedSessionData,
   ) {
     this.instructions = options.instructions;
+    this.logger = options.logger ?? new ConsoleLogger();
     const cwd = options.cwd || process.cwd();
     this.tools = options.tools || [];
     this.skillRefs = options.skills || [];
@@ -107,9 +110,11 @@ export class GeminiCliSession {
             return await loadSkillsFromDir(ref.path);
           }
         } catch (e) {
-          // TODO: refactor this to use a proper logger interface
-          // eslint-disable-next-line no-console
-          console.error(`Failed to load skills from ${ref.path}:`, e);
+          this.logger.error(`Failed to load skills from ${ref.path}`, {
+            path: ref.path,
+            type: ref.type,
+            error: e instanceof Error ? e.message : String(e),
+          });
         }
         return [];
       });

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -9,6 +9,7 @@ import type { Tool } from './tool.js';
 import type { SkillReference } from './skills.js';
 import type { GeminiCliAgent } from './agent.js';
 import type { GeminiCliSession } from './session.js';
+import type { Logger } from './logger.js';
 
 export type SystemInstructions =
   | string
@@ -24,6 +25,12 @@ export interface GeminiCliAgentOptions {
   debug?: boolean;
   recordResponses?: string;
   fakeResponses?: string;
+  /**
+   * Optional logger instance for structured logging.
+   * If not provided, a ConsoleLogger with INFO level is used by default.
+   * Pass a NoopLogger to suppress all logging output (useful for testing).
+   */
+  logger?: Logger;
 }
 
 export interface AgentFilesystem {


### PR DESCRIPTION
## Summary

Introduces a standardized `Logger` interface for the SDK session module,
replacing the ad-hoc `console.error` call referenced by the TODO at
`packages/sdk/src/session.ts:110`.

Fixes #22184

## Changes

| File | Change |
|---|---|
| `src/logger.ts` | New `Logger` interface, `ConsoleLogger`, `NoopLogger`, `LogLevel` enum |
| `src/logger.test.ts` | Unit tests for all logger implementations |
| `src/types.ts` | Added optional `logger` to `GeminiCliAgentOptions` |
| `src/session.ts` | Replaced `console.error` with injectable `this.logger.error()` |
| `src/index.ts` | Export new logger module |

## Backward Compatibility

Fully backward compatible. When no `logger` option is provided,
`ConsoleLogger` with `INFO` level is used — preserving existing behavior.

## Usage

```typescript
import { GeminiCliAgent, ConsoleLogger, NoopLogger, LogLevel } from '@google/gemini-cli-sdk';

// Default behavior (same as before)
const agent = new GeminiCliAgent({ instructions: '...' });

// Verbose logging
const agent = new GeminiCliAgent({
  instructions: '...',
  logger: new ConsoleLogger(LogLevel.DEBUG),
});

// Silent (for tests)
const agent = new GeminiCliAgent({
  instructions: '...',
  logger: new NoopLogger(),
});