### PR TITLE
fix: extend omission placeholder detector to handle # and /* comment styles

### DIFF
--- a/packages/core/src/tools/omissionPlaceholderDetector.test.ts
+++ b/packages/core/src/tools/omissionPlaceholderDetector.test.ts
@@ -21,6 +21,15 @@ describe('detectOmissionPlaceholders', () => {
     expect(detectOmissionPlaceholders('// rest of methods ...')).toEqual([
       'rest of methods ...',
     ]);
+    expect(detectOmissionPlaceholders('# rest of methods ...')).toEqual([
+      'rest of methods ...',
+    ]);
+    expect(detectOmissionPlaceholders('-- rest of methods ...')).toEqual([
+      'rest of methods ...',
+    ]);
+    expect(detectOmissionPlaceholders('/* rest of methods ... */')).toEqual([
+      'rest of methods ...',
+    ]);
   });
 
   it('detects case-insensitive placeholders', () => {

--- a/packages/core/src/tools/omissionPlaceholderDetector.ts
+++ b/packages/core/src/tools/omissionPlaceholderDetector.ts
@@ -58,6 +58,18 @@ function normalizePlaceholder(line: string): string | null {
     text = text.slice(2).trim();
   }
 
+  if (text.startsWith('#')) {
+    text = text.slice(1).trim();
+  }
+
+  if (text.startsWith('--')) {
+    text = text.slice(2).trim();
+  }
+
+  if (text.startsWith('/*') && text.endsWith('*/')) {
+    text = text.slice(2, -2).trim();
+  }
+
   if (text.startsWith('(') && text.endsWith(')')) {
     text = text.slice(1, -1).trim();
   }

--- a/packages/core/src/tools/omissionPlaceholderDetector.ts
+++ b/packages/core/src/tools/omissionPlaceholderDetector.ts
@@ -56,17 +56,11 @@ function normalizePlaceholder(line: string): string | null {
 
   if (text.startsWith('//')) {
     text = text.slice(2).trim();
-  }
-
-  if (text.startsWith('#')) {
+  } else if (text.startsWith('#')) {
     text = text.slice(1).trim();
-  }
-
-  if (text.startsWith('--')) {
+  } else if (text.startsWith('--')) {
     text = text.slice(2).trim();
-  }
-
-  if (text.startsWith('/*') && text.endsWith('*/')) {
+  } else if (text.startsWith('/*') && text.endsWith('*/')) {
     text = text.slice(2, -2).trim();
   }
 


### PR DESCRIPTION
## Summary

Extends the omission placeholder detector to catch placeholders in `#` and `/* */` comment styles, in addition to the existing `//` style.

## Details

`normalizePlaceholder()` only stripped `//` prefixes when checking for omission patterns like `// rest of code...`. This meant placeholders in Python-style (`# rest of implementation...`) or C/Java-style (`/* remaining methods */`) comments were not detected, allowing incomplete generated code to be written to disk without triggering the omission guard.

The fix adds `#` and `/*` to the prefix stripping logic and adds corresponding test cases.

## Related Issues

Fixes #23013

## How to Validate

```bash
npx vitest run src/tools/omissionPlaceholderDetector.test.ts --reporter verbose --pool threads
```

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)