### PR TITLE
feat(core): refine User-Agent for VS Code traffic (unified format)

### DIFF
--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -132,6 +132,7 @@ describe('createContentGenerator', () => {
     // Set a fixed version for testing
     vi.stubEnv('CLI_VERSION', '1.2.3');
     vi.stubEnv('TERM_PROGRAM', 'iTerm.app');
+    vi.stubEnv('VSCODE_PID', '');
 
     const mockGenerator = {
       models: {},
@@ -171,6 +172,7 @@ describe('createContentGenerator', () => {
     // Set a fixed version for testing
     vi.stubEnv('CLI_VERSION', '1.2.3');
     vi.stubEnv('TERM_PROGRAM', 'iTerm.app');
+    vi.stubEnv('VSCODE_PID', '');
 
     const mockGenerator = {
       models: {},
@@ -207,6 +209,7 @@ describe('createContentGenerator', () => {
     vi.stubEnv('CLI_VERSION', '1.2.3');
     // Mock the environment variable that the VS Code extension host would provide to the a2a-server process
     vi.stubEnv('VSCODE_PID', '12345');
+    vi.stubEnv('TERM_PROGRAM', 'vscode');
     vi.stubEnv('TERM_PROGRAM_VERSION', '1.85.0');
 
     const mockGenerator = {
@@ -243,6 +246,7 @@ describe('createContentGenerator', () => {
     // Set a fixed version for testing
     vi.stubEnv('CLI_VERSION', '1.2.3');
     vi.stubEnv('TERM_PROGRAM', 'iTerm.app');
+    vi.stubEnv('VSCODE_PID', '');
 
     const mockGenerator = {
       models: {},

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -131,6 +131,7 @@ describe('createContentGenerator', () => {
 
     // Set a fixed version for testing
     vi.stubEnv('CLI_VERSION', '1.2.3');
+    vi.stubEnv('TERM_PROGRAM', 'iTerm.app');
 
     const mockGenerator = {
       models: {},
@@ -149,7 +150,7 @@ describe('createContentGenerator', () => {
       httpOptions: expect.objectContaining({
         headers: expect.objectContaining({
           'User-Agent': expect.stringMatching(
-            /GeminiCLI\/1\.2\.3\/gemini-pro \(.*; .*; .*\)/,
+            /GeminiCLI\/1\.2\.3\/gemini-pro \(.*; .*; terminal\)/,
           ),
         }),
       }),
@@ -159,7 +160,7 @@ describe('createContentGenerator', () => {
     );
   });
 
-  it('should include clientName prefix in User-Agent when specified', async () => {
+  it('should use standard User-Agent for a2a-server running outside VS Code', async () => {
     const mockConfig = {
       getModel: vi.fn().mockReturnValue('gemini-pro'),
       getProxy: vi.fn().mockReturnValue(undefined),
@@ -169,6 +170,7 @@ describe('createContentGenerator', () => {
 
     // Set a fixed version for testing
     vi.stubEnv('CLI_VERSION', '1.2.3');
+    vi.stubEnv('TERM_PROGRAM', 'iTerm.app');
 
     const mockGenerator = {
       models: {},
@@ -185,8 +187,111 @@ describe('createContentGenerator', () => {
         httpOptions: expect.objectContaining({
           headers: expect.objectContaining({
             'User-Agent': expect.stringMatching(
-              /GeminiCLI-a2a-server\/.*\/gemini-pro \(.*; .*; .*\)/,
+              /GeminiCLI-a2a-server\/1\.2\.3\/gemini-pro \(.*; .*; terminal\)/,
             ),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('should include unified User-Agent for a2a-server (VS Code Agent Mode)', async () => {
+    const mockConfig = {
+      getModel: vi.fn().mockReturnValue('gemini-pro'),
+      getProxy: vi.fn().mockReturnValue(undefined),
+      getUsageStatisticsEnabled: () => true,
+      getClientName: vi.fn().mockReturnValue('a2a-server'),
+    } as unknown as Config;
+
+    // Set a fixed version for testing
+    vi.stubEnv('CLI_VERSION', '1.2.3');
+    // Mock the environment variable that the VS Code extension host would provide to the a2a-server process
+    vi.stubEnv('VSCODE_PID', '12345');
+    vi.stubEnv('TERM_PROGRAM_VERSION', '1.85.0');
+
+    const mockGenerator = {
+      models: {},
+    } as unknown as GoogleGenAI;
+    vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator as never);
+    await createContentGenerator(
+      { apiKey: 'test-api-key', authType: AuthType.USE_GEMINI },
+      mockConfig,
+      undefined,
+    );
+
+    expect(GoogleGenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpOptions: expect.objectContaining({
+          headers: expect.objectContaining({
+            'User-Agent': expect.stringMatching(
+              /CloudCodeVSCode\/1\.2\.3 \(aidev_client; os_type=.*; os_version=.*; arch=.*; host_path=VSCode\/1\.85\.0; proxy_client=geminicli\)/,
+            ),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('should include clientName prefix in User-Agent when specified (non-VSCode)', async () => {
+    const mockConfig = {
+      getModel: vi.fn().mockReturnValue('gemini-pro'),
+      getProxy: vi.fn().mockReturnValue(undefined),
+      getUsageStatisticsEnabled: () => true,
+      getClientName: vi.fn().mockReturnValue('my-client'),
+    } as unknown as Config;
+
+    // Set a fixed version for testing
+    vi.stubEnv('CLI_VERSION', '1.2.3');
+    vi.stubEnv('TERM_PROGRAM', 'iTerm.app');
+
+    const mockGenerator = {
+      models: {},
+    } as unknown as GoogleGenAI;
+    vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator as never);
+    await createContentGenerator(
+      { apiKey: 'test-api-key', authType: AuthType.USE_GEMINI },
+      mockConfig,
+      undefined,
+    );
+
+    expect(GoogleGenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpOptions: expect.objectContaining({
+          headers: expect.objectContaining({
+            'User-Agent': expect.stringMatching(
+              /GeminiCLI-my-client\/1\.2\.3\/gemini-pro \(.*; .*; terminal\)/,
+            ),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('should allow custom headers to override User-Agent', async () => {
+    const mockConfig = {
+      getModel: vi.fn().mockReturnValue('gemini-pro'),
+      getProxy: vi.fn().mockReturnValue(undefined),
+      getUsageStatisticsEnabled: () => true,
+      getClientName: vi.fn().mockReturnValue(undefined),
+    } as unknown as Config;
+
+    vi.stubEnv('GEMINI_CLI_CUSTOM_HEADERS', 'User-Agent:MyCustomUA');
+
+    const mockGenerator = {
+      models: {},
+    } as unknown as GoogleGenAI;
+    vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator as never);
+    await createContentGenerator(
+      { apiKey: 'test-api-key', authType: AuthType.USE_GEMINI },
+      mockConfig,
+      undefined,
+    );
+
+    expect(GoogleGenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpOptions: expect.objectContaining({
+          headers: expect.objectContaining({
+            'User-Agent': 'MyCustomUA',
           }),
         }),
       }),

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -133,6 +133,8 @@ describe('createContentGenerator', () => {
     vi.stubEnv('CLI_VERSION', '1.2.3');
     vi.stubEnv('TERM_PROGRAM', 'iTerm.app');
     vi.stubEnv('VSCODE_PID', '');
+    vi.stubEnv('GITHUB_SHA', '');
+    vi.stubEnv('GEMINI_CLI_SURFACE', '');
 
     const mockGenerator = {
       models: {},
@@ -173,6 +175,8 @@ describe('createContentGenerator', () => {
     vi.stubEnv('CLI_VERSION', '1.2.3');
     vi.stubEnv('TERM_PROGRAM', 'iTerm.app');
     vi.stubEnv('VSCODE_PID', '');
+    vi.stubEnv('GITHUB_SHA', '');
+    vi.stubEnv('GEMINI_CLI_SURFACE', '');
 
     const mockGenerator = {
       models: {},
@@ -247,6 +251,8 @@ describe('createContentGenerator', () => {
     vi.stubEnv('CLI_VERSION', '1.2.3');
     vi.stubEnv('TERM_PROGRAM', 'iTerm.app');
     vi.stubEnv('VSCODE_PID', '');
+    vi.stubEnv('GITHUB_SHA', '');
+    vi.stubEnv('GEMINI_CLI_SURFACE', '');
 
     const mockGenerator = {
       models: {},

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -13,7 +13,9 @@ import {
   type EmbedContentResponse,
   type EmbedContentParameters,
 } from '@google/genai';
+import * as os from 'node:os';
 import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
+import { isCloudShell } from '../ide/detect-ide.js';
 import type { Config } from '../config/config.js';
 import { loadApiKey } from './apiKeyCredentialStorage.js';
 
@@ -185,19 +187,46 @@ export async function createContentGenerator(
     const customHeadersEnv =
       process.env['GEMINI_CLI_CUSTOM_HEADERS'] || undefined;
     const clientName = gcConfig.getClientName();
-    const userAgentPrefix = clientName
-      ? `GeminiCLI-${clientName}`
-      : 'GeminiCLI';
     const surface = determineSurface();
-    const userAgent = `${userAgentPrefix}/${version}/${model} (${process.platform}; ${process.arch}; ${surface})`;
+
+    let userAgent: string;
+    // Use unified format for VS Code traffic.
+    // Note: We don't automatically assume a2a-server is VS Code,
+    // as it could be used by other clients unless the surface explicitly says 'vscode'.
+    if (clientName === 'acp-vscode' || surface === 'vscode') {
+      const osTypeMap: Record<string, string> = {
+        darwin: 'macOS',
+        win32: 'Windows',
+        linux: 'Linux',
+      };
+      const osType = osTypeMap[process.platform] || process.platform;
+      const osVersion = os.release();
+      const arch = process.arch;
+
+      const vscodeVersion = process.env['TERM_PROGRAM_VERSION'] || 'unknown';
+      let hostPath = `VSCode/${vscodeVersion}`;
+      if (isCloudShell()) {
+        const cloudShellVersion =
+          process.env['CLOUD_SHELL_VERSION'] || 'unknown';
+        hostPath += ` > CloudShell/${cloudShellVersion}`;
+      }
+
+      userAgent = `CloudCodeVSCode/${version} (aidev_client; os_type=${osType}; os_version=${osVersion}; arch=${arch}; host_path=${hostPath}; proxy_client=geminicli)`;
+    } else {
+      const userAgentPrefix = clientName
+        ? `GeminiCLI-${clientName}`
+        : 'GeminiCLI';
+      userAgent = `${userAgentPrefix}/${version}/${model} (${process.platform}; ${process.arch}; ${surface})`;
+    }
+
     const customHeadersMap = parseCustomHeaders(customHeadersEnv);
     const apiKeyAuthMechanism =
       process.env['GEMINI_API_KEY_AUTH_MECHANISM'] || 'x-goog-api-key';
     const apiVersionEnv = process.env['GOOGLE_GENAI_API_VERSION'];
 
     const baseHeaders: Record<string, string> = {
-      ...customHeadersMap,
       'User-Agent': userAgent,
+      ...customHeadersMap,
     };
 
     if (

--- a/packages/core/src/utils/surface.ts
+++ b/packages/core/src/utils/surface.ts
@@ -37,9 +37,10 @@ export function determineSurface(): string {
     return ide.name;
   }
 
-  // If the detected IDE is 'vscode', we only accept it if TERM_PROGRAM confirms it.
-  // This prevents generic terminals from being misidentified as VSCode.
-  if (process.env['TERM_PROGRAM'] === 'vscode') {
+  // If the detected IDE is 'vscode', we only accept it if TERM_PROGRAM or VSCODE_PID confirms it.
+  // This prevents generic terminals from being misidentified as VSCode, while still detecting
+  // background processes spawned by the VS Code extension host (like a2a-server).
+  if (process.env['TERM_PROGRAM'] === 'vscode' || process.env['VSCODE_PID']) {
     return ide.name;
   }
 


### PR DESCRIPTION
## Summary

Refined the `User-Agent` header to use a unified format for all VS Code-originated traffic (Gemini Code Assist Agent Mode, ACP, and integrated terminal). This change addresses issue #23254 and ensures accurate backend metrics and quota attribution for enterprise users.

## Details

- Implemented unified VS Code User-Agent format: `CloudCodeVSCode/<version> (aidev_client; os_type=<os>; os_version=<version>; arch=<arch>; host_path=VSCode/<vscode_version>; proxy_client=geminicli)`
- Enhanced VS Code detection by checking for `VSCODE_PID` environment variable (captures background processes like `a2a-server` spawned by the extension host).
- Ensured `aidev_client` identity comment is included for accurate backend parsing.
- Updated `GEMINI_CLI_CUSTOM_HEADERS` precedence to allow explicit overrides by enterprise users.
- Maintained legacy format for standalone Gemini CLI usage (non-VS Code).

## Related Issues

Fixes #23254

## How to Validate

Run unit tests for the content generator:
```bash
npm test -w @google/gemini-cli-core -- src/core/contentGenerator.test.ts
```

Verify that traffic from VS Code uses the new format:
1. Start `a2a-server` with `VSCODE_PID` and `TERM_PROGRAM_VERSION` set.
2. Check the `User-Agent` header in sent requests.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
