### PR TITLE
fix(core): handle surrogate pairs in truncateString

### DIFF
--- a/packages/core/src/utils/textUtils.test.ts
+++ b/packages/core/src/utils/textUtils.test.ts
@@ -102,6 +102,22 @@ describe('truncateString', () => {
   it('should handle empty string', () => {
     expect(truncateString('', 5)).toBe('');
   });
+
+  it('should not slice surrogate pairs', () => {
+    const emoji = '😭'; // \uD83D\uDE2D, length 2
+    const str = 'a' + emoji; // length 3
+    // Truncating at length 2 would break the emoji pair
+    expect(truncateString(str, 2, '')).toBe('a');
+    expect(truncateString(str, 1, '')).toBe('a');
+    expect(truncateString(emoji, 1, '')).toBe('');
+    expect(truncateString(emoji, 2, '')).toBe(emoji);
+  });
+
+  it('should handle pre-existing dangling high surrogates at the cut point', () => {
+    // \uD83D is a high surrogate without a following low surrogate
+    const str = 'a\uD83Db';
+    expect(truncateString(str, 2, '')).toBe('a');
+  });
 });
 
 describe('safeTemplateReplace', () => {

--- a/packages/core/src/utils/textUtils.test.ts
+++ b/packages/core/src/utils/textUtils.test.ts
@@ -118,6 +118,16 @@ describe('truncateString', () => {
     const str = 'a\uD83Db';
     expect(truncateString(str, 2, '')).toBe('a');
   });
+
+  it('should handle multi-code-point grapheme clusters like combining marks', () => {
+    const combinedChar = 'e\u0301'; // 'é' (length 2)
+    const str = 'a' + combinedChar; // length 3
+    // Truncating at length 2 would break the 'é'
+    expect(truncateString(str, 2, '')).toBe('a');
+    expect(truncateString(str, 1, '')).toBe('a');
+    expect(truncateString(combinedChar, 1, '')).toBe('');
+    expect(truncateString(combinedChar, 2, '')).toBe(combinedChar);
+  });
 });
 
 describe('safeTemplateReplace', () => {

--- a/packages/core/src/utils/textUtils.test.ts
+++ b/packages/core/src/utils/textUtils.test.ts
@@ -106,7 +106,8 @@ describe('truncateString', () => {
   it('should not slice surrogate pairs', () => {
     const emoji = '😭'; // \uD83D\uDE2D, length 2
     const str = 'a' + emoji; // length 3
-    // Truncating at length 2 would break the emoji pair
+
+    // We expect 'a' (len 1). Adding the emoji (len 2) would make it 3, exceeding maxLength 2.
     expect(truncateString(str, 2, '')).toBe('a');
     expect(truncateString(str, 1, '')).toBe('a');
     expect(truncateString(emoji, 1, '')).toBe('');
@@ -116,16 +117,27 @@ describe('truncateString', () => {
   it('should handle pre-existing dangling high surrogates at the cut point', () => {
     // \uD83D is a high surrogate without a following low surrogate
     const str = 'a\uD83Db';
+    // 'a' (1) + '\uD83D' (1) = 2.
+    // BUT our function should strip the dangling surrogate for safety.
     expect(truncateString(str, 2, '')).toBe('a');
   });
 
   it('should handle multi-code-point grapheme clusters like combining marks', () => {
-    const combinedChar = 'e\u0301'; // 'é' (length 2)
-    const str = 'a' + combinedChar; // length 3
-    // Truncating at length 2 would break the 'é'
+    // FORCE Decomposed form (NFD) to ensure 'e' + 'accent' are separate code units
+    // This ensures the test behaves the same on Linux and Mac.
+    const combinedChar = 'e\u0301'.normalize('NFD');
+
+    // In NFD, combinedChar.length is 2.
+    const str = 'a' + combinedChar; // 'a' + 'e' + '\u0301' (length 3)
+
+    // Truncating at 2: 'a' (1) + 'e\u0301' (2) = 3. Too long, should stay at 'a'.
     expect(truncateString(str, 2, '')).toBe('a');
     expect(truncateString(str, 1, '')).toBe('a');
+
+    // Truncating combinedChar (len 2) at maxLength 1: too long, should be empty.
     expect(truncateString(combinedChar, 1, '')).toBe('');
+
+    // Truncating combinedChar (len 2) at maxLength 2: fits perfectly.
     expect(truncateString(combinedChar, 2, '')).toBe(combinedChar);
   });
 });

--- a/packages/core/src/utils/textUtils.ts
+++ b/packages/core/src/utils/textUtils.ts
@@ -81,16 +81,28 @@ export function truncateString(
     return str;
   }
 
-  const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+  // This regex matches a "Grapheme Cluster" manually:
+  // 1. A surrogate pair OR a single character...
+  // 2. Followed by any number of "Combining Marks" (\p{M})
+  // 'u' flag is required for Unicode property escapes
+  const graphemeRegex = /(?:[\uD800-\uDBFF][\uDC00-\uDFFF]|.)\p{M}*/gu;
+
   let truncatedStr = '';
-  for (const { segment } of segmenter.segment(str)) {
+  let match: RegExpExecArray | null;
+
+  while ((match = graphemeRegex.exec(str)) !== null) {
+    const segment = match[0];
+
+    // If adding the whole cluster (base char + accent) exceeds maxLength, stop.
     if (truncatedStr.length + segment.length > maxLength) {
       break;
     }
+
     truncatedStr += segment;
+    if (truncatedStr.length >= maxLength) break;
   }
 
-  // Double-check if we ended with a dangling high surrogate (e.g. if the input was malformed).
+  // Final safety check for dangling high surrogates
   if (truncatedStr.length > 0) {
     const lastCode = truncatedStr.charCodeAt(truncatedStr.length - 1);
     if (lastCode >= 0xd800 && lastCode <= 0xdbff) {

--- a/packages/core/src/utils/textUtils.ts
+++ b/packages/core/src/utils/textUtils.ts
@@ -80,7 +80,17 @@ export function truncateString(
   if (str.length <= maxLength) {
     return str;
   }
-  return str.slice(0, maxLength) + suffix;
+
+  let actualMaxLength = maxLength;
+  const lastCode = str.charCodeAt(maxLength - 1);
+  // If the last character is a high surrogate, it's either the start of a pair
+  // that we're about to slice, or it was already a dangling surrogate.
+  // In either case, we should remove it to ensure a valid UTF-16 string.
+  if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+    actualMaxLength--;
+  }
+
+  return str.slice(0, actualMaxLength) + suffix;
 }
 
 /**

--- a/packages/core/src/utils/textUtils.ts
+++ b/packages/core/src/utils/textUtils.ts
@@ -81,16 +81,24 @@ export function truncateString(
     return str;
   }
 
-  let actualMaxLength = maxLength;
-  const lastCode = str.charCodeAt(maxLength - 1);
-  // If the last character is a high surrogate, it's either the start of a pair
-  // that we're about to slice, or it was already a dangling surrogate.
-  // In either case, we should remove it to ensure a valid UTF-16 string.
-  if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
-    actualMaxLength--;
+  const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+  let truncatedStr = '';
+  for (const { segment } of segmenter.segment(str)) {
+    if (truncatedStr.length + segment.length > maxLength) {
+      break;
+    }
+    truncatedStr += segment;
   }
 
-  return str.slice(0, actualMaxLength) + suffix;
+  // Double-check if we ended with a dangling high surrogate (e.g. if the input was malformed).
+  if (truncatedStr.length > 0) {
+    const lastCode = truncatedStr.charCodeAt(truncatedStr.length - 1);
+    if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+      truncatedStr = truncatedStr.slice(0, -1);
+    }
+  }
+
+  return truncatedStr + suffix;
 }
 
 /**


### PR DESCRIPTION
## Summary
`truncateString` now robustly handles UTF-16 surrogate pairs by ensuring it never returns a dangling high surrogate at the truncation point.

## Details
When a string is truncated at a position that falls within a surrogate pair, or if the input string already ends with an orphaned high surrogate at the truncation point, the function now removes that surrogate to ensure the resulting string is well-formed UTF-16. This prevents potential API crashes downstream.

## Related Issues
Fixes #22753

## How to Validate
Run the updated tests:
```bash
npm test -w @google/gemini-cli-core -- src/utils/textUtils.test.ts
```

## Pre-Merge Checklist
- [x] Added/updated tests (if needed)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
