### PR TITLE
fix(core): fix empty-parts false positive in messageInspectors and add tests

### DIFF
--- a/packages/core/src/utils/messageInspectors.test.ts
+++ b/packages/core/src/utils/messageInspectors.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Content } from '@google/genai';
+import { isFunctionResponse, isFunctionCall } from './messageInspectors.js';
+
+describe('messageInspectors', () => {
+  describe('isFunctionResponse', () => {
+    it('returns true for a user message with a single functionResponse part', () => {
+      const content: Content = {
+        role: 'user',
+        parts: [{ functionResponse: { name: 'tool', response: {} } }],
+      };
+      expect(isFunctionResponse(content)).toBe(true);
+    });
+
+    it('returns true for a user message with multiple functionResponse parts', () => {
+      const content: Content = {
+        role: 'user',
+        parts: [
+          { functionResponse: { name: 'tool1', response: {} } },
+          { functionResponse: { name: 'tool2', response: {} } },
+        ],
+      };
+      expect(isFunctionResponse(content)).toBe(true);
+    });
+
+    it('returns false for a model message with functionResponse parts', () => {
+      const content: Content = {
+        role: 'model',
+        parts: [{ functionResponse: { name: 'tool', response: {} } }],
+      };
+      expect(isFunctionResponse(content)).toBe(false);
+    });
+
+    it('returns false for a user message with text parts', () => {
+      const content: Content = {
+        role: 'user',
+        parts: [{ text: 'hello' }],
+      };
+      expect(isFunctionResponse(content)).toBe(false);
+    });
+
+    it('returns false for a user message with mixed parts', () => {
+      const content: Content = {
+        role: 'user',
+        parts: [
+          { functionResponse: { name: 'tool', response: {} } },
+          { text: 'hello' },
+        ],
+      };
+      expect(isFunctionResponse(content)).toBe(false);
+    });
+
+    it('returns false when parts is undefined', () => {
+      const content: Content = { role: 'user' };
+      expect(isFunctionResponse(content)).toBe(false);
+    });
+
+    it('returns false when parts is empty', () => {
+      const content: Content = { role: 'user', parts: [] };
+      expect(isFunctionResponse(content)).toBe(false);
+    });
+  });
+
+  describe('isFunctionCall', () => {
+    it('returns true for a model message with a single functionCall part', () => {
+      const content: Content = {
+        role: 'model',
+        parts: [{ functionCall: { name: 'tool', args: {} } }],
+      };
+      expect(isFunctionCall(content)).toBe(true);
+    });
+
+    it('returns true for a model message with multiple functionCall parts', () => {
+      const content: Content = {
+        role: 'model',
+        parts: [
+          { functionCall: { name: 'tool1', args: {} } },
+          { functionCall: { name: 'tool2', args: {} } },
+        ],
+      };
+      expect(isFunctionCall(content)).toBe(true);
+    });
+
+    it('returns false for a user message with functionCall parts', () => {
+      const content: Content = {
+        role: 'user',
+        parts: [{ functionCall: { name: 'tool', args: {} } }],
+      };
+      expect(isFunctionCall(content)).toBe(false);
+    });
+
+    it('returns false for a model message with text parts', () => {
+      const content: Content = {
+        role: 'model',
+        parts: [{ text: 'hello' }],
+      };
+      expect(isFunctionCall(content)).toBe(false);
+    });
+
+    it('returns false for a model message with mixed parts', () => {
+      const content: Content = {
+        role: 'model',
+        parts: [
+          { functionCall: { name: 'tool', args: {} } },
+          { text: 'hello' },
+        ],
+      };
+      expect(isFunctionCall(content)).toBe(false);
+    });
+
+    it('returns false when parts is undefined', () => {
+      const content: Content = { role: 'model' };
+      expect(isFunctionCall(content)).toBe(false);
+    });
+
+    it('returns false when parts is empty', () => {
+      const content: Content = { role: 'model', parts: [] };
+      expect(isFunctionCall(content)).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/utils/messageInspectors.ts
+++ b/packages/core/src/utils/messageInspectors.ts
@@ -10,6 +10,7 @@ export function isFunctionResponse(content: Content): boolean {
   return (
     content.role === 'user' &&
     !!content.parts &&
+    content.parts.length > 0 &&
     content.parts.every((part) => !!part.functionResponse)
   );
 }
@@ -18,6 +19,7 @@ export function isFunctionCall(content: Content): boolean {
   return (
     content.role === 'model' &&
     !!content.parts &&
+    content.parts.length > 0 &&
     content.parts.every((part) => !!part.functionCall)
   );
 }


### PR DESCRIPTION
## Summary

Fixes #22912

`isFunctionResponse()` and `isFunctionCall()` in `messageInspectors.ts` return `true` for messages with empty `parts` arrays due to JavaScript's `Array.every([])` returning `true` (vacuous truth). This causes consumers to incorrectly treat empty-parts messages as valid function calls/responses.

## Changes

### Bug fix (`messageInspectors.ts`)
Added `content.parts.length > 0` guard to both functions to prevent empty parts from being treated as valid function calls/responses.

### Tests (`messageInspectors.test.ts`)
14 tests covering:
- Single/multiple valid parts
- Wrong role returns `false`
- Text parts and mixed parts return `false`
- Undefined parts returns `false`
- Empty parts returns `false` (the bug fix)

## Verification
```
npx vitest run packages/core/src/utils/messageInspectors.test.ts
✓ 14 tests passed
```