### PR TITLE
fix(tracker): nest dependency chains in task graph visualization

### DIFF
--- a/packages/core/src/tools/trackerTools.test.ts
+++ b/packages/core/src/tools/trackerTools.test.ts
@@ -235,6 +235,66 @@ describe('Tracker Tools Integration', () => {
       ]);
     });
 
+    it('nests children by dependency chain', async () => {
+      const epic = {
+        id: 'epic1',
+        title: 'Tracker Feature Test Epic',
+        type: TaskType.EPIC,
+        status: TaskStatus.CLOSED,
+        dependencies: [],
+      };
+      // 0b0c88 depends on f7a1ac, f7a1ac depends on 9e22bc
+      const taskA = {
+        id: '0b0c88',
+        title: 'Verify the test file',
+        type: TaskType.TASK,
+        status: TaskStatus.CLOSED,
+        parentId: 'epic1',
+        dependencies: ['f7a1ac'],
+      };
+      const taskB = {
+        id: '9e22bc',
+        title: 'Create a test file',
+        type: TaskType.TASK,
+        status: TaskStatus.CLOSED,
+        parentId: 'epic1',
+        dependencies: [],
+      };
+      const taskC = {
+        id: 'f7a1ac',
+        title: 'Modify the test file',
+        type: TaskType.TASK,
+        status: TaskStatus.CLOSED,
+        parentId: 'epic1',
+        dependencies: ['9e22bc'],
+      };
+
+      const mockService = {
+        listTasks: async () => [epic, taskA, taskB, taskC],
+      } as unknown as TrackerService;
+      const display = await buildTodosReturnDisplay(mockService);
+
+      // Should be nested by dependency chain: 9e22bc -> f7a1ac -> 0b0c88
+      expect(display.todos).toEqual([
+        {
+          description: `epic: Tracker Feature Test Epic (epic1)`,
+          status: 'completed',
+        },
+        {
+          description: `  task: Create a test file (9e22bc)`,
+          status: 'completed',
+        },
+        {
+          description: `    task: Modify the test file (f7a1ac)`,
+          status: 'completed',
+        },
+        {
+          description: `      task: Verify the test file (0b0c88)`,
+          status: 'completed',
+        },
+      ]);
+    });
+
     it('detects cycles', async () => {
       // Since TrackerTask only has a single parentId, a true cycle is unreachable from roots.
       // We simulate a database corruption (two tasks with same ID, one root, one child)

--- a/packages/core/src/tools/trackerTools.ts
+++ b/packages/core/src/tools/trackerTools.ts
@@ -89,9 +89,9 @@ export async function buildTodosReturnDisplay(
 
     const children = childrenMap.get(task.id) ?? [];
     children.sort(sortTasks);
-    for (const child of children) {
-      addTask(child, depth + 1, visited);
-    }
+    renderChildrenByDependency(children, depth, visited, (child, d) =>
+      addTask(child, d, visited),
+    );
     visited.delete(task.id);
   };
 
@@ -617,13 +617,20 @@ class TrackerVisualizeInvocation extends BaseToolInvocation<
 
       const indent = '  '.repeat(depth);
       output += `${indent}${statusEmojis[task.status]} ${task.id} ${TASK_TYPE_LABELS[task.type]} ${task.title}\n`;
-      if (task.dependencies.length > 0) {
-        output += `${indent}  └─ Depends on: ${task.dependencies.join(', ')}\n`;
+
+      const siblings = task.parentId
+        ? (childrenMap.get(task.parentId) ?? [])
+        : [];
+      const siblingIds = new Set(siblings.map((s) => s.id));
+      const externalDeps = task.dependencies.filter((d) => !siblingIds.has(d));
+      if (externalDeps.length > 0) {
+        output += `${indent}  └─ Depends on: ${externalDeps.join(', ')}\n`;
       }
+
       const children = childrenMap.get(task.id) ?? [];
-      for (const child of children) {
-        renderTask(child, depth + 1, visited);
-      }
+      renderChildrenByDependency(children, depth, visited, (child, d) =>
+        renderTask(child, d, visited),
+      );
       visited.delete(task.id);
     };
 
@@ -669,5 +676,62 @@ export class TrackerVisualizeTool extends BaseDeclarativeTool<
   }
   override getSchema(modelId?: string) {
     return resolveToolDeclaration(TRACKER_VISUALIZE_DEFINITION, modelId);
+  }
+}
+
+// --- render children by dependency ---
+
+function renderChildrenByDependency(
+  children: TrackerTask[],
+  parentDepth: number,
+  visited: Set<string>,
+  renderFn: (task: TrackerTask, depth: number) => void,
+): void {
+  if (children.length === 0) return;
+
+  const childIds = new Set(children.map((c) => c.id));
+
+  const dependentsMap = new Map<string, TrackerTask[]>();
+  const hasSiblingDep = new Set<string>();
+
+  for (const child of children) {
+    for (const depId of child.dependencies) {
+      if (childIds.has(depId)) {
+        hasSiblingDep.add(child.id);
+        if (!dependentsMap.has(depId)) {
+          dependentsMap.set(depId, []);
+        }
+        dependentsMap.get(depId)!.push(child);
+      }
+    }
+  }
+
+  const depRoots = children.filter((c) => !hasSiblingDep.has(c.id));
+  const rendered = new Set<string>();
+
+  const renderDepChain = (task: TrackerTask, depth: number) => {
+    if (rendered.has(task.id)) return;
+    rendered.add(task.id);
+    renderFn(task, depth);
+
+    const dependents = dependentsMap.get(task.id) ?? [];
+    for (const dep of dependents) {
+      const allDepsRendered = dep.dependencies
+        .filter((id) => childIds.has(id))
+        .every((id) => rendered.has(id));
+      if (allDepsRendered) {
+        renderDepChain(dep, depth + 1);
+      }
+    }
+  };
+
+  for (const root of depRoots) {
+    renderDepChain(root, parentDepth + 1);
+  }
+
+  for (const child of children) {
+    if (!rendered.has(child.id)) {
+      renderFn(child, parentDepth + 1);
+    }
   }
 }


### PR DESCRIPTION
## Summary

Nest task dependency chains as a tree instead of showing flat "Depends on" annotations in tracker visualization.                                                               


## Details

Extracted a `renderChildrenByDependency` helper that builds a reverse-dependency graph among sibling tasks, finds dependency roots (tasks with no intra-sibling deps), and renders the chain with increasing depth. Applied to both `buildTodosReturnDisplay` (deterministic UI checklist) and the visualize tool's `llmContent` (informational context for the model). Handles diamonds (multi-dep tasks render once all deps are rendered) and circular deps (fallback to flat).

Also I was testing some other visuals like 
<img width="414" height="82" alt="image" src="https://github.com/user-attachments/assets/7518067b-f614-49ca-9275-9754dfde4c70" />
AND
<img width="414" height="82" alt="image" src="https://github.com/user-attachments/assets/b2bde7fe-5e3a-4400-9bdf-1cbdee70ec2e" />

I sort of liked this last one, specially on the multiple icon flow like (hypthetical)
<img width="414" height="102" alt="image" src="https://github.com/user-attachments/assets/9ab79be1-626e-4162-ad40-2afe4064afbc" />

let me know if you want these `|__` at start or something else, i didn't do that as didn't wanted to mess with practice in code.

PS: how it looks after this implemented change
<img width="1075" height="129" alt="image" src="https://github.com/user-attachments/assets/20f733f2-3fe6-4109-aaaa-b99e2ac3d1ae" />




## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Closes #22816 

## How to Validate

  1. Enable tracker: set `"experimental": { "taskTracker": true }` in `~/.gemini/settings.json`                                                                                  
  2. `npm run build` and `npm start`
  3. Prompt: "Create an epic with three subtasks where A depends on B and B depends on C. Visualize the task graph."                                                             
  4. Verify output nests as a three-level tree (C → B → A) instead of flat list with "Depends on" text                                                                           
  5. Also the simple added test runs fine.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [X] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [X] MacOS
    - [X] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
