### PR TITLE
fix(core): remove no-unsafe-type-assertion suppressions in JSON & Config utils

### DIFF
--- a/packages/core/src/utils/safeJsonStringify.ts
+++ b/packages/core/src/utils/safeJsonStringify.ts
@@ -11,7 +11,6 @@
  * @param space - Optional space parameter for formatting (defaults to no formatting)
  * @returns JSON string with circular references replaced by [Circular]
  */
-import type { Config } from '../config/config.js';
 
 export function safeJsonStringify(
   obj: unknown,
@@ -58,8 +57,7 @@ function removeEmptyObjects(data: any): object {
 export function safeJsonStringifyBooleanValuesOnly(obj: any): string {
   let configSeen = false;
   return JSON.stringify(removeEmptyObjects(obj), (key, value) => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    if ((value as Config) !== null && !configSeen) {
+    if (value !== null && !configSeen) {
       configSeen = true;
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return value;

--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -11,11 +11,86 @@ import Ajv2020Pkg from 'ajv/dist/2020.js';
 import * as addFormats from 'ajv-formats';
 import { debugLogger } from './debugLogger.js';
 
-// Ajv's ESM/CJS interop: use 'any' for compatibility as recommended by Ajv docs
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-assignment
-const AjvClass = (AjvPkg as any).default || AjvPkg;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-assignment
-const Ajv2020Class = (Ajv2020Pkg as any).default || Ajv2020Pkg;
+/**
+ * Type guard: checks whether the given value is a constructor function
+ * compatible with Ajv's constructor signature.
+ */
+function isAjvConstructor(
+  val: unknown,
+): val is new (opts: Record<string, unknown>) => Ajv {
+  return typeof val === 'function';
+}
+
+/**
+ * Resolves an Ajv constructor from a module that may export it as a default
+ * property (CJS interop) or directly (ESM).
+ */
+function resolveAjvConstructor(
+  mod: typeof AjvPkg | typeof Ajv2020Pkg,
+): new (opts: Record<string, unknown>) => Ajv {
+  if (isAjvConstructor(mod)) {
+    return mod;
+  }
+  if (
+    typeof mod === 'object' &&
+    mod !== null &&
+    'default' in mod &&
+    isAjvConstructor(mod.default)
+  ) {
+    return mod.default;
+  }
+  throw new Error('Unable to resolve Ajv constructor from module');
+}
+
+/**
+ * Type guard: checks whether the given value is a function that accepts
+ * an Ajv instance (the ajv-formats plugin signature).
+ */
+function isFormatsPlugin(val: unknown): val is (ajv: Ajv) => void {
+  return typeof val === 'function';
+}
+
+/**
+ * Resolves the addFormats plugin function from a module that may export it
+ * as a default property (CJS interop) or directly (ESM).
+ */
+function resolveFormatsPlugin(mod: unknown): (ajv: Ajv) => void {
+  if (isFormatsPlugin(mod)) {
+    return mod;
+  }
+  if (
+    typeof mod === 'object' &&
+    mod !== null &&
+    'default' in mod &&
+    isFormatsPlugin(mod.default)
+  ) {
+    return mod.default;
+  }
+  throw new Error('Unable to resolve ajv-formats plugin from module');
+}
+
+/**
+ * Type guard for objects that have a string-valued `$schema` property.
+ */
+interface SchemaWithUri {
+  $schema: string;
+}
+
+function hasSchemaUri(val: unknown): val is SchemaWithUri {
+  if (typeof val !== 'object' || val === null || !('$schema' in val)) {
+    return false;
+  }
+  // After `in` narrowing, TypeScript knows val has $schema
+  return typeof val.$schema === 'string';
+}
+
+/**
+ * Extracts the $schema URI from a schema object using a type guard,
+ * avoiding inline unsafe type assertions.
+ */
+function getSchemaUri(schema: unknown): string {
+  return hasSchemaUri(schema) ? schema.$schema : '<no $schema>';
+}
 
 const ajvOptions = {
   // See: https://ajv.js.org/options.html#strict-mode-options
@@ -28,16 +103,17 @@ const ajvOptions = {
   strictSchema: false,
 };
 
+// Ajv's ESM/CJS interop: resolved via type-guarded helper functions
+const AjvClass = resolveAjvConstructor(AjvPkg);
+const Ajv2020Class = resolveAjvConstructor(Ajv2020Pkg);
+
 // Draft-07 validator (default)
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const ajvDefault: Ajv = new AjvClass(ajvOptions);
 
 // Draft-2020-12 validator for MCP servers using rmcp
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const ajv2020: Ajv = new Ajv2020Class(ajvOptions);
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-assignment
-const addFormatsFunc = (addFormats as any).default || addFormats;
+const addFormatsFunc = resolveFormatsPlugin(addFormats);
 addFormatsFunc(ajvDefault);
 addFormatsFunc(ajv2020);
 
@@ -91,10 +167,7 @@ export class SchemaValidator {
       // Skip validation rather than blocking tool usage.
       // This matches LenientJsonSchemaValidator behavior in mcp-client.ts.
       debugLogger.warn(
-        `Failed to compile schema (${
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          (schema as Record<string, unknown>)?.['$schema'] ?? '<no $schema>'
-        }): ${error instanceof Error ? error.message : String(error)}. ` +
+        `Failed to compile schema (${getSchemaUri(schema)}): ${error instanceof Error ? error.message : String(error)}. ` +
           'Skipping parameter validation.',
       );
       return null;
@@ -123,10 +196,7 @@ export class SchemaValidator {
       // Schema validation failed (unsupported version, etc.)
       // Skip validation rather than blocking tool usage.
       debugLogger.warn(
-        `Failed to validate schema (${
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          (schema as Record<string, unknown>)?.['$schema'] ?? '<no $schema>'
-        }): ${error instanceof Error ? error.message : String(error)}. ` +
+        `Failed to validate schema (${getSchemaUri(schema)}): ${error instanceof Error ? error.message : String(error)}. ` +
           'Skipping schema validation.',
       );
       return null;

--- a/packages/core/src/utils/userAccountManager.ts
+++ b/packages/core/src/utils/userAccountManager.ts
@@ -25,21 +25,23 @@ export class UserAccountManager {
    * @returns A valid UserAccounts object.
    */
   private parseAndValidateAccounts(content: string): UserAccounts {
-    const defaultState = { active: null, old: [] };
+    const defaultState: UserAccounts = { active: null, old: [] };
     if (!content.trim()) {
       return defaultState;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const parsed = JSON.parse(content);
+    const parsed: unknown = JSON.parse(content);
 
-    // Inlined validation logic
+    // Validate top-level structure
     if (typeof parsed !== 'object' || parsed === null) {
       debugLogger.log('Invalid accounts file schema, starting fresh.');
       return defaultState;
     }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    const { active, old } = parsed as Partial<UserAccounts>;
+
+    // Use `in` operator for safe property narrowing instead of unsafe cast
+    const active: unknown = 'active' in parsed ? parsed.active : undefined;
+    const old: unknown = 'old' in parsed ? parsed.old : undefined;
+
     const isValid =
       (active === undefined || active === null || typeof active === 'string') &&
       (old === undefined ||
@@ -51,10 +53,8 @@ export class UserAccountManager {
     }
 
     return {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      active: parsed.active ?? null,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      old: parsed.old ?? [],
+      active: typeof active === 'string' ? active : null,
+      old: Array.isArray(old) ? old : [],
     };
   }
 


### PR DESCRIPTION
SUMMARY

Fixes #19710

This removes all no-unsafe-type-assertion suppressions in safeJsonStringify.ts, schemaValidator.ts, and userAccountManager.ts. I replaced the unsafe casts with safe property narrowing using the in operator and type-guarded resolvers. 

DETAILS

safeJsonStringify: Removed a pointless null check cast and unused imports.
schemaValidator: Replaced ESM to CJS interop casts with type-guarded resolver functions. Used in operator narrowing for schema URI access.
userAccountManager: Replaced Partial cast with in operator narrowing to safely extract and validate JSON properties with zero runtime overhead, unlike the previous PR which introduced Zod unnecessarily.

HOW TO VALIDATE

Typecheck:
npx tsc --noEmit --project packages/core/tsconfig.json

Lint:
npx eslint packages/core/src/utils/safeJsonStringify.ts packages/core/src/utils/schemaValidator.ts packages/core/src/utils/userAccountManager.ts

Tests:
npx vitest run packages/core/src/utils/safeJsonStringify.test.ts packages/core/src/utils/schemaValidator.test.ts packages/core/src/utils/userAccountManager.test.ts
