### PR TITLE
test(integration): verify telemetry is not written when disabled

### DIFF
--- a/integration-tests/telemetry.test.ts
+++ b/integration-tests/telemetry.test.ts
@@ -6,6 +6,8 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TestRig } from './test-helper.js';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
 
 describe('telemetry', () => {
   let rig: TestRig;
@@ -29,5 +31,27 @@ describe('telemetry', () => {
     // Verify that a cli_command_count metric was emitted
     const cliCommandCountMetric = rig.readMetric('session.count');
     expect(cliCommandCountMetric).not.toBeNull();
+  });
+
+  it('should not write telemetry when disabled', async () => {
+    rig.setup('telemetry-disabled', {
+      fakeResponsesPath: join(
+        import.meta.dirname,
+        'hooks-system.session-startup.responses',
+      ),
+      settings: {
+        telemetry: { enabled: false },
+      },
+    });
+
+    // Run a simple command with telemetry disabled
+    await rig.run({
+      args: 'say hello',
+      env: { GEMINI_API_KEY: 'fake-key' },
+    });
+
+    // Verify that no telemetry log file was created
+    const telemetryLogPath = join(rig.homeDir!, 'telemetry.log');
+    expect(existsSync(telemetryLogPath)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Closes #11770

The telemetry integration suite had only a positive test (telemetry IS emitted when enabled). This adds the complementary negative case: when `telemetry.enabled: false` is set in user settings, the CLI must not create the telemetry log file at all.

- Uses an existing fake-responses fixture (`hooks-system.session-startup.responses`) so the test is deterministic and requires no live credential
- Passes `GEMINI_API_KEY: 'fake-key'` via `rig.run()` env — consistent with how `acp-telemetry.test.ts` handles fake-response tests
- Verifies `telemetry.log` is absent after a successful run

## Test plan

- [x] New test passes locally: `vitest run -t "should not write telemetry when disabled" telemetry.test.ts`
- [x] Existing tests unaffected
- [x] `npm run preflight` passes (17/17 unit tests)