### PR TITLE
fix(core): prevent redundant remote agent loading on model switch

### DIFF
--- a/packages/core/src/agents/registry.test.ts
+++ b/packages/core/src/agents/registry.test.ts
@@ -1223,17 +1223,12 @@ describe('AgentRegistry', () => {
 
       await registry.testRegisterAgent(remoteAgent);
 
-      // Initial registration calls loadAgent once
       expect(loadAgentSpy).toHaveBeenCalledTimes(1);
 
-      // Trigger the model change event
       coreEvents.emitModelChanged('new-model');
 
-      // The onModelChanged handler is synchronous but calls the async refreshAgents.
-      // We wait a tick for the promises to settle.
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      // loadAgent should NOT have been called again!
       expect(loadAgentSpy).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/core/src/agents/registry.test.ts
+++ b/packages/core/src/agents/registry.test.ts
@@ -1206,6 +1206,37 @@ describe('AgentRegistry', () => {
   });
 
   describe('inheritance and refresh', () => {
+    it('should skip remote agents when refreshing on model change', async () => {
+      const remoteAgent: AgentDefinition = {
+        kind: 'remote',
+        name: 'RemoteAgent',
+        description: 'A remote agent',
+        agentCardUrl: 'https://example.com/card',
+        inputConfig: { inputSchema: { type: 'object' } },
+      };
+
+      const loadAgentSpy = vi.fn().mockResolvedValue({ name: 'RemoteAgent' });
+      vi.spyOn(mockConfig, 'getA2AClientManager').mockReturnValue({
+        loadAgent: loadAgentSpy,
+        clearCache: vi.fn(),
+      } as unknown as A2AClientManager);
+
+      await registry.testRegisterAgent(remoteAgent);
+
+      // Initial registration calls loadAgent once
+      expect(loadAgentSpy).toHaveBeenCalledTimes(1);
+
+      // Trigger the model change event
+      coreEvents.emitModelChanged('new-model');
+
+      // The onModelChanged handler is synchronous but calls the async refreshAgents.
+      // We wait a tick for the promises to settle.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // loadAgent should NOT have been called again!
+      expect(loadAgentSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('should resolve "inherit" to the current model from configuration', async () => {
       const config = makeMockedConfig({ model: 'current-model' });
       const registry = new TestableAgentRegistry(config);

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -57,7 +57,7 @@ export class AgentRegistry {
   }
 
   private onModelChanged = () => {
-    this.refreshAgents().catch((e) => {
+    this.refreshAgents('local').catch((e) => {
       debugLogger.error(
         '[AgentRegistry] Failed to refresh agents on model change:',
         e,
@@ -270,12 +270,16 @@ export class AgentRegistry {
     }
   }
 
-  private async refreshAgents(): Promise<void> {
+  private async refreshAgents(
+    scope: 'local' | 'remote' | 'all' = 'all',
+  ): Promise<void> {
     this.loadBuiltInAgents();
     await Promise.allSettled(
-      Array.from(this.agents.values()).map((agent) =>
-        this.registerAgent(agent),
-      ),
+      Array.from(this.agents.values()).map(async (agent) => {
+        if (scope === 'all' || agent.kind === scope) {
+          await this.registerAgent(agent);
+        }
+      }),
     );
   }
 

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -271,7 +271,7 @@ export class AgentRegistry {
   }
 
   private async refreshAgents(
-    scope: 'local' | 'remote' | 'all' = 'all',
+    scope: AgentDefinition['kind'] | 'all' = 'all',
   ): Promise<void> {
     this.loadBuiltInAgents();
     await Promise.allSettled(


### PR DESCRIPTION
## Summary

Fixes the issue where remote agents are needlessly re-fetched from the network every time the user switches the active model via `/model`.

## Details

AgentRegistry's `onModelChanged` responds by refreshing the registered agents. It was previously doing this by iterating over *all* registered agents. For remote agents, this triggers an asynchronous network request to reload their Agent Card. If the remote agent is offline or fails to authenticate, it emits an `error` via `CoreEvent.UserFeedback` on *every* model switch, causing phantom errors to continuously print to the console.

This PR modifies `refreshAgents()` to take an optional `scope` parameter and updates `onModelChanged` to explicitly pass `scope: 'local'`, safely avoiding redundant network requests for remote agents.

## Related Issues

Fixes #23575

## How to Validate

1. Configure an offline or failing remote agent in your settings.
2. Run `gemini-cli` and observe the initial load failure.
3. Switch the model with `/model gemini-2.5-pro`.
4. Verify that the agent error is *not* reprinted.
5. Verify `npm test -w @google/gemini-cli-core` passes.

## Pre-Merge Checklist

- [x] Added/updated tests (if needed)
