### PR TITLE
fix(cli): consume Escape keypress in BaseSettingsDialog to prevent cancelling active turn

### DIFF
--- a/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
@@ -401,13 +401,13 @@ export function BaseSettingsDialog({
       // Tab - switch focus section
       if (key.name === 'tab' && finalShowScopeSelector) {
         setFocusSection((s) => (s === 'settings' ? 'scope' : 'settings'));
-        return;
+        return true;
       }
 
       // Escape - close dialog
       if (keyMatchers[Command.ESCAPE](key)) {
         onClose();
-        return;
+        return true;
       }
 
       return;

--- a/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/shared/BaseSettingsDialog.tsx
@@ -291,43 +291,43 @@ export function BaseSettingsDialog({
         // Navigation within edit buffer
         if (keyMatchers[Command.MOVE_LEFT](key)) {
           editDispatch({ type: 'MOVE_LEFT' });
-          return;
+          return true;
         }
         if (keyMatchers[Command.MOVE_RIGHT](key)) {
           editDispatch({ type: 'MOVE_RIGHT' });
-          return;
+          return true;
         }
         if (keyMatchers[Command.HOME](key)) {
           editDispatch({ type: 'HOME' });
-          return;
+          return true;
         }
         if (keyMatchers[Command.END](key)) {
           editDispatch({ type: 'END' });
-          return;
+          return true;
         }
 
         // Backspace
         if (keyMatchers[Command.DELETE_CHAR_LEFT](key)) {
           editDispatch({ type: 'DELETE_LEFT' });
-          return;
+          return true;
         }
 
         // Delete
         if (keyMatchers[Command.DELETE_CHAR_RIGHT](key)) {
           editDispatch({ type: 'DELETE_RIGHT' });
-          return;
+          return true;
         }
 
         // Escape in edit mode - commit (consistent with SettingsDialog)
         if (keyMatchers[Command.ESCAPE](key)) {
           commitEdit();
-          return;
+          return true;
         }
 
         // Enter in edit mode - commit
         if (keyMatchers[Command.RETURN](key)) {
           commitEdit();
-          return;
+          return true;
         }
 
         // Up/Down in edit mode - commit and navigate.
@@ -336,7 +336,7 @@ export function BaseSettingsDialog({
         if (keyMatchers[Command.DIALOG_NAVIGATION_UP](key) && !key.insertable) {
           commitEdit();
           moveUp();
-          return;
+          return true;
         }
         if (
           keyMatchers[Command.DIALOG_NAVIGATION_DOWN](key) &&
@@ -344,7 +344,7 @@ export function BaseSettingsDialog({
         ) {
           commitEdit();
           moveDown();
-          return;
+          return true;
         }
 
         // Character input
@@ -354,8 +354,9 @@ export function BaseSettingsDialog({
             char: key.sequence,
             isNumberType: type === 'number',
           });
+          return true;
         }
-        return;
+        return false;
       }
 
       // Not in edit mode - handle navigation and actions
@@ -410,7 +411,7 @@ export function BaseSettingsDialog({
         return true;
       }
 
-      return;
+      return false;
     },
     {
       isActive: true,


### PR DESCRIPTION
## Summary

When the agent is processing a turn (streaming a response or executing a tool) and the user opens the `/settings` dialog, pressing `Escape` to close the dialog was inadvertently cancelling the active turn. This fix ensures the `Escape` keypress is fully consumed by `BaseSettingsDialog` so it never reaches the global `useGeminiStream` cancel handler.

## Details

The root cause is an event bubbling issue. The `useKeypress` handler in `BaseSettingsDialog` was calling `onClose()` on Escape but not returning true, so the event propagated to the global `useGeminiStream` handler which interpreted it as a cancellation request.

The fix returns true from the `useKeypress` `Escape` handler in `BaseSettingsDialog` to mark the event as consumed and stop propagation. All key handlers in the dialog were also updated to explicitly return true when handled and false when not, including edit mode operations.

This fix applies to all dialogs using `BaseSettingsDialog` including the settings dialog and agent configuration dialog.

## Related Issues

Fixed #22787

## How to Validate

1. Start a long-running agent turn (e.g. a prompt that triggers tool execution)
2. While the turn is in progress, run `/settings` to open the settings dialog
3. Press `Escape` to close the dialog
4. **Expected:** Dialog closes, active turn continues uninterrupted
5. **Before fix:** Pressing `Escape` would cancel the active turn

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [X] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [X] Linux
    - [X] npm run
    - [ ] npx
    - [ ] Docker
