### PR TITLE
fix(core): add ENOTDIR to filesystem error messages

### DIFF
--- a/packages/core/src/utils/fsErrorMessages.test.ts
+++ b/packages/core/src/utils/fsErrorMessages.test.ts
@@ -129,6 +129,19 @@ describe('getFsErrorMessage', () => {
           'Resource busy or locked. Close any programs that might be using the file.',
       },
       {
+        code: 'ENOTDIR',
+        message: 'ENOTDIR: not a directory',
+        path: '/some/file.txt/child',
+        expected:
+          "Not a directory: '/some/file.txt/child'. A component of the path is a file, not a directory.",
+      },
+      {
+        code: 'ENOTDIR',
+        message: 'ENOTDIR: not a directory',
+        expected:
+          'Not a directory. A component of the path is a file, not a directory.',
+      },
+      {
         code: 'EMFILE',
         message: 'EMFILE: too many open files',
         expected:

--- a/packages/core/src/utils/fsErrorMessages.ts
+++ b/packages/core/src/utils/fsErrorMessages.ts
@@ -45,6 +45,9 @@ const errorMessageGenerators: Record<string, (path?: string) => string> = {
       ? `Resource busy or locked: '${path}'. `
       : 'Resource busy or locked. ') +
     'Close any programs that might be using the file.',
+  ENOTDIR: (path) =>
+    (path ? `Not a directory: '${path}'. ` : 'Not a directory. ') +
+    'A component of the path is a file, not a directory.',
   EMFILE: () => 'Too many open files. Close some unused files or applications.',
   ENFILE: () =>
     'Too many open files in system. Close some unused files or applications.',


### PR DESCRIPTION
## Summary
- Add user-friendly error message for the `ENOTDIR` filesystem error code in `fsErrorMessages.ts`
- Add corresponding test cases (with and without path) in `fsErrorMessages.test.ts`

Fixes #23350

## Test plan
- [x] Added unit tests for `ENOTDIR` with path: verifies message includes the path
- [x] Added unit tests for `ENOTDIR` without path: verifies generic message
- [x] All existing `fsErrorMessages` tests continue to pass (27 total)
- [x] `packages/core` test suite passes (6252 tests)