### PR TITLE
fix(core): remove stale MCP client from map on initialization failure

### DIFF
--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -751,6 +751,19 @@ describe('McpClientManager', () => {
       );
     });
 
+    it('should remove the client from the clients map if initialization fails', async () => {
+      const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
+      const name = 'test-server';
+      const config = { command: 'node', args: ['fail.js'] };
+
+      mockedMcpClient.connect.mockRejectedValue(new Error('Connection failed'));
+
+      // maybeDiscoverMcpServer returns a promise that resolves when discovery is finished.
+      await manager.maybeDiscoverMcpServer(name, config);
+
+      expect(manager.getClient(name)).toBeUndefined();
+    });
+
     it('should show previously deduplicated errors after interaction clears state', () => {
       const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
 

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -404,6 +404,7 @@ export class McpClientManager {
             await client.discover(this.cliConfig);
             this.eventEmitter?.emit('mcp-client-update', this.clients);
           } catch (error) {
+            this.clients.delete(name);
             this.eventEmitter?.emit('mcp-client-update', this.clients);
             // Check if this is a 401/auth error - if so, don't show as red error
             // (the info message was already shown in mcp-client.ts)
@@ -418,6 +419,7 @@ export class McpClientManager {
             }
           }
         } catch (error) {
+          this.clients.delete(name);
           const errorMessage = getErrorMessage(error);
           this.emitDiagnostic(
             'error',


### PR DESCRIPTION
Ensures that failed MCP client instances are correctly removed from the internal map, preventing stale state and ensuring deterministic re-initialization.