### PR TITLE
feat(browser): dynamically discover read-only tools

### DIFF
--- a/packages/core/src/agents/browser/browserAgentFactory.test.ts
+++ b/packages/core/src/agents/browser/browserAgentFactory.test.ts
@@ -379,9 +379,19 @@ describe('browserAgentFactory', () => {
 
     it('should register ALLOW rules for read-only tools', async () => {
       mockBrowserManager.getDiscoveredTools.mockResolvedValue([
-        { name: 'take_snapshot', description: 'Take snapshot' },
-        { name: 'take_screenshot', description: 'Take screenshot' },
-        { name: 'list_pages', description: 'list all pages' },
+        {
+          name: 'take_snapshot',
+          description: 'Take snapshot',
+        },
+        {
+          name: 'take_screenshot',
+          description: 'Take screenshot',
+        },
+        {
+          name: 'list_pages',
+          description: 'list all pages',
+          annotations: { readOnlyHint: true },
+        },
       ]);
 
       await createBrowserAgentDefinition(mockConfig, mockMessageBus);

--- a/packages/core/src/agents/browser/browserAgentFactory.ts
+++ b/packages/core/src/agents/browser/browserAgentFactory.ts
@@ -123,7 +123,6 @@ export async function createBrowserAgentDefinition(
     const readOnlyTools = (await browserManager.getDiscoveredTools())
       .filter((t) => !!t.annotations?.readOnlyHint)
       .map((t) => t.name);
-    debugLogger.log(`Mark read-only tools: ${readOnlyTools.join(', ')}`);
     // additional tools that we marked as read-only.
     const allowlistedReadonlyTools = ['take_snapshot', 'take_screenshot'];
 

--- a/packages/core/src/agents/browser/browserAgentFactory.ts
+++ b/packages/core/src/agents/browser/browserAgentFactory.ts
@@ -120,13 +120,14 @@ export async function createBrowserAgentDefinition(
     }
 
     // Reduce noise for read-only tools in default mode
-    const readOnlyTools = [
-      'take_snapshot',
-      'take_screenshot',
-      'list_pages',
-      'list_network_requests',
-    ];
-    for (const toolName of readOnlyTools) {
+    const readOnlyTools = (await browserManager.getDiscoveredTools())
+      .filter((t) => !!t.annotations?.readOnlyHint)
+      .map((t) => t.name);
+    debugLogger.log(`Mark read-only tools: ${readOnlyTools.join(', ')}`);
+    // additional tools that we marked as read-only.
+    const allowlistedReadonlyTools = ['take_snapshot', 'take_screenshot'];
+
+    for (const toolName of [...readOnlyTools, ...allowlistedReadonlyTools]) {
       if (availableToolNames.includes(toolName)) {
         const rule = generateAllowRules(toolName);
         if (!existingRules.some((r) => isRuleEqual(r, rule))) {

--- a/packages/core/src/agents/browser/browserAgentFactory.ts
+++ b/packages/core/src/agents/browser/browserAgentFactory.ts
@@ -123,7 +123,6 @@ export async function createBrowserAgentDefinition(
     const readOnlyTools = (await browserManager.getDiscoveredTools())
       .filter((t) => !!t.annotations?.readOnlyHint)
       .map((t) => t.name);
-    // additional tools that we marked as read-only.
     const allowlistedReadonlyTools = ['take_snapshot', 'take_screenshot'];
 
     for (const toolName of [...readOnlyTools, ...allowlistedReadonlyTools]) {


### PR DESCRIPTION
## Summary

Dynamically discover read-only tools using MCP annotations to assign ALLOW policies, rather than hardcoding them. This reduces noise and improves configurability for browser agent tool policies while maintaining backward compatibility for previously allowlisted visual tools.

## Details

- Modifies `createBrowserAgentDefinition` in `browserAgentFactory.ts` to inspect tool annotations for the `readOnlyHint` flag defined in chrome devtool mcp so that we can dynamically generates `ALLOW` rules for these read-only tools.

## Related Issues

Closes #23792 

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
