### PR TITLE
fix(evals): stale tool log snapshot, missing telemetry wait, and wrong import path

### DIFF
--- a/evals/edit-locations-eval.eval.ts
+++ b/evals/edit-locations-eval.eval.ts
@@ -72,6 +72,7 @@ test('capitalize capitalizes the first letter', () => {
     prompt: 'Fix the bug in src/math.ts. Do not run the code.',
     timeout: 180000,
     assert: async (rig) => {
+      await rig.waitForTelemetryReady();
       const toolLogs = rig.readToolLogs();
       const replaceCalls = toolLogs.filter(
         (t) => t.toolRequest.name === 'replace',
@@ -94,8 +95,6 @@ test('capitalize capitalizes the first letter', () => {
           return null;
         }
       });
-
-      console.log('DEBUG: targetFiles', targetFiles);
 
       expect(
         new Set(targetFiles).size,

--- a/evals/save_memory.eval.ts
+++ b/evals/save_memory.eval.ts
@@ -5,11 +5,11 @@
  */
 
 import { describe, expect } from 'vitest';
-import { evalTest } from './test-helper.js';
 import {
+  evalTest,
   assertModelHasOutput,
   checkModelOutputContent,
-} from '../integration-tests/test-helper.js';
+} from './test-helper.js';
 
 describe('save_memory', () => {
   const TEST_PREFIX = 'Save memory test: ';

--- a/evals/tracker.eval.ts
+++ b/evals/tracker.eval.ts
@@ -60,7 +60,8 @@ describe('tracker_mode', () => {
         'Expected tracker_update_task tool to be called',
       ).toBe(true);
 
-      const updateCall = toolLogs.find(
+      const updatedToolLogs = rig.readToolLogs();
+      const updateCall = updatedToolLogs.find(
         (log) => log.toolRequest.name === TRACKER_UPDATE_TASK_TOOL_NAME,
       );
       expect(updateCall).toBeDefined();


### PR DESCRIPTION
Fixes #23841

Three eval files had assertion reliability bugs where tool logs were read at the wrong time or imported from the wrong source.

**`tracker.eval.ts`** — `readToolLogs()` was captured once after `waitForToolCall(TRACKER_CREATE_TASK_TOOL_NAME)` (line 44). After a second `waitForToolCall(TRACKER_UPDATE_TASK_TOOL_NAME)` (line 55), the code searched the **stale** snapshot for the update call (line 63). The update call was not in that snapshot, so `updateCall` would be `undefined` and `JSON.parse(updateCall!.toolRequest.args)` would throw a misleading error instead of a clear assertion failure. Fixed by re-reading tool logs after the second wait.

**`edit-locations-eval.eval.ts`** — `readToolLogs()` was called without a preceding `waitForTelemetryReady()`, so tool logs could be incomplete when assertions ran. Also removed a leftover `console.log('DEBUG: targetFiles', targetFiles)` statement.

**`save_memory.eval.ts`** — Imported `assertModelHasOutput` and `checkModelOutputContent` from `../integration-tests/test-helper.js` instead of `./test-helper.js` (which re-exports the same functions via `export * from '@google/gemini-cli-test-utils'`). Every other eval file uses the local import. This is the same fix applied to `hierarchical_memory.eval.ts` in #23790.