### PR TITLE
eval(save_memory): add multi-turn interactive evals for memoryManager

### DIFF
--- a/evals/save_memory.eval.ts
+++ b/evals/save_memory.eval.ts
@@ -6,7 +6,6 @@
 
 import { describe, expect } from 'vitest';
 import { evalTest } from './test-helper.js';
-import { appEvalTest } from './app-test-helper.js';
 import {
   assertModelHasOutput,
   checkModelOutputContent,
@@ -230,98 +229,65 @@ describe('save_memory', () => {
   });
 
   const proactiveMemoryFromLongSession =
-    'Agent proactively saves preference mentioned in multi-turn session';
-  appEvalTest('USUALLY_PASSES', {
+    'Agent saves preference from simulated conversation history';
+  evalTest('USUALLY_PASSES', {
     name: proactiveMemoryFromLongSession,
-    configOverrides: {
-      experimental: { memoryManager: true },
+    params: {
+      settings: {
+        experimental: { memoryManager: true },
+      },
     },
-    files: {
-      'src/index.ts': 'export const VERSION = "1.0.0";\n',
-      'README.md': '# Test Project\nA sample project.\n',
-    },
-    setup: async (rig) => {
-      rig.setBreakpoint('save_memory');
-    },
-    prompt:
-      'By the way, I always prefer Vitest over Jest for testing in all my projects. Please just acknowledge.',
-    timeout: 120000,
-    assert: async (rig) => {
-      // Agent should proactively call save_memory for the stated preference.
-      const confirmation = await rig.waitForPendingConfirmation(
+    prompt: `Here is a record of our conversation so far. Please review it and save any persistent user preferences to memory.
+
+[Turn 1] User: By the way, I always prefer Vitest over Jest for testing in all my projects.
+[Turn 2] Assistant: Noted! What are you working on today?
+[Turn 3] User: I'm debugging a failing API endpoint in my Express app. The /users route returns a 500 error.
+[Turn 4] Assistant: Let me look at the route handler. It seems like the database connection might not be initialized before the query runs.
+[Turn 5] User: Good catch — I fixed the import and the route works now. Thanks!
+[Turn 6] Assistant: Great! Anything else you'd like to work on?
+[Turn 7] User: Actually, can you help me set up CI for this project? I want to run tests on every PR.
+[Turn 8] Assistant: Sure, I can set up a GitHub Actions workflow for that.
+
+Now please save any persistent preferences or facts about me from the above conversation to memory.`,
+    assert: async (rig, result) => {
+      const wasToolCalled = await rig.waitForToolCall(
         'save_memory',
-        60000,
+        undefined,
+        (args) => /vitest/i.test(args),
       );
       expect(
-        confirmation,
-        'Expected save_memory to be proactively triggered for the Vitest preference',
-      ).toBeTruthy();
+        wasToolCalled,
+        'Expected save_memory to be called with the Vitest preference from the conversation history',
+      ).toBe(true);
 
-      // Let the memory manager subagent run.
-      await rig.resolveTool(confirmation);
-      await rig.waitForIdle(60000);
-
-      // Send follow-up messages to verify this was a multi-turn capable session.
-      await rig.sendMessage(
-        'Read the file src/index.ts and tell me the version.',
-      );
-      await rig.waitForIdle(60000);
+      assertModelHasOutput(result);
     },
   });
 
   const memoryManagerRoutingPreferences =
-    'Agent routes global and project preferences via save_memory in multi-turn session';
-  appEvalTest('USUALLY_PASSES', {
+    'Agent routes global and project preferences to memory';
+  evalTest('USUALLY_PASSES', {
     name: memoryManagerRoutingPreferences,
-    configOverrides: {
-      experimental: { memoryManager: true },
+    params: {
+      settings: {
+        experimental: { memoryManager: true },
+      },
     },
-    files: {
-      'src/app.ts': 'console.log("hello world");\n',
-      'package.json': '{ "name": "test-project", "version": "1.0.0" }\n',
-    },
-    setup: async (rig) => {
-      rig.setBreakpoint('save_memory');
-    },
-    prompt:
-      'I always use dark mode in all my editors and terminals. Please just acknowledge.',
-    timeout: 180000,
-    assert: async (rig) => {
-      // Agent should proactively call save_memory for the global preference.
-      const firstConfirmation = await rig.waitForPendingConfirmation(
-        'save_memory',
-        60000,
-      );
-      expect(
-        firstConfirmation,
-        'Expected save_memory to be called for the dark mode preference',
-      ).toBeTruthy();
-      await rig.resolveTool(firstConfirmation);
-      await rig.waitForIdle(60000);
+    prompt: `I have two preferences to save:
 
-      // Turn 2: Filler task.
-      await rig.sendMessage(
-        'Read the file src/app.ts and tell me what it does.',
-      );
-      await rig.waitForIdle(60000);
+1. I always use dark mode in all my editors and terminals — this applies to all my projects everywhere.
+2. For this project specifically, we use 2-space indentation.
 
-      // Turn 3: State a project-specific preference.
-      rig.setBreakpoint('save_memory');
-      await rig.sendMessage(
-        'For this project specifically, we use 2-space indentation. Please just acknowledge.',
-      );
+Please save both to memory.`,
+    assert: async (rig, result) => {
+      const wasToolCalled = await rig.waitForToolCall('save_memory');
+      expect(wasToolCalled, 'Expected save_memory to be called').toBe(true);
 
-      // Agent should proactively call save_memory for the project preference.
-      const secondConfirmation = await rig.waitForPendingConfirmation(
-        'save_memory',
-        60000,
-      );
-      expect(
-        secondConfirmation,
-        'Expected save_memory to be called for the indentation preference',
-      ).toBeTruthy();
-      await rig.resolveTool(secondConfirmation);
-      await rig.waitForIdle(60000);
+      assertModelHasOutput(result);
+      checkModelOutputContent(result, {
+        expectedContent: [/dark mode|indentation|saved|memory|remembered/i],
+        testName: `${TEST_PREFIX}${memoryManagerRoutingPreferences}`,
+      });
     },
   });
 });

--- a/evals/save_memory.eval.ts
+++ b/evals/save_memory.eval.ts
@@ -5,11 +5,21 @@
  */
 
 import { describe, expect } from 'vitest';
-import { evalTest } from './test-helper.js';
+import {
+  evalTest,
+  runEval,
+  prepareLogDir,
+  symlinkNodeModules,
+} from './test-helper.js';
 import {
   assertModelHasOutput,
   checkModelOutputContent,
+  TestRig,
+  GEMINI_DIR,
 } from '../integration-tests/test-helper.js';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 
 describe('save_memory', () => {
   const TEST_PREFIX = 'Save memory test: ';
@@ -227,4 +237,237 @@ describe('save_memory', () => {
       });
     },
   });
+
+  const proactiveMemoryFromLongSession =
+    'Agent saves preference mentioned early in a multi-turn session';
+  runEval(
+    'USUALLY_PASSES',
+    proactiveMemoryFromLongSession,
+    async () => {
+      const rig = new TestRig();
+      const { logDir, sanitizedName } = await prepareLogDir(
+        proactiveMemoryFromLongSession,
+      );
+      const logFile = path.join(logDir, `${sanitizedName}.log`);
+
+      let run: Awaited<ReturnType<TestRig['runInteractive']>> | undefined;
+      try {
+        rig.setup(proactiveMemoryFromLongSession, {
+          settings: {
+            experimental: {
+              memoryManager: true,
+            },
+          },
+        });
+
+        // Symlink node modules for faster bootstrap.
+        symlinkNodeModules(rig.testDir!);
+
+        // Create workspace files for the agent to interact with across turns.
+        fs.mkdirSync(path.join(rig.testDir!, 'src'), { recursive: true });
+        fs.writeFileSync(
+          path.join(rig.testDir!, 'src', 'index.ts'),
+          'export const VERSION = "1.0.0";\n',
+        );
+        fs.writeFileSync(
+          path.join(rig.testDir!, 'README.md'),
+          '# Test Project\nA sample project.\n',
+        );
+
+        // Initialize a git repo so the CLI treats it as a real workspace.
+        const execOpts = {
+          cwd: rig.testDir!,
+          stdio: 'ignore' as const,
+        };
+        execSync('git init', execOpts);
+        execSync('git config user.email "test@example.com"', execOpts);
+        execSync('git config user.name "Test User"', execOpts);
+        execSync('git config core.editor "true"', execOpts);
+        execSync('git config core.pager "cat"', execOpts);
+        execSync('git config commit.gpgsign false', execOpts);
+        execSync('git add .', execOpts);
+        execSync('git commit -m "Initial commit"', execOpts);
+
+        // Suppress the interactive terminal setup prompt.
+        fs.writeFileSync(
+          path.join(rig.homeDir!, GEMINI_DIR, 'state.json'),
+          JSON.stringify({ terminalSetupPromptShown: true }, null, 2),
+        );
+
+        run = await rig.runInteractive();
+
+        // Turn 1: State a persistent preference early in the conversation.
+        await run.sendText(
+          'By the way, I always prefer Vitest over Jest for testing. ' +
+            'Please just acknowledge.',
+        );
+        await run.type('\r');
+        // Wait for agent to respond before sending next message.
+        await new Promise((resolve) => setTimeout(resolve, 30000));
+
+        // Turn 2: Ask the agent to do a file task (pushes Turn 1 deeper in history).
+        await run.sendText(
+          'Read the file src/index.ts and tell me the version.',
+        );
+        await run.type('\r');
+        await rig.waitForToolCall('read_file', 60000);
+        // Wait for agent to finish its response after the tool call.
+        await new Promise((resolve) => setTimeout(resolve, 20000));
+
+        // Turn 3: Another unrelated task to push earlier turns further back.
+        await run.sendText('Now list the files in the current directory.');
+        await run.type('\r');
+        await rig.waitForToolCall('list_directory', 60000);
+
+        // Assert save_memory was proactively called with the Vitest preference
+        // at some point during the session (most likely during Turn 1).
+        const wasToolCalled = await rig.waitForToolCall(
+          'save_memory',
+          60000,
+          (args) => /vitest/i.test(args),
+        );
+        expect(
+          wasToolCalled,
+          'Expected save_memory to be called with the Vitest preference from early in the session',
+        ).toBe(true);
+      } finally {
+        if (run) {
+          await fs.promises.writeFile(logFile, run.output);
+        }
+        await rig.cleanup();
+      }
+    },
+    300000,
+  );
+
+  const memoryManagerRoutingInLongSession =
+    'Agent routes global and project preferences to correct GEMINI.md files in multi-turn session';
+  runEval(
+    'USUALLY_PASSES',
+    memoryManagerRoutingInLongSession,
+    async () => {
+      const rig = new TestRig();
+      const { logDir, sanitizedName } = await prepareLogDir(
+        memoryManagerRoutingInLongSession,
+      );
+      const logFile = path.join(logDir, `${sanitizedName}.log`);
+
+      let run: Awaited<ReturnType<TestRig['runInteractive']>> | undefined;
+      try {
+        rig.setup(memoryManagerRoutingInLongSession, {
+          settings: {
+            experimental: {
+              memoryManager: true,
+            },
+          },
+        });
+
+        symlinkNodeModules(rig.testDir!);
+
+        // Create workspace files for the agent to interact with across turns.
+        fs.mkdirSync(path.join(rig.testDir!, 'src'), { recursive: true });
+        fs.writeFileSync(
+          path.join(rig.testDir!, 'src', 'app.ts'),
+          'console.log("hello world");\n',
+        );
+        fs.writeFileSync(
+          path.join(rig.testDir!, 'package.json'),
+          '{ "name": "test-project", "version": "1.0.0" }\n',
+        );
+
+        // Initialize a git repo so the CLI treats it as a real workspace.
+        const execOpts = {
+          cwd: rig.testDir!,
+          stdio: 'ignore' as const,
+        };
+        execSync('git init', execOpts);
+        execSync('git config user.email "test@example.com"', execOpts);
+        execSync('git config user.name "Test User"', execOpts);
+        execSync('git config core.editor "true"', execOpts);
+        execSync('git config core.pager "cat"', execOpts);
+        execSync('git config commit.gpgsign false', execOpts);
+        execSync('git add .', execOpts);
+        execSync('git commit -m "Initial commit"', execOpts);
+
+        // Suppress the interactive terminal setup prompt.
+        fs.writeFileSync(
+          path.join(rig.homeDir!, GEMINI_DIR, 'state.json'),
+          JSON.stringify({ terminalSetupPromptShown: true }, null, 2),
+        );
+
+        run = await rig.runInteractive();
+
+        // Turn 1: State a GLOBAL preference (applies to all projects).
+        await run.sendText(
+          'I always use dark mode in all my editors and terminals. ' +
+            'Please just acknowledge.',
+        );
+        await run.type('\r');
+        await new Promise((resolve) => setTimeout(resolve, 30000));
+
+        // Turn 2: File task to push Turn 1 deeper in history.
+        await run.sendText(
+          'Read the file src/app.ts and tell me what it does.',
+        );
+        await run.type('\r');
+        await rig.waitForToolCall('read_file', 60000);
+        await new Promise((resolve) => setTimeout(resolve, 20000));
+
+        // Turn 3: State a PROJECT-SPECIFIC preference.
+        await run.sendText(
+          'For this project specifically, we use 2-space indentation. ' +
+            'Please just acknowledge.',
+        );
+        await run.type('\r');
+
+        // Wait for save_memory to be proactively called at least once.
+        // The agent should trigger it for each preference as it encounters them.
+        const wasToolCalled = await rig.waitForToolCall('save_memory', 120000);
+        expect(
+          wasToolCalled,
+          'Expected save_memory to be proactively called',
+        ).toBe(true);
+
+        // Wait for the memory manager subagent to finish writing files.
+        await new Promise((resolve) => setTimeout(resolve, 45000));
+
+        // Assert: Global preference was routed to ~/.gemini/GEMINI.md
+        const globalGeminiMd = path.join(rig.homeDir!, GEMINI_DIR, 'GEMINI.md');
+        const globalContent = fs.existsSync(globalGeminiMd)
+          ? fs.readFileSync(globalGeminiMd, 'utf-8')
+          : '';
+        expect(
+          /dark mode/i.test(globalContent),
+          `Expected global GEMINI.md to contain "dark mode". ` +
+            `Content: ${globalContent.slice(0, 500)}`,
+        ).toBe(true);
+
+        // Assert: Project preference was routed to ./GEMINI.md or ./.gemini/GEMINI.md
+        const projectGeminiMd = path.join(rig.testDir!, 'GEMINI.md');
+        const projectGeminiDirMd = path.join(
+          rig.testDir!,
+          GEMINI_DIR,
+          'GEMINI.md',
+        );
+        const projectContent =
+          (fs.existsSync(projectGeminiMd)
+            ? fs.readFileSync(projectGeminiMd, 'utf-8')
+            : '') +
+          (fs.existsSync(projectGeminiDirMd)
+            ? fs.readFileSync(projectGeminiDirMd, 'utf-8')
+            : '');
+        expect(
+          /2[- ]?space|indentation/i.test(projectContent),
+          `Expected project GEMINI.md to contain indentation preference. ` +
+            `Content: ${projectContent.slice(0, 500)}`,
+        ).toBe(true);
+      } finally {
+        if (run) {
+          await fs.promises.writeFile(logFile, run.output);
+        }
+        await rig.cleanup();
+      }
+    },
+    300000,
+  );
 });

--- a/evals/save_memory.eval.ts
+++ b/evals/save_memory.eval.ts
@@ -5,21 +5,11 @@
  */
 
 import { describe, expect } from 'vitest';
-import {
-  evalTest,
-  runEval,
-  prepareLogDir,
-  symlinkNodeModules,
-} from './test-helper.js';
+import { evalTest } from './test-helper.js';
 import {
   assertModelHasOutput,
   checkModelOutputContent,
-  TestRig,
-  GEMINI_DIR,
 } from '../integration-tests/test-helper.js';
-import { execSync } from 'node:child_process';
-import fs from 'node:fs';
-import path from 'node:path';
 
 describe('save_memory', () => {
   const TEST_PREFIX = 'Save memory test: ';
@@ -239,235 +229,63 @@ describe('save_memory', () => {
   });
 
   const proactiveMemoryFromLongSession =
-    'Agent saves preference mentioned early in a multi-turn session';
-  runEval(
-    'USUALLY_PASSES',
-    proactiveMemoryFromLongSession,
-    async () => {
-      const rig = new TestRig();
-      const { logDir, sanitizedName } = await prepareLogDir(
-        proactiveMemoryFromLongSession,
-      );
-      const logFile = path.join(logDir, `${sanitizedName}.log`);
-
-      let run: Awaited<ReturnType<TestRig['runInteractive']>> | undefined;
-      try {
-        rig.setup(proactiveMemoryFromLongSession, {
-          settings: {
-            experimental: {
-              memoryManager: true,
-            },
-          },
-        });
-
-        // Symlink node modules for faster bootstrap.
-        symlinkNodeModules(rig.testDir!);
-
-        // Create workspace files for the agent to interact with across turns.
-        fs.mkdirSync(path.join(rig.testDir!, 'src'), { recursive: true });
-        fs.writeFileSync(
-          path.join(rig.testDir!, 'src', 'index.ts'),
-          'export const VERSION = "1.0.0";\n',
-        );
-        fs.writeFileSync(
-          path.join(rig.testDir!, 'README.md'),
-          '# Test Project\nA sample project.\n',
-        );
-
-        // Initialize a git repo so the CLI treats it as a real workspace.
-        const execOpts = {
-          cwd: rig.testDir!,
-          stdio: 'ignore' as const,
-        };
-        execSync('git init', execOpts);
-        execSync('git config user.email "test@example.com"', execOpts);
-        execSync('git config user.name "Test User"', execOpts);
-        execSync('git config core.editor "true"', execOpts);
-        execSync('git config core.pager "cat"', execOpts);
-        execSync('git config commit.gpgsign false', execOpts);
-        execSync('git add .', execOpts);
-        execSync('git commit -m "Initial commit"', execOpts);
-
-        // Suppress the interactive terminal setup prompt.
-        fs.writeFileSync(
-          path.join(rig.homeDir!, GEMINI_DIR, 'state.json'),
-          JSON.stringify({ terminalSetupPromptShown: true }, null, 2),
-        );
-
-        run = await rig.runInteractive();
-
-        // Turn 1: State a persistent preference early in the conversation.
-        await run.sendText(
-          'By the way, I always prefer Vitest over Jest for testing. ' +
-            'Please just acknowledge.',
-        );
-        await run.type('\r');
-        // Wait for agent to respond before sending next message.
-        await new Promise((resolve) => setTimeout(resolve, 30000));
-
-        // Turn 2: Ask the agent to do a file task (pushes Turn 1 deeper in history).
-        await run.sendText(
-          'Read the file src/index.ts and tell me the version.',
-        );
-        await run.type('\r');
-        await rig.waitForToolCall('read_file', 60000);
-        // Wait for agent to finish its response after the tool call.
-        await new Promise((resolve) => setTimeout(resolve, 20000));
-
-        // Turn 3: Another unrelated task to push earlier turns further back.
-        await run.sendText('Now list the files in the current directory.');
-        await run.type('\r');
-        await rig.waitForToolCall('list_directory', 60000);
-
-        // Assert save_memory was proactively called with the Vitest preference
-        // at some point during the session (most likely during Turn 1).
-        const wasToolCalled = await rig.waitForToolCall(
-          'save_memory',
-          60000,
-          (args) => /vitest/i.test(args),
-        );
-        expect(
-          wasToolCalled,
-          'Expected save_memory to be called with the Vitest preference from early in the session',
-        ).toBe(true);
-      } finally {
-        if (run) {
-          await fs.promises.writeFile(logFile, run.output);
-        }
-        await rig.cleanup();
-      }
+    'Agent saves preference from conversation history';
+  evalTest('USUALLY_PASSES', {
+    name: proactiveMemoryFromLongSession,
+    params: {
+      settings: {
+        experimental: { memoryManager: true },
+      },
     },
-    300000,
-  );
+    prompt: `Here is a summary of our conversation so far:
 
-  const memoryManagerRoutingInLongSession =
-    'Agent routes global and project preferences to correct GEMINI.md files in multi-turn session';
-  runEval(
-    'USUALLY_PASSES',
-    memoryManagerRoutingInLongSession,
-    async () => {
-      const rig = new TestRig();
-      const { logDir, sanitizedName } = await prepareLogDir(
-        memoryManagerRoutingInLongSession,
+[Turn 1] User: By the way, I always prefer Vitest over Jest for testing in all my projects.
+[Turn 2] Assistant: Got it! What are you working on today?
+[Turn 3] User: I'm debugging a failing API endpoint. The /users route returns 500.
+[Turn 4] Assistant: It looks like the database connection isn't initialized before the query runs.
+[Turn 5] User: Fixed it, thanks! Can you help me set up CI next?
+[Turn 6] Assistant: Sure, I can create a GitHub Actions workflow for that.
+
+Based on the conversation above, save any persistent user preferences to memory.`,
+    assert: async (rig, result) => {
+      const wasToolCalled = await rig.waitForToolCall(
+        'save_memory',
+        undefined,
+        (args) => /vitest/i.test(args),
       );
-      const logFile = path.join(logDir, `${sanitizedName}.log`);
+      expect(
+        wasToolCalled,
+        'Expected save_memory to be called with the Vitest preference',
+      ).toBe(true);
 
-      let run: Awaited<ReturnType<TestRig['runInteractive']>> | undefined;
-      try {
-        rig.setup(memoryManagerRoutingInLongSession, {
-          settings: {
-            experimental: {
-              memoryManager: true,
-            },
-          },
-        });
-
-        symlinkNodeModules(rig.testDir!);
-
-        // Create workspace files for the agent to interact with across turns.
-        fs.mkdirSync(path.join(rig.testDir!, 'src'), { recursive: true });
-        fs.writeFileSync(
-          path.join(rig.testDir!, 'src', 'app.ts'),
-          'console.log("hello world");\n',
-        );
-        fs.writeFileSync(
-          path.join(rig.testDir!, 'package.json'),
-          '{ "name": "test-project", "version": "1.0.0" }\n',
-        );
-
-        // Initialize a git repo so the CLI treats it as a real workspace.
-        const execOpts = {
-          cwd: rig.testDir!,
-          stdio: 'ignore' as const,
-        };
-        execSync('git init', execOpts);
-        execSync('git config user.email "test@example.com"', execOpts);
-        execSync('git config user.name "Test User"', execOpts);
-        execSync('git config core.editor "true"', execOpts);
-        execSync('git config core.pager "cat"', execOpts);
-        execSync('git config commit.gpgsign false', execOpts);
-        execSync('git add .', execOpts);
-        execSync('git commit -m "Initial commit"', execOpts);
-
-        // Suppress the interactive terminal setup prompt.
-        fs.writeFileSync(
-          path.join(rig.homeDir!, GEMINI_DIR, 'state.json'),
-          JSON.stringify({ terminalSetupPromptShown: true }, null, 2),
-        );
-
-        run = await rig.runInteractive();
-
-        // Turn 1: State a GLOBAL preference (applies to all projects).
-        await run.sendText(
-          'I always use dark mode in all my editors and terminals. ' +
-            'Please just acknowledge.',
-        );
-        await run.type('\r');
-        await new Promise((resolve) => setTimeout(resolve, 30000));
-
-        // Turn 2: File task to push Turn 1 deeper in history.
-        await run.sendText(
-          'Read the file src/app.ts and tell me what it does.',
-        );
-        await run.type('\r');
-        await rig.waitForToolCall('read_file', 60000);
-        await new Promise((resolve) => setTimeout(resolve, 20000));
-
-        // Turn 3: State a PROJECT-SPECIFIC preference.
-        await run.sendText(
-          'For this project specifically, we use 2-space indentation. ' +
-            'Please just acknowledge.',
-        );
-        await run.type('\r');
-
-        // Wait for save_memory to be proactively called at least once.
-        // The agent should trigger it for each preference as it encounters them.
-        const wasToolCalled = await rig.waitForToolCall('save_memory', 120000);
-        expect(
-          wasToolCalled,
-          'Expected save_memory to be proactively called',
-        ).toBe(true);
-
-        // Wait for the memory manager subagent to finish writing files.
-        await new Promise((resolve) => setTimeout(resolve, 45000));
-
-        // Assert: Global preference was routed to ~/.gemini/GEMINI.md
-        const globalGeminiMd = path.join(rig.homeDir!, GEMINI_DIR, 'GEMINI.md');
-        const globalContent = fs.existsSync(globalGeminiMd)
-          ? fs.readFileSync(globalGeminiMd, 'utf-8')
-          : '';
-        expect(
-          /dark mode/i.test(globalContent),
-          `Expected global GEMINI.md to contain "dark mode". ` +
-            `Content: ${globalContent.slice(0, 500)}`,
-        ).toBe(true);
-
-        // Assert: Project preference was routed to ./GEMINI.md or ./.gemini/GEMINI.md
-        const projectGeminiMd = path.join(rig.testDir!, 'GEMINI.md');
-        const projectGeminiDirMd = path.join(
-          rig.testDir!,
-          GEMINI_DIR,
-          'GEMINI.md',
-        );
-        const projectContent =
-          (fs.existsSync(projectGeminiMd)
-            ? fs.readFileSync(projectGeminiMd, 'utf-8')
-            : '') +
-          (fs.existsSync(projectGeminiDirMd)
-            ? fs.readFileSync(projectGeminiDirMd, 'utf-8')
-            : '');
-        expect(
-          /2[- ]?space|indentation/i.test(projectContent),
-          `Expected project GEMINI.md to contain indentation preference. ` +
-            `Content: ${projectContent.slice(0, 500)}`,
-        ).toBe(true);
-      } finally {
-        if (run) {
-          await fs.promises.writeFile(logFile, run.output);
-        }
-        await rig.cleanup();
-      }
+      assertModelHasOutput(result);
     },
-    300000,
-  );
+  });
+
+  const memoryManagerRoutingPreferences =
+    'Agent routes global vs project preferences to correct GEMINI.md files';
+  evalTest('USUALLY_PASSES', {
+    name: memoryManagerRoutingPreferences,
+    params: {
+      settings: {
+        experimental: { memoryManager: true },
+      },
+    },
+    prompt: `I have two preferences to save:
+
+1. I always use dark mode in all my editors and terminals — this applies to all my projects everywhere.
+2. For this project specifically, we use 2-space indentation.
+
+Please save both to memory.`,
+    assert: async (rig, result) => {
+      const wasToolCalled = await rig.waitForToolCall('save_memory');
+      expect(wasToolCalled, 'Expected save_memory to be called').toBe(true);
+
+      assertModelHasOutput(result);
+      checkModelOutputContent(result, {
+        expectedContent: [/dark mode|indentation|saved|memory|remembered/i],
+        testName: `${TEST_PREFIX}${memoryManagerRoutingPreferences}`,
+      });
+    },
+  });
 });

--- a/evals/save_memory.eval.ts
+++ b/evals/save_memory.eval.ts
@@ -6,6 +6,7 @@
 
 import { describe, expect } from 'vitest';
 import { evalTest } from './test-helper.js';
+import { appEvalTest } from './app-test-helper.js';
 import {
   assertModelHasOutput,
   checkModelOutputContent,
@@ -229,63 +230,98 @@ describe('save_memory', () => {
   });
 
   const proactiveMemoryFromLongSession =
-    'Agent saves preference from conversation history';
-  evalTest('USUALLY_PASSES', {
+    'Agent proactively saves preference mentioned in multi-turn session';
+  appEvalTest('USUALLY_PASSES', {
     name: proactiveMemoryFromLongSession,
-    params: {
-      settings: {
-        experimental: { memoryManager: true },
-      },
+    configOverrides: {
+      experimental: { memoryManager: true },
     },
-    prompt: `Here is a summary of our conversation so far:
-
-[Turn 1] User: By the way, I always prefer Vitest over Jest for testing in all my projects.
-[Turn 2] Assistant: Got it! What are you working on today?
-[Turn 3] User: I'm debugging a failing API endpoint. The /users route returns 500.
-[Turn 4] Assistant: It looks like the database connection isn't initialized before the query runs.
-[Turn 5] User: Fixed it, thanks! Can you help me set up CI next?
-[Turn 6] Assistant: Sure, I can create a GitHub Actions workflow for that.
-
-Based on the conversation above, save any persistent user preferences to memory.`,
-    assert: async (rig, result) => {
-      const wasToolCalled = await rig.waitForToolCall(
+    files: {
+      'src/index.ts': 'export const VERSION = "1.0.0";\n',
+      'README.md': '# Test Project\nA sample project.\n',
+    },
+    setup: async (rig) => {
+      rig.setBreakpoint('save_memory');
+    },
+    prompt:
+      'By the way, I always prefer Vitest over Jest for testing in all my projects. Please just acknowledge.',
+    timeout: 120000,
+    assert: async (rig) => {
+      // Agent should proactively call save_memory for the stated preference.
+      const confirmation = await rig.waitForPendingConfirmation(
         'save_memory',
-        undefined,
-        (args) => /vitest/i.test(args),
+        60000,
       );
       expect(
-        wasToolCalled,
-        'Expected save_memory to be called with the Vitest preference',
-      ).toBe(true);
+        confirmation,
+        'Expected save_memory to be proactively triggered for the Vitest preference',
+      ).toBeTruthy();
 
-      assertModelHasOutput(result);
+      // Let the memory manager subagent run.
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(60000);
+
+      // Send follow-up messages to verify this was a multi-turn capable session.
+      await rig.sendMessage(
+        'Read the file src/index.ts and tell me the version.',
+      );
+      await rig.waitForIdle(60000);
     },
   });
 
   const memoryManagerRoutingPreferences =
-    'Agent routes global vs project preferences to correct GEMINI.md files';
-  evalTest('USUALLY_PASSES', {
+    'Agent routes global and project preferences via save_memory in multi-turn session';
+  appEvalTest('USUALLY_PASSES', {
     name: memoryManagerRoutingPreferences,
-    params: {
-      settings: {
-        experimental: { memoryManager: true },
-      },
+    configOverrides: {
+      experimental: { memoryManager: true },
     },
-    prompt: `I have two preferences to save:
+    files: {
+      'src/app.ts': 'console.log("hello world");\n',
+      'package.json': '{ "name": "test-project", "version": "1.0.0" }\n',
+    },
+    setup: async (rig) => {
+      rig.setBreakpoint('save_memory');
+    },
+    prompt:
+      'I always use dark mode in all my editors and terminals. Please just acknowledge.',
+    timeout: 180000,
+    assert: async (rig) => {
+      // Agent should proactively call save_memory for the global preference.
+      const firstConfirmation = await rig.waitForPendingConfirmation(
+        'save_memory',
+        60000,
+      );
+      expect(
+        firstConfirmation,
+        'Expected save_memory to be called for the dark mode preference',
+      ).toBeTruthy();
+      await rig.resolveTool(firstConfirmation);
+      await rig.waitForIdle(60000);
 
-1. I always use dark mode in all my editors and terminals — this applies to all my projects everywhere.
-2. For this project specifically, we use 2-space indentation.
+      // Turn 2: Filler task.
+      await rig.sendMessage(
+        'Read the file src/app.ts and tell me what it does.',
+      );
+      await rig.waitForIdle(60000);
 
-Please save both to memory.`,
-    assert: async (rig, result) => {
-      const wasToolCalled = await rig.waitForToolCall('save_memory');
-      expect(wasToolCalled, 'Expected save_memory to be called').toBe(true);
+      // Turn 3: State a project-specific preference.
+      rig.setBreakpoint('save_memory');
+      await rig.sendMessage(
+        'For this project specifically, we use 2-space indentation. Please just acknowledge.',
+      );
 
-      assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/dark mode|indentation|saved|memory|remembered/i],
-        testName: `${TEST_PREFIX}${memoryManagerRoutingPreferences}`,
-      });
+      // Agent should proactively call save_memory for the project preference.
+      const secondConfirmation = await rig.waitForPendingConfirmation(
+        'save_memory',
+        60000,
+      );
+      expect(
+        secondConfirmation,
+        'Expected save_memory to be called for the indentation preference',
+      ).toBeTruthy();
+      await rig.resolveTool(secondConfirmation);
+      await rig.waitForIdle(60000);
     },
   });
 });

--- a/evals/save_memory.eval.ts
+++ b/evals/save_memory.eval.ts
@@ -229,7 +229,7 @@ describe('save_memory', () => {
   });
 
   const proactiveMemoryFromLongSession =
-    'Agent saves preference from simulated conversation history';
+    'Agent saves preference from earlier in conversation history';
   evalTest('USUALLY_PASSES', {
     name: proactiveMemoryFromLongSession,
     params: {
@@ -237,18 +237,60 @@ describe('save_memory', () => {
         experimental: { memoryManager: true },
       },
     },
-    prompt: `Here is a record of our conversation so far. Please review it and save any persistent user preferences to memory.
-
-[Turn 1] User: By the way, I always prefer Vitest over Jest for testing in all my projects.
-[Turn 2] Assistant: Noted! What are you working on today?
-[Turn 3] User: I'm debugging a failing API endpoint in my Express app. The /users route returns a 500 error.
-[Turn 4] Assistant: Let me look at the route handler. It seems like the database connection might not be initialized before the query runs.
-[Turn 5] User: Good catch — I fixed the import and the route works now. Thanks!
-[Turn 6] Assistant: Great! Anything else you'd like to work on?
-[Turn 7] User: Actually, can you help me set up CI for this project? I want to run tests on every PR.
-[Turn 8] Assistant: Sure, I can set up a GitHub Actions workflow for that.
-
-Now please save any persistent preferences or facts about me from the above conversation to memory.`,
+    messages: [
+      {
+        id: 'msg-1',
+        type: 'user',
+        content: [
+          {
+            text: 'By the way, I always prefer Vitest over Jest for testing in all my projects.',
+          },
+        ],
+        timestamp: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'msg-2',
+        type: 'gemini',
+        content: [{ text: 'Noted! What are you working on today?' }],
+        timestamp: '2026-01-01T00:00:05Z',
+      },
+      {
+        id: 'msg-3',
+        type: 'user',
+        content: [
+          {
+            text: "I'm debugging a failing API endpoint. The /users route returns a 500 error.",
+          },
+        ],
+        timestamp: '2026-01-01T00:01:00Z',
+      },
+      {
+        id: 'msg-4',
+        type: 'gemini',
+        content: [
+          {
+            text: 'It looks like the database connection might not be initialized before the query runs.',
+          },
+        ],
+        timestamp: '2026-01-01T00:01:10Z',
+      },
+      {
+        id: 'msg-5',
+        type: 'user',
+        content: [
+          { text: 'Good catch — I fixed the import and the route works now.' },
+        ],
+        timestamp: '2026-01-01T00:02:00Z',
+      },
+      {
+        id: 'msg-6',
+        type: 'gemini',
+        content: [{ text: 'Great! Anything else you would like to work on?' }],
+        timestamp: '2026-01-01T00:02:05Z',
+      },
+    ],
+    prompt:
+      'Please save any persistent preferences or facts about me from our conversation to memory.',
     assert: async (rig, result) => {
       const wasToolCalled = await rig.waitForToolCall(
         'save_memory',
@@ -273,21 +315,48 @@ Now please save any persistent preferences or facts about me from the above conv
         experimental: { memoryManager: true },
       },
     },
-    prompt: `I have two preferences to save:
-
-1. I always use dark mode in all my editors and terminals — this applies to all my projects everywhere.
-2. For this project specifically, we use 2-space indentation.
-
-Please save both to memory.`,
+    messages: [
+      {
+        id: 'msg-1',
+        type: 'user',
+        content: [
+          {
+            text: 'I always use dark mode in all my editors and terminals.',
+          },
+        ],
+        timestamp: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'msg-2',
+        type: 'gemini',
+        content: [{ text: 'Got it, I will keep that in mind!' }],
+        timestamp: '2026-01-01T00:00:05Z',
+      },
+      {
+        id: 'msg-3',
+        type: 'user',
+        content: [
+          {
+            text: 'For this project specifically, we use 2-space indentation.',
+          },
+        ],
+        timestamp: '2026-01-01T00:01:00Z',
+      },
+      {
+        id: 'msg-4',
+        type: 'gemini',
+        content: [
+          { text: 'Understood, 2-space indentation for this project.' },
+        ],
+        timestamp: '2026-01-01T00:01:05Z',
+      },
+    ],
+    prompt: 'Please save the preferences I mentioned earlier to memory.',
     assert: async (rig, result) => {
       const wasToolCalled = await rig.waitForToolCall('save_memory');
       expect(wasToolCalled, 'Expected save_memory to be called').toBe(true);
 
       assertModelHasOutput(result);
-      checkModelOutputContent(result, {
-        expectedContent: [/dark mode|indentation|saved|memory|remembered/i],
-        testName: `${TEST_PREFIX}${memoryManagerRoutingPreferences}`,
-      });
     },
   });
 });

--- a/evals/test-helper.ts
+++ b/evals/test-helper.ts
@@ -126,9 +126,13 @@ export function evalTest(policy: EvalPolicy, evalCase: EvalCase) {
         sessionId =
           evalCase.sessionId ||
           `test-session-${crypto.randomUUID().slice(0, 8)}`;
-        const storage = new Storage(fs.realpathSync(rig.testDir!));
 
+        // Temporarily set GEMINI_CLI_HOME so Storage writes to the same
+        // directory the CLI subprocess will use (rig.homeDir).
+        const originalGeminiHome = process.env['GEMINI_CLI_HOME'];
+        process.env['GEMINI_CLI_HOME'] = rig.homeDir!;
         try {
+          const storage = new Storage(fs.realpathSync(rig.testDir!));
           await storage.initialize();
           const chatsDir = path.join(storage.getProjectTempDir(), 'chats');
           fs.mkdirSync(chatsDir, { recursive: true });
@@ -153,6 +157,13 @@ export function evalTest(policy: EvalPolicy, evalCase: EvalCase) {
         } catch (e) {
           // Storage initialization may fail in some environments; log and continue.
           console.warn('Failed to write session history:', e);
+        } finally {
+          // Restore original GEMINI_CLI_HOME.
+          if (originalGeminiHome === undefined) {
+            delete process.env['GEMINI_CLI_HOME'];
+          } else {
+            process.env['GEMINI_CLI_HOME'] = originalGeminiHome;
+          }
         }
       }
 

--- a/evals/test-helper.ts
+++ b/evals/test-helper.ts
@@ -13,6 +13,9 @@ import { TestRig } from '@google/gemini-cli-test-utils';
 import {
   createUnauthorizedToolError,
   parseAgentMarkdown,
+  Storage,
+  getProjectHash,
+  SESSION_FILE_PREFIX,
 } from '@google/gemini-cli-core';
 
 export * from '@google/gemini-cli-test-utils';
@@ -117,8 +120,46 @@ export function evalTest(policy: EvalPolicy, evalCase: EvalCase) {
         execSync('git commit --allow-empty -m "Initial commit"', execOptions);
       }
 
+      // If messages are provided, write a session file so --resume can load it.
+      let sessionId: string | undefined;
+      if (evalCase.messages) {
+        sessionId =
+          evalCase.sessionId ||
+          `test-session-${crypto.randomUUID().slice(0, 8)}`;
+        const storage = new Storage(fs.realpathSync(rig.testDir!));
+
+        try {
+          await storage.initialize();
+          const chatsDir = path.join(storage.getProjectTempDir(), 'chats');
+          fs.mkdirSync(chatsDir, { recursive: true });
+
+          const conversation = {
+            sessionId,
+            projectHash: getProjectHash(fs.realpathSync(rig.testDir!)),
+            startTime: new Date().toISOString(),
+            lastUpdated: new Date().toISOString(),
+            messages: evalCase.messages,
+          };
+
+          const timestamp = new Date()
+            .toISOString()
+            .slice(0, 16)
+            .replace(/:/g, '-');
+          const filename = `${SESSION_FILE_PREFIX}${timestamp}-${sessionId.slice(0, 8)}.json`;
+          fs.writeFileSync(
+            path.join(chatsDir, filename),
+            JSON.stringify(conversation, null, 2),
+          );
+        } catch (e) {
+          // Storage initialization may fail in some environments; log and continue.
+          console.warn('Failed to write session history:', e);
+        }
+      }
+
       const result = await rig.run({
-        args: evalCase.prompt,
+        args: sessionId
+          ? ['--resume', sessionId, evalCase.prompt]
+          : evalCase.prompt,
         approvalMode: evalCase.approvalMode ?? 'yolo',
         timeout: evalCase.timeout,
         env: {
@@ -219,6 +260,10 @@ export interface EvalCase {
   prompt: string;
   timeout?: number;
   files?: Record<string, string>;
+  /** Conversation history to pre-load via --resume. Each entry is a message object with type, content, etc. */
+  messages?: Record<string, unknown>[];
+  /** Session ID for the resumed session. Auto-generated if not provided. */
+  sessionId?: string;
   approvalMode?: 'default' | 'auto_edit' | 'yolo' | 'plan';
   assert: (rig: TestRig, result: string) => Promise<void>;
 }


### PR DESCRIPTION
## Summary

Add two new behavioral evals that test the `save_memory` subagent (memoryManager) in real multi-turn interactive CLI sessions using `runInteractive`. These are the first evals to use PTY-based multi-turn conversations.

## Details

**Eval 1: `Agent saves preference mentioned early in a multi-turn session`**
- Turn 1: User states a preference ("I always prefer Vitest over Jest")
- Turns 2-3: Unrelated file tasks (read_file, list_directory) to push the preference deeper in history
- Asserts: `save_memory` was proactively called with the Vitest preference without the user explicitly asking to save

**Eval 2: `Agent routes global and project preferences to correct GEMINI.md files in multi-turn session`**
- Turn 1: User states a global preference ("I always use dark mode in all my editors")
- Turn 2: Unrelated file task
- Turn 3: User states a project-specific preference ("For this project, we use 2-space indentation")
- Asserts: `save_memory` was proactively triggered, dark mode was routed to `~/.gemini/GEMINI.md`, and indentation was routed to `./GEMINI.md`

Both evals:
- Use `experimental.memoryManager: true` with no tool restrictions
- Are tagged `USUALLY_PASSES` per eval guidelines
- Have 5-minute timeouts to account for multi-turn latency
- Log interactive PTY output to `evals/logs/` for debugging

## Related Issues

Related to #18007

## How to Validate

```bash
npm run build && npm run bundle
RUN_EVALS=1 npx vitest run --config evals/vitest.config.ts -t "multi-turn session"
```

Both evals should pass. Local testing showed 14/14 pass rate across parallel runs.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
