### PR TITLE
docs: fix broken relative link in subagents.md

### DIFF
--- a/docs/core/subagents.md
+++ b/docs/core/subagents.md
@@ -413,7 +413,7 @@ Gemini CLI can also delegate tasks to remote subagents using the Agent-to-Agent
 
 > **Note: Remote subagents are currently an experimental feature.**
 
-See the [Remote Subagents documentation](remote-agents) for detailed
+See the [Remote Subagents documentation](remote-agents.md) for detailed
 configuration, authentication, and usage instructions.
 
 ## Extension subagents


### PR DESCRIPTION
## Summary

Fixed a broken relative link in `subagents.md`

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
Fixed a broken relative link. to the Remote Subagents documentation in `docs/core/subagents.md` by adding the
   missing `.md` extension.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

Check that links on GitHub do not 404.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
