### PR TITLE
fix(sandbox): redact sensitive SANDBOX_ENV values in debug output (#22537)

### DIFF
--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,11 @@ import { spawn, exec, execFile, execSync } from 'node:child_process';
 import os from 'node:os';
 import fs from 'node:fs';
 import { start_sandbox } from './sandbox.js';
-import { FatalSandboxError, type SandboxConfig } from '@google/gemini-cli-core';
+import {
+  FatalSandboxError,
+  type SandboxConfig,
+  debugLogger,
+} from '@google/gemini-cli-core';
 import { createMockSandboxConfig } from '@google/gemini-cli-test-utils';
 import { EventEmitter } from 'node:events';
 
@@ -95,6 +99,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
         this.name = 'FatalSandboxError';
       }
     },
+    redactEnvironmentVariable: actual.redactEnvironmentVariable,
     GEMINI_DIR: '.gemini',
     homedir: mockedHomedir,
   };
@@ -437,6 +442,59 @@ describe('sandbox', () => {
       );
     });
 
+    it('should redact sensitive SANDBOX_ENV values in Docker logs', async () => {
+      const config: SandboxConfig = createMockSandboxConfig({
+        command: 'docker',
+        image: 'gemini-cli-sandbox',
+      });
+      process.env['SANDBOX_ENV'] = 'MY_API_KEY=sk-abc123,OTHER_VAR=value';
+
+      // Mock image check
+      interface MockProcessWithStdout extends EventEmitter {
+        stdout: EventEmitter;
+      }
+      const mockImageCheckProcess = new EventEmitter() as MockProcessWithStdout;
+      mockImageCheckProcess.stdout = new EventEmitter();
+      vi.mocked(spawn).mockImplementationOnce(() => {
+        setTimeout(() => {
+          mockImageCheckProcess.stdout.emit('data', Buffer.from('image-id'));
+          mockImageCheckProcess.emit('close', 0);
+        }, 1);
+        return mockImageCheckProcess as unknown as ReturnType<typeof spawn>;
+      });
+
+      const mockSpawnProcess = new EventEmitter() as unknown as ReturnType<
+        typeof spawn
+      >;
+      mockSpawnProcess.on = vi.fn().mockImplementation((event, cb) => {
+        if (event === 'close') {
+          setTimeout(() => cb(0), 10);
+        }
+        return mockSpawnProcess;
+      });
+      vi.mocked(spawn).mockImplementationOnce(() => mockSpawnProcess);
+
+      await start_sandbox(config);
+
+      // Check that the sensitive value is NOT in the logs
+      const logCalls = vi
+        .mocked(debugLogger.log)
+        .mock.calls.map((call) => call[0]);
+      expect(
+        logCalls.some(
+          (log) => typeof log === 'string' && log.includes('sk-abc123'),
+        ),
+      ).toBe(false);
+      expect(
+        logCalls.some(
+          (log) => typeof log === 'string' && log.includes('MY_API_KEY'),
+        ),
+      ).toBe(true);
+
+      // The individual log line should be redacted
+      expect(logCalls).toContain('SANDBOX_ENV: MY_API_KEY=[REDACTED]');
+    });
+
     it('should handle networkAccess: false in Docker', async () => {
       const config: SandboxConfig = createMockSandboxConfig({
         command: 'docker',
@@ -658,6 +716,56 @@ describe('sandbox', () => {
           expect.arrayContaining(['exec', 'gemini-sandbox', '--cwd']),
           expect.objectContaining({ stdio: 'inherit' }),
         );
+      });
+
+      it('should redact sensitive environment variables in LXC debug logs', async () => {
+        process.env['TEST_LXC_LIST_OUTPUT'] = LXC_RUNNING;
+        process.env['SANDBOX_ENV'] = 'MY_API_KEY=sk-abc123,OTHER_VAR=value';
+        const config: SandboxConfig = createMockSandboxConfig({
+          command: 'lxc',
+          image: 'gemini-sandbox',
+        });
+
+        const mockSpawnProcess = new EventEmitter() as unknown as ReturnType<
+          typeof spawn
+        >;
+        mockSpawnProcess.on = vi.fn().mockImplementation((event, cb) => {
+          if (event === 'close') {
+            setTimeout(() => cb(0), 10);
+          }
+          return mockSpawnProcess;
+        });
+
+        vi.mocked(spawn).mockImplementation((cmd) => {
+          if (cmd === 'lxc') {
+            return mockSpawnProcess;
+          }
+          return new EventEmitter() as unknown as ReturnType<typeof spawn>;
+        });
+
+        const promise = start_sandbox(config, [], undefined, ['arg1']);
+        await expect(promise).resolves.toBe(0);
+
+        // Check that the sensitive value is NOT in the logs
+        const logCalls = vi
+          .mocked(debugLogger.log)
+          .mock.calls.map((call) => call[0]);
+        expect(
+          logCalls.some(
+            (log) => typeof log === 'string' && log.includes('sk-abc123'),
+          ),
+        ).toBe(false);
+        expect(
+          logCalls.some(
+            (log) => typeof log === 'string' && log.includes('MY_API_KEY'),
+          ),
+        ).toBe(true);
+        expect(
+          logCalls.some(
+            (log) =>
+              typeof log === 'string' && log.includes('MY_API_KEY=[REDACTED]'),
+          ),
+        ).toBe(true);
       });
 
       it('should throw FatalSandboxError if lxc list fails', async () => {

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -25,6 +25,7 @@ import {
   FatalSandboxError,
   GEMINI_DIR,
   homedir,
+  redactEnvironmentVariable,
 } from '@google/gemini-cli-core';
 import { ConsolePatcher } from '../ui/utils/ConsolePatcher.js';
 import { randomBytes } from 'node:crypto';
@@ -619,7 +620,10 @@ export async function start_sandbox(
       for (let env of process.env['SANDBOX_ENV'].split(',')) {
         if ((env = env.trim())) {
           if (env.includes('=')) {
-            debugLogger.log(`SANDBOX_ENV: ${env}`);
+            const [key, value] = env.split('=', 2);
+            debugLogger.log(
+              `SANDBOX_ENV: ${key}=${redactEnvironmentVariable(key, value)}`,
+            );
             args.push('--env', env);
           } else {
             throw new FatalSandboxError(
@@ -1019,7 +1023,14 @@ async function start_lxc_sandbox(
       ...finalEntrypoint,
     ];
 
-    debugLogger.log(`lxc exec args: ${args.join(' ')}`);
+    const redactedArgs = args.map((arg, i) => {
+      if (i > 0 && args[i - 1] === '--env' && arg.includes('=')) {
+        const [key, value] = arg.split('=', 2);
+        return `${key}=${redactEnvironmentVariable(key, value)}`;
+      }
+      return arg;
+    });
+    debugLogger.log(`lxc exec args: ${redactedArgs.join(' ')}`);
 
     process.stdin.pause();
     const sandboxProcess = spawn('lxc', args, {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -118,6 +118,7 @@ export * from './utils/sessionUtils.js';
 export * from './utils/cache.js';
 
 // Export services
+export * from './services/environmentSanitization.js';
 export * from './services/fileDiscoveryService.js';
 export * from './services/gitService.js';
 export * from './services/FolderTrustDiscoveryService.js';

--- a/packages/core/src/services/environmentSanitization.ts
+++ b/packages/core/src/services/environmentSanitization.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -140,7 +140,17 @@ export const NEVER_ALLOWED_VALUE_PATTERNS = [
   /xox[abpr]-[a-zA-Z0-9-]+/i,
 ] as const;
 
-function shouldRedactEnvironmentVariable(
+export function redactEnvironmentVariable(
+  key: string,
+  value: string | undefined,
+): string {
+  if (!value) {
+    return '';
+  }
+  return shouldRedactEnvironmentVariable(key, value) ? '[REDACTED]' : value;
+}
+
+export function shouldRedactEnvironmentVariable(
   key: string,
   value: string | undefined,
   allowedSet?: Set<string>,


### PR DESCRIPTION
## Summary

Redacts sensitive environment variable values from `SANDBOX_ENV` in debug logs to prevent secret leakage.

## Details

- **Core Sanitization:** Updated `packages/core/src/services/environmentSanitization.ts` to export `shouldRedactEnvironmentVariable` and added `redactEnvironmentVariable` helper.
- **Service Export:** Exported the sanitization service from `@google/gemini-cli-core`.
- **Docker/Podman Logging:** Updated `packages/cli/src/utils/sandbox.ts` to redact individual environment variables from `SANDBOX_ENV` before logging.
- **LXC Logging:** Updated `packages/cli/src/utils/sandbox.ts` to redact `--env` arguments in the full `lxc exec` command log.
- **Tests:** Added unit tests in `packages/cli/src/utils/sandbox.test.ts` to verify redaction for both Docker and LXC paths.

## Related Issues

Fixes #22537

## How to Validate

1. Run with `DEBUG=1` and set `SANDBOX_ENV` with a sensitive key (e.g., `MY_API_KEY=sk-123`).
2. Verify that the output shows `SANDBOX_ENV: MY_API_KEY=[REDACTED]` instead of the plaintext value.
3. Run existing and new tests: `npm test -w @google/gemini-cli -- src/utils/sandbox.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Linux
    - [x] npm run
    - [x] Docker
