### PR TITLE
Codex/fix env redaction allowed

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2084,16 +2084,18 @@ from the system or loaded from `.env` files.
 
 You can customize this behavior in your `settings.json` file:
 
-- **`security.allowedEnvironmentVariables`**: A list of variable names to
-  _never_ redact, even if they match sensitive patterns.
-- **`security.blockedEnvironmentVariables`**: A list of variable names to
-  _always_ redact, even if they don't match sensitive patterns.
+- **`security.environmentVariableRedaction.allowed`**: A list of variable names
+  to _never_ redact, even if they match sensitive patterns.
+- **`security.environmentVariableRedaction.blocked`**: A list of variable names
+  to _always_ redact, even if they don't match sensitive patterns.
 
 ```json
 {
   "security": {
-    "allowedEnvironmentVariables": ["MY_PUBLIC_KEY", "NOT_A_SECRET_TOKEN"],
-    "blockedEnvironmentVariables": ["INTERNAL_IP_ADDRESS"]
+    "environmentVariableRedaction": {
+      "allowed": ["MY_PUBLIC_KEY", "NOT_A_SECRET_TOKEN"],
+      "blocked": ["INTERNAL_IP_ADDRESS"]
+    }
   }
 }
 ```

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -835,6 +835,32 @@ describe('loadCliConfig', () => {
 
     expect(config.isInteractive()).toBe(false);
   });
+
+  it('should pass environmentVariableRedaction.allowed into sanitization config', async () => {
+    process.argv = ['node', 'script.js'];
+    const settings = createTestMergedSettings({
+      security: {
+        environmentVariableRedaction: {
+          allowed: ['MY_ALLOWED_VAR', 'ANOTHER_SAFE_VAR'],
+          blocked: ['MY_BLOCKED_VAR'],
+          enabled: true,
+        },
+      },
+    });
+    const argv = await parseArguments(createTestMergedSettings());
+    const config = await loadCliConfig(settings, 'test-session', argv);
+
+    expect(config.sanitizationConfig.allowedEnvironmentVariables).toEqual([
+      'MY_ALLOWED_VAR',
+      'ANOTHER_SAFE_VAR',
+    ]);
+    expect(config.sanitizationConfig.blockedEnvironmentVariables).toEqual([
+      'MY_BLOCKED_VAR',
+    ]);
+    expect(config.sanitizationConfig.enableEnvironmentVariableRedaction).toBe(
+      true,
+    );
+  });
 });
 
 describe('Hierarchical Memory Loading (config.ts) - Placeholder Suite', () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -822,6 +822,8 @@ export async function loadCliConfig(
         ? undefined
         : settings.mcp?.excluded
       : undefined,
+    allowedEnvironmentVariables:
+      settings.security?.environmentVariableRedaction?.allowed,
     blockedEnvironmentVariables:
       settings.security?.environmentVariableRedaction?.blocked,
     enableEnvironmentVariableRedaction:


### PR DESCRIPTION
## Summary

Fixes a config wiring bug where `security.environmentVariableRedaction.allowed` was defined in settings but not passed into runtime sanitization config.

Without this fix, allowlisted env vars were ignored at the CLI config layer.

## Details

- Updated `loadCliConfig` to pass:
  - `settings.security.environmentVariableRedaction.allowed`
  into core config as `allowedEnvironmentVariables`.
- Added a config test that verifies `allowed`, `blocked`, and `enabled` are all propagated to `config.sanitizationConfig`.

## Related Issues

Closes #23204

## How to Validate

1. Run targeted test:
   ```bash
   npm --workspace @google/gemini-cli run test -- src/config/config.test.ts -t "environmentVariableRedaction.allowed"
   ```
2. Expected result:
   - The new test passes:
     - `should pass environmentVariableRedaction.allowed into sanitization config`
3. Optional sanity check:
   - Confirm `config.sanitizationConfig.allowedEnvironmentVariables` includes values from:
     `security.environmentVariableRedaction.allowed`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) - none
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker