### PR TITLE
fix(core): handle NaN in GIT_CONFIG_COUNT environment variable parsing

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -2053,4 +2053,38 @@ describe('ShellExecutionService environment variables', () => {
 
     vi.unstubAllEnvs();
   });
+
+  it('should handle invalid GIT_CONFIG_COUNT gracefully by defaulting to 0', async () => {
+    vi.resetModules();
+    vi.stubEnv('GIT_CONFIG_COUNT', 'invalid_value');
+
+    const { ShellExecutionService } = await import(
+      './shellExecutionService.js'
+    );
+
+    mockGetPty.mockResolvedValue(null); // Force child_process fallback
+    await ShellExecutionService.execute(
+      'test-cp-invalid-git-config-count',
+      '/',
+      vi.fn(),
+      new AbortController().signal,
+      false, // non-interactive
+      shellExecutionConfig,
+    );
+
+    expect(mockCpSpawn).toHaveBeenCalled();
+    const cpEnv = mockCpSpawn.mock.calls[0][2].env;
+
+    // Should default to 0 when GIT_CONFIG_COUNT is invalid (not NaN)
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_COUNT', '1');
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_KEY_0', 'credential.helper');
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_VALUE_0', '');
+
+    // Ensure child_process exits
+    mockChildProcess.emit('exit', 0, null);
+    mockChildProcess.emit('close', 0, null);
+    await new Promise(process.nextTick);
+
+    vi.unstubAllEnvs();
+  });
 });

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -406,7 +406,8 @@ export class ShellExecutionService {
         baseEnv[key] = process.env[key];
       }
 
-      const gitConfigCount = parseInt(baseEnv['GIT_CONFIG_COUNT'] || '0', 10);
+      const parsedCount = parseInt(baseEnv['GIT_CONFIG_COUNT'] || '0', 10);
+      const gitConfigCount = Number.isNaN(parsedCount) ? 0 : parsedCount;
       const newKey = `GIT_CONFIG_KEY_${gitConfigCount}`;
       const newValue = `GIT_CONFIG_VALUE_${gitConfigCount}`;
 


### PR DESCRIPTION
## Summary

- Fix NaN handling when parsing `GIT_CONFIG_COUNT` environment variable
- Add validation using `Number.isNaN()` to default to 0 for invalid values
- Add test case to verify the fix handles invalid values correctly

## Problem

When `GIT_CONFIG_COUNT` contains an invalid non-numeric value (e.g., `"invalid"`, `"abc123"`), `parseInt` returns `NaN`. This causes:

1. `GIT_CONFIG_KEY_NaN` and `GIT_CONFIG_VALUE_NaN` to be created as environment variable names
2. `GIT_CONFIG_COUNT` to be set to `"NaN"` (string)
3. Potential silent failures in git operations

## Solution

```typescript
const parsedCount = parseInt(baseEnv['GIT_CONFIG_COUNT'] || '0', 10);
const gitConfigCount = Number.isNaN(parsedCount) ? 0 : parsedCount;
```

## Test plan

- [x] Added unit test for invalid `GIT_CONFIG_COUNT` values
- [ ] Run `npm run preflight` (CI will verify)

Fixes #23351

