### PR TITLE
fix(core): preserve a2a contextId and reset zombie taskIds in remote invocation

### DIFF
--- a/packages/core/src/agents/remote-invocation.test.ts
+++ b/packages/core/src/agents/remote-invocation.test.ts
@@ -370,6 +370,140 @@ describe('RemoteAgentInvocation', () => {
       );
     });
 
+    it('should correctly accept an empty string contextId to clear the context', async () => {
+      mockClientManager.getClient.mockReturnValue({});
+
+      // First call: Agent sets an active contextId
+      mockClientManager.sendMessageStream.mockImplementationOnce(
+        async function* () {
+          yield {
+            kind: 'message',
+            messageId: 'msg-1',
+            role: 'agent',
+            parts: [{ kind: 'text', text: 'Response 1' }],
+            contextId: 'ctx-1',
+            taskId: 'task-1',
+          };
+        },
+      );
+
+      const invocation1 = new RemoteAgentInvocation(
+        mockDefinition,
+        { query: 'first' },
+        mockMessageBus,
+      );
+      await invocation1.execute(new AbortController().signal);
+
+      // Second call: Agent explicitly clears the context by returning an empty string
+      mockClientManager.sendMessageStream.mockImplementationOnce(
+        async function* () {
+          yield {
+            kind: 'message',
+            messageId: 'msg-2',
+            role: 'agent',
+            parts: [{ kind: 'text', text: 'Context Cleared' }],
+            contextId: '', // Empty string should be respected, not treated as falsy and ignored
+            taskId: 'task-1',
+          };
+        },
+      );
+
+      const invocation2 = new RemoteAgentInvocation(
+        mockDefinition,
+        { query: 'second' },
+        mockMessageBus,
+      );
+      await invocation2.execute(new AbortController().signal);
+
+      // Third call: Should send the empty string contextId, proving it wasn't ignored
+      mockClientManager.sendMessageStream.mockImplementationOnce(
+        async function* () {
+          yield {
+            kind: 'message',
+            messageId: 'msg-3',
+            role: 'agent',
+            parts: [{ kind: 'text', text: 'New Context' }],
+          };
+        },
+      );
+
+      const invocation3 = new RemoteAgentInvocation(
+        mockDefinition,
+        { query: 'third' },
+        mockMessageBus,
+      );
+      await invocation3.execute(new AbortController().signal);
+
+      expect(mockClientManager.sendMessageStream).toHaveBeenLastCalledWith(
+        'test-agent',
+        'third',
+        { contextId: '', taskId: 'task-1', signal: expect.any(Object) },
+      );
+    });
+
+    it('should prevent trailing artifact updates from resurrecting a cleared taskId', async () => {
+      mockClientManager.getClient.mockReturnValue({});
+
+      mockClientManager.sendMessageStream.mockImplementationOnce(
+        async function* () {
+          // 1. Task indicates it is done
+          yield {
+            kind: 'task',
+            id: 'task-1',
+            status: { state: 'completed', message: undefined },
+            artifacts: [],
+            history: [],
+          };
+          // 2. A trailing artifact update arrives AFTER the task is terminal.
+          // This used to cause `clearTaskId` to be false for this chunk, resurrecting `task-1`.
+          yield {
+            kind: 'artifact-update',
+            taskId: 'task-1',
+            append: false,
+            artifact: {
+              artifactId: 'art-1',
+              name: 'Result',
+              parts: [{ kind: 'text', text: 'Final Artifact' }],
+            },
+          };
+        },
+      );
+
+      const invocation1 = new RemoteAgentInvocation(
+        mockDefinition,
+        { query: 'first' },
+        mockMessageBus,
+      );
+      await invocation1.execute(new AbortController().signal);
+
+      // Second call: Should start a new task because the previous one was terminal,
+      // despite the trailing artifact update.
+      mockClientManager.sendMessageStream.mockImplementationOnce(
+        async function* () {
+          yield {
+            kind: 'message',
+            messageId: 'msg-2',
+            role: 'agent',
+            parts: [{ kind: 'text', text: 'New Task' }],
+          };
+        },
+      );
+
+      const invocation2 = new RemoteAgentInvocation(
+        mockDefinition,
+        { query: 'second' },
+        mockMessageBus,
+      );
+      await invocation2.execute(new AbortController().signal);
+
+      expect(mockClientManager.sendMessageStream).toHaveBeenLastCalledWith(
+        'test-agent',
+        'second',
+        // taskId should be undefined, not 'task-1'
+        { contextId: undefined, taskId: undefined, signal: expect.any(Object) },
+      );
+    });
+
     it('should handle streaming updates and reassemble output', async () => {
       mockClientManager.getClient.mockReturnValue({});
       mockClientManager.sendMessageStream.mockImplementation(

--- a/packages/core/src/agents/remote-invocation.ts
+++ b/packages/core/src/agents/remote-invocation.ts
@@ -156,6 +156,8 @@ export class RemoteAgentInvocation extends BaseToolInvocation<
 
       let finalResponse: SendMessageResult | undefined;
 
+      let isSessionTerminal = false;
+
       for await (const chunk of stream) {
         if (_signal.aborted) {
           throw new Error('Operation aborted');
@@ -173,11 +175,17 @@ export class RemoteAgentInvocation extends BaseToolInvocation<
           clearTaskId,
         } = extractIdsFromResponse(chunk);
 
-        if (newContextId) {
+        if (newContextId !== undefined) {
           this.contextId = newContextId;
         }
 
-        this.taskId = clearTaskId ? undefined : (newTaskId ?? this.taskId);
+        if (clearTaskId) {
+          isSessionTerminal = true;
+        }
+
+        this.taskId = isSessionTerminal
+          ? undefined
+          : (newTaskId ?? this.taskId);
       }
 
       if (!finalResponse) {


### PR DESCRIPTION
# Walkthrough: A2A Client Context ID Fixes

## Goal
The user identified a critical issue with `contextId` handling in the A2A client implementation: stateful interactions were at risk because `contextId` was not always being properly passed back to the remote agent in every request. The goal was to verify the implementation in `a2a-client-manager.ts` and its callers, and ensure both `taskId` and `contextId` are correctly managed.

## Investigation

I investigated the core A2A client architecture:
1.  **`A2AClientManager` (`packages/core/src/agents/a2a-client-manager.ts`)**: Confirmed that `sendMessageStream` correctly extracts `contextId` and `taskId` from the `options` object and embeds them into `messageParams.message`. No bugs here.
2.  **`extractIdsFromResponse` (`packages/core/src/agents/a2aUtils.ts`)**: Confirmed this helper accurately pulls `contextId` and `taskId` (and calculates the boolean `clearTaskId`) from all 4 chunk kinds (`message`, `task`, `status-update`, `artifact-update`).
3.  **`RemoteAgentInvocation` (`packages/core/src/agents/remote-invocation.ts`)**: Examined the `sessionState` persistence layer and the `execute()` loop. This is where the bugs were found.

## Bugs Identified & Fixed

In `RemoteAgentInvocation.execute()`, I found two closely-related state tracking bugs:

### Bug 1: The Falsy `contextId` Check
```typescript
// BEFORE
if (newContextId) {
  this.contextId = newContextId;
}
```
Because an empty string `""` is falsy in JavaScript, if a remote agent intentionally sent back `contextId: ""` to instruct the client to reset/clear the context, the client ignored it. It kept using the old `contextId` for subsequent turns.

**Fix**: Changed the condition to strict undefined checking: `if (newContextId !== undefined) { ... }`.

### Bug 2: `taskId` Resurrection (Zombie Task IDs)
When a task finishes, the A2A spec requires the client to stop sending the `taskId` on subsequent messages so a new task can implicitly start. `extractIdsFromResponse()` signals this by returning `clearTaskId: true`.

However, the `execute()` loop evaluated state on a *per-chunk* basis without remembering previous chunks in the same stream. If an agent returned a terminal `status-update` (yielding `clearTaskId: true`) but then *immediately* streamed a trailing `artifact-update` or `message` (yielding `clearTaskId: false` but still containing the old `taskId`), the client would bounce from `this.taskId = undefined` right back to `this.taskId = oldTaskId`.

**Fix**: Introduced a loop-scoped flag `let isSessionTerminal = false;` tracking if *any* chunk in the current stream requested a clear.

## Code Changes

I applied these fixes to `packages/core/src/agents/remote-invocation.ts`:

render_diffs(file:///Users/adamfweidman/Desktop/vars/gemini-cli/packages/core/src/agents/remote-invocation.ts)

## Verification
I wrote two new unit tests in `packages/core/src/agents/remote-invocation.test.ts` to codify these edge cases and prevent future regressions:

1.  `'should correctly accept an empty string contextId to clear the context'`: Proves that sending `""` successfully clears `contextId` for the next request.
2.  `'should prevent trailing artifact updates from resurrecting a cleared taskId'`: Proves that a trailing chunk after a terminal status update does not resurrect the `taskId`.

All 21 tests in `remote-invocation.test.ts` passed successfully.

To finalize, I ran the entire build, typing, and linting pipeline via `npm run preflight`. The pipeline succeeded in ~5 minutes without regressions.
