### PR TITLE
feat(extensions): show package.json version alongside tag in extension info

### DIFF
--- a/packages/cli/src/commands/extensions/update.ts
+++ b/packages/cli/src/commands/extensions/update.ts
@@ -22,6 +22,7 @@ import { ExtensionManager } from '../../config/extension-manager.js';
 import { requestConsentNonInteractive } from '../../config/extensions/consent.js';
 import { loadSettings } from '../../config/settings.js';
 import { promptForSetting } from '../../config/extensions/extensionSettings.js';
+import { getPackageVersion, formatVersion } from '../../config/extension.js';
 import { exitCli } from '../utils.js';
 
 interface UpdateArgs {
@@ -58,7 +59,10 @@ export async function handleUpdate(args: UpdateArgs) {
         }
 
         const installedExtensions = extensions
-          .map((extension) => `${extension.name} (${extension.version})`)
+          .map(
+            (extension) =>
+              `${extension.name} (${formatVersion(extension.version, getPackageVersion(extension.path))})`,
+          )
           .join('\n');
         coreEvents.emitFeedback(
           'error',

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -11,7 +11,12 @@ import chalk from 'chalk';
 import { ExtensionEnablementManager } from './extensions/extensionEnablement.js';
 import { type MergedSettings, SettingScope } from './settings.js';
 import { createHash, randomUUID } from 'node:crypto';
-import { loadInstallMetadata, type ExtensionConfig } from './extension.js';
+import {
+  loadInstallMetadata,
+  getPackageVersion,
+  formatVersion,
+  type ExtensionConfig,
+} from './extension.js';
 import {
   isWorkspaceTrusted,
   loadTrustedFolders,
@@ -1117,7 +1122,7 @@ Would you like to attempt to install via "git clone" instead?`,
     );
 
     const status = workspaceEnabled ? chalk.green('✓') : chalk.red('✗');
-    let output = `${status} ${extension.name} (${extension.version})`;
+    let output = `${status} ${extension.name} (${formatVersion(extension.version, getPackageVersion(extension.path))})`;
     output += `\n ID: ${extension.id}`;
     output += `\n name: ${hashValue(extension.name)}`;
 

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -67,3 +67,34 @@ export function loadInstallMetadata(
     return undefined;
   }
 }
+
+/**
+ * Reads the `version` field from an extension's `package.json`, if present.
+ * Returns undefined when no package.json exists or it cannot be parsed.
+ */
+export function getPackageVersion(extensionDir: string): string | undefined {
+  try {
+    const pkgPath = path.join(extensionDir, 'package.json');
+    const content = fs.readFileSync(pkgPath, 'utf-8');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const pkg = JSON.parse(content) as { version?: string };
+    return pkg.version;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Formats a version string for display. When the config version (e.g. "latest")
+ * differs from the actual package.json version, appends the concrete version in
+ * parentheses so users see meaningful info: `latest (0.20.2)`.
+ */
+export function formatVersion(
+  configVersion: string,
+  packageVersion?: string,
+): string {
+  if (!packageVersion || packageVersion === configVersion) {
+    return configVersion;
+  }
+  return `${configVersion} (${packageVersion})`;
+}

--- a/packages/cli/src/config/extensions/update.test.ts
+++ b/packages/cli/src/config/extensions/update.test.ts
@@ -42,6 +42,10 @@ vi.mock('./github.js', () => ({
 
 vi.mock('../extension.js', () => ({
   loadInstallMetadata: vi.fn(),
+  getPackageVersion: vi.fn(),
+  formatVersion: vi.fn(
+    (configVersion: string, _packageVersion?: string) => configVersion,
+  ),
 }));
 
 vi.mock('node:fs', async (importOriginal) => {

--- a/packages/cli/src/config/extensions/update.ts
+++ b/packages/cli/src/config/extensions/update.ts
@@ -9,7 +9,11 @@ import {
   ExtensionUpdateState,
   type ExtensionUpdateStatus,
 } from '../../ui/state/extensions.js';
-import { loadInstallMetadata } from '../extension.js';
+import {
+  loadInstallMetadata,
+  getPackageVersion,
+  formatVersion,
+} from '../extension.js';
 import { checkForExtensionUpdate } from './github.js';
 import {
   debugLogger,
@@ -97,7 +101,10 @@ export async function updateExtension(
     }
   }
 
-  const originalVersion = extension.version;
+  const originalVersion = formatVersion(
+    extension.version,
+    getPackageVersion(extension.path),
+  );
 
   const tempDir = await ExtensionStorage.createTmpDir();
   try {
@@ -119,7 +126,10 @@ export async function updateExtension(
         `Updated extension not found after installation, got error:\n${e}`,
       );
     }
-    const updatedVersion = updatedExtension.version;
+    const updatedVersion = formatVersion(
+      updatedExtension.version,
+      getPackageVersion(updatedExtension.path),
+    );
     dispatchExtensionStateUpdate({
       type: 'SET_STATE',
       payload: {


### PR DESCRIPTION
## Summary

When extensions use non-descriptive version strings like `"latest"` in their `gemini-extension.json`, the `/extensions list` and `/extensions update` commands now also display the concrete version from `package.json`. For example: `latest (0.20.2)` instead of just `latest`.

## Details

Added two utility functions in `extension.ts`:

- **`getPackageVersion(extensionDir)`** — reads the `version` field from an extension's `package.json`, returning `undefined` if unavailable.
- **`formatVersion(configVersion, packageVersion?)`** — returns just the config version when it matches the package version (or when no package version exists), otherwise combines them: `configVersion (packageVersion)`.

These are applied in:
- `extension-manager.ts` — `toOutputString()` for `/extensions list`
- `config/extensions/update.ts` — `originalVersion`/`updatedVersion` in `ExtensionUpdateInfo`
- `commands/extensions/update.ts` — "extension not found" error message listing

When config version equals package version (i.e., the author already uses proper semver), the display is unchanged.

## Related Issues

Closes #22932

## How to Validate

1. Install an extension that uses `"latest"` as its version in `gemini-extension.json` (e.g. `chrome-devtools-mcp`).
2. Run `/extensions list` — the output should now show `latest (x.y.z)` instead of just `latest`.
3. Run `/extensions update <name>` — the success message should show meaningful version transitions like `latest (0.20.0) → latest (0.20.2)` instead of `latest → latest`.
4. Install an extension that already uses proper semver (e.g. `1.0.0`) — verify the display remains unchanged (no duplicate version).

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run