### PR TITLE
fix(cli): truncate errored tool call description in mapToDisplay

### DIFF
--- a/packages/cli/src/ui/hooks/toolMapping.ts
+++ b/packages/cli/src/ui/hooks/toolMapping.ts
@@ -45,7 +45,9 @@ export function mapToDisplay(
       // with a full file body as an arg).
       const rawArgs = JSON.stringify(call.request.args);
       description =
-        rawArgs.length > 120 ? rawArgs.slice(0, 117) + '...' : rawArgs;
+        rawArgs.length > 120
+          ? [...rawArgs].slice(0, 117).join('') + '...'
+          : rawArgs;
     } else {
       description = call.invocation.getDescription();
       renderOutputAsMarkdown = call.tool.isOutputMarkdown;

--- a/packages/cli/src/ui/hooks/toolMapping.ts
+++ b/packages/cli/src/ui/hooks/toolMapping.ts
@@ -40,7 +40,12 @@ export function mapToDisplay(
     const displayName = call.tool?.displayName ?? call.request.name;
 
     if (call.status === CoreToolCallStatus.Error) {
-      description = JSON.stringify(call.request.args);
+      // Truncate to avoid blowing out the tree-node
+      // row width when tools are called with large payloads (e.g. write_file
+      // with a full file body as an arg).
+      const rawArgs = JSON.stringify(call.request.args);
+      description =
+        rawArgs.length > 120 ? rawArgs.slice(0, 117) + '...' : rawArgs;
     } else {
       description = call.invocation.getDescription();
       renderOutputAsMarkdown = call.tool.isOutputMarkdown;


### PR DESCRIPTION
## Summary

fixes #22591 

## Details

For ``ErroredToolCall``, description falls back to JSON.stringify(args). When a tool is called with a large payload (e.g. write_file with a full file body), this produces an unbounded string that overflows tree-node row width in the task tree. Cap at 120 chars with an ellipsis.


## How to Validate
1. Trigger a tool call failure with a large argument payload, e.g. call `write_file` with several kilobytes of content and arrange for it to error at validation time (bad path, missing permission, etc.).
  2. **Before fix:** the tool row in the task tree or flat list displays the full JSON-serialized args — potentially hundreds of kilobytes of text on one line.
  3. **After fix:** the description is capped at 120 characters with `...`.


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
