### PR TITLE
fix: circumvent genai sdk requirement for api key when using gateway auth via ACP

### DIFF
--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -725,6 +725,26 @@ describe('createContentGeneratorConfig', () => {
     expect(config.apiKey).toBeUndefined();
     expect(config.vertexai).toBeUndefined();
   });
+  it('should configure for GATEWAY using dummy placeholder if GEMINI_API_KEY is set', async () => {
+    vi.stubEnv('GEMINI_API_KEY', 'env-gemini-key');
+    const config = await createContentGeneratorConfig(
+      mockConfig,
+      AuthType.GATEWAY,
+    );
+    expect(config.apiKey).toBe('gateway-placeholder-key');
+    expect(config.vertexai).toBe(false);
+  });
+
+  it('should configure for GATEWAY using dummy placeholder if GEMINI_API_KEY is not set', async () => {
+    vi.stubEnv('GEMINI_API_KEY', '');
+    vi.mocked(loadApiKey).mockResolvedValue(null);
+    const config = await createContentGeneratorConfig(
+      mockConfig,
+      AuthType.GATEWAY,
+    );
+    expect(config.apiKey).toBe('gateway-placeholder-key');
+    expect(config.vertexai).toBe(false);
+  });
 });
 
 describe('validateBaseUrl', () => {

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -150,6 +150,13 @@ export async function createContentGeneratorConfig(
     return contentGeneratorConfig;
   }
 
+  if (authType === AuthType.GATEWAY) {
+    contentGeneratorConfig.apiKey = apiKey || 'gateway-placeholder-key';
+    contentGeneratorConfig.vertexai = false;
+
+    return contentGeneratorConfig;
+  }
+
   return contentGeneratorConfig;
 }
 


### PR DESCRIPTION

## Summary

 Have GATEWAY authentication type for content generator configuration, using GEMINI_API_KEY or a placeholder.


## Details

- Update packages/core/src/core/contentGenerator.ts to automatically inject a dummy placeholder key whenever the IDE initializes a session using the GATEWAY auth type and no GEMINI_API_KEY is present. 
- This seamlessly bypasses the @google/genai SDK's strict constructor validation, allowing the gateway connection to proceed without requiring the IDE to supply a workaround environment variable.
- added relevant unit test.

## Related Issues

Fixes  [Agent throws AUTH_REQUIRED if API_KEY is missing for Gateway Auth](https://github.com/google-gemini/maintainers-gemini-cli/issues/1567)

## How to Validate

* Setting up  Gateway auth ACP shouldn't require API key to be given in the acp.json or the appropriate settings file for ACP.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [✅] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [✅] Validated on required platforms/methods:
  - [✅] MacOS
    - [✅] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
