### PR TITLE
feat(cli): add /context command to show context window breakdown

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -26,6 +26,7 @@ import { chatCommand, debugCommand } from '../ui/commands/chatCommand.js';
 import { clearCommand } from '../ui/commands/clearCommand.js';
 import { commandsCommand } from '../ui/commands/commandsCommand.js';
 import { compressCommand } from '../ui/commands/compressCommand.js';
+import { contextCommand } from '../ui/commands/contextCommand.js';
 import { copyCommand } from '../ui/commands/copyCommand.js';
 import { corgiCommand } from '../ui/commands/corgiCommand.js';
 import { docsCommand } from '../ui/commands/docsCommand.js';
@@ -128,6 +129,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       clearCommand,
       commandsCommand,
       compressCommand,
+      contextCommand,
       copyCommand,
       corgiCommand,
       docsCommand,

--- a/packages/cli/src/ui/commands/contextCommand.ts
+++ b/packages/cli/src/ui/commands/contextCommand.ts
@@ -1,0 +1,157 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  MessageType,
+  type ContextWindowTurn,
+  type ContextWindowTurnKind,
+} from '../types.js';
+import {
+  type CommandContext,
+  type SlashCommand,
+  CommandKind,
+} from './types.js';
+import { tokenLimit, estimateTokenCountSync } from '@google/gemini-cli-core';
+import type { Content, Tool } from '@google/genai';
+
+function estimateStringTokens(text: string): number {
+  if (!text) return 0;
+  return estimateTokenCountSync([{ text }]);
+}
+
+function estimateTurnTokens(content: Content): number {
+  return estimateTokenCountSync(content.parts || []);
+}
+
+function estimateToolDeclarationTokens(tools: Tool[]): number {
+  if (!tools || tools.length === 0) return 0;
+  return Math.floor(JSON.stringify(tools).length / 4);
+}
+
+/**
+ * Classifies a conversation turn by its dominant content type.
+ */
+function classifyTurn(content: Content): ContextWindowTurnKind {
+  const parts = content.parts || [];
+  let hasText = false;
+  let hasCall = false;
+  let hasResult = false;
+  let hasMedia = false;
+
+  for (const part of parts) {
+    if (typeof part.text === 'string' && part.text.length > 0) hasText = true;
+    else if (part.functionCall) hasCall = true;
+    else if (part.functionResponse) hasResult = true;
+    else if ('inlineData' in part || 'fileData' in part) hasMedia = true;
+  }
+
+  const count = [hasText, hasCall, hasResult, hasMedia].filter(Boolean).length;
+  if (count > 1) return 'mixed';
+  if (hasCall) return 'tool_call';
+  if (hasResult) return 'tool_result';
+  if (hasMedia) return 'media';
+  return 'text';
+}
+
+function getContentPreview(content: Content, maxLen: number = 80): string {
+  const parts = content.parts || [];
+  const segments: string[] = [];
+
+  for (const part of parts) {
+    if (typeof part.text === 'string' && part.text.length > 0) {
+      segments.push(part.text);
+    } else if (part.functionCall) {
+      segments.push(`[call: ${part.functionCall.name}]`);
+    } else if (part.functionResponse) {
+      segments.push(`[result: ${part.functionResponse.name}]`);
+    } else if ('inlineData' in part || 'fileData' in part) {
+      segments.push('[media]');
+    }
+  }
+
+  const full = segments.join(' ').replace(/\n+/g, ' ').trim();
+  if (full.length <= maxLen) return full;
+  return full.slice(0, maxLen - 3) + '...';
+}
+
+function contextAction(context: CommandContext): void {
+  const config = context.services.config;
+  if (!config) {
+    context.ui.addItem({
+      type: MessageType.ERROR,
+      text: 'Config not available.',
+    });
+    return;
+  }
+
+  const client = config.getGeminiClient();
+  if (!client || !client.isInitialized()) {
+    context.ui.addItem({
+      type: MessageType.ERROR,
+      text: 'Chat not initialized yet.',
+    });
+    return;
+  }
+
+  const chat = client.getChat();
+  const history = chat.getHistory();
+  const model = config.getModel() || 'unknown';
+  const limit = tokenLimit(model);
+
+  const sysInstruction = chat.getSystemInstruction();
+  const systemPromptTokens = estimateStringTokens(sysInstruction);
+
+  const tools = chat.getTools();
+  const toolDeclarationTokens = estimateToolDeclarationTokens(tools);
+  const toolCount = tools.reduce(
+    (sum, t) => sum + (t.functionDeclarations?.length ?? 0),
+    0,
+  );
+
+  const turns: ContextWindowTurn[] = [];
+  let conversationTokens = 0;
+
+  for (let i = 0; i < history.length; i++) {
+    const turn = history[i];
+    const tokens = estimateTurnTokens(turn);
+    conversationTokens += tokens;
+    turns.push({
+      index: i + 1,
+      role: turn.role || 'unknown',
+      kind: classifyTurn(turn),
+      tokens,
+      preview: getContentPreview(turn),
+    });
+  }
+
+  // Sum our estimates for the total — the API-reported
+  // lastPromptTokenCount only covers conversation history, not
+  // system prompt or tool schemas.
+  const tokensUsed =
+    systemPromptTokens + toolDeclarationTokens + conversationTokens;
+
+  context.ui.addItem({
+    type: MessageType.CONTEXT_WINDOW,
+    data: {
+      model,
+      tokenLimit: limit,
+      tokensUsed,
+      systemPromptTokens,
+      toolDeclarationTokens,
+      toolCount,
+      conversationTokens,
+      turns,
+    },
+  });
+}
+
+export const contextCommand: SlashCommand = {
+  name: 'context',
+  description: 'Show what is in the current context window',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: contextAction,
+};

--- a/packages/cli/src/ui/commands/contextCommand.ts
+++ b/packages/cli/src/ui/commands/contextCommand.ts
@@ -32,7 +32,7 @@ function estimateToolDeclarationTokens(tools: readonly Tool[]): number {
 }
 
 async function contextAction(context: CommandContext): Promise<void> {
-  const config = context.services.config;
+  const config = context.services.agentContext?.config;
   if (!config) {
     context.ui.addItem({
       type: MessageType.ERROR,

--- a/packages/cli/src/ui/commands/contextCommand.ts
+++ b/packages/cli/src/ui/commands/contextCommand.ts
@@ -4,18 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  MessageType,
-  type ContextWindowTurn,
-  type ContextWindowTurnKind,
-  type HistoryItemContextWindow,
-} from '../types.js';
+import { MessageType, type HistoryItemContextWindow } from '../types.js';
 import {
   type CommandContext,
   type SlashCommand,
   CommandKind,
 } from './types.js';
-import { tokenLimit, estimateTokenCountSync } from '@google/gemini-cli-core';
+import {
+  tokenLimit,
+  estimateTokenCountSync,
+  flattenMemory,
+} from '@google/gemini-cli-core';
 import type { Content, Tool } from '@google/genai';
 
 function estimateStringTokens(text: string): number {
@@ -32,56 +31,7 @@ function estimateToolDeclarationTokens(tools: readonly Tool[]): number {
   return Math.floor(JSON.stringify(tools).length / 4);
 }
 
-/**
- * Classifies a conversation turn by its dominant content type.
- */
-function classifyTurn(content: Content): ContextWindowTurnKind {
-  const parts = content.parts || [];
-  let hasText = false;
-  let hasCall = false;
-  let hasResult = false;
-  let hasMedia = false;
-
-  for (const part of parts) {
-    if (typeof part.text === 'string' && part.text.length > 0) hasText = true;
-    if (part.functionCall) hasCall = true;
-    if (part.functionResponse) hasResult = true;
-    if ('inlineData' in part || 'fileData' in part) hasMedia = true;
-  }
-
-  const count = [hasText, hasCall, hasResult, hasMedia].filter(Boolean).length;
-  if (count > 1) return 'mixed';
-  if (hasCall) return 'tool_call';
-  if (hasResult) return 'tool_result';
-  if (hasMedia) return 'media';
-  return 'text';
-}
-
-function getContentPreview(content: Content, maxLen: number = 80): string {
-  const parts = content.parts || [];
-  const segments: string[] = [];
-
-  for (const part of parts) {
-    if (typeof part.text === 'string' && part.text.length > 0) {
-      segments.push(part.text);
-    }
-    if (part.functionCall) {
-      segments.push(`[call: ${part.functionCall.name}]`);
-    }
-    if (part.functionResponse) {
-      segments.push(`[result: ${part.functionResponse.name}]`);
-    }
-    if ('inlineData' in part || 'fileData' in part) {
-      segments.push('[media]');
-    }
-  }
-
-  const full = segments.join(' ').replace(/\n+/g, ' ').trim();
-  if (full.length <= maxLen) return full;
-  return full.slice(0, maxLen - 3) + '...';
-}
-
-function contextAction(context: CommandContext): void {
+async function contextAction(context: CommandContext): Promise<void> {
   const config = context.services.config;
   if (!config) {
     context.ui.addItem({
@@ -105,9 +55,20 @@ function contextAction(context: CommandContext): void {
   const model = config.getModel() || 'unknown';
   const limit = tokenLimit(model);
 
+  // System prompt tokens (includes memory content)
   const sysInstruction = chat.getSystemInstruction();
-  const systemPromptTokens = estimateStringTokens(sysInstruction);
+  const totalSystemTokens = estimateStringTokens(sysInstruction);
 
+  // Memory tokens from the *loaded* content (what's actually in the system
+  // instruction), not from disk — files may have been edited since load.
+  const loadedMemory = flattenMemory(config.getUserMemory());
+  const memoryTokens = estimateStringTokens(loadedMemory);
+  const memoryFileCount = config.getGeminiMdFileCount();
+
+  // Core system prompt = total system instruction minus loaded memory
+  const systemPromptTokens = Math.max(0, totalSystemTokens - memoryTokens);
+
+  // Tool declarations
   const tools = chat.getTools();
   const toolDeclarationTokens = estimateToolDeclarationTokens(tools);
   const toolCount = tools.reduce(
@@ -115,27 +76,32 @@ function contextAction(context: CommandContext): void {
     0,
   );
 
-  const turns: ContextWindowTurn[] = [];
+  // Conversation history
+  const turnCount = history.length;
   let conversationTokens = 0;
-
-  for (let i = 0; i < history.length; i++) {
-    const turn = history[i];
-    const tokens = estimateTurnTokens(turn);
-    conversationTokens += tokens;
-    turns.push({
-      index: i + 1,
-      role: turn.role || 'unknown',
-      kind: classifyTurn(turn),
-      tokens,
-      preview: getContentPreview(turn),
-    });
+  for (const turn of history) {
+    conversationTokens += estimateTurnTokens(turn);
   }
 
-  // Sum our estimates for the total — the API-reported
-  // lastPromptTokenCount only covers conversation history, not
-  // system prompt or tool schemas.
+  // Compression threshold
+  const compressionThreshold = (await config.getCompressionThreshold()) ?? 0.5;
+
+  // Estimated turns remaining before compression
   const tokensUsed =
-    systemPromptTokens + toolDeclarationTokens + conversationTokens;
+    systemPromptTokens +
+    memoryTokens +
+    toolDeclarationTokens +
+    conversationTokens;
+  const compressionTokenLimit = compressionThreshold * limit;
+  const tokensUntilCompression = Math.max(
+    0,
+    compressionTokenLimit - tokensUsed,
+  );
+  const avgTokensPerTurn = turnCount > 0 ? conversationTokens / turnCount : 0;
+  const estimatedTurnsRemaining =
+    avgTokensPerTurn > 0
+      ? Math.floor(tokensUntilCompression / avgTokensPerTurn)
+      : null;
 
   const item: HistoryItemContextWindow = {
     type: MessageType.CONTEXT_WINDOW,
@@ -144,10 +110,14 @@ function contextAction(context: CommandContext): void {
       tokenLimit: limit,
       tokensUsed,
       systemPromptTokens,
+      memoryTokens,
+      memoryFileCount,
       toolDeclarationTokens,
       toolCount,
       conversationTokens,
-      turns,
+      turnCount,
+      compressionThreshold,
+      estimatedTurnsRemaining,
     },
   };
   context.ui.addItem(item);

--- a/packages/cli/src/ui/commands/contextCommand.ts
+++ b/packages/cli/src/ui/commands/contextCommand.ts
@@ -8,6 +8,7 @@ import {
   MessageType,
   type ContextWindowTurn,
   type ContextWindowTurnKind,
+  type HistoryItemContextWindow,
 } from '../types.js';
 import {
   type CommandContext,
@@ -26,7 +27,7 @@ function estimateTurnTokens(content: Content): number {
   return estimateTokenCountSync(content.parts || []);
 }
 
-function estimateToolDeclarationTokens(tools: Tool[]): number {
+function estimateToolDeclarationTokens(tools: readonly Tool[]): number {
   if (!tools || tools.length === 0) return 0;
   return Math.floor(JSON.stringify(tools).length / 4);
 }
@@ -43,9 +44,9 @@ function classifyTurn(content: Content): ContextWindowTurnKind {
 
   for (const part of parts) {
     if (typeof part.text === 'string' && part.text.length > 0) hasText = true;
-    else if (part.functionCall) hasCall = true;
-    else if (part.functionResponse) hasResult = true;
-    else if ('inlineData' in part || 'fileData' in part) hasMedia = true;
+    if (part.functionCall) hasCall = true;
+    if (part.functionResponse) hasResult = true;
+    if ('inlineData' in part || 'fileData' in part) hasMedia = true;
   }
 
   const count = [hasText, hasCall, hasResult, hasMedia].filter(Boolean).length;
@@ -63,11 +64,14 @@ function getContentPreview(content: Content, maxLen: number = 80): string {
   for (const part of parts) {
     if (typeof part.text === 'string' && part.text.length > 0) {
       segments.push(part.text);
-    } else if (part.functionCall) {
+    }
+    if (part.functionCall) {
       segments.push(`[call: ${part.functionCall.name}]`);
-    } else if (part.functionResponse) {
+    }
+    if (part.functionResponse) {
       segments.push(`[result: ${part.functionResponse.name}]`);
-    } else if ('inlineData' in part || 'fileData' in part) {
+    }
+    if ('inlineData' in part || 'fileData' in part) {
       segments.push('[media]');
     }
   }
@@ -133,7 +137,7 @@ function contextAction(context: CommandContext): void {
   const tokensUsed =
     systemPromptTokens + toolDeclarationTokens + conversationTokens;
 
-  context.ui.addItem({
+  const item: HistoryItemContextWindow = {
     type: MessageType.CONTEXT_WINDOW,
     data: {
       model,
@@ -145,7 +149,8 @@ function contextAction(context: CommandContext): void {
       conversationTokens,
       turns,
     },
-  });
+  };
+  context.ui.addItem(item);
 }
 
 export const contextCommand: SlashCommand = {

--- a/packages/cli/src/ui/components/ContextWindowDisplay.tsx
+++ b/packages/cli/src/ui/components/ContextWindowDisplay.tsx
@@ -50,6 +50,38 @@ function fmtNum(n: number): string {
 }
 
 /**
+ * Builds the sub-bar annotation line, aligning the compress label with
+ * the │ marker on the bar above. Prefers └ to the right of the marker;
+ * falls back to ┘ on the left if the label would extend past the bar.
+ */
+function buildSubBarLine(
+  data: ContextWindowData,
+  total: number,
+  markerPos: number,
+): string {
+  const leftLabel = ` used (${((data.tokensUsed / total) * 100).toFixed(0)}%)`;
+  const pctText =
+    'compress at ' + (data.compressionThreshold * 100).toFixed(0) + '%';
+  const lineWidth = BAR_WIDTH + 2;
+
+  // +1 for the ▐ border character
+  const markerCol = markerPos + 1;
+
+  // Try placing └ label to the RIGHT of the marker
+  const rightLabel = '\u2514 ' + pctText;
+  if (markerCol + rightLabel.length <= lineWidth) {
+    const gap = Math.max(1, markerCol - leftLabel.length);
+    return leftLabel + ' '.repeat(gap) + rightLabel;
+  }
+
+  // Fall back to placing ┘ label to the LEFT of the marker
+  const leftArrow = pctText + ' \u2518';
+  const arrowStart = markerCol - leftArrow.length + 1;
+  const gap = Math.max(1, arrowStart - leftLabel.length);
+  return leftLabel + ' '.repeat(gap) + leftArrow;
+}
+
+/**
  * Renders a segmented bar showing proportional usage by category,
  * with a compression threshold marker.
  */
@@ -124,17 +156,10 @@ const SegmentedBar: React.FC<{ data: ContextWindowData }> = ({ data }) => {
         <Text color={categoryColors.free}>{'\u258C'}</Text>
       </Box>
 
-      <Box
-        flexDirection="row"
-        justifyContent="space-between"
-        width={BAR_WIDTH + 2}
-      >
+      {/* Sub-bar labels: position the ┘/└ to align with the │ marker */}
+      <Box flexDirection="row" width={BAR_WIDTH + 2}>
         <Text color={theme.text.secondary}>
-          {' '}
-          used ({((data.tokensUsed / total) * 100).toFixed(0)}%)
-        </Text>
-        <Text color={theme.text.secondary}>
-          compress at {(data.compressionThreshold * 100).toFixed(0)}%{' \u2518'}
+          {buildSubBarLine(data, total, markerPos)}
         </Text>
       </Box>
     </Box>

--- a/packages/cli/src/ui/components/ContextWindowDisplay.tsx
+++ b/packages/cli/src/ui/components/ContextWindowDisplay.tsx
@@ -7,264 +7,269 @@
 import type React from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../semantic-colors.js';
-import type { ContextWindowData, ContextWindowTurn } from '../types.js';
+import type { ContextWindowData } from '../types.js';
 
-const BAR_WIDTH = 30;
-const LABEL_WIDTH = 22;
-const TOKEN_WIDTH = 14;
-const PCT_WIDTH = 7;
+const BAR_WIDTH = 60;
 
 /**
- * Renders a visual progress bar using Unicode block characters.
+ * Color mapping for each context category.
+ * Chosen for perceptual distinctness and color-blind accessibility:
+ * blue, purple, yellow, cyan avoid the red-green confusion axis.
  */
-function renderBar(fraction: number, width: number): string {
-  const clamped = Math.max(0, Math.min(1, fraction));
-  const filled = Math.round(clamped * width);
-  const empty = width - filled;
-  return '\u2588'.repeat(filled) + '\u2591'.repeat(empty);
+const categoryColors = {
+  get system() {
+    return theme.text.link;
+  }, // AccentBlue
+  get memory() {
+    return theme.status.warning;
+  }, // AccentYellow
+  get tools() {
+    return theme.text.accent;
+  }, // AccentPurple
+  get conversation() {
+    return theme.ui.symbol;
+  }, // AccentCyan
+  get free() {
+    return theme.ui.dark;
+  }, // DarkGray
+  get marker() {
+    return theme.text.primary;
+  }, // Foreground
+};
+
+/** Format a token count compactly: 1,200 → "1.2k", 48,446 → "48k", 1,048,576 → "1,049k" */
+function fmtCompact(n: number): string {
+  if (n >= 10_000) return `${Math.round(n / 1_000)}k`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return Math.floor(n).toString();
 }
 
-/**
- * Formats a number with thousands separators.
- */
+/** Format a number with thousands separators. */
 function fmtNum(n: number): string {
   return Math.floor(n).toLocaleString();
 }
 
 /**
- * Returns a color based on how full the bar is.
+ * Renders a segmented bar showing proportional usage by category,
+ * with a compression threshold marker.
  */
-function barColor(fraction: number): string {
-  if (fraction >= 0.9) return theme.status.error;
-  if (fraction >= 0.6) return theme.status.warning;
-  return theme.ui.focus;
-}
+const SegmentedBar: React.FC<{ data: ContextWindowData }> = ({ data }) => {
+  const total = data.tokenLimit;
+  if (total <= 0) return null;
 
-/**
- * Returns an icon for a conversation turn based on its kind.
- */
-function turnIcon(turn: ContextWindowTurn): string {
-  switch (turn.kind) {
-    case 'tool_call':
-      return '\u0192'; // ƒ
-    case 'tool_result':
-      return '\u2398'; // ⎘
-    case 'media':
-      return '\u25A3'; // ▣
-    default:
-      return ' ';
+  // Compute character counts for each segment
+  const segments = [
+    { tokens: data.systemPromptTokens, color: categoryColors.system },
+    { tokens: data.memoryTokens, color: categoryColors.memory },
+    { tokens: data.toolDeclarationTokens, color: categoryColors.tools },
+    { tokens: data.conversationTokens, color: categoryColors.conversation },
+  ];
+
+  const usedChars = segments.map((s) => {
+    const fraction = s.tokens / total;
+    return Math.max(fraction > 0 ? 1 : 0, Math.round(fraction * BAR_WIDTH));
+  });
+
+  // Ensure we don't exceed BAR_WIDTH for the used portion
+  let totalUsedChars = usedChars.reduce((a, b) => a + b, 0);
+  while (totalUsedChars > BAR_WIDTH) {
+    const maxIdx = usedChars.indexOf(Math.max(...usedChars));
+    usedChars[maxIdx]--;
+    totalUsedChars--;
   }
-}
+
+  const freeChars = BAR_WIDTH - totalUsedChars;
+
+  // Compression threshold marker position
+  const markerPos = Math.round(data.compressionThreshold * BAR_WIDTH);
+
+  // Build the bar as an array of { char, color } entries
+  const bar: Array<{ char: string; color: string }> = [];
+
+  for (let i = 0; i < segments.length; i++) {
+    for (let j = 0; j < usedChars[i]; j++) {
+      bar.push({ char: '\u2588', color: segments[i].color }); // █
+    }
+  }
+
+  for (let i = 0; i < freeChars; i++) {
+    bar.push({ char: '\u2591', color: categoryColors.free }); // ░
+  }
+
+  // Insert compression marker (replace the character at that position)
+  if (markerPos > 0 && markerPos < BAR_WIDTH) {
+    bar[markerPos] = { char: '\u2502', color: categoryColors.marker }; // │
+  }
+
+  // Group consecutive characters with the same color for efficient rendering
+  const groups: Array<{ text: string; color: string }> = [];
+  for (const entry of bar) {
+    const last = groups[groups.length - 1];
+    if (last && last.color === entry.color) {
+      last.text += entry.char;
+    } else {
+      groups.push({ text: entry.char, color: entry.color });
+    }
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Box flexDirection="row">
+        <Text color={categoryColors.free}>{'\u2590'}</Text>
+        {groups.map((g, i) => (
+          <Text key={i} color={g.color}>
+            {g.text}
+          </Text>
+        ))}
+        <Text color={categoryColors.free}>{'\u258C'}</Text>
+      </Box>
+
+      <Box
+        flexDirection="row"
+        justifyContent="space-between"
+        width={BAR_WIDTH + 2}
+      >
+        <Text color={theme.text.secondary}>
+          {' '}
+          used ({((data.tokensUsed / total) * 100).toFixed(0)}%)
+        </Text>
+        <Text color={theme.text.secondary}>
+          compress at {(data.compressionThreshold * 100).toFixed(0)}%{' \u2518'}
+        </Text>
+      </Box>
+    </Box>
+  );
+};
 
 /**
- * A row in the breakdown section showing a category with a visual bar.
+ * A single row in the breakdown table.
  */
-const BreakdownRow: React.FC<{
+const CategoryRow: React.FC<{
   label: string;
   tokens: number;
-  total: number;
+  pctOfLimit: number;
+  color: string;
   detail?: string;
-}> = ({ label, tokens, total, detail }) => {
-  const fraction = total > 0 ? tokens / total : 0;
-  const pct = (fraction * 100).toFixed(0);
-
-  return (
-    <Box flexDirection="row">
-      <Box width={LABEL_WIDTH}>
-        <Text bold color={theme.text.link}>
-          {label}
-        </Text>
-      </Box>
-      <Box width={BAR_WIDTH + 1}>
-        <Text color={barColor(fraction)}>{renderBar(fraction, BAR_WIDTH)}</Text>
-      </Box>
-      <Box width={PCT_WIDTH} justifyContent="flex-end">
-        <Text color={theme.text.secondary}>{pct}%</Text>
-      </Box>
-      <Box width={TOKEN_WIDTH} justifyContent="flex-end">
-        <Text color={theme.text.primary}>{fmtNum(tokens)}</Text>
-      </Box>
-      {detail && (
-        <Box marginLeft={1}>
-          <Text color={theme.text.secondary}>{detail}</Text>
-        </Box>
-      )}
+}> = ({ label, tokens, pctOfLimit, color, detail }) => (
+  <Box flexDirection="row">
+    <Box width={20}>
+      <Text color={color}>{label}</Text>
     </Box>
-  );
-};
-
-/**
- * A single conversation turn row.
- */
-const TurnRow: React.FC<{
-  turn: ContextWindowTurn;
-}> = ({ turn }) => {
-  const icon = turnIcon(turn);
-  const roleColor = turn.role === 'user' ? theme.ui.focus : theme.text.accent;
-
-  return (
-    <Box flexDirection="row">
-      <Box width={5} justifyContent="flex-end">
-        <Text color={theme.text.secondary}>{turn.index}</Text>
-      </Box>
-      <Box width={2}>
-        <Text color={theme.text.secondary}>{icon}</Text>
-      </Box>
-      <Box width={7}>
-        <Text color={roleColor}>{turn.role}</Text>
-      </Box>
-      <Box width={TOKEN_WIDTH} justifyContent="flex-end">
-        <Text color={theme.text.primary}>{fmtNum(turn.tokens)}</Text>
-      </Box>
-      <Box marginLeft={2} flexShrink={1}>
-        <Text color={theme.text.secondary} wrap="truncate">
-          {turn.preview}
-        </Text>
-      </Box>
+    <Box width={12} justifyContent="flex-end">
+      <Text>{fmtNum(tokens)}</Text>
     </Box>
-  );
-};
+    <Box width={8} justifyContent="flex-end">
+      <Text color={theme.text.secondary}>{pctOfLimit.toFixed(1)}%</Text>
+    </Box>
+    {detail && (
+      <Box marginLeft={3}>
+        <Text color={theme.text.secondary}>{detail}</Text>
+      </Box>
+    )}
+  </Box>
+);
 
 export const ContextWindowDisplay: React.FC<{ data: ContextWindowData }> = ({
   data,
 }) => {
-  const usageFraction =
-    data.tokenLimit > 0 ? data.tokensUsed / data.tokenLimit : 0;
-  const usagePct = (usageFraction * 100).toFixed(1);
+  const pctUsed = data.tokenLimit > 0 ? data.tokensUsed / data.tokenLimit : 0;
+  const remaining = Math.max(0, data.tokenLimit - data.tokensUsed);
 
-  const maxTurnsToShow = 30;
-  const turnsToShow = data.turns.slice(0, maxTurnsToShow);
-  const hiddenTurns = data.turns.length - turnsToShow.length;
+  const turnsEstimate =
+    data.estimatedTurnsRemaining !== null
+      ? ` \u00B7 \u2248 ${fmtNum(data.estimatedTurnsRemaining)} turns at current rate`
+      : '';
 
   return (
-    <Box
-      borderStyle="round"
-      borderColor={theme.border.default}
-      flexDirection="column"
-      padding={1}
-      marginY={1}
-      width={88}
-    >
-      {/* Title */}
-      <Box marginBottom={1}>
-        <Text bold color={theme.text.accent}>
-          Context Window
-        </Text>
-      </Box>
-
-      {/* Model and overall usage */}
-      <Box flexDirection="row">
-        <Text color={theme.text.secondary}>Model: </Text>
-        <Text color={theme.text.primary}>{data.model}</Text>
-      </Box>
-
-      {/* Overall progress bar */}
-      <Box flexDirection="row">
-        <Text color={barColor(usageFraction)}>
-          {renderBar(usageFraction, BAR_WIDTH)}
-        </Text>
-        <Text color={theme.text.secondary}>
-          {' '}
-          {usagePct}% of {fmtNum(data.tokenLimit)}
-        </Text>
-      </Box>
-      <Box marginBottom={1}>
-        <Text bold color={theme.text.primary}>
-          {fmtNum(data.tokensUsed)} tokens used
-        </Text>
-      </Box>
-
-      {/* Divider */}
+    <Box flexDirection="column" marginY={1}>
+      {/* Header */}
       <Box
-        borderStyle="single"
-        borderBottom={true}
-        borderTop={false}
-        borderLeft={false}
-        borderRight={false}
-        borderColor={theme.border.default}
-        width="100%"
-        marginBottom={1}
-      />
-
-      {/* Breakdown header */}
-      <Box marginBottom={1}>
-        <Text bold color={theme.text.primary}>
-          Breakdown
+        flexDirection="row"
+        justifyContent="space-between"
+        width={BAR_WIDTH + 2}
+      >
+        <Box flexDirection="row">
+          <Text bold color={theme.text.primary}>
+            Context
+          </Text>
+          <Text color={theme.text.secondary}>
+            {' \u00B7 '}
+            {data.model}
+          </Text>
+        </Box>
+        <Text color={theme.text.secondary}>
+          {fmtCompact(data.tokensUsed)} / {fmtCompact(data.tokenLimit)} tokens
         </Text>
       </Box>
 
-      {/* Category bars */}
-      <BreakdownRow
-        label="System Prompt"
-        tokens={data.systemPromptTokens}
-        total={data.tokensUsed}
-      />
-      <BreakdownRow
-        label="Tool Declarations"
-        tokens={data.toolDeclarationTokens}
-        total={data.tokensUsed}
-        detail={`${data.toolCount} tools`}
-      />
-      <BreakdownRow
-        label="Conversation"
-        tokens={data.conversationTokens}
-        total={data.tokensUsed}
-        detail={`${data.turns.length} turns`}
-      />
+      {/* Segmented bar */}
+      <Box marginTop={1}>
+        <SegmentedBar data={data} />
+      </Box>
 
-      {/* Conversation turns */}
-      {data.turns.length > 0 && (
-        <Box flexDirection="column" marginTop={1}>
-          {/* Divider */}
-          <Box
-            borderStyle="single"
-            borderBottom={true}
-            borderTop={false}
-            borderLeft={false}
-            borderRight={false}
-            borderColor={theme.border.default}
-            width="100%"
-            marginBottom={1}
-          />
+      {/* Remaining headline */}
+      <Box marginTop={1}>
+        <Text
+          bold
+          color={
+            pctUsed >= 0.9
+              ? theme.status.error
+              : pctUsed >= 0.6
+                ? theme.status.warning
+                : theme.text.primary
+          }
+        >
+          {fmtCompact(remaining)} tokens remaining
+        </Text>
+        <Text color={theme.text.secondary}>{turnsEstimate}</Text>
+      </Box>
 
-          <Box>
-            <Text bold color={theme.text.primary}>
-              Conversation History
-            </Text>
-          </Box>
-
-          {/* Column header */}
-          <Box flexDirection="row">
-            <Box width={5} justifyContent="flex-end">
-              <Text color={theme.text.secondary}>#</Text>
-            </Box>
-            <Box width={2}>
-              <Text> </Text>
-            </Box>
-            <Box width={7}>
-              <Text color={theme.text.secondary}>Role</Text>
-            </Box>
-            <Box width={TOKEN_WIDTH} justifyContent="flex-end">
-              <Text color={theme.text.secondary}>Tokens</Text>
-            </Box>
-            <Box marginLeft={2}>
-              <Text color={theme.text.secondary}>Content</Text>
-            </Box>
-          </Box>
-
-          {turnsToShow.map((turn) => (
-            <TurnRow key={turn.index} turn={turn} />
-          ))}
-
-          {hiddenTurns > 0 && (
-            <Box marginLeft={5}>
-              <Text color={theme.text.secondary}>
-                ... and {hiddenTurns} more turns
-              </Text>
-            </Box>
-          )}
-        </Box>
-      )}
+      {/* Breakdown table */}
+      <Box flexDirection="column" marginTop={1}>
+        <CategoryRow
+          label="System prompt"
+          tokens={data.systemPromptTokens}
+          pctOfLimit={
+            data.tokenLimit > 0
+              ? (data.systemPromptTokens / data.tokenLimit) * 100
+              : 0
+          }
+          color={categoryColors.system}
+        />
+        <CategoryRow
+          label="Tool schemas"
+          tokens={data.toolDeclarationTokens}
+          pctOfLimit={
+            data.tokenLimit > 0
+              ? (data.toolDeclarationTokens / data.tokenLimit) * 100
+              : 0
+          }
+          color={categoryColors.tools}
+          detail={`${data.toolCount} tools`}
+        />
+        <CategoryRow
+          label="Memory files"
+          tokens={data.memoryTokens}
+          pctOfLimit={
+            data.tokenLimit > 0
+              ? (data.memoryTokens / data.tokenLimit) * 100
+              : 0
+          }
+          color={categoryColors.memory}
+          detail={`${data.memoryFileCount} files`}
+        />
+        <CategoryRow
+          label="Conversation"
+          tokens={data.conversationTokens}
+          pctOfLimit={
+            data.tokenLimit > 0
+              ? (data.conversationTokens / data.tokenLimit) * 100
+              : 0
+          }
+          color={categoryColors.conversation}
+          detail={`${data.turnCount} turns`}
+        />
+      </Box>
     </Box>
   );
 };

--- a/packages/cli/src/ui/components/ContextWindowDisplay.tsx
+++ b/packages/cli/src/ui/components/ContextWindowDisplay.tsx
@@ -1,0 +1,270 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box, Text } from 'ink';
+import { theme } from '../semantic-colors.js';
+import type { ContextWindowData, ContextWindowTurn } from '../types.js';
+
+const BAR_WIDTH = 30;
+const LABEL_WIDTH = 22;
+const TOKEN_WIDTH = 14;
+const PCT_WIDTH = 7;
+
+/**
+ * Renders a visual progress bar using Unicode block characters.
+ */
+function renderBar(fraction: number, width: number): string {
+  const clamped = Math.max(0, Math.min(1, fraction));
+  const filled = Math.round(clamped * width);
+  const empty = width - filled;
+  return '\u2588'.repeat(filled) + '\u2591'.repeat(empty);
+}
+
+/**
+ * Formats a number with thousands separators.
+ */
+function fmtNum(n: number): string {
+  return Math.floor(n).toLocaleString();
+}
+
+/**
+ * Returns a color based on how full the bar is.
+ */
+function barColor(fraction: number): string {
+  if (fraction >= 0.9) return theme.status.error;
+  if (fraction >= 0.6) return theme.status.warning;
+  return theme.ui.focus;
+}
+
+/**
+ * Returns an icon for a conversation turn based on its kind.
+ */
+function turnIcon(turn: ContextWindowTurn): string {
+  switch (turn.kind) {
+    case 'tool_call':
+      return '\u0192'; // ƒ
+    case 'tool_result':
+      return '\u2398'; // ⎘
+    case 'media':
+      return '\u25A3'; // ▣
+    default:
+      return ' ';
+  }
+}
+
+/**
+ * A row in the breakdown section showing a category with a visual bar.
+ */
+const BreakdownRow: React.FC<{
+  label: string;
+  tokens: number;
+  total: number;
+  detail?: string;
+}> = ({ label, tokens, total, detail }) => {
+  const fraction = total > 0 ? tokens / total : 0;
+  const pct = (fraction * 100).toFixed(0);
+
+  return (
+    <Box flexDirection="row">
+      <Box width={LABEL_WIDTH}>
+        <Text bold color={theme.text.link}>
+          {label}
+        </Text>
+      </Box>
+      <Box width={BAR_WIDTH + 1}>
+        <Text color={barColor(fraction)}>{renderBar(fraction, BAR_WIDTH)}</Text>
+      </Box>
+      <Box width={PCT_WIDTH} justifyContent="flex-end">
+        <Text color={theme.text.secondary}>{pct}%</Text>
+      </Box>
+      <Box width={TOKEN_WIDTH} justifyContent="flex-end">
+        <Text color={theme.text.primary}>{fmtNum(tokens)}</Text>
+      </Box>
+      {detail && (
+        <Box marginLeft={1}>
+          <Text color={theme.text.secondary}>{detail}</Text>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+/**
+ * A single conversation turn row.
+ */
+const TurnRow: React.FC<{
+  turn: ContextWindowTurn;
+}> = ({ turn }) => {
+  const icon = turnIcon(turn);
+  const roleColor = turn.role === 'user' ? theme.ui.focus : theme.text.accent;
+
+  return (
+    <Box flexDirection="row">
+      <Box width={5} justifyContent="flex-end">
+        <Text color={theme.text.secondary}>{turn.index}</Text>
+      </Box>
+      <Box width={2}>
+        <Text color={theme.text.secondary}>{icon}</Text>
+      </Box>
+      <Box width={7}>
+        <Text color={roleColor}>{turn.role}</Text>
+      </Box>
+      <Box width={TOKEN_WIDTH} justifyContent="flex-end">
+        <Text color={theme.text.primary}>{fmtNum(turn.tokens)}</Text>
+      </Box>
+      <Box marginLeft={2} flexShrink={1}>
+        <Text color={theme.text.secondary} wrap="truncate">
+          {turn.preview}
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+
+export const ContextWindowDisplay: React.FC<{ data: ContextWindowData }> = ({
+  data,
+}) => {
+  const usageFraction =
+    data.tokenLimit > 0 ? data.tokensUsed / data.tokenLimit : 0;
+  const usagePct = (usageFraction * 100).toFixed(1);
+
+  const maxTurnsToShow = 30;
+  const turnsToShow = data.turns.slice(0, maxTurnsToShow);
+  const hiddenTurns = data.turns.length - turnsToShow.length;
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={theme.border.default}
+      flexDirection="column"
+      padding={1}
+      marginY={1}
+      width={88}
+    >
+      {/* Title */}
+      <Box marginBottom={1}>
+        <Text bold color={theme.text.accent}>
+          Context Window
+        </Text>
+      </Box>
+
+      {/* Model and overall usage */}
+      <Box flexDirection="row">
+        <Text color={theme.text.secondary}>Model: </Text>
+        <Text color={theme.text.primary}>{data.model}</Text>
+      </Box>
+
+      {/* Overall progress bar */}
+      <Box flexDirection="row">
+        <Text color={barColor(usageFraction)}>
+          {renderBar(usageFraction, BAR_WIDTH)}
+        </Text>
+        <Text color={theme.text.secondary}>
+          {' '}
+          {usagePct}% of {fmtNum(data.tokenLimit)}
+        </Text>
+      </Box>
+      <Box marginBottom={1}>
+        <Text bold color={theme.text.primary}>
+          {fmtNum(data.tokensUsed)} tokens used
+        </Text>
+      </Box>
+
+      {/* Divider */}
+      <Box
+        borderStyle="single"
+        borderBottom={true}
+        borderTop={false}
+        borderLeft={false}
+        borderRight={false}
+        borderColor={theme.border.default}
+        width="100%"
+        marginBottom={1}
+      />
+
+      {/* Breakdown header */}
+      <Box marginBottom={1}>
+        <Text bold color={theme.text.primary}>
+          Breakdown
+        </Text>
+      </Box>
+
+      {/* Category bars */}
+      <BreakdownRow
+        label="System Prompt"
+        tokens={data.systemPromptTokens}
+        total={data.tokensUsed}
+      />
+      <BreakdownRow
+        label="Tool Declarations"
+        tokens={data.toolDeclarationTokens}
+        total={data.tokensUsed}
+        detail={`${data.toolCount} tools`}
+      />
+      <BreakdownRow
+        label="Conversation"
+        tokens={data.conversationTokens}
+        total={data.tokensUsed}
+        detail={`${data.turns.length} turns`}
+      />
+
+      {/* Conversation turns */}
+      {data.turns.length > 0 && (
+        <Box flexDirection="column" marginTop={1}>
+          {/* Divider */}
+          <Box
+            borderStyle="single"
+            borderBottom={true}
+            borderTop={false}
+            borderLeft={false}
+            borderRight={false}
+            borderColor={theme.border.default}
+            width="100%"
+            marginBottom={1}
+          />
+
+          <Box>
+            <Text bold color={theme.text.primary}>
+              Conversation History
+            </Text>
+          </Box>
+
+          {/* Column header */}
+          <Box flexDirection="row">
+            <Box width={5} justifyContent="flex-end">
+              <Text color={theme.text.secondary}>#</Text>
+            </Box>
+            <Box width={2}>
+              <Text> </Text>
+            </Box>
+            <Box width={7}>
+              <Text color={theme.text.secondary}>Role</Text>
+            </Box>
+            <Box width={TOKEN_WIDTH} justifyContent="flex-end">
+              <Text color={theme.text.secondary}>Tokens</Text>
+            </Box>
+            <Box marginLeft={2}>
+              <Text color={theme.text.secondary}>Content</Text>
+            </Box>
+          </Box>
+
+          {turnsToShow.map((turn) => (
+            <TurnRow key={turn.index} turn={turn} />
+          ))}
+
+          {hiddenTurns > 0 && (
+            <Box marginLeft={5}>
+              <Text color={theme.text.secondary}>
+                ... and {hiddenTurns} more turns
+              </Text>
+            </Box>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/ContextWindowDisplay.tsx
+++ b/packages/cli/src/ui/components/ContextWindowDisplay.tsx
@@ -206,7 +206,13 @@ export const ContextWindowDisplay: React.FC<{ data: ContextWindowData }> = ({
       : '';
 
   return (
-    <Box flexDirection="column" marginY={1}>
+    <Box
+      borderStyle="round"
+      borderColor={theme.border.default}
+      flexDirection="column"
+      paddingTop={1}
+      paddingX={2}
+    >
       {/* Header */}
       <Box
         flexDirection="row"
@@ -214,7 +220,7 @@ export const ContextWindowDisplay: React.FC<{ data: ContextWindowData }> = ({
         width={BAR_WIDTH + 2}
       >
         <Box flexDirection="row">
-          <Text bold color={theme.text.primary}>
+          <Text bold color={theme.text.accent}>
             Context
           </Text>
           <Text color={theme.text.secondary}>
@@ -228,12 +234,12 @@ export const ContextWindowDisplay: React.FC<{ data: ContextWindowData }> = ({
       </Box>
 
       {/* Segmented bar */}
-      <Box marginTop={1}>
-        <SegmentedBar data={data} />
-      </Box>
+      <Box height={1} />
+      <SegmentedBar data={data} />
 
       {/* Remaining headline */}
-      <Box marginTop={1}>
+      <Box height={1} />
+      <Box>
         <Text
           bold
           color={
@@ -250,7 +256,8 @@ export const ContextWindowDisplay: React.FC<{ data: ContextWindowData }> = ({
       </Box>
 
       {/* Breakdown table */}
-      <Box flexDirection="column" marginTop={1}>
+      <Box height={1} />
+      <Box flexDirection="column">
         <CategoryRow
           label="System prompt"
           tokens={data.systemPromptTokens}

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -22,6 +22,7 @@ import { AboutBox } from './AboutBox.js';
 import { StatsDisplay } from './StatsDisplay.js';
 import { ModelStatsDisplay } from './ModelStatsDisplay.js';
 import { ToolStatsDisplay } from './ToolStatsDisplay.js';
+import { ContextWindowDisplay } from './ContextWindowDisplay.js';
 import { SessionSummaryDisplay } from './SessionSummaryDisplay.js';
 import { Help } from './Help.js';
 import type { SlashCommand } from '../commands/types.js';
@@ -232,6 +233,9 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
       )}
       {itemForDisplay.type === 'chat_list' && (
         <ChatList chats={itemForDisplay.chats} />
+      )}
+      {itemForDisplay.type === 'context_window' && (
+        <ContextWindowDisplay data={itemForDisplay.data} />
       )}
     </Box>
   );

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -352,30 +352,19 @@ export type HistoryItemMcpStatus = HistoryItemBase & {
   showSchema: boolean;
 };
 
-export type ContextWindowTurnKind =
-  | 'text'
-  | 'tool_call'
-  | 'tool_result'
-  | 'media'
-  | 'mixed';
-
-export interface ContextWindowTurn {
-  index: number;
-  role: string;
-  kind: ContextWindowTurnKind;
-  tokens: number;
-  preview: string;
-}
-
 export interface ContextWindowData {
   model: string;
   tokenLimit: number;
   tokensUsed: number;
   systemPromptTokens: number;
+  memoryTokens: number;
+  memoryFileCount: number;
   toolDeclarationTokens: number;
   toolCount: number;
   conversationTokens: number;
-  turns: ContextWindowTurn[];
+  turnCount: number;
+  compressionThreshold: number;
+  estimatedTurnsRemaining: number | null;
 }
 
 export type HistoryItemContextWindow = HistoryItemBase & {

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -352,6 +352,37 @@ export type HistoryItemMcpStatus = HistoryItemBase & {
   showSchema: boolean;
 };
 
+export type ContextWindowTurnKind =
+  | 'text'
+  | 'tool_call'
+  | 'tool_result'
+  | 'media'
+  | 'mixed';
+
+export interface ContextWindowTurn {
+  index: number;
+  role: string;
+  kind: ContextWindowTurnKind;
+  tokens: number;
+  preview: string;
+}
+
+export interface ContextWindowData {
+  model: string;
+  tokenLimit: number;
+  tokensUsed: number;
+  systemPromptTokens: number;
+  toolDeclarationTokens: number;
+  toolCount: number;
+  conversationTokens: number;
+  turns: ContextWindowTurn[];
+}
+
+export type HistoryItemContextWindow = HistoryItemBase & {
+  type: 'context_window';
+  data: ContextWindowData;
+};
+
 // Using Omit<HistoryItem, 'id'> seems to have some issues with typescript's
 // type inference e.g. historyItem.type === 'tool_group' isn't auto-inferring that
 // 'tools' in historyItem.
@@ -380,7 +411,8 @@ export type HistoryItemWithoutId =
   | HistoryItemMcpStatus
   | HistoryItemChatList
   | HistoryItemThinking
-  | HistoryItemHint;
+  | HistoryItemHint
+  | HistoryItemContextWindow;
 
 export type HistoryItem = HistoryItemWithoutId & { id: number };
 
@@ -405,6 +437,7 @@ export enum MessageType {
   MCP_STATUS = 'mcp_status',
   CHAT_LIST = 'chat_list',
   HINT = 'hint',
+  CONTEXT_WINDOW = 'context_window',
 }
 
 // Simplified message structure for internal feedback

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -274,6 +274,14 @@ export class GeminiChat {
     this.systemInstruction = sysInstr;
   }
 
+  getSystemInstruction(): string {
+    return this.systemInstruction;
+  }
+
+  getTools(): Tool[] {
+    return [...this.tools];
+  }
+
   /**
    * Sends a message to the model and returns the response in chunks.
    *

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -278,7 +278,7 @@ export class GeminiChat {
     return this.systemInstruction;
   }
 
-  getTools(): Tool[] {
+  getTools(): readonly Tool[] {
     return [...this.tools];
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,6 +119,7 @@ export * from './utils/constants.js';
 export * from './utils/sessionUtils.js';
 export * from './utils/cache.js';
 export * from './utils/markdownUtils.js';
+export { estimateTokenCountSync } from './utils/tokenCalculation.js';
 
 // Export services
 export * from './services/fileDiscoveryService.js';


### PR DESCRIPTION
## Summary

Add a `/context` slash command that shows a compact visual breakdown of what is consuming the model's context window.

## Details

The command displays:

- **Segmented usage bar** — a single horizontal bar with color-coded segments per category (system prompt, tool schemas, memory files, conversation), plus a compression threshold marker at 50%
- **Remaining tokens headline** — prominently shows free space and estimated turns remaining at the current average rate
- **Category breakdown table** — token counts and percentage of limit for each category, with category labels colored to match their bar segments
- **Compression awareness** — marker on the bar and label showing where auto-compression kicks in

### Design decisions

- **Segmented bar over waffle grid** — more space-efficient (2 lines vs 10+), proportions are immediately readable
- **"Remaining" over "used" as headline** — answers the user's actual question ("am I running out?")
- **No turn-by-turn conversation dump** — not actionable; just noise. Total conversation tokens + turn count is sufficient.
- **Memory tokens from loaded state** — uses `getUserMemory()` (what's actually in the system instruction) rather than re-reading files from disk, avoiding stale data if files were edited mid-session
- **Color-blind accessible** — blue/purple/yellow/cyan avoids the red-green confusion axis; uses theme tokens for automatic dark/light/ANSI/custom theme compatibility

### Core changes
- `GeminiChat`: add `getSystemInstruction()` and `getTools()` public getters
- `index.ts`: export `estimateTokenCountSync` for CLI consumption

### CLI changes
- New `contextCommand.ts` — extracts context data from loaded in-memory state
- New `ContextWindowDisplay.tsx` — renders the segmented bar, breakdown table, and remaining headline
- Updated `types.ts` — `ContextWindowData` with memory/compression/turns fields

## Related Issues

Fixes #23165

## Test plan

- [ ] Run `/context` in a fresh session — should show bar with system prompt + tools + memory, no conversation
- [ ] Run `/context` after several turns — conversation segment appears, turns remaining estimate shown
- [ ] Verify on dark and light terminal themes — colors should be readable on both
- [ ] Verify compression threshold marker appears at ~50% position on bar
- [ ] Run `npm run preflight` — all checks pass
