### PR TITLE
fix(about): mask PII fields in /about output by default

### DIFF
--- a/packages/cli/src/ui/components/AboutBox.test.tsx
+++ b/packages/cli/src/ui/components/AboutBox.test.tsx
@@ -5,13 +5,46 @@
  */
 
 import { renderWithProviders } from '../../test-utils/render.js';
-import { AboutBox } from './AboutBox.js';
+import { AboutBox, maskEmail, maskGcpProject } from './AboutBox.js';
 import { describe, it, expect, vi } from 'vitest';
 
 // Mock GIT_COMMIT_INFO
 vi.mock('../../generated/git-commit.js', () => ({
   GIT_COMMIT_INFO: 'mock-commit-hash',
 }));
+
+describe('maskEmail', () => {
+  it('masks the local part of a standard email', () => {
+    expect(maskEmail('john.doe@company.com')).toBe('j***@company.com');
+  });
+
+  it('masks a single-char local part', () => {
+    expect(maskEmail('a@example.com')).toBe('a***@example.com');
+  });
+
+  it('returns *** for invalid email without @', () => {
+    expect(maskEmail('no-at-sign')).toBe('***');
+  });
+
+  it('returns *** for email starting with @', () => {
+    expect(maskEmail('@example.com')).toBe('***');
+  });
+});
+
+describe('maskGcpProject', () => {
+  it('masks a standard project ID', () => {
+    expect(maskGcpProject('my-prod-project-123456')).toBe('***3456');
+  });
+
+  it('masks a short project (more than 4 chars)', () => {
+    expect(maskGcpProject('abcde')).toBe('***bcde');
+  });
+
+  it('returns *** for very short project (4 or fewer chars)', () => {
+    expect(maskGcpProject('abcd')).toBe('***');
+    expect(maskGcpProject('ab')).toBe('***');
+  });
+});
 
 describe('AboutBox', () => {
   const defaultProps = {
@@ -41,29 +74,32 @@ describe('AboutBox', () => {
   });
 
   it.each([
-    ['gcpProject', 'my-project', 'GCP Project'],
-    ['ideClient', 'vscode', 'IDE Client'],
-    ['tier', 'Enterprise', 'Tier'],
-  ])('renders optional prop %s', async (prop, value, label) => {
-    const props = { ...defaultProps, [prop]: value };
-    const { lastFrame, waitUntilReady, unmount } = await renderWithProviders(
-      <AboutBox {...props} />,
-    );
-    await waitUntilReady();
-    const output = lastFrame();
-    expect(output).toContain(label);
-    expect(output).toContain(value);
-    unmount();
-  });
+    ['gcpProject', 'my-project', 'GCP Project', '***ject'],
+    ['ideClient', 'vscode', 'IDE Client', 'vscode'],
+    ['tier', 'Enterprise', 'Tier', 'Enterprise'],
+  ])(
+    'renders optional prop %s',
+    async (prop, value, label, expectedDisplay) => {
+      const props = { ...defaultProps, [prop]: value };
+      const { lastFrame, waitUntilReady, unmount } =
+        await renderWithProviders(<AboutBox {...props} />);
+      await waitUntilReady();
+      const output = lastFrame();
+      expect(output).toContain(label);
+      expect(output).toContain(expectedDisplay);
+      unmount();
+    },
+  );
 
-  it('renders Auth Method with email when userEmail is provided', async () => {
+  it('renders Auth Method with masked email when userEmail is provided', async () => {
     const props = { ...defaultProps, userEmail: 'test@example.com' };
     const { lastFrame, waitUntilReady, unmount } = await renderWithProviders(
       <AboutBox {...props} />,
     );
     await waitUntilReady();
     const output = lastFrame();
-    expect(output).toContain('Signed in with Google (test@example.com)');
+    expect(output).toContain('Signed in with Google (t***@example.com)');
+    expect(output).not.toContain('test@example.com');
     unmount();
   });
 

--- a/packages/cli/src/ui/components/AboutBox.tsx
+++ b/packages/cli/src/ui/components/AboutBox.tsx
@@ -11,6 +11,25 @@ import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
 import { useSettings } from '../contexts/SettingsContext.js';
 import { getDisplayString } from '@google/gemini-cli-core';
 
+/**
+ * Masks an email address to prevent PII exposure.
+ * Example: "john.doe@company.com" → "j***@company.com"
+ */
+export function maskEmail(email: string): string {
+  const atIndex = email.indexOf('@');
+  if (atIndex <= 0) return '***';
+  return email[0] + '***' + email.substring(atIndex);
+}
+
+/**
+ * Masks a GCP project ID to prevent PII exposure.
+ * Example: "my-prod-project-123456" → "***3456"
+ */
+export function maskGcpProject(project: string): string {
+  if (project.length <= 4) return '***';
+  return '***' + project.substring(project.length - 4);
+}
+
 interface AboutBoxProps {
   cliVersion: string;
   osVersion: string;
@@ -116,7 +135,7 @@ export const AboutBox: React.FC<AboutBoxProps> = ({
             <Text color={theme.text.primary}>
               {selectedAuthType.startsWith('oauth')
                 ? userEmail
-                  ? `Signed in with Google (${userEmail})`
+                  ? `Signed in with Google (${maskEmail(userEmail)})`
                   : 'Signed in with Google'
                 : selectedAuthType}
             </Text>
@@ -143,7 +162,7 @@ export const AboutBox: React.FC<AboutBoxProps> = ({
             </Text>
           </Box>
           <Box>
-            <Text color={theme.text.primary}>{gcpProject}</Text>
+            <Text color={theme.text.primary}>{maskGcpProject(gcpProject)}</Text>
           </Box>
         </Box>
       )}


### PR DESCRIPTION
## Summary

The `/about` command exposes the user's full email address and GCP Project ID in plaintext. Since the bug report template explicitly instructs users to paste `/about` output, this routinely leads to PII being published on public GitHub issues. This PR applies partial masking by default to both fields.

## Details

Two pure utility functions added to `AboutBox.tsx`:

- `maskEmail`: `john.doe@company.com` → `j***@company.com` (first char + `***` + full domain)
- `maskGcpProject`: `my-prod-project-123456` → `***3456` (last 4 chars only)

The masking strategy preserves enough context to confirm the right account/project without exposing the full value — the same pattern Google's own account-switching UI uses for emails.

`gcpProject` was previously rendered with no guard at all (not even respecting `showUserIdentity`). Both fields are now consistently masked.

No new settings or flags added — this is a privacy-by-default fix.

## Related Issues

Fixes #22804

## How to Validate

1. Log in with a Google OAuth account
2. Run `gemini` and type `/about`
3. Confirm email appears as `j***@domain.com` instead of full address
4. Set `GOOGLE_CLOUD_PROJECT=my-prod-project-123456` and repeat — confirm `***3456` is shown
5. Log in with API key — confirm no email field appears (unchanged behavior)

Run unit tests: `npm test -- --testPathPattern=AboutBox`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Windows
    - [x] npm run
