### PR TITLE
test(acp): add missing coverage for extensions command error paths

### DIFF
--- a/packages/cli/src/acp/commands/extensions.test.ts
+++ b/packages/cli/src/acp/commands/extensions.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { DisableExtensionCommand, UninstallExtensionCommand } from './extensions.js';
+import type { CommandContext } from './types.js';
+import { ExtensionManager } from '../../config/extension-manager.js';
+
+// Minimal mock of Config that returns a mock ExtensionManager
+function createMockContext(overrides: {
+  disableExtension?: (...args: unknown[]) => Promise<void>;
+  uninstallExtension?: (...args: unknown[]) => Promise<void>;
+  getExtensions?: () => { name: string; isActive: boolean }[];
+}): CommandContext {
+  const extensionManager = {
+    disableExtension:
+      overrides.disableExtension ?? vi.fn().mockResolvedValue(undefined),
+    uninstallExtension:
+      overrides.uninstallExtension ?? vi.fn().mockResolvedValue(undefined),
+    getExtensions: overrides.getExtensions ?? vi.fn().mockReturnValue([]),
+  };
+
+  // Make the mock pass the `instanceof ExtensionManager` check
+  Object.setPrototypeOf(extensionManager, ExtensionManager.prototype);
+
+  return {
+    config: {
+      getExtensionLoader: () => extensionManager,
+    },
+  } as unknown as CommandContext;
+}
+
+describe('DisableExtensionCommand', () => {
+  let command: DisableExtensionCommand;
+
+  beforeEach(() => {
+    command = new DisableExtensionCommand();
+  });
+
+  it('returns error when disabling fails', async () => {
+    const context = createMockContext({
+      disableExtension: vi.fn().mockRejectedValue(
+        new Error('Extension with name test-ext does not exist.'),
+      ),
+    });
+
+    const result = await command.execute(context, ['test-ext']);
+
+    expect(result.name).toBe('extensions disable');
+    expect(result.data).toContain('Failed to disable "test-ext"');
+    expect(result.data).toContain(
+      'Extension with name test-ext does not exist.',
+    );
+  });
+
+  it('returns usage message when no args provided', async () => {
+    const context = createMockContext({});
+    const result = await command.execute(context, []);
+
+    expect(result.data).toContain('Usage:');
+    expect(result.data).toContain('/extensions disable');
+  });
+
+  it('reports success when disable succeeds', async () => {
+    const context = createMockContext({
+      disableExtension: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await command.execute(context, ['my-extension']);
+
+    expect(result.data).toContain('Extension "my-extension" disabled');
+  });
+});
+
+describe('UninstallExtensionCommand', () => {
+  let command: UninstallExtensionCommand;
+
+  beforeEach(() => {
+    command = new UninstallExtensionCommand();
+  });
+
+  it('returns error when uninstalling a non-existent extension', async () => {
+    const context = createMockContext({
+      uninstallExtension: vi.fn().mockRejectedValue(
+        new Error('Extension not found.'),
+      ),
+    });
+
+    const result = await command.execute(context, ['nonexistent-ext']);
+
+    expect(result.name).toBe('extensions uninstall');
+    expect(result.data).toContain(
+      'Failed to uninstall extension "nonexistent-ext"',
+    );
+    expect(result.data).toContain('Extension not found.');
+  });
+
+  it('returns usage message when no args and no --all flag', async () => {
+    const context = createMockContext({});
+    const result = await command.execute(context, []);
+
+    expect(result.data).toContain('Usage:');
+    expect(result.data).toContain('/extensions uninstall');
+  });
+
+  it('reports success when uninstall succeeds', async () => {
+    const context = createMockContext({
+      uninstallExtension: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await command.execute(context, ['my-extension']);
+
+    expect(result.data).toContain(
+      'Extension "my-extension" uninstalled successfully.',
+    );
+  });
+
+  it('reports "No extensions installed" for --all with empty list', async () => {
+    const context = createMockContext({
+      getExtensions: vi.fn().mockReturnValue([]),
+    });
+
+    const result = await command.execute(context, ['--all']);
+
+    expect(result.data).toBe('No extensions installed.');
+  });
+});


### PR DESCRIPTION
## Summary

Adds test coverage for error paths in ACP extension commands (`DisableExtensionCommand` and `UninstallExtensionCommand`) that were not previously tested. These commands are in `packages/cli/src/acp/commands/extensions.ts`.

## Details

### New test cases (8 total)

**`DisableExtensionCommand`:**
- `returns error when disabling fails` — verifies error message format when `extensionManager.disableExtension()` throws (e.g. extension does not exist)
- `returns usage message when no args provided` — verifies usage hint is shown
- `reports success when disable succeeds` — happy path baseline

**`UninstallExtensionCommand`:**
- `returns error when uninstalling a non-existent extension` — verifies error message includes extension name and propagated error
- `returns usage message when no args and no --all flag` — verifies usage hint
- `reports success when uninstall succeeds` — happy path baseline
- `reports "No extensions installed" for --all with empty list` — edge case for `--all` flag with no installed extensions

### Approach

Uses a `createMockContext()` helper that constructs a minimal `CommandContext` with a mock `ExtensionManager` (set via `Object.setPrototypeOf` to pass the `instanceof` check in the command implementations). This isolates the command logic from the full extension manager infrastructure.

## Related Issues

Closes #22934
Related to #22798

## How to Validate

```bash
npm run test --workspace @google/gemini-cli -- src/acp/commands/extensions.test.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)