### PR TITLE
fix(core): don't persist browser consent sentinel in non-interactive mode

### DIFF
--- a/packages/core/src/utils/browserConsent.test.ts
+++ b/packages/core/src/utils/browserConsent.test.ts
@@ -47,7 +47,7 @@ describe('browserConsent', () => {
     expect(emitSpy).not.toHaveBeenCalled();
   });
 
-  it('should auto-accept in non-interactive mode (no listeners)', async () => {
+  it('should auto-accept in non-interactive mode (no listeners) without persisting consent', async () => {
     // Consent file does not exist
     vi.mocked(fs.access).mockRejectedValue(new Error('ENOENT'));
     // No listeners registered
@@ -56,11 +56,9 @@ describe('browserConsent', () => {
     const result = await getBrowserConsentIfNeeded();
 
     expect(result).toBe(true);
-    // Should persist the consent
-    expect(fs.writeFile).toHaveBeenCalledWith(
-      expect.stringContaining('browser-consent-acknowledged.txt'),
-      expect.stringContaining('consent acknowledged'),
-    );
+    // Should NOT persist the consent — an interactive user on the same machine
+    // must still see the dialog the first time they use the browser agent.
+    expect(fs.writeFile).not.toHaveBeenCalled();
   });
 
   it('should request consent interactively and return true when accepted', async () => {

--- a/packages/core/src/utils/browserConsent.ts
+++ b/packages/core/src/utils/browserConsent.ts
@@ -42,9 +42,11 @@ export async function getBrowserConsentIfNeeded(): Promise<boolean> {
     void 0;
   }
 
-  // Non-interactive mode (no UI listeners): auto-accept.
+  // Non-interactive mode (no UI listeners): skip the dialog for this session
+  // only. Do NOT persist the sentinel file — an interactive user on the same
+  // machine should still see the consent dialog the first time they use the
+  // browser agent.
   if (coreEvents.listenerCount(CoreEvent.ConsentRequest) === 0) {
-    await markConsentAsAcknowledged(consentFilePath);
     return true;
   }
 


### PR DESCRIPTION
## Summary

Fixes #23072

In non-interactive mode (no `ConsentRequest` listeners — e.g. `gemini -p "..."`, CI pipelines, scripts), `getBrowserConsentIfNeeded()` was auto-accepting the browser privacy consent **and** permanently writing the sentinel file to disk. This caused the interactive consent dialog to be silently bypassed for any subsequent interactive session on the same machine.

- Remove the `markConsentAsAcknowledged()` call from the non-interactive path
- Non-interactive sessions now return `true` for that session only, without touching the sentinel file
- Interactive users on the same machine will still see the consent dialog on their first use of the browser agent

## Test plan

- [x] Updated the existing `should auto-accept in non-interactive mode` test to assert that `fs.writeFile` is **not** called in the non-interactive path
- [x] All 5 tests in `browserConsent.test.ts` pass
- [x] Existing interactive consent tests (accept + decline) are unchanged