### PR TITLE
fix(core): normalize MCP tool schemas to ensure type:'object' at root

### DIFF
--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -1155,4 +1155,28 @@ describe('normalizeToolSchema', () => {
       properties: {},
     });
   });
+
+  it('should fix null properties even when type is already object', () => {
+    const schema = { type: 'object', properties: null };
+    expect(normalizeToolSchema(schema)).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('should fix non-object properties when type is already object', () => {
+    const schema = { type: 'object', properties: 'invalid' };
+    expect(normalizeToolSchema(schema)).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('should fix array properties when type is already object', () => {
+    const schema = { type: 'object', properties: [{ type: 'string' }] };
+    expect(normalizeToolSchema(schema)).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
 });

--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -19,7 +19,8 @@ import {
   DiscoveredMCPTool,
   generateValidName,
   formatMcpToolName,
-} from './mcp-tool.js'; // Added getStringifiedResultForDisplay
+  normalizeToolSchema,
+} from './mcp-tool.js';
 import { ToolConfirmationOutcome, type ToolResult } from './tools.js';
 import type { CallableTool, Part } from '@google/genai';
 import { ToolErrorType } from './tool-error.js';
@@ -1059,6 +1060,99 @@ describe('MCP Tool Naming Regression Fixes', () => {
 
       const qn = tool.getFullyQualifiedName();
       expect(qn).toBe('mcp_123-server_tool');
+    });
+  });
+});
+
+describe('normalizeToolSchema', () => {
+  it('should return fallback for undefined', () => {
+    expect(normalizeToolSchema(undefined)).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('should return fallback for null', () => {
+    expect(normalizeToolSchema(null)).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('should return fallback for primitive values', () => {
+    expect(normalizeToolSchema('string')).toEqual({
+      type: 'object',
+      properties: {},
+    });
+    expect(normalizeToolSchema(42)).toEqual({
+      type: 'object',
+      properties: {},
+    });
+    expect(normalizeToolSchema(true)).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('should return fallback for arrays', () => {
+    expect(normalizeToolSchema([{ type: 'string' }])).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('should inject type:"object" when type is missing', () => {
+    const schema = { properties: { name: { type: 'string' } } };
+    expect(normalizeToolSchema(schema)).toEqual({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    });
+  });
+
+  it('should inject type:"object" when type is non-object', () => {
+    const schema = { type: 'string', properties: { x: { type: 'number' } } };
+    expect(normalizeToolSchema(schema)).toEqual({
+      type: 'object',
+      properties: { x: { type: 'number' } },
+    });
+  });
+
+  it('should add empty properties when missing and type is wrong', () => {
+    const schema = { type: 'array' };
+    expect(normalizeToolSchema(schema)).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('should preserve a valid schema unchanged', () => {
+    const schema = {
+      type: 'object',
+      properties: { query: { type: 'string', description: 'Search query' } },
+      required: ['query'],
+    };
+    expect(normalizeToolSchema(schema)).toEqual(schema);
+  });
+
+  it('should preserve additional fields like description and required', () => {
+    const schema = {
+      description: 'Tool params',
+      required: ['a'],
+      properties: { a: { type: 'string' } },
+    };
+    const result = normalizeToolSchema(schema);
+    expect(result).toEqual({
+      description: 'Tool params',
+      required: ['a'],
+      type: 'object',
+      properties: { a: { type: 'string' } },
+    });
+  });
+
+  it('should return fallback for empty object', () => {
+    expect(normalizeToolSchema({})).toEqual({
+      type: 'object',
+      properties: {},
     });
   });
 });

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -115,6 +115,25 @@ export function isMcpToolAnnotation(
 
 type ToolParams = Record<string, unknown>;
 
+/**
+ * Normalize an MCP tool's input schema so the top-level type is always
+ * "object".  Many providers (and the Gemini API itself in strict mode)
+ * require tool parameter schemas to have type:'object' at root.  MCP
+ * servers may omit this or supply a non-object type.
+ */
+export function normalizeToolSchema(schema: unknown): Record<string, unknown> {
+  const fallback: Record<string, unknown> = { type: 'object', properties: {} };
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+    return fallback;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowed by typeof+Array guards above
+  const obj = schema as Record<string, unknown>;
+  if (obj['type'] !== 'object') {
+    return { ...obj, type: 'object', properties: obj['properties'] ?? {} };
+  }
+  return obj;
+}
+
 // Discriminated union for MCP Content Blocks to ensure type safety.
 type McpTextBlock = {
   type: 'text';
@@ -337,12 +356,14 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
   ToolParams,
   ToolResult
 > {
+  override readonly parameterSchema: Record<string, unknown>;
+
   constructor(
     private readonly mcpTool: CallableTool,
     readonly serverName: string,
     readonly serverToolName: string,
     description: string,
-    override readonly parameterSchema: unknown,
+    rawParameterSchema: unknown,
     messageBus: MessageBus,
     readonly trust?: boolean,
     isReadOnly?: boolean,
@@ -352,6 +373,7 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
     override readonly extensionId?: string,
     private readonly _toolAnnotations?: Record<string, unknown>,
   ) {
+    const normalized = normalizeToolSchema(rawParameterSchema);
     super(
       nameOverride ??
         generateValidName(
@@ -360,13 +382,14 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
       `${serverToolName} (${serverName} MCP Server)`,
       description,
       Kind.Other,
-      parameterSchema,
+      normalized,
       messageBus,
       true, // isOutputMarkdown
       false, // canUpdateOutput,
       extensionName,
       extensionId,
     );
+    this.parameterSchema = normalized;
     this._isReadOnly = isReadOnly;
   }
 

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -128,10 +128,16 @@ export function normalizeToolSchema(schema: unknown): Record<string, unknown> {
   }
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowed by typeof+Array guards above
   const obj = schema as Record<string, unknown>;
-  if (obj['type'] !== 'object') {
-    return { ...obj, type: 'object', properties: obj['properties'] ?? {} };
-  }
-  return obj;
+
+  const properties = obj['properties'];
+  const hasValidProperties =
+    properties && typeof properties === 'object' && !Array.isArray(properties);
+
+  return {
+    ...obj,
+    type: 'object',
+    properties: hasValidProperties ? properties : {},
+  };
 }
 
 // Discriminated union for MCP Content Blocks to ensure type safety.

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -17,7 +17,7 @@ import type { Config } from '../config/config.js';
 import { ApprovalMode } from '../policy/types.js';
 import { spawn } from 'node:child_process';
 import { StringDecoder } from 'node:string_decoder';
-import { DiscoveredMCPTool } from './mcp-tool.js';
+import { DiscoveredMCPTool, normalizeToolSchema } from './mcp-tool.js';
 import { parse } from 'shell-quote';
 import { ToolErrorType } from './tool-error.js';
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
@@ -490,8 +490,8 @@ export class ToolRegistry {
             func.name,
             DISCOVERED_TOOL_PREFIX + func.name,
             func.description ?? '',
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-            parameters as Record<string, unknown>,
+             
+            normalizeToolSchema(parameters),
             this.messageBus,
           ),
         );


### PR DESCRIPTION
Fixes #23382

## What

Add `normalizeToolSchema()` to ensure every MCP and extension-discovered tool parameter schema has `type: 'object'` at root level before it reaches the API.

## Why

MCP servers from the ecosystem (Zapier, Linear, custom servers) can advertise schemas that are `undefined`, `null`, missing `type`, or have a non-object type at root. The Gemini API is lenient today, but:

- Vertex AI in strict mode rejects non-conformant schemas
- Any downstream consumer that validates JSON Schema strictly will fail
- The JSON Schema spec requires tool parameter schemas to be objects

This is a zero-risk normalization — valid schemas pass through unchanged.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/tools/mcp-tool.ts` | Add exported `normalizeToolSchema()`, apply in `DiscoveredMCPTool` constructor |
| `packages/core/src/tools/tool-registry.ts` | Apply `normalizeToolSchema()` at `DiscoveredTool` registration |
| `packages/core/src/tools/mcp-tool.test.ts` | 10 test cases covering undefined, null, primitives, arrays, missing type, wrong type, valid schemas |

## Test Plan

- [x] `npx vitest run packages/core/src/tools/mcp-tool.test.ts` — 66 tests pass
- [x] Pre-commit hooks (ESLint + Prettier) pass
- [x] No behavior change for well-formed schemas

Made with [Cursor](https://cursor.com)