### PR TITLE
fix(core): explicitly set error names to avoid bundling renaming issues

### DIFF
--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -19,6 +19,7 @@ import {
   debugLogger,
   coreEvents,
   getErrorMessage,
+  getErrorType,
 } from '@google/gemini-cli-core';
 import { runSyncCleanup } from './cleanup.js';
 
@@ -82,7 +83,7 @@ export function handleError(
       timestamp: new Date().toISOString(),
       status: 'error',
       error: {
-        type: error instanceof Error ? error.constructor.name : 'Error',
+        type: getErrorType(error),
         message: errorMessage,
       },
       stats: streamFormatter.convertToStreamStats(metrics, 0),
@@ -177,7 +178,7 @@ export function handleCancellationError(config: Config): never {
       timestamp: new Date().toISOString(),
       status: 'error',
       error: {
-        type: 'FatalCancellationError',
+        type: getErrorType(cancellationError),
         message: cancellationError.message,
       },
       stats: streamFormatter.convertToStreamStats(metrics, 0),
@@ -218,7 +219,7 @@ export function handleMaxTurnsExceededError(config: Config): never {
       timestamp: new Date().toISOString(),
       status: 'error',
       error: {
-        type: 'FatalTurnLimitedError',
+        type: getErrorType(maxTurnsError),
         message: maxTurnsError.message,
       },
       stats: streamFormatter.convertToStreamStats(metrics, 0),

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -32,6 +32,7 @@ export class ProjectIdRequiredError extends Error {
     super(
       'This account requires setting the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT_ID env var. See https://goo.gle/gemini-cli-auth-docs#workspace-gca',
     );
+    this.name = 'ProjectIdRequiredError';
   }
 }
 
@@ -42,6 +43,7 @@ export class ProjectIdRequiredError extends Error {
 export class ValidationCancelledError extends Error {
   constructor() {
     super('User cancelled account validation');
+    this.name = 'ValidationCancelledError';
   }
 }
 
@@ -51,6 +53,7 @@ export class IneligibleTierError extends Error {
   constructor(ineligibleTiers: IneligibleTier[]) {
     const reasons = ineligibleTiers.map((t) => t.reasonMessage).join(', ');
     super(reasons);
+    this.name = 'IneligibleTierError';
     this.ineligibleTiers = ineligibleTiers;
   }
 }

--- a/packages/core/src/utils/errors.test.ts
+++ b/packages/core/src/utils/errors.test.ts
@@ -355,12 +355,29 @@ describe('getErrorType', () => {
     expect(getErrorType(undefined)).toBe('unknown');
   });
 
-  it('should strip leading underscores from error names', () => {
-    class _GaxiosError extends Error {}
+  it('should use explicitly set error names', () => {
+    class _GaxiosError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'GaxiosError';
+      }
+    }
     expect(getErrorType(new _GaxiosError('test'))).toBe('GaxiosError');
 
-    const errorWithUnderscoreName = new Error('test');
-    errorWithUnderscoreName.name = '_CodeBuddyError';
-    expect(getErrorType(errorWithUnderscoreName)).toBe('CodeBuddyError');
+    class BadRequestError3 extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'BadRequestError';
+      }
+    }
+    expect(getErrorType(new BadRequestError3('test'))).toBe('BadRequestError');
+
+    class _AbortError2 extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'AbortError';
+      }
+    }
+    expect(getErrorType(new _AbortError2('test'))).toBe('AbortError');
   });
 });

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -58,9 +58,14 @@ export function getErrorType(error: unknown): string {
   if (!(error instanceof Error)) return 'unknown';
 
   // Use the constructor name if the standard error name is missing or generic.
-  return error.name && error.name !== 'Error'
-    ? error.name
-    : (error.constructor?.name ?? 'Error');
+  const name =
+    error.name && error.name !== 'Error'
+      ? error.name
+      : (error.constructor?.name ?? 'Error');
+
+  // Strip leading underscore from error names. Bundlers like esbuild sometimes
+  // rename classes to avoid scope collisions.
+  return name.replace(/^_+/, '');
 }
 
 export class FatalError extends Error {

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -57,13 +57,10 @@ export function getErrorMessage(error: unknown): string {
 export function getErrorType(error: unknown): string {
   if (!(error instanceof Error)) return 'unknown';
 
-  // Return constructor name if the generic 'Error' name is used (for custom errors)
-  const name =
-    error.name === 'Error' ? (error.constructor?.name ?? 'Error') : error.name;
-
-  // Strip leading underscore from error names. Bundlers like esbuild sometimes
-  // rename classes to avoid scope collisions.
-  return name.replace(/^_+/, '');
+  // Use the constructor name if the standard error name is missing or generic.
+  return error.name && error.name !== 'Error'
+    ? error.name
+    : (error.constructor?.name ?? 'Error');
 }
 
 export class FatalError extends Error {
@@ -72,42 +69,50 @@ export class FatalError extends Error {
     readonly exitCode: number,
   ) {
     super(message);
+    this.name = 'FatalError';
   }
 }
 
 export class FatalAuthenticationError extends FatalError {
   constructor(message: string) {
     super(message, 41);
+    this.name = 'FatalAuthenticationError';
   }
 }
 export class FatalInputError extends FatalError {
   constructor(message: string) {
     super(message, 42);
+    this.name = 'FatalInputError';
   }
 }
 export class FatalSandboxError extends FatalError {
   constructor(message: string) {
     super(message, 44);
+    this.name = 'FatalSandboxError';
   }
 }
 export class FatalConfigError extends FatalError {
   constructor(message: string) {
     super(message, 52);
+    this.name = 'FatalConfigError';
   }
 }
 export class FatalTurnLimitedError extends FatalError {
   constructor(message: string) {
     super(message, 53);
+    this.name = 'FatalTurnLimitedError';
   }
 }
 export class FatalToolExecutionError extends FatalError {
   constructor(message: string) {
     super(message, 54);
+    this.name = 'FatalToolExecutionError';
   }
 }
 export class FatalCancellationError extends FatalError {
   constructor(message: string) {
     super(message, 130); // Standard exit code for SIGINT
+    this.name = 'FatalCancellationError';
   }
 }
 
@@ -118,7 +123,12 @@ export class CanceledError extends Error {
   }
 }
 
-export class ForbiddenError extends Error {}
+export class ForbiddenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ForbiddenError';
+  }
+}
 export class AccountSuspendedError extends ForbiddenError {
   readonly appealUrl?: string;
   readonly appealLinkText?: string;
@@ -130,8 +140,18 @@ export class AccountSuspendedError extends ForbiddenError {
     this.appealLinkText = metadata?.['appeal_url_link_text'];
   }
 }
-export class UnauthorizedError extends Error {}
-export class BadRequestError extends Error {}
+export class UnauthorizedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnauthorizedError';
+  }
+}
+export class BadRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BadRequestError';
+  }
+}
 
 export class ChangeAuthRequestedError extends Error {
   constructor() {
@@ -264,10 +284,7 @@ export function isAuthenticationError(error: unknown): boolean {
   }
 
   // Check for UnauthorizedError class (from MCP SDK or our own)
-  if (
-    error instanceof Error &&
-    error.constructor.name === 'UnauthorizedError'
-  ) {
+  if (error instanceof Error && error.name === 'UnauthorizedError') {
     return true;
   }
 


### PR DESCRIPTION
## Summary

This PR fixes the issue where telemetry reports error types with trailing numbers (e.g., `RateLimitError2`, `BadRequestError3`). This happens when `esbuild` renames colliding classes during bundling.

## Details

Previously, we were using a regex in `getErrorType` to strip leading underscores. I've updated the approach to explicitly set the `name` property on all custom error classes. This is more robust than trying to "fix" the name after bundling and ensures consistency in metrics.

I've also updated the CLI's error handling to use `getErrorType` instead of `error.constructor.name` for more reliable error type reporting in JSON output.

## Related Issues

Related to #22989
Related to google-gemini/maintainers-gemini-cli#1434

## How to Validate

Run the unit tests in `@google/gemini-cli-core`:
`npm test -w @google/gemini-cli-core -- src/utils/errors.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run