### PR TITLE
fix(cli): consume keypress events in BaseSettingsDialog to prevent bubbling

### DIFF
--- a/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
@@ -275,7 +275,7 @@ export function BaseSettingsDialog({
     (key: Key) => {
       // Let parent handle custom keys first (only if not editing)
       if (!editingKey && onKeyPress?.(key, currentItem)) {
-        return;
+        return true;
       }
 
       // Edit mode handling
@@ -286,43 +286,43 @@ export function BaseSettingsDialog({
         // Navigation within edit buffer
         if (keyMatchers[Command.MOVE_LEFT](key)) {
           editDispatch({ type: 'MOVE_LEFT' });
-          return;
+          return true;
         }
         if (keyMatchers[Command.MOVE_RIGHT](key)) {
           editDispatch({ type: 'MOVE_RIGHT' });
-          return;
+          return true;
         }
         if (keyMatchers[Command.HOME](key)) {
           editDispatch({ type: 'HOME' });
-          return;
+          return true;
         }
         if (keyMatchers[Command.END](key)) {
           editDispatch({ type: 'END' });
-          return;
+          return true;
         }
 
         // Backspace
         if (keyMatchers[Command.DELETE_CHAR_LEFT](key)) {
           editDispatch({ type: 'DELETE_LEFT' });
-          return;
+          return true;
         }
 
         // Delete
         if (keyMatchers[Command.DELETE_CHAR_RIGHT](key)) {
           editDispatch({ type: 'DELETE_RIGHT' });
-          return;
+          return true;
         }
 
         // Escape in edit mode - commit (consistent with SettingsDialog)
         if (keyMatchers[Command.ESCAPE](key)) {
           commitEdit();
-          return;
+          return true;
         }
 
         // Enter in edit mode - commit
         if (keyMatchers[Command.RETURN](key)) {
           commitEdit();
-          return;
+          return true;
         }
 
         // Up/Down in edit mode - commit and navigate.
@@ -331,7 +331,7 @@ export function BaseSettingsDialog({
         if (keyMatchers[Command.DIALOG_NAVIGATION_UP](key) && !key.insertable) {
           commitEdit();
           moveUp();
-          return;
+          return true;
         }
         if (
           keyMatchers[Command.DIALOG_NAVIGATION_DOWN](key) &&
@@ -339,7 +339,7 @@ export function BaseSettingsDialog({
         ) {
           commitEdit();
           moveDown();
-          return;
+          return true;
         }
 
         // Character input
@@ -350,7 +350,7 @@ export function BaseSettingsDialog({
             isNumberType: type === 'number',
           });
         }
-        return;
+        return true;
       }
 
       // Not in edit mode - handle navigation and actions
@@ -396,13 +396,13 @@ export function BaseSettingsDialog({
       // Tab - switch focus section
       if (key.name === 'tab' && finalShowScopeSelector) {
         setFocusSection((s) => (s === 'settings' ? 'scope' : 'settings'));
-        return;
+        return true;
       }
 
       // Escape - close dialog
       if (keyMatchers[Command.ESCAPE](key)) {
         onClose();
-        return;
+        return true;
       }
 
       return;


### PR DESCRIPTION
## Description

The `useKeypress` handler in `BaseSettingsDialog` returned `void` for handled keys like Escape and Tab. Because the `KeypressContext` propagation system only stops bubbling when a handler returns `true`, these events propagated to lower-priority global handlers. This caused pressing Escape while the `/settings` dialog was open to cancel the active agent turn instead of simply closing the dialog.

This fix returns `true` for all handled key events in the `BaseSettingsDialog` keypress handler, consistent with how the non-edit-mode navigation keys (Up/Down, Enter, Ctrl+L) already behaved.

Fixes #22787

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactor (code restructuring with no functional changes)

## Testing
- All 33 `BaseSettingsDialog.test.tsx` tests pass, including escape and tab key handling
- All 9 `AgentConfigDialog.test.tsx` tests pass
- All non-snapshot `SettingsDialog.test.tsx` tests pass (9 pre-existing snapshot failures unrelated to this change)
- Build compiles with zero errors from the modified file