### PR TITLE
fix(evals): use local test-helper.js to fix inconsistent imports

### DIFF
--- a/evals/hierarchical_memory.eval.ts
+++ b/evals/hierarchical_memory.eval.ts
@@ -6,8 +6,7 @@
 
 import { describe, expect } from 'vitest';
 import { evalTest } from './test-helper.js';
-import { assertModelHasOutput } from '../integration-tests/test-helper.js';
-
+import { assertModelHasOutput } from './test-helper.js';
 describe('Hierarchical Memory', () => {
   const conflictResolutionTest =
     'Agent follows hierarchy for contradictory instructions';

--- a/evals/save_memory.eval.ts
+++ b/evals/save_memory.eval.ts
@@ -9,8 +9,7 @@ import { evalTest } from './test-helper.js';
 import {
   assertModelHasOutput,
   checkModelOutputContent,
-} from '../integration-tests/test-helper.js';
-
+} from './test-helper.js';
 describe('save_memory', () => {
   const TEST_PREFIX = 'Save memory test: ';
   const rememberingFavoriteColor = "Agent remembers user's favorite color";


### PR DESCRIPTION
## Description
This PR fixes the inconsistent imports in evals/save_memory.eval.ts and evals/hierarchical_memory.eval.ts as described in #23756.

## Changes Made
- Replaced the fragile cross-directory dependency with the local ./test-helper.js.
- Ensured consistency with the rest of the eval codebase.

Fixes #23756