### PR TITLE
fix(core): throttle shell text output UI updates

### DIFF
--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -240,8 +240,24 @@ export class ShellToolInvocation extends BaseToolInvocation<
             switch (event.type) {
               case 'data':
                 if (isBinaryStream) break;
-                cumulativeOutput = event.chunk;
-                shouldUpdate = true;
+                // PTY mode emits AnsiOutput (full terminal snapshot) —
+                // overwrite. Pipe mode emits partial strings — accumulate
+                // so intermediate chunks aren't lost between throttled
+                // UI updates.
+                if (typeof event.chunk === 'string') {
+                  cumulativeOutput =
+                    typeof cumulativeOutput === 'string'
+                      ? cumulativeOutput + event.chunk
+                      : event.chunk;
+                } else {
+                  cumulativeOutput = event.chunk;
+                }
+                // Throttle UI updates to avoid excessive re-renders when
+                // commands produce high-volume output (e.g. thousands of
+                // warning lines).
+                if (Date.now() - lastUpdateTime > OUTPUT_UPDATE_INTERVAL_MS) {
+                  shouldUpdate = true;
+                }
                 break;
               case 'binary_detected':
                 isBinaryStream = true;


### PR DESCRIPTION
## Summary
- Shell tool text output (`data` events) triggered a React re-render on every chunk, while `binary_progress` already throttled to 1s intervals via `OUTPUT_UPDATE_INTERVAL_MS`
- Commands that produce thousands of lines (e.g. build warnings, manifest generation with ~2000 duplicate warnings) caused the UI to freeze — each line forced a full re-render of the shell output panel
- Apply the same `OUTPUT_UPDATE_INTERVAL_MS` throttle to text data events. The final output is unaffected — it is rendered from the complete result after the command exits

## Test plan
- [x] Verified existing `shell.test.ts` tests are unaffected (only test using `type: 'data'` is for background mode which already skips `updateOutput`)
- [ ] Manual test: run a command that produces high-volume output (e.g. `for i in $(seq 1 5000); do echo "line $i"; done`) and verify the UI remains responsive
- [ ] Verify final output after command completion is still complete and correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)