### PR TITLE
doc: Update local-model-routing.md

### DIFF
--- a/docs/core/local-model-routing.md
+++ b/docs/core/local-model-routing.md
@@ -105,7 +105,7 @@ Download complete.
 #### MacOS
 
 ```bash
-$ ./lit.lit.macos_arm64 pull gemma3-1b-gpu-custom
+$ ./lit.macos_arm64 pull gemma3-1b-gpu-custom
 
 [Legal] The model you are about to download is governed by
 the Gemma Terms of Use and Prohibited Use Policy. Please review these terms and ensure you agree before continuing.


### PR DESCRIPTION
removes double "lit" ("lit.lit") which is not the binary name in the rest of doc for macos

## Summary

removes double "lit" ("lit.lit") which is not the binary name in the rest of doc for macos.

## Details


## Related Issues


## How to Validate



## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
