### PR TITLE
feat(cli): add /fork command for session branching

### DIFF
--- a/docs/cli/fork.md
+++ b/docs/cli/fork.md
@@ -1,0 +1,95 @@
+# Fork
+
+The `/fork` command creates an independent copy of your current conversation
+session. This allows you to explore different directions from the same
+conversation point without write conflicts that occur when using `--resume` in
+multiple terminals.
+
+## Problem it solves
+
+When you use `--resume` in multiple terminals to work on the same session, both
+processes write to the same session file with no locking. This can lead to data
+loss due to last-write-wins corruption.
+
+The `/fork` command solves this by creating a completely independent session
+with its own file, allowing safe parallel work.
+
+## Usage
+
+To fork your current session, simply type `/fork` into the input prompt and
+press **Enter**.
+
+## Output
+
+When you create a fork, you'll see a confirmation message with:
+
+1.  **Short ID:** An 8-character identifier for your forked session
+2.  **Resume command:** The exact command to resume the fork in another terminal
+3.  **Browse hint:** A reminder that you can list all sessions with `/chat`
+
+Example output:
+
+```text
+> /fork
+Fork saved (a1b2c3d4).
+Resume with: gemini --resume a1b2c3d4
+Or browse sessions with: /chat
+```
+
+## Use cases
+
+### Explore a risky path
+
+Fork before attempting a large refactor or experimental change. If it goes
+wrong, the original session remains untouched and you can simply resume it
+instead.
+
+```text
+1. Start working on a feature
+2. Run /fork to save your current state
+3. Attempt the risky refactor in the current session
+4. If it fails, use /chat to find and resume your fork
+```
+
+### Compare approaches
+
+Resume the fork in another terminal to try a different implementation approach
+while keeping the original session intact.
+
+```text
+Terminal 1: Original session
+> /fork
+Fork saved (a1b2c3d4).
+Resume with: gemini --resume a1b2c3d4
+
+Terminal 2: Forked session
+$ gemini --resume a1b2c3d4
+> Now you can explore a different direction
+```
+
+### Hand off a sub-task
+
+Fork your session so a separate window handles a parallel workstream, allowing
+you to work on two related tasks simultaneously without conflicts.
+
+## Key considerations
+
+- **Independent sessions:** Each fork is a completely independent session with
+  its own file. Changes in one session don't affect the other.
+- **Full conversation copy:** The fork includes all messages, context, and
+  history from the original session at the time of forking.
+- **New session ID:** The fork receives a new unique session ID for proper
+  tracking and resumption.
+- **No file locking needed:** Since each fork has its own file, there's no risk
+  of write conflicts or data corruption.
+- **Discoverable:** Forks appear in `/chat` listings alongside your regular
+  sessions, making them easy to find and resume.
+
+## Combining with other commands
+
+The `/fork` command composes well with other session management commands:
+
+- **`/fork` + `/rewind`:** Fork to preserve your current state, then rewind to
+  explore earlier points
+- **`/chat`:** Browse and select from all your sessions including forks
+- **`--resume`:** Resume any fork by its short ID or index number

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -132,6 +132,7 @@
             "badge": "🔬",
             "slug": "docs/core/remote-agents"
           },
+          { "label": "Fork", "slug": "docs/cli/fork" },
           { "label": "Rewind", "slug": "docs/cli/rewind" },
           { "label": "Sandboxing", "slug": "docs/cli/sandbox" },
           { "label": "Settings", "slug": "docs/cli/settings" },

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -49,6 +49,7 @@ import { policiesCommand } from '../ui/commands/policiesCommand.js';
 import { privacyCommand } from '../ui/commands/privacyCommand.js';
 import { profileCommand } from '../ui/commands/profileCommand.js';
 import { quitCommand } from '../ui/commands/quitCommand.js';
+import { forkCommand } from '../ui/commands/forkCommand.js';
 import { restoreCommand } from '../ui/commands/restoreCommand.js';
 import { resumeCommand } from '../ui/commands/resumeCommand.js';
 import { statsCommand } from '../ui/commands/statsCommand.js';
@@ -154,6 +155,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
             },
           ]
         : [extensionsCommand(this.config?.getEnableExtensionReloading())]),
+      forkCommand,
       helpCommand,
       footerCommand,
       shortcutsCommand,

--- a/packages/cli/src/ui/commands/forkCommand.test.ts
+++ b/packages/cli/src/ui/commands/forkCommand.test.ts
@@ -1,0 +1,313 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { forkCommand } from './forkCommand.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import type { Config, ConversationRecord } from '@google/gemini-cli-core';
+
+// Mock fs module
+vi.mock('node:fs/promises', () => ({
+  readdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  stat: vi.fn(),
+}));
+
+import * as fs from 'node:fs/promises';
+
+describe('forkCommand', () => {
+  let mockConfig: Config;
+  const testSessionId = 'abc12345-1234-1234-1234-abcdef123456';
+  const testShortId = testSessionId.slice(0, 8);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock config
+    mockConfig = {
+      getSessionId: vi.fn().mockReturnValue(testSessionId),
+      storage: {
+        getProjectTempDir: vi.fn().mockReturnValue('/tmp/test-project'),
+      },
+    } as unknown as Config;
+  });
+
+  it('should return error when config is null', async () => {
+    const nullConfigContext = createMockCommandContext({
+      services: {
+        config: null,
+      },
+    });
+
+    if (!forkCommand.action) {
+      throw new Error('forkCommand must have an action.');
+    }
+
+    const result = await forkCommand.action(nullConfigContext, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Cannot fork: No active session.',
+    });
+  });
+
+  it('should return error when no session files are found', async () => {
+    const mockContext = createMockCommandContext({
+      services: {
+        config: mockConfig,
+      },
+    });
+
+    vi.mocked(fs.readdir).mockResolvedValue([]);
+
+    if (!forkCommand.action) {
+      throw new Error('forkCommand must have an action.');
+    }
+
+    const result = await forkCommand.action(mockContext, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Cannot fork: No active session file found.',
+    });
+  });
+
+  it('should successfully fork a session and return success message', async () => {
+    const mockContext = createMockCommandContext({
+      services: {
+        config: mockConfig,
+      },
+    });
+
+    const mockConversation: ConversationRecord = {
+      sessionId: testSessionId,
+      projectHash: 'test-project-hash',
+      startTime: new Date().toISOString(),
+      lastUpdated: new Date().toISOString(),
+      messages: [],
+      kind: 'main',
+    };
+
+    vi.mocked(fs.readdir).mockResolvedValue([
+      `session-2025-03-17T12-00-00-${testShortId}.json`,
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+
+    vi.mocked(fs.stat).mockResolvedValue({
+      mtimeMs: Date.now(),
+    } as Awaited<ReturnType<typeof fs.stat>>);
+
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(mockConversation));
+
+    vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+
+    if (!forkCommand.action) {
+      throw new Error('forkCommand must have an action.');
+    }
+
+    const result = await forkCommand.action(mockContext, '');
+
+    expect(result).toBeDefined();
+    if (result && typeof result === 'object' && 'type' in result) {
+      expect(result.type).toBe('message');
+      if ('messageType' in result) {
+        expect(result.messageType).toBe('info');
+      }
+      if ('content' in result && typeof result.content === 'string') {
+        expect(result.content).toMatch(/^Fork saved \([a-f0-9]{8}\)\./);
+        expect(result.content).toMatch(
+          /Resume with: gemini --resume [a-f0-9]{8}/,
+        );
+        expect(result.content).toMatch(/Or browse sessions with: \/chat/);
+      }
+    }
+
+    // Verify write was called
+    expect(fs.writeFile).toHaveBeenCalled();
+  });
+
+  it('should handle multiple session files by selecting the most recent', async () => {
+    const mockContext = createMockCommandContext({
+      services: {
+        config: mockConfig,
+      },
+    });
+
+    const mockConversation: ConversationRecord = {
+      sessionId: testSessionId,
+      projectHash: 'test-project-hash',
+      startTime: new Date().toISOString(),
+      lastUpdated: new Date().toISOString(),
+      messages: [],
+      kind: 'main',
+    };
+
+    const now = Date.now();
+    const olderFile = `session-2025-03-17T10-00-00-${testShortId}.json`;
+    const newerFile = `session-2025-03-17T12-00-00-${testShortId}.json`;
+
+    vi.mocked(fs.readdir).mockResolvedValue([
+      olderFile,
+      newerFile,
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+
+    vi.mocked(fs.stat).mockImplementation(async (filePath) => {
+      if (filePath.toString().includes('10-00-00')) {
+        return { mtimeMs: now - 3600000 } as Awaited<
+          ReturnType<typeof fs.stat>
+        >;
+      }
+      return { mtimeMs: now } as Awaited<ReturnType<typeof fs.stat>>;
+    });
+
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(mockConversation));
+
+    vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+
+    if (!forkCommand.action) {
+      throw new Error('forkCommand must have an action.');
+    }
+
+    const result = await forkCommand.action(mockContext, '');
+
+    expect(result).toBeDefined();
+    if (result && typeof result === 'object' && 'type' in result) {
+      expect(result.type).toBe('message');
+    }
+
+    // Verify it read the newer file
+    expect(fs.readFile).toHaveBeenCalledWith(
+      expect.stringContaining('12-00-00'),
+      'utf8',
+    );
+  });
+
+  it('should return error message when file read fails', async () => {
+    const mockContext = createMockCommandContext({
+      services: {
+        config: mockConfig,
+      },
+    });
+
+    vi.mocked(fs.readdir).mockResolvedValue([
+      `session-2025-03-17T12-00-00-${testShortId}.json`,
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+
+    vi.mocked(fs.stat).mockResolvedValue({
+      mtimeMs: Date.now(),
+    } as Awaited<ReturnType<typeof fs.stat>>);
+
+    vi.mocked(fs.readFile).mockRejectedValue(
+      new Error('EACCES: permission denied'),
+    );
+
+    if (!forkCommand.action) {
+      throw new Error('forkCommand must have an action.');
+    }
+
+    const result = await forkCommand.action(mockContext, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Failed to fork session: EACCES: permission denied',
+    });
+  });
+
+  it('should return error message when file write fails', async () => {
+    const mockContext = createMockCommandContext({
+      services: {
+        config: mockConfig,
+      },
+    });
+
+    const mockConversation: ConversationRecord = {
+      sessionId: testSessionId,
+      projectHash: 'test-project-hash',
+      startTime: new Date().toISOString(),
+      lastUpdated: new Date().toISOString(),
+      messages: [],
+      kind: 'main',
+    };
+
+    vi.mocked(fs.readdir).mockResolvedValue([
+      `session-2025-03-17T12-00-00-${testShortId}.json`,
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+
+    vi.mocked(fs.stat).mockResolvedValue({
+      mtimeMs: Date.now(),
+    } as Awaited<ReturnType<typeof fs.stat>>);
+
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(mockConversation));
+
+    vi.mocked(fs.writeFile).mockRejectedValue(
+      new Error('ENOSPC: no space left on device'),
+    );
+
+    if (!forkCommand.action) {
+      throw new Error('forkCommand must have an action.');
+    }
+
+    const result = await forkCommand.action(mockContext, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Failed to fork session: ENOSPC: no space left on device',
+    });
+  });
+
+  it('should create forked conversation with new session ID and updated timestamp', async () => {
+    const mockContext = createMockCommandContext({
+      services: {
+        config: mockConfig,
+      },
+    });
+
+    const mockConversation: ConversationRecord = {
+      sessionId: testSessionId,
+      projectHash: 'test-project-hash',
+      startTime: '2025-03-17T10:00:00.000Z',
+      lastUpdated: '2025-03-17T12:00:00.000Z',
+      messages: [],
+      kind: 'main',
+    };
+
+    vi.mocked(fs.readdir).mockResolvedValue([
+      `session-2025-03-17T12-00-00-${testShortId}.json`,
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+
+    vi.mocked(fs.stat).mockResolvedValue({
+      mtimeMs: Date.now(),
+    } as Awaited<ReturnType<typeof fs.stat>>);
+
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(mockConversation));
+
+    let writtenConversation: ConversationRecord | null = null;
+    vi.mocked(fs.writeFile).mockImplementation(async (_path, content) => {
+      writtenConversation = JSON.parse(content as string);
+    });
+
+    if (!forkCommand.action) {
+      throw new Error('forkCommand must have an action.');
+    }
+
+    await forkCommand.action(mockContext, '');
+
+    expect(writtenConversation).not.toBeNull();
+    expect(writtenConversation!.sessionId).not.toBe(testSessionId);
+    expect(writtenConversation!.sessionId).toMatch(
+      /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/,
+    );
+    expect(writtenConversation!.projectHash).toBe(mockConversation.projectHash);
+    expect(writtenConversation!.startTime).toBe(mockConversation.startTime);
+    expect(writtenConversation!.lastUpdated).not.toBe(
+      mockConversation.lastUpdated,
+    );
+  });
+});

--- a/packages/cli/src/ui/commands/forkCommand.ts
+++ b/packages/cli/src/ui/commands/forkCommand.ts
@@ -44,7 +44,9 @@ export const forkCommand: SlashCommand = {
       const shortSessionId = currentSessionId.slice(0, 8);
       const files = await fs.readdir(chatsDir);
       const currentSessionFiles = files.filter(
-        (f) => f.startsWith(SESSION_FILE_PREFIX) && f.includes(shortSessionId),
+        (f) =>
+          f.startsWith(SESSION_FILE_PREFIX) &&
+          f.endsWith(`-${shortSessionId}.json`),
       );
 
       if (currentSessionFiles.length === 0) {
@@ -77,7 +79,7 @@ export const forkCommand: SlashCommand = {
       const newShortId = newSessionId.slice(0, 8);
       const timestamp = new Date()
         .toISOString()
-        .slice(0, 16)
+        .slice(0, 19)
         .replace(/:/g, '-');
       const newFileName = `${SESSION_FILE_PREFIX}${timestamp}-${newShortId}.json`;
       const newFilePath = path.join(chatsDir, newFileName);

--- a/packages/cli/src/ui/commands/forkCommand.ts
+++ b/packages/cli/src/ui/commands/forkCommand.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { randomUUID } from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import path from 'node:path';
+import { SESSION_FILE_PREFIX } from '@google/gemini-cli-core';
+import { CommandKind, type SlashCommand } from './types.js';
+import type {
+  MessageActionReturn,
+  ConversationRecord,
+} from '@google/gemini-cli-core';
+
+/**
+ * Fork command: Creates an independent copy of the current conversation session.
+ * This allows users to explore different directions from the same conversation point
+ * without write conflicts that occur when using --resume in multiple terminals.
+ */
+export const forkCommand: SlashCommand = {
+  name: 'fork',
+  description: 'Create a fork of the current conversation session',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: async (context, _args): Promise<MessageActionReturn> => {
+    const config = context.services.config;
+    if (!config) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'Cannot fork: No active session.',
+      };
+    }
+
+    try {
+      // Get the current session ID and temp directory
+      const currentSessionId = config.getSessionId();
+      const projectTempDir = config.storage.getProjectTempDir();
+      const chatsDir = path.join(projectTempDir, 'chats');
+
+      // Find the current session file by searching for files ending with the short session ID
+      const shortSessionId = currentSessionId.slice(0, 8);
+      const files = await fs.readdir(chatsDir);
+      const currentSessionFiles = files.filter(
+        (f) => f.startsWith(SESSION_FILE_PREFIX) && f.includes(shortSessionId),
+      );
+
+      if (currentSessionFiles.length === 0) {
+        return {
+          type: 'message',
+          messageType: 'error',
+          content: 'Cannot fork: No active session file found.',
+        };
+      }
+
+      // If multiple files match, use the most recently modified
+      const sessionFilesWithStats = await Promise.all(
+        currentSessionFiles.map(async (fileName) => {
+          const filePath = path.join(chatsDir, fileName);
+          const stats = await fs.stat(filePath);
+          return { fileName, filePath, mtime: stats.mtimeMs };
+        }),
+      );
+
+      sessionFilesWithStats.sort((a, b) => b.mtime - a.mtime);
+      const currentSessionFile = sessionFilesWithStats[0].filePath;
+
+      // Read the current conversation
+      const fileContent = await fs.readFile(currentSessionFile, 'utf8');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const conversation: ConversationRecord = JSON.parse(fileContent);
+
+      // Create a new session with a unique ID
+      const newSessionId = randomUUID();
+      const newShortId = newSessionId.slice(0, 8);
+      const timestamp = new Date()
+        .toISOString()
+        .slice(0, 16)
+        .replace(/:/g, '-');
+      const newFileName = `${SESSION_FILE_PREFIX}${timestamp}-${newShortId}.json`;
+      const newFilePath = path.join(chatsDir, newFileName);
+
+      // Create the forked conversation with updated metadata
+      const forkedConversation: ConversationRecord = {
+        ...conversation,
+        sessionId: newSessionId,
+        lastUpdated: new Date().toISOString(),
+      };
+
+      // Write the forked conversation to the new file
+      await fs.writeFile(
+        newFilePath,
+        JSON.stringify(forkedConversation, null, 2),
+        'utf8',
+      );
+
+      // Return success message with resume instructions
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: `Fork saved (${newShortId}).\nResume with: gemini --resume ${newShortId}\nOr browse sessions with: /chat`,
+      };
+    } catch (error) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: `Failed to fork session: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      };
+    }
+  },
+};


### PR DESCRIPTION
## Summary

Implements \`/fork\` slash command that creates an independent copy of the current conversation session. This solves the critical issue where using \`--resume\` in multiple terminals shares the same session file, leading to write conflicts and potential data loss due to last-write-wins corruption.

## Details

The \`/fork\` command:
1. Reads the current \`ConversationRecord\` from the active session file
2. Generates a new unique session UUID
3. Writes the forked conversation to a new timestamped session file
4. Returns the fork's short ID with instructions to resume it

Both the original and forked sessions are fully independent with separate files, eliminating write conflicts.

**Files changed:**
- \`packages/cli/src/ui/commands/forkCommand.ts\` - Command implementation
- \`packages/cli/src/ui/commands/forkCommand.test.ts\` - Comprehensive unit tests
- \`packages/cli/src/services/BuiltinCommandLoader.ts\` - Command registration
- \`docs/cli/fork.md\` - User-facing documentation
- \`docs/sidebar.json\` - Added fork command to documentation sidebar

## Related Issues

Closes #22563

## How to Validate

1. Start a conversation in gemini-cli
2. Run \`/fork\` command
3. Verify success message with short ID and resume instructions
4. In a second terminal, run \`gemini --resume <shortId>\`
5. Verify both sessions are independent (changes in one don't affect the other)
6. Run \`/chat\` to verify forked session appears in session list

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (docs/cli/fork.md)
- [x] Added/updated tests (forkCommand.test.ts)
- [ ] Noted breaking changes (none - pure additive feature)
- [ ] Validated on required platforms/methods: