### PR TITLE
feat(voice): add AudioWaveform component for voice session state visualization

### DIFF
--- a/packages/cli/src/ui/components/AudioWaveform.test.tsx
+++ b/packages/cli/src/ui/components/AudioWaveform.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '../../test-utils/render.js';
+import stripAnsi from 'strip-ansi';
+import { AudioWaveform } from './AudioWaveform.js';
+import type { VoiceState } from './AudioWaveform.js';
+
+describe('<AudioWaveform />', () => {
+  it('renders nothing in idle state', async () => {
+    const { lastFrame, waitUntilReady, unmount } = await render(
+      <AudioWaveform state="idle" />,
+    );
+    await waitUntilReady();
+    expect(lastFrame({ allowEmpty: true })).toBe('');
+    unmount();
+  });
+
+  it.each(['listening', 'processing', 'speaking', 'error'] as VoiceState[])(
+    'renders a non-empty waveform in %s state',
+    async (state) => {
+      const { lastFrame, waitUntilReady, unmount } = await render(
+        <AudioWaveform state={state} width={20} />,
+      );
+      await waitUntilReady();
+      expect(stripAnsi(lastFrame()).trim().length).toBeGreaterThan(0);
+      unmount();
+    },
+  );
+
+  it.each([
+    ['listening', 'listening'],
+    ['processing', 'processing'],
+    ['speaking', 'speaking'],
+    ['error', 'error'],
+  ] as Array<[VoiceState, string]>)(
+    'shows label in %s state',
+    async (state, label) => {
+      const { lastFrame, waitUntilReady, unmount } = await render(
+        <AudioWaveform state={state} width={30} />,
+      );
+      await waitUntilReady();
+      expect(stripAnsi(lastFrame()).trim()).toContain(label);
+      unmount();
+    },
+  );
+
+  it('renders unicode block characters for non-zero amplitudes', async () => {
+    const amplitudes = [0.25, 0.5, 0.75, 1.0, 0.75, 0.5, 0.25];
+    const { lastFrame, waitUntilReady, unmount } = await render(
+      <AudioWaveform state="speaking" amplitudes={amplitudes} width={20} />,
+    );
+    await waitUntilReady();
+    expect(/[▁▂▃▄▅▆▇█]/.test(lastFrame())).toBe(true);
+    unmount();
+  });
+
+  it('uses all-low bars for all-zero amplitudes', async () => {
+    const amplitudes = new Array(10).fill(0);
+    const { lastFrame, waitUntilReady, unmount } = await render(
+      <AudioWaveform state="listening" amplitudes={amplitudes} width={20} />,
+    );
+    await waitUntilReady();
+    expect(/[▃▄▅▆▇█]/.test(lastFrame())).toBe(false);
+    unmount();
+  });
+
+  it('uses all-full bars for all-one amplitudes', async () => {
+    const amplitudes = new Array(10).fill(1.0);
+    const { lastFrame, waitUntilReady, unmount } = await render(
+      <AudioWaveform state="speaking" amplitudes={amplitudes} width={20} />,
+    );
+    await waitUntilReady();
+    expect(lastFrame()).toContain('█');
+    unmount();
+  });
+
+  it('generates synthetic animation in listening state', async () => {
+    const { lastFrameRaw, waitUntilReady, unmount } = await render(
+      <AudioWaveform state="listening" width={20} />,
+    );
+    await waitUntilReady();
+    const frame1 = stripAnsi(lastFrameRaw()).trim();
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    const frame2 = stripAnsi(lastFrameRaw()).trim();
+    expect(frame1.length).toBeGreaterThan(0);
+    expect(frame2.length).toBeGreaterThan(0);
+    expect(frame1).not.toBe(frame2);
+    unmount();
+  });
+
+  it('error state is static', async () => {
+    const { lastFrame, waitUntilReady, unmount } = await render(
+      <AudioWaveform state="error" width={20} />,
+    );
+    await waitUntilReady();
+    const frame1 = stripAnsi(lastFrame()).trim();
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const frame2 = stripAnsi(lastFrame()).trim();
+    expect(frame1).toBe(frame2);
+    unmount();
+  });
+
+  it('respects a narrow width', async () => {
+    const { lastFrame, waitUntilReady, unmount } = await render(
+      <AudioWaveform
+        state="listening"
+        amplitudes={new Array(5).fill(1.0)}
+        width={10}
+      />,
+    );
+    await waitUntilReady();
+    const text = stripAnsi(lastFrame()).replace('listening', '').trim();
+    expect(text.length).toBeLessThanOrEqual(10);
+    unmount();
+  });
+});

--- a/packages/cli/src/ui/components/AudioWaveform.tsx
+++ b/packages/cli/src/ui/components/AudioWaveform.tsx
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type React from 'react';
+import { useEffect, useState } from 'react';
+import { Text, Box } from 'ink';
+import { debugState } from '../debug.js';
+
+export type VoiceState =
+  | 'idle'
+  | 'listening'
+  | 'processing'
+  | 'speaking'
+  | 'error';
+
+export interface AudioWaveformProps {
+  state: VoiceState;
+  /**
+   * Amplitude samples in [0, 1]. When omitted a synthetic animation is
+   * generated at 80 ms/tick so the component works before the audio pipeline
+   * is wired up.
+   */
+  amplitudes?: number[];
+  /**
+   * Total width available in terminal columns (bars + label).
+   * @default 40
+   */
+  width?: number;
+}
+
+// Unicode block characters ordered from empty to full (9 levels, indices 0-8).
+const BARS = ' ▁▂▃▄▅▆▇█';
+
+const STATE_COLOR: Record<VoiceState, string> = {
+  idle: 'gray',
+  listening: 'green',
+  processing: 'yellow',
+  speaking: 'cyan',
+  error: 'red',
+};
+
+const STATE_LABEL: Record<VoiceState, string> = {
+  idle: '',
+  listening: ' listening',
+  processing: ' processing',
+  speaking: ' speaking',
+  error: ' error',
+};
+
+const ANIMATION_INTERVAL_MS = 80;
+
+function syntheticAmplitudes(
+  tick: number,
+  barCount: number,
+  state: VoiceState,
+): number[] {
+  if (state === 'processing') {
+    const pulse = (1 + Math.sin((tick * Math.PI) / 15)) / 2;
+    return Array.from({ length: barCount }, () => 0.2 + 0.6 * pulse);
+  }
+  return Array.from({ length: barCount }, (_, i) => {
+    const phase = (i / barCount) * Math.PI * 2;
+    return (1 + Math.sin(phase + tick * 0.3)) / 2;
+  });
+}
+
+function amplitudeToChar(amp: number): string {
+  const index = Math.round(Math.max(0, Math.min(1, amp)) * (BARS.length - 1));
+  return BARS[index] ?? '█';
+}
+
+/**
+ * Animated terminal waveform that visualises the current voice session state.
+ *
+ * Renders nothing in idle state. In all other states a bar chart built from
+ * Unicode block characters is shown alongside a text label.
+ */
+export function AudioWaveform({
+  state,
+  amplitudes,
+  width = 40,
+}: AudioWaveformProps): React.ReactElement | null {
+  const safeWidth = Math.max(0, Math.floor(width));
+  const isAnimated =
+    state === 'listening' || state === 'processing' || state === 'speaking';
+
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!isAnimated) return;
+    debugState.debugNumAnimatedComponents++;
+    const id = setInterval(() => setTick((t) => t + 1), ANIMATION_INTERVAL_MS);
+    return () => {
+      clearInterval(id);
+      debugState.debugNumAnimatedComponents--;
+    };
+  }, [isAnimated]);
+
+  if (state === 'idle') return null;
+
+  const label = STATE_LABEL[state];
+  const barCount = Math.max(0, safeWidth - label.length);
+
+  let bars: number[];
+  if (amplitudes && amplitudes.length > 0) {
+    bars = Array.from({ length: barCount }, (_, i) => {
+      const srcIdx = Math.round(
+        (i / (barCount - 1 || 1)) * (amplitudes.length - 1),
+      );
+      return amplitudes[Math.min(srcIdx, amplitudes.length - 1)] ?? 0;
+    });
+  } else if (isAnimated) {
+    bars = syntheticAmplitudes(tick, barCount, state);
+  } else {
+    bars = Array.from({ length: barCount }, () => 0.15);
+  }
+
+  const color = STATE_COLOR[state];
+  const waveform = bars.map(amplitudeToChar).join('');
+
+  return (
+    <Box>
+      <Text color={color}>{waveform}</Text>
+      <Text color={color} bold>
+        {label}
+      </Text>
+    </Box>
+  );
+}


### PR DESCRIPTION
Fixes #21109

Implements the `<AudioWaveform>` Ink component proposed in #21109. Two previous attempts (#21115, #21186) were closed without merging, this is a clean implementation on current main with no unrelated changes.

## States

| State | Appearance |
|---|---|
| `idle` | renders `null` - no output |
| `listening` | green rippling sine-wave bars + ` listening` label |
| `processing` | yellow smooth pulsing bars + ` processing` label |
| `speaking` | cyan rippling sine-wave bars + ` speaking` label |
| `error` | red static low-amplitude flat line + ` error` label |

## Design decisions

**Smooth sine vs. abs-sine for synthetic amplitudes**
The component uses `(1 + sin(x)) / 2` rather than `|sin(x)|` for synthetic animation. The abs formulation creates a double-hump per cycle where the wave appears to bounce off zero, the smooth formulation gives one natural peak per cycle, which reads as a cleaner waveform in a terminal context.

**Width sanitization**
`width` is clamped with `Math.max(0, Math.floor(width))` before any array allocation to prevent `RangeError` on fractional or negative inputs.

**Label-aware bar count**
Label columns are reserved before bar columns are allocated so the total rendered output never exceeds the requested terminal width regardless of state.

**Amplitude resampling**
Caller-supplied amplitude arrays of any length are resampled to exactly `barCount` columns via index interpolation, so the component works with raw audio buffers without requiring the caller to pre-size the array.

## Tests (15/15)

- renders nothing in idle state
- renders a non-empty waveform in listening / processing / speaking / error (4 parametrized)
- shows correct label in each active state (4 parametrized)
- renders unicode block characters for non-zero amplitudes
- uses all-low bars for all-zero amplitudes
- uses all-full bars for all-one amplitudes
- generates synthetic animation - frames differ over 500ms (real timer)
- error state is static - frames identical over 300ms
- respects a narrow width

Animation tests use real timers rather than `vi.useFakeTimers()` in `beforeEach` to avoid blocking `waitUntilReady()` which uses `setTimeout` internally, fake timers in `beforeEach` cause all animated-state tests to time out.