### PR TITLE
test: silence console logs during test runs for cleaner output

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,11 @@
     "clean": "node scripts/clean.js",
     "pre-commit": "node scripts/pre-commit.js"
   },
+  "vitest": {
+    "setupFiles": [
+      "./vitest.setup.ts"
+    ]
+  },
   "overrides": {
     "ink": "npm:@jrichman/ink@6.4.11",
     "wrap-ansi": "9.0.2",

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+let originalConsole: typeof console;
+
+beforeEach(() => {
+  originalConsole = { ...console };
+
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  console.log = originalConsole.log;
+  console.warn = originalConsole.warn;
+  console.error = originalConsole.error;
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -3,18 +3,12 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-let originalConsole: typeof console;
-
 beforeEach(() => {
-  originalConsole = { ...console };
-
   vi.spyOn(console, 'log').mockImplementation(() => {});
   vi.spyOn(console, 'warn').mockImplementation(() => {});
   vi.spyOn(console, 'error').mockImplementation(() => {});
 });
 
 afterEach(() => {
-  console.log = originalConsole.log;
-  console.warn = originalConsole.warn;
-  console.error = originalConsole.error;
+  vi.restoreAllMocks();
 });


### PR DESCRIPTION
This PR reduces noisy console output during test runs by mocking console.log, console.warn, and console.error in a global Vitest setup file.

Motivation:
As discussed in issue #23328, the current test suite produces excessive logs, making it difficult to identify failures.

Changes:
- Added a global Vitest setup file
- Mocked console methods during tests using vi.spyOn
- Restored original console after each test to avoid side effects

This improves readability of test output without affecting functionality.