### PR TITLE
[Google Summer of Code] feat(skills): add eval coverage analyzer skill

### DIFF
--- a/.gemini/skills/eval-coverage-analyzer/SKILL.md
+++ b/.gemini/skills/eval-coverage-analyzer/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: eval-coverage-analyzer
+description:
+  Analyze behavioral eval coverage across tools and prompt behaviors. Use when
+  assessing which agent behaviors have eval tests and which don't, identifying
+  gaps for new eval contributions, or reviewing overall eval health. Trigger
+  when the user asks about eval coverage, eval gaps, what needs testing, or
+  which tools lack behavioral tests.
+---
+
+# Eval Coverage Analyzer
+
+Scans existing behavioral evals and cross-references them with tool definitions
+and system prompt behaviors to produce a coverage report. This helps
+contributors identify where new evals are most needed.
+
+> The [behavioral-evals](.gemini/skills/behavioral-evals/SKILL.md) skill tells
+> you HOW to write evals. This skill tells you WHAT to write by finding gaps.
+
+## Workflow
+
+### 1. Scan existing evals
+
+Read all `evals/*.eval.ts` files. For each test case, extract:
+
+- the `describe` block name (feature area)
+- the test `name` (specific behavior)
+- which tool names appear in assertions (look for constants like `read_file`,
+  `replace`, `write_file`, `grep_search`, `ask_user`, etc.)
+- the type of assertion (tool was called, tool was NOT called, tool ordering,
+  file content check)
+
+Also check `evals/app-test-helper.ts` for tests using `appEvalTest` (these test
+interactive/UI behaviors with breakpoints).
+
+### 2. Get the full tool inventory
+
+Read `packages/core/src/tools/tool-names.ts` and find the
+`ALL_BUILTIN_TOOL_NAMES` array. This is the authoritative list of every built-in
+tool. The actual string values for each constant are in
+`packages/core/src/tools/definitions/base-declarations.ts`.
+
+### 3. Scan prompt behaviors
+
+Read `packages/core/src/prompts/snippets.ts` and extract the key behavioral
+instructions from:
+
+- **Core Mandates** section (security, context efficiency)
+- **Engineering Standards** section (conventions, testing, libraries, proactiveness)
+- **Context Efficiency** examples (searching, editing, reading patterns)
+
+Each of these represents a behavior that could be tested by an eval.
+
+### 4. Cross-reference and report
+
+Produce a coverage report with these sections:
+
+#### Tools with eval coverage
+
+For each tool that appears in at least one eval assertion, list:
+- tool name
+- which eval file(s) test it
+- what behaviors are tested
+
+#### Tools with NO eval coverage
+
+List every tool from `ALL_BUILTIN_TOOL_NAMES` that does not appear in any eval
+assertion. These are the primary gaps.
+
+#### Prompt behaviors with coverage
+
+Map the behavioral instructions from snippets.ts to existing evals. For example:
+- "do not stage or commit changes unless requested" → `gitRepo.eval.ts`
+- "use ranged reads for large files" → `frugalReads.eval.ts`
+
+#### Prompt behaviors without coverage
+
+List behavioral instructions from snippets.ts that have no corresponding eval.
+
+#### Suggested next evals
+
+Based on the gaps found, suggest the top 3-5 most important missing evals,
+prioritized by:
+1. tools/behaviors used frequently by users
+2. behaviors that are safety-critical (e.g., not deleting files unprompted)
+3. behaviors that have been the subject of bug reports or regressions
+
+For detailed guidance on writing the suggested evals, see
+**[references/coverage-analysis-guide.md](references/coverage-analysis-guide.md)**.

--- a/.gemini/skills/eval-coverage-analyzer/references/coverage-analysis-guide.md
+++ b/.gemini/skills/eval-coverage-analyzer/references/coverage-analysis-guide.md
@@ -1,0 +1,105 @@
+# Coverage Analysis Guide
+
+Detailed instructions for performing the eval coverage analysis.
+
+## How to read eval files
+
+Each eval file follows one of two patterns:
+
+### Standard evals (evalTest)
+
+```typescript
+import { evalTest } from './test-helper.js';
+
+evalTest('USUALLY_PASSES', {
+  name: 'should do X',
+  files: { ... },
+  prompt: '...',
+  assert: async (rig, result) => {
+    const toolLogs = rig.readToolLogs();
+    // assertions on toolLogs
+  },
+});
+```
+
+Look for tool names in the assert function:
+- `log.toolRequest.name === 'tool_name'` — direct tool check
+- `EDIT_TOOL_NAMES.has(...)` — checks for replace or write_file
+- `toolLogs.filter(...)` / `toolLogs.find(...)` / `toolLogs.findIndex(...)` —
+  tool presence or ordering checks
+- `rig.readFile(...)` — file content assertions (tests that edits happened
+  correctly)
+
+### Interactive evals (appEvalTest)
+
+```typescript
+import { appEvalTest } from './app-test-helper.js';
+
+appEvalTest('USUALLY_PASSES', {
+  name: 'should pause for confirmation',
+  setup: async (rig) => {
+    rig.setBreakpoint(['ask_user']);
+  },
+  assert: async (rig) => {
+    const confirmation = await rig.waitForPendingConfirmation('ask_user');
+    // assertions
+  },
+});
+```
+
+Look for:
+- `rig.setBreakpoint([...])` — which tools are breakpointed
+- `rig.waitForPendingConfirmation(...)` — which tools are waited on
+
+## Tool name reference
+
+The full list from `packages/core/src/tools/tool-names.ts`:
+
+| Constant | String value |
+|----------|-------------|
+| `GLOB_TOOL_NAME` | `glob` |
+| `GREP_TOOL_NAME` | `grep_search` |
+| `LS_TOOL_NAME` | `list_directory` |
+| `READ_FILE_TOOL_NAME` | `read_file` |
+| `READ_MANY_FILES_TOOL_NAME` | `read_many_files` |
+| `SHELL_TOOL_NAME` | `run_shell_command` |
+| `WRITE_FILE_TOOL_NAME` | `write_file` |
+| `EDIT_TOOL_NAME` | `replace` |
+| `WEB_SEARCH_TOOL_NAME` | `google_web_search` |
+| `WEB_FETCH_TOOL_NAME` | `web_fetch` |
+| `WRITE_TODOS_TOOL_NAME` | `write_todos` |
+| `MEMORY_TOOL_NAME` | `save_memory` |
+| `GET_INTERNAL_DOCS_TOOL_NAME` | `get_internal_docs` |
+| `ACTIVATE_SKILL_TOOL_NAME` | `activate_skill` |
+| `ASK_USER_TOOL_NAME` | `ask_user` |
+| `ENTER_PLAN_MODE_TOOL_NAME` | `enter_plan_mode` |
+| `EXIT_PLAN_MODE_TOOL_NAME` | `exit_plan_mode` |
+| `TRACKER_CREATE_TASK_TOOL_NAME` | `tracker_create_task` |
+| `TRACKER_UPDATE_TASK_TOOL_NAME` | `tracker_update_task` |
+| `TRACKER_GET_TASK_TOOL_NAME` | `tracker_get_task` |
+| `TRACKER_LIST_TASKS_TOOL_NAME` | `tracker_list_tasks` |
+| `TRACKER_ADD_DEPENDENCY_TOOL_NAME` | `tracker_add_dependency` |
+| `TRACKER_VISUALIZE_TOOL_NAME` | `tracker_visualize` |
+
+## Prompt behavior categories
+
+When scanning `packages/core/src/prompts/snippets.ts`, look for these
+behavioral categories:
+
+1. **Security** — credential protection, source control restrictions
+2. **Context efficiency** — search patterns, read patterns, turn minimization
+3. **Engineering standards** — conventions, libraries, testing, proactiveness
+4. **Intent alignment** — directive vs inquiry distinction
+5. **Tool-specific guidance** — edit tool instructions, shell tool restrictions
+6. **Plan mode** — read plan first, track tasks, iterate
+
+## Report format
+
+Output the report as markdown with clear sections. Use tables for the tool
+coverage mapping. Keep the suggested next evals section actionable — each
+suggestion should include:
+
+- what behavior to test
+- which tool(s) are involved
+- a one-line description of the test scenario
+- estimated difficulty (easy/medium/hard)


### PR DESCRIPTION
## Summary

adds a new Gemini CLI skill that analyzes behavioral eval coverage by scanning eval files and cross-referencing with tool definitions and system prompt behaviors. outputs a gap report showing what's tested vs what's not.

## Details

the skill sits alongside the existing behavioral-evals skill. that one tells you how to write evals, this one tells you what to write by finding gaps. it works by:

1. scanning all evals/*.eval.ts files and extracting which tools/behaviors each test covers
2. reading ALL_BUILTIN_TOOL_NAMES from packages/core/src/tools/tool-names.ts for the full tool inventory
3. reading behavioral instructions from packages/core/src/prompts/snippets.ts
4. cross-referencing and reporting tools with no coverage and prompt behaviors with no tests

includes a references/coverage-analysis-guide.md with detailed instructions on how to read eval files and interpret the tool name constants.

## Related Issues

Fixes #23596
Related to #23331

## How to Validate

read the SKILL.md and compare against existing skills in .gemini/skills/ for pattern consistency. check that the tool name reference table matches packages/core/src/tools/definitions/base-declarations.ts.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)