### PR TITLE
test: align vitest config across workspaces

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     exclude: ['**/node_modules/**', '**/dist/**', '**/cypress/**'],
     environment: 'node',
     globals: true,
+    silent: true,
     reporters: ['default', 'junit'],
 
     outputFile: {

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -9,6 +9,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
+    silent: true,
     environment: 'node',
   },
 });


### PR DESCRIPTION
## Summary

`cli` and `sdk` were the only two packages missing silent: true in their vitest configs. All other workspaces (core, a2a-server, test-utils) already had it set. This caused passing tests to forward all console.* output to the terminal.

## Details

Two-line change. Adds `silent: true` to packages/cli/vitest.config.ts and packages/sdk/vitest.config.ts.

Before: `npm run test` produces ~12,100 lines / 1.1 MB of output.
After: ~3,800 lines / 387 KB. **68% reduction.**

Remaining noise comes from `stderr` (Node.js `MaxListenersExceededWarning`, React `act()` warnings) which `silent` doesn't suppress would need separate fixes.

## How to Validate

1. `npm run test 2>&1 | Out-File output.txt` (or `> output.txt 2>&1` on Unix)
2. Check line count and file size — should be ~3,800 lines instead of ~12,000.
3. All tests should still pass with the same results.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [x] Docker
