### PR TITLE
chore(config): disable agents by default

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1535,7 +1535,7 @@ their corresponding top-level category object in your `settings.json` file.
 
 - **`experimental.enableAgents`** (boolean):
   - **Description:** Enable local and remote subagents.
-  - **Default:** `true`
+  - **Default:** `false`
   - **Requires restart:** Yes
 
 - **`experimental.worktrees`** (boolean):

--- a/integration-tests/browser-policy.test.ts
+++ b/integration-tests/browser-policy.test.ts
@@ -63,6 +63,9 @@ describe.skipIf(!chromeAvailable)('browser-policy', () => {
     rig.setup('browser-policy-skip-confirmation', {
       fakeResponsesPath: join(__dirname, 'browser-policy.responses'),
       settings: {
+        experimental: {
+          enableAgents: true,
+        },
         agents: {
           overrides: {
             browser_agent: {
@@ -180,6 +183,9 @@ priority = 200
     rig.setup('browser-session-warning', {
       fakeResponsesPath: join(__dirname, 'browser-agent.cleanup.responses'),
       settings: {
+        experimental: {
+          enableAgents: true,
+        },
         general: {
           enableAutoUpdateNotification: false,
         },

--- a/packages/a2a-server/src/config/config.test.ts
+++ b/packages/a2a-server/src/config/config.test.ts
@@ -341,11 +341,11 @@ describe('loadConfig', () => {
       );
     });
 
-    it('should default enableAgents to true when not provided', async () => {
+    it('should default enableAgents to false when not provided', async () => {
       await loadConfig(mockSettings, mockExtensionLoader, taskId);
       expect(Config).toHaveBeenCalledWith(
         expect.objectContaining({
-          enableAgents: true,
+          enableAgents: false,
         }),
       );
     });

--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -127,7 +127,7 @@ export async function loadConfig(
     interactive: !isHeadlessMode(),
     enableInteractiveShell: !isHeadlessMode(),
     ptyInfo: 'auto',
-    enableAgents: settings.experimental?.enableAgents ?? true,
+    enableAgents: settings.experimental?.enableAgents ?? false,
   };
 
   const fileService = new FileDiscoveryService(workspaceDir, {

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -400,7 +400,7 @@ describe('SettingsSchema', () => {
       expect(setting).toBeDefined();
       expect(setting.type).toBe('boolean');
       expect(setting.category).toBe('Experimental');
-      expect(setting.default).toBe(true);
+      expect(setting.default).toBe(false);
       expect(setting.requiresRestart).toBe(true);
       expect(setting.showInDialog).toBe(false);
       expect(setting.description).toBe('Enable local and remote subagents.');

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1922,7 +1922,7 @@ const SETTINGS_SCHEMA = {
         label: 'Enable Agents',
         category: 'Experimental',
         requiresRestart: true,
-        default: true,
+        default: false,
         description: 'Enable local and remote subagents.',
         showInDialog: false,
       },

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1001,7 +1001,7 @@ export class Config implements McpContext, AgentLoopContext {
     this.model = params.model;
     this.disableLoopDetection = params.disableLoopDetection ?? false;
     this._activeModel = params.model;
-    this.enableAgents = params.enableAgents ?? true;
+    this.enableAgents = params.enableAgents ?? false;
     this.agents = params.agents ?? {};
     this.disableLLMCorrection = params.disableLLMCorrection ?? true;
     this.planEnabled = params.plan ?? true;

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -2673,8 +2673,8 @@
         "enableAgents": {
           "title": "Enable Agents",
           "description": "Enable local and remote subagents.",
-          "markdownDescription": "Enable local and remote subagents.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `true`",
-          "default": true,
+          "markdownDescription": "Enable local and remote subagents.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
+          "default": false,
           "type": "boolean"
         },
         "worktrees": {


### PR DESCRIPTION
## Summary

Disables `enableAgents` by default to postpone the feature launch to stable for this week's cut, reverting behavior to a state similar to PR 22386.

## Details

- Changed default `enableAgents` value from `true` to `false` in:
  - `packages/cli/src/config/settingsSchema.ts`
  - `packages/core/src/config/config.ts`
  - `packages/a2a-server/src/config/config.ts`
- Regenerated settings schema and documentation.
- Updated tests in `a2a-server` and `cli` to match new default.

## Related Issues

## How to Validate

Targeted tests pass:
```bash
npx vitest run packages/a2a-server/src/config/config.test.ts
npx vitest run packages/cli/src/config/settingsSchema.test.ts
npx vitest run packages/core/src/config/config.test.ts
```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
