### PR TITLE
fix: guard against empty parts in message inspectors

### DIFF
--- a/packages/core/src/utils/messageInspectors.test.ts
+++ b/packages/core/src/utils/messageInspectors.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Content } from '@google/genai';
+import { isFunctionCall, isFunctionResponse } from './messageInspectors.js';
+
+describe('isFunctionCall', () => {
+  it('should return true for a model message with function call parts', () => {
+    const content: Content = {
+      role: 'model',
+      parts: [{ functionCall: { name: 'tool', args: {} } }],
+    };
+    expect(isFunctionCall(content)).toBe(true);
+  });
+
+  it('should return true for multiple function call parts', () => {
+    const content: Content = {
+      role: 'model',
+      parts: [
+        { functionCall: { name: 'tool_a', args: {} } },
+        { functionCall: { name: 'tool_b', args: { x: 1 } } },
+      ],
+    };
+    expect(isFunctionCall(content)).toBe(true);
+  });
+
+  it('should return false for an empty parts array', () => {
+    const content: Content = {
+      role: 'model',
+      parts: [],
+    };
+    expect(isFunctionCall(content)).toBe(false);
+  });
+
+  it('should return false when parts is undefined', () => {
+    const content: Content = {
+      role: 'model',
+    };
+    expect(isFunctionCall(content)).toBe(false);
+  });
+
+  it('should return false for a user message with function call parts', () => {
+    const content: Content = {
+      role: 'user',
+      parts: [{ functionCall: { name: 'tool', args: {} } }],
+    };
+    expect(isFunctionCall(content)).toBe(false);
+  });
+
+  it('should return false when parts contain text instead of function calls', () => {
+    const content: Content = {
+      role: 'model',
+      parts: [{ text: 'hello' }],
+    };
+    expect(isFunctionCall(content)).toBe(false);
+  });
+
+  it('should return false when parts mix function calls and text', () => {
+    const content: Content = {
+      role: 'model',
+      parts: [{ functionCall: { name: 'tool', args: {} } }, { text: 'hello' }],
+    };
+    expect(isFunctionCall(content)).toBe(false);
+  });
+});
+
+describe('isFunctionResponse', () => {
+  it('should return true for a user message with function response parts', () => {
+    const content: Content = {
+      role: 'user',
+      parts: [{ functionResponse: { name: 'tool', response: {} } }],
+    };
+    expect(isFunctionResponse(content)).toBe(true);
+  });
+
+  it('should return true for multiple function response parts', () => {
+    const content: Content = {
+      role: 'user',
+      parts: [
+        { functionResponse: { name: 'tool_a', response: {} } },
+        { functionResponse: { name: 'tool_b', response: { result: 'ok' } } },
+      ],
+    };
+    expect(isFunctionResponse(content)).toBe(true);
+  });
+
+  it('should return false for an empty parts array', () => {
+    const content: Content = {
+      role: 'user',
+      parts: [],
+    };
+    expect(isFunctionResponse(content)).toBe(false);
+  });
+
+  it('should return false when parts is undefined', () => {
+    const content: Content = {
+      role: 'user',
+    };
+    expect(isFunctionResponse(content)).toBe(false);
+  });
+
+  it('should return false for a model message with function response parts', () => {
+    const content: Content = {
+      role: 'model',
+      parts: [{ functionResponse: { name: 'tool', response: {} } }],
+    };
+    expect(isFunctionResponse(content)).toBe(false);
+  });
+
+  it('should return false when parts contain text instead of function responses', () => {
+    const content: Content = {
+      role: 'user',
+      parts: [{ text: 'hello' }],
+    };
+    expect(isFunctionResponse(content)).toBe(false);
+  });
+
+  it('should return false when parts mix function responses and text', () => {
+    const content: Content = {
+      role: 'user',
+      parts: [
+        { functionResponse: { name: 'tool', response: {} } },
+        { text: 'hello' },
+      ],
+    };
+    expect(isFunctionResponse(content)).toBe(false);
+  });
+});

--- a/packages/core/src/utils/messageInspectors.ts
+++ b/packages/core/src/utils/messageInspectors.ts
@@ -10,6 +10,7 @@ export function isFunctionResponse(content: Content): boolean {
   return (
     content.role === 'user' &&
     !!content.parts &&
+    content.parts.length > 0 &&
     content.parts.every((part) => !!part.functionResponse)
   );
 }
@@ -18,6 +19,7 @@ export function isFunctionCall(content: Content): boolean {
   return (
     content.role === 'model' &&
     !!content.parts &&
+    content.parts.length > 0 &&
     content.parts.every((part) => !!part.functionCall)
   );
 }


### PR DESCRIPTION
## Summary

`isFunctionCall()` and `isFunctionResponse()` return `true` for messages with empty `parts` arrays because `Array.every([])` is vacuously `true` in JavaScript. This causes consumers to incorrectly treat empty-parts messages as valid function calls or responses.

## Details

Added `content.parts.length > 0` guard to both functions. Also added test coverage for `messageInspectors.ts` which previously had no tests (14 tests covering valid inputs, empty parts, undefined parts, wrong roles, text parts, and mixed parts).

## Related Issues

Fixes #23195

## How to Validate

Run the new test file:
```
npx vitest run packages/core/src/utils/messageInspectors.test.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker