### PR TITLE
fix(core): merge user settings with extension-provided MCP servers

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -729,6 +729,35 @@ tools. The model will automatically:
 
 The MCP integration tracks several states:
 
+#### Overriding extension configurations
+
+If an MCP server is provided by an extension (for example, the
+`google-workspace` extension), you can still override its settings in your local
+`settings.json`. Gemini CLI merges your local configuration with the extension's
+defaults:
+
+- **Tool lists:** The `includeTools` and `excludeTools` arrays from both sources
+  are combined (unioned). Because `excludeTools` always takes precedence over
+  `includeTools`, if either the extension or you exclude a tool, it remains
+  disabled, even if the other source includes it. This ensures you always have
+  veto power over any tools provided by an extension.
+- **Environment variables:** The `env` objects are merged. If the same variable
+  is defined in both places, your local value takes precedence.
+- **Scalar properties:** Properties like `command`, `url`, and `timeout` are
+  replaced by your local values if provided.
+
+**Example override:**
+
+```json
+{
+  "mcpServers": {
+    "google-workspace": {
+      "excludeTools": ["gmail.send"]
+    }
+  }
+}
+```
+
 #### Server status (`MCPServerStatus`)
 
 - **`DISCONNECTED`:** Server is not connected or has errors

--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -736,11 +736,19 @@ If an MCP server is provided by an extension (for example, the
 `settings.json`. Gemini CLI merges your local configuration with the extension's
 defaults:
 
-- **Tool lists:** The `includeTools` and `excludeTools` arrays from both sources
-  are combined (unioned). Because `excludeTools` always takes precedence over
-  `includeTools`, if either the extension or you exclude a tool, it remains
-  disabled, even if the other source includes it. This ensures you always have
-  veto power over any tools provided by an extension.
+- **Tool lists:** Tool lists are merged securely to ensure the most restrictive
+  policy wins:
+  - **Exclusions (`excludeTools`):** Arrays are combined (unioned). If either
+    source blocks a tool, it remains disabled.
+  - **Inclusions (`includeTools`):** Arrays are intersected. If both sources
+    provide an allowlist, only tools present in **both** lists are enabled. If
+    only one source provides an allowlist, that list is respected.
+  - **Precedence:** `excludeTools` always takes precedence over `includeTools`.
+
+  This ensures you always have veto power over tools provided by an extension
+  and that an extension cannot re-enable tools you have omitted from your
+  personal allowlist.
+
 - **Environment variables:** The `env` objects are merged. If the same variable
   is defined in both places, your local value takes precedence.
 - **Scalar properties:** Properties like `command`, `url`, and `timeout` are

--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -296,7 +296,7 @@ describe('McpClientManager', () => {
 
       // A NEW McpClient should have been constructed with the updated config
       expect(constructorCalls).toHaveLength(2);
-      expect(constructorCalls[1][1]).toBe(updatedConfig);
+      expect(constructorCalls[1][1]).toMatchObject(updatedConfig);
     });
   });
 
@@ -452,17 +452,14 @@ describe('McpClientManager', () => {
       expect(lastCall[1].extension).toEqual(extension);
     });
 
-    it('should union tool lists and merge env variables between extension and user config', async () => {
+    it('should union tool lists and merge env variables regardless of load order', async () => {
       const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
+
       const userConfig = {
         excludeTools: ['user-tool'],
         includeTools: ['user-inc'],
         env: { USER_VAR: 'user-val', OVERRIDE_VAR: 'user-override' },
       };
-
-      mockConfig.getMcpServers.mockReturnValue({
-        'test-server': userConfig,
-      });
 
       const extension: GeminiCLIExtension = {
         name: 'test-extension',
@@ -482,22 +479,54 @@ describe('McpClientManager', () => {
         id: '123',
       };
 
+      // Case 1: Extension loads first, then User config (e.g. from startConfiguredMcpServers)
+      // startExtension and maybeDiscoverMcpServer return promises that resolve when discovery for that call is done.
       await manager.startExtension(extension);
 
-      const lastCall = vi.mocked(McpClient).mock.calls[0];
-      const mergedConfig = lastCall[1];
+      // In Case 1, we simulate that the existing client returns the extension's config
+      // But we must include the 'extension' metadata which is added during startExtension
+      mockedMcpClient.getServerConfig.mockReturnValue({
+        ...extension.mcpServers!['test-server'],
+        extension,
+      });
 
-      // Arrays should be unioned
+      await manager.maybeDiscoverMcpServer('test-server', userConfig);
+
+      let lastCall = vi.mocked(McpClient).mock.calls[1]; // Second call due to re-discovery
+      let mergedConfig = lastCall[1];
+
       expect(mergedConfig.excludeTools).toContain('ext-tool');
       expect(mergedConfig.excludeTools).toContain('user-tool');
       expect(mergedConfig.includeTools).toContain('ext-inc');
       expect(mergedConfig.includeTools).toContain('user-inc');
+      expect(mergedConfig.env!['EXT_VAR']).toBe('ext-val');
+      expect(mergedConfig.env!['USER_VAR']).toBe('user-val');
+      expect(mergedConfig.env!['OVERRIDE_VAR']).toBe('user-override');
+      expect(mergedConfig.extension).toBe(extension); // Extension ID preserved!
 
-      // Env should be merged
-      const env = mergedConfig.env!;
-      expect(env['EXT_VAR']).toBe('ext-val');
-      expect(env['USER_VAR']).toBe('user-val');
-      expect(env['OVERRIDE_VAR']).toBe('user-override'); // User wins on collisions
+      // Reset for Case 2
+      vi.mocked(McpClient).mockClear();
+      const manager2 = new McpClientManager('0.0.1', toolRegistry, mockConfig);
+
+      // Case 2: User config loads first, then Extension loads
+      await manager2.maybeDiscoverMcpServer('test-server', userConfig);
+
+      // In Case 2, the existing client returns the user config (no extension metadata yet)
+      mockedMcpClient.getServerConfig.mockReturnValue(userConfig);
+
+      await manager2.startExtension(extension);
+
+      lastCall = vi.mocked(McpClient).mock.calls[1];
+      mergedConfig = lastCall[1];
+
+      expect(mergedConfig.excludeTools).toContain('ext-tool');
+      expect(mergedConfig.excludeTools).toContain('user-tool');
+      expect(mergedConfig.includeTools).toContain('ext-inc');
+      expect(mergedConfig.includeTools).toContain('user-inc');
+      expect(mergedConfig.env!['EXT_VAR']).toBe('ext-val');
+      expect(mergedConfig.env!['USER_VAR']).toBe('user-val');
+      expect(mergedConfig.env!['OVERRIDE_VAR']).toBe('user-override');
+      expect(mergedConfig.extension).toBe(extension); // Extension ID preserved!
     });
 
     it('should remove servers from blockedMcpServers when stopExtension is called', async () => {

--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -561,6 +561,26 @@ describe('McpClientManager', () => {
       expect(lastCall[1].includeTools).toEqual(['user-tool']);
     });
 
+    it('should allow partial overrides of connection properties', async () => {
+      const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
+      const extConfig = { command: 'node', args: ['ext.js'], timeout: 1000 };
+      const userOverride = { args: ['overridden.js'] };
+
+      // Load extension first
+      await manager.maybeDiscoverMcpServer('test-server', extConfig);
+      mockedMcpClient.getServerConfig.mockReturnValue(extConfig);
+
+      // Apply partial user override
+      await manager.maybeDiscoverMcpServer('test-server', userOverride);
+
+      const lastCall = vi.mocked(McpClient).mock.calls[1];
+      const finalConfig = lastCall[1];
+
+      expect(finalConfig.command).toBe('node'); // Preserved from base
+      expect(finalConfig.args).toEqual(['overridden.js']); // Overridden
+      expect(finalConfig.timeout).toBe(1000); // Preserved from base
+    });
+
     it('should remove servers from blockedMcpServers when stopExtension is called', async () => {
       mockConfig.getBlockedMcpServers.mockReturnValue(['blocked-server']);
       const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);

--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -452,12 +452,12 @@ describe('McpClientManager', () => {
       expect(lastCall[1].extension).toEqual(extension);
     });
 
-    it('should union tool lists and merge env variables regardless of load order', async () => {
+    it('should securely merge tool lists and env variables regardless of load order', async () => {
       const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
 
       const userConfig = {
         excludeTools: ['user-tool'],
-        includeTools: ['user-inc'],
+        includeTools: ['shared-inc', 'user-only-inc'],
         env: { USER_VAR: 'user-val', OVERRIDE_VAR: 'user-override' },
       };
 
@@ -468,7 +468,7 @@ describe('McpClientManager', () => {
             command: 'node',
             args: ['ext.js'],
             excludeTools: ['ext-tool'],
-            includeTools: ['ext-inc'],
+            includeTools: ['shared-inc', 'ext-only-inc'],
             env: { EXT_VAR: 'ext-val', OVERRIDE_VAR: 'ext-override' },
           },
         },
@@ -480,11 +480,8 @@ describe('McpClientManager', () => {
       };
 
       // Case 1: Extension loads first, then User config (e.g. from startConfiguredMcpServers)
-      // startExtension and maybeDiscoverMcpServer return promises that resolve when discovery for that call is done.
       await manager.startExtension(extension);
 
-      // In Case 1, we simulate that the existing client returns the extension's config
-      // But we must include the 'extension' metadata which is added during startExtension
       mockedMcpClient.getServerConfig.mockReturnValue({
         ...extension.mcpServers!['test-server'],
         extension,
@@ -495,10 +492,15 @@ describe('McpClientManager', () => {
       let lastCall = vi.mocked(McpClient).mock.calls[1]; // Second call due to re-discovery
       let mergedConfig = lastCall[1];
 
+      // Exclude list should be unioned (most restrictive)
       expect(mergedConfig.excludeTools).toContain('ext-tool');
       expect(mergedConfig.excludeTools).toContain('user-tool');
-      expect(mergedConfig.includeTools).toContain('ext-inc');
-      expect(mergedConfig.includeTools).toContain('user-inc');
+
+      // Include list should be intersected (most restrictive)
+      expect(mergedConfig.includeTools).toContain('shared-inc');
+      expect(mergedConfig.includeTools).not.toContain('user-only-inc');
+      expect(mergedConfig.includeTools).not.toContain('ext-only-inc');
+
       expect(mergedConfig.env!['EXT_VAR']).toBe('ext-val');
       expect(mergedConfig.env!['USER_VAR']).toBe('user-val');
       expect(mergedConfig.env!['OVERRIDE_VAR']).toBe('user-override');
@@ -510,8 +512,6 @@ describe('McpClientManager', () => {
 
       // Case 2: User config loads first, then Extension loads
       await manager2.maybeDiscoverMcpServer('test-server', userConfig);
-
-      // In Case 2, the existing client returns the user config (no extension metadata yet)
       mockedMcpClient.getServerConfig.mockReturnValue(userConfig);
 
       await manager2.startExtension(extension);
@@ -521,12 +521,44 @@ describe('McpClientManager', () => {
 
       expect(mergedConfig.excludeTools).toContain('ext-tool');
       expect(mergedConfig.excludeTools).toContain('user-tool');
-      expect(mergedConfig.includeTools).toContain('ext-inc');
-      expect(mergedConfig.includeTools).toContain('user-inc');
+      expect(mergedConfig.includeTools).toContain('shared-inc');
+      expect(mergedConfig.includeTools).not.toContain('user-only-inc');
+      expect(mergedConfig.includeTools).not.toContain('ext-only-inc');
+
       expect(mergedConfig.env!['EXT_VAR']).toBe('ext-val');
       expect(mergedConfig.env!['USER_VAR']).toBe('user-val');
       expect(mergedConfig.env!['OVERRIDE_VAR']).toBe('user-override');
       expect(mergedConfig.extension).toBe(extension); // Extension ID preserved!
+    });
+
+    it('should result in empty includeTools if intersection is empty', async () => {
+      const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
+      const userConfig = { includeTools: ['user-tool'] };
+      const extConfig = {
+        command: 'node',
+        args: ['ext.js'],
+        includeTools: ['ext-tool'],
+      };
+
+      await manager.maybeDiscoverMcpServer('test-server', userConfig);
+      mockedMcpClient.getServerConfig.mockReturnValue(userConfig);
+      await manager.maybeDiscoverMcpServer('test-server', extConfig);
+
+      const lastCall = vi.mocked(McpClient).mock.calls[1];
+      expect(lastCall[1].includeTools).toEqual([]); // Empty array = no tools allowed
+    });
+
+    it('should respect a single allowlist if only one is provided', async () => {
+      const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
+      const userConfig = { includeTools: ['user-tool'] };
+      const extConfig = { command: 'node', args: ['ext.js'] };
+
+      await manager.maybeDiscoverMcpServer('test-server', userConfig);
+      mockedMcpClient.getServerConfig.mockReturnValue(userConfig);
+      await manager.maybeDiscoverMcpServer('test-server', extConfig);
+
+      const lastCall = vi.mocked(McpClient).mock.calls[1];
+      expect(lastCall[1].includeTools).toEqual(['user-tool']);
     });
 
     it('should remove servers from blockedMcpServers when stopExtension is called', async () => {

--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -415,7 +415,7 @@ describe('McpClientManager', () => {
       expect(manager.getMcpServers()).not.toHaveProperty('test-server');
     });
 
-    it('should ignore an extension attempting to register a server with an existing name', async () => {
+    it('should merge extension configuration with an existing user-configured server', async () => {
       const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
       const userConfig = { command: 'node', args: ['user-server.js'] };
 
@@ -441,8 +441,63 @@ describe('McpClientManager', () => {
 
       await manager.startExtension(extension);
 
-      expect(mockedMcpClient.disconnect).not.toHaveBeenCalled();
-      expect(mockedMcpClient.connect).toHaveBeenCalledTimes(1);
+      // It should disconnect the user-only version and reconnect with the merged version
+      expect(mockedMcpClient.disconnect).toHaveBeenCalledTimes(1);
+      expect(mockedMcpClient.connect).toHaveBeenCalledTimes(2);
+
+      // Verify user settings (command/args) still win in the merged config
+      const lastCall = vi.mocked(McpClient).mock.calls[1];
+      expect(lastCall[1].command).toBe('node');
+      expect(lastCall[1].args).toEqual(['user-server.js']);
+      expect(lastCall[1].extension).toEqual(extension);
+    });
+
+    it('should union tool lists and merge env variables between extension and user config', async () => {
+      const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
+      const userConfig = {
+        excludeTools: ['user-tool'],
+        includeTools: ['user-inc'],
+        env: { USER_VAR: 'user-val', OVERRIDE_VAR: 'user-override' },
+      };
+
+      mockConfig.getMcpServers.mockReturnValue({
+        'test-server': userConfig,
+      });
+
+      const extension: GeminiCLIExtension = {
+        name: 'test-extension',
+        mcpServers: {
+          'test-server': {
+            command: 'node',
+            args: ['ext.js'],
+            excludeTools: ['ext-tool'],
+            includeTools: ['ext-inc'],
+            env: { EXT_VAR: 'ext-val', OVERRIDE_VAR: 'ext-override' },
+          },
+        },
+        isActive: true,
+        version: '1.0.0',
+        path: '/some-path',
+        contextFiles: [],
+        id: '123',
+      };
+
+      await manager.startExtension(extension);
+
+      const lastCall = vi.mocked(McpClient).mock.calls[0];
+      const mergedConfig = lastCall[1];
+
+      // Arrays should be unioned
+      expect(mergedConfig.excludeTools).toContain('ext-tool');
+      expect(mergedConfig.excludeTools).toContain('user-tool');
+      expect(mergedConfig.includeTools).toContain('ext-inc');
+      expect(mergedConfig.includeTools).toContain('user-inc');
+
+      // Env should be merged
+      const env = mergedConfig.env!;
+      expect(env['EXT_VAR']).toBe('ext-val');
+      expect(env['USER_VAR']).toBe('user-val');
+      expect(env['OVERRIDE_VAR']).toBe('user-override'); // User wins on collisions
     });
 
     it('should remove servers from blockedMcpServers when stopExtension is called', async () => {

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -185,13 +185,38 @@ export class McpClientManager {
    */
   async startExtension(extension: GeminiCLIExtension) {
     debugLogger.log(`Loading extension: ${extension.name}`);
+    const localMcpServers = this.cliConfig.getMcpServers() ?? {};
     await Promise.all(
-      Object.entries(extension.mcpServers ?? {}).map(([name, config]) =>
-        this.maybeDiscoverMcpServer(name, {
+      Object.entries(extension.mcpServers ?? {}).map(([name, config]) => {
+        const userConfig = localMcpServers[name] ?? {};
+
+        // Merge arrays (union) so user overrides don't accidentally re-enable
+        // tools excluded by the extension for security/compatibility reasons.
+        const includeTools = [
+          ...new Set([
+            ...(config.includeTools ?? []),
+            ...(userConfig.includeTools ?? []),
+          ]),
+        ];
+        const excludeTools = [
+          ...new Set([
+            ...(config.excludeTools ?? []),
+            ...(userConfig.excludeTools ?? []),
+          ]),
+        ];
+
+        // Merge env objects instead of replacing them entirely.
+        const env = { ...(config.env ?? {}), ...(userConfig.env ?? {}) };
+
+        return this.maybeDiscoverMcpServer(name, {
           ...config,
+          ...userConfig,
+          includeTools: includeTools.length > 0 ? includeTools : undefined,
+          excludeTools: excludeTools.length > 0 ? excludeTools : undefined,
+          env: Object.keys(env).length > 0 ? env : undefined,
           extension,
-        }),
-      ),
+        });
+      }),
     );
     await this.scheduleMcpContextRefresh();
   }
@@ -264,6 +289,8 @@ export class McpClientManager {
     const existing = this.clients.get(name);
     if (
       existing &&
+      existing.getServerConfig().extension?.id &&
+      config.extension?.id &&
       existing.getServerConfig().extension?.id !== config.extension?.id
     ) {
       const extensionText = config.extension

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -292,17 +292,9 @@ export class McpClientManager {
 
     const env = { ...(base.env ?? {}), ...(override.env ?? {}) };
 
-    // If override doesn't provide connection details, keep the base ones.
-    const hasConnection =
-      !!override.command || !!override.url || !!override.httpUrl;
-
     return {
       ...base,
       ...override,
-      command: hasConnection ? override.command : base.command,
-      args: hasConnection ? override.args : base.args,
-      url: hasConnection ? override.url : base.url,
-      httpUrl: hasConnection ? override.httpUrl : base.httpUrl,
       includeTools,
       excludeTools: excludeTools.length > 0 ? excludeTools : undefined,
       env: Object.keys(env).length > 0 ? env : undefined,

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -185,38 +185,13 @@ export class McpClientManager {
    */
   async startExtension(extension: GeminiCLIExtension) {
     debugLogger.log(`Loading extension: ${extension.name}`);
-    const localMcpServers = this.cliConfig.getMcpServers() ?? {};
     await Promise.all(
-      Object.entries(extension.mcpServers ?? {}).map(([name, config]) => {
-        const userConfig = localMcpServers[name] ?? {};
-
-        // Merge arrays (union) so user overrides don't accidentally re-enable
-        // tools excluded by the extension for security/compatibility reasons.
-        const includeTools = [
-          ...new Set([
-            ...(config.includeTools ?? []),
-            ...(userConfig.includeTools ?? []),
-          ]),
-        ];
-        const excludeTools = [
-          ...new Set([
-            ...(config.excludeTools ?? []),
-            ...(userConfig.excludeTools ?? []),
-          ]),
-        ];
-
-        // Merge env objects instead of replacing them entirely.
-        const env = { ...(config.env ?? {}), ...(userConfig.env ?? {}) };
-
-        return this.maybeDiscoverMcpServer(name, {
+      Object.entries(extension.mcpServers ?? {}).map(([name, config]) =>
+        this.maybeDiscoverMcpServer(name, {
           ...config,
-          ...userConfig,
-          includeTools: includeTools.length > 0 ? includeTools : undefined,
-          excludeTools: excludeTools.length > 0 ? excludeTools : undefined,
-          env: Object.keys(env).length > 0 ? env : undefined,
           extension,
-        });
-      }),
+        }),
+      ),
     );
     await this.scheduleMcpContextRefresh();
   }
@@ -282,16 +257,59 @@ export class McpClientManager {
     }
   }
 
+  /**
+   * Merges two MCP configurations. The second configuration (override)
+   * takes precedence for scalar properties, but array properties are
+   * unioned and environment objects are merged.
+   */
+  private mergeMcpConfigs(
+    base: MCPServerConfig,
+    override: MCPServerConfig,
+  ): MCPServerConfig {
+    const includeTools = [
+      ...new Set([
+        ...(base.includeTools ?? []),
+        ...(override.includeTools ?? []),
+      ]),
+    ];
+    const excludeTools = [
+      ...new Set([
+        ...(base.excludeTools ?? []),
+        ...(override.excludeTools ?? []),
+      ]),
+    ];
+
+    const env = { ...(base.env ?? {}), ...(override.env ?? {}) };
+
+    // If override doesn't provide connection details, keep the base ones.
+    const hasConnection =
+      !!override.command || !!override.url || !!override.httpUrl;
+
+    return {
+      ...base,
+      ...override,
+      command: hasConnection ? override.command : base.command,
+      args: hasConnection ? override.args : base.args,
+      url: hasConnection ? override.url : base.url,
+      httpUrl: hasConnection ? override.httpUrl : base.httpUrl,
+      includeTools: includeTools.length > 0 ? includeTools : undefined,
+      excludeTools: excludeTools.length > 0 ? excludeTools : undefined,
+      env: Object.keys(env).length > 0 ? env : undefined,
+      extension: override.extension ?? base.extension,
+    };
+  }
+
   async maybeDiscoverMcpServer(
     name: string,
     config: MCPServerConfig,
   ): Promise<void> {
     const existing = this.clients.get(name);
+    const existingConfig = existing?.getServerConfig();
     if (
       existing &&
-      existing.getServerConfig().extension?.id &&
+      existingConfig?.extension?.id &&
       config.extension?.id &&
-      existing.getServerConfig().extension?.id !== config.extension?.id
+      existingConfig.extension.id !== config.extension.id
     ) {
       const extensionText = config.extension
         ? ` from extension "${config.extension.name}"`
@@ -302,15 +320,28 @@ export class McpClientManager {
       return;
     }
 
+    let finalConfig = config;
+    if (existing && existingConfig) {
+      // If we're merging an extension config into a user config,
+      // the user config should be the override.
+      if (config.extension && !existingConfig.extension) {
+        finalConfig = this.mergeMcpConfigs(config, existingConfig);
+      } else {
+        // Otherwise (User over Extension, or User over User),
+        // the incoming config is the override.
+        finalConfig = this.mergeMcpConfigs(existingConfig, config);
+      }
+    }
+
     // Always track server config for UI display
-    this.allServerConfigs.set(name, config);
+    this.allServerConfigs.set(name, finalConfig);
 
     // Check if blocked by admin settings (allowlist/excludelist)
     if (this.isBlockedBySettings(name)) {
       if (!this.blockedMcpServers.find((s) => s.name === name)) {
         this.blockedMcpServers?.push({
           name,
-          extensionName: config.extension?.name ?? '',
+          extensionName: finalConfig.extension?.name ?? '',
         });
       }
       return;
@@ -325,7 +356,7 @@ export class McpClientManager {
     if (!this.cliConfig.isTrustedFolder()) {
       return;
     }
-    if (config.extension && !config.extension.isActive) {
+    if (finalConfig.extension && !finalConfig.extension.isActive) {
       return;
     }
 
@@ -339,7 +370,7 @@ export class McpClientManager {
 
           const client = new McpClient(
             name,
-            config,
+            finalConfig,
             this.toolRegistry,
             this.cliConfig.getPromptRegistry(),
             this.cliConfig.getResourceRegistry(),

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -260,18 +260,29 @@ export class McpClientManager {
   /**
    * Merges two MCP configurations. The second configuration (override)
    * takes precedence for scalar properties, but array properties are
-   * unioned and environment objects are merged.
+   * merged securely (exclude = union, include = intersection) and
+   * environment objects are merged.
    */
   private mergeMcpConfigs(
     base: MCPServerConfig,
     override: MCPServerConfig,
   ): MCPServerConfig {
-    const includeTools = [
-      ...new Set([
-        ...(base.includeTools ?? []),
-        ...(override.includeTools ?? []),
-      ]),
-    ];
+    // For allowlists (includeTools), use intersection to ensure the most
+    // restrictive policy wins. A tool must be allowed by BOTH parties.
+    let includeTools: string[] | undefined;
+    if (base.includeTools && override.includeTools) {
+      includeTools = base.includeTools.filter((t) =>
+        override.includeTools!.includes(t),
+      );
+      // If the intersection is empty, we must keep an empty array to indicate
+      // that NO tools are allowed (undefined would allow everything).
+    } else {
+      // If only one provides an allowlist, use that.
+      includeTools = override.includeTools ?? base.includeTools;
+    }
+
+    // For blocklists (excludeTools), use union so if ANY party blocks it,
+    // it stays blocked.
     const excludeTools = [
       ...new Set([
         ...(base.excludeTools ?? []),
@@ -292,7 +303,7 @@ export class McpClientManager {
       args: hasConnection ? override.args : base.args,
       url: hasConnection ? override.url : base.url,
       httpUrl: hasConnection ? override.httpUrl : base.httpUrl,
-      includeTools: includeTools.length > 0 ? includeTools : undefined,
+      includeTools,
       excludeTools: excludeTools.length > 0 ? excludeTools : undefined,
       env: Object.keys(env).length > 0 ? env : undefined,
       extension: override.extension ?? base.extension,


### PR DESCRIPTION
## Summary

Fixes a bug where user-defined MCP server settings (like `excludeTools`) in `settings.json` were ignored for MCP servers provided by extensions.

## Details

When an extension contributes an MCP server, the `McpClientManager` was previously using the extension's configuration as-is. This PR modifies `startExtension` to merge the extension's configuration with any matching local user overrides. 

It also updates `maybeDiscoverMcpServer` to allow extensions to "enrich" existing server configurations that were initially registered without an extension ID (which is the case for user-provided overrides).

## Related Issues

Fixes the reported issue where `excludeTools` for the `google-workspace` extension (and others) were not being respected.

## How to Validate

1. Install `google-workspace` extension.
2. In `settings.json`, add:
   ```json
   "mcpServers": {
     "google-workspace": {
       "excludeTools": ["gmail.send"]
     }
   }
   ```
3. Run `/mcp list`. 
4. Verify `mcp_google-workspace_gmail.send` is NOT in the list.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
