### PR TITLE
fix(cli): allow reading IDE-provided absolute file paths in ACP (DRAFT)

### DIFF
--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -65,6 +65,7 @@ import {
 } from '../config/settings.js';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 import { randomUUID } from 'node:crypto';
@@ -1184,11 +1185,17 @@ export class Session {
           };
         case 'resource_link': {
           if (part.uri.startsWith(FILE_URI_SCHEME)) {
+            let fileUri = part.uri.slice(FILE_URI_SCHEME.length);
+            try {
+              fileUri = fileURLToPath(new URL(part.uri));
+            } catch (e) {
+              // fallback to slice if parsing fails
+            }
             return {
               fileData: {
                 mimeData: part.mimeType,
                 name: part.name,
-                fileUri: part.uri.slice(FILE_URI_SCHEME.length),
+                fileUri,
               },
             };
           } else {
@@ -1285,7 +1292,7 @@ export class Session {
         }
       } catch (error) {
         if (isNodeError(error) && error.code === 'ENOENT') {
-          if (this.context.config.getEnableRecursiveFileSearch() && globTool) {
+          if (this.context.config.getEnableRecursiveFileSearch() && globTool && !path.isAbsolute(pathName)) {
             this.debug(
               `Path ${pathName} not found directly, attempting glob search.`,
             );

--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -1262,6 +1262,22 @@ export class Session {
             this.debug(`Path ${pathName} resolved to file: ${currentPathSpec}`);
           }
           resolvedSuccessfully = true;
+        } else if (path.isAbsolute(pathName)) {
+          const stats = await fs.stat(absolutePath);
+          this.context.config.getWorkspaceContext().addReadOnlyPath(absolutePath);
+          
+          if (stats.isDirectory()) {
+            currentPathSpec = absolutePath.endsWith('/')
+              ? `${absolutePath}**`
+              : `${absolutePath}/**`;
+            this.debug(
+              `Path ${pathName} is outside root but provided by IDE. Added read-only access to directory, using glob: ${currentPathSpec}`,
+            );
+          } else {
+            currentPathSpec = absolutePath;
+            this.debug(`Path ${pathName} is outside root but provided by IDE. Added read-only access to file: ${currentPathSpec}`);
+          }
+          resolvedSuccessfully = true;
         } else {
           this.debug(
             `Path ${pathName} is outside the project directory. Skipping.`,

--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -132,13 +132,6 @@ class ReadManyFilesToolInvocation extends BaseToolInvocation<
   }
 
   getDescription(): string {
-    const pathDesc = `using patterns: 
-${this.params.include.join('`, `')}
- (within target directory: 
-${this.config.getTargetDir()}
-) `;
-
-    // Determine the final list of exclusion patterns exactly as in execute method
     const paramExcludes = this.params.exclude || [];
     const paramUseDefaultExcludes = this.params.useDefaultExcludes !== false;
     const finalExclusionPatternsForDescription: string[] =
@@ -156,6 +149,21 @@ ${finalExclusionPatternsForDescription
   )}${finalExclusionPatternsForDescription.length > 2 ? '...`' : '`'}`
         : 'none specified'
     }`;
+
+    // Handle single absolute paths cleanly (e.g. IDE attachments)
+    if (this.params.include.length === 1) {
+      const singlePath = this.params.include[0];
+      // Check if it's absolute and doesn't contain basic glob characters
+      if (path.isAbsolute(singlePath) && !/[*?\[\]{}]/.test(singlePath)) {
+        return `Reading file: \`${singlePath}\`.`;
+      }
+    }
+
+    const pathDesc = `using patterns: 
+${this.params.include.join('`, `')}
+ (within target directory: 
+${this.config.getTargetDir()}
+) `;
 
     return `Will attempt to read and concatenate files ${pathDesc}. ${excludeDesc}. File encoding: ${DEFAULT_ENCODING}. Separator: "${DEFAULT_OUTPUT_SEPARATOR_FORMAT.replace(
       '{filePath}',


### PR DESCRIPTION
**NOTE:** Feel free to review and adjust as appropriate. I put this together to demonstrate a potential solution. 

## Summary

When users paste an image or attach a file from outside the workspace into an IDE chat box, the IDE saves it to a system temporary folder and sends the absolute file path to Gemini CLI via ACP. Currently, `acpClient.ts` strictly enforces `isWithinRoot()`. Because the IDE's temp folder is outside the project workspace, the CLI refuses to resolve the path. This results in the AI failing to read the image data automatically and instead attempting to run a `cp` command to move the file into the project, which adds significant friction to a standard IDE workflow.

## Details

This PR proposes a very limited read-only allowlist for absolute paths explicitly provided by the IDE via ACP. 

1. **Surgical Allowlisting (`acpClient.ts`)**: If the ACP payload provides an explicit, valid absolute path outside the workspace, we now call `this.context.config.getWorkspaceContext().addReadOnlyPath(absolutePath)`. 
* *Security Note:* It grants the AI read-only access to that *specific file only* for the duration of the session. It does not grant list permissions for the parent directory or write access.
* *Safety check:* We explicitly check `path.isAbsolute(pathName)` against the *original* string provided by the IDE to ensure we aren't accidentally allowing directory traversal tricks via `path.resolve()`.

2. **UX Improvement (`read-many-files.ts`)**: When `ReadManyFilesTool` is passed a single absolute file (like these IDE attachments), it now outputs a clean `Reading file: /path.png` description instead of the verbose glob-concatenation logging.

3. **Edge Case Handling**: 
* Prevents unnecessary fallback glob searches when an explicit absolute path is provided but missing.
* Migrates the `file://` URI parsing to use Node's native `fileURLToPath` for better cross-platform reliability on Windows.


## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
