### PR TITLE
fix(telemetry): wrap logChatCompression in bufferTelemetryEvent

### DIFF
--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -457,16 +457,18 @@ export function logChatCompression(
 ): void {
   ClearcutLogger.getInstance(config)?.logChatCompressionEvent(event);
 
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
 
-  recordChatCompressionMetrics(config, {
-    tokens_before: event.tokens_before,
-    tokens_after: event.tokens_after,
+    recordChatCompressionMetrics(config, {
+      tokens_before: event.tokens_before,
+      tokens_after: event.tokens_after,
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

This PR wraps the logChatCompression function in the bufferTelemetryEvent utility within packages/core/src/telemetry/loggers.ts. This ensures that chat compression events—which typically fire during heavy, long-running sessions—are correctly buffered until the OpenTelemetry SDK is fully initialized, preventing silent data loss.

## Details

Upon auditing the telemetry pipeline, logChatCompression was identified as the only logging function (~1 of 48) bypassing the bufferTelemetryEvent wrapper.

     - The Fix: Moved logger.emit() and recordChatCompressionMetrics() inside the buffer wrapper.
     - Design Decision: Left ClearcutLogger outside the wrapper to maintain its immediate execution pattern, matching the implementation of peer functions like logToolCall.

## Related Issues

Fixes #23445

## How to Validate

1. Static Analysis: Verify that logChatCompression now follows the exact structural pattern of logMalformedJsonResponse or logToolCall in packages/core/src/telemetry/loggers.ts.

2. Build & Lint: ```bash

      ### Use increased heap size to prevent OOM during heavy linting cycles
      NODE_OPTIONS="--max-old-space-size=4096" npm run preflight

3. Execution: Run the CLI with a long conversation that triggers context compression. Ensure no "No-op provider" warnings appear in debug logs (DEBUG=gemini:*).

 
## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
