### PR TITLE
fix(acp): apply ProceedAlways decisions for use of tools to the policy engine in ACP Mode

### DIFF
--- a/packages/cli/src/acp/acpClient.test.ts
+++ b/packages/cli/src/acp/acpClient.test.ts
@@ -171,6 +171,10 @@ describe('GeminiAgent', () => {
         subscribe: vi.fn(),
         unsubscribe: vi.fn(),
       }),
+      getPolicyEngine: vi.fn().mockReturnValue({}),
+      storage: {
+        getProjectTempDir: vi.fn().mockReturnValue('/tmp/project'),
+      },
       getApprovalMode: vi.fn().mockReturnValue('default'),
       isPlanEnabled: vi.fn().mockReturnValue(true),
       getGemini31LaunchedSync: vi.fn().mockReturnValue(false),
@@ -652,6 +656,10 @@ describe('Session', () => {
       getEnableRecursiveFileSearch: vi.fn().mockReturnValue(false),
       getDebugMode: vi.fn().mockReturnValue(false),
       getMessageBus: vi.fn().mockReturnValue(mockMessageBus),
+      getPolicyEngine: vi.fn().mockReturnValue({}),
+      storage: {
+        getProjectTempDir: vi.fn().mockReturnValue('/tmp/project'),
+      },
       setApprovalMode: vi.fn(),
       setModel: vi.fn(),
       isPlanEnabled: vi.fn().mockReturnValue(true),

--- a/packages/cli/src/acp/acpClient.test.ts
+++ b/packages/cli/src/acp/acpClient.test.ts
@@ -111,6 +111,7 @@ vi.mock(
         }),
       })),
       logToolCall: vi.fn(),
+      updatePolicy: vi.fn(),
       isWithinRoot: vi.fn().mockReturnValue(true),
       LlmRole: {
         MAIN: 'main',
@@ -656,6 +657,9 @@ describe('Session', () => {
       getEnableRecursiveFileSearch: vi.fn().mockReturnValue(false),
       getDebugMode: vi.fn().mockReturnValue(false),
       getMessageBus: vi.fn().mockReturnValue(mockMessageBus),
+      get messageBus() {
+        return mockMessageBus;
+      },
       getPolicyEngine: vi.fn().mockReturnValue({}),
       storage: {
         getProjectTempDir: vi.fn().mockReturnValue('/tmp/project'),
@@ -966,6 +970,15 @@ describe('Session', () => {
     expect(mockConnection.requestPermission).toHaveBeenCalled();
     expect(confirmationDetails.onConfirm).toHaveBeenCalledWith(
       ToolConfirmationOutcome.ProceedOnce,
+    );
+    const { updatePolicy } = await import('@google/gemini-cli-core');
+    expect(updatePolicy).toHaveBeenCalledWith(
+      mockTool,
+      ToolConfirmationOutcome.ProceedOnce,
+      expect.objectContaining({ type: 'info' }),
+      expect.anything(),
+      mockMessageBus,
+      expect.anything(),
     );
   });
 

--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -1008,11 +1008,13 @@ export class Session {
 
         await confirmationDetails.onConfirm(outcome);
 
+        const { onConfirm: _onConfirm, ...serializableDetails } =
+          confirmationDetails;
+
         await updatePolicy(
           tool,
           outcome,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
-          confirmationDetails as any, // SerializableConfirmationDetails structure matches what updatePolicy needs
+          serializableDetails,
           this.context,
           this.context.messageBus,
           invocation,

--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -47,6 +47,7 @@ import {
   DEFAULT_GEMINI_MODEL_AUTO,
   PREVIEW_GEMINI_MODEL_AUTO,
   getDisplayString,
+  updatePolicy,
   type AgentLoopContext,
 } from '@google/gemini-cli-core';
 import * as acp from '@agentclientprotocol/sdk';
@@ -69,6 +70,7 @@ import { z } from 'zod';
 
 import { randomUUID } from 'node:crypto';
 import { loadCliConfig, type CliArgs } from '../config/config.js';
+import { createPolicyUpdater } from '../config/policy.js';
 import { runExitCleanup } from '../utils/cleanup.js';
 import { SessionSelector } from '../utils/sessionUtils.js';
 
@@ -299,6 +301,11 @@ export class GeminiAgent {
     }
 
     await config.initialize();
+    createPolicyUpdater(
+      config.getPolicyEngine(),
+      config.getMessageBus(),
+      config.storage,
+    );
     startupProfiler.flush(config);
 
     const geminiClient = config.getGeminiClient();
@@ -437,6 +444,11 @@ export class GeminiAgent {
     // 3. Now that we are authenticated, it is safe to initialize the config
     // which starts the MCP servers and other heavy resources.
     await config.initialize();
+    createPolicyUpdater(
+      config.getPolicyEngine(),
+      config.getMessageBus(),
+      config.storage,
+    );
     startupProfiler.flush(config);
 
     return config;
@@ -995,6 +1007,16 @@ export class Session {
                 .parse(output.outcome.optionId);
 
         await confirmationDetails.onConfirm(outcome);
+
+        await updatePolicy(
+          tool,
+          outcome,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+          confirmationDetails as any, // SerializableConfirmationDetails structure matches what updatePolicy needs
+          this.context,
+          this.context.messageBus,
+          invocation,
+        );
 
         switch (outcome) {
           case ToolConfirmationOutcome.Cancel:

--- a/packages/cli/src/acp/acpResume.test.ts
+++ b/packages/cli/src/acp/acpResume.test.ts
@@ -88,6 +88,12 @@ describe('GeminiAgent Session Resume', () => {
         resumeChat: vi.fn().mockResolvedValue(undefined),
         getChat: vi.fn().mockReturnValue({}),
       }),
+      getPolicyEngine: vi.fn().mockReturnValue({}),
+      getMessageBus: vi.fn().mockReturnValue({
+        publish: vi.fn(),
+        subscribe: vi.fn(),
+        unsubscribe: vi.fn(),
+      }),
       storage: {
         getProjectTempDir: vi.fn().mockReturnValue('/tmp/project'),
       },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,6 +44,7 @@ export * from './core/tokenLimits.js';
 export * from './core/turn.js';
 export * from './core/geminiRequest.js';
 export * from './core/coreToolScheduler.js';
+export * from './scheduler/policy.js';
 export * from './scheduler/scheduler.js';
 export * from './scheduler/types.js';
 export * from './scheduler/tool-executor.js';


### PR DESCRIPTION
### The Problem:

When using the Gemini CLI as an ACP Server (e.g., in an IDE extension), selecting "Always Allow" (or ProceedAlways) on a tool execution prompt only approved that single invocation. The decision was not remembered for the rest of the session, causing the user to be repeatedly prompted for the same tool.

This occurred because the manual Session.prompt execution loop in acpClient.ts bypassed the core Scheduler, meaning the outcome of a tool confirmation was never sent back to the PolicyEngine.

### The Solution:
This PR bridges the gap between the ACP client loop and the core policy engine, mirroring how the interactive terminal CLI behaves:
1. Policy Updater Initialization: Added createPolicyUpdater() during ACP session initialization (newSession and newSessionConfig) so that the session's MessageBus is actively listening for policy update events.
2. Dispatching the Policy Update: Exported updatePolicy from the core package and invoked it directly within acpClient.ts immediately after the ACP client returns a confirmation outcome. The callback functions are stripped from the details object before dispatching to ensure safe serialization.

### Testing:
- Added unit tests in acpClient.test.ts to explicitly verify that updatePolicy is called with the correct parameters and ToolConfirmationOutcome when a tool is confirmed.
- Updated mockConfig in ACP tests to include getPolicyEngine and messageBus getters.
- Verified manually that selecting "Always Allow" in an IDE now correctly bypasses subsequent prompts for the same tool.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
