### PR TITLE
feat(skills): SkillResourceIndex + categorized activation summary (Phase 1, #15895)

### DIFF
--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -114,8 +114,9 @@ gemini skills disable my-expertise --scope workspace
 3.  **Consent**: You will see a confirmation prompt in the UI detailing the
     skill's name, purpose, and the directory path it will gain access to.
 4.  **Injection**: Upon your approval:
-    - The `SKILL.md` body and folder structure is added to the conversation
-      history.
+    - The `SKILL.md` body and a compact **categorized resource index** (paths
+      under `references/`, `scripts/`, `assets/`, and other files—not the full
+      directory tree or file contents) is added to the conversation history.
     - The skill's directory is added to the agent's allowed file paths, granting
       it permission to read any bundled assets.
 5.  **Execution**: The model proceeds with the specialized expertise active. It

--- a/docs/tools/activate-skill.md
+++ b/docs/tools/activate-skill.md
@@ -28,6 +28,12 @@ skill's specific instructions until the task is complete.
 
 ## Behavior
 
+When a skill is activated, the model receives the `SKILL.md` body plus a short
+**resource index**: paths grouped as references, scripts, assets, and other
+files (relative to the skill root). This is a path list only—not a full
+directory tree and not the contents of those files; reading bundled files still
+uses the normal file tools (or a future dedicated references reader).
+
 The agent uses this tool to provide professional-grade assistance:
 
 - **Specialized logic:** Skills contain expert-level procedures for complex

--- a/packages/core/src/skills/skillLoader.test.ts
+++ b/packages/core/src/skills/skillLoader.test.ts
@@ -44,7 +44,32 @@ describe('skillLoader', () => {
     expect(skills[0].description).toBe('A test skill');
     expect(skills[0].location).toBe(skillFile);
     expect(skills[0].body).toBe('# Instructions\nDo something.');
+    expect(skills[0].resources).toEqual({
+      scripts: [],
+      references: [],
+      assets: [],
+      other: [],
+    });
     expect(coreEvents.emitFeedback).not.toHaveBeenCalled();
+  });
+
+  it('should attach resource index when references and scripts exist', async () => {
+    const skillDir = path.join(testRootDir, 'res-skill');
+    await fs.mkdir(path.join(skillDir, 'references'), { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, 'references', 'x.md'),
+      'ref body',
+    );
+    const skillFile = path.join(skillDir, 'SKILL.md');
+    await fs.writeFile(
+      skillFile,
+      `---\nname: res-skill\ndescription: Has refs\n---\n# Instructions\n`,
+    );
+
+    const skills = await loadSkillsFromDir(testRootDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].resources?.references).toContain('references/x.md');
   });
 
   it('should emit feedback when no valid skills are found in a non-empty directory', async () => {

--- a/packages/core/src/skills/skillLoader.ts
+++ b/packages/core/src/skills/skillLoader.ts
@@ -10,6 +10,12 @@ import { glob } from 'glob';
 import { load } from 'js-yaml';
 import { debugLogger } from '../utils/debugLogger.js';
 import { coreEvents } from '../utils/events.js';
+import {
+  buildSkillResourceIndex,
+  type SkillResourceIndex,
+} from './skillResourceIndex.js';
+
+export type { SkillResourceIndex } from './skillResourceIndex.js';
 
 /**
  * Represents the definition of an Agent Skill.
@@ -29,6 +35,12 @@ export interface SkillDefinition {
   isBuiltin?: boolean;
   /** The name of the extension that provided this skill, if any. */
   extensionName?: string;
+  /**
+   * Indexed bundled files under the skill root (relative POSIX paths), if
+   * built at load time (e.g. from disk). Undefined for programmatically
+   * injected skills.
+   */
+  resources?: SkillResourceIndex;
 }
 
 export const FRONTMATTER_REGEX =
@@ -179,11 +191,29 @@ export async function loadSkillFromFile(
     // Sanitize name for use as a filename/directory name (e.g. replace ':' with '-')
     const sanitizedName = frontmatter.name.replace(/[:\\/<>*?"|]/g, '-');
 
+    const root = path.dirname(filePath);
+    let resources: SkillResourceIndex;
+    try {
+      resources = await buildSkillResourceIndex(root);
+    } catch (error) {
+      debugLogger.debug(
+        `Failed to build skill resource index for ${filePath}:`,
+        error,
+      );
+      resources = {
+        scripts: [],
+        references: [],
+        assets: [],
+        other: [],
+      };
+    }
+
     return {
       name: sanitizedName,
       description: frontmatter.description,
       location: filePath,
       body: match[2]?.trim() ?? '',
+      resources,
     };
   } catch (error) {
     debugLogger.log(`Error parsing skill file ${filePath}:`, error);

--- a/packages/core/src/skills/skillResourceIndex.test.ts
+++ b/packages/core/src/skills/skillResourceIndex.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  buildSkillResourceIndex,
+  formatSkillResourceSummary,
+  loadSkillReferenceFile,
+  normalizeRelativePosixPath,
+  safeResolveWithinRoot,
+} from './skillResourceIndex.js';
+
+describe('skillResourceIndex', () => {
+  let testRootDir: string;
+
+  beforeEach(async () => {
+    testRootDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'skill-resource-index-test-'),
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(testRootDir, { recursive: true, force: true });
+  });
+
+  it('should return empty buckets for skill with only SKILL.md', async () => {
+    const skillDir = path.join(testRootDir, 'only-skill');
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, 'SKILL.md'),
+      '---\nname: x\ndescription: y\n---\n',
+    );
+
+    const index = await buildSkillResourceIndex(skillDir);
+    expect(index).toEqual({
+      scripts: [],
+      references: [],
+      assets: [],
+      other: [],
+    });
+    expect(formatSkillResourceSummary(index)).toBe(
+      'No indexed resource files under this skill (only SKILL.md or ignored dirs).',
+    );
+  });
+
+  it('should classify paths into buckets', async () => {
+    const skillDir = path.join(testRootDir, 'multi');
+    await fs.mkdir(path.join(skillDir, 'references'), { recursive: true });
+    await fs.mkdir(path.join(skillDir, 'scripts'), { recursive: true });
+    await fs.mkdir(path.join(skillDir, 'assets'), { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, 'SKILL.md'),
+      '---\nname: x\ndescription: y\n---\n',
+    );
+    await fs.writeFile(path.join(skillDir, 'references', 'a.md'), 'a');
+    await fs.writeFile(path.join(skillDir, 'references', 'b.md'), 'b');
+    await fs.writeFile(path.join(skillDir, 'scripts', 'run.sh'), 'x');
+    await fs.writeFile(path.join(skillDir, 'assets', 'c.png'), 'x');
+    await fs.mkdir(path.join(skillDir, 'misc'), { recursive: true });
+    await fs.writeFile(path.join(skillDir, 'misc', 'd.txt'), 'd');
+
+    const index = await buildSkillResourceIndex(skillDir);
+    expect(index.references).toEqual(['references/a.md', 'references/b.md']);
+    expect(index.scripts).toEqual(['scripts/run.sh']);
+    expect(index.assets).toEqual(['assets/c.png']);
+    expect(index.other).toEqual(['misc/d.txt']);
+  });
+
+  it('should not descend into node_modules', async () => {
+    const skillDir = path.join(testRootDir, 'nm');
+    await fs.mkdir(path.join(skillDir, 'node_modules', 'pkg'), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(skillDir, 'node_modules', 'pkg', 'index.js'),
+      'x',
+    );
+    await fs.writeFile(
+      path.join(skillDir, 'SKILL.md'),
+      '---\nname: x\ndescription: y\n---\n',
+    );
+
+    const index = await buildSkillResourceIndex(skillDir);
+    expect(index.scripts).toEqual([]);
+    expect(index.references).toEqual([]);
+    expect(index.assets).toEqual([]);
+    expect(index.other).toEqual([]);
+  });
+
+  it('should read references via loadSkillReferenceFile', async () => {
+    const skillDir = path.join(testRootDir, 'ref-read');
+    await fs.mkdir(path.join(skillDir, 'references'), { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, 'references', 'doc.md'),
+      'hello ref',
+    );
+
+    const content = await loadSkillReferenceFile(
+      skillDir,
+      'references/doc.md',
+    );
+    expect(content).toBe('hello ref');
+  });
+
+  it('normalizeRelativePosixPath should reject traversal and absolute paths', () => {
+    expect(() => normalizeRelativePosixPath('../x')).toThrow(
+      'Path traversal is not allowed',
+    );
+    expect(() => normalizeRelativePosixPath('references/../x')).toThrow(
+      'Path traversal is not allowed',
+    );
+    expect(() => normalizeRelativePosixPath('/abs')).toThrow(
+      'Absolute paths are not allowed',
+    );
+    expect(normalizeRelativePosixPath('references/a.md')).toBe(
+      'references/a.md',
+    );
+  });
+
+  it('loadSkillReferenceFile should reject non-references paths', async () => {
+    const skillDir = path.join(testRootDir, 'nr');
+    await fs.mkdir(path.join(skillDir, 'scripts'), { recursive: true });
+    await fs.writeFile(path.join(skillDir, 'scripts', 'x.sh'), 'x');
+
+    await expect(
+      loadSkillReferenceFile(skillDir, 'scripts/x.sh'),
+    ).rejects.toThrow('Only references/ paths are allowed');
+  });
+
+  it('safeResolveWithinRoot should reject escape after normalization', () => {
+    const root = path.join(testRootDir, 'safe');
+    expect(() =>
+      safeResolveWithinRoot(root, 'references/../../../etc/passwd'),
+    ).toThrow('Path traversal is not allowed');
+  });
+});

--- a/packages/core/src/skills/skillResourceIndex.ts
+++ b/packages/core/src/skills/skillResourceIndex.ts
@@ -1,0 +1,216 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { DEFAULT_IGNORED_FOLDERS } from '../utils/getFolderStructure.js';
+import { debugLogger } from '../utils/debugLogger.js';
+
+const DEFAULT_MAX_PER_CATEGORY = 30;
+
+/** Relative paths under the skill root (POSIX `/` separators). */
+export type SkillResourceIndex = {
+  scripts: string[];
+  references: string[];
+  assets: string[];
+  other: string[];
+};
+
+function toPosixRelative(skillRootAbs: string, fileAbs: string): string {
+  return path.relative(skillRootAbs, fileAbs).split(path.sep).join('/');
+}
+
+function classifyPath(relPosix: string): keyof SkillResourceIndex | null {
+  if (relPosix === 'SKILL.md') {
+    return null;
+  }
+  if (relPosix.startsWith('scripts/')) {
+    return 'scripts';
+  }
+  if (relPosix.startsWith('references/')) {
+    return 'references';
+  }
+  if (relPosix.startsWith('assets/')) {
+    return 'assets';
+  }
+  return 'other';
+}
+
+/**
+ * Walks the skill root and builds a semantic index of bundled files.
+ * Ignores the same directory basenames as {@link getFolderStructure}.
+ * Does not follow symbolic links. Never throws; logs and returns partial/empty
+ * buckets on failure.
+ */
+export async function buildSkillResourceIndex(
+  skillRootAbs: string,
+): Promise<SkillResourceIndex> {
+  const root = path.resolve(skillRootAbs);
+  const index: SkillResourceIndex = {
+    scripts: [],
+    references: [],
+    assets: [],
+    other: [],
+  };
+
+  async function walk(currentDir: string): Promise<void> {
+    let entries;
+    try {
+      entries = await fs.readdir(currentDir, { withFileTypes: true });
+    } catch (error: unknown) {
+      debugLogger.debug(
+        `skillResourceIndex: could not read directory ${currentDir}:`,
+        error,
+      );
+      return;
+    }
+
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const dirent of entries) {
+      try {
+        if (dirent.isSymbolicLink()) {
+          continue;
+        }
+        const fullPath = path.join(currentDir, dirent.name);
+        if (dirent.isDirectory()) {
+          if (DEFAULT_IGNORED_FOLDERS.has(dirent.name)) {
+            continue;
+          }
+          await walk(fullPath);
+        } else if (dirent.isFile()) {
+          const relPosix = toPosixRelative(root, fullPath);
+          const bucket = classifyPath(relPosix);
+          if (bucket) {
+            index[bucket].push(relPosix);
+          }
+        }
+      } catch (error: unknown) {
+        debugLogger.debug(
+          `skillResourceIndex: skipping entry under ${currentDir}:`,
+          error,
+        );
+      }
+    }
+  }
+
+  try {
+    await walk(root);
+  } catch (error: unknown) {
+    debugLogger.debug(
+      `skillResourceIndex: walk failed for ${root}:`,
+      error,
+    );
+  }
+
+  for (const key of Object.keys(index) as (keyof SkillResourceIndex)[]) {
+    index[key].sort((a, b) => a.localeCompare(b));
+  }
+
+  return index;
+}
+
+export type FormatSkillResourceSummaryOptions = {
+  maxPerCategory?: number;
+};
+
+/**
+ * Renders a short, stable summary for prompts (paths only; never reads files).
+ */
+export function formatSkillResourceSummary(
+  index: SkillResourceIndex,
+  options?: FormatSkillResourceSummaryOptions,
+): string {
+  const maxPer = options?.maxPerCategory ?? DEFAULT_MAX_PER_CATEGORY;
+
+  const allEmpty =
+    index.scripts.length === 0 &&
+    index.references.length === 0 &&
+    index.assets.length === 0 &&
+    index.other.length === 0;
+
+  if (allEmpty) {
+    return 'No indexed resource files under this skill (only SKILL.md or ignored dirs).';
+  }
+
+  const formatBucket = (label: string, paths: string[]): string => {
+    if (paths.length === 0) {
+      return `- ${label}: (none)`;
+    }
+    const shown = paths.slice(0, maxPer);
+    const rest = paths.length - shown.length;
+    const list = shown.join(', ');
+    const suffix = rest > 0 ? ` … and ${rest} more` : '';
+    return `- ${label}: ${list}${suffix}`;
+  };
+
+  return [
+    'Skill resource index (paths relative to skill root):',
+    formatBucket('References', index.references),
+    formatBucket('Scripts', index.scripts),
+    formatBucket('Assets', index.assets),
+    formatBucket('Other', index.other),
+  ].join('\n');
+}
+
+/**
+ * Normalizes a user-provided relative path to POSIX segments, rejecting
+ * traversal and absolute paths.
+ */
+export function normalizeRelativePosixPath(input: string): string {
+  const trimmed = input.replace(/\\/g, '/').trim();
+  if (trimmed === '') {
+    throw new Error('Path is empty');
+  }
+  if (
+    trimmed.startsWith('/') ||
+    /^[A-Za-z]:\//.test(trimmed) ||
+    /^[A-Za-z]:\\/.test(trimmed)
+  ) {
+    throw new Error('Absolute paths are not allowed');
+  }
+  const parts = trimmed.split('/').filter((p) => p !== '' && p !== '.');
+  for (const p of parts) {
+    if (p === '..') {
+      throw new Error('Path traversal is not allowed');
+    }
+  }
+  return parts.join('/');
+}
+
+/**
+ * Resolves a relative POSIX path under root; rejects escape attempts.
+ */
+export function safeResolveWithinRoot(
+  rootAbs: string,
+  relativePosixPath: string,
+): string {
+  const root = path.resolve(rootAbs);
+  const normalized = normalizeRelativePosixPath(relativePosixPath);
+  const segments = normalized.split('/');
+  const resolved = path.resolve(root, ...segments);
+  const relToRoot = path.relative(root, resolved);
+  if (relToRoot.startsWith('..') || path.isAbsolute(relToRoot)) {
+    throw new Error('Resolved path escapes skill root');
+  }
+  return resolved;
+}
+
+/**
+ * Reads a UTF-8 file under skill root, only when the normalized path is under
+ * `references/`. Intended for tests and future dedicated tools.
+ */
+export async function loadSkillReferenceFile(
+  skillRootAbs: string,
+  relativePathFromUser: string,
+): Promise<string> {
+  const normalized = normalizeRelativePosixPath(relativePathFromUser);
+  if (!normalized.startsWith('references/')) {
+    throw new Error('Only references/ paths are allowed');
+  }
+  const fullPath = safeResolveWithinRoot(skillRootAbs, normalized);
+  return fs.readFile(fullPath, 'utf8');
+}

--- a/packages/core/src/tools/activate-skill.test.ts
+++ b/packages/core/src/tools/activate-skill.test.ts
@@ -9,6 +9,7 @@ import { ActivateSkillTool } from './activate-skill.js';
 import type { Config } from '../config/config.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
+import { getFolderStructure } from '../utils/getFolderStructure.js';
 
 vi.mock('../utils/getFolderStructure.js', () => ({
   getFolderStructure: vi.fn().mockResolvedValue('Mock folder structure'),
@@ -146,5 +147,79 @@ describe('ActivateSkillTool', () => {
     expect(() =>
       tool.build({ name: '' } as unknown as { name: string }),
     ).toThrow();
+  });
+
+  it('should use categorized resource summary when skill has resources', async () => {
+    vi.mocked(getFolderStructure).mockClear();
+
+    const skillWithResources = {
+      name: 'test-skill',
+      description: 'A test skill',
+      location: '/path/to/test-skill/SKILL.md',
+      body: 'Skill instructions content.',
+      resources: {
+        scripts: ['scripts/run.sh'],
+        references: ['references/doc.md'],
+        assets: [],
+        other: [],
+      },
+    };
+
+    mockConfig = {
+      getWorkspaceContext: vi.fn().mockReturnValue({
+        addDirectory: vi.fn(),
+      }),
+      getSkillManager: vi.fn().mockReturnValue({
+        getSkills: vi.fn().mockReturnValue([skillWithResources]),
+        getAllSkills: vi.fn().mockReturnValue([skillWithResources]),
+        getSkill: vi.fn().mockReturnValue(skillWithResources),
+        activateSkill: vi.fn(),
+      }),
+    } as unknown as Config;
+
+    const toolWithResources = new ActivateSkillTool(mockConfig, mockMessageBus);
+    const invocation = toolWithResources.build({ name: 'test-skill' });
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.llmContent).toContain('Skill resource index');
+    expect(result.llmContent).toContain('references/doc.md');
+    expect(result.llmContent).not.toContain('Mock folder structure');
+    expect(getFolderStructure).not.toHaveBeenCalled();
+  });
+
+  it('should not embed reference file contents in available_resources', async () => {
+    const secret = 'SECRET_REF_BODY_XYZ';
+    const skillWithResources = {
+      name: 'test-skill',
+      description: 'A test skill',
+      location: '/path/to/test-skill/SKILL.md',
+      body: 'Only instruction body here.',
+      resources: {
+        scripts: [],
+        references: ['references/secret.md'],
+        assets: [],
+        other: [],
+      },
+    };
+
+    mockConfig = {
+      getWorkspaceContext: vi.fn().mockReturnValue({
+        addDirectory: vi.fn(),
+      }),
+      getSkillManager: vi.fn().mockReturnValue({
+        getSkills: vi.fn().mockReturnValue([skillWithResources]),
+        getAllSkills: vi.fn().mockReturnValue([skillWithResources]),
+        getSkill: vi.fn().mockReturnValue(skillWithResources),
+        activateSkill: vi.fn(),
+      }),
+    } as unknown as Config;
+
+    const t = new ActivateSkillTool(mockConfig, mockMessageBus);
+    const result = await t
+      .build({ name: 'test-skill' })
+      .execute(new AbortController().signal);
+
+    expect(result.llmContent).toContain('references/secret.md');
+    expect(result.llmContent).not.toContain(secret);
   });
 });

--- a/packages/core/src/tools/activate-skill.ts
+++ b/packages/core/src/tools/activate-skill.ts
@@ -6,6 +6,8 @@
 
 import * as path from 'node:path';
 import { getFolderStructure } from '../utils/getFolderStructure.js';
+import type { SkillDefinition } from '../skills/skillLoader.js';
+import { formatSkillResourceSummary } from '../skills/skillResourceIndex.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import {
   BaseDeclarativeTool,
@@ -36,7 +38,7 @@ class ActivateSkillToolInvocation extends BaseToolInvocation<
   ActivateSkillToolParams,
   ToolResult
 > {
-  private cachedFolderStructure: string | undefined;
+  private cachedResourcePresentation: string | undefined;
 
   constructor(
     private config: Config,
@@ -57,15 +59,20 @@ class ActivateSkillToolInvocation extends BaseToolInvocation<
     return `"${skillName}" (?) unknown skill`;
   }
 
-  private async getOrFetchFolderStructure(
-    skillLocation: string,
-  ): Promise<string> {
-    if (this.cachedFolderStructure === undefined) {
-      this.cachedFolderStructure = await getFolderStructure(
-        path.dirname(skillLocation),
-      );
+  private async getResourcePresentation(skill: SkillDefinition): Promise<string> {
+    if (skill.resources !== undefined) {
+      return formatSkillResourceSummary(skill.resources);
     }
-    return this.cachedFolderStructure;
+    return await getFolderStructure(path.dirname(skill.location));
+  }
+
+  private async getOrFetchResourcePresentation(
+    skill: SkillDefinition,
+  ): Promise<string> {
+    if (this.cachedResourcePresentation === undefined) {
+      this.cachedResourcePresentation = await this.getResourcePresentation(skill);
+    }
+    return this.cachedResourcePresentation;
   }
 
   protected override async getConfirmationDetails(
@@ -86,8 +93,8 @@ class ActivateSkillToolInvocation extends BaseToolInvocation<
       return false;
     }
 
-    const folderStructure = await this.getOrFetchFolderStructure(
-      skill.location,
+    const resourcePresentation = await this.getOrFetchResourcePresentation(
+      skill,
     );
 
     const confirmationDetails: ToolCallConfirmationDetails = {
@@ -99,7 +106,7 @@ class ActivateSkillToolInvocation extends BaseToolInvocation<
 ${skill.description}
 
 **Resources to be shared with the model:**
-${folderStructure}`,
+${resourcePresentation}`,
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         await this.publishPolicyUpdate(outcome);
       },
@@ -134,8 +141,8 @@ ${folderStructure}`,
       .getWorkspaceContext()
       .addDirectory(path.dirname(skill.location));
 
-    const folderStructure = await this.getOrFetchFolderStructure(
-      skill.location,
+    const resourcePresentation = await this.getOrFetchResourcePresentation(
+      skill,
     );
 
     return {
@@ -145,10 +152,10 @@ ${folderStructure}`,
   </instructions>
 
   <available_resources>
-    ${folderStructure}
+    ${resourcePresentation}
   </available_resources>
 </activated_skill>`,
-      returnDisplay: `Skill **${skillName}** activated. Resources loaded from \`${path.dirname(skill.location)}\`:\n\n${folderStructure}`,
+      returnDisplay: `Skill **${skillName}** activated. Resources loaded from \`${path.dirname(skill.location)}\`:\n\n${resourcePresentation}`,
     };
   }
 }

--- a/packages/core/src/utils/getFolderStructure.ts
+++ b/packages/core/src/utils/getFolderStructure.ts
@@ -18,9 +18,15 @@ import {
 } from '../config/constants.js';
 import { debugLogger } from './debugLogger.js';
 
-const MAX_ITEMS = 200;
+/** Default cap on files + folders shown in folder-structure summaries. */
+export const MAX_ITEMS = 200;
 const TRUNCATION_INDICATOR = '...';
-const DEFAULT_IGNORED_FOLDERS = new Set([
+/**
+ * Basenames of directories skipped when walking a tree (case-sensitive).
+ * Exported for skill resource indexing so ignore rules stay aligned with
+ * {@link getFolderStructure}.
+ */
+export const DEFAULT_IGNORED_FOLDERS = new Set([
   'node_modules',
   '.git',
   'dist',


### PR DESCRIPTION
## Summary
- Build a `SkillResourceIndex` when loading `SKILL.md` (`loadSkillFromFile`) and attach it to `SkillDefinition` as optional `resources`.
- On `activate_skill`, prefer a short per-bucket path summary (`references/` / `scripts/` / `assets/` / `other`) for `<available_resources>` and the confirmation prompt; if `resources` is missing (e.g. programmatically injected skills), fall back to existing `getFolderStructure`.
- Export `DEFAULT_IGNORED_FOLDERS` (and `MAX_ITEMS`) from `getFolderStructure` so indexing matches default folder-tree ignore rules.
- Add `loadSkillReferenceFile` + path helpers in `skillResourceIndex.ts` for unit tests and a future dedicated `references/` reader tool.

## Motivation
Partial implementation for #15895: semantic resource buckets + lighter activation context (progressive disclosure direction).

## Out of scope
- No new core tool for reading `references/` yet (planned follow-up).
- No `manifestExtras` / `allowed-tools` / script execution.

cc #15895