### PR TITLE
eval(model-steering): add skip-step and path-correction behavioral evals

### DIFF
--- a/evals/model_steering.eval.ts
+++ b/evals/model_steering.eval.ts
@@ -84,4 +84,79 @@ describe('Model Steering Behavioral Evals', () => {
       expect(fs.existsSync(hwPy), 'hw.py should exist').toBe(true);
     },
   });
+
+  appEvalTest('USUALLY_PASSES', {
+    name: 'Skip Step: Model omits a planned step when instructed via hint',
+    configOverrides: {
+      modelSteering: true,
+    },
+    files: {
+      'src/math.ts':
+        'export function multiply(a: number, b: number): number {\n  return a * b;\n}\n',
+    },
+    prompt:
+      'Refactor the multiply function in src/math.ts to use arrow function syntax, then create a file called done.txt to confirm completion.',
+    setup: async (rig) => {
+      // Pause on the first write_file so we can inject a hint before done.txt is created
+      rig.setBreakpoint(['write_file']);
+    },
+    assert: async (rig) => {
+      // Wait for the model to write the refactored src/math.ts
+      await rig.waitForPendingConfirmation('write_file', 30000);
+
+      // Instruct the model to skip the done.txt step
+      await rig.addUserHint(
+        'Skip creating done.txt — the refactor is all I need.',
+      );
+
+      await rig.resolveAwaitedTool();
+      await rig.waitForIdle(60000);
+
+      const testDir = rig.getTestDir();
+      const mathTs = path.join(testDir, 'src/math.ts');
+      const doneTxt = path.join(testDir, 'done.txt');
+
+      // The refactor should have happened
+      expect(fs.existsSync(mathTs), 'src/math.ts should exist').toBe(true);
+      expect(fs.readFileSync(mathTs, 'utf8')).toMatch(/=>/);
+
+      // The skipped step should not have happened
+      expect(fs.existsSync(doneTxt), 'done.txt should not exist').toBe(false);
+    },
+  });
+
+  appEvalTest('USUALLY_PASSES', {
+    name: 'Path Correction: Model searches correct directory after hint',
+    configOverrides: {
+      modelSteering: true,
+    },
+    files: {
+      'src/common/utils/helpers.ts':
+        'export const DATABASE_URL = "postgres://localhost:5432/mydb";\n',
+      'src/index.ts': '// Entry point — no constants here\n',
+    },
+    prompt: 'Find the DATABASE_URL constant and tell me its value.',
+    setup: async (rig) => {
+      rig.setBreakpoint(['read_file', 'glob', 'grep', 'list_directory']);
+    },
+    assert: async (rig) => {
+      // Wait for the model to start searching
+      await rig.waitForPendingConfirmation(
+        /read_file|glob|grep|list_directory/i,
+        30000,
+      );
+
+      // Correct the search path
+      await rig.addUserHint(
+        'The constants are in src/common/utils/, not the root src/ directory.',
+      );
+
+      await rig.resolveAwaitedTool();
+      await rig.waitForIdle(60000);
+
+      // The model should have found and reported the value
+      const output = rig.getStaticOutput();
+      expect(output).toMatch(/postgres/i);
+    },
+  });
 });


### PR DESCRIPTION
## Summary

Adds two new `USUALLY_PASSES` evals to `model_steering.eval.ts` covering
use cases documented in `docs/cli/model-steering.md` but previously untested.
`model_steering.eval.ts` goes from 2 tests to 4, covering 4 of the 5 documented
steering use cases.

## Details

- **Skip Step** — verifies the model omits a planned step (`done.txt`) when
  instructed via a steering hint mid-task, while still completing the primary
  task (arrow-function refactor of `src/math.ts`).

- **Path Correction** — verifies the model searches the correct directory
  (`src/common/utils/`) after a hint corrects its initial search path.

Both tests follow the existing `appEvalTest` pattern from the two tests already
in this file. The remaining untested use case (handling ambiguity) is a candidate
for a follow-up eval.

## Related Issues

Refs #23331

## How to Validate

```bash
RUN_EVALS=1 npm run test:all_evals -- --reporter=verbose 2>&1 | grep "model.steering"
