### PR TITLE
feat(cli): add --headless-interactive flag for multi-turn stdin sessions

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -90,6 +90,7 @@ export interface CliArgs {
   allowedTools: string[] | undefined;
   acp?: boolean;
   experimentalAcp?: boolean;
+  headlessInteractive?: boolean;
   extensions: string[] | undefined;
   listExtensions: boolean | undefined;
   resume: string | typeof RESUME_LATEST | undefined;
@@ -254,6 +255,11 @@ export async function parseArguments(
           description:
             'Starts the agent in ACP mode (deprecated, use --acp instead)',
         })
+        .option('headless-interactive', {
+          type: 'boolean',
+          description:
+            'Run in headless interactive mode: read newline-delimited prompts from stdin, maintain conversation state, output to stdout.',
+        })
         .option('allowed-mcp-server-names', {
           type: 'array',
           string: true,
@@ -376,6 +382,12 @@ export async function parseArguments(
       }
       if (argv['yolo'] && argv['approvalMode']) {
         return 'Cannot use both --yolo (-y) and --approval-mode together. Use --approval-mode=yolo instead.';
+      }
+      if (argv['headlessInteractive'] && argv['prompt']) {
+        return 'Cannot use both --headless-interactive and --prompt (-p) together.';
+      }
+      if (argv['headlessInteractive'] && argv['promptInteractive']) {
+        return 'Cannot use both --headless-interactive and --prompt-interactive (-i) together.';
       }
       if (
         argv['outputFormat'] &&

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -75,6 +75,7 @@ import {
 } from './core/initializer.js';
 import { validateAuthMethod } from './config/auth.js';
 import { runAcpClient } from './acp/acpClient.js';
+import { runHeadlessInteractive } from './headlessInteractiveCli.js';
 import { validateNonInteractiveAuth } from './validateNonInterActiveAuth.js';
 import { appEvents, AppEvent } from './utils/events.js';
 import { SessionError, SessionSelector } from './utils/sessionUtils.js';
@@ -595,6 +596,20 @@ export async function main() {
     }
 
     cliStartupHandle?.end();
+
+    if (argv.headlessInteractive) {
+      await config.initialize();
+      startupProfiler.flush(config);
+      initializeOutputListenersAndFlush();
+      await runHeadlessInteractive({
+        config,
+        settings,
+        resumedSessionData,
+      });
+      await runExitCleanup();
+      process.exit(ExitCodes.SUCCESS);
+    }
+
     // Render UI, passing necessary config values. Check that there is no command line question.
     if (config.isInteractive()) {
       await startInteractiveUI(

--- a/packages/cli/src/headlessInteractiveCli.ts
+++ b/packages/cli/src/headlessInteractiveCli.ts
@@ -1,0 +1,432 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  Config,
+  ToolCallRequestInfo,
+  ResumedSessionData,
+  UserFeedbackPayload,
+} from '@google/gemini-cli-core';
+import type { LoadedSettings } from './config/settings.js';
+import {
+  convertSessionToClientHistory,
+  GeminiEventType,
+  FatalInputError,
+  promptIdContext,
+  OutputFormat,
+  StreamJsonFormatter,
+  JsonStreamEventType,
+  uiTelemetryService,
+  debugLogger,
+  coreEvents,
+  CoreEvent,
+  createWorkingStdio,
+  recordToolCallInteractions,
+  ToolErrorType,
+  Scheduler,
+  ROOT_SCHEDULER_ID,
+} from '@google/gemini-cli-core';
+
+import type { Content, Part } from '@google/genai';
+import readline from 'node:readline';
+import stripAnsi from 'strip-ansi';
+
+import { isSlashCommand } from './ui/utils/commandUtils.js';
+import { handleSlashCommand } from './nonInteractiveCliCommands.js';
+import { ConsolePatcher } from './ui/utils/ConsolePatcher.js';
+import { handleAtCommand } from './ui/hooks/atCommandProcessor.js';
+import {
+  handleToolError,
+  handleCancellationError,
+  handleMaxTurnsExceededError,
+} from './utils/errors.js';
+import { TextOutput } from './ui/utils/textOutput.js';
+
+export interface RunHeadlessInteractiveParams {
+  config: Config;
+  settings: LoadedSettings;
+  resumedSessionData?: ResumedSessionData;
+}
+
+/**
+ * Runs the CLI in headless interactive mode: reads newline-delimited prompts
+ * from stdin, maintains conversation state across prompts, and outputs
+ * responses to stdout. No Ink UI is used.
+ */
+export async function runHeadlessInteractive({
+  config,
+  settings,
+  resumedSessionData,
+}: RunHeadlessInteractiveParams): Promise<void> {
+  const consolePatcher = new ConsolePatcher({
+    stderr: true,
+    debugMode: config.getDebugMode(),
+    onNewMessage: (msg) => {
+      coreEvents.emitConsoleLog(msg.type, msg.content);
+    },
+  });
+
+  const { stdout: workingStdout } = createWorkingStdio();
+  const textOutput = new TextOutput(workingStdout);
+
+  const handleUserFeedback = (payload: UserFeedbackPayload) => {
+    const prefix = payload.severity.toUpperCase();
+    process.stderr.write(`[${prefix}] ${payload.message}\n`);
+    if (payload.error && config.getDebugMode()) {
+      const errorToLog =
+        payload.error instanceof Error
+          ? payload.error.stack || payload.error.message
+          : String(payload.error);
+      process.stderr.write(`${errorToLog}\n`);
+    }
+  };
+
+  const streamFormatter =
+    config.getOutputFormat() === OutputFormat.STREAM_JSON
+      ? new StreamJsonFormatter()
+      : null;
+
+  const geminiClient = config.getGeminiClient();
+  const scheduler = new Scheduler({
+    context: config,
+    messageBus: config.getMessageBus(),
+    getPreferredEditor: () => undefined,
+    schedulerId: ROOT_SCHEDULER_ID,
+  });
+
+  // Resume session if data is provided
+  if (resumedSessionData) {
+    await geminiClient.resumeChat(
+      convertSessionToClientHistory(resumedSessionData.conversation.messages),
+      resumedSessionData,
+    );
+  }
+
+  consolePatcher.patch();
+
+  if (process.env['GEMINI_CLI_ACTIVITY_LOG_TARGET']) {
+    const { setupInitialActivityLogger } = await import(
+      './utils/devtoolsService.js'
+    );
+    await setupInitialActivityLogger(config);
+  }
+
+  coreEvents.on(CoreEvent.UserFeedback, handleUserFeedback);
+  coreEvents.drainBacklogs();
+
+  // Handle EPIPE errors when piped output closes early
+  process.stdout.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EPIPE') {
+      process.exit(0);
+    }
+  });
+
+  // Emit init event once
+  if (streamFormatter) {
+    streamFormatter.emitEvent({
+      type: JsonStreamEventType.INIT,
+      timestamp: new Date().toISOString(),
+      session_id: config.getSessionId(),
+      model: config.getModel(),
+    });
+  }
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    terminal: false,
+  });
+
+  let promptCount = 0;
+
+  try {
+    for await (const line of rl) {
+      const input = line.trim();
+      if (!input) continue;
+
+      promptCount++;
+      const promptId = `${config.getSessionId()}-${promptCount}`;
+
+      try {
+        await processPrompt({
+          config,
+          settings,
+          input,
+          promptId,
+          geminiClient,
+          scheduler,
+          streamFormatter,
+          textOutput,
+        });
+      } catch (error) {
+        // Emit error but don't kill the session
+        if (streamFormatter) {
+          streamFormatter.emitEvent({
+            type: JsonStreamEventType.ERROR,
+            timestamp: new Date().toISOString(),
+            severity: 'error',
+            message: error instanceof Error ? error.message : String(error),
+          });
+        } else {
+          process.stderr.write(
+            `[ERROR] ${error instanceof Error ? error.message : String(error)}\n`,
+          );
+        }
+      }
+    }
+  } finally {
+    consolePatcher.cleanup();
+    coreEvents.off(CoreEvent.UserFeedback, handleUserFeedback);
+  }
+}
+
+interface ProcessPromptParams {
+  config: Config;
+  settings: LoadedSettings;
+  input: string;
+  promptId: string;
+  geminiClient: ReturnType<Config['getGeminiClient']>;
+  scheduler: InstanceType<typeof Scheduler>;
+  streamFormatter: StreamJsonFormatter | null;
+  textOutput: TextOutput;
+}
+
+async function processPrompt({
+  config,
+  settings,
+  input,
+  promptId,
+  geminiClient,
+  scheduler,
+  streamFormatter,
+  textOutput,
+}: ProcessPromptParams): Promise<void> {
+  return promptIdContext.run(promptId, async () => {
+    const startTime = Date.now();
+    const abortController = new AbortController();
+
+    const emitResultAndFinish = (): void => {
+      if (streamFormatter) {
+        const metrics = uiTelemetryService.getMetrics();
+        const durationMs = Date.now() - startTime;
+        streamFormatter.emitEvent({
+          type: JsonStreamEventType.RESULT,
+          timestamp: new Date().toISOString(),
+          status: 'success',
+          stats: streamFormatter.convertToStreamStats(metrics, durationMs),
+        });
+      }
+      textOutput.ensureTrailingNewline();
+    };
+
+    let query: Part[] | undefined;
+
+    if (isSlashCommand(input)) {
+      const slashCommandResult = await handleSlashCommand(
+        input,
+        abortController,
+        config,
+        settings,
+      );
+      if (slashCommandResult) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        query = slashCommandResult as Part[];
+      }
+    }
+
+    if (!query) {
+      const { processedQuery, error } = await handleAtCommand({
+        query: input,
+        config,
+        addItem: (_item, _timestamp) => 0,
+        onDebugMessage: () => {},
+        messageId: Date.now(),
+        signal: abortController.signal,
+        escapePastedAtSymbols: false,
+      });
+      if (error || !processedQuery) {
+        throw new FatalInputError(error || 'Error processing the @ command.');
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      query = processedQuery as Part[];
+    }
+
+    if (streamFormatter) {
+      streamFormatter.emitEvent({
+        type: JsonStreamEventType.MESSAGE,
+        timestamp: new Date().toISOString(),
+        role: 'user',
+        content: input,
+      });
+    }
+
+    let currentMessages: Content[] = [{ role: 'user', parts: query }];
+
+    let turnCount = 0;
+    while (true) {
+      turnCount++;
+      if (
+        config.getMaxSessionTurns() >= 0 &&
+        turnCount > config.getMaxSessionTurns()
+      ) {
+        handleMaxTurnsExceededError(config);
+      }
+      const toolCallRequests: ToolCallRequestInfo[] = [];
+
+      const responseStream = geminiClient.sendMessageStream(
+        currentMessages[0]?.parts || [],
+        abortController.signal,
+        promptId,
+        undefined,
+        false,
+        turnCount === 1 ? input : undefined,
+      );
+
+      for await (const event of responseStream) {
+        if (abortController.signal.aborted) {
+          handleCancellationError(config);
+        }
+
+        if (event.type === GeminiEventType.Content) {
+          const isRaw =
+            config.getRawOutput() || config.getAcceptRawOutputRisk();
+          const output = isRaw ? event.value : stripAnsi(event.value);
+          if (streamFormatter) {
+            streamFormatter.emitEvent({
+              type: JsonStreamEventType.MESSAGE,
+              timestamp: new Date().toISOString(),
+              role: 'assistant',
+              content: output,
+              delta: true,
+            });
+          } else if (event.value) {
+            textOutput.write(output);
+          }
+        } else if (event.type === GeminiEventType.ToolCallRequest) {
+          if (streamFormatter) {
+            streamFormatter.emitEvent({
+              type: JsonStreamEventType.TOOL_USE,
+              timestamp: new Date().toISOString(),
+              tool_name: event.value.name,
+              tool_id: event.value.callId,
+              parameters: event.value.args,
+            });
+          }
+          toolCallRequests.push(event.value);
+        } else if (event.type === GeminiEventType.LoopDetected) {
+          if (streamFormatter) {
+            streamFormatter.emitEvent({
+              type: JsonStreamEventType.ERROR,
+              timestamp: new Date().toISOString(),
+              severity: 'warning',
+              message: 'Loop detected, stopping execution',
+            });
+          }
+        } else if (event.type === GeminiEventType.MaxSessionTurns) {
+          if (streamFormatter) {
+            streamFormatter.emitEvent({
+              type: JsonStreamEventType.ERROR,
+              timestamp: new Date().toISOString(),
+              severity: 'error',
+              message: 'Maximum session turns exceeded',
+            });
+          }
+        } else if (event.type === GeminiEventType.Error) {
+          throw event.value.error;
+        } else if (event.type === GeminiEventType.AgentExecutionStopped) {
+          const stopMessage = `Agent execution stopped: ${event.value.systemMessage?.trim() || event.value.reason}`;
+          if (config.getOutputFormat() === OutputFormat.TEXT) {
+            process.stderr.write(`${stopMessage}\n`);
+          }
+          emitResultAndFinish();
+          return;
+        } else if (event.type === GeminiEventType.AgentExecutionBlocked) {
+          const blockMessage = `Agent execution blocked: ${event.value.systemMessage?.trim() || event.value.reason}`;
+          if (config.getOutputFormat() === OutputFormat.TEXT) {
+            process.stderr.write(`[WARNING] ${blockMessage}\n`);
+          }
+        }
+      }
+
+      if (toolCallRequests.length > 0) {
+        textOutput.ensureTrailingNewline();
+        const completedToolCalls = await scheduler.schedule(
+          toolCallRequests,
+          abortController.signal,
+        );
+        const toolResponseParts: Part[] = [];
+
+        for (const completedToolCall of completedToolCalls) {
+          const toolResponse = completedToolCall.response;
+          const requestInfo = completedToolCall.request;
+
+          if (streamFormatter) {
+            streamFormatter.emitEvent({
+              type: JsonStreamEventType.TOOL_RESULT,
+              timestamp: new Date().toISOString(),
+              tool_id: requestInfo.callId,
+              status:
+                completedToolCall.status === 'error' ? 'error' : 'success',
+              output:
+                typeof toolResponse.resultDisplay === 'string'
+                  ? toolResponse.resultDisplay
+                  : undefined,
+              error: toolResponse.error
+                ? {
+                    type: toolResponse.errorType || 'TOOL_EXECUTION_ERROR',
+                    message: toolResponse.error.message,
+                  }
+                : undefined,
+            });
+          }
+
+          if (toolResponse.error) {
+            handleToolError(
+              requestInfo.name,
+              toolResponse.error,
+              config,
+              toolResponse.errorType || 'TOOL_EXECUTION_ERROR',
+              typeof toolResponse.resultDisplay === 'string'
+                ? toolResponse.resultDisplay
+                : undefined,
+            );
+          }
+
+          if (toolResponse.responseParts) {
+            toolResponseParts.push(...toolResponse.responseParts);
+          }
+        }
+
+        try {
+          const currentModel =
+            geminiClient.getCurrentSequenceModel() ?? config.getModel();
+          geminiClient
+            .getChat()
+            .recordCompletedToolCalls(currentModel, completedToolCalls);
+
+          await recordToolCallInteractions(config, completedToolCalls);
+        } catch (error) {
+          debugLogger.error(
+            `Error recording completed tool call information: ${error}`,
+          );
+        }
+
+        const stopExecutionTool = completedToolCalls.find(
+          (tc) => tc.response.errorType === ToolErrorType.STOP_EXECUTION,
+        );
+
+        if (stopExecutionTool && stopExecutionTool.response.error) {
+          emitResultAndFinish();
+          return;
+        }
+
+        currentMessages = [{ role: 'user', parts: toolResponseParts }];
+      } else {
+        emitResultAndFinish();
+        return;
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- Add `--headless-interactive` CLI flag that enables headless interactive mode for programmatic consumers
- Reads newline-delimited prompts from stdin, maintains conversation state across turns, outputs to stdout
- No Ink UI required — works when `stdin.isTTY === false`

## Context

Issue #13924 requests the ability to keep the CLI alive for multi-turn sessions when launched programmatically (e.g., from Java, Node.js, or backend services). Currently, `isHeadlessMode()` forces non-interactive mode when stdin is not a TTY, which reads all stdin as one prompt and exits.

I investigated existing solutions:

- **ACP mode** (`--acp`) technically provides headless interactive capabilities, but requires ndJSON protocol handshake (initialize → authenticate → newSession → prompt) and SDK dependency
- **Non-interactive mode** (`--prompt`) supports session resumption via `--resume`, but each invocation is independent — no persistent process
- **PR #20700** addresses the related #15338 with a daemon mode (Unix sockets), which is a larger-scope solution

This PR offers a lightweight alternative: a plain-text stdin/stdout interface following the same pattern as `nonInteractiveCli.ts`. It's complementary to both ACP and the daemon approach — different interface for different use cases.

## How to Validate

```bash
# Single prompt
echo "what is 2+2?" | gemini --headless-interactive

# Multi-turn session (second prompt references first)
node -e "
const { spawn } = require('child_process');
const child = spawn('npx', ['gemini', '--headless-interactive'], { stdio: ['pipe', 'pipe', 'inherit'] });
child.stdout.on('data', d => console.log(d.toString()));
child.stdin.write('My name is Alice.\n');
setTimeout(() => child.stdin.write('What is my name?\n'), 10000);
setTimeout(() => child.stdin.end(), 20000);
"

# With structured output
echo "hello" | gemini --headless-interactive --output-format stream-json
```

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/config/config.ts` | Add `--headless-interactive` flag, `CliArgs` field, mutual exclusivity checks |
| `packages/cli/src/gemini.tsx` | Add routing branch after ACP, before interactive mode |
| `packages/cli/src/headlessInteractiveCli.ts` | New readline-based headless REPL runner |

## Related Issues

Fixes #13924
Related: #15338, PR #20700

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] macOS
    - [x] npm run