### PR TITLE
fix(chat-compression): return fullNewHistory instead of extraHistory

### DIFF
--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -464,7 +464,7 @@ export class ChatCompressionService {
       };
     } else {
       return {
-        newHistory: extraHistory,
+        newHistory: fullNewHistory,
         info: {
           originalTokenCount,
           newTokenCount,


### PR DESCRIPTION
## Summary
Fixes an issue where compressed chat history returned incomplete history.

## Problem
The function constructs `fullNewHistory` using `getInitialChatHistory`, which includes system context.

However, it incorrectly returned `extraHistory`, leading to loss of context.

## Fix
Return `fullNewHistory` instead of `extraHistory`.

## Impact
- Preserves system messages
- Maintains correct chat context
- Improves reliability of compressed history