### PR TITLE
DOCS: Create a preliminary markdoc file and enable render on Github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,3 +22,6 @@ Makefile eol=lf
 *.eot binary
 *.ttf binary
 *.otf binary
+
+# Configure GitHub to treat Markdoc files as Markdown
+*.mdoc linguist-language=Markdown

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Learn all about Gemini CLI in our [documentation](https://geminicli.com/docs/).
 ## 📦 Installation
 
 See
-[Gemini CLI installation, execution, and releases](./docs/get-started/installation.mdoc)
+[Gemini CLI installation, execution, and releases](https://geminicli.com/docs/get-started/installation/)
 for recommended system specifications and a detailed installation guide.
 
 ### Quick Install

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Learn all about Gemini CLI in our [documentation](https://geminicli.com/docs/).
 ## 📦 Installation
 
 See
-[Gemini CLI installation, execution, and releases](./docs/get-started/installation.md)
+[Gemini CLI installation, execution, and releases](./docs/get-started/installation.mdoc)
 for recommended system specifications and a detailed installation guide.
 
 ### Quick Install

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -24,7 +24,8 @@ Once Gemini CLI is installed, run Gemini CLI from your command line:
 gemini
 ```
 
-For more installation options, see [Gemini CLI Installation](./installation.md).
+For more installation options, see
+[Gemini CLI Installation](./installation.mdoc).
 
 ## Authenticate
 

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -24,8 +24,7 @@ Once Gemini CLI is installed, run Gemini CLI from your command line:
 gemini
 ```
 
-For more installation options, see
-[Gemini CLI Installation](./installation.mdoc).
+For more installation options, see [Gemini CLI Installation](./installation).
 
 ## Authenticate
 

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -24,7 +24,7 @@ Once Gemini CLI is installed, run Gemini CLI from your command line:
 gemini
 ```
 
-For more installation options, see [Gemini CLI Installation](./installation).
+For more installation options, see [Gemini CLI Installation](./installation/).
 
 ## Authenticate
 

--- a/docs/get-started/installation.mdoc
+++ b/docs/get-started/installation.mdoc
@@ -23,34 +23,33 @@ installation methods, and release types.
 We recommend most users install Gemini CLI using one of the following
 installation methods:
 
-- npm
-- Homebrew
-- MacPorts
-- Anaconda
-
-Note that Gemini CLI comes pre-installed on
-[**Cloud Shell**](https://docs.cloud.google.com/shell/docs) and
-[**Cloud Workstations**](https://cloud.google.com/workstations).
-
-### Install globally with npm
+{% tabs %}
+{% tabitem label="npm" %}
+Install globally with npm:
 
 ```bash
 npm install -g @google/gemini-cli
 ```
+{% /tabitem %}
 
-### Install globally with Homebrew (macOS/Linux)
+{% tabitem label="Homebrew" %}
+Install globally with Homebrew (macOS/Linux):
 
 ```bash
 brew install gemini-cli
 ```
+{% /tabitem %}
 
-### Install globally with MacPorts (macOS)
+{% tabitem label="MacPorts" %}
+Install globally with MacPorts (macOS):
 
 ```bash
 sudo port install gemini-cli
 ```
+{% /tabitem %}
 
-### Install with Anaconda (for restricted environments)
+{% tabitem label="Anaconda" %}
+Install with Anaconda (for restricted environments):
 
 ```bash
 # Create and activate a new environment
@@ -60,6 +59,12 @@ conda activate gemini_env
 # Install Gemini CLI globally via npm (inside the environment)
 npm install -g @google/gemini-cli
 ```
+{% /tabitem %}
+{% /tabs %}
+
+Note that Gemini CLI comes pre-installed on
+[**Cloud Shell**](https://docs.cloud.google.com/shell/docs) and
+[**Cloud Workstations**](https://cloud.google.com/workstations).
 
 ## Run Gemini CLI
 
@@ -102,7 +107,7 @@ the default way that the CLI executes tools that might have side effects.
   to run the CLI.
   ```bash
   # Run the published sandbox image
-  docker run --rm -it us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.1
+  docker run --rm -it us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:latest
   ```
 - **Using the `--sandbox` flag:** If you have Gemini CLI installed locally
   (using the standard installation described above), you can instruct it to run

--- a/docs/get-started/installation.mdx
+++ b/docs/get-started/installation.mdx
@@ -1,0 +1,157 @@
+# Gemini CLI installation, execution, and releases
+
+This document provides an overview of Gemini CLI's system requirements,
+installation methods, and release types.
+
+## Recommended system specifications
+
+- **Operating System:**
+  - macOS 15+
+  - Windows 11 24H2+
+  - Ubuntu 20.04+
+- **Hardware:**
+  - "Casual" usage: 4GB+ RAM (short sessions, common tasks and edits)
+  - "Power" usage: 16GB+ RAM (long sessions, large codebases, deep context)
+- **Runtime:** Node.js 20.0.0+
+- **Shell:** Bash, Zsh, or PowerShell
+- **Location:**
+  [Gemini Code Assist supported locations](https://developers.google.com/gemini-code-assist/resources/available-locations#americas)
+- **Internet connection required**
+
+## Install Gemini CLI
+
+We recommend most users install Gemini CLI using one of the following
+installation methods:
+
+<Tabs>
+  <TabItem label="npm">
+  Install globally with npm:
+
+  ```bash
+  npm install -g @google/gemini-cli
+  ```
+  </TabItem>
+  <TabItem label="Homebrew">
+  Install globally with Homebrew (macOS/Linux):
+
+  ```bash
+  brew install gemini-cli
+  ```
+  </TabItem>
+</Tabs>
+
+Note that Gemini CLI comes pre-installed on
+[**Cloud Shell**](https://docs.cloud.google.com/shell/docs) and
+[**Cloud Workstations**](https://cloud.google.com/workstations).
+
+## Run Gemini CLI
+
+For most users, we recommend running Gemini CLI with the `gemini` command:
+
+```bash
+gemini
+```
+
+For a list of options and additional commands, see the
+[CLI cheatsheet](../cli/cli-reference.md).
+
+You can also run Gemini CLI using one of the following advanced methods:
+
+- Run instantly with npx. You can run Gemini CLI without permanent installation.
+- In a sandbox. This method offers increased security and isolation.
+- From the source. This is recommended for contributors to the project.
+
+### Run instantly with npx
+
+```bash
+# Using npx (no installation required)
+npx @google/gemini-cli
+```
+
+You can also execute the CLI directly from the main branch on GitHub, which is
+helpful for testing features still in development:
+
+```bash
+npx https://github.com/google-gemini/gemini-cli
+```
+
+### Run in a sandbox (Docker/Podman)
+
+For security and isolation, Gemini CLI can be run inside a container. This is
+the default way that the CLI executes tools that might have side effects.
+
+- **Directly from the registry:** You can run the published sandbox image
+  directly. This is useful for environments where you only have Docker and want
+  to run the CLI.
+  ```bash
+  # Run the published sandbox image
+  docker run --rm -it us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:latest
+  ```
+- **Using the `--sandbox` flag:** If you have Gemini CLI installed locally
+  (using the standard installation described above), you can instruct it to run
+  inside the sandbox container.
+  ```bash
+  gemini --sandbox -y -p "your prompt here"
+  ```
+
+### Run from source (recommended for Gemini CLI contributors)
+
+Contributors to the project will want to run the CLI directly from the source
+code.
+
+- **Development mode:** This method provides hot-reloading and is useful for
+  active development.
+  ```bash
+  # From the root of the repository
+  npm run start
+  ```
+- **Production-like mode (linked package):** This method simulates a global
+  installation by linking your local package. It's useful for testing a local
+  build in a production workflow.
+
+  ```bash
+  # Link the local cli package to your global node_modules
+  npm link packages/cli
+
+  # Now you can run your local version using the `gemini` command
+  gemini
+  ```
+
+## Releases
+
+Gemini CLI has three release channels: nightly, preview, and stable. For most
+users, we recommend the stable release, which is the default installation.
+
+### Stable
+
+New stable releases are published each week. The stable release is the promotion
+of last week's `preview` release along with any bug fixes. The stable release
+uses `latest` tag, but omitting the tag also installs the latest stable release
+by default:
+
+```bash
+# Both commands install the latest stable release.
+npm install -g @google/gemini-cli
+npm install -g @google/gemini-cli@latest
+```
+
+### Preview
+
+New preview releases will be published each week. These releases are not fully
+vetted and may contain regressions or other outstanding issues. Try out the
+preview release by using the `preview` tag:
+
+```bash
+npm install -g @google/gemini-cli@preview
+```
+
+### Nightly
+
+Nightly releases are published every day. The nightly release includes all
+changes from the main branch at time of release. It should be assumed there are
+pending validations and issues. You can help test the latest changes by
+installing with the `nightly` tag:
+
+```bash
+npm install -g @google/gemini-cli@nightly
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ npm install -g @google/gemini-cli
 Jump in to Gemini CLI.
 
 - **[Quickstart](./get-started/index.md):** Your first session with Gemini CLI.
-- **[Installation](./get-started/installation):** How to install Gemini CLI on
+- **[Installation](./get-started/installation/):** How to install Gemini CLI on
   your system.
 - **[Authentication](./get-started/authentication.md):** Setup instructions for
   personal and enterprise accounts.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,8 +15,8 @@ npm install -g @google/gemini-cli
 Jump in to Gemini CLI.
 
 - **[Quickstart](./get-started/index.md):** Your first session with Gemini CLI.
-- **[Installation](./get-started/installation.mdoc):** How to install Gemini CLI
-  on your system.
+- **[Installation](./get-started/installation):** How to install Gemini CLI on
+  your system.
 - **[Authentication](./get-started/authentication.md):** Setup instructions for
   personal and enterprise accounts.
 - **[Examples](./get-started/examples.md):** Practical examples of Gemini CLI in

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ npm install -g @google/gemini-cli
 Jump in to Gemini CLI.
 
 - **[Quickstart](./get-started/index.md):** Your first session with Gemini CLI.
-- **[Installation](./get-started/installation.md):** How to install Gemini CLI
+- **[Installation](./get-started/installation.mdoc):** How to install Gemini CLI
   on your system.
 - **[Authentication](./get-started/authentication.md):** Setup instructions for
   personal and enterprise accounts.


### PR DESCRIPTION
## Summary

Create a preliminary markdoc file and enable render on GH.

-    **File Rename & Refactor:** Renamed docs/get-started/installation.md to installation.mdoc.
-    **Tabbed Interface:** Refactored the installation methods (npm, Homebrew, MacPorts, Anaconda) to use Markdoc {% tabs %} and {% tabitem %} syntax, consolidating them into a cleaner, tabbed view.
-    **Update References:** Updated internal Markdown links in README.md, docs/index.md, and docs/get-started/index.md to point to the new .mdoc file path.

-    **GitHub Rendering:** Added a rule to .gitattributes (*.mdoc linguist-language=Markdown) to configure GitHub to treat .mdoc files as standard Markdown, preventing them from being displayed as raw code.



Related to google-gemini/maintainers-gemini-cli#1334

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [X] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
