### PR TITLE
fix(ui): update broken Terms of Service link in /auth (#23027)

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -4,3 +4,6 @@ https://github.com/google-gemini/maintainers-gemini-cli/blob/main/npm.md
 https://github.com/settings/personal-access-tokens/new
 https://github.com/settings/tokens/new
 https://www.npmjs.com/package/@google/gemini-cli
+/docs/assets/connected_devtools.png
+/docs/sidebar.json
+/docs/assets/gemini-screenshot.png

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -409,7 +409,7 @@ To debug the CLI's React-based UI, you can use React DevTools.
     ```
 
     Your running CLI application should then connect to React DevTools.
-    ![](./docs/assets/connected_devtools.png)
+    ![](/docs/assets/connected_devtools.png)
 
 ### Sandboxing
 
@@ -505,7 +505,7 @@ code.
 
 ### Documentation structure
 
-Our documentation is organized using [sidebar.json](./docs/sidebar.json) as the
+Our documentation is organized using [sidebar.json](/docs/sidebar.json) as the
 table of contents. When adding new documentation:
 
 1. Create your markdown file **in the appropriate directory** under `/docs`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -557,7 +557,7 @@ Before submitting your documentation pull request, please:
 
 If you have questions about contributing documentation:
 
-- Check our [FAQ](https://geminicli.com/docs/resources/faq).
+- Check our [FAQ](https://geminicli.com/docs/faq).
 - Review existing documentation for examples.
 - Open [an issue](https://github.com/google-gemini/gemini-cli/issues) to discuss
   your proposed changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -409,7 +409,7 @@ To debug the CLI's React-based UI, you can use React DevTools.
     ```
 
     Your running CLI application should then connect to React DevTools.
-    ![](/docs/assets/connected_devtools.png)
+    ![](./docs/assets/connected_devtools.png)
 
 ### Sandboxing
 
@@ -505,7 +505,7 @@ code.
 
 ### Documentation structure
 
-Our documentation is organized using [sidebar.json](/docs/sidebar.json) as the
+Our documentation is organized using [sidebar.json](./docs/sidebar.json) as the
 table of contents. When adding new documentation:
 
 1. Create your markdown file **in the appropriate directory** under `/docs`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/github/license/google-gemini/gemini-cli)](https://github.com/google-gemini/gemini-cli/blob/main/LICENSE)
 [![View Code Wiki](https://assets.codewiki.google/readme-badge/static.svg)](https://codewiki.google/github.com/google-gemini/gemini-cli?utm_source=badge&utm_medium=github&utm_campaign=github.com/google-gemini/gemini-cli)
 
-![Gemini CLI Screenshot](./docs/assets/gemini-screenshot.png)
+![Gemini CLI Screenshot](/docs/assets/gemini-screenshot.png)
 
 Gemini CLI is an open-source AI agent that brings the power of Gemini directly
 into your terminal. It provides lightweight access to Gemini, giving you the

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/github/license/google-gemini/gemini-cli)](https://github.com/google-gemini/gemini-cli/blob/main/LICENSE)
 [![View Code Wiki](https://assets.codewiki.google/readme-badge/static.svg)](https://codewiki.google/github.com/google-gemini/gemini-cli?utm_source=badge&utm_medium=github&utm_campaign=github.com/google-gemini/gemini-cli)
 
-![Gemini CLI Screenshot](/docs/assets/gemini-screenshot.png)
+![Gemini CLI Screenshot](./docs/assets/gemini-screenshot.png)
 
 Gemini CLI is an open-source AI agent that brings the power of Gemini directly
 into your terminal. It provides lightweight access to Gemini, giving you the

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ instructions.
 ## 📄 Legal
 
 - **License**: [Apache License 2.0](LICENSE)
-- **Terms of Service**: [Terms & Privacy](./docs/resources/tos-privacy.md)
+- **Terms of Service**: [Terms & Privacy](./docs/tos-privacy)
 - **Security**: [Security Policy](SECURITY.md)
 
 ---

--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -187,11 +187,11 @@ visualize your telemetry.
 Find this dashboard under **Google Cloud Monitoring Dashboard Templates** as
 "**Gemini CLI Monitoring**".
 
-![Gemini CLI Monitoring Dashboard Overview](/docs/assets/monitoring-dashboard-overview.png)
+![Gemini CLI Monitoring Dashboard Overview](../assets/monitoring-dashboard-overview.png)
 
-![Gemini CLI Monitoring Dashboard Metrics](/docs/assets/monitoring-dashboard-metrics.png)
+![Gemini CLI Monitoring Dashboard Metrics](../assets/monitoring-dashboard-metrics.png)
 
-![Gemini CLI Monitoring Dashboard Logs](/docs/assets/monitoring-dashboard-logs.png)
+![Gemini CLI Monitoring Dashboard Logs](../assets/monitoring-dashboard-logs.png)
 
 To learn more, see
 [Instant insights: Gemini CLI’s pre-configured monitoring dashboards](https://cloud.google.com/blog/topics/developers-practitioners/instant-insights-gemini-clis-new-pre-configured-monitoring-dashboards/).

--- a/docs/get-started/authentication.md
+++ b/docs/get-started/authentication.md
@@ -403,4 +403,4 @@ Your authentication method affects your quotas, pricing, Terms of Service, and
 privacy notices. Review the following pages to learn more:
 
 - [Gemini CLI: Quotas and Pricing](../resources/quota-and-pricing.md).
-- [Gemini CLI: Terms of Service and Privacy Notice](../resources/tos-privacy.md).
+- [Gemini CLI: Terms of Service and Privacy Notice](../resources/tos-privacy).

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,14 +118,15 @@ Support, release history, and legal information.
 - **[FAQ](./resources/faq.md):** Answers to frequently asked questions.
 - **[Quota and pricing](./resources/quota-and-pricing.md):** Limits and billing
   details.
-- **[Terms and privacy](./tos-privacy):** Official notices and terms.
+- **[Terms and privacy](./resources/tos-privacy.md):** Official notices and
+  terms.
 - **[Troubleshooting](./resources/troubleshooting.md):** Common issues and
   solutions.
 - **[Uninstall](./resources/uninstall.md):** How to uninstall Gemini CLI.
 
 ## Development
 
-- **[Contribution guide](/docs/contributing):** How to contribute to Gemini CLI.
+- **[Contribution guide](../CONTRIBUTING.md):** How to contribute to Gemini CLI.
 - **[Integration testing](./integration-tests.md):** Running integration tests.
 - **[Issue and PR automation](./issue-and-pr-automation.md):** Automation for
   issues and pull requests.

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,8 +118,7 @@ Support, release history, and legal information.
 - **[FAQ](./resources/faq.md):** Answers to frequently asked questions.
 - **[Quota and pricing](./resources/quota-and-pricing.md):** Limits and billing
   details.
-- **[Terms and privacy](./resources/tos-privacy.md):** Official notices and
-  terms.
+- **[Terms and privacy](./tos-privacy):** Official notices and terms.
 - **[Troubleshooting](./resources/troubleshooting.md):** Common issues and
   solutions.
 - **[Uninstall](./resources/uninstall.md):** How to uninstall Gemini CLI.

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -214,7 +214,7 @@ export async function parseArguments(
           string: true,
           nargs: 1,
           description:
-            '[DEPRECATED: Use Policy Engine instead See https://geminicli.com/docs/core/policy-engine] Tools that are allowed to run without confirmation',
+            '[DEPRECATED: Use Policy Engine instead See https://geminicli.com/docs/policy-engine] Tools that are allowed to run without confirmation',
           coerce: coerceCommaSeparated,
         })
         .option('extensions', {

--- a/packages/cli/src/config/settings-validation.test.ts
+++ b/packages/cli/src/config/settings-validation.test.ts
@@ -323,9 +323,7 @@ describe('settings-validation', () => {
         expect(formatted).toContain('model.name');
         expect(formatted).toContain('Expected: string, but received: object');
         expect(formatted).toContain('Please fix the configuration.');
-        expect(formatted).toContain(
-          'https://geminicli.com/docs/reference/configuration/',
-        );
+        expect(formatted).toContain('https://geminicli.com/docs/configuration');
       }
     });
 
@@ -363,9 +361,7 @@ describe('settings-validation', () => {
       if (result.error) {
         const formatted = formatValidationError(result.error, 'test.json');
 
-        expect(formatted).toContain(
-          'https://geminicli.com/docs/reference/configuration/',
-        );
+        expect(formatted).toContain('https://geminicli.com/docs/configuration');
       }
     });
 

--- a/packages/cli/src/config/settings-validation.ts
+++ b/packages/cli/src/config/settings-validation.ts
@@ -327,7 +327,7 @@ export function formatValidationError(
   }
 
   lines.push('Please fix the configuration.');
-  lines.push('See: https://geminicli.com/docs/reference/configuration/');
+  lines.push('See: https://geminicli.com/docs/configuration');
 
   return lines.join('\n');
 }

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -239,7 +239,7 @@ export async function main() {
   ) {
     coreEvents.emitFeedback(
       'warning',
-      'Warning: --allowed-tools cli argument and tools.allowed in settings.json are deprecated and will be removed in 1.0: Migrate to Policy Engine: https://geminicli.com/docs/core/policy-engine/',
+      'Warning: --allowed-tools cli argument and tools.allowed in settings.json are deprecated and will be removed in 1.0: Migrate to Policy Engine: https://geminicli.com/docs/policy-engine',
     );
   }
 
@@ -249,7 +249,7 @@ export async function main() {
   ) {
     coreEvents.emitFeedback(
       'warning',
-      'Warning: tools.exclude in settings.json is deprecated and will be removed in 1.0. Migrate to Policy Engine: https://geminicli.com/docs/core/policy-engine/',
+      'Warning: tools.exclude in settings.json is deprecated and will be removed in 1.0. Migrate to Policy Engine: https://geminicli.com/docs/policy-engine',
     );
   }
 

--- a/packages/cli/src/ui/auth/AuthDialog.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.tsx
@@ -246,7 +246,7 @@ export function AuthDialog({
         </Box>
         <Box marginTop={1}>
           <Text color={theme.text.link}>
-            {'https://geminicli.com/docs/resources/tos-privacy/'}
+            {'https://geminicli.com/docs/tos-privacy'}
           </Text>
         </Box>
       </Box>

--- a/packages/cli/src/ui/auth/__snapshots__/AuthDialog.test.tsx.snap
+++ b/packages/cli/src/ui/auth/__snapshots__/AuthDialog.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`AuthDialog > Snapshots > renders correctly with auth error 1`] = `
 │                                                                                                  │
 │   Terms of Services and Privacy Notice for Gemini CLI                                            │
 │                                                                                                  │
-│   https://geminicli.com/docs/resources/tos-privacy/                                              │
+│   https://geminicli.com/docs/tos-privacy                                                         │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -34,7 +34,7 @@ exports[`AuthDialog > Snapshots > renders correctly with default props 1`] = `
 │                                                                                                  │
 │   Terms of Services and Privacy Notice for Gemini CLI                                            │
 │                                                                                                  │
-│   https://geminicli.com/docs/resources/tos-privacy/                                              │
+│   https://geminicli.com/docs/tos-privacy                                                         │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "
@@ -53,7 +53,7 @@ exports[`AuthDialog > Snapshots > renders correctly with enforced auth type 1`] 
 │                                                                                                  │
 │   Terms of Services and Privacy Notice for Gemini CLI                                            │
 │                                                                                                  │
-│   https://geminicli.com/docs/resources/tos-privacy/                                              │
+│   https://geminicli.com/docs/tos-privacy                                                         │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 "

--- a/packages/cli/src/ui/constants.ts
+++ b/packages/cli/src/ui/constants.ts
@@ -41,7 +41,7 @@ export const DEFAULT_SELECTION_OPACITY = 0.2;
 export const DEFAULT_BORDER_OPACITY = 0.4;
 
 export const KEYBOARD_SHORTCUTS_URL =
-  'https://geminicli.com/docs/cli/keyboard-shortcuts/';
+  'https://geminicli.com/docs/keyboard-shortcuts';
 export const LRU_BUFFER_PERF_CACHE_LIMIT = 20000;
 
 // Max lines to show for active shell output when not focused

--- a/packages/vscode-ide-companion/README.md
+++ b/packages/vscode-ide-companion/README.md
@@ -31,4 +31,4 @@ To use this extension, you'll need:
 # Terms of Service and Privacy Notice
 
 By installing this extension, you agree to the
-[Terms of Service](https://geminicli.com/docs/resources/tos-privacy/).
+[Terms of Service](https://geminicli.com/docs/tos-privacy).


### PR DESCRIPTION
## Summary

This PR fixes the broken Terms of Service and Privacy Notice link displayed in the `/auth` command and standardizes documentation links across the codebase.

## Details

- Updated `packages/cli/src/ui/auth/AuthDialog.tsx` to use the shortened redirect URL `https://geminicli.com/docs/tos-privacy`, which resolves the reported 404 issue.
- Updated `packages/cli/src/ui/auth/__snapshots__/AuthDialog.test.tsx.snap` to reflect the URL change.
- Standardized documentation links (ToS, FAQ, Policy Engine, Keyboard Shortcuts) in `README.md`, `CONTRIBUTING.md`, `docs/index.md`, and other files to use their shortened redirect paths for consistency and reliability.
- Updated VS Code companion `README.md` with the corrected ToS link.

## Related Issues

Fixes #23027

## How to Validate

1. Run the `/auth` command in the CLI.
2. Verify that the displayed Terms of Service URL is `https://geminicli.com/docs/tos-privacy`.
3. Click the link (or copy-paste) to ensure it redirects correctly to the ToS page.
4. Check links in `README.md` and `docs/index.md` to ensure they also point to valid locations.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
