### PR TITLE
fix(cli): correctly handle auto-update for standalone binaries

### DIFF
--- a/packages/cli/src/utils/handleAutoUpdate.test.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.test.ts
@@ -202,7 +202,12 @@ describe('handleAutoUpdate', () => {
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
-  it.each([PackageManager.NPX, PackageManager.PNPX, PackageManager.BUNX])(
+  it.each([
+    PackageManager.NPX,
+    PackageManager.PNPX,
+    PackageManager.BUNX,
+    PackageManager.BINARY,
+  ])(
     'should suppress update notifications when running via %s',
     (packageManager) => {
       mockGetInstallationInfo.mockReturnValue({

--- a/packages/cli/src/utils/handleAutoUpdate.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.ts
@@ -87,9 +87,12 @@ export function handleAutoUpdate(
   );
 
   if (
-    [PackageManager.NPX, PackageManager.PNPX, PackageManager.BUNX].includes(
-      installationInfo.packageManager,
-    )
+    [
+      PackageManager.NPX,
+      PackageManager.PNPX,
+      PackageManager.BUNX,
+      PackageManager.BINARY,
+    ].includes(installationInfo.packageManager)
   ) {
     return;
   }

--- a/packages/cli/src/utils/installationInfo.test.ts
+++ b/packages/cli/src/utils/installationInfo.test.ts
@@ -58,6 +58,19 @@ describe('getInstallationInfo', () => {
     process.argv = originalArgv;
   });
 
+  it('should detect running as a standalone binary', () => {
+    vi.stubEnv('IS_BINARY', 'true');
+    process.argv[1] = '/path/to/binary';
+    const info = getInstallationInfo(projectRoot, true);
+    expect(info.packageManager).toBe(PackageManager.BINARY);
+    expect(info.isGlobal).toBe(true);
+    expect(info.updateMessage).toBe(
+      'Running as a standalone binary. Please update by downloading the latest version from GitHub.',
+    );
+    expect(info.updateCommand).toBeUndefined();
+    vi.unstubAllEnvs();
+  });
+
   it('should return UNKNOWN when cliPath is not available', () => {
     process.argv[1] = '';
     const info = getInstallationInfo(projectRoot, true);

--- a/packages/cli/src/utils/installationInfo.ts
+++ b/packages/cli/src/utils/installationInfo.ts
@@ -21,6 +21,7 @@ export enum PackageManager {
   BUNX = 'bunx',
   HOMEBREW = 'homebrew',
   NPX = 'npx',
+  BINARY = 'binary',
   UNKNOWN = 'unknown',
 }
 
@@ -41,6 +42,16 @@ export function getInstallationInfo(
   }
 
   try {
+    // Check for standalone binary first
+    if (process.env['IS_BINARY'] === 'true') {
+      return {
+        packageManager: PackageManager.BINARY,
+        isGlobal: true,
+        updateMessage:
+          'Running as a standalone binary. Please update by downloading the latest version from GitHub.',
+      };
+    }
+
     // Normalize path separators to forward slashes for consistent matching.
     const realPath = fs.realpathSync(cliPath).replace(/\\/g, '/');
     const normalizedProjectRoot = projectRoot?.replace(/\\/g, '/');


### PR DESCRIPTION
## Summary

This PR fixes an issue where the auto-update mechanism falsely reported "Update successful! The new version will be used on your next run." for standalone binary installations of Gemini CLI. 

## Details

Previously, the auto-updater would mistakenly assume an unmanaged installation was an `npm` global installation and attempt to update it by running `npm i -g @google/gemini-cli@latest`. For the SEA standalone binary, this command would install a version in `node_modules` but leave the binary itself untouched. The application would then incorrectly report a successful update.

This PR adds:
- A new `BINARY` package manager type in `packages/cli/src/utils/installationInfo.ts`.
- Logic to detect a standalone binary (by checking the `IS_BINARY` environment variable).
- A helpful message explaining that the user must download the latest binary from GitHub to update.
- Suppression logic in `handleAutoUpdate.ts` so the system no longer attempts an automatic background update.

## Related Issues

N/A

## How to Validate

1. Build a binary locally (`npm run build:binary`) and run it. 
2. Ensure you have an outdated version, or artificially set a lower version.
3. Observe that it now prints "Running as a standalone binary. Please update by downloading the latest version from GitHub." instead of trying to run `npm i -g`.
4. Tests have also been added to cover these scenarios automatically.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
