### PR TITLE
fix(evals): correct misplaced params in answer-vs-act and tool_output_masking

### DIFF
--- a/evals/answer-vs-act.eval.ts
+++ b/evals/answer-vs-act.eval.ts
@@ -138,7 +138,7 @@ describe('Answer vs. ask eval', () => {
     name: 'should not edit files when user notes an issue',
     prompt: 'The add function subtracts numbers.',
     files: FILES,
-    params: { timeout: 20000 }, // 20s timeout
+    timeout: 20000,
     assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
 

--- a/evals/test-helper.ts
+++ b/evals/test-helper.ts
@@ -366,7 +366,8 @@ export interface EvalCase {
   name: string;
   params?: {
     settings?: ForbiddenToolSettings & Record<string, unknown>;
-    [key: string]: unknown;
+    state?: Record<string, unknown>;
+    fakeResponsesPath?: string;
   };
   prompt: string;
   timeout?: number;

--- a/evals/tool_output_masking.eval.ts
+++ b/evals/tool_output_masking.eval.ts
@@ -33,9 +33,11 @@ describe('Tool Output Masking Behavioral Evals', () => {
   evalTest('USUALLY_PASSES', {
     name: 'should attempt to read the redirected full output file when information is masked',
     params: {
-      security: {
-        folderTrust: {
-          enabled: true,
+      settings: {
+        security: {
+          folderTrust: {
+            enabled: true,
+          },
         },
       },
     },
@@ -169,9 +171,11 @@ Output too large. Full output available at: ${outputFilePath}
   evalTest('USUALLY_PASSES', {
     name: 'should NOT read the full output file when the information is already in the preview',
     params: {
-      security: {
-        folderTrust: {
-          enabled: true,
+      settings: {
+        security: {
+          folderTrust: {
+            enabled: true,
+          },
         },
       },
     },


### PR DESCRIPTION
Fixes #23787

Found two eval files where config properties were at the wrong nesting level, causing them to be silently ignored.

**`answer-vs-act.eval.ts`** — `timeout` was inside `params` instead of being a top-level `EvalCase` property. `evalTest` passes `evalCase.timeout` to `rig.run()`, not anything from `params`, so the 20s timeout was never applied (defaulted to 300s).

**`tool_output_masking.eval.ts`** — `security` was directly in `params` instead of under `settings`. `TestRig.setup()` passes `options.settings` to `_createSettingsFile`, so the folder trust config was never written. (Compare with `hierarchical_memory.eval.ts` which does this correctly.)

Both slipped through because `EvalCase.params` had `[key: string]: unknown`, accepting any key without complaint. Replaced the index signature with the specific keys `TestRig.setup()` actually reads: `settings`, `state`, `fakeResponsesPath`.