### PR TITLE
fix tests: silence console output in cli and sdk test suites

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -111,12 +111,18 @@ policy.** A subset that prove to be highly stable over time may be promoted to
 
 - `name`: The name of the evaluation case.
 - `prompt`: The prompt to send to the model.
+- `files`: An optional map of file paths to contents. Files are written to the
+  test workspace before the agent runs, letting you provide source files,
+  configs, or other context the agent should operate on.
 - `params`: An optional object with parameters to pass to the test rig (e.g.,
   settings).
+- `approvalMode`: An optional approval mode for the agent during this eval.
+  Accepted values: `'default'`, `'auto_edit'`, `'yolo'`, `'plan'`. Defaults to
+  `'auto_edit'` when not set.
+- `timeout`: An optional timeout in milliseconds for the eval case. Overrides
+  the default test timeout.
 - `assert`: An async function that takes the test rig and the result of the run
   and asserts that the result is correct.
-- `log`: An optional boolean that, if set to `true`, will log the tool calls to
-  a file in the `evals/logs` directory.
 
 ### Example
 
@@ -128,9 +134,13 @@ describe('my_feature', () => {
   // New tests MUST start as USUALLY_PASSES and be promoted based on consistency metrics
   evalTest('USUALLY_PASSES', {
     name: 'should do something',
-    prompt: 'do it',
+    prompt: 'Add a hello() function to greet.ts',
+    files: {
+      'greet.ts': 'export {};\n',
+    },
     assert: async (rig, result) => {
-      // assertions
+      const content = await rig.readFile('greet.ts');
+      expect(content).toContain('hello');
     },
   });
 });

--- a/packages/cli/test-setup.ts
+++ b/packages/cli/test-setup.ts
@@ -36,6 +36,8 @@ process.env.TERM_PROGRAM = 'generic';
 import './src/test-utils/customMatchers.js';
 
 let consoleErrorSpy: vi.SpyInstance;
+let consoleLogSpy: vi.SpyInstance;
+let consoleWarnSpy: vi.SpyInstance;
 let actWarnings: Array<{ message: string; stack: string }> = [];
 
 beforeEach(() => {
@@ -43,6 +45,9 @@ beforeEach(() => {
   themeManager.resetForTesting();
 
   actWarnings = [];
+  // Silence console.log and console.warn to keep test output clean.
+  consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
   consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
     const firstArg = args[0];
     if (
@@ -79,6 +84,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  consoleLogSpy.mockRestore();
+  consoleWarnSpy.mockRestore();
   consoleErrorSpy.mockRestore();
 
   vi.unstubAllEnvs();

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
     testTimeout: 60000,
     hookTimeout: 60000,
     pool: 'forks',
+    silent: true,
     coverage: {
       enabled: true,
       provider: 'v8',

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -10,5 +10,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    silent: true,
+    reporters: ['default', 'junit'],
+    outputFile: {
+      junit: 'junit.xml',
+    },
   },
 });


### PR DESCRIPTION
## Summary

two vitest configs were missing silent: true, causing the CLI and SDK test suites to dump console output during passing test runs. added silent: true to both configs and extended the CLI test setup to explicitly silence console.log and console.warn. also synced the EvalCase properties section in evals/README.md with the actual interface in evals/test-helper.ts — removed a documented property that doesn't exist and added three that were missing.

## Details

added silent: true to packages/cli/vitest.config.ts, this was the main source of noise. core, a2a-server, and test-utils already had this set; cli was the outlier.

added silent: true to packages/sdk/vitest.config.ts along with standard reporters and outputFile fields to bring it in line with other packages.

added consoleLogSpy and consoleWarnSpy to packages/cli/test-setup.ts, the setup already silenced console.error via a spy (needed to preserve act() warning detection). log and warn had no equivalent, so they leaked output even with silent: true in place. the spies are restored in afterEach like the existing error spy.

the act() warning detection is unaffected as it works by wrapping console.error with vi.spyOn in beforeEach and throwing in afterEach if any warnings were captured. this is independent of vitest's silent flag.
 
removed log from the EvalCase properties section in evals/README.m, this property isn't in the EvalCase interface. tool logs are always written automatically (test-helper.ts line 152), not
  conditionally.

added files, timeout, and approvalMode to evals/README.md, all three exist in the interface but were undocumented. updated the example to use files so it reflects realistic eval usage instead of a minimal skeleton.
## Related Issues

 Fixes #23328 and #23331

## How to Validate

run npm run test in packages/cli and packages/sdk. passing tests should produce no console output.  
to confirm act() detection still works, temporarily add console.error('was not wrapped in act(...)') inside a test and verify it causes a failure.