### PR TITLE
fix(cli): show helpful guidance when no skills are available

### DIFF
--- a/packages/cli/src/ui/components/views/SkillsList.test.tsx
+++ b/packages/cli/src/ui/components/views/SkillsList.test.tsx
@@ -8,6 +8,7 @@ import { render } from '../../../test-utils/render.js';
 import { describe, it, expect } from 'vitest';
 import { SkillsList } from './SkillsList.js';
 import { type SkillDefinition } from '@google/gemini-cli-core';
+import { SKILLS_DOCS_URL } from '../../constants.js';
 
 describe('SkillsList Component', () => {
   const mockSkills: SkillDefinition[] = [
@@ -74,9 +75,8 @@ describe('SkillsList Component', () => {
       <SkillsList skills={[]} showDescriptions={true} />,
     );
     const output = lastFrame();
-
-    expect(output).toContain('No skills available');
-
+    expect(output).toContain('No skills available.');
+    expect(output).toContain(`Learn how to add skills: ${SKILLS_DOCS_URL}`);
     unmount();
   });
 

--- a/packages/cli/src/ui/components/views/SkillsList.tsx
+++ b/packages/cli/src/ui/components/views/SkillsList.tsx
@@ -8,6 +8,7 @@ import type React from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../../semantic-colors.js';
 import { type SkillDefinition } from '../../types.js';
+import { SKILLS_DOCS_URL } from '../../constants.js';
 
 interface SkillsListProps {
   skills: readonly SkillDefinition[];
@@ -86,7 +87,13 @@ export const SkillsList: React.FC<SkillsListProps> = ({
       )}
 
       {skills.length === 0 && (
-        <Text color={theme.text.primary}> No skills available</Text>
+        <Box flexDirection="column">
+          <Text color={theme.text.primary}>No skills available.</Text>
+          <Box flexDirection="row">
+            <Text color={theme.text.primary}>Learn how to add skills: </Text>
+            <Text color={theme.text.link}>{SKILLS_DOCS_URL}</Text>
+          </Box>
+        </Box>
       )}
     </Box>
   );

--- a/packages/cli/src/ui/constants.ts
+++ b/packages/cli/src/ui/constants.ts
@@ -58,3 +58,7 @@ export const MIN_TERMINAL_WIDTH_FOR_FULL_LABEL = 100;
 
 /** Default context usage fraction at which to trigger compression */
 export const DEFAULT_COMPRESSION_THRESHOLD = 0.5;
+
+/** Documentation URL for skills setup and configuration */
+export const SKILLS_DOCS_URL =
+  'https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/skills.md';


### PR DESCRIPTION
## Summary
I filed this issue and wanted to fix it too. Running `/skills` with nothing configured just showed "No skills available", no hint of what to do next, which is confusing for new users.

## Details
Updated the empty state in `SkillsList.tsx` to show a docs link so new users know where to go.

## Related Issues
Fixes #23441

## How to Validate
Run `/skills` with no skills configured should now show a helpful message with a link to the docs.

## Pre-Merge Checklist
- [x] Added/updated tests (if needed)
- [x] Validated on required platforms/methods:
 - [x] Windows
 - [x] npm run

## Screenshots

**Wide terminal:**

![preview](https://github.com/user-attachments/assets/5fcb7275-8798-4658-920f-59e3abffd142)


**Narrow terminal:**

![preview (1)](https://github.com/user-attachments/assets/49f1e2db-6236-4e3d-8e3a-1ea9b9f7fe0f)
