### PR TITLE
chore(docker): install vi and nano in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   psmisc \
   lsof \
   socat \
+  vi \
+  nano \
   ca-certificates \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

Add possible editors on sandbox container to support editing prompts with them (Ctrl-X). Not urgent.

## Details

Adds "vi" and "nano" to the sandbox image. User will have the option to set $EDITOR on ~/.gemini/.env.

Current behavior is an error when trying to edit prompt with $EDITOR.

## Related Issues

Closes #22936

## How to Validate

1. Add `EDITOR="vi"` to "$HOME/.gemini/.env".
2. Open "gemini" interactive mode.
3. "Ctrl+X" to edit prompt on $EDITOR.

Expect the editor to open editing a file on /tmp.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
