### PR TITLE
fix(core): return structured error when start_line exceeds file length

### DIFF
--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -991,6 +991,29 @@ describe('fileUtils', () => {
       expect(result.linesShown).toEqual([1, 2]);
     });
 
+    it('should return a structured error when startLine exceeds file length', async () => {
+      const lines = Array.from({ length: 100 }, (_, i) => `Line ${i + 1}`);
+      actualNodeFs.writeFileSync(testTextFilePath, lines.join('\n'));
+
+      const result = await processSingleFileContent(
+        testTextFilePath,
+        tempRootDir,
+        new StandardFileSystemService(),
+        5000,
+      );
+
+      expect(result.error).toContain('start_line 5000 exceeds file length');
+      expect(result.errorType).toBe('invalid_tool_params');
+      expect(typeof result.llmContent).toBe('string');
+      expect(result.llmContent as string).toContain(
+        'start_line 5000 is out of range',
+      );
+      expect(result.llmContent as string).toContain('100 lines');
+      // Must not return an inverted or empty range as valid truncated content
+      expect(result.isTruncated).toBeUndefined();
+      expect(result.linesShown).toBeUndefined();
+    });
+
     it('should truncate long lines in text files', async () => {
       const longLine = 'a'.repeat(2500);
       actualNodeFs.writeFileSync(

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -492,6 +492,19 @@ export async function processSingleFileContent(
 
         // Ensure selectedLines doesn't try to slice beyond array bounds
         const actualStart = Math.min(sliceStart, originalLineCount);
+
+        // Guard: if start_line exceeds the file's total line count, return a
+        // structured error so the LLM can self-correct instead of receiving an
+        // inverted range and empty content that looks like valid truncated output.
+        if (startLine !== undefined && actualStart >= originalLineCount) {
+          return {
+            llmContent: `Error: start_line ${startLine} is out of range. The file '${relativePathForDisplay}' only has ${originalLineCount} line${originalLineCount === 1 ? '' : 's'} (lines 1–${originalLineCount}).`,
+            returnDisplay: `start_line out of range for ${relativePathForDisplay}`,
+            error: `start_line ${startLine} exceeds file length (${originalLineCount} lines) for ${filePath}`,
+            errorType: ToolErrorType.INVALID_TOOL_PARAMS,
+          };
+        }
+
         const selectedLines = lines.slice(actualStart, sliceEnd);
 
         let linesWereTruncatedInLength = false;


### PR DESCRIPTION
## Summary

Fixes #22817

When `read_file` is called with a `start_line` value greater than the total number of lines in the file, `processSingleFileContent` produced a logically impossible result:

- `linesShown` was set to an inverted tuple like `[101, 100]`
- `returnDisplay` showed `"Read lines 101-100 of 100 from file.ts"`
- `llmContent` was an empty string with no error indicator
- `isTruncated` was `true`, falsely implying valid truncated content was returned

The LLM then received a misleading "IMPORTANT: The file content has been truncated" header wrapping empty content, causing it to hallucinate or produce incorrect responses in agentic file-editing workflows.

## Fix

Added a guard clause in `processSingleFileContent` (in `packages/core/src/utils/fileUtils.ts`) immediately after `actualStart` is computed:

```ts
if (startLine !== undefined && actualStart >= originalLineCount) {
  return {
    llmContent: `Error: start_line ${startLine} is out of range. The file '${relativePathForDisplay}' only has ${originalLineCount} line(s) (lines 1–${originalLineCount}).`,
    returnDisplay: `start_line out of range for ${relativePathForDisplay}`,
    error: `start_line ${startLine} exceeds file length (${originalLineCount} lines) for ${filePath}`,
    errorType: ToolErrorType.INVALID_TOOL_PARAMS,
  };
}
```

This returns a clear, structured error with the file's actual line count so the LLM can self-correct on the next call.

## Test plan

- [x] Added `should return a structured error when startLine exceeds file length` unit test in `fileUtils.test.ts` (mirrors the existing `endLine exceeding file length` test)
- [x] All 87 existing tests in `fileUtils.test.ts` continue to pass
- [x] Pre-commit hooks (prettier + eslint) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)