### PR TITLE
  fix(cli): forward ACP video prompt blocks as inlineData

### DIFF
--- a/packages/cli/src/acp/acpClient.test.ts
+++ b/packages/cli/src/acp/acpClient.test.ts
@@ -1650,6 +1650,44 @@ describe('Session', () => {
     );
   });
 
+  it('should forward video prompt blocks as inlineData', async () => {
+    const stream = createMockStream([
+      {
+        type: StreamEventType.CHUNK,
+        value: { candidates: [] },
+      },
+    ]);
+    mockChat.sendMessageStream.mockResolvedValue(stream);
+
+    await session.prompt({
+      sessionId: 'session-1',
+      prompt: [
+        { type: 'text', text: 'Describe this clip' },
+        {
+          type: 'video',
+          mimeType: 'video/mp4',
+          data: 'base64-video-data',
+        } as unknown as acp.ContentBlock,
+      ],
+    });
+
+    expect(mockChat.sendMessageStream).toHaveBeenCalledWith(
+      expect.anything(),
+      [
+        { text: 'Describe this clip' },
+        {
+          inlineData: {
+            mimeType: 'video/mp4',
+            data: 'base64-video-data',
+          },
+        },
+      ],
+      expect.anything(),
+      expect.any(AbortSignal),
+      LlmRole.MAIN,
+    );
+  });
+
   it('should handle @path resolution error', async () => {
     (path.resolve as unknown as Mock).mockReturnValue('/tmp/error.txt');
     (fs.stat as unknown as Mock).mockResolvedValue({

--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -87,6 +87,16 @@ const RequestPermissionResponseSchema = z.object({
   ]),
 });
 
+type VideoContentBlock = {
+  type: 'video';
+  mimeType: string;
+  data: string;
+};
+
+type SupportedInlineMediaBlock =
+  | Extract<acp.ContentBlock, { type: 'image' | 'audio' }>
+  | VideoContentBlock;
+
 export async function runAcpClient(
   config: Config,
   settings: LoadedSettings,
@@ -1209,36 +1219,41 @@ export class Session {
     const embeddedContext: acp.EmbeddedResourceResource[] = [];
 
     const parts = message.map((part) => {
-      switch (part.type) {
+      const contentBlock = part as acp.ContentBlock | VideoContentBlock;
+
+      switch (contentBlock.type) {
         case 'text':
-          return { text: part.text };
+          return { text: contentBlock.text };
         case 'image':
         case 'audio':
+        case 'video': {
+          const mediaPart = contentBlock as SupportedInlineMediaBlock;
           return {
             inlineData: {
-              mimeType: part.mimeType,
-              data: part.data,
+              mimeType: mediaPart.mimeType,
+              data: mediaPart.data,
             },
           };
+        }
         case 'resource_link': {
-          if (part.uri.startsWith(FILE_URI_SCHEME)) {
+          if (contentBlock.uri.startsWith(FILE_URI_SCHEME)) {
             return {
               fileData: {
-                mimeData: part.mimeType,
-                name: part.name,
-                fileUri: part.uri.slice(FILE_URI_SCHEME.length),
+                mimeData: contentBlock.mimeType,
+                name: contentBlock.name,
+                fileUri: contentBlock.uri.slice(FILE_URI_SCHEME.length),
               },
             };
           } else {
-            return { text: `@${part.uri}` };
+            return { text: `@${contentBlock.uri}` };
           }
         }
         case 'resource': {
-          embeddedContext.push(part.resource);
-          return { text: `@${part.resource.uri}` };
+          embeddedContext.push(contentBlock.resource);
+          return { text: `@${contentBlock.resource.uri}` };
         }
         default: {
-          const unreachable: never = part;
+          const unreachable: never = contentBlock;
           throw new Error(`Unexpected chunk type: '${unreachable}'`);
         }
       }


### PR DESCRIPTION
## Summary

  Fix ACP prompt resolution so `video` content blocks are forwarded to Gemini as `inlineData`, matching the existing handling for `image` and `audio`.

  This addresses video attachments submitted through the ACP / IDE companion path.

  ## Root cause

  `Session.#resolvePrompt()` in `packages/cli/src/acp/acpClient.ts` handled:

  - `text`
  - `image`
  - `audio`
  - `resource_link`
  - `resource`

  but did not handle `video`.

  As a result, video prompt blocks were not passed through correctly to `sendMessageStream()`.

  ## Changes

  - add `video` handling in ACP prompt resolution
  - map video blocks to Gemini `inlineData`
  - add a regression test covering a `video/mp4` prompt block

  ## Notes

  This fix is scoped to the ACP / IDE companion input path in `acpClient.ts`.
  It does not claim to change every possible media input path in the CLI.

  ## Testing

  Ran:

  ```bash
  npm ci
  npm run build --workspace @google/gemini-cli-core
  npm test --workspace @google/gemini-cli -- --run src/acp/acpClient.test.ts

  Result:

  ✓ src/acp/acpClient.test.ts (55 tests)
  Test Files  1 passed (1)
  Tests  55 passed (55)
