### PR TITLE
fix(core): resolve strict auth consent and credential clearing issues

### DIFF
--- a/packages/core/src/code_assist/oauth-credential-storage.test.ts
+++ b/packages/core/src/code_assist/oauth-credential-storage.test.ts
@@ -136,9 +136,9 @@ describe('OAuthCredentialStorage', () => {
         mockError,
       );
 
-      await expect(OAuthCredentialStorage.loadCredentials()).rejects.toThrow(
-        'Failed to load OAuth credentials',
-      );
+      await expect(
+        OAuthCredentialStorage.loadCredentials(),
+      ).resolves.toBeNull();
       expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
         'error',
         'Failed to load OAuth credentials',
@@ -153,9 +153,9 @@ describe('OAuthCredentialStorage', () => {
       );
       vi.spyOn(fs, 'readFile').mockRejectedValue(mockError);
 
-      await expect(OAuthCredentialStorage.loadCredentials()).rejects.toThrow(
-        'Failed to load OAuth credentials',
-      );
+      await expect(
+        OAuthCredentialStorage.loadCredentials(),
+      ).resolves.toBeNull();
       expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
         'error',
         'Failed to load OAuth credentials',
@@ -186,9 +186,9 @@ describe('OAuthCredentialStorage', () => {
       );
       vi.spyOn(fs, 'readFile').mockResolvedValue('invalid json');
 
-      await expect(OAuthCredentialStorage.loadCredentials()).rejects.toThrow(
-        'Failed to load OAuth credentials',
-      );
+      await expect(
+        OAuthCredentialStorage.loadCredentials(),
+      ).resolves.toBeNull();
     });
 
     it('should not delete the old file if saving migrated credentials fails', async () => {
@@ -202,9 +202,9 @@ describe('OAuthCredentialStorage', () => {
         new Error('Save failed'),
       );
 
-      await expect(OAuthCredentialStorage.loadCredentials()).rejects.toThrow(
-        'Failed to load OAuth credentials',
-      );
+      await expect(
+        OAuthCredentialStorage.loadCredentials(),
+      ).resolves.toBeNull();
 
       expect(fs.rm).not.toHaveBeenCalled();
     });
@@ -306,12 +306,12 @@ describe('OAuthCredentialStorage', () => {
         mockError,
       );
 
-      await expect(OAuthCredentialStorage.clearCredentials()).rejects.toThrow(
-        'Failed to clear OAuth credentials',
-      );
+      await expect(
+        OAuthCredentialStorage.clearCredentials(),
+      ).resolves.toBeUndefined();
       expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
         'error',
-        'Failed to clear OAuth credentials',
+        'Failed to clear OAuth credentials: Deletion error',
         mockError,
       );
     });

--- a/packages/core/src/code_assist/oauth-credential-storage.ts
+++ b/packages/core/src/code_assist/oauth-credential-storage.ts
@@ -12,6 +12,7 @@ import * as path from 'node:path';
 import { promises as fs } from 'node:fs';
 import { GEMINI_DIR, homedir } from '../utils/paths.js';
 import { coreEvents } from '../utils/events.js';
+import { getErrorMessage } from '../utils/errors.js';
 
 const KEYCHAIN_SERVICE_NAME = 'gemini-cli-oauth';
 const MAIN_ACCOUNT_KEY = 'main-account';
@@ -54,7 +55,7 @@ export class OAuthCredentialStorage {
         'Failed to load OAuth credentials',
         error,
       );
-      throw new Error('Failed to load OAuth credentials', { cause: error });
+      return null;
     }
   }
 
@@ -95,10 +96,9 @@ export class OAuthCredentialStorage {
     } catch (error: unknown) {
       coreEvents.emitFeedback(
         'error',
-        'Failed to clear OAuth credentials',
+        `Failed to clear OAuth credentials: ${getErrorMessage(error)}`,
         error,
       );
-      throw new Error('Failed to clear OAuth credentials', { cause: error });
     }
   }
 

--- a/packages/core/src/utils/authConsent.test.ts
+++ b/packages/core/src/utils/authConsent.test.ts
@@ -9,7 +9,6 @@ import readline from 'node:readline';
 import process from 'node:process';
 import { coreEvents } from './events.js';
 import { getConsentForOauth } from './authConsent.js';
-import { FatalAuthenticationError } from './errors.js';
 import { writeToStdout } from './stdio.js';
 import { isHeadlessMode } from './headless.js';
 
@@ -87,12 +86,25 @@ describe('getConsentForOauth', () => {
       expect(result).toBe(false);
     });
 
-    it('should throw FatalAuthenticationError when no UI listeners are present', async () => {
+    it('should emit consent request and wait even if no UI listeners are present (backlog)', async () => {
       vi.spyOn(coreEvents, 'listenerCount').mockReturnValue(0);
+      const emitSpy = vi.spyOn(coreEvents, 'emitConsentRequest');
 
-      await expect(getConsentForOauth('Login required.')).rejects.toThrow(
-        FatalAuthenticationError,
+      const promise = getConsentForOauth('Login required.');
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt:
+            'Login required. Opening authentication page in your browser. \n\nDo you want to continue?',
+        }),
       );
+
+      // Simulate listener draining the backlog later and confirming
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const payload = emitSpy.mock.calls[0][0] as any;
+      payload.onConfirm(true);
+
+      expect(await promise).toBe(true);
     });
   });
 

--- a/packages/core/src/utils/authConsent.ts
+++ b/packages/core/src/utils/authConsent.ts
@@ -5,8 +5,7 @@
  */
 
 import readline from 'node:readline';
-import { CoreEvent, coreEvents } from './events.js';
-import { FatalAuthenticationError } from './errors.js';
+import { coreEvents } from './events.js';
 import { createWorkingStdio, writeToStdout } from './stdio.js';
 import { isHeadlessMode } from './headless.js';
 
@@ -21,14 +20,8 @@ export async function getConsentForOauth(prompt: string): Promise<boolean> {
 
   if (isHeadlessMode()) {
     return getOauthConsentNonInteractive(finalPrompt);
-  } else if (coreEvents.listenerCount(CoreEvent.ConsentRequest) > 0) {
-    return getOauthConsentInteractive(finalPrompt);
   }
-  throw new FatalAuthenticationError(
-    'Authentication consent could not be obtained.\n' +
-      'Please run Gemini CLI in an interactive terminal to authenticate, ' +
-      'or use NO_BROWSER=true for manual authentication.',
-  );
+  return getOauthConsentInteractive(finalPrompt);
 }
 
 async function getOauthConsentNonInteractive(prompt: string) {


### PR DESCRIPTION
This PR resolves a microtask race condition during early authentication that caused the UI to throw an opaque 'Authentication consent could not be obtained' error. By leveraging `coreEvents.drainBacklogs()`, the event is queued safely until the UI listener finishes mounting. 

Additionally, this pipes the actual underlying error into the `emitFeedback` payload when `clearCredentials` fails, ensuring users and telemetry capture why file deletion or keychain eviction failed rather than returning a generic message.