### PR TITLE
fix(core): guard against empty parts array in messageInspectors

### DIFF
--- a/packages/core/src/utils/messageInspectors.test.ts
+++ b/packages/core/src/utils/messageInspectors.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Content } from '@google/genai';
+import { isFunctionCall, isFunctionResponse } from './messageInspectors.js';
+
+describe('messageInspectors', () => {
+  describe('isFunctionCall', () => {
+    it('returns true for a model message with functionCall parts', () => {
+      const content: Content = {
+        role: 'model',
+        parts: [{ functionCall: { name: 'readFile', args: {} } }],
+      };
+      expect(isFunctionCall(content)).toBe(true);
+    });
+
+    it('returns true for multiple functionCall parts', () => {
+      const content: Content = {
+        role: 'model',
+        parts: [
+          { functionCall: { name: 'readFile', args: {} } },
+          { functionCall: { name: 'writeFile', args: {} } },
+        ],
+      };
+      expect(isFunctionCall(content)).toBe(true);
+    });
+
+    it('returns false for a user message with functionCall parts', () => {
+      const content: Content = {
+        role: 'user',
+        parts: [{ functionCall: { name: 'readFile', args: {} } }],
+      };
+      expect(isFunctionCall(content)).toBe(false);
+    });
+
+    it('returns false for a model message with text parts', () => {
+      const content: Content = {
+        role: 'model',
+        parts: [{ text: 'hello' }],
+      };
+      expect(isFunctionCall(content)).toBe(false);
+    });
+
+    it('returns false for mixed functionCall and text parts', () => {
+      const content: Content = {
+        role: 'model',
+        parts: [
+          { functionCall: { name: 'readFile', args: {} } },
+          { text: 'some text' },
+        ],
+      };
+      expect(isFunctionCall(content)).toBe(false);
+    });
+
+    it('returns false for empty parts array', () => {
+      const content: Content = { role: 'model', parts: [] };
+      expect(isFunctionCall(content)).toBe(false);
+    });
+
+    it('returns false when parts is undefined', () => {
+      const content = { role: 'model' } as Content;
+      expect(isFunctionCall(content)).toBe(false);
+    });
+  });
+
+  describe('isFunctionResponse', () => {
+    it('returns true for a user message with functionResponse parts', () => {
+      const content: Content = {
+        role: 'user',
+        parts: [
+          { functionResponse: { name: 'readFile', response: { output: '' } } },
+        ],
+      };
+      expect(isFunctionResponse(content)).toBe(true);
+    });
+
+    it('returns true for multiple functionResponse parts', () => {
+      const content: Content = {
+        role: 'user',
+        parts: [
+          { functionResponse: { name: 'readFile', response: { output: '' } } },
+          {
+            functionResponse: {
+              name: 'writeFile',
+              response: { output: '' },
+            },
+          },
+        ],
+      };
+      expect(isFunctionResponse(content)).toBe(true);
+    });
+
+    it('returns false for a model message with functionResponse parts', () => {
+      const content: Content = {
+        role: 'model',
+        parts: [
+          { functionResponse: { name: 'readFile', response: { output: '' } } },
+        ],
+      };
+      expect(isFunctionResponse(content)).toBe(false);
+    });
+
+    it('returns false for a user message with text parts', () => {
+      const content: Content = {
+        role: 'user',
+        parts: [{ text: 'hello' }],
+      };
+      expect(isFunctionResponse(content)).toBe(false);
+    });
+
+    it('returns false for empty parts array', () => {
+      const content: Content = { role: 'user', parts: [] };
+      expect(isFunctionResponse(content)).toBe(false);
+    });
+
+    it('returns false when parts is undefined', () => {
+      const content = { role: 'user' } as Content;
+      expect(isFunctionResponse(content)).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/utils/messageInspectors.ts
+++ b/packages/core/src/utils/messageInspectors.ts
@@ -10,6 +10,7 @@ export function isFunctionResponse(content: Content): boolean {
   return (
     content.role === 'user' &&
     !!content.parts &&
+    content.parts.length > 0 &&
     content.parts.every((part) => !!part.functionResponse)
   );
 }
@@ -18,6 +19,7 @@ export function isFunctionCall(content: Content): boolean {
   return (
     content.role === 'model' &&
     !!content.parts &&
+    content.parts.length > 0 &&
     content.parts.every((part) => !!part.functionCall)
   );
 }


### PR DESCRIPTION
## Summary

`isFunctionCall()` and `isFunctionResponse()` in `messageInspectors.ts` return `true` for messages with empty `parts` arrays because `Array.every([])` is vacuously `true` in JavaScript. This causes consumers to incorrectly treat empty-parts messages as valid function calls/responses.

## Details

Added `content.parts.length > 0` guard to both functions. Also added comprehensive test coverage — `messageInspectors.ts` previously had no tests.

**13 tests** covering:
- Valid function call/response messages (single and multiple parts)
- Wrong role (user message with functionCall, model message with functionResponse)
- Messages with text parts only
- Mixed functionCall + text parts
- **Empty parts arrays** (the bug scenario)
- Undefined parts

## Related Issues

Closes #22912

## How to Validate

```bash
cd packages/core
npx vitest run src/utils/messageInspectors.test.ts
```

All 13 tests should pass. The key tests are "returns false for empty parts array" which would fail without the fix.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run