### PR TITLE
refactor(cli): remove extra newlines in ShellToolMessage.tsx

### DIFF
--- a/packages/cli/src/ui/components/messages/ShellToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ShellToolMessage.tsx
@@ -42,33 +42,19 @@ export interface ShellToolMessageProps extends ToolMessageProps {
 
 export const ShellToolMessage: React.FC<ShellToolMessageProps> = ({
   name,
-
   description,
-
   resultDisplay,
-
   status,
-
   availableTerminalHeight,
-
   terminalWidth,
-
   emphasis = 'medium',
-
   renderOutputAsMarkdown = true,
-
   ptyId,
-
   config,
-
   isFirst,
-
   borderColor,
-
   borderDimColor,
-
   isExpandable,
-
   originalRequestName,
 }) => {
   const {
@@ -142,11 +128,9 @@ export const ShellToolMessage: React.FC<ShellToolMessageProps> = ({
   }, [isThisShellFocused, embeddedShellFocused, setEmbeddedShellFocused]);
 
   const headerRef = React.useRef<DOMElement>(null);
-
   const contentRef = React.useRef<DOMElement>(null);
 
   // The shell is focusable if it's the shell command, it's executing, and the interactive shell is enabled.
-
   const isThisShellFocusable = checkIsShellFocusable(name, status, config);
 
   const handleFocus = () => {
@@ -156,7 +140,6 @@ export const ShellToolMessage: React.FC<ShellToolMessageProps> = ({
   };
 
   useMouseClick(headerRef, handleFocus, { isActive: !!isThisShellFocusable });
-
   useMouseClick(contentRef, handleFocus, { isActive: !!isThisShellFocusable });
 
   const { shouldShowFocusHint } = useFocusHint(


### PR DESCRIPTION
## Summary

This PR removes unnecessary extra newlines from `ShellToolMessage.tsx` to improve code density and align with the formatting of other message components in the codebase.

## Details

- Removed blank lines between properties in the `ShellToolMessage` props destructuring.
- Removed extra blank lines within the component body.
- Verified other components in `packages/cli/src/ui/components/messages/` for similar issues (none found).

## Related Issues

None.

## How to Validate

1. Inspect the code changes in `packages/cli/src/ui/components/messages/ShellToolMessage.tsx`.
2. Run tests for `ShellToolMessage`:
   ```bash
   npm test -w @google/gemini-cli -t ShellToolMessage
   ```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed) - (N/A, formatting only, existing tests cover functionality)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
