### PR TITLE
feat(core): implement robust CLI timeouts for long-running operations

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -104,7 +104,7 @@ export interface CliArgs {
   startupMessages?: string[];
   rawOutput: boolean | undefined;
   acceptRawOutputRisk: boolean | undefined;
-  requestTimeout: number | undefined;
+  requestTimeout?: number;
   isCommand: boolean | undefined;
 }
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -104,6 +104,7 @@ export interface CliArgs {
   startupMessages?: string[];
   rawOutput: boolean | undefined;
   acceptRawOutputRisk: boolean | undefined;
+  requestTimeout: number | undefined;
   isCommand: boolean | undefined;
 }
 
@@ -442,6 +443,11 @@ export async function parseArguments(
         .option('accept-raw-output-risk', {
           type: 'boolean',
           description: 'Suppress the security warning when using --raw-output.',
+        })
+        .option('request-timeout', {
+          type: 'number',
+          description:
+            'Maximum time (in milliseconds) to wait for a request to complete, including retries.',
         }),
     )
     .version(await getVersion()) // This will enable the --version flag based on package.json
@@ -1007,6 +1013,7 @@ export async function loadCliConfig(
     retryFetchErrors: settings.general?.retryFetchErrors,
     billing: settings.billing,
     maxAttempts: settings.general?.maxAttempts,
+    requestTimeoutMs: argv.requestTimeout ?? settings.general?.requestTimeoutMs,
     ptyInfo: ptyInfo?.name,
     disableLLMCorrection: settings.tools?.disableLLMCorrection,
     rawOutput: argv.rawOutput,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -335,6 +335,16 @@ const SETTINGS_SCHEMA = {
           'Maximum number of attempts for requests to the main chat model. Cannot exceed 10.',
         showInDialog: true,
       },
+      requestTimeoutMs: {
+        type: 'number',
+        label: 'Request Timeout (ms)',
+        category: 'General',
+        requiresRestart: false,
+        default: 300000,
+        description:
+          'Maximum time (in milliseconds) to wait for a request to complete, including retries. Default: 300,000 (5 minutes).',
+        showInDialog: true,
+      },
       debugKeystrokeLogging: {
         type: 'boolean',
         label: 'Debug Keystroke Logging',

--- a/packages/cli/src/ui/hooks/useLoadingIndicator.ts
+++ b/packages/cli/src/ui/hooks/useLoadingIndicator.ts
@@ -84,7 +84,7 @@ export const useLoadingIndicator = ({
       ? retryStatus.attempt >= LOW_VERBOSITY_RETRY_HINT_ATTEMPT_THRESHOLD
         ? "This is taking a bit longer, we're still on it."
         : null
-      : `Trying to reach ${getDisplayString(retryStatus.model)} (Attempt ${retryStatus.attempt + 1}/${retryStatus.maxAttempts})`
+      : `Trying to reach ${getDisplayString(retryStatus.model)} (Attempt ${retryStatus.attempt + 1}/${retryStatus.maxAttempts})${retryStatus.error ? `: ${retryStatus.error}` : ''}`
     : null;
 
   return {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -601,6 +601,7 @@ export interface ConfigParameters {
   blockedEnvironmentVariables?: string[];
   enableEnvironmentVariableRedaction?: boolean;
   noBrowser?: boolean;
+  requestTimeoutMs?: number;
   summarizeToolOutput?: Record<string, SummarizeToolOutputSettings>;
   folderTrust?: boolean;
   ideMode?: boolean;
@@ -757,6 +758,7 @@ export class Config implements McpContext, AgentLoopContext {
   // null = unknown (quota not fetched); true = has access; false = definitively no access
   private hasAccessToPreviewModel: boolean | null = null;
   private readonly noBrowser: boolean;
+  private readonly requestTimeoutMs: number | undefined;
   private readonly folderTrust: boolean;
   private ideMode: boolean;
 
@@ -982,6 +984,7 @@ export class Config implements McpContext, AgentLoopContext {
     this.blockedEnvironmentVariables = params.blockedEnvironmentVariables ?? [];
     this.enableEnvironmentVariableRedaction =
       params.enableEnvironmentVariableRedaction ?? false;
+    this.requestTimeoutMs = params.requestTimeoutMs;
     this.userMemory = params.userMemory ?? '';
     this.geminiMdFileCount = params.geminiMdFileCount ?? 0;
     this.geminiMdFilePaths = params.geminiMdFilePaths ?? [];
@@ -1398,6 +1401,10 @@ export class Config implements McpContext, AgentLoopContext {
 
   getContentGenerator(): ContentGenerator {
     return this.contentGenerator;
+  }
+
+  getRequestTimeoutMs(): number | undefined {
+    return this.requestTimeoutMs;
   }
 
   async refreshAuth(

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -524,24 +524,7 @@ export class GeminiChat {
     const requestTimeoutMs =
       this.context.config.getRequestTimeoutMs() ?? 300_000;
 
-    const timeoutController = new AbortController();
-    const timerId = setTimeout(
-      () => timeoutController.abort(),
-      requestTimeoutMs,
-    );
-
-    let combinedSignal = abortSignal;
-    if (typeof AbortSignal.any === 'function') {
-      combinedSignal = AbortSignal.any([abortSignal, timeoutController.signal]);
-    } else {
-      // Fallback for older Node.js
-      abortSignal?.addEventListener('abort', () => timeoutController.abort(), {
-        once: true,
-      });
-      combinedSignal = timeoutController.signal;
-    }
-
-    const apiCall = async () => {
+    const apiCall = async (signal?: AbortSignal) => {
       const useGemini3_1 =
         (await this.context.config.getGemini31Launched?.()) ?? false;
       // Default to the last used model (which respects arguments/availability selection)
@@ -581,7 +564,7 @@ export class GeminiChat {
         // passed via config.
         systemInstruction: this.systemInstruction,
         tools: this.tools,
-        abortSignal: combinedSignal,
+        abortSignal: signal,
       };
 
       let contentsToUse: Content[] = supportsModernFeatures(modelToUse)
@@ -687,44 +670,40 @@ export class GeminiChat {
       );
     };
 
-    try {
-      const streamResponse = await retryWithBackoff(apiCall, {
-        onPersistent429: onPersistent429Callback,
-        onValidationRequired: onValidationRequiredCallback,
-        authType: this.context.config.getContentGeneratorConfig()?.authType,
-        retryFetchErrors: this.context.config.getRetryFetchErrors(),
-        signal: combinedSignal,
-        overallTimeoutMs: requestTimeoutMs,
-        maxAttempts:
-          availabilityMaxAttempts ?? this.context.config.getMaxAttempts(),
-        getAvailabilityContext,
-        onRetry: (attempt, error, delayMs) => {
-          coreEvents.emitRetryAttempt({
-            attempt,
-            maxAttempts:
-              availabilityMaxAttempts ?? this.context.config.getMaxAttempts(),
-            delayMs,
-            error: error instanceof Error ? error.message : String(error),
-            model: lastModelToUse,
-          });
-        },
-      });
+    const streamResponse = await retryWithBackoff(apiCall, {
+      onPersistent429: onPersistent429Callback,
+      onValidationRequired: onValidationRequiredCallback,
+      authType: this.context.config.getContentGeneratorConfig()?.authType,
+      retryFetchErrors: this.context.config.getRetryFetchErrors(),
+      signal: abortSignal,
+      overallTimeoutMs: requestTimeoutMs,
+      maxAttempts:
+        availabilityMaxAttempts ?? this.context.config.getMaxAttempts(),
+      getAvailabilityContext,
+      onRetry: (attempt, error, delayMs) => {
+        coreEvents.emitRetryAttempt({
+          attempt,
+          maxAttempts:
+            availabilityMaxAttempts ?? this.context.config.getMaxAttempts(),
+          delayMs,
+          error: error instanceof Error ? error.message : String(error),
+          model: lastModelToUse,
+        });
+      },
+    });
 
-      // Store the original request for AfterModel hooks
-      const originalRequest: GenerateContentParameters = {
-        model: lastModelToUse,
-        config: lastConfig,
-        contents: lastContentsToUse,
-      };
+    // Store the original request for AfterModel hooks
+    const originalRequest: GenerateContentParameters = {
+      model: lastModelToUse,
+      config: lastConfig,
+      contents: lastContentsToUse,
+    };
 
-      return this.processStreamResponse(
-        lastModelToUse,
-        streamResponse,
-        originalRequest,
-      );
-    } finally {
-      clearTimeout(timerId);
-    }
+    return this.processStreamResponse(
+      lastModelToUse,
+      streamResponse,
+      originalRequest,
+    );
   }
 
   /**

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -521,6 +521,26 @@ export class GeminiChat {
     // Track initial active model to detect fallback changes
     const initialActiveModel = this.context.config.getActiveModel();
 
+    const requestTimeoutMs =
+      this.context.config.getRequestTimeoutMs() ?? 300_000;
+
+    const timeoutController = new AbortController();
+    const timerId = setTimeout(
+      () => timeoutController.abort(),
+      requestTimeoutMs,
+    );
+
+    let combinedSignal = abortSignal;
+    if (typeof AbortSignal.any === 'function') {
+      combinedSignal = AbortSignal.any([abortSignal, timeoutController.signal]);
+    } else {
+      // Fallback for older Node.js
+      abortSignal?.addEventListener('abort', () => timeoutController.abort(), {
+        once: true,
+      });
+      combinedSignal = timeoutController.signal;
+    }
+
     const apiCall = async () => {
       const useGemini3_1 =
         (await this.context.config.getGemini31Launched?.()) ?? false;
@@ -561,7 +581,7 @@ export class GeminiChat {
         // passed via config.
         systemInstruction: this.systemInstruction,
         tools: this.tools,
-        abortSignal,
+        abortSignal: combinedSignal,
       };
 
       let contentsToUse: Content[] = supportsModernFeatures(modelToUse)
@@ -667,39 +687,44 @@ export class GeminiChat {
       );
     };
 
-    const streamResponse = await retryWithBackoff(apiCall, {
-      onPersistent429: onPersistent429Callback,
-      onValidationRequired: onValidationRequiredCallback,
-      authType: this.context.config.getContentGeneratorConfig()?.authType,
-      retryFetchErrors: this.context.config.getRetryFetchErrors(),
-      signal: abortSignal,
-      maxAttempts:
-        availabilityMaxAttempts ?? this.context.config.getMaxAttempts(),
-      getAvailabilityContext,
-      onRetry: (attempt, error, delayMs) => {
-        coreEvents.emitRetryAttempt({
-          attempt,
-          maxAttempts:
-            availabilityMaxAttempts ?? this.context.config.getMaxAttempts(),
-          delayMs,
-          error: error instanceof Error ? error.message : String(error),
-          model: lastModelToUse,
-        });
-      },
-    });
+    try {
+      const streamResponse = await retryWithBackoff(apiCall, {
+        onPersistent429: onPersistent429Callback,
+        onValidationRequired: onValidationRequiredCallback,
+        authType: this.context.config.getContentGeneratorConfig()?.authType,
+        retryFetchErrors: this.context.config.getRetryFetchErrors(),
+        signal: combinedSignal,
+        overallTimeoutMs: requestTimeoutMs,
+        maxAttempts:
+          availabilityMaxAttempts ?? this.context.config.getMaxAttempts(),
+        getAvailabilityContext,
+        onRetry: (attempt, error, delayMs) => {
+          coreEvents.emitRetryAttempt({
+            attempt,
+            maxAttempts:
+              availabilityMaxAttempts ?? this.context.config.getMaxAttempts(),
+            delayMs,
+            error: error instanceof Error ? error.message : String(error),
+            model: lastModelToUse,
+          });
+        },
+      });
 
-    // Store the original request for AfterModel hooks
-    const originalRequest: GenerateContentParameters = {
-      model: lastModelToUse,
-      config: lastConfig,
-      contents: lastContentsToUse,
-    };
+      // Store the original request for AfterModel hooks
+      const originalRequest: GenerateContentParameters = {
+        model: lastModelToUse,
+        config: lastConfig,
+        contents: lastContentsToUse,
+      };
 
-    return this.processStreamResponse(
-      lastModelToUse,
-      streamResponse,
-      originalRequest,
-    );
+      return this.processStreamResponse(
+        lastModelToUse,
+        streamResponse,
+        originalRequest,
+      );
+    } finally {
+      clearTimeout(timerId);
+    }
   }
 
   /**

--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -634,6 +634,28 @@ describe('retryWithBackoff', () => {
     );
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
+  it('should throw timeout error when overallTimeoutMs is exceeded', async () => {
+    const mockFn = vi.fn(async () => {
+      // Simulate a long operation that takes 200ms
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      return 'success';
+    });
+
+    const promise = retryWithBackoff(mockFn, {
+      maxAttempts: 3,
+      initialDelayMs: 10,
+      overallTimeoutMs: 100, // Timeout is shorter than the operation
+    });
+
+    // We need to advance timers and await the promise
+    await vi.advanceTimersByTimeAsync(150);
+
+    await expect(promise).rejects.toThrow(
+      'Operation timed out after 100ms and 0 attempts.',
+    );
+    // Depending on when the abort happens, mockFn might have been called 1 time
+    // but the test should catch the timeout.
+  });
   it('should trigger fallback for OAuth personal users on persistent 500 errors', async () => {
     const fallbackCallback = vi.fn().mockResolvedValue('gemini-2.5-flash');
 

--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -27,7 +27,7 @@ const createFailingFunction = (
   successValue: string = 'success',
 ) => {
   let attempts = 0;
-  return vi.fn(async () => {
+  return vi.fn(async (_signal?: AbortSignal) => {
     attempts++;
     if (attempts <= failures) {
       // Simulate a retryable error
@@ -635,26 +635,36 @@ describe('retryWithBackoff', () => {
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
   it('should throw timeout error when overallTimeoutMs is exceeded', async () => {
-    const mockFn = vi.fn(async () => {
-      // Simulate a long operation that takes 200ms
-      await new Promise((resolve) => setTimeout(resolve, 200));
+    let internalSignal: AbortSignal | undefined;
+    const mockFn = vi.fn(async (signal?: AbortSignal) => {
+      internalSignal = signal;
+      // Simulation of work that respects the signal
+      await new Promise((resolve, reject) => {
+        const timeout = setTimeout(resolve, 200);
+        signal?.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(timeout);
+            reject(new Error('Aborted'));
+          },
+          { once: true },
+        );
+      });
       return 'success';
     });
 
     const promise = retryWithBackoff(mockFn, {
       maxAttempts: 3,
       initialDelayMs: 10,
-      overallTimeoutMs: 100, // Timeout is shorter than the operation
+      overallTimeoutMs: 100,
     });
 
-    // We need to advance timers and await the promise
     await vi.advanceTimersByTimeAsync(150);
 
     await expect(promise).rejects.toThrow(
       'Operation timed out after 100ms and 0 attempts.',
     );
-    // Depending on when the abort happens, mockFn might have been called 1 time
-    // but the test should catch the timeout.
+    expect(internalSignal?.aborted).toBe(true);
   });
   it('should trigger fallback for OAuth personal users on persistent 500 errors', async () => {
     const fallbackCallback = vi.fn().mockResolvedValue('gemini-2.5-flash');

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -197,7 +197,7 @@ export function isRetryableError(
  * @throws The last error encountered if all attempts fail.
  */
 export async function retryWithBackoff<T>(
-  fn: () => Promise<T>,
+  fn: (signal?: AbortSignal) => Promise<T>,
   options?: Partial<RetryOptions>,
 ): Promise<T> {
   if (options?.signal?.aborted) {
@@ -272,7 +272,7 @@ export async function retryWithBackoff<T>(
       attempt++;
       try {
         const result = await Promise.race([
-          fn(),
+          fn(overallSignal),
           new Promise<never>((_, reject) => {
             const onAbort = () => {
               if (
@@ -306,7 +306,7 @@ export async function retryWithBackoff<T>(
           if (onRetry) {
             onRetry(attempt, new Error('Invalid content'), delayWithJitter);
           }
-          await delay(delayWithJitter, signal);
+          await delay(delayWithJitter, overallSignal);
           currentDelay = Math.min(maxDelayMs, currentDelay * 2);
           continue;
         }

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -37,6 +37,7 @@ export interface RetryOptions {
   signal?: AbortSignal;
   getAvailabilityContext?: () => RetryAvailabilityContext | undefined;
   onRetry?: (attempt: number, error: unknown, delayMs: number) => void;
+  overallTimeoutMs?: number;
 }
 
 const DEFAULT_RETRY_OPTIONS: RetryOptions = {
@@ -224,6 +225,7 @@ export async function retryWithBackoff<T>(
     signal,
     getAvailabilityContext,
     onRetry,
+    overallTimeoutMs,
   } = {
     ...DEFAULT_RETRY_OPTIONS,
     shouldRetryOnError: isRetryableError,
@@ -232,98 +234,106 @@ export async function retryWithBackoff<T>(
 
   let attempt = 0;
   let currentDelay = initialDelayMs;
+  const startTime = Date.now();
+  let overallSignal = signal;
+  let timeoutId: NodeJS.Timeout | undefined;
 
-  while (attempt < maxAttempts) {
-    if (signal?.aborted) {
-      throw createAbortError();
+  if (overallTimeoutMs) {
+    const timeoutController = new AbortController();
+    timeoutId = setTimeout(() => timeoutController.abort(), overallTimeoutMs);
+    if (signal) {
+      // AbortSignal.any is available in Node.js >= 20.3.0
+      // For compatibility with earlier Node 20.x, we could use manually manually.
+      // But the project says recommended ~20.19.0.
+      if (typeof AbortSignal.any === 'function') {
+        overallSignal = AbortSignal.any([signal, timeoutController.signal]);
+      } else {
+        // Fallback for older Node.js 20 versions
+        signal.addEventListener('abort', () => timeoutController.abort(), {
+          once: true,
+        });
+        overallSignal = timeoutController.signal;
+      }
+    } else {
+      overallSignal = timeoutController.signal;
     }
-    attempt++;
-    try {
-      const result = await fn();
+  }
 
-      if (
-        shouldRetryOnContent &&
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        shouldRetryOnContent(result as GenerateContentResponse)
-      ) {
-        const jitter = currentDelay * 0.3 * (Math.random() * 2 - 1);
-        const delayWithJitter = Math.max(0, currentDelay + jitter);
-        if (onRetry) {
-          onRetry(attempt, new Error('Invalid content'), delayWithJitter);
-        }
-        await delay(delayWithJitter, signal);
-        currentDelay = Math.min(maxDelayMs, currentDelay * 2);
-        continue;
-      }
-
-      const successContext = getAvailabilityContext?.();
-      if (successContext) {
-        successContext.service.markHealthy(successContext.policy.model);
-      }
-
-      return result;
-    } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
-        throw error;
-      }
-
-      const classifiedError = classifyGoogleError(error);
-
-      const errorCode = getErrorStatus(error);
-
-      if (
-        classifiedError instanceof TerminalQuotaError ||
-        classifiedError instanceof ModelNotFoundError
-      ) {
-        if (onPersistent429) {
-          try {
-            const fallbackModel = await onPersistent429(
-              authType,
-              classifiedError,
-            );
-            if (fallbackModel) {
-              attempt = 0; // Reset attempts and retry with the new model.
-              currentDelay = initialDelayMs;
-              continue;
-            }
-          } catch (fallbackError) {
-            debugLogger.warn('Fallback to Flash model failed:', fallbackError);
-          }
-        }
-        // Terminal/not_found already recorded; nothing else to mark here.
-        throw classifiedError; // Throw if no fallback or fallback failed.
-      }
-
-      // Handle ValidationRequiredError - user needs to verify before proceeding
-      if (classifiedError instanceof ValidationRequiredError) {
-        if (onValidationRequired) {
-          try {
-            const intent = await onValidationRequired(classifiedError);
-            if (intent === 'verify') {
-              // User verified, retry the request
-              attempt = 0;
-              currentDelay = initialDelayMs;
-              continue;
-            }
-            // 'change_auth' or 'cancel' - mark as handled and throw
-            classifiedError.userHandled = true;
-          } catch (validationError) {
-            debugLogger.warn('Validation handler failed:', validationError);
-          }
-        }
-        throw classifiedError;
-      }
-
-      const is500 =
-        errorCode !== undefined && errorCode >= 500 && errorCode < 600;
-
-      if (classifiedError instanceof RetryableQuotaError || is500) {
-        if (attempt >= maxAttempts) {
-          const errorMessage =
-            classifiedError instanceof Error ? classifiedError.message : '';
-          debugLogger.warn(
-            `Attempt ${attempt} failed${errorMessage ? `: ${errorMessage}` : ''}. Max attempts reached`,
+  try {
+    while (attempt < maxAttempts) {
+      if (overallSignal?.aborted) {
+        if (overallTimeoutMs && Date.now() - startTime >= overallTimeoutMs) {
+          throw new Error(
+            `Operation timed out after ${overallTimeoutMs}ms and ${attempt} attempts.`,
           );
+        }
+        throw createAbortError();
+      }
+      attempt++;
+      try {
+        const result = await Promise.race([
+          fn(),
+          new Promise<never>((_, reject) => {
+            const onAbort = () => {
+              if (
+                overallTimeoutMs &&
+                Date.now() - startTime >= overallTimeoutMs
+              ) {
+                reject(
+                  new Error(
+                    `Operation timed out after ${overallTimeoutMs}ms and ${attempt - 1} attempts.`,
+                  ),
+                );
+              } else {
+                reject(createAbortError());
+              }
+            };
+            if (overallSignal?.aborted) {
+              onAbort();
+            } else {
+              overallSignal?.addEventListener('abort', onAbort, { once: true });
+            }
+          }),
+        ]);
+
+        if (
+          shouldRetryOnContent &&
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          shouldRetryOnContent(result as GenerateContentResponse)
+        ) {
+          const jitter = currentDelay * 0.3 * (Math.random() * 2 - 1);
+          const delayWithJitter = Math.max(0, currentDelay + jitter);
+          if (onRetry) {
+            onRetry(attempt, new Error('Invalid content'), delayWithJitter);
+          }
+          await delay(delayWithJitter, signal);
+          currentDelay = Math.min(maxDelayMs, currentDelay * 2);
+          continue;
+        }
+
+        const successContext = getAvailabilityContext?.();
+        if (successContext) {
+          successContext.service.markHealthy(successContext.policy.model);
+        }
+
+        return result;
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          (error.name === 'AbortError' ||
+            error.message.includes('Operation timed out'))
+        ) {
+          throw error;
+        }
+
+        const classifiedError = classifyGoogleError(error);
+
+        const errorCode = getErrorStatus(error);
+
+        if (
+          classifiedError instanceof TerminalQuotaError ||
+          classifiedError instanceof ModelNotFoundError
+        ) {
           if (onPersistent429) {
             try {
               const fallbackModel = await onPersistent429(
@@ -336,67 +346,124 @@ export async function retryWithBackoff<T>(
                 continue;
               }
             } catch (fallbackError) {
-              debugLogger.warn('Model fallback failed:', fallbackError);
+              debugLogger.warn(
+                'Fallback to Flash model failed:',
+                fallbackError,
+              );
             }
           }
-          throw classifiedError instanceof RetryableQuotaError
-            ? classifiedError
-            : error;
+          // Terminal/not_found already recorded; nothing else to mark here.
+          throw classifiedError; // Throw if no fallback or fallback failed.
         }
 
+        // Handle ValidationRequiredError - user needs to verify before proceeding
+        if (classifiedError instanceof ValidationRequiredError) {
+          if (onValidationRequired) {
+            try {
+              const intent = await onValidationRequired(classifiedError);
+              if (intent === 'verify') {
+                // User verified, retry the request
+                attempt = 0;
+                currentDelay = initialDelayMs;
+                continue;
+              }
+              // 'change_auth' or 'cancel' - mark as handled and throw
+              classifiedError.userHandled = true;
+            } catch (validationError) {
+              debugLogger.warn('Validation handler failed:', validationError);
+            }
+          }
+          throw classifiedError;
+        }
+
+        const is500 =
+          errorCode !== undefined && errorCode >= 500 && errorCode < 600;
+
+        if (classifiedError instanceof RetryableQuotaError || is500) {
+          if (attempt >= maxAttempts) {
+            const errorMessage =
+              classifiedError instanceof Error ? classifiedError.message : '';
+            debugLogger.warn(
+              `Attempt ${attempt} failed${errorMessage ? `: ${errorMessage}` : ''}. Max attempts reached`,
+            );
+            if (onPersistent429) {
+              try {
+                const fallbackModel = await onPersistent429(
+                  authType,
+                  classifiedError,
+                );
+                if (fallbackModel) {
+                  attempt = 0; // Reset attempts and retry with the new model.
+                  currentDelay = initialDelayMs;
+                  continue;
+                }
+              } catch (fallbackError) {
+                debugLogger.warn('Model fallback failed:', fallbackError);
+              }
+            }
+            throw classifiedError instanceof RetryableQuotaError
+              ? classifiedError
+              : error;
+          }
+
+          if (
+            classifiedError instanceof RetryableQuotaError &&
+            classifiedError.retryDelayMs !== undefined
+          ) {
+            currentDelay = Math.max(currentDelay, classifiedError.retryDelayMs);
+            // Positive jitter up to +20% while respecting server minimum delay
+            const jitter = currentDelay * 0.2 * Math.random();
+            const delayWithJitter = currentDelay + jitter;
+            debugLogger.warn(
+              `Attempt ${attempt} failed: ${classifiedError.message}. Retrying after ${Math.round(delayWithJitter)}ms...`,
+            );
+            if (onRetry) {
+              onRetry(attempt, error, delayWithJitter);
+            }
+            await delay(delayWithJitter, overallSignal);
+            currentDelay = Math.min(maxDelayMs, currentDelay * 2);
+            continue;
+          } else {
+            const errorStatus = getErrorStatus(error);
+            logRetryAttempt(attempt, error, errorStatus);
+
+            // Exponential backoff with jitter for non-quota errors
+            const jitter = currentDelay * 0.3 * (Math.random() * 2 - 1);
+            const delayWithJitter = Math.max(0, currentDelay + jitter);
+            if (onRetry) {
+              onRetry(attempt, error, delayWithJitter);
+            }
+            await delay(delayWithJitter, overallSignal);
+            currentDelay = Math.min(maxDelayMs, currentDelay * 2);
+            continue;
+          }
+        }
+
+        // Generic retry logic for other errors
         if (
-          classifiedError instanceof RetryableQuotaError &&
-          classifiedError.retryDelayMs !== undefined
+          attempt >= maxAttempts ||
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          !shouldRetryOnError(error as Error, retryFetchErrors)
         ) {
-          currentDelay = Math.max(currentDelay, classifiedError.retryDelayMs);
-          // Positive jitter up to +20% while respecting server minimum delay
-          const jitter = currentDelay * 0.2 * Math.random();
-          const delayWithJitter = currentDelay + jitter;
-          debugLogger.warn(
-            `Attempt ${attempt} failed: ${classifiedError.message}. Retrying after ${Math.round(delayWithJitter)}ms...`,
-          );
-          if (onRetry) {
-            onRetry(attempt, error, delayWithJitter);
-          }
-          await delay(delayWithJitter, signal);
-          currentDelay = Math.min(maxDelayMs, currentDelay * 2);
-          continue;
-        } else {
-          const errorStatus = getErrorStatus(error);
-          logRetryAttempt(attempt, error, errorStatus);
-
-          // Exponential backoff with jitter for non-quota errors
-          const jitter = currentDelay * 0.3 * (Math.random() * 2 - 1);
-          const delayWithJitter = Math.max(0, currentDelay + jitter);
-          if (onRetry) {
-            onRetry(attempt, error, delayWithJitter);
-          }
-          await delay(delayWithJitter, signal);
-          currentDelay = Math.min(maxDelayMs, currentDelay * 2);
-          continue;
+          throw error;
         }
-      }
 
-      // Generic retry logic for other errors
-      if (
-        attempt >= maxAttempts ||
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        !shouldRetryOnError(error as Error, retryFetchErrors)
-      ) {
-        throw error;
-      }
+        const errorStatus = getErrorStatus(error);
+        logRetryAttempt(attempt, error, errorStatus);
 
-      const errorStatus = getErrorStatus(error);
-      logRetryAttempt(attempt, error, errorStatus);
-
-      // Exponential backoff with jitter for non-quota errors
-      const jitter = currentDelay * 0.3 * (Math.random() * 2 - 1);
-      const delayWithJitter = Math.max(0, currentDelay + jitter);
-      if (onRetry) {
-        onRetry(attempt, error, delayWithJitter);
+        // Exponential backoff with jitter for non-quota errors
+        const jitter = currentDelay * 0.3 * (Math.random() * 2 - 1);
+        const delayWithJitter = Math.max(0, currentDelay + jitter);
+        if (onRetry) {
+          onRetry(attempt, error, delayWithJitter);
+        }
+        await delay(delayWithJitter, overallSignal);
+        currentDelay = Math.min(maxDelayMs, currentDelay * 2);
       }
-      await delay(delayWithJitter, signal);
-      currentDelay = Math.min(maxDelayMs, currentDelay * 2);
+    }
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
     }
   }
 


### PR DESCRIPTION
## Summary

This PR implements robust CLI timeouts and explicit abort logic to resolve indefinite hangs during long-running API operations (Issue #23688). It ensures that requests are always bounded and the CLI provides actionable feedback instead of silent unresponsiveness.

## Details

### 1. Robust Retry Timing & Global Timeout
*   Enhanced the [retryWithBackoff](cci:1://file:///c:/Users/91991/OneDrive/Desktop/gemini-cli/packages/core/src/utils/retry.ts:191:0-470:1) utility in `@google/gemini-cli-core` to support an `overallTimeoutMs` parameter.
*   Implemented a global timeout that spans the entire request lifecycle (including all retry attempts).
*   Introduced `Promise.race` inside the retry loop to forcefully interrupt hanging API calls that do not natively handle `AbortSignal`.

### 2. Configurable Durations
*   Added `requestTimeoutMs` to the global settings schema with a **default of 5 minutes** (300,000ms).
*   Exposed a new CLI flag `--request-timeout <ms>` for temporary overrides.
*   Updated [GeminiChat](cci:2://file:///c:/Users/91991/OneDrive/Desktop/gemini-cli/packages/core/src/core/geminiChat.ts:248:0-1090:1) to orchestrate proper cleanup of timeout timers using `try/finally` blocks and combined `AbortSignal` management.

### 3. Improved UI Transparency
*   Updated the [useLoadingIndicator](cci:1://file:///c:/Users/91991/OneDrive/Desktop/gemini-cli/packages/cli/src/ui/hooks/useLoadingIndicator.ts:28:0-98:2) hook to append the **actual error message** (e.g., `ETIMEDOUT`, `503 Service Unavailable`) to the retry hint.
*   The UI now explicitly shows the current attempt count (e.g., `Attempt 2/10`), giving users better visibility into connection status.

## Related Issues

Fixes #23688

## How to Validate

1. **Verify Default Timeout**:
   - Run the CLI in an environment with high latency or simulated network hangs.
   - Confirm that the operation fails with a timeout message after exactly 5 minutes rather than hanging indefinitely.
2. **Test Custom Timeout Flag**:
   - Run: `gemini --request-timeout 10000 "How does a transistor work?"` while throttling your network.
   - Observe that the CLI correctly aborts and returns an error within ~10 seconds.
3. **Verify Retry Visibility**:
   - Trigger a retryable failure (e.g., by temporarily disconnecting internet).
   - Observe the loading indicator showing the specific error: `Trying to reach gemini-1.5-pro (Attempt 2/10): fetch failed`.
4. **Automated Tests**:
   - Run: `npm test -w @google/gemini-cli-core -- src/utils/retry.test.ts`
   - Ensure the new test case `should throw timeout error when overallTimeoutMs is exceeded` passes.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
