### PR TITLE
Fix TypeScript inference issue for BrowserAgentCustomConfig in getBrowserAgentConfig

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -3186,20 +3186,23 @@ export class Config implements McpContext, AgentLoopContext {
   } {
     const override = this.getAgentOverride('browser_agent');
     const customConfig = this.getAgentsSettings()?.browser ?? {};
+
+    const resolvedConfig: BrowserAgentCustomConfig = {
+      sessionMode: customConfig.sessionMode ?? 'persistent',
+      headless: customConfig.headless ?? false,
+      profilePath: customConfig.profilePath,
+      visualModel: customConfig.visualModel,
+      allowedDomains: customConfig.allowedDomains,
+      disableUserInput: customConfig.disableUserInput,
+      maxActionsPerTask: customConfig.maxActionsPerTask ?? 100,
+      confirmSensitiveActions: customConfig.confirmSensitiveActions,
+      blockFileUploads: customConfig.blockFileUploads,
+    };
+
     return {
       enabled: override?.enabled ?? false,
       model: override?.modelConfig?.model,
-      customConfig: {
-        sessionMode: customConfig.sessionMode ?? 'persistent',
-        headless: customConfig.headless ?? false,
-        profilePath: customConfig.profilePath,
-        visualModel: customConfig.visualModel,
-        allowedDomains: customConfig.allowedDomains,
-        disableUserInput: customConfig.disableUserInput,
-        maxActionsPerTask: customConfig.maxActionsPerTask ?? 100,
-        confirmSensitiveActions: customConfig.confirmSensitiveActions,
-        blockFileUploads: customConfig.blockFileUploads,
-      },
+      customConfig: resolvedConfig,
     };
   }
 


### PR DESCRIPTION
## Summary

This change ensures TypeScript correctly recognizes all properties of BrowserAgentCustomConfig, fixing a false-negative type error without altering functionality.

## Details

TypeScript type inference issue in getBrowserAgentConfig, where the returned customConfig object was not being strictly recognized as BrowserAgentCustomConfig.

Although maxActionsPerTask is defined in the interface and correctly set at runtime (with a default of 100), TypeScript inferred the object as a generic literal type. This caused errors in tests such as:
```
Property 'maxActionsPerTask' does not exist on type 'BrowserAgentCustomConfig'
```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
