### PR TITLE
fix(core): add missing binary file extensions to ignore patterns

### DIFF
--- a/packages/core/src/utils/ignorePatterns.ts
+++ b/packages/core/src/utils/ignorePatterns.ts
@@ -47,6 +47,29 @@ export const BINARY_FILE_PATTERNS: string[] = [
   '**/*.odt',
   '**/*.ods',
   '**/*.odp',
+  // Game engine and large archive formats
+  '**/*.pak',
+  '**/*.rpa',
+  '**/*.unity3d',
+  '**/*.asset',
+  '**/*.bundle',
+  // Disk images and installers
+  '**/*.iso',
+  '**/*.dmg',
+  '**/*.msi',
+  '**/*.deb',
+  '**/*.rpm',
+  '**/*.apk',
+  // Additional archive formats
+  '**/*.xz',
+  '**/*.zst',
+  '**/*.lz4',
+  '**/*.cab',
+  // Electron / platform-specific
+  '**/*.asar',
+  // Python distribution
+  '**/*.whl',
+  '**/*.egg',
 ];
 
 /**


### PR DESCRIPTION
## Summary

Adds missing binary file extensions to `BINARY_FILE_PATTERNS` in `ignorePatterns.ts` to prevent the CLI from including large binary files in the context bundle.

## Details

When running Gemini CLI in directories containing large game modding and archive binaries (e.g., `.pak` Unreal Engine archives, `.rpa` Ren'Py archives), the CLI fails to filter them out. This causes the context size to inflate to 192+ MB, resulting in silent timeouts (15+ minutes) without any error message.

The fix adds the following extension categories to `BINARY_FILE_PATTERNS`:
- **Game engine archives**: `.pak`, `.rpa`, `.unity3d`, `.asset`, `.bundle`
- **Disk images & installers**: `.iso`, `.dmg`, `.msi`, `.deb`, `.rpm`, `.apk`
- **Additional archive formats**: `.xz`, `.zst`, `.lz4`, `.cab`
- **Electron**: `.asar`
- **Python distribution**: `.whl`, `.egg`

## Related Issues

Fixes #22565

## How to Validate

1. Create a directory with large `.pak` or `.rpa` files (or any of the newly added extensions)
2. Run Gemini CLI in that directory
3. Verify the context size in the status bar does not include these binary files
4. Verify the CLI does not hang or timeout

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any): None
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
  - [x] Linux