### PR TITLE
Codex/fix env redaction allowed clean

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2084,16 +2084,18 @@ from the system or loaded from `.env` files.
 
 You can customize this behavior in your `settings.json` file:
 
-- **`security.allowedEnvironmentVariables`**: A list of variable names to
-  _never_ redact, even if they match sensitive patterns.
-- **`security.blockedEnvironmentVariables`**: A list of variable names to
-  _always_ redact, even if they don't match sensitive patterns.
+- **`security.environmentVariableRedaction.allowed`**: A list of variable names
+  to _never_ redact, even if they match sensitive patterns.
+- **`security.environmentVariableRedaction.blocked`**: A list of variable names
+  to _always_ redact, even if they don't match sensitive patterns.
 
 ```json
 {
   "security": {
-    "allowedEnvironmentVariables": ["MY_PUBLIC_KEY", "NOT_A_SECRET_TOKEN"],
-    "blockedEnvironmentVariables": ["INTERNAL_IP_ADDRESS"]
+    "environmentVariableRedaction": {
+      "allowed": ["MY_PUBLIC_KEY", "NOT_A_SECRET_TOKEN"],
+      "blocked": ["INTERNAL_IP_ADDRESS"]
+    }
   }
 }
 ```

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -835,6 +835,32 @@ describe('loadCliConfig', () => {
 
     expect(config.isInteractive()).toBe(false);
   });
+
+  it('should pass environmentVariableRedaction.allowed into sanitization config', async () => {
+    process.argv = ['node', 'script.js'];
+    const settings = createTestMergedSettings({
+      security: {
+        environmentVariableRedaction: {
+          allowed: ['MY_ALLOWED_VAR', 'ANOTHER_SAFE_VAR'],
+          blocked: ['MY_BLOCKED_VAR'],
+          enabled: true,
+        },
+      },
+    });
+    const argv = await parseArguments(createTestMergedSettings());
+    const config = await loadCliConfig(settings, 'test-session', argv);
+
+    expect(config.sanitizationConfig.allowedEnvironmentVariables).toEqual([
+      'MY_ALLOWED_VAR',
+      'ANOTHER_SAFE_VAR',
+    ]);
+    expect(config.sanitizationConfig.blockedEnvironmentVariables).toEqual([
+      'MY_BLOCKED_VAR',
+    ]);
+    expect(config.sanitizationConfig.enableEnvironmentVariableRedaction).toBe(
+      true,
+    );
+  });
 });
 
 describe('Hierarchical Memory Loading (config.ts) - Placeholder Suite', () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -822,6 +822,8 @@ export async function loadCliConfig(
         ? undefined
         : settings.mcp?.excluded
       : undefined,
+    allowedEnvironmentVariables:
+      settings.security?.environmentVariableRedaction?.allowed,
     blockedEnvironmentVariables:
       settings.security?.environmentVariableRedaction?.blocked,
     enableEnvironmentVariableRedaction:


### PR DESCRIPTION
## Summary

Fixes environment variable redaction allowlist wiring and removes confusing duplicate config docs.

This ensures `security.environmentVariableRedaction.allowed` is actually propagated into runtime sanitization config, and documents a single canonical config path.

## Details

- `loadCliConfig` now passes:
  - `settings.security.environmentVariableRedaction.allowed`
  to core config as `allowedEnvironmentVariables`.
- Added test coverage in `config.test.ts` to verify `allowed`, `blocked`, and `enabled` all propagate to `config.sanitizationConfig`.
- Updated docs to remove legacy/redundant key examples and use only:
  - `security.environmentVariableRedaction.allowed`
  - `security.environmentVariableRedaction.blocked`

## Related Issues

Closes #23204

## How to Validate

1. Run targeted test:
   ```bash
   npm --workspace @google/gemini-cli run test -- src/config/config.test.ts -t "environmentVariableRedaction.allowed"
   ```
2. Expected:
   - Test passes:
     - `should pass environmentVariableRedaction.allowed into sanitization config`
3. Verify docs consistency:
   - `docs/reference/configuration.md` only references `security.environmentVariableRedaction.*` for env redaction customization.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) - none
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker