### PR TITLE
fix(cli): expand tilde in policy paths from settings.json

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -3347,7 +3347,10 @@ describe('Policy Engine Integration in loadCliConfig', () => {
 
     expect(ServerConfig.createPolicyEngineConfig).toHaveBeenCalledWith(
       expect.objectContaining({
-        policyPaths: ['/path/to/policy1.toml', '/path/to/policy2.toml'],
+        policyPaths: [
+          path.normalize('/path/to/policy1.toml'),
+          path.normalize('/path/to/policy2.toml'),
+        ],
       }),
       expect.anything(),
     );

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -650,8 +650,12 @@ export async function loadCliConfig(
       ...settings.mcp,
       allowed: argv.allowedMcpServerNames ?? settings.mcp?.allowed,
     },
-    policyPaths: argv.policy ?? settings.policyPaths,
-    adminPolicyPaths: argv.adminPolicy ?? settings.adminPolicyPaths,
+    policyPaths: (argv.policy ?? settings.policyPaths)?.map((p) =>
+      resolvePath(p),
+    ),
+    adminPolicyPaths: (argv.adminPolicy ?? settings.adminPolicyPaths)?.map(
+      (p) => resolvePath(p),
+    ),
   };
 
   const { workspacePoliciesDir, policyUpdateConfirmationRequest } =


### PR DESCRIPTION
## Summary

Expands the tilde `~` character to the user's home directory for `policyPaths` and `adminPolicyPaths` when defined in `settings.json`. Settings defined in JSON don't benefit from shell expansion, causing policy loading to fail if they used `~`.

## Related Issues

Resolves the user report regarding policy path expansion in settings.

## How to Validate

1. Add `"policyPaths": ["~/.gemini/temp-pol"]` to `~/.gemini/settings.json`.
2. Create `~/.gemini/temp-pol` directory and put a valid `.toml` policy inside.
3. Run `gemini` and trigger an action matching the `.toml` policy to verify it loads successfully.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
