### PR TITLE
fix(test): silence policy-engine integration test noise

### DIFF
--- a/packages/cli/src/config/policy-engine.integration.test.ts
+++ b/packages/cli/src/config/policy-engine.integration.test.ts
@@ -36,10 +36,7 @@ describe('Policy Engine Integration Tests', () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-    vi.restoreAllMocks();
-  });
+  afterEach(() => vi.unstubAllEnvs());
 
   describe('Policy configuration produces valid PolicyEngine config', () => {
     it('should create a working PolicyEngine from basic settings', async () => {

--- a/packages/cli/src/config/policy-engine.integration.test.ts
+++ b/packages/cli/src/config/policy-engine.integration.test.ts
@@ -29,9 +29,17 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
 });
 
 describe('Policy Engine Integration Tests', () => {
-  beforeEach(() => vi.stubEnv('GEMINI_SYSTEM_MD', ''));
+  beforeEach(() => {
+    vi.stubEnv('GEMINI_SYSTEM_MD', '');
+    // Silence debugLogger output (routes through console.debug/console.log)
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
 
-  afterEach(() => vi.unstubAllEnvs());
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
 
   describe('Policy configuration produces valid PolicyEngine config', () => {
     it('should create a working PolicyEngine from basic settings', async () => {


### PR DESCRIPTION
`policy-engine.integration.test.ts` dumps ~300 lines of `[PolicyEngine.check]` debug output to stdout on every run because `debugLogger` routes through `console.debug`/`console.log` and neither was mocked.

Fixed by spying on `console.debug` and `console.log` in `beforeEach` and restoring in `afterEach`. All 19 tests still pass, zero stdout noise.

### Before (325 lines)

```
stdout | ...should create a working PolicyEngine from basic settings
[PolicyEngine.check] toolCall.name: run_shell_command, stringifiedArgs: undefined
[PolicyEngine.check] MATCHED rule: toolName=run_shell_command, decision=allow, priority=4.3, argsPattern=none

stdout | ...should create a working PolicyEngine from basic settings
[PolicyEngine.check] toolCall.name: write_file, stringifiedArgs: undefined
[PolicyEngine.check] MATCHED rule: toolName=write_file, decision=deny, priority=4.4, argsPattern=none
... (300+ more lines)
```

### After (13 lines)

```
 ✓ src/config/policy-engine.integration.test.ts (19 tests) 206ms

 Test Files  1 passed (1)
      Tests  19 passed (19)
```

Relates to #23328.