### PR TITLE
fix(config): ensure discoveryMaxDirs is passed to global config during initialization

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -738,7 +738,7 @@ export async function loadCliConfig(
     loadMemoryFromIncludeDirectories:
       settings.context?.loadMemoryFromIncludeDirectories || false,
     discoveryMaxDirs: settings.context?.discoveryMaxDirs,
-    importFormat: settings.context?.importFormat || 'tree',
+    importFormat: settings.context?.importFormat,
     debugMode,
     question,
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -737,6 +737,8 @@ export async function loadCliConfig(
     includeDirectories,
     loadMemoryFromIncludeDirectories:
       settings.context?.loadMemoryFromIncludeDirectories || false,
+    discoveryMaxDirs: settings.context?.discoveryMaxDirs,
+    importFormat: settings.context?.importFormat || 'tree',
     debugMode,
     question,
 


### PR DESCRIPTION
## Summary

Fixes a race condition in memory discovery where `2nd-level` `GEMINI/AGENTS.md` files intermittently appear in the `/memory` list, even when `context.discoveryMaxDirs` is set to `0`. This ensures that user-configured discovery limits are strictly adhered to during background memory refreshes.

## Details

Previously, the `discoveryMaxDirs` and `importFormat` settings were read and respected during the initial memory load, but they were omitted when constructing the global `Config` instance in `packages/cli/src/config/config.ts`. Consequently, the global `Config` object fell back to the default `discoveryMaxDirs` limit of `200`.

Later, when extensions finished loading and triggered `refreshServerHierarchicalMemory()`, the refresh utilized the global config's default limit (`200`) instead of the user's configured limit (`0`). This caused the BFS file scanner to incorrectly explore subdirectories and pick up unintended memory files. 

This PR fixes the issue by correctly passing `discoveryMaxDirs` and `importFormat` directly from `settings.context` into the `ConfigParams` during CLI initialization.

## Related Issues

Fixes #22742

## How to Validate

1. Open your `settings.json` and set `"context": { "discoveryMaxDirs": 0 }`.
2. Ensure you have extensions installed/linked.
3. Create a nested `GEMINI.md` or `GEMINI/AGENTS.md` file deep within your local workspace directory.
4. Launch the CLI locally (`npm run start`).
5. After the CLI starts and the extensions finish linking (which triggers the background memory refresh), run the `/memory` command.
6. **Expected Result**: The nested `GEMINI.md` or `GEMINI/AGENTS.md` file should **not** appear in the memory list, strictly respecting the `0` directory depth limit.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

