### PR TITLE
chore: disable evals job in chained_e2e workflow

### DIFF
--- a/.github/workflows/chained_e2e.yml
+++ b/.github/workflows/chained_e2e.yml
@@ -330,7 +330,7 @@ jobs:
           echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
 
       - name: 'Run Evals (Required to pass)'
-        if: "false"
+        if: "${{ steps.check_evals.outputs.should_run == 'true' }}"
         env:
           GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
         run: 'npm run test:always_passing_evals'

--- a/.github/workflows/chained_e2e.yml
+++ b/.github/workflows/chained_e2e.yml
@@ -303,7 +303,7 @@ jobs:
       - 'merge_queue_skipper'
       - 'parse_run_context'
     runs-on: 'gemini-cli-ubuntu-16-core'
-    if: "false"
+    if: 'false'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v5

--- a/.github/workflows/chained_e2e.yml
+++ b/.github/workflows/chained_e2e.yml
@@ -303,8 +303,7 @@ jobs:
       - 'merge_queue_skipper'
       - 'parse_run_context'
     runs-on: 'gemini-cli-ubuntu-16-core'
-    if: |
-      github.repository == 'google-gemini/gemini-cli' && always() && (needs.merge_queue_skipper.result !='success' || needs.merge_queue_skipper.outputs.skip != 'true')
+    if: "false"
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v5
@@ -331,7 +330,7 @@ jobs:
           echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
 
       - name: 'Run Evals (Required to pass)'
-        if: "${{ steps.check_evals.outputs.should_run == 'true' }}"
+        if: "false"
         env:
           GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
         run: 'npm run test:always_passing_evals'
@@ -344,7 +343,6 @@ jobs:
       - 'e2e_linux'
       - 'e2e_mac'
       - 'e2e_windows'
-      - 'evals'
       - 'merge_queue_skipper'
     runs-on: 'gemini-cli-ubuntu-16-core'
     steps:
@@ -352,8 +350,7 @@ jobs:
         run: |
           if [[ ${NEEDS_E2E_LINUX_RESULT} != 'success' || \
                ${NEEDS_E2E_MAC_RESULT} != 'success' || \
-               ${NEEDS_E2E_WINDOWS_RESULT} != 'success' || \
-               ${NEEDS_EVALS_RESULT} != 'success' ]]; then
+               ${NEEDS_E2E_WINDOWS_RESULT} != 'success' ]]; then
             echo "One or more E2E jobs failed."
             exit 1
           fi
@@ -362,7 +359,6 @@ jobs:
           NEEDS_E2E_LINUX_RESULT: '${{ needs.e2e_linux.result }}'
           NEEDS_E2E_MAC_RESULT: '${{ needs.e2e_mac.result }}'
           NEEDS_E2E_WINDOWS_RESULT: '${{ needs.e2e_windows.result }}'
-          NEEDS_EVALS_RESULT: '${{ needs.evals.result }}'
 
   set_workflow_status:
     runs-on: 'gemini-cli-ubuntu-16-core'


### PR DESCRIPTION
This PR disables the `evals` job in the `chained_e2e.yml` workflow and removes it from the `e2e` job's dependencies and results check.

Updated workflow run: https://github.com/google-gemini/gemini-cli/actions/runs/23454443514