### PR TITLE
docs(contributing): clarify self-assignment policy for issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,9 @@ assign or unassign the issue as requested, provided the conditions are met
 (e.g., an issue must be unassigned to be assigned).
 
 Please note that you can have a maximum of 3 issues assigned to you at any given
-time.
+time and that only
+[issues labeled "help wanted"](https://github.com/google-gemini/gemini-cli/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22)
+may be self-assigned.
 
 ### Pull request guidelines
 


### PR DESCRIPTION
Update the contributing guidelines to explicitly state that only issues labeled with "help wanted" are eligible for self-assignment using the /assign command. This helps guide contributors toward tasks that have been vetted and are ready for community participation.

This prevents wasting time trying to self-assign issues where it will just fail:

https://github.com/google-gemini/gemini-cli/issues/4101#issuecomment-4072821664

## Summary

Update the contributing guidelines to clarify that only issues labeled "help wanted" can be self-assigned via the `/assign` command.

## Details

The previous wording implied any issue could be self-assigned, which led to confusion when the bot rejected assignments on ineligible issues. This change explicitly links to the "help wanted" filter to
guide contributors toward vetted tasks and prevent them from wasting time.

## Related Issues

None.

## How to Validate

1. Review the modified "Self-assigning and unassigning issues" section in `CONTRIBUTING.md`.
2. Verify the markdown link correctly points to the `help wanted` issue filter.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
