### PR TITLE
feat(core): add channel notification support for MCP servers

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1220,6 +1220,30 @@ Logging in with Google... Restarting Gemini CLI to continue.
     isMcpReady,
   });
 
+  // Listen for channel messages from MCP servers (e.g. Telegram)
+  // and feed them into the message queue for processing.
+  useEffect(() => {
+    const handleChannelMessage = (payload: {
+      content: string;
+      serverName: string;
+      meta?: Record<string, string>;
+    }) => {
+      debugLogger.log(`📨 Channel message received from ${payload.serverName}`);
+      // Add to message queue — it will be submitted when Gemini is idle
+      addMessage(payload.content);
+      // Show in chat history
+      historyManager.addItem({
+        type: 'hint',
+        text: `[${payload.serverName}] ${payload.content}`,
+      });
+    };
+
+    coreEvents.on(CoreEvent.ChannelMessage, handleChannelMessage);
+    return () => {
+      coreEvents.off(CoreEvent.ChannelMessage, handleChannelMessage);
+    };
+  }, [addMessage, historyManager]);
+
   cancelHandlerRef.current = useCallback(
     (shouldRestorePrompt: boolean = true) => {
       const pendingHistoryItems = [

--- a/packages/core/src/config/injectionService.ts
+++ b/packages/core/src/config/injectionService.ts
@@ -12,7 +12,10 @@
 
 import { debugLogger } from '../utils/debugLogger.js';
 
-export type InjectionSource = 'user_steering' | 'background_completion';
+export type InjectionSource =
+  | 'user_steering'
+  | 'background_completion'
+  | 'channel_message';
 
 /**
  * Typed listener that receives both the injection text and its source.
@@ -43,6 +46,8 @@ export class InjectionService {
    * Other sources (e.g. `background_completion`) are always accepted.
    */
   addInjection(text: string, source: InjectionSource): void {
+    // Only user_steering is gated on model steering being enabled.
+    // Other sources (background_completion, channel_message) are always accepted.
     if (source === 'user_steering' && !this.isEnabled()) {
       return;
     }

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -478,6 +478,48 @@ export class McpClient implements McpProgressReporter {
         }
       },
     );
+
+    // Handle channel messages from MCP servers (e.g. Telegram, Slack).
+    // MCP servers can push messages into the conversation by sending a
+    // notification with method "notifications/channel".
+    const existingFallback = this.client.fallbackNotificationHandler;
+    this.client.fallbackNotificationHandler = async (notification: {
+      method: string;
+      params?: Record<string, unknown>;
+    }) => {
+      if (notification.method === 'notifications/channel') {
+        const params = notification.params ?? {};
+        const rawContent = params['content'];
+        const content = isString(rawContent) ? rawContent : '';
+        const rawMeta = params['meta'];
+        const meta: Record<string, string> = isStringRecord(rawMeta)
+          ? rawMeta
+          : {};
+
+        if (content) {
+          debugLogger.log(
+            `📨 Channel message from '${this.serverName}': ${content.slice(0, 100)}...`,
+          );
+
+          // Format as a channel block for the model
+          const metaAttrs = Object.entries(meta)
+            .map(([k, v]) => `${k}="${v}"`)
+            .join(' ');
+          const formatted = `<channel source="${this.serverName}" ${metaAttrs}>\n${content}\n</channel>`;
+
+          coreEvents.emitChannelMessage({
+            serverName: this.serverName,
+            content: formatted,
+            meta,
+          });
+        }
+      }
+
+      // Chain to any existing fallback handler
+      if (existingFallback) {
+        await existingFallback(notification);
+      }
+    };
   }
 
   /**
@@ -877,6 +919,25 @@ export function getMCPDiscoveryState(): MCPDiscoveryState {
  * @param errorString The error message string
  * @returns The www-authenticate header value if found, null otherwise
  */
+function isString(value: unknown): value is string {
+  return Object.prototype.toString.call(value) === '[object String]';
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (value === null || value === undefined || Array.isArray(value)) {
+    return false;
+  }
+  if (Object.prototype.toString.call(value) !== '[object Object]') {
+    return false;
+  }
+  for (const v of Object.values(Object(value))) {
+    if (Object.prototype.toString.call(v) !== '[object String]') {
+      return false;
+    }
+  }
+  return true;
+}
+
 function extractWWWAuthenticateHeader(errorString: string): string | null {
   // Try multiple patterns to extract the header
   const patterns = [

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -501,11 +501,23 @@ export class McpClient implements McpProgressReporter {
             `📨 Channel message from '${this.serverName}': ${content.slice(0, 100)}...`,
           );
 
-          // Format as a channel block for the model
+          // Format as a channel block for the model.
+          // Sanitize untrusted input to prevent prompt injection via
+          // crafted metadata values or content that breaks out of the XML block.
+          const escapeAttr = (s: string) =>
+            s
+              .replace(/&/g, '&amp;')
+              .replace(/"/g, '&quot;')
+              .replace(/</g, '&lt;')
+              .replace(/>/g, '&gt;');
           const metaAttrs = Object.entries(meta)
-            .map(([k, v]) => `${k}="${v}"`)
+            .map(([k, v]) => `${escapeAttr(k)}="${escapeAttr(v)}"`)
             .join(' ');
-          const formatted = `<channel source="${this.serverName}" ${metaAttrs}>\n${content}\n</channel>`;
+          const safeContent = content.replace(
+            /<\/channel>/gi,
+            '&lt;/channel&gt;',
+          );
+          const formatted = `<channel source="${escapeAttr(this.serverName)}" ${metaAttrs}>\n${safeContent}\n</channel>`;
 
           coreEvents.emitChannelMessage({
             serverName: this.serverName,

--- a/packages/core/src/utils/events.ts
+++ b/packages/core/src/utils/events.ts
@@ -192,6 +192,7 @@ export enum CoreEvent {
   QuotaChanged = 'quota-changed',
   TelemetryKeychainAvailability = 'telemetry-keychain-availability',
   TelemetryTokenStorageType = 'telemetry-token-storage-type',
+  ChannelMessage = 'channel-message',
 }
 
 /**
@@ -199,6 +200,20 @@ export enum CoreEvent {
  */
 export interface EditorSelectedPayload {
   editor?: EditorType;
+}
+
+/**
+ * Payload for channel messages received from MCP servers.
+ * Enables external channels (e.g. Telegram, Slack) to push messages
+ * into a running Gemini CLI session.
+ */
+export interface ChannelMessagePayload {
+  /** Name of the MCP server that sent the notification */
+  serverName: string;
+  /** The message content to inject into the conversation */
+  content: string;
+  /** Optional metadata (chat_id, user, timestamp, etc.) */
+  meta?: Record<string, string>;
 }
 
 export interface CoreEvents extends ExtensionEvents {
@@ -225,6 +240,7 @@ export interface CoreEvents extends ExtensionEvents {
   [CoreEvent.SlashCommandConflicts]: [SlashCommandConflictsPayload];
   [CoreEvent.TelemetryKeychainAvailability]: [KeychainAvailabilityEvent];
   [CoreEvent.TelemetryTokenStorageType]: [TokenStorageInitializationEvent];
+  [CoreEvent.ChannelMessage]: [ChannelMessagePayload];
 }
 
 type EventBacklogItem = {
@@ -381,6 +397,13 @@ export class CoreEventEmitter extends EventEmitter<CoreEvents> {
   emitAgentsDiscovered(agents: AgentDefinition[]): void {
     const payload: AgentsDiscoveredPayload = { agents };
     this._emitOrQueue(CoreEvent.AgentsDiscovered, payload);
+  }
+
+  /**
+   * Notifies subscribers that a channel message has been received from an MCP server.
+   */
+  emitChannelMessage(payload: ChannelMessagePayload): void {
+    this._emitOrQueue(CoreEvent.ChannelMessage, payload);
   }
 
   emitSlashCommandConflicts(conflicts: SlashCommandConflict[]): void {


### PR DESCRIPTION
## ELI5 (Explain Like I'm 5)

Right now, Gemini CLI can only talk TO external tools (MCP servers) — like asking a question and getting an answer. But those tools can't tap Gemini on the shoulder and say "hey, someone just sent you a message!"

This PR adds a doorbell. Any MCP server can now ring `notifications/channel` and Gemini will hear it, read the message, and respond. Think of it like giving Gemini CLI a phone — it can now receive texts from Telegram, Slack, Discord, or anything else, while it's already running in your terminal.

**Before:** Gemini asks tool → tool answers. One way.
**After:** Gemini asks tool → tool answers. Tool can ALSO push messages to Gemini anytime. Two way.

---

## Summary

Adds support for MCP servers to push real-time messages into a running Gemini CLI session via `notifications/channel`. This enables external communication channels (e.g., Telegram, Slack, Discord) to deliver inbound messages directly into the conversation — allowing Gemini to act as a bridge between the terminal and messaging platforms.

This is analogous to Claude Code's `notifications/claude/channel` feature, adapted for Gemini CLI's architecture.

**Closes #3052**

## Details

### Problem

Currently, MCP servers in Gemini CLI can only respond to tool calls — they cannot proactively push messages into a running session. This means external messaging integrations (chat bots, webhooks, monitoring alerts) have no way to deliver real-time messages to the model while a session is active.

### Solution

This PR adds a lightweight notification pipeline that allows any MCP server to push messages into the conversation by sending a standard MCP notification:

```typescript
// From an MCP server:
server.notification({
  method: "notifications/channel",
  params: {
    content: "Hello from Telegram!",
    meta: {
      chat_id: "12345",
      user: "alice",
      ts: "2026-03-22T12:00:00Z"
    }
  }
});
```

The pipeline works as follows:

```
MCP Server → notifications/channel → fallbackNotificationHandler (mcp-client.ts)
  → CoreEvent.ChannelMessage (events.ts)
  → AppContainer.tsx listener → addMessage() → message queue
  → Gemini processes it on next idle cycle
```

### Changes

**4 files modified, ~60 lines of logic added:**

1. **`packages/core/src/utils/events.ts`**
   - Added `ChannelMessage` to `CoreEvent` enum
   - Added `ChannelMessagePayload` interface (`serverName`, `content`, `meta`)
   - Added `emitChannelMessage()` method to `CoreEventEmitter`
   - Added event type mapping in `CoreEvents` interface

2. **`packages/core/src/config/injectionService.ts`**
   - Added `'channel_message'` to `InjectionSource` type union
   - `channel_message` bypasses the `isEnabled()` gate (same as `background_completion`) — channel messages are always accepted regardless of model steering settings

3. **`packages/core/src/tools/mcp-client.ts`**
   - Added `fallbackNotificationHandler` in `registerNotificationHandlers()` that catches `notifications/channel` notifications
   - Extracts `content` (string) and `meta` (key-value pairs) from the notification params using type guard functions
   - Formats as a `<channel>` XML block for the model:
     ```xml
     <channel source="server-name" chat_id="123" user="alice">
     Hello from Telegram!
     </channel>
     ```
   - Emits via `coreEvents.emitChannelMessage()`
   - Chains to any existing fallback handler (non-destructive)

4. **`packages/cli/src/ui/AppContainer.tsx`**
   - Added `useEffect` listener for `CoreEvent.ChannelMessage`
   - Feeds channel messages into `addMessage()` (the existing message queue), which submits them to Gemini when the model is idle
   - Displays messages in chat history as `'hint'` type for visibility

### Design Decisions

- **Uses `fallbackNotificationHandler`**: This is the MCP SDK's built-in mechanism for handling custom/unregistered notification methods. No SDK modifications needed.
- **XML `<channel>` format**: Structured format lets the model distinguish channel messages from other input and extract metadata (source, user, chat_id, etc.) reliably.
- **Message queue integration**: Messages go through the existing `addMessage()` queue rather than being injected directly. This means they're processed when Gemini is idle, avoiding race conditions with in-progress responses.
- **Always-accept semantics**: Channel messages bypass the model steering gate (`isEnabled()`) because they represent external input that should never be silently dropped.
- **Non-breaking**: All changes are additive. MCP servers that don't send `notifications/channel` are completely unaffected. No existing behavior is modified.

### Tradeoffs & Constraints

| Aspect | Detail |
|--------|--------|
| **One-at-a-time processing** | Messages are queued and processed sequentially. If Gemini is mid-response, incoming messages wait. This is inherent to the single-turn architecture. |
| **No message batching** | Each notification becomes a separate turn. Rapid-fire messages create separate processing cycles. MCP server authors may want to implement their own batching/debouncing. |
| **No built-in rate limiting** | The pipeline trusts MCP servers not to flood. Malicious or buggy servers could spam the queue. Rate limiting is left to the MCP server or a future middleware layer. |
| **Text-only content** | The `content` field is a string. Binary data (images, files) should be referenced by path in `meta`, not embedded in `content`. |
| **No delivery confirmation** | MCP servers don't receive acknowledgment that the message was processed. This is fire-and-forget, consistent with the MCP notification model. |

### How MCP Server Authors Can Use This

Any MCP server can push messages into a running Gemini CLI session. Here's a minimal example:

```typescript
import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";

const server = new McpServer({ name: "my-channel", version: "1.0.0" });
const internal = (server as any).server;

// When you receive an external message (webhook, bot, etc.):
await internal.notification({
  method: "notifications/channel",
  params: {
    content: "User said: Hello!",
    meta: {
      source: "my-platform",
      user: "alice",
      ts: new Date().toISOString(),
    },
  },
});

const transport = new StdioServerTransport();
await server.connect(transport);
```

The model receives it as:
```xml
<channel source="my-channel" source="my-platform" user="alice" ts="2026-03-22T12:00:00Z">
User said: Hello!
</channel>
```

### Example Use Cases

- **Telegram/Slack/Discord bots**: Receive messages from a chat platform and push them into Gemini for processing. Gemini responds using MCP tools exposed by the same server.
- **Webhook receivers**: Listen for GitHub webhooks, CI/CD notifications, or monitoring alerts and inject them into an active session.
- **Inter-agent communication**: Other AI agents or services can push messages into a Gemini session for collaborative workflows.
- **IoT/sensor data**: Push real-time sensor readings or alerts into a session for analysis.

### Testing Status

This feature has been **validated end-to-end with a Telegram bot integration** on Windows. The MCP server runs a Telegram bot (via [grammY](https://grammy.dev/)), receives messages, and pushes them into the Gemini CLI session via `notifications/channel`. Gemini processes the messages and responds using MCP tools exposed by the same server.

**What has been tested:**
- Telegram bot receiving DMs and group messages → notifications/channel → Gemini processes and replies via tool call
- Multiple rapid messages queuing correctly
- Photo/image messages with file path in `meta`
- Long messages chunked across multiple Telegram API calls
- Access control (allowlist, pairing flow, group policies) handled at the MCP server level
- Session persistence across multiple message exchanges

**What has NOT been tested (but should work — the pipeline is platform-agnostic):**
- Slack, Discord, or other messaging platforms
- macOS and Linux (code paths are identical — no platform-specific logic)
- Headless/non-interactive mode (`-p` flag) — channel messages currently require the interactive UI (`AppContainer.tsx`) for the `useEffect` listener

## Related Issues

- Closes #3052 — Support mcp server notifications/messages

## How to Validate

1. **Build the project:**
   ```bash
   npm run build
   ```

2. **Create a minimal test MCP server** that sends `notifications/channel` (see example above).

3. **Register it in settings or as an extension**, then start Gemini CLI:
   ```bash
   gemini --yolo
   ```

4. **Trigger a notification** from the MCP server. Verify:
   - The `<channel>` block appears in the chat history as a hint
   - Gemini processes the message on its next idle cycle
   - The model can read the `source`, `meta` attributes, and `content`

5. **Send multiple messages rapidly** — verify they queue and process sequentially without crashes.

## Pre-Merge Checklist

- [ ] Updated documentation/README
- [ ] Added/updated tests
- [x] Noted breaking changes (none — fully additive)
- [x] Validated on Windows (macOS/Linux use identical code paths)
