### PR TITLE
fix(automation): harden stale PR closer permissions and maintainer detection

### DIFF
--- a/.github/workflows/gemini-scheduled-stale-pr-closer.yml
+++ b/.github/workflows/gemini-scheduled-stale-pr-closer.yml
@@ -40,6 +40,8 @@ jobs:
           github-token: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           script: |
             const dryRun = process.env.DRY_RUN === 'true';
+            const fourteenDaysAgo = new Date();
+            fourteenDaysAgo.setDate(fourteenDaysAgo.getDate() - 14);
             const thirtyDaysAgo = new Date();
             thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
@@ -56,48 +58,38 @@ jobs:
                 for (const m of members) maintainerLogins.add(m.login.toLowerCase());
                 core.info(`Successfully fetched ${members.length} team members from ${team_slug}`);
               } catch (e) {
-                core.warning(`Failed to fetch team members from ${team_slug}: ${e.message}`);
+                // Silently skip if permissions are insufficient; we will rely on author_association
+                core.debug(`Skipped team fetch for ${team_slug}: ${e.message}`);
               }
             }
 
-            const isGooglerCache = new Map();
-            const isGoogler = async (login) => {
-              if (isGooglerCache.has(login)) return isGooglerCache.get(login);
+            const isMaintainer = async (login, assoc) => {
+              // Reliably identify maintainers using authorAssociation (provided by GitHub)
+              // and organization membership (if available).
+              const isTeamMember = maintainerLogins.has(login.toLowerCase());
+              const isRepoMaintainer = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(assoc);
 
+              if (isTeamMember || isRepoMaintainer) return true;
+
+              // Fallback: Check if user belongs to the 'google' or 'googlers' orgs (requires permission)
               try {
-                // Check membership in 'googlers' or 'google' orgs
                 const orgs = ['googlers', 'google'];
                 for (const org of orgs) {
                   try {
-                    await github.rest.orgs.checkMembershipForUser({
-                      org: org,
-                      username: login
-                    });
-                    core.info(`User ${login} is a member of ${org} organization.`);
-                    isGooglerCache.set(login, true);
+                    await github.rest.orgs.checkMembershipForUser({ org: org, username: login });
                     return true;
                   } catch (e) {
-                    // 404 just means they aren't a member, which is fine
                     if (e.status !== 404) throw e;
                   }
                 }
               } catch (e) {
-                core.warning(`Failed to check org membership for ${login}: ${e.message}`);
+                // Gracefully ignore failures here
               }
 
-              isGooglerCache.set(login, false);
               return false;
             };
 
-            const isMaintainer = async (login, assoc) => {
-              const isTeamMember = maintainerLogins.has(login.toLowerCase());
-              const isRepoMaintainer = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(assoc);
-              if (isTeamMember || isRepoMaintainer) return true;
-
-              return await isGoogler(login);
-            };
-
-            // 2. Determine which PRs to check
+            // 2. Fetch all open PRs
             let prs = [];
             if (context.eventName === 'pull_request') {
               const { data: pr } = await github.rest.pulls.get({
@@ -118,64 +110,77 @@ jobs:
             for (const pr of prs) {
               const maintainerPr = await isMaintainer(pr.user.login, pr.author_association);
               const isBot = pr.user.type === 'Bot' || pr.user.login.endsWith('[bot]');
+              if (maintainerPr || isBot) continue;
 
-              // Detection Logic for Linked Issues
-              // Check 1: Official GitHub "Closing Issue" link (GraphQL)
-              const linkedIssueQuery = `query($owner:String!, $repo:String!, $number:Int!) {
+              // Helper: Fetch labels and linked issues via GraphQL
+              const prDetailsQuery = `query($owner:String!, $repo:String!, $number:Int!) {
                 repository(owner:$owner, name:$repo) {
                   pullRequest(number:$number) {
-                    closingIssuesReferences(first: 1) { totalCount }
+                    closingIssuesReferences(first: 10) {
+                      nodes {
+                        number
+                        labels(first: 20) {
+                          nodes { name }
+                        }
+                      }
+                    }
                   }
                 }
               }`;
 
-              let hasClosingLink = false;
+              let linkedIssues = [];
               try {
-                const res = await github.graphql(linkedIssueQuery, {
+                const res = await github.graphql(prDetailsQuery, {
                   owner: context.repo.owner, repo: context.repo.repo, number: pr.number
                 });
-                hasClosingLink = res.repository.pullRequest.closingIssuesReferences.totalCount > 0;
-              } catch (e) {}
-
-              // Check 2: Regex for mentions (e.g., "Related to #123", "Part of #123", "#123")
-              // We check for # followed by numbers or direct URLs to issues.
-              const body = pr.body || '';
-              const mentionRegex = /(?:#|https:\/\/github\.com\/[^\/]+\/[^\/]+\/issues\/)(\d+)/i;
-              const hasMentionLink = mentionRegex.test(body);
-
-              const hasLinkedIssue = hasClosingLink || hasMentionLink;
-
-              // Logic for Closed PRs (Auto-Reopen)
-              if (pr.state === 'closed' && context.eventName === 'pull_request' && context.payload.action === 'edited') {
-                if (hasLinkedIssue) {
-                  core.info(`PR #${pr.number} now has a linked issue. Reopening.`);
-                  if (!dryRun) {
-                    await github.rest.pulls.update({
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      pull_number: pr.number,
-                      state: 'open'
-                    });
-                    await github.rest.issues.createComment({
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      issue_number: pr.number,
-                      body: "Thank you for linking an issue! This pull request has been automatically reopened."
-                    });
-                  }
-                }
-                continue;
+                linkedIssues = res.repository.pullRequest.closingIssuesReferences.nodes;
+              } catch (e) {
+                core.warning(`GraphQL fetch failed for PR #${pr.number}: ${e.message}`);
               }
 
-              // Logic for Open PRs (Immediate Closure)
-              if (pr.state === 'open' && !maintainerPr && !hasLinkedIssue && !isBot) {
-                core.info(`PR #${pr.number} is missing a linked issue. Closing.`);
+              // Check for mentions in body as fallback (regex)
+              const body = pr.body || '';
+              const mentionRegex = /(?:#|https:\/\/github\.com\/[^\/]+\/[^\/]+\/issues\/)(\d+)/i;
+              const matches = body.match(mentionRegex);
+              if (matches && linkedIssues.length === 0) {
+                const issueNumber = parseInt(matches[1]);
+                try {
+                  const { data: issue } = await github.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber
+                  });
+                  linkedIssues = [{ number: issueNumber, labels: { nodes: issue.labels.map(l => ({ name: l.name })) } }];
+                } catch (e) {}
+              }
+
+              // 3. Enforcement Logic
+              const prLabels = pr.labels.map(l => l.name.toLowerCase());
+              const hasHelpWanted = prLabels.includes('help wanted') ||
+                                    linkedIssues.some(issue => issue.labels.nodes.some(l => l.name.toLowerCase() === 'help wanted'));
+
+              const hasMaintainerOnly = prLabels.includes('🔒 maintainer only') ||
+                                        linkedIssues.some(issue => issue.labels.nodes.some(l => l.name.toLowerCase() === '🔒 maintainer only'));
+
+              const hasLinkedIssue = linkedIssues.length > 0;
+
+              // Closure Policy: No help-wanted label = Close after 14 days
+              if (pr.state === 'open' && !hasHelpWanted && !hasMaintainerOnly) {
+                const prCreatedAt = new Date(pr.created_at);
+
+                // We give a 14-day grace period for non-help-wanted PRs to be manually reviewed/labeled by an EM
+                if (prCreatedAt > fourteenDaysAgo) {
+                  core.info(`PR #${pr.number} is new and lacks 'help wanted'. Giving 14-day grace period for EM review.`);
+                  continue;
+                }
+
+                core.info(`PR #${pr.number} is older than 14 days and lacks 'help wanted' association. Closing.`);
                 if (!dryRun) {
                   await github.rest.issues.createComment({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: pr.number,
-                    body: "Hi there! Thank you for your contribution to Gemini CLI. \n\nTo improve our contribution process and better track changes, we now require all pull requests to be associated with an existing issue, as announced in our [recent discussion](https://github.com/google-gemini/gemini-cli/discussions/16706) and as detailed in our [CONTRIBUTING.md](https://github.com/google-gemini/gemini-cli/blob/main/CONTRIBUTING.md#1-link-to-an-existing-issue).\n\nThis pull request is being closed because it is not currently linked to an issue. **Once you have updated the description of this PR to link an issue (e.g., by adding `Fixes #123` or `Related to #123`), it will be automatically reopened.**\n\n**How to link an issue:**\nAdd a keyword followed by the issue number (e.g., `Fixes #123`) in the description of your pull request. For more details on supported keywords and how linking works, please refer to the [GitHub Documentation on linking pull requests to issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).\n\nThank you for your understanding and for being a part of our community!"
+                    body: "Hi there! Thank you for your interest in contributing to Gemini CLI. \n\nTo ensure we maintain high code quality and focus on our prioritized roadmap, we have updated our contribution policy (see [Discussion #17383](https://github.com/google-gemini/gemini-cli/discussions/17383)). \n\n**We only *guarantee* review and consideration of pull requests for issues that are explicitly labeled as 'help wanted'.** All other community pull requests are subject to closure after 14 days if they do not align with our current focus areas. For this reason, we strongly recommend that contributors only submit pull requests against issues explicitly labeled as **'help-wanted'**. \n\nThis pull request is being closed as it has been open for 14 days without a 'help wanted' designation. We encourage you to find and contribute to existing 'help wanted' issues in our backlog! Thank you for your understanding and for being part of our community!"
                   });
                   await github.rest.pulls.update({
                     owner: context.repo.owner,
@@ -187,27 +192,24 @@ jobs:
                 continue;
               }
 
-              // Staleness check (Scheduled runs only)
+              // Also check for linked issue even if it has help wanted (redundant but safe)
+              if (pr.state === 'open' && !hasLinkedIssue) {
+                 // Already covered by hasHelpWanted check above, but good for future-proofing
+                 continue;
+              }
+
+              // 4. Staleness Check (Scheduled only)
               if (pr.state === 'open' && context.eventName !== 'pull_request') {
-                const labels = pr.labels.map(l => l.name.toLowerCase());
-                if (labels.includes('help wanted') || labels.includes('🔒 maintainer only')) continue;
+                // PRs with help wanted/maintainer only labels are still checked for staleness
+                // but usually given more leeway. Here we stick to 30 days of no maintainer activity.
 
-                // Skip PRs that were created less than 30 days ago - they cannot be stale yet
                 const prCreatedAt = new Date(pr.created_at);
-                if (prCreatedAt > thirtyDaysAgo) {
-                  const daysOld = Math.floor((Date.now() - prCreatedAt.getTime()) / (1000 * 60 * 60 * 24));
-                  core.info(`PR #${pr.number} was created ${daysOld} days ago. Skipping staleness check.`);
-                  continue;
-                }
+                if (prCreatedAt > thirtyDaysAgo) continue;
 
-                // Initialize lastActivity to PR creation date (not epoch) as a safety baseline.
-                // This ensures we never incorrectly mark a PR as stale due to failed activity lookups.
                 let lastActivity = new Date(pr.created_at);
                 try {
                   const reviews = await github.paginate(github.rest.pulls.listReviews, {
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    pull_number: pr.number
+                    owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.number
                   });
                   for (const r of reviews) {
                     if (await isMaintainer(r.user.login, r.author_association)) {
@@ -216,9 +218,7 @@ jobs:
                     }
                   }
                   const comments = await github.paginate(github.rest.issues.listComments, {
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: pr.number
+                    owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number
                   });
                   for (const c of comments) {
                     if (await isMaintainer(c.user.login, c.author_association)) {
@@ -226,16 +226,7 @@ jobs:
                       if (d > lastActivity) lastActivity = d;
                     }
                   }
-                } catch (e) {
-                  core.warning(`Failed to fetch reviews/comments for PR #${pr.number}: ${e.message}`);
-                }
-
-                // For maintainer PRs, the PR creation itself counts as maintainer activity.
-                // (Now redundant since we initialize to pr.created_at, but kept for clarity)
-                if (maintainerPr) {
-                  const d = new Date(pr.created_at);
-                  if (d > lastActivity) lastActivity = d;
-                }
+                } catch (e) {}
 
                 if (lastActivity < thirtyDaysAgo) {
                   core.info(`PR #${pr.number} is stale.`);
@@ -244,7 +235,7 @@ jobs:
                       owner: context.repo.owner,
                       repo: context.repo.repo,
                       issue_number: pr.number,
-                      body: "Hi there! Thank you for your contribution to Gemini CLI. We really appreciate the time and effort you've put into this pull request.\n\nTo keep our backlog manageable and ensure we're focusing on current priorities, we are closing pull requests that haven't seen maintainer activity for 30 days. Currently, the team is prioritizing work associated with **🔒 maintainer only** or **help wanted** issues.\n\nIf you believe this change is still critical, please feel free to comment with updated details. Otherwise, we encourage contributors to focus on open issues labeled as **help wanted**. Thank you for your understanding!"
+                      body: "Hi there! Thank you for your contribution. To keep our backlog manageable, we are closing pull requests that haven't seen maintainer activity for 30 days. If you're still working on this, please let us know!"
                     });
                     await github.rest.pulls.update({
                       owner: context.repo.owner,


### PR DESCRIPTION
## Summary
- Use `authorAssociation` and org membership instead of the team API for maintainer detection, avoiding permission errors on the scheduled stale PR closer workflow
- Enforce `help-wanted` label policy for external PRs via linked issues
- Add 14-day grace period and improve closure messaging
- Remove invalid `members` permission scope

## Test plan
- [ ] Verify the scheduled workflow runs without permission errors
- [ ] Confirm maintainer PRs are correctly identified and skipped
- [ ] Confirm external PRs without `help-wanted` linked issues are flagged appropriately

Supersedes #22555 (rebased cleanly onto main to avoid snapshot noise).