### PR TITLE
fix: filter redirect entries from policy sub-command checks

### DIFF
--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -1218,6 +1218,32 @@ describe('PolicyEngine', () => {
       ).toBe(PolicyDecision.ALLOW);
     });
 
+    it('should allow redirected commands with commandPrefix-style argsPattern when allowRedirection is true', async () => {
+      // Reproduces #23096: commandPrefix = ["echo"] with allow_redirection = true
+      // should not prompt for action when the command contains redirection.
+      const argsPatterns = buildArgsPatterns(undefined, ['echo']);
+      const rules: PolicyRule[] = argsPatterns.map((pattern) => ({
+        toolName: 'run_shell_command',
+        argsPattern: pattern ? new RegExp(pattern) : undefined,
+        decision: PolicyDecision.ALLOW,
+        allowRedirection: true,
+      }));
+
+      engine = new PolicyEngine({ rules });
+
+      expect(
+        (
+          await engine.check(
+            {
+              name: 'run_shell_command',
+              args: { command: 'echo "hello" > test.txt' },
+            },
+            undefined,
+          )
+        ).decision,
+      ).toBe(PolicyDecision.ALLOW);
+    });
+
     it('should NOT downgrade ALLOW to ASK_USER for quoted redirection chars', async () => {
       const rules: PolicyRule[] = [
         {

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -24,6 +24,8 @@ import {
   initializeShellParsers,
   splitCommands,
   hasRedirection,
+  parseCommandDetails,
+  REDIRECTION_NAMES,
 } from '../utils/shell-utils.js';
 import { getToolAliases } from '../tools/tool-names.js';
 import {
@@ -242,7 +244,21 @@ export class PolicyEngine {
     }
 
     await initializeShellParsers();
-    const subCommands = splitCommands(command);
+
+    // Filter out redirection entries (e.g. "> file.txt") from the parsed
+    // sub-commands.  Redirection is already handled separately by
+    // shouldDowngradeForRedirection on the full command string.  Without
+    // this filter, redirect entries are recursively checked via this.check()
+    // where they fail to match the user's commandPrefix rule and fall
+    // through to a catch-all ASK_USER, defeating allow_redirection.
+    const parsed = parseCommandDetails(command);
+    const subCommands =
+      parsed && !parsed.hasError
+        ? parsed.details
+            .filter((detail) => !REDIRECTION_NAMES.has(detail.name))
+            .map((detail) => detail.text)
+            .filter(Boolean)
+        : splitCommands(command);
 
     if (subCommands.length === 0) {
       // If the matched rule says DENY, we should respect it immediately even if parsing fails.

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -251,6 +251,11 @@ export class PolicyEngine {
     // this filter, redirect entries are recursively checked via this.check()
     // where they fail to match the user's commandPrefix rule and fall
     // through to a catch-all ASK_USER, defeating allow_redirection.
+    //
+    // The filter uses tree-sitter AST node types (file_redirect,
+    // heredoc_redirect, herestring_redirect) via REDIRECTION_NAMES, not
+    // string matching on command text, so it cannot be bypassed by naming
+    // an executable after a redirection marker.
     const parsed = parseCommandDetails(command);
     const subCommands =
       parsed && !parsed.hasError

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -197,7 +197,7 @@ foreach ($commandAst in $commandAsts) {
   'utf16le',
 ).toString('base64');
 
-const REDIRECTION_NAMES = new Set([
+export const REDIRECTION_NAMES = new Set([
   'redirection (<)',
   'redirection (>)',
   'heredoc (<<)',


### PR DESCRIPTION
## Summary

`allow_redirection = true` in user policy rules was not being respected. Commands like `echo "hello" > file.txt` still triggered the "Action Required" dialog even when the matching rule allowed redirection.

## Details

The tree-sitter parser returns redirect operators (e.g. `> file.txt`) as separate command entries from `splitCommands()`. The policy engine recursively checks each sub-command via `this.check()`, but redirect entries do not match the user's `commandPrefix` rule (which only matches the actual command like `echo`), so they fall through to a catch-all ASK_USER, defeating `allow_redirection`.

The fix filters out redirection entries before the recursive sub-command check loop in the policy engine. Redirection is already handled separately by `shouldDowngradeForRedirection` on the full command string, so these entries do not need individual policy evaluation.

The fix is in the policy engine rather than `splitCommands()`, keeping the utility function's behavior unchanged for other consumers.

## Related Issues

Fixes #23096

## How to Validate

1. Create a policy file at `~/.gemini/policies/test.toml`:
   ```toml
   [[rule]]
   toolName = "run_shell_command"
   commandPrefix = ["echo"]
   allow_redirection = true
   decision = "allow"
   priority = 100
   ```
2. Prompt the CLI with: `Run echo "hello" > test.txt`
3. The command should execute without an "Action Required" prompt

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker