### PR TITLE
fix(evals): enforce checkModelOutputContent return value assertions

### DIFF
--- a/evals/grep_search_functionality.eval.ts
+++ b/evals/grep_search_functionality.eval.ts
@@ -25,10 +25,12 @@ describe('grep_search_functionality', () => {
     assert: async (rig: TestRig, result: string) => {
       await rig.waitForToolCall('grep_search');
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/L2: world/, /L3: hello world/],
-        testName: `${TEST_PREFIX}simple search`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/L2: world/, /L3: hello world/],
+          testName: `${TEST_PREFIX}simple search`,
+        }),
+      ).toBe(true);
     },
   });
 
@@ -54,11 +56,13 @@ describe('grep_search_functionality', () => {
       ).toBe(true);
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/L1: Hello/],
-        forbiddenContent: [/L2: hello/],
-        testName: `${TEST_PREFIX}case-sensitive search`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/L1: Hello/],
+          forbiddenContent: [/L2: hello/],
+          testName: `${TEST_PREFIX}case-sensitive search`,
+        }),
+      ).toBe(true);
     },
   });
 
@@ -84,11 +88,13 @@ describe('grep_search_functionality', () => {
       ).toBe(true);
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/file1.txt/, /file2.txt/],
-        forbiddenContent: [/L1:/],
-        testName: `${TEST_PREFIX}names_only search`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/file1.txt/, /file2.txt/],
+          forbiddenContent: [/L1:/],
+          testName: `${TEST_PREFIX}names_only search`,
+        }),
+      ).toBe(true);
     },
   });
 
@@ -114,11 +120,13 @@ describe('grep_search_functionality', () => {
       ).toBe(true);
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/file.js/],
-        forbiddenContent: [/file.ts/],
-        testName: `${TEST_PREFIX}include_pattern glob search`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/file.js/],
+          forbiddenContent: [/file.ts/],
+          testName: `${TEST_PREFIX}include_pattern glob search`,
+        }),
+      ).toBe(true);
     },
   });
 
@@ -144,11 +152,13 @@ describe('grep_search_functionality', () => {
       ).toBe(true);
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/unique_string_1/],
-        forbiddenContent: [/unique_string_2/],
-        testName: `${TEST_PREFIX}subdirectory search`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/unique_string_1/],
+          forbiddenContent: [/unique_string_2/],
+          testName: `${TEST_PREFIX}subdirectory search`,
+        }),
+      ).toBe(true);
     },
   });
 
@@ -161,10 +171,12 @@ describe('grep_search_functionality', () => {
     assert: async (rig: TestRig, result: string) => {
       await rig.waitForToolCall('grep_search');
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/No matches found/],
-        testName: `${TEST_PREFIX}no matches`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/No matches found/],
+          testName: `${TEST_PREFIX}no matches`,
+        }),
+      ).toBe(true);
     },
   });
 });

--- a/evals/plan_mode.eval.ts
+++ b/evals/plan_mode.eval.ts
@@ -58,10 +58,14 @@ describe('plan_mode', () => {
       ).not.toContain('README.md');
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/plan mode|read-only|cannot modify|refuse|exiting/i],
-        testName: `${TEST_PREFIX}should refuse file modification in plan mode`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [
+            /plan mode|read-only|cannot modify|refuse|exiting/i,
+          ],
+          testName: `${TEST_PREFIX}should refuse file modification in plan mode`,
+        }),
+      ).toBe(true);
     },
   });
 
@@ -95,10 +99,12 @@ describe('plan_mode', () => {
       ).toBe(false);
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/plan mode|read-only|cannot modify|refuse|exit/i],
-        testName: `${TEST_PREFIX}should refuse saving docs to repo`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/plan mode|read-only|cannot modify|refuse|exit/i],
+          testName: `${TEST_PREFIX}should refuse saving docs to repo`,
+        }),
+      ).toBe(true);
     },
   });
 

--- a/evals/save_memory.eval.ts
+++ b/evals/save_memory.eval.ts
@@ -27,10 +27,12 @@ describe('save_memory', () => {
       );
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: 'blue',
-        testName: `${TEST_PREFIX}${rememberingFavoriteColor}`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: 'blue',
+          testName: `${TEST_PREFIX}${rememberingFavoriteColor}`,
+        }),
+      ).toBe(true);
     },
   });
   const rememberingCommandRestrictions = 'Agent remembers command restrictions';
@@ -45,10 +47,12 @@ describe('save_memory', () => {
       );
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/not run npm commands|remember|ok/i],
-        testName: `${TEST_PREFIX}${rememberingCommandRestrictions}`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/not run npm commands|remember|ok/i],
+          testName: `${TEST_PREFIX}${rememberingCommandRestrictions}`,
+        }),
+      ).toBe(true);
     },
   });
 
@@ -64,10 +68,12 @@ describe('save_memory', () => {
       );
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/always|ok|remember|will do/i],
-        testName: `${TEST_PREFIX}${rememberingWorkflow}`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/always|ok|remember|will do/i],
+          testName: `${TEST_PREFIX}${rememberingWorkflow}`,
+        }),
+      ).toBe(true);
     },
   });
 
@@ -88,10 +94,12 @@ describe('save_memory', () => {
       ).toBe(false);
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        testName: `${TEST_PREFIX}${ignoringTemporaryInformation}`,
-        forbiddenContent: [/remember|will do/i],
-      });
+      expect(
+        checkModelOutputContent(result, {
+          testName: `${TEST_PREFIX}${ignoringTemporaryInformation}`,
+          forbiddenContent: [/remember|will do/i],
+        }),
+      ).toBe(true);
     },
   });
 
@@ -107,10 +115,12 @@ describe('save_memory', () => {
       );
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/Buddy/i],
-        testName: `${TEST_PREFIX}${rememberingPetName}`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/Buddy/i],
+          testName: `${TEST_PREFIX}${rememberingPetName}`,
+        }),
+      ).toBe(true);
     },
   });
 
@@ -126,10 +136,12 @@ describe('save_memory', () => {
       );
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/npm run dev|start server|ok|remember|will do/i],
-        testName: `${TEST_PREFIX}${rememberingCommandAlias}`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/npm run dev|start server|ok|remember|will do/i],
+          testName: `${TEST_PREFIX}${rememberingCommandAlias}`,
+        }),
+      ).toBe(true);
     },
   });
 
@@ -165,10 +177,12 @@ describe('save_memory', () => {
       );
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/tabs instead of spaces|ok|remember|will do/i],
-        testName: `${TEST_PREFIX}${rememberingCodingStyle}`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/tabs instead of spaces|ok|remember|will do/i],
+          testName: `${TEST_PREFIX}${rememberingCodingStyle}`,
+        }),
+      ).toBe(true);
     },
   });
 
@@ -221,10 +235,12 @@ describe('save_memory', () => {
       );
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/June 15th|ok|remember|will do/i],
-        testName: `${TEST_PREFIX}${rememberingBirthday}`,
-      });
+      expect(
+        checkModelOutputContent(result, {
+          expectedContent: [/June 15th|ok|remember|will do/i],
+          testName: `${TEST_PREFIX}${rememberingBirthday}`,
+        }),
+      ).toBe(true);
     },
   });
 });


### PR DESCRIPTION
## Summary
- Wrap all 16 `checkModelOutputContent()` call sites in `expect().toBe(true)` across 3 eval files
- Previously, the function's boolean return value was silently discarded at every call site, making content validation effectively a no-op
- Tests would pass even when model output didn't match expected/forbidden content patterns

**Scope:** This PR addresses only the 3 eval files (16 call sites). Integration test call sites could be addressed separately.

### Files changed
- `evals/save_memory.eval.ts` (8 call sites)
- `evals/grep_search_functionality.eval.ts` (6 call sites)
- `evals/plan_mode.eval.ts` (2 call sites)

Fixes #20547

## Test plan
- [x] All 16 call sites wrapped in `expect(checkModelOutputContent(...)).toBe(true)`
- [x] Prettier formatting verified
- [x] No changes to `checkModelOutputContent()` function itself (it correctly returns `boolean`)
- [x] All affected evals are `USUALLY_PASSES` or `ALWAYS_PASSES` (nightly CI gated by `RUN_EVALS`)
