### PR TITLE
docs: fix incorrect enforcedAuthType field name in enterprise docs

### DIFF
--- a/docs/changelogs/index.md
+++ b/docs/changelogs/index.md
@@ -802,7 +802,8 @@ on GitHub.
   [@gsquared94](https://github.com/gsquared94))
 - **Enforced authentication:** System administrators can now mandate a specific
   authentication method via
-  `"enforcedAuthType": "oauth-personal|gemini-api-key|…"`in `settings.json`.
+  `"security": { "auth": { "enforcedType": "oauth-personal|gemini-api-key|…" } }`
+  in `settings.json`.
   ([pr](https://github.com/google-gemini/gemini-cli/pull/6564) by
   [@chrstnb](https://github.com/chrstnb))
 - **A2A development-tool extension:** An RFC for an Agent2Agent

--- a/docs/cli/enterprise.md
+++ b/docs/cli/enterprise.md
@@ -505,16 +505,20 @@ other events. For more information, see the
 
 ## Authentication
 
-You can enforce a specific authentication method for all users by setting the
-`enforcedAuthType` in the system-level `settings.json` file. This prevents users
-from choosing a different authentication method. See the
+You can enforce a specific authentication method for all users by setting
+`security.auth.enforcedType` in the system-level `settings.json` file. This
+prevents users from choosing a different authentication method. See the
 [Authentication docs](../get-started/authentication.md) for more details.
 
 **Example:** Enforce the use of Google login for all users.
 
 ```json
 {
-  "enforcedAuthType": "oauth-personal"
+  "security": {
+    "auth": {
+      "enforcedType": "oauth-personal"
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary

Fix the documented setting name for enforced authentication from the non-existent `enforcedAuthType` to the correct `security.auth.enforcedType`.

## Details

The enterprise authentication docs reference a top-level `enforcedAuthType` field, but the actual codebase uses `security.auth.enforcedType` (see `settingsSchema.ts:1754`, `useAuth.ts:25`, `validateNonInterActiveAuth.ts:29`).

### Files changed

| File | Change |
|------|--------|
| `docs/cli/enterprise.md` | Fix field name and JSON example to use nested `security.auth.enforcedType` |
| `docs/changelogs/index.md` | Fix the same field reference in the changelog entry |

## How to Validate

Compare with the schema definition:
```typescript
// packages/cli/src/config/settingsSchema.ts:1754
enforcedType: {
  type: "string",
  ...
}
// nested under security.auth
```

## Checklist

- [x] This PR addresses a specific issue: #22783
- [x] Documentation-only change — no code changes