### PR TITLE
docs: fix typos and grammar in evals/README.md and release-confidence.md

### DIFF
--- a/docs/release-confidence.md
+++ b/docs/release-confidence.md
@@ -1,8 +1,8 @@
 # Release confidence strategy
 
 This document outlines the strategy for gaining confidence in every release of
-the Gemini CLI. It serves as a checklist and quality gate for release manager to
-ensure we are shipping a high-quality product.
+the Gemini CLI. It serves as a checklist and quality gate for the release
+manager to ensure we are shipping a high-quality product.
 
 ## The goal
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -57,7 +57,7 @@ real-world usage while remaining small and maintainable.
 - **Unambiguous and Reliable Assertions**: Assertions must be clear and specific
   to ensure the test passes for the right reason.
   - _Good_: Checking that a modified file contains a specific AST node or exact
-    string, or verifying that a tool was called with with the right parameters.
+    string, or verifying that a tool was called with the right parameters.
   - _Bad_: Only checking for a tool call, which could happen for an unrelated
     reason. Expecting specific LLM output.
 - **Fail First**: Have tests that failed before your prompt or tool change. We
@@ -269,7 +269,7 @@ It's highly recommended to manually review and/or ask the agent to iterate on
 any prompt changes, even if they pass all evals. The prompt should prefer
 positive traits ('do X') and resort to negative traits ('do not do X') only when
 unable to accomplish the goal with positive traits. Gemini is quite good at
-instrospecting on its prompt when asked the right questions.
+introspecting on its prompt when asked the right questions.
 
 ## Promoting evaluations
 


### PR DESCRIPTION
## Summary
Fixed three small problems with the documentation that I found while carefully looking over the codebase as a new contributor.

## Changes Made

### evals/README.md
- Line 60: Removed duplicate word "with with" → "with"
- Line 272: Fixed spelling "instrospecting" → "introspecting"
### docs/release-confidence.md
- Line 5: Added the missing article "for release manager" to "for the release manager."

## Why This Matters
New contributors who are learning the codebase need to have accurate documentation. These little mistakes can make things unclear or make people less sure of the quality of the docs.

## Type of Change
- [x] Documentation fix only (no functional code changed)