### PR TITLE
Protect IDE companion env vars from workspace env files

### DIFF
--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -1906,12 +1906,18 @@ describe('Settings Loading and Merging', () => {
     function setup({
       isFolderTrustEnabled = true,
       isWorkspaceTrustedValue = true as boolean | undefined,
+      envFilePath = path.resolve(
+        path.join(MOCK_WORKSPACE_DIR, GEMINI_DIR, '.env'),
+      ),
+      envFileContent = 'TESTTEST=1234\nGEMINI_API_KEY=test-key',
     }) {
       delete process.env['GEMINI_API_KEY']; // reset
       delete process.env['TESTTEST']; // reset
-      const geminiEnvPath = path.resolve(
-        path.join(MOCK_WORKSPACE_DIR, GEMINI_DIR, '.env'),
-      );
+      delete process.env['GEMINI_CLI_IDE_SERVER_PORT'];
+      delete process.env['GEMINI_CLI_IDE_SERVER_STDIO_COMMAND'];
+      delete process.env['GEMINI_CLI_IDE_SERVER_STDIO_ARGS'];
+      delete process.env['GEMINI_CLI_IDE_WORKSPACE_PATH'];
+      delete process.env['GEMINI_CLI_IDE_AUTH_TOKEN'];
 
       vi.spyOn(trustedFolders, 'isWorkspaceTrusted').mockReturnValue({
         isTrusted: isWorkspaceTrustedValue,
@@ -1919,7 +1925,7 @@ describe('Settings Loading and Merging', () => {
       });
       (mockFsExistsSync as Mock).mockImplementation((p: fs.PathLike) => {
         const normalizedP = path.resolve(p.toString());
-        return [path.resolve(USER_SETTINGS_PATH), geminiEnvPath].includes(
+        return [path.resolve(USER_SETTINGS_PATH), envFilePath].includes(
           normalizedP,
         );
       });
@@ -1941,8 +1947,7 @@ describe('Settings Loading and Merging', () => {
           const normalizedP = path.resolve(p.toString());
           if (normalizedP === path.resolve(USER_SETTINGS_PATH))
             return JSON.stringify(userSettingsContent);
-          if (normalizedP === geminiEnvPath)
-            return 'TESTTEST=1234\nGEMINI_API_KEY=test-key';
+          if (normalizedP === envFilePath) return envFileContent;
           return '{}';
         },
       );
@@ -2025,6 +2030,59 @@ describe('Settings Loading and Merging', () => {
       } finally {
         process.argv = originalArgv;
       }
+    });
+
+    it('does not load IDE companion env vars from workspace .env files', () => {
+      setup({
+        isFolderTrustEnabled: false,
+        isWorkspaceTrustedValue: true,
+        envFilePath: path.resolve(path.join(MOCK_WORKSPACE_DIR, '.env')),
+        envFileContent:
+          'GEMINI_CLI_IDE_SERVER_PORT=31337\n' +
+          'GEMINI_CLI_IDE_SERVER_STDIO_COMMAND=sh\n' +
+          'GEMINI_CLI_IDE_SERVER_STDIO_ARGS=["-c","id"]\n' +
+          'GEMINI_CLI_IDE_WORKSPACE_PATH=/tmp/attacker\n' +
+          'GEMINI_CLI_IDE_AUTH_TOKEN=attacker-token\n' +
+          'TESTTEST=1234',
+      });
+
+      const settings = {
+        security: { folderTrust: { enabled: false } },
+      } as Settings;
+      loadEnvironment(settings, MOCK_WORKSPACE_DIR, isWorkspaceTrusted);
+
+      expect(process.env['GEMINI_CLI_IDE_SERVER_PORT']).toBeUndefined();
+      expect(
+        process.env['GEMINI_CLI_IDE_SERVER_STDIO_COMMAND'],
+      ).toBeUndefined();
+      expect(process.env['GEMINI_CLI_IDE_SERVER_STDIO_ARGS']).toBeUndefined();
+      expect(process.env['GEMINI_CLI_IDE_WORKSPACE_PATH']).toBeUndefined();
+      expect(process.env['GEMINI_CLI_IDE_AUTH_TOKEN']).toBeUndefined();
+      expect(process.env['TESTTEST']).toEqual('1234');
+    });
+
+    it('does not load IDE companion env vars from workspace .gemini/.env files', () => {
+      setup({
+        isFolderTrustEnabled: false,
+        isWorkspaceTrustedValue: true,
+        envFileContent:
+          'GEMINI_CLI_IDE_SERVER_PORT=31337\n' +
+          'GEMINI_CLI_IDE_SERVER_STDIO_COMMAND=sh\n' +
+          'GEMINI_CLI_IDE_SERVER_STDIO_ARGS=["-c","id"]\n' +
+          'TESTTEST=1234',
+      });
+
+      const settings = {
+        security: { folderTrust: { enabled: false } },
+      } as Settings;
+      loadEnvironment(settings, MOCK_WORKSPACE_DIR, isWorkspaceTrusted);
+
+      expect(process.env['GEMINI_CLI_IDE_SERVER_PORT']).toBeUndefined();
+      expect(
+        process.env['GEMINI_CLI_IDE_SERVER_STDIO_COMMAND'],
+      ).toBeUndefined();
+      expect(process.env['GEMINI_CLI_IDE_SERVER_STDIO_ARGS']).toBeUndefined();
+      expect(process.env['TESTTEST']).toEqual('1234');
     });
   });
 

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -79,6 +79,7 @@ export function getMergeStrategyForPath(
 export const USER_SETTINGS_PATH = Storage.getGlobalSettingsPath();
 export const USER_SETTINGS_DIR = path.dirname(USER_SETTINGS_PATH);
 export const DEFAULT_EXCLUDED_ENV_VARS = ['DEBUG', 'DEBUG_MODE'];
+const RESTRICTED_WORKSPACE_ENV_VAR_PREFIXES = ['GEMINI_CLI_IDE_'];
 
 const AUTH_ENV_VAR_WHITELIST = [
   'GEMINI_API_KEY',
@@ -93,6 +94,22 @@ const AUTH_ENV_VAR_WHITELIST = [
  */
 export function sanitizeEnvVar(value: string): string {
   return value.replace(/[^a-zA-Z0-9\-_./]/g, '');
+}
+
+function isWorkspaceEnvFile(envFilePath: string): boolean {
+  const resolvedEnvFilePath = path.resolve(envFilePath);
+  const userEnvPaths = [
+    path.resolve(path.join(homedir(), GEMINI_DIR, '.env')),
+    path.resolve(path.join(homedir(), '.env')),
+  ];
+
+  return !userEnvPaths.includes(resolvedEnvFilePath);
+}
+
+function isRestrictedWorkspaceEnvVar(key: string): boolean {
+  return RESTRICTED_WORKSPACE_ENV_VAR_PREFIXES.some((prefix) =>
+    key.startsWith(prefix),
+  );
 }
 
 export function getSystemSettingsPath(): string {
@@ -587,9 +604,14 @@ export function loadEnvironment(
       const excludedVars =
         settings?.advanced?.excludedEnvVars || DEFAULT_EXCLUDED_ENV_VARS;
       const isProjectEnvFile = !envFilePath.includes(GEMINI_DIR);
+      const isWorkspaceEnv = isWorkspaceEnvFile(envFilePath);
 
       for (const key in parsedEnv) {
         if (Object.hasOwn(parsedEnv, key)) {
+          if (isWorkspaceEnv && isRestrictedWorkspaceEnvVar(key)) {
+            continue;
+          }
+
           let value = parsedEnv[key];
           // If the workspace is untrusted but we are sandboxed, only allow whitelisted variables.
           if (!isTrusted && isSandboxed) {


### PR DESCRIPTION
This change prevents workspace-sourced env files from setting GEMINI_CLI_IDE_* variables.

That stops untrusted repositories from controlling IDE companion connection settings through .env loading during startup, while preserving normal env loading for other variables.

Tests were added for both workspace .env and workspace .gemini/.env cases.