### PR TITLE
fix(tests): safely access toolRequest.error via type narrowing

### DIFF
--- a/integration-tests/concurrency-limit.test.ts
+++ b/integration-tests/concurrency-limit.test.ts
@@ -9,6 +9,13 @@ import { TestRig } from './test-helper.js';
 import { join } from 'node:path';
 
 describe('web-fetch rate limiting', () => {
+  //Generic type guard (strict-safe)
+  function hasError<T extends Record<string, unknown>>(
+    req: T,
+  ): req is T & { error: string } {
+    return typeof req['error'] === 'string';
+  }
+
   let rig: TestRig;
 
   beforeEach(() => {
@@ -36,20 +43,12 @@ describe('web-fetch rate limiting', () => {
 
     // We expect to find at least one tool call that failed with a rate limit error.
     const toolLogs = rig.readToolLogs();
-    function hasError(req: {
-      name: string;
-      args: string;
-      success: boolean;
-      duration_ms: number;
-      error?: string;
-    }): req is typeof req & { error: string } {
-      return 'error' in req && typeof req.error === 'string';
-    }
+
     const rateLimitedCalls = toolLogs.filter(
       (log) =>
         log.toolRequest.name === 'web_fetch' &&
         hasError(log.toolRequest) &&
-        log.toolRequest.error.includes('Rate limit exceeded'),
+        log.toolRequest['error'].includes('Rate limit exceeded'),
     );
 
     expect(rateLimitedCalls.length).toBeGreaterThan(0);

--- a/integration-tests/concurrency-limit.test.ts
+++ b/integration-tests/concurrency-limit.test.ts
@@ -36,10 +36,20 @@ describe('web-fetch rate limiting', () => {
 
     // We expect to find at least one tool call that failed with a rate limit error.
     const toolLogs = rig.readToolLogs();
+    function hasError(req: {
+      name: string;
+      args: string;
+      success: boolean;
+      duration_ms: number;
+      error?: string;
+    }): req is typeof req & { error: string } {
+      return 'error' in req && typeof req.error === 'string';
+    }
     const rateLimitedCalls = toolLogs.filter(
       (log) =>
         log.toolRequest.name === 'web_fetch' &&
-        log.toolRequest.error?.includes('Rate limit exceeded'),
+        hasError(log.toolRequest) &&
+        log.toolRequest.error.includes('Rate limit exceeded'),
     );
 
     expect(rateLimitedCalls.length).toBeGreaterThan(0);


### PR DESCRIPTION
This PR fixes a TypeScript error in the `integration-tests/concurrency-limit.test.ts`: web-fetch rate limiting test caused by accessing toolRequest.error on a union type without narrowing.
