### PR TITLE
fix: prevent duplicate tool confirmations and fragmented UI boxes

### DIFF
--- a/packages/cli/src/ui/components/__snapshots__/ConfigInitDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ConfigInitDisplay.test.tsx.snap
@@ -18,19 +18,7 @@ Spinner Connecting to MCP servers... (0/5) - Waiting for: s1, s2, s3, +2 more
 "
 `;
 
-exports[`ConfigInitDisplay > truncates list of waiting servers if too many 2`] = `
-"
-Spinner Connecting to MCP servers... (0/5) - Waiting for: s1, s2, s3, +2 more
-"
-`;
-
 exports[`ConfigInitDisplay > updates message on McpClientUpdate event 1`] = `
-"
-Spinner Connecting to MCP servers... (1/2) - Waiting for: server2
-"
-`;
-
-exports[`ConfigInitDisplay > updates message on McpClientUpdate event 2`] = `
 "
 Spinner Connecting to MCP servers... (1/2) - Waiting for: server2
 "

--- a/packages/cli/src/ui/components/messages/ShellToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ShellToolMessage.tsx
@@ -64,12 +64,10 @@ export const ShellToolMessage: React.FC<ShellToolMessageProps> = ({
   isFirst,
 
   borderColor,
-
   borderDimColor,
-
   isExpandable,
-
   originalRequestName,
+  progress,
 }) => {
   const {
     activePtyId: activeShellPtyId,
@@ -196,35 +194,39 @@ export const ShellToolMessage: React.FC<ShellToolMessageProps> = ({
         {emphasis === 'high' && <TrailingIndicator />}
       </StickyHeader>
 
-      <Box
-        ref={contentRef}
-        width={terminalWidth}
-        borderStyle="round"
-        borderColor={borderColor}
-        borderDimColor={borderDimColor}
-        borderTop={false}
-        borderBottom={false}
-        borderLeft={true}
-        borderRight={true}
-        paddingX={1}
-        flexDirection="column"
-      >
-        <ToolResultDisplay
-          resultDisplay={resultDisplay}
-          availableTerminalHeight={availableTerminalHeight}
-          terminalWidth={terminalWidth}
-          renderOutputAsMarkdown={renderOutputAsMarkdown}
-          hasFocus={isThisShellFocused}
-          maxLines={maxLines}
-        />
-        {isThisShellFocused && config && (
-          <ShellInputPrompt
-            activeShellPtyId={activeShellPtyId ?? null}
-            focus={embeddedShellFocused}
-            scrollPageSize={availableTerminalHeight ?? ACTIVE_SHELL_MAX_LINES}
+      {(!!resultDisplay ||
+        (status === CoreToolCallStatus.Executing && progress !== undefined) ||
+        (isThisShellFocused && !!config)) && (
+        <Box
+          ref={contentRef}
+          width={terminalWidth}
+          borderStyle="round"
+          borderColor={borderColor}
+          borderDimColor={borderDimColor}
+          borderTop={false}
+          borderBottom={false}
+          borderLeft={true}
+          borderRight={true}
+          paddingX={1}
+          flexDirection="column"
+        >
+          <ToolResultDisplay
+            resultDisplay={resultDisplay}
+            availableTerminalHeight={availableTerminalHeight}
+            terminalWidth={terminalWidth}
+            renderOutputAsMarkdown={renderOutputAsMarkdown}
+            hasFocus={isThisShellFocused}
+            maxLines={maxLines}
           />
-        )}
-      </Box>
+          {isThisShellFocused && config && (
+            <ShellInputPrompt
+              activeShellPtyId={activeShellPtyId ?? null}
+              focus={embeddedShellFocused}
+              scrollPageSize={availableTerminalHeight ?? ACTIVE_SHELL_MAX_LINES}
+            />
+          )}
+        </Box>
+      )}
     </>
   );
 };

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -109,48 +109,53 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
         />
         {emphasis === 'high' && <TrailingIndicator />}
       </StickyHeader>
-      <Box
-        width={terminalWidth}
-        borderStyle="round"
-        borderColor={borderColor}
-        borderDimColor={borderDimColor}
-        borderTop={false}
-        borderBottom={false}
-        borderLeft={true}
-        borderRight={true}
-        paddingX={1}
-        flexDirection="column"
-      >
-        {status === CoreToolCallStatus.Executing && progress !== undefined && (
-          <McpProgressIndicator
-            progress={progress}
-            total={progressTotal}
-            message={progressMessage}
-            barWidth={20}
+      {(!!resultDisplay ||
+        (status === CoreToolCallStatus.Executing && progress !== undefined) ||
+        (isThisShellFocused && !!config)) && (
+        <Box
+          width={terminalWidth}
+          borderStyle="round"
+          borderColor={borderColor}
+          borderDimColor={borderDimColor}
+          borderTop={false}
+          borderBottom={false}
+          borderLeft={true}
+          borderRight={true}
+          paddingX={1}
+          flexDirection="column"
+        >
+          {status === CoreToolCallStatus.Executing &&
+            progress !== undefined && (
+              <McpProgressIndicator
+                progress={progress}
+                total={progressTotal}
+                message={progressMessage}
+                barWidth={20}
+              />
+            )}
+          <ToolResultDisplay
+            resultDisplay={resultDisplay}
+            availableTerminalHeight={availableTerminalHeight}
+            terminalWidth={terminalWidth}
+            renderOutputAsMarkdown={renderOutputAsMarkdown}
+            hasFocus={isThisShellFocused}
+            maxLines={
+              kind === Kind.Agent && availableTerminalHeight !== undefined
+                ? SUBAGENT_MAX_LINES
+                : undefined
+            }
+            overflowDirection={kind === Kind.Agent ? 'bottom' : 'top'}
           />
-        )}
-        <ToolResultDisplay
-          resultDisplay={resultDisplay}
-          availableTerminalHeight={availableTerminalHeight}
-          terminalWidth={terminalWidth}
-          renderOutputAsMarkdown={renderOutputAsMarkdown}
-          hasFocus={isThisShellFocused}
-          maxLines={
-            kind === Kind.Agent && availableTerminalHeight !== undefined
-              ? SUBAGENT_MAX_LINES
-              : undefined
-          }
-          overflowDirection={kind === Kind.Agent ? 'bottom' : 'top'}
-        />
-        {isThisShellFocused && config && (
-          <Box paddingLeft={STATUS_INDICATOR_WIDTH} marginTop={1}>
-            <ShellInputPrompt
-              activeShellPtyId={activeShellPtyId ?? null}
-              focus={embeddedShellFocused}
-            />
-          </Box>
-        )}
-      </Box>
+          {isThisShellFocused && config && (
+            <Box paddingLeft={STATUS_INDICATOR_WIDTH} marginTop={1}>
+              <ShellInputPrompt
+                activeShellPtyId={activeShellPtyId ?? null}
+                focus={embeddedShellFocused}
+              />
+            </Box>
+          )}
+        </Box>
+      )}
     </>
   );
 };

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -455,9 +455,9 @@ export class Scheduler {
         c.status === CoreToolCallStatus.Validating,
     );
     if (validatingCalls.length > 0) {
-      await Promise.all(
-        validatingCalls.map((c) => this._processValidatingCall(c, signal)),
-      );
+      for (const c of validatingCalls) {
+        await this._processValidatingCall(c, signal);
+      }
     }
 
     // 2. Execute scheduled calls


### PR DESCRIPTION
## Summary

- Process tool validations sequentially rather than concurrently in the scheduler. This resolves a race condition where parallel tool calls evaluated policy simultaneously, causing subsequent tools to ignore global `AUTO_EDIT` mode switches triggered by earlier confirmations.
- Conditionally render result display containers in `ToolMessage` and `ShellToolMessage`. Empty padded boxes are now hidden when a tool is pending or executing with no output, preventing overlapping disjointed borders from fragmenting the interactive queue.

## Details

- Hide the empty border boxes in ToolMessage.tsx and ShellToolMessage.tsx so that tools waiting in a pending state no longer draw floating horizontal lines in your terminal.
- Fix a race condition in the Scheduler by evaluating tool confirmations sequentially instead of concurrently via Promise.all.
- This sequence change guarantees that selecting "Allow for this session" on the first tool instantly enables AUTO_EDIT mode for all subsequent tools in the same batch, preventing duplicate confirmation popups and keeping the group visually unified.

## Related Issues

Fixes #22878 

## How to Validate

* Prompt a multi-tool invoking request and ensure that the confirmations are not stacked and the allow-choices are respected.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [✅] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [✅] Validated on required platforms/methods:
  - [✅] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
