### PR TITLE
feat(cli): add structured task workflow commands

### DIFF
--- a/docs/cli/cli-reference.md
+++ b/docs/cli/cli-reference.md
@@ -37,6 +37,9 @@ These commands are available within the interactive REPL.
 | `/memory reload`     | Reload context files (e.g., `GEMINI.md`) |
 | `/mcp reload`        | Restart and reload MCP servers           |
 | `/extensions reload` | Reload all active extensions             |
+| `/task run "goal"`   | Start structured task workflow           |
+| `/task status`       | Show active task workflow status         |
+| `/task list`         | List recent task workflow runs           |
 | `/help`              | Show help for all commands               |
 | `/quit`              | Exit the interactive session             |
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -452,6 +452,26 @@ Slash commands provide meta-level control over the CLI itself.
 - **Description:** Open a dialog that lets you change the visual theme of Gemini
   CLI.
 
+### `/task`
+
+- **Description:** Run and manage structured task workflows that guide the model
+  through plan, execute, verify, and summarize phases.
+- **Sub-commands:**
+  - **`run "<goal>"`**:
+    - **Description:** Start a new task workflow for the provided goal.
+  - **`status`**:
+    - **Description:** Show the current task, including task ID, trace ID, and
+      phase sequence.
+  - **`list`**:
+    - **Description:** List recent task workflow runs with status and trace IDs.
+  - **`resume`**:
+    - **Description:** Resume the most recent task workflow and continue
+      execution.
+  - **`cancel`**:
+    - **Description:** Cancel the active task workflow.
+  - **`clear`**:
+    - **Description:** Clear the active task workflow state.
+
 ### `/tools`
 
 - **Description:** Display a list of tools that are currently available within

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -52,6 +52,7 @@ import { quitCommand } from '../ui/commands/quitCommand.js';
 import { restoreCommand } from '../ui/commands/restoreCommand.js';
 import { resumeCommand } from '../ui/commands/resumeCommand.js';
 import { statsCommand } from '../ui/commands/statsCommand.js';
+import { taskCommand } from '../ui/commands/taskCommand.js';
 import { themeCommand } from '../ui/commands/themeCommand.js';
 import { toolsCommand } from '../ui/commands/toolsCommand.js';
 import { skillsCommand } from '../ui/commands/skillsCommand.js';
@@ -195,6 +196,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
         subCommands: addDebugToChatResumeSubCommands(resumeCommand.subCommands),
       },
       statsCommand,
+      taskCommand,
       themeCommand,
       toolsCommand,
       ...(this.config?.isSkillsSupportEnabled()

--- a/packages/cli/src/services/TaskWorkflowService.test.ts
+++ b/packages/cli/src/services/TaskWorkflowService.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const persistentStateMock = {
+  get: vi.fn(),
+  set: vi.fn(),
+};
+
+vi.mock('../utils/persistentState.js', () => ({
+  persistentState: persistentStateMock,
+}));
+
+describe('TaskWorkflowService', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    persistentStateMock.get.mockReset();
+    persistentStateMock.set.mockReset();
+    persistentStateMock.get.mockImplementation((key: string) =>
+      key === 'taskWorkflowHistory' ? [] : null,
+    );
+  });
+
+  it('loads persisted workflow state on first initialization', async () => {
+    persistentStateMock.get.mockImplementation((key: string) =>
+      key === 'taskWorkflow'
+        ? {
+            id: 'task-persisted',
+            traceId: 'trace-persisted',
+            goal: 'persisted goal',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            status: 'submitted',
+            phases: ['plan', 'execute', 'verify', 'summarize'],
+          }
+        : [],
+    );
+
+    const { TaskWorkflowService } = await import('./TaskWorkflowService.js');
+    const service = TaskWorkflowService.getInstance();
+
+    expect(service.getStatus()?.id).toBe('task-persisted');
+    expect(persistentStateMock.get).toHaveBeenCalledWith('taskWorkflow');
+  });
+
+  it('persists updates when starting and clearing task state', async () => {
+    const { TaskWorkflowService } = await import('./TaskWorkflowService.js');
+    const service = TaskWorkflowService.getInstance();
+
+    const started = service.start('ship persistence');
+    expect(started.goal).toBe('ship persistence');
+    expect(started.traceId).toContain('trace-');
+    expect(persistentStateMock.set).toHaveBeenCalledWith(
+      'taskWorkflow',
+      expect.objectContaining({
+        goal: 'ship persistence',
+        status: 'submitted',
+      }),
+    );
+
+    service.clear();
+    expect(persistentStateMock.set).toHaveBeenCalledWith('taskWorkflow', null);
+  });
+});

--- a/packages/cli/src/services/TaskWorkflowService.ts
+++ b/packages/cli/src/services/TaskWorkflowService.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TaskRun } from './task/types.js';
+import { persistentState } from '../utils/persistentState.js';
+import { ActivityLogger } from '../utils/activityLogger.js';
+
+const DEFAULT_PHASES = ['plan', 'execute', 'verify', 'summarize'] as const;
+const MAX_HISTORY = 20;
+
+/**
+ * In-memory task workflow store for slash-command orchestration.
+ * This is intentionally small for the first vertical slice.
+ */
+export class TaskWorkflowService {
+  private static instance: TaskWorkflowService | undefined;
+
+  private lastRun: TaskRun | null = null;
+  private history: TaskRun[] = [];
+  private readonly activityLogger = ActivityLogger.getInstance();
+
+  private constructor() {
+    this.lastRun = persistentState.get('taskWorkflow') ?? null;
+    this.history = persistentState.get('taskWorkflowHistory') ?? [];
+  }
+
+  static getInstance(): TaskWorkflowService {
+    if (!TaskWorkflowService.instance) {
+      TaskWorkflowService.instance = new TaskWorkflowService();
+    }
+    return TaskWorkflowService.instance;
+  }
+
+  start(goal: string): TaskRun {
+    const now = new Date().toISOString();
+    const run: TaskRun = {
+      id: `task-${Date.now().toString(36)}`,
+      traceId: `trace-${Date.now().toString(36)}`,
+      goal,
+      createdAt: now,
+      updatedAt: now,
+      status: 'submitted',
+      phases: DEFAULT_PHASES,
+    };
+    this.lastRun = run;
+    this.recordHistory(run);
+    this.activityLogger.logConsole({
+      type: 'log',
+      content: `[task] started ${run.id} (${run.traceId})`,
+    });
+    this.persist();
+    return run;
+  }
+
+  getStatus(): TaskRun | null {
+    return this.lastRun;
+  }
+
+  getHistory(): readonly TaskRun[] {
+    return [...this.history].reverse();
+  }
+
+  resetForTesting(): void {
+    this.lastRun = null;
+    this.history = [];
+    this.persist();
+  }
+
+  cancel(): TaskRun | null {
+    if (!this.lastRun) {
+      return null;
+    }
+
+    const now = new Date().toISOString();
+    this.lastRun = {
+      ...this.lastRun,
+      status: 'cancelled',
+      updatedAt: now,
+    };
+    this.recordHistory(this.lastRun);
+    this.activityLogger.logConsole({
+      type: 'log',
+      content: `[task] cancelled ${this.lastRun.id} (${this.lastRun.traceId})`,
+    });
+    this.persist();
+    return this.lastRun;
+  }
+
+  resume(): TaskRun | null {
+    if (!this.lastRun) {
+      return null;
+    }
+    const now = new Date().toISOString();
+    this.lastRun = {
+      ...this.lastRun,
+      status: 'submitted',
+      updatedAt: now,
+    };
+    this.recordHistory(this.lastRun);
+    this.activityLogger.logConsole({
+      type: 'log',
+      content: `[task] resumed ${this.lastRun.id} (${this.lastRun.traceId})`,
+    });
+    this.persist();
+    return this.lastRun;
+  }
+
+  clear(): void {
+    this.lastRun = null;
+    this.activityLogger.logConsole({
+      type: 'log',
+      content: '[task] cleared active task state',
+    });
+    this.persist();
+  }
+
+  private persist(): void {
+    persistentState.set('taskWorkflow', this.lastRun);
+    persistentState.set('taskWorkflowHistory', this.history);
+  }
+
+  private recordHistory(run: TaskRun): void {
+    this.history.push(run);
+    if (this.history.length > MAX_HISTORY) {
+      this.history = this.history.slice(this.history.length - MAX_HISTORY);
+    }
+  }
+}

--- a/packages/cli/src/services/task/types.ts
+++ b/packages/cli/src/services/task/types.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type TaskPhase = 'plan' | 'execute' | 'verify' | 'summarize';
+
+export type TaskStatus = 'idle' | 'submitted' | 'cancelled';
+
+export interface TaskRun {
+  id: string;
+  traceId: string;
+  goal: string;
+  createdAt: string;
+  updatedAt: string;
+  status: TaskStatus;
+  phases: readonly TaskPhase[];
+}

--- a/packages/cli/src/ui/commands/taskCommand.test.ts
+++ b/packages/cli/src/ui/commands/taskCommand.test.ts
@@ -1,0 +1,193 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { taskCommand } from './taskCommand.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { MessageType } from '../types.js';
+import { TaskWorkflowService } from '../../services/TaskWorkflowService.js';
+
+vi.mock('../../utils/persistentState.js', () => ({
+  persistentState: {
+    get: vi.fn().mockReturnValue(null),
+    set: vi.fn(),
+  },
+}));
+
+describe('taskCommand', () => {
+  beforeEach(async () => {
+    TaskWorkflowService.getInstance().resetForTesting();
+    // Ensure each test starts from a clean task state.
+    const mockContext = createMockCommandContext();
+    const cancel = taskCommand.subCommands?.find(
+      (cmd) => cmd.name === 'cancel',
+    );
+    if (cancel?.action) {
+      await cancel.action(mockContext, '');
+    }
+  });
+
+  it('returns usage error when run has no goal', async () => {
+    const context = createMockCommandContext();
+    const run = taskCommand.subCommands?.find((cmd) => cmd.name === 'run');
+    if (!run?.action) throw new Error('Action not defined');
+
+    await run.action(context, '');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith({
+      type: MessageType.ERROR,
+      text: 'Usage: /task run "<goal>"',
+    });
+  });
+
+  it('starts a task and returns submit_prompt payload', async () => {
+    const context = createMockCommandContext();
+    const run = taskCommand.subCommands?.find((cmd) => cmd.name === 'run');
+    if (!run?.action) throw new Error('Action not defined');
+
+    const result = await run.action(context, '"add plugin API support"');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.INFO,
+        text: expect.stringContaining(
+          'Started task workflow for: add plugin API support',
+        ),
+      }),
+    );
+    expect(result).toMatchObject({
+      type: 'submit_prompt',
+    });
+  });
+
+  it('shows status after run', async () => {
+    const context = createMockCommandContext();
+    const run = taskCommand.subCommands?.find((cmd) => cmd.name === 'run');
+    const status = taskCommand.subCommands?.find(
+      (cmd) => cmd.name === 'status',
+    );
+    if (!run?.action || !status?.action) throw new Error('Action not defined');
+
+    await run.action(context, '"ship task workflow"');
+    await status.action(context, '');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.INFO,
+        text: expect.stringContaining('Status: submitted'),
+      }),
+    );
+  });
+
+  it('cancels and resumes the same task', async () => {
+    const context = createMockCommandContext();
+    const run = taskCommand.subCommands?.find((cmd) => cmd.name === 'run');
+    const cancel = taskCommand.subCommands?.find(
+      (cmd) => cmd.name === 'cancel',
+    );
+    const resume = taskCommand.subCommands?.find(
+      (cmd) => cmd.name === 'resume',
+    );
+    const status = taskCommand.subCommands?.find(
+      (cmd) => cmd.name === 'status',
+    );
+    if (!run?.action || !cancel?.action || !resume?.action || !status?.action) {
+      throw new Error('Action not defined');
+    }
+
+    await run.action(context, '"finish onboarding polish"');
+    await cancel.action(context, '');
+    await status.action(context, '');
+    await resume.action(context, '');
+    await status.action(context, '');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.INFO,
+        text: expect.stringContaining('Status: cancelled'),
+      }),
+    );
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.INFO,
+        text: expect.stringContaining('Status: submitted'),
+      }),
+    );
+  });
+
+  it('returns an error when resume has no task', async () => {
+    const context = createMockCommandContext();
+    const resume = taskCommand.subCommands?.find(
+      (cmd) => cmd.name === 'resume',
+    );
+    if (!resume?.action) throw new Error('Action not defined');
+
+    await resume.action(context, '');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith({
+      type: MessageType.ERROR,
+      text: 'No task found to resume. Start one with /task run "<goal>".',
+    });
+  });
+
+  it('clears task state and status reflects empty state', async () => {
+    const context = createMockCommandContext();
+    const run = taskCommand.subCommands?.find((cmd) => cmd.name === 'run');
+    const clear = taskCommand.subCommands?.find((cmd) => cmd.name === 'clear');
+    const status = taskCommand.subCommands?.find(
+      (cmd) => cmd.name === 'status',
+    );
+    if (!run?.action || !clear?.action || !status?.action) {
+      throw new Error('Action not defined');
+    }
+
+    await run.action(context, '"cleanup old tasks"');
+    await clear.action(context, '');
+    await status.action(context, '');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith({
+      type: MessageType.INFO,
+      text: 'Cleared task workflow state.',
+    });
+    expect(context.ui.addItem).toHaveBeenCalledWith({
+      type: MessageType.INFO,
+      text: 'No active task. Start one with /task run "<goal>".',
+    });
+  });
+
+  it('lists recent task runs with trace ids', async () => {
+    const context = createMockCommandContext();
+    const run = taskCommand.subCommands?.find((cmd) => cmd.name === 'run');
+    const list = taskCommand.subCommands?.find((cmd) => cmd.name === 'list');
+    if (!run?.action || !list?.action) {
+      throw new Error('Action not defined');
+    }
+
+    await run.action(context, '"add task history"');
+    await list.action(context, '');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.INFO,
+        text: expect.stringContaining('[trace-'),
+      }),
+    );
+  });
+
+  it('shows task help and status when /task is run without subcommands', async () => {
+    const context = createMockCommandContext();
+    if (!taskCommand.action) throw new Error('Action not defined');
+
+    await taskCommand.action(context, '');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.INFO,
+        text: expect.stringContaining('Task workflow commands:'),
+      }),
+    );
+  });
+});

--- a/packages/cli/src/ui/commands/taskCommand.ts
+++ b/packages/cli/src/ui/commands/taskCommand.ts
@@ -1,0 +1,211 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  type CommandContext,
+  type SlashCommand,
+  CommandKind,
+} from './types.js';
+import { MessageType } from '../types.js';
+import { TaskWorkflowService } from '../../services/TaskWorkflowService.js';
+
+const taskService = TaskWorkflowService.getInstance();
+
+const getGoalFromArgs = (args?: string): string => {
+  const goal = args?.trim() ?? '';
+  return goal.replace(/^['"]|['"]$/g, '').trim();
+};
+
+const formatTaskStatus = () => {
+  const status = taskService.getStatus();
+  if (!status) {
+    return 'No active task. Start one with /task run "<goal>".';
+  }
+
+  return [
+    `Task: ${status.id}`,
+    `Trace: ${status.traceId}`,
+    `Goal: ${status.goal}`,
+    `Status: ${status.status}`,
+    `Phases: ${status.phases.join(' -> ')}`,
+    `Updated: ${status.updatedAt}`,
+  ].join('\n');
+};
+
+const formatTaskHelp = () =>
+  [
+    'Task workflow commands:',
+    '/task run "<goal>"   Start a new workflow run',
+    '/task status         Show the active workflow status',
+    '/task list           List recent workflow runs',
+    '/task resume         Resume the most recent workflow',
+    '/task cancel         Cancel the current workflow',
+    '/task clear          Clear active workflow state',
+  ].join('\n');
+
+const formatTaskHistory = () => {
+  const history = taskService.getHistory();
+  if (history.length === 0) {
+    return 'No task history yet. Start one with /task run "<goal>".';
+  }
+
+  return history
+    .slice(0, 10)
+    .map(
+      (run, idx) =>
+        `${idx + 1}. ${run.id} (${run.status}) [${run.traceId}] - ${run.goal}`,
+    )
+    .join('\n');
+};
+
+const runSubCommand: SlashCommand = {
+  name: 'run',
+  description: 'Run a structured task workflow against a goal.',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: async (context: CommandContext, args?: string) => {
+    const goal = getGoalFromArgs(args);
+    if (!goal) {
+      context.ui.addItem({
+        type: MessageType.ERROR,
+        text: 'Usage: /task run "<goal>"',
+      });
+      return;
+    }
+
+    const started = taskService.start(goal);
+    context.ui.addItem({
+      type: MessageType.INFO,
+      text: `Started task workflow for: ${goal} [${started.traceId}]`,
+    });
+
+    return {
+      type: 'submit_prompt',
+      content: [
+        `Execute this task goal: ${goal}`,
+        'Follow these phases in order:',
+        '1) plan',
+        '2) execute',
+        '3) verify',
+        '4) summarize',
+        'Keep outputs concise and include explicit verification results.',
+      ].join('\n'),
+    };
+  },
+};
+
+const statusSubCommand: SlashCommand = {
+  name: 'status',
+  description: 'Show the latest task workflow status.',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: async (context: CommandContext) => {
+    context.ui.addItem({
+      type: MessageType.INFO,
+      text: formatTaskStatus(),
+    });
+  },
+};
+
+const cancelSubCommand: SlashCommand = {
+  name: 'cancel',
+  description: 'Cancel the current task workflow.',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: async (context: CommandContext) => {
+    const cancelled = taskService.cancel();
+    context.ui.addItem({
+      type: cancelled ? MessageType.INFO : MessageType.ERROR,
+      text: cancelled
+        ? `Cancelled task ${cancelled.id}.`
+        : 'No active task to cancel.',
+    });
+  },
+};
+
+const resumeSubCommand: SlashCommand = {
+  name: 'resume',
+  description: 'Resume the most recent task workflow.',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: async (context: CommandContext) => {
+    const resumed = taskService.resume();
+    if (!resumed) {
+      context.ui.addItem({
+        type: MessageType.ERROR,
+        text: 'No task found to resume. Start one with /task run "<goal>".',
+      });
+      return;
+    }
+
+    context.ui.addItem({
+      type: MessageType.INFO,
+      text: `Resumed task ${resumed.id}: ${resumed.goal}`,
+    });
+
+    return {
+      type: 'submit_prompt',
+      content: [
+        `Resume this task goal: ${resumed.goal}`,
+        `Task ID: ${resumed.id}`,
+        'Continue from the current progress and finish phases in order:',
+        '1) plan',
+        '2) execute',
+        '3) verify',
+        '4) summarize',
+        'Include what was already done and what is newly completed.',
+      ].join('\n'),
+    };
+  },
+};
+
+const clearSubCommand: SlashCommand = {
+  name: 'clear',
+  description: 'Clear the saved task workflow state.',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: async (context: CommandContext) => {
+    taskService.clear();
+    context.ui.addItem({
+      type: MessageType.INFO,
+      text: 'Cleared task workflow state.',
+    });
+  },
+};
+
+const listSubCommand: SlashCommand = {
+  name: 'list',
+  description: 'List recent task workflow runs.',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: async (context: CommandContext) => {
+    context.ui.addItem({
+      type: MessageType.INFO,
+      text: formatTaskHistory(),
+    });
+  },
+};
+
+export const taskCommand: SlashCommand = {
+  name: 'task',
+  description: 'Run and manage structured task workflows.',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: false,
+  subCommands: [
+    runSubCommand,
+    statusSubCommand,
+    cancelSubCommand,
+    resumeSubCommand,
+    clearSubCommand,
+    listSubCommand,
+  ],
+  action: async (context: CommandContext): Promise<void> => {
+    context.ui.addItem({
+      type: MessageType.INFO,
+      text: [formatTaskHelp(), '', formatTaskStatus()].join('\n'),
+    });
+  },
+};

--- a/packages/cli/src/utils/persistentState.ts
+++ b/packages/cli/src/utils/persistentState.ts
@@ -7,6 +7,7 @@
 import { Storage, debugLogger } from '@google/gemini-cli-core';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import type { TaskRun } from '../services/task/types.js';
 
 const STATE_FILENAME = 'state.json';
 
@@ -17,6 +18,8 @@ interface PersistentStateData {
   hasSeenScreenReaderNudge?: boolean;
   focusUiEnabled?: boolean;
   startupWarningCounts?: Record<string, number>;
+  taskWorkflow?: TaskRun | null;
+  taskWorkflowHistory?: TaskRun[];
   // Add other persistent state keys here as needed
 }
 


### PR DESCRIPTION
## Summary
- add a new built-in `/task` command with `run`, `status`, `list`, `resume`, `cancel`, and `clear` subcommands
- introduce `TaskWorkflowService` with persisted active state, bounded history, and trace IDs for easier task diagnostics
- document `/task` usage in command references and add focused tests for command behavior and workflow persistence

## Test plan
- [x] `npm run test --workspace @google/gemini-cli -- taskCommand.test.ts TaskWorkflowService.test.ts`
- [x] Verify `/task` command is included in built-in command loader
- [x] Verify persisted task state keys are added to persistent state storage

Made with [Cursor](https://cursor.com)