### PR TITLE
docs: update `/mcp refresh` to `/mcp reload`

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -250,8 +250,8 @@ Slash commands provide meta-level control over the CLI itself.
   - **`list`** or **`ls`**:
     - **Description:** List configured MCP servers and tools. This is the
       default action if no subcommand is specified.
-  - **`refresh`**:
-    - **Description:** Restarts all MCP servers and re-discovers their available
+  - **`reload`**:
+    - **Description:** Reloads all MCP servers and re-discovers their available
       tools.
   - **`schema`**:
     - **Description:** List configured MCP servers and tools with descriptions


### PR DESCRIPTION
## Summary

This PR updates the documentation to reflect that the command to reload MCP servers is `/mcp reload` instead of `/mcp refresh`. This matches the current actual behavior of the CLI.

## Details

Changed the description of the `reload` command under the `/mcp` section in `docs/reference/commands.md` to indicate that it "Reloads all MCP servers and re-discovers their available tools." (previously listed as `refresh` and described as "Restarts...").

## Related Issues

None

## How to Validate

Read the updated documentation in `docs/reference/commands.md` and confirm it says `/mcp reload` and uses the word "Reloads".

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker