### PR TITLE
perf(cli): parallelize and background startup cleanup tasks

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -213,16 +213,14 @@ export async function main() {
   loadSettingsHandle?.end();
 
   // If a worktree is requested and enabled, set it up early.
+  // This must be awaited before any other async tasks that depend on CWD (like loadCliConfig)
+  // because setupWorktree calls process.chdir().
   const requestedWorktree = cliConfig.getRequestedWorktreeName(settings);
-  let worktreeInfoPromise: Promise<WorktreeInfo | undefined> =
-    Promise.resolve(undefined);
+  let worktreeInfo: WorktreeInfo | undefined;
   if (requestedWorktree !== undefined) {
     const worktreeHandle = startupProfiler.start('setup_worktree');
-    worktreeInfoPromise = setupWorktree(requestedWorktree || undefined).finally(
-      () => {
-        worktreeHandle?.end();
-      },
-    );
+    worktreeInfo = await setupWorktree(requestedWorktree || undefined);
+    worktreeHandle?.end();
   }
 
   const cleanupOpsHandle = startupProfiler.start('cleanup_ops');
@@ -450,7 +448,6 @@ export async function main() {
   // to run Gemini CLI. It is now safe to perform expensive initialization that
   // may have side effects.
   {
-    const worktreeInfo = await worktreeInfoPromise;
     const loadConfigHandle = startupProfiler.start('load_cli_config');
     const config = await loadCliConfig(settings.merged, sessionId, argv, {
       projectHooks: settings.workspace.settings.hooks,

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -214,10 +214,36 @@ export async function main() {
 
   // If a worktree is requested and enabled, set it up early.
   const requestedWorktree = cliConfig.getRequestedWorktreeName(settings);
-  let worktreeInfo: WorktreeInfo | undefined;
+  let worktreeInfoPromise: Promise<WorktreeInfo | undefined> =
+    Promise.resolve(undefined);
   if (requestedWorktree !== undefined) {
-    worktreeInfo = await setupWorktree(requestedWorktree || undefined);
+    const worktreeHandle = startupProfiler.start('setup_worktree');
+    worktreeInfoPromise = setupWorktree(requestedWorktree || undefined).finally(
+      () => {
+        worktreeHandle?.end();
+      },
+    );
   }
+
+  const cleanupOpsHandle = startupProfiler.start('cleanup_ops');
+  Promise.all([
+    cleanupCheckpoints(),
+    cleanupToolOutputFiles(settings.merged),
+    cleanupBackgroundLogs(),
+  ])
+    .catch((e) => {
+      debugLogger.error('Early cleanup failed:', e);
+    })
+    .finally(() => {
+      cleanupOpsHandle?.end();
+    });
+
+  const parseArgsHandle = startupProfiler.start('parse_arguments');
+  const argvPromise = parseArguments(settings.merged).finally(() => {
+    parseArgsHandle?.end();
+  });
+
+  const rawStartupWarningsPromise = getStartupWarnings();
 
   // Report settings errors once during startup
   settings.errors.forEach((error) => {
@@ -232,15 +258,7 @@ export async function main() {
     );
   });
 
-  await Promise.all([
-    cleanupCheckpoints(),
-    cleanupToolOutputFiles(settings.merged),
-    cleanupBackgroundLogs(),
-  ]);
-
-  const parseArgsHandle = startupProfiler.start('parse_arguments');
-  const argv = await parseArguments(settings.merged);
-  parseArgsHandle?.end();
+  const argv = await argvPromise;
 
   if (
     (argv.allowedTools && argv.allowedTools.length > 0) ||
@@ -432,6 +450,7 @@ export async function main() {
   // to run Gemini CLI. It is now safe to perform expensive initialization that
   // may have side effects.
   {
+    const worktreeInfo = await worktreeInfoPromise;
     const loadConfigHandle = startupProfiler.start('load_cli_config');
     const config = await loadCliConfig(settings.merged, sessionId, argv, {
       projectHooks: settings.workspace.settings.hooks,
@@ -467,12 +486,10 @@ export async function main() {
       await config.getHookSystem()?.fireSessionEndEvent(SessionEndReason.Exit);
     });
 
-    // Cleanup sessions after config initialization
-    try {
-      await cleanupExpiredSessions(config, settings.merged);
-    } catch (e) {
+    // Launch cleanup expired sessions as a background task
+    cleanupExpiredSessions(config, settings.merged).catch((e) => {
       debugLogger.error('Failed to cleanup expired sessions:', e);
-    }
+    });
 
     if (config.getListExtensions()) {
       debugLogger.log('Installed extensions:');
@@ -524,7 +541,9 @@ export async function main() {
       });
     }
 
+    const terminalHandle = startupProfiler.start('setup_terminal');
     await setupTerminalAndTheme(config, settings);
+    terminalHandle?.end();
 
     const initAppHandle = startupProfiler.start('initialize_app');
     const initializationResult = await initializeApp(config, settings);
@@ -548,7 +567,7 @@ export async function main() {
       isAlternateBufferEnabled(config),
       config.getScreenReader(),
     );
-    const rawStartupWarnings = await getStartupWarnings();
+    const rawStartupWarnings = await rawStartupWarningsPromise;
     const startupWarnings: StartupWarning[] = [
       ...rawStartupWarnings.map((message) => ({
         id: `startup-${createHash('sha256').update(message).digest('hex').substring(0, 16)}`,


### PR DESCRIPTION
## Summary

Parallelizes and backgrounds startup cleanup tasks to reduce overall CLI startup latency.

## Details

- Initiates early cleanup tasks (`cleanupCheckpoints`, `cleanupToolOutputFiles`, `cleanupBackgroundLogs`) in parallel and backgrounds them as fire-and-forget tasks.
- Defers worktree setup and startup warnings until needed, initiating them in parallel with other early tasks.
- Initiates session cleanup as a fire-and-forget background task.
- Replaces sequential `await`s with parallel `Promise.all` and background execution for non-critical paths.
- Ensures cleanup tasks complete their profiler spans individually in the background.

## Related Issues

Related to #21528

## How to Validate

- Run `gemini` in interactive mode.
- Run `gemini` with any CLI question.
- Observe startup profiler logs (in debug mode) to verify that `cleanup_ops` no longer blocks the main thread.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
