### PR TITLE
docs: fix step numbering, add Windows nvm note and sandbox version warning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,6 +207,12 @@ development setup of this project.
       tool like [nvm](https://github.com/nvm-sh/nvm) to manage Node.js versions.
     - **Production:** For running the CLI in a production environment, any
       version of Node.js `>=20` is acceptable.
+
+      > **Note:** To install a specific Node.js version, use
+      > `nvm install 20.19.0 && nvm use 20.19.0`. Windows users: `nvm` is not
+      > available by default. Please use
+      > [nvm-windows](https://github.com/coreybutler/nvm-windows) instead.
+
 2.  **Git**
 
 ### Build process
@@ -356,8 +362,8 @@ npm run lint
 
 #### VS Code
 
-0.  Run the CLI to interactively debug in VS Code with `F5`
-1.  Start the CLI in debug mode from the root directory:
+1.  Run the CLI to interactively debug in VS Code with `F5`
+2.  Start the CLI in debug mode from the root directory:
     ```bash
     npm run debug
     ```
@@ -365,7 +371,7 @@ npm run lint
     `packages/cli` directory, pausing execution until a debugger attaches. You
     can then open `chrome://inspect` in your Chrome browser to connect to the
     debugger.
-2.  In VS Code, use the "Attach" launch configuration (found in
+3.  In VS Code, use the "Attach" launch configuration (found in
     `.vscode/launch.json`).
 
 Alternatively, you can use the "Launch Program" configuration in VS Code if you

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -100,10 +100,18 @@ the default way that the CLI executes tools that might have side effects.
 - **Directly from the registry:** You can run the published sandbox image
   directly. This is useful for environments where you only have Docker and want
   to run the CLI.
+
   ```bash
+
+  > **Note:** Replace `0.1.1` with the latest sandbox
+  > image version. Using an outdated tag may cause
+  > errors. Check the latest version on the
+  > [releases page](https://github.com/google-gemini/gemini-cli/releases).
+
   # Run the published sandbox image
   docker run --rm -it us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.1
   ```
+
 - **Using the `--sandbox` flag:** If you have Gemini CLI installed locally
   (using the standard installation described above), you can instruct it to run
   inside the sandbox container.


### PR DESCRIPTION
## Summary
Fixed three documentation issues that confuse and 
block new contributors during setup and debugging.

## Changes Made

### CONTRIBUTING.md
- Fixed debugging step numbering starting at 0
  changed to start at 1 for standard readability
- Added Windows-friendly note for nvm installation
  since nvm is not available on Windows by default
  and requires nvm-windows instead

### docs/get-started/installation.md
- Added warning about hardcoded Docker sandbox 
  image version 0.1.1 which may become stale and
  cause silent errors for new contributors

## Why This Matters
- Step numbering at 0 confuses beginners who think
  they missed a step
- Windows contributors get stuck with no guidance
  on nvm installation
- Hardcoded Docker version breaks silently when
  version becomes outdated

## Type of Change
- [x] Documentation fix only (no functional code changed)

## Related Issue
Part of improving contributor onboarding for
behavioral evals area (GSoC #23331)