### PR TITLE
fix(core): redact proxy credentials in feedback errors

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1534,6 +1534,30 @@ describe('Server Config (config.ts)', () => {
       );
     });
 
+    it('should redact embedded proxy credentials in emitted proxy errors', () => {
+      const proxyError = new Error(
+        'Invalid proxy URL: http://api-key-123:super-secret@proxy.example.com:8080',
+      );
+      mockSetGlobalProxy.mockImplementation(() => {
+        throw proxyError;
+      });
+
+      const paramsWithProxy: ConfigParameters = {
+        ...baseParams,
+        proxy: 'http://api-key-123:super-secret@proxy.example.com:8080',
+      };
+      new Config(paramsWithProxy);
+
+      expect(mockCoreEvents.emitFeedback).toHaveBeenCalledTimes(1);
+      const emittedError = mockCoreEvents.emitFeedback.mock.calls[0]?.[2];
+      expect(emittedError).toBeInstanceOf(Error);
+      expect((emittedError as Error).message).toContain(
+        'http://[REDACTED]@proxy.example.com:8080',
+      );
+      expect((emittedError as Error).message).not.toContain('api-key-123');
+      expect((emittedError as Error).message).not.toContain('super-secret');
+    });
+
     it('should not emit error feedback when setGlobalProxy succeeds', () => {
       mockSetGlobalProxy.mockImplementation(() => {
         // Success - no error thrown

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -54,6 +54,7 @@ import {
   uiTelemetryService,
   type TelemetryTarget,
 } from '../telemetry/index.js';
+import { sanitizeErrorMessage } from '../utils/agent-sanitization-utils.js';
 import { coreEvents, CoreEvent } from '../utils/events.js';
 import { tokenLimit } from '../core/tokenLimits.js';
 import {
@@ -158,6 +159,34 @@ import { InjectionService } from './injectionService.js';
 import { ExecutionLifecycleService } from '../services/executionLifecycleService.js';
 import { WORKSPACE_POLICY_TIER } from '../policy/config.js';
 import { loadPoliciesFromToml } from '../policy/toml-loader.js';
+
+function sanitizeFeedbackError(error: unknown): unknown {
+  if (typeof error === 'string') {
+    return sanitizeErrorMessage(error);
+  }
+
+  if (!(error instanceof Error)) {
+    return error;
+  }
+
+  const sanitizedMessage = sanitizeErrorMessage(error.message);
+  const sanitizedStack = error.stack
+    ? sanitizeErrorMessage(error.stack)
+    : undefined;
+
+  if (sanitizedMessage === error.message && sanitizedStack === error.stack) {
+    return error;
+  }
+
+  const sanitizedError = new Error(sanitizedMessage, { cause: error.cause });
+  sanitizedError.name = error.name;
+
+  if (sanitizedStack) {
+    sanitizedError.stack = sanitizedStack;
+  }
+
+  return sanitizedError;
+}
 
 import { CheckerRunner } from '../safety/checker-runner.js';
 import { ContextBuilder } from '../safety/context-builder.js';
@@ -1232,7 +1261,7 @@ export class Config implements McpContext, AgentLoopContext {
         coreEvents.emitFeedback(
           'error',
           'Invalid proxy configuration detected. Check debug drawer for more details (F12)',
-          error,
+          sanitizeFeedbackError(error),
         );
       }
     }

--- a/packages/core/src/utils/agent-sanitization-utils.test.ts
+++ b/packages/core/src/utils/agent-sanitization-utils.test.ts
@@ -49,6 +49,16 @@ describe('agent-sanitization-utils', () => {
       expect(result).not.toContain('secret123');
     });
 
+    it('should redact credentials embedded in URLs', () => {
+      const input =
+        'Invalid proxy URL: http://api-key-123:super-secret@proxy.example.com:8080';
+      const result = sanitizeErrorMessage(input);
+
+      expect(result).toContain('http://[REDACTED]@proxy.example.com:8080');
+      expect(result).not.toContain('api-key-123');
+      expect(result).not.toContain('super-secret');
+    });
+
     it('should redact space-separated sensitive keywords', () => {
       // The keyword regex requires tokens to be 8+ chars
       const input = 'Using password mySuperSecretPassword123';

--- a/packages/core/src/utils/agent-sanitization-utils.ts
+++ b/packages/core/src/utils/agent-sanitization-utils.ts
@@ -81,6 +81,12 @@ export function sanitizeErrorMessage(message: string): string {
 
   let sanitized = message;
 
+  // 0. Redact credentials embedded in URLs (e.g. proxy URLs)
+  sanitized = sanitized.replace(
+    /\b([a-z][a-z0-9+.-]*:\/\/)([^/\s@]+)@/gi,
+    '$1[REDACTED]@',
+  );
+
   // 1. Redact inline PEM content (Safe iterative approach to avoid ReDoS)
   let startIndex = 0;
   while ((startIndex = sanitized.indexOf('-----BEGIN', startIndex)) !== -1) {

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -5,6 +5,7 @@
  */
 
 import { getErrorMessage, isNodeError } from './errors.js';
+import { sanitizeErrorMessage } from './agent-sanitization-utils.js';
 import { URL } from 'node:url';
 import { Agent, ProxyAgent, setGlobalDispatcher } from 'undici';
 import ipaddr from 'ipaddr.js';
@@ -191,11 +192,25 @@ export async function fetchWithTimeout(
 }
 
 export function setGlobalProxy(proxy: string) {
-  setGlobalDispatcher(
-    new ProxyAgent({
-      uri: proxy,
-      headersTimeout: DEFAULT_HEADERS_TIMEOUT,
-      bodyTimeout: DEFAULT_BODY_TIMEOUT,
-    }),
-  );
+  try {
+    setGlobalDispatcher(
+      new ProxyAgent({
+        uri: proxy,
+        headersTimeout: DEFAULT_HEADERS_TIMEOUT,
+        bodyTimeout: DEFAULT_BODY_TIMEOUT,
+      }),
+    );
+  } catch (error) {
+    if (error instanceof Error) {
+      const sanitizedError = new Error(sanitizeErrorMessage(error.message), {
+        cause: error.cause,
+      });
+      sanitizedError.name = error.name;
+      sanitizedError.stack = error.stack
+        ? sanitizeErrorMessage(error.stack)
+        : undefined;
+      throw sanitizedError;
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
## Summary

Fixes a security issue where invalid proxy configuration errors could expose credentials embedded in proxy URLs.

For example, an error involving a proxy like:

```text
http://api-key-123:super-secret@proxy.example.com:8080
