### PR TITLE
fix: "allow always" for commands with paths

### DIFF
--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -119,8 +119,10 @@ describe('getCommandRoots', () => {
     expect(getCommandRoots('ls -l')).toEqual(['ls']);
   });
 
-  it('should handle paths and return the binary name', () => {
-    expect(getCommandRoots('/usr/local/bin/node script.js')).toEqual(['node']);
+  it('should handle paths and return the full path', () => {
+    expect(getCommandRoots('/usr/local/bin/node script.js')).toEqual([
+      '/usr/local/bin/node',
+    ]);
   });
 
   it('should return an empty array for an empty string', () => {

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -264,11 +264,7 @@ function normalizeCommandName(raw: string): string {
       return raw.slice(1, -1);
     }
   }
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return trimmed;
-  }
-  return trimmed.split(/[\\/]/).pop() ?? trimmed;
+  return raw.trim();
 }
 
 function extractNameFromNode(node: Node): string | null {


### PR DESCRIPTION
## Summary

Don't strip paths from long commands when writing allow policies.

## Details

This also changes it to display the full name of the command in the UI. This is probably better since users should understand what command they are approving.

<img width="1000" height="398" alt="Screenshot 2026-03-23 at 9 49 59 AM" src="https://github.com/user-attachments/assets/10075294-5163-4f78-96e9-496db12610dc" />

Previously this would have read `Allow execution of: 'command'?`

## Related Issues

For #16450

## How to Validate

1. ask gemini to run `long/path/to/command` with the shell tool.
2. Hit "approval for all future sessions"
3. Verify that the new entry in `auto-saved.toml` includes the full path.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
