### PR TITLE
test(integration): skip flaky 'should exit gracefully on second Ctrl+C' test

### DIFF
--- a/integration-tests/ctrl-c-exit.test.ts
+++ b/integration-tests/ctrl-c-exit.test.ts
@@ -17,7 +17,7 @@ describe('Ctrl+C exit', () => {
 
   afterEach(async () => await rig.cleanup());
 
-  it('should exit gracefully on second Ctrl+C', async () => {
+  it.skip('should exit gracefully on second Ctrl+C', async () => {
     await rig.setup('should exit gracefully on second Ctrl+C', {
       settings: { tools: { useRipgrep: false } },
     });


### PR DESCRIPTION
## Summary

This PR skips the `should exit gracefully on second Ctrl+C` integration test in `ctrl-c-exit.test.ts`. This test is currently flaky on macOS and is causing E2E test failures in CI.

## Details

The test uses multiple `ctrl-c` signals which are proving to be unreliable specifically on the macOS environment in CI runs. It is disabled to unblock the main branch while a more robust solution is developed. Tagging @SandyTao520 for visibility as they were the last person to touch this file/test.

## Related Issues

Related to #23733

## How to Validate

Run the integration tests to confirm the test is skipped:
`npm test -w @google/gemini-cli-core -- integration-tests/ctrl-c-exit.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
