### PR TITLE
fix(policy): honor allow_redirection for redirection-only shell fragments

### DIFF
--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -1586,6 +1586,41 @@ describe('PolicyEngine', () => {
       expect(result.decision).toBe(PolicyDecision.ALLOW);
     });
 
+    it('should allow redirection-only fragments when the matched rule explicitly allows redirection', async () => {
+      const rules: PolicyRule[] = [
+        {
+          toolName: 'run_shell_command',
+          argsPattern: /"command":"echo\b/,
+          decision: PolicyDecision.ALLOW,
+          priority: 20,
+          allowRedirection: true,
+        },
+        {
+          toolName: 'run_shell_command',
+          decision: PolicyDecision.ASK_USER,
+          priority: 10,
+        },
+      ];
+
+      engine = new PolicyEngine({ rules });
+
+      const { splitCommands } = await import('../utils/shell-utils.js');
+      vi.mocked(splitCommands).mockReturnValueOnce([
+        'echo "hello"',
+        '> test.txt',
+      ]);
+
+      const result = await engine.check(
+        {
+          name: 'run_shell_command',
+          args: { command: 'echo "hello" > test.txt' },
+        },
+        undefined,
+      );
+
+      expect(result.decision).toBe(PolicyDecision.ALLOW);
+    });
+
     it('should allow compound commands with safe operators (&&, ||) if individual commands are allowed', async () => {
       const rules: PolicyRule[] = [
         {

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -24,6 +24,7 @@ import {
   initializeShellParsers,
   splitCommands,
   hasRedirection,
+  getCommandRoots,
 } from '../utils/shell-utils.js';
 import { getToolAliases } from '../tools/tool-names.js';
 import {
@@ -37,6 +38,16 @@ import {
 function isWildcardPattern(name: string): boolean {
   return name === '*' || name.includes('*');
 }
+
+const REDIRECTION_ONLY_ROOTS = new Set([
+  '>',
+  '>>',
+  '<',
+  'redirection (<)',
+  'redirection (>)',
+  'heredoc (<<)',
+  'herestring (<<<)',
+]);
 
 /**
  * Checks if a tool call matches a wildcard pattern.
@@ -243,6 +254,15 @@ export class PolicyEngine {
     );
   }
 
+  private isRedirectionOnlyFragment(command: string): boolean {
+    const roots = getCommandRoots(command);
+    if (roots.length > 0) {
+      return roots.every((root) => REDIRECTION_ONLY_ROOTS.has(root));
+    }
+
+    return /^\d*(?:>>?|<<<?|<)(?!\()/.test(command.trim());
+  }
+
   /**
    * Check if a shell command is allowed.
    */
@@ -340,6 +360,13 @@ export class PolicyEngine {
               responsibleRule = rule;
             }
           }
+          continue;
+        }
+
+        if (allowRedirection && this.isRedirectionOnlyFragment(subCmd)) {
+          debugLogger.debug(
+            `[PolicyEngine.check] Skipping redirection-only fragment allowed by matching rule: ${subCmd}`,
+          );
           continue;
         }
 

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -260,7 +260,7 @@ export class PolicyEngine {
       return roots.every((root) => REDIRECTION_ONLY_ROOTS.has(root));
     }
 
-    return /^\d*(?:>>?|<<<?|<)(?!\()/.test(command.trim());
+    return /^\d*(?:\u003e\u003e?|\u0026\u003e|\u003c\u003c\u003c?|\u003c|\u003e\u0026|\u003c\u0026)(?!\()/.test(command.trim());
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes a policy engine bug where shell commands allowed by a rule with `allow_redirection = true` could still fall back to `ASK_USER`.

This happened because redirect-only fragments such as `> test.txt` could be recursively re-evaluated as standalone shell commands, causing them to miss the matched allow rule and fall through to lower-priority or default policy behavior.

## Details

The fix stays in the policy engine layer.

Changes:
- add detection for redirection-only shell fragments
- skip recursive policy re-checks for those fragments when the matched rule explicitly allows redirection
- add a regression test covering the reported case

This preserves the existing recursive checks for real subcommands and process substitutions, while making `allow_redirection` behave as intended for plain output/input redirection.

## Related Issues

Fixes #23096

## How to Validate

1. Run the focused policy test suites:
   ```sh
   npx vitest run packages/core/src/policy/policy-engine.test.ts packages/core/src/policy/shell-safety.test.ts
