### PR TITLE
fix: detect omission placeholders in # and /* */ comment styles

### DIFF
--- a/packages/core/src/tools/omissionPlaceholderDetector.test.ts
+++ b/packages/core/src/tools/omissionPlaceholderDetector.test.ts
@@ -21,6 +21,42 @@ describe('detectOmissionPlaceholders', () => {
     expect(detectOmissionPlaceholders('// rest of methods ...')).toEqual([
       'rest of methods ...',
     ]);
+    expect(detectOmissionPlaceholders('# rest of code ...')).toEqual([
+      'rest of code ...',
+    ]);
+    expect(detectOmissionPlaceholders('/* rest of code ... */')).toEqual([
+      'rest of code ...',
+    ]);
+  });
+
+  it('detects placeholders in # comment style', () => {
+    expect(detectOmissionPlaceholders('# rest of methods ...')).toEqual([
+      'rest of methods ...',
+    ]);
+    expect(detectOmissionPlaceholders('# unchanged code ...')).toEqual([
+      'unchanged code ...',
+    ]);
+    expect(detectOmissionPlaceholders('  # rest of code ...')).toEqual([
+      'rest of code ...',
+    ]);
+  });
+
+  it('detects placeholders in /* */ comment style', () => {
+    expect(detectOmissionPlaceholders('/* rest of methods ... */')).toEqual([
+      'rest of methods ...',
+    ]);
+    expect(detectOmissionPlaceholders('/* unchanged code ... */')).toEqual([
+      'unchanged code ...',
+    ]);
+    expect(
+      detectOmissionPlaceholders('  /* rest of code ... */'),
+    ).toEqual(['rest of code ...']);
+  });
+
+  it('detects /* comment without closing */', () => {
+    expect(detectOmissionPlaceholders('/* rest of code ...')).toEqual([
+      'rest of code ...',
+    ]);
   });
 
   it('detects case-insensitive placeholders', () => {
@@ -52,6 +88,12 @@ describe('detectOmissionPlaceholders', () => {
   it('does not detect omission phrase when inline in a comment', () => {
     expect(
       detectOmissionPlaceholders('return value; // rest of methods ...'),
+    ).toEqual([]);
+    expect(
+      detectOmissionPlaceholders('x = 1 # rest of methods ...'),
+    ).toEqual([]);
+    expect(
+      detectOmissionPlaceholders('int x = 0; /* rest of code ... */'),
     ).toEqual([]);
   });
 

--- a/packages/core/src/tools/omissionPlaceholderDetector.ts
+++ b/packages/core/src/tools/omissionPlaceholderDetector.ts
@@ -56,6 +56,10 @@ function normalizePlaceholder(line: string): string | null {
 
   if (text.startsWith('//')) {
     text = text.slice(2).trim();
+  } else if (text.startsWith('#')) {
+    text = text.slice(1).trim();
+  } else if (text.startsWith('/*')) {
+    text = text.slice(2, text.endsWith('*/') ? -2 : undefined).trim();
   }
 
   if (text.startsWith('(') && text.endsWith(')')) {
@@ -88,6 +92,8 @@ function normalizePlaceholder(line: string): string | null {
  * - (rest of code ...)
  * - (unchanged code ...)
  * - // rest of methods ...
+ * - # rest of code ...
+ * - /\* rest of code ... *\/
  *
  * Returns all placeholders found as normalized tokens.
  */


### PR DESCRIPTION
## Summary

The omission placeholder detector only recognized `//` comment-style prefixes (e.g. `// ... rest of code`), missing `#` comments (Python, Ruby, YAML, Bash) and `/* */` block comments (CSS, C, Java).

## Details

- Extended `normalizePlaceholder()` in `omissionPlaceholderDetector.ts` to strip `#` and `/* ... */` comment delimiters before checking for omission patterns
- Added tests for `#` comment style, `/* */` block comment style, and unclosed `/*` comments
- Added negative tests ensuring inline `#` and `/* */` comments with preceding code are not false-positives

## Related Issues

Closes #23013

## How to Validate

```bash
npx vitest run packages/core/src/tools/omissionPlaceholderDetector.test.ts
```

All 9 tests should pass, including the new cases:
- `# rest of code ...`
- `/* rest of code ... */`
- `/* rest of code ...` (unclosed)

## Pre-Merge Checklist

- [x] Code compiles without errors
- [x] All existing tests pass
- [x] New tests added for the changes
- [x] Changes are minimal and focused on the issue