### PR TITLE
fix(core): remove orphaned user turn from history when send fails

### DIFF
--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -346,6 +346,7 @@ export class GeminiChat {
     }
 
     // Add user content to history ONCE before any attempts.
+    const historyLengthBeforeUserPush = this.history.length;
     this.history.push(userContent);
     const requestContents = this.getHistory(true);
 
@@ -484,6 +485,9 @@ export class GeminiChat {
           }
         }
       } finally {
+        if (this.history.length === historyLengthBeforeUserPush + 1) {
+          this.history.pop();
+        }
         streamDoneResolver!();
       }
     };


### PR DESCRIPTION
## Summary

When sendMessageStream exhausts all retry attempts and throws, the user turn that was pre-pushed into this.history is left orphaned with no corresponding model turn. On the next message, a second user turn is pushed on top, producing two consecutive role: "user" entries that cause a 400 API error or corrupt the model's context for the remainder of the session.


## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
