### PR TITLE
fix(evals): move timeout from params to top-level in answer-vs-act eval

### DIFF
--- a/evals/answer-vs-act.eval.ts
+++ b/evals/answer-vs-act.eval.ts
@@ -138,7 +138,7 @@ describe('Answer vs. ask eval', () => {
     name: 'should not edit files when user notes an issue',
     prompt: 'The add function subtracts numbers.',
     files: FILES,
-    params: { timeout: 20000 }, // 20s timeout
+    timeout: 20000, // 20s timeout
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
 


### PR DESCRIPTION
## Summary
- Move `timeout: 20000` from inside `params` to the top-level `EvalCase` field in `answer-vs-act.eval.ts`
- The eval harness reads `evalCase.timeout` (top-level), not `evalCase.params.timeout` — the timeout was silently ignored and fell back to the 300s global default

Fixes #20649

## Test plan
- [x] Verified `EvalCase` interface defines `timeout` as a top-level field (`evals/test-helper.ts` line 220)
- [x] Verified `params` is passed to `rig.setup()` which only reads `settings`, `state`, and `fakeResponsesPath`
- [x] Grep confirmed no other eval files have the same `params: { timeout }` pattern
- [x] Change is a 1-line fix with no behavioral impact beyond enforcing the intended 20s timeout
