### PR TITLE
fix(cli): replace hardcoded /resume references with dynamic command n…

### DIFF
--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -90,7 +90,7 @@ const listCommand: SlashCommand = {
 const saveCommand: SlashCommand = {
   name: 'save',
   description:
-    'Save the current conversation as a checkpoint. Usage: /resume save <tag>',
+    'Save the current conversation as a checkpoint. Usage: /chat save <tag>',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
   action: async (context, args): Promise<SlashCommandActionReturn | void> => {
@@ -99,7 +99,7 @@ const saveCommand: SlashCommand = {
       return {
         type: 'message',
         messageType: 'error',
-        content: 'Missing tag. Usage: /resume save <tag>',
+        content: 'Missing tag. Usage: /chat save <tag>',
       };
     }
 
@@ -119,7 +119,7 @@ const saveCommand: SlashCommand = {
             ' already exists. Do you want to overwrite it?',
           ),
           originalInvocation: {
-            raw: context.invocation?.raw || `/resume save ${tag}`,
+            raw: context.invocation?.raw || `/${context.invocation?.name ?? 'chat'} save ${tag}`,
           },
         };
       }
@@ -159,7 +159,7 @@ const resumeCheckpointCommand: SlashCommand = {
   name: 'resume',
   altNames: ['load'],
   description:
-    'Resume a conversation from a checkpoint. Usage: /resume resume <tag>',
+    'Resume a conversation from a checkpoint. Usage: /chat resume <tag>',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
   action: async (context, args) => {
@@ -168,7 +168,7 @@ const resumeCheckpointCommand: SlashCommand = {
       return {
         type: 'message',
         messageType: 'error',
-        content: 'Missing tag. Usage: /resume resume <tag>',
+        content: `Missing tag. Usage: /${context.invocation?.name ?? 'chat'} resume <tag>`,
       };
     }
 
@@ -237,7 +237,7 @@ const resumeCheckpointCommand: SlashCommand = {
 
 const deleteCommand: SlashCommand = {
   name: 'delete',
-  description: 'Delete a conversation checkpoint. Usage: /resume delete <tag>',
+  description: 'Delete a conversation checkpoint. Usage: /chat delete <tag>',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
   action: async (context, args): Promise<MessageActionReturn> => {
@@ -246,7 +246,7 @@ const deleteCommand: SlashCommand = {
       return {
         type: 'message',
         messageType: 'error',
-        content: 'Missing tag. Usage: /resume delete <tag>',
+        content: `Missing tag. Usage: /${context.invocation?.name ?? 'chat'} delete <tag>`,
       };
     }
 
@@ -279,7 +279,16 @@ const deleteCommand: SlashCommand = {
 const shareCommand: SlashCommand = {
   name: 'share',
   description:
-    'Share the current conversation to a markdown or json file. Usage: /resume share <file>',
+    'Share the current conversation to a markdown or json file. Usage: /chat share <file>',
+```
+
+---
+
+## How To Edit The File
+
+Open the file in Notepad. In your terminal type:
+```
+notepad chatCommand.ts
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
   action: async (context, args): Promise<MessageActionReturn> => {

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -99,7 +99,7 @@ const saveCommand: SlashCommand = {
       return {
         type: 'message',
         messageType: 'error',
-        content: 'Missing tag. Usage: /chat save <tag>',
+        content: `Missing tag. Usage: /${context.invocation?.name ?? 'chat'} save <tag>`,
       };
     }
 
@@ -279,16 +279,7 @@ const deleteCommand: SlashCommand = {
 const shareCommand: SlashCommand = {
   name: 'share',
   description:
-    'Share the current conversation to a markdown or json file. Usage: /chat share <file>',
-```
-
----
-
-## How To Edit The File
-
-Open the file in Notepad. In your terminal type:
-```
-notepad chatCommand.ts
+    'Share the current conversation to a markdown or json file. Usage: /chat share <file>'
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
   action: async (context, args): Promise<MessageActionReturn> => {

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -90,7 +90,7 @@ const listCommand: SlashCommand = {
 const saveCommand: SlashCommand = {
   name: 'save',
   description:
-    'Save the current conversation as a checkpoint. Usage: /chat save <tag>',
+    'Save the current conversation as a checkpoint. Usage:  save <tag>',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
   action: async (context, args): Promise<SlashCommandActionReturn | void> => {
@@ -159,7 +159,7 @@ const resumeCheckpointCommand: SlashCommand = {
   name: 'resume',
   altNames: ['load'],
   description:
-    'Resume a conversation from a checkpoint. Usage: /chat resume <tag>',
+    'Resume a conversation from a checkpoint. Usage:  resume <tag>',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
   action: async (context, args) => {
@@ -237,7 +237,7 @@ const resumeCheckpointCommand: SlashCommand = {
 
 const deleteCommand: SlashCommand = {
   name: 'delete',
-  description: 'Delete a conversation checkpoint. Usage: /chat delete <tag>',
+  description: 'Delete a conversation checkpoint. Usage:  delete <tag>',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
   action: async (context, args): Promise<MessageActionReturn> => {
@@ -279,7 +279,7 @@ const deleteCommand: SlashCommand = {
 const shareCommand: SlashCommand = {
   name: 'share',
   description:
-    'Share the current conversation to a markdown or json file. Usage: /chat share <file>'
+    'Share the current conversation to a markdown or json file. Usage:  share <file>'
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
   action: async (context, args): Promise<MessageActionReturn> => {


### PR DESCRIPTION
## Summary

## Summary

Fixes #22421

The `/chat` subcommand usage strings were incorrectly referencing `/resume` 
(the previous command name) instead of the actual command the user typed.

## Changes Made

- Updated `saveCommand` description and error message
- Updated `resumeCheckpointCommand` description and error message  
- Updated `deleteCommand` description and error message
- Updated `shareCommand` description
- Used `context.invocation?.name ?? 'chat'` dynamically where possible
  so the message works correctly for both `/chat` and `/resume`

## Before

Missing tag. Usage: /resume save <tag>

## After

Missing tag. Usage: /chat save <tag>

## How To Validate

1. Run gemiini-cli locally
2. Type `/chat save` without a tag — error should now say 
   `Missing tag. Usage: /chat save <tag>`
3. Type `/chat resume` without a tag — error should now say 
   `Missing tag. Usage: /chat resume <tag>`
4. Type `/chat delete` without a tag — error should now say 
   `Missing tag. Usage: /chat delete <tag>`
5. Type `/resume save` without a tag — should still work correctly 
   since `/resume` is a wrapper for `/chat`
6. Check `/help` output — all usage strings should reference 
   the correct command name

## Notes

The fix uses `context.invocation?.name ?? 'chat'` dynamically so it 
works correctly for both `/chat` and `/resume` without hardcoding either.