### PR TITLE
fix(core): fix agent description indentation

### DIFF
--- a/packages/core/src/agents/codebase-investigator.ts
+++ b/packages/core/src/agents/codebase-investigator.ts
@@ -66,9 +66,7 @@ export const CodebaseInvestigatorAgent = (
     name: 'codebase_investigator',
     kind: 'local',
     displayName: 'Codebase Investigator Agent',
-    description: `The specialized tool for codebase analysis, architectural mapping, and understanding system-wide dependencies.
-    Invoke this tool for tasks like vague requests, bug root-cause analysis, system refactoring, comprehensive feature implementation or to answer questions about the codebase that require investigation.
-    It returns a structured report with key file paths, symbols, and actionable architectural insights.`,
+    description: `The specialized tool for codebase analysis, architectural mapping, and understanding system-wide dependencies. Invoke this tool for tasks like vague requests, bug root-cause analysis, system refactoring, comprehensive feature implementation or to answer questions about the codebase that require investigation. It returns a structured report with key file paths, symbols, and actionable architectural insights.`,
     inputConfig: {
       inputSchema: {
         type: 'object',

--- a/packages/core/src/agents/codebase-investigator.ts
+++ b/packages/core/src/agents/codebase-investigator.ts
@@ -66,7 +66,10 @@ export const CodebaseInvestigatorAgent = (
     name: 'codebase_investigator',
     kind: 'local',
     displayName: 'Codebase Investigator Agent',
-    description: `The specialized tool for codebase analysis, architectural mapping, and understanding system-wide dependencies. Invoke this tool for tasks like vague requests, bug root-cause analysis, system refactoring, comprehensive feature implementation or to answer questions about the codebase that require investigation. It returns a structured report with key file paths, symbols, and actionable architectural insights.`,
+    description:
+      `The specialized tool for codebase analysis, architectural mapping, and understanding system-wide dependencies. ` +
+      `Invoke this tool for tasks like vague requests, bug root-cause analysis, system refactoring, comprehensive feature implementation or to answer questions about the codebase that require investigation. ` +
+      `It returns a structured report with key file paths, symbols, and actionable architectural insights.`,
     inputConfig: {
       inputSchema: {
         type: 'object',


### PR DESCRIPTION
## Summary

Fixes weird indentation in the `/agents` list command output for the Codebase Investigator Agent.

## Details

The description for `codebase_investigator` in `packages/core/src/agents/codebase-investigator.ts` was using a multi-line template literal with leading spaces on subsequent lines. These spaces were preserved in the rendered description by `MarkdownDisplay`.

Converted the description to a single continuous line to allow the layout system to wrap it correctly, matching other agent definitions.

## Related Issues

None.

## How to Validate

1. Run current build or `npm run start`.
2. Run `/agents` list.
3. Verify descriptions align cleanly.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
