### PR TITLE
fix: prevent fatal crash on loop detection abort during streaming

### DIFF
--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -764,7 +764,18 @@ export class GeminiClient {
     }
 
     if (loopDetectedAbort) {
-      controller.abort();
+      // Defer abort to next microtask so the stream's async iterator can
+      // settle and re-attach its error listeners before the AbortSignal fires.
+      // Without this, node-fetch emits a synchronous 'error' event during a
+      // listener gap, causing an uncaught exception (see #20106).
+      await Promise.resolve();
+      try {
+        controller.abort();
+      } catch (e) {
+        if (!isAbortError(e)) {
+          throw e;
+        }
+      }
       return turn;
     }
 
@@ -1239,7 +1250,18 @@ export class GeminiClient {
     displayContent?: PartListUnion,
     controllerToAbort?: AbortController,
   ): AsyncGenerator<ServerGeminiStreamEvent, Turn> {
-    controllerToAbort?.abort();
+    // Wrap abort in try-catch to gracefully handle AbortError that may
+    // be thrown when the stream's async iterator has detached its error
+    // listeners during yield suspension (see #20106).
+    if (controllerToAbort) {
+      try {
+        controllerToAbort.abort();
+      } catch (e) {
+        if (!isAbortError(e)) {
+          throw e;
+        }
+      }
+    }
 
     // Clear the detection flag so the recursive turn can proceed, but the count remains 1.
     this.loopDetector.clearDetection();

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -21,6 +21,7 @@ import { getResponseText } from '../utils/partUtils.js';
 import { reportError } from '../utils/errorReporting.js';
 import {
   getErrorMessage,
+  isAbortError,
   UnauthorizedError,
   toFriendlyError,
 } from '../utils/errors.js';
@@ -359,9 +360,9 @@ export class Turn {
         }
       }
     } catch (e) {
-      if (signal.aborted) {
+      if (signal.aborted || isAbortError(e)) {
         yield { type: GeminiEventType.UserCancelled };
-        // Regular cancellation error, fail gracefully.
+        // Regular cancellation or loop-detection abort error, fail gracefully.
         return;
       }
 


### PR DESCRIPTION
## Summary

Fixes #20106 — the CLI hard-crashes with an unhandled `AbortError` when `LoopDetectionService` detects repetitive LLM output during streaming.

### Root Cause

When loop detection triggers, `controller.abort()` is called synchronously. The `@google/genai` SDK wraps `node-fetch` streams in `ReadableStreamToAsyncIterable`, which temporarily detaches its `'error'` listeners during `yield` suspension. The synchronous abort causes `node-fetch` to emit an `'error'` event with no active listeners, triggering a fatal `process.nextTick` error that bypasses all `try...catch` blocks.

### Changes

- **`client.ts` (processTurn)**: Defer `controller.abort()` to the next microtask via `await Promise.resolve()`, giving the async iterator time to settle. Wrap in try-catch as defense against residual `AbortError`.
- **`client.ts` (_recoverFromLoop)**: Apply same defensive try-catch pattern to the `controllerToAbort.abort()` call, which has the same race condition.
- **`turn.ts` (run)**: Add `isAbortError(e)` check in the catch block alongside `signal.aborted`. The `isAbortError()` helper already existed in `utils/errors.ts` but was not used here — this ensures any `AbortError` from loop detection is treated as graceful cancellation.

### Test Plan

- [x] All 104 existing tests pass (`client.test.ts`: 82 passed, `turn.test.ts`: 22 passed)
- [x] Existing test "should cleanly abort and return Turn on LoopDetected without unhandled promise rejections" continues to pass
- [ ] Manual verification: `npm start -- -p "Repeat the following sequence exactly 50 times: la li lu le lo"` should no longer crash