### PR TITLE
fix(test): move flaky ctrl-c-exit test to non-blocking suite

### DIFF
--- a/integration-tests/ctrl-c-exit.test.ts
+++ b/integration-tests/ctrl-c-exit.test.ts
@@ -6,9 +6,9 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as os from 'node:os';
-import { TestRig } from './test-helper.js';
+import { TestRig, skipFlaky } from './test-helper.js';
 
-describe('Ctrl+C exit', () => {
+describe.skipIf(skipFlaky)('Ctrl+C exit', () => {
   let rig: TestRig;
 
   beforeEach(() => {


### PR DESCRIPTION
Following the pattern in #23259, this PR moves the flaky `ctrl-c-exit.test.ts` to the non-blocking suite by using the `skipFlaky` helper. This test has been intermittently failing in CI and blocking PRs.