### PR TITLE
fix(acp): prevent crash on empty response in ACP mode

### DIFF
--- a/packages/cli/src/acp/acpClient.test.ts
+++ b/packages/cli/src/acp/acpClient.test.ts
@@ -28,6 +28,7 @@ import {
   LlmRole,
   type GitService,
   processSingleFileContent,
+  InvalidStreamError,
 } from '@google/gemini-cli-core';
 import {
   SettingScope,
@@ -760,6 +761,32 @@ describe('Session', () => {
         content: { type: 'text', text: 'Hello' },
       },
     });
+    expect(result).toMatchObject({ stopReason: 'end_turn' });
+  });
+
+  it('should handle prompt with empty response (InvalidStreamError)', async () => {
+    mockChat.sendMessageStream.mockRejectedValue(
+      new InvalidStreamError('Empty response', 'NO_RESPONSE_TEXT'),
+    );
+
+    const result = await session.prompt({
+      sessionId: 'session-1',
+      prompt: [{ type: 'text', text: 'Hi' }],
+    });
+
+    expect(mockChat.sendMessageStream).toHaveBeenCalled();
+    expect(result).toMatchObject({ stopReason: 'end_turn' });
+  });
+
+  it('should handle prompt with empty response (NO_RESPONSE_TEXT anomaly)', async () => {
+    mockChat.sendMessageStream.mockRejectedValue({ type: 'NO_RESPONSE_TEXT' });
+
+    const result = await session.prompt({
+      sessionId: 'session-1',
+      prompt: [{ type: 'text', text: 'Hi' }],
+    });
+
+    expect(mockChat.sendMessageStream).toHaveBeenCalled();
     expect(result).toMatchObject({ stopReason: 'end_turn' });
   });
 

--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -48,6 +48,7 @@ import {
   PREVIEW_GEMINI_MODEL_AUTO,
   getDisplayString,
   processSingleFileContent,
+  InvalidStreamError,
   type AgentLoopContext,
 } from '@google/gemini-cli-core';
 import * as acp from '@agentclientprotocol/sdk';
@@ -839,6 +840,37 @@ export class Session {
           (error instanceof Error && error.name === 'AbortError')
         ) {
           return { stopReason: CoreToolCallStatus.Cancelled };
+        }
+
+        if (
+          error instanceof InvalidStreamError ||
+          (error &&
+            typeof error === 'object' &&
+            'type' in error &&
+            error.type === 'NO_RESPONSE_TEXT')
+        ) {
+          // The stream ended with an empty response or malformed tool call.
+          // Treat this as a graceful end to the model's turn rather than a crash.
+          return {
+            stopReason: 'end_turn',
+            _meta: {
+              quota: {
+                token_count: {
+                  input_tokens: totalInputTokens,
+                  output_tokens: totalOutputTokens,
+                },
+                model_usage: Array.from(modelUsageMap.entries()).map(
+                  ([modelName, counts]) => ({
+                    model: modelName,
+                    token_count: {
+                      input_tokens: counts.input,
+                      output_tokens: counts.output,
+                    },
+                  }),
+                ),
+              },
+            },
+          };
         }
 
         throw new acp.RequestError(


### PR DESCRIPTION
## Summary

Prevent crash on empty response in ACP mode

## Details

- Catch InvalidStreamError and treat it as a graceful end of turn in ACP Client.
- Added tests to verify handling of empty responses.

## Related Issues

Fixes [maintainers-gemini-cli#1602](https://github.com/google-gemini/maintainers-gemini-cli/issues/1602)

## How to Validate

Forcing an empty response from the real Gemini model is probabilistic and difficult to reproduce, the automated unit tests are validating this. Manual validation via a script maybe a bit too much. 

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [√] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [√] Validated on required platforms/methods:
  - [√] MacOS
    - [√] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
