### PR TITLE
chore(evals): increase nightly eval runs to 10 for precision baseline

### DIFF
--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -26,6 +26,7 @@ jobs:
     if: "github.repository == 'google-gemini/gemini-cli'"
     strategy:
       fail-fast: false
+      max-parallel: 10
       matrix:
         model:
           - 'gemini-3.1-pro-preview-customtools'
@@ -63,6 +64,11 @@ jobs:
           TEST_NAME_PATTERN: '${{ github.event.inputs.test_name_pattern }}'
           VITEST_RETRY: 0
         run: |
+          # Add jitter to prevent all jobs from hitting API simultaneously
+          SLEEP_TIME=$((RANDOM % 60))
+          echo "Jitter: Sleeping for $SLEEP_TIME seconds..."
+          sleep $SLEEP_TIME
+
           CMD="npm run test:all_evals"
           PATTERN="${TEST_NAME_PATTERN}"
 

--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -34,7 +34,7 @@ jobs:
           - 'gemini-2.5-pro'
           - 'gemini-2.5-flash'
           - 'gemini-2.5-flash-lite'
-        run_attempt: [1, 2, 3]
+        run_attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5


### PR DESCRIPTION
## Summary

### Establishing a High-Fidelity Stability Baseline (Nightly Evals 3 → 10)

This PR increases the nightly evaluation run count from 3 to 10 attempts per model. This is a foundational shift designed to **eliminate the "noisy floor"** that currently bottlenecks our ability to validate introduced by PR regressions in evals.

## Details

### The Problem: The "Toil of 33%"
Our current 3-run baseline is mathematically too granular. A single random failure in a nightly run moves the stability score by **33.3%**. This high variance makes it impossible for automated checks to distinguish between expected LLM non-determinism and genuine code regressions.

As a result, if we enable the automated check engineers will be forced into "Investigation Toil":
1.  **Chasing "Ghost" Regressions**: Spending hours debugging PR failures that turn out to be pre-existing flaky tests.
2.  **Productivity Drain**: Repeatedly re-running CI to "get a green light" breaks focus and delays critical merges.
3.  **Trust Decay**: When CI "cries wolf" too often, we risk ignoring real red lights, allowing actual regressions to slip into `main`.

### The Solution: Precision-Based "Smart Blocking"
By moving to 10 runs (10% resolution), we establish a high-fidelity stability baseline that enables **Confidence-Based Blocking**:
*   **Identify Stable vs. Noisy**: We can mathematically differentiate between tests that are 90%+ stable and those that are naturally 60% stable.
*   **Automated Triage**: We can now automate PR checks to ignore noise in known flaky tests while strictly blocking on significant drops in stable behaviors.
*   **Faster Hardening**: We gather as much stability data in 2 nights (20 samples) as we previously did in a full week, allowing us to harden the suite and promote tests to `ALWAYS_PASSES` faster.

**Mitigating API Pressure**:
To handle the increased volume of 60 total nightly runs (6 models x 10 attempts), this PR adds:
* `max-parallel: 10`: Limits the number of concurrent jobs to prevent overwhelming the API backend.
* **Random Jitter**: Introduces a 0-60 second sleep at the start of each job to prevent a "thundering herd" of simultaneous requests.

### The Outcome
This change trades marginal, asynchronous API costs for **massive gains in developer productivity**. We are "buying back" hours of engineering focus every week by ensuring that when a PR fails, it is for a real, actionable reason—not a statistical fluke.

## Related Issues

Related to #23169

## How to Validate

Example run: https://github.com/google-gemini/gemini-cli/actions/runs/23516551306

1.  Inspect `.github/workflows/evals-nightly.yml`.
2.  Verify the `run_attempt` matrix has been updated from `[1, 2, 3]` to `[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]`.
3.  (Optional) Trigger the workflow manually to verify it spawns 10 parallel runs per model.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (updated evaluation configuration)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt