### PR TITLE
fix(cli): add screen reader support for ask_user dialog

### DIFF
--- a/packages/cli/src/ui/components/AskUserDialog.test.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.test.tsx
@@ -13,6 +13,15 @@ import { waitFor } from '../../test-utils/async.js';
 import { AskUserDialog } from './AskUserDialog.js';
 import { QuestionType, type Question } from '@google/gemini-cli-core';
 import { UIStateContext, type UIState } from '../contexts/UIStateContext.js';
+import { useIsScreenReaderEnabled } from 'ink';
+
+vi.mock('ink', async () => {
+  const actual = await vi.importActual('ink');
+  return {
+    ...actual,
+    useIsScreenReaderEnabled: vi.fn(() => false),
+  };
+});
 
 // Helper to write to stdin with proper act() wrapping
 const writeKey = (stdin: { write: (data: string) => void }, key: string) => {
@@ -1500,7 +1509,6 @@ describe('AskUserDialog', () => {
       });
     });
   });
-
   it('shows at least 3 selection options even in small terminal heights', async () => {
     const questions: Question[] = [
       {
@@ -1524,7 +1532,7 @@ describe('AskUserDialog', () => {
         onSubmit={vi.fn()}
         onCancel={vi.fn()}
         width={80}
-        availableHeight={12} // Very small height
+        availableHeight={12}
       />,
       { width: 80 },
     );
@@ -1532,7 +1540,6 @@ describe('AskUserDialog', () => {
     await waitFor(async () => {
       await waitUntilReady();
       const frame = lastFrame();
-      // Should show at least 3 options
       expect(frame).toContain('1.  Option 1');
       expect(frame).toContain('2.  Option 2');
       expect(frame).toContain('3.  Option 3');
@@ -1565,7 +1572,7 @@ describe('AskUserDialog', () => {
         onSubmit={vi.fn()}
         onCancel={vi.fn()}
         width={80}
-        availableHeight={40} // Tall terminal
+        availableHeight={40}
       />,
       { width: 80 },
     );
@@ -1573,12 +1580,225 @@ describe('AskUserDialog', () => {
     await waitFor(async () => {
       await waitUntilReady();
       const frame = lastFrame();
-      // Should show more than 15 lines of the question
-      // (The limit was previously 15, so showing Line 20 proves it's working)
       expect(frame).toContain('Line 20');
       expect(frame).toContain('Line 25');
-      // Should still show the options
       expect(frame).toContain('1.  Option 1');
+    });
+  });
+
+  describe('Screen reader mode', () => {
+    let mockUseIsScreenReaderEnabled: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockUseIsScreenReaderEnabled = vi.mocked(useIsScreenReaderEnabled);
+      mockUseIsScreenReaderEnabled.mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      mockUseIsScreenReaderEnabled.mockReturnValue(false);
+    });
+
+    const choiceQuestion: Question[] = [
+      {
+        question: 'Which language do you prefer?',
+        header: 'Language',
+        type: QuestionType.CHOICE,
+        options: [
+          { label: 'TypeScript', description: 'Typed JavaScript' },
+          { label: 'Python', description: 'Great for data science' },
+          { label: 'Rust', description: 'Memory safe' },
+        ],
+        multiSelect: false,
+      },
+    ];
+
+    const multiSelectQuestion: Question[] = [
+      {
+        question: 'Which languages do you use?',
+        header: 'Languages',
+        type: QuestionType.CHOICE,
+        options: [
+          { label: 'TypeScript', description: 'Typed JavaScript' },
+          { label: 'Python', description: 'Great for data science' },
+          { label: 'Rust', description: 'Memory safe' },
+        ],
+        multiSelect: true,
+      },
+    ];
+
+    const yesNoQuestion: Question[] = [
+      {
+        question: 'Do you like TypeScript?',
+        header: 'TypeScript',
+        type: QuestionType.YESNO,
+      },
+    ];
+
+    const textQuestion: Question[] = [
+      {
+        question: 'What is your name?',
+        header: 'Name',
+        type: QuestionType.TEXT,
+      },
+    ];
+
+    it('renders plain text options for CHOICE question', async () => {
+      const { lastFrame, waitUntilReady } = await renderWithProviders(
+        <AskUserDialog
+          questions={choiceQuestion}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          width={80}
+        />,
+      );
+      await waitUntilReady();
+      const frame = lastFrame();
+      expect(frame).toContain('Which language do you prefer?');
+      expect(frame).toContain('1. TypeScript - Typed JavaScript');
+      expect(frame).toContain('2. Python - Great for data science');
+      expect(frame).toContain('3. Rust - Memory safe');
+      expect(frame).toContain('Type a number and press Enter');
+    });
+
+    it('renders plain text options for YESNO question', async () => {
+      const { lastFrame, waitUntilReady } = await renderWithProviders(
+        <AskUserDialog
+          questions={yesNoQuestion}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          width={80}
+        />,
+      );
+      await waitUntilReady();
+      const frame = lastFrame();
+      expect(frame).toContain('Do you like TypeScript?');
+      expect(frame).toContain('1. Yes');
+      expect(frame).toContain('2. No');
+      expect(frame).toContain('Type a number and press Enter');
+    });
+
+    it('renders text input prompt for TEXT question', async () => {
+      const { lastFrame, waitUntilReady } = await renderWithProviders(
+        <AskUserDialog
+          questions={textQuestion}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          width={80}
+        />,
+      );
+      await waitUntilReady();
+      const frame = lastFrame();
+      expect(frame).toContain('What is your name?');
+      expect(frame).toContain('Type your answer and press Enter');
+    });
+
+    it('submits correct answer for single select', async () => {
+      const onSubmit = vi.fn();
+      const { stdin, waitUntilReady } = await renderWithProviders(
+        <AskUserDialog
+          questions={choiceQuestion}
+          onSubmit={onSubmit}
+          onCancel={vi.fn()}
+          width={80}
+        />,
+      );
+      await waitUntilReady();
+      writeKey(stdin, '2');
+      writeKey(stdin, '\r');
+      await waitFor(async () => {
+        expect(onSubmit).toHaveBeenCalledWith({ '0': 'Python' });
+      });
+    });
+
+    it('submits correct answers for multiSelect', async () => {
+      const onSubmit = vi.fn();
+      const { stdin, waitUntilReady } = await renderWithProviders(
+        <AskUserDialog
+          questions={multiSelectQuestion}
+          onSubmit={onSubmit}
+          onCancel={vi.fn()}
+          width={80}
+        />,
+      );
+      await waitUntilReady();
+      writeKey(stdin, '1');
+      writeKey(stdin, ' ');
+      writeKey(stdin, '3');
+      writeKey(stdin, '\r');
+      await waitFor(async () => {
+        expect(onSubmit).toHaveBeenCalledWith({ '0': 'TypeScript, Rust' });
+      });
+    });
+
+    it('shows error for out of range input', async () => {
+      const { stdin, lastFrame, waitUntilReady } = await renderWithProviders(
+        <AskUserDialog
+          questions={choiceQuestion}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          width={80}
+        />,
+      );
+      await waitUntilReady();
+      writeKey(stdin, '9');
+      writeKey(stdin, '\r');
+      await waitFor(async () => {
+        expect(lastFrame()).toContain('Invalid input');
+      });
+    });
+
+    it('shows error for multiple numbers on single select', async () => {
+      const { stdin, lastFrame, waitUntilReady } = await renderWithProviders(
+        <AskUserDialog
+          questions={choiceQuestion}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          width={80}
+        />,
+      );
+      await waitUntilReady();
+      writeKey(stdin, '1');
+      writeKey(stdin, ' ');
+      writeKey(stdin, '2');
+      writeKey(stdin, '\r');
+      await waitFor(async () => {
+        expect(lastFrame()).toContain('only accepts one answer');
+      });
+    });
+
+    it('backspace removes last character from input', async () => {
+      const { stdin, lastFrame, waitUntilReady } = await renderWithProviders(
+        <AskUserDialog
+          questions={choiceQuestion}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          width={80}
+        />,
+      );
+      await waitUntilReady();
+      writeKey(stdin, '1');
+      writeKey(stdin, '2');
+      writeKey(stdin, '\x7f');
+      await waitFor(async () => {
+        expect(lastFrame()).toContain('Input: 1');
+      });
+    });
+
+    it('escape cancels the dialog', async () => {
+      const onCancel = vi.fn();
+      const { stdin, waitUntilReady } = await renderWithProviders(
+        <AskUserDialog
+          questions={choiceQuestion}
+          onSubmit={vi.fn()}
+          onCancel={onCancel}
+          width={80}
+        />,
+      );
+      await waitUntilReady();
+      writeKey(stdin, '\x1b');
+      await waitFor(async () => {
+        expect(onCancel).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/packages/cli/src/ui/components/AskUserDialog.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.tsx
@@ -1214,7 +1214,12 @@ export const AskUserDialog: React.FC<AskUserDialogProps> = ({
           handleAnswer(srInput.trim());
           setSrInput('');
         } else {
-          const raw = srInput.trim().split(/\s+/).map(Number);
+          setSrInputError('');
+
+          const raw = srInput.trim()
+            ? srInput.trim().split(/\s+/).map(Number)
+            : [];
+
           const maxOption = effectiveQuestion.options?.length ?? 0;
           const valid = raw.filter(
             (n) => !isNaN(n) && n >= 1 && n <= maxOption,
@@ -1282,20 +1287,26 @@ export const AskUserDialog: React.FC<AskUserDialogProps> = ({
     return (
       <Box flexDirection="column" width={width}>
         <Text>{questionNumber}</Text>
-        <Text>{srQuestion?.header}</Text>
-        <Text>{srQuestion?.question}</Text>
+        <Text>
+          <RenderInline text={srQuestion?.header || ''} />
+        </Text>
+        <Text>
+          <RenderInline text={srQuestion?.question || ''} />
+        </Text>
         {srQuestion?.type !== 'text' && srQuestion?.options && (
           <Box flexDirection="column" marginTop={1}>
             <Text>Options:</Text>
             {srQuestion.options.map((opt, i) => (
               <Text key={i}>
                 {'  '}
-                {i + 1}. {opt.label}
-                {opt.description ? ` - ${opt.description}` : ''}
+                {i + 1}. <RenderInline text={opt.label} />
+                {opt.description ? ' - ' : ''}
+                {opt.description && <RenderInline text={opt.description} />}
               </Text>
             ))}
           </Box>
         )}
+
         <Box marginTop={1}>
           {srQuestion?.type === 'text' ? (
             <Text>

--- a/packages/cli/src/ui/components/AskUserDialog.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.tsx
@@ -6,6 +6,7 @@
 
 import type React from 'react';
 import {
+  useState,
   useCallback,
   useMemo,
   useRef,
@@ -13,7 +14,7 @@ import {
   useReducer,
   useContext,
 } from 'react';
-import { Box, Text } from 'ink';
+import { Box, Text, useIsScreenReaderEnabled } from 'ink';
 import { theme } from '../semantic-colors.js';
 import { checkExhaustive, type Question } from '@google/gemini-cli-core';
 import { BaseSelectionList } from './shared/BaseSelectionList.js';
@@ -1010,6 +1011,9 @@ export const AskUserDialog: React.FC<AskUserDialogProps> = ({
   extraParts,
 }) => {
   const keyMatchers = useKeyMatchers();
+  const isScreenReaderEnabled = useIsScreenReaderEnabled();
+  const [srInput, setSrInput] = useState('');
+  const [srInputError, setSrInputError] = useState('');
   const uiState = useContext(UIStateContext);
   const availableHeight =
     availableHeightProp ??
@@ -1063,7 +1067,7 @@ export const AskUserDialog: React.FC<AskUserDialogProps> = ({
   );
 
   useKeypress(handleCancel, {
-    isActive: !submitted,
+    isActive: !submitted && !isScreenReaderEnabled,
   });
 
   const isOnReviewTab = currentQuestionIndex === reviewTabIndex;
@@ -1195,6 +1199,124 @@ export const AskUserDialog: React.FC<AskUserDialogProps> = ({
         completedIndices={answeredIndices}
       />
     ) : null;
+
+  const handleSrKeypress = useCallback(
+    (key: Key) => {
+      if (keyMatchers[Command.ESCAPE](key)) {
+        onCancel();
+        return true;
+      }
+      if (keyMatchers[Command.RETURN](key)) {
+        // Use effectiveQuestion not currentQuestion - YES/NO type is transformed
+        // to a CHOICE question with Yes/No options at this point, but we want to keep the original type for handling answers
+        if (!effectiveQuestion) return false;
+        if (effectiveQuestion.type === 'text') {
+          handleAnswer(srInput.trim());
+          setSrInput('');
+        } else {
+          const raw = srInput.trim().split(/\s+/).map(Number);
+          const maxOption = effectiveQuestion.options?.length ?? 0;
+          const valid = raw.filter(
+            (n) => !isNaN(n) && n >= 1 && n <= maxOption,
+          );
+          const invalid = raw.filter((n) => isNaN(n) || n < 1 || n > maxOption);
+
+          if (invalid.length > 0) {
+            setSrInputError(
+              `Invalid input: ${invalid.join(', ')}. Please enter numbers between 1 and ${maxOption}, separated by spaces.`,
+            );
+            setSrInput('');
+          } else if (valid.length > 0) {
+            if (!effectiveQuestion.multiSelect && valid.length > 1) {
+              setSrInputError(
+                `This question only accepts one answer. Please enter a single number between 1 and ${maxOption}.`,
+              );
+              setSrInput('');
+            } else {
+              const selected = valid
+                .map((n) => effectiveQuestion.options![n - 1].label)
+                .join(', ');
+              handleAnswer(selected);
+              setSrInput('');
+              setSrInputError('');
+            }
+          }
+        }
+        return true;
+      }
+      // Backspace(ASCII - \x7f): allow user to correct input without cancelling the dialog
+      if (key.sequence === '\x7f') {
+        setSrInput((prev) => prev.slice(0, -1));
+        return true;
+      }
+      if (
+        key.sequence &&
+        !key.ctrl &&
+        !key.alt &&
+        !key.cmd &&
+        key.sequence.charCodeAt(0) >= 32
+      ) {
+        setSrInput((prev) => prev + key.sequence);
+        return true;
+      }
+      return false;
+    },
+    [
+      keyMatchers,
+      onCancel,
+      effectiveQuestion,
+      srInput,
+      handleAnswer,
+      setSrInputError,
+    ],
+  );
+
+  useKeypress(handleSrKeypress, {
+    isActive: isScreenReaderEnabled && !submitted,
+  });
+
+  // Screen reader mode: render plain accessible text UI instead of cursor-driven Ink components
+  if (isScreenReaderEnabled) {
+    const srQuestion = effectiveQuestion ?? questions[0];
+    const questionNumber = `Question ${currentQuestionIndex + 1} of ${questions.length}`;
+    return (
+      <Box flexDirection="column" width={width}>
+        <Text>{questionNumber}</Text>
+        <Text>{srQuestion?.header}</Text>
+        <Text>{srQuestion?.question}</Text>
+        {srQuestion?.type !== 'text' && srQuestion?.options && (
+          <Box flexDirection="column" marginTop={1}>
+            <Text>Options:</Text>
+            {srQuestion.options.map((opt, i) => (
+              <Text key={i}>
+                {'  '}
+                {i + 1}. {opt.label}
+                {opt.description ? ` - ${opt.description}` : ''}
+              </Text>
+            ))}
+          </Box>
+        )}
+        <Box marginTop={1}>
+          {srQuestion?.type === 'text' ? (
+            <Text>
+              Type your answer and press Enter. Press Escape to cancel.
+            </Text>
+          ) : srQuestion?.multiSelect ? (
+            <Text>
+              Type numbers separated by spaces (e.g. 1 2) and press Enter. Press
+              Escape to cancel.
+            </Text>
+          ) : (
+            <Text>Type a number and press Enter. Press Escape to cancel.</Text>
+          )}
+        </Box>
+        {srInput.length > 0 && <Text>Input: {srInput}</Text>}
+        {srInputError.length > 0 && (
+          <Text color={theme.status.error}>{srInputError}</Text>
+        )}
+      </Box>
+    );
+  }
 
   if (isOnReviewTab) {
     return (

--- a/packages/cli/src/ui/components/__snapshots__/AskUserDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/AskUserDialog.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`AskUserDialog > Choice question placeholder > uses default placeholder 
 
   1.  TypeScript
   2.  JavaScript
-● 3.  Enter a custom value                                                      
+● 3.  Enter a custom value
 
 Enter to submit · Esc to cancel
 "
@@ -16,7 +16,7 @@ exports[`AskUserDialog > Choice question placeholder > uses placeholder for "Oth
 
   1.  TypeScript
   2.  JavaScript
-● 3.  Type another language...                                                  
+● 3.  Type another language...
 
 Enter to submit · Esc to cancel
 "
@@ -26,8 +26,8 @@ exports[`AskUserDialog > Scroll Arrows (useAlternateBuffer: false) > shows scrol
 "Choose an option
 
 ▲
-●  1.  Option 1                                                                 
-       Description 1                                                            
+●  1.  Option 1
+       Description 1
    2.  Option 2
        Description 2
    3.  Option 3
@@ -41,9 +41,8 @@ Enter to select · ↑/↓ to navigate · Esc to cancel
 exports[`AskUserDialog > Scroll Arrows (useAlternateBuffer: true) > shows scroll arrows correctly when useAlternateBuffer is true 1`] = `
 "Choose an option
 
-▲
-●  1.  Option 1                                                                 
-       Description 1                                                            
+●  1.  Option 1
+       Description 1
    2.  Option 2
        Description 2
    3.  Option 3
@@ -101,8 +100,8 @@ Enter to submit · Tab/Shift+Tab to edit answers · Esc to cancel
 exports[`AskUserDialog > hides progress header for single question 1`] = `
 "Which authentication method should we use?
 
-● 1.  OAuth 2.0                                                                                                         
-      Industry standard, supports SSO                                                                                   
+● 1.  OAuth 2.0
+      Industry standard, supports SSO
   2.  JWT tokens
       Stateless, good for APIs
   3.  Enter a custom value
@@ -114,8 +113,8 @@ Enter to select · ↑/↓ to navigate · Esc to cancel
 exports[`AskUserDialog > renders question and options 1`] = `
 "Which authentication method should we use?
 
-● 1.  OAuth 2.0                                                                                                         
-      Industry standard, supports SSO                                                                                   
+● 1.  OAuth 2.0
+      Industry standard, supports SSO
   2.  JWT tokens
       Stateless, good for APIs
   3.  Enter a custom value
@@ -129,8 +128,8 @@ exports[`AskUserDialog > shows Review tab in progress header for multiple questi
 
 Which framework?
 
-● 1.  React                                                                                                             
-      Component library                                                                                                 
+● 1.  React
+      Component library
   2.  Vue
       Progressive framework
   3.  Enter a custom value
@@ -142,8 +141,8 @@ Enter to select · ←/→ to switch questions · Esc to cancel
 exports[`AskUserDialog > shows keyboard hints 1`] = `
 "Which authentication method should we use?
 
-● 1.  OAuth 2.0                                                                                                         
-      Industry standard, supports SSO                                                                                   
+● 1.  OAuth 2.0
+      Industry standard, supports SSO
   2.  JWT tokens
       Stateless, good for APIs
   3.  Enter a custom value
@@ -157,8 +156,8 @@ exports[`AskUserDialog > shows progress header for multiple questions 1`] = `
 
 Which database should we use?
 
-● 1.  PostgreSQL                                                                                                        
-      Relational database                                                                                               
+● 1.  PostgreSQL
+      Relational database
   2.  MongoDB
       Document database
   3.  Enter a custom value

--- a/packages/cli/src/ui/components/__snapshots__/AskUserDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/AskUserDialog.test.tsx.snap
@@ -11,12 +11,34 @@ Enter to submit · Esc to cancel
 "
 `;
 
+exports[`AskUserDialog > Choice question placeholder > uses default placeholder when not provided 2`] = `
+"Select your preferred language:
+
+  1.  TypeScript
+  2.  JavaScript
+● 3.  Enter a custom value                                                      
+
+Enter to submit · Esc to cancel
+"
+`;
+
 exports[`AskUserDialog > Choice question placeholder > uses placeholder for "Other" option when provided 1`] = `
 "Select your preferred language:
 
   1.  TypeScript
   2.  JavaScript
 ● 3.  Type another language...
+
+Enter to submit · Esc to cancel
+"
+`;
+
+exports[`AskUserDialog > Choice question placeholder > uses placeholder for "Other" option when provided 2`] = `
+"Select your preferred language:
+
+  1.  TypeScript
+  2.  JavaScript
+● 3.  Type another language...                                                  
 
 Enter to submit · Esc to cancel
 "
@@ -38,6 +60,20 @@ Enter to select · ↑/↓ to navigate · Esc to cancel
 "
 `;
 
+exports[`AskUserDialog > Scroll Arrows (useAlternateBuffer: false) > shows scroll arrows correctly when useAlternateBuffer is false 2`] = `
+"Choose an option
+
+▲
+●  1.  Option 1                                                                 
+       Description 1                                                            
+   2.  Option 2
+       Description 2
+▼
+
+Enter to select · ↑/↓ to navigate · Esc to cancel
+"
+`;
+
 exports[`AskUserDialog > Scroll Arrows (useAlternateBuffer: true) > shows scroll arrows correctly when useAlternateBuffer is true 1`] = `
 "Choose an option
 
@@ -48,6 +84,45 @@ exports[`AskUserDialog > Scroll Arrows (useAlternateBuffer: true) > shows scroll
    3.  Option 3
        Description 3
 ▼
+
+Enter to select · ↑/↓ to navigate · Esc to cancel
+"
+`;
+
+exports[`AskUserDialog > Scroll Arrows (useAlternateBuffer: true) > shows scroll arrows correctly when useAlternateBuffer is true 2`] = `
+"Choose an option
+
+●  1.  Option 1                                                                 
+       Description 1                                                            
+   2.  Option 2
+       Description 2
+   3.  Option 3
+       Description 3
+   4.  Option 4
+       Description 4
+   5.  Option 5
+       Description 5
+   6.  Option 6
+       Description 6
+   7.  Option 7
+       Description 7
+   8.  Option 8
+       Description 8
+   9.  Option 9
+       Description 9
+  10.  Option 10
+       Description 10
+  11.  Option 11
+       Description 11
+  12.  Option 12
+       Description 12
+  13.  Option 13
+       Description 13
+  14.  Option 14
+       Description 14
+  15.  Option 15
+       Description 15
+  16.  Enter a custom value
 
 Enter to select · ↑/↓ to navigate · Esc to cancel
 "


### PR DESCRIPTION
## Summary
AskUserDialog does not handle screen reader mode, causing the dialog to render without usable interaction and blocking keyboard input when the `--screen-reader` flag is enabled.

This PR adds a dedicated screen reader rendering path, restoring full keyboard interaction and making all question types accessible.

## Details
- Added `useIsScreenReaderEnabled()` handling in `AskUserDialog.tsx`
- Implemented plain text rendering for all question types:
  - CHOICE (single select)
  - CHOICE (multiSelect)
  - YESNO
  - TEXT
- Restored keyboard interaction in screen reader mode:
  - Numeric input for selections
  - Text input support
  - Enter to submit, Escape to cancel
- Added input validation for invalid and out-of-range selections
- Ensured YESNO questions use `effectiveQuestion` so options render correctly
- Updated tests to cover screen reader mode across all question types

## Related Issues
Fixes #20889  
Also fixes #22514

## How to Validate
1. Run the CLI with screen reader mode:
   ```bash
   gemini --screen-reader
## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
