### PR TITLE
fix(plan): update telemetry attribute keys and add timestamp

### DIFF
--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -2184,7 +2184,8 @@ export class ApprovalModeSwitchEvent implements BaseTelemetryEvent {
   toOpenTelemetryAttributes(config: Config): LogAttributes {
     return {
       ...getCommonAttributes(config),
-      event_name: EVENT_APPROVAL_MODE_SWITCH,
+      'event.name': EVENT_APPROVAL_MODE_SWITCH,
+      'event.timestamp': this['event.timestamp'],
       from_mode: this.from_mode,
       to_mode: this.to_mode,
     };
@@ -2214,7 +2215,8 @@ export class ApprovalModeDurationEvent implements BaseTelemetryEvent {
   toOpenTelemetryAttributes(config: Config): LogAttributes {
     return {
       ...getCommonAttributes(config),
-      event_name: EVENT_APPROVAL_MODE_DURATION,
+      'event.name': EVENT_APPROVAL_MODE_DURATION,
+      'event.timestamp': this['event.timestamp'],
       mode: this.mode,
       duration_ms: this.duration_ms,
     };


### PR DESCRIPTION
## Summary

Fixes the attribute key from `event_name` to `'event.name'` and adds the missing `'event.timestamp'` in `ApprovalModeSwitchEvent` and `ApprovalModeDurationEvent` to align with the canonical telemetry pattern used across the codebase.

## Details

- Modified `ApprovalModeSwitchEvent.toOpenTelemetryAttributes` in `packages/core/src/telemetry/types.ts`.
- Modified `ApprovalModeDurationEvent.toOpenTelemetryAttributes` in `packages/core/src/telemetry/types.ts`.
- These changes ensure that these events are correctly captured and indexed in OpenTelemetry-compatible backends.

## Related Issues

Fixes #23444

## How to Validate

1. Verify the changes in `packages/core/src/telemetry/types.ts` manually or via `git diff`.
2. Run type checking to ensure no regressions: `npm run typecheck -w @google/gemini-cli-core`.
3. (Optional) Inspect the emitted events in an OTel collector to confirm the keys are now correctly formatted as `'event.name'`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
