### PR TITLE
Don't try removing a tag from a non-existent release.

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -221,7 +221,9 @@ runs:
           --dry-run="${INPUTS_DRY_RUN}" \
           --workspace="${INPUTS_CLI_PACKAGE_NAME}" \
           --no-tag
-        npm dist-tag rm ${INPUTS_CLI_PACKAGE_NAME} false
+        if [[ "${INPUTS_DRY_RUN}" == "false" ]]; then
+          npm dist-tag rm ${INPUTS_CLI_PACKAGE_NAME} false
+        fi
 
     - name: 'Get a2a-server Token'
       uses: './.github/actions/npm-auth-token'


### PR DESCRIPTION
## Summary

In dry run mode the release is not created so there's no point in trying to remove the tag from it.