### PR TITLE
test(cli): simplify createMockSettings calls

### DIFF
--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -99,9 +99,7 @@ describe('App', () => {
       {
         uiState: mockUIState,
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
       },
     );
     await waitUntilReady();
@@ -123,9 +121,7 @@ describe('App', () => {
       {
         uiState: quittingUIState,
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
       },
     );
     await waitUntilReady();
@@ -147,9 +143,7 @@ describe('App', () => {
       {
         uiState: quittingUIState,
         config: makeFakeConfig({ useAlternateBuffer: true }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: true } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
       },
     );
     await waitUntilReady();
@@ -170,9 +164,7 @@ describe('App', () => {
       {
         uiState: dialogUIState,
         config: makeFakeConfig({ useAlternateBuffer: true }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: true } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
       },
     );
     await waitUntilReady();
@@ -200,9 +192,7 @@ describe('App', () => {
         {
           uiState,
           config: makeFakeConfig({ useAlternateBuffer: true }),
-          settings: createMockSettings({
-            merged: { ui: { useAlternateBuffer: true } },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
         },
       );
       await waitUntilReady();
@@ -220,9 +210,7 @@ describe('App', () => {
       {
         uiState: mockUIState,
         config: makeFakeConfig({ useAlternateBuffer: true }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: true } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
       },
     );
     await waitUntilReady();
@@ -242,9 +230,7 @@ describe('App', () => {
       {
         uiState: mockUIState,
         config: makeFakeConfig({ useAlternateBuffer: true }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: true } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
       },
     );
     await waitUntilReady();
@@ -300,9 +286,7 @@ describe('App', () => {
       {
         uiState: stateWithConfirmingTool,
         config: configWithExperiment,
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: true } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
       },
     );
     await waitUntilReady();
@@ -323,9 +307,7 @@ describe('App', () => {
         {
           uiState: mockUIState,
           config: makeFakeConfig({ useAlternateBuffer: true }),
-          settings: createMockSettings({
-            merged: { ui: { useAlternateBuffer: true } },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
         },
       );
       await waitUntilReady();
@@ -340,9 +322,7 @@ describe('App', () => {
         {
           uiState: mockUIState,
           config: makeFakeConfig({ useAlternateBuffer: true }),
-          settings: createMockSettings({
-            merged: { ui: { useAlternateBuffer: true } },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
         },
       );
       await waitUntilReady();
@@ -360,9 +340,7 @@ describe('App', () => {
         {
           uiState: dialogUIState,
           config: makeFakeConfig({ useAlternateBuffer: true }),
-          settings: createMockSettings({
-            merged: { ui: { useAlternateBuffer: true } },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
         },
       );
       await waitUntilReady();

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -486,17 +486,15 @@ describe('AppContainer State Management', () => {
 
     // Mock LoadedSettings
     mockSettings = createMockSettings({
-      merged: {
-        hideBanner: false,
-        hideFooter: false,
-        hideTips: false,
-        showMemoryUsage: false,
-        theme: 'default',
-        ui: {
-          showStatusInTitle: false,
-          hideWindowTitle: false,
-          useAlternateBuffer: false,
-        },
+      hideBanner: false,
+      hideFooter: false,
+      hideTips: false,
+      showMemoryUsage: false,
+      theme: 'default',
+      ui: {
+        showStatusInTitle: false,
+        hideWindowTitle: false,
+        useAlternateBuffer: false,
       },
     });
 
@@ -1007,12 +1005,10 @@ describe('AppContainer State Management', () => {
   describe('Settings Integration', () => {
     it('handles settings with all display options disabled', async () => {
       const settingsAllHidden = createMockSettings({
-        merged: {
-          hideBanner: true,
-          hideFooter: true,
-          hideTips: true,
-          showMemoryUsage: false,
-        },
+        hideBanner: true,
+        hideFooter: true,
+        hideTips: true,
+        showMemoryUsage: false,
       });
 
       let unmount: () => void;
@@ -1026,9 +1022,7 @@ describe('AppContainer State Management', () => {
 
     it('handles settings with memory usage enabled', async () => {
       const settingsWithMemory = createMockSettings({
-        merged: {
-          showMemoryUsage: true,
-        },
+        showMemoryUsage: true,
       });
 
       let unmount: () => void;
@@ -1488,11 +1482,9 @@ describe('AppContainer State Management', () => {
     it('should update terminal title with Working… when showStatusInTitle is false', () => {
       // Arrange: Set up mock settings with showStatusInTitle disabled
       const mockSettingsWithShowStatusFalse = createMockSettings({
-        merged: {
-          ui: {
-            showStatusInTitle: false,
-            hideWindowTitle: false,
-          },
+        ui: {
+          showStatusInTitle: false,
+          hideWindowTitle: false,
         },
       });
 
@@ -1523,11 +1515,9 @@ describe('AppContainer State Management', () => {
     it('should use legacy terminal title when dynamicWindowTitle is false', () => {
       // Arrange: Set up mock settings with dynamicWindowTitle disabled
       const mockSettingsWithDynamicTitleFalse = createMockSettings({
-        merged: {
-          ui: {
-            dynamicWindowTitle: false,
-            hideWindowTitle: false,
-          },
+        ui: {
+          dynamicWindowTitle: false,
+          hideWindowTitle: false,
         },
       });
 
@@ -1558,11 +1548,9 @@ describe('AppContainer State Management', () => {
     it('should not update terminal title when hideWindowTitle is true', () => {
       // Arrange: Set up mock settings with hideWindowTitle enabled
       const mockSettingsWithHideTitleTrue = createMockSettings({
-        merged: {
-          ui: {
-            showStatusInTitle: true,
-            hideWindowTitle: true,
-          },
+        ui: {
+          showStatusInTitle: true,
+          hideWindowTitle: true,
         },
       });
 
@@ -1583,11 +1571,9 @@ describe('AppContainer State Management', () => {
     it('should update terminal title with thought subject when in active state', () => {
       // Arrange: Set up mock settings with showStatusInTitle enabled
       const mockSettingsWithTitleEnabled = createMockSettings({
-        merged: {
-          ui: {
-            showStatusInTitle: true,
-            hideWindowTitle: false,
-          },
+        ui: {
+          showStatusInTitle: true,
+          hideWindowTitle: false,
         },
       });
 
@@ -1619,11 +1605,9 @@ describe('AppContainer State Management', () => {
     it('should update terminal title with default text when in Idle state and no thought subject', () => {
       // Arrange: Set up mock settings with showStatusInTitle enabled
       const mockSettingsWithTitleEnabled = createMockSettings({
-        merged: {
-          ui: {
-            showStatusInTitle: true,
-            hideWindowTitle: false,
-          },
+        ui: {
+          showStatusInTitle: true,
+          hideWindowTitle: false,
         },
       });
 
@@ -1650,11 +1634,9 @@ describe('AppContainer State Management', () => {
     it('should update terminal title when in WaitingForConfirmation state with thought subject', async () => {
       // Arrange: Set up mock settings with showStatusInTitle enabled
       const mockSettingsWithTitleEnabled = createMockSettings({
-        merged: {
-          ui: {
-            showStatusInTitle: true,
-            hideWindowTitle: false,
-          },
+        ui: {
+          showStatusInTitle: true,
+          hideWindowTitle: false,
         },
       });
 
@@ -1709,11 +1691,9 @@ describe('AppContainer State Management', () => {
 
         // Arrange: Set up mock settings with showStatusInTitle enabled
         const mockSettingsWithTitleEnabled = createMockSettings({
-          merged: {
-            ui: {
-              showStatusInTitle: true,
-              hideWindowTitle: false,
-            },
+          ui: {
+            showStatusInTitle: true,
+            hideWindowTitle: false,
           },
         });
 
@@ -1765,11 +1745,9 @@ describe('AppContainer State Management', () => {
 
         // Arrange: Set up mock settings with showStatusInTitle enabled
         const mockSettingsWithTitleEnabled = createMockSettings({
-          merged: {
-            ui: {
-              showStatusInTitle: true,
-              hideWindowTitle: false,
-            },
+          ui: {
+            showStatusInTitle: true,
+            hideWindowTitle: false,
           },
         });
 
@@ -1832,11 +1810,9 @@ describe('AppContainer State Management', () => {
 
         // Arrange: Set up mock settings with showStatusInTitle enabled
         const mockSettingsWithTitleEnabled = createMockSettings({
-          merged: {
-            ui: {
-              showStatusInTitle: true,
-              hideWindowTitle: false,
-            },
+          ui: {
+            showStatusInTitle: true,
+            hideWindowTitle: false,
           },
         });
 
@@ -1879,11 +1855,9 @@ describe('AppContainer State Management', () => {
 
         // Arrange: Set up mock settings with showStatusInTitle enabled
         const mockSettingsWithTitleEnabled = createMockSettings({
-          merged: {
-            ui: {
-              showStatusInTitle: true,
-              hideWindowTitle: false,
-            },
+          ui: {
+            showStatusInTitle: true,
+            hideWindowTitle: false,
           },
         });
 
@@ -1960,11 +1934,9 @@ describe('AppContainer State Management', () => {
     it('should pad title to exactly 80 characters', () => {
       // Arrange: Set up mock settings with showStatusInTitle enabled
       const mockSettingsWithTitleEnabled = createMockSettings({
-        merged: {
-          ui: {
-            showStatusInTitle: true,
-            hideWindowTitle: false,
-          },
+        ui: {
+          showStatusInTitle: true,
+          hideWindowTitle: false,
         },
       });
 
@@ -1997,11 +1969,9 @@ describe('AppContainer State Management', () => {
     it('should use correct ANSI escape code format', () => {
       // Arrange: Set up mock settings with showStatusInTitle enabled
       const mockSettingsWithTitleEnabled = createMockSettings({
-        merged: {
-          ui: {
-            showStatusInTitle: true,
-            hideWindowTitle: false,
-          },
+        ui: {
+          showStatusInTitle: true,
+          hideWindowTitle: false,
         },
       });
 
@@ -2032,11 +2002,9 @@ describe('AppContainer State Management', () => {
     it('should use CLI_TITLE environment variable when set', () => {
       // Arrange: Set up mock settings with showStatusInTitle disabled (so it shows suffix)
       const mockSettingsWithTitleDisabled = createMockSettings({
-        merged: {
-          ui: {
-            showStatusInTitle: false,
-            hideWindowTitle: false,
-          },
+        ui: {
+          showStatusInTitle: false,
+          hideWindowTitle: false,
         },
       });
 
@@ -2608,11 +2576,7 @@ describe('AppContainer State Management', () => {
 
       // Update settings for this test run
       const testSettings = createMockSettings({
-        merged: {
-          ui: {
-            useAlternateBuffer: isAlternateMode,
-          },
-        },
+        ui: { useAlternateBuffer: isAlternateMode },
       });
 
       function TestChild() {
@@ -3323,11 +3287,7 @@ describe('AppContainer State Management', () => {
       let unmount: () => void;
       await act(async () => {
         unmount = renderAppContainer({
-          settings: createMockSettings({
-            merged: {
-              ui: { useAlternateBuffer: false },
-            },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
         }).unmount;
       });
 
@@ -3363,11 +3323,7 @@ describe('AppContainer State Management', () => {
       let unmount: () => void;
       await act(async () => {
         unmount = renderAppContainer({
-          settings: createMockSettings({
-            merged: {
-              ui: { useAlternateBuffer: true },
-            },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
         }).unmount;
       });
 
@@ -3637,11 +3593,7 @@ describe('AppContainer State Management', () => {
 
     it('DOES set showIsExpandableHint when overflow occurs in Alternate Buffer Mode', async () => {
       const settingsWithAlternateBuffer = createMockSettings({
-        merged: {
-          ui: {
-            useAlternateBuffer: true,
-          },
-        },
+        ui: { useAlternateBuffer: true },
       });
 
       vi.spyOn(mockConfig, 'getUseAlternateBuffer').mockReturnValue(true);

--- a/packages/cli/src/ui/components/AskUserDialog.test.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.test.tsx
@@ -317,9 +317,7 @@ describe('AskUserDialog', () => {
           />,
           {
             config: makeFakeConfig({ useAlternateBuffer }),
-            settings: createMockSettings({
-              merged: { ui: { useAlternateBuffer } },
-            }),
+            settings: createMockSettings({ ui: { useAlternateBuffer } }),
           },
         );
 
@@ -1300,9 +1298,7 @@ describe('AskUserDialog', () => {
       </UIStateContext.Provider>,
       {
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
       },
     );
 
@@ -1341,9 +1337,7 @@ describe('AskUserDialog', () => {
       </UIStateContext.Provider>,
       {
         config: makeFakeConfig({ useAlternateBuffer: true }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: true } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
       },
     );
 

--- a/packages/cli/src/ui/components/Composer.test.tsx
+++ b/packages/cli/src/ui/components/Composer.test.tsx
@@ -408,7 +408,7 @@ describe('Composer', () => {
         thought: { subject: 'Hidden', description: 'Should not show' },
       });
       const settings = createMockSettings({
-        merged: { ui: { loadingPhrases: 'off' } },
+        ui: { loadingPhrases: 'off' },
       });
 
       const { lastFrame } = await renderComposer(uiState, settings);

--- a/packages/cli/src/ui/components/DetailedMessagesDisplay.test.tsx
+++ b/packages/cli/src/ui/components/DetailedMessagesDisplay.test.tsx
@@ -38,9 +38,7 @@ describe('DetailedMessagesDisplay', () => {
         hasFocus={false}
       />,
       {
-        settings: createMockSettings({
-          merged: { ui: { errorVerbosity: 'full' } },
-        }),
+        settings: createMockSettings({ ui: { errorVerbosity: 'full' } }),
       },
     );
     await waitUntilReady();
@@ -64,9 +62,7 @@ describe('DetailedMessagesDisplay', () => {
         hasFocus={true}
       />,
       {
-        settings: createMockSettings({
-          merged: { ui: { errorVerbosity: 'full' } },
-        }),
+        settings: createMockSettings({ ui: { errorVerbosity: 'full' } }),
       },
     );
     await waitUntilReady();
@@ -89,9 +85,7 @@ describe('DetailedMessagesDisplay', () => {
         hasFocus={true}
       />,
       {
-        settings: createMockSettings({
-          merged: { ui: { errorVerbosity: 'low' } },
-        }),
+        settings: createMockSettings({ ui: { errorVerbosity: 'low' } }),
       },
     );
     await waitUntilReady();
@@ -112,9 +106,7 @@ describe('DetailedMessagesDisplay', () => {
         hasFocus={true}
       />,
       {
-        settings: createMockSettings({
-          merged: { ui: { errorVerbosity: 'full' } },
-        }),
+        settings: createMockSettings({ ui: { errorVerbosity: 'full' } }),
       },
     );
     await waitUntilReady();
@@ -135,9 +127,7 @@ describe('DetailedMessagesDisplay', () => {
         hasFocus={false}
       />,
       {
-        settings: createMockSettings({
-          merged: { ui: { errorVerbosity: 'full' } },
-        }),
+        settings: createMockSettings({ ui: { errorVerbosity: 'full' } }),
       },
     );
     await waitUntilReady();

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
@@ -167,9 +167,7 @@ Implement a comprehensive authentication system with multiple providers.
           }),
           getUseAlternateBuffer: () => useAlternateBuffer,
         } as unknown as import('@google/gemini-cli-core').Config,
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer } }),
       },
     );
   };
@@ -449,9 +447,7 @@ Implement a comprehensive authentication system with multiple providers.
               getUseAlternateBuffer: () => useAlternateBuffer ?? true,
             } as unknown as import('@google/gemini-cli-core').Config,
             settings: createMockSettings({
-              merged: {
-                ui: { useAlternateBuffer: useAlternateBuffer ?? true },
-              },
+              ui: { useAlternateBuffer: useAlternateBuffer ?? true },
             }),
           },
         );

--- a/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
@@ -80,9 +80,7 @@ describe('FolderTrustDialog', () => {
       {
         width: 80,
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
         uiState: { constrainHeight: true, terminalHeight: 24 },
       },
     );
@@ -113,9 +111,7 @@ describe('FolderTrustDialog', () => {
       {
         width: 80,
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
         uiState: { constrainHeight: true, terminalHeight: 14 },
       },
     );
@@ -147,9 +143,7 @@ describe('FolderTrustDialog', () => {
       {
         width: 80,
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
         uiState: { constrainHeight: true, terminalHeight: 10 },
       },
     );
@@ -179,9 +173,7 @@ describe('FolderTrustDialog', () => {
       {
         width: 80,
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
         // Initially constrained
         uiState: { constrainHeight: true, terminalHeight: 24 },
       },
@@ -208,9 +200,7 @@ describe('FolderTrustDialog', () => {
         {
           width: 80,
           config: makeFakeConfig({ useAlternateBuffer: false }),
-          settings: createMockSettings({
-            merged: { ui: { useAlternateBuffer: false } },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
           uiState: { constrainHeight: false, terminalHeight: 24 },
         },
       );
@@ -451,9 +441,7 @@ describe('FolderTrustDialog', () => {
         {
           width: 80,
           config: makeFakeConfig({ useAlternateBuffer: true }),
-          settings: createMockSettings({
-            merged: { ui: { useAlternateBuffer: true } },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
           uiState: { constrainHeight: false, terminalHeight: 15 },
         },
       );

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -673,9 +673,7 @@ describe('<Footer />', () => {
             errorCount: 2,
             showErrorDetails: false,
           },
-          settings: createMockSettings({
-            merged: { ui: { errorVerbosity: 'low' } },
-          }),
+          settings: createMockSettings({ ui: { errorVerbosity: 'low' } }),
         },
       );
       await waitUntilReady();
@@ -694,9 +692,7 @@ describe('<Footer />', () => {
             errorCount: 2,
             showErrorDetails: false,
           },
-          settings: createMockSettings({
-            merged: { ui: { errorVerbosity: 'low' } },
-          }),
+          settings: createMockSettings({ ui: { errorVerbosity: 'low' } }),
         },
       );
       await waitUntilReady();
@@ -715,9 +711,7 @@ describe('<Footer />', () => {
             errorCount: 2,
             showErrorDetails: false,
           },
-          settings: createMockSettings({
-            merged: { ui: { errorVerbosity: 'full' } },
-          }),
+          settings: createMockSettings({ ui: { errorVerbosity: 'full' } }),
         },
       );
       await waitUntilReady();

--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -87,9 +87,7 @@ describe('<HistoryItemDisplay />', () => {
         <HistoryItemDisplay {...baseItem} item={item} />,
         {
           config: makeFakeConfig({ useAlternateBuffer }),
-          settings: createMockSettings({
-            merged: { ui: { useAlternateBuffer } },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer } }),
         },
       );
       await waitUntilReady();
@@ -284,9 +282,7 @@ describe('<HistoryItemDisplay />', () => {
       const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
         <HistoryItemDisplay {...baseItem} item={item} />,
         {
-          settings: createMockSettings({
-            merged: { ui: { inlineThinkingMode: 'full' } },
-          }),
+          settings: createMockSettings({ ui: { inlineThinkingMode: 'full' } }),
         },
       );
       await waitUntilReady();
@@ -304,9 +300,7 @@ describe('<HistoryItemDisplay />', () => {
       const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
         <HistoryItemDisplay {...baseItem} item={item} isFirstThinking={true} />,
         {
-          settings: createMockSettings({
-            merged: { ui: { inlineThinkingMode: 'full' } },
-          }),
+          settings: createMockSettings({ ui: { inlineThinkingMode: 'full' } }),
         },
       );
       await waitUntilReady();
@@ -324,9 +318,7 @@ describe('<HistoryItemDisplay />', () => {
       const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
         <HistoryItemDisplay {...baseItem} item={item} />,
         {
-          settings: createMockSettings({
-            merged: { ui: { inlineThinkingMode: 'off' } },
-          }),
+          settings: createMockSettings({ ui: { inlineThinkingMode: 'off' } }),
         },
       );
       await waitUntilReady();
@@ -360,9 +352,7 @@ describe('<HistoryItemDisplay />', () => {
           />,
           {
             config: makeFakeConfig({ useAlternateBuffer }),
-            settings: createMockSettings({
-              merged: { ui: { useAlternateBuffer } },
-            }),
+            settings: createMockSettings({ ui: { useAlternateBuffer } }),
           },
         );
         await waitUntilReady();
@@ -387,9 +377,7 @@ describe('<HistoryItemDisplay />', () => {
           />,
           {
             config: makeFakeConfig({ useAlternateBuffer }),
-            settings: createMockSettings({
-              merged: { ui: { useAlternateBuffer } },
-            }),
+            settings: createMockSettings({ ui: { useAlternateBuffer } }),
           },
         );
         await waitUntilReady();
@@ -413,9 +401,7 @@ describe('<HistoryItemDisplay />', () => {
           />,
           {
             config: makeFakeConfig({ useAlternateBuffer }),
-            settings: createMockSettings({
-              merged: { ui: { useAlternateBuffer } },
-            }),
+            settings: createMockSettings({ ui: { useAlternateBuffer } }),
           },
         );
         await waitUntilReady();
@@ -440,9 +426,7 @@ describe('<HistoryItemDisplay />', () => {
           />,
           {
             config: makeFakeConfig({ useAlternateBuffer }),
-            settings: createMockSettings({
-              merged: { ui: { useAlternateBuffer } },
-            }),
+            settings: createMockSettings({ ui: { useAlternateBuffer } }),
           },
         );
         await waitUntilReady();

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -3514,9 +3514,7 @@ describe('InputPrompt', () => {
         {
           mouseEventsEnabled: true,
           config: makeFakeConfig({ useAlternateBuffer: true }),
-          settings: createMockSettings({
-            merged: { ui: { useAlternateBuffer: true } },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
           uiActions,
         },
       );
@@ -3608,9 +3606,7 @@ describe('InputPrompt', () => {
         {
           mouseEventsEnabled: true,
           config: makeFakeConfig({ useAlternateBuffer: true }),
-          settings: createMockSettings({
-            merged: { ui: { useAlternateBuffer: true } },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
           uiActions,
         },
       );

--- a/packages/cli/src/ui/components/MainContent.test.tsx
+++ b/packages/cli/src/ui/components/MainContent.test.tsx
@@ -484,9 +484,7 @@ describe('MainContent', () => {
       {
         uiState: uiState as Partial<UIState>,
         config: makeFakeConfig({ useAlternateBuffer: true }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: true } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
       },
     );
 
@@ -514,9 +512,7 @@ describe('MainContent', () => {
       {
         uiState: uiState as unknown as Partial<UIState>,
         config: makeFakeConfig({ useAlternateBuffer: true }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: true } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
       },
     );
 
@@ -742,7 +738,7 @@ describe('MainContent', () => {
             uiState: uiState as Partial<UIState>,
             config: makeFakeConfig({ useAlternateBuffer: isAlternateBuffer }),
             settings: createMockSettings({
-              merged: { ui: { useAlternateBuffer: isAlternateBuffer } },
+              ui: { useAlternateBuffer: isAlternateBuffer },
             }),
           },
         );

--- a/packages/cli/src/ui/components/ToolConfirmationQueue.test.tsx
+++ b/packages/cli/src/ui/components/ToolConfirmationQueue.test.tsx
@@ -167,9 +167,7 @@ describe('ToolConfirmationQueue', () => {
           ...mockConfig,
           getUseAlternateBuffer: () => true,
         } as unknown as Config,
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: true } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
         uiState: {
           terminalWidth: 80,
           terminalHeight: 20,
@@ -218,9 +216,7 @@ describe('ToolConfirmationQueue', () => {
       />,
       {
         config: mockConfig,
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
         uiState: {
           terminalWidth: 80,
           terminalHeight: 40,

--- a/packages/cli/src/ui/components/messages/DiffRenderer.test.tsx
+++ b/packages/cli/src/ui/components/messages/DiffRenderer.test.tsx
@@ -46,9 +46,7 @@ index 0000000..e69de29
           </OverflowProvider>,
           {
             config: makeFakeConfig({ useAlternateBuffer }),
-            settings: createMockSettings({
-              merged: { ui: { useAlternateBuffer } },
-            }),
+            settings: createMockSettings({ ui: { useAlternateBuffer } }),
           },
         );
         await waitFor(() =>
@@ -83,9 +81,7 @@ index 0000000..e69de29
           </OverflowProvider>,
           {
             config: makeFakeConfig({ useAlternateBuffer }),
-            settings: createMockSettings({
-              merged: { ui: { useAlternateBuffer } },
-            }),
+            settings: createMockSettings({ ui: { useAlternateBuffer } }),
           },
         );
         await waitFor(() =>
@@ -116,9 +112,7 @@ index 0000000..e69de29
           </OverflowProvider>,
           {
             config: makeFakeConfig({ useAlternateBuffer }),
-            settings: createMockSettings({
-              merged: { ui: { useAlternateBuffer } },
-            }),
+            settings: createMockSettings({ ui: { useAlternateBuffer } }),
           },
         );
         await waitFor(() =>
@@ -154,9 +148,7 @@ index 0000001..0000002 100644
           </OverflowProvider>,
           {
             config: makeFakeConfig({ useAlternateBuffer }),
-            settings: createMockSettings({
-              merged: { ui: { useAlternateBuffer } },
-            }),
+            settings: createMockSettings({ ui: { useAlternateBuffer } }),
           },
         );
         // colorizeCode is used internally by the line-by-line rendering, not for the whole block
@@ -190,9 +182,7 @@ index 1234567..1234567 100644
           </OverflowProvider>,
           {
             config: makeFakeConfig({ useAlternateBuffer }),
-            settings: createMockSettings({
-              merged: { ui: { useAlternateBuffer } },
-            }),
+            settings: createMockSettings({ ui: { useAlternateBuffer } }),
           },
         );
         await waitFor(() => expect(lastFrame()).toBeDefined());
@@ -207,9 +197,7 @@ index 1234567..1234567 100644
           </OverflowProvider>,
           {
             config: makeFakeConfig({ useAlternateBuffer }),
-            settings: createMockSettings({
-              merged: { ui: { useAlternateBuffer } },
-            }),
+            settings: createMockSettings({ ui: { useAlternateBuffer } }),
           },
         );
         await waitFor(() => expect(lastFrame()).toBeDefined());
@@ -242,9 +230,7 @@ index 123..456 100644
           </OverflowProvider>,
           {
             config: makeFakeConfig({ useAlternateBuffer }),
-            settings: createMockSettings({
-              merged: { ui: { useAlternateBuffer } },
-            }),
+            settings: createMockSettings({ ui: { useAlternateBuffer } }),
           },
         );
         await waitFor(() => expect(lastFrame()).toContain('added line'));
@@ -281,9 +267,7 @@ index abc..def 100644
           </OverflowProvider>,
           {
             config: makeFakeConfig({ useAlternateBuffer }),
-            settings: createMockSettings({
-              merged: { ui: { useAlternateBuffer } },
-            }),
+            settings: createMockSettings({ ui: { useAlternateBuffer } }),
           },
         );
         await waitFor(() => expect(lastFrame()).toContain('context line 15'));
@@ -336,9 +320,7 @@ index 123..789 100644
               </OverflowProvider>,
               {
                 config: makeFakeConfig({ useAlternateBuffer }),
-                settings: createMockSettings({
-                  merged: { ui: { useAlternateBuffer } },
-                }),
+                settings: createMockSettings({ ui: { useAlternateBuffer } }),
               },
             );
             await waitFor(() => expect(lastFrame()).toContain('anotherNew'));
@@ -375,9 +357,7 @@ fileDiff Index: file.txt
           </OverflowProvider>,
           {
             config: makeFakeConfig({ useAlternateBuffer }),
-            settings: createMockSettings({
-              merged: { ui: { useAlternateBuffer } },
-            }),
+            settings: createMockSettings({ ui: { useAlternateBuffer } }),
           },
         );
         await waitFor(() => expect(lastFrame()).toContain('newVar'));
@@ -407,9 +387,7 @@ fileDiff Index: Dockerfile
           </OverflowProvider>,
           {
             config: makeFakeConfig({ useAlternateBuffer }),
-            settings: createMockSettings({
-              merged: { ui: { useAlternateBuffer } },
-            }),
+            settings: createMockSettings({ ui: { useAlternateBuffer } }),
           },
         );
         await waitFor(() => expect(lastFrame()).toContain('RUN npm run build'));

--- a/packages/cli/src/ui/components/messages/ShellToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ShellToolMessage.test.tsx
@@ -147,9 +147,7 @@ describe('<ShellToolMessage />', () => {
         },
         {
           config: makeFakeConfig({ useAlternateBuffer: true }),
-          settings: createMockSettings({
-            merged: { ui: { useAlternateBuffer: true } },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
           uiState: {
             embeddedShellFocused: true,
             activePtyId: 1,
@@ -164,9 +162,7 @@ describe('<ShellToolMessage />', () => {
         },
         {
           config: makeFakeConfig({ useAlternateBuffer: true }),
-          settings: createMockSettings({
-            merged: { ui: { useAlternateBuffer: true } },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
           uiState: {
             embeddedShellFocused: false,
             activePtyId: 1,
@@ -235,9 +231,7 @@ describe('<ShellToolMessage />', () => {
           {
             uiActions,
             config: makeFakeConfig({ useAlternateBuffer: true }),
-            settings: createMockSettings({
-              merged: { ui: { useAlternateBuffer: true } },
-            }),
+            settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
             uiState: {
               activePtyId: focused ? 1 : 2,
               embeddedShellFocused: focused,
@@ -266,9 +260,7 @@ describe('<ShellToolMessage />', () => {
         {
           uiActions,
           config: makeFakeConfig({ useAlternateBuffer: false }),
-          settings: createMockSettings({
-            merged: { ui: { useAlternateBuffer: false } },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
         },
       );
 
@@ -293,9 +285,7 @@ describe('<ShellToolMessage />', () => {
         {
           uiActions,
           config: makeFakeConfig({ useAlternateBuffer: true }),
-          settings: createMockSettings({
-            merged: { ui: { useAlternateBuffer: true } },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
           uiState: {
             constrainHeight: false,
           },
@@ -325,9 +315,7 @@ describe('<ShellToolMessage />', () => {
         {
           uiActions,
           config: makeFakeConfig({ useAlternateBuffer: true }),
-          settings: createMockSettings({
-            merged: { ui: { useAlternateBuffer: true } },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
           uiState: {
             constrainHeight: false,
           },

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -65,14 +65,10 @@ describe('<ToolGroupMessage />', () => {
     enableInteractiveShell: true,
   });
   const fullVerbositySettings = createMockSettings({
-    merged: {
-      ui: { errorVerbosity: 'full' },
-    },
+    ui: { errorVerbosity: 'full' },
   });
   const lowVerbositySettings = createMockSettings({
-    merged: {
-      ui: { errorVerbosity: 'low' },
-    },
+    ui: { errorVerbosity: 'low' },
   });
 
   describe('Golden Snapshots', () => {

--- a/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
@@ -465,9 +465,7 @@ describe('<ToolMessage />', () => {
           },
           width: 80,
           config: makeFakeConfig({ useAlternateBuffer: false }),
-          settings: createMockSettings({
-            merged: { ui: { useAlternateBuffer: false } },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
         },
       );
       await waitUntilReady();
@@ -501,9 +499,7 @@ describe('<ToolMessage />', () => {
           uiState: { streamingState: StreamingState.Idle },
           width: 80,
           config: makeFakeConfig({ useAlternateBuffer: false }),
-          settings: createMockSettings({
-            merged: { ui: { useAlternateBuffer: false } },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
         },
       );
       await waitUntilReady();
@@ -532,9 +528,7 @@ describe('<ToolMessage />', () => {
           uiState: { streamingState: StreamingState.Idle },
           width: 80,
           config: makeFakeConfig({ useAlternateBuffer: false }),
-          settings: createMockSettings({
-            merged: { ui: { useAlternateBuffer: false } },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
         },
       );
       await waitUntilReady();

--- a/packages/cli/src/ui/components/messages/ToolMessageRawMarkdown.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessageRawMarkdown.test.tsx
@@ -74,9 +74,7 @@ describe('<ToolMessage /> - Raw Markdown Display Snapshots', () => {
         {
           uiState: { renderMarkdown, streamingState: StreamingState.Idle },
           config: makeFakeConfig({ useAlternateBuffer }),
-          settings: createMockSettings({
-            merged: { ui: { useAlternateBuffer } },
-          }),
+          settings: createMockSettings({ ui: { useAlternateBuffer } }),
         },
       );
       await waitUntilReady();

--- a/packages/cli/src/ui/components/messages/ToolOverflowConsistencyChecks.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolOverflowConsistencyChecks.test.tsx
@@ -58,9 +58,7 @@ describe('ToolOverflowConsistencyChecks: ToolGroupMessage and ToolResultDisplay 
           constrainHeight: true,
         },
         config: makeFakeConfig({ useAlternateBuffer: true }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: true } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
       },
     );
 
@@ -111,9 +109,7 @@ describe('ToolOverflowConsistencyChecks: ToolGroupMessage and ToolResultDisplay 
           constrainHeight: true,
         },
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
       },
     );
 

--- a/packages/cli/src/ui/components/messages/ToolResultDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolResultDisplay.test.tsx
@@ -39,9 +39,7 @@ describe('ToolResultDisplay', () => {
       />,
       {
         config: makeFakeConfig({ useAlternateBuffer: true }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: true } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
       },
     );
     await waitUntilReady();
@@ -60,9 +58,7 @@ describe('ToolResultDisplay', () => {
       />,
       {
         config: makeFakeConfig({ useAlternateBuffer: true }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: true } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
       },
     );
     await waitUntilReady();
@@ -82,9 +78,7 @@ describe('ToolResultDisplay', () => {
       />,
       {
         config: makeFakeConfig({ useAlternateBuffer: true }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: true } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
       },
     );
     await waitUntilReady();
@@ -98,9 +92,7 @@ describe('ToolResultDisplay', () => {
       <ToolResultDisplay resultDisplay="**Some result**" terminalWidth={80} />,
       {
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
       },
     );
     await waitUntilReady();
@@ -120,9 +112,7 @@ describe('ToolResultDisplay', () => {
       />,
       {
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
         uiState: { constrainHeight: true },
       },
     );
@@ -143,9 +133,7 @@ describe('ToolResultDisplay', () => {
       />,
       {
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
         uiState: { constrainHeight: true },
       },
     );
@@ -169,9 +157,7 @@ describe('ToolResultDisplay', () => {
       />,
       {
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
       },
     );
     await waitUntilReady();
@@ -204,9 +190,7 @@ describe('ToolResultDisplay', () => {
       />,
       {
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
       },
     );
     await waitUntilReady();
@@ -228,9 +212,7 @@ describe('ToolResultDisplay', () => {
       />,
       {
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
       },
     );
     await waitUntilReady();
@@ -251,9 +233,7 @@ describe('ToolResultDisplay', () => {
       />,
       {
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
         uiState: { constrainHeight: true },
       },
     );
@@ -273,9 +253,7 @@ describe('ToolResultDisplay', () => {
       />,
       {
         config: makeFakeConfig({ useAlternateBuffer: true }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: true } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
       },
     );
     await waitUntilReady();
@@ -357,9 +335,7 @@ describe('ToolResultDisplay', () => {
       />,
       {
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
         uiState: { constrainHeight: true },
       },
     );
@@ -396,9 +372,7 @@ describe('ToolResultDisplay', () => {
       />,
       {
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
         uiState: { constrainHeight: true },
       },
     );

--- a/packages/cli/src/ui/components/messages/ToolResultDisplayOverflow.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolResultDisplayOverflow.test.tsx
@@ -22,9 +22,7 @@ describe('ToolResultDisplay Overflow', () => {
       />,
       {
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
         uiState: { constrainHeight: true },
       },
     );
@@ -51,9 +49,7 @@ describe('ToolResultDisplay Overflow', () => {
       />,
       {
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
         uiState: { constrainHeight: true },
       },
     );
@@ -91,9 +87,7 @@ describe('ToolResultDisplay Overflow', () => {
       />,
       {
         config: makeFakeConfig({ useAlternateBuffer: false }),
-        settings: createMockSettings({
-          merged: { ui: { useAlternateBuffer: false } },
-        }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
         uiState: { constrainHeight: true },
       },
     );

--- a/packages/cli/src/ui/utils/borderStyles.test.tsx
+++ b/packages/cli/src/ui/utils/borderStyles.test.tsx
@@ -20,9 +20,7 @@ vi.mock('../components/CliSpinner.js', () => ({
 
 const altBufferOptions = {
   config: makeFakeConfig({ useAlternateBuffer: true }),
-  settings: createMockSettings({
-    merged: { ui: { useAlternateBuffer: true } },
-  }),
+  settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
 };
 
 describe('getToolGroupBorderAppearance', () => {


### PR DESCRIPTION
## Summary

simplify createMockSettings calls

## Details

It's not necessary to specify `merged` settings in most cases since the default is `user` which will get compiled into the `merged`.

## Related Issues

None.

## How to Validate

```bash
npm test -w packages/cli
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker