### PR TITLE
fix(evals): use local test-helper imports in save_memory and hierarchical_memory

### DIFF
--- a/evals/hierarchical_memory.eval.ts
+++ b/evals/hierarchical_memory.eval.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect } from 'vitest';
 import { evalTest } from './test-helper.js';
-import { assertModelHasOutput } from '../integration-tests/test-helper.js';
+import { assertModelHasOutput } from './test-helper.js';
 
 describe('Hierarchical Memory', () => {
   const conflictResolutionTest =

--- a/evals/save_memory.eval.ts
+++ b/evals/save_memory.eval.ts
@@ -9,7 +9,7 @@ import { evalTest } from './test-helper.js';
 import {
   assertModelHasOutput,
   checkModelOutputContent,
-} from '../integration-tests/test-helper.js';
+} from './test-helper.js';
 
 describe('save_memory', () => {
   const TEST_PREFIX = 'Save memory test: ';


### PR DESCRIPTION
## Summary

- Fix inconsistent imports in `save_memory.eval.ts` and `hierarchical_memory.eval.ts` that reach into `../integration-tests/test-helper.js` instead of using the local `./test-helper.js`
- The local helper re-exports the same symbols via `@google/gemini-cli-test-utils`, matching the convention used by all other eval files

## Related Issues

Fixes #23756
Related to #23331