### PR TITLE
fix(cli): prevent infinite re-render loop in useFlickerDetector and useSessionResume

### DIFF
--- a/packages/cli/src/ui/hooks/useFlickerDetector.test.ts
+++ b/packages/cli/src/ui/hooks/useFlickerDetector.test.ts
@@ -106,14 +106,16 @@ describe('useFlickerDetector', () => {
   it('should re-evaluate on re-render', async () => {
     // Start with a valid height
     mockMeasureElement.mockReturnValue({ width: 80, height: 20 });
-    const { rerender } = await renderHook(() =>
-      useFlickerDetector(mockRef, 25),
+    const { rerender } = await renderHook(
+      ({ height }) => useFlickerDetector(mockRef, height),
+      { initialProps: { height: 25 } },
     );
     expect(mockRecordFlickerFrame).not.toHaveBeenCalled();
 
     // Now, simulate a re-render where the height is too great
     mockMeasureElement.mockReturnValue({ width: 80, height: 30 });
-    rerender();
+    // Trigger a change in terminalHeight dependency to force effect to run
+    rerender({ height: 24 });
 
     expect(mockRecordFlickerFrame).toHaveBeenCalledTimes(1);
     expect(mockAppEventsEmit).toHaveBeenCalledTimes(1);

--- a/packages/cli/src/ui/hooks/useFlickerDetector.ts
+++ b/packages/cli/src/ui/hooks/useFlickerDetector.ts
@@ -39,5 +39,5 @@ export function useFlickerDetector(
         appEvents.emit(AppEvent.Flicker);
       }
     }
-  });
+  }, [rootUiRef, terminalHeight, config, constrainHeight]);
 }

--- a/packages/cli/src/ui/hooks/useSessionResume.ts
+++ b/packages/cli/src/ui/hooks/useSessionResume.ts
@@ -49,7 +49,7 @@ export function useSessionResume({
   useEffect(() => {
     historyManagerRef.current = historyManager;
     refreshStaticRef.current = refreshStatic;
-  });
+  }, [historyManager, refreshStatic]);
 
   const loadHistoryForResume = useCallback(
     async (


### PR DESCRIPTION
## Summary

Fixes a critical "lockup" bug in gCLI where the UI stops responding to input and timers stop updating. This was caused by `useEffect` hooks in `useFlickerDetector` and `useSessionResume` lacking dependency arrays, leading to infinite re-render loops when certain conditions (like UI flicker) were met.

## Details

- Added `[rootUiRef, terminalHeight, config, constrainHeight]` as dependencies to `useFlickerDetector`'s `useEffect`.
- Added `[historyManager, refreshStatic]` as dependencies to `useSessionResume`'s `useEffect`.
- Updated `useFlickerDetector.test.ts` to correctly handle the new dependency requirement by passing props to `renderHook`.
- These changes ensure the hooks only run when their relevant data changes, breaking the cycle of infinite re-renders that previously starved the Node.js event loop.

## Related Issues

Fixes #23752

## How to Validate

1. Run `npm test -w @google/gemini-cli -- src/ui/hooks/useFlickerDetector.test.ts` to verify the fix and the updated test case.
2. Run `npm test -w @google/gemini-cli -- src/ui/hooks/useSessionResume.test.ts` to ensure no regressions.
3. Observe that the gCLI remains responsive and timers continue to update even during complex rendering scenarios.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
