### PR TITLE
fix(integration-tests): resolve TypeScript strict-null errors in test files

### DIFF
--- a/integration-tests/concurrency-limit.test.ts
+++ b/integration-tests/concurrency-limit.test.ts
@@ -39,6 +39,7 @@ describe('web-fetch rate limiting', () => {
     const rateLimitedCalls = toolLogs.filter(
       (log) =>
         log.toolRequest.name === 'web_fetch' &&
+        'error' in log.toolRequest &&
         log.toolRequest.error?.includes('Rate limit exceeded'),
     );
 

--- a/integration-tests/hooks-system.test.ts
+++ b/integration-tests/hooks-system.test.ts
@@ -158,9 +158,9 @@ describe('Hooks System Integration', { timeout: 120000 }, () => {
             log.hookCall.stderr.includes('"decision":"deny"')),
       );
       expect(blockHook).toBeDefined();
-      expect(blockHook?.hookCall.stdout + blockHook?.hookCall.stderr).toContain(
-        blockMsg,
-      );
+      expect(
+        (blockHook?.hookCall.stdout ?? '') + (blockHook?.hookCall.stderr ?? ''),
+      ).toContain(blockMsg);
     });
 
     it('should allow tool execution when hook returns allow decision', async () => {


### PR DESCRIPTION
## Summary
- Fix 3 TypeScript strict-null errors in integration test files that surface when running `tsc --noEmit -p integration-tests/tsconfig.json`
- `concurrency-limit.test.ts`: `toolRequest` is a union type where `error` only exists on one variant. Added `'error' in log.toolRequest` type guard before accessing the property
- `hooks-system.test.ts`: `hookCall.stdout` and `hookCall.stderr` are possibly `undefined`. Added nullish coalescing (`?? ''`) to handle the undefined case

Fixes #21919

## Test plan
- [x] `tsc --noEmit -p integration-tests/tsconfig.json` passes with zero errors after the fix
- [x] Changes are minimal type-narrowing fixes that preserve existing runtime behavior
- [x] No functional changes to test logic
