### PR TITLE
feat(ui): allow immediate user input during startup

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -700,7 +700,10 @@ export const AppContainer = (props: AppContainerProps) => {
 
   // Derive auth state variables for backward compatibility with UIStateContext
   const isAuthDialogOpen = authState === AuthState.Updating;
-  const isAuthenticating = authState === AuthState.Unauthenticated;
+  // TODO: Consider handling other auth types that should also skip the blocking screen
+  const isAuthenticating =
+    authState === AuthState.Unauthenticated &&
+    settings.merged.security.auth.selectedType !== AuthType.USE_GEMINI;
 
   // Session browser and resume functionality
   const isGeminiClientInitialized = config.getGeminiClient()?.isInitialized();
@@ -1300,7 +1303,8 @@ Logging in with Google... Restarting Gemini CLI to continue.
         return;
       }
 
-      if (isSlash || (isIdle && isMcpReady)) {
+      const isMcpOrConfigReady = isConfigInitialized && isMcpReady;
+      if ((isSlash && isConfigInitialized) || (isIdle && isMcpOrConfigReady)) {
         if (!isSlash) {
           const permissions = await checkPermissions(submittedValue, config);
           if (permissions.length > 0) {
@@ -1323,10 +1327,12 @@ Logging in with Google... Restarting Gemini CLI to continue.
         void submitQuery(submittedValue);
       } else {
         // Check messageQueue.length === 0 to only notify on the first queued item
-        if (isIdle && !isMcpReady && messageQueue.length === 0) {
+        if (isIdle && !isMcpOrConfigReady && messageQueue.length === 0) {
           coreEvents.emitFeedback(
             'info',
-            'Waiting for MCP servers to initialize... Slash commands are still available and prompts will be queued.',
+            !isConfigInitialized
+              ? 'Initializing... Prompts will be queued.'
+              : 'Waiting for MCP servers to initialize... Slash commands are still available and prompts will be queued.',
           );
         }
         addMessage(submittedValue);
@@ -1350,6 +1356,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       refreshStatic,
       reset,
       handleHintSubmit,
+      isConfigInitialized,
       triggerExpandHint,
     ],
   );
@@ -1380,11 +1387,9 @@ Logging in with Google... Restarting Gemini CLI to continue.
    * - Any future streaming states not explicitly allowed
    */
   const isInputActive =
-    isConfigInitialized &&
     !initError &&
     !isProcessing &&
     !isResuming &&
-    !!slashCommands &&
     (streamingState === StreamingState.Idle ||
       streamingState === StreamingState.Responding ||
       streamingState === StreamingState.WaitingForConfirmation) &&

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -518,12 +518,8 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
       flexGrow={0}
       flexShrink={0}
     >
-      {(!uiState.slashCommands ||
-        !uiState.isConfigInitialized ||
-        uiState.isResuming) && (
-        <ConfigInitDisplay
-          message={uiState.isResuming ? 'Resuming session...' : undefined}
-        />
+      {uiState.isResuming && (
+        <ConfigInitDisplay message="Resuming session..." />
       )}
 
       {showUiDetails && (


### PR DESCRIPTION
## Summary

Allows the user to start typing and submitting prompts immediately upon launching the Gemini CLI, even before initialization (configuration, MCP servers, slash commands) or API key authentication is complete.

## Details

- **Immediate Input Availability:** The `InputPrompt` is now active as soon as the CLI launches, regardless of `isConfigInitialized` or `isAuthenticating` (for API key users).
- **Queuing Mechanism:** Submissions made during early startup are automatically queued and processed once initialization finishes.
- **UX Improvements:**
    - Removed the "Initializing..." full-screen display for normal startup (now only used for session resumption).
    - Removed the "Waiting for authentication..." screen for API key users.
    - Added informative feedback when the first message is queued during startup.
- **Dependency Fix:** Added `isConfigInitialized` to `handleFinalSubmit`'s dependency array to fix a React Hook warning.

## Related Issues

Related to https://github.com/google-gemini/gemini-cli/issues/21259

## How to Validate

1. Launch the CLI with `npm run start`.
2. Observe that the chat box appears immediately.
3. Type a message and hit Enter before initialization completes (you might see a brief "Initializing... Prompts will be queued." message).
4. Verify that the message is automatically sent once the CLI is ready.
5. For API key users, verify that the "Waiting for authentication..." screen no longer appears.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
