### PR TITLE
fix(plan): clarify that plan mode policies are combined with normal mode

### DIFF
--- a/packages/cli/src/ui/commands/policiesCommand.test.ts
+++ b/packages/cli/src/ui/commands/policiesCommand.test.ts
@@ -116,7 +116,9 @@ describe('policiesCommand', () => {
       expect(content).toContain(
         '### Yolo Mode Policies (combined with normal mode policies)',
       );
-      expect(content).toContain('### Plan Mode Policies');
+      expect(content).toContain(
+        '### Plan Mode Policies (combined with normal mode policies)',
+      );
       expect(content).toContain(
         '**DENY** tool: `dangerousTool` [Priority: 10]',
       );
@@ -162,7 +164,9 @@ describe('policiesCommand', () => {
       const content = (call[0] as { text: string }).text;
 
       // Plan-only rules appear under Plan Mode section
-      expect(content).toContain('### Plan Mode Policies');
+      expect(content).toContain(
+        '### Plan Mode Policies (combined with normal mode policies)',
+      );
       // glob ALLOW is plan-only, should appear in plan section
       expect(content).toContain('**ALLOW** tool: `glob` [Priority: 70]');
       // shell ALLOW has no modes (applies to all), appears in normal section

--- a/packages/cli/src/ui/commands/policiesCommand.ts
+++ b/packages/cli/src/ui/commands/policiesCommand.ts
@@ -100,7 +100,10 @@ const listPoliciesCommand: SlashCommand = {
       'Yolo Mode Policies (combined with normal mode policies)',
       uniqueYolo,
     );
-    content += formatSection('Plan Mode Policies', uniquePlan);
+    content += formatSection(
+      'Plan Mode Policies (combined with normal mode policies)',
+      uniquePlan,
+    );
 
     context.ui.addItem(
       {


### PR DESCRIPTION
## Summary

Clarifies in the `policies` command output that Plan Mode policies are combined with Normal Mode policies.

## Details

Updated the `listPoliciesCommand` in `packages/cli/src/ui/commands/policiesCommand.ts` to use the more descriptive section header: "Plan Mode Policies (combined with normal mode policies)". Updated corresponding unit tests to reflect this change.

## Related Issues

Fixes #22434

## How to Validate

1. Run the `/policies` command in the CLI.
2. Observe the output section for Plan Mode policies.
3. Verify it contains the clarified parenthetical note.
4. Run unit tests: `npm test -w @google/gemini-cli -- src/ui/commands/policiesCommand.test.ts`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run


