### PR TITLE
fix(write-file): remove unreachable condition in isNewFile

### DIFF
--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -295,11 +295,7 @@ class WriteFileToolInvocation extends BaseToolInvocation<
     } = correctedContentResult;
     // fileExists is true if the file existed (and was readable or unreadable but caught by readError).
     // fileExists is false if the file did not exist (ENOENT).
-    const isNewFile =
-      !fileExists ||
-      (correctedContentResult.error !== undefined &&
-        !correctedContentResult.fileExists);
-
+    const isNewFile = !fileExists;
     try {
       const dirName = path.dirname(this.resolvedPath);
       try {


### PR DESCRIPTION
## Summary
Removes unreachable condition in isNewFile calculation.

## Problem
The condition:
correctedContentResult.error !== undefined

is always false because the function already returns earlier when an error occurs.

## Fix
Simplified logic to:
const isNewFile = !fileExists;

## Impact
Removes dead code and improves correctness.