### PR TITLE
Add note about root privileges in sandbox docs

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2325,9 +2325,13 @@ can be based on the base sandbox image:
 ```dockerfile
 FROM gemini-cli-sandbox
 
-# Add your custom dependencies or configurations here
+# Add your custom dependencies or configurations here.
+# Note: The base image runs as the non-root 'node' user.
+# You must switch to 'root' to install system packages.
 # For example:
+# USER root
 # RUN apt-get update && apt-get install -y some-package
+# USER node
 # COPY ./my-config /app/my-config
 ```
 


### PR DESCRIPTION
## Summary

The `gemini-cli-sandbox` base image configures the container to run as the non-root `node` user by default. Therefore, any custom Dockerfile that extends from `gemini-cli-sandbox` inherits this non-root user execution context.

As a result, running the sample `RUN apt-get update && apt-get install -y some-package` snippet would result in a "Permission denied" error for users setting up their own project-specific sandboxes, leading to confusing first-time development experiences. This clarifies the requirement to elevate privileges explicitly.

## Details

- Updated the custom `sandbox.Dockerfile` example in `docs/reference/configuration.md` to explicitly switch to `USER root` before executing system package installations containing `apt-get` commands.
- Included an additional instruction to switch back to `USER node` following the installation to restrict runtime privileges and enforce container security best practices.

## Related Issues

Fixes #17500 

## Pre-Merge Checklist

- [ X ] Updated relevant documentation and README (if needed)