### PR TITLE
fix(ui): replace estimated string lengths with accurate text measurement

### DIFF
--- a/packages/cli/src/ui/components/Composer.test.tsx
+++ b/packages/cli/src/ui/components/Composer.test.tsx
@@ -10,6 +10,7 @@ import { act, useEffect } from 'react';
 import { Box, Text } from 'ink';
 import { Composer } from './Composer.js';
 import { UIStateContext, type UIState } from '../contexts/UIStateContext.js';
+import * as useTerminalSize from '../hooks/useTerminalSize.js';
 import {
   UIActionsContext,
   type UIActions,
@@ -28,6 +29,7 @@ import { TransientMessageType } from '../../utils/events.js';
 import type { LoadedSettings } from '../../config/settings.js';
 import type { SessionMetrics } from '../contexts/SessionContext.js';
 import type { TextBuffer } from './shared/text-buffer.js';
+import { getCachedStringWidth } from '../utils/textUtils.js';
 
 // Mock VimModeContext hook
 vi.mock('../contexts/VimModeContext.js', () => ({
@@ -43,6 +45,8 @@ vi.mock('../hooks/useTerminalSize.js', () => ({
     rows: 24,
   })),
 }));
+
+const useTerminalSizeMock = vi.mocked(useTerminalSize.useTerminalSize);
 
 const composerTestControls = vi.hoisted(() => ({
   suggestionsVisible: false,
@@ -501,6 +505,119 @@ describe('Composer', () => {
 
       const output = lastFrame();
       expect(output).not.toContain('LoadingIndicator');
+    });
+  });
+
+  describe('Tip collision width', () => {
+    it('hides the proactive tip when it does not fit by measured display width', async () => {
+      const elapsedTime = 1; // keeps cancel string stable as (esc to cancel, 1s)
+      const thoughtSubject = 'Thinking...';
+      const cancelAndTimerContentStr = `(esc to cancel, ${elapsedTime}s)`;
+
+      // Fullwidth characters are width=2 in terminal but length=1 in JS, so this
+      // specifically exercises display-width measurement.
+      const tipChar = 'Ａ';
+      let tipCount = 20;
+
+      let terminalWidthBoundary = 0;
+      // Ensure we stay out of "narrow" mode (isNarrowWidth < 80).
+      while (true) {
+        const tip = tipChar.repeat(tipCount);
+        const tipLabel = `Tip: ${tip}`;
+
+        // Mirror the logic in Composer.tsx for the showLoadingIndicator path.
+        const statusWidthForTipCollision =
+          // inlineSpinnerCharWidth
+          1 +
+          // spinnerAndPrimaryGapWidth
+          1 +
+          getCachedStringWidth(thoughtSubject) +
+          // interactiveExtra (empty)
+          0 +
+          // cancelShown: cancelSpacerWidth + width(cancel string)
+          1 +
+          getCachedStringWidth(cancelAndTimerContentStr);
+
+        terminalWidthBoundary =
+          statusWidthForTipCollision + getCachedStringWidth(tipLabel) + 5;
+
+        if (terminalWidthBoundary - 1 >= 80) break;
+        tipCount += 5;
+      }
+
+      const tip = tipChar.repeat(tipCount);
+
+      // Columns just below the measured collision boundary -> tip should not show.
+      vi.mocked(useTerminalSizeMock).mockReturnValue({
+        columns: terminalWidthBoundary - 1,
+        rows: 24,
+      });
+
+      const uiState = createMockUIState({
+        streamingState: StreamingState.Responding,
+        thought: { subject: thoughtSubject, description: '' },
+        elapsedTime,
+        currentTip: tip,
+        // Avoid shortcut fallback; we want to test the proactive tip only.
+        cleanUiDetailsVisible: false,
+        buffer: { text: 'x' } as unknown as TextBuffer,
+      });
+
+      const settings = createMockSettings({
+        ui: { loadingPhrases: 'tips', showShortcutsHint: false },
+      });
+
+      const { lastFrame } = await renderComposer(uiState, settings);
+      const output = lastFrame();
+
+      expect(output).not.toContain(`Tip: ${tip}`);
+    });
+
+    it('shows the proactive tip when it fits by measured display width', async () => {
+      const elapsedTime = 1;
+      const thoughtSubject = 'Thinking...';
+      const cancelAndTimerContentStr = `(esc to cancel, ${elapsedTime}s)`;
+
+      const tipChar = 'Ａ';
+      const tipCount = 20;
+      const tip = tipChar.repeat(tipCount);
+      const tipLabel = `Tip: ${tip}`;
+
+      const statusWidthForTipCollision =
+        1 + // inlineSpinnerCharWidth
+        1 + // spinnerAndPrimaryGapWidth
+        getCachedStringWidth(thoughtSubject) +
+        1 + // cancelSpacerWidth
+        getCachedStringWidth(cancelAndTimerContentStr);
+
+      const terminalWidthBoundary =
+        statusWidthForTipCollision + getCachedStringWidth(tipLabel) + 5;
+
+      // Ensure we are not in narrow mode.
+      expect(terminalWidthBoundary).toBeGreaterThanOrEqual(80);
+
+      vi.mocked(useTerminalSizeMock).mockReturnValue({
+        columns: terminalWidthBoundary,
+        rows: 24,
+      });
+
+      const uiState = createMockUIState({
+        streamingState: StreamingState.Responding,
+        thought: { subject: thoughtSubject, description: '' },
+        elapsedTime,
+        currentTip: tip,
+        cleanUiDetailsVisible: false,
+        buffer: { text: 'x' } as unknown as TextBuffer,
+      });
+
+      const settings = createMockSettings({
+        ui: { loadingPhrases: 'tips', showShortcutsHint: false },
+      });
+
+      const { lastFrame } = await renderComposer(uiState, settings);
+      const output = lastFrame();
+
+      expect(output).toContain(`Tip: ${tip}`);
     });
   });
 

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -21,10 +21,12 @@ import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
 import { isNarrowWidth } from '../utils/isNarrowWidth.js';
 import { isContextUsageHigh } from '../utils/contextUsage.js';
+import { formatDuration } from '../utils/formatters.js';
 import { theme } from '../semantic-colors.js';
 import { GENERIC_WORKING_LABEL } from '../textConstants.js';
 import { INTERACTIVE_SHELL_WAITING_PHRASE } from '../hooks/usePhraseCycler.js';
 import { StreamingState, type HistoryItemToolGroup } from '../types.js';
+import { getCachedStringWidth } from '../utils/textUtils.js';
 import { LoadingIndicator } from './LoadingIndicator.js';
 import { ContextUsageDisplay } from './ContextUsageDisplay.js';
 import { StatusDisplay } from './StatusDisplay.js';
@@ -166,6 +168,27 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
   const userVisibleHooks = allHooks.filter((h) => isUserVisibleHook(h.source));
   const hasUserVisibleHooks = userVisibleHooks.length > 0;
 
+  const hookText = (() => {
+    if (!hasAnyHooks) return undefined;
+
+    let computedHookText = GENERIC_WORKING_LABEL;
+
+    if (hasUserVisibleHooks) {
+      const label =
+        userVisibleHooks.length > 1 ? 'Executing Hooks' : 'Executing Hook';
+      const displayNames = userVisibleHooks.map((h) => {
+        let name = h.name;
+        if (h.index && h.total && h.total > 1) {
+          name += ` (${h.index}/${h.total})`;
+        }
+        return name;
+      });
+      computedHookText = `${label}: ${displayNames.join(', ')}`;
+    }
+
+    return computedHookText;
+  })();
+
   const shouldReserveSpaceForShortcutsHint =
     settings.merged.ui.showShortcutsHint &&
     !hideUiDetailsForSuggestions &&
@@ -175,40 +198,90 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
     INTERACTIVE_SHELL_WAITING_PHRASE,
   );
 
+  const cancelAndTimerContentStr =
+    uiState.streamingState !== StreamingState.WaitingForConfirmation
+      ? `(esc to cancel, ${
+          uiState.elapsedTime < 60
+            ? `${uiState.elapsedTime}s`
+            : formatDuration(uiState.elapsedTime * 1000)
+        })`
+      : '';
+
   /**
-   * Calculate the estimated length of the status message to avoid collisions
-   * with the tips area.
+   * Calculate the measured display width of the status row.
+   *
+   * This is used to decide whether the "tip" line can safely fit without
+   * colliding with the status area.
    */
-  let estimatedStatusLength = 0;
-  if (hasAnyHooks) {
-    if (hasUserVisibleHooks) {
-      const hookLabel =
-        userVisibleHooks.length > 1 ? 'Executing Hooks' : 'Executing Hook';
-      const hookNames = userVisibleHooks
-        .map(
-          (h) =>
-            h.name +
-            (h.index && h.total && h.total > 1
-              ? ` (${h.index}/${h.total})`
-              : ''),
-        )
-        .join(', ');
-      estimatedStatusLength = hookLabel.length + hookNames.length + 10;
-    } else {
-      estimatedStatusLength = GENERIC_WORKING_LABEL.length + 10;
+  const statusWidthForTipCollision = (() => {
+    const inlineSpinnerCharWidth = hasAnyHooks || showLoadingIndicator ? 1 : 0;
+    const spinnerAndPrimaryGapWidth = 1; // LoadingIndicator marginRight={1}
+    const cancelSpacerWidth = 1; // LoadingIndicator width={1}
+    const wittySpacerWidth = 1; // LoadingIndicator marginLeft={1}
+    const interactiveShellFocusSuffix = ' (press tab to focus)';
+
+    if (hasAnyHooks && hookText) {
+      const primaryText = hookText;
+      const interactiveExtra =
+        primaryText === INTERACTIVE_SHELL_WAITING_PHRASE
+          ? interactiveShellFocusSuffix
+          : '';
+      const cancelShown =
+        uiState.streamingState !== StreamingState.WaitingForConfirmation;
+      const inlineWittyShown =
+        showWit &&
+        Boolean(uiState.currentWittyPhrase) &&
+        primaryText === 'Thinking...';
+
+      return (
+        inlineSpinnerCharWidth +
+        spinnerAndPrimaryGapWidth +
+        getCachedStringWidth(primaryText) +
+        getCachedStringWidth(interactiveExtra) +
+        (cancelShown
+          ? cancelSpacerWidth + getCachedStringWidth(cancelAndTimerContentStr)
+          : 0) +
+        (inlineWittyShown
+          ? wittySpacerWidth + getCachedStringWidth(uiState.currentWittyPhrase!)
+          : 0)
+      );
     }
-  } else if (showLoadingIndicator) {
-    const thoughtText = uiState.thought?.subject || GENERIC_WORKING_LABEL;
-    const inlineWittyLength =
-      showWit && uiState.currentWittyPhrase
-        ? uiState.currentWittyPhrase.length + 1
-        : 0;
-    estimatedStatusLength = thoughtText.length + 25 + inlineWittyLength;
-  } else if (hasPendingActionRequired) {
-    estimatedStatusLength = 20;
-  } else if (hasToast) {
-    estimatedStatusLength = 40;
-  }
+
+    if (showLoadingIndicator) {
+      const primaryText =
+        uiState.thought?.subject ??
+        (uiState.streamingState === StreamingState.Responding
+          ? 'Thinking...'
+          : undefined);
+      const interactiveExtra =
+        primaryText === INTERACTIVE_SHELL_WAITING_PHRASE
+          ? interactiveShellFocusSuffix
+          : '';
+      const cancelShown =
+        uiState.streamingState !== StreamingState.WaitingForConfirmation;
+      const inlineWittyShown =
+        showWit &&
+        Boolean(uiState.currentWittyPhrase) &&
+        primaryText === 'Thinking...';
+
+      return (
+        inlineSpinnerCharWidth +
+        spinnerAndPrimaryGapWidth +
+        getCachedStringWidth(primaryText ?? '') +
+        getCachedStringWidth(interactiveExtra) +
+        (cancelShown
+          ? cancelSpacerWidth + getCachedStringWidth(cancelAndTimerContentStr)
+          : 0) +
+        (inlineWittyShown
+          ? wittySpacerWidth + getCachedStringWidth(uiState.currentWittyPhrase!)
+          : 0)
+      );
+    }
+
+    if (hasPendingActionRequired) return 20;
+    if (hasToast) return 40;
+    return 0;
+  })();
 
   /**
    * Determine the ambient text (tip) to display.
@@ -224,7 +297,9 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
       )
     ) {
       if (
-        estimatedStatusLength + uiState.currentTip.length + 10 <=
+        statusWidthForTipCollision +
+          getCachedStringWidth(`Tip: ${uiState.currentTip}`) +
+          5 <=
         terminalWidth
       ) {
         return uiState.currentTip;
@@ -244,39 +319,44 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
     return undefined;
   })();
 
-  const tipLength = tipContentStr?.length || 0;
-  const willCollideTip = estimatedStatusLength + tipLength + 5 > terminalWidth;
+  const tipDisplayText =
+    tipContentStr && tipContentStr === uiState.currentTip
+      ? `Tip: ${tipContentStr}`
+      : tipContentStr;
+  const tipWidth = tipDisplayText ? getCachedStringWidth(tipDisplayText) : 0;
+  const willCollideTip =
+    statusWidthForTipCollision + tipWidth + 5 > terminalWidth;
 
   const showTipLine =
     !hasPendingActionRequired && tipContentStr && !willCollideTip && !isNarrow;
 
   // Mini Mode VIP Flags (Pure Content Triggers)
-  const miniMode_ShowApprovalMode =
+  const miniModeShowApprovalMode =
     Boolean(modeContentObj) && !hideUiDetailsForSuggestions;
-  const miniMode_ShowToast = hasToast;
-  const miniMode_ShowShortcuts = shouldReserveSpaceForShortcutsHint;
-  const miniMode_ShowStatus = showLoadingIndicator || hasAnyHooks;
-  const miniMode_ShowTip = showTipLine;
-  const miniMode_ShowContext = isContextUsageHigh(
+  const miniModeShowToast = hasToast;
+  const miniModeShowShortcuts = shouldReserveSpaceForShortcutsHint;
+  const miniModeShowStatus = showLoadingIndicator || hasAnyHooks;
+  const miniModeShowTip = showTipLine;
+  const miniModeShowContext = isContextUsageHigh(
     uiState.sessionStats.lastPromptTokenCount,
     uiState.currentModel,
     settings.merged.model?.compressionThreshold,
   );
 
   // Composite Mini Mode Triggers
-  const showRow1_MiniMode =
-    miniMode_ShowToast ||
-    miniMode_ShowStatus ||
-    miniMode_ShowShortcuts ||
-    miniMode_ShowTip;
+  const showRow1MiniMode =
+    miniModeShowToast ||
+    miniModeShowStatus ||
+    miniModeShowShortcuts ||
+    miniModeShowTip;
 
-  const showRow2_MiniMode = miniMode_ShowApprovalMode || miniMode_ShowContext;
+  const showRow2MiniMode = miniModeShowApprovalMode || miniModeShowContext;
 
   // Final Display Rules (Stable Footer Architecture)
-  const showRow1 = showUiDetails || showRow1_MiniMode;
-  const showRow2 = showUiDetails || showRow2_MiniMode;
+  const showRow1 = showUiDetails || showRow1MiniMode;
+  const showRow2 = showUiDetails || showRow2MiniMode;
 
-  const showMinimalBleedThroughRow = !showUiDetails && showRow2_MiniMode;
+  const showMinimalBleedThroughRow = !showUiDetails && showRow2MiniMode;
 
   const renderTipNode = () => {
     if (!tipContentStr) return null;
@@ -307,53 +387,25 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
   };
 
   const renderStatusNode = () => {
-    const allHooks = uiState.activeHooks;
-    if (allHooks.length === 0 && !showLoadingIndicator) return null;
+    if (!hasAnyHooks && !showLoadingIndicator) return null;
 
-    if (allHooks.length > 0) {
-      const userVisibleHooks = allHooks.filter((h) =>
-        isUserVisibleHook(h.source),
-      );
+    const commonProps = {
+      inline: true,
+      showTips,
+      showWit,
+      errorVerbosity: settings.merged.ui.errorVerbosity,
+      elapsedTime: uiState.elapsedTime,
+      forceRealStatusOnly: false,
+      wittyPhrase: uiState.currentWittyPhrase,
+    } as const;
 
-      let hookText = GENERIC_WORKING_LABEL;
-      if (userVisibleHooks.length > 0) {
-        const label =
-          userVisibleHooks.length > 1 ? 'Executing Hooks' : 'Executing Hook';
-        const displayNames = userVisibleHooks.map((h) => {
-          let name = h.name;
-          if (h.index && h.total && h.total > 1) {
-            name += ` (${h.index}/${h.total})`;
-          }
-          return name;
-        });
-        hookText = `${label}: ${displayNames.join(', ')}`;
-      }
-
-      return (
-        <LoadingIndicator
-          inline
-          showTips={showTips}
-          showWit={showWit}
-          errorVerbosity={settings.merged.ui.errorVerbosity}
-          currentLoadingPhrase={hookText}
-          elapsedTime={uiState.elapsedTime}
-          forceRealStatusOnly={false}
-          wittyPhrase={uiState.currentWittyPhrase}
-        />
-      );
-    }
-
-    return (
+    return hasAnyHooks ? (
       <LoadingIndicator
-        inline
-        showTips={showTips}
-        showWit={showWit}
-        errorVerbosity={settings.merged.ui.errorVerbosity}
-        thought={uiState.thought}
-        elapsedTime={uiState.elapsedTime}
-        forceRealStatusOnly={false}
-        wittyPhrase={uiState.currentWittyPhrase}
+        {...commonProps}
+        currentLoadingPhrase={hookText ?? GENERIC_WORKING_LABEL}
       />
+    ) : (
+      <LoadingIndicator {...commonProps} thought={uiState.thought} />
     );
   };
 
@@ -367,7 +419,7 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
       {renderStatusNode()}
       {showMinimalBleedThroughRow && (
         <Box>
-          {miniMode_ShowApprovalMode && modeContentObj && (
+          {miniModeShowApprovalMode && modeContentObj && (
             <Text color={modeContentObj.color}>● {modeContentObj.text}</Text>
           )}
         </Box>
@@ -375,9 +427,9 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
     </Box>
   );
 
-  const renderStatusRow = () => {
+  const StatusRow = () => {
     // Mini Mode Height Reservation (The "Anti-Jitter" line)
-    if (!showUiDetails && !showRow1_MiniMode && !showRow2_MiniMode) {
+    if (!showUiDetails && !showRow1MiniMode && !showRow2MiniMode) {
       return <Box height={1} />;
     }
 
@@ -393,7 +445,7 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
             minHeight={1}
           >
             <Box flexDirection="row" flexGrow={1} flexShrink={1}>
-              {!showUiDetails && showRow1_MiniMode ? (
+              {!showUiDetails && showRow1MiniMode ? (
                 renderMinimalMetaRowContent()
               ) : isInteractiveShellWaiting ? (
                 <Box width="100%" marginLeft={1}>
@@ -423,7 +475,7 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
         {/* Internal Separator Line */}
         {showRow1 &&
           showRow2 &&
-          (showUiDetails || (showRow1_MiniMode && showRow2_MiniMode)) && (
+          (showUiDetails || (showRow1MiniMode && showRow2MiniMode)) && (
             <Box width="100%">
               <HorizontalLine dim />
             </Box>
@@ -474,7 +526,7 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
                   )}
                 </>
               ) : (
-                miniMode_ShowApprovalMode &&
+                miniModeShowApprovalMode &&
                 modeContentObj && (
                   <Text color={modeContentObj.color}>
                     ● {modeContentObj.text}
@@ -488,10 +540,10 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
               alignItems="center"
               marginLeft={isNarrow ? 1 : 0}
             >
-              {(showUiDetails || miniMode_ShowContext) && (
+              {(showUiDetails || miniModeShowContext) && (
                 <StatusDisplay hideContextSummary={hideContextSummary} />
               )}
-              {miniMode_ShowContext && !showUiDetails && (
+              {miniModeShowContext && !showUiDetails && (
                 <Box marginLeft={1}>
                   <ContextUsageDisplay
                     promptTokenCount={uiState.sessionStats.lastPromptTokenCount}
@@ -530,14 +582,14 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
 
       {showShortcutsHelp && <ShortcutsHelp />}
 
-      {(showUiDetails || miniMode_ShowToast) && (
+      {(showUiDetails || miniModeShowToast) && (
         <Box minHeight={1} marginLeft={isNarrow ? 0 : 1}>
           <ToastDisplay />
         </Box>
       )}
 
       <Box width="100%" flexDirection="column">
-        {renderStatusRow()}
+        <StatusRow />
       </Box>
 
       {showUiDetails && uiState.showErrorDetails && (

--- a/packages/cli/src/ui/hooks/usePhraseCycler.test.tsx
+++ b/packages/cli/src/ui/hooks/usePhraseCycler.test.tsx
@@ -102,6 +102,32 @@ describe('usePhraseCycler', () => {
     unmount();
   });
 
+  it('should not cycle phrases while shouldShowFocusHint is true', async () => {
+    vi.spyOn(Math, 'random').mockImplementation(() => 0.5);
+
+    const { lastFrame, waitUntilReady, unmount } = await render(
+      <TestComponent
+        isActive={true}
+        isWaiting={false}
+        shouldShowFocusHint={true}
+        showTips={true}
+        showWit={true}
+      />,
+    );
+    await waitUntilReady();
+
+    const initial = lastFrame().trim();
+    expect(initial).toBe(INTERACTIVE_SHELL_WAITING_PHRASE);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PHRASE_CHANGE_INTERVAL_MS * 2);
+    });
+    await waitUntilReady();
+
+    expect(lastFrame().trim()).toBe(INTERACTIVE_SHELL_WAITING_PHRASE);
+    unmount();
+  });
+
   it('should prioritize interactive shell waiting over normal waiting immediately', async () => {
     const { lastFrame, rerender, waitUntilReady, unmount } = await render(
       <TestComponent isActive={true} isWaiting={true} />,

--- a/packages/cli/src/ui/hooks/usePhraseCycler.ts
+++ b/packages/cli/src/ui/hooks/usePhraseCycler.ts
@@ -66,11 +66,11 @@ export const usePhraseCycler = (
 
     if (shouldShowFocusHint || isWaiting) {
       // These are handled by the return value directly for immediate feedback
-      return;
+      return clearTimers;
     }
 
     if (!isActive || (!showTips && !showWit)) {
-      return;
+      return clearTimers;
     }
 
     const wittyPhrasesList =


### PR DESCRIPTION
## Summary

Fixes all five issues from #23573: replaces `.length` + magic number width hacks in `Composer.tsx` with `getCachedStringWidth()`, deduplicates `<LoadingIndicator />`, fixes `miniMode_*` naming violations, converts `renderStatusRow` to a React component, and ensures `usePhraseCycler` always returns `clearTimers` from its effect to prevent a timer leak on unmount.

## Details

This PR fixes five different issues from #23573:

- **String length hacks**: Replaced `.length` + magic numbers (`+10`, `+25`) in `estimatedStatusLength` with `getCachedStringWidth()`, consistent with `text-buffer.tsx`. Fixes incorrect collision detection for wide unicode/emoji where display width ≠ char count.

- **Duplicate `<LoadingIndicator />`**: `renderStatusNode()` had two near-identical branches. Consolidated into a shared `commonProps` object, switching only `currentLoadingPhrase` vs `thought` per branch.

- **Naming violations**: Renamed `miniMode_ShowApprovalMode`, `showRow1_MiniMode` etc. to `miniModeShowApprovalMode`, `showRow1MiniMode` across all declarations and usages.

- **`renderStatusRow` → `StatusRow`**: Converted from inline render-helper to a proper React component. No behavioral change — still closes over the same state.

- **`clearTimers` leak**: Early `return;` paths in `usePhraseCycler`'s `useEffect` meant React received no cleanup function on those cycles. Changed to `return clearTimers;`on all paths.

## Related Issues

Fixes #23573

## How to Validate

1. Run targeted tests:
`npm test --workspace @google/gemini-cli -- src/ui/components/Composer.test.tsx`
`npm test --workspace @google/gemini-cli -- src/ui/hooks/usePhraseCycler.test.tsx`
2. Verify tip line hides/shows correctly when terminal width is narrowed (tip should not overlap status text).
3. Verify no lint errors:
`npm run lint --workspace @google/gemini-cli`
5. Verify all TypeScript Typechecks passes:
`npm run typecheck --workspace @google/gemini-cli`

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [X] Tests added/updated for tip collision width logic
- [X] Tests added for `shouldShowFocusHint` suppressing phrase cycling
- [X] `eslint` passes on modified files
- [X] TypeScript typecheck passes