### PR TITLE
refactor(ide): replace dynamic undici import with static fetch import

### DIFF
--- a/packages/core/src/ide/ide-connection-utils.test.ts
+++ b/packages/core/src/ide/ide-connection-utils.test.ts
@@ -696,4 +696,15 @@ describe('ide-connection-utils', () => {
       ); // Short-circuiting
     });
   });
+
+  describe('createProxyAwareFetch', () => {
+    it('should return a fetch function without throwing fetch resolution errors', async () => {
+      const { createProxyAwareFetch } = await import(
+        './ide-connection-utils.js'
+      );
+      // Tests that the IIFE resolves the undici exports correctly and returns a function
+      const fetcher = await createProxyAwareFetch('127.0.0.1');
+      expect(typeof fetcher).toBe('function');
+    });
+  });
 });

--- a/packages/core/src/ide/ide-connection-utils.test.ts
+++ b/packages/core/src/ide/ide-connection-utils.test.ts
@@ -698,11 +698,10 @@ describe('ide-connection-utils', () => {
   });
 
   describe('createProxyAwareFetch', () => {
-    it('should return a fetch function without throwing fetch resolution errors', async () => {
+    it('should return a proxy-aware fetcher function', async () => {
       const { createProxyAwareFetch } = await import(
         './ide-connection-utils.js'
       );
-      // Tests that the IIFE resolves the undici exports correctly and returns a function
       const fetcher = await createProxyAwareFetch('127.0.0.1');
       expect(typeof fetcher).toBe('function');
     });

--- a/packages/core/src/ide/ide-connection-utils.ts
+++ b/packages/core/src/ide/ide-connection-utils.ts
@@ -295,7 +295,8 @@ export async function createProxyAwareFetch(ideServerHost: string) {
     const fetchFn = (() => {
       const fn =
         undiciExports.fetch ??
-        (undiciExports as { default?: { fetch?: typeof undiciExports.fetch } }).default?.fetch;
+        (undiciExports as { default?: { fetch?: typeof undiciExports.fetch } })
+          .default?.fetch;
       if (typeof fn !== 'function') {
         throw new Error('Failed to import `fetch` from `undici`.');
       }

--- a/packages/core/src/ide/ide-connection-utils.ts
+++ b/packages/core/src/ide/ide-connection-utils.ts
@@ -7,7 +7,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { EnvHttpProxyAgent } from 'undici';
+import { EnvHttpProxyAgent, fetch as undiciFetch } from 'undici';
 import { debugLogger } from '../utils/debugLogger.js';
 import { isSubpath, resolveToRealPath } from '../utils/paths.js';
 import { isNodeError } from '../utils/errors.js';
@@ -286,22 +286,7 @@ export async function createProxyAwareFetch(ideServerHost: string) {
   const agent = new EnvHttpProxyAgent({
     noProxy: [existingNoProxy, ideServerHost].filter(Boolean).join(','),
   });
-  const undiciPromise = import('undici');
-  // Suppress unhandled rejection if the promise is not awaited immediately.
-  // If the import fails, the error will be thrown when awaiting undiciPromise below.
-  undiciPromise.catch(() => {});
   return async (url: string | URL, init?: RequestInit): Promise<Response> => {
-    const undiciExports = await undiciPromise;
-    const fetchFn = (() => {
-      const fn =
-        undiciExports.fetch ??
-        (undiciExports as { default?: { fetch?: typeof undiciExports.fetch } })
-          .default?.fetch;
-      if (typeof fn !== 'function') {
-        throw new Error('Failed to import `fetch` from `undici`.');
-      }
-      return fn;
-    })();
     const fetchOptions: RequestInit & { dispatcher?: unknown } = {
       ...init,
       dispatcher: agent,
@@ -309,7 +294,7 @@ export async function createProxyAwareFetch(ideServerHost: string) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const options = fetchOptions as unknown as import('undici').RequestInit;
     try {
-      const response = await fetchFn(url, options);
+      const response = await undiciFetch(url, options);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       return new Response(response.body as ReadableStream<unknown> | null, {
         status: response.status,

--- a/packages/core/src/ide/ide-connection-utils.ts
+++ b/packages/core/src/ide/ide-connection-utils.ts
@@ -292,8 +292,9 @@ export async function createProxyAwareFetch(ideServerHost: string) {
   undiciPromise.catch(() => {});
   return async (url: string | URL, init?: RequestInit): Promise<Response> => {
     const undiciExports = await undiciPromise;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    const fetchFn = undiciExports.fetch ?? (undiciExports as any).default?.fetch;
+    const fetchFn =
+      undiciExports.fetch ??
+      (undiciExports as { default?: { fetch?: typeof undiciExports.fetch } }).default?.fetch;
     const fetchOptions: RequestInit & { dispatcher?: unknown } = {
       ...init,
       dispatcher: agent,

--- a/packages/core/src/ide/ide-connection-utils.ts
+++ b/packages/core/src/ide/ide-connection-utils.ts
@@ -291,7 +291,9 @@ export async function createProxyAwareFetch(ideServerHost: string) {
   // If the import fails, the error will be thrown when awaiting undiciPromise below.
   undiciPromise.catch(() => {});
   return async (url: string | URL, init?: RequestInit): Promise<Response> => {
-    const { fetch: fetchFn } = await undiciPromise;
+    const undiciExports = await undiciPromise;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    const fetchFn = undiciExports.fetch ?? (undiciExports as any).default?.fetch;
     const fetchOptions: RequestInit & { dispatcher?: unknown } = {
       ...init,
       dispatcher: agent,

--- a/packages/core/src/ide/ide-connection-utils.ts
+++ b/packages/core/src/ide/ide-connection-utils.ts
@@ -292,9 +292,15 @@ export async function createProxyAwareFetch(ideServerHost: string) {
   undiciPromise.catch(() => {});
   return async (url: string | URL, init?: RequestInit): Promise<Response> => {
     const undiciExports = await undiciPromise;
-    const fetchFn =
-      undiciExports.fetch ??
-      (undiciExports as { default?: { fetch?: typeof undiciExports.fetch } }).default?.fetch;
+    const fetchFn = (() => {
+      const fn =
+        undiciExports.fetch ??
+        (undiciExports as { default?: { fetch?: typeof undiciExports.fetch } }).default?.fetch;
+      if (typeof fn !== 'function') {
+        throw new Error('Failed to import `fetch` from `undici`.');
+      }
+      return fn;
+    })();
     const fetchOptions: RequestInit & { dispatcher?: unknown } = {
       ...init,
       dispatcher: agent,


### PR DESCRIPTION
## Summary

Fixes the `TypeError: fetchFn is not a function` bug when initializing the IDE companion SSE connection.

## Details

The CLI was dynamically importing `undici` using `await import('undici')` to retrieve `fetch`. However, due to bundler/CJS interop quirks under esbuild, this sometimes resolved into nested default structures like `undiciExports.default.fetch` rather than plain exports, causing crashes at runtime (especially evident in Cloudtop environments).

Since `EnvHttpProxyAgent` is already imported statically at the top of the `ide-connection-utils.ts` file, I refactored the fetch logic to simply use the static `import { fetch } from 'undici'` instead. This entirely eliminates the fragile dynamic module resolution block, cleans up the codebase, and prevents the `fetchFn` crash from happening.

## Related Issues

Fixes #23269

Resolves Buganizer issues:
- b/494301466
- b/493605123

## How to Validate

1. Build the local bundle: `npm run bundle`
2. Run the CLI: `npm run start -- --debug`
3. Enter `/ide enable`.
4. Ensure the SSE transport initializes correctly without crashing on `fetchFn`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
