### PR TITLE
feat(core): add ETIMEDOUT filesystem error message with tests

### DIFF
--- a/packages/core/src/utils/fsErrorMessages.test.ts
+++ b/packages/core/src/utils/fsErrorMessages.test.ts
@@ -140,6 +140,19 @@ describe('getFsErrorMessage', () => {
         expected:
           'Too many open files in system. Close some unused files or applications.',
       },
+      {
+        code: 'ETIMEDOUT',
+        message: 'ETIMEDOUT: operation timed out',
+        path: '/mnt/network/file.txt',
+        expected:
+          "Operation timed out: could not access '/mnt/network/file.txt'. Check your network connection or try again later.",
+      },
+      {
+        code: 'ETIMEDOUT',
+        message: 'ETIMEDOUT: operation timed out',
+        expected:
+          'Operation timed out. Check your network connection or try again later.',
+      },
     ];
 
     it.each(testCases)(

--- a/packages/core/src/utils/fsErrorMessages.ts
+++ b/packages/core/src/utils/fsErrorMessages.ts
@@ -48,6 +48,11 @@ const errorMessageGenerators: Record<string, (path?: string) => string> = {
   EMFILE: () => 'Too many open files. Close some unused files or applications.',
   ENFILE: () =>
     'Too many open files in system. Close some unused files or applications.',
+  ETIMEDOUT: (path) =>
+    (path
+      ? `Operation timed out: could not access '${path}'. `
+      : 'Operation timed out. ') +
+    'Check your network connection or try again later.',
 };
 
 /**


### PR DESCRIPTION
Fixes #23399

## Summary
Added handling for ETIMEDOUT filesystem error with a clearer message.

## Details
- Added ETIMEDOUT case in fsErrorMessages.ts
- Added test cases for both with and without path

## Why this is needed
Currently, ETIMEDOUT is not handled explicitly. This improves clarity when operations time out.

## Testing
Ran npm test and verified all tests pass.