### PR TITLE
fix(core): fail-fast on publish() error in MessageBus.request()

### DIFF
--- a/packages/core/src/confirmation-bus/message-bus.ts
+++ b/packages/core/src/confirmation-bus/message-bus.ts
@@ -19,6 +19,13 @@ export class MessageBus extends EventEmitter {
   ) {
     super();
     this.debug = debug;
+
+    //Register a default handler here so that fire-and-forget publish() calls never produce an unhandled 'error' event
+    this.on('error', (err: unknown) => {
+      debugLogger.debug(
+        `[MESSAGE_BUS] Unhandled publish error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
   }
 
   private isValidMessage(message: Message): boolean {
@@ -160,9 +167,16 @@ export class MessageBus extends EventEmitter {
       // Subscribe to responses
       this.subscribe<TResponse>(responseType, responseHandler);
 
-      // Publish the request with correlation ID
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises, @typescript-eslint/no-unsafe-type-assertion
-      this.publish({ ...request, correlationId } as TRequest);
+      // Publish the request with correlation ID.  If publish() fails (e.g.
+      // isValidMessage rejects, policy check throws), propagate the error
+      // immediately instead of silently hanging until the 60-second timeout.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      this.publish({ ...request, correlationId } as TRequest).catch(
+        (err: unknown) => {
+          cleanup();
+          reject(err instanceof Error ? err : new Error(String(err)));
+        },
+      );
     });
   }
 }


### PR DESCRIPTION
## Summary

Fixes #22588 
  `MessageBus.request()` contained a floating `Promise` that caused two failure
  modes when `publish()` rejected: (1) the error was emitted as an EventEmitter
  `'error'` event — crashing the process if no listener was registered — and
  (2) the `Promise` returned by `request()` silently hung for the full 60-second
  timeout instead of failing fast. This fix chains `.catch(reject)` on the
  publish call so failures immediately surface to the caller.

  ## Details

  Inside `request()`, the publish call lived inside a `new Promise()` constructor
  callback and was intentionally left unawaited (with a `@typescript-eslint/no-floating-promises`
  disable comment). If `publish()` threw — e.g. `isValidMessage()` returning
  false, or the policy engine rejecting — the error path was:

  publish() catch block → this.emit('error', error)

  Two problems with that path:

  1. **Crash risk.** Node.js EventEmitter throws synchronously when `'error'` is
     emitted with no registered listener. `MessageBus` had no default error
     handler, so any publish failure in a context without an explicit `'error'`
     listener would terminate the process.

  2. **Silent hang.** Even with a listener, the `Promise` created by `request()`
     had no connection to that error path — it would just sit unresolved until
     the 60-second timeout fired, giving callers no actionable signal.

  Fix: remove the eslint-disable comment and chain `.catch(reject)` so any
  publish rejection calls `cleanup()` (clears the timeout + unsubscribes the
  response handler) and immediately rejects the outer `Promise`.

  This failure mode is directly relevant to the planned `STEP_THROUGH_REQUEST /
  STEP_THROUGH_RESPONSE` scheduler flow, where a malformed step message would
  deadlock the scheduler for 60 seconds with no user-visible error.

  ## How to Validate

  1. In a test or scratch file, construct a `MessageBus` with a mock
     `PolicyEngine` that throws on `check()`.
  2. Call `messageBus.request(...)` with a `TOOL_CONFIRMATION_REQUEST` message
     that will trigger the policy check.
  3. **Before fix:** the returned `Promise` hangs for 60 seconds, then rejects
     with a timeout error. If no `'error'` listener is attached to the bus, the
     process crashes immediately.
  4. **After fix:** the returned `Promise` rejects immediately with the
     underlying error from `publish()`.

  Unit test path:
  ```bash
  npm run test --workspace @google/gemini-cli-core -- src/confirmation-bus/message-bus.test.ts

