### PR TITLE
fix(core): dedupe repeated shell command names in Action Required confirmations

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -798,6 +798,22 @@ describe('ShellTool', () => {
   });
 
   describe('getConfirmationDetails', () => {
+    it('should deduplicate repeated command names in chained commands', async () => {
+      const shellTool = new ShellTool(mockConfig, createMockMessageBus());
+      const command = 'git status && git diff && git log --oneline';
+      const invocation = shellTool.build({ command });
+
+      // @ts-expect-error - getConfirmationDetails is protected
+      const details = await invocation.getConfirmationDetails(
+        new AbortController().signal,
+      );
+
+      expect(details).not.toBe(false);
+      if (details && details.type === 'exec') {
+        expect(details.rootCommand).toBe('git');
+      }
+    });
+
     it('should annotate sub-commands with redirection correctly', async () => {
       const shellTool = new ShellTool(mockConfig, createMockMessageBus());
       const command = 'mkdir -p baz && echo "hello" > baz/test.md && ls';
@@ -845,6 +861,24 @@ describe('ShellTool', () => {
       expect(details).not.toBe(false);
       if (details && details.type === 'exec') {
         expect(details.rootCommand).toBe('ls, grep');
+      }
+    });
+
+    it('should keep redirection annotations while deduplicating command names', async () => {
+      const shellTool = new ShellTool(mockConfig, createMockMessageBus());
+      const command = 'echo "hello" > first.txt && echo "world" > second.txt';
+      const invocation = shellTool.build({ command });
+
+      // @ts-expect-error - getConfirmationDetails is protected
+      const details = await invocation.getConfirmationDetails(
+        new AbortController().signal,
+      );
+
+      expect(details).not.toBe(false);
+      if (details && details.type === 'exec') {
+        expect(details.rootCommand).toBe(
+          'echo, redirection (>), redirection (>)',
+        );
       }
     });
   });

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -50,6 +50,37 @@ export const OUTPUT_UPDATE_INTERVAL_MS = 1000;
 
 // Delay so user does not see the output of the process before the process is moved to the background.
 const BACKGROUND_DELAY_MS = 200;
+const SHELL_DETAIL_ANNOTATION_PREFIXES = [
+  'redirection (',
+  'heredoc (',
+  'herestring (',
+];
+
+function isShellDetailAnnotation(name: string): boolean {
+  return SHELL_DETAIL_ANNOTATION_PREFIXES.some((prefix) =>
+    name.startsWith(prefix),
+  );
+}
+
+function formatRootCommandDisplay(details: Array<{ name: string }>): string {
+  const seenCommandNames = new Set<string>();
+
+  return details
+    .filter((detail) => {
+      if (isShellDetailAnnotation(detail.name)) {
+        return true;
+      }
+
+      if (seenCommandNames.has(detail.name)) {
+        return false;
+      }
+
+      seenCommandNames.add(detail.name);
+      return true;
+    })
+    .map((detail) => detail.name)
+    .join(', ');
+}
 
 export interface ShellToolParams {
   command: string;
@@ -124,9 +155,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
         rootCommandDisplay += ', redirection';
       }
     } else {
-      rootCommandDisplay = parsed.details
-        .map((detail) => detail.name)
-        .join(', ');
+      rootCommandDisplay = formatRootCommandDisplay(parsed.details);
     }
 
     const rootCommands = [...new Set(getCommandRoots(command))];


### PR DESCRIPTION
## Summary

Fixes a shell confirmation display bug where chained commands could repeat the same executable name multiple times in the Action Required prompt.

For example, a command like:

```sh
git status && git diff && git log
