### PR TITLE
feat(cli): auto-remove clean Gemini worktrees on exit

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -64,7 +64,7 @@ import {
   registerTelemetryConfig,
   setupSignalHandlers,
 } from './utils/cleanup.js';
-import { setupWorktree } from './utils/worktreeSetup.js';
+import { cleanupWorktreeOnExit, setupWorktree } from './utils/worktreeSetup.js';
 import {
   cleanupToolOutputFiles,
   cleanupExpiredSessions,
@@ -466,6 +466,10 @@ export async function main() {
     registerCleanup(async () => {
       await config.getHookSystem()?.fireSessionEndEvent(SessionEndReason.Exit);
     });
+
+    if (config.getWorktreeSettings()) {
+      registerCleanup(() => cleanupWorktreeOnExit(config));
+    }
 
     // Cleanup sessions after config initialization
     try {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -130,6 +130,7 @@ import { appEvents, AppEvent, TransientMessageType } from '../utils/events.js';
 import { type UpdateObject } from './utils/updateCheck.js';
 import { setUpdateHandler } from '../utils/handleAutoUpdate.js';
 import { registerCleanup, runExitCleanup } from '../utils/cleanup.js';
+import { cleanupWorktreeOnExit } from '../utils/worktreeSetup.js';
 import { relaunchApp } from '../utils/processUtils.js';
 import type { SessionInfo } from '../utils/sessionUtils.js';
 import { useMessageQueue } from './hooks/useMessageQueue.js';
@@ -908,11 +909,14 @@ Logging in with Google... Restarting Gemini CLI to continue.
       openAgentConfigDialog,
       openPermissionsDialog,
       quit: (messages: HistoryItem[]) => {
-        setQuittingMessages(messages);
-        setTimeout(async () => {
-          await runExitCleanup();
-          process.exit(0);
-        }, 100);
+        void (async () => {
+          await cleanupWorktreeOnExit(config);
+          setQuittingMessages(messages);
+          setTimeout(async () => {
+            await runExitCleanup();
+            process.exit(0);
+          }, 100);
+        })();
       },
       setDebugMessage,
       toggleCorgiMode: () => setCorgiMode((prev) => !prev),
@@ -951,6 +955,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       toggleDebugProfiler,
       setShortcutsHelpVisible,
       stableSetText,
+      config,
     ],
   );
 

--- a/packages/cli/src/ui/components/SessionSummaryDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SessionSummaryDisplay.test.tsx
@@ -207,7 +207,29 @@ describe('<SessionSummaryDisplay />', () => {
   });
 
   describe('Worktree status', () => {
-    it('renders worktree instructions when worktreeSettings are present', async () => {
+    it('renders cleanup message when worktree was removed', async () => {
+      const worktreeSettings: WorktreeSettings = {
+        name: 'foo-bar',
+        path: '/path/to/foo-bar',
+        baseSha: 'base-sha',
+        removed: true,
+      };
+
+      const { lastFrame, unmount } = await renderWithMockedStats(
+        emptyMetrics,
+        'test-session',
+        worktreeSettings,
+      );
+      const output = lastFrame();
+
+      expect(output).toContain('Worktree cleaned up (no changes detected).');
+      expect(output).toContain('gemini --resume test-session');
+      expect(output).not.toContain('To resume work in this worktree:');
+      expect(output).not.toContain('git worktree remove');
+      unmount();
+    });
+
+    it('renders preserved worktree resume instructions when worktreeSettings are present', async () => {
       const worktreeSettings: WorktreeSettings = {
         name: 'foo-bar',
         path: '/path/to/foo-bar',
@@ -221,6 +243,7 @@ describe('<SessionSummaryDisplay />', () => {
       );
       const output = lastFrame();
 
+      expect(output).toContain('Worktree preserved.');
       expect(output).toContain('To resume work in this worktree:');
       expect(output).toContain(
         'cd /path/to/foo-bar && gemini --resume test-session',

--- a/packages/cli/src/ui/components/SessionSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/SessionSummaryDisplay.tsx
@@ -26,8 +26,13 @@ export const SessionSummaryDisplay: React.FC<SessionSummaryDisplayProps> = ({
   const escapedSessionId = escapeShellArg(stats.sessionId, shell);
   let footer = `To resume this session: gemini --resume ${escapedSessionId}`;
 
-  if (worktreeSettings) {
+  if (worktreeSettings?.removed) {
     footer =
+      `Worktree cleaned up (no changes detected).\n` +
+      `To resume this session: gemini --resume ${escapedSessionId}`;
+  } else if (worktreeSettings) {
+    footer =
+      `Worktree preserved.\n` +
       `To resume work in this worktree: cd ${escapeShellArg(worktreeSettings.path, shell)} && gemini --resume ${escapedSessionId}\n` +
       `To remove manually: git worktree remove ${escapeShellArg(worktreeSettings.path, shell)}`;
   }

--- a/packages/cli/src/utils/worktreeSetup.test.ts
+++ b/packages/cli/src/utils/worktreeSetup.test.ts
@@ -5,10 +5,24 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { setupWorktree } from './worktreeSetup.js';
+import { access } from 'node:fs/promises';
+import {
+  setupWorktree,
+  cleanupWorktreeOnExit,
+  resetWorktreeExitCleanupForTesting,
+} from './worktreeSetup.js';
 import * as coreFunctions from '@google/gemini-cli-core';
 
+const hoisted = vi.hoisted(() => ({
+  mockMaybeCleanup: vi.fn(),
+  mockIsGeminiWorktree: vi.fn(),
+}));
+
 // Mock dependencies
+vi.mock('node:fs/promises', () => ({
+  access: vi.fn(),
+}));
+
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('@google/gemini-cli-core')>();
@@ -16,6 +30,10 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     ...actual,
     getProjectRootForWorktree: vi.fn(),
     createWorktreeService: vi.fn(),
+    WorktreeService: vi.fn().mockImplementation(() => ({
+      maybeCleanup: hoisted.mockMaybeCleanup,
+    })),
+    isGeminiWorktree: hoisted.mockIsGeminiWorktree,
     debugLogger: {
       log: vi.fn(),
       error: vi.fn(),
@@ -37,6 +55,8 @@ describe('setupWorktree', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetWorktreeExitCleanupForTesting();
+    hoisted.mockIsGeminiWorktree.mockReturnValue(true);
     process.env = { ...originalEnv };
 
     // Mock process.cwd and process.chdir
@@ -120,5 +140,120 @@ describe('setupWorktree', () => {
     expect(mockExit).toHaveBeenCalledWith(1);
 
     mockExit.mockRestore();
+  });
+});
+
+describe('cleanupWorktreeOnExit', () => {
+  const originalCwd = process.cwd;
+  const worktreePath = '/mock/project/.gemini/worktrees/my-feature';
+
+  const createConfig = () => ({
+    getWorktreeSettings: vi.fn(),
+    markWorktreeRemoved: vi.fn(),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetWorktreeExitCleanupForTesting();
+    hoisted.mockIsGeminiWorktree.mockReturnValue(true);
+    hoisted.mockMaybeCleanup.mockResolvedValue(false);
+    vi.mocked(coreFunctions.getProjectRootForWorktree).mockResolvedValue(
+      '/mock/project',
+    );
+    vi.mocked(access).mockRejectedValue(new Error('ENOENT'));
+
+    let currentPath = worktreePath;
+    process.cwd = vi.fn().mockImplementation(() => currentPath);
+    process.chdir = vi.fn().mockImplementation((newPath: string) => {
+      currentPath = newPath;
+    });
+  });
+
+  afterEach(() => {
+    process.cwd = originalCwd;
+    delete (process as { chdir?: typeof process.chdir }).chdir;
+  });
+
+  it('returns false when there are no worktree settings', async () => {
+    const config = createConfig();
+    config.getWorktreeSettings.mockReturnValue(undefined);
+
+    await expect(cleanupWorktreeOnExit(config as never)).resolves.toBe(false);
+    expect(hoisted.mockMaybeCleanup).not.toHaveBeenCalled();
+  });
+
+  it('returns false without cleanup when path is not a Gemini worktree', async () => {
+    hoisted.mockIsGeminiWorktree.mockReturnValue(false);
+    const config = createConfig();
+    config.getWorktreeSettings.mockReturnValue({
+      name: 'x',
+      path: '/evil/other/path',
+      baseSha: 'sha',
+    });
+
+    await expect(cleanupWorktreeOnExit(config as never)).resolves.toBe(false);
+    expect(hoisted.mockMaybeCleanup).not.toHaveBeenCalled();
+  });
+
+  it('calls markWorktreeRemoved only when maybeCleanup succeeds and path is gone', async () => {
+    hoisted.mockMaybeCleanup.mockResolvedValue(true);
+    vi.mocked(access).mockRejectedValue(new Error('ENOENT'));
+    const config = createConfig();
+    config.getWorktreeSettings.mockReturnValue({
+      name: 'my-feature',
+      path: worktreePath,
+      baseSha: 'base-sha',
+    });
+
+    await expect(cleanupWorktreeOnExit(config as never)).resolves.toBe(true);
+    expect(config.markWorktreeRemoved).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not mark removed when path still exists after maybeCleanup', async () => {
+    hoisted.mockMaybeCleanup.mockResolvedValue(true);
+    vi.mocked(access).mockResolvedValue(undefined);
+    const config = createConfig();
+    config.getWorktreeSettings.mockReturnValue({
+      name: 'my-feature',
+      path: worktreePath,
+      baseSha: 'base-sha',
+    });
+
+    await expect(cleanupWorktreeOnExit(config as never)).resolves.toBe(false);
+    expect(config.markWorktreeRemoved).not.toHaveBeenCalled();
+  });
+
+  it('restores cwd after cleanup', async () => {
+    hoisted.mockMaybeCleanup.mockResolvedValue(false);
+    const config = createConfig();
+    config.getWorktreeSettings.mockReturnValue({
+      name: 'my-feature',
+      path: worktreePath,
+      baseSha: 'base-sha',
+    });
+
+    await cleanupWorktreeOnExit(config as never);
+
+    expect(process.chdir).toHaveBeenCalledWith('/mock/project');
+    expect(process.chdir).toHaveBeenCalledWith(worktreePath);
+    const chdirMock = vi.mocked(process.chdir);
+    expect(chdirMock.mock.calls[chdirMock.mock.calls.length - 1]?.[0]).toBe(
+      worktreePath,
+    );
+  });
+
+  it('runs at most once per process', async () => {
+    hoisted.mockMaybeCleanup.mockResolvedValue(false);
+    const config = createConfig();
+    config.getWorktreeSettings.mockReturnValue({
+      name: 'my-feature',
+      path: worktreePath,
+      baseSha: 'base-sha',
+    });
+
+    await cleanupWorktreeOnExit(config as never);
+    await cleanupWorktreeOnExit(config as never);
+
+    expect(hoisted.mockMaybeCleanup).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/src/utils/worktreeSetup.ts
+++ b/packages/cli/src/utils/worktreeSetup.ts
@@ -4,12 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { access } from 'node:fs/promises';
 import {
-  getProjectRootForWorktree,
+  type Config,
   createWorktreeService,
+  getProjectRootForWorktree,
+  isGeminiWorktree,
   writeToStderr,
+  WorktreeService,
   type WorktreeInfo,
 } from '@google/gemini-cli-core';
+
+let worktreeExitCleanupDone = false;
+
+/**
+ * Resets exit-cleanup guard state for tests (same idea as `resetCleanupForTesting`).
+ */
+export function resetWorktreeExitCleanupForTesting(): void {
+  worktreeExitCleanupDone = false;
+}
 
 /**
  * Sets up a git worktree for parallel sessions.
@@ -39,5 +52,60 @@ export async function setupWorktree(
     const errorMessage = error instanceof Error ? error.message : String(error);
     writeToStderr(`Failed to create or switch to worktree: ${errorMessage}\n`);
     process.exit(1);
+  }
+}
+
+/**
+ * Removes the Gemini-managed worktree and its branch on exit when the tree is
+ * clean (no staged, unstaged, or untracked changes and HEAD matches baseSha).
+ *
+ * Safe-by-default: any git error or dirty state preserves the worktree. Runs
+ * at most once per process (quit path and registered cleanup share the same
+ * guard).
+ *
+ * @param config Active CLI configuration.
+ * @returns True if the worktree was removed, false if preserved or not applicable.
+ */
+export async function cleanupWorktreeOnExit(config: Config): Promise<boolean> {
+  if (worktreeExitCleanupDone) {
+    return false;
+  }
+  const settings = config.getWorktreeSettings();
+  if (!settings) {
+    return false;
+  }
+
+  const projectRoot = await getProjectRootForWorktree(settings.path);
+  if (!isGeminiWorktree(settings.path, projectRoot)) {
+    return false;
+  }
+
+  worktreeExitCleanupDone = true;
+
+  const previousCwd = process.cwd();
+  try {
+    try {
+      process.chdir(projectRoot);
+    } catch {
+      // Best-effort unlock for `git worktree remove`; cleanup may still succeed.
+    }
+
+    const service = new WorktreeService(projectRoot);
+    let removed = await service.maybeCleanup(settings);
+    if (removed) {
+      try {
+        await access(settings.path);
+        removed = false;
+      } catch {
+        config.markWorktreeRemoved();
+      }
+    }
+    return removed;
+  } finally {
+    try {
+      process.chdir(previousCwd);
+    } catch {
+      // Ignore restore failures (e.g. previousCwd was removed).
+    }
   }
 }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -536,6 +536,8 @@ export interface WorktreeSettings {
   name: string;
   path: string;
   baseSha: string;
+  /** Set when the worktree was auto-removed on exit (clean session). */
+  removed?: boolean;
 }
 
 export interface ConfigParameters {
@@ -1570,6 +1572,16 @@ export class Config implements McpContext, AgentLoopContext {
 
   getWorktreeSettings(): WorktreeSettings | undefined {
     return this.worktreeSettings;
+  }
+
+  /**
+   * Marks the active Gemini worktree as auto-removed so the exit summary can
+   * show resume instructions without a stale worktree path.
+   */
+  markWorktreeRemoved(): void {
+    if (this.worktreeSettings) {
+      this.worktreeSettings.removed = true;
+    }
   }
 
   getClientName(): string | undefined {


### PR DESCRIPTION
Run maybeCleanup on exit when worktree settings are for a Gemini-managed path; preserve on dirty tree, git errors, or failed removal. Exit summary shows cleaned up vs preserved. Guard with isGeminiWorktree, verify path removed before marking UI state, restore cwd after chdir.


## Summary

On exit, automatically remove Gemini-managed worktrees and their temporary branches when the working tree is clean (no modified/staged/untracked changes; HEAD matches `baseSha`). If anything is dirty, git fails, removal fails, or the path is not under `.gemini/worktrees`, the worktree is preserved. The quit summary states whether the worktree was cleaned up or preserved, with resume / manual-remove instructions when preserved.

## Details

- Runs `maybeCleanup` from the quit path before the exit UI, and registers the same cleanup for signal-driven shutdown.
- Defense in depth: `isGeminiWorktree` before any removal; after `maybeCleanup`, verify the worktree path no longer exists before marking UI state; restore `process.cwd()` after `chdir` to the project root.
- `WorktreeSettings.removed` + `Config.markWorktreeRemoved()` drive the exit summary copy.
- Tests: `worktreeSetup.test.ts` (cleanup paths), `SessionSummaryDisplay` tests for removed vs preserved.

## Related Issues


## How to Validate

1. Enable experimental worktrees, start CLI with `-w` / worktree flag in a clean repo; exit with `/quit` — worktree dir and `worktree-*` branch should be removed when unchanged.
2. Make a change (or leave untracked files), exit — worktree preserved; summary shows preserved + resume / `git worktree remove` hints.
3. (Optional) `npm run test:ci` or targeted tests: `worktreeSetup.test.ts`, `SessionSummaryDisplay.test.tsx`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) - none
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [ ] Docker
