### PR TITLE
[Google Summer of Code] fix(docs): update EvalCase properties in evals/README.md

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -140,6 +140,34 @@ describe('my_feature', () => {
 });
 ```
 
+### `appEvalTest`
+
+For evals that need to test UI interactions or use breakpoints, use
+`appEvalTest` from `evals/app-test-helper.ts`. It runs the CLI in-process using
+`AppRig` instead of as a subprocess, which allows pausing execution at specific
+tool calls.
+
+|             | `evalTest`               | `appEvalTest`                                  |
+| ----------- | ------------------------ | ---------------------------------------------- |
+| Rig         | `TestRig` (subprocess)   | `AppRig` (in-process)                          |
+| Import      | `./test-helper.js`       | `./app-test-helper.js`                         |
+| Breakpoints | No                       | Yes (`rig.setBreakpoint()`)                    |
+| Setup hook  | No                       | Yes (`setup: async (rig) => {}`)               |
+| Use when    | Standard workspace tests | UI/interaction tests, tool confirmation checks |
+
+#### `AppEvalCase` Properties
+
+- `name`: The name of the evaluation case.
+- `prompt`: The prompt to send to the model.
+- `files`: Same as `EvalCase` — optional file map for workspace setup.
+- `configOverrides`: An optional object for configuration overrides. Restricting
+  tools (`excludeTools`, `coreTools`, `allowedTools`) is forbidden.
+- `timeout`: An optional timeout in milliseconds. Defaults to 60 seconds.
+- `setup`: An optional async function that runs after file creation but before
+  the prompt is sent. Use this to set breakpoints.
+- `assert`: An async function that takes the rig and output string and asserts
+  correctness.
+
 ## Running Evaluations
 
 First, build the bundled Gemini CLI. You must do this after every code change.

--- a/evals/README.md
+++ b/evals/README.md
@@ -107,12 +107,20 @@ policy.** A subset that prove to be highly stable over time may be promoted to
 
 - `name`: The name of the evaluation case.
 - `prompt`: The prompt to send to the model.
+- `files`: An optional object mapping relative file paths to their contents
+  (e.g., `{ 'src/app.ts': 'const x = 1;' }`). When provided, the test helper
+  creates these files in a temporary directory and initializes a git repository
+  with an initial commit.
 - `params`: An optional object with parameters to pass to the test rig (e.g.,
-  settings).
+  settings). Note: restricting core tools via `tools.core` is forbidden and
+  enforced at compile time.
+- `timeout`: An optional timeout in milliseconds. Overrides the default 5-minute
+  timeout from the vitest config.
+- `approvalMode`: An optional string controlling how tool calls are approved
+  during the eval. One of `'default'`, `'auto_edit'`, `'yolo'`, or `'plan'`.
+  Defaults to `'yolo'` (all tools auto-approved).
 - `assert`: An async function that takes the test rig and the result of the run
   and asserts that the result is correct.
-- `log`: An optional boolean that, if set to `true`, will log the tool calls to
-  a file in the `evals/logs` directory.
 
 ### Example
 


### PR DESCRIPTION
## Summary

the EvalCase Properties section in evals/README.md was out of sync with the actual code, and appEvalTest was completely undocumented despite being used by 3 eval files.

## Details

first commit: removed the documented log property which doesn't exist in the EvalCase interface (test-helper.ts). added files, timeout, and approvalMode which exist in the interface but weren't documented.

second commit: added a section documenting appEvalTest and AppEvalCase from app-test-helper.ts. includes a comparison table showing when to use appEvalTest (in-process, breakpoints, UI tests) vs evalTest (subprocess, standard workspace tests).

## Related Issues

Fixes #23591
Fixes #23595
Related to #23331

## How to Validate

compare the updated EvalCase properties against the interface in evals/test-helper.ts lines 213-224. compare appEvalTest docs against evals/app-test-helper.ts.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)