### PR TITLE
fix(cli): prevent Ctrl+D exit when input buffer is not empty (#23019)

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -2141,7 +2141,7 @@ describe('AppContainer State Management', () => {
         unmount();
       });
 
-      it('should NOT quit if buffer is not empty', async () => {
+      it('should NEVER quit if buffer is not empty', async () => {
         mockedUseTextBuffer.mockReturnValue({
           text: 'some text',
           setText: vi.fn(),
@@ -2152,18 +2152,13 @@ describe('AppContainer State Management', () => {
         await setupKeypressTest();
 
         pressKey('\x04'); // Ctrl+D
-
-        // Should only be called once, so count is 1, not quitting yet.
         expect(mockHandleSlashCommand).not.toHaveBeenCalled();
 
         pressKey('\x04'); // Ctrl+D
-        // Now count is 2, it should quit.
-        expect(mockHandleSlashCommand).toHaveBeenCalledWith(
-          '/quit',
-          undefined,
-          undefined,
-          false,
-        );
+        expect(mockHandleSlashCommand).not.toHaveBeenCalled();
+
+        pressKey('\x04'); // Ctrl+D
+        expect(mockHandleSlashCommand).not.toHaveBeenCalled();
         unmount();
       });
 

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1701,7 +1701,10 @@ Logging in with Google... Restarting Gemini CLI to continue.
 
         handleCtrlCPress();
         return true;
-      } else if (keyMatchers[Command.EXIT](key)) {
+      } else if (
+        keyMatchers[Command.EXIT](key) &&
+        bufferRef.current.text.length === 0
+      ) {
         handleCtrlDPress();
         return true;
       } else if (keyMatchers[Command.SUSPEND_APP](key)) {
@@ -1879,6 +1882,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       triggerExpandHint,
       keyMatchers,
       isHelpDismissKey,
+      bufferRef,
     ],
   );
 


### PR DESCRIPTION
This PR fixes Issue #23019. Previously, pressing Ctrl+D would exit the CLI even if the input buffer had content. This change ensures that Ctrl+D only triggers an exit when the buffer is empty. Tests have been updated to verify this behavior.