### PR TITLE
Increase memory limited for eslint.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test:integration:sandbox:none": "cross-env GEMINI_SANDBOX=false vitest run --root ./integration-tests",
     "test:integration:sandbox:docker": "cross-env GEMINI_SANDBOX=docker npm run build:sandbox && cross-env GEMINI_SANDBOX=docker vitest run --root ./integration-tests",
     "test:integration:sandbox:podman": "cross-env GEMINI_SANDBOX=podman vitest run --root ./integration-tests",
-    "lint": "eslint . --cache --max-warnings 0",
+    "lint": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" eslint . --cache --max-warnings 0",
     "lint:fix": "eslint . --fix --ext .ts,.tsx && eslint integration-tests --fix && eslint scripts --fix && npm run format",
     "lint:ci": "npm run lint:all",
     "lint:all": "node scripts/lint.js",


### PR DESCRIPTION
## Summary

The ESLinter can run out of memory on the project. Increase its heap size to work around the issue. Likely we could optimize how we are using the ESLinter to better mitigate the issue but slightly excessive ESLint memory usage isn't a huge deal.