### PR TITLE
fix(cli): only show updating spinner when auto-update is in progress

### DIFF
--- a/packages/cli/src/ui/components/AppHeader.tsx
+++ b/packages/cli/src/ui/components/AppHeader.tsx
@@ -108,7 +108,7 @@ export const AppHeader = ({ version, showDetails = true }: AppHeaderProps) => {
           Gemini CLI
         </Text>
         <Text color={theme.text.secondary}> v{version}</Text>
-        {updateInfo && (
+        {updateInfo?.isUpdating && (
           <Box marginLeft={2}>
             <Text color={theme.text.secondary}>
               <CliSpinner /> Updating

--- a/packages/cli/src/ui/utils/updateCheck.ts
+++ b/packages/cli/src/ui/utils/updateCheck.ts
@@ -27,6 +27,7 @@ export interface UpdateInfo {
 export interface UpdateObject {
   message: string;
   update: UpdateInfo;
+  isUpdating?: boolean;
 }
 
 /**

--- a/packages/cli/src/utils/handleAutoUpdate.test.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.test.ts
@@ -197,7 +197,9 @@ describe('handleAutoUpdate', () => {
 
     expect(updateEventEmitter.emit).toHaveBeenCalledTimes(1);
     expect(updateEventEmitter.emit).toHaveBeenCalledWith('update-received', {
+      ...mockUpdateInfo,
       message: 'An update is available!\nPlease update manually.',
+      isUpdating: false,
     });
     expect(mockSpawn).not.toHaveBeenCalled();
   });
@@ -236,7 +238,9 @@ describe('handleAutoUpdate', () => {
 
     expect(updateEventEmitter.emit).toHaveBeenCalledTimes(1);
     expect(updateEventEmitter.emit).toHaveBeenCalledWith('update-received', {
+      ...mockUpdateInfo,
       message: 'An update is available!\nCannot determine update command.',
+      isUpdating: false,
     });
     expect(mockSpawn).not.toHaveBeenCalled();
   });
@@ -253,7 +257,9 @@ describe('handleAutoUpdate', () => {
 
     expect(updateEventEmitter.emit).toHaveBeenCalledTimes(1);
     expect(updateEventEmitter.emit).toHaveBeenCalledWith('update-received', {
+      ...mockUpdateInfo,
       message: 'An update is available!\nThis is an additional message.',
+      isUpdating: false,
     });
   });
 

--- a/packages/cli/src/utils/handleAutoUpdate.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.ts
@@ -102,17 +102,22 @@ export function handleAutoUpdate(
     combinedMessage += `\n${installationInfo.updateMessage}`;
   }
 
-  updateEventEmitter.emit('update-received', {
-    message: combinedMessage,
-  });
-
   if (
     !installationInfo.updateCommand ||
     !settings.merged.general.enableAutoUpdate
   ) {
+    updateEventEmitter.emit('update-received', {
+      ...info,
+      message: combinedMessage,
+      isUpdating: false,
+    });
     return;
   }
-
+  updateEventEmitter.emit('update-received', {
+    ...info,
+    message: combinedMessage,
+    isUpdating: true,
+  });
   if (_updateInProgress) {
     return;
   }


### PR DESCRIPTION
## Summary

Fixes the "Updating" spinner showing continuously even when auto-update is disabled. The UI now relies on an `isUpdating` flag explicitly passed in the `update-received` event payload rather than relying purely on the presence of update notification data.

## Details

- Added `isUpdating?: boolean` to the `UpdateObject` interface.
- Updated `handleAutoUpdate.ts` to explicitly set `isUpdating` to `false` when early-returning (e.g. if auto-updates are disabled or no update command was found) and `true` only when the update process is actually spawned.
- The `AppHeader` now uses `{updateInfo?.isUpdating && (...)}` to conditionally render the `<CliSpinner /> Updating` text.
- Updated `handleAutoUpdate.test.ts` to assert against the newly added payload fields (`isUpdating` and `...mockUpdateInfo`).

## Related Issues

N/A

## How to Validate

1. Set `enableAutoUpdate: false` in user `settings.json`.
2. Run the CLI.
3. Observe that the "A new version of Gemini CLI is available!" banner might appear if an update is detected, but the header does not constantly display the `Updating` spinner.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker