### PR TITLE
fix: systemMessage visibility in interactive mode

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -364,6 +364,10 @@ export async function runNonInteractive({
             }
           } else if (event.type === GeminiEventType.Error) {
             throw event.value.error;
+          } else if (event.type === GeminiEventType.SystemMessage) {
+            if (config.getOutputFormat() === OutputFormat.TEXT) {
+              process.stderr.write(`[INFO] ${event.value}\n`);
+            }
           } else if (event.type === GeminiEventType.AgentExecutionStopped) {
             const stopMessage = `Agent execution stopped: ${event.value.systemMessage?.trim() || event.value.reason}`;
             if (config.getOutputFormat() === OutputFormat.TEXT) {

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -3209,6 +3209,61 @@ describe('useGeminiStream', () => {
       );
     });
 
+    it('should handle SystemMessage event', async () => {
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.SystemMessage,
+            value: 'This is a system message',
+          };
+          yield { type: ServerGeminiEventType.Content, value: 'test content' };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: { reason: 'STOP', usageMetadata: undefined },
+          };
+        })(),
+      );
+
+      const { result } = await renderHookWithProviders(() =>
+        useGeminiStream(
+          new MockedGeminiClientClass(mockConfig),
+          [],
+          mockAddItem,
+          mockConfig,
+          mockLoadedSettings,
+          mockOnDebugMessage,
+          mockHandleSlashCommand,
+          false,
+          () => 'vscode' as EditorType,
+          () => {},
+          () => Promise.resolve(),
+          false,
+          () => {},
+          () => {},
+          () => {},
+          80,
+          24,
+        ),
+      );
+
+      await act(async () => {
+        await result.current.submitQuery('test sys msg');
+      });
+
+      await waitFor(
+        () => {
+          expect(mockAddItem).toHaveBeenCalledWith(
+            {
+              type: MessageType.INFO,
+              text: 'This is a system message',
+            },
+            expect.any(Number),
+          );
+        },
+        { timeout: 5000 },
+      );
+    });
+
     it('should update lastOutputTime on Gemini thought and content events', async () => {
       vi.useFakeTimers();
       const startTime = 1000000;

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -248,6 +248,11 @@ export const useGeminiStream = (
     useStateAndRef<ThoughtSummary | null>(null);
   const [pendingHistoryItem, pendingHistoryItemRef, setPendingHistoryItem] =
     useStateAndRef<HistoryItemWithoutId | null>(null);
+  const [
+    pendingSystemMessages,
+    pendingSystemMessagesRef,
+    setPendingSystemMessages,
+  ] = useStateAndRef<HistoryItemWithoutId[]>([]);
 
   const [lastGeminiActivityTime, setLastGeminiActivityTime] =
     useState<number>(0);
@@ -1296,6 +1301,19 @@ export const useGeminiStream = (
     ],
   );
 
+  const handleSystemMessageEvent = useCallback(
+    (systemMessage: string, _userMessageTimestamp: number) => {
+      setPendingSystemMessages([
+        ...pendingSystemMessagesRef.current,
+        {
+          type: MessageType.INFO,
+          text: systemMessage,
+        } as HistoryItemWithoutId,
+      ]);
+    },
+    [setPendingSystemMessages, pendingSystemMessagesRef],
+  );
+
   const processGeminiStreamEvents = useCallback(
     async (
       stream: AsyncIterable<GeminiEvent>,
@@ -1333,6 +1351,9 @@ export const useGeminiStream = (
             break;
           case ServerGeminiEventType.Error:
             handleErrorEvent(event.value, userMessageTimestamp);
+            break;
+          case ServerGeminiEventType.SystemMessage:
+            handleSystemMessageEvent(event.value, userMessageTimestamp);
             break;
           case ServerGeminiEventType.AgentExecutionStopped:
             handleAgentExecutionStoppedEvent(
@@ -1413,6 +1434,7 @@ export const useGeminiStream = (
       handleContextWindowWillOverflowEvent,
       handleCitationEvent,
       handleChatModelEvent,
+      handleSystemMessageEvent,
       handleAgentExecutionStoppedEvent,
       handleAgentExecutionBlockedEvent,
       addItem,
@@ -1527,6 +1549,12 @@ export const useGeminiStream = (
                 addItem(pendingHistoryItemRef.current, userMessageTimestamp);
                 setPendingHistoryItem(null);
               }
+              if (pendingSystemMessagesRef.current.length > 0) {
+                pendingSystemMessagesRef.current.forEach((item) => {
+                  addItem(item, userMessageTimestamp);
+                });
+                setPendingSystemMessages([]);
+              }
               if (loopDetectedRef.current) {
                 loopDetectedRef.current = false;
                 // Show the confirmation dialog to choose whether to disable loop detection
@@ -1616,6 +1644,8 @@ export const useGeminiStream = (
       maybeAddLowVerbosityFailureNote,
       settings.merged.billing?.overageStrategy,
       setIsResponding,
+      pendingSystemMessagesRef,
+      setPendingSystemMessages,
     ],
   );
 
@@ -1878,10 +1908,12 @@ export const useGeminiStream = (
 
   const pendingHistoryItems = useMemo(
     () =>
-      [pendingHistoryItem, ...pendingToolGroupItems].filter(
-        (i): i is HistoryItemWithoutId => i !== undefined && i !== null,
-      ),
-    [pendingHistoryItem, pendingToolGroupItems],
+      [
+        pendingHistoryItem,
+        ...pendingSystemMessages,
+        ...pendingToolGroupItems,
+      ].filter((i): i is HistoryItemWithoutId => i !== undefined && i !== null),
+    [pendingHistoryItem, pendingSystemMessages, pendingToolGroupItems],
   );
 
   useEffect(() => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -3512,6 +3512,40 @@ ${JSON.stringify(
         expect(mockTurnRunFn).not.toHaveBeenCalled();
       });
 
+      it('should yield SystemMessage in BeforeAgent when hook returns decision: allow with a systemMessage', async () => {
+        mockHookSystem.fireBeforeAgentEvent.mockResolvedValue({
+          shouldStopExecution: () => false,
+          isBlockingDecision: () => false,
+          getEffectiveReason: () => '',
+          getAdditionalContext: () => undefined,
+          systemMessage: 'Allowed with a reason',
+        });
+
+        const mockChat: Partial<GeminiChat> = {
+          addHistory: vi.fn(),
+          setTools: vi.fn(),
+          getHistory: vi.fn().mockReturnValue([]),
+          getLastPromptTokenCount: vi.fn(),
+        };
+        client['chat'] = mockChat as GeminiChat;
+        mockTurnRunFn.mockImplementation(async function* () {
+          yield { type: GeminiEventType.Content, value: 'response' };
+        });
+
+        const request = [{ text: 'Hello' }];
+        const stream = client.sendMessageStream(
+          request,
+          new AbortController().signal,
+          'test-prompt',
+        );
+        const events = await fromAsync(stream);
+
+        expect(events).toContainEqual({
+          type: GeminiEventType.SystemMessage,
+          value: 'Allowed with a reason',
+        });
+      });
+
       it('should block execution in BeforeAgent when hook returns decision: block', async () => {
         mockHookSystem.fireBeforeAgentEvent.mockResolvedValue({
           shouldStopExecution: () => false,
@@ -3676,6 +3710,31 @@ ${JSON.stringify(
         expect(resetChatSpy).toHaveBeenCalledTimes(1);
 
         resetChatSpy.mockRestore();
+      });
+
+      it('should yield SystemMessage in AfterAgent when hook returns a systemMessage', async () => {
+        mockHookSystem.fireAfterAgentEvent.mockResolvedValue({
+          shouldStopExecution: () => false,
+          isBlockingDecision: () => false,
+          getEffectiveReason: () => '',
+          systemMessage: 'After agent message',
+        });
+
+        mockTurnRunFn.mockImplementation(async function* () {
+          yield { type: GeminiEventType.Content, value: 'response' };
+        });
+
+        const stream = client.sendMessageStream(
+          { text: 'Hi' },
+          new AbortController().signal,
+          'test-prompt',
+        );
+        const events = await fromAsync(stream);
+
+        expect(events).toContainEqual({
+          type: GeminiEventType.SystemMessage,
+          value: 'After agent message',
+        });
       });
     });
   });

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -89,7 +89,11 @@ type BeforeAgentHookReturn =
       type: GeminiEventType.AgentExecutionBlocked;
       value: { reason: string; systemMessage?: string };
     }
-  | { additionalContext: string | undefined }
+  | {
+      type: 'continue';
+      additionalContext: string | undefined;
+      systemMessage: string | undefined;
+    }
   | undefined;
 
 export class GeminiClient {
@@ -195,10 +199,11 @@ export class GeminiClient {
     }
 
     const additionalContext = hookOutput?.getAdditionalContext();
-    if (additionalContext) {
-      return { additionalContext };
-    }
-    return undefined;
+    return {
+      type: 'continue',
+      additionalContext,
+      systemMessage: hookOutput?.systemMessage,
+    };
   }
 
   private async fireAfterAgentHookSafe(
@@ -894,6 +899,12 @@ export class GeminiClient {
           'type' in hookResult &&
           hookResult.type === GeminiEventType.AgentExecutionStopped
         ) {
+          if (hookResult.value.systemMessage) {
+            yield {
+              type: GeminiEventType.SystemMessage,
+              value: hookResult.value.systemMessage,
+            };
+          }
           // Add user message to history before returning so it's kept in the transcript
           this.getChat().addHistory(createUserContent(request));
           yield hookResult;
@@ -902,9 +913,21 @@ export class GeminiClient {
           'type' in hookResult &&
           hookResult.type === GeminiEventType.AgentExecutionBlocked
         ) {
+          if (hookResult.value.systemMessage) {
+            yield {
+              type: GeminiEventType.SystemMessage,
+              value: hookResult.value.systemMessage,
+            };
+          }
           yield hookResult;
           return new Turn(this.getChat(), prompt_id);
-        } else if ('additionalContext' in hookResult) {
+        } else if ('type' in hookResult && hookResult.type === 'continue') {
+          if (hookResult.systemMessage) {
+            yield {
+              type: GeminiEventType.SystemMessage,
+              value: hookResult.systemMessage,
+            };
+          }
           const additionalContext = hookResult.additionalContext;
           if (additionalContext) {
             const requestArray = Array.isArray(request) ? request : [request];
@@ -942,6 +965,13 @@ export class GeminiClient {
 
         // Cast to AfterAgentHookOutput for access to shouldClearContext()
         const afterAgentOutput = hookOutput as AfterAgentHookOutput | undefined;
+
+        if (afterAgentOutput?.systemMessage) {
+          yield {
+            type: GeminiEventType.SystemMessage,
+            value: afterAgentOutput.systemMessage,
+          };
+        }
 
         if (afterAgentOutput?.shouldStopExecution()) {
           const contextCleared = afterAgentOutput.shouldClearContext();

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -68,6 +68,7 @@ export enum GeminiEventType {
   ModelInfo = 'model_info',
   AgentExecutionStopped = 'agent_execution_stopped',
   AgentExecutionBlocked = 'agent_execution_blocked',
+  SystemMessage = 'system_message',
 }
 
 export type ServerGeminiRetryEvent = {
@@ -90,6 +91,11 @@ export type ServerGeminiAgentExecutionBlockedEvent = {
     systemMessage?: string;
     contextCleared?: boolean;
   };
+};
+
+export type ServerGeminiSystemMessageEvent = {
+  type: GeminiEventType.SystemMessage;
+  value: string;
 };
 
 export type ServerGeminiContextWindowWillOverflowEvent = {
@@ -232,7 +238,8 @@ export type ServerGeminiStreamEvent =
   | ServerGeminiInvalidStreamEvent
   | ServerGeminiModelInfoEvent
   | ServerGeminiAgentExecutionStoppedEvent
-  | ServerGeminiAgentExecutionBlockedEvent;
+  | ServerGeminiAgentExecutionBlockedEvent
+  | ServerGeminiSystemMessageEvent;
 
 // A turn manages the agentic loop turn within the server context.
 export class Turn {

--- a/packages/core/src/hooks/hookAggregator.ts
+++ b/packages/core/src/hooks/hookAggregator.ts
@@ -42,6 +42,7 @@ export class HookAggregator {
   ): AggregatedHookResult {
     const allOutputs: HookOutput[] = [];
     const errors: Error[] = [];
+    const stderrs: string[] = [];
     let totalDuration = 0;
 
     // Collect all outputs and errors
@@ -55,10 +56,23 @@ export class HookAggregator {
       if (result.output) {
         allOutputs.push(result.output);
       }
+
+      if (result.stderr?.trim()) {
+        stderrs.push(result.stderr.trim());
+      }
     }
 
     // Merge outputs using event-specific strategy
     const mergedOutput = this.mergeOutputs(allOutputs, eventName);
+
+    // Append collected stderrs to systemMessage if any
+    if (stderrs.length > 0 && mergedOutput) {
+      const existingMsg = mergedOutput.systemMessage || '';
+      mergedOutput.systemMessage = existingMsg
+        ? `${existingMsg}\n${stderrs.join('\n')}`
+        : stderrs.join('\n');
+    }
+
     const finalOutput = mergedOutput
       ? this.createSpecificHookOutput(mergedOutput, eventName)
       : undefined;


### PR DESCRIPTION
### Description
Currently, `systemMessage` notifications returned by hooks (`BeforeAgent` and `AfterAgent`) are only rendered by the Gemini CLI terminal if the hook returns `decision: 'deny'`. For all other hook results (e.g., adding `additionalContext`), any provided `systemMessage` is silently ignored by the client and never reaches the UI.

This PR introduces a first-class `GeminiEventType.SystemMessage` to the protocol, ensuring that these notifications are yielded by the `GeminiClient` and rendered dynamically in the terminal UI during an active turn.

Fixes google-gemini/gemini-cli#23427

### Changes

#### `packages/core`
- **Protocol:** Added `GeminiEventType.SystemMessage` to the `ServerGeminiStreamEvent` union.
- **Client:** Updated `GeminiClient` to yield a `SystemMessage` event whenever a hook fires and returns a `systemMessage`, regardless of whether the execution is blocked.
- **Tests:** Added comprehensive unit tests in `client.test.ts` to verify event yielding for both `BeforeAgent` and `AfterAgent`.

#### `packages/cli`
- **UI State:** Introduced `pendingSystemMessages` state in `useGeminiStream` to track notifications during an active turn.
- **Rendering:** Updated the `pendingHistoryItems` logic to include these messages, allowing them to render live above the Thinking block or model response.
- **Persistence:** Ensured that pending system messages are committed to the permanent history once the turn completes.
- **Non-Interactive:** Updated the headless CLI mode to output these messages to `stderr` with an `[INFO]` prefix.
- **Tests:** Added UI unit tests in `useGeminiStream.test.tsx` to verify correct handling and display of the new event type.