### PR TITLE
fix: set maxOutputTokens default in chat-base to prevent silent truncation

### DIFF
--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -31,6 +31,7 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
           temperature: 1,
           topP: 0.95,
           topK: 64,
+          maxOutputTokens: 65536,
         },
       },
     },


### PR DESCRIPTION
## Summary

Fixes #23081.

The `chat-base` model config (parent of all interactive chat configs including `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3-pro-preview`, etc.) did not specify `maxOutputTokens`, causing the Gemini API to use its default of **8,192 tokens**. This silently truncated long outputs with no warning.

## Details

### Problem
The inheritance chain `gemini-2.5-pro → chat-base-2.5 → chat-base → base` never sets `maxOutputTokens`, so the API default (8,192) is applied. For models supporting up to 65,536 output tokens, this causes silent mid-sentence truncation.

### Fix
Added `maxOutputTokens: 65536` to the `chat-base` config. This is the maximum supported by current Gemini models and a safe default — the API will cap it at the model's actual limit if lower. Internal configs (`classifier`, `summarizer`, `fast-ack-helper`, etc.) already override with their own lower values.

## How to validate

```bash
echo "Y" | gemini -p "List ALL countries in the world by continent. For each include: name, capital, population, currency, language. At the end write 'END OF LIST'." -m gemini-2.5-pro -o text 2>/dev/null > output.md
# Before: ~50KB truncated, no 'END OF LIST'
# After: complete output with 'END OF LIST' marker
```

## Checklist

- [x] Code compiles correctly
- [x] All existing tests pass (100/100 in `models.test.ts` + `modelConfigService.test.ts`)
- [x] Change is minimal and focused
- [x] No new dependencies