### PR TITLE
fix(tests): ensure type safety when accessing hook logs (avoid possib…

### DIFF
--- a/integration-tests/hooks-system.test.ts
+++ b/integration-tests/hooks-system.test.ts
@@ -163,9 +163,11 @@ describe.skipIf(skipFlaky)(
               log.hookCall.stderr.includes('"decision":"deny"')),
         );
         expect(blockHook).toBeDefined();
-        expect(
-          blockHook?.hookCall.stdout + blockHook?.hookCall.stderr,
-        ).toContain(blockMsg);
+        if (!blockHook) {
+          throw new Error('Expected blockHook to be defined');
+        }
+        const output = blockHook.hookCall.stdout + blockHook.hookCall.stderr;
+        expect(output).toContain(blockMsg);
       });
 
       it('should allow tool execution when hook returns allow decision', async () => {

--- a/integration-tests/hooks-system.test.ts
+++ b/integration-tests/hooks-system.test.ts
@@ -163,10 +163,7 @@ describe.skipIf(skipFlaky)(
               log.hookCall.stderr.includes('"decision":"deny"')),
         );
         expect(blockHook).toBeDefined();
-        if (!blockHook) {
-          throw new Error('Expected blockHook to be defined');
-        }
-        const output = blockHook.hookCall.stdout + blockHook.hookCall.stderr;
+        const output = blockHook!.hookCall.stdout + blockHook!.hookCall.stderr;
         expect(output).toContain(blockMsg);
       });
 


### PR DESCRIPTION
TypeScript flagged unsafe access to `blockHook.hookCall.stdout` and `stderr` because `blockHook` can be undefined. Although the test asserts existence using `expect(blockHook).toBeDefined()`, TypeScript does not narrow types based on runtime assertions.

This change adds an explicit runtime guard to ensure `blockHook` is defined before accessing its properties, eliminating TS18048 errors and improving type safety.

No functional behavior changes; this is purely a type-safety fix for tests.