### PR TITLE
fix(evals): read tool logs after telemetry flush in subagents eval

### DIFF
--- a/evals/hierarchical_memory.eval.ts
+++ b/evals/hierarchical_memory.eval.ts
@@ -5,8 +5,7 @@
  */
 
 import { describe, expect } from 'vitest';
-import { evalTest } from './test-helper.js';
-import { assertModelHasOutput } from '../integration-tests/test-helper.js';
+import { evalTest, assertModelHasOutput } from './test-helper.js';
 
 describe('Hierarchical Memory', () => {
   const conflictResolutionTest =

--- a/evals/subagents.eval.ts
+++ b/evals/subagents.eval.ts
@@ -76,6 +76,7 @@ describe('subagent eval test cases', () => {
       'index.ts': INDEX_TS,
     },
     assert: async (rig, _result) => {
+      await rig.waitForTelemetryReady();
       const updatedIndex = readProjectFile(rig, 'index.ts');
       const toolLogs = rig.readToolLogs() as Array<{
         toolRequest: { name: string };
@@ -128,11 +129,11 @@ describe('subagent eval test cases', () => {
       ),
     },
     assert: async (rig, _result) => {
+      await rig.expectToolCallSuccess([TEST_AGENTS.TESTING_AGENT.name]);
       const toolLogs = rig.readToolLogs() as Array<{
         toolRequest: { name: string };
       }>;
 
-      await rig.expectToolCallSuccess([TEST_AGENTS.TESTING_AGENT.name]);
       expect(toolLogs.some((l) => l.toolRequest.name === 'generalist')).toBe(
         false,
       );
@@ -175,15 +176,15 @@ describe('subagent eval test cases', () => {
       ),
     },
     assert: async (rig, _result) => {
+      await rig.expectToolCallSuccess([
+        TEST_AGENTS.DOCS_AGENT.name,
+        TEST_AGENTS.TESTING_AGENT.name,
+      ]);
       const toolLogs = rig.readToolLogs() as Array<{
         toolRequest: { name: string };
       }>;
       const readme = readProjectFile(rig, 'README.md');
 
-      await rig.expectToolCallSuccess([
-        TEST_AGENTS.DOCS_AGENT.name,
-        TEST_AGENTS.TESTING_AGENT.name,
-      ]);
       expect(readme).not.toContain('TODO: update the README.');
       expect(toolLogs.some((l) => l.toolRequest.name === 'generalist')).toBe(
         false,


### PR DESCRIPTION
Fixes #23789

Three test cases in `subagents.eval.ts` call `readToolLogs()` before telemetry has flushed, then assert on that snapshot. The negative checks ("generalist was not used") can false-pass if the call only appears in logs after flush.

**Changes:**
- **"trivial direct edit"** — added `waitForTelemetryReady()` before `readToolLogs()`
- **"prefer specialist"** — moved `readToolLogs()` after `expectToolCallSuccess()` (which waits for telemetry internally)
- **"multiple specialists"** — same reorder

Also consolidated the `hierarchical_memory.eval.ts` import of `assertModelHasOutput` to use `./test-helper.js` like every other eval, instead of reaching into `../integration-tests/test-helper.js`.