### PR TITLE
docs: clarify settings.json path with GEMINI_CLI_HOME

### DIFF
--- a/docs/cli/enterprise.md
+++ b/docs/cli/enterprise.md
@@ -225,6 +225,11 @@ use the `GEMINI_CLI_HOME` environment variable to point to a unique directory
 for a specific user or job. The CLI will create a `.gemini` folder inside the
 specified path.
 
+> **Note:** If you use custom settings (e.g. `customAliases` in
+> `settings.json`), you must place the file at
+> `$GEMINI_CLI_HOME/.gemini/settings.json` — not at the root of
+> `$GEMINI_CLI_HOME`.
+
 **macOS/Linux**
 
 ```bash

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1953,7 +1953,12 @@ the `advanced.excludedEnvVars` setting in your `settings.json` file.
     storage.
   - By default, this is the user's system home directory. The CLI will create a
     `.gemini` folder inside this directory.
-  - Useful for shared compute environments or keeping CLI state isolated.
+  - All configuration files, including `settings.json` (with `customAliases`),
+    must be placed inside the `.gemini` subdirectory — for example,
+    `$GEMINI_CLI_HOME/.gemini/settings.json`, not
+    `$GEMINI_CLI_HOME/settings.json`.
+  - Useful for shared compute environments, keeping CLI state isolated, or
+    running multiple accounts on the same machine.
   - Example: `export GEMINI_CLI_HOME="/path/to/user/config"` (Windows
     PowerShell: `$env:GEMINI_CLI_HOME="C:\path\to\user\config"`)
 - **`GEMINI_CLI_SURFACE`**:


### PR DESCRIPTION
## Summary

Clarifies that when `GEMINI_CLI_HOME` is set, `settings.json` (including `customAliases`) must be placed at `$GEMINI_CLI_HOME/.gemini/settings.json`, not at the root of `$GEMINI_CLI_HOME`.

Without this clarification, users place `settings.json` at the wrong path and `customAliases` are silently ignored, resulting in `ModelNotFoundError` for custom model aliases.

## Changes

- `docs/reference/configuration.md`: Added note about `.gemini/` subdirectory for settings.json
- `docs/cli/enterprise.md`: Added Note callout about correct settings.json placement

Fixes #23622
