### PR TITLE
fix(cli): prevent DiffRenderer crashes on large YOLO file diffs (Wind…

### DIFF
--- a/packages/cli/src/ui/components/messages/DiffRenderer.test.tsx
+++ b/packages/cli/src/ui/components/messages/DiffRenderer.test.tsx
@@ -381,6 +381,39 @@ fileDiff Index: Dockerfile
         await waitFor(() => expect(lastFrame()).toContain('RUN npm run build'));
         expect(lastFrame()).toMatchSnapshot();
       });
+
+      it('should render a safe summary for very large diffs', async () => {
+        const largeContextBlock = Array.from(
+          { length: 21000 },
+          (_, i) => ` line ${i + 1}`,
+        ).join('\n');
+        const largeDiff = `
+diff --git a/huge.js b/huge.js
+index 1111111..2222222 100644
+--- a/huge.js
++++ b/huge.js
+@@ -1,21000 +1,21000 @@
+${largeContextBlock}
+`;
+
+        const { lastFrame } = await renderWithProviders(
+          <OverflowProvider>
+            <DiffRenderer
+              diffContent={largeDiff}
+              filename="huge.js"
+              terminalWidth={80}
+            />
+          </OverflowProvider>,
+          {
+            settings: createMockSettings({ ui: { useAlternateBuffer } }),
+          },
+        );
+
+        await waitFor(() =>
+          expect(lastFrame()).toContain('Diff is too large to render safely.'),
+        );
+        expect(lastFrame()).toContain('Showing summary only (21000 lines).');
+      });
     },
   );
 });

--- a/packages/cli/src/ui/components/messages/DiffRenderer.tsx
+++ b/packages/cli/src/ui/components/messages/DiffRenderer.tsx
@@ -91,6 +91,7 @@ interface DiffRendererProps {
 }
 
 const DEFAULT_TAB_WIDTH = 4; // Spaces per tab for normalization
+const MAX_RENDERABLE_DIFF_LINES = 20000;
 
 export const DiffRenderer: React.FC<DiffRendererProps> = ({
   diffContent,
@@ -225,11 +226,33 @@ const renderDiffContent = (
     );
   }
 
-  const maxLineNumber = Math.max(
-    0,
-    ...displayableLines.map((l) => l.oldLine ?? 0),
-    ...displayableLines.map((l) => l.newLine ?? 0),
-  );
+  if (displayableLines.length > MAX_RENDERABLE_DIFF_LINES) {
+    return (
+      <Box
+        borderStyle="round"
+        borderColor={semanticTheme.border.default}
+        padding={1}
+        flexDirection="column"
+      >
+        <Text color={semanticTheme.status.warning}>
+          Diff is too large to render safely.
+        </Text>
+        <Text dimColor>
+          {`Showing summary only (${displayableLines.length} lines).`}
+        </Text>
+      </Box>
+    );
+  }
+
+  let maxLineNumber = 0;
+  for (const line of displayableLines) {
+    if (line.oldLine !== undefined) {
+      maxLineNumber = Math.max(maxLineNumber, line.oldLine);
+    }
+    if (line.newLine !== undefined) {
+      maxLineNumber = Math.max(maxLineNumber, line.newLine);
+    }
+  }
   const gutterWidth = Math.max(1, maxLineNumber.toString().length);
 
   const fileExtension = filename?.split('.').pop() || null;


### PR DESCRIPTION
Fix:#23643
What issue does this PR fix?
Fixes frequent Gemini CLI crashes in YOLO mode on Windows when editing large .js files, where users see a stack trace and the CLI exits.

Root cause
DiffRenderer computed maxLineNumber using Math.max(0, ...largeArray, ...largeArray).
For large diffs, spreading huge arrays into function arguments can throw RangeError: Maximum call stack size exceeded, causing an uncaught exception and process exit.

Fix
Replaced spread-based Math.max with a safe linear scan over diff lines.
Added a large-diff safety guard to render a summary instead of full diff rendering when the diff is very large.
Added a regression test for a very large diff to verify no crash path.