### PR TITLE
[Google Summer of Code] feat(skills): add log-to-eval conversion skill

### DIFF
--- a/.gemini/skills/log-to-eval/SKILL.md
+++ b/.gemini/skills/log-to-eval/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: log-to-eval
+description:
+  Convert a chat session log into a behavioral eval scaffold. Use when you want
+  to capture an observed agent behavior as a regression test, generate an eval
+  from a real session, or turn a bug reproduction into a behavioral eval.
+  Trigger when the user mentions converting logs to evals, generating evals
+  from sessions, or capturing agent behavior as a test.
+---
+
+# Log-to-Eval Conversion
+
+Converts a recorded Gemini CLI session into a behavioral eval scaffold. The
+agent reads a session file, presents the key interactions, and generates an
+eval that reproduces the observed behavior.
+
+> [!IMPORTANT]
+> The generated eval is a **scaffold**. You must review and refine the
+> assertions before submitting. Follow the
+> [Fail First](evals/README.md) principle — the eval should fail before your
+> prompt/tool change and pass after.
+
+## Workflow
+
+### 1. Find the session
+
+Session files are stored at `~/.gemini/tmp/<project_id>/chats/`. List
+available sessions:
+
+```bash
+ls -lt ~/.gemini/tmp/*/chats/session-*.json | head -10
+```
+
+The user can also provide a direct path to a session file.
+
+### 2. Parse the session
+
+Run the parse script to extract a readable summary of the session:
+
+```bash
+node .gemini/skills/log-to-eval/scripts/parse-session.js <path-to-session.json>
+```
+
+This outputs a JSON summary with:
+
+- each user prompt
+- each tool call the agent made (name, key args, success/failure)
+- files the agent read or wrote
+
+### 3. Select the behavior to capture
+
+Present the parsed summary to the user. Ask which interaction they want to turn
+into an eval. A good eval candidate is:
+
+- a specific tool call sequence that should always happen (e.g., read before edit)
+- a decision the agent made correctly that could regress (e.g., choosing the
+  right tool)
+- a mistake the agent made that a prompt change should fix
+
+### 4. Generate the eval scaffold
+
+Create the eval file at `evals/<behavior_name>.eval.ts` with:
+
+- Apache-2.0 license header (Copyright 2026 Google LLC)
+- `evalTest('USUALLY_PASSES', { ... })` from `evals/test-helper.js`
+- `files:` object populated from the session's file interactions. Extract only
+  the relevant portions of files — not full contents. If the agent read a
+  1000-line file but only edited lines 50-60, include just enough context
+  around those lines.
+- `prompt:` from the original user message in the session
+- `assert:` function with tool call checks matching the session's tool sequence.
+  Use patterns from existing evals (see
+  [references/session-format.md](references/session-format.md) for the data
+  structures).
+- `timeout: 180000` (3 minutes, matching other evals)
+
+### 5. Remind about fail-first
+
+After generating, remind the user:
+
+- the eval should **fail** before their prompt/tool change
+- if it already passes, it may be asserting behavior the agent gets for free
+- review `evals/README.md` for best practices before submitting
+
+## Key files
+
+| File                                               | Purpose                              |
+| -------------------------------------------------- | ------------------------------------ |
+| `~/.gemini/tmp/<id>/chats/session-*.json`          | recorded session data                |
+| `evals/test-helper.ts`                             | EvalCase interface for generated code |
+| `.gemini/skills/behavioral-evals/SKILL.md`         | how to write evals (companion skill) |
+| `packages/core/src/services/chatRecordingService.ts` | ConversationRecord type definitions |
+
+## References
+
+- **[session-format.md](references/session-format.md)**: data structures for
+  ConversationRecord, MessageRecord, and ToolCallRecord

--- a/.gemini/skills/log-to-eval/references/session-format.md
+++ b/.gemini/skills/log-to-eval/references/session-format.md
@@ -1,0 +1,88 @@
+# Session file format
+
+Reference for the data structures in chat session files, as defined in
+`packages/core/src/services/chatRecordingService.ts`.
+
+## ConversationRecord
+
+The top-level object in each session file.
+
+```typescript
+interface ConversationRecord {
+  sessionId: string; // UUID
+  projectHash: string; // SHA-256 hash of project root
+  startTime: string; // ISO 8601
+  lastUpdated: string; // ISO 8601
+  messages: MessageRecord[];
+  summary?: string;
+  directories?: string[];
+  kind?: 'main' | 'subagent';
+}
+```
+
+## MessageRecord
+
+Each entry in the messages array. The `type` field determines which extra
+fields are present.
+
+```typescript
+interface BaseMessageRecord {
+  id: string; // UUID
+  timestamp: string; // ISO 8601
+  content: PartListUnion; // gemini content parts
+  displayContent?: PartListUnion;
+}
+
+// user messages
+type UserMessage = BaseMessageRecord & {
+  type: 'user' | 'info' | 'error' | 'warning';
+};
+
+// agent messages
+type GeminiMessage = BaseMessageRecord & {
+  type: 'gemini';
+  toolCalls?: ToolCallRecord[];
+  thoughts?: Array<{ summary: string; timestamp: string }>;
+  tokens?: TokensSummary | null;
+  model?: string;
+};
+```
+
+## ToolCallRecord
+
+Each tool invocation within an agent message.
+
+```typescript
+interface ToolCallRecord {
+  id: string; // UUID
+  name: string; // tool name (e.g. 'read_file', 'replace')
+  args: Record<string, unknown>; // arguments passed to the tool
+  result?: PartListUnion | null; // tool output
+  status: Status; // execution status
+  timestamp: string; // ISO 8601
+  displayName?: string;
+  description?: string;
+}
+```
+
+## Common tool call args by tool
+
+| Tool | Key args |
+| --- | --- |
+| `read_file` | `file_path`, `start_line`, `end_line` |
+| `write_file` | `file_path`, `content` |
+| `replace` | `file_path`, `old_string`, `new_string` |
+| `grep_search` | `pattern`, `include_pattern`, `path` |
+| `glob` | `pattern`, `path` |
+| `run_shell_command` | `command`, `is_background` |
+| `ask_user` | `questions` |
+
+## File location
+
+Session files are at:
+
+```
+~/.gemini/tmp/<project_short_id>/chats/session-YYYY-MM-DDTHH-MM-<8chars>.json
+```
+
+The project short ID is derived from the project root path hash.

--- a/.gemini/skills/log-to-eval/scripts/parse-session.js
+++ b/.gemini/skills/log-to-eval/scripts/parse-session.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Parses a Gemini CLI session file and extracts a summary of user prompts,
+ * tool calls, and file interactions for use in eval generation.
+ *
+ * Usage: node parse-session.js <path-to-session.json>
+ *
+ * Output: JSON object with session summary to stdout.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const sessionPath = process.argv[2];
+
+if (!sessionPath) {
+  console.error('Usage: node parse-session.js <path-to-session.json>');
+  process.exit(1);
+}
+
+let session;
+try {
+  const raw = readFileSync(resolve(sessionPath), 'utf-8');
+  session = JSON.parse(raw);
+} catch (err) {
+  console.error(`Failed to read session file: ${err.message}`);
+  process.exit(1);
+}
+
+const FILE_TOOLS = new Set([
+  'read_file',
+  'write_file',
+  'replace',
+  'read_many_files',
+]);
+
+const summary = {
+  sessionId: session.sessionId,
+  startTime: session.startTime,
+  messageCount: session.messages?.length ?? 0,
+  turns: [],
+  filesInteracted: new Set(),
+};
+
+for (const message of session.messages ?? []) {
+  if (message.type === 'user') {
+    const text = extractText(message.content);
+    if (text) {
+      summary.turns.push({
+        role: 'user',
+        text: text.slice(0, 500),
+      });
+    }
+  }
+
+  if (message.type === 'gemini' && message.toolCalls?.length) {
+    const calls = message.toolCalls.map((tc) => {
+      const call = {
+        name: tc.name,
+        args: summarizeArgs(tc.args),
+        status: tc.status,
+      };
+
+      if (tc.args?.file_path) {
+        summary.filesInteracted.add(tc.args.file_path);
+      }
+      if (tc.args?.path) {
+        summary.filesInteracted.add(tc.args.path);
+      }
+
+      return call;
+    });
+
+    summary.turns.push({
+      role: 'agent',
+      toolCalls: calls,
+    });
+  }
+}
+
+summary.filesInteracted = [...summary.filesInteracted];
+
+console.log(JSON.stringify(summary, null, 2));
+
+function extractText(content) {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((p) => p.text)
+      .map((p) => p.text)
+      .join('\n');
+  }
+  if (content?.parts) {
+    return content.parts
+      .filter((p) => p.text)
+      .map((p) => p.text)
+      .join('\n');
+  }
+  return null;
+}
+
+function summarizeArgs(args) {
+  if (!args || typeof args !== 'object') return {};
+  const result = {};
+  for (const [key, value] of Object.entries(args)) {
+    if (typeof value === 'string' && value.length > 200) {
+      result[key] = value.slice(0, 200) + '...';
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

adds a skill that converts recorded chat sessions into behavioral eval scaffolds. includes a parse script that extracts user prompts, tool calls, and file interactions from session JSON files.

## Details

the chat recording infrastructure (chatRecordingService.ts) already captures everything needed to generate evals — tool calls with names, args, results, and the full conversation flow. but nothing bridges that to actual eval test files. this skill fills that gap.

the workflow: point it at a session file in ~/.gemini/tmp/<id>/chats/, the parse script extracts a summary, the user picks which behavior to capture, and the skill generates an evalTest scaffold with file fixtures, the original prompt, and assertion patterns matching the session's tool sequence.

includes:
- SKILL.md with the full conversion workflow
- scripts/parse-session.js (node script, tested on real session files)
- references/session-format.md documenting ConversationRecord, MessageRecord, ToolCallRecord

## Related Issues

Fixes #23598
Related to #23331

## How to Validate

run the parse script on a real session file:
```bash
node .gemini/skills/log-to-eval/scripts/parse-session.js ~/.gemini/tmp/*/chats/session-*.json
```

compare SKILL.md structure against existing skills in .gemini/skills/ for pattern consistency.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)