### PR TITLE
fix(cli): harden prompt trimming and improve version detection

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1400,7 +1400,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
         }
       }
 
-      const isSlash = isSlashCommand(submittedValue.trim());
+      const isSlash = isSlashCommand(String(submittedValue ?? '').trim());
       const isIdle = streamingState === StreamingState.Idle;
       const isAgentRunning =
         streamingState === StreamingState.Responding ||

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -453,7 +453,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   const handleSubmit = useCallback(
     (submittedValue: string) => {
-      const trimmedMessage = submittedValue.trim();
+      const trimmedMessage = String(submittedValue ?? '').trim();
       const isSlash = isSlashCommand(trimmedMessage);
 
       const isShell = shellModeActive;

--- a/packages/cli/src/utils/settingsUtils.test.ts
+++ b/packages/cli/src/utils/settingsUtils.test.ts
@@ -783,6 +783,33 @@ describe('SettingsUtils', () => {
         expect(result).toBe('{"enabled":true,"host":"localhost"}*');
         expect(result).not.toContain('[object Object]');
       });
+
+      it('should display arrays as JSON strings', () => {
+        vi.mocked(getSettingsSchema).mockReturnValue({
+          ui: {
+            properties: {
+              favoriteModels: {
+                type: 'array',
+                label: 'Favorite Models',
+                category: 'UI',
+                requiresRestart: false,
+                default: [],
+                description: 'Favorite models.',
+                showInDialog: true,
+              },
+            },
+          },
+        } as unknown as SettingsSchemaType);
+
+        const settings = makeMockSettings({
+          ui: {
+            favoriteModels: ['gemini-2.5-pro', 'gemini-2.5-flash'],
+          },
+        });
+        const result = getDisplayValue('ui.favoriteModels', settings, settings);
+
+        expect(result).toBe('["gemini-2.5-pro","gemini-2.5-flash"]*');
+      });
     });
 
     describe('getDisplayValue with units', () => {

--- a/packages/cli/src/utils/settingsUtils.ts
+++ b/packages/cli/src/utils/settingsUtils.ts
@@ -281,16 +281,15 @@ export function getDisplayValue(
     value = getDefaultValue(key);
   }
 
-  let valueString = String(value);
+  let valueString: string;
 
-  // Handle object types by stringifying them
-  if (
-    definition?.type === 'object' &&
-    value !== null &&
-    typeof value === 'object'
-  ) {
+  if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
     valueString = JSON.stringify(value);
-  } else if (definition?.type === 'enum' && definition.options) {
+  } else {
+    valueString = String(value);
+  }
+
+  if (definition?.type === 'enum' && definition.options) {
     const option = definition.options?.find((option) => option.value === value);
     valueString = option?.label ?? `${value}`;
   }

--- a/packages/core/src/utils/version.test.ts
+++ b/packages/core/src/utils/version.test.ts
@@ -6,10 +6,11 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getVersion, resetVersionCache } from './version.js';
-import { getPackageJson } from './package.js';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
 
-vi.mock('./package.js', () => ({
-  getPackageJson: vi.fn(),
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
 }));
 
 describe('version', () => {
@@ -20,7 +21,7 @@ describe('version', () => {
     vi.clearAllMocks();
     resetVersionCache();
     process.env = { ...originalEnv };
-    vi.mocked(getPackageJson).mockResolvedValue({ version: '1.0.0' });
+    vi.mocked(readFile).mockResolvedValue('{"version":"1.0.0"}');
   });
 
   afterEach(() => {
@@ -41,24 +42,52 @@ describe('version', () => {
 
   it('should return "unknown" if package.json is not found and CLI_VERSION is not set', async () => {
     delete process.env['CLI_VERSION'];
-    vi.mocked(getPackageJson).mockResolvedValue(undefined);
+    vi.mocked(readFile).mockRejectedValue(new Error('not found'));
     const version = await getVersion();
     expect(version).toBe('unknown');
   });
 
-  it('should cache the version and only call getPackageJson once', async () => {
+  it('prefers the repository package version when running from source', async () => {
     delete process.env['CLI_VERSION'];
-    vi.mocked(getPackageJson).mockResolvedValue({ version: '1.2.3' });
+    vi.mocked(readFile).mockImplementation(async (filePath) => {
+      const normalizedPath = String(filePath).replace(/\\/g, '/');
+      if (normalizedPath.endsWith('/packages/core/package.json')) {
+        return '{"name":"@google/gemini-cli-core","version":"0.35.0"}';
+      }
+      if (
+        normalizedPath.endsWith('/gemini-cli-work/package.json') ||
+        normalizedPath.endsWith('/gemini-cli/package.json')
+      ) {
+        return '{"name":"@google/gemini-cli","version":"0.36.0"}';
+      }
+      throw new Error('not found');
+    });
+
+    const version = await getVersion();
+
+    expect(version).toBe('0.36.0');
+    expect(vi.mocked(readFile)).toHaveBeenCalledWith(
+      expect.stringContaining(
+        ['packages', 'core', 'package.json'].join(path.sep),
+      ),
+      'utf8',
+    );
+  });
+
+  it('should cache the version and only call readFile once', async () => {
+    delete process.env['CLI_VERSION'];
+    vi.mocked(readFile).mockResolvedValue('{"version":"1.2.3"}');
 
     const version1 = await getVersion();
     expect(version1).toBe('1.2.3');
-    expect(getPackageJson).toHaveBeenCalledTimes(1);
+    const callsAfterFirstLookup = vi.mocked(readFile).mock.calls.length;
+    expect(callsAfterFirstLookup).toBeGreaterThan(0);
 
     // Change the mock value to simulate an update on disk
-    vi.mocked(getPackageJson).mockResolvedValue({ version: '2.0.0' });
+    vi.mocked(readFile).mockResolvedValue('{"version":"2.0.0"}');
 
     const version2 = await getVersion();
     expect(version2).toBe('1.2.3'); // Should still be the cached version
-    expect(getPackageJson).toHaveBeenCalledTimes(1); // Should not have been called again
+    expect(readFile).toHaveBeenCalledTimes(callsAfterFirstLookup);
   });
 });

--- a/packages/core/src/utils/version.ts
+++ b/packages/core/src/utils/version.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getPackageJson } from './package.js';
+import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
@@ -13,13 +13,67 @@ const __dirname = path.dirname(__filename);
 
 let versionPromise: Promise<string> | undefined;
 
+type VersionPackageJson = {
+  name?: string;
+  version?: string;
+};
+
+async function readPackageJsonAtDir(
+  dir: string,
+): Promise<VersionPackageJson | undefined> {
+  try {
+    const packageJsonPath = path.join(dir, 'package.json');
+    const packageJsonText = await readFile(packageJsonPath, 'utf8');
+    const parsedPackageJson: unknown = JSON.parse(packageJsonText);
+    if (!parsedPackageJson || typeof parsedPackageJson !== 'object') {
+      return undefined;
+    }
+
+    const name =
+      'name' in parsedPackageJson ? parsedPackageJson.name : undefined;
+    const version =
+      'version' in parsedPackageJson ? parsedPackageJson.version : undefined;
+    return {
+      name: typeof name === 'string' ? name : undefined,
+      version: typeof version === 'string' ? version : undefined,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 export function getVersion(): Promise<string> {
   if (versionPromise) {
     return versionPromise;
   }
   versionPromise = (async () => {
-    const pkgJson = await getPackageJson(__dirname);
-    return process.env['CLI_VERSION'] || pkgJson?.version || 'unknown';
+    if (process.env['CLI_VERSION']) {
+      return process.env['CLI_VERSION'];
+    }
+
+    let currentDir = __dirname;
+    let bestVersion = 'unknown';
+
+    while (true) {
+      const pkgJson = await readPackageJsonAtDir(currentDir);
+      if (pkgJson?.version) {
+        bestVersion = pkgJson.version;
+        if (
+          pkgJson.name === '@google/gemini-cli' ||
+          pkgJson.name === 'gemini-cli'
+        ) {
+          break;
+        }
+      }
+
+      const parentDir = path.dirname(currentDir);
+      if (parentDir === currentDir) {
+        break;
+      }
+      currentDir = parentDir;
+    }
+
+    return bestVersion;
   })();
   return versionPromise;
 }


### PR DESCRIPTION
## Summary
- Split the non-docs changes out of #21679 for separate review
- Harden prompt submission by safely coercing `submittedValue` before trimming in the CLI input flow
- Stringify array settings values in the settings dialog and prefer the repository package version when running from source

## Testing
- `npx vitest run src/utils/version.test.ts`
- `npx vitest run src/utils/settingsUtils.test.ts`
