### PR TITLE
fix(tests): silence excessive log noise in AppContainer.test.tsx

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -60,6 +60,19 @@ const terminalNotificationsMocks = vi.hoisted(() => ({
   })),
 }));
 
+// Hoisted mock for generateSummary so it survives vi.clearAllMocks()
+const mockGenerateSummary = vi.hoisted(() =>
+  vi.fn(() => Promise.resolve(undefined)),
+);
+
+// Hoisted no-op debugLogger to silence console output from debugLogger calls
+const mockDebugLogger = vi.hoisted(() => ({
+  log: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('@google/gemini-cli-core')>();
@@ -92,6 +105,10 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
       start: vi.fn(),
       end: vi.fn(),
     },
+    // Silence "[SessionSummary] Error finding previous session" noise
+    generateSummary: mockGenerateSummary,
+    // Silence all debugLogger output (debug, log, warn, error) during tests
+    debugLogger: mockDebugLogger,
   };
 });
 import ansiEscapes from 'ansi-escapes';
@@ -204,6 +221,15 @@ vi.mock('../utils/events.js');
 vi.mock('../utils/handleAutoUpdate.js');
 vi.mock('./utils/ConsolePatcher.js');
 vi.mock('../utils/cleanup.js');
+// Silence "Failed to read or parse keybindings" noise from real fs reads
+vi.mock('./utils/terminalSetup.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('./utils/terminalSetup.js')>();
+  return {
+    ...actual,
+    useTerminalSetupPrompt: vi.fn(),
+  };
+});
 
 import { useHistory } from './hooks/useHistoryManager.js';
 import { useThemeCommand } from './hooks/useThemeCommand.js';
@@ -340,6 +366,25 @@ describe('AppContainer State Management', () => {
   beforeEach(() => {
     persistentStateMock.reset();
     vi.clearAllMocks();
+
+    // Suppress console noise from unmocked code paths (e.g. debugLogger
+    // calls that slip through, React act() warnings, etc.).
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Suppress the well-known React "act(...)" environment warning that fires
+    // on every render in a non-browser test environment, while still letting
+    // unexpected errors through.
+    // eslint-disable-next-line no-console
+    const originalError = console.error;
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      const msg = String(args[0] ?? '');
+      if (msg.includes('not configured to support act')) return;
+      originalError.call(console, ...args);
+    });
+
+    // Re-set after clearAllMocks so generateSummary().catch() doesn't blow up
+    mockGenerateSummary.mockImplementation(() => Promise.resolve(undefined));
 
     mockIdeClient.getInstance.mockReturnValue(new Promise(() => {}));
 


### PR DESCRIPTION
## Problem

The `AppContainer.test.tsx` suite (107 tests) was dumping **hundreds of lines** of noisy output on every run, drowning out actual test results and making CI logs hard to read.

Every single test case produced at least these two lines of noise:
- `[SessionSummary] Error finding previous session: Storage must be initialized before use`
- `Failed to read or parse keybindings, assuming prompt is needed: SyntaxError: Unexpected token ...`

Plus ~6 lines per test of React `act(...)` environment warnings on stderr.

## Root Causes and Fixes

### 1. generateSummary was not mocked
The real `generateSummary()` from `@google/gemini-cli-core` was called during each test, hitting uninitialised storage and logging via `debugLogger.debug()`.

**Fix:** Added a hoisted mock for `generateSummary` (returning a resolved Promise) in the `vi.mock` factory, and re-set it in `beforeEach` after `vi.clearAllMocks()`.

### 2. useTerminalSetupPrompt was not mocked
The real hook tried to read keybindings files from the host filesystem, failed, and logged via `debugLogger.debug()`.

**Fix:** Added `vi.mock('./utils/terminalSetup.js')` that stubs `useTerminalSetupPrompt` as a no-op.

### 3. debugLogger was not mocked
All remaining `debugLogger.log/warn/error/debug` calls in `AppContainer.tsx` were hitting real `console.*` methods.

**Fix:** Added a hoisted no-op `debugLogger` mock in the core mock factory, plus targeted `console` spies in `beforeEach` (`console.error` only suppresses the known React act() warning, letting real errors through).

## Result

| Before | After |
|--------|-------|
| Hundreds of noise lines per run | ~14 lines total (test results only) |
| 97 unhandled rejection errors | 0 errors |
| 107 tests passing | 107 tests passing |

## Related Issues
#23328
