### PR TITLE
chore(review): unify agent-assisted review guidance

### DIFF
--- a/.gemini/commands/oncall/pr-review.toml
+++ b/.gemini/commands/oncall/pr-review.toml
@@ -5,6 +5,9 @@ prompt = """
 
 Today, our mission is to meticulously review community pull requests (PRs) for this project. We will proceed systematically, evaluating each candidate PR for its quality, adherence to standards, and readiness for merging.
 
+Before you start, load and enforce the shared review rules in:
+!{cat .gemini/commands/strict-development-rules.md}
+
 ### Workflow:
 
 1.  **PR Preparation & Initial Assessment**:

--- a/.gemini/commands/strict-development-rules.md
+++ b/.gemini/commands/strict-development-rules.md
@@ -1,5 +1,9 @@
 # Gemini CLI Strict Development Rules
 
+This file is the single source of truth for agent-assisted review rules in this
+repository. If you want to add, remove, or change review guidance, update this
+file and ensure all review entry points continue to reference it.
+
 These rules apply strictly to all code modifications and additions within the
 Gemini CLI project.
 

--- a/.gemini/skills/code-reviewer/SKILL.md
+++ b/.gemini/skills/code-reviewer/SKILL.md
@@ -27,13 +27,15 @@ This skill guides the agent in conducting professional and thorough code reviews
     ```bash
     npm run preflight
     ```
-3.  **Context**: Read the PR description and any existing comments to understand the goal and history.
+3.  **Shared Rules**: Read `.gemini/commands/strict-development-rules.md` and apply it as the canonical review rule set.
+4.  **Context**: Read the PR description and any existing comments to understand the goal and history.
 
 #### For Local Changes:
 1.  **Identify Changes**:
     *   Check status: `git status`
     *   Read diffs: `git diff` (working tree) and/or `git diff --staged` (staged).
-2.  **Preflight (Optional)**: If the changes are substantial, ask the user if they want to run `npm run preflight` before reviewing.
+2.  **Shared Rules**: Read `.gemini/commands/strict-development-rules.md` and apply it as the canonical review rule set.
+3.  **Preflight (Optional)**: If the changes are substantial, ask the user if they want to run `npm run preflight` before reviewing.
 
 ### 3. In-Depth Analysis
 Analyze the code changes based on the following pillars:


### PR DESCRIPTION
## Summary

Unifies agent-assisted PR review guidance so review entry points use a shared canonical ruleset, reducing drift between review configurations.

## Details

- Declares `.gemini/commands/strict-development-rules.md` as the single source of truth for agent-assisted review guidance.
- Updates `.gemini/commands/oncall/pr-review.toml` to explicitly load and enforce the shared rules.
- Updates `.gemini/skills/code-reviewer/SKILL.md` so both remote-PR and local-change workflows explicitly apply the same shared rules.

## Related Issues

Closes #21479

## How to Validate

1. Open `.gemini/commands/oncall/pr-review.toml` and verify it includes:
   - `!{cat .gemini/commands/strict-development-rules.md}`
2. Open `.gemini/skills/code-reviewer/SKILL.md` and verify both workflows (remote PR and local changes) instruct loading `.gemini/commands/strict-development-rules.md`.
3. Open `.gemini/commands/strict-development-rules.md` and verify it explicitly states it is the canonical source for agent-assisted review rules.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
  - [x] Windows
    - [x] npm run
  - [x] Linux
    - [x] npm run