### PR TITLE
new linting check: github-actions-pinning

### DIFF
--- a/.github/actions/push-sandbox/action.yml
+++ b/.github/actions/push-sandbox/action.yml
@@ -34,7 +34,7 @@ runs:
         JSON_INPUTS: '${{ toJSON(inputs) }}'
       run: 'echo "$JSON_INPUTS"'
     - name: 'Checkout'
-      uses: 'actions/checkout@v4'
+      uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # ratchet:actions/checkout@v4
       with:
         ref: '${{ inputs.github-sha }}'
         fetch-depth: 0
@@ -45,11 +45,11 @@ runs:
       shell: 'bash'
       run: 'npm run build'
     - name: 'Set up QEMU'
-      uses: 'docker/setup-qemu-action@v3'
+      uses: 'docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130' # ratchet:docker/setup-qemu-action@v3
     - name: 'Set up Docker Buildx'
-      uses: 'docker/setup-buildx-action@v3'
+      uses: 'docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f' # ratchet:docker/setup-buildx-action@v3
     - name: 'Log in to GitHub Container Registry'
-      uses: 'docker/login-action@v3'
+      uses: 'docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9' # ratchet:docker/login-action@v3
       with:
         registry: 'docker.io'
         username: '${{ inputs.dockerhub-username }}'

--- a/.github/actions/verify-release/action.yml
+++ b/.github/actions/verify-release/action.yml
@@ -36,7 +36,7 @@ runs:
       run: 'echo "$JSON_INPUTS"'
 
     - name: 'setup node'
-      uses: 'actions/setup-node@v4'
+      uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
       with:
         node-version: '20'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           cache: 'npm'
 
       - name: 'Cache Linters'
-        uses: 'actions/cache@v4'
+        uses: 'actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830' # ratchet:actions/cache@v4
         with:
           path: '${{ env.GEMINI_LINT_TEMP_DIR }}'
           key: "${{ runner.os }}-${{ runner.arch }}-linters-${{ hashFiles('scripts/lint.js') }}"
@@ -76,7 +76,7 @@ jobs:
         run: 'npm ci'
 
       - name: 'Cache ESLint'
-        uses: 'actions/cache@v4'
+        uses: 'actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830' # ratchet:actions/cache@v4
         with:
           path: '.eslintcache'
           key: "${{ runner.os }}-eslint-${{ hashFiles('package-lock.json', 'eslint.config.js') }}"
@@ -113,6 +113,9 @@ jobs:
 
       - name: 'Run sensitive keyword linter'
         run: 'node scripts/lint.js --sensitive-keywords'
+
+      - name: 'Run GitHub Actions pinning linter'
+        run: 'node scripts/lint.js --check-github-actions-pinning'
 
   link_checker:
     name: 'Link Checker'

--- a/.github/workflows/gemini-scheduled-stale-issue-closer.yml
+++ b/.github/workflows/gemini-scheduled-stale-issue-closer.yml
@@ -28,14 +28,14 @@ jobs:
     steps:
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        uses: 'actions/create-github-app-token@v2'
+        uses: 'actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349' # ratchet:actions/create-github-app-token@v2
         with:
           app-id: '${{ secrets.APP_ID }}'
           private-key: '${{ secrets.PRIVATE_KEY }}'
           permission-issues: 'write'
 
       - name: 'Process Stale Issues'
-        uses: 'actions/github-script@v7'
+        uses: 'actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b' # ratchet:actions/github-script@v7
         env:
           DRY_RUN: '${{ inputs.dry_run }}'
         with:

--- a/.github/workflows/gemini-scheduled-stale-pr-closer.yml
+++ b/.github/workflows/gemini-scheduled-stale-pr-closer.yml
@@ -27,13 +27,13 @@ jobs:
           APP_ID: '${{ secrets.APP_ID }}'
         if: |-
           ${{ env.APP_ID != '' }}
-        uses: 'actions/create-github-app-token@v2'
+        uses: 'actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349' # ratchet:actions/create-github-app-token@v2
         with:
           app-id: '${{ secrets.APP_ID }}'
           private-key: '${{ secrets.PRIVATE_KEY }}'
 
       - name: 'Process Stale PRs'
-        uses: 'actions/github-script@v7'
+        uses: 'actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b' # ratchet:actions/github-script@v7
         env:
           DRY_RUN: '${{ inputs.dry_run }}'
         with:

--- a/.github/workflows/label-backlog-child-issues.yml
+++ b/.github/workflows/label-backlog-child-issues.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@v4'
+        uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # ratchet:actions/checkout@v4
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@v4'
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -40,10 +40,10 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@v4'
+        uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # ratchet:actions/checkout@v4
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@v4'
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/label-workstream-rollup.yml
+++ b/.github/workflows/label-workstream-rollup.yml
@@ -15,7 +15,7 @@ jobs:
       issues: 'write'
     steps:
       - name: 'Check for Parent Workstream and Apply Label'
-        uses: 'actions/github-script@v7'
+        uses: 'actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b' # ratchet:actions/github-script@v7
         with:
           script: |
             const labelToAdd = 'workstream-rollup';

--- a/.github/workflows/pr-contribution-guidelines-notifier.yml
+++ b/.github/workflows/pr-contribution-guidelines-notifier.yml
@@ -19,7 +19,7 @@ jobs:
           APP_ID: '${{ secrets.APP_ID }}'
         if: |-
           ${{ env.APP_ID != '' }}
-        uses: 'actions/create-github-app-token@v2'
+        uses: 'actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349' # ratchet:actions/create-github-app-token@v2
         with:
           app-id: '${{ secrets.APP_ID }}'
           private-key: '${{ secrets.PRIVATE_KEY }}'

--- a/.github/workflows/release-change-tags.yml
+++ b/.github/workflows/release-change-tags.yml
@@ -40,7 +40,7 @@ jobs:
       issues: 'write'
     steps:
       - name: 'Checkout repository'
-        uses: 'actions/checkout@v4'
+        uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # ratchet:actions/checkout@v4
         with:
           ref: '${{ github.ref }}'
           fetch-depth: 0

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -29,14 +29,14 @@ jobs:
       pull-requests: 'write'
     steps:
       - name: 'Checkout repository'
-        uses: 'actions/checkout@v4'
+        uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # ratchet:actions/checkout@v4
         with:
           # The user-level skills need to be available to the workflow
           fetch-depth: 0
           ref: 'main'
 
       - name: 'Set up Node.js'
-        uses: 'actions/setup-node@v4'
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
         with:
           node-version: '20'
 
@@ -86,7 +86,7 @@ jobs:
 
       - name: 'Create Pull Request'
         if: "steps.validate_version.outputs.CONTINUE == 'true'"
-        uses: 'peter-evans/create-pull-request@v6'
+        uses: 'peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c' # ratchet:peter-evans/create-pull-request@v6
         with:
           token: '${{ secrets.GEMINI_CLI_ROBOT_GITHUB_PAT }}'
           commit-message: 'docs(changelog): update for ${{ steps.release_info.outputs.VERSION }}'

--- a/.github/workflows/test-build-binary.yml
+++ b/.github/workflows/test-build-binary.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@v4'
+        uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # ratchet:actions/checkout@v4
 
       - name: 'Optimize Windows Performance'
         if: "matrix.os == 'windows-latest'"
@@ -46,7 +46,7 @@ jobs:
         shell: 'powershell'
 
       - name: 'Set up Node.js'
-        uses: 'actions/setup-node@v4'
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           architecture: '${{ matrix.arch }}'
@@ -63,7 +63,7 @@ jobs:
 
       - name: 'Setup Windows SDK (Windows)'
         if: "matrix.os == 'windows-latest'"
-        uses: 'microsoft/setup-msbuild@v2'
+        uses: 'microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce' # ratchet:microsoft/setup-msbuild@v2
 
       - name: 'Add Signtool to Path (Windows)'
         if: "matrix.os == 'windows-latest'"
@@ -153,7 +153,7 @@ jobs:
           npm run test:integration:sandbox:none -- --testTimeout=600000
 
       - name: 'Upload Artifact'
-        uses: 'actions/upload-artifact@v4'
+        uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
         with:
           name: 'gemini-cli-${{ matrix.platform_name }}'
           path: 'dist/${{ matrix.platform_name }}/'

--- a/.github/workflows/unassign-inactive-assignees.yml
+++ b/.github/workflows/unassign-inactive-assignees.yml
@@ -40,13 +40,13 @@ jobs:
     steps:
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        uses: 'actions/create-github-app-token@v2'
+        uses: 'actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349' # ratchet:actions/create-github-app-token@v2
         with:
           app-id: '${{ secrets.APP_ID }}'
           private-key: '${{ secrets.PRIVATE_KEY }}'
 
       - name: 'Unassign inactive assignees'
-        uses: 'actions/github-script@v7'
+        uses: 'actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b' # ratchet:actions/github-script@v7
         env:
           DRY_RUN: '${{ inputs.dry_run }}'
         with:

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -400,7 +400,7 @@ export function runGithubActionsPinningLinter() {
   let files = [];
   try {
     files = execSync(
-      "git ls-files '.github/workflows/*.yml' '.github/workflows/*.yaml'",
+      "git ls-files '.github/workflows/*.yml' '.github/workflows/*.yaml' '.github/actions/**/*.yml' '.github/actions/**/*.yaml'",
     )
       .toString()
       .trim()
@@ -458,8 +458,8 @@ export function runGithubActionsPinningLinter() {
 GitHub Actions pinning violations found. Please use exact commit hashes.
 
 To automatically fix these, you can use the "ratchet" tool (https://github.com/sethvargo/ratchet):
-  - Mac/Linux (Homebrew): brew install ratchet && ratchet pin .github/workflows/*.yml
-  - Other platforms: Download from GitHub releases and run "ratchet pin .github/workflows/*.yml"
+  - Mac/Linux (Homebrew): brew install ratchet && ratchet pin .github/workflows/*.yml .github/actions/**/*.yml
+  - Other platforms: Download from GitHub releases and run "ratchet pin .github/workflows/*.yml .github/actions/**/*.yml"
 
 If you must use a tag, you can ignore this check by adding a comment (discouraged):
   uses: some-action@v1 # github-actions-pinning:ignore

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -394,6 +394,82 @@ export function runTSConfigLinter() {
   }
 }
 
+export function runGithubActionsPinningLinter() {
+  console.log('\nRunning GitHub Actions pinning linter...');
+
+  let files = [];
+  try {
+    files = execSync(
+      "git ls-files '.github/workflows/*.yml' '.github/workflows/*.yaml'",
+    )
+      .toString()
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+  } catch (e) {
+    console.error('Error finding GitHub Actions workflow files:', e.message);
+    process.exit(1);
+  }
+
+  let violationsFound = false;
+  // Improved regex to capture action name and ref, handling optional quotes and comments.
+  const USES_PATTERN = /uses:\s*['"]?([^@\s'"]+)@([^#\s'"]+)['"]?/;
+  const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+  for (const file of files) {
+    if (!existsSync(file) || lstatSync(file).isDirectory()) {
+      continue;
+    }
+    const content = readFileSync(file, 'utf-8');
+    const lines = content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const match = line.match(USES_PATTERN);
+      if (match) {
+        const action = match[1];
+        let ref = match[2];
+
+        // Clean up any trailing quotes that might have been captured
+        ref = ref.replace(/['"]$/, '');
+
+        // Skip local actions (starting with ./), docker actions, and explicit exclusions
+        if (
+          action.startsWith('./') ||
+          action.startsWith('docker://') ||
+          line.includes('# github-actions-pinning:ignore')
+        ) {
+          continue;
+        }
+
+        if (!SHA_PATTERN.test(ref)) {
+          violationsFound = true;
+          const lineNum = i + 1;
+          console.error(
+            `::error file=${file},line=${lineNum}::Action "${action}" uses "${ref}" instead of a 40-character SHA.`,
+          );
+        }
+      }
+    }
+  }
+
+  if (violationsFound) {
+    console.error(`
+GitHub Actions pinning violations found. Please use exact commit hashes.
+
+To automatically fix these, you can use the "ratchet" tool (https://github.com/sethvargo/ratchet):
+  - Mac/Linux (Homebrew): brew install ratchet && ratchet pin .github/workflows/*.yml
+  - Other platforms: Download from GitHub releases and run "ratchet pin .github/workflows/*.yml"
+
+If you must use a tag, you can ignore this check by adding a comment (discouraged):
+  uses: some-action@v1 # github-actions-pinning:ignore
+`);
+    process.exit(1);
+  } else {
+    console.log('No GitHub Actions pinning violations found.');
+  }
+}
+
 function main() {
   const args = process.argv.slice(2);
 
@@ -421,6 +497,9 @@ function main() {
   if (args.includes('--tsconfig')) {
     runTSConfigLinter();
   }
+  if (args.includes('--check-github-actions-pinning')) {
+    runGithubActionsPinningLinter();
+  }
 
   if (args.length === 0) {
     setupLinters();
@@ -431,6 +510,7 @@ function main() {
     runPrettier();
     runSensitiveKeywordLinter();
     runTSConfigLinter();
+    runGithubActionsPinningLinter();
     console.log('\nAll linting checks passed!');
   }
 }


### PR DESCRIPTION
## Summary

This PR introduces a new linting check to ensure all GitHub Actions are pinned to specific commit SHAs. It also updates all existing workflows to use pinned SHAs instead of tags, enhancing the security and reproducibility of our CI/CD pipelines by preventing "moving target" dependencies.

## Details

- **Linter Implementation**: Added `runGithubActionsPinningLinter` to `scripts/lint.js`. It validates that `uses:` fields (excluding local and docker actions) match a 40-character SHA pattern.
- **CI Integration**: Added the `--check-github-actions-pinning` flag to the `ci.yml` workflow to enforce pinning on every PR.
- **Action Pinning**: Updated all workflow files in `.github/workflows/` and `.github/actions/` to use exact commit SHAs. The original tags are preserved as comments (e.g., `# ratchet:actions/checkout@v4`) for readability.
- **Escape Hatch**: Supported `# github-actions-pinning:ignore` for cases where a tag is explicitly required.

## Related Issues

N/A

## How to Validate

1. **Verify Success**: Run the new linter locally:
   ```bash
   node scripts/lint.js --check-github-actions-pinning
   ```
   It should exit with code 0.
2. **Verify Failure**: Temporarily change an action from a SHA to a tag (e.g., `uses: actions/checkout@v4`) and run the command again.
   - It should fail with an error message indicating the line number and the violation.
   - It should provide instructions on how to fix the issue using the `ratchet` tool.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
