### PR TITLE
fix: updates Docker image reference for GitHub MCP server

### DIFF
--- a/docs/cli/tutorials/mcp-setup.md
+++ b/docs/cli/tutorials/mcp-setup.md
@@ -52,7 +52,7 @@ You tell Gemini about new servers by editing your `settings.json`.
         "--rm",
         "-e",
         "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "ghcr.io/modelcontextprotocol/servers/github:latest"
+        "ghcr.io/github/github-mcp-server:latest"
       ],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"


### PR DESCRIPTION
## Summary

Updates the GitHub MCP Docker image in the CLI docs to the correct and maintained image. This fixes setup failures caused by the previously referenced non-existent image.

---

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

* Replaces outdated image:

  ```
  ghcr.io/modelcontextprotocol/servers/github:latest
  ```

  with:

  ```
  ghcr.io/github/github-mcp-server
  ```
* Aligns documentation with the current GitHub MCP server distribution
* Prevents Docker `manifest unknown` errors and MCP “Disconnected” state during setup

---

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues
Fixes #22925

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

1. Set GitHub PAT:

   ```bash
   export GITHUB_PERSONAL_ACCESS_TOKEN="your_token"
   ```

2. Update `~/.gemini/settings.json` with new image

3. Run:

   ```bash
   docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN=$GITHUB_PERSONAL_ACCESS_TOKEN ghcr.io/github/github-mcp-server
   ```

   **Expected:** Container starts and stays running

4. Restart Gemini CLI and run:

   ```
   /mcp list
   ```

   **Expected:** `github - Connected`

---

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

* [x] Updated relevant documentation and README (if needed)
* [ ] Added/updated tests (not needed – docs change only)
* [ ] Noted breaking changes (none)
* [x] Validated on required platforms/methods:

  * [x] MacOS

    * [ ] npm run
    * [ ] npx
    * [x] Docker
    * [ ] Podman
    * [ ] Seatbelt
  * [ ] Windows

    * [ ] npm run
    * [ ] npx
    * [ ] Docker
  * [ ] Linux

    * [ ] npm run
    * [ ] npx
    * [ ] Docker

---
