### PR TITLE
perf(cli): background IDE client to speed up initialization

### DIFF
--- a/packages/cli/src/core/initializer.test.ts
+++ b/packages/cli/src/core/initializer.test.ts
@@ -105,6 +105,9 @@ describe('initializer', () => {
       mockSettings,
     );
 
+    // Wait for the background promise to resolve
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
     expect(result).toEqual({
       authError: null,
       accountSuspensionInfo: null,

--- a/packages/cli/src/core/initializer.ts
+++ b/packages/cli/src/core/initializer.ts
@@ -13,6 +13,7 @@ import {
   StartSessionEvent,
   logCliConfiguration,
   startupProfiler,
+  debugLogger,
 } from '@google/gemini-cli-core';
 import { type LoadedSettings } from '../config/settings.js';
 import { performInitialAuth } from './auth.js';
@@ -55,9 +56,18 @@ export async function initializeApp(
   );
 
   if (config.getIdeMode()) {
-    const ideClient = await IdeClient.getInstance();
-    await ideClient.connect();
-    logIdeConnection(config, new IdeConnectionEvent(IdeConnectionType.START));
+    IdeClient.getInstance()
+      .then(async (ideClient) => {
+        await ideClient.connect();
+        logIdeConnection(
+          config,
+          new IdeConnectionEvent(IdeConnectionType.START),
+        );
+      })
+      .catch((e) => {
+        // We log locally if IDE connection setup fails in the background.
+        debugLogger.error('Failed to initialize IDE client:', e);
+      });
   }
 
   return {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1288,27 +1288,18 @@ export class Config implements McpContext, AgentLoopContext {
     // Initialize centralized FileDiscoveryService
     const discoverToolsHandle = startupProfiler.start('discover_tools');
     this.getFileService();
-
-    const discoveryPromises: Array<Promise<unknown>> = [];
-
     if (this.getCheckpointingEnabled()) {
-      discoveryPromises.push(this.getGitService());
+      await this.getGitService();
     }
-
     this._promptRegistry = new PromptRegistry();
     this._resourceRegistry = new ResourceRegistry();
 
     this.agentRegistry = new AgentRegistry(this);
-    discoveryPromises.push(this.agentRegistry.initialize());
+    await this.agentRegistry.initialize();
 
     coreEvents.on(CoreEvent.AgentsRefreshed, this.onAgentsRefreshed);
 
-    const toolRegistryPromise = this.createToolRegistry().then((registry) => {
-      this._toolRegistry = registry;
-    });
-    discoveryPromises.push(toolRegistryPromise);
-
-    await Promise.all(discoveryPromises);
+    this._toolRegistry = await this.createToolRegistry();
     discoverToolsHandle?.end();
     this.mcpClientManager = new McpClientManager(
       this.clientVersion,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1288,18 +1288,27 @@ export class Config implements McpContext, AgentLoopContext {
     // Initialize centralized FileDiscoveryService
     const discoverToolsHandle = startupProfiler.start('discover_tools');
     this.getFileService();
+
+    const discoveryPromises: Array<Promise<unknown>> = [];
+
     if (this.getCheckpointingEnabled()) {
-      await this.getGitService();
+      discoveryPromises.push(this.getGitService());
     }
+
     this._promptRegistry = new PromptRegistry();
     this._resourceRegistry = new ResourceRegistry();
 
     this.agentRegistry = new AgentRegistry(this);
-    await this.agentRegistry.initialize();
+    discoveryPromises.push(this.agentRegistry.initialize());
 
     coreEvents.on(CoreEvent.AgentsRefreshed, this.onAgentsRefreshed);
 
-    this._toolRegistry = await this.createToolRegistry();
+    const toolRegistryPromise = this.createToolRegistry().then((registry) => {
+      this._toolRegistry = registry;
+    });
+    discoveryPromises.push(toolRegistryPromise);
+
+    await Promise.all(discoveryPromises);
     discoverToolsHandle?.end();
     this.mcpClientManager = new McpClientManager(
       this.clientVersion,


### PR DESCRIPTION
## Summary

Optimizes core initialization tasks by backgrounding the IDE client setup. This reduces the blocking time during the CLI startup phase.

## Details

- **IDE Client:** Modified `IdeClient.getInstance()` and `connect()` to run as a fire-and-forget background promise. This prevents slow process tree traversals from blocking the main initialization thread in `initializeApp`.
- Updated `initializer.test.ts` to accommodate the asynchronous IDE client setup.

## Related Issues

Related to #21528

## How to Validate

- Run `gemini` in interactive mode or with a question in an IDE terminal (like VS Code).
- Check the debug logs (F12) and verify that `initialize_app` duration is significantly reduced.
- Verify that IDE integration features (like context trust and terminal switching) still function correctly after startup.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
