### PR TITLE
fix(core): refine CliHelpAgent description for better delegation

### DIFF
--- a/evals/cli_help_delegation.eval.ts
+++ b/evals/cli_help_delegation.eval.ts
@@ -1,0 +1,25 @@
+import { describe, expect } from 'vitest';
+import { evalTest } from './test-helper.js';
+
+describe('CliHelpAgent Delegation', () => {
+  evalTest('USUALLY_PASSES', {
+    name: 'should delegate to cli_help agent for subagent creation questions',
+    params: {
+      settings: {
+        experimental: {
+          enableAgents: true,
+        },
+      },
+    },
+    prompt: 'Help me create a subagent in this project',
+    timeout: 60000,
+    assert: async (rig, _result) => {
+      const toolLogs = rig.readToolLogs();
+      const toolCallIndex = toolLogs.findIndex(
+        (log) => log.toolRequest.name === 'cli_help',
+      );
+      expect(toolCallIndex).toBeGreaterThan(-1);
+      expect(toolCallIndex).toBeLessThan(5); // Called within first 5 turns
+    },
+  });
+});

--- a/packages/core/src/agents/cli-help-agent.ts
+++ b/packages/core/src/agents/cli-help-agent.ts
@@ -30,7 +30,7 @@ export const CliHelpAgent = (
   kind: 'local',
   displayName: 'CLI Help Agent',
   description:
-    'Specialized in answering questions about how users use you, (Gemini CLI): features, documentation, and current runtime configuration.',
+    'Specialized agent for answering questions about the Gemini CLI application. Invoke this agent for questions regarding CLI features, configuration schemas (e.g., policies), or instructions on how to create custom subagents. It queries internal documentation to provide accurate usage guidance.',
   inputConfig: {
     inputSchema: {
       type: 'object',


### PR DESCRIPTION
## Summary

Refine the description of the `CliHelpAgent` to clarify its triggers and specialized role in answering questions about documentation, schemas, and custom subagents.

## Details

- Updated description in `packages/core/src/agents/cli-help-agent.ts` from "Specialized in answering questions about how users use you..." to a more prescriptive trigger-based description.
- Framed capabilities around answering questions about features/schemas to prevent inappropriate action triggers.

## Related Issues

N/A

## How to Validate

- Run agent unit test: `npm test -w @google/gemini-cli-core -- src/agents/cli-help-agent.test.ts`
- Run preflight in root: `npm run preflight`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
