### PR TITLE
feat(acp): provide additional data with RequestError

### DIFF
--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -50,7 +50,7 @@ import {
 } from '@google/gemini-cli-core';
 import * as acp from '@agentclientprotocol/sdk';
 import { AcpFileSystemService } from './fileSystemService.js';
-import { getAcpErrorMessage } from './acpErrors.js';
+import { getAcpErrorDetails, getAcpErrorMessage } from './acpErrors.js';
 import { Readable, Writable } from 'node:stream';
 
 function hasMeta(obj: unknown): obj is { _meta?: Record<string, unknown> } {
@@ -213,6 +213,7 @@ export class GeminiAgent {
           throw new acp.RequestError(
             -32602,
             `Malformed gateway payload: ${result.error.message}`,
+            getAcpErrorDetails(result.error),
           );
         }
       }
@@ -227,7 +228,11 @@ export class GeminiAgent {
         headers,
       );
     } catch (e) {
-      throw new acp.RequestError(-32000, getAcpErrorMessage(e));
+      throw new acp.RequestError(
+        -32000,
+        getAcpErrorMessage(e),
+        getAcpErrorDetails(e),
+      );
     }
     this.settings.setValue(
       SettingScope.User,
@@ -254,6 +259,7 @@ export class GeminiAgent {
 
     let isAuthenticated = false;
     let authErrorMessage = '';
+    let authErrorDetails = undefined;
     try {
       await config.refreshAuth(
         authType,
@@ -275,6 +281,7 @@ export class GeminiAgent {
     } catch (e) {
       isAuthenticated = false;
       authErrorMessage = getAcpErrorMessage(e);
+      authErrorDetails = getAcpErrorDetails(e);
       debugLogger.error(
         `Authentication failed: ${e instanceof Error ? e.stack : e}`,
       );
@@ -284,6 +291,7 @@ export class GeminiAgent {
       throw new acp.RequestError(
         -32000,
         authErrorMessage || 'Authentication required.',
+        authErrorDetails,
       );
     }
 
@@ -430,7 +438,7 @@ export class GeminiAgent {
       );
     } catch (e) {
       debugLogger.error(`Authentication failed: ${e}`);
-      throw acp.RequestError.authRequired();
+      throw acp.RequestError.authRequired(getAcpErrorDetails(e));
     }
 
     // 3. Now that we are authenticated, it is safe to initialize the config
@@ -768,6 +776,7 @@ export class Session {
           throw new acp.RequestError(
             429,
             'Rate limit exceeded. Try again later.',
+            getAcpErrorDetails(error),
           );
         }
 
@@ -781,6 +790,7 @@ export class Session {
         throw new acp.RequestError(
           getErrorStatus(error) || 500,
           getAcpErrorMessage(error),
+          getAcpErrorDetails(error),
         );
       }
 

--- a/packages/cli/src/acp/acpErrors.ts
+++ b/packages/cli/src/acp/acpErrors.ts
@@ -42,3 +42,20 @@ function extractRecursiveMessage(input: string): string {
   }
   return input;
 }
+
+export function getAcpErrorDetails(error: unknown): unknown {
+  try {
+    const json = JSON.stringify(error);
+    if (json && json !== '{}') {
+      return error;
+    }
+  } catch {
+    return undefined;
+  }
+
+  try {
+    return String(error);
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary

Report additional raw data with RequestError

## Details

ACP clients may specially process certain errors to improve the user experience. The best example is `ValidationRequiredError`, which indicates that user validation is required to continue.

## Related Issues

-

## How to Validate

Made a request with an error

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
