### PR TITLE
fix(windows): resolve interactive shell arrow-key navigation on Windows

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1034,8 +1034,16 @@ describe('ShellExecutionService', () => {
 
       expect(mockPtySpawn).toHaveBeenCalledWith(
         'powershell.exe',
-        ['-NoProfile', '-Command', 'chcp 65001 >$null;dir "foo bar"'],
-        expect.any(Object),
+        [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          'chcp 65001 >$null;dir "foo bar"',
+        ],
+        expect.objectContaining({
+          handleFlowControl: false,
+          useConpty: true,
+        }),
       );
     });
 
@@ -1051,7 +1059,9 @@ describe('ShellExecutionService', () => {
           '-c',
           'shopt -u promptvars nullglob extglob nocaseglob dotglob; ls "foo bar"',
         ],
-        expect.any(Object),
+        expect.objectContaining({
+          handleFlowControl: true,
+        }),
       );
     });
   });
@@ -1644,7 +1654,7 @@ describe('ShellExecutionService child_process fallback', () => {
 
       expect(mockCpSpawn).toHaveBeenCalledWith(
         'powershell.exe',
-        ['-NoProfile', '-Command', 'dir "foo bar"'],
+        ['-NoProfile', '-NonInteractive', '-Command', 'dir "foo bar"'],
         expect.objectContaining({
           shell: false,
           detached: false,

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -946,6 +946,7 @@ export class ShellExecutionService {
         cwd: finalCwd,
       } = prepared;
 
+      const isWindowsPlatform = os.platform() === 'win32';
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const ptyProcess = ptyInfo.module.spawn(finalExecutable, finalArgs, {
         cwd: finalCwd,
@@ -953,7 +954,16 @@ export class ShellExecutionService {
         cols,
         rows,
         env: finalEnv,
-        handleFlowControl: true,
+        // handleFlowControl intercepts XON/XOFF (Ctrl+S/Q) and prevents them
+        // from reaching the child.  On Windows, the flag can interfere with
+        // ConPTY's internal input routing and cause interactive TUI tools to
+        // miss key events, so we disable it there.
+        handleFlowControl: !isWindowsPlatform,
+        // On Windows, explicitly request ConPTY (introduced in Windows 10 1809).
+        // Without this, @lydell/node-pty may silently fall back to WinPTY, which
+        // has known incompatibilities with interactive Node.js TUI applications
+        // that rely on VT-sequence-based arrow-key navigation.
+        ...(isWindowsPlatform ? { useConpty: true } : {}),
       });
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
@@ -993,6 +1003,13 @@ export class ShellExecutionService {
           }).catch(() => {});
         },
         isActive: () => {
+          // On Windows, process.kill(pid, 0) can return false negatives
+          // for ConPTY-managed shell wrappers (powershell.exe), causing
+          // writeToPty to silently discard input (including arrow keys).
+          // Check the internal activePtys map first for reliable status.
+          if (ShellExecutionService.activePtys.has(ptyPid)) {
+            return true;
+          }
           try {
             return process.kill(ptyPid, 0);
           } catch {

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -486,7 +486,11 @@ describe('getShellConfiguration', () => {
     it('should return PowerShell configuration by default', () => {
       const config = getShellConfiguration();
       expect(config.executable).toBe('powershell.exe');
-      expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
+      expect(config.argsPrefix).toEqual([
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+      ]);
       expect(config.shell).toBe('powershell');
     });
 
@@ -511,7 +515,11 @@ describe('getShellConfiguration', () => {
       vi.stubEnv('ComSpec', 'C:\\WINDOWS\\system32\\cmd.exe');
       const config = getShellConfiguration();
       expect(config.executable).toBe('powershell.exe');
-      expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
+      expect(config.argsPrefix).toEqual([
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+      ]);
       expect(config.shell).toBe('powershell');
     });
 
@@ -521,7 +529,11 @@ describe('getShellConfiguration', () => {
       vi.stubEnv('ComSpec', psPath);
       const config = getShellConfiguration();
       expect(config.executable).toBe(psPath);
-      expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
+      expect(config.argsPrefix).toEqual([
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+      ]);
       expect(config.shell).toBe('powershell');
     });
 
@@ -530,7 +542,11 @@ describe('getShellConfiguration', () => {
       vi.stubEnv('ComSpec', pwshPath);
       const config = getShellConfiguration();
       expect(config.executable).toBe(pwshPath);
-      expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
+      expect(config.argsPrefix).toEqual([
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+      ]);
       expect(config.shell).toBe('powershell');
     });
 
@@ -538,7 +554,11 @@ describe('getShellConfiguration', () => {
       vi.stubEnv('ComSpec', 'C:\\Path\\To\\POWERSHELL.EXE');
       const config = getShellConfiguration();
       expect(config.executable).toBe('C:\\Path\\To\\POWERSHELL.EXE');
-      expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
+      expect(config.argsPrefix).toEqual([
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+      ]);
       expect(config.shell).toBe('powershell');
     });
   });

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -657,6 +657,11 @@ export function parseCommandDetails(
  */
 export function getShellConfiguration(): ShellConfiguration {
   if (isWindows()) {
+    // -NonInteractive prevents PSReadLine from intercepting console input
+    // events inside the ConPTY session, which otherwise causes interactive
+    // TUI tools (e.g. pnpm create vite, vim) to receive malformed key events
+    // and exit when arrow keys are pressed.
+    const powershellArgsPrefix = ['-NoProfile', '-NonInteractive', '-Command'];
     const comSpec = process.env['ComSpec'];
     if (comSpec) {
       const executable = comSpec.toLowerCase();
@@ -666,7 +671,7 @@ export function getShellConfiguration(): ShellConfiguration {
       ) {
         return {
           executable: comSpec,
-          argsPrefix: ['-NoProfile', '-Command'],
+          argsPrefix: powershellArgsPrefix,
           shell: 'powershell',
         };
       }
@@ -684,7 +689,7 @@ export function getShellConfiguration(): ShellConfiguration {
     // Fall back to Windows PowerShell 5.1 when pwsh.exe is not installed.
     return {
       executable: 'powershell.exe',
-      argsPrefix: ['-NoProfile', '-Command'],
+      argsPrefix: powershellArgsPrefix,
       shell: 'powershell',
     };
   }


### PR DESCRIPTION
Problem On Windows 10/11, pressing arrow keys inside interactive CLI tools (e.g., pnpm create vite) through Gemini CLI's PTY shell caused the interactive window to crash and the CLI to become unresponsive. Closes #20675.

Root Causes & Changes

PSReadLine interference: PowerShell was launching without -NonInteractive, allowing PSReadLine hooks to intercept VT key events meant for child process TUI libraries (@clack/prompts, etc.). -> Fix: Added -NonInteractive to Windows powershellArgsPrefix.
Flow Control interception: handleFlowControl: true in node-pty disrupts ConPTY's input pipeline on Windows, causing missed key events. -> Fix: Set handleFlowControl: false on Windows.
WinPTY fallback: Missing useConpty flag allowed silent fallbacks to WinPTY on older builds. -> Fix: Added useConpty: true on Windows.
isPtyActive false-negatives: process.kill(pid, 0) is unreliable for ConPTY wrappers, causing writeToPty to silently discard arrow-key writes. -> Fix: Check activePtys.has(pid) first for reliable status detection.
Testing

Validated pnpm create vite on Windows 10 works with Up/Down arrow navigation.
All 118 unit tests passing.