### PR TITLE
docs: fix duplicate link and add missing prerequisite notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,6 @@ gemini
 - [**Enterprise Guide**](./docs/cli/enterprise.md) - Deploy and manage in a
   corporate environment.
 - [**Telemetry & Monitoring**](./docs/cli/telemetry.md) - Usage tracking.
-- [**Tools reference**](./docs/reference/tools.md) - Built-in tools overview.
 - [**Local development**](./docs/local-development.md) - Local development
   tooling.
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -134,6 +134,9 @@ describe('my_feature', () => {
 
 ## Running Evaluations
 
+> **Note:** If you have just cloned the repository, first run `npm install` to
+> install all dependencies before building.
+
 First, build the bundled Gemini CLI. You must do this after every code change.
 
 ```bash
@@ -233,6 +236,10 @@ issue.
 
 This command is designed to automate the investigation and fixing process for
 failing evaluations. It will:
+
+> **Note:** This command requires the [GitHub CLI (gh)](https://cli.github.com/)
+> to be installed and authenticated. Run `gh auth login` if you have not set it
+> up yet.
 
 1.  **Investigate**: Fetch the latest results from the nightly workflow using
     the `gh` CLI, identify the failing test, and review test trajectory logs in


### PR DESCRIPTION
## Summary
Fixed three documentation issues found while studying 
the codebase as a new contributor preparing for GSoC.

## Changes Made

### README.md
- Removed duplicate link to tools reference that 
  already existed at line 304

### evals/README.md
- Added missing gh CLI prerequisite note for the 
  /fix-behavioral-eval command
- Added missing npm install prerequisite note for 
  the Running Evaluations section

## Why This Matters
These gaps block new contributors from successfully 
running evals for the first time. As a first-time 
contributor I hit each of these blockers personally.

## Type of Change
- [x] Documentation fix only (no functional code changed)

## Related Issue
Part of improving contributor onboarding for 
behavioral evals area (GSoC #23331)