### PR TITLE
fix: allow_redirection policy not working due to redirect sub-commands in splitCommands

### DIFF
--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -1218,6 +1218,48 @@ describe('PolicyEngine', () => {
       ).toBe(PolicyDecision.ALLOW);
     });
 
+    it('should allow redirected shell commands with allowRedirection even when a lower-priority catch-all rule exists', async () => {
+      vi.mocked(initializeShellParsers).mockResolvedValue(undefined);
+      const { splitCommands } = await import('../utils/shell-utils.js');
+      // Before the fix, splitCommands would return redirect details as separate entries,
+      // e.g., ['echo "hello"', '> file.txt']. The redirect sub-command '> file.txt'
+      // would not match the user's commandPrefix rule and would fall through to
+      // the built-in catch-all ASK_USER rule, defeating allowRedirection.
+      //
+      // After the fix, splitCommands filters out redirect entries, so only
+      // actual command sub-commands are returned.
+      vi.mocked(splitCommands).mockReturnValueOnce(['echo "hello"']);
+
+      const rules: PolicyRule[] = [
+        {
+          toolName: 'run_shell_command',
+          argsPattern: /"command":"echo/,
+          decision: PolicyDecision.ALLOW,
+          allowRedirection: true,
+          priority: 100,
+        },
+        {
+          toolName: 'run_shell_command',
+          decision: PolicyDecision.ASK_USER,
+          priority: 10,
+        },
+      ];
+
+      engine = new PolicyEngine({ rules });
+
+      expect(
+        (
+          await engine.check(
+            {
+              name: 'run_shell_command',
+              args: { command: 'echo "hello" > file.txt' },
+            },
+            undefined,
+          )
+        ).decision,
+      ).toBe(PolicyDecision.ALLOW);
+    });
+
     it('should NOT downgrade ALLOW to ASK_USER for quoted redirection chars', async () => {
       const rules: PolicyRule[] = [
         {

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -667,7 +667,10 @@ export function splitCommands(command: string): string[] {
     return [];
   }
 
-  return parsed.details.map((detail) => detail.text).filter(Boolean);
+  return parsed.details
+    .filter((detail) => !REDIRECTION_NAMES.has(detail.name))
+    .map((detail) => detail.text)
+    .filter(Boolean);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #23096 — `allow_redirection = true` in user policy rules was not being respected. Commands with redirection (e.g., `echo "hello" > file.txt`) still triggered the "Action Required" confirmation dialog.

## Details

**Root cause:** `splitCommands()` uses the tree-sitter bash parser, which extracts redirect operators (e.g., `> file.txt`) as separate "command" detail entries alongside the actual command (`echo "hello"`). When the policy engine processed these sub-commands recursively via `this.check()`, the redirect entry did not match the user's `commandPrefix` rule (which only matched the actual command like `echo`), causing it to fall through to a lower-priority catch-all `run_shell_command` `ask_user` rule — defeating `allow_redirection`.

**Fix:** Filter redirect entries (`redirection (<)`, `redirection (>)`, `heredoc (<<)`, `herestring (<<<)`) from `splitCommands()` output, consistent with how `getCommandRoots()` already filters them via `REDIRECTION_NAMES`. The `hasRedirection()` check on the full command string (called in `shouldDowngradeForRedirection`) still correctly handles redirection detection for rules without `allow_redirection`.

## How to Validate

1. Create `~/.gemini/policies/test.toml`:
```toml
[[rule]]
toolName = "run_shell_command"
commandPrefix = ["echo"]
allow_redirection = true
decision = "allow"
priority = 100
```
2. Run: `echo "hello" > test.txt`
3. **Before fix:** "Action Required" dialog appears
4. **After fix:** Command executes without confirmation

Or run the tests: `npx vitest run packages/core/src/policy/`

## Checklist

- [x] Code compiles without errors
- [x] All existing tests pass (277 policy tests)
- [x] New test added for the specific scenario
- [x] Changes are minimal and focused on the bug