### PR TITLE
fix(cli): fix Windows quoting in the "To resume this session" reminder

### DIFF
--- a/packages/cli/src/ui/components/SessionSummaryDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SessionSummaryDisplay.test.tsx
@@ -195,7 +195,7 @@ describe('<SessionSummaryDisplay />', () => {
       unmount();
     });
 
-    it('sanitizes a malicious session ID in the footer', async () => {
+    it('safely quotes a malicious-looking session ID in the footer', async () => {
       const maliciousSessionId = "'; rm -rf / #";
       const { lastFrame, unmount } = await renderWithMockedStats(
         emptyMetrics,
@@ -203,7 +203,8 @@ describe('<SessionSummaryDisplay />', () => {
       );
       const output = lastFrame();
 
-      // escapeShellArg with bash (shell-quote) wraps special characters in double quotes.
+      // escapeShellArg with bash (shell-quote) keeps this payload as a
+      // single shell argument instead of allowing it to break out.
       expect(output).toContain('gemini --resume "\'; rm -rf / #"');
       unmount();
     });

--- a/packages/cli/src/ui/components/SessionSummaryDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SessionSummaryDisplay.test.tsx
@@ -140,8 +140,8 @@ describe('<SessionSummaryDisplay />', () => {
     unmount();
   });
 
-  describe('Session ID escaping', () => {
-    it('renders a standard UUID-formatted session ID in the footer (bash)', async () => {
+  describe('Session ID in footer', () => {
+    it('renders session ID without quotes (bash)', async () => {
       const uuidSessionId = '1234-abcd-5678-efgh';
       const { lastFrame, unmount } = await renderWithMockedStats(
         emptyMetrics,
@@ -149,25 +149,14 @@ describe('<SessionSummaryDisplay />', () => {
       );
       const output = lastFrame();
 
-      // Standard UUID characters should not be escaped/quoted by default for bash.
+      // Session IDs are UUIDs and should never be quoted, as quoting
+      // style differences across shells (e.g., single quotes in cmd.exe)
+      // cause the resume command to fail.
       expect(output).toContain('gemini --resume 1234-abcd-5678-efgh');
       unmount();
     });
 
-    it('sanitizes a malicious session ID in the footer (bash)', async () => {
-      const maliciousSessionId = "'; rm -rf / #";
-      const { lastFrame, unmount } = await renderWithMockedStats(
-        emptyMetrics,
-        maliciousSessionId,
-      );
-      const output = lastFrame();
-
-      // escapeShellArg (using shell-quote for bash) will wrap special characters in double quotes.
-      expect(output).toContain('gemini --resume "\'; rm -rf / #"');
-      unmount();
-    });
-
-    it('renders a standard UUID-formatted session ID in the footer (powershell)', async () => {
+    it('renders session ID without quotes (powershell)', async () => {
       getShellConfigurationMock.mockReturnValue({
         executable: 'powershell.exe',
         argsPrefix: ['-NoProfile', '-Command'],
@@ -181,18 +170,32 @@ describe('<SessionSummaryDisplay />', () => {
       );
       const output = lastFrame();
 
-      // PowerShell wraps strings in single quotes
-      expect(output).toContain("gemini --resume '1234-abcd-5678-efgh'");
+      // Session IDs are UUIDs — no quoting needed on any shell.
+      expect(output).toContain('gemini --resume 1234-abcd-5678-efgh');
       unmount();
     });
 
-    it('sanitizes a malicious session ID in the footer (powershell)', async () => {
+    it('renders session ID without quotes (cmd)', async () => {
       getShellConfigurationMock.mockReturnValue({
-        executable: 'powershell.exe',
-        argsPrefix: ['-NoProfile', '-Command'],
-        shell: 'powershell',
+        executable: 'cmd.exe',
+        argsPrefix: ['/d', '/s', '/c'],
+        shell: 'cmd',
       });
 
+      const uuidSessionId = '935c6d18-0c3f-4f42-8113-370b2daada1a';
+      const { lastFrame, unmount } = await renderWithMockedStats(
+        emptyMetrics,
+        uuidSessionId,
+      );
+      const output = lastFrame();
+
+      expect(output).toContain(
+        'gemini --resume 935c6d18-0c3f-4f42-8113-370b2daada1a',
+      );
+      unmount();
+    });
+
+    it('sanitizes a malicious session ID in the footer', async () => {
       const maliciousSessionId = "'; rm -rf / #";
       const { lastFrame, unmount } = await renderWithMockedStats(
         emptyMetrics,
@@ -200,8 +203,8 @@ describe('<SessionSummaryDisplay />', () => {
       );
       const output = lastFrame();
 
-      // PowerShell wraps in single quotes and escapes internal single quotes by doubling them
-      expect(output).toContain("gemini --resume '''; rm -rf / #'");
+      // escapeShellArg with bash (shell-quote) wraps special characters in double quotes.
+      expect(output).toContain('gemini --resume "\'; rm -rf / #"');
       unmount();
     });
   });

--- a/packages/cli/src/ui/components/SessionSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/SessionSummaryDisplay.tsx
@@ -23,7 +23,13 @@ export const SessionSummaryDisplay: React.FC<SessionSummaryDisplayProps> = ({
 
   const worktreeSettings = config.getWorktreeSettings();
 
-  const escapedSessionId = escapeShellArg(stats.sessionId, shell);
+  // Always escape the session ID with POSIX/bash rules (via shell-quote)
+  // instead of the detected shell. getShellConfiguration() may not reflect
+  // the user's actual shell (e.g., defaults to PowerShell on Windows even
+  // when running in cmd.exe), and PowerShell-style single quotes break in
+  // cmd.exe. POSIX escaping leaves safe strings like UUIDs unquoted while
+  // still sanitizing any unexpected characters.
+  const escapedSessionId = escapeShellArg(stats.sessionId, 'bash');
   let footer = `To resume this session: gemini --resume ${escapedSessionId}`;
 
   if (worktreeSettings) {


### PR DESCRIPTION
## Summary

Fix the "To resume this session" reminder producing a broken command on Windows CMD. The session ID was escaped using the detected shell (PowerShell by default on Windows), wrapping it in single quotes that CMD treats as literal characters.

## Details

`getShellConfiguration()` defaults to PowerShell on Windows even when the user is running in CMD. This caused `escapeShellArg` to wrap the session ID in single quotes (PowerShell style), which CMD passes through literally:

```
# What was displayed:
gemini --resume '935c6d18-0c3f-4f42-8113-370b2daada1a'

# What CMD parsed:
--resume = "'935c6d18-0c3f-4f42-8113-370b2daada1a'"  ← includes quotes
```

The fix hardcodes `'bash'` as the shell type for session ID escaping. POSIX/bash escaping (via `shell-quote`) leaves safe strings like UUIDs unquoted while still sanitizing any unexpected characters — making the output correct across all shells.

Worktree paths continue to use the detected shell for escaping since they can contain spaces and special characters.

## Related Issues

Fixes #23718

## How to Validate

1. Run the updated tests:
   ```bash
   npm test -w @google/gemini-cli -- src/ui/components/SessionSummaryDisplay.test.tsx
   ```
2. All 6 tests should pass, including:
   - `renders session ID without quotes (bash)`
   - `renders session ID without quotes (powershell)`
   - `renders session ID without quotes (cmd)`
   - `sanitizes a malicious session ID in the footer`
3. Run `gemini`, start a session, then quit. Verify the footer shows:
   ```
   To resume this session: gemini --resume 935c6d18-0c3f-4f42-8113-370b2daada1a
   ```
   (no quotes around the UUID)

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
