### PR TITLE
fix(cli): add common slash command argument validation

### DIFF
--- a/packages/cli/src/ui/commands/aboutCommand.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.ts
@@ -23,6 +23,7 @@ export const aboutCommand: SlashCommand = {
   description: 'Show version info',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   isSafeConcurrent: true,
   action: async (context) => {
     const osVersion = process.platform;

--- a/packages/cli/src/ui/commands/agentsCommand.ts
+++ b/packages/cli/src/ui/commands/agentsCommand.ts
@@ -20,6 +20,7 @@ const agentsListCommand: SlashCommand = {
   description: 'List available local and remote agents',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (context: CommandContext) => {
     const config = context.services.agentContext?.config;
     if (!config) {
@@ -303,6 +304,7 @@ const enableCommand: SlashCommand = {
   description: 'Enable a disabled agent',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
+  argsSpec: { min: 1, max: 1 },
   action: enableAction,
   completion: completeAgentsToEnable,
 };
@@ -312,6 +314,7 @@ const disableCommand: SlashCommand = {
   description: 'Disable an enabled agent',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
+  argsSpec: { min: 1, max: 1 },
   action: disableAction,
   completion: completeAgentsToDisable,
 };
@@ -321,6 +324,7 @@ const configCommand: SlashCommand = {
   description: 'Configure an agent',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
+  argsSpec: { min: 1, max: 1 },
   action: configAction,
   completion: completeAllAgents,
 };
@@ -330,6 +334,7 @@ const agentsReloadCommand: SlashCommand = {
   altNames: ['refresh'],
   description: 'Reload the agent registry',
   kind: CommandKind.BUILT_IN,
+  argsSpec: { max: 0 },
   action: async (context: CommandContext) => {
     const config = context.services.agentContext?.config;
     const agentRegistry = config?.getAgentRegistry();

--- a/packages/cli/src/ui/commands/authCommand.ts
+++ b/packages/cli/src/ui/commands/authCommand.ts
@@ -19,6 +19,7 @@ const authLoginCommand: SlashCommand = {
   description: 'Sign in or change the authentication method',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: (_context, _args): OpenDialogActionReturn => ({
     type: 'dialog',
     dialog: 'auth',
@@ -30,6 +31,7 @@ const authLogoutCommand: SlashCommand = {
   altNames: ['logout'],
   description: 'Sign out and clear all cached credentials',
   kind: CommandKind.BUILT_IN,
+  argsSpec: { max: 0 },
   action: async (context, _args): Promise<LogoutActionReturn> => {
     await clearCachedCredentialFile();
     // Clear the selected auth type so user sees the auth selection menu

--- a/packages/cli/src/ui/commands/bugCommand.ts
+++ b/packages/cli/src/ui/commands/bugCommand.ts
@@ -30,6 +30,7 @@ export const bugCommand: SlashCommand = {
   description: 'Submit a bug report',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
+  argsSpec: { max: 0 },
   action: async (context: CommandContext, args?: string): Promise<void> => {
     const bugDescription = (args || '').trim();
     const agentContext = context.services.agentContext;

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -75,6 +75,7 @@ const listCommand: SlashCommand = {
   description: 'List saved manual conversation checkpoints',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (context): Promise<void> => {
     const chatDetails = await getSavedChatTags(context, false);
 
@@ -93,6 +94,7 @@ const saveCommand: SlashCommand = {
     'Save the current conversation as a checkpoint. Usage: /resume save <tag>',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
+  argsSpec: { min: 1, max: 1 },
   action: async (context, args): Promise<SlashCommandActionReturn | void> => {
     const tag = args.trim();
     if (!tag) {
@@ -163,6 +165,7 @@ const resumeCheckpointCommand: SlashCommand = {
     'Resume a conversation from a checkpoint. Usage: /resume resume <tag>',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { min: 1, max: 1 },
   action: async (context, args) => {
     const tag = args.trim();
     if (!tag) {
@@ -242,6 +245,7 @@ const deleteCommand: SlashCommand = {
   description: 'Delete a conversation checkpoint. Usage: /resume delete <tag>',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { min: 1, max: 1 },
   action: async (context, args): Promise<MessageActionReturn> => {
     const tag = args.trim();
     if (!tag) {
@@ -284,6 +288,7 @@ const shareCommand: SlashCommand = {
     'Share the current conversation to a markdown or json file. Usage: /resume share <file>',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
+  argsSpec: { max: 1 },
   action: async (context, args): Promise<MessageActionReturn> => {
     let filePathArg = args.trim();
     if (!filePathArg) {
@@ -345,6 +350,7 @@ export const debugCommand: SlashCommand = {
   description: 'Export the most recent API request as a JSON payload',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (context): Promise<MessageActionReturn> => {
     const req = context.services.agentContext?.config.getLatestApiRequest();
     if (!req) {

--- a/packages/cli/src/ui/commands/clearCommand.ts
+++ b/packages/cli/src/ui/commands/clearCommand.ts
@@ -19,6 +19,7 @@ export const clearCommand: SlashCommand = {
   description: 'Clear the screen and conversation history',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (context, _args) => {
     const geminiClient = context.services.agentContext?.geminiClient;
     const config = context.services.agentContext?.config;

--- a/packages/cli/src/ui/commands/commandsCommand.ts
+++ b/packages/cli/src/ui/commands/commandsCommand.ts
@@ -74,6 +74,7 @@ export const commandsCommand: SlashCommand = {
         'Reload custom command definitions from .toml files. Usage: /commands reload',
       kind: CommandKind.BUILT_IN,
       autoExecute: true,
+      argsSpec: { max: 0 },
       action: reloadAction,
     },
   ],

--- a/packages/cli/src/ui/commands/compressCommand.ts
+++ b/packages/cli/src/ui/commands/compressCommand.ts
@@ -13,6 +13,7 @@ export const compressCommand: SlashCommand = {
   description: 'Compresses the context by replacing it with a summary',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (context) => {
     const { ui } = context;
     if (ui.pendingItem) {

--- a/packages/cli/src/ui/commands/copyCommand.ts
+++ b/packages/cli/src/ui/commands/copyCommand.ts
@@ -17,6 +17,7 @@ export const copyCommand: SlashCommand = {
   description: 'Copy the last result or code snippet to clipboard',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (context, _args): Promise<SlashCommandActionReturn | void> => {
     const chat = context.services.agentContext?.geminiClient?.getChat();
     const history = chat?.getHistory();

--- a/packages/cli/src/ui/commands/corgiCommand.ts
+++ b/packages/cli/src/ui/commands/corgiCommand.ts
@@ -12,6 +12,7 @@ export const corgiCommand: SlashCommand = {
   hidden: true,
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: (context, _args) => {
     context.ui.toggleCorgiMode();
   },

--- a/packages/cli/src/ui/commands/docsCommand.ts
+++ b/packages/cli/src/ui/commands/docsCommand.ts
@@ -18,6 +18,7 @@ export const docsCommand: SlashCommand = {
   description: 'Open full Gemini CLI documentation in your browser',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (context: CommandContext): Promise<void> => {
     const docsUrl = 'https://goo.gle/gemini-cli-docs';
 

--- a/packages/cli/src/ui/commands/editorCommand.ts
+++ b/packages/cli/src/ui/commands/editorCommand.ts
@@ -15,6 +15,7 @@ export const editorCommand: SlashCommand = {
   description: 'Set external editor preference',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: (): OpenDialogActionReturn => ({
     type: 'dialog',
     dialog: 'editor',

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -789,6 +789,7 @@ const listExtensionsCommand: SlashCommand = {
   description: 'List active extensions',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: listAction,
 };
 
@@ -797,6 +798,7 @@ const updateExtensionsCommand: SlashCommand = {
   description: 'Update extensions. Usage: update <extension-names>|--all',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
+  argsSpec: { min: 1 },
   action: updateAction,
   completion: completeExtensions,
 };
@@ -806,6 +808,7 @@ const disableCommand: SlashCommand = {
   description: 'Disable an extension',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
+  argsSpec: { min: 1 },
   action: disableAction,
   completion: completeExtensionsAndScopes,
 };
@@ -815,6 +818,7 @@ const enableCommand: SlashCommand = {
   description: 'Enable an extension',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
+  argsSpec: { min: 1 },
   action: enableAction,
   completion: completeExtensionsAndScopes,
 };
@@ -824,6 +828,7 @@ const installCommand: SlashCommand = {
   description: 'Install an extension from a git repo or local path',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
+  argsSpec: { min: 1 },
   action: installAction,
 };
 
@@ -832,6 +837,7 @@ const linkCommand: SlashCommand = {
   description: 'Link an extension from a local path',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
+  argsSpec: { min: 1 },
   action: linkAction,
 };
 
@@ -840,6 +846,7 @@ const uninstallCommand: SlashCommand = {
   description: 'Uninstall an extension',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
+  argsSpec: { min: 1 },
   action: uninstallAction,
   completion: completeExtensions,
 };
@@ -849,15 +856,18 @@ const exploreExtensionsCommand: SlashCommand = {
   description: 'Open extensions page in your browser',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: exploreAction,
 };
 
 const reloadCommand: SlashCommand = {
   name: 'reload',
   altNames: ['restart'],
-  description: 'Reload all extensions',
+  description:
+    'Reload specified extensions. Usage: /extensions reload <name|--all>',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
+  argsSpec: { min: 1 },
   action: restartAction,
   completion: completeExtensions,
 };
@@ -867,6 +877,7 @@ const configCommand: SlashCommand = {
   description: 'Configure extension settings',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
+  argsSpec: { min: 1 },
   action: configAction,
 };
 

--- a/packages/cli/src/ui/commands/helpCommand.ts
+++ b/packages/cli/src/ui/commands/helpCommand.ts
@@ -12,6 +12,7 @@ export const helpCommand: SlashCommand = {
   kind: CommandKind.BUILT_IN,
   description: 'For help on gemini-cli',
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (context) => {
     const helpItem: Omit<HistoryItemHelp, 'id'> = {
       type: MessageType.HELP,

--- a/packages/cli/src/ui/commands/hooksCommand.ts
+++ b/packages/cli/src/ui/commands/hooksCommand.ts
@@ -357,6 +357,7 @@ const panelCommand: SlashCommand = {
   description: 'Display all registered hooks with their status',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: panelAction,
 };
 
@@ -365,6 +366,7 @@ const enableCommand: SlashCommand = {
   description: 'Enable a hook by name',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { min: 1, max: 1 },
   action: enableAction,
   completion: completeDisabledHookNames,
 };
@@ -374,6 +376,7 @@ const disableCommand: SlashCommand = {
   description: 'Disable a hook by name',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { min: 1, max: 1 },
   action: disableAction,
   completion: completeEnabledHookNames,
 };
@@ -384,6 +387,7 @@ const enableAllCommand: SlashCommand = {
   description: 'Enable all disabled hooks',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: enableAllAction,
 };
 
@@ -393,6 +397,7 @@ const disableAllCommand: SlashCommand = {
   description: 'Disable all enabled hooks',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: disableAllAction,
 };
 

--- a/packages/cli/src/ui/commands/ideCommand.ts
+++ b/packages/cli/src/ui/commands/ideCommand.ts
@@ -164,6 +164,7 @@ export const ideCommand = async (): Promise<SlashCommand> => {
     description: 'Check status of IDE integration',
     kind: CommandKind.BUILT_IN,
     autoExecute: true,
+    argsSpec: { max: 0 },
     action: async (): Promise<SlashCommandActionReturn> => {
       const { messageType, content } =
         await getIdeStatusMessageWithFiles(ideClient);
@@ -180,6 +181,7 @@ export const ideCommand = async (): Promise<SlashCommand> => {
     description: `Install required IDE companion for ${ideClient.getDetectedIdeDisplayName()}`,
     kind: CommandKind.BUILT_IN,
     autoExecute: true,
+    argsSpec: { max: 0 },
     action: async (context) => {
       const installer = getIdeInstaller(currentIDE);
       if (!installer) {
@@ -260,6 +262,7 @@ export const ideCommand = async (): Promise<SlashCommand> => {
     description: 'Enable IDE integration',
     kind: CommandKind.BUILT_IN,
     autoExecute: true,
+    argsSpec: { max: 0 },
     action: async (context: CommandContext) => {
       context.services.settings.setValue(
         SettingScope.User,
@@ -286,6 +289,7 @@ export const ideCommand = async (): Promise<SlashCommand> => {
     description: 'Disable IDE integration',
     kind: CommandKind.BUILT_IN,
     autoExecute: true,
+    argsSpec: { max: 0 },
     action: async (context: CommandContext) => {
       context.services.settings.setValue(
         SettingScope.User,

--- a/packages/cli/src/ui/commands/initCommand.ts
+++ b/packages/cli/src/ui/commands/initCommand.ts
@@ -19,6 +19,7 @@ export const initCommand: SlashCommand = {
   description: 'Analyzes the project and creates a tailored GEMINI.md file',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (
     context: CommandContext,
     _args: string,

--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -37,6 +37,7 @@ const authCommand: SlashCommand = {
   description: 'Authenticate with an OAuth-enabled MCP server',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { min: 1, max: 1 },
   action: async (
     context: CommandContext,
     args: string,
@@ -306,6 +307,7 @@ const listCommand: SlashCommand = {
   description: 'List configured MCP servers and tools',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: (context) => listAction(context),
 };
 
@@ -315,6 +317,7 @@ const descCommand: SlashCommand = {
   description: 'List configured MCP servers and tools with descriptions',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: (context) => listAction(context, true),
 };
 
@@ -324,6 +327,7 @@ const schemaCommand: SlashCommand = {
     'List configured MCP servers and tools with descriptions and schemas',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: (context) => listAction(context, true, true),
 };
 
@@ -333,6 +337,7 @@ const reloadCommand: SlashCommand = {
   description: 'Reloads MCP servers',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (
     context: CommandContext,
   ): Promise<void | SlashCommandActionReturn> => {
@@ -503,6 +508,7 @@ const enableCommand: SlashCommand = {
   description: 'Enable a disabled MCP server',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { min: 1, max: 1 },
   action: (ctx, args) => handleEnableDisable(ctx, args, true),
   completion: (ctx, arg) => getEnablementCompletion(ctx, arg, false),
 };
@@ -512,6 +518,7 @@ const disableCommand: SlashCommand = {
   description: 'Disable an MCP server',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { min: 1, max: 1 },
   action: (ctx, args) => handleEnableDisable(ctx, args, false),
   completion: (ctx, arg) => getEnablementCompletion(ctx, arg, true),
 };

--- a/packages/cli/src/ui/commands/memoryCommand.ts
+++ b/packages/cli/src/ui/commands/memoryCommand.ts
@@ -28,6 +28,7 @@ export const memoryCommand: SlashCommand = {
       description: 'Show the current memory contents',
       kind: CommandKind.BUILT_IN,
       autoExecute: true,
+      argsSpec: { max: 0 },
       action: async (context) => {
         const config = context.services.agentContext?.config;
         if (!config) return;
@@ -47,6 +48,7 @@ export const memoryCommand: SlashCommand = {
       description: 'Add content to the memory',
       kind: CommandKind.BUILT_IN,
       autoExecute: false,
+      argsSpec: { min: 1 },
       action: (context, args): SlashCommandActionReturn | void => {
         const result = addMemory(args);
 
@@ -71,6 +73,7 @@ export const memoryCommand: SlashCommand = {
       description: 'Reload the memory from the source',
       kind: CommandKind.BUILT_IN,
       autoExecute: true,
+      argsSpec: { max: 0 },
       action: async (context) => {
         context.ui.addItem(
           {
@@ -110,6 +113,7 @@ export const memoryCommand: SlashCommand = {
       description: 'Lists the paths of the GEMINI.md files in use',
       kind: CommandKind.BUILT_IN,
       autoExecute: true,
+      argsSpec: { max: 0 },
       action: async (context) => {
         const config = context.services.agentContext?.config;
         if (!config) return;

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -21,6 +21,7 @@ const setModelCommand: SlashCommand = {
     'Set the model to use. Usage: /model set <model-name> [--persist]',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
+  argsSpec: { min: 1 },
   action: async (context: CommandContext, args: string) => {
     const parts = args.trim().split(/\s+/).filter(Boolean);
     if (parts.length === 0) {
@@ -52,6 +53,7 @@ const manageModelCommand: SlashCommand = {
   description: 'Opens a dialog to configure the model',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (context: CommandContext) => {
     if (context.services.agentContext?.config) {
       await context.services.agentContext.config.refreshUserQuota();

--- a/packages/cli/src/ui/commands/permissionsCommand.ts
+++ b/packages/cli/src/ui/commands/permissionsCommand.ts
@@ -27,6 +27,7 @@ export const permissionsCommand: SlashCommand = {
         'Manage folder trust settings. Usage: /permissions trust [<directory-path>]',
       kind: CommandKind.BUILT_IN,
       autoExecute: false,
+      argsSpec: { max: 1 },
       action: (context, input): SlashCommandActionReturn => {
         const dirPath = input.trim();
         let targetDirectory: string;

--- a/packages/cli/src/ui/commands/planCommand.ts
+++ b/packages/cli/src/ui/commands/planCommand.ts
@@ -52,6 +52,7 @@ export const planCommand: SlashCommand = {
   description: 'Switch to Plan Mode and view current plan',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
+  argsSpec: { max: 0 },
   action: async (context) => {
     const config = context.services.agentContext?.config;
     if (!config) {
@@ -100,6 +101,7 @@ export const planCommand: SlashCommand = {
       description: 'Copy the currently approved plan to your clipboard',
       kind: CommandKind.BUILT_IN,
       autoExecute: true,
+      argsSpec: { max: 0 },
       action: copyAction,
     },
   ],

--- a/packages/cli/src/ui/commands/policiesCommand.ts
+++ b/packages/cli/src/ui/commands/policiesCommand.ts
@@ -50,6 +50,7 @@ const listPoliciesCommand: SlashCommand = {
   description: 'List all active policies grouped by mode',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (context) => {
     const agentContext = context.services.agentContext;
     const config = agentContext?.config;

--- a/packages/cli/src/ui/commands/privacyCommand.ts
+++ b/packages/cli/src/ui/commands/privacyCommand.ts
@@ -15,6 +15,7 @@ export const privacyCommand: SlashCommand = {
   description: 'Display the privacy notice',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: (): OpenDialogActionReturn => ({
     type: 'dialog',
     dialog: 'privacy',

--- a/packages/cli/src/ui/commands/profileCommand.ts
+++ b/packages/cli/src/ui/commands/profileCommand.ts
@@ -13,6 +13,7 @@ export const profileCommand: SlashCommand | null = isDevelopment
       kind: CommandKind.BUILT_IN,
       description: 'Toggle the debug profile display',
       autoExecute: true,
+      argsSpec: { max: 0 },
       action: async (context) => {
         context.ui.toggleDebugProfiler();
         return {

--- a/packages/cli/src/ui/commands/quitCommand.ts
+++ b/packages/cli/src/ui/commands/quitCommand.ts
@@ -13,6 +13,7 @@ export const quitCommand: SlashCommand = {
   description: 'Exit the cli',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: (context) => {
     const now = Date.now();
     const { sessionStartTime } = context.session.stats;

--- a/packages/cli/src/ui/commands/restoreCommand.ts
+++ b/packages/cli/src/ui/commands/restoreCommand.ts
@@ -167,6 +167,7 @@ export const restoreCommand = (config: Config | null): SlashCommand | null => {
       'Restore a tool call. This will reset the conversation and file history to the state it was in when the tool call was suggested',
     kind: CommandKind.BUILT_IN,
     autoExecute: true,
+    argsSpec: { max: 0 },
     action: restoreAction,
     completion,
   };

--- a/packages/cli/src/ui/commands/resumeCommand.ts
+++ b/packages/cli/src/ui/commands/resumeCommand.ts
@@ -17,6 +17,7 @@ export const resumeCommand: SlashCommand = {
   description: 'Browse auto-saved conversations and manage chat checkpoints',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (
     _context: CommandContext,
     _args: string,

--- a/packages/cli/src/ui/commands/settingsCommand.ts
+++ b/packages/cli/src/ui/commands/settingsCommand.ts
@@ -15,6 +15,7 @@ export const settingsCommand: SlashCommand = {
   description: 'View and edit Gemini CLI settings',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   isSafeConcurrent: true,
   action: (_context, _args): OpenDialogActionReturn => ({
     type: 'dialog',

--- a/packages/cli/src/ui/commands/setupGithubCommand.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.ts
@@ -209,6 +209,7 @@ export const setupGithubCommand: SlashCommand = {
   description: 'Set up GitHub Actions',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (
     context: CommandContext,
   ): Promise<SlashCommandActionReturn> => {

--- a/packages/cli/src/ui/commands/shellsCommand.ts
+++ b/packages/cli/src/ui/commands/shellsCommand.ts
@@ -12,6 +12,7 @@ export const shellsCommand: SlashCommand = {
   kind: CommandKind.BUILT_IN,
   description: 'Toggle background shells view',
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (context) => {
     context.ui.toggleBackgroundShell();
   },

--- a/packages/cli/src/ui/commands/shortcutsCommand.ts
+++ b/packages/cli/src/ui/commands/shortcutsCommand.ts
@@ -12,6 +12,7 @@ export const shortcutsCommand: SlashCommand = {
   kind: CommandKind.BUILT_IN,
   description: 'Toggle the shortcuts panel above the input',
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: (context) => {
     context.ui.toggleShortcutsHelp();
   },

--- a/packages/cli/src/ui/commands/skillsCommand.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.ts
@@ -369,6 +369,7 @@ export const skillsCommand: SlashCommand = {
       description:
         'List available agent skills. Usage: /skills list [nodesc] [all]',
       kind: CommandKind.BUILT_IN,
+      argsSpec: { max: 2 },
       action: listAction,
     },
     {
@@ -376,12 +377,14 @@ export const skillsCommand: SlashCommand = {
       description:
         'Link an agent skill from a local path. Usage: /skills link <path> [--scope user|workspace]',
       kind: CommandKind.BUILT_IN,
+      argsSpec: { min: 1 },
       action: linkAction,
     },
     {
       name: 'disable',
       description: 'Disable a skill by name. Usage: /skills disable <name>',
       kind: CommandKind.BUILT_IN,
+      argsSpec: { min: 1, max: 1 },
       action: disableAction,
       completion: disableCompletion,
     },
@@ -390,6 +393,7 @@ export const skillsCommand: SlashCommand = {
       description:
         'Enable a disabled skill by name. Usage: /skills enable <name>',
       kind: CommandKind.BUILT_IN,
+      argsSpec: { min: 1, max: 1 },
       action: enableAction,
       completion: enableCompletion,
     },
@@ -399,6 +403,7 @@ export const skillsCommand: SlashCommand = {
       description:
         'Reload the list of discovered skills. Usage: /skills reload',
       kind: CommandKind.BUILT_IN,
+      argsSpec: { max: 0 },
       action: reloadAction,
     },
   ],

--- a/packages/cli/src/ui/commands/statsCommand.ts
+++ b/packages/cli/src/ui/commands/statsCommand.ts
@@ -87,6 +87,7 @@ export const statsCommand: SlashCommand = {
   description: 'Check session stats. Usage: /stats [session|model|tools]',
   kind: CommandKind.BUILT_IN,
   autoExecute: false,
+  argsSpec: { max: 1 },
   isSafeConcurrent: true,
   action: async (context: CommandContext) => {
     await defaultSessionView(context);
@@ -97,6 +98,7 @@ export const statsCommand: SlashCommand = {
       description: 'Show session-specific usage statistics',
       kind: CommandKind.BUILT_IN,
       autoExecute: true,
+      argsSpec: { max: 0 },
       isSafeConcurrent: true,
       action: async (context: CommandContext) => {
         await defaultSessionView(context);
@@ -107,6 +109,7 @@ export const statsCommand: SlashCommand = {
       description: 'Show model-specific usage statistics',
       kind: CommandKind.BUILT_IN,
       autoExecute: true,
+      argsSpec: { max: 0 },
       isSafeConcurrent: true,
       action: (context: CommandContext) => {
         const { selectedAuthType, userEmail, tier } = getUserIdentity(context);
@@ -134,6 +137,7 @@ export const statsCommand: SlashCommand = {
       description: 'Show tool-specific usage statistics',
       kind: CommandKind.BUILT_IN,
       autoExecute: true,
+      argsSpec: { max: 0 },
       isSafeConcurrent: true,
       action: (context: CommandContext) => {
         context.ui.addItem({

--- a/packages/cli/src/ui/commands/terminalSetupCommand.ts
+++ b/packages/cli/src/ui/commands/terminalSetupCommand.ts
@@ -20,6 +20,7 @@ export const terminalSetupCommand: SlashCommand = {
     'Configure terminal keybindings for multiline input (VS Code, Cursor, Windsurf)',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (): Promise<MessageActionReturn> => {
     try {
       const result = await terminalSetup();

--- a/packages/cli/src/ui/commands/themeCommand.ts
+++ b/packages/cli/src/ui/commands/themeCommand.ts
@@ -15,6 +15,7 @@ export const themeCommand: SlashCommand = {
   description: 'Change the theme',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: (_context, _args): OpenDialogActionReturn => ({
     type: 'dialog',
     dialog: 'theme',

--- a/packages/cli/src/ui/commands/toolsCommand.ts
+++ b/packages/cli/src/ui/commands/toolsCommand.ts
@@ -46,6 +46,7 @@ const listSubCommand: SlashCommand = {
   description: 'List available Gemini CLI tools.',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (context: CommandContext): Promise<void> =>
     listTools(context, false),
 };
@@ -56,6 +57,7 @@ const descSubCommand: SlashCommand = {
   description: 'List available Gemini CLI tools with descriptions.',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (context: CommandContext): Promise<void> =>
     listTools(context, true),
 };

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -240,5 +240,11 @@ export interface SlashCommand {
    */
   showCompletionLoading?: boolean;
 
+  /**
+   * Optional argument count constraints for validation.
+   * min: minimum number of arguments required (default 0)
+   * max: maximum number of arguments allowed (omit for unlimited)
+   */
+  argsSpec?: { min?: number; max?: number };
   subCommands?: SlashCommand[];
 }

--- a/packages/cli/src/ui/commands/upgradeCommand.ts
+++ b/packages/cli/src/ui/commands/upgradeCommand.ts
@@ -22,6 +22,7 @@ export const upgradeCommand: SlashCommand = {
   kind: CommandKind.BUILT_IN,
   description: 'Upgrade your Gemini Code Assist tier for higher limits',
   autoExecute: true,
+  argsSpec: { max: 0 },
   action: async (context) => {
     const config = context.services.agentContext?.config;
     const authType = config?.getContentGeneratorConfig()?.authType;

--- a/packages/cli/src/ui/commands/vimCommand.ts
+++ b/packages/cli/src/ui/commands/vimCommand.ts
@@ -11,6 +11,7 @@ export const vimCommand: SlashCommand = {
   description: 'Toggle vim mode on/off',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
+  argsSpec: { max: 0 },
   isSafeConcurrent: true,
   action: async (context, _args) => {
     const newVimState = await context.ui.toggleVimEnabled();

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -53,7 +53,7 @@ import { BuiltinCommandLoader } from '../../services/BuiltinCommandLoader.js';
 import { FileCommandLoader } from '../../services/FileCommandLoader.js';
 import { McpPromptLoader } from '../../services/McpPromptLoader.js';
 import { SkillCommandLoader } from '../../services/SkillCommandLoader.js';
-import { parseSlashCommand } from '../../utils/commands.js';
+import { parseSlashCommand, validateArgs } from '../../utils/commands.js';
 import {
   type ExtensionUpdateAction,
   type ExtensionUpdateStatus,
@@ -413,6 +413,21 @@ export const useSlashCommandProcessor = (
 
       try {
         if (commandToExecute) {
+          const argsError = validateArgs(
+            args,
+            commandToExecute.argsSpec,
+            resolvedCommandPath,
+            commandToExecute.description,
+          );
+          if (argsError) {
+            addMessage({
+              type: MessageType.ERROR,
+              content: argsError,
+              timestamp: new Date(),
+            });
+            setIsProcessing(false);
+            return { type: 'handled' };
+          }
           if (commandToExecute.action) {
             const fullCommandContext: CommandContext = {
               ...commandContext,

--- a/packages/cli/src/utils/commands.test.ts
+++ b/packages/cli/src/utils/commands.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { parseSlashCommand } from './commands.js';
+import { parseSlashCommand, countArgs, validateArgs } from './commands.js';
 import { CommandKind, type SlashCommand } from '../ui/commands/types.js';
 
 // Mock command structure for testing
@@ -136,5 +136,76 @@ describe('parseSlashCommand', () => {
     expect(result.commandToExecute).toBeUndefined();
     expect(result.args).toBe('');
     expect(result.canonicalPath).toEqual([]);
+  });
+});
+
+describe('countArgs', () => {
+  it('should return 0 for empty string', () => {
+    expect(countArgs('')).toBe(0);
+  });
+  it('should return 0 for whitespace-only string', () => {
+    expect(countArgs('   ')).toBe(0);
+  });
+  it('should return 1 for a single argument', () => {
+    expect(countArgs('foo')).toBe(1);
+  });
+  it('should return 2 for two arguments', () => {
+    expect(countArgs('foo bar')).toBe(2);
+  });
+  it('should handle multiple spaces between arguments', () => {
+    expect(countArgs('foo   bar   baz')).toBe(3);
+  });
+});
+
+describe('validateArgs', () => {
+  it('should return undefined when argsSpec is undefined', () => {
+    expect(validateArgs('foo', undefined, ['test'])).toBeUndefined();
+  });
+  it('should return undefined when args count is within range', () => {
+    expect(validateArgs('', { max: 0 }, ['test'])).toBeUndefined();
+    expect(validateArgs('foo', { min: 1, max: 1 }, ['test'])).toBeUndefined();
+    expect(
+      validateArgs('foo bar', { min: 1, max: 3 }, ['test']),
+    ).toBeUndefined();
+  });
+  it('should error when no args given but min is 1', () => {
+    expect(validateArgs('', { min: 1 }, ['test'])).toBe(
+      '/test requires at least 1 argument.',
+    );
+  });
+  it('should error when args below minimum', () => {
+    expect(validateArgs('foo', { min: 3 }, ['test'])).toBe(
+      '/test requires at least 3 arguments, but got 1.',
+    );
+  });
+  it('should error when args exceed max of 0', () => {
+    expect(validateArgs('foo', { max: 0 }, ['agents', 'list'])).toBe(
+      '/agents list does not accept any arguments.',
+    );
+  });
+  it('should error when args exceed max of 1', () => {
+    expect(validateArgs('foo bar', { max: 1 }, ['test'])).toBe(
+      '/test accepts at most 1 argument, but got 2.',
+    );
+  });
+  it('should error when args exceed max (plural)', () => {
+    expect(validateArgs('a b c d', { max: 2 }, ['test'])).toBe(
+      '/test accepts at most 2 arguments, but got 4.',
+    );
+  });
+  it('should append usage hint from description when present', () => {
+    expect(
+      validateArgs(
+        '',
+        { min: 1 },
+        ['chat', 'save'],
+        'Save a checkpoint. Usage: /chat save <tag>',
+      ),
+    ).toBe('/chat save requires at least 1 argument. Usage: /chat save <tag>');
+  });
+  it('should not append usage hint when description has no Usage:', () => {
+    expect(validateArgs('', { min: 1 }, ['test'], 'Some description')).toBe(
+      '/test requires at least 1 argument.',
+    );
   });
 });

--- a/packages/cli/src/utils/commands.ts
+++ b/packages/cli/src/utils/commands.ts
@@ -69,3 +69,51 @@ export const parseSlashCommand = (
 
   return { commandToExecute, args, canonicalPath };
 };
+
+/**
+ * Counts the number of whitespace-separated arguments in a string.
+ */
+export const countArgs = (args: string): number => {
+  const trimmed = args.trim();
+  return trimmed === '' ? 0 : trimmed.split(/\s+/).length;
+};
+
+/**
+ * Validates argument count against a command's argsSpec.
+ * Returns an error string if invalid, undefined if valid.
+ * Appends usage hint from the command description when available.
+ */
+export const validateArgs = (
+  args: string,
+  argsSpec: SlashCommand['argsSpec'],
+  commandPath: string[],
+  description?: string,
+): string | undefined => {
+  if (!argsSpec) return undefined;
+
+  const count = countArgs(args);
+  const min = argsSpec.min ?? 0;
+  const max = argsSpec.max;
+  const cmd = `/${commandPath.join(' ')}`;
+
+  const usageHint = (() => {
+    const match = description?.match(/Usage:\s*(\S.*)/i);
+    return match ? ` Usage: ${match[1]}` : '';
+  })();
+
+  if (count < min) {
+    if (count === 0 && min === 1) {
+      return `${cmd} requires at least 1 argument.${usageHint}`;
+    }
+    return `${cmd} requires at least ${min} argument${min === 1 ? '' : 's'}, but got ${count}.${usageHint}`;
+  }
+
+  if (max !== undefined && count > max) {
+    if (max === 0) {
+      return `${cmd} does not accept any arguments.`;
+    }
+    return `${cmd} accepts at most ${max} argument${max === 1 ? '' : 's'}, but got ${count}.${usageHint}`;
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
## Problem

Fixes #16559

Each slash command parsed its args independently with no shared validation. Nonsensical invocations like `/agents list foo bar` or `/hooks enable` (no name given) silently succeeded or produced confusing internal errors instead of clear feedback.

## Fix

**`packages/cli/src/ui/commands/types.ts`**
Add `argsSpec?: { min?: number; max?: number }` to `SlashCommand` - a lightweight contract expressing each command's argument expectations.

**`packages/cli/src/utils/commands.ts`**
Add two exported helpers:
- `countArgs(args)` - counts whitespace-separated tokens
- `validateArgs(args, argsSpec, commandPath, description?)` - validates count against argsSpec, returns a human-readable error string or `undefined`. Appends usage hint extracted from the command's `description` field when a `Usage:` pattern is present.

**`packages/cli/src/ui/hooks/slashCommandProcessor.ts`**
Call `validateArgs()` before command execution. Surfaces errors via `MessageType.ERROR` and returns early - identical to how unknown commands are handled.

**All 38 built-in commands** annotated with their constraints.

## Examples
```
/agents list foo bar   →  /agents list does not accept any arguments.
/chat save             →  /chat save requires at least 1 argument. Usage: /chat save <tag>
/model set             →  /model set requires at least 1 argument. Usage: /model set <model-name> [--persist]
/hooks enable          →  /hooks enable requires at least 1 argument.
/mcp auth              →  /mcp auth requires at least 1 argument.
```

## Design notes

- Commands with no `argsSpec` pass through unchanged - third-party and extension commands are unaffected.
- Parent container commands (`/agents`, `/mcp`, `/extensions`) are intentionally not annotated - they route to subcommands and the resolver handles unknown subcommand args separately.
- `validateArgs()` and `countArgs()` are exported for use in tests and future extension.

## Testing
```bash
npx vitest run packages/cli/src/utils/commands.test.ts
# 26 passed (12 existing + 5 countArgs + 9 validateArgs)
```

Note: a previous attempt by @calm329 (commit a27616c, Jan 14) was never turned into a PR after 2+ months. This is an independent implementation with the same interface design but adds usage hint surfacing and covers all 38 commands.