### PR TITLE
fix(core): prevent thought parts leak as text in CodeAssistServer

### DIFF
--- a/packages/core/src/code_assist/converter.test.ts
+++ b/packages/core/src/code_assist/converter.test.ts
@@ -393,7 +393,30 @@ describe('converter', () => {
       ]);
     });
 
-    it('should convert thought parts to text parts for API compatibility', () => {
+    it('should convert thought parts to text parts for API compatibility when isCountToken is true', () => {
+      const contentWithThought: ContentListUnion = {
+        role: 'model',
+        parts: [
+          { text: 'regular text' },
+          { thought: 'thinking about the problem' } as Part & {
+            thought: string;
+          },
+          { text: 'more text' },
+        ],
+      };
+      expect(toContents(contentWithThought, { isCountToken: true })).toEqual([
+        {
+          role: 'model',
+          parts: [
+            { text: 'regular text' },
+            { text: '[Thought: thinking about the problem]' },
+            { text: 'more text' },
+          ],
+        },
+      ]);
+    });
+
+    it('should preserve thought parts by default', () => {
       const contentWithThought: ContentListUnion = {
         role: 'model',
         parts: [
@@ -409,14 +432,14 @@ describe('converter', () => {
           role: 'model',
           parts: [
             { text: 'regular text' },
-            { text: '[Thought: thinking about the problem]' },
+            { thought: 'thinking about the problem' },
             { text: 'more text' },
           ],
         },
       ]);
     });
 
-    it('should combine text and thought for text parts with thoughts', () => {
+    it('should combine text and thought for text parts with thoughts when isCountToken is true', () => {
       const contentWithTextAndThought: ContentListUnion = {
         role: 'model',
         parts: [
@@ -426,7 +449,9 @@ describe('converter', () => {
           } as Part & { thought: string },
         ],
       };
-      expect(toContents(contentWithTextAndThought)).toEqual([
+      expect(
+        toContents(contentWithTextAndThought, { isCountToken: true }),
+      ).toEqual([
         {
           role: 'model',
           parts: [
@@ -438,7 +463,7 @@ describe('converter', () => {
       ]);
     });
 
-    it('should preserve non-thought properties while removing thought', () => {
+    it('should preserve non-thought properties while removing thought when isCountToken is true', () => {
       const contentWithComplexPart: ContentListUnion = {
         role: 'model',
         parts: [
@@ -448,7 +473,9 @@ describe('converter', () => {
           } as Part & { thought: string },
         ],
       };
-      expect(toContents(contentWithComplexPart)).toEqual([
+      expect(
+        toContents(contentWithComplexPart, { isCountToken: true }),
+      ).toEqual([
         {
           role: 'model',
           parts: [
@@ -460,7 +487,7 @@ describe('converter', () => {
       ]);
     });
 
-    it('should convert invalid text content to valid text part with thought', () => {
+    it('should convert invalid text content to valid text part with thought when isCountToken is true', () => {
       const contentWithInvalidText: ContentListUnion = {
         role: 'model',
         parts: [
@@ -470,7 +497,9 @@ describe('converter', () => {
           } as Part & { thought: string; text: number },
         ],
       };
-      expect(toContents(contentWithInvalidText)).toEqual([
+      expect(
+        toContents(contentWithInvalidText, { isCountToken: true }),
+      ).toEqual([
         {
           role: 'model',
           parts: [

--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -108,7 +108,7 @@ export function toCountTokenRequest(
   return {
     request: {
       model: 'models/' + req.model,
-      contents: toContents(req.contents),
+      contents: toContents(req.contents, { isCountToken: true }),
     },
   };
 }
@@ -177,13 +177,16 @@ function toVertexGenerateContentRequest(
   };
 }
 
-export function toContents(contents: ContentListUnion): Content[] {
+export function toContents(
+  contents: ContentListUnion,
+  options?: { isCountToken?: boolean },
+): Content[] {
   if (Array.isArray(contents)) {
     // it's a Content[] or a PartsUnion[]
-    return contents.map(toContent);
+    return contents.map((c) => toContent(c, options));
   }
   // it's a Content or a PartsUnion
-  return [toContent(contents)];
+  return [toContent(contents, options)];
 }
 
 function maybeToContent(content?: ContentUnion): Content | undefined {
@@ -203,12 +206,15 @@ function isPart(c: ContentUnion): c is PartUnion {
   );
 }
 
-function toContent(content: ContentUnion): Content {
+function toContent(
+  content: ContentUnion,
+  options?: { isCountToken?: boolean },
+): Content {
   if (Array.isArray(content)) {
     // it's a PartsUnion[]
     return {
       role: 'user',
-      parts: toParts(content),
+      parts: toParts(content, options),
     };
   }
   if (typeof content === 'string') {
@@ -223,22 +229,28 @@ function toContent(content: ContentUnion): Content {
     return {
       ...content,
       parts: content.parts
-        ? toParts(content.parts.filter((p) => p != null))
+        ? toParts(
+            content.parts.filter((p) => p != null),
+            options,
+          )
         : [],
     };
   }
   // it's a Part
   return {
     role: 'user',
-    parts: [toPart(content)],
+    parts: [toPart(content, options)],
   };
 }
 
-export function toParts(parts: PartUnion[]): Part[] {
-  return parts.map(toPart);
+export function toParts(
+  parts: PartUnion[],
+  options?: { isCountToken?: boolean },
+): Part[] {
+  return parts.map((p) => toPart(p, options));
 }
 
-function toPart(part: PartUnion): Part {
+function toPart(part: PartUnion, options?: { isCountToken?: boolean }): Part {
   if (typeof part === 'string') {
     // it's a string
     return { text: part };
@@ -247,7 +259,7 @@ function toPart(part: PartUnion): Part {
   // Handle thought parts for CountToken API compatibility
   // The CountToken API expects parts to have certain required "oneof" fields initialized,
   // but thought parts don't conform to this schema and cause API failures
-  if ('thought' in part && part.thought) {
+  if (options?.isCountToken && 'thought' in part && part.thought) {
     const thoughtText = `[Thought: ${part.thought}]`;
 
     const newPart = { ...part };


### PR DESCRIPTION
## Summary

This PR fixes a "reasoning leak" issue where thought parts in the conversation history were being converted to text with a `[Thought: true]` prefix when using the Code Assist Server (Google Account login).

## Details

The `toPart` converter in `packages/core/src/code_assist/converter.ts` was unconditionally applying a thought-to-text conversion meant only for `CountToken` API compatibility. This caused thought parts in the history of `GenerateContent` requests to be mangled.

I've updated the converter functions (`toContents`, `toContent`, `toParts`, `toPart`) to accept an optional `isCountToken` flag. The conversion now only occurs when this flag is explicitly set to `true`, which is only done in `toCountTokenRequest`.

## Related Issues

Fixes #23525

## How to Validate

1. Run the updated unit tests for the converter:
   ```bash
   npm test -w @google/gemini-cli-core -- src/code_assist/converter.test.ts
   ```
2. (Manual) Use the CLI with a Google Account login and interact for several turns. Verify that previous thoughts do not appear as `[Thought: true]` text in subsequent turns and that the model doesn't start imitating this format.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Windows
    - [x] npm run
