### PR TITLE
fix(cli): override j/k navigation in settings dialog to fix search input conflict

### DIFF
--- a/packages/cli/src/ui/components/SettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.test.tsx
@@ -52,6 +52,8 @@ enum TerminalKeys {
   RIGHT_ARROW = '\u001B[C',
   ESCAPE = '\u001B',
   BACKSPACE = '\u0008',
+  CTRL_P = '\u0010',
+  CTRL_N = '\u000E',
 }
 
 vi.mock('../../config/settingsSchema.js', async (importOriginal) => {
@@ -357,9 +359,9 @@ describe('SettingsDialog', () => {
         up: TerminalKeys.UP_ARROW,
       },
       {
-        name: 'vim keys (j/k)',
-        down: 'j',
-        up: 'k',
+        name: 'emacs keys (Ctrl+P/N)',
+        down: TerminalKeys.CTRL_N,
+        up: TerminalKeys.CTRL_P,
       },
     ])('should navigate with $name', async ({ down, up }) => {
       const settings = createMockSettings();
@@ -394,6 +396,35 @@ describe('SettingsDialog', () => {
         expect(lastFrame()).toContain('Vim Mode');
       });
 
+      unmount();
+    });
+
+    it('should allow j and k characters to be typed in search without triggering navigation', async () => {
+      const settings = createMockSettings();
+      const onSelect = vi.fn();
+      const { lastFrame, stdin, waitUntilReady, unmount } = renderDialog(
+        settings,
+        onSelect,
+      );
+      await waitUntilReady();
+
+      // Enter 'j' and 'k' in search
+      await act(async () => {
+        stdin.write('j');
+      });
+      await waitUntilReady();
+      await act(async () => {
+        stdin.write('k');
+      });
+      await waitUntilReady();
+
+      await waitFor(() => {
+        const frame = lastFrame();
+        // The search box should contain 'jk'
+        expect(frame).toContain('jk');
+        // Since 'jk' doesn't match any setting labels, it should say "No matches found."
+        expect(frame).toContain('No matches found.');
+      });
       unmount();
     });
 

--- a/packages/cli/src/ui/components/SettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.test.tsx
@@ -409,13 +409,9 @@ describe('SettingsDialog', () => {
       await waitUntilReady();
 
       // Enter 'j' and 'k' in search
-      await act(async () => {
-        stdin.write('j');
-      });
+      await act(async () => stdin.write('j'));
       await waitUntilReady();
-      await act(async () => {
-        stdin.write('k');
-      });
+      await act(async () => stdin.write('k'));
       await waitUntilReady();
 
       await waitFor(() => {

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -43,6 +43,8 @@ import {
   BaseSettingsDialog,
   type SettingsDialogItem,
 } from './shared/BaseSettingsDialog.js';
+import { useKeyMatchers } from '../hooks/useKeyMatchers.js';
+import { Command } from '../key/keyMatchers.js';
 
 interface FzfResult {
   item: string;
@@ -336,6 +338,15 @@ export function SettingsDialog({
     onSelect(undefined, selectedScope as SettingScope);
   }, [onSelect, selectedScope]);
 
+  const globalKeyMatchers = useKeyMatchers();
+  const settingsKeyMatchers = useMemo(() => ({
+      ...globalKeyMatchers,
+      [Command.DIALOG_NAVIGATION_UP]: (key: Key) =>
+        key.name === 'up' || (key.ctrl && key.name === 'p'),
+      [Command.DIALOG_NAVIGATION_DOWN]: (key: Key) =>
+        key.name === 'down' || (key.ctrl && key.name === 'n'),
+    }), [globalKeyMatchers]);
+
   // Custom key handler for restart key
   const handleKeyPress = useCallback(
     (key: Key, _currentItem: SettingsDialogItem | undefined): boolean => {
@@ -371,6 +382,7 @@ export function SettingsDialog({
       onItemClear={handleItemClear}
       onClose={handleClose}
       onKeyPress={handleKeyPress}
+      keyMatchers={settingsKeyMatchers}
       footer={
         showRestartPrompt
           ? {

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -339,13 +339,16 @@ export function SettingsDialog({
   }, [onSelect, selectedScope]);
 
   const globalKeyMatchers = useKeyMatchers();
-  const settingsKeyMatchers = useMemo(() => ({
+  const settingsKeyMatchers = useMemo(
+    () => ({
       ...globalKeyMatchers,
       [Command.DIALOG_NAVIGATION_UP]: (key: Key) =>
         key.name === 'up' || (key.ctrl && key.name === 'p'),
       [Command.DIALOG_NAVIGATION_DOWN]: (key: Key) =>
         key.name === 'down' || (key.ctrl && key.name === 'n'),
-    }), [globalKeyMatchers]);
+    }),
+    [globalKeyMatchers],
+  );
 
   // Custom key handler for restart key
   const handleKeyPress = useCallback(

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -62,6 +62,11 @@ interface SettingsDialogProps {
 
 const MAX_ITEMS_TO_SHOW = 8;
 
+const KEY_UP = new KeyBinding('up');
+const KEY_CTRL_P = new KeyBinding('ctrl+p');
+const KEY_DOWN = new KeyBinding('down');
+const KEY_CTRL_N = new KeyBinding('ctrl+n');
+
 // Create a snapshot of the initial per-scope state of Restart Required Settings
 // This creates a nested map of the form
 // restartRequiredSetting -> Map { scopeName -> value }
@@ -343,11 +348,9 @@ export function SettingsDialog({
     () => ({
       ...globalKeyMatchers,
       [Command.DIALOG_NAVIGATION_UP]: (key: Key) =>
-        new KeyBinding('up').matches(key) ||
-        new KeyBinding('ctrl+p').matches(key),
+        KEY_UP.matches(key) || KEY_CTRL_P.matches(key),
       [Command.DIALOG_NAVIGATION_DOWN]: (key: Key) =>
-        new KeyBinding('down').matches(key) ||
-        new KeyBinding('ctrl+n').matches(key),
+        KEY_DOWN.matches(key) || KEY_CTRL_N.matches(key),
     }),
     [globalKeyMatchers],
   );

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -44,7 +44,7 @@ import {
   type SettingsDialogItem,
 } from './shared/BaseSettingsDialog.js';
 import { useKeyMatchers } from '../hooks/useKeyMatchers.js';
-import { Command } from '../key/keyMatchers.js';
+import { Command, KeyBinding } from '../key/keyBindings.js';
 
 interface FzfResult {
   item: string;
@@ -343,9 +343,11 @@ export function SettingsDialog({
     () => ({
       ...globalKeyMatchers,
       [Command.DIALOG_NAVIGATION_UP]: (key: Key) =>
-        key.name === 'up' || (key.ctrl && key.name === 'p'),
+        new KeyBinding('up').matches(key) ||
+        new KeyBinding('ctrl+p').matches(key),
       [Command.DIALOG_NAVIGATION_DOWN]: (key: Key) =>
-        key.name === 'down' || (key.ctrl && key.name === 'n'),
+        new KeyBinding('down').matches(key) ||
+        new KeyBinding('ctrl+n').matches(key),
     }),
     [globalKeyMatchers],
   );

--- a/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
@@ -19,7 +19,7 @@ import { TextInput } from './TextInput.js';
 import type { TextBuffer } from './text-buffer.js';
 import { cpSlice, cpLen, cpIndexToOffset } from '../../utils/textUtils.js';
 import { useKeypress, type Key } from '../../hooks/useKeypress.js';
-import { Command } from '../../key/keyMatchers.js';
+import { Command, type KeyMatchers } from '../../key/keyMatchers.js';
 import { useSettingsNavigation } from '../../hooks/useSettingsNavigation.js';
 import { useInlineEditBuffer } from '../../hooks/useInlineEditBuffer.js';
 import { formatCommand } from '../../key/keybindingUtils.js';
@@ -103,6 +103,9 @@ export interface BaseSettingsDialogProps {
     currentItem: SettingsDialogItem | undefined,
   ) => boolean;
 
+  /** Optional override for key matchers used for navigation. */
+  keyMatchers?: KeyMatchers;
+
   /** Available terminal height for dynamic windowing */
   availableHeight?: number;
 
@@ -134,10 +137,12 @@ export function BaseSettingsDialog({
   onItemClear,
   onClose,
   onKeyPress,
+  keyMatchers: customKeyMatchers,
   availableHeight,
   footer,
 }: BaseSettingsDialogProps): React.JSX.Element {
-  const keyMatchers = useKeyMatchers();
+  const globalKeyMatchers = useKeyMatchers();
+  const keyMatchers = customKeyMatchers ?? globalKeyMatchers;
   // Calculate effective max items and scope visibility based on terminal height
   const { effectiveMaxItemsToShow, finalShowScopeSelector } = useMemo(() => {
     const initialShowScope = showScopeSelector;


### PR DESCRIPTION
## Description
Overrides the `j` and `k` dialog navigation shortcuts specifically for the `/settings` command dialog.

This resolves an issue where users were unable to type the letters `j` and `k` into the settings search input box because the keystrokes were intercepted and used to trigger list navigation. Navigation in the dialog is still possible via the arrow keys and `Ctrl+N`/`Ctrl+P`.

Fixes #22797.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactor (code restructuring with no functional changes)

## Testing
- Modified `SettingsDialog.test.tsx` to verify `j` and `k` can be typed into the search box without triggering navigation.
- Modified tests to use `Ctrl+N` and `Ctrl+P` for navigation shortcuts instead.
