### PR TITLE
fix(core): preserve trailing newlines in shell execution

### DIFF
--- a/integration-tests/run_shell_command.test.ts
+++ b/integration-tests/run_shell_command.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { join } from 'node:path';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   TestRig,
@@ -14,6 +15,7 @@ import {
 import { getShellConfiguration } from '../packages/core/src/utils/shell-utils.js';
 
 const { shell } = getShellConfiguration();
+const itBashOnly = shell === 'bash' ? it : it.skip;
 
 function getLineCountCommand(): { command: string; tool: string } {
   switch (shell) {
@@ -164,6 +166,53 @@ describe('run_shell_command', () => {
       expectedContent: 'test-stdin',
       testName: 'Shell command stdin test',
     });
+  });
+
+  itBashOnly('should preserve trailing newlines for heredoc shell commands', async () => {
+    await rig.setup('should preserve trailing newlines for heredoc shell commands', {
+      fakeResponsesPath: join(
+        import.meta.dirname,
+        'shell-trailing-newline.responses',
+      ),
+      settings: { tools: { core: ['run_shell_command'] } },
+    });
+
+    const result = await rig.run({
+      stdin: 'Run the heredoc command exactly as provided.',
+      approvalMode: 'yolo',
+    });
+
+    const foundToolCall = await rig.waitForToolCall(
+      'run_shell_command',
+      15000,
+      (args) => JSON.parse(args).command.includes('TRAILING_NEWLINE_20755'),
+    );
+
+    if (!foundToolCall || !result.includes('TRAILING_NEWLINE_20755')) {
+      printDebugInfo(rig, result, {
+        'Found tool call': foundToolCall,
+        ToolLogs: rig.readToolLogs(),
+      });
+    }
+
+    expect(foundToolCall).toBe(true);
+
+    const toolCall = rig
+      .readToolLogs()
+      .find((toolCall) => toolCall.toolRequest.name === 'run_shell_command');
+
+    expect(toolCall).toBeDefined();
+    expect(toolCall!.toolRequest.success).toBe(true);
+
+    const parsedArgs = JSON.parse(toolCall!.toolRequest.args) as {
+      command: string;
+    };
+    expect(parsedArgs.command.endsWith('\n')).toBe(true);
+
+    expect(result).toContain('TRAILING_NEWLINE_20755');
+    expect(result).not.toMatch(
+      /here-document delimited by end-of-file|syntax error: unexpected end of file/i,
+    );
   });
 
   it.skip('should run allowed sub-command in non-interactive mode', async () => {

--- a/integration-tests/run_shell_command.test.ts
+++ b/integration-tests/run_shell_command.test.ts
@@ -168,52 +168,58 @@ describe('run_shell_command', () => {
     });
   });
 
-  itBashOnly('should preserve trailing newlines for heredoc shell commands', async () => {
-    await rig.setup('should preserve trailing newlines for heredoc shell commands', {
-      fakeResponsesPath: join(
-        import.meta.dirname,
-        'shell-trailing-newline.responses',
-      ),
-      settings: { tools: { core: ['run_shell_command'] } },
-    });
+  itBashOnly(
+    'should preserve trailing newlines for heredoc shell commands',
+    async () => {
+      await rig.setup(
+        'should preserve trailing newlines for heredoc shell commands',
+        {
+          fakeResponsesPath: join(
+            import.meta.dirname,
+            'shell-trailing-newline.responses',
+          ),
+          settings: { tools: { core: ['run_shell_command'] } },
+        },
+      );
 
-    const result = await rig.run({
-      stdin: 'Run the heredoc command exactly as provided.',
-      approvalMode: 'yolo',
-    });
-
-    const foundToolCall = await rig.waitForToolCall(
-      'run_shell_command',
-      15000,
-      (args) => JSON.parse(args).command.includes('TRAILING_NEWLINE_20755'),
-    );
-
-    if (!foundToolCall || !result.includes('TRAILING_NEWLINE_20755')) {
-      printDebugInfo(rig, result, {
-        'Found tool call': foundToolCall,
-        ToolLogs: rig.readToolLogs(),
+      const result = await rig.run({
+        stdin: 'Run the heredoc command exactly as provided.',
+        approvalMode: 'yolo',
       });
-    }
 
-    expect(foundToolCall).toBe(true);
+      const foundToolCall = await rig.waitForToolCall(
+        'run_shell_command',
+        15000,
+        (args) => JSON.parse(args).command.includes('TRAILING_NEWLINE_20755'),
+      );
 
-    const toolCall = rig
-      .readToolLogs()
-      .find((toolCall) => toolCall.toolRequest.name === 'run_shell_command');
+      if (!foundToolCall || !result.includes('TRAILING_NEWLINE_20755')) {
+        printDebugInfo(rig, result, {
+          'Found tool call': foundToolCall,
+          ToolLogs: rig.readToolLogs(),
+        });
+      }
 
-    expect(toolCall).toBeDefined();
-    expect(toolCall!.toolRequest.success).toBe(true);
+      expect(foundToolCall).toBe(true);
 
-    const parsedArgs = JSON.parse(toolCall!.toolRequest.args) as {
-      command: string;
-    };
-    expect(parsedArgs.command.endsWith('\n')).toBe(true);
+      const toolCall = rig
+        .readToolLogs()
+        .find((toolCall) => toolCall.toolRequest.name === 'run_shell_command');
 
-    expect(result).toContain('TRAILING_NEWLINE_20755');
-    expect(result).not.toMatch(
-      /here-document delimited by end-of-file|syntax error: unexpected end of file/i,
-    );
-  });
+      expect(toolCall).toBeDefined();
+      expect(toolCall!.toolRequest.success).toBe(true);
+
+      const parsedArgs = JSON.parse(toolCall!.toolRequest.args) as {
+        command: string;
+      };
+      expect(parsedArgs.command.endsWith('\n')).toBe(true);
+
+      expect(result).toContain('TRAILING_NEWLINE_20755');
+      expect(result).not.toMatch(
+        /here-document delimited by end-of-file|syntax error: unexpected end of file/i,
+      );
+    },
+  );
 
   it.skip('should run allowed sub-command in non-interactive mode', async () => {
     await rig.setup('should run allowed sub-command in non-interactive mode');

--- a/integration-tests/shell-trailing-newline.responses
+++ b/integration-tests/shell-trailing-newline.responses
@@ -1,0 +1,2 @@
+{"method":"generateContentStream","response":[{"candidates":[{"content":{"parts":[{"functionCall":{"name":"run_shell_command","args":{"command":"cat <<'EOF'\nTRAILING_NEWLINE_20755\nEOF\n","description":"Run a heredoc command to verify trailing newline preservation."}}}],"role":"model"},"finishReason":"STOP","index":0}]}]}
+{"method":"generateContentStream","response":[{"candidates":[{"content":{"parts":[{"text":"TRAILING_NEWLINE_20755"}],"role":"model"},"finishReason":"STOP","index":0}]}]}

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -44,7 +44,10 @@ vi.mock('node:os', async (importOriginal) => {
 vi.mock('crypto');
 vi.mock('../utils/summarizer.js');
 
-import { escapeShellArg, initializeShellParsers } from '../utils/shell-utils.js';
+import {
+  escapeShellArg,
+  initializeShellParsers,
+} from '../utils/shell-utils.js';
 import { ShellTool, OUTPUT_UPDATE_INTERVAL_MS } from './shell.js';
 import { debugLogger } from '../index.js';
 import { type Config } from '../config/config.js';

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -325,6 +325,7 @@ describe('ShellTool', () => {
       const promise = invocation.execute(mockAbortSignal);
       resolveShellExecution({ pid: 54321 });
 
+      // Simulate pgrep output file creation by the shell command
       const tmpFile = path.join(os.tmpdir(), 'shell_pgrep_abcdef.tmp');
       fs.writeFileSync(tmpFile, `54321${os.EOL}54322${os.EOL}`);
 
@@ -385,7 +386,6 @@ describe('ShellTool', () => {
         expect.any(Object),
       );
     });
-
     it('should use the provided absolute directory as cwd', async () => {
       const subdir = path.join(tempRootDir, 'subdir');
       const invocation = shellTool.build({

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -44,7 +44,7 @@ vi.mock('node:os', async (importOriginal) => {
 vi.mock('crypto');
 vi.mock('../utils/summarizer.js');
 
-import { initializeShellParsers } from '../utils/shell-utils.js';
+import { escapeShellArg, initializeShellParsers } from '../utils/shell-utils.js';
 import { ShellTool, OUTPUT_UPDATE_INTERVAL_MS } from './shell.js';
 import { debugLogger } from '../index.js';
 import { type Config } from '../config/config.js';
@@ -301,7 +301,8 @@ describe('ShellTool', () => {
 
       const result = await promise;
 
-      const wrappedCommand = `(\n${'my-command &'}\n); __code=$?; pgrep -g 0 >${tmpFile} 2>&1; exit $__code;`;
+      const escapedTmpFile = escapeShellArg(tmpFile, 'bash');
+      const wrappedCommand = `(\nmy-command &\n); __code=$?; pgrep -g 0 >${escapedTmpFile} 2>&1; exit $__code;`;
       expect(mockShellExecutionService).toHaveBeenCalledWith(
         wrappedCommand,
         tempRootDir,
@@ -319,6 +320,34 @@ describe('ShellTool', () => {
       expect(fs.existsSync(tmpFile)).toBe(false);
     });
 
+    it('should preserve trailing spaces after background commands on linux', async () => {
+      const invocation = shellTool.build({ command: 'my-command & ' });
+      const promise = invocation.execute(mockAbortSignal);
+      resolveShellExecution({ pid: 54321 });
+
+      const tmpFile = path.join(os.tmpdir(), 'shell_pgrep_abcdef.tmp');
+      fs.writeFileSync(tmpFile, `54321${os.EOL}54322${os.EOL}`);
+
+      const result = await promise;
+
+      const escapedTmpFile = escapeShellArg(tmpFile, 'bash');
+      const wrappedCommand = `(\nmy-command & \n); __code=$?; pgrep -g 0 >${escapedTmpFile} 2>&1; exit $__code;`;
+      expect(mockShellExecutionService).toHaveBeenCalledWith(
+        wrappedCommand,
+        tempRootDir,
+        expect.any(Function),
+        expect.any(AbortSignal),
+        false,
+        expect.objectContaining({
+          pager: 'cat',
+          sanitizationConfig: {},
+          sandboxManager: expect.any(Object),
+        }),
+      );
+      expect(result.llmContent).toContain('Background PIDs: 54322');
+      expect(fs.existsSync(tmpFile)).toBe(false);
+    });
+
     it('should add a space when command ends with a backslash to prevent escaping newline', async () => {
       const invocation = shellTool.build({ command: 'ls\\' });
       const promise = invocation.execute(mockAbortSignal);
@@ -326,7 +355,8 @@ describe('ShellTool', () => {
       await promise;
 
       const tmpFile = path.join(os.tmpdir(), 'shell_pgrep_abcdef.tmp');
-      const wrappedCommand = `(\nls\\ \n); __code=$?; pgrep -g 0 >${tmpFile} 2>&1; exit $__code;`;
+      const escapedTmpFile = escapeShellArg(tmpFile, 'bash');
+      const wrappedCommand = `(\nls\\ \n); __code=$?; pgrep -g 0 >${escapedTmpFile} 2>&1; exit $__code;`;
       expect(mockShellExecutionService).toHaveBeenCalledWith(
         wrappedCommand,
         tempRootDir,
@@ -344,7 +374,8 @@ describe('ShellTool', () => {
       await promise;
 
       const tmpFile = path.join(os.tmpdir(), 'shell_pgrep_abcdef.tmp');
-      const wrappedCommand = `(\nls # comment\n); __code=$?; pgrep -g 0 >${tmpFile} 2>&1; exit $__code;`;
+      const escapedTmpFile = escapeShellArg(tmpFile, 'bash');
+      const wrappedCommand = `(\nls # comment\n); __code=$?; pgrep -g 0 >${escapedTmpFile} 2>&1; exit $__code;`;
       expect(mockShellExecutionService).toHaveBeenCalledWith(
         wrappedCommand,
         tempRootDir,
@@ -366,7 +397,8 @@ describe('ShellTool', () => {
       await promise;
 
       const tmpFile = path.join(os.tmpdir(), 'shell_pgrep_abcdef.tmp');
-      const wrappedCommand = `(\n${'ls'}\n); __code=$?; pgrep -g 0 >${tmpFile} 2>&1; exit $__code;`;
+      const escapedTmpFile = escapeShellArg(tmpFile, 'bash');
+      const wrappedCommand = `(\nls\n); __code=$?; pgrep -g 0 >${escapedTmpFile} 2>&1; exit $__code;`;
       expect(mockShellExecutionService).toHaveBeenCalledWith(
         wrappedCommand,
         subdir,
@@ -391,10 +423,96 @@ describe('ShellTool', () => {
       await promise;
 
       const tmpFile = path.join(os.tmpdir(), 'shell_pgrep_abcdef.tmp');
-      const wrappedCommand = `(\n${'ls'}\n); __code=$?; pgrep -g 0 >${tmpFile} 2>&1; exit $__code;`;
+      const escapedTmpFile = escapeShellArg(tmpFile, 'bash');
+      const wrappedCommand = `(\nls\n); __code=$?; pgrep -g 0 >${escapedTmpFile} 2>&1; exit $__code;`;
       expect(mockShellExecutionService).toHaveBeenCalledWith(
         wrappedCommand,
         path.join(tempRootDir, 'subdir'),
+        expect.any(Function),
+        expect.any(AbortSignal),
+        false,
+        expect.objectContaining({
+          pager: 'cat',
+          sanitizationConfig: {},
+          sandboxManager: expect.any(Object),
+        }),
+      );
+    });
+
+    it('should preserve trailing newlines for heredoc commands on linux', async () => {
+      const invocation = shellTool.build({
+        command: `cat <<EOF
+hello
+EOF
+`,
+      });
+      const promise = invocation.execute(mockAbortSignal);
+      resolveShellExecution();
+      await promise;
+
+      const tmpFile = path.join(os.tmpdir(), 'shell_pgrep_abcdef.tmp');
+      const escapedTmpFile = escapeShellArg(tmpFile, 'bash');
+      const wrappedCommand = `(
+cat <<EOF
+hello
+EOF
+); __code=$?; pgrep -g 0 >${escapedTmpFile} 2>&1; exit $__code;`;
+      expect(mockShellExecutionService).toHaveBeenCalledWith(
+        wrappedCommand,
+        tempRootDir,
+        expect.any(Function),
+        expect.any(AbortSignal),
+        false,
+        expect.objectContaining({
+          pager: 'cat',
+          sanitizationConfig: {},
+          sandboxManager: expect.any(Object),
+        }),
+      );
+    });
+
+    it('should preserve trailing newlines for comment-only commands on linux', async () => {
+      const invocation = shellTool.build({
+        command: `# comment
+`,
+      });
+      const promise = invocation.execute(mockAbortSignal);
+      resolveShellExecution();
+      await promise;
+
+      const tmpFile = path.join(os.tmpdir(), 'shell_pgrep_abcdef.tmp');
+      const escapedTmpFile = escapeShellArg(tmpFile, 'bash');
+      const wrappedCommand = `(
+# comment
+); __code=$?; pgrep -g 0 >${escapedTmpFile} 2>&1; exit $__code;`;
+      expect(mockShellExecutionService).toHaveBeenCalledWith(
+        wrappedCommand,
+        tempRootDir,
+        expect.any(Function),
+        expect.any(AbortSignal),
+        false,
+        expect.objectContaining({
+          pager: 'cat',
+          sanitizationConfig: {},
+          sandboxManager: expect.any(Object),
+        }),
+      );
+    });
+
+    it('should treat only newline sequences as trailing line terminators on linux', async () => {
+      const invocation = shellTool.build({
+        command: 'printf hello\r',
+      });
+      const promise = invocation.execute(mockAbortSignal);
+      resolveShellExecution();
+      await promise;
+
+      const tmpFile = path.join(os.tmpdir(), 'shell_pgrep_abcdef.tmp');
+      const escapedTmpFile = escapeShellArg(tmpFile, 'bash');
+      const wrappedCommand = `(\nprintf hello\r\n); __code=$?; pgrep -g 0 >${escapedTmpFile} 2>&1; exit $__code;`;
+      expect(mockShellExecutionService).toHaveBeenCalledWith(
+        wrappedCommand,
+        tempRootDir,
         expect.any(Function),
         expect.any(AbortSignal),
         false,

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -40,6 +40,7 @@ import {
 import { formatBytes } from '../utils/formatters.js';
 import type { AnsiOutput } from '../utils/terminalSerializer.js';
 import {
+  escapeShellArg,
   getCommandRoots,
   initializeShellParsers,
   stripShellWrapper,
@@ -106,14 +107,21 @@ export class ShellToolInvocation extends BaseToolInvocation<
     if (isWindows) {
       return command;
     }
-    let trimmed = command.trim();
-    if (!trimmed) {
+    if (!command.trim()) {
       return '';
     }
-    if (trimmed.endsWith('\\')) {
-      trimmed += ' ';
+
+    let wrappedCommand = command;
+    const hasTrailingLineTerminator = /\r?\n$/.test(wrappedCommand);
+
+    if (!hasTrailingLineTerminator && /\\[^\S\r\n]*$/.test(wrappedCommand)) {
+      wrappedCommand += ' ';
     }
-    return `(\n${trimmed}\n); __code=$?; pgrep -g 0 >${tempFilePath} 2>&1; exit $__code;`;
+
+    const closingNewline = hasTrailingLineTerminator ? '' : '\n';
+    const escapedTempFilePath = escapeShellArg(tempFilePath, 'bash');
+
+    return `(\n${wrappedCommand}${closingNewline}); __code=$?; pgrep -g 0 >${escapedTempFilePath} 2>&1; exit $__code;`;
   }
 
   private getContextualDetails(): string {
@@ -434,7 +442,9 @@ export class ShellToolInvocation extends BaseToolInvocation<
     options?: ExecuteOptions,
   ): Promise<ToolResult> {
     const { shellExecutionConfig, setExecutionIdCallback } = options ?? {};
-    const strippedCommand = stripShellWrapper(this.params.command);
+    const strippedCommand = stripShellWrapper(this.params.command, {
+      preserveTrailingWhitespace: true,
+    });
 
     if (signal.aborted) {
       return {

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -395,12 +395,15 @@ describe('stripShellWrapper', () => {
 
   it('should preserve trailing newlines for wrapped execution commands', () => {
     expect(
-      stripShellWrapper(`bash -c "cat <<EOF
+      stripShellWrapper(
+        `bash -c "cat <<EOF
 text
 EOF
-"`, {
-        preserveTrailingWhitespace: true,
-      }),
+"`,
+        {
+          preserveTrailingWhitespace: true,
+        },
+      ),
     ).toEqual(`cat <<EOF
 text
 EOF
@@ -409,10 +412,13 @@ EOF
 
   it('should preserve trailing newlines for wrapped comment-only commands', () => {
     expect(
-      stripShellWrapper(`bash -c "# comment
-"`, {
-        preserveTrailingWhitespace: true,
-      }),
+      stripShellWrapper(
+        `bash -c "# comment
+"`,
+        {
+          preserveTrailingWhitespace: true,
+        },
+      ),
     ).toEqual(`# comment
 `);
   });

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -392,6 +392,30 @@ describe('stripShellWrapper', () => {
   it('should not strip anything if no wrapper is present', () => {
     expect(stripShellWrapper('ls -l')).toEqual('ls -l');
   });
+
+  it('should preserve trailing newlines for wrapped execution commands', () => {
+    expect(
+      stripShellWrapper(`bash -c "cat <<EOF
+text
+EOF
+"`, {
+        preserveTrailingWhitespace: true,
+      }),
+    ).toEqual(`cat <<EOF
+text
+EOF
+`);
+  });
+
+  it('should preserve trailing newlines for wrapped comment-only commands', () => {
+    expect(
+      stripShellWrapper(`bash -c "# comment
+"`, {
+        preserveTrailingWhitespace: true,
+      }),
+    ).toEqual(`# comment
+`);
+  });
 });
 
 describe('escapeShellArg', () => {

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -796,21 +796,57 @@ export function getCommandRoots(command: string): string[] {
     .filter(Boolean);
 }
 
-export function stripShellWrapper(command: string): string {
+interface StripShellWrapperOptions {
+  preserveTrailingWhitespace?: boolean;
+}
+
+function stripSurroundingQuotes(
+  command: string,
+  preserveTrailingWhitespace: boolean,
+): string {
+  if (!command) {
+    return command;
+  }
+
+  if (!preserveTrailingWhitespace) {
+    let trimmedCommand = command.trim();
+    if (
+      (trimmedCommand.startsWith('"') && trimmedCommand.endsWith('"')) ||
+      (trimmedCommand.startsWith("'") && trimmedCommand.endsWith("'"))
+    ) {
+      trimmedCommand = trimmedCommand.substring(1, trimmedCommand.length - 1);
+    }
+    return trimmedCommand;
+  }
+
+  const firstChar = command[0];
+  if (firstChar !== '"' && firstChar !== "'") {
+    return command;
+  }
+
+  const trimmedEnd = command.trimEnd();
+  if (!trimmedEnd.endsWith(firstChar)) {
+    return command;
+  }
+
+  return trimmedEnd.substring(1, trimmedEnd.length - 1);
+}
+
+export function stripShellWrapper(
+  command: string,
+  options: StripShellWrapperOptions = {},
+): string {
+  const { preserveTrailingWhitespace = false } = options;
   const pattern =
     /^\s*(?:(?:(?:\S+\/)?(?:sh|bash|zsh))\s+-c|cmd\.exe\s+\/c|powershell(?:\.exe)?\s+(?:-NoProfile\s+)?-Command|pwsh(?:\.exe)?\s+(?:-NoProfile\s+)?-Command)\s+/i;
   const match = command.match(pattern);
   if (match) {
-    let newCommand = command.substring(match[0].length).trim();
-    if (
-      (newCommand.startsWith('"') && newCommand.endsWith('"')) ||
-      (newCommand.startsWith("'") && newCommand.endsWith("'"))
-    ) {
-      newCommand = newCommand.substring(1, newCommand.length - 1);
-    }
-    return newCommand;
+    return stripSurroundingQuotes(
+      command.substring(match[0].length),
+      preserveTrailingWhitespace,
+    );
   }
-  return command.trim();
+  return preserveTrailingWhitespace ? command : command.trim();
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes a regression in `run_shell_command` where trailing newlines were stripped before execution, which breaks heredocs and other multiline shell constructs that require a final newline delimiter.

## Details

This change keeps the fix narrowly scoped to the execution path.

- Preserve trailing whitespace only when preparing the command for execution.
- Keep existing trimmed behavior for confirmation text, command-root parsing, and allowlist/policy-related parsing so the patch has a smaller blast radius.
- Update the Unix `pgrep` wrapper so newline-terminated commands close cleanly instead of being trimmed and forced onto a same-line `;`.
- Add focused regression coverage for:
  - wrapped heredoc commands
  - wrapped comment-only commands
  - Linux shell execution wrapping
  - a bash-only integration case driven by fake responses

No documentation changes were needed.

## Related Issues

Fixes #20755

## How to Validate

1. Run the core shell regressions:

   ```bash
   npm run test --workspace @google/gemini-cli-core -- shell.test.ts shell-utils.test.ts
   ```

   Expected result:
   - `shell.test.ts` passes
   - `shell-utils.test.ts` passes

2. In a bash environment, run the targeted integration regression:

   ```bash
   npm run test:integration:sandbox:none -- run_shell_command.test.ts -t "should preserve trailing newlines for heredoc shell commands"
   ```

   Expected result:
   - the test passes
   - the recorded `run_shell_command` args still end with `\n`
   - the output contains `TRAILING_NEWLINE_20755`
   - the output does not contain `here-document delimited by end-of-file` or `syntax error: unexpected end of file`

3. Manual sanity check in a bash environment:

   Execute a shell tool call with:

   ```bash
   cat <<EOF
   test
   EOF
   ```

   Expected result:
   - command succeeds
   - output contains `test`
   - no heredoc EOF or syntax error is emitted

4. Optional extra edge case:

   Execute a comment-only command ending in a newline:

   ```bash
   # comment
   ```

   Expected result:
   - no unexpected EOF caused by trimming

Note:
- The new integration regression is bash-only, so it is skipped on Windows.
- I validated the unit test coverage locally on Windows with `npm run`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
