### PR TITLE
Fix `cpSync` throwing `EEXIST` error in Node.js 22 when the destination directory already exists

### DIFF
--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -17,7 +17,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { copyFileSync, existsSync, mkdirSync, cpSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, cpSync, rmSync } from 'node:fs';
 import { dirname, join, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { glob } from 'glob';
@@ -58,7 +58,14 @@ console.log(`Copied ${policyFiles.length} policy files to bundle/policies/`);
 const docsSrc = join(root, 'docs');
 const docsDest = join(bundleDir, 'docs');
 if (existsSync(docsSrc)) {
-  cpSync(docsSrc, docsDest, { recursive: true, dereference: true });
+  if (existsSync(docsDest)) {
+    rmSync(docsDest, { recursive: true, force: true });
+  }
+  cpSync(docsSrc, docsDest, {
+    recursive: true,
+    dereference: true,
+    force: true,
+  });
   console.log('Copied docs to bundle/docs/');
 }
 
@@ -66,9 +73,13 @@ if (existsSync(docsSrc)) {
 const builtinSkillsSrc = join(root, 'packages/core/src/skills/builtin');
 const builtinSkillsDest = join(bundleDir, 'builtin');
 if (existsSync(builtinSkillsSrc)) {
+  if (existsSync(builtinSkillsDest)) {
+    rmSync(builtinSkillsDest, { recursive: true, force: true });
+  }
   cpSync(builtinSkillsSrc, builtinSkillsDest, {
     recursive: true,
     dereference: true,
+    force: true,
   });
   console.log('Copied built-in skills to bundle/builtin/');
 }
@@ -84,9 +95,14 @@ const devtoolsDest = join(
 const devtoolsDistSrc = join(devtoolsSrc, 'dist');
 if (existsSync(devtoolsDistSrc)) {
   mkdirSync(devtoolsDest, { recursive: true });
-  cpSync(devtoolsDistSrc, join(devtoolsDest, 'dist'), {
+  const destDist = join(devtoolsDest, 'dist');
+  if (existsSync(destDist)) {
+    rmSync(destDist, { recursive: true, force: true });
+  }
+  cpSync(devtoolsDistSrc, destDist, {
     recursive: true,
     dereference: true,
+    force: true,
   });
   copyFileSync(
     join(devtoolsSrc, 'package.json'),
@@ -99,7 +115,14 @@ if (existsSync(devtoolsDistSrc)) {
 const bundleMcpSrc = join(root, 'packages/core/dist/bundled');
 const bundleMcpDest = join(bundleDir, 'bundled');
 if (existsSync(bundleMcpSrc)) {
-  cpSync(bundleMcpSrc, bundleMcpDest, { recursive: true, dereference: true });
+  if (existsSync(bundleMcpDest)) {
+    rmSync(bundleMcpDest, { recursive: true, force: true });
+  }
+  cpSync(bundleMcpSrc, bundleMcpDest, {
+    recursive: true,
+    dereference: true,
+    force: true,
+  });
   console.log('Copied bundled chrome-devtools-mcp to bundle/bundled/');
 }
 

--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -26,6 +26,28 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
 const bundleDir = join(root, 'bundle');
 
+/**
+ * Copy a directory to destination, replacing any existing content.
+ * @param {string} src - Source directory path
+ * @param {string} dest - Destination directory path
+ * @param {string} [logMessage] - Optional message to log after copy
+ */
+function copyAndReplaceDir(src, dest, logMessage) {
+  if (!existsSync(src)) {
+    return;
+  }
+  // rmSync with force:true handles non-existent paths gracefully.
+  rmSync(dest, { recursive: true, force: true });
+  cpSync(src, dest, {
+    recursive: true,
+    dereference: true,
+    force: true,
+  });
+  if (logMessage) {
+    console.log(logMessage);
+  }
+}
+
 // Create the bundle directory if it doesn't exist
 if (!existsSync(bundleDir)) {
   mkdirSync(bundleDir);
@@ -57,32 +79,16 @@ console.log(`Copied ${policyFiles.length} policy files to bundle/policies/`);
 // 3. Copy Documentation (docs/)
 const docsSrc = join(root, 'docs');
 const docsDest = join(bundleDir, 'docs');
-if (existsSync(docsSrc)) {
-  if (existsSync(docsDest)) {
-    rmSync(docsDest, { recursive: true, force: true });
-  }
-  cpSync(docsSrc, docsDest, {
-    recursive: true,
-    dereference: true,
-    force: true,
-  });
-  console.log('Copied docs to bundle/docs/');
-}
+copyAndReplaceDir(docsSrc, docsDest, 'Copied docs to bundle/docs/');
 
 // 4. Copy Built-in Skills (packages/core/src/skills/builtin)
 const builtinSkillsSrc = join(root, 'packages/core/src/skills/builtin');
 const builtinSkillsDest = join(bundleDir, 'builtin');
-if (existsSync(builtinSkillsSrc)) {
-  if (existsSync(builtinSkillsDest)) {
-    rmSync(builtinSkillsDest, { recursive: true, force: true });
-  }
-  cpSync(builtinSkillsSrc, builtinSkillsDest, {
-    recursive: true,
-    dereference: true,
-    force: true,
-  });
-  console.log('Copied built-in skills to bundle/builtin/');
-}
+copyAndReplaceDir(
+  builtinSkillsSrc,
+  builtinSkillsDest,
+  'Copied built-in skills to bundle/builtin/',
+);
 
 // 5. Copy DevTools package so the external dynamic import resolves at runtime
 const devtoolsSrc = join(root, 'packages/devtools');
@@ -93,17 +99,10 @@ const devtoolsDest = join(
   'gemini-cli-devtools',
 );
 const devtoolsDistSrc = join(devtoolsSrc, 'dist');
+const devtoolsDistDest = join(devtoolsDest, 'dist');
 if (existsSync(devtoolsDistSrc)) {
   mkdirSync(devtoolsDest, { recursive: true });
-  const destDist = join(devtoolsDest, 'dist');
-  if (existsSync(destDist)) {
-    rmSync(destDist, { recursive: true, force: true });
-  }
-  cpSync(devtoolsDistSrc, destDist, {
-    recursive: true,
-    dereference: true,
-    force: true,
-  });
+  copyAndReplaceDir(devtoolsDistSrc, devtoolsDistDest);
   copyFileSync(
     join(devtoolsSrc, 'package.json'),
     join(devtoolsDest, 'package.json'),
@@ -114,16 +113,10 @@ if (existsSync(devtoolsDistSrc)) {
 // 6. Copy bundled chrome-devtools-mcp
 const bundleMcpSrc = join(root, 'packages/core/dist/bundled');
 const bundleMcpDest = join(bundleDir, 'bundled');
-if (existsSync(bundleMcpSrc)) {
-  if (existsSync(bundleMcpDest)) {
-    rmSync(bundleMcpDest, { recursive: true, force: true });
-  }
-  cpSync(bundleMcpSrc, bundleMcpDest, {
-    recursive: true,
-    dereference: true,
-    force: true,
-  });
-  console.log('Copied bundled chrome-devtools-mcp to bundle/bundled/');
-}
+copyAndReplaceDir(
+  bundleMcpSrc,
+  bundleMcpDest,
+  'Copied bundled chrome-devtools-mcp to bundle/bundled/',
+);
 
 console.log('Assets copied to bundle/');


### PR DESCRIPTION
## Summary

   Fix `cpSync` throwing `EEXIST` error in Node.js 22 when the destination directory already exists. The fix adds directory cleanup before copying operations in
   `copy_bundle_assets.js` and adds `force: true` option to ensure overwrite behavior.

   ## Details

   In Node.js 22, `cpSync` behaves differently when the destination directory already exists - it throws an `EEXIST` error. This fix adds directory cleanup logic before the
   following copy operations:
   - `docs/` to `bundle/docs/`
   - `builtin skills` to `bundle/builtin/`
   - `devtools dist` to `bundle/devtools/dist/`
   - `bundled MCP` to `bundle/bundled/`

   ## How to Validate

   1. Ensure Node.js version is v22+
   2. Run `npm run bundle` or `node scripts/copy_bundle_assets.js`
   3. Verify bundle directory is generated correctly with docs, builtin, devtools, and bundled subdirectories