### PR TITLE
test(telemetry): add boundary and edge case coverage for HighWaterMarkTracker

### DIFF
--- a/packages/core/src/telemetry/high-water-mark-tracker.test.ts
+++ b/packages/core/src/telemetry/high-water-mark-tracker.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { HighWaterMarkTracker } from './high-water-mark-tracker.js';
 
 describe('HighWaterMarkTracker', () => {
@@ -177,9 +177,15 @@ describe('HighWaterMarkTracker', () => {
   });
 
   describe('time-based cleanup', () => {
-    it('should clean up old readings', () => {
+    beforeEach(() => {
       vi.useFakeTimers();
+    });
 
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should clean up old readings', () => {
       // Add readings
       tracker.shouldRecordMetric('heap_used', 1000000);
 
@@ -191,13 +197,9 @@ describe('HighWaterMarkTracker', () => {
 
       // Entry should be removed
       expect(tracker.getHighWaterMark('heap_used')).toBe(0);
-
-      vi.useRealTimers();
     });
 
     it('should preserve fresh entries while removing stale ones', () => {
-      vi.useFakeTimers();
-
       tracker.shouldRecordMetric('heap_used', 1000000);
 
       // Advance time so first entry becomes stale
@@ -211,8 +213,6 @@ describe('HighWaterMarkTracker', () => {
 
       expect(tracker.getHighWaterMark('heap_used')).toBe(0);
       expect(tracker.getHighWaterMark('rss')).toBe(2000000);
-
-      vi.useRealTimers();
     });
 
     it('should be a no-op when no entries are stale', () => {
@@ -290,6 +290,14 @@ describe('HighWaterMarkTracker', () => {
       expect(tracker.getHighWaterMark('heap_used')).toBe(2000000);
     });
 
+    it('should handle zero values correctly', () => {
+      // First call with 0: no prior entry exists, treated as first measurement
+      expect(tracker.shouldRecordMetric('zero', 0)).toBe(true);
+
+      // Second call with 0: entry exists, value has not grown — should not record
+      expect(tracker.shouldRecordMetric('zero', 0)).toBe(false);
+    });
+
     it('should treat first measurement as always recording regardless of value', () => {
       // Even a very small first value should be recorded
       expect(tracker.shouldRecordMetric('tiny', 1)).toBe(true);
@@ -351,9 +359,15 @@ describe('HighWaterMarkTracker', () => {
   });
 
   describe('lastUpdateTimes tracking', () => {
-    it('should update lastUpdateTime even when metric does not trigger recording', () => {
+    beforeEach(() => {
       vi.useFakeTimers();
+    });
 
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should update lastUpdateTime even when metric does not trigger recording', () => {
       tracker.shouldRecordMetric('heap_used', 1000000);
 
       vi.advanceTimersByTime(5000);
@@ -366,8 +380,6 @@ describe('HighWaterMarkTracker', () => {
       // Cleanup with 10s max age: the entry was touched 8s ago, so it's fresh
       tracker.cleanup(10000);
       expect(tracker.getHighWaterMark('heap_used')).toBe(1000000);
-
-      vi.useRealTimers();
     });
   });
 });

--- a/packages/core/src/telemetry/high-water-mark-tracker.test.ts
+++ b/packages/core/src/telemetry/high-water-mark-tracker.test.ts
@@ -251,40 +251,42 @@ describe('HighWaterMarkTracker', () => {
       expect(result).toBe(true);
     });
 
-    it('should trigger on every increase with a zero threshold', () => {
-      const zeroTracker = new HighWaterMarkTracker(0);
+    describe('with a zero threshold', () => {
+      let zeroTracker: HighWaterMarkTracker;
 
-      zeroTracker.shouldRecordMetric('heap_used', 1000000);
+      beforeEach(() => {
+        zeroTracker = new HighWaterMarkTracker(0);
+        expect(zeroTracker.shouldRecordMetric('heap_used', 1000000)).toBe(true);
+      });
 
-      // Any increase above current mark should trigger with 0% threshold
-      // threshold = 1000000 * (1 + 0/100) = 1000000, so >1000000 triggers
-      expect(zeroTracker.shouldRecordMetric('heap_used', 1000001)).toBe(true);
-      expect(zeroTracker.shouldRecordMetric('heap_used', 1000002)).toBe(true);
-    });
+      it('should trigger on every increase', () => {
+        // Any increase above current mark should trigger with 0% threshold
+        // threshold = 1000000 * (1 + 0/100) = 1000000, so >1000000 triggers
+        expect(zeroTracker.shouldRecordMetric('heap_used', 1000001)).toBe(true);
+        expect(zeroTracker.shouldRecordMetric('heap_used', 1000002)).toBe(true);
+      });
 
-    it('should not trigger for equal value with zero threshold', () => {
-      const zeroTracker = new HighWaterMarkTracker(0);
-
-      zeroTracker.shouldRecordMetric('heap_used', 1000000);
-
-      // Exactly the same value should not trigger (> not >=)
-      expect(zeroTracker.shouldRecordMetric('heap_used', 1000000)).toBe(false);
+      it('should not trigger for equal value', () => {
+        // Exactly the same value should not trigger (> not >=)
+        expect(zeroTracker.shouldRecordMetric('heap_used', 1000000)).toBe(
+          false,
+        );
+      });
     });
 
     it('should handle the high-water mark only ratcheting upward', () => {
-      tracker.shouldRecordMetric('heap_used', 1000000);
+      expect(tracker.shouldRecordMetric('heap_used', 1000000)).toBe(true);
 
       // Large increase updates the mark
-      tracker.shouldRecordMetric('heap_used', 2000000);
+      expect(tracker.shouldRecordMetric('heap_used', 2000000)).toBe(true);
       expect(tracker.getHighWaterMark('heap_used')).toBe(2000000);
 
       // Drop back down — mark stays at 2000000
-      tracker.shouldRecordMetric('heap_used', 500000);
+      expect(tracker.shouldRecordMetric('heap_used', 500000)).toBe(false);
       expect(tracker.getHighWaterMark('heap_used')).toBe(2000000);
 
       // A value above the OLD mark but below the CURRENT mark should not trigger
-      const result = tracker.shouldRecordMetric('heap_used', 1500000);
-      expect(result).toBe(false);
+      expect(tracker.shouldRecordMetric('heap_used', 1500000)).toBe(false);
       expect(tracker.getHighWaterMark('heap_used')).toBe(2000000);
     });
 

--- a/packages/core/src/telemetry/high-water-mark-tracker.test.ts
+++ b/packages/core/src/telemetry/high-water-mark-tracker.test.ts
@@ -194,5 +194,178 @@ describe('HighWaterMarkTracker', () => {
 
       vi.useRealTimers();
     });
+
+    it('should preserve fresh entries while removing stale ones', () => {
+      vi.useFakeTimers();
+
+      tracker.shouldRecordMetric('heap_used', 1000000);
+
+      // Advance time so first entry becomes stale
+      vi.advanceTimersByTime(15000);
+
+      // Add a fresh entry after the time advance
+      tracker.shouldRecordMetric('rss', 2000000);
+
+      // Cleanup with 10s max age — heap_used is stale, rss is fresh
+      tracker.cleanup(10000);
+
+      expect(tracker.getHighWaterMark('heap_used')).toBe(0);
+      expect(tracker.getHighWaterMark('rss')).toBe(2000000);
+
+      vi.useRealTimers();
+    });
+
+    it('should be a no-op when no entries are stale', () => {
+      tracker.shouldRecordMetric('heap_used', 1000000);
+      tracker.shouldRecordMetric('rss', 2000000);
+
+      // Cleanup with 1 hour max age — nothing is stale
+      tracker.cleanup(3600000);
+
+      expect(tracker.getHighWaterMark('heap_used')).toBe(1000000);
+      expect(tracker.getHighWaterMark('rss')).toBe(2000000);
+    });
+
+    it('should be a no-op on an empty tracker', () => {
+      // Should not throw when cleaning up with no entries
+      expect(() => tracker.cleanup(10000)).not.toThrow();
+      expect(tracker.getAllHighWaterMarks()).toEqual({});
+    });
+  });
+
+  describe('boundary conditions', () => {
+    it('should not trigger at exactly the threshold boundary', () => {
+      // With 5% threshold: 1000000 * 1.05 = 1050000
+      // The check is strictly greater-than, so exactly 1050000 should NOT trigger
+      tracker.shouldRecordMetric('heap_used', 1000000);
+
+      const result = tracker.shouldRecordMetric('heap_used', 1050000);
+      expect(result).toBe(false);
+    });
+
+    it('should trigger just above the threshold boundary', () => {
+      tracker.shouldRecordMetric('heap_used', 1000000);
+
+      // 1050001 is just above the 5% threshold of 1050000
+      const result = tracker.shouldRecordMetric('heap_used', 1050001);
+      expect(result).toBe(true);
+    });
+
+    it('should trigger on every increase with a zero threshold', () => {
+      const zeroTracker = new HighWaterMarkTracker(0);
+
+      zeroTracker.shouldRecordMetric('heap_used', 1000000);
+
+      // Any increase above current mark should trigger with 0% threshold
+      // threshold = 1000000 * (1 + 0/100) = 1000000, so >1000000 triggers
+      expect(zeroTracker.shouldRecordMetric('heap_used', 1000001)).toBe(true);
+      expect(zeroTracker.shouldRecordMetric('heap_used', 1000002)).toBe(true);
+    });
+
+    it('should not trigger for equal value with zero threshold', () => {
+      const zeroTracker = new HighWaterMarkTracker(0);
+
+      zeroTracker.shouldRecordMetric('heap_used', 1000000);
+
+      // Exactly the same value should not trigger (> not >=)
+      expect(zeroTracker.shouldRecordMetric('heap_used', 1000000)).toBe(false);
+    });
+
+    it('should handle the high-water mark only ratcheting upward', () => {
+      tracker.shouldRecordMetric('heap_used', 1000000);
+
+      // Large increase updates the mark
+      tracker.shouldRecordMetric('heap_used', 2000000);
+      expect(tracker.getHighWaterMark('heap_used')).toBe(2000000);
+
+      // Drop back down — mark stays at 2000000
+      tracker.shouldRecordMetric('heap_used', 500000);
+      expect(tracker.getHighWaterMark('heap_used')).toBe(2000000);
+
+      // A value above the OLD mark but below the CURRENT mark should not trigger
+      const result = tracker.shouldRecordMetric('heap_used', 1500000);
+      expect(result).toBe(false);
+      expect(tracker.getHighWaterMark('heap_used')).toBe(2000000);
+    });
+
+    it('should treat first measurement as always recording regardless of value', () => {
+      // Even a very small first value should be recorded
+      expect(tracker.shouldRecordMetric('tiny', 1)).toBe(true);
+      expect(tracker.getHighWaterMark('tiny')).toBe(1);
+    });
+
+    it('should handle large values without overflow', () => {
+      // Values near V8 heap limit (~4GB in 64-bit)
+      const largeValue = 4 * 1024 * 1024 * 1024; // 4GB in bytes
+      tracker.shouldRecordMetric('heap_used', largeValue);
+
+      // 5% growth above 4GB
+      const grownValue = largeValue * 1.06;
+      const result = tracker.shouldRecordMetric('heap_used', grownValue);
+      expect(result).toBe(true);
+      expect(tracker.getHighWaterMark('heap_used')).toBe(grownValue);
+    });
+  });
+
+  describe('reset and re-record behavior', () => {
+    it('should treat next measurement as first after reset', () => {
+      tracker.shouldRecordMetric('heap_used', 1000000);
+      expect(tracker.getHighWaterMark('heap_used')).toBe(1000000);
+
+      tracker.resetHighWaterMark('heap_used');
+
+      // After reset, next measurement should be treated as first (always records)
+      const result = tracker.shouldRecordMetric('heap_used', 500);
+      expect(result).toBe(true);
+      expect(tracker.getHighWaterMark('heap_used')).toBe(500);
+    });
+
+    it('should treat all metrics as first after resetAll', () => {
+      tracker.shouldRecordMetric('heap_used', 1000000);
+      tracker.shouldRecordMetric('rss', 2000000);
+
+      tracker.resetAllHighWaterMarks();
+
+      // Both should record as first measurements
+      expect(tracker.shouldRecordMetric('heap_used', 100)).toBe(true);
+      expect(tracker.shouldRecordMetric('rss', 200)).toBe(true);
+    });
+
+    it('should not affect other metrics when resetting one', () => {
+      tracker.shouldRecordMetric('heap_used', 1000000);
+      tracker.shouldRecordMetric('rss', 2000000);
+
+      tracker.resetHighWaterMark('heap_used');
+
+      // rss should still have its mark and require 5% growth to trigger
+      expect(tracker.getHighWaterMark('rss')).toBe(2000000);
+      expect(tracker.shouldRecordMetric('rss', 2030000)).toBe(false); // 1.5% — no trigger
+    });
+
+    it('should handle resetting a non-existent metric gracefully', () => {
+      // Should not throw
+      expect(() => tracker.resetHighWaterMark('nonexistent')).not.toThrow();
+    });
+  });
+
+  describe('lastUpdateTimes tracking', () => {
+    it('should update lastUpdateTime even when metric does not trigger recording', () => {
+      vi.useFakeTimers();
+
+      tracker.shouldRecordMetric('heap_used', 1000000);
+
+      vi.advanceTimersByTime(5000);
+
+      // This does not trigger (3% < 5%) but should still update lastUpdateTime
+      tracker.shouldRecordMetric('heap_used', 1030000);
+
+      vi.advanceTimersByTime(8000);
+
+      // Cleanup with 10s max age: the entry was touched 8s ago, so it's fresh
+      tracker.cleanup(10000);
+      expect(tracker.getHighWaterMark('heap_used')).toBe(1000000);
+
+      vi.useRealTimers();
+    });
   });
 });

--- a/packages/core/src/telemetry/high-water-mark-tracker.ts
+++ b/packages/core/src/telemetry/high-water-mark-tracker.ts
@@ -31,10 +31,10 @@ export class HighWaterMarkTracker {
     // Track last seen time for cleanup regardless of whether we record
     this.lastUpdateTimes.set(metricType, now);
     // Get current high-water mark
-    const currentWaterMark = this.waterMarks.get(metricType) || 0;
+    const currentWaterMark = this.waterMarks.get(metricType);
 
     // For first measurement, always record
-    if (currentWaterMark === 0) {
+    if (currentWaterMark === undefined) {
       this.waterMarks.set(metricType, currentValue);
       this.lastUpdateTimes.set(metricType, now);
       return true;
@@ -58,7 +58,7 @@ export class HighWaterMarkTracker {
    * Get current high-water mark for a metric type
    */
   getHighWaterMark(metricType: string): number {
-    return this.waterMarks.get(metricType) || 0;
+    return this.waterMarks.get(metricType) ?? 0;
   }
 
   /**


### PR DESCRIPTION
## Updated Summary

Adds 16 targeted edge-case and boundary-condition tests for `HighWaterMarkTracker` covering paths not exercised by the existing 18-test suite. Also tightens the implementation to use nullish coalescing (`?? 0`) over logical OR (`|| 0`) and `=== undefined` over `=== 0` for first-measurement detection, improving semantic correctness of the zero-value code path.

## Implementation improvement

- `this.waterMarks.get(metricType) || 0` → removed fallback, with `=== 0` → `=== undefined` for first-measurement detection — semantically more correct, as it distinguishes "metric exists with value 0" from "metric never seen."
- `|| 0` → `?? 0` in `getHighWaterMark()` for consistency with the above.

## Changes

### Boundary conditions (8 tests)

- Exact threshold: value at exactly 5% growth does NOT trigger (`>` not `>=`)
- Just above threshold: 5.0001% triggers correctly
- Zero threshold — every increase triggers
- Zero threshold — equal values do not trigger
- Ratchet behavior: high-water mark only goes up, drops don't reset it
- Zero values: correctly distinguishes "value is 0" from "metric never seen"
- First measurement: always records regardless of value size
- Large values: 4GB+ values without arithmetic overflow

### Cleanup edge cases (3 tests)

- Mixed fresh/stale entries: only stale removed
- No-op when nothing is stale
- No-op on empty tracker (no throw)

### Reset behavior (4 tests)

- Next measurement after `resetHighWaterMark()` treated as first
- `resetAllHighWaterMarks()` clears everything independently
- Single-metric reset does not affect other metrics
- Resetting non-existent metric does not throw

### lastUpdateTimes tracking (1 test)

- `shouldRecordMetric` updates `lastUpdateTimes` even when below threshold, preventing premature cleanup of actively-monitored metrics

## Testing

```
npx vitest run packages/core/src/telemetry/high-water-mark-tracker.test.ts
```

Fixes #23534
