### PR TITLE
feat(cli): add inline natural-language shell expansion

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -575,6 +575,10 @@ Gemini CLI.
         Indicator".
       - While in shell mode, text you type is interpreted directly as a shell
         command.
+      - If a shell-mode line starts with `?`, Gemini converts the rest of the
+        line from natural language into a single editable shell command inline.
+        The command is inserted into the prompt but is not executed
+        automatically.
     - **Exiting shell mode:**
       - When exited, the UI reverts to its standard appearance and normal Gemini
         CLI behavior resumes.

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -213,6 +213,9 @@ a `key` combination.
   The panel also auto-hides while the agent is running/streaming or when
   action-required dialogs are shown. Press `?` again to close the panel and
   insert a `?` into the prompt.
+- `?` at the start of a shell-mode prompt: Expand a natural-language request
+  into an editable shell command inline. The generated command is inserted into
+  the prompt and is not executed until you press `Enter` again.
 - `Tab` + `Tab` (while typing in the prompt): Toggle between minimal and full UI
   details when no completion/search interaction is active. The selected mode is
   remembered for future sessions. Full UI remains the default on first run, and

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -51,6 +51,7 @@ import {
 import clipboardy from 'clipboardy';
 import * as clipboardUtils from '../utils/clipboardUtils.js';
 import { useKittyKeyboardProtocol } from '../hooks/useKittyKeyboardProtocol.js';
+import { useShellCommandExpansion } from '../hooks/useShellCommandExpansion.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import stripAnsi from 'strip-ansi';
 import chalk from 'chalk';
@@ -74,6 +75,16 @@ vi.mock('../hooks/useReverseSearchCompletion.js');
 vi.mock('clipboardy');
 vi.mock('../utils/clipboardUtils.js');
 vi.mock('../hooks/useKittyKeyboardProtocol.js');
+vi.mock('../hooks/useShellCommandExpansion.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('../hooks/useShellCommandExpansion.js')
+    >();
+  return {
+    ...actual,
+    useShellCommandExpansion: vi.fn(),
+  };
+});
 vi.mock('../utils/terminalUtils.js', () => ({
   isLowColorDepth: vi.fn(() => false),
 }));
@@ -159,6 +170,10 @@ describe('InputPrompt', () => {
   let mockCommandCompletion: UseCommandCompletionReturn;
   let mockInputHistory: UseInputHistoryReturn;
   let mockReverseSearchCompletion: UseReverseSearchCompletionReturn;
+  let mockShellCommandExpansion: {
+    isExpanding: boolean;
+    expandShellCommand: ReturnType<typeof vi.fn>;
+  };
   let mockBuffer: TextBuffer;
   let mockCommandContext: CommandContext;
 
@@ -169,6 +184,7 @@ describe('InputPrompt', () => {
     useReverseSearchCompletion,
   );
   const mockedUseKittyKeyboardProtocol = vi.mocked(useKittyKeyboardProtocol);
+  const mockedUseShellCommandExpansion = vi.mocked(useShellCommandExpansion);
   const mockSetEmbeddedShellFocused = vi.fn();
   const mockSetCleanUiDetailsVisible = vi.fn();
   const mockToggleCleanUiDetailsVisible = vi.fn();
@@ -335,6 +351,11 @@ describe('InputPrompt', () => {
       enabled: false,
       checking: false,
     });
+    mockShellCommandExpansion = {
+      isExpanding: false,
+      expandShellCommand: vi.fn(),
+    };
+    mockedUseShellCommandExpansion.mockReturnValue(mockShellCommandExpansion);
 
     vi.mocked(clipboardy.read).mockResolvedValue('');
 
@@ -352,6 +373,7 @@ describe('InputPrompt', () => {
         getWorkspaceContext: () => ({
           getDirectories: () => ['/test/project/src'],
         }),
+        getGeminiClient: vi.fn(),
       } as unknown as Config,
       slashCommands: mockSlashCommands,
       commandContext: mockCommandContext,
@@ -431,6 +453,80 @@ describe('InputPrompt', () => {
         'ls -l',
       );
       expect(props.onSubmit).toHaveBeenCalledWith('ls -l');
+    });
+    unmount();
+  });
+
+  it('should expand a natural-language shell request inline instead of submitting it', async () => {
+    props.shellModeActive = true;
+    props.buffer.setText('? delete all .log files older than 7 days');
+    mockShellCommandExpansion.expandShellCommand.mockResolvedValue({
+      status: 'expanded',
+      command: 'find . -name "*.log" -mtime +7 -delete',
+    });
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
+
+    await act(async () => {
+      stdin.write('\r');
+    });
+
+    await waitFor(() => {
+      expect(mockShellCommandExpansion.expandShellCommand).toHaveBeenCalledWith(
+        '? delete all .log files older than 7 days',
+      );
+      expect(props.buffer.setText).toHaveBeenLastCalledWith(
+        'find . -name "*.log" -mtime +7 -delete',
+      );
+    });
+
+    expect(props.onSubmit).not.toHaveBeenCalled();
+    expect(mockShellHistory.addCommandToHistory).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should not open shortcuts help with ? on an empty prompt in shell mode', async () => {
+    props.shellModeActive = true;
+    props.buffer.handleInput = vi.fn((key: Key) => {
+      if (key.sequence === '?' && key.insertable) {
+        props.buffer.setText('?');
+        return true;
+      }
+      return false;
+    });
+
+    const setShortcutsHelpVisible = vi.fn();
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions: { setShortcutsHelpVisible },
+    });
+
+    await act(async () => {
+      stdin.write('?');
+    });
+
+    await waitFor(() => {
+      expect(setShortcutsHelpVisible).not.toHaveBeenCalled();
+      expect(props.buffer.setText).toHaveBeenLastCalledWith('?');
+    });
+    unmount();
+  });
+
+  it('should show a hint when a shell-mode prompt starts with ?', async () => {
+    props.shellModeActive = true;
+    const emitSpy = vi.spyOn(appEvents, 'emit');
+    props.buffer.setText('?');
+
+    const { unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
+
+    await waitFor(() => {
+      expect(emitSpy).toHaveBeenCalledWith(AppEvent.TransientMessage, {
+        message: 'Press Enter to generate an editable shell command.',
+        type: TransientMessageType.Hint,
+      });
     });
     unmount();
   });

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -80,6 +80,12 @@ import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
 import { useIsHelpDismissKey } from '../utils/shortcutsHelp.js';
 import { useRepeatedKeyPress } from '../hooks/useRepeatedKeyPress.js';
 import { useKeyMatchers } from '../hooks/useKeyMatchers.js';
+import {
+  SHELL_COMMAND_EXPANSION_EMPTY_MESSAGE,
+  SHELL_COMMAND_EXPANSION_FAILURE_MESSAGE,
+  shouldExpandShellCommandInline,
+  useShellCommandExpansion,
+} from '../hooks/useShellCommandExpansion.js';
 
 /**
  * Returns if the terminal can be trusted to handle paste events atomically
@@ -273,6 +279,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   ]);
   const [expandedSuggestionIndex, setExpandedSuggestionIndex] =
     useState<number>(-1);
+  const hasShownShellExpansionHint = useRef(false);
   const shellHistory = useShellHistory(config.getProjectRoot(), config.storage);
   const shellHistoryData = shellHistory.history;
 
@@ -292,6 +299,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     shellHistoryData,
     reverseSearchActive,
   );
+  const { isExpanding, expandShellCommand } = useShellCommandExpansion({
+    config,
+  });
 
   const reversedUserMessages = useMemo(
     () => [...userMessages].reverse(),
@@ -434,6 +444,79 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       streamingState,
       setQueueErrorMessage,
       slashCommands,
+    ],
+  );
+
+  const tryExpandShellCommandInline = useCallback(
+    (submittedValue: string) => {
+      if (!shellModeActive || !shouldExpandShellCommandInline(submittedValue)) {
+        return false;
+      }
+
+      if (isExpanding) {
+        appEvents.emit(AppEvent.TransientMessage, {
+          message: 'Generating shell command...',
+          type: TransientMessageType.Hint,
+        });
+        return true;
+      }
+
+      const pendingInput = submittedValue;
+      setSuppressCompletion(true);
+      hasUserNavigatedSuggestions.current = false;
+      appEvents.emit(AppEvent.TransientMessage, {
+        message: 'Generating shell command...',
+        type: TransientMessageType.Hint,
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      (async () => {
+        const result = await expandShellCommand(pendingInput);
+
+        if (buffer.text !== pendingInput) {
+          return;
+        }
+
+        switch (result.status) {
+          case 'expanded':
+            buffer.setText(result.command);
+            resetCompletionState();
+            resetReverseSearchCompletionState();
+            resetCommandSearchCompletionState();
+            setExpandedSuggestionIndex(-1);
+            return;
+          case 'empty_request':
+            appEvents.emit(AppEvent.TransientMessage, {
+              message: SHELL_COMMAND_EXPANSION_EMPTY_MESSAGE,
+              type: TransientMessageType.Warning,
+            });
+            return;
+          case 'failed':
+          case 'unavailable':
+            appEvents.emit(AppEvent.TransientMessage, {
+              message: SHELL_COMMAND_EXPANSION_FAILURE_MESSAGE,
+              type: TransientMessageType.Warning,
+            });
+            return;
+          case 'aborted':
+            return;
+          default: {
+            const exhaustiveCheck: never = result;
+            return exhaustiveCheck;
+          }
+        }
+      })();
+
+      return true;
+    },
+    [
+      shellModeActive,
+      isExpanding,
+      expandShellCommand,
+      buffer,
+      resetCompletionState,
+      resetReverseSearchCompletionState,
+      resetCommandSearchCompletionState,
     ],
   );
 
@@ -798,7 +881,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         key.sequence === '?' &&
         key.insertable &&
         !shortcutsHelpVisible &&
-        buffer.text.length === 0
+        buffer.text.length === 0 &&
+        !shellModeActive
       ) {
         setShortcutsHelpVisible(true);
         return true;
@@ -969,6 +1053,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           (completion.activeSuggestionIndex <= 0 &&
             !hasUserNavigatedSuggestions.current))
       ) {
+        if (tryExpandShellCommandInline(buffer.text)) {
+          return true;
+        }
         handleSubmit(buffer.text);
         return true;
       }
@@ -1020,6 +1107,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
                 setExpandedSuggestionIndex(-1);
                 hasUserNavigatedSuggestions.current = false;
                 if (buffer.text.trim()) {
+                  if (tryExpandShellCommandInline(buffer.text)) {
+                    return true;
+                  }
                   handleSubmit(buffer.text);
                 }
                 return true;
@@ -1179,6 +1269,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             buffer.backspace();
             buffer.newline();
           } else {
+            if (tryExpandShellCommandInline(buffer.text)) {
+              return true;
+            }
             handleSubmit(buffer.text);
           }
         }
@@ -1304,6 +1397,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       keyMatchers,
       isHelpDismissKey,
       settings,
+      tryExpandShellCommandInline,
     ],
   );
 
@@ -1452,6 +1546,26 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       onSuggestionsVisibilityChange(shouldShowSuggestions);
     }
   }, [shouldShowSuggestions, onSuggestionsVisibilityChange]);
+
+  useEffect(() => {
+    const shouldShowHint =
+      shellModeActive && shouldExpandShellCommandInline(buffer.text);
+
+    if (!shouldShowHint) {
+      hasShownShellExpansionHint.current = false;
+      return;
+    }
+
+    if (hasShownShellExpansionHint.current) {
+      return;
+    }
+
+    appEvents.emit(AppEvent.TransientMessage, {
+      message: 'Press Enter to generate an editable shell command.',
+      type: TransientMessageType.Hint,
+    });
+    hasShownShellExpansionHint.current = true;
+  }, [buffer.text, shellModeActive]);
 
   const showAutoAcceptStyling =
     !shellModeActive && approvalMode === ApprovalMode.AUTO_EDIT;

--- a/packages/cli/src/ui/hooks/useShellCommandExpansion.test.ts
+++ b/packages/cli/src/ui/hooks/useShellCommandExpansion.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  extractShellCommandFromResponse,
+  shouldExpandShellCommandInline,
+} from './useShellCommandExpansion.js';
+
+describe('useShellCommandExpansion helpers', () => {
+  it('detects the inline shell expansion prefix only at the start', () => {
+    expect(shouldExpandShellCommandInline('? list open tcp ports')).toBe(true);
+    expect(shouldExpandShellCommandInline(' ? list open tcp ports')).toBe(
+      false,
+    );
+    expect(shouldExpandShellCommandInline('l?ist open tcp ports')).toBe(false);
+  });
+
+  it('extracts a command from fenced output', () => {
+    expect(
+      extractShellCommandFromResponse(
+        '```sh\nfind . -name "*.log" -mtime +7 -delete\n```',
+      ),
+    ).toBe('find . -name "*.log" -mtime +7 -delete');
+  });
+
+  it('extracts the first command line from noisy output', () => {
+    expect(
+      extractShellCommandFromResponse(
+        '$ lsof -iTCP -sTCP:LISTEN -n -P\nThis lists listening TCP ports.',
+      ),
+    ).toBe('lsof -iTCP -sTCP:LISTEN -n -P');
+  });
+});

--- a/packages/cli/src/ui/hooks/useShellCommandExpansion.ts
+++ b/packages/cli/src/ui/hooks/useShellCommandExpansion.ts
@@ -1,0 +1,177 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Content } from '@google/genai';
+import {
+  debugLogger,
+  getResponseText,
+  LlmRole,
+  type Config,
+} from '@google/gemini-cli-core';
+
+export const SHELL_NATURAL_LANGUAGE_PREFIX = '?';
+export const SHELL_COMMAND_EXPANSION_FAILURE_MESSAGE =
+  'Could not generate a shell command.';
+export const SHELL_COMMAND_EXPANSION_EMPTY_MESSAGE =
+  'Enter a shell request after ?.';
+
+export type ShellCommandExpansionResult =
+  | { status: 'expanded'; command: string }
+  | { status: 'aborted' | 'empty_request' | 'failed' | 'unavailable' };
+
+export function shouldExpandShellCommandInline(input: string): boolean {
+  return input.startsWith(SHELL_NATURAL_LANGUAGE_PREFIX);
+}
+
+export function extractShellCommandFromResponse(
+  responseText: string,
+): string | null {
+  const trimmed = responseText.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const fencedBlockMatch = trimmed.match(/```(?:[\w-]+)?\s*([\s\S]*?)```/);
+  const normalized = (fencedBlockMatch?.[1] ?? trimmed).trim();
+  const lines = normalized
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (lines.length === 0) {
+    return null;
+  }
+
+  let command = lines[0]
+    .replace(/^(?:Command:\s*)/i, '')
+    .replace(/^(?:\$|>)\s*/, '')
+    .replace(/^[-*]\s+/, '')
+    .trim();
+
+  command = command.replace(/^`+|`+$/g, '').trim();
+
+  return command.length > 0 ? command : null;
+}
+
+function buildShellCommandExpansionPrompt(
+  request: string,
+  targetDir: string,
+): string {
+  const shellEnvironment =
+    process.platform === 'win32'
+      ? 'Return a single command suitable for a standard Windows shell, preferring PowerShell-compatible syntax.'
+      : 'Return a single POSIX shell command suitable for bash.';
+
+  return [
+    'Convert the following natural language request into a single shell command.',
+    'Return only the command.',
+    'Do not include explanations, markdown, comments, backticks, prompts, labels, or multiple alternatives.',
+    'The output must be exactly one line.',
+    shellEnvironment,
+    'Prefer safe, standard, idiomatic commands.',
+    'If the request is explicitly destructive, you may return a destructive command.',
+    'If the request is ambiguous and could be destructive, prefer an inspectable command over an irreversible one.',
+    `Current working directory: ${targetDir}`,
+    `User request: ${request}`,
+  ].join('\n');
+}
+
+export interface UseShellCommandExpansionOptions {
+  config: Config;
+}
+
+export function useShellCommandExpansion({
+  config,
+}: UseShellCommandExpansionOptions) {
+  const [isExpanding, setIsExpanding] = useState(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const expandShellCommand = useCallback(
+    async (input: string): Promise<ShellCommandExpansionResult> => {
+      const geminiClient = config.getGeminiClient();
+      if (!geminiClient) {
+        return { status: 'unavailable' };
+      }
+
+      const request = input.slice(SHELL_NATURAL_LANGUAGE_PREFIX.length).trim();
+      if (!request) {
+        return { status: 'empty_request' };
+      }
+
+      abortControllerRef.current?.abort();
+
+      const controller = new AbortController();
+      const signal = controller.signal;
+      abortControllerRef.current = controller;
+      setIsExpanding(true);
+
+      try {
+        const contents: Content[] = [
+          {
+            role: 'user',
+            parts: [
+              {
+                text: buildShellCommandExpansionPrompt(
+                  request,
+                  config.getTargetDir(),
+                ),
+              },
+            ],
+          },
+        ];
+
+        const response = await geminiClient.generateContent(
+          { model: 'prompt-completion' },
+          contents,
+          signal,
+          LlmRole.UTILITY_AUTOCOMPLETE,
+        );
+
+        if (signal.aborted) {
+          return { status: 'aborted' };
+        }
+
+        const command = extractShellCommandFromResponse(
+          getResponseText(response) ?? '',
+        );
+
+        if (!command) {
+          return { status: 'failed' };
+        }
+
+        return { status: 'expanded', command };
+      } catch (error) {
+        if (
+          signal.aborted ||
+          (error instanceof Error && error.name === 'AbortError')
+        ) {
+          return { status: 'aborted' };
+        }
+
+        debugLogger.warn(
+          `[WARN] shell command expansion failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return { status: 'failed' };
+      } finally {
+        if (abortControllerRef.current === controller) {
+          abortControllerRef.current = null;
+        }
+        if (!signal.aborted) {
+          setIsExpanding(false);
+        }
+      }
+    },
+    [config],
+  );
+
+  useEffect(() => () => abortControllerRef.current?.abort(), []);
+
+  return {
+    isExpanding,
+    expandShellCommand,
+  };
+}


### PR DESCRIPTION
## Title

feat(cli): add inline natural-language shell expansion in shell mode

## Body

## Summary

Adds inline natural-language command expansion to shell mode.

When shell mode is active, input that starts with `?` is treated as a request to
generate a single editable shell command instead of being executed directly.
This covers the gap between “I know the exact shell command” and “I need a full
agent conversation,” while keeping the shell workflow fast and explicit.

## Details

This PR adds a shell-mode-only expansion flow rather than introducing a new
agent mode.

Behavior:
1. In shell mode, a line beginning with `?` is intercepted before normal shell
   execution.
2. The natural-language text after `?` is sent to Gemini with a constrained
   prompt that asks for a single shell command only.
3. The generated command is normalized and inserted back into the input buffer.
4. The command remains fully editable and is never auto-executed.
5. A small user hint is shown when the line starts with `?`, and a transient
   “Generating shell command...” message is shown while expansion is in flight.

Implementation notes:
- Added a dedicated shell expansion hook for prompt construction and response
  cleanup.
- Updated `InputPrompt` to route `?`-prefixed shell input through inline
  expansion.
- Preserved existing shell editing and execution flow after the command is
  inserted.
- Kept `?` shortcuts help behavior unchanged outside shell mode.
- Updated relevant shell-mode docs.

This issue is currently labeled `priority/p2`.

<img width="1354" height="136" alt="image" src="https://github.com/user-attachments/assets/7723e416-0c74-4ce1-b72c-148a9bc172d2" />

<img width="1354" height="136" alt="image" src="https://github.com/user-attachments/assets/fda7fdfb-8c64-42bd-80f0-b2a9b1084419" />

<img width="1354" height="136" alt="image" src="https://github.com/user-attachments/assets/96a56bb8-76f2-4a67-bf9b-e1f02f766293" />


## Related Issues

Closes #21798  
Related to #21192

## How to Validate

Build and run from the repo root:

```bash
npm run generate
npm run build
npm run start
```

If Gemini auth is not already configured, set an API key first:

```bash
export GEMINI_API_KEY=YOUR_API_KEY
npm run generate
npm run build
npm run start
```

Manual validation:
1. Start the CLI.
2. Enter shell mode with `!`.
3. Type `? find all .log files older than 7 days`.
4. Confirm a hint appears telling you that `Enter` will generate an editable
   shell command.
5. Press `Enter`.
6. Confirm the current input is replaced with a generated shell command.
7. Confirm nothing executes automatically.
8. Edit the generated command if needed.
9. Press `Enter` again to execute it.

Additional prompts to try:
- `? find all .log files`
- `? show processes using port 3000`
- `? show commits from the last 3 days`

Edge cases:
1. In shell mode, type only `?` and press `Enter`.
   Expected: a short error/hint is shown and nothing executes.
2. Outside shell mode, type `?` on an empty prompt.
   Expected: the existing shortcuts help behavior still works.
3. In shell mode, type `? ...`, generate a command, then edit it manually.
   Expected: normal shell editing behavior is preserved.

Automated checks run:

```bash
npm run generate
npm run build --workspace @google/gemini-cli-core
cd packages/cli
npx vitest run src/ui/components/InputPrompt.test.tsx src/ui/hooks/useShellCommandExpansion.test.ts
npx eslint src/ui/components/InputPrompt.tsx src/ui/components/InputPrompt.test.tsx src/ui/hooks/useShellCommandExpansion.ts src/ui/hooks/useShellCommandExpansion.test.ts
```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (none)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [ ] npm run
    - [x] npx
    - [ ] Docker
