### PR TITLE
feat(browser): add blockedUrlPatterns config for proxy bypass prevention

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1188,6 +1188,20 @@ const SETTINGS_SCHEMA = {
             showInDialog: false,
             items: { type: 'string' },
           },
+          blockedUrlPatterns: {
+            type: 'array',
+            label: 'Blocked URL Patterns',
+            category: 'Advanced',
+            requiresRestart: false,
+            default: [] as string[],
+            description: oneLine`
+              URL glob patterns to always block, even on allowed domains.
+              Useful for blocking proxy services that bypass allowedDomains
+              (e.g., ["*translate.google.*/translate*"]).
+            `,
+            showInDialog: false,
+            items: { type: 'string' },
+          },
           disableUserInput: {
             type: 'boolean',
             label: 'Disable User Input',

--- a/packages/core/src/agents/browser/browserManager.test.ts
+++ b/packages/core/src/agents/browser/browserManager.test.ts
@@ -270,6 +270,43 @@ describe('BrowserManager', () => {
       expect(result.isError).toBe(true);
       expect((result.content || [])[0]?.text).toContain('not permitted');
     });
+
+    it('should block URL matching blockedUrlPatterns', async () => {
+      const restrictedConfig = makeFakeConfig({
+        agents: {
+          browser: {
+            allowedDomains: ['*.google.com'],
+            blockedUrlPatterns: ['*translate.google.*/translate*'],
+          },
+        },
+      });
+      const manager = new BrowserManager(restrictedConfig);
+      const result = await manager.callTool('new_page', {
+        url: 'https://translate.google.com/translate?u=https://blocked.org',
+      });
+
+      expect(result.isError).toBe(true);
+      expect((result.content || [])[0]?.text).toContain(
+        'blocked by a URL pattern',
+      );
+    });
+
+    it('should allow URL on allowed domain when not matching blockedUrlPatterns', async () => {
+      const restrictedConfig = makeFakeConfig({
+        agents: {
+          browser: {
+            allowedDomains: ['*.google.com'],
+            blockedUrlPatterns: ['*translate.google.*/translate*'],
+          },
+        },
+      });
+      const manager = new BrowserManager(restrictedConfig);
+      const result = await manager.callTool('new_page', {
+        url: 'https://www.google.com/search?q=test',
+      });
+
+      expect(result.isError).toBe(false);
+    });
   });
 
   describe('MCP connection', () => {

--- a/packages/core/src/agents/browser/browserManager.ts
+++ b/packages/core/src/agents/browser/browserManager.ts
@@ -29,6 +29,7 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { injectAutomationOverlay } from './automationOverlay.js';
+import picomatch from 'picomatch';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -573,8 +574,8 @@ export class BrowserManager {
       return undefined;
     }
 
-    const allowedDomains =
-      this.config.getBrowserAgentConfig().customConfig.allowedDomains;
+    const browserConfig = this.config.getBrowserAgentConfig().customConfig;
+    const allowedDomains = browserConfig.allowedDomains;
     if (!allowedDomains || allowedDomains.length === 0) {
       return undefined;
     }
@@ -585,6 +586,15 @@ export class BrowserManager {
     }
     if (typeof url !== 'string') {
       return `Invalid URL: URL must be a string.`;
+    }
+
+    // Check blockedUrlPatterns first — these take precedence over allowedDomains.
+    const blockedPatterns = browserConfig.blockedUrlPatterns;
+    if (blockedPatterns && blockedPatterns.length > 0) {
+      const isBlocked = picomatch(blockedPatterns, { contains: true });
+      if (isBlocked(url)) {
+        return `Tool '${toolName}' is blocked by a URL pattern in your browser settings.`;
+      }
     }
 
     try {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -328,6 +328,8 @@ export interface BrowserAgentCustomConfig {
   visualModel?: string;
   /** List of allowed domains for the browser agent (e.g., ["github.com", "*.google.com"]). */
   allowedDomains?: string[];
+  /** URL glob patterns to always block, even on allowed domains. */
+  blockedUrlPatterns?: string[];
   /** Disable user input on the browser window during automation. Default: true in non-headless mode */
   disableUserInput?: boolean;
 }
@@ -3121,6 +3123,7 @@ export class Config implements McpContext, AgentLoopContext {
         profilePath: customConfig.profilePath,
         visualModel: customConfig.visualModel,
         allowedDomains: customConfig.allowedDomains,
+        blockedUrlPatterns: customConfig.blockedUrlPatterns,
         disableUserInput: customConfig.disableUserInput,
       },
     };


### PR DESCRIPTION
# PR Title
feat(browser): add blockedUrlPatterns config for proxy bypass prevention

# PR Body
Related to #23224

**Rationale & Context:**
While the previous PR (#23225) introduced a basic, hardcoded mechanism to detect proxy behaviors within query parameters, this PR introduces a more granular and flexible **blacklist pattern mechanism (`blockedUrlPatterns`)**.

- **Fine-Grained Control**: It allows users to use glob patterns to explicitly reject certain URLs, even if their top-level domains pass the `allowedDomains` whitelist check.
- **Target Audience / Use Case**: This is particularly suited for individuals or enterprise users operating in highly sensitive, private environments. This mechanism empowers users to immediately block newly discovered bypass vectors (like unknown translation or proxy services) via configuration, without waiting for code updates.

**Configuration Example**:
```json
  "agents": {
    "browser": {
      "blockedUrlPatterns": [
        "*translate.google.*/translate*",
        "*/proxy?url=*"
      ]
    }
  }
```

**Pros vs. Cons / Design Trade-offs:**
- **Advantage:** Maximum flexibility. Users can target any part of the URL (paths, query strings, specific subdomains) to block malicious or proxy-like patterns.
- **Disadvantage:** Increased complexity. The existing `allowedDomains` whitelist is simple and easy to understand (just domain names). The new `blockedUrlPatterns` uses glob patterns, which require a bit more technical understanding to configure correctly without accidentally blocking valid URLs.

Since this introduces a broader configuration change and a slightly more complex filtering mechanism to the core browser agent, I'd really appreciate community feedback on whether this dual approach (simple domain whitelist + granular pattern blacklist) feels right for advanced use cases. Feel free to suggest changes!

