### PR TITLE
fix(askquestion): allow ask question to use the full height not just a max of 15 lines

### DIFF
--- a/packages/cli/src/ui/components/AskUserDialog.test.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.test.tsx
@@ -1453,4 +1453,42 @@ describe('AskUserDialog', () => {
       });
     });
   });
+
+  it('shows at least 3 selection options even in small terminal heights', async () => {
+    const questions: Question[] = [
+      {
+        question:
+          'A very long question that would normally take up most of the space and squeeze the list if we did not have a heuristic to prevent it. This line is just to make it longer. And another one. Imagine this is a plan.',
+        header: 'Test',
+        type: QuestionType.CHOICE,
+        options: [
+          { label: 'Option 1', description: 'Description 1' },
+          { label: 'Option 2', description: 'Description 2' },
+          { label: 'Option 3', description: 'Description 3' },
+          { label: 'Option 4', description: 'Description 4' },
+        ],
+        multiSelect: false,
+      },
+    ];
+
+    const { lastFrame, waitUntilReady } = await renderWithProviders(
+      <AskUserDialog
+        questions={questions}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+        width={80}
+        availableHeight={12} // Very small height
+      />,
+      { width: 80 },
+    );
+
+    await waitFor(async () => {
+      await waitUntilReady();
+      const frame = lastFrame();
+      // Should show at least 3 options
+      expect(frame).toContain('1.  Option 1');
+      expect(frame).toContain('2.  Option 2');
+      expect(frame).toContain('3.  Option 3');
+    });
+  });
 });

--- a/packages/cli/src/ui/components/AskUserDialog.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.tsx
@@ -849,11 +849,19 @@ const ChoiceQuestionView: React.FC<ChoiceQuestionViewProps> = ({
     ? Math.max(1, availableHeight - overhead)
     : undefined;
 
+  // Reserve space for at least 3 items if more selectionItems available.
+  const reservedListHeight = Math.min(selectionItems.length * 2, 6);
   const questionHeightLimit =
     listHeight && !isAlternateBuffer
       ? question.unconstrainedHeight
         ? Math.max(1, listHeight - selectionItems.length * 2)
-        : Math.min(15, Math.max(1, listHeight - DIALOG_PADDING))
+        : Math.min(
+            15,
+            Math.max(
+              1,
+              listHeight - Math.max(DIALOG_PADDING, reservedListHeight),
+            ),
+          )
       : undefined;
 
   const maxItemsToShow =

--- a/packages/cli/src/ui/components/__snapshots__/AskUserDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/AskUserDialog.test.tsx.snap
@@ -30,6 +30,8 @@ exports[`AskUserDialog > Scroll Arrows (useAlternateBuffer: false) > shows scrol
        Description 1                                                            
    2.  Option 2
        Description 2
+   3.  Option 3
+       Description 3
 ▼
 
 Enter to select · ↑/↓ to navigate · Esc to cancel


### PR DESCRIPTION
## Summary

As question tools particularly when used for plan mode should be allowed to expand to the whole terminal height or very close to it rather than being capped at 15 lines.

Also fix issues with spurious box bottoms render above the line art tool.

Fixes #23577