### PR TITLE
feat(tools): add structured error classification and recovery hints to tool error responses

### DIFF
--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -2309,6 +2309,11 @@ describe('CoreToolScheduler Sequential Execution', () => {
       expect(result.response.error.message).toBe(
         'Tool execution denied by policy.',
       );
+      const responsePayload =
+        result.response.responseParts[0].functionResponse.response;
+      expect(responsePayload.error_type).toBe(ToolErrorType.POLICY_VIOLATION);
+      expect(responsePayload.recoverable).toBe(true);
+      expect(responsePayload.hint).toBeDefined();
     });
 
     it('should return custom deny message when denied in Plan Mode with a specific rule message', async () => {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -15,7 +15,11 @@ import {
 import type { EditorType } from '../utils/editor.js';
 import { PolicyDecision } from '../policy/types.js';
 import { logToolCall } from '../telemetry/loggers.js';
-import { ToolErrorType } from '../tools/tool-error.js';
+import {
+  ToolErrorType,
+  isFatalToolError,
+  getRecoveryHint,
+} from '../tools/tool-error.js';
 import { ToolCallEvent } from '../telemetry/types.js';
 import { runInDevTraceSpan } from '../telemetry/trace.js';
 import { ToolModificationHandler } from '../scheduler/tool-modifier.js';
@@ -75,22 +79,30 @@ const createErrorResponse = (
   request: ToolCallRequestInfo,
   error: Error,
   errorType: ToolErrorType | undefined,
-): ToolCallResponseInfo => ({
-  callId: request.callId,
-  error,
-  responseParts: [
-    {
-      functionResponse: {
-        id: request.callId,
-        name: request.name,
-        response: { error: error.message },
+): ToolCallResponseInfo => {
+  const response: Record<string, unknown> = { error: error.message };
+  if (errorType) {
+    response['error_type'] = errorType;
+    response['recoverable'] = !isFatalToolError(errorType);
+    response['hint'] = getRecoveryHint(errorType);
+  }
+  return {
+    callId: request.callId,
+    error,
+    responseParts: [
+      {
+        functionResponse: {
+          id: request.callId,
+          name: request.name,
+          response,
+        },
       },
-    },
-  ],
-  resultDisplay: error.message,
-  errorType,
-  contentLength: error.message.length,
-});
+    ],
+    resultDisplay: error.message,
+    errorType,
+    contentLength: JSON.stringify(response).length,
+  };
+};
 
 interface CoreToolSchedulerOptions {
   context: AgentLoopContext;

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -25,7 +25,11 @@ import {
   CoreToolCallStatus,
   type ScheduledToolCall,
 } from './types.js';
-import { ToolErrorType } from '../tools/tool-error.js';
+import {
+  ToolErrorType,
+  isFatalToolError,
+  getRecoveryHint,
+} from '../tools/tool-error.js';
 import { PolicyDecision, type ApprovalMode } from '../policy/types.js';
 import {
   ToolConfirmationOutcome,
@@ -70,22 +74,30 @@ const createErrorResponse = (
   request: ToolCallRequestInfo,
   error: Error,
   errorType: ToolErrorType | undefined,
-): ToolCallResponseInfo => ({
-  callId: request.callId,
-  error,
-  responseParts: [
-    {
-      functionResponse: {
-        id: request.callId,
-        name: request.name,
-        response: { error: error.message },
+): ToolCallResponseInfo => {
+  const response: Record<string, unknown> = { error: error.message };
+  if (errorType) {
+    response['error_type'] = errorType;
+    response['recoverable'] = !isFatalToolError(errorType);
+    response['hint'] = getRecoveryHint(errorType);
+  }
+  return {
+    callId: request.callId,
+    error,
+    responseParts: [
+      {
+        functionResponse: {
+          id: request.callId,
+          name: request.name,
+          response,
+        },
       },
-    },
-  ],
-  resultDisplay: error.message,
-  errorType,
-  contentLength: error.message.length,
-});
+    ],
+    resultDisplay: error.message,
+    errorType,
+    contentLength: JSON.stringify(response).length,
+  };
+};
 
 /**
  * Event-Driven Orchestrator for Tool Execution.

--- a/packages/core/src/scheduler/tool-executor.test.ts
+++ b/packages/core/src/scheduler/tool-executor.test.ts
@@ -10,6 +10,7 @@ import {
   type Config,
   type ToolResult,
   type AnyToolInvocation,
+  ToolErrorType,
 } from '../index.js';
 import { makeFakeConfig } from '../test-utils/config.js';
 import { MockTool } from '../test-utils/mock-tool.js';
@@ -765,6 +766,148 @@ describe('ToolExecutor', () => {
         ?.response as Record<string, unknown>;
       expect(response['output']).toBe('TruncatedContent...');
       expect(result.response.outputFile).toBe('/tmp/truncated_output.txt');
+    }
+  });
+
+  it('should include structured error fields for typed tool errors', async () => {
+    const mockTool = new MockTool({
+      name: 'readFile',
+      description: 'Read a file',
+    });
+    const invocation = mockTool.build({});
+
+    vi.mocked(coreToolHookTriggers.executeToolWithHooks).mockResolvedValue({
+      llmContent: '',
+      returnDisplay: 'File not found',
+      error: {
+        message: 'File not found: /src/utils/halper.ts',
+        type: ToolErrorType.FILE_NOT_FOUND,
+      },
+    } as ToolResult);
+
+    const scheduledCall: ScheduledToolCall = {
+      status: CoreToolCallStatus.Scheduled,
+      request: {
+        callId: 'call-structured-err',
+        name: 'readFile',
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'prompt-structured-err',
+      },
+      tool: mockTool,
+      invocation: invocation as unknown as AnyToolInvocation,
+      startTime: Date.now(),
+    };
+
+    const result = await executor.execute({
+      call: scheduledCall,
+      signal: new AbortController().signal,
+      onUpdateToolCall: vi.fn(),
+    });
+
+    expect(result.status).toBe(CoreToolCallStatus.Error);
+    if (result.status === CoreToolCallStatus.Error) {
+      const response = result.response.responseParts[0]?.functionResponse
+        ?.response as Record<string, unknown>;
+      expect(response['error']).toBe('File not found: /src/utils/halper.ts');
+      expect(response['error_type']).toBe('file_not_found');
+      expect(response['recoverable']).toBe(true);
+      expect(response['hint']).toBe(
+        'Verify the file path exists. Use glob or list_directory to find the correct path.',
+      );
+    }
+  });
+
+  it('should include structured error fields for fatal errors', async () => {
+    const mockTool = new MockTool({
+      name: 'writeFile',
+      description: 'Write a file',
+    });
+    const invocation = mockTool.build({});
+
+    vi.mocked(coreToolHookTriggers.executeToolWithHooks).mockResolvedValue({
+      llmContent: '',
+      returnDisplay: 'No space left',
+      error: {
+        message: 'No space left on device',
+        type: ToolErrorType.NO_SPACE_LEFT,
+      },
+    } as ToolResult);
+
+    const scheduledCall: ScheduledToolCall = {
+      status: CoreToolCallStatus.Scheduled,
+      request: {
+        callId: 'call-fatal-err',
+        name: 'writeFile',
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'prompt-fatal-err',
+      },
+      tool: mockTool,
+      invocation: invocation as unknown as AnyToolInvocation,
+      startTime: Date.now(),
+    };
+
+    const result = await executor.execute({
+      call: scheduledCall,
+      signal: new AbortController().signal,
+      onUpdateToolCall: vi.fn(),
+    });
+
+    expect(result.status).toBe(CoreToolCallStatus.Error);
+    if (result.status === CoreToolCallStatus.Error) {
+      const response = result.response.responseParts[0]?.functionResponse
+        ?.response as Record<string, unknown>;
+      expect(response['error']).toBe('No space left on device');
+      expect(response['error_type']).toBe('no_space_left');
+      expect(response['recoverable']).toBe(false);
+      expect(response['hint']).toBe(
+        'The disk is full. Cannot write files until space is freed.',
+      );
+    }
+  });
+
+  it('should include structured error fields for unhandled exceptions', async () => {
+    const mockTool = new MockTool({
+      name: 'failTool',
+      description: 'A failing tool',
+    });
+    const invocation = mockTool.build({});
+
+    vi.mocked(coreToolHookTriggers.executeToolWithHooks).mockRejectedValue(
+      new Error('Unexpected crash'),
+    );
+
+    const scheduledCall: ScheduledToolCall = {
+      status: CoreToolCallStatus.Scheduled,
+      request: {
+        callId: 'call-unhandled',
+        name: 'failTool',
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'prompt-unhandled',
+      },
+      tool: mockTool,
+      invocation: invocation as unknown as AnyToolInvocation,
+      startTime: Date.now(),
+    };
+
+    const result = await executor.execute({
+      call: scheduledCall,
+      signal: new AbortController().signal,
+      onUpdateToolCall: vi.fn(),
+    });
+
+    expect(result.status).toBe(CoreToolCallStatus.Error);
+    if (result.status === CoreToolCallStatus.Error) {
+      const response = result.response.responseParts[0]?.functionResponse
+        ?.response as Record<string, unknown>;
+      expect(response['error']).toBe('Unexpected crash');
+      expect(response['error_type']).toBe('unhandled_exception');
+      expect(response['recoverable']).toBe(true);
+      expect(response['hint']).toBe(
+        'Review the error message and adjust your approach.',
+      );
     }
   });
 });

--- a/packages/core/src/scheduler/tool-executor.ts
+++ b/packages/core/src/scheduler/tool-executor.ts
@@ -16,6 +16,7 @@ import {
   type AgentLoopContext,
   type ToolLiveOutput,
 } from '../index.js';
+import { isFatalToolError, getRecoveryHint } from '../tools/tool-error.js';
 import { isAbortError } from '../utils/errors.js';
 import { SHELL_TOOL_NAME } from '../tools/tool-names.js';
 import { DiscoveredMCPTool } from '../tools/mcp-tool.js';
@@ -436,6 +437,12 @@ export class ToolExecutor {
     returnDisplay?: string,
   ): ToolCallResponseInfo {
     const displayText = returnDisplay ?? error.message;
+    const response: Record<string, unknown> = { error: error.message };
+    if (errorType) {
+      response['error_type'] = errorType;
+      response['recoverable'] = !isFatalToolError(errorType);
+      response['hint'] = getRecoveryHint(errorType);
+    }
     return {
       callId: request.callId,
       error,
@@ -444,13 +451,13 @@ export class ToolExecutor {
           functionResponse: {
             id: request.callId,
             name: request.originalRequestName || request.name,
-            response: { error: error.message },
+            response,
           },
         },
       ],
       resultDisplay: displayText,
       errorType,
-      contentLength: displayText.length,
+      contentLength: JSON.stringify(response).length,
     };
   }
 }

--- a/packages/core/src/tools/tool-error.test.ts
+++ b/packages/core/src/tools/tool-error.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  ToolErrorType,
+  isFatalToolError,
+  getRecoveryHint,
+} from './tool-error.js';
+
+describe('isFatalToolError', () => {
+  it('should return true for NO_SPACE_LEFT', () => {
+    expect(isFatalToolError(ToolErrorType.NO_SPACE_LEFT)).toBe(true);
+  });
+
+  it('should return false for recoverable errors', () => {
+    expect(isFatalToolError(ToolErrorType.FILE_NOT_FOUND)).toBe(false);
+    expect(isFatalToolError(ToolErrorType.PERMISSION_DENIED)).toBe(false);
+    expect(isFatalToolError(ToolErrorType.INVALID_TOOL_PARAMS)).toBe(false);
+  });
+
+  it('should return false for undefined', () => {
+    expect(isFatalToolError(undefined)).toBe(false);
+  });
+});
+
+describe('getRecoveryHint', () => {
+  it('should return specific hint for FILE_NOT_FOUND', () => {
+    expect(getRecoveryHint(ToolErrorType.FILE_NOT_FOUND)).toBe(
+      'Verify the file path exists. Use glob or list_directory to find the correct path.',
+    );
+  });
+
+  it('should return specific hint for PERMISSION_DENIED', () => {
+    expect(getRecoveryHint(ToolErrorType.PERMISSION_DENIED)).toBe(
+      'The path is not accessible. Try a different path within the workspace.',
+    );
+  });
+
+  it('should return specific hint for PATH_NOT_IN_WORKSPACE', () => {
+    expect(getRecoveryHint(ToolErrorType.PATH_NOT_IN_WORKSPACE)).toBe(
+      'The path is outside the allowed workspace. Use a path within the project directory.',
+    );
+  });
+
+  it('should return specific hint for INVALID_TOOL_PARAMS', () => {
+    expect(getRecoveryHint(ToolErrorType.INVALID_TOOL_PARAMS)).toBe(
+      'Check the parameter types and required fields against the tool schema.',
+    );
+  });
+
+  it('should return specific hint for EDIT_NO_OCCURRENCE_FOUND', () => {
+    expect(getRecoveryHint(ToolErrorType.EDIT_NO_OCCURRENCE_FOUND)).toBe(
+      'The old_string was not found. Use read_file to verify the exact content, including whitespace and indentation.',
+    );
+  });
+
+  it('should return specific hint for EDIT_EXPECTED_OCCURRENCE_MISMATCH', () => {
+    expect(
+      getRecoveryHint(ToolErrorType.EDIT_EXPECTED_OCCURRENCE_MISMATCH),
+    ).toBe(
+      'Multiple occurrences found. Set allow_multiple to true, or use a more specific old_string.',
+    );
+  });
+
+  it('should return specific hint for SHELL_EXECUTE_ERROR', () => {
+    expect(getRecoveryHint(ToolErrorType.SHELL_EXECUTE_ERROR)).toBe(
+      'The command failed. Check the error output and adjust the command.',
+    );
+  });
+
+  it('should return specific hint for NO_SPACE_LEFT', () => {
+    expect(getRecoveryHint(ToolErrorType.NO_SPACE_LEFT)).toBe(
+      'The disk is full. Cannot write files until space is freed.',
+    );
+  });
+
+  it('should return specific hint for GREP_EXECUTION_ERROR', () => {
+    expect(getRecoveryHint(ToolErrorType.GREP_EXECUTION_ERROR)).toBe(
+      'The search failed. Check the pattern syntax and search path.',
+    );
+  });
+
+  it('should return specific hint for GLOB_EXECUTION_ERROR', () => {
+    expect(getRecoveryHint(ToolErrorType.GLOB_EXECUTION_ERROR)).toBe(
+      'The glob pattern failed. Check the pattern syntax.',
+    );
+  });
+
+  it('should return default hint for unmapped error types', () => {
+    const defaultHint = 'Review the error message and adjust your approach.';
+    expect(getRecoveryHint(ToolErrorType.UNKNOWN)).toBe(defaultHint);
+    expect(getRecoveryHint(ToolErrorType.UNHANDLED_EXCEPTION)).toBe(
+      defaultHint,
+    );
+    expect(getRecoveryHint(ToolErrorType.MCP_TOOL_ERROR)).toBe(defaultHint);
+  });
+});

--- a/packages/core/src/tools/tool-error.ts
+++ b/packages/core/src/tools/tool-error.ts
@@ -105,3 +105,42 @@ export function isFatalToolError(errorType?: string): boolean {
 
   return fatalErrors.has(errorType);
 }
+
+const RECOVERY_HINTS: Partial<Record<ToolErrorType, string>> = {
+  [ToolErrorType.FILE_NOT_FOUND]:
+    'Verify the file path exists. Use glob or list_directory to find the correct path.',
+  [ToolErrorType.PERMISSION_DENIED]:
+    'The path is not accessible. Try a different path within the workspace.',
+  [ToolErrorType.PATH_NOT_IN_WORKSPACE]:
+    'The path is outside the allowed workspace. Use a path within the project directory.',
+  [ToolErrorType.INVALID_TOOL_PARAMS]:
+    'Check the parameter types and required fields against the tool schema.',
+  [ToolErrorType.EDIT_NO_OCCURRENCE_FOUND]:
+    'The old_string was not found. Use read_file to verify the exact content, including whitespace and indentation.',
+  [ToolErrorType.EDIT_EXPECTED_OCCURRENCE_MISMATCH]:
+    'Multiple occurrences found. Set allow_multiple to true, or use a more specific old_string.',
+  [ToolErrorType.SHELL_EXECUTE_ERROR]:
+    'The command failed. Check the error output and adjust the command.',
+  [ToolErrorType.NO_SPACE_LEFT]:
+    'The disk is full. Cannot write files until space is freed.',
+  [ToolErrorType.GREP_EXECUTION_ERROR]:
+    'The search failed. Check the pattern syntax and search path.',
+  [ToolErrorType.GLOB_EXECUTION_ERROR]:
+    'The glob pattern failed. Check the pattern syntax.',
+};
+
+const DEFAULT_RECOVERY_HINT =
+  'Review the error message and adjust your approach.';
+
+/**
+ * Returns a recovery hint for a given tool error type.
+ *
+ * Recovery hints provide actionable guidance to help the LLM recover from
+ * tool errors by suggesting specific corrective actions.
+ *
+ * @param errorType - The tool error type to get a hint for
+ * @returns A short, actionable recovery hint string
+ */
+export function getRecoveryHint(errorType: ToolErrorType): string {
+  return RECOVERY_HINTS[errorType] ?? DEFAULT_RECOVERY_HINT;
+}


### PR DESCRIPTION
## Summary

- Add structured metadata (`error_type`, `recoverable`, `hint`) to tool error `functionResponse.response` so the model can distinguish recoverable errors from fatal ones and get actionable guidance
- Update all three `createErrorResponse` sites (ToolExecutor, CoreToolScheduler, Scheduler) for consistency
- Fix `contentLength` to use serialized response payload size instead of display text length

## Details

**Before:**
```json
{ "error": "Error: File not found: /src/utils/halper.ts" }
```

**After:**
```json
{
  "error": "Error: File not found: /src/utils/halper.ts",
  "error_type": "file_not_found",
  "recoverable": true,
  "hint": "Verify the file path exists. Use glob or list_directory to find the correct path."
}
```

**Changes:**
- `tool-error.ts` — `getRecoveryHint()` with lookup table mapping 10 `ToolErrorType` variants to hints
- `tool-executor.ts` — structured error fields in ToolExecutor's `createErrorResponse()`
- `coreToolScheduler.ts` — same enhancement to CoreToolScheduler's `createErrorResponse()`
- `scheduler.ts` — same enhancement to Scheduler's `createErrorResponse()`
- `tool-error.test.ts` — 14 tests for `isFatalToolError` and `getRecoveryHint`
- `tool-executor.test.ts` — 3 tests for structured error response format
- `coreToolScheduler.test.ts` — added structured field assertions to policy violation tests

Backward compatible — new fields only appear when `errorType` is defined. No interface changes, no new dependencies.

## How to Validate

\`\`\`bash
npx -w @google/gemini-cli-core vitest run src/tools/tool-error.test.ts src/scheduler/tool-executor.test.ts src/core/coreToolScheduler.test.ts
\`\`\`

All 53 tests pass. `tsc --noEmit` clean.

Fixes #23156