### PR TITLE
fix(core): move sendPromise lock and history mutation inside generator body

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -2569,4 +2569,64 @@ describe('GeminiChat', () => {
       });
     });
   });
+
+  describe('sendMessageStream generator abandonment (fix #22521)', () => {
+    it('should not mutate history if the returned generator is never iterated', async () => {
+      // Obtain the generator but never iterate it
+      await chat.sendMessageStream(
+        { model: 'gemini-pro' },
+        'abandoned message',
+        'prompt-id',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+
+      // History must remain empty � no orphaned user message
+      expect(chat.getHistory()).toHaveLength(0);
+    });
+
+    it('should not deadlock subsequent calls if the returned generator is never iterated', async () => {
+      mockRetryWithBackoff.mockImplementation(async (apiCall) => apiCall());
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        (async function* () {
+          yield {
+            candidates: [
+              {
+                content: { parts: [{ text: 'hello' }], role: 'model' },
+                finishReason: 'STOP',
+              },
+            ],
+          };
+        })(),
+      );
+
+      // First call � obtain generator but never iterate it
+      await chat.sendMessageStream(
+        { model: 'gemini-pro' },
+        'first message never iterated',
+        'prompt-id-1',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+
+      // Second call � must resolve without hanging
+      const secondStream = await chat.sendMessageStream(
+        { model: 'gemini-pro' },
+        'second message',
+        'prompt-id-2',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+
+      const events: StreamEvent[] = [];
+      for await (const event of secondStream) {
+        events.push(event);
+      }
+
+      // Second call must succeed and history must have exactly one exchange
+      expect(chat.getHistory()).toHaveLength(2);
+      expect(chat.getHistory()[0]).toMatchObject({ role: 'user' });
+      expect(chat.getHistory()[1]).toMatchObject({ role: 'model' });
+    });
+  });
 });

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -307,49 +307,53 @@ export class GeminiChat {
   ): Promise<AsyncGenerator<StreamEvent>> {
     await this.sendPromise;
 
-    let streamDoneResolver: () => void;
-    const streamDonePromise = new Promise<void>((resolve) => {
-      streamDoneResolver = resolve;
-    });
-    this.sendPromise = streamDonePromise;
-
     const userContent = createUserContent(message);
     const { model } =
       this.context.config.modelConfigService.getResolvedConfig(modelConfigKey);
 
-    // Record user input - capture complete message with all parts (text, files, images, etc.)
-    // but skip recording function responses (tool call results) as they should be stored in tool call records
-    if (!isFunctionResponse(userContent)) {
-      const userMessageParts = userContent.parts || [];
-      const userMessageContent = partListUnionToString(userMessageParts);
-
-      let finalDisplayContent: Part[] | undefined = undefined;
-      if (displayContent !== undefined) {
-        const displayParts = toParts(
-          Array.isArray(displayContent) ? displayContent : [displayContent],
-        );
-        const displayContentString = partListUnionToString(displayParts);
-        if (displayContentString !== userMessageContent) {
-          finalDisplayContent = displayParts;
-        }
-      }
-
-      this.chatRecordingService.recordMessage({
-        model,
-        type: 'user',
-        content: userMessageParts,
-        displayContent: finalDisplayContent,
-      });
-    }
-
-    // Add user content to history ONCE before any attempts.
-    this.history.push(userContent);
-    const requestContents = this.getHistory(true);
-
     const streamWithRetries = async function* (
       this: GeminiChat,
     ): AsyncGenerator<StreamEvent, void, void> {
+      // Acquire the send lock inside the generator body so that if the caller
+      // obtains the generator but never iterates it, sendPromise is never
+      // locked and history is never mutated — preventing a permanent deadlock
+      // and orphaned history entries. Fixes #22521.
+      let streamDoneResolver: () => void;
+      const streamDonePromise = new Promise<void>((resolve) => {
+        streamDoneResolver = resolve;
+      });
+      this.sendPromise = streamDonePromise;
+
       try {
+        // Record user input - capture complete message with all parts (text, files, images, etc.)
+        // but skip recording function responses (tool call results) as they should be stored in tool call records
+        if (!isFunctionResponse(userContent)) {
+          const userMessageParts = userContent.parts || [];
+          const userMessageContent = partListUnionToString(userMessageParts);
+
+          let finalDisplayContent: Part[] | undefined = undefined;
+          if (displayContent !== undefined) {
+            const displayParts = toParts(
+              Array.isArray(displayContent) ? displayContent : [displayContent],
+            );
+            const displayContentString = partListUnionToString(displayParts);
+            if (displayContentString !== userMessageContent) {
+              finalDisplayContent = displayParts;
+            }
+          }
+
+          this.chatRecordingService.recordMessage({
+            model,
+            type: 'user',
+            content: userMessageParts,
+            displayContent: finalDisplayContent,
+          });
+        }
+
+        // Add user content to history ONCE before any attempts.
+        this.history.push(userContent);
+        const requestContents = this.getHistory(true);
+
         const maxAttempts = this.context.config.getMaxAttempts();
 
         for (let attempt = 0; attempt < maxAttempts; attempt++) {


### PR DESCRIPTION
## Summary

`GeminiChat.sendMessageStream` eagerly locked `sendPromise` and mutated `history` before returning the generator. If the caller obtained the generator but never iterated it, `sendPromise` never resolved — permanently deadlocking all subsequent sends on that chat instance. History was also left with an orphaned user message, corrupting the next API call with a 400 error.

## Details

`sendMessageStream` is a regular `async` function (not `async *`). The `streamDoneResolver()` that unlocks `sendPromise` lives inside the `finally` block of the returned async generator — which only runs when the generator is iterated. Moving the lock acquisition and `history.push` inside the generator body ensures no side effects occur if the generator is abandoned.

## Related Issues

Fixes #22521

## How to Validate

Run the regression tests:
`cd packages/core && npx vitest run src/core/geminiChat.test.ts`

All 51 tests should pass, including the two new tests under `sendMessageStream generator abandonment (fix #22521)`:
- `should not mutate history if the returned generator is never iterated`
- `should not deadlock subsequent calls if the returned generator is never iterated`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (added 2 regression tests)
- [ ] Noted breaking changes (if any)
