### PR TITLE
Reduce duplicate auth work and startup overhead on Alpine

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -9,6 +9,16 @@
 import { main } from './src/gemini.js';
 import { FatalError, writeToStderr } from '@google/gemini-cli-core';
 import { runExitCleanup } from './src/utils/cleanup.js';
+import { existsSync } from 'node:fs';
+
+if (
+  process.platform === 'linux' &&
+  existsSync('/etc/alpine-release') &&
+  !process.env['GEMINI_CLI_NO_RELAUNCH'] &&
+  !process.env['GEMINI_CLI_FORCE_RELAUNCH']
+) {
+  process.env['GEMINI_CLI_NO_RELAUNCH'] = 'true';
+}
 
 // --- Global Entry Point ---
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -418,6 +418,8 @@ export interface LoadCliConfigOptions {
   projectHooks?: { [K in HookEventName]?: HookDefinition[] } & {
     disabled?: string[];
   };
+  skipMemoryLoad?: boolean;
+  skipExtensionLoad?: boolean;
 }
 
 export async function loadCliConfig(
@@ -426,7 +428,12 @@ export async function loadCliConfig(
   argv: CliArgs,
   options: LoadCliConfigOptions = {},
 ): Promise<Config> {
-  const { cwd = process.cwd(), projectHooks } = options;
+  const {
+    cwd = process.cwd(),
+    projectHooks,
+    skipMemoryLoad = false,
+    skipExtensionLoad = false,
+  } = options;
   const debugMode = isDebugMode(argv);
 
   const loadedSettings = loadSettings(cwd);
@@ -488,11 +495,15 @@ export async function loadCliConfig(
     eventEmitter: coreEvents as EventEmitter<ExtensionEvents>,
     clientVersion: await getVersion(),
   });
-  await extensionManager.loadExtensions();
+  if (!skipExtensionLoad) {
+    await extensionManager.loadExtensions();
+  }
 
-  const extensionPlanSettings = extensionManager
-    .getExtensions()
-    .find((ext) => ext.isActive && ext.plan?.directory)?.plan;
+  const extensionPlanSettings = skipExtensionLoad
+    ? undefined
+    : extensionManager
+        .getExtensions()
+        .find((ext) => ext.isActive && ext.plan?.directory)?.plan;
 
   const experimentalJitContext = settings.experimental?.jitContext ?? false;
 
@@ -510,7 +521,7 @@ export async function loadCliConfig(
   let fileCount = 0;
   let filePaths: string[] = [];
 
-  if (!experimentalJitContext) {
+  if (!skipMemoryLoad && !experimentalJitContext) {
     // Call the (now wrapper) loadHierarchicalGeminiMemory which calls the server's version
     const result = await loadServerHierarchicalMemory(
       cwd,

--- a/packages/cli/src/core/auth.ts
+++ b/packages/cli/src/core/auth.ts
@@ -43,7 +43,7 @@ export async function performInitialAuth(
     if (e instanceof ValidationRequiredError) {
       // Don't treat validation required as a fatal auth error during startup.
       // This allows the React UI to load and show the ValidationDialog.
-      return { authError: null, accountSuspensionInfo: null };
+      return { authError: null, accountSuspensionInfo: null, authSucceeded: false };
     }
     const suspendedError = isAccountSuspendedError(e);
     if (suspendedError) {

--- a/packages/cli/src/core/auth.ts
+++ b/packages/cli/src/core/auth.ts
@@ -18,6 +18,7 @@ import type { AccountSuspensionInfo } from '../ui/contexts/UIStateContext.js';
 export interface InitialAuthResult {
   authError: string | null;
   accountSuspensionInfo: AccountSuspensionInfo | null;
+  authSucceeded: boolean;
 }
 
 /**
@@ -31,7 +32,7 @@ export async function performInitialAuth(
   authType: AuthType | undefined,
 ): Promise<InitialAuthResult> {
   if (!authType) {
-    return { authError: null, accountSuspensionInfo: null };
+    return { authError: null, accountSuspensionInfo: null, authSucceeded: false };
   }
 
   try {
@@ -53,6 +54,7 @@ export async function performInitialAuth(
           appealUrl: suspendedError.appealUrl,
           appealLinkText: suspendedError.appealLinkText,
         },
+        authSucceeded: false,
       };
     }
     if (e instanceof ProjectIdRequiredError) {
@@ -61,13 +63,15 @@ export async function performInitialAuth(
       return {
         authError: getErrorMessage(e),
         accountSuspensionInfo: null,
+        authSucceeded: false,
       };
     }
     return {
       authError: `Failed to sign in. Message: ${getErrorMessage(e)}`,
       accountSuspensionInfo: null,
+      authSucceeded: false,
     };
   }
 
-  return { authError: null, accountSuspensionInfo: null };
+  return { authError: null, accountSuspensionInfo: null, authSucceeded: true };
 }

--- a/packages/cli/src/core/initializer.ts
+++ b/packages/cli/src/core/initializer.ts
@@ -22,6 +22,7 @@ import type { AccountSuspensionInfo } from '../ui/contexts/UIStateContext.js';
 export interface InitializationResult {
   authError: string | null;
   accountSuspensionInfo: AccountSuspensionInfo | null;
+  initialAuthSucceeded: boolean;
   themeError: string | null;
   shouldOpenAuthDialog: boolean;
   geminiMdFileCount: number;
@@ -39,7 +40,7 @@ export async function initializeApp(
   settings: LoadedSettings,
 ): Promise<InitializationResult> {
   const authHandle = startupProfiler.start('authenticate');
-  const { authError, accountSuspensionInfo } = await performInitialAuth(
+  const { authError, accountSuspensionInfo, authSucceeded } = await performInitialAuth(
     config,
     settings.merged.security.auth.selectedType,
   );
@@ -63,6 +64,7 @@ export async function initializeApp(
   return {
     authError,
     accountSuspensionInfo,
+    initialAuthSucceeded: authSucceeded,
     themeError,
     shouldOpenAuthDialog,
     geminiMdFileCount: config.getGeminiMdFileCount(),

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -302,14 +302,20 @@ export async function main() {
 
   const partialConfig = await loadCliConfig(settings.merged, sessionId, argv, {
     projectHooks: settings.workspace.settings.hooks,
+    skipMemoryLoad: true,
+    skipExtensionLoad: true,
   });
   adminControlsListner.setConfig(partialConfig);
+  const sandboxConfig = await loadSandboxConfig(settings.merged, argv);
+  const shouldPreAuthenticate =
+    !settings.merged.security.auth.useExternal &&
+    (!!sandboxConfig || !process.env['GEMINI_CLI_NO_RELAUNCH']);
 
   // Refresh auth to fetch remote admin settings from CCPA and before entering
   // the sandbox because the sandbox will interfere with the Oauth2 web
   // redirect.
   let initialAuthFailed = false;
-  if (!settings.merged.security.auth.useExternal) {
+  if (shouldPreAuthenticate) {
     try {
       if (
         partialConfig.isInteractive() &&
@@ -365,7 +371,6 @@ export async function main() {
     const memoryArgs = settings.merged.advanced.autoConfigureMemory
       ? getNodeMemoryArgs(isDebugMode)
       : [];
-    const sandboxConfig = await loadSandboxConfig(settings.merged, argv);
     // We intentionally omit the list of extensions here because extensions
     // should not impact auth or setting up the sandbox.
     // TODO(jacobr): refactor loadCliConfig so there is a minimal version

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -686,6 +686,7 @@ export const AppContainer = (props: AppContainerProps) => {
     config,
     initializationResult.authError,
     initializationResult.accountSuspensionInfo,
+    initializationResult.initialAuthSucceeded,
   );
   const [authContext, setAuthContext] = useState<{ requiresRestart?: boolean }>(
     {},

--- a/packages/cli/src/ui/auth/useAuth.test.tsx
+++ b/packages/cli/src/ui/auth/useAuth.test.tsx
@@ -153,6 +153,21 @@ describe('useAuth', () => {
       });
     });
 
+    it('should initialize as Authenticated when startup auth already succeeded', () => {
+      const { result } = renderHook(() =>
+        useAuthCommand(
+          createSettings(AuthType.LOGIN_WITH_GOOGLE),
+          mockConfig,
+          null,
+          null,
+          true,
+        ),
+      );
+
+      expect(result.current.authState).toBe(AuthState.Authenticated);
+      expect(mockConfig.refreshAuth).not.toHaveBeenCalled();
+    });
+
     it('should set error if no auth type is selected and no env key', async () => {
       const { result } = renderHook(() =>
         useAuthCommand(createSettings(undefined), mockConfig),

--- a/packages/cli/src/ui/auth/useAuth.ts
+++ b/packages/cli/src/ui/auth/useAuth.ts
@@ -43,9 +43,14 @@ export const useAuthCommand = (
   config: Config,
   initialAuthError: string | null = null,
   initialAccountSuspensionInfo: AccountSuspensionInfo | null = null,
+  initialAuthSucceeded = false,
 ) => {
   const [authState, setAuthState] = useState<AuthState>(
-    initialAuthError ? AuthState.Updating : AuthState.Unauthenticated,
+    initialAuthError
+      ? AuthState.Updating
+      : initialAuthSucceeded
+        ? AuthState.Authenticated
+        : AuthState.Unauthenticated,
   );
 
   const [authError, setAuthError] = useState<string | null>(initialAuthError);


### PR DESCRIPTION
## Summary
- avoid refreshing auth twice during startup
- carry initial auth success into the UI auth hook so the TUI starts authenticated immediately
- reduce Alpine startup work by using a lighter first config load
- default Alpine to `GEMINI_CLI_NO_RELAUNCH=true` unless explicitly overridden

## Why
On Alpine Linux, startup was still spending too much time before the first usable prompt.
Two local causes were worth fixing:
- startup auth was being refreshed twice
- the first config load was doing more memory/extension work than needed before the CLI was fully up

This patch keeps the scope to startup/auth behavior and does not include the lower-level shell/PTy compatibility work from the separate Alpine core PR.

## Validation
- live Alpine smoke validation on the patched CLI:
  - startup no longer shows the old duplicate auth path
  - startup time dropped materially on the Alpine VPS after the lighter first-pass config load
- attempted package-level vitest runs for the touched CLI files in this checkout, but this repo state still has the existing local `@google/gemini-cli-core` package-resolution issue in `packages/cli` test setup

## Notes
- This PR is intentionally separate from the narrower Alpine core compatibility PR.
- Both PRs touch `packages/cli/index.ts`, so if one lands first the other will need a small rebase.
