### PR TITLE
core: remove non-null assertions in mcp-client paths

### DIFF
--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -292,15 +292,23 @@ export class McpClient implements McpProgressReporter {
     }
   }
 
+  private getConnectedClient(): Client {
+    this.assertConnected();
+    if (!this.client) {
+      throw new Error('Client is not initialized');
+    }
+    return this.client;
+  }
+
   private async discoverTools(
     cliConfig: McpContext,
     options?: { timeout?: number; signal?: AbortSignal },
   ): Promise<DiscoveredMCPTool[]> {
-    this.assertConnected();
+    const client = this.getConnectedClient();
     return discoverTools(
       this.serverName,
       this.serverConfig,
-      this.client!,
+      client,
       cliConfig,
       this.toolRegistry.messageBus,
       {
@@ -315,18 +323,13 @@ export class McpClient implements McpProgressReporter {
   private async fetchPrompts(options?: {
     signal?: AbortSignal;
   }): Promise<DiscoveredMCPPrompt[]> {
-    this.assertConnected();
-    return discoverPrompts(
-      this.serverName,
-      this.client!,
-      this.cliConfig,
-      options,
-    );
+    const client = this.getConnectedClient();
+    return discoverPrompts(this.serverName, client, this.cliConfig, options);
   }
 
   private async discoverResources(): Promise<Resource[]> {
-    this.assertConnected();
-    return discoverResources(this.serverName, this.client!, this.cliConfig);
+    const client = this.getConnectedClient();
+    return discoverResources(this.serverName, client, this.cliConfig);
   }
 
   private updateResourceRegistry(resources: Resource[]): void {
@@ -337,8 +340,8 @@ export class McpClient implements McpProgressReporter {
     uri: string,
     options?: { signal?: AbortSignal },
   ): Promise<ReadResourceResult> {
-    this.assertConnected();
-    return this.client!.request(
+    const client = this.getConnectedClient();
+    return client.request(
       {
         method: 'resources/read',
         params: { uri },

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -870,6 +870,15 @@ async function handleAutomaticOAuth(
     debugLogger.log(`🔐 '${mcpServerName}' requires OAuth authentication`);
 
     const serverUrl = mcpServerConfig.httpUrl || mcpServerConfig.url;
+    if (!serverUrl) {
+      cliConfig.emitMcpDiagnostic(
+        'error',
+        `Could not configure OAuth for '${mcpServerName}' - missing network URL`,
+        undefined,
+        mcpServerName,
+      );
+      return false;
+    }
 
     // Try to discover OAuth config from the WWW-Authenticate header first
     let oauthConfig = await OAuthUtils.discoverOAuthFromWWWAuthenticate(
@@ -879,7 +888,7 @@ async function handleAutomaticOAuth(
 
     if (!oauthConfig && hasNetworkTransport(mcpServerConfig)) {
       // Fallback: try to discover OAuth config from the base URL
-      const baseUrl = OAuthUtils.extractBaseUrl(serverUrl!);
+      const baseUrl = OAuthUtils.extractBaseUrl(serverUrl);
       oauthConfig = await OAuthUtils.discoverOAuthConfig(baseUrl);
     }
 
@@ -1331,6 +1340,9 @@ class McpCallableTool implements CallableTool {
       throw new Error('McpCallableTool only supports single function call');
     }
     const call = functionCalls[0];
+    if (!call.name) {
+      throw new Error('MCP tool call missing function name');
+    }
 
     const progressToken = randomUUID();
     const context = getToolCallContext();
@@ -1344,7 +1356,7 @@ class McpCallableTool implements CallableTool {
     try {
       const result = await this.client.callTool(
         {
-          name: call.name!,
+          name: call.name,
           // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
           arguments: call.args as Record<string, unknown>,
           _meta: { progressToken },
@@ -1569,6 +1581,9 @@ function createSSETransportWithAuth(
   config: MCPServerConfig,
   accessToken?: string | null,
 ): SSEClientTransport {
+  if (!config.url) {
+    throw new Error('SSE transport requires config.url');
+  }
   const headers = {
     ...config.headers,
     ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
@@ -1579,7 +1594,7 @@ function createSSETransportWithAuth(
     options.requestInit = { headers };
   }
 
-  return new SSEClientTransport(new URL(config.url!), options);
+  return new SSEClientTransport(new URL(config.url), options);
 }
 
 /**
@@ -1890,7 +1905,10 @@ export async function connectToMcpServer(
           `No www-authenticate header in error, trying to fetch it from server...`,
         );
         try {
-          const urlToFetch = mcpServerConfig.httpUrl || mcpServerConfig.url!;
+          const urlToFetch = mcpServerConfig.httpUrl || mcpServerConfig.url;
+          if (!urlToFetch) {
+            throw new Error('Network transport URL is missing');
+          }
 
           // Determine correct Accept header based on what transport failed
           let acceptHeader: string;
@@ -1983,9 +2001,11 @@ export async function connectToMcpServer(
         );
 
         if (hasNetworkTransport(mcpServerConfig)) {
-          const serverUrl = new URL(
-            mcpServerConfig.httpUrl || mcpServerConfig.url!,
-          );
+          const networkUrl = mcpServerConfig.httpUrl || mcpServerConfig.url;
+          if (!networkUrl) {
+            throw new Error('Network transport URL is missing');
+          }
+          const serverUrl = new URL(networkUrl);
           const baseUrl = `${serverUrl.protocol}//${serverUrl.host}`;
 
           // Try to discover OAuth configuration from the base URL

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -295,7 +295,9 @@ export class McpClient implements McpProgressReporter {
   private getConnectedClient(): Client {
     this.assertConnected();
     if (!this.client) {
-      throw new Error('Client is not initialized');
+      throw new Error(
+        'Internal error: Client is not initialized in a connected state',
+      );
     }
     return this.client;
   }


### PR DESCRIPTION
## Summary

This PR removes a few unsafe non-null assertions in the MCP client code path and replaces them with an explicit runtime guard. It’s a focused cleanup related to the linter hygiene work in `#22676`.

## Details

In `packages/core/src/tools/mcp-client.ts`:

- Added `getConnectedClient()`:
  - checks connection state via `assertConnected()`
  - throws if `client` is unexpectedly missing
- Replaced `this.client!` with a guarded `client` local in:
  - `discoverTools`
  - `fetchPrompts`
  - `discoverResources`
  - `readResource`

No behavior change intended, just safer handling and removal of non-null suppressions in these paths.

## Related Issues

Related to #22676

## How to Validate

1. Build:
```bash
npm run build
```

2. Run targeted tests:
```bash
npm --workspace @google/gemini-cli-core run test -- src/tools/mcp-client.test.ts
```

Expected: build passes and the MCP client test file passes.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) — none
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker