### PR TITLE
fix: replace stale 'edit' tool name with 'replace' in file-system.tes…

### DIFF
--- a/integration-tests/file-system.test.ts
+++ b/integration-tests/file-system.test.ts
@@ -68,7 +68,6 @@ describe('file-system', () => {
     // Accept multiple valid tools for editing files
     const foundToolCall = await rig.waitForAnyToolCall([
       'write_file',
-      'edit',
       'replace',
     ]);
 
@@ -79,7 +78,7 @@ describe('file-system', () => {
 
     expect(
       foundToolCall,
-      'Expected to find a write_file, edit, or replace tool call',
+      'Expected to find a write_file or replace tool call',
     ).toBeTruthy();
 
     assertModelHasOutput(result);
@@ -183,7 +182,7 @@ describe('file-system', () => {
       args: `rewrite the file ${fileName} to replace all instances of "test line" with "new line"`,
     });
 
-    const validTools = ['write_file', 'edit'];
+    const validTools = ['write_file', 'replace'];
     const foundToolCall = await rig.waitForAnyToolCall(validTools);
     if (!foundToolCall) {
       printDebugInfo(rig, result, {


### PR DESCRIPTION
## Summary

Found `'edit'` hardcoded as a tool name in `file-system.test.ts` but there's no tool called `'edit'` — it's actually `'replace'`. Fixed both spots.

## Details

I was reading through `integration-tests/file-system.test.ts` and something looked off. On line 71, the test calls `waitForAnyToolCall(['write_file', 'edit', 'replace'])` — that `'edit'` in the middle caught my eye because I couldn't find any tool registered with that name anywhere.

Dug into `packages/core/src/tools/definitions/base-declarations.ts` and yep, `EDIT_TOOL_NAME` is set to `'replace'`, not `'edit'`. Also checked `TOOL_LEGACY_ALIASES` in `tool-names.ts` — no `edit → replace` mapping there either. So `'edit'` is basically a ghost string that never matches anything.

There are two spots with this problem:

- **Line 71** — array has `['write_file', 'edit', 'replace']`. Test still passes because `'replace'` is right there next to it. `'edit'` is just dead weight, never actually matches a tool call.

- **Line 186** — this is the real problem. `validTools = ['write_file', 'edit']` and `'replace'` isn't in the array at all. This test is currently skipped (`it.skip`), but the moment someone removes that skip, it'll break. `waitForAnyToolCall` won't find `'edit'` (doesn't exist), and if the model uses `replace` (which it will, since that's the actual tool), the `validTools.includes(log.toolRequest.name)` check also fails.

Ran a quick sanity check to make sure I wasn't missing something:
```js
const logs = [{ toolRequest: { name: 'replace', success: true } }];
['write_file', 'edit'].some(n => logs.some(l => l.toolRequest.name === n));    // false — yep, broken
['write_file', 'replace'].some(n => logs.some(l => l.toolRequest.name === n)); // true
```

So the fix is just: drop `'edit'` from line 71, swap `'edit'` for `'replace'` on line 186. That's it.

## Related Issues

#22543 

## How to Validate

1. Open `integration-tests/file-system.test.ts`
2. Line ~69 should now have `['write_file', 'replace']` — no more `'edit'`
3. Line ~185 should have `validTools = ['write_file', 'replace']`
4. You can grep `packages/core/src/tools/` for any tool named `'edit'` — there aren't any
5. `EDIT_TOOL_NAME` in `base-declarations.ts:22` confirms it's `'replace'`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
