### PR TITLE
Refine onboarding metrics to log the duration explicitly and use the tier name.

### DIFF
--- a/packages/core/src/code_assist/setup.test.ts
+++ b/packages/core/src/code_assist/setup.test.ts
@@ -15,8 +15,20 @@ import { CodeAssistServer } from '../code_assist/server.js';
 import type { OAuth2Client } from 'google-auth-library';
 import { UserTierId, type GeminiUserTier } from './types.js';
 import type { Config } from '../config/config.js';
+import {
+  logOnboardingSuccess,
+  OnboardingSuccessEvent,
+} from '../telemetry/index.js';
 
 vi.mock('../code_assist/server.js');
+vi.mock('../telemetry/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../telemetry/index.js')>();
+  return {
+    ...actual,
+    logOnboardingStart: vi.fn(),
+    logOnboardingSuccess: vi.fn(),
+  };
+});
 
 const mockPaidTier: GeminiUserTier = {
   id: UserTierId.STANDARD,
@@ -214,7 +226,20 @@ describe('setupUser', () => {
       mockLoad.mockResolvedValue({
         allowedTiers: [mockPaidTier],
       });
-      const userData = await setupUser({} as OAuth2Client, mockConfig);
+      mockOnboardUser.mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+        return {
+          done: true,
+          response: {
+            cloudaicompanionProject: {
+              id: 'server-project',
+            },
+          },
+        };
+      });
+      const userDataPromise = setupUser({} as OAuth2Client, mockConfig);
+      await vi.advanceTimersByTimeAsync(1500);
+      const userData = await userDataPromise;
       expect(mockOnboardUser).toHaveBeenCalledWith(
         expect.objectContaining({
           tierId: UserTierId.STANDARD,
@@ -227,6 +252,13 @@ describe('setupUser', () => {
         userTierName: 'paid',
         hasOnboardedPreviously: false,
       });
+      expect(logOnboardingSuccess).toHaveBeenCalledWith(
+        mockConfig,
+        expect.any(OnboardingSuccessEvent),
+      );
+      const event = vi.mocked(logOnboardingSuccess).mock.calls[0][1];
+      expect(event.userTier).toBe(UserTierId.STANDARD);
+      expect(event.duration_ms).toBeGreaterThanOrEqual(1500);
     });
 
     it('should onboard a new free user when project ID is not set', async () => {

--- a/packages/core/src/code_assist/setup.test.ts
+++ b/packages/core/src/code_assist/setup.test.ts
@@ -257,7 +257,7 @@ describe('setupUser', () => {
         expect.any(OnboardingSuccessEvent),
       );
       const event = vi.mocked(logOnboardingSuccess).mock.calls[0][1];
-      expect(event.userTier).toBe(UserTierId.STANDARD);
+      expect(event.userTier).toBe('paid');
       expect(event.duration_ms).toBeGreaterThanOrEqual(1500);
     });
 

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -262,10 +262,9 @@ async function _doSetupUser(
     }
   }
 
-  const userTier = tier.id ?? UserTierId.STANDARD;
   logOnboardingSuccess(
     config,
-    new OnboardingSuccessEvent(userTier, Date.now() - onboardingStartTime),
+    new OnboardingSuccessEvent(tier.name, Date.now() - onboardingStartTime),
   );
 
   if (!lroRes.response?.cloudaicompanionProject?.id) {

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -251,6 +251,7 @@ async function _doSetupUser(
   }
 
   logOnboardingStart(config, new OnboardingStartEvent());
+  const onboardingStartTime = Date.now();
 
   let lroRes = await caServer.onboardUser(onboardReq);
   if (!lroRes.done && lroRes.name) {
@@ -262,7 +263,10 @@ async function _doSetupUser(
   }
 
   const userTier = tier.id ?? UserTierId.STANDARD;
-  logOnboardingSuccess(config, new OnboardingSuccessEvent(userTier));
+  logOnboardingSuccess(
+    config,
+    new OnboardingSuccessEvent(userTier, Date.now() - onboardingStartTime),
+  );
 
   if (!lroRes.response?.cloudaicompanionProject?.id) {
     if (projectId) {

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -1675,7 +1675,7 @@ describe('ClearcutLogger', () => {
   describe('logOnboardingSuccessEvent', () => {
     it('logs an event with proper name and user tier', () => {
       const { logger } = setup();
-      const event = new OnboardingSuccessEvent('standard-tier');
+      const event = new OnboardingSuccessEvent('standard-tier', 100);
 
       logger?.logOnboardingSuccessEvent(event);
 
@@ -1685,6 +1685,10 @@ describe('ClearcutLogger', () => {
       expect(events[0]).toHaveMetadataValue([
         EventMetadataKey.GEMINI_CLI_ONBOARDING_USER_TIER,
         'standard-tier',
+      ]);
+      expect(events[0]).toHaveMetadataValue([
+        EventMetadataKey.GEMINI_CLI_ONBOARDING_DURATION_MS,
+        '100',
       ]);
     });
   });

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -1821,6 +1821,12 @@ export class ClearcutLogger {
         value: event.userTier,
       });
     }
+    if (event.duration_ms !== undefined) {
+      data.push({
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_ONBOARDING_DURATION_MS,
+        value: event.duration_ms.toString(),
+      });
+    }
     this.enqueueLogEvent(
       this.createLogEvent(EventNames.ONBOARDING_SUCCESS, data),
     );

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -7,7 +7,7 @@
 // Defines valid event metadata keys for Clearcut logging.
 export enum EventMetadataKey {
   // Deleted enums: 24
-  // Next ID: 194
+  // Next ID: 195
 
   GEMINI_CLI_KEY_UNKNOWN = 0,
 
@@ -722,4 +722,7 @@ export enum EventMetadataKey {
 
   // Logs the user tier for onboarding success events.
   GEMINI_CLI_ONBOARDING_USER_TIER = 193,
+
+  // Logs the duration of the onboarding process in milliseconds.
+  GEMINI_CLI_ONBOARDING_DURATION_MS = 194,
 }

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -2566,7 +2566,7 @@ describe('loggers', () => {
     });
 
     it('should log onboarding success event to Clearcut and OTEL, and record metrics', () => {
-      const event = new OnboardingSuccessEvent('standard-tier');
+      const event = new OnboardingSuccessEvent('standard-tier', 100);
 
       logOnboardingSuccess(mockConfig, event);
 
@@ -2575,7 +2575,7 @@ describe('loggers', () => {
       ).toHaveBeenCalledWith(event);
 
       expect(mockLogger.emit).toHaveBeenCalledWith({
-        body: 'Onboarding succeeded. Tier: standard-tier',
+        body: 'Onboarding succeeded. Tier: standard-tier. Duration: 100ms',
         attributes: {
           'session.id': 'test-session-id',
           'user.email': 'test-user@example.com',
@@ -2584,12 +2584,14 @@ describe('loggers', () => {
           'event.timestamp': '2025-01-01T00:00:00.000Z',
           interactive: false,
           user_tier: 'standard-tier',
+          duration_ms: 100,
         },
       });
 
       expect(metrics.recordOnboardingSuccess).toHaveBeenCalledWith(
         mockConfig,
         'standard-tier',
+        100,
       );
     });
   });

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -909,7 +909,7 @@ export function logOnboardingSuccess(
     };
     logger.emit(logRecord);
 
-    recordOnboardingSuccess(config, event.userTier);
+    recordOnboardingSuccess(config, event.userTier, event.duration_ms);
   });
 }
 

--- a/packages/core/src/telemetry/metrics.test.ts
+++ b/packages/core/src/telemetry/metrics.test.ts
@@ -100,6 +100,7 @@ describe('Telemetry Metrics', () => {
   let recordFlickerFrameModule: typeof import('./metrics.js').recordFlickerFrame;
   let recordExitFailModule: typeof import('./metrics.js').recordExitFail;
   let recordAgentRunMetricsModule: typeof import('./metrics.js').recordAgentRunMetrics;
+  let recordOnboardingSuccessModule: typeof import('./metrics.js').recordOnboardingSuccess;
   let recordLinesChangedModule: typeof import('./metrics.js').recordLinesChanged;
   let recordSlowRenderModule: typeof import('./metrics.js').recordSlowRender;
   let recordPlanExecutionModule: typeof import('./metrics.js').recordPlanExecution;
@@ -148,6 +149,7 @@ describe('Telemetry Metrics', () => {
     recordFlickerFrameModule = metricsJsModule.recordFlickerFrame;
     recordExitFailModule = metricsJsModule.recordExitFail;
     recordAgentRunMetricsModule = metricsJsModule.recordAgentRunMetrics;
+    recordOnboardingSuccessModule = metricsJsModule.recordOnboardingSuccess;
     recordLinesChangedModule = metricsJsModule.recordLinesChanged;
     recordSlowRenderModule = metricsJsModule.recordSlowRender;
     recordPlanExecutionModule = metricsJsModule.recordPlanExecution;
@@ -622,6 +624,56 @@ describe('Telemetry Metrics', () => {
         'installation.id': 'test-installation-id',
         'user.email': 'test@example.com',
         agent_name: 'TestAgent',
+      });
+    });
+  });
+
+  describe('recordOnboardingSuccess', () => {
+    const mockConfig = {
+      getSessionId: () => 'test-session-id',
+      getTelemetryEnabled: () => true,
+    } as unknown as Config;
+
+    it('should not record metrics if not initialized', () => {
+      recordOnboardingSuccessModule(mockConfig, 'standard-tier', 100);
+      expect(mockCounterAddFn).not.toHaveBeenCalled();
+      expect(mockHistogramRecordFn).not.toHaveBeenCalled();
+    });
+
+    it('should record onboarding success metrics without duration', () => {
+      initializeMetricsModule(mockConfig);
+      mockCounterAddFn.mockClear();
+      mockHistogramRecordFn.mockClear();
+
+      recordOnboardingSuccessModule(mockConfig, 'standard-tier');
+
+      expect(mockCounterAddFn).toHaveBeenCalledWith(1, {
+        'session.id': 'test-session-id',
+        'installation.id': 'test-installation-id',
+        'user.email': 'test@example.com',
+        user_tier: 'standard-tier',
+      });
+      expect(mockHistogramRecordFn).not.toHaveBeenCalled();
+    });
+
+    it('should record onboarding success metrics with duration', () => {
+      initializeMetricsModule(mockConfig);
+      mockCounterAddFn.mockClear();
+      mockHistogramRecordFn.mockClear();
+
+      recordOnboardingSuccessModule(mockConfig, 'standard-tier', 1500);
+
+      expect(mockCounterAddFn).toHaveBeenCalledWith(1, {
+        'session.id': 'test-session-id',
+        'installation.id': 'test-installation-id',
+        'user.email': 'test@example.com',
+        user_tier: 'standard-tier',
+      });
+      expect(mockHistogramRecordFn).toHaveBeenCalledWith(1500, {
+        'session.id': 'test-session-id',
+        'installation.id': 'test-installation-id',
+        'user.email': 'test@example.com',
+        user_tier: 'standard-tier',
       });
     });
   });

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -53,6 +53,7 @@ const OVERAGE_OPTION_COUNT = 'gemini_cli.overage_option.count';
 const CREDIT_PURCHASE_COUNT = 'gemini_cli.credit_purchase.count';
 const EVENT_ONBOARDING_START = 'gemini_cli.onboarding.start';
 const EVENT_ONBOARDING_SUCCESS = 'gemini_cli.onboarding.success';
+const EVENT_ONBOARDING_DURATION_MS = 'gemini_cli.onboarding.duration';
 
 // Agent Metrics
 const AGENT_RUN_COUNT = 'gemini_cli.agent.run.count';
@@ -430,6 +431,15 @@ const HISTOGRAM_DEFINITIONS = {
       success: boolean;
     },
   },
+  [EVENT_ONBOARDING_DURATION_MS]: {
+    description: 'Duration of onboarding in milliseconds.',
+    unit: 'ms',
+    valueType: ValueType.INT,
+    assign: (h: Histogram) => (onboardingDurationHistogram = h),
+    attributes: {} as {
+      user_tier?: string;
+    },
+  },
 } as const;
 
 const PERFORMANCE_COUNTER_DEFINITIONS = {
@@ -658,6 +668,7 @@ let overageOptionCounter: Counter | undefined;
 let creditPurchaseCounter: Counter | undefined;
 let onboardingStartCounter: Counter | undefined;
 let onboardingSuccessCounter: Counter | undefined;
+let onboardingDurationHistogram: Histogram | undefined;
 
 // OpenTelemetry GenAI Semantic Convention Metrics
 let genAiClientTokenUsageHistogram: Histogram | undefined;
@@ -847,12 +858,25 @@ export function recordOnboardingStart(config: Config): void {
 export function recordOnboardingSuccess(
   config: Config,
   userTier?: string,
+  durationMs?: number,
 ): void {
-  if (!onboardingSuccessCounter || !isMetricsInitialized) return;
-  onboardingSuccessCounter.add(1, {
+  if (
+    !onboardingSuccessCounter ||
+    !onboardingDurationHistogram ||
+    !isMetricsInitialized
+  )
+    return;
+
+  const attributes: Attributes = {
     ...baseMetricDefinition.getCommonAttributes(config),
     ...(userTier && { user_tier: userTier }),
-  });
+  };
+
+  onboardingSuccessCounter.add(1, attributes);
+
+  if (durationMs !== undefined) {
+    onboardingDurationHistogram.record(durationMs, attributes);
+  }
 }
 
 /**

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -860,21 +860,18 @@ export function recordOnboardingSuccess(
   userTier?: string,
   durationMs?: number,
 ): void {
-  if (
-    !onboardingSuccessCounter ||
-    !onboardingDurationHistogram ||
-    !isMetricsInitialized
-  )
-    return;
+  if (!isMetricsInitialized) return;
 
   const attributes: Attributes = {
     ...baseMetricDefinition.getCommonAttributes(config),
     ...(userTier && { user_tier: userTier }),
   };
 
-  onboardingSuccessCounter.add(1, attributes);
+  if (onboardingSuccessCounter) {
+    onboardingSuccessCounter.add(1, attributes);
+  }
 
-  if (durationMs !== undefined) {
+  if (durationMs !== undefined && onboardingDurationHistogram) {
     onboardingDurationHistogram.record(durationMs, attributes);
   }
 }

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -44,7 +44,6 @@ import { getFileDiffFromResultDisplay } from '../utils/fileDiffUtils.js';
 import { LlmRole } from './llmRole.js';
 export { LlmRole };
 import type { HookType } from '../hooks/types.js';
-import type { UserTierId } from '../code_assist/types.js';
 
 export interface BaseTelemetryEvent {
   'event.name': string;
@@ -2388,10 +2387,10 @@ export const EVENT_ONBOARDING_SUCCESS = 'gemini_cli.onboarding.success';
 export class OnboardingSuccessEvent implements BaseTelemetryEvent {
   'event.name': 'onboarding_success';
   'event.timestamp': string;
-  userTier?: UserTierId;
+  userTier?: string;
   duration_ms?: number;
 
-  constructor(userTier?: UserTierId, duration_ms?: number) {
+  constructor(userTier?: string, duration_ms?: number) {
     this['event.name'] = 'onboarding_success';
     this['event.timestamp'] = new Date().toISOString();
     this.userTier = userTier;

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -2389,11 +2389,13 @@ export class OnboardingSuccessEvent implements BaseTelemetryEvent {
   'event.name': 'onboarding_success';
   'event.timestamp': string;
   userTier?: UserTierId;
+  duration_ms?: number;
 
-  constructor(userTier?: UserTierId) {
+  constructor(userTier?: UserTierId, duration_ms?: number) {
     this['event.name'] = 'onboarding_success';
     this['event.timestamp'] = new Date().toISOString();
     this.userTier = userTier;
+    this.duration_ms = duration_ms;
   }
 
   toOpenTelemetryAttributes(config: Config): LogAttributes {
@@ -2402,11 +2404,12 @@ export class OnboardingSuccessEvent implements BaseTelemetryEvent {
       'event.name': EVENT_ONBOARDING_SUCCESS,
       'event.timestamp': this['event.timestamp'],
       user_tier: this.userTier ?? '',
+      duration_ms: this.duration_ms ?? 0,
     };
   }
 
   toLogBody(): string {
-    return `Onboarding succeeded.${this.userTier ? ` Tier: ${this.userTier}` : ''}`;
+    return `Onboarding succeeded.${this.userTier ? ` Tier: ${this.userTier}` : ''}${this.duration_ms !== undefined ? `. Duration: ${this.duration_ms}ms` : ''}`;
   }
 }
 


### PR DESCRIPTION
## Summary

Explicitly log the onboarding duration (GEMINI_CLI_ONBOARDING_DURATION_MS) with the user tier name for onboarding success events.

## Details
- DS team wants to measure the onboarding duration but cannot use the native clearcut timestamps -  event timestamp with granularity of seconds are removed from analysis datamart as in combination with other fields it can act as PII.
- Use user tier name in logging instead of the user tier id for accurate metrics - cli doesn't have all tier names defined for all tiers sent from the server.

## Related Issues

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/1513

## How to Validate

Run tests.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
