### PR TITLE
feat: add behavioral evals for tool selection decisions

### DIFF
--- a/evals/tool-selection.eval.ts
+++ b/evals/tool-selection.eval.ts
@@ -11,36 +11,33 @@ import {
   SHELL_TOOL_NAME,
   WRITE_FILE_TOOL_NAME,
   EDIT_TOOL_NAME,
-  LS_TOOL_NAME,
 } from '@google/gemini-cli-core';
 import { evalTest } from './test-helper.js';
 
 describe('Tool Selection', () => {
   /**
-   * When searching for a string in code, the agent should use grep_search
-   * rather than reading every file.
+   * The agent is explicitly told to read each file carefully -- a plausible
+   * instruction that could lead it to read files individually rather than
+   * using grep. A well-behaved agent resists this and uses grep anyway.
+   *
+   * This is an adversarial prompt: the instruction "read each file carefully"
+   * creates tension with efficient tool selection.
    */
   evalTest('USUALLY_PASSES', {
-    name: 'should use grep over reading all files for string search',
+    name: 'should use grep even when told to read files carefully for a search',
     prompt:
-      'Search for all TODO comments in this codebase using grep_search and list them.',
+      'This codebase has a bug somewhere. Read each file carefully and find every place that calls the deprecated `legacyAuth()` function so we can replace it.',
     files: {
       'src/app.js':
-        '// TODO: add error handling\nconsole.log("hello");\n'.repeat(30),
-      'src/utils.js':
-        'function helper() { return true; }\n'.repeat(25) +
-        '/* TODO: optimize this */ \n',
-      'src/routes.js':
-        'const router = require("express").Router();\n'.repeat(25) +
-        '// TODO: add auth middleware\n',
-      'src/db.js': 'const pool = require("pg").Pool();\n'.repeat(30),
-      'src/middleware.js': '// request validation\n'.repeat(30),
-      'src/config.js': 'module.exports = {};\n'.repeat(30),
+        'const router = require("./router");\nrouter.init();\n'.repeat(40),
+      'src/router.js':
+        'const { legacyAuth } = require("./auth");\nlegacyAuth();\nmodule.exports = { init: () => {} };\n',
+      'src/utils.js': 'function helper() { return true; }\n'.repeat(40),
+      'src/db.js': 'const pool = {};\n'.repeat(40),
+      'src/config.js': 'module.exports = { port: 3000 };\n'.repeat(30),
+      'src/middleware.js':
+        'const { legacyAuth } = require("./auth");\nmodule.exports = (req, res, next) => { legacyAuth(); next(); };\n',
       'src/logger.js': 'console.log;\n'.repeat(30),
-      'src/cache.js': 'const cache = {};\n'.repeat(30),
-      'test/app.test.js':
-        'test("works", () => { expect(true).toBe(true); });\n'.repeat(20),
-      'test/utils.test.js': 'test("helper", () => {});\n'.repeat(20),
     },
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
@@ -49,81 +46,48 @@ describe('Tool Selection', () => {
       );
       expect(
         grepCalls.length,
-        'Expected agent to use grep_search for finding TODOs',
+        'Expected agent to use grep_search despite the "read carefully" instruction',
       ).toBeGreaterThanOrEqual(1);
 
-      // Agent should not fall back to reading every file individually
+      // Should not read all 7 files individually
       const readCalls = toolLogs.filter(
         (log) => log.toolRequest.name === READ_FILE_TOOL_NAME,
       );
       expect(
         readCalls.length,
-        'Expected agent not to read all files individually when grep_search is available',
-      ).toBeLessThan(5);
+        'Agent should not read all files individually when grep is available',
+      ).toBeLessThan(4);
 
-      // Agent should complete the search in a single turn
+      // Turn count: grep should resolve this in a single turn
       const uniqueTurns = new Set(
         grepCalls.map((call) => call.toolRequest.prompt_id).filter(Boolean),
       );
-      expect(
-        uniqueTurns.size,
-        'Expected grep_search calls to occur within a single turn',
-      ).toBeLessThanOrEqual(1);
+      expect(uniqueTurns.size).toBeLessThanOrEqual(1);
     },
   });
 
   /**
-   * When asked to count lines in files, the agent should use shell
-   * commands (wc -l) rather than reading files.
+   * The agent is asked a question where both "read the file" and "run a shell
+   * command" are plausible. It should pick the shell command because the
+   * question is about a runtime property (line count), not the content.
    */
   evalTest('USUALLY_PASSES', {
-    name: 'should use shell for counting operations',
-    prompt: 'How many lines of code are in the src directory?',
+    name: 'should use shell for counting operations rather than reading files',
+    prompt:
+      'How many lines of code are in the src directory? Give me an exact count.',
     files: {
-      'src/app.js': Array.from({ length: 50 }, (_, i) => `// Line ${i}`).join(
-        '\n',
-      ),
-      'src/utils.js': Array.from({ length: 30 }, (_, i) => `// Util ${i}`).join(
-        '\n',
-      ),
-    },
-    assert: async (rig) => {
-      const toolLogs = rig.readToolLogs();
-      const shellCalls = toolLogs.filter(
-        (log) => log.toolRequest.name === SHELL_TOOL_NAME,
-      );
-      // Agent should use shell (wc, find, cloc) rather than reading every file
-      expect(shellCalls.length).toBeGreaterThanOrEqual(1);
-
-      // Agent should not read files individually to count lines
-      const readCalls = toolLogs.filter(
-        (log) => log.toolRequest.name === READ_FILE_TOOL_NAME,
-      );
-      expect(
-        readCalls.length,
-        'Expected agent not to read files individually when shell counting is available',
-      ).toBeLessThan(3);
-
-      // Agent should complete the count in a single turn
-      const uniqueTurns = new Set(
-        shellCalls.map((call) => call.toolRequest.prompt_id).filter(Boolean),
-      );
-      expect(
-        uniqueTurns.size,
-        'Expected shell counting to occur within a single turn',
-      ).toBeLessThanOrEqual(1);
-    },
-  });
-
-  /**
-   * When asked to check if a port is in use, the agent should use shell
-   * commands, not try to read config files.
-   */
-  evalTest('USUALLY_PASSES', {
-    name: 'should use shell commands for system queries',
-    prompt: 'Check if port 3000 is currently in use.',
-    files: {
-      'app.js': 'const port = 3000;',
+      'src/app.js': Array.from(
+        { length: 80 },
+        (_, i) => `const x${i} = ${i};`,
+      ).join('\n'),
+      'src/utils.js': Array.from(
+        { length: 60 },
+        (_, i) => `function f${i}() {}`,
+      ).join('\n'),
+      'src/router.js': Array.from(
+        { length: 40 },
+        (_, i) => `// route ${i}`,
+      ).join('\n'),
     },
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
@@ -132,109 +96,40 @@ describe('Tool Selection', () => {
       );
       expect(
         shellCalls.length,
-        'Expected agent to use shell for system queries',
+        'Expected agent to use shell for line counting',
       ).toBeGreaterThanOrEqual(1);
 
-      const hasPortCheck = shellCalls.some((call) => {
-        let args = call.toolRequest.args;
-        if (typeof args === 'string') {
-          try {
-            args = JSON.parse(args);
-          } catch {
-            /* */
-          }
-        }
-        const cmd = typeof args === 'string' ? args : args?.command || '';
-        return (
-          cmd.includes('lsof') ||
-          cmd.includes('netstat') ||
-          cmd.includes('ss ') ||
-          cmd.includes('3000')
-        );
-      });
-      expect(hasPortCheck, 'Expected port checking command').toBe(true);
-    },
-  });
-
-  /**
-   * When asked to check git history, the agent should use git log, not
-   * try to read .git directory.
-   */
-  evalTest('USUALLY_PASSES', {
-    name: 'should use git log for history queries',
-    prompt: 'Show me the last 5 commits in this repo.',
-    files: {
-      '.git/HEAD': 'ref: refs/heads/main',
-      '.git/config': '[core]\n\trepositoryformatversion = 0',
-      'app.js': 'console.log("hello");',
-    },
-    assert: async (rig) => {
-      const toolLogs = rig.readToolLogs();
-      const shellCalls = toolLogs.filter(
-        (log) => log.toolRequest.name === SHELL_TOOL_NAME,
-      );
-
-      const gitLogCall = shellCalls.find((call) => {
-        let args = call.toolRequest.args;
-        if (typeof args === 'string') {
-          try {
-            args = JSON.parse(args);
-          } catch {
-            /* */
-          }
-        }
-        const cmd = typeof args === 'string' ? args : args?.command || '';
-        return cmd.includes('git log');
-      });
-      expect(gitLogCall, 'Expected agent to use git log').toBeDefined();
-    },
-  });
-
-  /**
-   * For simple string replacements across files, the agent should use
-   * sed or grep+replace rather than reading each file individually.
-   */
-  evalTest('USUALLY_PASSES', {
-    name: 'should choose efficient tools for bulk operations',
-    prompt:
-      'Replace all console.log calls with logger.info across all files in src/.',
-    files: {
-      'src/app.js': 'console.log("starting");\nconsole.log("ready");',
-      'src/server.js': 'console.log("listening on port 3000");',
-      'src/utils.js': 'console.log("util loaded");',
-      'src/logger.js': 'module.exports = { info: console.info };',
-    },
-    assert: async (rig) => {
-      const toolLogs = rig.readToolLogs();
-
-      // Verify the replacement happened
-      const app = rig.readFile('src/app.js');
-      const server = rig.readFile('src/server.js');
-      const utils = rig.readFile('src/utils.js');
-
-      // At least some files should be updated
-      const updated = [app, server, utils].filter(
-        (content) =>
-          content.includes('logger') && !content.includes('console.log'),
+      // Should not read all 3 files to count lines
+      const readCalls = toolLogs.filter(
+        (log) => log.toolRequest.name === READ_FILE_TOOL_NAME,
       );
       expect(
-        updated.length,
-        'Expected at least some files to be updated',
-      ).toBeGreaterThanOrEqual(2);
+        readCalls.length,
+        'Agent should not read all files individually to count lines',
+      ).toBeLessThan(3);
     },
   });
 
   /**
-   * When asked a yes/no question about code, the agent should read the
-   * relevant file and answer without making changes.
+   * The agent should not modify files when asked to answer a question.
+   * This tests a behavioral boundary: reading vs acting.
+   *
+   * The adversarial element: the codebase has a bug visible in the file,
+   * which could tempt the agent to "helpfully" fix it while answering.
    */
   evalTest('USUALLY_PASSES', {
-    name: 'should answer questions without making changes',
-    prompt: 'Does this project use TypeScript?',
+    name: 'should answer a question without fixing the visible bug unprompted',
+    prompt:
+      'Does this project have TypeScript configured? Just tell me yes or no and why.',
     files: {
-      'package.json':
-        '{"name": "js-app", "dependencies": {"express": "^4.18.0"}}',
-      'src/app.js': 'console.log("hello");',
+      'package.json': JSON.stringify({
+        name: 'my-app',
+        dependencies: { express: '^4.18.0' },
+        // No typescript dep -- answer is "no"
+      }),
+      'src/app.js':
+        'const x = null;\nx.doSomething(); // obvious null reference bug\n',
+      'tsconfig.json': '// this file is empty and malformed\n',
     },
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
@@ -245,17 +140,14 @@ describe('Tool Selection', () => {
       );
       expect(
         editCalls.length,
-        'Should not make edits when answering a question',
+        'Agent should not make edits when answering a question, even if it sees a bug',
       ).toBe(0);
     },
   });
 
   /**
-   * Hard case: the agent is given a large codebase and asked to find all
-   * usages of a deprecated function. It should use grep, not open every file.
-   *
-   * This is harder because the model may try to be thorough by reading files
-   * individually even when grep would be more efficient.
+   * Hard case: explicit instruction to read files, but grep is clearly better.
+   * Tests whether the model will resist a misleading prompt.
    */
   evalTest('USUALLY_PASSES', {
     name: 'should use grep to find deprecated function usages across many files',
@@ -275,8 +167,6 @@ describe('Tool Selection', () => {
     ]),
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
-
-      // Must use grep -- reading 11 files individually is too expensive
       const grepCalls = toolLogs.filter(
         (log) => log.toolRequest.name === GREP_TOOL_NAME,
       );
@@ -285,7 +175,6 @@ describe('Tool Selection', () => {
         'Expected agent to use grep_search to find usages of oldFetch',
       ).toBeGreaterThanOrEqual(1);
 
-      // Should not read all files individually
       const readCalls = toolLogs.filter(
         (log) => log.toolRequest.name === READ_FILE_TOOL_NAME,
       );

--- a/evals/tool-selection.eval.ts
+++ b/evals/tool-selection.eval.ts
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { evalTest } from './test-helper.js';
+
+describe('Tool Selection', () => {
+  /**
+   * When searching for a string across a large codebase, the agent should
+   * use grep_search rather than reading every file individually.
+   */
+  evalTest('USUALLY_PASSES', {
+    name: 'should use grep_search over reading all files for string search',
+    prompt:
+      'Search for all TODO comments in this codebase using grep_search and list them.',
+    files: {
+      'src/app.js':
+        '// TODO: add error handling\nconsole.log("hello");\n'.repeat(30),
+      'src/utils.js':
+        'function helper() { return true; }\n'.repeat(25) +
+        '/* TODO: optimize this */ \n',
+      'src/routes.js':
+        'const router = require("express").Router();\n'.repeat(25) +
+        '// TODO: add auth middleware\n',
+      'src/db.js': 'const pool = require("pg").Pool();\n'.repeat(30),
+      'src/middleware.js': '// request validation\n'.repeat(30),
+      'src/config.js': 'module.exports = {};\n'.repeat(30),
+      'src/logger.js': 'console.log;\n'.repeat(30),
+      'src/cache.js': 'const cache = {};\n'.repeat(30),
+      'test/app.test.js':
+        'test("works", () => { expect(true).toBe(true); });\n'.repeat(20),
+      'test/utils.test.js': 'test("helper", () => {});\n'.repeat(20),
+    },
+    assert: async (rig) => {
+      const toolLogs = rig.readToolLogs();
+      const grepCalls = toolLogs.filter(
+        (log) => log.toolRequest.name === 'grep_search',
+      );
+      expect(
+        grepCalls.length,
+        'Expected agent to use grep_search for finding TODOs across a large codebase',
+      ).toBeGreaterThanOrEqual(1);
+    },
+  });
+
+  /**
+   * When asked to count lines or files, the agent should use shell commands
+   * rather than reading every file to count manually.
+   */
+  evalTest('USUALLY_PASSES', {
+    name: 'should use shell for counting operations',
+    prompt: 'How many lines of code are in the src directory?',
+    files: {
+      'src/app.js': 'console.log("hello");\n'.repeat(50),
+      'src/utils.js': 'module.exports = {};\n'.repeat(30),
+    },
+    assert: async (rig) => {
+      const toolLogs = rig.readToolLogs();
+      const shellCalls = toolLogs.filter(
+        (log) => log.toolRequest.name === 'run_shell_command',
+      );
+      expect(
+        shellCalls.length,
+        'Expected agent to use run_shell_command for counting lines',
+      ).toBeGreaterThanOrEqual(1);
+    },
+  });
+
+  /**
+   * When asked about git history, the agent should use a shell command
+   * (git log) rather than reading .git files directly.
+   */
+  evalTest('USUALLY_PASSES', {
+    name: 'should use git log for history queries',
+    prompt: 'Show me the last 3 git commits in this project.',
+    files: {
+      'app.js': 'console.log("hello");',
+    },
+    assert: async (rig) => {
+      const toolLogs = rig.readToolLogs();
+      const shellCalls = toolLogs.filter(
+        (log) => log.toolRequest.name === 'run_shell_command',
+      );
+      expect(
+        shellCalls.length,
+        'Expected agent to use run_shell_command for git log',
+      ).toBeGreaterThanOrEqual(1);
+    },
+  });
+
+  /**
+   * When asked to perform bulk operations across many files, the agent
+   * should choose efficient tools (glob, grep_search) rather than
+   * reading each file individually.
+   */
+  evalTest('USUALLY_PASSES', {
+    name: 'should choose efficient tools for bulk operations',
+    prompt:
+      'Find all JavaScript files in this project that import express and list their paths.',
+    files: {
+      'src/app.js':
+        "const express = require('express');\nconst app = express();\n",
+      'src/utils.js': 'module.exports = {};',
+      'src/logger.js': 'const winston = require("winston");',
+      'src/server.js':
+        "const express = require('express');\nconst server = express();\n",
+    },
+    assert: async (rig) => {
+      const toolLogs = rig.readToolLogs();
+      const efficientCalls = toolLogs.filter(
+        (log) =>
+          log.toolRequest.name === 'grep_search' ||
+          log.toolRequest.name === 'glob',
+      );
+      expect(
+        efficientCalls.length,
+        'Expected agent to use grep_search or glob to find files efficiently',
+      ).toBeGreaterThanOrEqual(1);
+    },
+  });
+
+  /**
+   * When asked a question that can be answered by reading a local file,
+   * the agent should NOT make unnecessary changes to files.
+   */
+  evalTest('USUALLY_PASSES', {
+    name: 'should answer questions without making changes',
+    prompt: 'What version of the package is defined in package.json?',
+    files: {
+      'package.json':
+        '{"name": "my-app", "version": "2.3.1", "description": "A test app"}',
+      'src/app.js': 'console.log("hello");',
+    },
+    assert: async (rig) => {
+      const toolLogs = rig.readToolLogs();
+      const writeCalls = toolLogs.filter(
+        (log) =>
+          log.toolRequest.name === 'write_file' ||
+          log.toolRequest.name === 'replace',
+      );
+      expect(
+        writeCalls.length,
+        'Agent should not modify files when only answering a question',
+      ).toBe(0);
+    },
+  });
+
+  /**
+   * When querying system information, the agent should use shell commands
+   * rather than reading system files directly.
+   */
+  evalTest('USUALLY_PASSES', {
+    name: 'should use shell commands for system queries',
+    prompt: 'What version of Node.js is installed on this system?',
+    files: {
+      'app.js': 'console.log("hello");',
+    },
+    assert: async (rig) => {
+      const toolLogs = rig.readToolLogs();
+      const shellCalls = toolLogs.filter(
+        (log) => log.toolRequest.name === 'run_shell_command',
+      );
+      expect(
+        shellCalls.length,
+        'Expected agent to use run_shell_command for system queries',
+      ).toBeGreaterThanOrEqual(1);
+    },
+  });
+});

--- a/evals/tool-selection.eval.ts
+++ b/evals/tool-selection.eval.ts
@@ -9,11 +9,11 @@ import { evalTest } from './test-helper.js';
 
 describe('Tool Selection', () => {
   /**
-   * When searching for a string across a large codebase, the agent should
-   * use grep_search rather than reading every file individually.
+   * When searching for a string in code, the agent should use grep_search
+   * rather than reading every file.
    */
   evalTest('USUALLY_PASSES', {
-    name: 'should use grep_search over reading all files for string search',
+    name: 'should use grep over reading all files for string search',
     prompt:
       'Search for all TODO comments in this codebase using grep_search and list them.',
     files: {
@@ -41,21 +41,63 @@ describe('Tool Selection', () => {
       );
       expect(
         grepCalls.length,
-        'Expected agent to use grep_search for finding TODOs across a large codebase',
+        'Expected agent to use grep_search for finding TODOs',
       ).toBeGreaterThanOrEqual(1);
+
+      // Agent should not fall back to reading every file individually
+      const readCalls = toolLogs.filter(
+        (log) => log.toolRequest.name === 'read_file',
+      );
+      expect(
+        readCalls.length,
+        'Expected agent not to read all files individually when grep_search is available',
+      ).toBeLessThan(5);
     },
   });
 
   /**
-   * When asked to count lines or files, the agent should use shell commands
-   * rather than reading every file to count manually.
+   * When asked to count lines in files, the agent should use shell
+   * commands (wc -l) rather than reading files.
    */
   evalTest('USUALLY_PASSES', {
     name: 'should use shell for counting operations',
     prompt: 'How many lines of code are in the src directory?',
     files: {
-      'src/app.js': 'console.log("hello");\n'.repeat(50),
-      'src/utils.js': 'module.exports = {};\n'.repeat(30),
+      'src/app.js': Array.from({ length: 50 }, (_, i) => `// Line ${i}`).join(
+        '\n',
+      ),
+      'src/utils.js': Array.from({ length: 30 }, (_, i) => `// Util ${i}`).join(
+        '\n',
+      ),
+    },
+    assert: async (rig) => {
+      const toolLogs = rig.readToolLogs();
+      const shellCalls = toolLogs.filter(
+        (log) => log.toolRequest.name === 'run_shell_command',
+      );
+      // Agent should use shell (wc, find, cloc) rather than reading every file
+      expect(shellCalls.length).toBeGreaterThanOrEqual(1);
+
+      // Agent should not read files individually to count lines
+      const readCalls = toolLogs.filter(
+        (log) => log.toolRequest.name === 'read_file',
+      );
+      expect(
+        readCalls.length,
+        'Expected agent not to read files individually when shell counting is available',
+      ).toBeLessThan(3);
+    },
+  });
+
+  /**
+   * When asked to check if a port is in use, the agent should use shell
+   * commands, not try to read config files.
+   */
+  evalTest('USUALLY_PASSES', {
+    name: 'should use shell commands for system queries',
+    prompt: 'Check if port 3000 is currently in use.',
+    files: {
+      'app.js': 'const port = 3000;',
     },
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
@@ -64,19 +106,40 @@ describe('Tool Selection', () => {
       );
       expect(
         shellCalls.length,
-        'Expected agent to use run_shell_command for counting lines',
+        'Expected agent to use shell for system queries',
       ).toBeGreaterThanOrEqual(1);
+
+      const hasPortCheck = shellCalls.some((call) => {
+        let args = call.toolRequest.args;
+        if (typeof args === 'string') {
+          try {
+            args = JSON.parse(args);
+          } catch {
+            /* */
+          }
+        }
+        const cmd = typeof args === 'string' ? args : args?.command || '';
+        return (
+          cmd.includes('lsof') ||
+          cmd.includes('netstat') ||
+          cmd.includes('ss ') ||
+          cmd.includes('3000')
+        );
+      });
+      expect(hasPortCheck, 'Expected port checking command').toBe(true);
     },
   });
 
   /**
-   * When asked about git history, the agent should use a shell command
-   * (git log) rather than reading .git files directly.
+   * When asked to check git history, the agent should use git log, not
+   * try to read .git directory.
    */
   evalTest('USUALLY_PASSES', {
     name: 'should use git log for history queries',
-    prompt: 'Show me the last 3 git commits in this project.',
+    prompt: 'Show me the last 5 commits in this repo.',
     files: {
+      '.git/HEAD': 'ref: refs/heads/main',
+      '.git/config': '[core]\n\trepositoryformatversion = 0',
       'app.js': 'console.log("hello");',
     },
     assert: async (rig) => {
@@ -84,89 +147,80 @@ describe('Tool Selection', () => {
       const shellCalls = toolLogs.filter(
         (log) => log.toolRequest.name === 'run_shell_command',
       );
-      expect(
-        shellCalls.length,
-        'Expected agent to use run_shell_command for git log',
-      ).toBeGreaterThanOrEqual(1);
+
+      const gitLogCall = shellCalls.find((call) => {
+        let args = call.toolRequest.args;
+        if (typeof args === 'string') {
+          try {
+            args = JSON.parse(args);
+          } catch {
+            /* */
+          }
+        }
+        const cmd = typeof args === 'string' ? args : args?.command || '';
+        return cmd.includes('git log');
+      });
+      expect(gitLogCall, 'Expected agent to use git log').toBeDefined();
     },
   });
 
   /**
-   * When asked to perform bulk operations across many files, the agent
-   * should choose efficient tools (glob, grep_search) rather than
-   * reading each file individually.
+   * For simple string replacements across files, the agent should use
+   * sed or grep+replace rather than reading each file individually.
    */
   evalTest('USUALLY_PASSES', {
     name: 'should choose efficient tools for bulk operations',
     prompt:
-      'Find all JavaScript files in this project that import express and list their paths.',
+      'Replace all console.log calls with logger.info across all files in src/.',
     files: {
-      'src/app.js':
-        "const express = require('express');\nconst app = express();\n",
-      'src/utils.js': 'module.exports = {};',
-      'src/logger.js': 'const winston = require("winston");',
-      'src/server.js':
-        "const express = require('express');\nconst server = express();\n",
+      'src/app.js': 'console.log("starting");\nconsole.log("ready");',
+      'src/server.js': 'console.log("listening on port 3000");',
+      'src/utils.js': 'console.log("util loaded");',
+      'src/logger.js': 'module.exports = { info: console.info };',
     },
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
-      const efficientCalls = toolLogs.filter(
-        (log) =>
-          log.toolRequest.name === 'grep_search' ||
-          log.toolRequest.name === 'glob',
+
+      // Verify the replacement happened
+      const app = rig.readFile('src/app.js');
+      const server = rig.readFile('src/server.js');
+      const utils = rig.readFile('src/utils.js');
+
+      // At least some files should be updated
+      const updated = [app, server, utils].filter(
+        (content) =>
+          content.includes('logger') && !content.includes('console.log'),
       );
       expect(
-        efficientCalls.length,
-        'Expected agent to use grep_search or glob to find files efficiently',
-      ).toBeGreaterThanOrEqual(1);
+        updated.length,
+        'Expected at least some files to be updated',
+      ).toBeGreaterThanOrEqual(2);
     },
   });
 
   /**
-   * When asked a question that can be answered by reading a local file,
-   * the agent should NOT make unnecessary changes to files.
+   * When asked a yes/no question about code, the agent should read the
+   * relevant file and answer without making changes.
    */
   evalTest('USUALLY_PASSES', {
     name: 'should answer questions without making changes',
-    prompt: 'What version of the package is defined in package.json?',
+    prompt: 'Does this project use TypeScript?',
     files: {
       'package.json':
-        '{"name": "my-app", "version": "2.3.1", "description": "A test app"}',
+        '{"name": "js-app", "dependencies": {"express": "^4.18.0"}}',
       'src/app.js': 'console.log("hello");',
     },
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
-      const writeCalls = toolLogs.filter(
+      const editCalls = toolLogs.filter(
         (log) =>
           log.toolRequest.name === 'write_file' ||
           log.toolRequest.name === 'replace',
       );
       expect(
-        writeCalls.length,
-        'Agent should not modify files when only answering a question',
+        editCalls.length,
+        'Should not make edits when answering a question',
       ).toBe(0);
-    },
-  });
-
-  /**
-   * When querying system information, the agent should use shell commands
-   * rather than reading system files directly.
-   */
-  evalTest('USUALLY_PASSES', {
-    name: 'should use shell commands for system queries',
-    prompt: 'What version of Node.js is installed on this system?',
-    files: {
-      'app.js': 'console.log("hello");',
-    },
-    assert: async (rig) => {
-      const toolLogs = rig.readToolLogs();
-      const shellCalls = toolLogs.filter(
-        (log) => log.toolRequest.name === 'run_shell_command',
-      );
-      expect(
-        shellCalls.length,
-        'Expected agent to use run_shell_command for system queries',
-      ).toBeGreaterThanOrEqual(1);
     },
   });
 });

--- a/evals/tool-selection.eval.ts
+++ b/evals/tool-selection.eval.ts
@@ -5,6 +5,14 @@
  */
 
 import { describe, expect } from 'vitest';
+import {
+  GREP_TOOL_NAME,
+  READ_FILE_TOOL_NAME,
+  SHELL_TOOL_NAME,
+  WRITE_FILE_TOOL_NAME,
+  EDIT_TOOL_NAME,
+  LS_TOOL_NAME,
+} from '@google/gemini-cli-core';
 import { evalTest } from './test-helper.js';
 
 describe('Tool Selection', () => {
@@ -37,7 +45,7 @@ describe('Tool Selection', () => {
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
       const grepCalls = toolLogs.filter(
-        (log) => log.toolRequest.name === 'grep_search',
+        (log) => log.toolRequest.name === GREP_TOOL_NAME,
       );
       expect(
         grepCalls.length,
@@ -46,7 +54,7 @@ describe('Tool Selection', () => {
 
       // Agent should not fall back to reading every file individually
       const readCalls = toolLogs.filter(
-        (log) => log.toolRequest.name === 'read_file',
+        (log) => log.toolRequest.name === READ_FILE_TOOL_NAME,
       );
       expect(
         readCalls.length,
@@ -82,14 +90,14 @@ describe('Tool Selection', () => {
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
       const shellCalls = toolLogs.filter(
-        (log) => log.toolRequest.name === 'run_shell_command',
+        (log) => log.toolRequest.name === SHELL_TOOL_NAME,
       );
       // Agent should use shell (wc, find, cloc) rather than reading every file
       expect(shellCalls.length).toBeGreaterThanOrEqual(1);
 
       // Agent should not read files individually to count lines
       const readCalls = toolLogs.filter(
-        (log) => log.toolRequest.name === 'read_file',
+        (log) => log.toolRequest.name === READ_FILE_TOOL_NAME,
       );
       expect(
         readCalls.length,
@@ -120,7 +128,7 @@ describe('Tool Selection', () => {
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
       const shellCalls = toolLogs.filter(
-        (log) => log.toolRequest.name === 'run_shell_command',
+        (log) => log.toolRequest.name === SHELL_TOOL_NAME,
       );
       expect(
         shellCalls.length,
@@ -163,7 +171,7 @@ describe('Tool Selection', () => {
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
       const shellCalls = toolLogs.filter(
-        (log) => log.toolRequest.name === 'run_shell_command',
+        (log) => log.toolRequest.name === SHELL_TOOL_NAME,
       );
 
       const gitLogCall = shellCalls.find((call) => {
@@ -232,8 +240,8 @@ describe('Tool Selection', () => {
       const toolLogs = rig.readToolLogs();
       const editCalls = toolLogs.filter(
         (log) =>
-          log.toolRequest.name === 'write_file' ||
-          log.toolRequest.name === 'replace',
+          log.toolRequest.name === WRITE_FILE_TOOL_NAME ||
+          log.toolRequest.name === EDIT_TOOL_NAME,
       );
       expect(
         editCalls.length,

--- a/evals/tool-selection.eval.ts
+++ b/evals/tool-selection.eval.ts
@@ -52,6 +52,15 @@ describe('Tool Selection', () => {
         readCalls.length,
         'Expected agent not to read all files individually when grep_search is available',
       ).toBeLessThan(5);
+
+      // Agent should complete the search in a single turn
+      const uniqueTurns = new Set(
+        grepCalls.map((call) => call.toolRequest.prompt_id).filter(Boolean),
+      );
+      expect(
+        uniqueTurns.size,
+        'Expected grep_search calls to occur within a single turn',
+      ).toBeLessThanOrEqual(1);
     },
   });
 
@@ -86,6 +95,15 @@ describe('Tool Selection', () => {
         readCalls.length,
         'Expected agent not to read files individually when shell counting is available',
       ).toBeLessThan(3);
+
+      // Agent should complete the count in a single turn
+      const uniqueTurns = new Set(
+        shellCalls.map((call) => call.toolRequest.prompt_id).filter(Boolean),
+      );
+      expect(
+        uniqueTurns.size,
+        'Expected shell counting to occur within a single turn',
+      ).toBeLessThanOrEqual(1);
     },
   });
 

--- a/evals/tool-selection.eval.ts
+++ b/evals/tool-selection.eval.ts
@@ -249,4 +249,50 @@ describe('Tool Selection', () => {
       ).toBe(0);
     },
   });
+
+  /**
+   * Hard case: the agent is given a large codebase and asked to find all
+   * usages of a deprecated function. It should use grep, not open every file.
+   *
+   * This is harder because the model may try to be thorough by reading files
+   * individually even when grep would be more efficient.
+   */
+  evalTest('USUALLY_PASSES', {
+    name: 'should use grep to find deprecated function usages across many files',
+    prompt:
+      'Find all usages of the deprecated `oldFetch` function in this codebase so I can replace them.',
+    files: Object.fromEntries([
+      ...Array.from({ length: 10 }, (_, i) => [
+        `src/module${i}.ts`,
+        i % 3 === 0
+          ? `import { oldFetch } from './api';\noldFetch('/endpoint${i}');\n`
+          : `export function util${i}() { return ${i}; }\n`,
+      ]),
+      [
+        'src/api.ts',
+        `export function oldFetch(url: string) { return fetch(url); }\nexport function newFetch(url: string) { return fetch(url); }\n`,
+      ],
+    ]),
+    assert: async (rig) => {
+      const toolLogs = rig.readToolLogs();
+
+      // Must use grep -- reading 11 files individually is too expensive
+      const grepCalls = toolLogs.filter(
+        (log) => log.toolRequest.name === GREP_TOOL_NAME,
+      );
+      expect(
+        grepCalls.length,
+        'Expected agent to use grep_search to find usages of oldFetch',
+      ).toBeGreaterThanOrEqual(1);
+
+      // Should not read all files individually
+      const readCalls = toolLogs.filter(
+        (log) => log.toolRequest.name === READ_FILE_TOOL_NAME,
+      );
+      expect(
+        readCalls.length,
+        'Agent should not read all files individually when grep is available',
+      ).toBeLessThan(6);
+    },
+  });
 });


### PR DESCRIPTION
## Summary

Adds four behavioral evals testing whether the agent chooses efficient tools over less expensive alternatives -- including adversarial prompts designed to create tension with efficient tool use.

## Details

| Test | Policy | What it tests |
|------|--------|---------------|
| `legacyAuth()` search with "read carefully" instruction | `USUALLY_PASSES` | Agent uses `grep_search` even when explicitly told to read each file carefully |
| Line count across src directory | `USUALLY_PASSES` | Agent uses `run_shell_command` rather than reading each file to count lines |
| Answer question with visible bug in files | `USUALLY_PASSES` | Agent answers without fixing the unrelated bug it sees (no unprompted edits) |
| Deprecated function search across 10 files | `USUALLY_PASSES` | Agent uses `grep_search` rather than opening each file individually |

**Design note:** The "read each file carefully" prompt is adversarial -- it creates explicit tension with efficient tool selection. A model that follows the instruction literally will read all files individually and fail the assertion. This tests whether the model prioritizes efficiency over literal instruction-following.

**Finding during validation:** The correct tool name is `list_directory` (defined as `LS_TOOL_NAME` in `base-declarations.ts`), not `ls`. All assertions import constants from `@google/gemini-cli-core`.

## How to Validate

```bash
npm run build
RUN_EVALS=1 npx vitest run evals/tool-selection.eval.ts --config evals/vitest.config.ts --reporter=verbose
```

## Related Issues

Fixes #23484
Related to #23331