### PR TITLE
docs: fix minor typos in tests and documentation

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -57,7 +57,7 @@ real-world usage while remaining small and maintainable.
 - **Unambiguous and Reliable Assertions**: Assertions must be clear and specific
   to ensure the test passes for the right reason.
   - _Good_: Checking that a modified file contains a specific AST node or exact
-    string, or verifying that a tool was called with with the right parameters.
+    string, or verifying that a tool was called with the right parameters.
   - _Bad_: Only checking for a tool call, which could happen for an unrelated
     reason. Expecting specific LLM output.
 - **Fail First**: Have tests that failed before your prompt or tool change. We

--- a/evals/test-helper.ts
+++ b/evals/test-helper.ts
@@ -107,7 +107,7 @@ export function evalTest(policy: EvalPolicy, evalCase: EvalCase) {
         execSync('git config user.name "Test User"', execOptions);
 
         // Temporarily disable the interactive editor and git pager
-        // to avoid hanging the tests. It seems the the agent isn't
+        // to avoid hanging the tests. It seems the agent isn't
         // consistently honoring the instructions to avoid interactive
         // commands.
         execSync('git config core.editor "true"', execOptions);

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx
@@ -433,7 +433,7 @@ describe('useSlashCommandProcessor', () => {
       );
     });
 
-    it('sets isProcessing to false if the the input is not a command', async () => {
+    it('sets isProcessing to false if the input is not a command', async () => {
       const setMockIsProcessing = vi.fn();
       const result = await setupProcessorHook({
         setIsProcessing: setMockIsProcessing,


### PR DESCRIPTION
This PR fixes several minor typos (duplicate words like "the the" and "with with") found in the test suites and documentation.This is my first PR for Gemini CLI so do not be judgemental. Everyone has to start somewhere, this is where I choose to start.