### PR TITLE
docs(changelog): remove internal commands from release notes

### DIFF
--- a/docs/changelogs/index.md
+++ b/docs/changelogs/index.md
@@ -125,10 +125,6 @@ on GitHub.
 
 ## Announcements: v0.28.0 - 2026-02-10
 
-- **Slash Command:** We've added a new `/prompt-suggest` slash command to help
-  you generate prompt suggestions
-  ([#17264](https://github.com/google-gemini/gemini-cli/pull/17264) by
-  @NTaylorMullen).
 - **IDE Support:** Gemini CLI now supports the Positron IDE
   ([#15047](https://github.com/google-gemini/gemini-cli/pull/15047) by
   @kapsner).
@@ -168,8 +164,8 @@ on GitHub.
   ([#16638](https://github.com/google-gemini/gemini-cli/pull/16638) by
   @joshualitt).
 - **UI/UX Improvements:** You can now "Rewind" through your conversation history
-  ([#15717](https://github.com/google-gemini/gemini-cli/pull/15717) by @Adib234)
-  and use a new `/introspect` command for debugging.
+  ([#15717](https://github.com/google-gemini/gemini-cli/pull/15717) by
+  @Adib234).
 - **Core and Scheduler Refactoring:** The core scheduler has been significantly
   refactored to improve performance and reliability
   ([#16895](https://github.com/google-gemini/gemini-cli/pull/16895) by


### PR DESCRIPTION
## Summary

This PR removes mentions of internal slash commands (`/prompt-suggest` and `/introspect`) from the release notes in `docs/changelogs/index.md` as they are not available in production builds.

## Details

The issue pointed out three internal commands: `/prompt-suggest`, `/introspect`, and `/review-and-fix`. `/review-and-fix` was not found in the docs, but the other two were removed to prevent user confusion.

## Related Issues

Fixes #19009

## How to Validate

1. Verify `docs/changelogs/index.md` no longer contains `/prompt-suggest` or `/introspect`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods: