### PR TITLE
fix: preserve externally-added settings.json keys on save

### DIFF
--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -1627,7 +1627,7 @@ describe('Settings Loading and Merging', () => {
         saveSettings(settings1.user);
 
         const settings2 = loadSettings(MOCK_WORKSPACE_DIR);
-        expect(mockedRead).toHaveBeenCalledTimes(10); // Should have re-read from disk
+        expect(mockedRead).toHaveBeenCalledTimes(11); // +1 for preserving external settings on save
         expect(settings1).not.toBe(settings2);
       });
 
@@ -1651,8 +1651,8 @@ describe('Settings Loading and Merging', () => {
         const settings2W1 = loadSettings(workspace1);
         const settings2W2 = loadSettings(workspace2);
 
-        // Both workspace caches should have been cleared and re-read from disk (+10 reads)
-        expect(mockedRead).toHaveBeenCalledTimes(20);
+        // Both workspace caches should have been cleared and re-read from disk (+10 reads + 1 for preserving external settings)
+        expect(mockedRead).toHaveBeenCalledTimes(21);
         expect(settings1W1).not.toBe(settings2W1);
         expect(settings1W2).not.toBe(settings2W2);
       });
@@ -2600,6 +2600,81 @@ describe('Settings Loading and Merging', () => {
         'error',
         'Failed to save settings: Write failed',
         error,
+      );
+    });
+
+    it('should preserve externally-added top-level keys from disk', () => {
+      const mockUpdateSettings = vi.mocked(updateSettingsFilePreservingFormat);
+      const settingsFile = createMockSettings({ ui: { theme: 'light' } }).user;
+      settingsFile.path = path.resolve('/mock/settings.json');
+
+      // File exists on disk with an extra top-level key added externally
+      (vi.mocked(fs.existsSync) as Mock).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockReturnValue(
+        JSON.stringify({
+          ui: { theme: 'dark' },
+          hooks: { afterTurn: [{ command: 'echo done' }] },
+        }),
+      );
+
+      saveSettings(settingsFile);
+
+      // The saved output should include the in-memory ui.theme (takes
+      // precedence) AND the externally-added hooks key
+      expect(mockUpdateSettings).toHaveBeenCalledWith(
+        path.resolve('/mock/settings.json'),
+        expect.objectContaining({
+          ui: { theme: 'light' },
+          hooks: { afterTurn: [{ command: 'echo done' }] },
+        }),
+      );
+    });
+
+    it('should not overwrite tracked keys with disk values', () => {
+      const mockUpdateSettings = vi.mocked(updateSettingsFilePreservingFormat);
+      const settingsFile = createMockSettings({
+        ui: { theme: 'light' },
+        sandbox: true,
+      }).user;
+      settingsFile.path = path.resolve('/mock/settings.json');
+
+      // Disk has different values for tracked keys
+      (vi.mocked(fs.existsSync) as Mock).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockReturnValue(
+        JSON.stringify({
+          ui: { theme: 'dark' },
+          sandbox: false,
+        }),
+      );
+
+      saveSettings(settingsFile);
+
+      // In-memory values should take precedence over disk values
+      expect(mockUpdateSettings).toHaveBeenCalledWith(
+        path.resolve('/mock/settings.json'),
+        expect.objectContaining({
+          ui: { theme: 'light' },
+          sandbox: true,
+        }),
+      );
+    });
+
+    it('should handle unparseable disk file gracefully', () => {
+      const mockUpdateSettings = vi.mocked(updateSettingsFilePreservingFormat);
+      const settingsFile = createMockSettings({ ui: { theme: 'light' } }).user;
+      settingsFile.path = path.resolve('/mock/settings.json');
+
+      (vi.mocked(fs.existsSync) as Mock).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockReturnValue('not valid json {{{');
+
+      saveSettings(settingsFile);
+
+      // Should still save without crashing
+      expect(mockUpdateSettings).toHaveBeenCalledWith(
+        path.resolve('/mock/settings.json'),
+        expect.objectContaining({
+          ui: { theme: 'light' },
+        }),
       );
     });
   });

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -1066,13 +1066,36 @@ export function saveSettings(settingsFile: SettingsFile): void {
       fs.mkdirSync(dirPath, { recursive: true });
     }
 
-    const settingsToSave = settingsFile.originalSettings;
+    // Preserve externally-added settings: re-read the file from disk and
+    // adopt any top-level keys that originalSettings does not already track.
+    // This prevents sync-by-omission in the format-preserving writer from
+    // deleting keys that were added while the CLI was running (e.g. hooks).
+    const settingsToSave: Record<string, unknown> = {
+      ...settingsFile.originalSettings,
+    };
+    if (fs.existsSync(settingsFile.path)) {
+      try {
+        const diskContent = fs.readFileSync(settingsFile.path, 'utf-8');
+        const parsed: unknown = JSON.parse(stripJsonComments(diskContent));
+        if (
+          typeof parsed === 'object' &&
+          parsed !== null &&
+          !Array.isArray(parsed)
+        ) {
+          for (const [key, value] of Object.entries(parsed)) {
+            if (!Object.prototype.hasOwnProperty.call(settingsToSave, key)) {
+              settingsToSave[key] = value;
+            }
+          }
+        }
+      } catch {
+        // If the file can't be read or parsed, proceed with in-memory
+        // settings only. This matches existing error-tolerance behavior.
+      }
+    }
 
     // Use the format-preserving update function
-    updateSettingsFilePreservingFormat(
-      settingsFile.path,
-      settingsToSave as Record<string, unknown>,
-    );
+    updateSettingsFilePreservingFormat(settingsFile.path, settingsToSave);
   } catch (error) {
     const detailedErrorMessage = getFsErrorMessage(error);
     coreEvents.emitFeedback(


### PR DESCRIPTION
## Summary

When the CLI saves settings (e.g. on theme change), the format-preserving writer uses sync-by-omission semantics that delete any top-level keys not present in the in-memory `originalSettings`. If a user manually added keys to `settings.json` while the CLI was running (like `hooks`), those additions get silently wiped on the next save.

## Details

Before writing, `saveSettings` now re-reads the current file from disk and adopts any top-level keys that `originalSettings` does not already track. In-memory keys always take precedence so intentional CLI changes are not lost. If the disk file is missing or unparseable the save proceeds with in-memory settings only, matching existing error-tolerance behavior.

Uses a shallow copy (`{ ...originalSettings }`) to avoid mutating the in-memory state.

## Related Issues

Closes #23138

## How to Validate

1. Start the CLI, note your `settings.json` path via `/settings`
2. While the CLI is running, manually add a top-level key to `settings.json` (e.g. `"hooks": { "afterTurn": [{ "command": "echo done" }] }`)
3. Change the theme via `/settings` to trigger a save
4. Check `settings.json` -- the `hooks` key should still be present

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker