### PR TITLE
feat: ACP: Add token usage metadata to the `send` method's return value

### DIFF
--- a/packages/cli/src/acp/acpClient.test.ts
+++ b/packages/cli/src/acp/acpClient.test.ts
@@ -551,7 +551,7 @@ describe('GeminiAgent', () => {
     });
 
     expect(session.prompt).toHaveBeenCalled();
-    expect(result).toEqual({ stopReason: 'end_turn' });
+    expect(result).toMatchObject({ stopReason: 'end_turn' });
   });
 
   it('should delegate setMode to session', async () => {
@@ -750,7 +750,7 @@ describe('Session', () => {
         content: { type: 'text', text: 'Hello' },
       },
     });
-    expect(result).toEqual({ stopReason: 'end_turn' });
+    expect(result).toMatchObject({ stopReason: 'end_turn' });
   });
 
   it('should handle /memory command', async () => {
@@ -767,7 +767,7 @@ describe('Session', () => {
       prompt: [{ type: 'text', text: '/memory view' }],
     });
 
-    expect(result).toEqual({ stopReason: 'end_turn' });
+    expect(result).toMatchObject({ stopReason: 'end_turn' });
     expect(handleCommandSpy).toHaveBeenCalledWith(
       '/memory view',
       expect.any(Object),
@@ -789,7 +789,7 @@ describe('Session', () => {
       prompt: [{ type: 'text', text: '/extensions list' }],
     });
 
-    expect(result).toEqual({ stopReason: 'end_turn' });
+    expect(result).toMatchObject({ stopReason: 'end_turn' });
     expect(handleCommandSpy).toHaveBeenCalledWith(
       '/extensions list',
       expect.any(Object),
@@ -811,7 +811,7 @@ describe('Session', () => {
       prompt: [{ type: 'text', text: '/extensions explore' }],
     });
 
-    expect(result).toEqual({ stopReason: 'end_turn' });
+    expect(result).toMatchObject({ stopReason: 'end_turn' });
     expect(handleCommandSpy).toHaveBeenCalledWith(
       '/extensions explore',
       expect.any(Object),
@@ -833,7 +833,7 @@ describe('Session', () => {
       prompt: [{ type: 'text', text: '/restore' }],
     });
 
-    expect(result).toEqual({ stopReason: 'end_turn' });
+    expect(result).toMatchObject({ stopReason: 'end_turn' });
     expect(handleCommandSpy).toHaveBeenCalledWith(
       '/restore',
       expect.any(Object),
@@ -855,7 +855,7 @@ describe('Session', () => {
       prompt: [{ type: 'text', text: '/init' }],
     });
 
-    expect(result).toEqual({ stopReason: 'end_turn' });
+    expect(result).toMatchObject({ stopReason: 'end_turn' });
     expect(handleCommandSpy).toHaveBeenCalledWith('/init', expect.any(Object));
     expect(mockChat.sendMessageStream).not.toHaveBeenCalled();
   });
@@ -909,7 +909,7 @@ describe('Session', () => {
         }),
       }),
     );
-    expect(result).toEqual({ stopReason: 'end_turn' });
+    expect(result).toMatchObject({ stopReason: 'end_turn' });
   });
 
   it('should handle tool call permission request', async () => {

--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -699,9 +699,21 @@ export class Session {
       // It uses `parts` argument but effectively ignores it in current implementation
       const handled = await this.handleCommand(commandText, parts);
       if (handled) {
-        return { stopReason: 'end_turn' };
+        return {
+          stopReason: 'end_turn',
+          _meta: {
+            quota: {
+              token_count: { input_tokens: 0, output_tokens: 0 },
+              model_usage: [],
+            },
+          },
+        };
       }
     }
+
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    const modelUsageMap = new Map<string, { input: number; output: number }>();
 
     let nextMessage: Content | null = { role: 'user', parts };
 
@@ -727,9 +739,23 @@ export class Session {
         );
         nextMessage = null;
 
+        let turnInputTokens = 0;
+        let turnOutputTokens = 0;
+        let turnModelId = model;
+
         for await (const resp of responseStream) {
           if (pendingSend.signal.aborted) {
             return { stopReason: CoreToolCallStatus.Cancelled };
+          }
+
+          if (resp.type === StreamEventType.CHUNK && resp.value.usageMetadata) {
+            turnInputTokens =
+              resp.value.usageMetadata.promptTokenCount ?? turnInputTokens;
+            turnOutputTokens =
+              resp.value.usageMetadata.candidatesTokenCount ?? turnOutputTokens;
+            if (resp.value.modelVersion) {
+              turnModelId = resp.value.modelVersion;
+            }
           }
 
           if (
@@ -761,6 +787,19 @@ export class Session {
           if (resp.type === StreamEventType.CHUNK && resp.value.functionCalls) {
             functionCalls.push(...resp.value.functionCalls);
           }
+        }
+
+        totalInputTokens += turnInputTokens;
+        totalOutputTokens += turnOutputTokens;
+
+        if (turnInputTokens > 0 || turnOutputTokens > 0) {
+          const existing = modelUsageMap.get(turnModelId) ?? {
+            input: 0,
+            output: 0,
+          };
+          existing.input += turnInputTokens;
+          existing.output += turnOutputTokens;
+          modelUsageMap.set(turnModelId, existing);
         }
 
         if (pendingSend.signal.aborted) {
@@ -799,7 +838,28 @@ export class Session {
       }
     }
 
-    return { stopReason: 'end_turn' };
+    const modelUsageArray = Array.from(modelUsageMap.entries()).map(
+      ([modelName, counts]) => ({
+        model: modelName,
+        token_count: {
+          input_tokens: counts.input,
+          output_tokens: counts.output,
+        },
+      }),
+    );
+
+    return {
+      stopReason: 'end_turn',
+      _meta: {
+        quota: {
+          token_count: {
+            input_tokens: totalInputTokens,
+            output_tokens: totalOutputTokens,
+          },
+          model_usage: modelUsageArray,
+        },
+      },
+    };
   }
 
   private async handleCommand(


### PR DESCRIPTION

## Summary

PromptResponse should include:
```
{
  "stopReason": "end_turn",
  "_meta": {
    "quota": {
      "token_count": { "input_tokens": 1234, "output_tokens": 567 },
      "model_usage": [
        { "model": "gemini-2.0-flash", "token_count": { "input_tokens": 1234, "output_tokens": 567 } }
      ]
    }
  }
}
```
## Details

- Added logic to aggregate `input_tokens` and `output_tokens` across the entire prompt turn by listening to usageMetadata payloads during the text generation stream.
- Implemented a continuous modelUsageMap that maps and tracks token tallies by the specific model (modelVersion) used, accommodating scenarios where the model changes mid-task.
- Extended PromptResponse at end_turn to return the new structured quota data, while updating test assertions (via toMatchObject) to ensure backward compatibility with existing tests.

## Related Issues

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/1330 

## How to Validate

- Connect Zed or JB via ACP and do a simple prompt
- ACP detailed log should show the token usage prompt response in end-turn.

### Example for a simple hello with gemini 3.1 selected
```
{
  "stopReason": "end_turn",
  "_meta": {
    "quota": {
      "token_count": {
        "input_tokens": 8461,
        "output_tokens": 9
      },
      "model_usage": [
        {
          "model": "gemini-3.1-pro-preview",
          "token_count": {
            "input_tokens": 8461,
            "output_tokens": 9
          }
        }
      ]
    }
  }
}
```

### Example for returning a fibonacci function with gemini 2.5 selected.

```
{
  "stopReason": "end_turn",
  "_meta": {
    "quota": {
      "token_count": {
        "input_tokens": 8473,
        "output_tokens": 333
      },
      "model_usage": [
        {
          "model": "gemini-2.5-pro",
          "token_count": {
            "input_tokens": 8473,
            "output_tokens": 333
          }
        }
      ]
    }
  }
}

```


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [✅] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [✅] Validated on required platforms/methods:
  - [✅] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
