### PR TITLE
fix(settings): preserve externally added keys when saving settings

### DIFF
--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -1627,7 +1627,7 @@ describe('Settings Loading and Merging', () => {
         saveSettings(settings1.user);
 
         const settings2 = loadSettings(MOCK_WORKSPACE_DIR);
-        expect(mockedRead).toHaveBeenCalledTimes(10); // Should have re-read from disk
+        expect(mockedRead).toHaveBeenCalledTimes(11); // 5 initial + 1 disk re-read in saveSettings + 5 re-load
         expect(settings1).not.toBe(settings2);
       });
 
@@ -1651,8 +1651,8 @@ describe('Settings Loading and Merging', () => {
         const settings2W1 = loadSettings(workspace1);
         const settings2W2 = loadSettings(workspace2);
 
-        // Both workspace caches should have been cleared and re-read from disk (+10 reads)
-        expect(mockedRead).toHaveBeenCalledTimes(20);
+        // Both workspace caches should have been cleared and re-read from disk (+10 reads + 1 disk re-read in saveSettings)
+        expect(mockedRead).toHaveBeenCalledTimes(21);
         expect(settings1W1).not.toBe(settings2W1);
         expect(settings1W2).not.toBe(settings2W2);
       });
@@ -2600,6 +2600,57 @@ describe('Settings Loading and Merging', () => {
         'error',
         'Failed to save settings: Write failed',
         error,
+      );
+    });
+
+    it('should preserve externally added top-level keys on save', () => {
+      const mockFsExistsSync = vi.mocked(fs.existsSync);
+      const mockFsReadFileSync = vi.mocked(fs.readFileSync);
+      const mockUpdateSettings = vi.mocked(updateSettingsFilePreservingFormat);
+
+      const settingsFile = createMockSettings({ ui: { theme: 'dark' } }).user;
+      settingsFile.path = path.resolve('/mock/settings.json');
+
+      // Directory exists, file exists
+      mockFsExistsSync.mockReturnValue(true);
+      // Disk has an extra "hooks" key added externally while the CLI was running
+      mockFsReadFileSync.mockReturnValue(
+        JSON.stringify({
+          ui: { theme: 'dark' },
+          hooks: { onSave: 'lint' },
+        }),
+      );
+
+      saveSettings(settingsFile);
+
+      expect(mockUpdateSettings).toHaveBeenCalledWith(
+        path.resolve('/mock/settings.json'),
+        expect.objectContaining({
+          ui: { theme: 'dark' },
+          hooks: { onSave: 'lint' },
+        }),
+      );
+    });
+
+    it('should fall back gracefully when disk read fails during save', () => {
+      const mockFsExistsSync = vi.mocked(fs.existsSync);
+      const mockFsReadFileSync = vi.mocked(fs.readFileSync);
+      const mockUpdateSettings = vi.mocked(updateSettingsFilePreservingFormat);
+
+      const settingsFile = createMockSettings({ ui: { theme: 'dark' } }).user;
+      settingsFile.path = path.resolve('/mock/settings.json');
+
+      mockFsExistsSync.mockReturnValue(true);
+      mockFsReadFileSync.mockImplementation(() => {
+        throw new Error('EACCES: permission denied');
+      });
+
+      // Should not throw — save must proceed without the merge
+      saveSettings(settingsFile);
+
+      expect(mockUpdateSettings).toHaveBeenCalledWith(
+        path.resolve('/mock/settings.json'),
+        { ui: { theme: 'dark' } },
       );
     });
   });

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -1068,6 +1068,35 @@ export function saveSettings(settingsFile: SettingsFile): void {
 
     const settingsToSave = settingsFile.originalSettings;
 
+    // Re-read disk to preserve top-level keys added externally (e.g. hooks,
+    // security) while the CLI was running.  originalSettings is a startup
+    // snapshot, so any key it doesn't track would be deleted by the
+    // sync-by-omission semantics of applyKeyDiff.  See #23138.
+    try {
+      if (fs.existsSync(settingsFile.path)) {
+        const diskContent = fs.readFileSync(settingsFile.path, 'utf-8');
+        const parsed: unknown = JSON.parse(diskContent);
+        if (
+          parsed !== null &&
+          typeof parsed === 'object' &&
+          !Array.isArray(parsed)
+        ) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          const diskSettings = parsed as Record<string, unknown>;
+           
+          const target = settingsToSave as Record<string, unknown>;
+          for (const key of Object.keys(diskSettings)) {
+            if (!Object.prototype.hasOwnProperty.call(target, key)) {
+              target[key] = diskSettings[key];
+            }
+          }
+        }
+      }
+    } catch {
+      // Disk read/parse failure is non-fatal — fall back to saving without
+      // the merge.  The save itself must never be blocked.
+    }
+
     // Use the format-preserving update function
     updateSettingsFilePreservingFormat(
       settingsFile.path,


### PR DESCRIPTION
## Summary

Fixes #23138.

When the CLI saves settings (e.g. on a system theme change), it uses `originalSettings` — a snapshot loaded at startup — as the source of truth. Any top-level keys added to `settings.json` externally while the CLI was running (e.g. `hooks`, `security`) are absent from that snapshot. Because `applyKeyDiff` uses sync-by-omission semantics, those keys are silently removed on the next save.

## Root Cause

`saveSettings()` passes `originalSettings` (startup snapshot) to `updateSettingsFilePreservingFormat()`, which calls `applyKeyDiff()`. Keys not present in the snapshot are treated as deleted — even if the user added them manually to the file after the CLI started.

## Solution

Re-read `settings.json` from disk immediately before each save and merge any top-level keys that `originalSettings` does not already track. Keys managed by the CLI always take precedence. Disk read failure is treated as non-fatal — the save is never blocked.

```ts
// Re-read disk to preserve top-level keys added externally (e.g. hooks,
// security) while the CLI was running.  originalSettings is a startup
// snapshot, so any key it doesn't track would be deleted by the
// sync-by-omission semantics of applyKeyDiff.  See #23138.
try {
  if (fs.existsSync(settingsFile.path)) {
    const parsed: unknown = JSON.parse(fs.readFileSync(settingsFile.path, 'utf-8'));
    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
      const diskSettings = parsed as Record<string, unknown>;
      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
      const target = settingsToSave as Record<string, unknown>;
      for (const key of Object.keys(diskSettings)) {
        if (!Object.prototype.hasOwnProperty.call(target, key)) {
          target[key] = diskSettings[key];
        }
      }
    }
  }
} catch {
  // Disk read/parse failure is non-fatal — fall back to saving without
  // the merge.  The save itself must never be blocked.
}
```

## Design Decisions

- **No behavior change for existing users** — only merges keys not already tracked by the CLI; never removes or overrides managed settings
- **Surgical change** — two files modified (`settings.ts` + `settings.test.ts`), no schema changes, no new dependencies
- **Resilient** — disk read/parse failure is caught and silently ignored; save always proceeds

## Testing

Added 2 new tests to `settings.test.ts`:

1. **Happy path** — externally added `hooks` key is preserved after a theme-change save
2. **Fallback** — disk read failure (`EACCES`) does not block the save; existing settings are written normally

All 103 existing tests pass.
