### PR TITLE
feat: add behavioral evals for web tool selection

### DIFF
--- a/evals/web-tools.eval.ts
+++ b/evals/web-tools.eval.ts
@@ -13,15 +13,16 @@ import { evalTest } from './test-helper.js';
 
 describe('Web Tools', () => {
   /**
-   * When asked to search for current information that cannot be answered
-   * from local files, the agent should use google_web_search.
+   * Agent must decide to use google_web_search without being told to.
+   * The task requires current external information not available locally.
+   * No URL is provided -- the agent must choose search over fetch.
    */
   evalTest('USUALLY_PASSES', {
-    name: 'should use google_web_search for current information queries',
+    name: 'should use google_web_search for current information not in local files',
     prompt:
-      'What are the top tech news stories happening right now today? Search the web to find out.',
+      'What is the current stable version of Node.js? I need to update my Dockerfile.',
     files: {
-      'app.js': 'console.log("hello world");',
+      Dockerfile: 'FROM node:18\nWORKDIR /app\nCOPY . .\nRUN npm install\n',
     },
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
@@ -30,39 +31,37 @@ describe('Web Tools', () => {
       );
       expect(
         searchCalls.length,
-        'Expected agent to call google_web_search for current information',
+        'Expected agent to search for current Node.js version',
       ).toBeGreaterThanOrEqual(1);
 
-      // Agent should not also call web_fetch for the same query (wrong tool)
+      // Should not use web_fetch (no URL was given)
       const fetchCalls = toolLogs.filter(
         (log) => log.toolRequest.name === WEB_FETCH_TOOL_NAME,
       );
       expect(
         fetchCalls.length,
-        'Expected agent to use google_web_search, not web_fetch, for open-ended queries',
+        'Agent should not use web_fetch when no URL is provided',
       ).toBe(0);
 
-      // Search should complete in a single turn
+      // Should complete in a single turn
       const uniqueTurns = new Set(
-        searchCalls.map((call) => call.toolRequest.prompt_id).filter(Boolean),
+        searchCalls.map((c) => c.toolRequest.prompt_id).filter(Boolean),
       );
-      expect(
-        uniqueTurns.size,
-        'Expected web search to occur within a single turn',
-      ).toBeLessThanOrEqual(1);
+      expect(uniqueTurns.size).toBeLessThanOrEqual(1);
     },
   });
 
   /**
-   * When asked to read or summarize a specific URL, the agent should use
-   * web_fetch rather than google_web_search.
+   * Agent must choose web_fetch over web_search when a specific URL is given.
+   * The agent may be tempted to search for the topic instead of fetching
+   * the exact URL -- this tests that it respects the explicit URL.
    */
   evalTest('USUALLY_PASSES', {
-    name: 'should use web_fetch when given a specific URL',
+    name: 'should use web_fetch for a specific URL rather than searching',
     prompt:
-      'Read the contents of https://example.com and summarize what it says.',
+      'Can you pull the content from https://raw.githubusercontent.com/nodejs/node/main/CHANGELOG.md and tell me what changed in the latest release?',
     files: {
-      'notes.md': '# Notes\n',
+      'notes.md': '# Release Notes\n',
     },
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
@@ -71,35 +70,35 @@ describe('Web Tools', () => {
       );
       expect(
         fetchCalls.length,
-        'Expected agent to call web_fetch for a specific URL',
+        'Expected agent to use web_fetch for the specific URL provided',
       ).toBeGreaterThanOrEqual(1);
 
-      // Agent should not use google_web_search when a direct URL is given
+      // Should not search -- the URL was already provided
       const searchCalls = toolLogs.filter(
         (log) => log.toolRequest.name === WEB_SEARCH_TOOL_NAME,
       );
       expect(
         searchCalls.length,
-        'Expected agent to use web_fetch, not google_web_search, when given a specific URL',
+        'Agent should not use google_web_search when a specific URL was given',
       ).toBe(0);
     },
   });
 
   /**
-   * When the answer is clearly available in local files, the agent should
-   * NOT use web tools — even when the prompt could be interpreted as
-   * requiring external information.
+   * The answer is in local files. Agent should read the file, not search.
+   * The question is phrased ambiguously -- "what version" could suggest
+   * searching, but the package.json has the answer locally.
    */
   evalTest('USUALLY_PASSES', {
-    name: 'should not use web tools when answer is in local files',
-    prompt: 'What does the greeting function in app.js return?',
+    name: 'should read local files rather than searching when the answer is local',
+    prompt: 'What version of React is this project using?',
     files: {
-      'app.js': `
-function greeting(name) {
-  return "Hello, " + name + "!";
-}
-module.exports = { greeting };
-`,
+      'package.json': JSON.stringify({
+        name: 'my-app',
+        dependencies: { react: '18.2.0', 'react-dom': '18.2.0' },
+      }),
+      'src/App.js':
+        'import React from "react";\nexport default function App() { return <div>Hello</div>; }\n',
     },
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
@@ -110,35 +109,25 @@ module.exports = { greeting };
       );
       expect(
         webCalls.length,
-        'Agent should not use web tools when the answer is in local files',
+        'Agent should not use web tools when the answer is in package.json',
       ).toBe(0);
     },
   });
 
   /**
-   * Hard case: the prompt mentions a URL in passing but the actual task is
-   * a local code question. The agent should NOT fetch the URL.
-   *
-   * This is a harder behavioral test -- the model sometimes fetches URLs
-   * mentioned in context even when the task does not require it.
+   * Hard case: a URL is mentioned in context but the task is purely local.
+   * The agent should resist fetching the URL and focus on the local task.
    */
   evalTest('USUALLY_PASSES', {
     name: 'should not fetch a URL mentioned in context when the task is local',
     prompt:
       'I found this library at https://lodash.com but I want to implement my own version. Look at utils.js and add a clamp function that limits a number between min and max.',
     files: {
-      'utils.js': `
-// Utility functions
-function range(start, end) {
-  return Array.from({ length: end - start }, (_, i) => i + start);
-}
-module.exports = { range };
-`,
+      'utils.js':
+        'function range(start, end) {\n  return Array.from({ length: end - start }, (_, i) => i + start);\n}\nmodule.exports = { range };\n',
     },
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
-
-      // Should NOT fetch the lodash URL -- it was mentioned as context only
       const webCalls = toolLogs.filter(
         (log) =>
           log.toolRequest.name === WEB_SEARCH_TOOL_NAME ||
@@ -149,17 +138,7 @@ module.exports = { range };
         'Agent should not fetch the URL when the task is purely local',
       ).toBe(0);
 
-      // Should have added a clamp function
-      const writeCalls = toolLogs.filter(
-        (log) =>
-          log.toolRequest.name === 'write_file' ||
-          log.toolRequest.name === 'replace',
-      );
-      expect(
-        writeCalls.length,
-        'Expected agent to write the clamp function',
-      ).toBeGreaterThanOrEqual(1);
-
+      // Should have added the clamp function
       const content = rig.readFile('utils.js');
       expect(
         content.includes('clamp'),

--- a/evals/web-tools.eval.ts
+++ b/evals/web-tools.eval.ts
@@ -114,4 +114,57 @@ module.exports = { greeting };
       ).toBe(0);
     },
   });
+
+  /**
+   * Hard case: the prompt mentions a URL in passing but the actual task is
+   * a local code question. The agent should NOT fetch the URL.
+   *
+   * This is a harder behavioral test -- the model sometimes fetches URLs
+   * mentioned in context even when the task does not require it.
+   */
+  evalTest('USUALLY_PASSES', {
+    name: 'should not fetch a URL mentioned in context when the task is local',
+    prompt:
+      'I found this library at https://lodash.com but I want to implement my own version. Look at utils.js and add a clamp function that limits a number between min and max.',
+    files: {
+      'utils.js': `
+// Utility functions
+function range(start, end) {
+  return Array.from({ length: end - start }, (_, i) => i + start);
+}
+module.exports = { range };
+`,
+    },
+    assert: async (rig) => {
+      const toolLogs = rig.readToolLogs();
+
+      // Should NOT fetch the lodash URL -- it was mentioned as context only
+      const webCalls = toolLogs.filter(
+        (log) =>
+          log.toolRequest.name === WEB_SEARCH_TOOL_NAME ||
+          log.toolRequest.name === WEB_FETCH_TOOL_NAME,
+      );
+      expect(
+        webCalls.length,
+        'Agent should not fetch the URL when the task is purely local',
+      ).toBe(0);
+
+      // Should have added a clamp function
+      const writeCalls = toolLogs.filter(
+        (log) =>
+          log.toolRequest.name === 'write_file' ||
+          log.toolRequest.name === 'replace',
+      );
+      expect(
+        writeCalls.length,
+        'Expected agent to write the clamp function',
+      ).toBeGreaterThanOrEqual(1);
+
+      const content = rig.readFile('utils.js');
+      expect(
+        content.includes('clamp'),
+        'Expected clamp function to be added to utils.js',
+      ).toBe(true);
+    },
+  });
 });

--- a/evals/web-tools.eval.ts
+++ b/evals/web-tools.eval.ts
@@ -5,6 +5,10 @@
  */
 
 import { describe, expect } from 'vitest';
+import {
+  WEB_SEARCH_TOOL_NAME,
+  WEB_FETCH_TOOL_NAME,
+} from '@google/gemini-cli-core';
 import { evalTest } from './test-helper.js';
 
 describe('Web Tools', () => {
@@ -22,7 +26,7 @@ describe('Web Tools', () => {
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
       const searchCalls = toolLogs.filter(
-        (log) => log.toolRequest.name === 'google_web_search',
+        (log) => log.toolRequest.name === WEB_SEARCH_TOOL_NAME,
       );
       expect(
         searchCalls.length,
@@ -31,7 +35,7 @@ describe('Web Tools', () => {
 
       // Agent should not also call web_fetch for the same query (wrong tool)
       const fetchCalls = toolLogs.filter(
-        (log) => log.toolRequest.name === 'web_fetch',
+        (log) => log.toolRequest.name === WEB_FETCH_TOOL_NAME,
       );
       expect(
         fetchCalls.length,
@@ -63,7 +67,7 @@ describe('Web Tools', () => {
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
       const fetchCalls = toolLogs.filter(
-        (log) => log.toolRequest.name === 'web_fetch',
+        (log) => log.toolRequest.name === WEB_FETCH_TOOL_NAME,
       );
       expect(
         fetchCalls.length,
@@ -72,7 +76,7 @@ describe('Web Tools', () => {
 
       // Agent should not use google_web_search when a direct URL is given
       const searchCalls = toolLogs.filter(
-        (log) => log.toolRequest.name === 'google_web_search',
+        (log) => log.toolRequest.name === WEB_SEARCH_TOOL_NAME,
       );
       expect(
         searchCalls.length,
@@ -101,8 +105,8 @@ module.exports = { greeting };
       const toolLogs = rig.readToolLogs();
       const webCalls = toolLogs.filter(
         (log) =>
-          log.toolRequest.name === 'google_web_search' ||
-          log.toolRequest.name === 'web_fetch',
+          log.toolRequest.name === WEB_SEARCH_TOOL_NAME ||
+          log.toolRequest.name === WEB_FETCH_TOOL_NAME,
       );
       expect(
         webCalls.length,

--- a/evals/web-tools.eval.ts
+++ b/evals/web-tools.eval.ts
@@ -28,6 +28,24 @@ describe('Web Tools', () => {
         searchCalls.length,
         'Expected agent to call google_web_search for current information',
       ).toBeGreaterThanOrEqual(1);
+
+      // Agent should not also call web_fetch for the same query (wrong tool)
+      const fetchCalls = toolLogs.filter(
+        (log) => log.toolRequest.name === 'web_fetch',
+      );
+      expect(
+        fetchCalls.length,
+        'Expected agent to use google_web_search, not web_fetch, for open-ended queries',
+      ).toBe(0);
+
+      // Search should complete in a single turn
+      const uniqueTurns = new Set(
+        searchCalls.map((call) => call.toolRequest.prompt_id).filter(Boolean),
+      );
+      expect(
+        uniqueTurns.size,
+        'Expected web search to occur within a single turn',
+      ).toBeLessThanOrEqual(1);
     },
   });
 
@@ -51,6 +69,15 @@ describe('Web Tools', () => {
         fetchCalls.length,
         'Expected agent to call web_fetch for a specific URL',
       ).toBeGreaterThanOrEqual(1);
+
+      // Agent should not use google_web_search when a direct URL is given
+      const searchCalls = toolLogs.filter(
+        (log) => log.toolRequest.name === 'google_web_search',
+      );
+      expect(
+        searchCalls.length,
+        'Expected agent to use web_fetch, not google_web_search, when given a specific URL',
+      ).toBe(0);
     },
   });
 

--- a/evals/web-tools.eval.ts
+++ b/evals/web-tools.eval.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { evalTest } from './test-helper.js';
+
+describe('Web Tools', () => {
+  /**
+   * When asked to search for current information that cannot be answered
+   * from local files, the agent should use google_web_search.
+   */
+  evalTest('USUALLY_PASSES', {
+    name: 'should use google_web_search for current information queries',
+    prompt:
+      'What are the top tech news stories happening right now today? Search the web to find out.',
+    files: {
+      'app.js': 'console.log("hello world");',
+    },
+    assert: async (rig) => {
+      const toolLogs = rig.readToolLogs();
+      const searchCalls = toolLogs.filter(
+        (log) => log.toolRequest.name === 'google_web_search',
+      );
+      expect(
+        searchCalls.length,
+        'Expected agent to call google_web_search for current information',
+      ).toBeGreaterThanOrEqual(1);
+    },
+  });
+
+  /**
+   * When asked to read or summarize a specific URL, the agent should use
+   * web_fetch rather than google_web_search.
+   */
+  evalTest('USUALLY_PASSES', {
+    name: 'should use web_fetch when given a specific URL',
+    prompt:
+      'Read the contents of https://example.com and summarize what it says.',
+    files: {
+      'notes.md': '# Notes\n',
+    },
+    assert: async (rig) => {
+      const toolLogs = rig.readToolLogs();
+      const fetchCalls = toolLogs.filter(
+        (log) => log.toolRequest.name === 'web_fetch',
+      );
+      expect(
+        fetchCalls.length,
+        'Expected agent to call web_fetch for a specific URL',
+      ).toBeGreaterThanOrEqual(1);
+    },
+  });
+
+  /**
+   * When the answer is clearly available in local files, the agent should
+   * NOT use web tools — even when the prompt could be interpreted as
+   * requiring external information.
+   */
+  evalTest('USUALLY_PASSES', {
+    name: 'should not use web tools when answer is in local files',
+    prompt: 'What does the greeting function in app.js return?',
+    files: {
+      'app.js': `
+function greeting(name) {
+  return "Hello, " + name + "!";
+}
+module.exports = { greeting };
+`,
+    },
+    assert: async (rig) => {
+      const toolLogs = rig.readToolLogs();
+      const webCalls = toolLogs.filter(
+        (log) =>
+          log.toolRequest.name === 'google_web_search' ||
+          log.toolRequest.name === 'web_fetch',
+      );
+      expect(
+        webCalls.length,
+        'Agent should not use web tools when the answer is in local files',
+      ).toBe(0);
+    },
+  });
+});


### PR DESCRIPTION
## Summary

Adds four behavioral evals testing the agent's ability to correctly choose between web tools based on the nature of the request -- without being told which tool to use.

## Details

| Test | Policy | What it tests |
|------|--------|---------------|
| Current info not in local files | `USUALLY_PASSES` | Agent chooses `google_web_search` for version info not available locally |
| Specific URL provided | `USUALLY_PASSES` | Agent uses `web_fetch` for an explicit URL, not `google_web_search` |
| Answer available locally | `USUALLY_PASSES` | Agent reads `package.json` rather than searching the web |
| URL mentioned in context but task is local | `USUALLY_PASSES` | Agent resists fetching a URL mentioned as context when the task only requires local edits |

**Design note:** Prompts do not name the expected tool. Each eval creates a situation where the agent must infer the right tool from context. This tests genuine decision-making rather than instruction-following.

**Finding during validation:** The correct tool name is `google_web_search` (defined as `WEB_SEARCH_TOOL_NAME` in `base-declarations.ts`). Documentation uses `web_search`. All assertions import constants from `@google/gemini-cli-core` rather than using string literals.

## How to Validate

```bash
npm run build
RUN_EVALS=1 npx vitest run evals/web-tools.eval.ts --config evals/vitest.config.ts --reporter=verbose
```

## Related Issues

Fixes #23483
Related to #23331