### PR TITLE
fix(cli): improve capacity error handling with actionable messages, auto-fallback, and auth switch option

### DIFF
--- a/packages/cli/src/ui/components/ProQuotaDialog.test.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.test.tsx
@@ -239,7 +239,7 @@ describe('ProQuotaDialog', () => {
     });
 
     describe('when it is a capacity error', () => {
-      it('should render keep trying, switch, and stop options', () => {
+      it('should render keep trying, switch, and stop options (no auth)', () => {
         const { unmount } = render(
           <ProQuotaDialog
             failedModel="gemini-2.5-pro"
@@ -263,6 +263,45 @@ describe('ProQuotaDialog', () => {
                 label: 'Switch to gemini-2.5-flash',
                 value: 'retry_always',
                 key: 'retry_always',
+              },
+              { label: 'Stop', value: 'retry_later', key: 'retry_later' },
+            ],
+          }),
+          undefined,
+        );
+        unmount();
+      });
+
+      it('should render switch to API key option for LOGIN_WITH_GOOGLE', () => {
+        const { unmount } = render(
+          <ProQuotaDialog
+            failedModel="gemini-2.5-pro"
+            fallbackModel="gemini-2.5-flash"
+            message="capacity error"
+            isTerminalQuotaError={false}
+            isModelNotFoundError={false}
+            authType={AuthType.LOGIN_WITH_GOOGLE}
+            onChoice={mockOnChoice}
+          />,
+        );
+
+        expect(RadioButtonSelect).toHaveBeenCalledWith(
+          expect.objectContaining({
+            items: [
+              {
+                label: 'Keep trying',
+                value: 'retry_once',
+                key: 'retry_once',
+              },
+              {
+                label: 'Switch to gemini-2.5-flash',
+                value: 'retry_always',
+                key: 'retry_always',
+              },
+              {
+                label: 'Switch to API key (/auth)',
+                value: 'change_auth',
+                key: 'change_auth',
               },
               { label: 'Stop', value: 'retry_later', key: 'retry_later' },
             ],

--- a/packages/cli/src/ui/components/ProQuotaDialog.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.tsx
@@ -20,7 +20,12 @@ interface ProQuotaDialogProps {
   authType?: AuthType;
   tierName?: string;
   onChoice: (
-    choice: 'retry_later' | 'retry_once' | 'retry_always' | 'upgrade',
+    choice:
+      | 'retry_later'
+      | 'retry_once'
+      | 'retry_always'
+      | 'upgrade'
+      | 'change_auth',
   ) => void;
 }
 
@@ -87,6 +92,15 @@ export function ProQuotaDialog({
         value: 'retry_always' as const,
         key: 'retry_always',
       },
+      ...(authType === AuthType.LOGIN_WITH_GOOGLE
+        ? [
+            {
+              label: 'Switch to API key (/auth)',
+              value: 'change_auth' as const,
+              key: 'change_auth',
+            },
+          ]
+        : []),
       {
         label: 'Stop',
         value: 'retry_later' as const,
@@ -96,7 +110,12 @@ export function ProQuotaDialog({
   }
 
   const handleSelect = (
-    choice: 'retry_later' | 'retry_once' | 'retry_always' | 'upgrade',
+    choice:
+      | 'retry_later'
+      | 'retry_once'
+      | 'retry_always'
+      | 'upgrade'
+      | 'change_auth',
   ) => {
     onChoice(choice);
   };

--- a/packages/cli/src/ui/contexts/UIActionsContext.tsx
+++ b/packages/cli/src/ui/contexts/UIActionsContext.tsx
@@ -60,7 +60,12 @@ export interface UIActions {
   handleFinalSubmit: (value: string) => Promise<void>;
   handleClearScreen: () => void;
   handleProQuotaChoice: (
-    choice: 'retry_later' | 'retry_once' | 'retry_always' | 'upgrade',
+    choice:
+      | 'retry_later'
+      | 'retry_once'
+      | 'retry_always'
+      | 'upgrade'
+      | 'change_auth',
   ) => void;
   handleValidationChoice: (choice: 'verify' | 'change_auth' | 'cancel') => void;
   handleOverageMenuChoice: (choice: OverageMenuIntent) => void;

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
@@ -179,7 +179,7 @@ describe('useQuotaAndFallback', () => {
         .calls[0][0] as FallbackModelHandler;
       const intent = await handler(
         'gemini-pro',
-        'gemini-flash',
+        'gemini-pro',
         new RetryableQuotaError('retryable quota', mockGoogleApiError, 5),
       );
 
@@ -439,7 +439,8 @@ describe('useQuotaAndFallback', () => {
 
           let promise: Promise<FallbackIntent | null>;
           act(() => {
-            promise = handler('model-A', 'model-B', error);
+            // Use the same model to trigger the dialog (prevent PR 3 auto-fallback)
+            promise = handler('model-A', 'model-A', error);
           });
 
           // The hook should now have a pending request for the UI to handle
@@ -451,32 +452,177 @@ describe('useQuotaAndFallback', () => {
           // Check that the correct initial message was generated
           expect(mockHistoryManager.addItem).not.toHaveBeenCalled();
           const message = request!.message;
-          expect(message).toContain(
-            'We are currently experiencing high demand.',
-          );
+          expect(message).toContain('Server capacity exceeded for model-A.');
 
-          // Simulate the user choosing to continue with the fallback model
+          // Simulate the user choosing to retry
           act(() => {
-            result.current.handleProQuotaChoice('retry_always');
+            result.current.handleProQuotaChoice('retry_once');
           });
 
-          expect(mockSetModelSwitchedFromQuotaError).toHaveBeenCalledWith(true);
           // The original promise from the handler should now resolve
           const intent = await promise!;
-          expect(intent).toBe('retry_always');
+          expect(intent).toBe('retry_once');
 
           // The pending request should be cleared from the state
           expect(result.current.proQuotaRequest).toBeNull();
-          expect(mockConfig.setQuotaErrorOccurred).toHaveBeenCalledWith(true);
-
-          // Check for the "Switched to fallback model" message
-          expect(mockHistoryManager.addItem).toHaveBeenCalledTimes(1);
-          const lastCall = (mockHistoryManager.addItem as Mock).mock
-            .calls[0][0];
-          expect(lastCall.type).toBe(MessageType.INFO);
-          expect(lastCall.text).toContain('Switched to fallback model model-B');
         });
       }
+
+      it('should auto-fallback for capacity errors when fallback differs from failed model', async () => {
+        const { result } = renderHook(() =>
+          useQuotaAndFallback({
+            config: mockConfig,
+            historyManager: mockHistoryManager,
+            userTier: UserTierId.FREE,
+            setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+            onShowAuthSelection: mockOnShowAuthSelection,
+            paidTier: null,
+            settings: mockSettings,
+          }),
+        );
+
+        const handler = setFallbackHandlerSpy.mock
+          .calls[0][0] as FallbackModelHandler;
+
+        let promise: Promise<FallbackIntent | null>;
+        act(() => {
+          promise = handler(
+            'gemini-pro',
+            'gemini-flash',
+            new Error('server error'),
+          );
+        });
+
+        // Dialog should NOT be shown
+        const request = result.current.proQuotaRequest;
+        expect(request).toBeNull();
+
+        const intent = await promise!;
+        expect(intent).toBe('retry_always');
+        expect(mockSetModelSwitchedFromQuotaError).toHaveBeenCalledWith(true);
+
+        expect(mockHistoryManager.addItem).toHaveBeenCalledTimes(1);
+        const lastCall = (mockHistoryManager.addItem as Mock).mock.calls[0][0];
+        expect(lastCall.type).toBe(MessageType.INFO);
+        expect(lastCall.text).toContain('Auto-switching to gemini-flash');
+      });
+
+      it('should omit fallback model tip in capacity error when models are the same', async () => {
+        const { result } = renderHook(() =>
+          useQuotaAndFallback({
+            config: mockConfig,
+            historyManager: mockHistoryManager,
+            userTier: UserTierId.FREE,
+            setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+            onShowAuthSelection: mockOnShowAuthSelection,
+            paidTier: null,
+            settings: mockSettings,
+          }),
+        );
+
+        const handler = setFallbackHandlerSpy.mock
+          .calls[0][0] as FallbackModelHandler;
+
+        let promise: Promise<FallbackIntent | null>;
+        act(() => {
+          promise = handler(
+            'gemini-pro',
+            'gemini-pro', // Same model
+            new Error('server error'),
+          );
+        });
+
+        const request = result.current.proQuotaRequest;
+        expect(request).not.toBeNull();
+        const message = request!.message;
+        expect(message).toContain('Server capacity exceeded for gemini-pro.');
+        expect(message).not.toContain('Tip: Try /model');
+
+        act(() => {
+          result.current.handleProQuotaChoice('retry_later');
+        });
+        await promise!;
+      });
+
+      it('should include auth switch suggestion for OAuth users on capacity error', async () => {
+        vi.spyOn(mockConfig, 'getContentGeneratorConfig').mockReturnValue({
+          authType: AuthType.LOGIN_WITH_GOOGLE,
+        });
+
+        const { result } = renderHook(() =>
+          useQuotaAndFallback({
+            config: mockConfig,
+            historyManager: mockHistoryManager,
+            userTier: UserTierId.FREE,
+            setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+            onShowAuthSelection: mockOnShowAuthSelection,
+            paidTier: null,
+            settings: mockSettings,
+          }),
+        );
+
+        const handler = setFallbackHandlerSpy.mock
+          .calls[0][0] as FallbackModelHandler;
+
+        let promise: Promise<FallbackIntent | null>;
+        act(() => {
+          // Use same model so the dialog appears instead of auto-fallback
+          promise = handler(
+            'gemini-pro',
+            'gemini-pro',
+            new Error('server error'),
+          );
+        });
+
+        const message = result.current.proQuotaRequest!.message;
+        expect(message).toContain(
+          '/auth to switch to API key (separate capacity pool).',
+        );
+
+        act(() => {
+          result.current.handleProQuotaChoice('retry_later');
+        });
+        await promise!;
+      });
+
+      it('should omit auth switch suggestion for API key users on capacity error', async () => {
+        vi.spyOn(mockConfig, 'getContentGeneratorConfig').mockReturnValue({
+          authType: AuthType.USE_GEMINI,
+        });
+
+        const { result } = renderHook(() =>
+          useQuotaAndFallback({
+            config: mockConfig,
+            historyManager: mockHistoryManager,
+            userTier: UserTierId.FREE,
+            setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+            onShowAuthSelection: mockOnShowAuthSelection,
+            paidTier: null,
+            settings: mockSettings,
+          }),
+        );
+
+        const handler = setFallbackHandlerSpy.mock
+          .calls[0][0] as FallbackModelHandler;
+
+        let promise: Promise<FallbackIntent | null>;
+        act(() => {
+          // Use same model so dialog appears
+          promise = handler(
+            'gemini-pro',
+            'gemini-pro',
+            new Error('server error'),
+          );
+        });
+
+        const message = result.current.proQuotaRequest!.message;
+        expect(message).not.toContain('/auth');
+
+        act(() => {
+          result.current.handleProQuotaChoice('retry_later');
+        });
+        await promise!;
+      });
 
       it('should handle ModelNotFoundError correctly', async () => {
         const { result } = renderHook(() =>
@@ -934,18 +1080,18 @@ Your admin might have disabled the access. Contact them to enable the Preview Re
         result.current.handleProQuotaChoice('retry_always');
       });
 
-      await promise!;
+      // Auto-fallback triggers since models differ (preview != pro)
+      const intent = await promise!;
+      expect(intent).toBe('retry_always');
 
       expect(mockHistoryManager.addItem).toHaveBeenCalledTimes(1);
       const lastCall = (mockHistoryManager.addItem as Mock).mock.calls[0][0];
       expect(lastCall.type).toBe(MessageType.INFO);
-      expect(lastCall.text).toContain(
-        `Switched to fallback model gemini-2.5-pro`,
-      );
+      expect(lastCall.text).toContain(`Auto-switching to gemini-2.5-pro`);
     });
 
     it('should show a special message when falling back from the preview model, but do not show periodical check message for flash model fallback', async () => {
-      const { result } = renderHook(() =>
+      renderHook(() =>
         useQuotaAndFallback({
           config: mockConfig,
           historyManager: mockHistoryManager,
@@ -968,18 +1114,14 @@ Your admin might have disabled the access. Contact them to enable the Preview Re
         );
       });
 
-      act(() => {
-        result.current.handleProQuotaChoice('retry_always');
-      });
-
-      await promise!;
+      // Auto-fallback triggers since models differ (preview != flash)
+      const intent = await promise!;
+      expect(intent).toBe('retry_always');
 
       expect(mockHistoryManager.addItem).toHaveBeenCalledTimes(1);
       const lastCall = (mockHistoryManager.addItem as Mock).mock.calls[0][0];
       expect(lastCall.type).toBe(MessageType.INFO);
-      expect(lastCall.text).toContain(
-        `Switched to fallback model gemini-2.5-flash`,
-      );
+      expect(lastCall.text).toContain(`Auto-switching to gemini-2.5-flash`);
     });
   });
 

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -150,15 +150,38 @@ export function useQuotaAndFallback({
         }
       } else {
         const messageLines = [
-          `We are currently experiencing high demand.`,
-          'We apologize and appreciate your patience.',
+          `Server capacity exceeded for ${failedModel}.`,
+          'This is a temporary server-side issue, not a quota limit.',
+          failedModel !== fallbackModel
+            ? `Tip: Try /model ${fallbackModel} for a less congested model.`
+            : null,
+          contentGeneratorConfig?.authType === AuthType.LOGIN_WITH_GOOGLE
+            ? '/auth to switch to API key (separate capacity pool).'
+            : null,
           '/model to switch models.',
-        ];
+        ].filter(Boolean);
         message = messageLines.join('\n');
       }
 
+      // Auto-fallback for capacity errors when a different fallback model is available
+      if (
+        !isTerminalQuotaError &&
+        !isModelNotFoundError &&
+        fallbackModel !== failedModel
+      ) {
+        historyManager.addItem(
+          {
+            type: MessageType.INFO,
+            text: `Server capacity exceeded for ${failedModel}. Auto-switching to ${fallbackModel}.`,
+          },
+          Date.now(),
+        );
+        setModelSwitchedFromQuotaError(true);
+        return 'retry_always';
+      }
+
       // In low verbosity mode, auto-retry transient capacity failures
-      // without interrupting with a dialog.
+      // without interrupting with a dialog, if models are the same.
       if (
         errorVerbosity === 'low' &&
         !isTerminalQuotaError &&
@@ -243,6 +266,11 @@ export function useQuotaAndFallback({
       setProQuotaRequest(null);
       isDialogPending.current = false; // Reset the flag here
 
+      if (choice === 'change_auth') {
+        onShowAuthSelection();
+        return;
+      }
+
       if (choice === 'retry_always' || choice === 'retry_once') {
         // Reset quota error flags to allow the agent loop to continue.
         setModelSwitchedFromQuotaError(false);
@@ -259,7 +287,13 @@ export function useQuotaAndFallback({
         }
       }
     },
-    [proQuotaRequest, historyManager, config, setModelSwitchedFromQuotaError],
+    [
+      proQuotaRequest,
+      historyManager,
+      config,
+      setModelSwitchedFromQuotaError,
+      onShowAuthSelection,
+    ],
   );
 
   const handleValidationChoice = useCallback(

--- a/packages/core/src/availability/policyCatalog.test.ts
+++ b/packages/core/src/availability/policyCatalog.test.ts
@@ -48,7 +48,7 @@ describe('policyCatalog', () => {
   it('returns default chain when preview disabled', () => {
     const chain = getModelPolicyChain({ previewEnabled: false });
     expect(chain[0]?.model).toBe(DEFAULT_GEMINI_MODEL);
-    expect(chain).toHaveLength(2);
+    expect(chain).toHaveLength(3);
   });
 
   it('marks preview transients as sticky retries', () => {

--- a/packages/core/src/availability/policyCatalog.ts
+++ b/packages/core/src/availability/policyCatalog.ts
@@ -56,7 +56,8 @@ const DEFAULT_STATE: ModelPolicyStateMap = {
 
 const DEFAULT_CHAIN: ModelPolicyChain = [
   definePolicy({ model: DEFAULT_GEMINI_MODEL }),
-  definePolicy({ model: DEFAULT_GEMINI_FLASH_MODEL, isLastResort: true }),
+  definePolicy({ model: DEFAULT_GEMINI_FLASH_MODEL }),
+  definePolicy({ model: DEFAULT_GEMINI_FLASH_LITE_MODEL, isLastResort: true }),
 ];
 
 const FLASH_LITE_CHAIN: ModelPolicyChain = [

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -20,6 +20,7 @@ import type { ModelAvailabilityService } from '../availability/modelAvailability
 import { createAvailabilityServiceMock } from '../availability/testUtils.js';
 import { AuthType } from '../core/contentGenerator.js';
 import {
+  DEFAULT_GEMINI_FLASH_LITE_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
   DEFAULT_GEMINI_MODEL,
   DEFAULT_GEMINI_MODEL_AUTO,
@@ -138,6 +139,7 @@ describe('handleFallback', () => {
 
       expect(availability.selectFirstAvailable).toHaveBeenCalledWith([
         DEFAULT_GEMINI_FLASH_MODEL,
+        DEFAULT_GEMINI_FLASH_LITE_MODEL,
       ]);
     });
 
@@ -154,7 +156,7 @@ describe('handleFallback', () => {
 
       expect(policyHandler).toHaveBeenCalledWith(
         MOCK_PRO_MODEL,
-        DEFAULT_GEMINI_FLASH_MODEL,
+        DEFAULT_GEMINI_FLASH_LITE_MODEL,
         undefined,
       );
     });
@@ -197,7 +199,7 @@ describe('handleFallback', () => {
     });
 
     it('does not wrap around to upgrade candidates if the current model was selected at the end (e.g. by router)', async () => {
-      // Last-resort failure (Flash) in [Preview, Pro, Flash] checks Preview then Pro (all upstream).
+      // Last-resort failure (Flash Lite) in [Pro, Flash, Flash Lite] checks Pro then Flash (all upstream).
       vi.mocked(policyConfig.getModel).mockReturnValue(
         DEFAULT_GEMINI_MODEL_AUTO,
       );
@@ -210,14 +212,14 @@ describe('handleFallback', () => {
 
       await handleFallback(
         policyConfig,
-        DEFAULT_GEMINI_FLASH_MODEL,
+        DEFAULT_GEMINI_FLASH_LITE_MODEL,
         AUTH_OAUTH,
       );
 
       expect(availability.selectFirstAvailable).not.toHaveBeenCalled();
       expect(policyHandler).toHaveBeenCalledWith(
-        DEFAULT_GEMINI_FLASH_MODEL,
-        DEFAULT_GEMINI_FLASH_MODEL,
+        DEFAULT_GEMINI_FLASH_LITE_MODEL,
+        DEFAULT_GEMINI_FLASH_LITE_MODEL,
         undefined,
       );
     });
@@ -352,7 +354,7 @@ describe('handleFallback', () => {
 
       const result = await handleFallback(
         policyConfig,
-        DEFAULT_GEMINI_FLASH_MODEL,
+        DEFAULT_GEMINI_FLASH_LITE_MODEL,
         AUTH_OAUTH,
       );
 
@@ -360,8 +362,8 @@ describe('handleFallback', () => {
 
       expect(result).not.toBeNull();
       expect(policyHandler).toHaveBeenCalledWith(
-        DEFAULT_GEMINI_FLASH_MODEL,
-        DEFAULT_GEMINI_FLASH_MODEL,
+        DEFAULT_GEMINI_FLASH_LITE_MODEL,
+        DEFAULT_GEMINI_FLASH_LITE_MODEL,
         undefined,
       );
     });

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -158,6 +158,10 @@ async function processIntent(
       await handleUpgrade();
       return false;
 
+    case 'change_auth':
+      // The UI has initiated the auth switch flow; stop the current request.
+      return false;
+
     default:
       throw new Error(
         `Unexpected fallback intent received from fallbackModelHandler: "${intent}"`,

--- a/packages/core/src/fallback/types.ts
+++ b/packages/core/src/fallback/types.ts
@@ -20,7 +20,8 @@ export type FallbackIntent =
   | 'retry_with_credits' // Retry the current request using Google One AI credits (and potentially future ones if strategy is 'always').
   | 'stop' // Switch to fallback for future requests, but stop the current request.
   | 'retry_later' // Stop the current request and do not fallback. Intend to try again later with the same model.
-  | 'upgrade'; // Give user an option to upgrade the tier.
+  | 'upgrade' // Give user an option to upgrade the tier.
+  | 'change_auth'; // Give user an option to switch auth method.
 
 export interface FallbackRecommendation extends ModelSelectionResult {
   action: FallbackAction;


### PR DESCRIPTION
## Summary

This PR improves the user experience when encountering capacity/high-demand errors in Gemini CLI by making error messages more actionable, adding automatic model fallback, and providing OAuth users with a path to switch authentication methods.

Fixes #20834

## Changes

### 1. Actionable Error Messages (useQuotaAndFallback.ts)
- **Before:** Generic We are currently experiencing high demand. We apologize and appreciate your patience.
- **After:** Server capacity exceeded for {model}. This is a temporary server-side issue, not a quota limit. with contextual tips:
  - Suggests a specific fallback model via /model {fallback}
  - For OAuth users: suggests /auth to switch to API key (separate capacity pool)

### 2. Automatic Model Fallback (useQuotaAndFallback.ts)
- When a capacity error occurs and a different fallback model is available, the CLI now **automatically switches** to the fallback model instead of interrupting the user with a dialog
- Displays an info message: Server capacity exceeded for {model}. Auto-switching to {fallback}.
- The dialog is still shown when no alternative model is available (same model fallback)

### 3. Auth Switch Option in Dialog (ProQuotaDialog.tsx, UIActionsContext.tsx)
- Adds a **'Switch to API key (/auth)'** option in the capacity error dialog, exclusively for users authenticated via Google OAuth
- This provides a direct escape hatch to a potentially less-congested API backend

### 4. Extended Fallback Chain (policyCatalog.ts)
- Adds gemini-2.5-flash-lite as the final last-resort model in the default policy chain
- Chain is now: gemini-2.5-pro → gemini-2.5-flash → gemini-2.5-flash-lite

### 5. Type System Updates (	ypes.ts, handler.ts)
- Added 'change_auth' to FallbackIntent union type
- Added case 'change_auth' handler in processIntent (stops current request, triggers auth flow)

## Files Changed (10 files, +297/-50)

| File | Change |
|---|---|
| packages/core/src/fallback/types.ts | Added \change_auth\ to \FallbackIntent\ |
| packages/core/src/fallback/handler.ts | Handle \change_auth\ in \processIntent\ |
| packages/core/src/availability/policyCatalog.ts | Added flash-lite to default chain |
| packages/cli/src/ui/hooks/useQuotaAndFallback.ts | Improved messages + auto-fallback + auth switch |
| packages/cli/src/ui/components/ProQuotaDialog.tsx | Added 'Switch to API key' option |
| packages/cli/src/ui/contexts/UIActionsContext.tsx | Updated type signature |
| packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts | Updated + added tests |
| packages/cli/src/ui/components/ProQuotaDialog.test.tsx | Added auth switch test |
| packages/core/src/availability/policyCatalog.test.ts | Updated chain length |
| packages/core/src/fallback/handler.test.ts | Updated for flash-lite |

## Testing
- ✅ useQuotaAndFallback.test.ts: 32/32 passed
- ✅ ProQuotaDialog.test.tsx: 11/11 passed
- ✅ policyCatalog.test.ts: 12/12 passed
- ✅ handler.test.ts: 13/13 passed
- ✅ ESLint: 0 errors
- ✅ TypeScript: builds successfully