### PR TITLE
cli: remove non-null assertions in session cleanup

### DIFF
--- a/packages/cli/src/utils/sessionCleanup.ts
+++ b/packages/cli/src/utils/sessionCleanup.ts
@@ -192,6 +192,12 @@ export async function identifySessionsToDelete(
   allFiles: SessionFileEntry[],
   retentionConfig: SessionRetentionSettings,
 ): Promise<SessionFileEntry[]> {
+  const isValidSessionEntry = (
+    entry: SessionFileEntry,
+  ): entry is SessionFileEntry & {
+    sessionInfo: NonNullable<SessionFileEntry['sessionInfo']>;
+  } => entry.sessionInfo !== null;
+
   const sessionsToDelete: SessionFileEntry[] = [];
 
   // All corrupted files should be deleted
@@ -200,7 +206,7 @@ export async function identifySessionsToDelete(
   );
 
   // Now handle valid sessions based on retention policy
-  const validSessions = allFiles.filter((entry) => entry.sessionInfo !== null);
+  const validSessions = allFiles.filter(isValidSessionEntry);
   if (validSessions.length === 0) {
     return sessionsToDelete;
   }
@@ -223,18 +229,18 @@ export async function identifySessionsToDelete(
   // Sort valid sessions by lastUpdated (newest first) for count-based retention
   const sortedValidSessions = [...validSessions].sort(
     (a, b) =>
-      new Date(b.sessionInfo!.lastUpdated).getTime() -
-      new Date(a.sessionInfo!.lastUpdated).getTime(),
+      new Date(b.sessionInfo.lastUpdated).getTime() -
+      new Date(a.sessionInfo.lastUpdated).getTime(),
   );
 
   // Separate deletable sessions from the active session
   const deletableSessions = sortedValidSessions.filter(
-    (entry) => !entry.sessionInfo!.isCurrentSession,
+    (entry) => !entry.sessionInfo.isCurrentSession,
   );
 
   // Calculate how many deletable sessions to keep (accounting for the active session)
   const hasActiveSession = sortedValidSessions.some(
-    (e) => e.sessionInfo!.isCurrentSession,
+    (e) => e.sessionInfo.isCurrentSession,
   );
   const maxDeletableSessions =
     retentionConfig.maxCount && hasActiveSession
@@ -243,7 +249,7 @@ export async function identifySessionsToDelete(
 
   for (let i = 0; i < deletableSessions.length; i++) {
     const entry = deletableSessions[i];
-    const session = entry.sessionInfo!;
+    const session = entry.sessionInfo;
 
     let shouldDelete = false;
 


### PR DESCRIPTION
## Summary

This PR removes unsafe non-null assertions in session cleanup logic by narrowing valid session entries with a type guard. It keeps behavior the same while making the code safer and easier to reason about.

## Details

In `packages/cli/src/utils/sessionCleanup.ts` (`identifySessionsToDelete`):

- Added a local type guard `isValidSessionEntry` to narrow entries where `sessionInfo` is non-null.
- Replaced `sessionInfo!` usages in sorting, filtering, active-session detection, and loop processing with safely narrowed access.

No functional changes intended; this is a type-safety cleanup related to linter hygiene work.

## Related Issues

Related to #22676

## How to Validate

1. Run targeted tests:
```bash
npm --workspace @google/gemini-cli run test -- src/utils/sessionCleanup.test.ts src/utils/toolOutputCleanup.test.ts
```

2. Build CLI workspace:
```bash
npm --workspace @google/gemini-cli run build
```

Expected:
- Tests pass.
- Build succeeds.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed) *(no new tests required; existing relevant tests pass)*
- [x] Noted breaking changes (if any) *(none)*
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker