### PR TITLE
revert(core): support custom base URL via env vars

### DIFF
--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -10,7 +10,6 @@ import {
   AuthType,
   createContentGeneratorConfig,
   type ContentGenerator,
-  validateBaseUrl,
 } from './contentGenerator.js';
 import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
 import { GoogleGenAI } from '@google/genai';
@@ -605,122 +604,6 @@ describe('createContentGenerator', () => {
     );
   });
 
-  it('should pass GOOGLE_GEMINI_BASE_URL as httpOptions.baseUrl for Gemini API', async () => {
-    const mockConfig = {
-      getModel: vi.fn().mockReturnValue('gemini-pro'),
-      getProxy: vi.fn().mockReturnValue(undefined),
-      getUsageStatisticsEnabled: () => false,
-      getClientName: vi.fn().mockReturnValue(undefined),
-    } as unknown as Config;
-
-    const mockGenerator = {
-      models: {},
-    } as unknown as GoogleGenAI;
-    vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator as never);
-    vi.stubEnv('GOOGLE_GEMINI_BASE_URL', 'https://my-gemini-proxy.example.com');
-
-    await createContentGenerator(
-      {
-        apiKey: 'test-api-key',
-        authType: AuthType.USE_GEMINI,
-      },
-      mockConfig,
-    );
-
-    expect(GoogleGenAI).toHaveBeenCalledWith(
-      expect.objectContaining({
-        httpOptions: expect.objectContaining({
-          baseUrl: 'https://my-gemini-proxy.example.com',
-        }),
-      }),
-    );
-  });
-
-  it('should pass GOOGLE_VERTEX_BASE_URL as httpOptions.baseUrl for Vertex AI', async () => {
-    const mockConfig = {
-      getModel: vi.fn().mockReturnValue('gemini-pro'),
-      getProxy: vi.fn().mockReturnValue(undefined),
-      getUsageStatisticsEnabled: () => false,
-      getClientName: vi.fn().mockReturnValue(undefined),
-    } as unknown as Config;
-
-    const mockGenerator = {
-      models: {},
-    } as unknown as GoogleGenAI;
-    vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator as never);
-    vi.stubEnv('GOOGLE_VERTEX_BASE_URL', 'https://my-vertex-proxy.example.com');
-
-    await createContentGenerator(
-      {
-        apiKey: 'test-api-key',
-        vertexai: true,
-        authType: AuthType.USE_VERTEX_AI,
-      },
-      mockConfig,
-    );
-
-    expect(GoogleGenAI).toHaveBeenCalledWith(
-      expect.objectContaining({
-        httpOptions: expect.objectContaining({
-          baseUrl: 'https://my-vertex-proxy.example.com',
-        }),
-      }),
-    );
-  });
-
-  it('should not include baseUrl in httpOptions when GOOGLE_GEMINI_BASE_URL is not set', async () => {
-    vi.stubEnv('GOOGLE_GEMINI_BASE_URL', '');
-
-    const mockConfig = {
-      getModel: vi.fn().mockReturnValue('gemini-pro'),
-      getProxy: vi.fn().mockReturnValue(undefined),
-      getUsageStatisticsEnabled: () => false,
-      getClientName: vi.fn().mockReturnValue(undefined),
-    } as unknown as Config;
-
-    const mockGenerator = {
-      models: {},
-    } as unknown as GoogleGenAI;
-    vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator as never);
-
-    await createContentGenerator(
-      {
-        apiKey: 'test-api-key',
-        authType: AuthType.USE_GEMINI,
-      },
-      mockConfig,
-    );
-
-    expect(GoogleGenAI).toHaveBeenCalledWith(
-      expect.not.objectContaining({
-        httpOptions: expect.objectContaining({
-          baseUrl: expect.any(String),
-        }),
-      }),
-    );
-  });
-
-  it('should reject an insecure GOOGLE_GEMINI_BASE_URL for non-local hosts', async () => {
-    const mockConfig = {
-      getModel: vi.fn().mockReturnValue('gemini-pro'),
-      getProxy: vi.fn().mockReturnValue(undefined),
-      getUsageStatisticsEnabled: () => false,
-      getClientName: vi.fn().mockReturnValue(undefined),
-    } as unknown as Config;
-
-    vi.stubEnv('GOOGLE_GEMINI_BASE_URL', 'http://evil-proxy.example.com');
-
-    await expect(
-      createContentGenerator(
-        {
-          apiKey: 'test-api-key',
-          authType: AuthType.USE_GEMINI,
-        },
-        mockConfig,
-      ),
-    ).rejects.toThrow('Custom base URL must use HTTPS unless it is localhost.');
-  });
-
   it('should pass apiVersion for Vertex AI when GOOGLE_GENAI_API_VERSION is set', async () => {
     const mockConfig = {
       getModel: vi.fn().mockReturnValue('gemini-pro'),
@@ -859,35 +742,5 @@ describe('createContentGeneratorConfig', () => {
     );
     expect(config.apiKey).toBe('gateway-placeholder-key');
     expect(config.vertexai).toBe(false);
-  });
-});
-
-describe('validateBaseUrl', () => {
-  it('should accept a valid HTTPS URL', () => {
-    expect(() => validateBaseUrl('https://my-proxy.example.com')).not.toThrow();
-  });
-
-  it('should accept HTTP for localhost', () => {
-    expect(() => validateBaseUrl('http://localhost:8080')).not.toThrow();
-  });
-
-  it('should accept HTTP for 127.0.0.1', () => {
-    expect(() => validateBaseUrl('http://127.0.0.1:3000')).not.toThrow();
-  });
-
-  it('should accept HTTP for ::1', () => {
-    expect(() => validateBaseUrl('http://[::1]:8080')).not.toThrow();
-  });
-
-  it('should reject HTTP for non-local hosts', () => {
-    expect(() => validateBaseUrl('http://my-proxy.example.com')).toThrow(
-      'Custom base URL must use HTTPS unless it is localhost.',
-    );
-  });
-
-  it('should reject an invalid URL', () => {
-    expect(() => validateBaseUrl('not-a-url')).toThrow(
-      'Invalid custom base URL: not-a-url',
-    );
   });
 });

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -273,25 +273,13 @@ export async function createContentGenerator(
           'x-gemini-api-privileged-user-id': `${installationId}`,
         };
       }
-      let baseUrl = config.baseUrl;
-      if (!baseUrl) {
-        const envBaseUrl = config.vertexai
-          ? process.env['GOOGLE_VERTEX_BASE_URL']
-          : process.env['GOOGLE_GEMINI_BASE_URL'];
-        if (envBaseUrl) {
-          validateBaseUrl(envBaseUrl);
-          baseUrl = envBaseUrl;
-        }
-      } else {
-        validateBaseUrl(baseUrl);
-      }
       const httpOptions: {
         baseUrl?: string;
         headers: Record<string, string>;
       } = { headers };
 
-      if (baseUrl) {
-        httpOptions.baseUrl = baseUrl;
+      if (config.baseUrl) {
+        httpOptions.baseUrl = config.baseUrl;
       }
 
       const googleGenAI = new GoogleGenAI({
@@ -312,18 +300,4 @@ export async function createContentGenerator(
   }
 
   return generator;
-}
-
-const LOCAL_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]'];
-
-export function validateBaseUrl(baseUrl: string): void {
-  let url: URL;
-  try {
-    url = new URL(baseUrl);
-  } catch {
-    throw new Error(`Invalid custom base URL: ${baseUrl}`);
-  }
-  if (url.protocol !== 'https:' && !LOCAL_HOSTNAMES.includes(url.hostname)) {
-    throw new Error('Custom base URL must use HTTPS unless it is localhost.');
-  }
 }


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Reverts PR #21561. The `@google/genai` SDK inherently supports setting the `baseUrl` via the `GOOGLE_GEMINI_BASE_URL` and `GOOGLE_VERTEX_BASE_URL` environment variables. The custom environment variable parsing and validation logic introduced in PR #21561 is duplicative and overly restrictive (blocking valid enterprise proxies that use HTTP).

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
Prior to PR #21561, the CLI's initialization pattern initialized the `GoogleGenAI` class without passing an explicit `httpOptions.baseUrl` (unless `config.baseUrl` was configured explicitly). Because no explicit URL was provided to the constructor, the SDK automatically inherited and applied these environment variables natively. Reverting this returns the CLI to rely on the SDK's native environment variable parsing.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Reverts #21561
Fixes #6746 (Historically)

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
1. `npm run build`
2. `GOOGLE_GEMINI_BASE_URL=http://localhost:8080 GEMINI_API_KEY=test npm start`
3. The CLI should start and properly route requests to `http://localhost:8080`.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker