### PR TITLE
feat(cli): support skill discovery and namespacing for Open Plugins

### DIFF
--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -23,6 +23,8 @@ import {
   createOpenPlugin,
   type OpenPluginConfig,
   OPEN_PLUGIN_NAME_REGEX,
+  resolvePluginSkills,
+  type OpenPluginDiscoveryField,
 } from './plugin.js';
 import {
   isWorkspaceTrusted,
@@ -51,6 +53,7 @@ import {
   logExtensionUninstall,
   logExtensionUpdateEvent,
   loadSkillsFromDir,
+  type SkillDefinition,
   loadAgentsFromDirectory,
   homedir,
   ExtensionIntegrityManager,
@@ -343,9 +346,30 @@ Would you like to attempt to install via "git clone" instead?`,
           Object.keys(previous.hooks).length > 0
         );
 
-        const newSkills = await loadSkillsFromDir(
-          path.join(localSourcePath, 'skills'),
-        );
+        let newSkills: SkillDefinition[] = [];
+        if (newExtensionConfig.manifestType === 'open-plugin') {
+          const openPluginConfig = newExtensionConfig as OpenPluginConfig & {
+            skills?: OpenPluginDiscoveryField;
+          };
+          const hydrationContext = {
+            extensionPath: localSourcePath,
+            PLUGIN_ROOT: localSourcePath,
+            workspacePath: this.workspaceDir,
+            '/': path.sep,
+            pathSeparator: path.sep,
+          };
+          const resolvedSkills = await resolvePluginSkills(
+            localSourcePath,
+            newExtensionConfig.name,
+            hydrationContext,
+            openPluginConfig.skills,
+          );
+          newSkills = resolvedSkills || [];
+        } else {
+          newSkills = await loadSkillsFromDir(
+            path.join(localSourcePath, 'skills'),
+          );
+        }
         const previousSkills = previous?.skills ?? [];
         const isMigrating = Boolean(
           previous &&

--- a/packages/cli/src/config/open-plugin-discovery.test.ts
+++ b/packages/cli/src/config/open-plugin-discovery.test.ts
@@ -129,11 +129,10 @@ describe('ExtensionManager - Open Plugin Support', () => {
     expect(plugin?.description).toBe(`Uses root: ${pluginDir}`);
   });
 
-  it('should NOT load skills or context files for Open Plugins in v1', async () => {
+  it('should load skills for Open Plugins', async () => {
     const pluginDir = path.join(userExtensionsDir, 'feature-plugin');
-    const hiddenDir = path.join(pluginDir, '.plugin');
-    fs.mkdirSync(hiddenDir, { recursive: true });
-    const skillsDir = path.join(pluginDir, 'skills', 'test');
+    fs.mkdirSync(pluginDir, { recursive: true });
+    const skillsDir = path.join(pluginDir, 'skills', 'test-skill');
     fs.mkdirSync(skillsDir, { recursive: true });
 
     fs.writeFileSync(
@@ -147,20 +146,19 @@ describe('ExtensionManager - Open Plugin Support', () => {
     fs.writeFileSync(
       path.join(skillsDir, 'SKILL.md'),
       `---
-  name: test-skill
-  description: "Test"
-  ---
-  Body`,
+name: my-skill
+description: "Test description"
+---
+Body`,
     );
-
-    fs.writeFileSync(path.join(pluginDir, 'GEMINI.md'), '# Context');
 
     const extensions = await extensionManager.loadExtensions();
     const plugin = extensions.find((ext) => ext.name === 'feature-plugin');
 
     expect(plugin).toBeDefined();
-    expect(plugin?.skills).toBeUndefined();
-    expect(plugin?.contextFiles).toEqual([]);
+    expect(plugin?.skills).toBeDefined();
+    expect(plugin?.skills?.[0].name).toBe('feature-plugin:my-skill');
+    expect(plugin?.skills?.[0].extensionName).toBe('feature-plugin');
   });
 
   it('should prioritize gemini-extension.json over plugin.json', async () => {

--- a/packages/cli/src/config/open-plugin-discovery.test.ts
+++ b/packages/cli/src/config/open-plugin-discovery.test.ts
@@ -131,7 +131,8 @@ describe('ExtensionManager - Open Plugin Support', () => {
 
   it('should load skills for Open Plugins', async () => {
     const pluginDir = path.join(userExtensionsDir, 'feature-plugin');
-    fs.mkdirSync(pluginDir, { recursive: true });
+    const hiddenDir = path.join(pluginDir, '.plugin');
+    fs.mkdirSync(hiddenDir, { recursive: true });
     const skillsDir = path.join(pluginDir, 'skills', 'test-skill');
     fs.mkdirSync(skillsDir, { recursive: true });
 
@@ -159,6 +160,161 @@ Body`,
     expect(plugin?.skills).toBeDefined();
     expect(plugin?.skills?.[0].name).toBe('feature-plugin:my-skill');
     expect(plugin?.skills?.[0].extensionName).toBe('feature-plugin');
+  });
+
+  it('should load skills from custom path specified as string', async () => {
+    const pluginDir = path.join(userExtensionsDir, 'custom-path-plugin');
+    const hiddenDir = path.join(pluginDir, '.plugin');
+    fs.mkdirSync(hiddenDir, { recursive: true });
+    const skillsDir = path.join(pluginDir, 'custom-skills', 'test-skill');
+    fs.mkdirSync(skillsDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(hiddenDir, 'plugin.json'),
+      JSON.stringify({
+        name: 'custom-path-plugin',
+        version: '1.0.0',
+        skills: './custom-skills',
+      }),
+    );
+
+    fs.writeFileSync(
+      path.join(skillsDir, 'SKILL.md'),
+      `---
+name: my-skill
+description: "Test description"
+---
+Body`,
+    );
+
+    const extensions = await extensionManager.loadExtensions();
+    const plugin = extensions.find((ext) => ext.name === 'custom-path-plugin');
+
+    expect(plugin).toBeDefined();
+    expect(plugin?.skills).toBeDefined();
+    expect(plugin?.skills?.[0].name).toBe('custom-path-plugin:my-skill');
+  });
+
+  it('should load skills from custom paths specified as array', async () => {
+    const pluginDir = path.join(userExtensionsDir, 'array-path-plugin');
+    const hiddenDir = path.join(pluginDir, '.plugin');
+    fs.mkdirSync(hiddenDir, { recursive: true });
+    const skillsDir1 = path.join(pluginDir, 'skills1', 'skill1');
+    const skillsDir2 = path.join(pluginDir, 'skills2', 'skill2');
+    fs.mkdirSync(skillsDir1, { recursive: true });
+    fs.mkdirSync(skillsDir2, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(hiddenDir, 'plugin.json'),
+      JSON.stringify({
+        name: 'array-path-plugin',
+        version: '1.0.0',
+        skills: ['./skills1', './skills2'],
+      }),
+    );
+
+    fs.writeFileSync(
+      path.join(skillsDir1, 'SKILL.md'),
+      `---
+name: skill1
+description: "Desc 1"
+---
+Body`,
+    );
+
+    fs.writeFileSync(
+      path.join(skillsDir2, 'SKILL.md'),
+      `---
+name: skill2
+description: "Desc 2"
+---
+Body`,
+    );
+
+    const extensions = await extensionManager.loadExtensions();
+    const plugin = extensions.find((ext) => ext.name === 'array-path-plugin');
+
+    expect(plugin).toBeDefined();
+    expect(plugin?.skills).toHaveLength(2);
+    const skillNames = plugin?.skills?.map((s) => s.name);
+    expect(skillNames).toContain('array-path-plugin:skill1');
+    expect(skillNames).toContain('array-path-plugin:skill2');
+  });
+
+  it('should load skills from custom paths specified as object', async () => {
+    const pluginDir = path.join(userExtensionsDir, 'object-path-plugin');
+    const hiddenDir = path.join(pluginDir, '.plugin');
+    fs.mkdirSync(hiddenDir, { recursive: true });
+    const skillsDir = path.join(pluginDir, 'obj-skills', 'skill');
+    fs.mkdirSync(skillsDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(hiddenDir, 'plugin.json'),
+      JSON.stringify({
+        name: 'object-path-plugin',
+        version: '1.0.0',
+        skills: { paths: ['./obj-skills'] },
+      }),
+    );
+
+    fs.writeFileSync(
+      path.join(skillsDir, 'SKILL.md'),
+      `---
+name: skill1
+description: "Desc 1"
+---
+Body`,
+    );
+
+    const extensions = await extensionManager.loadExtensions();
+    const plugin = extensions.find((ext) => ext.name === 'object-path-plugin');
+
+    expect(plugin).toBeDefined();
+    expect(plugin?.skills?.[0].name).toBe('object-path-plugin:skill1');
+  });
+
+  it('should NOT load skills from default location if custom paths are specified', async () => {
+    const pluginDir = path.join(userExtensionsDir, 'override-plugin');
+    const hiddenDir = path.join(pluginDir, '.plugin');
+    fs.mkdirSync(hiddenDir, { recursive: true });
+    const defaultDir = path.join(pluginDir, 'skills', 'skill1');
+    const customDir = path.join(pluginDir, 'custom-skills', 'skill2');
+    fs.mkdirSync(defaultDir, { recursive: true });
+    fs.mkdirSync(customDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(hiddenDir, 'plugin.json'),
+      JSON.stringify({
+        name: 'override-plugin',
+        version: '1.0.0',
+        skills: './custom-skills',
+      }),
+    );
+
+    fs.writeFileSync(
+      path.join(defaultDir, 'SKILL.md'),
+      `---
+name: skill1
+description: "Default"
+---
+Body`,
+    );
+
+    fs.writeFileSync(
+      path.join(customDir, 'SKILL.md'),
+      `---
+name: skill2
+description: "Custom"
+---
+Body`,
+    );
+
+    const extensions = await extensionManager.loadExtensions();
+    const plugin = extensions.find((ext) => ext.name === 'override-plugin');
+
+    expect(plugin).toBeDefined();
+    expect(plugin?.skills).toHaveLength(1);
+    expect(plugin?.skills?.[0].name).toBe('override-plugin:skill2');
   });
 
   it('should prioritize gemini-extension.json over plugin.json', async () => {

--- a/packages/cli/src/config/plugin.ts
+++ b/packages/cli/src/config/plugin.ts
@@ -11,6 +11,7 @@ import {
   loadSkillsFromDir,
   type ExtensionInstallMetadata,
   type GeminiCLIExtension,
+  type SkillDefinition,
 } from '@google/gemini-cli-core';
 import {
   EXTENSIONS_CONFIG_FILENAME,
@@ -117,7 +118,7 @@ export async function loadOpenPluginConfig(
   manifestPath: string,
   extensionDir: string,
   workspaceDir: string,
-): Promise<ExtensionConfig> {
+): Promise<ExtensionConfig & { skills?: OpenPluginDiscoveryField }> {
   const content = await fs.promises.readFile(manifestPath, 'utf-8');
   const json = JSON.parse(content) as unknown;
   const result = openPluginSchema.safeParse(json);
@@ -151,6 +152,7 @@ export async function loadOpenPluginConfig(
     keywords: hydratedConfig.keywords,
     homepage: hydratedConfig.homepage,
     repository: hydratedConfig.repository,
+    skills: hydratedConfig.skills,
     // Features are explicitly NOT mapped here for v1 plugins
   };
 }
@@ -185,6 +187,7 @@ export async function createOpenPlugin(
     pluginDir,
     config.name,
     hydrationContext,
+    config.skills,
   );
 
   return {
@@ -216,19 +219,41 @@ export async function createOpenPlugin(
 /**
  * Discovers and namespaces skills for an Open Plugin.
  */
-async function resolvePluginSkills(
+export async function resolvePluginSkills(
   pluginDir: string,
   pluginName: string,
   hydrationContext: Record<string, string>,
+  skillsConfig?: OpenPluginDiscoveryField,
 ): Promise<GeminiCLIExtension['skills']> {
-  const skillsDir = path.join(pluginDir, 'skills');
-  const discoveredSkills = await loadSkillsFromDir(skillsDir);
+  let resolvedPaths: string[] = [];
 
-  if (discoveredSkills.length === 0) {
+  if (skillsConfig) {
+    if (typeof skillsConfig === 'string') {
+      resolvedPaths = [skillsConfig];
+    } else if (Array.isArray(skillsConfig)) {
+      resolvedPaths = skillsConfig;
+    } else if (typeof skillsConfig === 'object' && 'paths' in skillsConfig) {
+      resolvedPaths = skillsConfig.paths;
+    }
+  } else {
+    resolvedPaths = ['./skills/'];
+  }
+
+  const allDiscoveredSkills: SkillDefinition[] = [];
+
+  for (const relPath of resolvedPaths) {
+    const absPath = path.resolve(pluginDir, relPath);
+    if (fs.existsSync(absPath)) {
+      const discovered = await loadSkillsFromDir(absPath);
+      allDiscoveredSkills.push(...discovered);
+    }
+  }
+
+  if (allDiscoveredSkills.length === 0) {
     return undefined;
   }
 
-  return discoveredSkills.map((skill) => ({
+  return allDiscoveredSkills.map((skill) => ({
     ...recursivelyHydrateStrings(skill, hydrationContext),
     name: `${pluginName}:${skill.name}`,
     extensionName: pluginName,

--- a/packages/cli/src/config/plugin.ts
+++ b/packages/cli/src/config/plugin.ts
@@ -7,9 +7,10 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { z } from 'zod';
-import type {
-  ExtensionInstallMetadata,
-  GeminiCLIExtension,
+import {
+  loadSkillsFromDir,
+  type ExtensionInstallMetadata,
+  type GeminiCLIExtension,
 } from '@google/gemini-cli-core';
 import {
   EXTENSIONS_CONFIG_FILENAME,
@@ -156,7 +157,6 @@ export async function loadOpenPluginConfig(
 
 /**
  * Creates a GeminiCLIExtension from an Open Plugin directory.
- * v1: Does not enable skills, mcp servers, context files, or settings.
  */
 export async function createOpenPlugin(
   pluginDir: string,
@@ -171,6 +171,20 @@ export async function createOpenPlugin(
     manifestPath,
     pluginDir,
     workspaceDir,
+  );
+
+  const hydrationContext = {
+    extensionPath: pluginDir,
+    PLUGIN_ROOT: pluginDir,
+    workspacePath: workspaceDir,
+    '/': path.sep,
+    pathSeparator: path.sep,
+  };
+
+  const skills = await resolvePluginSkills(
+    pluginDir,
+    config.name,
+    hydrationContext,
   );
 
   return {
@@ -193,8 +207,30 @@ export async function createOpenPlugin(
     excludeTools: undefined,
     settings: undefined,
     resolvedSettings: undefined,
-    skills: undefined,
+    skills,
     agents: undefined,
     themes: undefined,
   };
+}
+
+/**
+ * Discovers and namespaces skills for an Open Plugin.
+ */
+async function resolvePluginSkills(
+  pluginDir: string,
+  pluginName: string,
+  hydrationContext: Record<string, string>,
+): Promise<GeminiCLIExtension['skills']> {
+  const skillsDir = path.join(pluginDir, 'skills');
+  const discoveredSkills = await loadSkillsFromDir(skillsDir);
+
+  if (discoveredSkills.length === 0) {
+    return undefined;
+  }
+
+  return discoveredSkills.map((skill) => ({
+    ...recursivelyHydrateStrings(skill, hydrationContext),
+    name: `${pluginName}:${skill.name}`,
+    extensionName: pluginName,
+  }));
 }

--- a/packages/cli/src/services/SlashCommandResolver.test.ts
+++ b/packages/cli/src/services/SlashCommandResolver.test.ts
@@ -218,6 +218,19 @@ describe('SlashCommandResolver', () => {
       expect(names).toContain('google-workspace:chat1');
     });
 
+    it('should NOT double-prefix when a skill name is already prefixed', () => {
+      const skill = {
+        ...createMockCommand('google-workspace:chat', CommandKind.SKILL),
+        extensionName: 'google-workspace',
+      };
+
+      const { finalCommands } = SlashCommandResolver.resolve([skill]);
+
+      const names = finalCommands.map((c) => c.name);
+      expect(names).toContain('google-workspace:chat');
+      expect(names).not.toContain('google-workspace:google-workspace:chat');
+    });
+
     it('should NOT prefix skills with "skill" when extension name is missing', () => {
       const builtin = createMockCommand('chat', CommandKind.BUILT_IN);
       const skill = createMockCommand('chat', CommandKind.SKILL);

--- a/packages/cli/src/services/SlashCommandResolver.ts
+++ b/packages/cli/src/services/SlashCommandResolver.ts
@@ -173,7 +173,15 @@ export class SlashCommandResolver {
     const isExtensionPrefix =
       kind === CommandKind.SKILL || kind === CommandKind.EXTENSION_FILE;
     const separator = isExtensionPrefix ? ':' : '.';
-    const base = prefix ? `${prefix}${separator}${name}` : name;
+
+    // Check if it's already correctly prefixed
+    const alreadyPrefixed = prefix && name.startsWith(`${prefix}${separator}`);
+    const base = alreadyPrefixed
+      ? name
+      : prefix
+        ? `${prefix}${separator}${name}`
+        : name;
+
     let renamedName = base;
     let suffix = 1;
 


### PR DESCRIPTION
## Summary

This PR implements convention-based skill discovery and namespacing for Open Plugins (plugin.json). Discovered skills are automatically prefixed with the plugin name (`plugin-name:skill-name`) ensuring they are properly namespaced for the model, policy engine, and slash commands.

<img width="3456" height="2160" alt="image" src="https://github.com/user-attachments/assets/9f2d49c3-f263-4506-bbdc-28e02c71cddf" />


## Details

- **Skill Discovery**: Updated `skillLoader` to support discovery in `skills/` subdirectories.
- **Convention-based Loading**: Open Plugins now automatically discover skills in their `skills/` folder.
- **Namespacing**: Plugin skills are prefixed with the plugin name at load time. This ensures that namespacing is consistent across the entire system.
- **Refactoring**: Extracted skill resolution logic into a separate `resolvePluginSkills` method in `plugin.ts` for better maintainability.
- **Slash Command Fix**: Updated `SlashCommandResolver` to handle pre-namespaced skills gracefully, avoiding double-prefixing.

## Related Issues

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/1592

## How to Validate

Run the following test suites:
- `npm test -w @google/gemini-cli -- src/config/open-plugin-discovery.test.ts`
- `npm test -w @google/gemini-cli -- src/services/SlashCommandResolver.test.ts`
- `npm test -w @google/gemini-cli-core -- src/skills/skillLoader.test.ts`

Manual verification:
1. Load an Open Plugin with a `skills/` directory.
2. Run `/skills list` and verify the skills appear with the `plugin:skill` format.

## Pre-Merge Checklist

- [x] Added/updated tests (if needed)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
