### PR TITLE
docs: fix broken link in writing-hooks.md

### DIFF
--- a/docs/hooks/writing-hooks.md
+++ b/docs/hooks/writing-hooks.md
@@ -470,5 +470,5 @@ console.error('Consolidating memories for session end...');
 
 While project-level hooks are great for specific repositories, you can share
 your hooks across multiple projects by packaging them as a
-[Gemini CLI extension](https://www.google.com/search?q=../extensions/index.md).
+[Gemini CLI extension](../extensions/index.md).
 This provides version control, easy distribution, and centralized management.


### PR DESCRIPTION
## Summary
The extension documentation link in the 'Packaging as an extension' section of writing-hooks.md was incorrectly wrapped in a Google search URL (`https://www.google.com/search?q=../extensions/index.md`).

This PR fixes the link to point directly to the extensions documentation using the correct relative path.

## Related Issue
Fixes #21712

## Changes
- Fixed the broken markdown link in `docs/hooks/writing-hooks.md`
- Changed from: `[Gemini CLI extension](https://www.google.com/search?q=../extensions/index.md)`
- Changed to: `[Gemini CLI extension](../extensions/index.md)`