### PR TITLE
feat(cli): add Ctrl+O toggle to expand/collapse truncated shell command descriptions

### DIFF
--- a/packages/cli/src/ui/components/messages/ShellToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ShellToolMessage.test.tsx
@@ -18,6 +18,8 @@ import {
 import { renderWithProviders } from '../../../test-utils/render.js';
 import { waitFor } from '../../../test-utils/async.js';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { formatCommand } from '../../key/keybindingUtils.js';
+import { Command } from '../../key/keyBindings.js';
 import { SHELL_COMMAND_NAME, ACTIVE_SHELL_MAX_LINES } from '../../constants.js';
 
 describe('<ShellToolMessage />', () => {
@@ -116,6 +118,82 @@ describe('<ShellToolMessage />', () => {
         expect(mockSetEmbeddedShellFocused).toHaveBeenCalledWith(false);
         expect(lastFrame()).not.toContain('(Shift+Tab to unfocus)');
       });
+      unmount();
+    });
+  });
+
+  describe('Expand description hotkey', () => {
+    it('expands and collapses description on Ctrl+O when focused', async () => {
+      const { lastFrame, stdin, unmount } = renderShell(
+        {
+          status: CoreToolCallStatus.Executing,
+          ptyId: 1,
+          name: SHELL_COMMAND_NAME,
+          description:
+            'this is a very long shell command that should be expanded when the user presses the right hotkeys',
+        },
+        {
+          uiState: {
+            embeddedShellFocused: true,
+            activePtyId: 1,
+          },
+        },
+      );
+
+      await waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain(
+          `(press ${formatCommand(Command.SHOW_MORE_LINES)} to expand command)`,
+        );
+      });
+
+      await act(async () => {
+        stdin.write('\x0f');
+      });
+
+      await waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain(
+          `(press ${formatCommand(Command.SHOW_MORE_LINES)} to collapse command)`,
+        );
+      });
+
+      unmount();
+    });
+
+    it('does not expand description on Ctrl+O when unfocused', async () => {
+      const { lastFrame, stdin, unmount } = renderShell(
+        {
+          status: CoreToolCallStatus.Executing,
+          ptyId: 1,
+          name: SHELL_COMMAND_NAME,
+        },
+        {
+          uiState: {
+            embeddedShellFocused: false,
+            activePtyId: undefined,
+          },
+        },
+      );
+
+      await waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).not.toContain(
+          `(press ${formatCommand(Command.SHOW_MORE_LINES)} to expand command)`,
+        );
+      });
+
+      await act(async () => {
+        stdin.write('\x0f');
+      });
+
+      await waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).not.toContain(
+          `(press ${formatCommand(Command.SHOW_MORE_LINES)} to collapse command)`,
+        );
+      });
+
       unmount();
     });
   });

--- a/packages/cli/src/ui/components/messages/ShellToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ShellToolMessage.tsx
@@ -5,7 +5,8 @@
  */
 
 import React from 'react';
-import { Box, type DOMElement } from 'ink';
+import { Box, Text, type DOMElement } from 'ink';
+import { theme } from '../../semantic-colors.js';
 import { ShellInputPrompt } from '../ShellInputPrompt.js';
 import { StickyHeader } from '../StickyHeader.js';
 import { useUIActions } from '../../contexts/UIActionsContext.js';
@@ -24,6 +25,10 @@ import type { ToolMessageProps } from './ToolMessage.js';
 import { ACTIVE_SHELL_MAX_LINES } from '../../constants.js';
 import { useAlternateBuffer } from '../../hooks/useAlternateBuffer.js';
 import { useUIState } from '../../contexts/UIStateContext.js';
+import { useKeypress } from '../../hooks/useKeypress.js';
+import { Command } from '../../key/keyBindings.js';
+import { useKeyMatchers } from '../../hooks/useKeyMatchers.js';
+import { formatCommand } from '../../key/keybindingUtils.js';
 import {
   type Config,
   ShellExecutionService,
@@ -34,6 +39,7 @@ import {
   calculateToolContentMaxLines,
   SHELL_CONTENT_OVERHEAD,
 } from '../../utils/toolLayoutUtils.js';
+import { cpLen } from '../../utils/textUtils.js';
 
 export interface ShellToolMessageProps extends ToolMessageProps {
   config?: Config;
@@ -165,6 +171,26 @@ export const ShellToolMessage: React.FC<ShellToolMessageProps> = ({
     resultDisplay,
   );
 
+  const [isExpandedDescription, setIsExpandedDescription] =
+    React.useState(false);
+  const keyMatchers = useKeyMatchers();
+  const expandHintKey = formatCommand(Command.SHOW_MORE_LINES);
+
+  useKeypress(
+    (key) => {
+      // Allow expansion regardless of whether the shell is focused/executing
+      if (keyMatchers[Command.SHOW_MORE_LINES](key)) {
+        setIsExpandedDescription((prev) => !prev);
+        return true;
+      }
+      return false;
+    },
+    // Scope the hotkey to the focused shell (while executing) or the most
+    // recent completed shell (`isExpandable` is only set on the last tool group).
+    // This ensures at most one ShellToolMessage responds to Ctrl+O at a time.
+    { isActive: isThisShellFocused || !!isExpandable },
+  );
+
   return (
     <>
       <StickyHeader
@@ -186,7 +212,20 @@ export const ShellToolMessage: React.FC<ShellToolMessageProps> = ({
           description={description}
           emphasis={emphasis}
           originalRequestName={originalRequestName}
+          isExpanded={isExpandedDescription}
         />
+
+        {/* 11 chars overhead for tool name + 10 for padding = ~25 overhead. If description + name is too long, or has newlines, show expand hint */}
+        {description &&
+          (cpLen(description) > terminalWidth - 25 ||
+            description.includes('\n')) && (
+            <Box marginLeft={1} flexShrink={0}>
+              <Text color={theme.ui.focus}>
+                (press {expandHintKey} to{' '}
+                {isExpandedDescription ? 'collapse' : 'expand'} command)
+              </Text>
+            </Box>
+          )}
 
         <FocusHint
           shouldShowFocusHint={shouldShowFocusHint}

--- a/packages/cli/src/ui/components/messages/ToolShared.tsx
+++ b/packages/cli/src/ui/components/messages/ToolShared.tsx
@@ -194,6 +194,7 @@ type ToolInfoProps = {
   emphasis: TextEmphasis;
   progressMessage?: string;
   originalRequestName?: string;
+  isExpanded?: boolean;
 };
 
 export const ToolInfo: React.FC<ToolInfoProps> = ({
@@ -203,6 +204,7 @@ export const ToolInfo: React.FC<ToolInfoProps> = ({
   emphasis,
   progressMessage: _progressMessage,
   originalRequestName,
+  isExpanded,
 }) => {
   const status = mapCoreStatusToDisplayStatus(coreStatus);
   const nameColor = React.useMemo<string>(() => {
@@ -224,8 +226,11 @@ export const ToolInfo: React.FC<ToolInfoProps> = ({
   const isCompletedAskUser = isCompletedAskUserTool(name, status);
 
   return (
-    <Box overflow="hidden" height={1} flexGrow={1} flexShrink={1}>
-      <Text strikethrough={status === ToolCallStatus.Canceled} wrap="truncate">
+    <Box overflow="hidden" flexGrow={1} flexShrink={1}>
+      <Text
+        strikethrough={status === ToolCallStatus.Canceled}
+        wrap={isExpanded ? 'wrap' : 'truncate'}
+      >
         <Text color={nameColor} bold>
           {name}
         </Text>


### PR DESCRIPTION
## Problem

Fixes #13809

When a shell command string is too long to fit in the terminal header, Ink's `wrap='truncate'` behavior truncates it with an ellipsis. Users had no way to see the full command that was executed.

## Solution

Added a **Ctrl+O** hotkey to expand/collapse the shell command description in the tool header.

### Changes

#### `ShellToolMessage.tsx`
- Adds `isExpandedDescription` local state
- Registers a `useKeypress` listener for `Command.SHOW_MORE_LINES` (Ctrl+O)
- Passes `isExpanded` to `ToolInfo` to toggle wrap mode
- Conditionally renders an expand/collapse hint **only** when the description is long enough to overflow the terminal width, or when it contains newlines
- Guards against `undefined` description in the length check

#### `ToolShared.tsx` (ToolInfo)
- Added optional `isExpanded` prop
- Toggles `wrap` between `'truncate'` and `'wrap'` based on the prop
- Removed fixed `height={1}` constraint to allow multi-line rendering when expanded

#### Tests
- Two new tests for expand/collapse toggle behavior
- Updated snapshots to reflect the new hint rendering

## Testing

```
npm test -w packages/cli -- src/ui/components/messages/ShellToolMessage.test.tsx
# 18/18 tests passing
```