### PR TITLE
feat(core): change user-facing auth type from oauth2 to oauth

### DIFF
--- a/docs/core/remote-agents.md
+++ b/docs/core/remote-agents.md
@@ -104,7 +104,7 @@ Gemini CLI supports the following authentication types:
 | `apiKey`             | Send a static API key as an HTTP header.                                                       |
 | `http`               | HTTP authentication (Bearer token, Basic credentials, or any IANA-registered scheme).          |
 | `google-credentials` | Google Application Default Credentials (ADC). Automatically selects access or identity tokens. |
-| `oauth2`             | OAuth 2.0 Authorization Code flow with PKCE. Opens a browser for interactive sign-in.          |
+| `oauth`              | OAuth 2.0 Authorization Code flow with PKCE. Opens a browser for interactive sign-in.          |
 
 ### Dynamic values
 
@@ -263,7 +263,7 @@ hosts:
 
 Requests to any other host will be rejected with an error. If your agent is
 hosted on a different domain, use one of the other auth types (`apiKey`, `http`,
-or `oauth2`).
+or `oauth`).
 
 #### Examples
 
@@ -297,7 +297,7 @@ auth:
 ---
 ```
 
-### OAuth 2.0 (`oauth2`)
+### OAuth 2.0 (`oauth`)
 
 Performs an interactive OAuth 2.0 Authorization Code flow with PKCE. On first
 use, Gemini CLI opens your browser for sign-in and persists the resulting tokens
@@ -305,7 +305,7 @@ for subsequent requests.
 
 | Field               | Type     | Required | Description                                                                                                                                        |
 | :------------------ | :------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`              | string   | Yes      | Must be `oauth2`.                                                                                                                                  |
+| `type`              | string   | Yes      | Must be `oauth`.                                                                                                                                   |
 | `client_id`         | string   | Yes\*    | OAuth client ID. Required for interactive auth.                                                                                                    |
 | `client_secret`     | string   | No\*     | OAuth client secret. Required by most authorization servers (confidential clients). Can be omitted for public clients that don't require a secret. |
 | `scopes`            | string[] | No       | Requested scopes. Can also be discovered from the agent card.                                                                                      |
@@ -318,15 +318,15 @@ kind: remote
 name: oauth-agent
 agent_card_url: https://example.com/.well-known/agent.json
 auth:
-  type: oauth2
+  type: oauth
   client_id: my-client-id.apps.example.com
 ---
 ```
 
-If the agent card advertises an `oauth2` security scheme with
-`authorizationCode` flow, the `authorization_url`, `token_url`, and `scopes` are
-automatically discovered. You only need to provide `client_id` (and
-`client_secret` if required).
+If the agent card advertises an `oauth` security scheme with `authorizationCode`
+flow, the `authorization_url`, `token_url`, and `scopes` are automatically
+discovered. You only need to provide `client_id` (and `client_secret` if
+required).
 
 Tokens are persisted to disk and refreshed automatically when they expire.
 

--- a/docs/core/remote-agents.md
+++ b/docs/core/remote-agents.md
@@ -323,10 +323,10 @@ auth:
 ---
 ```
 
-If the agent card advertises an `oauth2` security scheme with `authorizationCode`
-flow, the `authorization_url`, `token_url`, and `scopes` are automatically
-discovered. You only need to provide `client_id` (and `client_secret` if
-required).
+If the agent card advertises an `oauth2` security scheme with
+`authorizationCode` flow, the `authorization_url`, `token_url`, and `scopes` are
+automatically discovered. You only need to provide `client_id` (and
+`client_secret` if required).
 
 Tokens are persisted to disk and refreshed automatically when they expire.
 

--- a/docs/core/remote-agents.md
+++ b/docs/core/remote-agents.md
@@ -323,7 +323,7 @@ auth:
 ---
 ```
 
-If the agent card advertises an `oauth` security scheme with `authorizationCode`
+If the agent card advertises an `oauth2` security scheme with `authorizationCode`
 flow, the `authorization_url`, `token_url`, and `scopes` are automatically
 discovered. You only need to provide `client_id` (and `client_secret` if
 required).

--- a/packages/core/src/agents/agentLoader.test.ts
+++ b/packages/core/src/agents/agentLoader.test.ts
@@ -617,7 +617,7 @@ kind: remote
 name: oauth2-agent
 agent_card_url: https://example.com/card
 auth:
-  type: oauth2
+  type: oauth
   client_id: $MY_OAUTH_CLIENT_ID
   scopes:
     - read
@@ -630,7 +630,7 @@ auth:
         kind: 'remote',
         name: 'oauth2-agent',
         auth: {
-          type: 'oauth2',
+          type: 'oauth',
           client_id: '$MY_OAUTH_CLIENT_ID',
           scopes: ['read', 'write'],
         },
@@ -643,7 +643,7 @@ kind: remote
 name: oauth2-full-agent
 agent_card_url: https://example.com/card
 auth:
-  type: oauth2
+  type: oauth
   client_id: my-client-id
   client_secret: my-client-secret
   scopes:
@@ -659,7 +659,7 @@ auth:
         kind: 'remote',
         name: 'oauth2-full-agent',
         auth: {
-          type: 'oauth2',
+          type: 'oauth',
           client_id: 'my-client-id',
           client_secret: 'my-client-secret',
           scopes: ['openid', 'profile'],
@@ -675,7 +675,7 @@ kind: remote
 name: oauth2-minimal-agent
 agent_card_url: https://example.com/card
 auth:
-  type: oauth2
+  type: oauth
 ---
 `);
       const result = await parseAgentMarkdown(filePath);
@@ -684,7 +684,7 @@ auth:
         kind: 'remote',
         name: 'oauth2-minimal-agent',
         auth: {
-          type: 'oauth2',
+          type: 'oauth',
         },
       });
     });
@@ -695,7 +695,7 @@ kind: remote
 name: invalid-oauth2-agent
 agent_card_url: https://example.com/card
 auth:
-  type: oauth2
+  type: oauth
   client_id: my-client
   authorization_url: not-a-valid-url
 ---
@@ -709,7 +709,7 @@ kind: remote
 name: invalid-oauth2-agent
 agent_card_url: https://example.com/card
 auth:
-  type: oauth2
+  type: oauth
   client_id: my-client
   token_url: not-a-valid-url
 ---
@@ -723,7 +723,7 @@ auth:
         name: 'oauth2-convert-agent',
         agent_card_url: 'https://example.com/card',
         auth: {
-          type: 'oauth2' as const,
+          type: 'oauth' as const,
           client_id: '$MY_CLIENT_ID',
           scopes: ['read'],
           authorization_url: 'https://auth.example.com/authorize',

--- a/packages/core/src/agents/agentLoader.ts
+++ b/packages/core/src/agents/agentLoader.ts
@@ -63,7 +63,7 @@ interface FrontmatterLocalAgentDefinition
  * Authentication configuration for remote agents in frontmatter format.
  */
 interface FrontmatterAuthConfig {
-  type: 'apiKey' | 'http' | 'google-credentials' | 'oauth2';
+  type: 'apiKey' | 'http' | 'google-credentials' | 'oauth';
   // API Key
   key?: string;
   name?: string;
@@ -205,7 +205,7 @@ const googleCredentialsAuthSchema = z.object({
  */
 const oauth2AuthSchema = z.object({
   ...baseAuthFields,
-  type: z.literal('oauth2'),
+  type: z.literal('oauth'),
   client_id: z.string().optional(),
   client_secret: z.string().optional(),
   scopes: z.array(z.string()).optional(),
@@ -471,7 +471,7 @@ function convertFrontmatterAuthToConfig(
       }
     }
 
-    case 'oauth2':
+    case 'oauth':
       return {
         ...base,
         type: 'oauth2',


### PR DESCRIPTION
## Summary

This PR changes the user-facing authentication type from `oauth2` to `oauth` in the agent configuration to correctly align with the underlying scheme schema. The internal implementation continues to use `oauth2` for compatibility. 

## Details

- Updated `FrontmatterAuthConfig` to expect `oauth` instead of `oauth2`.
- Updated `oauth2AuthSchema` to use `z.literal('oauth')`.
- Modified `convertFrontmatterAuthToConfig` to accept `oauth` and convert it internally to `oauth2`.
- Updated related documentation and tests to reflect this change.

## Related Issues



## How to Validate

- Inspect updated remote agent documentation.
- Run `npm test -w @google/gemini-cli-core` to ensure `agentLoader` tests for OAuth pass with the updated configuration.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
