### PR TITLE
fix(core): accurately reflect subagent tool failure in UI

### DIFF
--- a/packages/cli/src/ui/components/messages/SubagentProgressDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/SubagentProgressDisplay.test.tsx
@@ -182,4 +182,25 @@ describe('<SubagentProgressDisplay />', () => {
     );
     expect(lastFrame()).toMatchSnapshot();
   });
+
+  it('renders error tool status correctly', async () => {
+    const progress: SubagentProgress = {
+      isSubagentProgress: true,
+      agentName: 'TestAgent',
+      recentActivity: [
+        {
+          id: '7',
+          type: 'tool_call',
+          content: 'run_shell_command',
+          args: '{"command": "echo hello"}',
+          status: 'error',
+        },
+      ],
+    };
+
+    const { lastFrame } = await render(
+      <SubagentProgressDisplay progress={progress} terminalWidth={80} />,
+    );
+    expect(lastFrame()).toMatchSnapshot();
+  });
 });

--- a/packages/cli/src/ui/components/messages/__snapshots__/SubagentProgressDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/SubagentProgressDisplay.test.tsx.snap
@@ -40,6 +40,13 @@ exports[`<SubagentProgressDisplay /> > renders correctly with file_path 1`] = `
 "
 `;
 
+exports[`<SubagentProgressDisplay /> > renders error tool status correctly 1`] = `
+"Running subagent TestAgent...
+
+x  run_shell_command echo hello
+"
+`;
+
 exports[`<SubagentProgressDisplay /> > renders thought bubbles correctly 1`] = `
 "Running subagent TestAgent...
 

--- a/packages/core/src/agents/browser/browserAgentInvocation.ts
+++ b/packages/core/src/agents/browser/browserAgentInvocation.ts
@@ -30,6 +30,7 @@ import {
   type SubagentActivityEvent,
   type SubagentProgress,
   type SubagentActivityItem,
+  isToolActivityError,
 } from '../types.js';
 import type { MessageBus } from '../../confirmation-bus/message-bus.js';
 import {
@@ -211,12 +212,7 @@ export class BrowserAgentInvocation extends BaseToolInvocation<
               ? String(activity.data['id'])
               : undefined;
             const data = activity.data['data'];
-            const isError =
-              data &&
-              typeof data === 'object' &&
-              'exitCode' in data &&
-              data.exitCode !== undefined &&
-              data.exitCode !== 0;
+            const isError = isToolActivityError(data);
 
             for (let i = recentActivity.length - 1; i >= 0; i--) {
               if (

--- a/packages/core/src/agents/browser/browserAgentInvocation.ts
+++ b/packages/core/src/agents/browser/browserAgentInvocation.ts
@@ -210,8 +210,14 @@ export class BrowserAgentInvocation extends BaseToolInvocation<
             const callId = activity.data['id']
               ? String(activity.data['id'])
               : undefined;
-            // Find the tool call by ID
-            // Find the tool call by ID
+            const data = activity.data['data'];
+            const isError =
+              data &&
+              typeof data === 'object' &&
+              'exitCode' in data &&
+              data.exitCode !== undefined &&
+              data.exitCode !== 0;
+
             for (let i = recentActivity.length - 1; i >= 0; i--) {
               if (
                 recentActivity[i].type === 'tool_call' &&
@@ -219,7 +225,7 @@ export class BrowserAgentInvocation extends BaseToolInvocation<
                 recentActivity[i].id === callId &&
                 recentActivity[i].status === 'running'
               ) {
-                recentActivity[i].status = 'completed';
+                recentActivity[i].status = isError ? 'error' : 'completed';
                 updated = true;
                 break;
               }

--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -1240,6 +1240,7 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
             name: toolName,
             id: call.request.callId,
             output: call.response.resultDisplay,
+            data: call.response.data,
           });
         } else if (call.status === 'error') {
           this.emitActivity('ERROR', {

--- a/packages/core/src/agents/local-invocation.test.ts
+++ b/packages/core/src/agents/local-invocation.test.ts
@@ -338,6 +338,42 @@ describe('LocalSubagentInvocation', () => {
       );
     });
 
+    it('should mark tool call as error when TOOL_CALL_END contains isError: true', async () => {
+      mockExecutorInstance.run.mockImplementation(async () => {
+        const onActivity = MockLocalAgentExecutor.create.mock.calls[0][2];
+
+        if (onActivity) {
+          onActivity({
+            isSubagentActivityEvent: true,
+            agentName: 'MockAgent',
+            type: 'TOOL_CALL_START',
+            data: { name: 'ls', args: {}, callId: 'call1' },
+          } as SubagentActivityEvent);
+          onActivity({
+            isSubagentActivityEvent: true,
+            agentName: 'MockAgent',
+            type: 'TOOL_CALL_END',
+            data: { name: 'ls', id: 'call1', data: { isError: true } },
+          } as SubagentActivityEvent);
+        }
+        return { result: 'Done', terminate_reason: AgentTerminateMode.GOAL };
+      });
+
+      await invocation.execute(signal, updateOutput);
+
+      expect(updateOutput).toHaveBeenCalled();
+      const lastCall = updateOutput.mock.calls[
+        updateOutput.mock.calls.length - 1
+      ][0] as SubagentProgress;
+      expect(lastCall.recentActivity).toContainEqual(
+        expect.objectContaining({
+          type: 'tool_call',
+          content: 'ls',
+          status: 'error',
+        }),
+      );
+    });
+
     it('should reflect tool rejections in the activity stream as cancelled but not abort the agent', async () => {
       mockExecutorInstance.run.mockImplementation(async () => {
         const onActivity = MockLocalAgentExecutor.create.mock.calls[0][2];

--- a/packages/core/src/agents/local-invocation.ts
+++ b/packages/core/src/agents/local-invocation.ts
@@ -21,6 +21,7 @@ import {
   SubagentActivityErrorType,
   SUBAGENT_REJECTED_ERROR_PREFIX,
   SUBAGENT_CANCELLED_ERROR_MESSAGE,
+  isToolActivityError,
 } from './types.js';
 import { randomUUID } from 'node:crypto';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
@@ -167,12 +168,7 @@ export class LocalSubagentInvocation extends BaseToolInvocation<
           case 'TOOL_CALL_END': {
             const name = String(activity.data['name']);
             const data = activity.data['data'];
-            const isError =
-              data &&
-              typeof data === 'object' &&
-              'exitCode' in data &&
-              data.exitCode !== undefined &&
-              data.exitCode !== 0;
+            const isError = isToolActivityError(data);
 
             for (let i = recentActivity.length - 1; i >= 0; i--) {
               if (

--- a/packages/core/src/agents/local-invocation.ts
+++ b/packages/core/src/agents/local-invocation.ts
@@ -166,14 +166,21 @@ export class LocalSubagentInvocation extends BaseToolInvocation<
           }
           case 'TOOL_CALL_END': {
             const name = String(activity.data['name']);
-            // Find the last running tool call with this name
+            const data = activity.data['data'];
+            const isError =
+              data &&
+              typeof data === 'object' &&
+              'exitCode' in data &&
+              data.exitCode !== undefined &&
+              data.exitCode !== 0;
+
             for (let i = recentActivity.length - 1; i >= 0; i--) {
               if (
                 recentActivity[i].type === 'tool_call' &&
                 recentActivity[i].content === name &&
                 recentActivity[i].status === 'running'
               ) {
-                recentActivity[i].status = 'completed';
+                recentActivity[i].status = isError ? 'error' : 'completed';
                 updated = true;
                 break;
               }

--- a/packages/core/src/agents/types.ts
+++ b/packages/core/src/agents/types.ts
@@ -113,6 +113,18 @@ export function isSubagentProgress(obj: unknown): obj is SubagentProgress {
 }
 
 /**
+ * Checks if the tool call data indicates an error.
+ */
+export function isToolActivityError(data: unknown): boolean {
+  return (
+    data !== null &&
+    typeof data === 'object' &&
+    'isError' in data &&
+    data.isError === true
+  );
+}
+
+/**
  * The base definition for an agent.
  * @template TOutput The specific Zod schema for the agent's final output object.
  */

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -381,6 +381,9 @@ export class ShellToolInvocation extends BaseToolInvocation<
 
         if (result.exitCode !== null && result.exitCode !== 0) {
           llmContentParts.push(`Exit Code: ${result.exitCode}`);
+          data = {
+            exitCode: result.exitCode,
+          };
         }
 
         if (result.signal) {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -383,6 +383,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
           llmContentParts.push(`Exit Code: ${result.exitCode}`);
           data = {
             exitCode: result.exitCode,
+            isError: true,
           };
         }
 


### PR DESCRIPTION
## Summary

Accurately reflect subagent tool failure in UI. Fixes issue where failed shell commands (non-zero exit code) were displayed as success (green check) due to missing exit code propagation.

## Details

-   **`packages/core/src/tools/shell.ts`**: Updated to include `exitCode` in the `data` payload of `ToolResult` when the command exits with a non-zero code.
-   **`packages/core/src/agents/local-executor.ts`**: Updated `TOOL_CALL_END` activity emission to pass `data: call.response.data`.
-   **`packages/core/src/agents/local-invocation.ts` & `browserAgentInvocation.ts`**: Updated `TOOL_CALL_END` handlers to inspect `data.exitCode` and set activity status to `'error'` if non-zero.

Example UI:

**Before:**

<img width="812" height="432" alt="image" src="https://github.com/user-attachments/assets/cfc8166c-8ba8-4c2b-8243-fbf233709855" />


**After:**

<img width="758" height="378" alt="Screenshot 2026-03-19 at 5 07 06 PM" src="https://github.com/user-attachments/assets/908baa09-efde-4d1d-86e8-a7377a2ff2eb" />

## Related Issues

Fixes tool failure UI display inconsistency.

## How to Validate

Run a subagent with a failing shell command (e.g., non-existent script) and verify the UI displays failure symbol (`x`) instead of success symbol (`✓`).

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) - N/A
- [x] Added/updated tests (if needed) - Verified with standard tests
- [x] Noted breaking changes (if any) - None
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
