### PR TITLE
fix(core): skip extension loading in early loadCliConfig call to prevent duplicate warnings

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -420,6 +420,8 @@ export interface LoadCliConfigOptions {
   projectHooks?: { [K in HookEventName]?: HookDefinition[] } & {
     disabled?: string[];
   };
+  /** Skip extension loading (used for early config loads that only need auth). */
+  skipExtensions?: boolean;
 }
 
 export async function loadCliConfig(
@@ -428,7 +430,7 @@ export async function loadCliConfig(
   argv: CliArgs,
   options: LoadCliConfigOptions = {},
 ): Promise<Config> {
-  const { cwd = process.cwd(), projectHooks } = options;
+  const { cwd = process.cwd(), projectHooks, skipExtensions } = options;
   const debugMode = isDebugMode(argv);
 
   if (argv.sandbox) {
@@ -510,7 +512,9 @@ export async function loadCliConfig(
     eventEmitter: coreEvents as EventEmitter<ExtensionEvents>,
     clientVersion: await getVersion(),
   });
-  await extensionManager.loadExtensions();
+  if (!skipExtensions) {
+    await extensionManager.loadExtensions();
+  }
 
   const extensionPlanSettings = extensionManager
     .getExtensions()

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -302,6 +302,7 @@ export async function main() {
 
   const partialConfig = await loadCliConfig(settings.merged, sessionId, argv, {
     projectHooks: settings.workspace.settings.hooks,
+    skipExtensions: true,
   });
   adminControlsListner.setConfig(partialConfig);
 


### PR DESCRIPTION
## Summary

Fix duplicate extension warnings displayed during CLI startup.

## Details

The CLI startup flow in `gemini.tsx` calls `loadCliConfig()` twice:

1. **Line 303** — early call for auth refresh and sandbox setup
2. **Line 427** — full initialization for the interactive session

Each call creates a new `ExtensionManager` and invokes `loadExtensions()`, which emits feedback warnings via `coreEvents` (e.g. missing configuration settings, `conductor` → `sdd` migration notices). Since the event emitter is shared, each warning is displayed twice in the terminal UI.

**Fix:** Added a `skipExtensions` option to `LoadCliConfigOptions`. The first (auth-only) call passes `skipExtensions: true`, so extensions are only loaded once during the second call. This aligns with the existing TODO at line 371: "refactor loadCliConfig so there is a minimal version that only initializes enough config to enable refreshAuth."

## How to Validate

1. Configure an extension with a missing required setting (or install the legacy `conductor` extension with `experimental.sdd` enabled)
2. Start the CLI
3. **Before:** Each warning appears twice
4. **After:** Each warning appears exactly once

## Checklist

- [x] Code compiles without errors
- [x] All 199 config tests pass
- [x] Change is minimal (2 files, 7 lines added)

Fixes #23172