### PR TITLE
fix(cli): wrap non-interactive execution in a root OTel trace span

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -30,6 +30,8 @@ import {
   ToolErrorType,
   Scheduler,
   ROOT_SCHEDULER_ID,
+  runInDevTraceSpan,
+  GeminiCliOperation,
 } from '@google/gemini-cli-core';
 
 import type { Content, Part } from '@google/genai';
@@ -62,7 +64,19 @@ export async function runNonInteractive({
   prompt_id,
   resumedSessionData,
 }: RunNonInteractiveParams): Promise<void> {
-  return promptIdContext.run(prompt_id, async () => {
+  return promptIdContext.run(prompt_id, () =>
+    runInDevTraceSpan(
+      { operation: GeminiCliOperation.UserPrompt },
+      async ({ metadata }) => {
+        if (config.getTelemetryLogPromptsEnabled()) {
+          metadata.input = input;
+        }
+        return runBody();
+      },
+    ),
+  );
+
+  async function runBody(): Promise<void> {
     const consolePatcher = new ConsolePatcher({
       stderr: true,
       debugMode: config.getDebugMode(),
@@ -530,5 +544,5 @@ export async function runNonInteractive({
     if (errorToHandle) {
       handleError(errorToHandle, config);
     }
-  });
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #23054

In **interactive** mode, `useGeminiStream.ts` wraps each query in `runInDevTraceSpan({ operation: GeminiCliOperation.UserPrompt })`, establishing a root span that all downstream `startActiveSpan` calls inherit — producing a single unified Trace ID.

In **non-interactive** mode (`gemini -y -p "..."`), `nonInteractiveCli.ts` had no equivalent wrapper. Every downstream span (`llm_call`, `schedule_tool_calls`, etc.) found no active parent context and created an independent root span with a fresh Trace ID, fragmenting the trace and making distributed tracing useless for automation pipelines.

**Changes:**
- Add `runInDevTraceSpan` and `GeminiCliOperation` to imports in `nonInteractiveCli.ts`
- Extract the function body into a hoisted `runBody()` helper
- Wrap the `promptIdContext.run` callback in `runInDevTraceSpan`, mirroring the interactive-mode pattern
- Guard `metadata.input = input` behind `config.getTelemetryLogPromptsEnabled()` to respect the user's prompt-logging preference

**Note:** `useGeminiStream.ts:1439` sets `spanMetadata.input = query` without the same guard — that is a pre-existing inconsistency outside the scope of this fix.

## Test plan

- [x] Run `gemini -y -p "Read /etc/hosts and summarize"` with an OTel collector — all spans should share one Trace ID
- [x] With `telemetry.logPrompts = false` in config, `metadata.input` is not set on the span
- [x] Existing non-interactive CLI behaviour is unchanged
- [x] No regression in interactive mode (untouched code path)