### PR TITLE
fix(evals): move timeout from params to top-level in answer-vs-act.eval.ts

### DIFF
--- a/evals/answer-vs-act.eval.ts
+++ b/evals/answer-vs-act.eval.ts
@@ -138,7 +138,7 @@ describe('Answer vs. ask eval', () => {
     name: 'should not edit files when user notes an issue',
     prompt: 'The add function subtracts numbers.',
     files: FILES,
-    params: { timeout: 20000 }, // 20s timeout
+    timeout: 20000, // 20s timeout
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
 


### PR DESCRIPTION
Fixes #20649

Moves the timeout parameter to the top level of the `EvalCase` object in `answer-vs-act.eval.ts` so that it is properly respected by the eval testing harness.