### PR TITLE
Improve Alpine Linux compatibility for CLI entrypoint and shell execution

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --no-warnings=DEP0040
+#!/usr/bin/env node
 
 /**
  * @license
@@ -6,9 +6,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { main } from './src/gemini.js';
-import { FatalError, writeToStderr } from '@google/gemini-cli-core';
-import { runExitCleanup } from './src/utils/cleanup.js';
+import { createRequire } from 'node:module';
+
+const argv = process.argv.slice(2);
+if (argv.length === 1 && (argv[0] === '--version' || argv[0] === '-v')) {
+  const require = createRequire(import.meta.url);
+  const { version } = require('../package.json');
+  process.stdout.write(`${version}\n`);
+  process.exit(0);
+}
+
+const [{ main }, { FatalError, writeToStderr }, { runExitCleanup }] =
+  await Promise.all([
+    import('./src/gemini.js'),
+    import('@google/gemini-cli-core'),
+    import('./src/utils/cleanup.js'),
+  ]);
 
 // --- Global Entry Point ---
 

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -16,12 +16,15 @@ if (argv.length === 1 && (argv[0] === '--version' || argv[0] === '-v')) {
   process.exit(0);
 }
 
-const [{ main }, { FatalError, writeToStderr }, { runExitCleanup }] =
-  await Promise.all([
-    import('./src/gemini.js'),
-    import('@google/gemini-cli-core'),
-    import('./src/utils/cleanup.js'),
-  ]);
+const [geminiModule, coreModule, cleanupModule] = await Promise.all([
+  import('./src/gemini.js'),
+  import('@google/gemini-cli-core'),
+  import('./src/utils/cleanup.js'),
+]);
+
+const { main } = geminiModule;
+const { FatalError, writeToStderr } = coreModule;
+const { runExitCleanup } = cleanupModule;
 
 // --- Global Entry Point ---
 

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -136,6 +136,7 @@ describe('ShellTool', () => {
       getGeminiClient: vi.fn().mockReturnValue({}),
       getShellToolInactivityTimeout: vi.fn().mockReturnValue(1000),
       getEnableInteractiveShell: vi.fn().mockReturnValue(false),
+      isInteractiveShellEnabled: vi.fn().mockReturnValue(false),
       getEnableShellOutputEfficiency: vi.fn().mockReturnValue(true),
       sanitizationConfig: {},
       sandboxManager: new NoopSandboxManager(),
@@ -292,6 +293,28 @@ describe('ShellTool', () => {
       expect(result.llmContent).toContain('Background PIDs: 54322');
       // The file should be deleted by the tool
       expect(fs.existsSync(tmpFile)).toBe(false);
+    });
+
+    it('should disable PTY execution when interactive shell is unavailable', async () => {
+      (mockConfig.getEnableInteractiveShell as Mock).mockReturnValue(true);
+      (mockConfig.isInteractiveShellEnabled as Mock).mockReturnValue(false);
+
+      const invocation = shellTool.build({ command: 'python --version' });
+      const promise = invocation.execute(mockAbortSignal);
+      resolveShellExecution({ pid: 54321 });
+
+      await promise;
+
+      expect(mockShellExecutionService).toHaveBeenCalledWith(
+        expect.any(String),
+        tempRootDir,
+        expect.any(Function),
+        expect.any(AbortSignal),
+        false,
+        expect.objectContaining({
+          pager: 'cat',
+        }),
+      );
     });
 
     it('should use the provided absolute directory as cwd', async () => {

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -277,7 +277,7 @@ describe('ShellTool', () => {
 
       const result = await promise;
 
-      const wrappedCommand = `{ my-command & }; __code=$?; pgrep -g 0 >${tmpFile} 2>&1; exit $__code;`;
+      const wrappedCommand = `{ my-command & }; __code=$?; pgrep -P $$ >${tmpFile} 2>&1; exit $__code;`;
       expect(mockShellExecutionService).toHaveBeenCalledWith(
         wrappedCommand,
         tempRootDir,
@@ -328,7 +328,7 @@ describe('ShellTool', () => {
       await promise;
 
       const tmpFile = path.join(os.tmpdir(), 'shell_pgrep_abcdef.tmp');
-      const wrappedCommand = `{ ls; }; __code=$?; pgrep -g 0 >${tmpFile} 2>&1; exit $__code;`;
+      const wrappedCommand = `{ ls; }; __code=$?; pgrep -P $$ >${tmpFile} 2>&1; exit $__code;`;
       expect(mockShellExecutionService).toHaveBeenCalledWith(
         wrappedCommand,
         subdir,
@@ -353,7 +353,7 @@ describe('ShellTool', () => {
       await promise;
 
       const tmpFile = path.join(os.tmpdir(), 'shell_pgrep_abcdef.tmp');
-      const wrappedCommand = `{ ls; }; __code=$?; pgrep -g 0 >${tmpFile} 2>&1; exit $__code;`;
+      const wrappedCommand = `{ ls; }; __code=$?; pgrep -P $$ >${tmpFile} 2>&1; exit $__code;`;
       expect(mockShellExecutionService).toHaveBeenCalledWith(
         wrappedCommand,
         path.join(tempRootDir, 'subdir'),

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -182,10 +182,11 @@ export class ShellToolInvocation extends BaseToolInvocation<
       const commandToExecute = isWindows
         ? strippedCommand
         : (() => {
-            // wrap command to append subprocess pids (via pgrep) to temporary file
+            // Wrap the command to capture direct child PIDs from the shell.
+            // `pgrep -P $$` works on BusyBox and GNU pgrep, unlike `pgrep -g 0`.
             let command = strippedCommand.trim();
             if (!command.endsWith('&')) command += ';';
-            return `{ ${command} }; __code=$?; pgrep -g 0 >${tempFilePath} 2>&1; exit $__code;`;
+            return `{ ${command} }; __code=$?; pgrep -P $$ >${tempFilePath} 2>&1; exit $__code;`;
           })();
 
       const cwd = this.params.dir_path

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -271,7 +271,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
             }
           },
           combinedController.signal,
-          this.context.config.getEnableInteractiveShell(),
+          this.context.config.isInteractiveShellEnabled(),
           {
             ...shellExecutionConfig,
             pager: 'cat',
@@ -470,7 +470,7 @@ export class ShellTool extends BaseDeclarativeTool<
       // Errors are surfaced when parsing commands.
     });
     const definition = getShellDefinition(
-      context.config.getEnableInteractiveShell(),
+      context.config.isInteractiveShellEnabled(),
       context.config.getEnableShellOutputEfficiency(),
     );
     super(
@@ -519,7 +519,7 @@ export class ShellTool extends BaseDeclarativeTool<
 
   override getSchema(modelId?: string) {
     const definition = getShellDefinition(
-      this.context.config.getEnableInteractiveShell(),
+      this.context.config.isInteractiveShellEnabled(),
       this.context.config.getEnableShellOutputEfficiency(),
     );
     return resolveToolDeclaration(definition, modelId);

--- a/packages/core/src/utils/getPty.ts
+++ b/packages/core/src/utils/getPty.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { existsSync } from 'node:fs';
+
 export type PtyImplementation = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   module: any;
@@ -21,21 +23,29 @@ export const getPty = async (): Promise<PtyImplementation> => {
   if (process.env['GEMINI_PTY_INFO'] === 'child_process') {
     return null;
   }
-  try {
-    const lydell = '@lydell/node-pty';
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const module = await import(lydell);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    return { module, name: 'lydell-node-pty' };
-  } catch (_e) {
+
+  const preferNodePty =
+    process.platform === 'linux' && existsSync('/etc/alpine-release');
+  const candidates = preferNodePty
+    ? ([
+        ['node-pty', 'node-pty'],
+        ['@lydell/node-pty', 'lydell-node-pty'],
+      ] as const)
+    : ([
+        ['@lydell/node-pty', 'lydell-node-pty'],
+        ['node-pty', 'node-pty'],
+      ] as const);
+
+  for (const [pkg, name] of candidates) {
     try {
-      const nodePty = 'node-pty';
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const module = await import(nodePty);
+      const module = await import(pkg);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      return { module, name: 'node-pty' };
-    } catch (_e2) {
-      return null;
+      return { module, name };
+    } catch (_e) {
+      continue;
     }
   }
+
+  return null;
 };


### PR DESCRIPTION
## Summary
- make the CLI entrypoint BusyBox-safe on Alpine
- bypass heavy startup work for `--version`
- avoid PTY shell execution in non-interactive mode
- prefer `node-pty` on Alpine and use a portable `pgrep` form

## Why
Gemini CLI is currently rough on Alpine Linux for a few concrete reasons:
- the `env -S` shebang breaks on BusyBox `env`
- `--version` is much slower than it should be
- PTY handling is brittle on Alpine/musl
- the current Linux child-process lookup uses a `pgrep` form that is not portable to BusyBox

This patch keeps the changes narrow and focused on the Alpine/Linux compatibility surface.

## Validation
- live Alpine repros on an Alpine Linux VPS
- `cd packages/core && npx vitest run src/tools/shell.test.ts --testNamePattern "disable PTY execution|wrap command on linux"`

## Notes
- This PR only contains upstreamable Apache-licensed source changes from my `mekineer-com/gemini-cli` fork.
- My separate `gemini-cli-alpine` companion repo is downstream packaging/docs only and is not part of this PR.
