### PR TITLE
fix(plan): reserve minimum height for selection list in AskUserDialog

### DIFF
--- a/packages/cli/src/ui/components/AskUserDialog.test.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.test.tsx
@@ -1453,4 +1453,42 @@ describe('AskUserDialog', () => {
       });
     });
   });
+
+  it('shows at least 3 selection options even in small terminal heights', async () => {
+    const questions: Question[] = [
+      {
+        question:
+          'A very long question that would normally take up most of the space and squeeze the list if we did not have a heuristic to prevent it. This line is just to make it longer. And another one. Imagine this is a plan.',
+        header: 'Test',
+        type: QuestionType.CHOICE,
+        options: [
+          { label: 'Option 1', description: 'Description 1' },
+          { label: 'Option 2', description: 'Description 2' },
+          { label: 'Option 3', description: 'Description 3' },
+          { label: 'Option 4', description: 'Description 4' },
+        ],
+        multiSelect: false,
+      },
+    ];
+
+    const { lastFrame, waitUntilReady } = await renderWithProviders(
+      <AskUserDialog
+        questions={questions}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+        width={80}
+        availableHeight={12} // Very small height
+      />,
+      { width: 80 },
+    );
+
+    await waitFor(async () => {
+      await waitUntilReady();
+      const frame = lastFrame();
+      // Should show at least 3 options
+      expect(frame).toContain('1.  Option 1');
+      expect(frame).toContain('2.  Option 2');
+      expect(frame).toContain('3.  Option 3');
+    });
+  });
 });

--- a/packages/cli/src/ui/components/AskUserDialog.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.tsx
@@ -849,11 +849,19 @@ const ChoiceQuestionView: React.FC<ChoiceQuestionViewProps> = ({
     ? Math.max(1, availableHeight - overhead)
     : undefined;
 
+  // Reserve space for at least 3 items if more selectionItems available.
+  const reservedListHeight = Math.min(selectionItems.length * 2, 6);
   const questionHeightLimit =
     listHeight && !isAlternateBuffer
       ? question.unconstrainedHeight
         ? Math.max(1, listHeight - selectionItems.length * 2)
-        : Math.min(15, Math.max(1, listHeight - DIALOG_PADDING))
+        : Math.min(
+            15,
+            Math.max(
+              1,
+              listHeight - Math.max(DIALOG_PADDING, reservedListHeight),
+            ),
+          )
       : undefined;
 
   const maxItemsToShow =

--- a/packages/cli/src/ui/components/__snapshots__/AskUserDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/AskUserDialog.test.tsx.snap
@@ -30,6 +30,8 @@ exports[`AskUserDialog > Scroll Arrows (useAlternateBuffer: false) > shows scrol
        Description 1                                                            
    2.  Option 2
        Description 2
+   3.  Option 3
+       Description 3
 ▼
 
 Enter to select · ↑/↓ to navigate · Esc to cancel


### PR DESCRIPTION


## Summary

This PR fixes a UI issue where the `ExitPlanModeDialog` truncated selection options in smaller terminal heights.

## Details

**UI Layout Fix**: In `ExitPlanModeDialog.tsx`, the `AskUserDialog` is configured with `unconstrainedHeight: false`.
The default height for plan content is `Math.min(15, Math.max(1, listHeight - DIALOG_PADDING))`, when 
In terminals with fewer than ~24 lines, the default 15-line cap for the plan content was starving the options list of space, causing it to truncate items. Updating the cap for plan content to leave space for at least 3 options if there are more.

## Related Issues

#23271 

## How to Validate

1.  **Build**: Run `npm run build` to ensure the compilation error is resolved.
2. **Unit test**: Run `npm test -w @google/gemini-cli -- src/ui/components/AskUserDialog.test.tsx`
3.  **Manual Check**:
    -   Resize your terminal to a small height (e.g., 20 lines).
    -   Enter plan mode and ask "create a dummy plan with 50 lines"
    -   Verify that all three options ("automatically accept", "manually accept", and "Type your feedback...") are visible simultaneously without scrolling.
<img width="2760" height="1014" alt="image" src="https://github.com/user-attachments/assets/9c21fb6b-1595-4fca-8e45-a624f8a0569a" />

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
