### PR TITLE
fix(core): strip leading underscores from error types in telemetry

### DIFF
--- a/packages/core/src/utils/errors.test.ts
+++ b/packages/core/src/utils/errors.test.ts
@@ -354,4 +354,13 @@ describe('getErrorType', () => {
     expect(getErrorType(null)).toBe('unknown');
     expect(getErrorType(undefined)).toBe('unknown');
   });
+
+  it('should strip leading underscores from error names', () => {
+    class _GaxiosError extends Error {}
+    expect(getErrorType(new _GaxiosError('test'))).toBe('GaxiosError');
+
+    const errorWithUnderscoreName = new Error('test');
+    errorWithUnderscoreName.name = '_CodeBuddyError';
+    expect(getErrorType(errorWithUnderscoreName)).toBe('CodeBuddyError');
+  });
 });

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -63,7 +63,7 @@ export function getErrorType(error: unknown): string {
 
   // Strip leading underscore from error names. Bundlers like esbuild sometimes
   // rename classes to avoid scope collisions.
-  return name.startsWith('_') ? name.slice(1) : name;
+  return name.replace(/^_+/, '');
 }
 
 export class FatalError extends Error {

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -58,9 +58,12 @@ export function getErrorType(error: unknown): string {
   if (!(error instanceof Error)) return 'unknown';
 
   // Return constructor name if the generic 'Error' name is used (for custom errors)
-  return error.name === 'Error'
-    ? (error.constructor?.name ?? 'Error')
-    : error.name;
+  const name =
+    error.name === 'Error' ? (error.constructor?.name ?? 'Error') : error.name;
+
+  // Strip leading underscore from error names. Bundlers like esbuild sometimes
+  // rename classes to avoid scope collisions.
+  return name.startsWith('_') ? name.slice(1) : name;
 }
 
 export class FatalError extends Error {


### PR DESCRIPTION
## Summary

Strips leading underscores from error types in telemetry to ensure naming consistency.

## Details

Internal error types often have leading underscores. This change strips them before reporting to telemetry to improve data clarity and align with existing reporting standards.

## Related Issues

Related to #22989 and https://github.com/google-gemini/maintainers-gemini-cli/issues/1434

## How to Validate

N/A (Skipped tests per user request for quick PR)

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
