### PR TITLE
fix(cli): consume Escape key in BaseSettingsDialog to prevent active turn cancellation

### DIFF
--- a/packages/cli/src/ui/components/shared/BaseSettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/shared/BaseSettingsDialog.test.tsx
@@ -7,13 +7,16 @@
 import { renderWithProviders } from '../../../test-utils/render.js';
 import { waitFor } from '../../../test-utils/async.js';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act } from 'react';
+import { act, useCallback } from 'react';
+import React from 'react';
 import { Text } from 'ink';
 import {
   BaseSettingsDialog,
   type BaseSettingsDialogProps,
   type SettingsDialogItem,
 } from './BaseSettingsDialog.js';
+import { type Key } from '../../contexts/KeypressContext.js';
+import { useKeypress } from '../../hooks/useKeypress.js';
 import { SettingScope } from '../../../config/settings.js';
 
 enum TerminalKeys {
@@ -115,6 +118,52 @@ describe('BaseSettingsDialog', () => {
     return result;
   };
 
+  /**
+   * A wrapper component that registers an outer keypress handler at lower
+   * priority than the dialog, used to verify that Escape events do not bubble.
+   */
+  const OuterHandlerWrapper = ({
+    onOuterKeypress,
+    children,
+  }: {
+    onOuterKeypress: (key: Key) => void;
+    children: React.ReactNode;
+  }) => {
+    const stableHandler = useCallback(
+      (key: Key) => {
+        onOuterKeypress(key);
+      },
+      [onOuterKeypress],
+    );
+    useKeypress(stableHandler, { isActive: true, priority: false });
+    return <>{children}</>;
+  };
+
+  const renderDialogWithOuterHandler = async (
+    outerHandler: (key: Key) => void,
+    props: Partial<BaseSettingsDialogProps> = {},
+  ) => {
+    const defaultProps: BaseSettingsDialogProps = {
+      title: 'Test Settings',
+      items: createMockItems(),
+      selectedScope: SettingScope.User,
+      maxItemsToShow: 8,
+      onItemToggle: mockOnItemToggle,
+      onEditCommit: mockOnEditCommit,
+      onItemClear: mockOnItemClear,
+      onClose: mockOnClose,
+      ...props,
+    };
+
+    const result = renderWithProviders(
+      <OuterHandlerWrapper onOuterKeypress={outerHandler}>
+        <BaseSettingsDialog {...defaultProps} />
+      </OuterHandlerWrapper>,
+    );
+    await result.waitUntilReady();
+    return result;
+  };
+
   describe('rendering', () => {
     it('should render the dialog with title', async () => {
       const { lastFrame, unmount } = await renderDialog();
@@ -191,6 +240,63 @@ describe('BaseSettingsDialog', () => {
       await waitFor(() => {
         expect(mockOnClose).toHaveBeenCalled();
       });
+      unmount();
+    });
+
+    it('should consume Escape key event so it does not bubble to outer handlers', async () => {
+      const outerHandler = vi.fn();
+      const { stdin, waitUntilReady, unmount } =
+        await renderDialogWithOuterHandler(outerHandler);
+
+      await act(async () => {
+        stdin.write(TerminalKeys.ESCAPE);
+      });
+      // Escape key has a 50ms timeout in KeypressContext, so we need to wrap waitUntilReady in act
+      await act(async () => {
+        await waitUntilReady();
+      });
+
+      await waitFor(() => {
+        expect(mockOnClose).toHaveBeenCalled();
+      });
+      // The outer handler must NOT have been called — the dialog consumed the event
+      expect(outerHandler).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'escape' }),
+      );
+      unmount();
+    });
+
+    it('should consume Escape key event in edit mode so it does not bubble to outer handlers', async () => {
+      const outerHandler = vi.fn();
+      const items = createMockItems(4);
+      const stringItem = items.find((i) => i.type === 'string')!;
+      const { stdin, waitUntilReady, unmount } =
+        await renderDialogWithOuterHandler(outerHandler, {
+          items: [stringItem],
+        });
+
+      // Enter edit mode
+      await act(async () => {
+        stdin.write(TerminalKeys.ENTER);
+      });
+      await waitUntilReady();
+
+      // Commit edit with Escape
+      await act(async () => {
+        stdin.write(TerminalKeys.ESCAPE);
+      });
+      // Escape key has a 50ms timeout in KeypressContext, so we need to wrap waitUntilReady in act
+      await act(async () => {
+        await waitUntilReady();
+      });
+
+      await waitFor(() => {
+        expect(mockOnEditCommit).toHaveBeenCalled();
+      });
+      // The outer handler must NOT have been called — the dialog consumed the event
+      expect(outerHandler).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'escape' }),
+      );
       unmount();
     });
 

--- a/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
@@ -321,7 +321,7 @@ export function BaseSettingsDialog({
         // Escape in edit mode - commit (consistent with SettingsDialog)
         if (keyMatchers[Command.ESCAPE](key)) {
           commitEdit();
-          return;
+          return true;
         }
 
         // Enter in edit mode - commit
@@ -407,7 +407,7 @@ export function BaseSettingsDialog({
       // Escape - close dialog
       if (keyMatchers[Command.ESCAPE](key)) {
         onClose();
-        return;
+        return true;
       }
 
       return;


### PR DESCRIPTION
## Problem

Fixes #22787

When the agent is processing a turn (streaming a response or executing a tool) and the user opens the `/settings` dialog, pressing **Escape** to close the dialog inadvertently cancels the active turn.

### Root cause

`KeypressContext` only stops event propagation when a keypress handler explicitly returns `true`. In `BaseSettingsDialog`, both Escape handlers were returning `undefined` (bare `return;`), so the event bubbled up to the global `useGeminiStream` handler which interpreted it as a turn cancellation request.

Affected paths:
- **Normal mode** (closing the dialog): `return;` → fixed to `return true;`  
- **Edit mode** (committing an inline edit): `return;` → fixed to `return true;`

## Fix

Return `true` from both Escape handlers in `BaseSettingsDialog` to mark the event as consumed.

## Tests

Added two new tests to `BaseSettingsDialog.test.tsx` that register a lower-priority outer keypress handler and assert that Escape events do **not** reach it after the dialog handles them:

1. `should consume Escape key event so it does not bubble to outer handlers`
2. `should consume Escape key event in edit mode so it does not bubble to outer handlers`

All 35 tests pass (`npx vitest run --root packages/cli "BaseSettingsDialog"`).