### PR TITLE
fix: prevent @ symbol from triggering file lookup for non-file patterns

### DIFF
--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -1860,6 +1860,32 @@ describe('handleAtCommand - email and quote scenarios', () => {
     });
   });
 
+  it('should still process @file after a closed quoted literal followed by a word', async () => {
+    const fileContent = 'Referenced file content.';
+    const filePath = await createTestFile('file.txt', fileContent);
+    const relativePath = path.relative(testRootDir, filePath);
+    const query = `say 'hello'world @${filePath}`;
+
+    const result = await handleAtCommand({
+      query,
+      config: mockConfig,
+      addItem: mockAddItem,
+      onDebugMessage: mockOnDebugMessage,
+      messageId: 912,
+      signal: abortController.signal,
+    });
+
+    expect(result).toEqual({
+      processedQuery: [
+        { text: `say 'hello'world @${relativePath}` },
+        { text: '\n--- Content from referenced files ---' },
+        { text: `\nContent from @${relativePath}:\n` },
+        { text: fileContent },
+        { text: '\n--- End of content ---' },
+      ],
+    });
+  });
+
   it('should recursively resolve extensionless filenames like Dockerfile', async () => {
     const fileContent = 'FROM node:20';
     await createTestFile(path.join('nested', 'Dockerfile'), fileContent);

--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -17,6 +17,7 @@ import {
   handleAtCommand,
   escapeAtSymbols,
   unescapeLiteralAt,
+  escapeAtInQuotedRegions,
 } from './atCommandProcessor.js';
 import {
   FileDiscoveryService,
@@ -1536,5 +1537,199 @@ describe('unescapeLiteralAt', () => {
   it('roundtrips correctly with escapeAtSymbols', () => {
     const input = 'user@example.com and @scope/pkg';
     expect(unescapeLiteralAt(escapeAtSymbols(input))).toBe(input);
+  });
+});
+
+describe('escapeAtInQuotedRegions', () => {
+  it('should escape @ inside backtick-quoted strings', () => {
+    expect(escapeAtInQuotedRegions('explain `@decorators` in Python')).toBe(
+      'explain `\\@decorators` in Python',
+    );
+  });
+
+  it('should escape @ inside single-quoted strings', () => {
+    expect(escapeAtInQuotedRegions("explain '@override' in Java")).toBe(
+      "explain '\\@override' in Java",
+    );
+  });
+
+  it('should not escape @ outside of quotes', () => {
+    expect(escapeAtInQuotedRegions('explain @file.py')).toBe(
+      'explain @file.py',
+    );
+  });
+
+  it('should handle mixed quoted and unquoted @', () => {
+    expect(
+      escapeAtInQuotedRegions('read @file.py and explain `@decorators`'),
+    ).toBe('read @file.py and explain `\\@decorators`');
+  });
+
+  it('should handle text with no @ symbols', () => {
+    expect(escapeAtInQuotedRegions('hello world')).toBe('hello world');
+  });
+
+  it('should handle empty string', () => {
+    expect(escapeAtInQuotedRegions('')).toBe('');
+  });
+});
+
+describe('handleAtCommand - email and quote scenarios', () => {
+  let testRootDir: string;
+  let mockConfig: Config;
+  const mockAddItem: Mock<UseHistoryManagerReturn['addItem']> = vi.fn();
+  const mockOnDebugMessage: Mock<(message: string) => void> = vi.fn();
+  let abortController: AbortController;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    vi.resetAllMocks();
+
+    testRootDir = await fsPromises.mkdtemp(
+      path.join(os.tmpdir(), 'at-command-email-test-'),
+    );
+
+    abortController = new AbortController();
+
+    const getToolRegistry = vi.fn();
+
+    const mockMessageBus = {
+      publish: vi.fn(),
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+    } as unknown as core.MessageBus;
+
+    mockConfig = {
+      getToolRegistry,
+      getTargetDir: () => testRootDir,
+      isSandboxed: () => false,
+      getExcludeTools: vi.fn(),
+      getFileService: () => new FileDiscoveryService(testRootDir),
+      getFileFilteringRespectGitIgnore: () => true,
+      getFileFilteringRespectGeminiIgnore: () => true,
+      getFileFilteringOptions: () => ({
+        respectGitIgnore: true,
+        respectGeminiIgnore: true,
+      }),
+      getFileSystemService: () => new StandardFileSystemService(),
+      getEnableRecursiveFileSearch: vi.fn(() => true),
+      getWorkspaceContext: () => ({
+        isPathWithinWorkspace: (p: string) =>
+          p.startsWith(testRootDir) || p.startsWith('/private' + testRootDir),
+        getDirectories: () => [testRootDir],
+      }),
+      storage: {
+        getProjectTempDir: () => path.join(os.tmpdir(), 'gemini-cli-temp'),
+      },
+      isPathAllowed(this: Config, absolutePath: string): boolean {
+        if (this.interactive && path.isAbsolute(absolutePath)) {
+          return true;
+        }
+        const workspaceContext = this.getWorkspaceContext();
+        if (workspaceContext.isPathWithinWorkspace(absolutePath)) {
+          return true;
+        }
+        const projectTempDir = this.storage.getProjectTempDir();
+        const resolvedProjectTempDir = path.resolve(projectTempDir);
+        return (
+          absolutePath.startsWith(resolvedProjectTempDir + path.sep) ||
+          absolutePath === resolvedProjectTempDir
+        );
+      },
+      validatePathAccess(this: Config, absolutePath: string): string | null {
+        if (this.isPathAllowed(absolutePath)) {
+          return null;
+        }
+        const workspaceDirs = this.getWorkspaceContext().getDirectories();
+        const projectTempDir = this.storage.getProjectTempDir();
+        return `Path validation failed: Attempted path "${absolutePath}" resolves outside the allowed workspace directories: ${workspaceDirs.join(', ')} or the project temp directory: ${projectTempDir}`;
+      },
+      getMcpServers: () => ({}),
+      getMcpServerCommand: () => undefined,
+      getPromptRegistry: () => ({
+        getPromptsByServer: () => [],
+      }),
+      getDebugMode: () => false,
+      getWorkingDir: () => '/working/dir',
+      getFileExclusions: () => ({
+        getCoreIgnorePatterns: () => COMMON_IGNORE_PATTERNS,
+        getDefaultExcludePatterns: () => [],
+        getGlobExcludes: () => [],
+        buildExcludePatterns: () => [],
+        getReadManyFilesExcludes: () => [],
+      }),
+      getUsageStatisticsEnabled: () => false,
+      getEnableExtensionReloading: () => false,
+      getResourceRegistry: () => ({
+        findResourceByUri: () => undefined,
+        getAllResources: () => [],
+      }),
+      getMcpClientManager: () => ({
+        getClient: () => undefined,
+      }),
+      getMessageBus: () => mockMessageBus,
+    } as unknown as Config;
+
+    const registry = new ToolRegistry(mockConfig, mockMessageBus);
+    registry.registerTool(new ReadManyFilesTool(mockConfig, mockMessageBus));
+    registry.registerTool(new GlobTool(mockConfig, mockMessageBus));
+    getToolRegistry.mockReturnValue(registry);
+  });
+
+  afterEach(async () => {
+    abortController.abort();
+    await fsPromises.rm(testRootDir, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+  });
+
+  it('should pass through query with email address as plain text', async () => {
+    const query = 'send email to user@gmail.com please';
+
+    const result = await handleAtCommand({
+      query,
+      config: mockConfig,
+      addItem: mockAddItem,
+      onDebugMessage: mockOnDebugMessage,
+      messageId: 900,
+      signal: abortController.signal,
+    });
+
+    expect(result).toEqual({
+      processedQuery: [{ text: query }],
+    });
+  });
+
+  it('should pass through query with backtick-quoted @ as plain text', async () => {
+    const query = 'explain `@decorators` in Python';
+
+    const result = await handleAtCommand({
+      query,
+      config: mockConfig,
+      addItem: mockAddItem,
+      onDebugMessage: mockOnDebugMessage,
+      messageId: 901,
+      signal: abortController.signal,
+    });
+
+    expect(result).toEqual({
+      processedQuery: [{ text: query }],
+    });
+  });
+
+  it('should pass through query with single-quoted @ as plain text', async () => {
+    const query = "explain '@override' in Java";
+
+    const result = await handleAtCommand({
+      query,
+      config: mockConfig,
+      addItem: mockAddItem,
+      onDebugMessage: mockOnDebugMessage,
+      messageId: 902,
+      signal: abortController.signal,
+    });
+
+    expect(result).toEqual({
+      processedQuery: [{ text: query }],
+    });
   });
 });

--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -1775,4 +1775,62 @@ describe('handleAtCommand - email and quote scenarios', () => {
       processedQuery: [{ text: query }],
     });
   });
+
+  it('should pass through query with unmatched single-quoted or backtick-quoted @ as plain text', async () => {
+    const singleQuoteQuery = "say '@file.txt";
+
+    const singleQuoteResult = await handleAtCommand({
+      query: singleQuoteQuery,
+      config: mockConfig,
+      addItem: mockAddItem,
+      onDebugMessage: mockOnDebugMessage,
+      messageId: 907,
+      signal: abortController.signal,
+    });
+
+    expect(singleQuoteResult).toEqual({
+      processedQuery: [{ text: singleQuoteQuery }],
+    });
+
+    const backtickQuery = 'say `@file.txt';
+
+    const backtickResult = await handleAtCommand({
+      query: backtickQuery,
+      config: mockConfig,
+      addItem: mockAddItem,
+      onDebugMessage: mockOnDebugMessage,
+      messageId: 908,
+      signal: abortController.signal,
+    });
+
+    expect(backtickResult).toEqual({
+      processedQuery: [{ text: backtickQuery }],
+    });
+  });
+
+  it('should preserve quoted literals while still processing a later @file', async () => {
+    const fileContent = 'Referenced file content.';
+    const filePath = await createTestFile('file.txt', fileContent);
+    const relativePath = path.relative(testRootDir, filePath);
+    const query = `explain '@override' and @${filePath}`;
+
+    const result = await handleAtCommand({
+      query,
+      config: mockConfig,
+      addItem: mockAddItem,
+      onDebugMessage: mockOnDebugMessage,
+      messageId: 909,
+      signal: abortController.signal,
+    });
+
+    expect(result).toEqual({
+      processedQuery: [
+        { text: `explain '@override' and @${relativePath}` },
+        { text: '\n--- Content from referenced files ---' },
+        { text: `\nContent from @${relativePath}:\n` },
+        { text: fileContent },
+        { text: '\n--- End of content ---' },
+      ],
+    });
+  });
 });

--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -1833,4 +1833,54 @@ describe('handleAtCommand - email and quote scenarios', () => {
       ],
     });
   });
+
+  it('should still process @file after an apostrophe in plain text', async () => {
+    const fileContent = 'Referenced file content.';
+    const filePath = await createTestFile('file.txt', fileContent);
+    const relativePath = path.relative(testRootDir, filePath);
+    const query = `don't @${filePath}`;
+
+    const result = await handleAtCommand({
+      query,
+      config: mockConfig,
+      addItem: mockAddItem,
+      onDebugMessage: mockOnDebugMessage,
+      messageId: 910,
+      signal: abortController.signal,
+    });
+
+    expect(result).toEqual({
+      processedQuery: [
+        { text: `don't @${relativePath}` },
+        { text: '\n--- Content from referenced files ---' },
+        { text: `\nContent from @${relativePath}:\n` },
+        { text: fileContent },
+        { text: '\n--- End of content ---' },
+      ],
+    });
+  });
+
+  it('should recursively resolve extensionless filenames like Dockerfile', async () => {
+    const fileContent = 'FROM node:20';
+    await createTestFile(path.join('nested', 'Dockerfile'), fileContent);
+
+    const result = await handleAtCommand({
+      query: '@Dockerfile',
+      config: mockConfig,
+      addItem: mockAddItem,
+      onDebugMessage: mockOnDebugMessage,
+      messageId: 911,
+      signal: abortController.signal,
+    });
+
+    expect(result).toEqual({
+      processedQuery: [
+        { text: '@nested/Dockerfile' },
+        { text: '\n--- Content from referenced files ---' },
+        { text: '\nContent from @nested/Dockerfile:\n' },
+        { text: fileContent },
+        { text: '\n--- End of content ---' },
+      ],
+    });
+  });
 });

--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -1776,6 +1776,24 @@ describe('handleAtCommand - email and quote scenarios', () => {
     });
   });
 
+  it('should keep @ literal inside a quoted contraction', async () => {
+    await createTestFile('mention', 'should stay literal');
+    const query = "say 'don't @mention people'";
+
+    const result = await handleAtCommand({
+      query,
+      config: mockConfig,
+      addItem: mockAddItem,
+      onDebugMessage: mockOnDebugMessage,
+      messageId: 9061,
+      signal: abortController.signal,
+    });
+
+    expect(result).toEqual({
+      processedQuery: [{ text: query }],
+    });
+  });
+
   it('should pass through query with unmatched single-quoted or backtick-quoted @ as plain text', async () => {
     const singleQuoteQuery = "say '@file.txt";
 

--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -1581,6 +1581,13 @@ describe('handleAtCommand - email and quote scenarios', () => {
   const mockOnDebugMessage: Mock<(message: string) => void> = vi.fn();
   let abortController: AbortController;
 
+  async function createTestFile(relativePath: string, contents: string) {
+    const fullPath = path.join(testRootDir, relativePath);
+    await fsPromises.mkdir(path.dirname(fullPath), { recursive: true });
+    await fsPromises.writeFile(fullPath, contents);
+    return fullPath;
+  }
+
   beforeEach(async () => {
     vi.restoreAllMocks();
     vi.resetAllMocks();
@@ -1699,6 +1706,42 @@ describe('handleAtCommand - email and quote scenarios', () => {
     });
   });
 
+  it('should pass through query when @ is preceded by a word character', async () => {
+    await createTestFile('file.txt', 'should not be read');
+    const query = 'hello@file.txt';
+
+    const result = await handleAtCommand({
+      query,
+      config: mockConfig,
+      addItem: mockAddItem,
+      onDebugMessage: mockOnDebugMessage,
+      messageId: 903,
+      signal: abortController.signal,
+    });
+
+    expect(result).toEqual({
+      processedQuery: [{ text: query }],
+    });
+  });
+
+  it('should pass through query when @ is escaped with a backslash', async () => {
+    await createTestFile('file.txt', 'should not be read');
+    const query = '\\@file.txt';
+
+    const result = await handleAtCommand({
+      query,
+      config: mockConfig,
+      addItem: mockAddItem,
+      onDebugMessage: mockOnDebugMessage,
+      messageId: 904,
+      signal: abortController.signal,
+    });
+
+    expect(result).toEqual({
+      processedQuery: [{ text: query }],
+    });
+  });
+
   it('should pass through query with backtick-quoted @ as plain text', async () => {
     const query = 'explain `@decorators` in Python';
 
@@ -1707,7 +1750,7 @@ describe('handleAtCommand - email and quote scenarios', () => {
       config: mockConfig,
       addItem: mockAddItem,
       onDebugMessage: mockOnDebugMessage,
-      messageId: 901,
+      messageId: 905,
       signal: abortController.signal,
     });
 
@@ -1724,7 +1767,7 @@ describe('handleAtCommand - email and quote scenarios', () => {
       config: mockConfig,
       addItem: mockAddItem,
       onDebugMessage: mockOnDebugMessage,
-      messageId: 902,
+      messageId: 906,
       signal: abortController.signal,
     });
 

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -90,15 +90,13 @@ export function isInsideQuotedRegion(text: string, position: number): boolean {
       continue;
     }
     if (char === "'" && !inBacktick) {
-      const prevChar = i > 0 ? text[i - 1] : undefined;
-      const nextChar = i + 1 < text.length ? text[i + 1] : undefined;
-
       if (inSingleQuote) {
-        if (!isWordChar(nextChar)) {
-          inSingleQuote = false;
-        }
+        inSingleQuote = false;
         continue;
       }
+
+      const prevChar = i > 0 ? text[i - 1] : undefined;
+      const nextChar = i + 1 < text.length ? text[i + 1] : undefined;
 
       // Ignore apostrophes in prose like "don't" or "students'".
       if (

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -115,7 +115,7 @@ function parseAllAtCommands(
   // This prevents email addresses (user@host), concatenated text (hello@file),
   // and escaped @-references (\\@file) from matching.
   const atCommandRegex = new RegExp(
-    `(?<![\\\\w\\\\\\\\])@${AT_COMMAND_PATH_REGEX_SOURCE}`,
+    `(?<![\\w\\\\])@${AT_COMMAND_PATH_REGEX_SOURCE}`,
     'g',
   );
 

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -64,6 +64,10 @@ export function escapeAtInQuotedRegions(text: string): string {
   );
 }
 
+function isWordChar(char: string | undefined): boolean {
+  return char !== undefined && /\w/.test(char);
+}
+
 /**
  * Returns true when the given position is inside an open single-quote or
  * backtick region. Double quotes are intentionally ignored because @"..."
@@ -86,7 +90,26 @@ export function isInsideQuotedRegion(text: string, position: number): boolean {
       continue;
     }
     if (char === "'" && !inBacktick) {
-      inSingleQuote = !inSingleQuote;
+      const prevChar = i > 0 ? text[i - 1] : undefined;
+      const nextChar = i + 1 < text.length ? text[i + 1] : undefined;
+
+      if (inSingleQuote) {
+        if (!isWordChar(nextChar)) {
+          inSingleQuote = false;
+        }
+        continue;
+      }
+
+      // Ignore apostrophes in prose like "don't" or "students'".
+      if (
+        isWordChar(prevChar) ||
+        nextChar === undefined ||
+        /\s/.test(nextChar)
+      ) {
+        continue;
+      }
+
+      inSingleQuote = true;
       continue;
     }
     if (char === '`' && !inSingleQuote) {
@@ -353,26 +376,24 @@ async function resolveFilePaths(
         break;
       } catch (error) {
         if (isNodeError(error) && error.code === 'ENOENT') {
-          // Only attempt glob search if the path looks like a real file path
-          // (contains '/', '.', or starts with '~'). Simple words like 'decorators'
-          // or 'host' should not trigger expensive glob searches.
           const looksLikePath =
             pathName.includes('/') ||
             pathName.includes('.') ||
             pathName.startsWith('~');
+          const globPattern = looksLikePath
+            ? `**/*${pathName}*`
+            : `**/${pathName}`;
 
-          if (
-            looksLikePath &&
-            config.getEnableRecursiveFileSearch() &&
-            globTool
-          ) {
+          if (config.getEnableRecursiveFileSearch() && globTool) {
             onDebugMessage(
-              `Path ${pathName} not found directly, attempting glob search.`,
+              looksLikePath
+                ? `Path ${pathName} not found directly, attempting glob search.`
+                : `Path ${pathName} not found directly, attempting exact-name glob search.`,
             );
             try {
               const globResult = await globTool.buildAndExecute(
                 {
-                  pattern: `**/*${pathName}*`,
+                  pattern: globPattern,
                   path: dir,
                 },
                 signal,
@@ -400,12 +421,12 @@ async function resolveFilePaths(
                   break;
                 } else {
                   onDebugMessage(
-                    `Glob search for '**/*${pathName}*' did not return a usable path. Path ${pathName} will be skipped.`,
+                    `Glob search for '${globPattern}' did not return a usable path. Path ${pathName} will be skipped.`,
                   );
                 }
               } else {
                 onDebugMessage(
-                  `Glob search for '**/*${pathName}*' found no files or an error. Path ${pathName} will be skipped.`,
+                  `Glob search for '${globPattern}' found no files or an error. Path ${pathName} will be skipped.`,
                 );
               }
             } catch (globError) {
@@ -416,10 +437,6 @@ async function resolveFilePaths(
                 `Error during glob search for ${pathName}. Path ${pathName} will be skipped.`,
               );
             }
-          } else if (!looksLikePath) {
-            onDebugMessage(
-              `Path ${pathName} does not look like a file path, skipping glob search.`,
-            );
           } else {
             onDebugMessage(
               `Glob tool not found. Path ${pathName} will be skipped.`,

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -65,6 +65,39 @@ export function escapeAtInQuotedRegions(text: string): string {
 }
 
 /**
+ * Returns true when the given position is inside an open single-quote or
+ * backtick region. Double quotes are intentionally ignored because @"..."
+ * is a valid Windows-style @path.
+ */
+export function isInsideQuotedRegion(text: string, position: number): boolean {
+  let inSingleQuote = false;
+  let inBacktick = false;
+  let escaped = false;
+
+  for (let i = 0; i < position; i++) {
+    const char = text[i];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === "'" && !inBacktick) {
+      inSingleQuote = !inSingleQuote;
+      continue;
+    }
+    if (char === '`' && !inSingleQuote) {
+      inBacktick = !inBacktick;
+    }
+  }
+
+  return inSingleQuote || inBacktick;
+}
+
+/**
  * Regex source for the path/command part of an @ reference.
  * It uses strict ASCII whitespace delimiters to allow Unicode characters like NNBSP in filenames.
  *
@@ -104,9 +137,6 @@ function parseAllAtCommands(
   query: string,
   escapePastedAtSymbols = false,
 ): AtCommandPart[] {
-  // Pre-process: escape @ inside quoted regions so they are treated as literal text.
-  const preprocessed = escapeAtInQuotedRegions(query);
-
   const parts: AtCommandPart[] = [];
   let lastIndex = 0;
 
@@ -121,9 +151,13 @@ function parseAllAtCommands(
 
   let match: RegExpExecArray | null;
 
-  while ((match = atCommandRegex.exec(preprocessed)) !== null) {
+  while ((match = atCommandRegex.exec(query)) !== null) {
     const matchIndex = match.index;
     const fullMatch = match[0];
+
+    if (isInsideQuotedRegion(query, matchIndex)) {
+      continue;
+    }
 
     // Add text before @
     if (matchIndex > lastIndex) {

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -51,6 +51,20 @@ export function unescapeLiteralAt(text: string): string {
 }
 
 /**
+ * Escapes @ symbols inside quoted regions (backticks and single quotes)
+ * so they are not interpreted as @path commands.
+ * This allows users to write `@decorator` or '@override' without triggering file lookup.
+ *
+ * Note: Double quotes are NOT handled here because AT_COMMAND_PATH_REGEX_SOURCE
+ * uses double quotes for Windows paths with spaces (e.g., @"C:\Program Files\file.txt").
+ */
+export function escapeAtInQuotedRegions(text: string): string {
+  return text.replace(/`[^`]*`|'[^']*'/g, (match) =>
+    match.replace(/@/g, '\\@'),
+  );
+}
+
+/**
  * Regex source for the path/command part of an @ reference.
  * It uses strict ASCII whitespace delimiters to allow Unicode characters like NNBSP in filenames.
  *
@@ -90,18 +104,23 @@ function parseAllAtCommands(
   query: string,
   escapePastedAtSymbols = false,
 ): AtCommandPart[] {
+  // Pre-process: escape @ inside quoted regions so they are treated as literal text.
+  const preprocessed = escapeAtInQuotedRegions(query);
+
   const parts: AtCommandPart[] = [];
   let lastIndex = 0;
 
   // Create a new RegExp instance for each call to avoid shared state/lastIndex issues.
+  // The lookbehind requires @ to be preceded by whitespace, start-of-string, or punctuation.
+  // This prevents email addresses (user@host) and concatenated text (hello@file) from matching.
   const atCommandRegex = new RegExp(
-    `(?<!\\\\)@${AT_COMMAND_PATH_REGEX_SOURCE}`,
+    `(?<=^|[\\s,;:!?()\\[\\]{}])@${AT_COMMAND_PATH_REGEX_SOURCE}`,
     'g',
   );
 
   let match: RegExpExecArray | null;
 
-  while ((match = atCommandRegex.exec(query)) !== null) {
+  while ((match = atCommandRegex.exec(preprocessed)) !== null) {
     const matchIndex = match.index;
     const fullMatch = match[0];
 
@@ -122,7 +141,7 @@ function parseAllAtCommands(
     lastIndex = matchIndex + fullMatch.length;
   }
 
-  // Add remaining text
+  // Add remaining text (use original query for text content, not preprocessed)
   if (lastIndex < query.length) {
     parts.push({
       type: 'text',
@@ -299,7 +318,19 @@ async function resolveFilePaths(
         break;
       } catch (error) {
         if (isNodeError(error) && error.code === 'ENOENT') {
-          if (config.getEnableRecursiveFileSearch() && globTool) {
+          // Only attempt glob search if the path looks like a real file path
+          // (contains '/', '.', or starts with '~'). Simple words like 'decorators'
+          // or 'host' should not trigger expensive glob searches.
+          const looksLikePath =
+            pathName.includes('/') ||
+            pathName.includes('.') ||
+            pathName.startsWith('~');
+
+          if (
+            looksLikePath &&
+            config.getEnableRecursiveFileSearch() &&
+            globTool
+          ) {
             onDebugMessage(
               `Path ${pathName} not found directly, attempting glob search.`,
             );
@@ -350,6 +381,10 @@ async function resolveFilePaths(
                 `Error during glob search for ${pathName}. Path ${pathName} will be skipped.`,
               );
             }
+          } else if (!looksLikePath) {
+            onDebugMessage(
+              `Path ${pathName} does not look like a file path, skipping glob search.`,
+            );
           } else {
             onDebugMessage(
               `Glob tool not found. Path ${pathName} will be skipped.`,

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -59,7 +59,7 @@ export function unescapeLiteralAt(text: string): string {
  * uses double quotes for Windows paths with spaces (e.g., @"C:\Program Files\file.txt").
  */
 export function escapeAtInQuotedRegions(text: string): string {
-  return text.replace(/`[^`]*`|'[^']*'/g, (match) =>
+  return text.replace(/`(\\.|[^`\\])*`|'(\\.|[^'\\])*'/g, (match) =>
     match.replace(/@/g, '\\@'),
   );
 }
@@ -111,10 +111,11 @@ function parseAllAtCommands(
   let lastIndex = 0;
 
   // Create a new RegExp instance for each call to avoid shared state/lastIndex issues.
-  // The lookbehind requires @ to be preceded by whitespace, start-of-string, or punctuation.
-  // This prevents email addresses (user@host) and concatenated text (hello@file) from matching.
+  // The lookbehind requires @ to NOT be preceded by a word character or backslash.
+  // This prevents email addresses (user@host), concatenated text (hello@file),
+  // and escaped @-references (\\@file) from matching.
   const atCommandRegex = new RegExp(
-    `(?<=^|[\\s,;:!?()\\[\\]{}])@${AT_COMMAND_PATH_REGEX_SOURCE}`,
+    `(?<![\\\\w\\\\\\\\])@${AT_COMMAND_PATH_REGEX_SOURCE}`,
     'g',
   );
 

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -68,6 +68,55 @@ function isWordChar(char: string | undefined): boolean {
   return char !== undefined && /\w/.test(char);
 }
 
+function hasLaterClosingQuoteAfterBoundary(
+  text: string,
+  start: number,
+): boolean {
+  let escaped = false;
+  let sawBoundary = false;
+
+  for (let i = start; i < text.length; i++) {
+    const char = text[i];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === "'") {
+      return sawBoundary;
+    }
+    if (!isWordChar(char)) {
+      sawBoundary = true;
+    }
+  }
+
+  return false;
+}
+
+function isQuotedWordApostrophe(text: string, index: number): boolean {
+  const prevChar = index > 0 ? text[index - 1] : undefined;
+  const nextChar = index + 1 < text.length ? text[index + 1] : undefined;
+
+  if (!isWordChar(prevChar) || !isWordChar(nextChar)) {
+    return false;
+  }
+
+  let end = index + 1;
+  while (end < text.length && /[A-Za-z]/.test(text[end])) {
+    end++;
+  }
+
+  const suffix = text.slice(index + 1, end).toLowerCase();
+  return (
+    ['s', 't', 're', 've', 'll', 'd', 'm', 'em'].includes(suffix) ||
+    hasLaterClosingQuoteAfterBoundary(text, index + 1)
+  );
+}
+
 /**
  * Returns true when the given position is inside an open single-quote or
  * backtick region. Double quotes are intentionally ignored because @"..."
@@ -91,6 +140,9 @@ export function isInsideQuotedRegion(text: string, position: number): boolean {
     }
     if (char === "'" && !inBacktick) {
       if (inSingleQuote) {
+        if (isQuotedWordApostrophe(text, i)) {
+          continue;
+        }
         inSingleQuote = false;
         continue;
       }

--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
@@ -314,6 +314,26 @@ describe('useCommandCompletion', () => {
         });
       });
 
+      it('should not trigger @ completion inside an unmatched single quote or backtick region', async () => {
+        const { result: singleQuoteResult } =
+          await renderCommandCompletionHook("say '@file");
+
+        await waitFor(() => {
+          expect(singleQuoteResult.current.completionMode).toBe(
+            CompletionMode.IDLE,
+          );
+        });
+
+        const { result: backtickResult } =
+          await renderCommandCompletionHook('say `@file');
+
+        await waitFor(() => {
+          expect(backtickResult.current.completionMode).toBe(
+            CompletionMode.IDLE,
+          );
+        });
+      });
+
       it.each([
         {
           shellModeActive: false,

--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
@@ -334,6 +334,16 @@ describe('useCommandCompletion', () => {
         });
       });
 
+      it('should not trigger @ completion inside a quoted contraction', async () => {
+        const { result } = await renderCommandCompletionHook(
+          "say 'don't @mention",
+        );
+
+        await waitFor(() => {
+          expect(result.current.completionMode).toBe(CompletionMode.IDLE);
+        });
+      });
+
       it('should not trigger @ completion when @ is preceded by an underscore', async () => {
         const { result } = await renderCommandCompletionHook('my_@file.txt');
 

--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
@@ -334,6 +334,14 @@ describe('useCommandCompletion', () => {
         });
       });
 
+      it('should not trigger @ completion when @ is preceded by an underscore', async () => {
+        const { result } = await renderCommandCompletionHook('my_@file.txt');
+
+        await waitFor(() => {
+          expect(result.current.completionMode).toBe(CompletionMode.IDLE);
+        });
+      });
+
       it.each([
         {
           shellModeActive: false,

--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
@@ -356,6 +356,22 @@ describe('useCommandCompletion', () => {
         });
       });
 
+      it('should still trigger @ completion after a closed quoted literal followed by a word', async () => {
+        const { result } = await renderCommandCompletionHook(
+          "say 'hello'world @file.txt",
+        );
+
+        await waitFor(() => {
+          expect(result.current.completionMode).toBe(CompletionMode.AT);
+          expect(useAtCompletion).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              enabled: true,
+              pattern: 'file.txt',
+            }),
+          );
+        });
+      });
+
       it('should not trigger @ completion when @ is escaped with a backslash', async () => {
         const { result } = await renderCommandCompletionHook('\\@file.txt');
 

--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
@@ -342,6 +342,28 @@ describe('useCommandCompletion', () => {
         });
       });
 
+      it('should still trigger @ completion after an apostrophe in plain text', async () => {
+        const { result } = await renderCommandCompletionHook("don't @file.txt");
+
+        await waitFor(() => {
+          expect(result.current.completionMode).toBe(CompletionMode.AT);
+          expect(useAtCompletion).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              enabled: true,
+              pattern: 'file.txt',
+            }),
+          );
+        });
+      });
+
+      it('should not trigger @ completion when @ is escaped with a backslash', async () => {
+        const { result } = await renderCommandCompletionHook('\\@file.txt');
+
+        await waitFor(() => {
+          expect(result.current.completionMode).toBe(CompletionMode.IDLE);
+        });
+      });
+
       it.each([
         {
           shellModeActive: false,

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -154,8 +154,8 @@ export function useCommandCompletion({
         // This prevents email addresses (user@host) from triggering suggestions.
         if (i > 0) {
           const prevChar = codePoints[i - 1];
-          if (prevChar && /[a-zA-Z0-9]/.test(prevChar)) {
-            break; // Preceded by alphanumeric — not a file reference
+          if (prevChar && /\w/.test(prevChar)) {
+            break; // Preceded by word character — not a file reference
           }
         }
 

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -148,6 +148,24 @@ export function useCommandCompletion({
           break;
         }
       } else if (char === '@') {
+        // Only trigger @ completion if @ is preceded by whitespace,
+        // start of line, or punctuation — not alphanumeric characters.
+        // This prevents email addresses (user@host) from triggering suggestions.
+        if (i > 0) {
+          const prevChar = codePoints[i - 1];
+          if (prevChar && /[a-zA-Z0-9]/.test(prevChar)) {
+            break; // Preceded by alphanumeric — not a file reference
+          }
+        }
+
+        // Check if @ is inside backtick or single-quote quoted region
+        const textBeforeAt = currentLine.substring(0, i);
+        const backtickCount = (textBeforeAt.match(/`/g) || []).length;
+        const singleQuoteCount = (textBeforeAt.match(/'/g) || []).length;
+        if (backtickCount % 2 !== 0 || singleQuoteCount % 2 !== 0) {
+          break; // Inside a quoted region — treat as literal
+        }
+
         let end = codePoints.length;
         for (let i = cursorCol; i < codePoints.length; i++) {
           if (codePoints[i] === ' ') {

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -150,12 +150,13 @@ export function useCommandCompletion({
         }
       } else if (char === '@') {
         // Only trigger @ completion if @ is preceded by whitespace,
-        // start of line, or punctuation — not alphanumeric characters.
-        // This prevents email addresses (user@host) from triggering suggestions.
+        // start of line, or punctuation — not word characters or backslashes.
+        // This prevents email addresses (user@host) and escaped literals (\@file)
+        // from triggering suggestions.
         if (i > 0) {
           const prevChar = codePoints[i - 1];
-          if (prevChar && /\w/.test(prevChar)) {
-            break; // Preceded by word character — not a file reference
+          if (prevChar && /[\w\\]/.test(prevChar)) {
+            break; // Preceded by word character or backslash — not a file reference
           }
         }
 

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -159,10 +159,28 @@ export function useCommandCompletion({
         }
 
         // Check if @ is inside backtick or single-quote quoted region
+        // using a state machine that correctly handles escaped quotes.
         const textBeforeAt = currentLine.substring(0, i);
-        const backtickCount = (textBeforeAt.match(/`/g) || []).length;
-        const singleQuoteCount = (textBeforeAt.match(/'/g) || []).length;
-        if (backtickCount % 2 !== 0 || singleQuoteCount % 2 !== 0) {
+        let inSingleQuote = false;
+        let inBacktick = false;
+        let escaped = false;
+        for (const char of textBeforeAt) {
+          if (escaped) {
+            escaped = false;
+            continue;
+          }
+          if (char === '\\') {
+            escaped = true;
+            continue;
+          }
+          if (char === "'" && !inBacktick) {
+            inSingleQuote = !inSingleQuote;
+          }
+          if (char === '`' && !inSingleQuote) {
+            inBacktick = !inBacktick;
+          }
+        }
+        if (inSingleQuote || inBacktick) {
           break; // Inside a quoted region — treat as literal
         }
 

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -11,6 +11,7 @@ import type { TextBuffer } from '../components/shared/text-buffer.js';
 import { logicalPosToOffset } from '../components/shared/text-buffer.js';
 import { isSlashCommand } from '../utils/commandUtils.js';
 import { toCodePoints } from '../utils/textUtils.js';
+import { isInsideQuotedRegion } from './atCommandProcessor.js';
 import { useAtCompletion } from './useAtCompletion.js';
 import { useSlashCompletion } from './useSlashCompletion.js';
 import { useShellCompletion } from './useShellCompletion.js';
@@ -159,28 +160,7 @@ export function useCommandCompletion({
         }
 
         // Check if @ is inside backtick or single-quote quoted region
-        // using a state machine that correctly handles escaped quotes.
-        const textBeforeAt = currentLine.substring(0, i);
-        let inSingleQuote = false;
-        let inBacktick = false;
-        let escaped = false;
-        for (const char of textBeforeAt) {
-          if (escaped) {
-            escaped = false;
-            continue;
-          }
-          if (char === '\\') {
-            escaped = true;
-            continue;
-          }
-          if (char === "'" && !inBacktick) {
-            inSingleQuote = !inSingleQuote;
-          }
-          if (char === '`' && !inSingleQuote) {
-            inBacktick = !inBacktick;
-          }
-        }
-        if (inSingleQuote || inBacktick) {
+        if (isInsideQuotedRegion(currentLine, i)) {
           break; // Inside a quoted region — treat as literal
         }
 

--- a/packages/cli/src/ui/utils/commandUtils.test.ts
+++ b/packages/cli/src/ui/utils/commandUtils.test.ts
@@ -206,6 +206,10 @@ describe('commandUtils', () => {
       expect(isAtCommand("it's @README")).toBe(true);
     });
 
+    it('should return true when a closed quoted literal is followed by a word before @', () => {
+      expect(isAtCommand("say 'hello'world @file.txt")).toBe(true);
+    });
+
     it('should return false when query does not contain any @<path> pattern', () => {
       expect(isAtCommand('file')).toBe(false);
       expect(isAtCommand('hello')).toBe(false);

--- a/packages/cli/src/ui/utils/commandUtils.test.ts
+++ b/packages/cli/src/ui/utils/commandUtils.test.ts
@@ -170,16 +170,30 @@ describe('commandUtils', () => {
       expect(isAtCommand('   @file')).toBe(true);
     });
 
-    it('should return true when @ is preceded by non-whitespace (external editor scenario)', () => {
+    it('should return true when @ is preceded by punctuation (external editor scenario)', () => {
       // When a user composes a prompt in an external editor, @-references may
       // appear after punctuation characters such as ':' or '(' without a space.
       // The processor must still recognise these as @-commands so that the
       // referenced files are pre-loaded before the query is sent to the model.
       expect(isAtCommand('check:@file.py')).toBe(true);
       expect(isAtCommand('analyze(@file.py)')).toBe(true);
-      expect(isAtCommand('hello@file')).toBe(true);
-      expect(isAtCommand('text@path/to/file')).toBe(true);
-      expect(isAtCommand('user@host')).toBe(true);
+    });
+
+    it('should return false when @ is preceded by alphanumeric characters', () => {
+      // Email-like patterns and concatenated text should NOT trigger file lookup.
+      expect(isAtCommand('hello@file')).toBe(false);
+      expect(isAtCommand('text@path/to/file')).toBe(false);
+      expect(isAtCommand('user@host')).toBe(false);
+      expect(isAtCommand('user@gmail.com')).toBe(false);
+    });
+
+    it('should return false when @ is inside backtick or single quotes', () => {
+      expect(isAtCommand('explain `@decorators` in Python')).toBe(false);
+      expect(isAtCommand("explain '@override' in Java")).toBe(false);
+    });
+
+    it('should return true when @ is outside quotes even if quotes exist', () => {
+      expect(isAtCommand('explain `something` @file.py')).toBe(true);
     });
 
     it('should return false when query does not contain any @<path> pattern', () => {
@@ -198,7 +212,9 @@ describe('commandUtils', () => {
       expect(isAtCommand('Please review:\n@src/main.py\nand fix bugs.')).toBe(
         true,
       );
-      // @file after a colon on the same line.
+      // @file after a comma on the same line.
+      expect(isAtCommand('Files: @src/a.py, @src/b.py')).toBe(true);
+      // @file after punctuation without spaces (colon, comma are in the allowed set).
       expect(isAtCommand('Files:@src/a.py,@src/b.py')).toBe(true);
     });
   });

--- a/packages/cli/src/ui/utils/commandUtils.test.ts
+++ b/packages/cli/src/ui/utils/commandUtils.test.ts
@@ -192,6 +192,11 @@ describe('commandUtils', () => {
       expect(isAtCommand("explain '@override' in Java")).toBe(false);
     });
 
+    it('should return false when @ is inside an unmatched single quote or backtick region', () => {
+      expect(isAtCommand("say '@file")).toBe(false);
+      expect(isAtCommand('say `@file')).toBe(false);
+    });
+
     it('should return true when @ is outside quotes even if quotes exist', () => {
       expect(isAtCommand('explain `something` @file.py')).toBe(true);
     });

--- a/packages/cli/src/ui/utils/commandUtils.test.ts
+++ b/packages/cli/src/ui/utils/commandUtils.test.ts
@@ -190,6 +190,7 @@ describe('commandUtils', () => {
     it('should return false when @ is inside backtick or single quotes', () => {
       expect(isAtCommand('explain `@decorators` in Python')).toBe(false);
       expect(isAtCommand("explain '@override' in Java")).toBe(false);
+      expect(isAtCommand("say 'don't @mention people'")).toBe(false);
     });
 
     it('should return false when @ is inside an unmatched single quote or backtick region', () => {

--- a/packages/cli/src/ui/utils/commandUtils.test.ts
+++ b/packages/cli/src/ui/utils/commandUtils.test.ts
@@ -201,6 +201,11 @@ describe('commandUtils', () => {
       expect(isAtCommand('explain `something` @file.py')).toBe(true);
     });
 
+    it('should return true when an apostrophe in prose appears before @', () => {
+      expect(isAtCommand("don't @file.txt")).toBe(true);
+      expect(isAtCommand("it's @README")).toBe(true);
+    });
+
     it('should return false when query does not contain any @<path> pattern', () => {
       expect(isAtCommand('file')).toBe(false);
       expect(isAtCommand('hello')).toBe(false);

--- a/packages/cli/src/ui/utils/commandUtils.ts
+++ b/packages/cli/src/ui/utils/commandUtils.ts
@@ -10,13 +10,17 @@ import type { SlashCommand } from '../commands/types.js';
 import fs from 'node:fs';
 import type { Writable } from 'node:stream';
 import type { Settings } from '../../config/settingsSchema.js';
-import { AT_COMMAND_PATH_REGEX_SOURCE } from '../hooks/atCommandProcessor.js';
+import {
+  AT_COMMAND_PATH_REGEX_SOURCE,
+  escapeAtInQuotedRegions,
+} from '../hooks/atCommandProcessor.js';
 
 // Pre-compiled regex for detecting @<path> patterns consistent with parseAllAtCommands.
 // Uses the same AT_COMMAND_PATH_REGEX_SOURCE so that isAtCommand is true whenever
 // parseAllAtCommands would find at least one atPath part.
+// The lookbehind requires @ to be preceded by whitespace, start-of-string, or punctuation.
 const AT_COMMAND_DETECT_REGEX = new RegExp(
-  `(?<!\\\\)@${AT_COMMAND_PATH_REGEX_SOURCE}`,
+  `(?<=^|[\\s,;:!?()\\[\\]{}])@${AT_COMMAND_PATH_REGEX_SOURCE}`,
 );
 
 /**
@@ -32,7 +36,7 @@ const AT_COMMAND_DETECT_REGEX = new RegExp(
  * @returns True if the query looks like an '@' command, false otherwise.
  */
 export const isAtCommand = (query: string): boolean =>
-  AT_COMMAND_DETECT_REGEX.test(query);
+  AT_COMMAND_DETECT_REGEX.test(escapeAtInQuotedRegions(query));
 
 /**
  * Checks if a query string potentially represents an '/' command.

--- a/packages/cli/src/ui/utils/commandUtils.ts
+++ b/packages/cli/src/ui/utils/commandUtils.ts
@@ -18,9 +18,9 @@ import {
 // Pre-compiled regex for detecting @<path> patterns consistent with parseAllAtCommands.
 // Uses the same AT_COMMAND_PATH_REGEX_SOURCE so that isAtCommand is true whenever
 // parseAllAtCommands would find at least one atPath part.
-// The lookbehind requires @ to be preceded by whitespace, start-of-string, or punctuation.
+// The lookbehind requires @ to NOT be preceded by a word character or backslash.
 const AT_COMMAND_DETECT_REGEX = new RegExp(
-  `(?<=^|[\\s,;:!?()\\[\\]{}])@${AT_COMMAND_PATH_REGEX_SOURCE}`,
+  `(?<![\\w\\\\])@${AT_COMMAND_PATH_REGEX_SOURCE}`,
 );
 
 /**

--- a/packages/cli/src/ui/utils/commandUtils.ts
+++ b/packages/cli/src/ui/utils/commandUtils.ts
@@ -12,16 +12,14 @@ import type { Writable } from 'node:stream';
 import type { Settings } from '../../config/settingsSchema.js';
 import {
   AT_COMMAND_PATH_REGEX_SOURCE,
-  escapeAtInQuotedRegions,
+  isInsideQuotedRegion,
 } from '../hooks/atCommandProcessor.js';
 
 // Pre-compiled regex for detecting @<path> patterns consistent with parseAllAtCommands.
 // Uses the same AT_COMMAND_PATH_REGEX_SOURCE so that isAtCommand is true whenever
 // parseAllAtCommands would find at least one atPath part.
 // The lookbehind requires @ to NOT be preceded by a word character or backslash.
-const AT_COMMAND_DETECT_REGEX = new RegExp(
-  `(?<![\\w\\\\])@${AT_COMMAND_PATH_REGEX_SOURCE}`,
-);
+const AT_COMMAND_DETECT_REGEX_SOURCE = `(?<![\\w\\\\])@${AT_COMMAND_PATH_REGEX_SOURCE}`;
 
 /**
  * Checks if a query string potentially represents an '@' command.
@@ -35,8 +33,18 @@ const AT_COMMAND_DETECT_REGEX = new RegExp(
  * @param query The input query string.
  * @returns True if the query looks like an '@' command, false otherwise.
  */
-export const isAtCommand = (query: string): boolean =>
-  AT_COMMAND_DETECT_REGEX.test(escapeAtInQuotedRegions(query));
+export const isAtCommand = (query: string): boolean => {
+  const atCommandRegex = new RegExp(AT_COMMAND_DETECT_REGEX_SOURCE, 'g');
+  let match: RegExpExecArray | null;
+
+  while ((match = atCommandRegex.exec(query)) !== null) {
+    if (!isInsideQuotedRegion(query, match.index)) {
+      return true;
+    }
+  }
+
+  return false;
+};
 
 /**
  * Checks if a query string potentially represents an '/' command.

--- a/packages/cli/src/ui/utils/highlight.test.ts
+++ b/packages/cli/src/ui/utils/highlight.test.ts
@@ -80,6 +80,17 @@ describe('parseInputForHighlighting', () => {
     ]);
   });
 
+  it('should not highlight @ inside an unmatched single quote or backtick region', () => {
+    expect(parseInputForHighlighting("say '@file.js", 0)).toEqual([
+      { text: "say '", type: 'default' },
+      { text: '@file.js', type: 'default' },
+    ]);
+    expect(parseInputForHighlighting('say `@file.js', 0)).toEqual([
+      { text: 'say `', type: 'default' },
+      { text: '@file.js', type: 'default' },
+    ]);
+  });
+
   it('should not highlight command at the end of the string', () => {
     const text = 'Get help with /help';
     expect(parseInputForHighlighting(text, 0)).toEqual([

--- a/packages/cli/src/ui/utils/highlight.test.ts
+++ b/packages/cli/src/ui/utils/highlight.test.ts
@@ -91,6 +91,16 @@ describe('parseInputForHighlighting', () => {
     ]);
   });
 
+  it('should not highlight @ inside a quoted contraction', () => {
+    expect(parseInputForHighlighting("say 'don't @mention people'", 0)).toEqual(
+      [
+        { text: "say 'don't ", type: 'default' },
+        { text: '@mention', type: 'default' },
+        { text: " people'", type: 'default' },
+      ],
+    );
+  });
+
   it('should still highlight @ after an apostrophe in plain text', () => {
     expect(parseInputForHighlighting("don't @file.js", 0)).toEqual([
       { text: "don't ", type: 'default' },

--- a/packages/cli/src/ui/utils/highlight.test.ts
+++ b/packages/cli/src/ui/utils/highlight.test.ts
@@ -72,11 +72,11 @@ describe('parseInputForHighlighting', () => {
     ]);
   });
 
-  it('should handle adjacent highlights at start', () => {
+  it('should not highlight @ after alphanumeric in adjacent text', () => {
     const text = '/run@file.js';
     expect(parseInputForHighlighting(text, 0)).toEqual([
       { text: '/run', type: 'command' },
-      { text: '@file.js', type: 'file' },
+      { text: '@file.js', type: 'default' },
     ]);
   });
 

--- a/packages/cli/src/ui/utils/highlight.test.ts
+++ b/packages/cli/src/ui/utils/highlight.test.ts
@@ -91,6 +91,13 @@ describe('parseInputForHighlighting', () => {
     ]);
   });
 
+  it('should still highlight @ after an apostrophe in plain text', () => {
+    expect(parseInputForHighlighting("don't @file.js", 0)).toEqual([
+      { text: "don't ", type: 'default' },
+      { text: '@file.js', type: 'file' },
+    ]);
+  });
+
   it('should not highlight command at the end of the string', () => {
     const text = 'Get help with /help';
     expect(parseInputForHighlighting(text, 0)).toEqual([

--- a/packages/cli/src/ui/utils/highlight.test.ts
+++ b/packages/cli/src/ui/utils/highlight.test.ts
@@ -98,6 +98,13 @@ describe('parseInputForHighlighting', () => {
     ]);
   });
 
+  it('should still highlight @ after a closed quoted literal followed by a word', () => {
+    expect(parseInputForHighlighting("say 'hello'world @file.js", 0)).toEqual([
+      { text: "say 'hello'world ", type: 'default' },
+      { text: '@file.js', type: 'file' },
+    ]);
+  });
+
   it('should not highlight command at the end of the string', () => {
     const text = 'Get help with /help';
     expect(parseInputForHighlighting(text, 0)).toEqual([

--- a/packages/cli/src/ui/utils/highlight.ts
+++ b/packages/cli/src/ui/utils/highlight.ts
@@ -24,8 +24,10 @@ export type HighlightToken = {
 // The @ pattern uses the same source as the command processor to ensure consistency.
 // It matches any character except strict delimiters (ASCII whitespace, comma, etc.).
 // This supports URIs like `@file:///example.txt` and filenames with Unicode spaces (like NNBSP).
+// The lookbehind requires @ to be preceded by whitespace, start-of-string, or punctuation,
+// preventing email-like patterns (user@host) from being highlighted as file references.
 const HIGHLIGHT_REGEX = new RegExp(
-  `(^/[a-zA-Z0-9_-]+|(?<!\\\\)@${AT_COMMAND_PATH_REGEX_SOURCE}|${PASTED_TEXT_PLACEHOLDER_REGEX.source})`,
+  `(^/[a-zA-Z0-9_-]+|(?<=^|[\\s,;:!?()\\[\\]{}])@${AT_COMMAND_PATH_REGEX_SOURCE}|${PASTED_TEXT_PLACEHOLDER_REGEX.source})`,
   'g',
 );
 

--- a/packages/cli/src/ui/utils/highlight.ts
+++ b/packages/cli/src/ui/utils/highlight.ts
@@ -21,13 +21,10 @@ export type HighlightToken = {
 // Matches slash commands (e.g., /help), @ references (files or MCP resource URIs),
 // and large paste placeholders (e.g., [Pasted Text: 6 lines]).
 //
-// The @ pattern uses the same source as the command processor to ensure consistency.
-// It matches any character except strict delimiters (ASCII whitespace, comma, etc.).
-// This supports URIs like `@file:///example.txt` and filenames with Unicode spaces (like NNBSP).
-// The lookbehind requires @ to be preceded by whitespace, start-of-string, or punctuation,
+// The lookbehind requires @ to NOT be preceded by a word character or backslash,
 // preventing email-like patterns (user@host) from being highlighted as file references.
 const HIGHLIGHT_REGEX = new RegExp(
-  `(^/[a-zA-Z0-9_-]+|(?<=^|[\\s,;:!?()\\[\\]{}])@${AT_COMMAND_PATH_REGEX_SOURCE}|${PASTED_TEXT_PLACEHOLDER_REGEX.source})`,
+  `(^/[a-zA-Z0-9_-]+|(?<![\\w\\\\])@${AT_COMMAND_PATH_REGEX_SOURCE}|${PASTED_TEXT_PLACEHOLDER_REGEX.source})`,
   'g',
 );
 

--- a/packages/cli/src/ui/utils/highlight.ts
+++ b/packages/cli/src/ui/utils/highlight.ts
@@ -11,7 +11,10 @@ import {
 import { LRUCache } from 'mnemonist';
 import { cpLen, cpSlice } from './textUtils.js';
 import { LRU_BUFFER_PERF_CACHE_LIMIT } from '../constants.js';
-import { AT_COMMAND_PATH_REGEX_SOURCE } from '../hooks/atCommandProcessor.js';
+import {
+  AT_COMMAND_PATH_REGEX_SOURCE,
+  isInsideQuotedRegion,
+} from '../hooks/atCommandProcessor.js';
 
 export type HighlightToken = {
   text: string;
@@ -82,27 +85,7 @@ export function parseInputForHighlighting(
 
       // If this is a file reference, check if @ is inside a quoted region
       if (type === 'file') {
-        const textBefore = text.slice(0, matchIndex);
-        let inSingleQuote = false;
-        let inBacktick = false;
-        let escaped = false;
-        for (const char of textBefore) {
-          if (escaped) {
-            escaped = false;
-            continue;
-          }
-          if (char === '\\') {
-            escaped = true;
-            continue;
-          }
-          if (char === "'" && !inBacktick) {
-            inSingleQuote = !inSingleQuote;
-          }
-          if (char === '`' && !inSingleQuote) {
-            inBacktick = !inBacktick;
-          }
-        }
-        if (inSingleQuote || inBacktick) {
+        if (isInsideQuotedRegion(text, matchIndex)) {
           type = 'default';
         }
       }

--- a/packages/cli/src/ui/utils/highlight.ts
+++ b/packages/cli/src/ui/utils/highlight.ts
@@ -74,11 +74,39 @@ export function parseInputForHighlighting(
         tokens.push({ text: text.slice(last, matchIndex), type: 'default' });
       }
 
-      const type = fullMatch.startsWith('/')
+      let type: HighlightToken['type'] = fullMatch.startsWith('/')
         ? 'command'
         : fullMatch.startsWith('@')
           ? 'file'
           : 'paste';
+
+      // If this is a file reference, check if @ is inside a quoted region
+      if (type === 'file') {
+        const textBefore = text.slice(0, matchIndex);
+        let inSingleQuote = false;
+        let inBacktick = false;
+        let escaped = false;
+        for (const char of textBefore) {
+          if (escaped) {
+            escaped = false;
+            continue;
+          }
+          if (char === '\\') {
+            escaped = true;
+            continue;
+          }
+          if (char === "'" && !inBacktick) {
+            inSingleQuote = !inSingleQuote;
+          }
+          if (char === '`' && !inSingleQuote) {
+            inBacktick = !inBacktick;
+          }
+        }
+        if (inSingleQuote || inBacktick) {
+          type = 'default';
+        }
+      }
+
       if (type === 'command' && index !== 0) {
         tokens.push({ text: fullMatch, type: 'default' });
       } else {


### PR DESCRIPTION
## Summary

This PR makes `@` handling more precise so literal text is no longer mistaken for a file reference, while preserving valid `@path` behavior.

It aligns the parser, `isAtCommand`, input highlighting, and autocomplete so they all make the same decision for cases like:
- email-style text such as `user@gmail.com`
- escaped literals like `\@file.txt`
- quoted literals like `'@override'` and `` `@decorator` ``
- apostrophes in prose like `don't @file.txt`
- closed quoted literals followed by words like `say 'hello'world @file.txt`

## Details

### What changed

1. Tightened `@` detection so it does not match when `@` is preceded by a word character or a backslash.
   This keeps email-like text, concatenated text, and escaped literals from being interpreted as file references.

2. Unified quoted-region handling behind shared logic.
   Parsing, command detection, highlighting, and autocomplete now all use the same quoted-region rules instead of drifting independently.

3. Fixed quote-state edge cases around single quotes.
   The new logic:
   - ignores apostrophes used as prose punctuation
   - still treats quoted literals as literal text
   - correctly resumes normal `@` parsing after a closed quoted literal, even when followed immediately by a word

4. Kept autocomplete behavior aligned with the backend parser.
   Autocomplete now avoids suggesting files for cases the parser will reject, including `_@...` and `\@...`.

5. Restored recursive resolution for extensionless filenames.
   References like `@Dockerfile` can be found again via exact-name glob fallback instead of being skipped.

### Test coverage

Regression coverage was added or updated for:
- word-preceded `@` and escaped `@`
- quoted and unmatched quoted literals
- apostrophes in prose
- closed quoted literals followed by words
- extensionless recursive lookup like `@Dockerfile`

## Related Issues

Fixes #23621  
Fixes #23527  
Fixes #22129  
Fixes #20702

## How to Validate

1. Build: `npm run build`
2. Run:
   ```bash
   npm test -- src/ui/hooks/atCommandProcessor.test.ts src/ui/hooks/useCommandCompletion.test.tsx src/ui/utils/commandUtils.test.ts src/ui/utils/highlight.test.ts
   ```
3. Type `user@gmail.com` — should NOT trigger file suggestions or file highlighting
4. Type `\@file.txt` — should stay literal and should NOT trigger file suggestions
5. Type `` `@decorator` `` or `'@override'` — should stay literal and should NOT trigger file suggestions
6. Type `@src/main.py` — should still trigger file suggestions and file highlighting
7. Type `don't @file.txt` — `@file.txt` should still behave like a normal file reference
8. Type `say 'hello'world @file.txt` — `@file.txt` should still behave like a normal file reference
9. Type `@Dockerfile` in a workspace with a nested `Dockerfile` — it should still resolve correctly
10. Confirm the focused test suite passes (`176` tests) and the package `posttest` build completes successfully

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker