### PR TITLE
fix(acp): Pass the cwd to `AcpFileSystemService` to avoid looping failures in asking for perms to write plan md file

### DIFF
--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -294,6 +294,7 @@ export class GeminiAgent {
         sessionId,
         this.clientCapabilities.fs,
         config.getFileSystemService(),
+        cwd,
       );
       config.setFileSystemService(acpFileSystemService);
     }
@@ -350,16 +351,6 @@ export class GeminiAgent {
     const sessionSelector = new SessionSelector(config);
     const { sessionData, sessionPath } =
       await sessionSelector.resolveSession(sessionId);
-
-    if (this.clientCapabilities?.fs) {
-      const acpFileSystemService = new AcpFileSystemService(
-        this.connection,
-        sessionId,
-        this.clientCapabilities.fs,
-        config.getFileSystemService(),
-      );
-      config.setFileSystemService(acpFileSystemService);
-    }
 
     const clientHistory = convertSessionToClientHistory(sessionData.messages);
 
@@ -434,7 +425,19 @@ export class GeminiAgent {
       throw acp.RequestError.authRequired();
     }
 
-    // 3. Now that we are authenticated, it is safe to initialize the config
+    // 3. Set the ACP FileSystemService (if supported) before config initialization
+    if (this.clientCapabilities?.fs) {
+      const acpFileSystemService = new AcpFileSystemService(
+        this.connection,
+        sessionId,
+        this.clientCapabilities.fs,
+        config.getFileSystemService(),
+        cwd,
+      );
+      config.setFileSystemService(acpFileSystemService);
+    }
+
+    // 4. Now that we are authenticated, it is safe to initialize the config
     // which starts the MCP servers and other heavy resources.
     await config.initialize();
     startupProfiler.flush(config);

--- a/packages/cli/src/acp/fileSystemService.test.ts
+++ b/packages/cli/src/acp/fileSystemService.test.ts
@@ -4,10 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach, type Mocked } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mocked,
+} from 'vitest';
 import { AcpFileSystemService } from './fileSystemService.js';
 import type { AgentSideConnection } from '@agentclientprotocol/sdk';
 import type { FileSystemService } from '@google/gemini-cli-core';
+import os from 'node:os';
+
+vi.mock('node:os', () => ({
+  default: {
+    homedir: vi.fn(),
+  },
+}));
 
 describe('AcpFileSystemService', () => {
   let mockConnection: Mocked<AgentSideConnection>;
@@ -25,13 +40,19 @@ describe('AcpFileSystemService', () => {
       readTextFile: vi.fn(),
       writeTextFile: vi.fn(),
     };
+    vi.mocked(os.homedir).mockReturnValue('/home/user');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   describe('readTextFile', () => {
     it.each([
       {
         capability: true,
-        desc: 'connection if capability exists',
+        path: '/path/to/file',
+        desc: 'connection if capability exists and file is inside root',
         setup: () => {
           mockConnection.readTextFile.mockResolvedValue({ content: 'content' });
         },
@@ -45,6 +66,7 @@ describe('AcpFileSystemService', () => {
       },
       {
         capability: false,
+        path: '/path/to/file',
         desc: 'fallback if capability missing',
         setup: () => {
           mockFallback.readTextFile.mockResolvedValue('content');
@@ -56,19 +78,72 @@ describe('AcpFileSystemService', () => {
           expect(mockConnection.readTextFile).not.toHaveBeenCalled();
         },
       },
-    ])('should use $desc', async ({ capability, setup, verify }) => {
+      {
+        capability: true,
+        path: '/outside/file',
+        desc: 'fallback if capability exists but file is outside root',
+        setup: () => {
+          mockFallback.readTextFile.mockResolvedValue('content');
+        },
+        verify: () => {
+          expect(mockFallback.readTextFile).toHaveBeenCalledWith(
+            '/outside/file',
+          );
+          expect(mockConnection.readTextFile).not.toHaveBeenCalled();
+        },
+      },
+      {
+        capability: true,
+        path: '/home/user/.gemini/tmp/file.md',
+        root: '/home/user',
+        desc: 'fallback if file is inside global gemini dir, even if root overlaps',
+        setup: () => {
+          mockFallback.readTextFile.mockResolvedValue('content');
+        },
+        verify: () => {
+          expect(mockFallback.readTextFile).toHaveBeenCalledWith(
+            '/home/user/.gemini/tmp/file.md',
+          );
+          expect(mockConnection.readTextFile).not.toHaveBeenCalled();
+        },
+      },
+    ])(
+      'should use $desc',
+      async ({ capability, path, root, setup, verify }) => {
+        service = new AcpFileSystemService(
+          mockConnection,
+          'session-1',
+          { readTextFile: capability, writeTextFile: true },
+          mockFallback,
+          root || '/path/to',
+        );
+        setup();
+
+        const result = await service.readTextFile(path);
+
+        expect(result).toBe('content');
+        verify();
+      },
+    );
+
+    it('should throw normalized ENOENT error when readTextFile encounters "Resource not found"', async () => {
       service = new AcpFileSystemService(
         mockConnection,
         'session-1',
-        { readTextFile: capability, writeTextFile: true },
+        { readTextFile: true, writeTextFile: true },
         mockFallback,
+        '/path/to',
       );
-      setup();
+      mockConnection.readTextFile.mockRejectedValue(
+        new Error('Resource not found for document'),
+      );
 
-      const result = await service.readTextFile('/path/to/file');
-
-      expect(result).toBe('content');
-      verify();
+      await expect(
+        service.readTextFile('/path/to/missing'),
+      ).rejects.toMatchObject({
+        code: 'ENOENT',
+        message: 'Resource not found for document',
+      });
     });
   });
 
@@ -76,7 +151,8 @@ describe('AcpFileSystemService', () => {
     it.each([
       {
         capability: true,
-        desc: 'connection if capability exists',
+        path: '/path/to/file',
+        desc: 'connection if capability exists and file is inside root',
         verify: () => {
           expect(mockConnection.writeTextFile).toHaveBeenCalledWith({
             path: '/path/to/file',
@@ -88,6 +164,7 @@ describe('AcpFileSystemService', () => {
       },
       {
         capability: false,
+        path: '/path/to/file',
         desc: 'fallback if capability missing',
         verify: () => {
           expect(mockFallback.writeTextFile).toHaveBeenCalledWith(
@@ -97,17 +174,63 @@ describe('AcpFileSystemService', () => {
           expect(mockConnection.writeTextFile).not.toHaveBeenCalled();
         },
       },
-    ])('should use $desc', async ({ capability, verify }) => {
+      {
+        capability: true,
+        path: '/outside/file',
+        desc: 'fallback if capability exists but file is outside root',
+        verify: () => {
+          expect(mockFallback.writeTextFile).toHaveBeenCalledWith(
+            '/outside/file',
+            'content',
+          );
+          expect(mockConnection.writeTextFile).not.toHaveBeenCalled();
+        },
+      },
+      {
+        capability: true,
+        path: '/home/user/.gemini/tmp/file.md',
+        root: '/home/user',
+        desc: 'fallback if file is inside global gemini dir, even if root overlaps',
+        verify: () => {
+          expect(mockFallback.writeTextFile).toHaveBeenCalledWith(
+            '/home/user/.gemini/tmp/file.md',
+            'content',
+          );
+          expect(mockConnection.writeTextFile).not.toHaveBeenCalled();
+        },
+      },
+    ])('should use $desc', async ({ capability, path, root, verify }) => {
       service = new AcpFileSystemService(
         mockConnection,
         'session-1',
         { writeTextFile: capability, readTextFile: true },
         mockFallback,
+        root || '/path/to',
       );
 
-      await service.writeTextFile('/path/to/file', 'content');
+      await service.writeTextFile(path, 'content');
 
       verify();
+    });
+
+    it('should throw normalized ENOENT error when writeTextFile encounters "Resource not found"', async () => {
+      service = new AcpFileSystemService(
+        mockConnection,
+        'session-1',
+        { readTextFile: true, writeTextFile: true },
+        mockFallback,
+        '/path/to',
+      );
+      mockConnection.writeTextFile.mockRejectedValue(
+        new Error('Resource not found for directory'),
+      );
+
+      await expect(
+        service.writeTextFile('/path/to/missing', 'content'),
+      ).rejects.toMatchObject({
+        code: 'ENOENT',
+        message: 'Resource not found for directory',
+      });
     });
   });
 });

--- a/packages/cli/src/acp/fileSystemService.ts
+++ b/packages/cli/src/acp/fileSystemService.ts
@@ -4,44 +4,82 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { FileSystemService } from '@google/gemini-cli-core';
+import { isWithinRoot, type FileSystemService } from '@google/gemini-cli-core';
 import type * as acp from '@agentclientprotocol/sdk';
+import os from 'node:os';
+import path from 'node:path';
 
 /**
  * ACP client-based implementation of FileSystemService
  */
 export class AcpFileSystemService implements FileSystemService {
+  private readonly geminiDir = path.join(os.homedir(), '.gemini');
+
   constructor(
     private readonly connection: acp.AgentSideConnection,
     private readonly sessionId: string,
     private readonly capabilities: acp.FileSystemCapabilities,
     private readonly fallback: FileSystemService,
+    private readonly root: string,
   ) {}
 
+  private shouldUseFallback(filePath: string): boolean {
+    // Files inside the global CLI directory must always use the native file system,
+    // even if the user runs the CLI directly from their home directory (which
+    // would make the IDE's project root overlap with the global directory).
+    return (
+      !isWithinRoot(filePath, this.root) ||
+      isWithinRoot(filePath, this.geminiDir)
+    );
+  }
+
+  private normalizeFileSystemError(err: unknown): never {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    if (
+      errorMessage.includes('Resource not found') ||
+      errorMessage.includes('ENOENT') ||
+      errorMessage.includes('does not exist') ||
+      errorMessage.includes('No such file')
+    ) {
+      const newErr = new Error(errorMessage) as NodeJS.ErrnoException;
+      newErr.code = 'ENOENT';
+      throw newErr;
+    }
+    throw err;
+  }
+
   async readTextFile(filePath: string): Promise<string> {
-    if (!this.capabilities.readTextFile) {
+    if (!this.capabilities.readTextFile || this.shouldUseFallback(filePath)) {
       return this.fallback.readTextFile(filePath);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const response = await this.connection.readTextFile({
-      path: filePath,
-      sessionId: this.sessionId,
-    });
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const response = await this.connection.readTextFile({
+        path: filePath,
+        sessionId: this.sessionId,
+      });
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return response.content;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return response.content;
+    } catch (err: unknown) {
+      this.normalizeFileSystemError(err);
+    }
   }
 
   async writeTextFile(filePath: string, content: string): Promise<void> {
-    if (!this.capabilities.writeTextFile) {
+    if (!this.capabilities.writeTextFile || this.shouldUseFallback(filePath)) {
       return this.fallback.writeTextFile(filePath, content);
     }
 
-    await this.connection.writeTextFile({
-      path: filePath,
-      content,
-      sessionId: this.sessionId,
-    });
+    try {
+      await this.connection.writeTextFile({
+        path: filePath,
+        content,
+        sessionId: this.sessionId,
+      });
+    } catch (err: unknown) {
+      this.normalizeFileSystemError(err);
+    }
   }
 }


### PR DESCRIPTION
## Summary

The gemini-cli agent was sending requests to the ACP IDE client to write its .md plan files into a designated scratch directory (`~/.gemini/tmp/`) located outside your project's workspace, causing the IDE to block the action for security reasons. To fix this, we need to update the ACP file system integration to detect when a target file resides outside the workspace root. When it does that, the agent bypasses the IDE's file system and natively writes the file to the local disk.

## Details

**Main issue**: The IDE's ACP implementation correctly denies writing files outside of its active workspace scope, which halted Plan Mode completely because the agent stores markdown plans in its internal global cache (`~/.gemini/tmp/`).
So we do the following: 
- Update` AcpFileSystemService` constructor to accept and store the active workspace's root directory string (cwd).
- Inject workspace context at  the session start by passing the cwd parameter down into the `AcpFileSystemService` from both the `newSession` and `loadSession` setup methods within `packages/cli/src/acp/acpClient.ts`.
- Import the `isWithinRoot` utility and wrap the ACP `readTextFile` and `writeTextFile` methods with it. If `isWithinRoot(filePath, this.root)` resolves to false, the operation aborts the IDE proxy communication and calls the native Node.js fallback instead.
- Update the `fileSystemService.test.ts` suite to instantiate the service with a dummy root path, adding dedicated tests to explicitly verify that out-of-bounds file paths trigger the fallback logic without calling the `mockConnection`.

## Related Issues

Fixes #22191 

## How to Validate

Use ACP in plan mode ans ensure that there is no failures to automatically write a plan.md file for the prompt.


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [✅] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [✅] Validated on required platforms/methods:
  - [✅] MacOS
    - [✅] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
