### PR TITLE
feat(cli): allow -i/--prompt-interactive with piped stdin

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -985,7 +985,10 @@ describe('gemini.tsx main function exit codes', () => {
     vi.restoreAllMocks();
   });
 
-  it('should exit with 42 for invalid input combination (prompt-interactive with non-TTY)', async () => {
+  it('should handle prompt-interactive with non-TTY without crashing', async () => {
+    // -i without TTY now falls through to headless interactive path.
+    // With mocked config (isInteractive=false), it exits with 42 (no input)
+    // because the mock doesn't derive interactive from argv.
     vi.mocked(loadCliConfig).mockResolvedValue(createMockConfig());
     vi.mocked(loadSettings).mockReturnValue(
       createMockSettings({

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -37,6 +37,7 @@ import {
 import { loadCliConfig, parseArguments } from './config/config.js';
 import * as cliConfig from './config/config.js';
 import { readStdin } from './utils/readStdin.js';
+import { readStdinLines } from './utils/readStdinLines.js';
 import { createHash } from 'node:crypto';
 import v8 from 'node:v8';
 import os from 'node:os';
@@ -268,15 +269,6 @@ export async function main() {
     });
   }
 
-  // Check for invalid input combinations early to prevent crashes
-  if (argv.promptInteractive && !process.stdin.isTTY) {
-    writeToStderr(
-      'Error: The --prompt-interactive flag cannot be used when input is piped from stdin.\n',
-    );
-    await runExitCleanup();
-    process.exit(ExitCodes.FATAL_INPUT_ERROR);
-  }
-
   const isDebugMode = cliConfig.isDebugMode(argv);
   const consolePatcher = new ConsolePatcher({
     stderr: true,
@@ -387,7 +379,7 @@ export async function main() {
         process.exit(ExitCodes.FATAL_AUTHENTICATION_ERROR);
       }
       let stdinData = '';
-      if (!process.stdin.isTTY) {
+      if (!process.stdin.isTTY && !argv.promptInteractive) {
         stdinData = await readStdin();
       }
 
@@ -596,7 +588,7 @@ export async function main() {
 
     cliStartupHandle?.end();
     // Render UI, passing necessary config values. Check that there is no command line question.
-    if (config.isInteractive()) {
+    if (config.isInteractive() && process.stdin.isTTY) {
       await startInteractiveUI(
         config,
         settings,
@@ -607,15 +599,13 @@ export async function main() {
       );
       return;
     }
-
     await config.initialize();
     startupProfiler.flush(config);
 
-    // If not a TTY, read from stdin
-    // This is for cases where the user pipes input directly into the command
-    let stdinData: string | undefined = undefined;
-    if (!process.stdin.isTTY) {
-      stdinData = await readStdin();
+    // If not a TTY, read from stdin as a single prompt.
+    // Skip in interactive mode (-i) — stdin will be read line-by-line.
+    if (!process.stdin.isTTY && !config.isInteractive()) {
+      const stdinData = await readStdin();
       if (stdinData) {
         input = input ? `${stdinData}\n\n${input}` : stdinData;
       }
@@ -649,25 +639,6 @@ export async function main() {
       await config.getHookSystem()?.fireSessionEndEvent(SessionEndReason.Exit);
     });
 
-    if (!input) {
-      debugLogger.error(
-        `No input provided via stdin. Input can be provided by piping data into gemini or using the --prompt option.`,
-      );
-      await runExitCleanup();
-      process.exit(ExitCodes.FATAL_INPUT_ERROR);
-    }
-
-    const prompt_id = sessionId;
-    logUserPrompt(
-      config,
-      new UserPromptEvent(
-        input.length,
-        prompt_id,
-        config.getContentGeneratorConfig()?.authType,
-        input,
-      ),
-    );
-
     const authType = await validateNonInteractiveAuth(
       settings.merged.security.auth.selectedType,
       settings.merged.security.auth.useExternal,
@@ -682,17 +653,61 @@ export async function main() {
 
     initializeOutputListenersAndFlush();
 
-    await runNonInteractive({
-      config,
-      settings,
-      input,
-      prompt_id,
-      resumedSessionData,
-    });
+    // Unified prompt loop: yields once for single-shot, multiple times for
+    // multi-turn pipe sessions. RESULT events signal each response end.
+    let promptCount = 0;
+    for await (const prompt of prompts(input, config.isInteractive())) {
+      promptCount++;
+      const prompt_id =
+        promptCount === 1 ? sessionId : `${sessionId}-${promptCount}`;
+      logUserPrompt(
+        config,
+        new UserPromptEvent(
+          prompt.length,
+          prompt_id,
+          config.getContentGeneratorConfig()?.authType,
+          prompt,
+        ),
+      );
+
+      await runNonInteractive({
+        config,
+        settings,
+        input: prompt,
+        prompt_id,
+        resumedSessionData: promptCount === 1 ? resumedSessionData : undefined,
+      });
+    }
+
+    if (promptCount === 0) {
+      debugLogger.error(
+        `No input provided via stdin. Input can be provided by piping data into gemini or using the --prompt option.`,
+      );
+      await runExitCleanup();
+      process.exit(ExitCodes.FATAL_INPUT_ERROR);
+    }
+
     // Call cleanup before process.exit, which causes cleanup to not run
     await runExitCleanup();
     process.exit(ExitCodes.SUCCESS);
   }
+}
+
+/**
+ * Yields prompts from the available input source.
+ * Single-shot (interactive=false): yields the provided input once.
+ * Multi-turn (interactive=true): yields initial input, then reads stdin line-by-line.
+ */
+async function* prompts(
+  input?: string,
+  interactive?: boolean,
+): AsyncGenerator<string> {
+  if (input) {
+    yield input;
+    if (!interactive) return;
+  }
+  if (!interactive || process.stdin.isTTY) return;
+  yield* readStdinLines();
 }
 
 export function initializeOutputListenersAndFlush() {

--- a/packages/cli/src/utils/readStdinLines.test.ts
+++ b/packages/cli/src/utils/readStdinLines.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, expect, it } from 'vitest';
+import { readStdinLines } from './readStdinLines.js';
+import { PassThrough } from 'node:stream';
+
+vi.mock('@google/gemini-cli-core', () => ({
+  debugLogger: {
+    warn: vi.fn(),
+  },
+}));
+
+/** Helper: collect all values from the async generator. */
+async function collect(gen: AsyncGenerator<string>): Promise<string[]> {
+  const results: string[] = [];
+  for await (const line of gen) {
+    results.push(line);
+  }
+  return results;
+}
+
+/** Helper: create a PassThrough stream and push lines into it. */
+function createStream(lines: string[]): PassThrough {
+  const stream = new PassThrough();
+  for (const line of lines) {
+    stream.write(line);
+  }
+  stream.end();
+  return stream;
+}
+
+describe('readStdinLines', () => {
+  it('should yield each non-empty line from piped input', async () => {
+    const stream = createStream(['hello\n', 'world\n']);
+    const result = await collect(readStdinLines(stream));
+    expect(result).toEqual(['hello', 'world']);
+  });
+
+  it('should skip empty lines', async () => {
+    const stream = createStream(['hello\n', '\n', '\n', 'world\n']);
+    const result = await collect(readStdinLines(stream));
+    expect(result).toEqual(['hello', 'world']);
+  });
+
+  it('should trim whitespace from lines', async () => {
+    const stream = createStream(['  hello  \n', '  world  \n']);
+    const result = await collect(readStdinLines(stream));
+    expect(result).toEqual(['hello', 'world']);
+  });
+
+  it('should handle input without trailing newline', async () => {
+    const stream = createStream(['hello\n', 'world']);
+    const result = await collect(readStdinLines(stream));
+    expect(result).toEqual(['hello', 'world']);
+  });
+
+  it('should yield nothing for empty stream', async () => {
+    const stream = createStream([]);
+    const result = await collect(readStdinLines(stream));
+    expect(result).toEqual([]);
+  });
+
+  it('should handle multi-byte UTF-8 characters (CJK)', async () => {
+    const stream = createStream(['한글 테스트\n', '日本語\n']);
+    const result = await collect(readStdinLines(stream));
+    expect(result).toEqual(['한글 테스트', '日本語']);
+  });
+
+  it('should handle emoji (4-byte UTF-8)', async () => {
+    const stream = createStream(['hello 😀🎉\n', 'world 🚀\n']);
+    const result = await collect(readStdinLines(stream));
+    expect(result).toEqual(['hello 😀🎉', 'world 🚀']);
+  });
+
+  it('should handle chunks split across multiple writes', async () => {
+    const stream = new PassThrough();
+    stream.write('hel');
+    stream.write('lo\nwor');
+    stream.write('ld\n');
+    stream.end();
+    const result = await collect(readStdinLines(stream));
+    expect(result).toEqual(['hello', 'world']);
+  });
+
+  it('should stop reading when total size exceeds cumulative limit', async () => {
+    // Create lines that accumulate past the 8MB total limit.
+    // Use a small stream with known byte sizes to verify the check fires.
+    const oneMB = 'a'.repeat(1024 * 1024);
+    const lines: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      lines.push(oneMB + '\n');
+    }
+    const stream = createStream(lines);
+    const result = await collect(readStdinLines(stream));
+    // 8 lines of ~1MB each should fit; the 9th should be rejected
+    expect(result.length).toBeLessThanOrEqual(8);
+    expect(result.length).toBeGreaterThanOrEqual(7);
+  });
+
+  it('should truncate oversized lines at valid UTF-8 boundary', async () => {
+    // A line of ~9MB of 3-byte Korean characters
+    const bigLine = '한'.repeat(3 * 1024 * 1024) + '\n'; // 9MB in UTF-8
+    const stream = createStream([bigLine]);
+    const result = await collect(readStdinLines(stream));
+    expect(result.length).toBe(1);
+    // The truncated line should be valid UTF-8 and <= 8MB
+    const resultBytes = Buffer.byteLength(result[0], 'utf8');
+    expect(resultBytes).toBeLessThanOrEqual(8 * 1024 * 1024);
+    // Should not end with a broken character (no replacement chars)
+    expect(result[0]).not.toContain('\uFFFD');
+  });
+
+  it('should handle oversized buffer without newline (flush path)', async () => {
+    // Write >8MB without any newline to trigger the flush path
+    const bigChunk = 'x'.repeat(9 * 1024 * 1024);
+    const stream = createStream([bigChunk]);
+    const result = await collect(readStdinLines(stream));
+    expect(result.length).toBe(1);
+    const resultBytes = Buffer.byteLength(result[0], 'utf8');
+    expect(resultBytes).toBeLessThanOrEqual(8 * 1024 * 1024);
+  });
+
+  it('should track totalSize consistently with post-truncation bytes', async () => {
+    // A 9MB CJK line followed by a small line.
+    // With post-truncation tracking, the truncated 8MB line leaves 0 budget,
+    // so the second line should be dropped.
+    const bigLine = '한'.repeat(3 * 1024 * 1024) + '\n'; // ~9MB UTF-8
+    const smallLine = 'hello\n';
+    const stream = createStream([bigLine, smallLine]);
+    const result = await collect(readStdinLines(stream));
+    // First line truncated to ~8MB, second should be dropped (totalSize exceeded)
+    expect(result.length).toBe(1);
+  });
+});

--- a/packages/cli/src/utils/readStdinLines.ts
+++ b/packages/cli/src/utils/readStdinLines.ts
@@ -7,11 +7,32 @@
 import { debugLogger } from '@google/gemini-cli-core';
 
 /**
+ * Truncates a string to fit within a UTF-8 byte limit without splitting
+ * multi-byte characters. Walks back from the cut point to find the last
+ * complete character boundary.
+ */
+function truncateUtf8Bytes(str: string, maxBytes: number): string {
+  const buf = Buffer.from(str, 'utf8');
+  if (buf.length <= maxBytes) return str;
+  let end = maxBytes;
+  // Walk backward past any UTF-8 continuation bytes (10xxxxxx)
+  while (end > 0 && (buf[end] & 0xc0) === 0x80) {
+    end--;
+  }
+  // end now points to the lead byte of an incomplete sequence — exclude it
+  return buf.subarray(0, end).toString('utf8');
+}
+
+/**
  * Reads piped stdin line-by-line as an async generator.
  *
  * Safety limits matching readStdin():
  * - Per-line: 8MB (truncates lines exceeding this)
  * - Total session: 8MB cumulative (stops reading when exceeded)
+ *
+ * Size tracking uses Buffer.byteLength for accurate UTF-8 byte
+ * measurement. Truncation uses truncateUtf8Bytes to avoid splitting
+ * multi-byte characters (e.g. CJK, emoji).
  *
  * Reads raw chunks instead of using readline.createInterface to enforce
  * size caps during buffering and prevent OOM from input without newline
@@ -32,24 +53,31 @@ export async function* readStdinLines(
       const line = buffer.slice(0, newlineIdx).trim();
       buffer = buffer.slice(newlineIdx + 1);
       if (!line) continue;
-      totalSize += line.length;
+      const lineBytes = Buffer.byteLength(line, 'utf8');
+      const truncated =
+        lineBytes > MAX_LINE_SIZE
+          ? truncateUtf8Bytes(line, MAX_LINE_SIZE)
+          : line;
+      const yieldBytes =
+        truncated === line ? lineBytes : Buffer.byteLength(truncated, 'utf8');
+      totalSize += yieldBytes;
       if (totalSize > MAX_TOTAL_SIZE) {
         debugLogger.warn(
           `Total piped input exceeds ${MAX_TOTAL_SIZE} bytes, stopping.`,
         );
         return;
       }
-      yield line.length > MAX_LINE_SIZE ? line.slice(0, MAX_LINE_SIZE) : line;
+      yield truncated;
     }
     // Flush buffer if it exceeds per-line limit without a newline
-    if (buffer.length > MAX_LINE_SIZE) {
+    if (Buffer.byteLength(buffer, 'utf8') > MAX_LINE_SIZE) {
       debugLogger.warn(
         `Stdin line exceeds ${MAX_LINE_SIZE} bytes, truncating.`,
       );
-      const line = buffer.slice(0, MAX_LINE_SIZE).trim();
+      const line = truncateUtf8Bytes(buffer.trim(), MAX_LINE_SIZE);
       buffer = '';
       if (line) {
-        totalSize += line.length;
+        totalSize += Buffer.byteLength(line, 'utf8');
         if (totalSize > MAX_TOTAL_SIZE) return;
         yield line;
       }
@@ -57,9 +85,12 @@ export async function* readStdinLines(
   }
   // Flush remaining buffer after EOF
   const remaining = buffer.trim();
-  if (remaining && totalSize + remaining.length <= MAX_TOTAL_SIZE) {
-    yield remaining.length > MAX_LINE_SIZE
-      ? remaining.slice(0, MAX_LINE_SIZE)
-      : remaining;
+  if (remaining) {
+    const remainingBytes = Buffer.byteLength(remaining, 'utf8');
+    if (totalSize + remainingBytes <= MAX_TOTAL_SIZE) {
+      yield remainingBytes > MAX_LINE_SIZE
+        ? truncateUtf8Bytes(remaining, MAX_LINE_SIZE)
+        : remaining;
+    }
   }
 }

--- a/packages/cli/src/utils/readStdinLines.ts
+++ b/packages/cli/src/utils/readStdinLines.ts
@@ -86,11 +86,13 @@ export async function* readStdinLines(
   // Flush remaining buffer after EOF
   const remaining = buffer.trim();
   if (remaining) {
-    const remainingBytes = Buffer.byteLength(remaining, 'utf8');
-    if (totalSize + remainingBytes <= MAX_TOTAL_SIZE) {
-      yield remainingBytes > MAX_LINE_SIZE
+    const lineToYield =
+      Buffer.byteLength(remaining, 'utf8') > MAX_LINE_SIZE
         ? truncateUtf8Bytes(remaining, MAX_LINE_SIZE)
         : remaining;
+    const yieldBytes = Buffer.byteLength(lineToYield, 'utf8');
+    if (totalSize + yieldBytes <= MAX_TOTAL_SIZE) {
+      yield lineToYield;
     }
   }
 }

--- a/packages/cli/src/utils/readStdinLines.ts
+++ b/packages/cli/src/utils/readStdinLines.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { debugLogger } from '@google/gemini-cli-core';
+
+/**
+ * Reads piped stdin line-by-line as an async generator.
+ *
+ * Safety limits matching readStdin():
+ * - Per-line: 8MB (truncates lines exceeding this)
+ * - Total session: 8MB cumulative (stops reading when exceeded)
+ *
+ * Reads raw chunks instead of using readline.createInterface to enforce
+ * size caps during buffering and prevent OOM from input without newline
+ * delimiters.
+ */
+export async function* readStdinLines(
+  stream: NodeJS.ReadableStream = process.stdin,
+): AsyncGenerator<string> {
+  const MAX_LINE_SIZE = 8 * 1024 * 1024; // 8MB per line
+  const MAX_TOTAL_SIZE = 8 * 1024 * 1024; // 8MB cumulative
+  let buffer = '';
+  let totalSize = 0;
+  stream.setEncoding('utf8');
+  for await (const chunk of stream) {
+    buffer += chunk;
+    let newlineIdx: number;
+    while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
+      const line = buffer.slice(0, newlineIdx).trim();
+      buffer = buffer.slice(newlineIdx + 1);
+      if (!line) continue;
+      totalSize += line.length;
+      if (totalSize > MAX_TOTAL_SIZE) {
+        debugLogger.warn(
+          `Total piped input exceeds ${MAX_TOTAL_SIZE} bytes, stopping.`,
+        );
+        return;
+      }
+      yield line.length > MAX_LINE_SIZE ? line.slice(0, MAX_LINE_SIZE) : line;
+    }
+    // Flush buffer if it exceeds per-line limit without a newline
+    if (buffer.length > MAX_LINE_SIZE) {
+      debugLogger.warn(
+        `Stdin line exceeds ${MAX_LINE_SIZE} bytes, truncating.`,
+      );
+      const line = buffer.slice(0, MAX_LINE_SIZE).trim();
+      buffer = '';
+      if (line) {
+        totalSize += line.length;
+        if (totalSize > MAX_TOTAL_SIZE) return;
+        yield line;
+      }
+    }
+  }
+  // Flush remaining buffer after EOF
+  const remaining = buffer.trim();
+  if (remaining && totalSize + remaining.length <= MAX_TOTAL_SIZE) {
+    yield remaining.length > MAX_LINE_SIZE
+      ? remaining.slice(0, MAX_LINE_SIZE)
+      : remaining;
+  }
+}


### PR DESCRIPTION
## Summary

Extends `-i`/`--prompt-interactive` to work when `stdin.isTTY` is false, enabling multi-turn interactive sessions over pipes for programmatic consumers.

**Problem**: When the CLI is launched programmatically (e.g., from Node.js, Java, or a backend service), `stdin` is not a TTY. Using `-i` with piped stdin immediately exited with `FATAL_INPUT_ERROR` because Ink TUI requires TTY. This forced programmatic consumers to either use single-shot `-p` with no session persistence, or adopt the full ACP protocol.

**Solution**: When `-i` is used with piped stdin, skip Ink TUI and fall through to a chunk-based stdin reader that processes each line as a separate prompt. Session state persists via shared `GeminiClient` instance.

### Changes

1. **`readStdinLines.ts`** (new utility): Reads piped stdin line-by-line with safety limits matching `readStdin()`:
   - Per-line: 8MB cap enforced during chunk buffering (not post-read like `readline.createInterface`)
   - Total session: 8MB cumulative cap to bound API calls and data volume

2. **`gemini.tsx`**: 
   - Remove `-i` + non-TTY error guard
   - Gate `startInteractiveUI()` on `isInteractive() && isTTY`
   - Skip `readStdin()` drain when `-i` is active (stdin consumed by `readStdinLines` instead)
   - Guard pre-sandbox `readStdin()` for `-i` to prevent early stdin consumption
   - Unified prompt loop with `prompts()` async generator

### Behavior matrix

| Scenario | Before | After |
|----------|--------|-------|
| `-i` + TTY | Ink TUI | Ink TUI (unchanged) |
| `-i` + piped stdin | `FATAL_INPUT_ERROR` | Multi-turn with session persistence |
| `-p` + piped stdin | Single prompt, exit | Single prompt, exit (unchanged) |
| Piped stdin, no flag | Drain all as one prompt | Drain all as one prompt (unchanged) |
| `--acp` | ACP client | ACP client (unchanged) |

### Design decisions

- **No new flag**: `-i` already means "execute prompt and continue interactive." Extending it to non-TTY is the natural reading of Issue #13924.
- **`readStdinLines` vs `readline.createInterface`**: `readline` buffers entire lines unbounded until `\n` arrives, risking OOM. Our chunk-based reader enforces the 8MB cap during buffering, matching `readStdin()`'s defense-in-depth pattern.
- **8MB cumulative cap**: Bounds total API calls and data volume per session, consistent with `readStdin()`'s safety limit.

### Known limitations

- **Sandbox mode**: Pre-sandbox path injects stdin as `--prompt` args. Multi-turn not supported in sandbox (follow-up).
- **No response-end signal in text mode**: Callers detect response completion by silence or use `--output-format stream-json` for explicit `RESULT` events.

## Test plan

- [x] Build passes
- [x] Existing tests pass (35/35)
- [x] Updated test: `-i` + non-TTY no longer exits with `FATAL_INPUT_ERROR`
- [x] Manual: `printf "what is 1+1?\n" | gemini -i "hello"` — two responses
- [x] Manual: Node.js child_process spawn — session maintained
- [ ] Verify TTY + `-i` still launches Ink TUI
- [ ] Verify `-p` unchanged
- [ ] Verify `--acp` unchanged

Closes #13924