### PR TITLE
feat(cli): add 'remove' and 'clear' subcommands to '/directory' command

### DIFF
--- a/packages/cli/src/ui/commands/directoryCommand.test.tsx
+++ b/packages/cli/src/ui/commands/directoryCommand.test.tsx
@@ -52,15 +52,32 @@ describe('directoryCommand', () => {
   const addCommand = directoryCommand.subCommands?.find(
     (c) => c.name === 'add',
   );
+  const removeCommand = directoryCommand.subCommands?.find(
+    (c) => c.name === 'remove',
+  );
+  const clearCommand = directoryCommand.subCommands?.find(
+    (c) => c.name === 'clear',
+  );
   const showCommand = directoryCommand.subCommands?.find(
     (c) => c.name === 'show',
   );
+  let mockGeminiClient: {
+    addDirectoryContext: Mock;
+    getChatRecordingService: Mock;
+  };
+  let mockChatRecordingService: {
+    recordDirectories: Mock;
+  };
 
   beforeEach(() => {
     mockWorkspaceContext = {
       targetDir: path.resolve('/test/dir'),
       addDirectory: vi.fn(),
       addDirectories: vi.fn().mockReturnValue({ added: [], failed: [] }),
+      getInitialDirectories: vi
+        .fn()
+        .mockReturnValue([path.resolve('/test/dir')]),
+      setDirectories: vi.fn(),
       getDirectories: vi
         .fn()
         .mockReturnValue([
@@ -69,15 +86,21 @@ describe('directoryCommand', () => {
         ]),
     } as unknown as WorkspaceContext;
 
+    mockChatRecordingService = {
+      recordDirectories: vi.fn(),
+    };
+
+    mockGeminiClient = {
+      addDirectoryContext: vi.fn(),
+      getChatRecordingService: vi
+        .fn()
+        .mockReturnValue(mockChatRecordingService),
+    };
+
     mockConfig = {
       getWorkspaceContext: () => mockWorkspaceContext,
       isRestrictiveSandbox: vi.fn().mockReturnValue(false),
-      getGeminiClient: vi.fn().mockReturnValue({
-        addDirectoryContext: vi.fn(),
-        getChatRecordingService: vi.fn().mockReturnValue({
-          recordDirectories: vi.fn(),
-        }),
-      }),
+      getGeminiClient: vi.fn().mockReturnValue(mockGeminiClient),
       getWorkingDir: () => path.resolve('/test/dir'),
       shouldLoadMemoryFromIncludeDirectories: () => false,
       getDebugMode: () => false,
@@ -119,6 +142,116 @@ describe('directoryCommand', () => {
           text: `Current workspace directories:\n- ${path.resolve(
             '/home/user/project1',
           )}\n- ${path.resolve('/home/user/project2')}`,
+        }),
+      );
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a manually added directory and persist the change', async () => {
+      const addedPath = path.resolve('/home/user/project1');
+      if (!removeCommand?.action) throw new Error('No action');
+
+      await removeCommand.action(mockContext, addedPath);
+
+      expect(mockWorkspaceContext.setDirectories).toHaveBeenCalledWith([
+        path.resolve('/home/user/project2'),
+      ]);
+      expect(mockGeminiClient.addDirectoryContext).toHaveBeenCalledOnce();
+      expect(mockChatRecordingService.recordDirectories).toHaveBeenCalledWith([
+        path.resolve('/home/user/project1'),
+        path.resolve('/home/user/project2'),
+      ]);
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: `Successfully removed directory:\n- ${addedPath}`,
+        }),
+      );
+    });
+
+    it('should reject removing the initial workspace directory', async () => {
+      const initialPath = path.resolve('/test/dir');
+      vi.mocked(mockWorkspaceContext.getDirectories).mockReturnValue([
+        initialPath,
+        path.resolve('/home/user/project1'),
+      ]);
+      vi.mocked(mockWorkspaceContext.getInitialDirectories).mockReturnValue([
+        initialPath,
+      ]);
+
+      if (!removeCommand?.action) throw new Error('No action');
+      await removeCommand.action(mockContext, initialPath);
+
+      expect(mockWorkspaceContext.setDirectories).not.toHaveBeenCalled();
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.ERROR,
+          text: `Cannot remove the initial workspace directory: ${initialPath}`,
+        }),
+      );
+    });
+
+    it('should show an error when removing a directory not in the workspace', async () => {
+      const missingPath = path.resolve('/home/user/missing-project');
+      if (!removeCommand?.action) throw new Error('No action');
+
+      await removeCommand.action(mockContext, missingPath);
+
+      expect(mockWorkspaceContext.setDirectories).not.toHaveBeenCalled();
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.ERROR,
+          text: `Directory is not in the workspace: ${missingPath}`,
+        }),
+      );
+    });
+  });
+
+  describe('clear', () => {
+    it('should clear all manually added directories and persist the change', async () => {
+      const initialPath = path.resolve('/test/dir');
+      vi.mocked(mockWorkspaceContext.getDirectories).mockReturnValue([
+        initialPath,
+        path.resolve('/home/user/project1'),
+        path.resolve('/home/user/project2'),
+      ]);
+      vi.mocked(mockWorkspaceContext.getInitialDirectories).mockReturnValue([
+        initialPath,
+      ]);
+
+      if (!clearCommand?.action) throw new Error('No action');
+      await clearCommand.action(mockContext, '');
+
+      expect(mockWorkspaceContext.setDirectories).toHaveBeenCalledWith([
+        initialPath,
+      ]);
+      expect(mockGeminiClient.addDirectoryContext).toHaveBeenCalledOnce();
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: `Successfully cleared directories:\n- ${path.resolve('/home/user/project1')}\n- ${path.resolve('/home/user/project2')}`,
+        }),
+      );
+    });
+
+    it('should show an info message when there are no manually added directories', async () => {
+      const initialPath = path.resolve('/test/dir');
+      vi.mocked(mockWorkspaceContext.getDirectories).mockReturnValue([
+        initialPath,
+      ]);
+      vi.mocked(mockWorkspaceContext.getInitialDirectories).mockReturnValue([
+        initialPath,
+      ]);
+
+      if (!clearCommand?.action) throw new Error('No action');
+      await clearCommand.action(mockContext, '');
+
+      expect(mockWorkspaceContext.setDirectories).not.toHaveBeenCalled();
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: 'No manually added directories to clear.',
         }),
       );
     });

--- a/packages/cli/src/ui/commands/directoryCommand.test.tsx
+++ b/packages/cli/src/ui/commands/directoryCommand.test.tsx
@@ -150,18 +150,27 @@ describe('directoryCommand', () => {
   describe('remove', () => {
     it('should remove a manually added directory and persist the change', async () => {
       const addedPath = path.resolve('/home/user/project1');
+      const updatedDirs = [path.resolve('/home/user/project2')];
       if (!removeCommand?.action) throw new Error('No action');
+
+      // Simulate setDirectories updating the workspace so that the subsequent
+      // getDirectories() call inside persistWorkspaceDirectories returns the
+      // post-removal list, not the original one.
+      vi.mocked(mockWorkspaceContext.setDirectories).mockImplementation(() => {
+        vi.mocked(mockWorkspaceContext.getDirectories).mockReturnValue(
+          updatedDirs,
+        );
+      });
 
       await removeCommand.action(mockContext, addedPath);
 
-      expect(mockWorkspaceContext.setDirectories).toHaveBeenCalledWith([
-        path.resolve('/home/user/project2'),
-      ]);
+      expect(mockWorkspaceContext.setDirectories).toHaveBeenCalledWith(
+        updatedDirs,
+      );
       expect(mockGeminiClient.addDirectoryContext).toHaveBeenCalledOnce();
-      expect(mockChatRecordingService.recordDirectories).toHaveBeenCalledWith([
-        path.resolve('/home/user/project1'),
-        path.resolve('/home/user/project2'),
-      ]);
+      expect(mockChatRecordingService.recordDirectories).toHaveBeenCalledWith(
+        updatedDirs,
+      );
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         expect.objectContaining({
           type: MessageType.INFO,
@@ -483,7 +492,6 @@ describe('directoryCommand', () => {
 
     beforeEach(() => {
       vi.spyOn(trustedFolders, 'isFolderTrustEnabled').mockReturnValue(true);
-      // isWorkspaceTrusted is no longer checked, so we don't need to mock it returning true
       mockIsPathTrusted = vi.fn();
       const mockLoadedFolders = {
         isPathTrusted: mockIsPathTrusted,
@@ -515,7 +523,7 @@ describe('directoryCommand', () => {
 
     it('should return a custom dialog for an explicitly untrusted directory (upgrade flow)', async () => {
       if (!addCommand?.action) throw new Error('No action');
-      mockIsPathTrusted.mockReturnValue(false); // DO_NOT_TRUST
+      mockIsPathTrusted.mockReturnValue(false);
       const newPath = path.resolve('/home/user/untrusted-project');
 
       const result = await addCommand.action(mockContext, newPath);
@@ -524,7 +532,7 @@ describe('directoryCommand', () => {
         expect.objectContaining({
           type: 'custom_dialog',
           component: expect.objectContaining({
-            type: expect.any(Function), // React component for MultiFolderTrustDialog
+            type: expect.any(Function),
           }),
         }),
       );
@@ -547,7 +555,7 @@ describe('directoryCommand', () => {
         expect.objectContaining({
           type: 'custom_dialog',
           component: expect.objectContaining({
-            type: expect.any(Function), // React component for MultiFolderTrustDialog
+            type: expect.any(Function),
           }),
         }),
       );
@@ -561,7 +569,6 @@ describe('directoryCommand', () => {
 
     it('should prompt for directory even if workspace is untrusted', async () => {
       if (!addCommand?.action) throw new Error('No action');
-      // Even if workspace is untrusted, we should still check directory trust
       vi.spyOn(trustedFolders, 'isWorkspaceTrusted').mockReturnValue({
         isTrusted: false,
         source: 'file',

--- a/packages/cli/src/ui/commands/directoryCommand.tsx
+++ b/packages/cli/src/ui/commands/directoryCommand.tsx
@@ -60,17 +60,7 @@ async function finishAddingDirectories(
   }
 
   if (added.length > 0) {
-    const gemini = config.getGeminiClient();
-    if (gemini) {
-      await gemini.addDirectoryContext();
-
-      // Persist directories to session file for resume support
-      const chatRecordingService = gemini.getChatRecordingService();
-      const workspaceContext = config.getWorkspaceContext();
-      chatRecordingService?.recordDirectories(
-        workspaceContext.getDirectories(),
-      );
-    }
+    await persistWorkspaceDirectories(config);
     addItem({
       type: MessageType.INFO,
       text: `Successfully added directories:\n- ${added.join('\n- ')}`,
@@ -80,6 +70,28 @@ async function finishAddingDirectories(
   if (errors.length > 0) {
     addItem({ type: MessageType.ERROR, text: errors.join('\n') });
   }
+}
+
+async function persistWorkspaceDirectories(config: Config) {
+  const gemini = config.getGeminiClient();
+  if (!gemini) {
+    return;
+  }
+
+  await gemini.addDirectoryContext();
+
+  const chatRecordingService = gemini.getChatRecordingService();
+  const workspaceContext = config.getWorkspaceContext();
+  chatRecordingService?.recordDirectories(workspaceContext.getDirectories());
+}
+
+function updateWorkspaceDirectories(
+  config: Config,
+  directories: readonly string[],
+) {
+  const workspaceContext = config.getWorkspaceContext();
+  workspaceContext.setDirectories(directories);
+  return persistWorkspaceDirectories(config);
 }
 
 export const directoryCommand: SlashCommand = {
@@ -290,6 +302,124 @@ export const directoryCommand: SlashCommand = {
         addItem({
           type: MessageType.INFO,
           text: `Current workspace directories:\n${directoryList}`,
+        });
+      },
+    },
+    {
+      name: 'remove',
+      description: 'Remove a manually added directory from the workspace',
+      kind: CommandKind.BUILT_IN,
+      action: async (context: CommandContext, args: string) => {
+        const {
+          ui: { addItem },
+          services: { config },
+        } = context;
+
+        if (!config) {
+          addItem({
+            type: MessageType.ERROR,
+            text: 'Configuration is not available.',
+          });
+          return;
+        }
+
+        const pathToRemove = args.trim();
+        if (!pathToRemove) {
+          addItem({
+            type: MessageType.ERROR,
+            text: 'Please provide a path to remove.',
+          });
+          return;
+        }
+
+        const workspaceContext = config.getWorkspaceContext();
+        const currentDirectories = workspaceContext.getDirectories();
+        const initialDirectories = new Set(
+          workspaceContext.getInitialDirectories(),
+        );
+
+        let resolvedPath: string;
+        try {
+          resolvedPath = fs.realpathSync(
+            path.resolve(
+              workspaceContext.targetDir,
+              expandHomeDir(pathToRemove),
+            ),
+          );
+        } catch {
+          addItem({
+            type: MessageType.ERROR,
+            text: `Directory is not in the workspace: ${pathToRemove}`,
+          });
+          return;
+        }
+
+        if (!currentDirectories.includes(resolvedPath)) {
+          addItem({
+            type: MessageType.ERROR,
+            text: `Directory is not in the workspace: ${pathToRemove}`,
+          });
+          return;
+        }
+
+        if (initialDirectories.has(resolvedPath)) {
+          addItem({
+            type: MessageType.ERROR,
+            text: `Cannot remove the initial workspace directory: ${resolvedPath}`,
+          });
+          return;
+        }
+
+        await updateWorkspaceDirectories(
+          config,
+          currentDirectories.filter((dir) => dir !== resolvedPath),
+        );
+
+        addItem({
+          type: MessageType.INFO,
+          text: `Successfully removed directory:\n- ${resolvedPath}`,
+        });
+      },
+    },
+    {
+      name: 'clear',
+      description: 'Remove all manually added directories from the workspace',
+      kind: CommandKind.BUILT_IN,
+      action: async (context: CommandContext) => {
+        const {
+          ui: { addItem },
+          services: { config },
+        } = context;
+
+        if (!config) {
+          addItem({
+            type: MessageType.ERROR,
+            text: 'Configuration is not available.',
+          });
+          return;
+        }
+
+        const workspaceContext = config.getWorkspaceContext();
+        const currentDirectories = workspaceContext.getDirectories();
+        const initialDirectories = workspaceContext.getInitialDirectories();
+        const initialDirectorySet = new Set(initialDirectories);
+        const removedDirectories = currentDirectories.filter(
+          (dir) => !initialDirectorySet.has(dir),
+        );
+
+        if (removedDirectories.length === 0) {
+          addItem({
+            type: MessageType.INFO,
+            text: 'No manually added directories to clear.',
+          });
+          return;
+        }
+
+        await updateWorkspaceDirectories(config, initialDirectories);
+
+        addItem({
+          type: MessageType.INFO,
+          text: `Successfully cleared directories:\n- ${removedDirectories.join('\n- ')}`,
         });
       },
     },


### PR DESCRIPTION
## Summary

Adds two new subcommands to `/directory` (alias `/dir`) to allow users to remove workspace directories mid-session without restarting.
- `/directory remove <path>` — removes a single manually added directory
- `/directory clear` — removes all manually added directories, restoring the initial workspace

## Details

Both subcommands share a `updateWorkspaceDirectories` helper that calls `setDirectories` and then `persistWorkspaceDirectories`, which keeps persistence logic (session recording via `recordDirectories`) in one place and consistent with how `/directory add` already behaves. `remove` guards against removing any directory that was present at
session start (`getInitialDirectories`), preventing accidental removal of the user's primary working directory.

## Related Issues

Closes #22019

## How to Validate
```bash
# Start a session in project-x
cd /path/to/project-x
gemini

# Add a reference directory
/directory add /path/to/project-y
/directory show   # should list both

# Remove it when done
/directory remove /path/to/project-y
/directory show   # should list only project-x

# Try to remove the initial directory (should be blocked)
/directory remove /path/to/project-x

# Add two directories, then clear both
/directory add /path/to/project-y
/directory add /path/to/project-z
/directory clear
/directory show   # should list only project-x

# Resume a session to verify directories were persisted correctly
```
## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [ ] Docker