### PR TITLE
feat: add block-no-verify BeforeTool hook to .gemini/settings.json

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -6,5 +6,19 @@
   },
   "general": {
     "devtools": true
+  },
+  "hooks": {
+    "BeforeTool": [
+      {
+        "matcher": "run_shell_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2",
+            "description": "Block git hook-bypass flag to protect pre-commit, commit-msg, and pre-push hooks"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as a `BeforeTool` hook in `.gemini/settings.json` to prevent Gemini CLI agents from bypassing git hooks via the `--no-verify` flag.

## Details

The `.gemini/settings.json` currently has no hooks configured. This PR adds the first hook: a `BeforeTool` entry that runs `npx block-no-verify@1.1.2` before every `run_shell_command` execution.

**Why it works with Gemini CLI:** The `BeforeTool` event sends `{ tool_input: { command: "..." } }` in stdin — `block-no-verify` already parses this format (same as Claude Code's `tool_input.command` structure). The package exits 2 to block if the hook-bypass flag is found.

**What it protects:** pre-commit hooks, commit-msg hooks, and pre-push hooks. Without this, an agent hitting a failing pre-commit hook can retry with `--no-verify` and silently push unvalidated code.

## Related Issues

Closes #23123

## How to Validate

1. In a repo with a pre-commit hook, ask Gemini CLI to run `git commit --no-verify`
2. The hook should block the command with an error message
3. `git commit` without the flag should pass through normally

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) — no docs change needed, hook is self-describing
- [ ] Added/updated tests (if needed) — integration test would require Gemini CLI runtime
- [x] Noted breaking changes (if any) — none; only blocks explicitly forbidden flag

---

_Disclosure: I am the author and maintainer of `block-no-verify`._
