### PR TITLE
test(core): silence console.log/warn/debug in test suite

### DIFF
--- a/packages/core/test-setup.ts
+++ b/packages/core/test-setup.ts
@@ -10,7 +10,7 @@ if (process.env.NO_COLOR !== undefined) {
 }
 
 import { setSimulate429 } from './src/utils/testUtils.js';
-import { vi, afterEach } from 'vitest';
+import { vi, beforeEach, afterEach } from 'vitest';
 import { coreEvents } from './src/utils/events.js';
 
 // Increase max listeners to avoid warnings in large test suites
@@ -19,7 +19,17 @@ coreEvents.setMaxListeners(100);
 // Disable 429 simulation globally for all tests
 setSimulate429(false);
 
+// Silence noisy console output from passing tests. Tests that intentionally
+// test logging behavior should use vi.mocked(console.log) or similar.
+// console.error is intentionally left unmocked so real errors are visible.
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'debug').mockImplementation(() => {});
+});
+
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.unstubAllEnvs();
 });
 


### PR DESCRIPTION
## Summary

This PR silences `console.log`, `console.warn`, and `console.debug` in the `packages/core` test suite to eliminate noise from passing tests, which is particularly bad because `debugLogger` proxies directly to `console.*`.

## Details

Add global `vi.spyOn` mocks for `console.log/warn/debug` in `beforeEach` so they are silenced for every test. `vi.restoreAllMocks()` in `afterEach` ensures clean per-test isolation. 

`console.error` is intentionally left unmocked so real errors (including missing `act()` wrappers) remain visible.

## Related Issues

Contributes to: #23328

## How to Validate

1. Delete the [packages/core/test-setup.ts](cci:7://file:///C:/Users/MADHURA/OneDrive/Desktop/New%20folder/gemini-cli/packages/core/test-setup.ts:0:0-0:0) changes locally to see the noise baseline.
2. Run `npm run test -- packages/core/src/policy/policy-engine.test.ts`
3. Notice the large amount of terminal noise.
4. Add the changes back and re-run. The output should be completely silent.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
  - [x] Windows
    - [x] npm run
  - [ ] Linux
