### PR TITLE
fix(cli): show manual update command when auto-update fails

### DIFF
--- a/docs/resources/troubleshooting.md
+++ b/docs/resources/troubleshooting.md
@@ -124,6 +124,20 @@ topics on:
     `advanced.excludedEnvVars` setting in your `settings.json` to exclude fewer
     variables.
 
+- **Error: `Automatic update failed. Please try updating manually`**
+  - **Cause:** The background auto-update process failed (for example, due to
+    insufficient permissions on the global `npm` prefix directory).
+  - **Solution:** The CLI will display the exact command to run for your package
+    manager. Run it manually in your terminal. For example, for a global `npm`
+    install:
+    ```bash
+    npm install -g @google/gemini-cli@latest
+    ```
+    If you see a permission error, you may need to prefix the command with
+    `sudo` (macOS/Linux) or run your terminal as Administrator (Windows). To
+    avoid needing `sudo` in the future, consider
+    [configuring npm to use a different global directory](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally).
+
 - **Warning: `npm WARN deprecated node-domexception@1.0.0` or
   `npm WARN deprecated glob` during install/update**
   - **Issue:** When installing or updating the Gemini CLI globally via

--- a/packages/cli/src/utils/handleAutoUpdate.test.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.test.ts
@@ -302,6 +302,7 @@ describe('handleAutoUpdate', () => {
     expect(updateEventEmitter.emit).toHaveBeenCalledWith('update-failed', {
       message:
         'Automatic update failed. Please try updating manually. (command: npm i -g @google/gemini-cli@2.0.0)',
+      updateCommand: 'npm i -g @google/gemini-cli@2.0.0',
     });
   });
 
@@ -326,6 +327,7 @@ describe('handleAutoUpdate', () => {
     expect(updateEventEmitter.emit).toHaveBeenCalledWith('update-failed', {
       message:
         'Automatic update failed. Please try updating manually. (error: Spawn error)',
+      updateCommand: 'npm i -g @google/gemini-cli@2.0.0',
     });
   });
 
@@ -435,13 +437,16 @@ describe('setUpdateHandler', () => {
   });
 
   it('should handle update-failed event', () => {
-    updateEventEmitter.emit('update-failed', { message: 'Failed' });
+    updateEventEmitter.emit('update-failed', {
+      message: 'Failed',
+      updateCommand: 'npm install -g @google/gemini-cli@latest',
+    });
 
     expect(setUpdateInfo).toHaveBeenCalledWith(null);
     expect(addItem).toHaveBeenCalledWith(
       {
         type: MessageType.ERROR,
-        text: 'Automatic update failed. Please try updating manually',
+        text: 'Automatic update failed. Please try updating manually:\n  npm install -g @google/gemini-cli@latest',
       },
       expect.any(Number),
     );

--- a/packages/cli/src/utils/handleAutoUpdate.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.ts
@@ -149,6 +149,7 @@ export function handleAutoUpdate(
     } else {
       updateEventEmitter.emit('update-failed', {
         message: `Automatic update failed. Please try updating manually. (command: ${updateCommand})`,
+        updateCommand,
       });
     }
   });
@@ -157,6 +158,7 @@ export function handleAutoUpdate(
     _updateInProgress = false;
     updateEventEmitter.emit('update-failed', {
       message: `Automatic update failed. Please try updating manually. (error: ${err.message})`,
+      updateCommand,
     });
   });
   return updateProcess;
@@ -184,12 +186,15 @@ export function setUpdateHandler(
     }, 60000);
   };
 
-  const handleUpdateFailed = () => {
+  const handleUpdateFailed = (data: {
+    message: string;
+    updateCommand: string;
+  }) => {
     setUpdateInfo(null);
     addItem(
       {
         type: MessageType.ERROR,
-        text: `Automatic update failed. Please try updating manually`,
+        text: `Automatic update failed. Please try updating manually:\n  ${data.updateCommand}`,
       },
       Date.now(),
     );


### PR DESCRIPTION
## Summary

When auto-update fails, the CLI showed a vague error with no actionable command. The `updateCommand` was already computed but never surfaced to the user on failure.

## Changes Made
`handleAutoUpdate.ts` :

`update-failed` emit on process close → added [updateCommand] field to event payload
`update-failed` emit on spawn error → same, added `updateCommand` field
`handleUpdateFailed` handler → now accepts event data and renders the command:

Before: `Automatic update failed. Please try updating manually`
After:  `Automatic update failed. Please try updating manually:\n  npm install -g @google/gemini-cli@2.0.0`

`handleAutoUpdate.test.ts` :

`update-failed` close test assertion → expects new `updateCommand` field in emitted event
`update-failed` error test assertion → same
`setUpdateHandler` "update-failed" test → emits `updateCommand` in event data and asserts the rendered message includes the command


## Related Issues
Fixes : [#23786 ](https://github.com/google-gemini/gemini-cli/issues/23786)

## How to Validate

# Run the unit tests

- npm run preflight

# Or just the affected test file
- npx vitest run packages/cli/src/utils/handleAutoUpdate.test.ts

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
