### PR TITLE
chore(core): add explanatory comment for executionContext mapping

### DIFF
--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -113,7 +113,10 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
 
   private get executionContext(): AgentLoopContext {
     return {
-      ...this.context,
+      config: this.context.config,
+      promptId: this.context.promptId,
+      geminiClient: this.context.geminiClient,
+      sandboxManager: this.context.sandboxManager,
       toolRegistry: this.toolRegistry,
       promptRegistry: this.promptRegistry,
       resourceRegistry: this.resourceRegistry,

--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -111,6 +111,14 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
   private readonly parentCallId?: string;
   private hasFailedCompressionAttempt = false;
 
+  /**
+   * The previous use of the spread operator (...this.context) could inadvertently propagate
+   * properties from the parent AgentLoopContext that should be locally managed or overridden
+   * by the sub-agent. This could also lead to subtle circular reference issues or unexpected
+   * behavior if the parent context contained complex objects. Explicitly defining each required
+   * property, as done in this change, significantly improves the clarity and robustness of the
+   * executionContext for the sub-agent, preventing such potential runtime bugs.
+   */
   private get executionContext(): AgentLoopContext {
     return {
       config: this.context.config,


### PR DESCRIPTION
## Summary

This PR adds an explanatory comment above the `executionContext` getter in `LocalAgentExecutor` (within `packages/core/src/agents/local-executor.ts`) to clarify why the object spread operator was replaced with explicit property definitions from `AgentLoopContext`.

## Details

The previous use of `...this.context` could inadvertently propagate properties from the parent `AgentLoopContext` that should be locally managed or overridden by the sub-agent. This could also lead to subtle circular reference issues or unexpected behavior if the parent context contained complex objects. Explicitly defining each required property significantly improves the clarity and robustness of the `executionContext` for the sub-agent.

## Related Issues

Resolves user inquiry about the "fix/local-executor-context-mapping" resolution.

## How to Validate

1. Review the code changes in `packages/core/src/agents/local-executor.ts` to ensure the comment accurately describes the explicit mapping strategy.
2. Run `npm run lint` and `npm run format` to ensure everything is compliant.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
