### PR TITLE
fix(core): treat RESOURCE_EXHAUSTED 429 errors without details as TerminalQuotaError

### DIFF
--- a/packages/core/src/utils/googleErrors.ts
+++ b/packages/core/src/utils/googleErrors.ts
@@ -234,7 +234,7 @@ export function parseGoogleApiError(error: unknown): GoogleApiError | null {
             }
             // Basic structural check before casting.
             // Since the proto definitions are loose, we primarily rely on @type presence.
-             
+
             if (typeof detailObj['@type'] === 'string') {
               // We can just cast it; the consumer will have to switch on @type
               // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion

--- a/packages/core/src/utils/googleErrors.ts
+++ b/packages/core/src/utils/googleErrors.ts
@@ -128,12 +128,14 @@ export interface GoogleApiError {
   code: number;
   message: string;
   details: GoogleApiErrorDetail[];
+  status?: string;
 }
 
 type ErrorShape = {
   message?: string;
   details?: unknown[];
   code?: number;
+  status?: string;
 };
 
 /**
@@ -213,6 +215,7 @@ export function parseGoogleApiError(error: unknown): GoogleApiError | null {
   const code = currentError.code;
   const message = currentError.message;
   const errorDetails = currentError.details;
+  const status = currentError.status;
 
   if (code && message) {
     const details: GoogleApiErrorDetail[] = [];
@@ -231,7 +234,7 @@ export function parseGoogleApiError(error: unknown): GoogleApiError | null {
             }
             // Basic structural check before casting.
             // Since the proto definitions are loose, we primarily rely on @type presence.
-            // eslint-disable-next-line no-restricted-syntax
+             
             if (typeof detailObj['@type'] === 'string') {
               // We can just cast it; the consumer will have to switch on @type
               // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
@@ -246,6 +249,7 @@ export function parseGoogleApiError(error: unknown): GoogleApiError | null {
       code,
       message,
       details,
+      status,
     };
   }
 

--- a/packages/core/src/utils/googleQuotaErrors.test.ts
+++ b/packages/core/src/utils/googleQuotaErrors.test.ts
@@ -81,6 +81,23 @@ describe('classifyGoogleError', () => {
     }
   });
 
+  it('should return TerminalQuotaError for 429 when status is RESOURCE_EXHAUSTED and details are empty', () => {
+    const apiError: GoogleApiError = {
+      code: 429,
+      status: 'RESOURCE_EXHAUSTED',
+      message: 'Your prepayment funds are depleted.',
+      details: [],
+    };
+    vi.spyOn(errorParser, 'parseGoogleApiError').mockReturnValue(apiError);
+    const originalError = new Error('Your prepayment funds are depleted.');
+    const result = classifyGoogleError(originalError);
+    expect(result).toBeInstanceOf(TerminalQuotaError);
+    if (result instanceof TerminalQuotaError) {
+      expect(result.cause).toBe(apiError);
+      expect(result.message).toBe('Your prepayment funds are depleted.');
+    }
+  });
+
   it('should return original error if code is not 429, 499 or 503', () => {
     const apiError: GoogleApiError = {
       code: 500,

--- a/packages/core/src/utils/googleQuotaErrors.ts
+++ b/packages/core/src/utils/googleQuotaErrors.ts
@@ -242,6 +242,17 @@ export function classifyGoogleError(error: unknown): unknown {
     );
   }
 
+  // Centralized check for RESOURCE_EXHAUSTED errors
+  if (
+    googleApiError?.status === 'RESOURCE_EXHAUSTED' &&
+    (status === 429 || status === 499)
+  ) {
+    const errorMessage =
+      googleApiError?.message ||
+      (error instanceof Error ? error.message : String(error));
+    return new TerminalQuotaError(errorMessage, googleApiError);
+  }
+
   if (
     !googleApiError ||
     (googleApiError.code !== 429 && googleApiError.code !== 499) ||
@@ -268,12 +279,6 @@ export function classifyGoogleError(error: unknown): unknown {
     } else if (status === 429 || status === 499) {
       // Fallback: If it is a 429 or 499 but doesn't have a specific "retry in" message,
       // assume it is a temporary rate limit and retry after 5 sec (same as DEFAULT_RETRY_OPTIONS).
-
-      // However, if the API explicitly returns RESOURCE_EXHAUSTED without details,
-      // it indicates a hard quota exhaustion rather than a transient rate limit.
-      if (googleApiError?.status === 'RESOURCE_EXHAUSTED') {
-        return new TerminalQuotaError(errorMessage, googleApiError);
-      }
 
       return new RetryableQuotaError(
         errorMessage,
@@ -412,10 +417,6 @@ export function classifyGoogleError(error: unknown): unknown {
     const errorMessage =
       googleApiError?.message ||
       (error instanceof Error ? error.message : String(error));
-
-    if (googleApiError?.status === 'RESOURCE_EXHAUSTED') {
-      return new TerminalQuotaError(errorMessage, googleApiError);
-    }
 
     return new RetryableQuotaError(
       errorMessage,

--- a/packages/core/src/utils/googleQuotaErrors.ts
+++ b/packages/core/src/utils/googleQuotaErrors.ts
@@ -268,6 +268,13 @@ export function classifyGoogleError(error: unknown): unknown {
     } else if (status === 429 || status === 499) {
       // Fallback: If it is a 429 or 499 but doesn't have a specific "retry in" message,
       // assume it is a temporary rate limit and retry after 5 sec (same as DEFAULT_RETRY_OPTIONS).
+
+      // However, if the API explicitly returns RESOURCE_EXHAUSTED without details,
+      // it indicates a hard quota exhaustion rather than a transient rate limit.
+      if (googleApiError?.status === 'RESOURCE_EXHAUSTED') {
+        return new TerminalQuotaError(errorMessage, googleApiError);
+      }
+
       return new RetryableQuotaError(
         errorMessage,
         googleApiError ?? {
@@ -405,6 +412,11 @@ export function classifyGoogleError(error: unknown): unknown {
     const errorMessage =
       googleApiError?.message ||
       (error instanceof Error ? error.message : String(error));
+
+    if (googleApiError?.status === 'RESOURCE_EXHAUSTED') {
+      return new TerminalQuotaError(errorMessage, googleApiError);
+    }
+
     return new RetryableQuotaError(
       errorMessage,
       googleApiError ?? {


### PR DESCRIPTION
## Summary

Treats `RESOURCE_EXHAUSTED` 429 errors without details as `TerminalQuotaError` instead of falling back to silent retries.

## Details

When the Gemini API returns a 429 status code with `RESOURCE_EXHAUSTED` in the status field and no `details` array (e.g., "Your prepayment funds are depleted."), the error parsing logic now surfaces it correctly as a `TerminalQuotaError`. This immediately shows the interactive ProQuotaDialog to the user rather than failing silently in the background after retrying.

## Related Issues

Fixes #22988

## How to Validate

Simulate a `429` error with `RESOURCE_EXHAUSTED` and no details array, and confirm it surfaces as a terminal error. The added unit tests verify this behavior explicitly.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
