### PR TITLE
fix: preserve OpenRouter model IDs for custom gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you need to use a specific model or require a higher request capacity, you ca
    export GEMINI_API_KEY="YOUR_API_KEY"
    ```
 
-For other authentication methods, including Google Workspace accounts, see the [authentication](./docs/cli/authentication.md) guide.
+For other authentication methods, including Google Workspace accounts and OpenRouter, see the [authentication](./docs/cli/authentication.md) guide. For OpenRouter specifically, see the [OpenRouter guide](./docs/openrouter.md).
 
 ## Examples
 

--- a/docs/openrouter.md
+++ b/docs/openrouter.md
@@ -1,0 +1,86 @@
+# Using OpenRouter with Gemini CLI
+
+OpenRouter support allows you to use Gemini models through the OpenRouter API gateway. This provides an alternative way to access Gemini models with a unified API interface.
+
+## Setup
+
+1. **Get an OpenRouter API Key**
+   - Sign up at [OpenRouter.ai](https://openrouter.ai)
+   - Create an API key from your dashboard
+
+2. **Set Environment Variable**
+   ```bash
+   export OPENROUTER_API_KEY="your-api-key-here"
+   ```
+
+   Or add it to your `.env` file:
+   ```
+   OPENROUTER_API_KEY=your-api-key-here
+   ```
+
+3. **Optional: Custom Base URL**
+   If you're using a custom OpenRouter endpoint:
+   ```bash
+   export OPENROUTER_BASE_URL="https://your-custom-endpoint.com/api/v1"
+   ```
+
+## Usage
+
+### Interactive Mode
+
+1. Start Gemini CLI:
+   ```bash
+   gemini
+   ```
+
+2. When prompted for authentication method, select **"OpenRouter"**
+
+3. The CLI will automatically use your OpenRouter API key
+
+### Non-Interactive Mode
+
+OpenRouter will be used automatically if you have the API key set:
+```bash
+echo "What is the capital of France?" | gemini
+```
+
+## Supported Models
+
+The following Gemini models are available through OpenRouter:
+
+- `gemini-2.5-pro` → `google/gemini-2.5-pro`
+- `gemini-2.5-flash` → `google/gemini-2.5-flash`
+- `gemini-2.5-pro-preview` → `google/gemini-2.5-pro-preview`
+- `gemini-2.5-flash-preview` → `google/gemini-2.5-flash-preview`
+- `gemini-2.0-flash-thinking-exp` → `google/gemini-2.0-flash-thinking-exp`
+- `gemini-2.0-flash-exp` → `google/gemini-2.0-flash-exp`
+- `gemini-pro` → `google/gemini-pro`
+- `gemini-pro-vision` → `google/gemini-pro-vision`
+- `gemini-1.5-pro` → `google/gemini-pro-1.5`
+- `gemini-1.5-flash` → `google/gemini-flash-1.5`
+
+## Features
+
+- ✅ Text generation
+- ✅ Streaming responses
+- ✅ Function calling
+- ✅ JSON mode
+- ❌ Embeddings (not supported for Gemini models via OpenRouter)
+
+## Pricing
+
+OpenRouter charges per token based on the model used. Check [OpenRouter pricing](https://openrouter.ai/models) for current rates.
+
+## Troubleshooting
+
+### "OPENROUTER_API_KEY not found" error
+Make sure you've set the environment variable correctly:
+```bash
+echo $OPENROUTER_API_KEY
+```
+
+### Rate limiting
+OpenRouter has rate limits based on your account tier. If you encounter rate limit errors, consider upgrading your OpenRouter account or reducing request frequency.
+
+### Model not available
+Some Gemini models may have limited availability on OpenRouter. Check the [OpenRouter models page](https://openrouter.ai/models) for current availability.

--- a/docs/openrouter.md
+++ b/docs/openrouter.md
@@ -24,6 +24,12 @@ OpenRouter support allows you to use Gemini models through the OpenRouter API ga
    export OPENROUTER_BASE_URL="https://your-custom-endpoint.com/api/v1"
    ```
 
+4. **Set model explicitly for custom endpoints**
+   For OpenRouter-compatible gateways (not `openrouter.ai`), set the provider-native model ID:
+   ```bash
+   export GEMINI_MODEL="glm-4.7"
+   ```
+
 ## Usage
 
 ### Interactive Mode
@@ -46,7 +52,8 @@ echo "What is the capital of France?" | gemini
 
 ## Supported Models
 
-The following Gemini models are available through OpenRouter:
+When `OPENROUTER_BASE_URL` is the official `openrouter.ai` endpoint, the CLI
+maps these Gemini aliases automatically:
 
 - `gemini-2.5-pro` → `google/gemini-2.5-pro`
 - `gemini-2.5-flash` → `google/gemini-2.5-flash`
@@ -58,6 +65,9 @@ The following Gemini models are available through OpenRouter:
 - `gemini-pro-vision` → `google/gemini-pro-vision`
 - `gemini-1.5-pro` → `google/gemini-pro-1.5`
 - `gemini-1.5-flash` → `google/gemini-flash-1.5`
+
+For custom OpenRouter-compatible endpoints, the CLI sends the model as-is. Use
+the exact model ID expected by your provider.
 
 ## Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,6 @@
       "workspaces": [
         "packages/*"
       ],
-      "dependencies": {
-        "@google/gemini-cli": "^0.1.1"
-      },
       "bin": {
         "gemini": "bundle/gemini.js"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2335,6 +2335,16 @@
         "undici-types": "~6.19.2"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
@@ -2849,6 +2859,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -2921,6 +2943,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -3236,6 +3270,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/atomically": {
       "version": "2.0.3",
@@ -3811,6 +3851,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/command-exists": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
@@ -4263,6 +4315,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -4651,7 +4712,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5160,6 +5220,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -5471,6 +5540,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
       }
     },
     "node_modules/forwarded": {
@@ -5899,7 +6003,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -6052,6 +6155,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/hyperdyperid": {
@@ -7739,6 +7851,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
@@ -11163,6 +11295,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -11768,6 +11909,7 @@
         "ignore": "^7.0.0",
         "micromatch": "^4.0.8",
         "open": "^10.1.2",
+        "openai": "^4.79.0",
         "shell-quote": "^1.8.2",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",
@@ -11787,6 +11929,15 @@
         "node": ">=18"
       }
     },
+    "packages/core/node_modules/@types/node": {
+      "version": "18.19.112",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.112.tgz",
+      "integrity": "sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "packages/core/node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -11795,6 +11946,42 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "packages/core/node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "packages/core/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "packages/core/node_modules/ws": {
       "version": "8.18.2",

--- a/package.json
+++ b/package.json
@@ -83,8 +83,5 @@
     "react-devtools-core": "^4.28.5",
     "typescript-eslint": "^8.30.1",
     "yargs": "^17.7.2"
-  },
-  "dependencies": {
-    "@google/gemini-cli": "^0.1.1"
   }
 }

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -35,5 +35,12 @@ export const validateAuthMethod = (authMethod: string): string | null => {
     return null;
   }
 
+  if (authMethod === AuthType.USE_OPENROUTER) {
+    if (!process.env.OPENROUTER_API_KEY) {
+      return 'OPENROUTER_API_KEY environment variable not found. Add that to your .env and try again, no reload needed!';
+    }
+    return null;
+  }
+
   return 'Invalid auth method selected.';
 };

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -277,14 +277,15 @@ async function validateNonInterActiveAuth(
   // making a special case for the cli. many headless environments might not have a settings.json set
   // so if GEMINI_API_KEY is set, we'll use that. However since the oauth things are interactive anyway, we'll
   // still expect that exists
-  if (!selectedAuthType && !process.env.GEMINI_API_KEY) {
+  if (!selectedAuthType && !process.env.GEMINI_API_KEY && !process.env.OPENROUTER_API_KEY) {
     console.error(
-      'Please set an Auth method in your .gemini/settings.json OR specify GEMINI_API_KEY env variable file before running',
+      'Please set an Auth method in your .gemini/settings.json OR specify GEMINI_API_KEY or OPENROUTER_API_KEY env variable file before running',
     );
     process.exit(1);
   }
 
-  selectedAuthType = selectedAuthType || AuthType.USE_GEMINI;
+  selectedAuthType = selectedAuthType || 
+    (process.env.OPENROUTER_API_KEY ? AuthType.USE_OPENROUTER : AuthType.USE_GEMINI);
   const err = validateAuthMethod(selectedAuthType);
   if (err != null) {
     console.error(err);

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -35,6 +35,7 @@ export function AuthDialog({
     },
     { label: 'Gemini API Key', value: AuthType.USE_GEMINI },
     { label: 'Vertex AI', value: AuthType.USE_VERTEX_AI },
+    { label: 'OpenRouter', value: AuthType.USE_OPENROUTER },
   ];
 
   let initialAuthIndex = items.findIndex(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,6 +41,7 @@
     "ignore": "^7.0.0",
     "micromatch": "^4.0.8",
     "open": "^10.1.2",
+    "openai": "^4.79.0",
     "shell-quote": "^1.8.2",
     "simple-git": "^3.28.0",
     "strip-ansi": "^7.1.0",

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -17,10 +17,40 @@ import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
 import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
 import { getEffectiveModel } from './modelCheck.js';
 
+const OPENROUTER_DEFAULT_BASE_URL = 'https://openrouter.ai/api/v1';
+
+function isOfficialOpenRouterBaseUrl(baseUrl: string): boolean {
+  try {
+    const parsed = new URL(baseUrl);
+    return (
+      parsed.hostname === 'openrouter.ai' ||
+      parsed.hostname.endsWith('.openrouter.ai')
+    );
+  } catch {
+    return /(^|\/\/)([^/]*\.)?openrouter\.ai(?=\/|$)/i.test(baseUrl);
+  }
+}
+
+function isGeminiAliasModel(model: string): boolean {
+  return (
+    model === 'gemini-pro' ||
+    model === 'gemini-pro-vision' ||
+    model.startsWith('gemini-')
+  );
+}
+
 /**
  * Maps Gemini model names to OpenRouter model IDs
  */
-function mapGeminiModelToOpenRouter(model: string): string {
+function mapGeminiModelToOpenRouter(model: string, baseUrl: string): string {
+  if (model.includes('/')) {
+    return model;
+  }
+
+  if (!isOfficialOpenRouterBaseUrl(baseUrl)) {
+    return model;
+  }
+
   const modelMap: Record<string, string> = {
     'gemini-2.5-pro': 'google/gemini-2.5-pro',
     'gemini-2.5-flash': 'google/gemini-2.5-flash',
@@ -35,7 +65,16 @@ function mapGeminiModelToOpenRouter(model: string): string {
     'gemini-1.5-flash': 'google/gemini-flash-1.5',
   };
 
-  return modelMap[model] || `google/${model}`;
+  const mappedModel = modelMap[model];
+  if (mappedModel) {
+    return mappedModel;
+  }
+
+  if (isGeminiAliasModel(model)) {
+    return `google/${model}`;
+  }
+
+  return model;
 }
 
 /**
@@ -123,12 +162,14 @@ export async function createContentGeneratorConfig(
   }
 
   if (authType === AuthType.USE_OPENROUTER && openRouterApiKey) {
+    const resolvedOpenRouterBaseUrl =
+      openRouterBaseUrl || OPENROUTER_DEFAULT_BASE_URL;
     contentGeneratorConfig.apiKey = openRouterApiKey;
-    contentGeneratorConfig.openRouterBaseUrl =
-      openRouterBaseUrl || 'https://openrouter.ai/api/v1';
+    contentGeneratorConfig.openRouterBaseUrl = resolvedOpenRouterBaseUrl;
     // Map Gemini model names to OpenRouter format
     contentGeneratorConfig.model = mapGeminiModelToOpenRouter(
       contentGeneratorConfig.model,
+      resolvedOpenRouterBaseUrl,
     );
 
     return contentGeneratorConfig;

--- a/packages/core/src/core/openRouterContentGenerator.test.ts
+++ b/packages/core/src/core/openRouterContentGenerator.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createOpenRouterContentGenerator } from './openRouterContentGenerator.js';
+import { ContentGeneratorConfig, AuthType } from './contentGenerator.js';
+
+describe('OpenRouter Content Generator', () => {
+  const mockConfig: ContentGeneratorConfig = {
+    model: 'google/gemini-2.5-flash',
+    apiKey: 'test-api-key',
+    authType: AuthType.USE_OPENROUTER,
+    openRouterBaseUrl: 'https://openrouter.ai/api/v1',
+  };
+
+  const mockHttpOptions = {
+    headers: {
+      'User-Agent': 'test-user-agent',
+    },
+  };
+
+  it('should create content generator with correct configuration', () => {
+    const generator = createOpenRouterContentGenerator(
+      mockConfig,
+      mockHttpOptions,
+    );
+
+    expect(generator).toBeDefined();
+    expect(generator.generateContent).toBeDefined();
+    expect(generator.generateContentStream).toBeDefined();
+    expect(generator.countTokens).toBeDefined();
+    expect(generator.embedContent).toBeDefined();
+  });
+
+  it('should estimate tokens correctly', async () => {
+    const generator = createOpenRouterContentGenerator(
+      mockConfig,
+      mockHttpOptions,
+    );
+
+    const result = await generator.countTokens({
+      model: 'google/gemini-2.5-flash',
+      contents: [
+        {
+          role: 'user',
+          parts: [{ text: 'Hello, how are you?' }],
+        },
+      ],
+    });
+
+    // "Hello, how are you?" is 19 characters, estimated as ~5 tokens
+    expect(result.totalTokens).toBe(5);
+    expect(result.cachedContentTokenCount).toBe(0);
+  });
+
+  it('should handle string content in countTokens', async () => {
+    const generator = createOpenRouterContentGenerator(
+      mockConfig,
+      mockHttpOptions,
+    );
+
+    const result = await generator.countTokens({
+      model: 'google/gemini-2.5-flash',
+      contents: 'Hello world',
+    });
+
+    // "Hello world" is 11 characters, estimated as ~3 tokens
+    expect(result.totalTokens).toBe(3);
+  });
+
+  it('should throw error for embedContent', async () => {
+    const generator = createOpenRouterContentGenerator(
+      mockConfig,
+      mockHttpOptions,
+    );
+
+    await expect(
+      generator.embedContent({
+        model: 'text-embedding-ada-002',
+        contents: ['test'],
+      }),
+    ).rejects.toThrow(
+      'Embeddings are not supported through OpenRouter for Gemini models',
+    );
+  });
+});
+
+describe('Model mapping', () => {
+  it('should map Gemini models to OpenRouter format', async () => {
+    // Set the environment variable for the test
+    process.env.OPENROUTER_API_KEY = 'test-key';
+
+    const { createContentGeneratorConfig } = await import(
+      './contentGenerator.js'
+    );
+
+    const config = await createContentGeneratorConfig(
+      'gemini-2.5-flash',
+      AuthType.USE_OPENROUTER,
+    );
+
+    expect(config.model).toBe('google/gemini-2.5-flash');
+
+    // Clean up
+    delete process.env.OPENROUTER_API_KEY;
+  });
+});

--- a/packages/core/src/core/openRouterContentGenerator.test.ts
+++ b/packages/core/src/core/openRouterContentGenerator.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createOpenRouterContentGenerator } from './openRouterContentGenerator.js';
 import { ContentGeneratorConfig, AuthType } from './contentGenerator.js';
 
@@ -89,22 +89,75 @@ describe('OpenRouter Content Generator', () => {
 });
 
 describe('Model mapping', () => {
-  it('should map Gemini models to OpenRouter format', async () => {
-    // Set the environment variable for the test
-    process.env.OPENROUTER_API_KEY = 'test-key';
+  const originalApiKey = process.env.OPENROUTER_API_KEY;
+  const originalBaseUrl = process.env.OPENROUTER_BASE_URL;
 
+  beforeEach(() => {
+    process.env.OPENROUTER_API_KEY = 'test-key';
+    delete process.env.OPENROUTER_BASE_URL;
+  });
+
+  afterEach(() => {
+    if (originalApiKey === undefined) {
+      delete process.env.OPENROUTER_API_KEY;
+    } else {
+      process.env.OPENROUTER_API_KEY = originalApiKey;
+    }
+
+    if (originalBaseUrl === undefined) {
+      delete process.env.OPENROUTER_BASE_URL;
+    } else {
+      process.env.OPENROUTER_BASE_URL = originalBaseUrl;
+    }
+  });
+
+  it('maps Gemini aliases to OpenRouter format for the official endpoint', async () => {
     const { createContentGeneratorConfig } = await import(
       './contentGenerator.js'
     );
-
     const config = await createContentGeneratorConfig(
       'gemini-2.5-flash',
       AuthType.USE_OPENROUTER,
     );
 
     expect(config.model).toBe('google/gemini-2.5-flash');
+  });
 
-    // Clean up
-    delete process.env.OPENROUTER_API_KEY;
+  it('keeps fully-qualified model IDs unchanged', async () => {
+    const { createContentGeneratorConfig } = await import(
+      './contentGenerator.js'
+    );
+    const config = await createContentGeneratorConfig(
+      'google/gemini-2.5-flash',
+      AuthType.USE_OPENROUTER,
+    );
+
+    expect(config.model).toBe('google/gemini-2.5-flash');
+  });
+
+  it('does not force non-Gemini models onto google/ for the official endpoint', async () => {
+    const { createContentGeneratorConfig } = await import(
+      './contentGenerator.js'
+    );
+    const config = await createContentGeneratorConfig(
+      'glm-4.7',
+      AuthType.USE_OPENROUTER,
+    );
+
+    expect(config.model).toBe('glm-4.7');
+  });
+
+  it('passes model IDs through unchanged for custom OpenRouter-compatible endpoints', async () => {
+    process.env.OPENROUTER_BASE_URL = 'https://open.bigmodel.cn/api/paas/v4';
+
+    const { createContentGeneratorConfig } = await import(
+      './contentGenerator.js'
+    );
+    const config = await createContentGeneratorConfig(
+      'glm-4.7',
+      AuthType.USE_OPENROUTER,
+    );
+
+    expect(config.model).toBe('glm-4.7');
   });
 });

--- a/packages/core/src/core/openRouterContentGenerator.ts
+++ b/packages/core/src/core/openRouterContentGenerator.ts
@@ -1,0 +1,451 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import OpenAI from 'openai';
+import {
+  ContentGenerator,
+  ContentGeneratorConfig,
+} from './contentGenerator.js';
+import {
+  CountTokensResponse,
+  GenerateContentResponse,
+  GenerateContentParameters,
+  CountTokensParameters,
+  EmbedContentResponse,
+  EmbedContentParameters,
+  Content,
+  Part,
+  Candidate,
+  FinishReason,
+  GenerateContentResponsePromptFeedback,
+  BlockedReason,
+  GenerateContentResponseUsageMetadata,
+  ContentUnion,
+} from '@google/genai';
+
+interface OpenRouterUsage {
+  completion_tokens?: number;
+  prompt_tokens?: number;
+  total_tokens?: number;
+}
+
+export function createOpenRouterContentGenerator(
+  config: ContentGeneratorConfig,
+  httpOptions: { headers: Record<string, string> },
+): ContentGenerator {
+  const openRouterClient = new OpenAI({
+    baseURL: config.openRouterBaseUrl || 'https://openrouter.ai/api/v1',
+    apiKey: config.apiKey,
+    defaultHeaders: {
+      ...httpOptions.headers,
+      'HTTP-Referer': 'https://github.com/google-gemini/gemini-cli',
+      'X-Title': 'Gemini CLI',
+    },
+  });
+
+  async function* doGenerateContentStream(
+    request: GenerateContentParameters,
+  ): AsyncGenerator<GenerateContentResponse> {
+    try {
+      const messages = convertToOpenAIFormat(request);
+      const systemInstruction = extractSystemInstruction(request);
+
+      const stream = await openRouterClient.chat.completions.create({
+        model: request.model || config.model,
+        messages: systemInstruction
+          ? [{ role: 'system', content: systemInstruction }, ...messages]
+          : messages,
+        temperature: request.config?.temperature,
+        top_p: request.config?.topP,
+        max_tokens: request.config?.maxOutputTokens || 20000,
+        tools: convertTools(request.config?.tools),
+        stream: true,
+        stream_options: { include_usage: true },
+      });
+
+      for await (const chunk of stream) {
+        yield convertChunkToGeminiResponse(chunk);
+      }
+    } catch (error) {
+      throw convertError(error);
+    }
+  }
+
+  const openRouterContentGenerator: ContentGenerator = {
+    async generateContent(
+      request: GenerateContentParameters,
+    ): Promise<GenerateContentResponse> {
+      try {
+        const messages = convertToOpenAIFormat(request);
+        const systemInstruction = extractSystemInstruction(request);
+
+        const completion = await openRouterClient.chat.completions.create({
+          model: request.model || config.model,
+          messages: systemInstruction
+            ? [{ role: 'system', content: systemInstruction }, ...messages]
+            : messages,
+          temperature: request.config?.temperature,
+          top_p: request.config?.topP,
+          max_tokens: request.config?.maxOutputTokens || 20000,
+          tools: convertTools(request.config?.tools),
+          response_format:
+            request.config?.responseMimeType === 'application/json'
+              ? { type: 'json_object' }
+              : undefined,
+          stream: false,
+          stream_options: { include_usage: true },
+        });
+
+        return convertToGeminiResponse(
+          completion as OpenAI.Chat.ChatCompletion,
+        );
+      } catch (error) {
+        throw convertError(error);
+      }
+    },
+
+    async generateContentStream(
+      request: GenerateContentParameters,
+    ): Promise<AsyncGenerator<GenerateContentResponse>> {
+      return doGenerateContentStream(request);
+    },
+
+    async countTokens(
+      request: CountTokensParameters,
+    ): Promise<CountTokensResponse> {
+      // OpenRouter doesn't have a dedicated token counting endpoint
+      // We'll estimate based on the tiktoken library or return a placeholder
+      // For now, return an estimate based on content length
+      const contents = normalizeContents(request.contents);
+      const totalText = contents
+        .map(
+          (content: Content) =>
+            content.parts
+              ?.map((part: Part) => {
+                if ('text' in part && part.text) return part.text;
+                return '';
+              })
+              .join(' ') || '',
+        )
+        .join(' ');
+
+      // Rough estimate: 1 token per 4 characters
+      const estimatedTokens = Math.ceil(totalText.length / 4);
+
+      return {
+        totalTokens: estimatedTokens,
+        cachedContentTokenCount: 0,
+      };
+    },
+
+    async embedContent(
+      _request: EmbedContentParameters,
+    ): Promise<EmbedContentResponse> {
+      // OpenRouter doesn't support embeddings for Gemini models
+      throw new Error(
+        'Embeddings are not supported through OpenRouter for Gemini models',
+      );
+    },
+  };
+
+  return openRouterContentGenerator;
+}
+
+function normalizeContents(contents: ContentUnion | ContentUnion[]): Content[] {
+  if (typeof contents === 'string') {
+    return [{ role: 'user', parts: [{ text: contents }] }];
+  }
+
+  if (Array.isArray(contents)) {
+    return contents.map((content) => {
+      if (typeof content === 'string') {
+        return { role: 'user', parts: [{ text: content }] };
+      }
+      // Check if it's a PartUnion[] (old format)
+      if (Array.isArray(content)) {
+        // Convert Part[] to Content
+        const parts: Part[] = content.map((part) => {
+          if (typeof part === 'string') {
+            return { text: part };
+          }
+          return part;
+        });
+        return { role: 'user', parts };
+      }
+      return content as Content;
+    });
+  }
+
+  return [contents as Content];
+}
+
+function extractSystemInstruction(
+  request: GenerateContentParameters,
+): string | undefined {
+  const instruction = request.config?.systemInstruction;
+  if (!instruction) return undefined;
+
+  if (typeof instruction === 'string') {
+    return instruction;
+  }
+
+  if ('parts' in instruction && instruction.parts) {
+    return instruction.parts
+      .map((part: Part) => ('text' in part && part.text ? part.text : ''))
+      .join('\n');
+  }
+
+  return undefined;
+}
+
+function convertToOpenAIFormat(
+  request: GenerateContentParameters,
+): OpenAI.Chat.ChatCompletionMessageParam[] {
+  const contents = normalizeContents(request.contents);
+
+  return contents
+    .map((content: Content) => {
+      const role =
+        content.role === 'model' ? 'assistant' : (content.role as string);
+      const parts = content.parts || [];
+
+      // Handle single text part
+      if (parts.length === 1 && parts[0] && 'text' in parts[0]) {
+        return {
+          role: role as 'user' | 'assistant',
+          content: parts[0].text || '',
+        };
+      }
+
+      // Handle function calls
+      const functionCalls = parts.filter(
+        (part: Part) => part && 'functionCall' in part,
+      );
+
+      if (functionCalls.length > 0 && role === 'assistant') {
+        const toolCalls = functionCalls
+          .map((part: Part, index: number) => {
+            const functionCall = part.functionCall;
+            if (!functionCall) return null;
+
+            return {
+              id: functionCall.id || `call_${index}`,
+              type: 'function' as const,
+              function: {
+                name: functionCall.name || '',
+                arguments: JSON.stringify(functionCall.args || {}),
+              },
+            };
+          })
+          .filter(Boolean);
+
+        return {
+          role: 'assistant' as const,
+          content: null,
+          tool_calls: toolCalls as OpenAI.Chat.ChatCompletionMessageToolCall[],
+        };
+      }
+
+      // Handle function responses
+      const functionResponses = parts.filter(
+        (part: Part) => part && 'functionResponse' in part,
+      );
+
+      if (functionResponses.length > 0 && role === 'function') {
+        return functionResponses.map((part: Part, index: number) => ({
+          role: 'tool' as const,
+          tool_call_id: part.functionResponse?.name || `call_${index}`,
+          content: JSON.stringify(part.functionResponse?.response || {}),
+        }));
+      }
+
+      // Handle text parts
+      const textParts = parts.filter((part: Part) => part && 'text' in part);
+      const text = textParts
+        .map((part: Part) => ('text' in part ? part.text || '' : ''))
+        .join('\n');
+
+      return {
+        role: (role === 'user' ? 'user' : 'assistant') as 'user' | 'assistant',
+        content: text,
+      };
+    })
+    .flat();
+}
+
+import type { ToolListUnion, Tool as GenaiTool } from '@google/genai';
+
+function convertTools(
+  tools?: ToolListUnion,
+): OpenAI.Chat.ChatCompletionTool[] | undefined {
+  if (!tools) return undefined;
+  
+  // Normalize tools to array
+  const toolsArray = Array.isArray(tools) ? tools : [tools];
+  if (toolsArray.length === 0) return undefined;
+  
+  // Get the first tool (usually only one tool object with function declarations)
+  const firstTool = toolsArray[0];
+  if (!firstTool || typeof firstTool === 'string') return undefined;
+  
+  const functionDeclarations = (firstTool as GenaiTool).functionDeclarations;
+  if (!functionDeclarations) return undefined;
+
+  return functionDeclarations.map((func) => ({
+    type: 'function' as const,
+    function: {
+      name: func.name || '',
+      description: func.description,
+      parameters: (func.parameters || {}) as Record<string, unknown>,
+    },
+  }));
+}
+
+function convertToGeminiResponse(
+  completion: OpenAI.Chat.ChatCompletion,
+): GenerateContentResponse {
+  const choice = completion.choices[0];
+  const message = choice.message;
+
+  const parts: Part[] = [];
+
+  if (message.content) {
+    parts.push({ text: message.content });
+  }
+
+  if (message.tool_calls) {
+    for (const toolCall of message.tool_calls) {
+      if (toolCall.function) {
+        parts.push({
+          functionCall: {
+            name: toolCall.function.name,
+            args: JSON.parse(toolCall.function.arguments),
+          },
+        });
+      }
+    }
+  }
+
+  const candidates: Candidate[] = [
+    {
+      content: {
+        role: 'model',
+        parts,
+      },
+      finishReason: mapFinishReason(choice.finish_reason),
+      avgLogprobs: 0,
+    },
+  ];
+
+  const promptFeedback = new GenerateContentResponsePromptFeedback();
+  promptFeedback.blockReason = BlockedReason.BLOCKED_REASON_UNSPECIFIED;
+  promptFeedback.safetyRatings = [];
+
+  const usage = completion.usage as OpenRouterUsage | undefined;
+
+  const usageMetadata = new GenerateContentResponseUsageMetadata();
+  usageMetadata.promptTokenCount = usage?.prompt_tokens || 0;
+  usageMetadata.candidatesTokenCount = usage?.completion_tokens || 0;
+  usageMetadata.totalTokenCount = usage?.total_tokens || 0;
+  usageMetadata.cachedContentTokenCount = 0;
+
+  const response = new GenerateContentResponse();
+  response.candidates = candidates;
+  response.promptFeedback = promptFeedback;
+  response.usageMetadata = usageMetadata;
+
+  return response;
+}
+
+function convertChunkToGeminiResponse(
+  chunk: OpenAI.Chat.ChatCompletionChunk,
+): GenerateContentResponse {
+  const choice = chunk.choices?.[0];
+  const delta = choice?.delta;
+
+  const parts: Part[] = [];
+
+  if (delta?.content) {
+    parts.push({ text: delta.content });
+  }
+
+  if (delta?.tool_calls) {
+    for (const toolCall of delta.tool_calls) {
+      if (toolCall.function) {
+        parts.push({
+          functionCall: {
+            name: toolCall.function.name,
+            args: toolCall.function.arguments
+              ? JSON.parse(toolCall.function.arguments)
+              : {},
+          },
+        });
+      }
+    }
+  }
+
+  const candidates: Candidate[] =
+    parts.length > 0
+      ? [
+          {
+            content: {
+              role: 'model',
+              parts,
+            },
+            finishReason: choice?.finish_reason
+              ? mapFinishReason(choice.finish_reason)
+              : FinishReason.STOP,
+            avgLogprobs: 0,
+          },
+        ]
+      : [];
+
+  const response = new GenerateContentResponse();
+  response.candidates = candidates;
+
+  const promptFeedback = new GenerateContentResponsePromptFeedback();
+  promptFeedback.blockReason = BlockedReason.BLOCKED_REASON_UNSPECIFIED;
+  promptFeedback.safetyRatings = [];
+  response.promptFeedback = promptFeedback;
+
+  const usage = chunk.usage as OpenRouterUsage | undefined;
+  if (usage) {
+    const usageMetadata = new GenerateContentResponseUsageMetadata();
+    usageMetadata.promptTokenCount = usage.prompt_tokens || 0;
+    usageMetadata.candidatesTokenCount = usage.completion_tokens || 0;
+    usageMetadata.totalTokenCount = usage.total_tokens || 0;
+    usageMetadata.cachedContentTokenCount = 0;
+    response.usageMetadata = usageMetadata;
+  }
+
+  return response;
+}
+
+function mapFinishReason(reason: string | null | undefined): FinishReason {
+  switch (reason) {
+    case 'stop':
+      return FinishReason.STOP;
+    case 'length':
+      return FinishReason.MAX_TOKENS;
+    case 'tool_calls':
+    case 'function_call':
+      return FinishReason.STOP;
+    case 'content_filter':
+      return FinishReason.SAFETY;
+    default:
+      return FinishReason.OTHER;
+  }
+}
+
+function convertError(error: unknown): Error {
+  if (error instanceof OpenAI.APIError) {
+    const message = `OpenRouter API Error: ${error.status} - ${error.message}`;
+    const newError = new Error(message);
+    (newError as Error & { status?: number }).status = error.status;
+    return newError;
+  }
+  return error instanceof Error ? error : new Error(String(error));
+}


### PR DESCRIPTION
## Summary
- preserve fully-qualified model IDs and non-Gemini model IDs when using OpenRouter
- only map Gemini aliases to google/* when talking to the official openrouter.ai endpoint
- document custom gateway behavior and add coverage for official and custom endpoint cases

## Testing
- npm run test --workspace packages/core -- openRouterContentGenerator.test.ts