### PR TITLE
Allow symlinking the policy path

### DIFF
--- a/packages/core/src/policy/toml-loader.test.ts
+++ b/packages/core/src/policy/toml-loader.test.ts
@@ -445,6 +445,35 @@ name = "allowed-path"
       expect(result.checkers[0].priority).toBe(1.1); // tier 1 + 100/1000
       expect(result.checkers[0].source).toBe('Default: test.toml');
     });
+    it('should support symlinked policy directories', async () => {
+      const realDir = path.join(tempDir, 'real-policies');
+      const symlinkDir = path.join(tempDir, 'symlinked-policies');
+      await fs.mkdir(realDir);
+      await fs.writeFile(
+        path.join(realDir, 'test.toml'),
+        '[[rule]]\ntoolName = "test"\ndecision = "allow"\npriority = 100\n',
+      );
+      await fs.symlink(realDir, symlinkDir);
+
+      const result = await loadPoliciesFromToml([symlinkDir], () => 1);
+      expect(result.rules).toHaveLength(1);
+      expect(result.rules[0].toolName).toBe('test');
+    });
+
+    it('should support symlinked policy files inside a directory', async () => {
+      const realFile = path.join(tempDir, 'real.toml');
+      const policiesDir = path.join(tempDir, 'policies');
+      await fs.mkdir(policiesDir);
+      await fs.writeFile(
+        realFile,
+        '[[rule]]\ntoolName = "test-file"\ndecision = "allow"\npriority = 100\n',
+      );
+      await fs.symlink(realFile, path.join(policiesDir, 'link.toml'));
+
+      const result = await loadPoliciesFromToml([policiesDir], () => 1);
+      expect(result.rules).toHaveLength(1);
+      expect(result.rules[0].toolName).toBe('test-file');
+    });
   });
 
   describe('Negative Tests', () => {

--- a/packages/core/src/policy/toml-loader.ts
+++ b/packages/core/src/policy/toml-loader.ts
@@ -166,7 +166,11 @@ export async function readPolicyFiles(
       baseDir = policyPath;
       const dirEntries = await fs.readdir(policyPath, { withFileTypes: true });
       filesToLoad = dirEntries
-        .filter((entry) => entry.isFile() && entry.name.endsWith('.toml'))
+        .filter(
+          (entry) =>
+            (entry.isFile() || entry.isSymbolicLink()) &&
+            entry.name.endsWith('.toml'),
+        )
         .map((entry) => entry.name);
     } else if (stats.isFile() && policyPath.endsWith('.toml')) {
       baseDir = path.dirname(policyPath);


### PR DESCRIPTION
## Summary

Allows .toml files to be synlinks

## Related Issues

Closes #20281

## How to Validate

Add a policy file in ~/.gemini/policies that is a symlink.
## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
