### PR TITLE
make integration tests use 3.0 flash instead of 2.5 pro

### DIFF
--- a/packages/test-utils/src/test-rig.ts
+++ b/packages/test-utils/src/test-rig.ts
@@ -11,7 +11,10 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { env } from 'node:process';
 import { setTimeout as sleep } from 'node:timers/promises';
-import { DEFAULT_GEMINI_MODEL, GEMINI_DIR } from '@google/gemini-cli-core';
+import {
+  PREVIEW_GEMINI_FLASH_MODEL,
+  GEMINI_DIR,
+} from '@google/gemini-cli-core';
 export { GEMINI_DIR };
 import * as pty from '@lydell/node-pty';
 import stripAnsi from 'strip-ansi';
@@ -434,7 +437,7 @@ export class TestRig {
         general: {
           // Nightly releases sometimes becomes out of sync with local code and
           // triggers auto-update, which causes tests to fail.
-          disableAutoUpdate: true,
+          enableAutoUpdate: false,
         },
         telemetry: {
           enabled: true,
@@ -456,7 +459,7 @@ export class TestRig {
         ...(env['GEMINI_TEST_TYPE'] === 'integration'
           ? {
               model: {
-                name: DEFAULT_GEMINI_MODEL,
+                name: PREVIEW_GEMINI_FLASH_MODEL,
               },
             }
           : {}),


### PR DESCRIPTION
## Summary

Our E2E tests are failing with 503 errors and we believe this model will be better.

Also, use `enableAutoUpdate: false` instead of deprecated `disableAutoUpdate: true`.