### PR TITLE
fix: upgrade ACP SDK from 0.12 to 0.16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "gemini": "bundle/gemini.js"
       },
       "devDependencies": {
-        "@agentclientprotocol/sdk": "^0.12.0",
+        "@agentclientprotocol/sdk": "^0.16.1",
         "@octokit/rest": "^22.0.0",
         "@types/marked": "^5.0.2",
         "@types/mime-types": "^3.0.1",
@@ -84,9 +84,9 @@
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.12.0.tgz",
-      "integrity": "sha512-V8uH/KK1t7utqyJmTA7y7DzKu6+jKFIXM+ZVouz8E55j8Ej2RV42rEvPKn3/PpBJlliI5crcGk1qQhZ7VwaepA==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.16.1.tgz",
+      "integrity": "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
@@ -17531,7 +17531,7 @@
       "version": "0.36.0-nightly.20260317.2f90b4653",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.12.0",
+        "@agentclientprotocol/sdk": "^0.16.1",
         "@google/gemini-cli-core": "file:../core",
         "@google/genai": "1.30.0",
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "LICENSE"
   ],
   "devDependencies": {
-    "@agentclientprotocol/sdk": "^0.12.0",
+    "@agentclientprotocol/sdk": "^0.16.1",
     "@octokit/rest": "^22.0.0",
     "@types/marked": "^5.0.2",
     "@types/mime-types": "^3.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,7 +30,7 @@
     "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.36.0-nightly.20260317.2f90b4653"
   },
   "dependencies": {
-    "@agentclientprotocol/sdk": "^0.12.0",
+    "@agentclientprotocol/sdk": "^0.16.1",
     "@google/gemini-cli-core": "file:../core",
     "@google/genai": "1.30.0",
     "@iarna/toml": "^2.2.5",

--- a/packages/cli/src/acp/fileSystemService.ts
+++ b/packages/cli/src/acp/fileSystemService.ts
@@ -14,7 +14,7 @@ export class AcpFileSystemService implements FileSystemService {
   constructor(
     private readonly connection: acp.AgentSideConnection,
     private readonly sessionId: string,
-    private readonly capabilities: acp.FileSystemCapability,
+    private readonly capabilities: acp.FileSystemCapabilities,
     private readonly fallback: FileSystemService,
   ) {}
 


### PR DESCRIPTION
## Summary

upgrade ACP SDK from 0.12 to the current latest 0.16.1

## Details

Need to ensure that we have all the latest capabilities of the SDK

## Related Issues

Fixes #23128 

## How to Validate

No regressions in test runs.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [NA] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [✅] Validated on required platforms/methods:
  - [✅] MacOS
    - [✅] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
