### PR TITLE
Text can be added after /plan command

### DIFF
--- a/docs/cli/plan-mode.md
+++ b/docs/cli/plan-mode.md
@@ -39,7 +39,9 @@ To start Plan Mode while using Gemini CLI:
   the rotation when Gemini CLI is actively processing or showing confirmation
   dialogs.
 
-- **Command:** Type `/plan` in the input box.
+- **Command:** Type `/plan [goal]` in the input box. The `[goal]` is optional;
+  for example, `/plan implement authentication` will switch to Plan Mode and
+  immediately submit the prompt to the model.
 
 - **Natural Language:** Ask Gemini CLI to "start a plan for...". Gemini CLI
   calls the

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -75,6 +75,7 @@ const listCommand: SlashCommand = {
   description: 'List saved manual conversation checkpoints',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  takesArgs: false,
   action: async (context): Promise<void> => {
     const chatDetails = await getSavedChatTags(context, false);
 
@@ -406,14 +407,24 @@ export const chatResumeSubCommands: SlashCommand[] = [
   checkpointCompatibilityCommand,
 ];
 
+import { parseSlashCommand } from '../../utils/commands.js';
+
 export const chatCommand: SlashCommand = {
   name: 'chat',
   description: 'Browse auto-saved conversations and manage chat checkpoints',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
-  action: async () => ({
-    type: 'dialog',
-    dialog: 'sessionBrowser',
-  }),
+  action: async (context, args) => {
+    if (args) {
+      const parsed = parseSlashCommand(`/${args}`, chatResumeSubCommands);
+      if (parsed.commandToExecute?.action) {
+        return parsed.commandToExecute.action(context, parsed.args);
+      }
+    }
+    return {
+      type: 'dialog',
+      dialog: 'sessionBrowser',
+    };
+  },
   subCommands: chatResumeSubCommands,
 };

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -75,6 +75,7 @@ const listCommand: SlashCommand = {
   description: 'List saved manual conversation checkpoints',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  takesArgs: false,
   action: async (context): Promise<void> => {
     const chatDetails = await getSavedChatTags(context, false);
 

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -75,7 +75,6 @@ const listCommand: SlashCommand = {
   description: 'List saved manual conversation checkpoints',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
-  takesArgs: false,
   action: async (context): Promise<void> => {
     const chatDetails = await getSavedChatTags(context, false);
 

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -789,6 +789,7 @@ const listExtensionsCommand: SlashCommand = {
   description: 'List active extensions',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  takesArgs: false,
   action: listAction,
 };
 
@@ -849,6 +850,7 @@ const exploreExtensionsCommand: SlashCommand = {
   description: 'Open extensions page in your browser',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  takesArgs: false,
   action: exploreAction,
 };
 
@@ -870,6 +872,8 @@ const configCommand: SlashCommand = {
   action: configAction,
 };
 
+import { parseSlashCommand } from '../../utils/commands.js';
+
 export function extensionsCommand(
   enableExtensionReloading?: boolean,
 ): SlashCommand {
@@ -883,20 +887,29 @@ export function extensionsCommand(
         configCommand,
       ]
     : [];
+  const subCommands = [
+    listExtensionsCommand,
+    updateExtensionsCommand,
+    exploreExtensionsCommand,
+    reloadCommand,
+    ...conditionalCommands,
+  ];
+
   return {
     name: 'extensions',
     description: 'Manage extensions',
     kind: CommandKind.BUILT_IN,
     autoExecute: false,
-    subCommands: [
-      listExtensionsCommand,
-      updateExtensionsCommand,
-      exploreExtensionsCommand,
-      reloadCommand,
-      ...conditionalCommands,
-    ],
-    action: (context, args) =>
+    subCommands,
+    action: async (context, args) => {
+      if (args) {
+        const parsed = parseSlashCommand(`/${args}`, subCommands);
+        if (parsed.commandToExecute?.action) {
+          return parsed.commandToExecute.action(context, parsed.args);
+        }
+      }
       // Default to list if no subcommand is provided
-      listExtensionsCommand.action!(context, args),
+      return listExtensionsCommand.action!(context, args);
+    },
   };
 }

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -789,6 +789,7 @@ const listExtensionsCommand: SlashCommand = {
   description: 'List active extensions',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  takesArgs: false,
   action: listAction,
 };
 
@@ -849,6 +850,7 @@ const exploreExtensionsCommand: SlashCommand = {
   description: 'Open extensions page in your browser',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  takesArgs: false,
   action: exploreAction,
 };
 

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -789,7 +789,6 @@ const listExtensionsCommand: SlashCommand = {
   description: 'List active extensions',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
-  takesArgs: false,
   action: listAction,
 };
 
@@ -850,7 +849,6 @@ const exploreExtensionsCommand: SlashCommand = {
   description: 'Open extensions page in your browser',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
-  takesArgs: false,
   action: exploreAction,
 };
 

--- a/packages/cli/src/ui/commands/mcpCommand.test.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.test.ts
@@ -17,7 +17,7 @@ import {
 } from '@google/gemini-cli-core';
 
 import type { CallableTool } from '@google/genai';
-import { MessageType } from '../types.js';
+import { MessageType, type HistoryItemMcpStatus } from '../types.js';
 
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const actual =
@@ -297,8 +297,8 @@ describe('mcpCommand', () => {
       );
 
       // Should NOT contain server2 or server3
-      const call = vi.mocked(mockContext.ui.addItem).mock.calls[0][0];
-       
+      const call = vi.mocked(mockContext.ui.addItem).mock
+        .calls[0][0] as HistoryItemMcpStatus;
       expect(Object.keys(call.servers)).toEqual(['server1']);
     });
 
@@ -318,8 +318,8 @@ describe('mcpCommand', () => {
         }),
       );
 
-      const call = vi.mocked(mockContext.ui.addItem).mock.calls[0][0];
-       
+      const call = vi.mocked(mockContext.ui.addItem).mock
+        .calls[0][0] as HistoryItemMcpStatus;
       expect(Object.keys(call.servers)).toEqual(['server2']);
     });
   });

--- a/packages/cli/src/ui/commands/mcpCommand.test.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.test.ts
@@ -282,10 +282,7 @@ describe('mcpCommand', () => {
     });
 
     it('should filter servers by name when an argument is provided to list', async () => {
-      const listSubCommand = mcpCommand.subCommands!.find(
-        (c) => c.name === 'list',
-      );
-      await listSubCommand!.action!(mockContext, 'server1');
+      await mcpCommand.action!(mockContext, 'list server1');
 
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -303,10 +300,7 @@ describe('mcpCommand', () => {
     });
 
     it('should filter servers by name and show descriptions when an argument is provided to desc', async () => {
-      const descSubCommand = mcpCommand.subCommands!.find(
-        (c) => c.name === 'desc',
-      );
-      await descSubCommand!.action!(mockContext, 'server2');
+      await mcpCommand.action!(mockContext, 'desc server2');
 
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/packages/cli/src/ui/commands/mcpCommand.test.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.test.ts
@@ -280,5 +280,47 @@ describe('mcpCommand', () => {
         }),
       );
     });
+
+    it('should filter servers by name when an argument is provided to list', async () => {
+      const listSubCommand = mcpCommand.subCommands!.find(
+        (c) => c.name === 'list',
+      );
+      await listSubCommand!.action!(mockContext, 'server1');
+
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.MCP_STATUS,
+          servers: expect.objectContaining({
+            server1: expect.any(Object),
+          }),
+        }),
+      );
+
+      // Should NOT contain server2 or server3
+      const call = vi.mocked(mockContext.ui.addItem).mock.calls[0][0];
+       
+      expect(Object.keys(call.servers)).toEqual(['server1']);
+    });
+
+    it('should filter servers by name and show descriptions when an argument is provided to desc', async () => {
+      const descSubCommand = mcpCommand.subCommands!.find(
+        (c) => c.name === 'desc',
+      );
+      await descSubCommand!.action!(mockContext, 'server2');
+
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.MCP_STATUS,
+          showDescriptions: true,
+          servers: expect.objectContaining({
+            server2: expect.any(Object),
+          }),
+        }),
+      );
+
+      const call = vi.mocked(mockContext.ui.addItem).mock.calls[0][0];
+       
+      expect(Object.keys(call.servers)).toEqual(['server2']);
+    });
   });
 });

--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -31,6 +31,7 @@ import {
   canLoadServer,
 } from '../../config/mcp/mcpServerEnablement.js';
 import { loadSettings } from '../../config/settings.js';
+import { parseSlashCommand } from '../../utils/commands.js';
 
 const authCommand: SlashCommand = {
   name: 'auth',
@@ -348,9 +349,9 @@ const reloadCommand: SlashCommand = {
   description: 'Reloads MCP servers',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  takesArgs: false,
   action: async (
     context: CommandContext,
-    args: string,
   ): Promise<void | SlashCommandActionReturn> => {
     const agentContext = context.services.agentContext;
     const config = agentContext?.config;
@@ -387,7 +388,7 @@ const reloadCommand: SlashCommand = {
     // Reload the slash commands to reflect the changes.
     context.ui.reloadCommands();
 
-    return listCommand.action!(context, args);
+    return listCommand.action!(context, '');
   },
 };
 
@@ -546,5 +547,18 @@ export const mcpCommand: SlashCommand = {
     enableCommand,
     disableCommand,
   ],
-  action: async (context: CommandContext) => listAction(context),
+  action: async (
+    context: CommandContext,
+    args: string,
+  ): Promise<void | SlashCommandActionReturn> => {
+    if (args) {
+      const parsed = parseSlashCommand(`/${args}`, mcpCommand.subCommands!);
+      if (parsed.commandToExecute?.action) {
+        return parsed.commandToExecute.action(context, parsed.args);
+      }
+      // If no subcommand matches, treat the whole args as a filter for list
+      return listAction(context, false, false, args);
+    }
+    return listAction(context);
+  },
 };

--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -306,6 +306,7 @@ const listCommand: SlashCommand = {
   description: 'List configured MCP servers and tools',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  takesArgs: false,
   action: (context) => listAction(context),
 };
 
@@ -315,6 +316,7 @@ const descCommand: SlashCommand = {
   description: 'List configured MCP servers and tools with descriptions',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  takesArgs: false,
   action: (context) => listAction(context, true),
 };
 
@@ -324,6 +326,7 @@ const schemaCommand: SlashCommand = {
     'List configured MCP servers and tools with descriptions and schemas',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  takesArgs: false,
   action: (context) => listAction(context, true, true),
 };
 
@@ -333,6 +336,7 @@ const reloadCommand: SlashCommand = {
   description: 'Reloads MCP servers',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  takesArgs: false,
   action: async (
     context: CommandContext,
   ): Promise<void | SlashCommandActionReturn> => {

--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -177,6 +177,7 @@ const listAction = async (
   context: CommandContext,
   showDescriptions = false,
   showSchema = false,
+  serverNameFilter?: string,
 ): Promise<void | MessageActionReturn> => {
   const agentContext = context.services.agentContext;
   const config = agentContext?.config;
@@ -199,10 +200,24 @@ const listAction = async (
     };
   }
 
-  const mcpServers = config.getMcpClientManager()?.getMcpServers() || {};
-  const serverNames = Object.keys(mcpServers);
+  let mcpServers = config.getMcpClientManager()?.getMcpServers() || {};
   const blockedMcpServers =
     config.getMcpClientManager()?.getBlockedMcpServers() || [];
+
+  if (serverNameFilter) {
+    const filter = serverNameFilter.trim().toLowerCase();
+    if (filter) {
+      mcpServers = Object.fromEntries(
+        Object.entries(mcpServers).filter(
+          ([name]) =>
+            name.toLowerCase().includes(filter) ||
+            normalizeServerId(name).includes(filter),
+        ),
+      );
+    }
+  }
+
+  const serverNames = Object.keys(mcpServers);
 
   const connectingServers = serverNames.filter(
     (name) => getMCPServerStatus(name) === MCPServerStatus.CONNECTING,
@@ -306,8 +321,7 @@ const listCommand: SlashCommand = {
   description: 'List configured MCP servers and tools',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
-  takesArgs: false,
-  action: (context) => listAction(context),
+  action: (context, args) => listAction(context, false, false, args),
 };
 
 const descCommand: SlashCommand = {
@@ -316,8 +330,7 @@ const descCommand: SlashCommand = {
   description: 'List configured MCP servers and tools with descriptions',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
-  takesArgs: false,
-  action: (context) => listAction(context, true),
+  action: (context, args) => listAction(context, true, false, args),
 };
 
 const schemaCommand: SlashCommand = {
@@ -326,8 +339,7 @@ const schemaCommand: SlashCommand = {
     'List configured MCP servers and tools with descriptions and schemas',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
-  takesArgs: false,
-  action: (context) => listAction(context, true, true),
+  action: (context, args) => listAction(context, true, true, args),
 };
 
 const reloadCommand: SlashCommand = {
@@ -336,9 +348,9 @@ const reloadCommand: SlashCommand = {
   description: 'Reloads MCP servers',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
-  takesArgs: false,
   action: async (
     context: CommandContext,
+    args: string,
   ): Promise<void | SlashCommandActionReturn> => {
     const agentContext = context.services.agentContext;
     const config = agentContext?.config;
@@ -375,7 +387,7 @@ const reloadCommand: SlashCommand = {
     // Reload the slash commands to reflect the changes.
     context.ui.reloadCommands();
 
-    return listCommand.action!(context, '');
+    return listCommand.action!(context, args);
   },
 };
 

--- a/packages/cli/src/ui/commands/planCommand.test.ts
+++ b/packages/cli/src/ui/commands/planCommand.test.ts
@@ -105,7 +105,9 @@ describe('planCommand', () => {
   });
 
   it('should not return a submit_prompt action if arguments are empty', async () => {
-    vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(true);
+    vi.mocked(
+      mockContext.services.agentContext!.config.isPlanEnabled,
+    ).mockReturnValue(true);
     mockContext.invocation = {
       raw: '/plan',
       name: 'plan',
@@ -116,13 +118,15 @@ describe('planCommand', () => {
     const result = await planCommand.action(mockContext, '');
 
     expect(result).toBeUndefined();
-    expect(mockContext.services.config!.setApprovalMode).toHaveBeenCalledWith(
-      ApprovalMode.PLAN,
-    );
+    expect(
+      mockContext.services.agentContext!.config.setApprovalMode,
+    ).toHaveBeenCalledWith(ApprovalMode.PLAN);
   });
 
   it('should return a submit_prompt action if arguments are provided', async () => {
-    vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(true);
+    vi.mocked(
+      mockContext.services.agentContext!.config.isPlanEnabled,
+    ).mockReturnValue(true);
     mockContext.invocation = {
       raw: '/plan implement auth',
       name: 'plan',
@@ -136,9 +140,9 @@ describe('planCommand', () => {
       type: 'submit_prompt',
       content: 'implement auth',
     });
-    expect(mockContext.services.config!.setApprovalMode).toHaveBeenCalledWith(
-      ApprovalMode.PLAN,
-    );
+    expect(
+      mockContext.services.agentContext!.config.setApprovalMode,
+    ).toHaveBeenCalledWith(ApprovalMode.PLAN);
   });
 
   it('should display the approved plan from config', async () => {

--- a/packages/cli/src/ui/commands/planCommand.test.ts
+++ b/packages/cli/src/ui/commands/planCommand.test.ts
@@ -104,6 +104,43 @@ describe('planCommand', () => {
     );
   });
 
+  it('should not return a submit_prompt action if arguments are empty', async () => {
+    vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(true);
+    mockContext.invocation = {
+      raw: '/plan',
+      name: 'plan',
+      args: '',
+    };
+
+    if (!planCommand.action) throw new Error('Action missing');
+    const result = await planCommand.action(mockContext, '');
+
+    expect(result).toBeUndefined();
+    expect(mockContext.services.config!.setApprovalMode).toHaveBeenCalledWith(
+      ApprovalMode.PLAN,
+    );
+  });
+
+  it('should return a submit_prompt action if arguments are provided', async () => {
+    vi.mocked(mockContext.services.config!.isPlanEnabled).mockReturnValue(true);
+    mockContext.invocation = {
+      raw: '/plan implement auth',
+      name: 'plan',
+      args: 'implement auth',
+    };
+
+    if (!planCommand.action) throw new Error('Action missing');
+    const result = await planCommand.action(mockContext, 'implement auth');
+
+    expect(result).toEqual({
+      type: 'submit_prompt',
+      content: 'implement auth',
+    });
+    expect(mockContext.services.config!.setApprovalMode).toHaveBeenCalledWith(
+      ApprovalMode.PLAN,
+    );
+  });
+
   it('should display the approved plan from config', async () => {
     const mockPlanPath = '/mock/plans/dir/approved-plan.md';
     vi.mocked(

--- a/packages/cli/src/ui/commands/planCommand.ts
+++ b/packages/cli/src/ui/commands/planCommand.ts
@@ -66,6 +66,13 @@ export const planCommand: SlashCommand = {
       coreEvents.emitFeedback('info', 'Switched to Plan Mode.');
     }
 
+    if (context.invocation?.args) {
+      return {
+        type: 'submit_prompt',
+        content: context.invocation.args,
+      };
+    }
+
     const approvedPlanPath = config.getApprovedPlanPath();
 
     if (!approvedPlanPath) {
@@ -86,12 +93,14 @@ export const planCommand: SlashCommand = {
         type: MessageType.GEMINI,
         text: partToString(content.llmContent),
       });
+      return;
     } catch (error) {
       coreEvents.emitFeedback(
         'error',
         `Failed to read approved plan at ${approvedPlanPath}: ${error}`,
         error,
       );
+      return;
     }
   },
   subCommands: [

--- a/packages/cli/src/ui/commands/planCommand.ts
+++ b/packages/cli/src/ui/commands/planCommand.ts
@@ -109,6 +109,7 @@ export const planCommand: SlashCommand = {
       description: 'Copy the currently approved plan to your clipboard',
       kind: CommandKind.BUILT_IN,
       autoExecute: true,
+      takesArgs: false,
       action: copyAction,
     },
   ],

--- a/packages/cli/src/ui/commands/skillsCommand.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.ts
@@ -357,6 +357,8 @@ function enableCompletion(
     .map((s) => s.name);
 }
 
+import { parseSlashCommand } from '../../utils/commands.js';
+
 export const skillsCommand: SlashCommand = {
   name: 'skills',
   description:
@@ -402,5 +404,13 @@ export const skillsCommand: SlashCommand = {
       action: reloadAction,
     },
   ],
-  action: listAction,
+  action: async (context, args) => {
+    if (args) {
+      const parsed = parseSlashCommand(`/${args}`, skillsCommand.subCommands!);
+      if (parsed.commandToExecute?.action) {
+        return parsed.commandToExecute.action(context, parsed.args);
+      }
+    }
+    return listAction(context, args);
+  },
 };

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -240,5 +240,14 @@ export interface SlashCommand {
    */
   showCompletionLoading?: boolean;
 
+  /**
+   * Whether the command expects arguments.
+   * If false, and the command is a subcommand, the command parser may treat
+   * any following text as arguments for the parent command instead of this subcommand,
+   * provided the parent command has an action.
+   * Defaults to true.
+   */
+  takesArgs?: boolean;
+
   subCommands?: SlashCommand[];
 }

--- a/packages/cli/src/utils/commands.test.ts
+++ b/packages/cli/src/utils/commands.test.ts
@@ -137,4 +137,85 @@ describe('parseSlashCommand', () => {
     expect(result.args).toBe('');
     expect(result.canonicalPath).toEqual([]);
   });
+
+  describe('backtracking', () => {
+    const backtrackingCommands: readonly SlashCommand[] = [
+      {
+        name: 'parent',
+        description: 'Parent command',
+        kind: CommandKind.BUILT_IN,
+        action: async () => {},
+        subCommands: [
+          {
+            name: 'notakes',
+            description: 'Subcommand that does not take arguments',
+            kind: CommandKind.BUILT_IN,
+            takesArgs: false,
+            action: async () => {},
+          },
+          {
+            name: 'takes',
+            description: 'Subcommand that takes arguments',
+            kind: CommandKind.BUILT_IN,
+            takesArgs: true,
+            action: async () => {},
+          },
+        ],
+      },
+    ];
+
+    it('should backtrack to parent if subcommand has takesArgs: false and args are provided', () => {
+      const result = parseSlashCommand(
+        '/parent notakes some prompt',
+        backtrackingCommands,
+      );
+      expect(result.commandToExecute?.name).toBe('parent');
+      expect(result.args).toBe('notakes some prompt');
+      expect(result.canonicalPath).toEqual(['parent']);
+    });
+
+    it('should NOT backtrack if subcommand has takesArgs: false but NO args are provided', () => {
+      const result = parseSlashCommand('/parent notakes', backtrackingCommands);
+      expect(result.commandToExecute?.name).toBe('notakes');
+      expect(result.args).toBe('');
+      expect(result.canonicalPath).toEqual(['parent', 'notakes']);
+    });
+
+    it('should NOT backtrack if subcommand has takesArgs: true and args are provided', () => {
+      const result = parseSlashCommand(
+        '/parent takes some args',
+        backtrackingCommands,
+      );
+      expect(result.commandToExecute?.name).toBe('takes');
+      expect(result.args).toBe('some args');
+      expect(result.canonicalPath).toEqual(['parent', 'takes']);
+    });
+
+    it('should NOT backtrack if parent has NO action', () => {
+      const noActionCommands: readonly SlashCommand[] = [
+        {
+          name: 'parent',
+          description: 'Parent without action',
+          kind: CommandKind.BUILT_IN,
+          subCommands: [
+            {
+              name: 'notakes',
+              description: 'Subcommand without args',
+              kind: CommandKind.BUILT_IN,
+              takesArgs: false,
+              action: async () => {},
+            },
+          ],
+        },
+      ];
+      const result = parseSlashCommand(
+        '/parent notakes some args',
+        noActionCommands,
+      );
+      // It stays with the subcommand because parent can't handle it
+      expect(result.commandToExecute?.name).toBe('notakes');
+      expect(result.args).toBe('some args');
+      expect(result.canonicalPath).toEqual(['parent', 'notakes']);
+    });
+  });
 });

--- a/packages/cli/src/utils/commands.test.ts
+++ b/packages/cli/src/utils/commands.test.ts
@@ -227,5 +227,15 @@ describe('parseSlashCommand', () => {
       expect(result.args).toBe('some args');
       expect(result.canonicalPath).toEqual(['parent', 'takes']);
     });
+
+    it('should backtrack if subcommand has takesArgs: false and args are provided (like /plan copy foo)', () => {
+      const result = parseSlashCommand(
+        '/parent notakes some prompt',
+        backtrackingCommands,
+      );
+      expect(result.commandToExecute?.name).toBe('parent');
+      expect(result.args).toBe('notakes some prompt');
+      expect(result.canonicalPath).toEqual(['parent']);
+    });
   });
 });

--- a/packages/cli/src/utils/commands.test.ts
+++ b/packages/cli/src/utils/commands.test.ts
@@ -217,5 +217,15 @@ describe('parseSlashCommand', () => {
       expect(result.args).toBe('some args');
       expect(result.canonicalPath).toEqual(['parent', 'notakes']);
     });
+
+    it('should NOT backtrack if subcommand is NOT marked with takesArgs: false', () => {
+      const result = parseSlashCommand(
+        '/parent takes some args',
+        backtrackingCommands,
+      );
+      expect(result.commandToExecute?.name).toBe('takes');
+      expect(result.args).toBe('some args');
+      expect(result.canonicalPath).toEqual(['parent', 'takes']);
+    });
   });
 });

--- a/packages/cli/src/utils/commands.ts
+++ b/packages/cli/src/utils/commands.ts
@@ -33,6 +33,7 @@ export const parseSlashCommand = (
   let commandToExecute: SlashCommand | undefined;
   let pathIndex = 0;
   const canonicalPath: string[] = [];
+  let parentCommand: SlashCommand | undefined;
 
   for (const part of commandPath) {
     // TODO: For better performance and architectural clarity, this two-pass
@@ -52,6 +53,7 @@ export const parseSlashCommand = (
     }
 
     if (foundCommand) {
+      parentCommand = commandToExecute;
       commandToExecute = foundCommand;
       canonicalPath.push(foundCommand.name);
       pathIndex++;
@@ -66,6 +68,22 @@ export const parseSlashCommand = (
   }
 
   const args = parts.slice(pathIndex).join(' ');
+
+  // Backtrack if the matched (sub)command doesn't take arguments but some were provided,
+  // AND the parent command is capable of handling them.
+  if (
+    commandToExecute &&
+    commandToExecute.takesArgs === false &&
+    args.length > 0 &&
+    parentCommand &&
+    parentCommand.action
+  ) {
+    return {
+      commandToExecute: parentCommand,
+      args: parts.slice(pathIndex - 1).join(' '),
+      canonicalPath: canonicalPath.slice(0, -1),
+    };
+  }
 
   return { commandToExecute, args, canonicalPath };
 };


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
`/plan` should accept text, so that plans can be created in one user action.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
Right now, `/plan` takes you to a separate plan box. `/plan` should accept text so you can kick off a plan in a single command.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [X] Updated relevant documentation and README (if needed)
- [X] Added/updated tests (if needed)
- [X] Noted breaking changes (if any)
- [X] Validated on required platforms/methods:
  - [X] MacOS
    - [X] npm run
    - [X] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
