### PR TITLE
docs: add Test Rig docs, fix HTML entities and documentation gaps in evals

### DIFF
--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -38,10 +38,10 @@ npm run test:e2e
 ## Running a specific set of tests
 
 To run a subset of test files, you can use
-`npm run <integration test command> <file_name1> ....` where &lt;integration
-test command&gt; is either `test:e2e` or `test:integration*` and `<file_name>`
-is any of the `.test.js` files in the `integration-tests/` directory. For
-example, the following command runs `list_directory.test.js` and
+`npm run <integration test command> <file_name1> ....` where
+`<integration test command>` is either `test:e2e` or `test:integration*` and
+`<file_name>` is any of the `.test.js` files in the `integration-tests/`
+directory. For example, the following command runs `list_directory.test.js` and
 `write_file.test.js`:
 
 ```bash

--- a/evals/README.md
+++ b/evals/README.md
@@ -115,8 +115,19 @@ policy.** A subset that prove to be highly stable over time may be promoted to
   settings).
 - `assert`: An async function that takes the test rig and the result of the run
   and asserts that the result is correct.
+
+> **Note:** The `rig` parameter is an instance of `TestRig` from
+> `@google/gemini-cli-test-utils`. It provides utilities to inspect the agent's
+> state, files written, and tool calls made during the evaluation. For available
+> methods and properties, see
+> [`test-rig.ts`](../packages/test-utils/src/test-rig.ts).
+
 - `log`: An optional boolean that, if set to `true`, will log the tool calls to
   a file in the `evals/logs` directory.
+- `approvalMode`: An optional string that controls how tool confirmations are
+  handled during the evaluation. Defaults to `'yolo'`, which means all tool
+  calls are auto-approved so evals can run non-interactively without requiring
+  manual confirmation.
 
 ### Example
 
@@ -175,6 +186,12 @@ of the individual executions passed.
 
 Googlers can schedule a manual run against their branch by clicking the link
 above.
+
+> **Note for external contributors:** If you are not a Googler, you do not have
+> access to manually trigger the nightly workflow. This is expected — simply
+> open your pull request with your changes and leave a comment asking a
+> maintainer to trigger the nightly eval run for you. Maintainers are happy to
+> help once they have done an initial review of your PR.
 
 Tests should score at least 66% with key models including Gemini 3.1 pro, Gemini
 3.0 pro, and Gemini 3 flash prior to check in and they must pass 100% of the


### PR DESCRIPTION
## Summary
Fixed four documentation gaps in the evals area 
that confuse and block new contributors trying to 
write their first behavioral eval.

## Changes Made

### evals/README.md
- Added TestRig explanation in EvalCase Properties
  section so contributors understand what the rig
  parameter provides and where to find its methods
- Added external contributor guidance for nightly
  workflow since non-Googlers cannot trigger it
  manually and need to know what to do instead
- Added approvalMode property documentation in
  EvalCase Properties section explaining the
  default yolo value and what it means

### docs/integration-tests.md
- Fixed HTML entities showing as literal text
  changed &lt; and &gt; to proper angle brackets
  wrapped in backticks for correct rendering

## Why This Matters
These are exactly the gaps that block new 
contributors from understanding and writing 
behavioral evals effectively:

- Without TestRig docs, contributors copy patterns 
  blindly without understanding why
- Without external contributor guidance, non-Googlers 
  are left confused about nightly workflow access
- Without approvalMode docs, contributors are confused 
  by the magic string yolo with no explanation
- HTML entities showing as literal text makes 
  commands look broken and unreadable

## Type of Change
- [x] Documentation fix only (no functional code changed)

## Related Issue
Part of improving contributor onboarding for
behavioral evals area (GSoC #23331)
