### PR TITLE
fix(code-assist): filter thought parts before sending to Code Assist API

### DIFF
--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -223,7 +223,7 @@ function toContent(content: ContentUnion): Content {
     return {
       ...content,
       parts: content.parts
-        ? toParts(content.parts.filter((p) => p != null))
+        ? toParts(content.parts.filter((p) => p != null && !p.thought))
         : [],
     };
   }


### PR DESCRIPTION
## Summary

Fixes #23046

When resuming a session, `convertSessionToClientHistory()` reconstructs model history including `{thought: true, text: '...'}` parts from saved `msg.thoughts` summaries. For Code Assist (OAuth/Vertex) users, these parts pass through `toPart()` in `converter.ts`, which converts `{thought: true, text: 'desc'}` to `{text: 'desc\n[Thought: true]'}` — stripping the `thought` flag and appending a literal marker string. The model then learns via in-context learning to emit `[Thought: true]` in its own responses, and the contamination self-propagates across turns.

## Details

`toContent()` already had a comment `// handle thought filtering` but the filter predicate for `thought: true` parts was missing. One-line fix:

```ts
// Before:
? toParts(content.parts.filter((p) => p != null))

// After:
? toParts(content.parts.filter((p) => p != null && !p.thought))
```

Thought context cannot be meaningfully restored for Code Assist on session resume regardless — `thoughtSignature` on live response parts is the only valid carrier of thinking context for this API path, and is not stored in session files. Filtering is therefore correct behavior, not just a workaround.

API key users (Direct Gemini) are not affected as they bypass `converter.ts` entirely.

## Related Issues

Fixes #23046

## How to Validate

1. Use Code Assist auth (Google OAuth login) with a thinking-capable model (e.g. `gemini-2.5-pro`)
2. Have a conversation where the model produces thinking blocks
3. Resume the session (`gemini --resume`)
4. Send any message

**Before:** Model responses contain `[Thought: true]` literal text, worsening each turn.  
**After:** Model responds normally.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker