### PR TITLE
Fix test flakes by globally mocking ink-spinner

### DIFF
--- a/packages/cli/src/test-utils/mockSpinner.tsx
+++ b/packages/cli/src/test-utils/mockSpinner.tsx
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi } from 'vitest';
+import type { SpinnerName } from 'cli-spinners';
+
+export function mockInkSpinner() {
+  vi.mock('ink-spinner', async () => {
+    const { Text } = await import('ink');
+    const cliSpinners = (await import('cli-spinners')).default;
+
+    return {
+      default: function MockSpinner({ type = 'dots' }: { type?: SpinnerName }) {
+        const spinner = cliSpinners[type];
+        const frame = spinner ? spinner.frames[0] : '⠋';
+        return <Text>{frame}</Text>;
+      },
+    };
+  });
+}

--- a/packages/cli/src/ui/components/messages/SubagentProgressDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/SubagentProgressDisplay.test.tsx
@@ -8,11 +8,6 @@ import { render, cleanup } from '../../../test-utils/render.js';
 import { SubagentProgressDisplay } from './SubagentProgressDisplay.js';
 import type { SubagentProgress } from '@google/gemini-cli-core';
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { Text } from 'ink';
-
-vi.mock('ink-spinner', () => ({
-  default: () => <Text>⠋</Text>,
-}));
 
 describe('<SubagentProgressDisplay />', () => {
   afterEach(() => {

--- a/packages/cli/test-setup.ts
+++ b/packages/cli/test-setup.ts
@@ -8,6 +8,10 @@ import { vi, beforeEach, afterEach } from 'vitest';
 import { format } from 'node:util';
 import { coreEvents } from '@google/gemini-cli-core';
 import { themeManager } from './src/ui/themes/theme-manager.js';
+import { mockInkSpinner } from './src/test-utils/mockSpinner.js';
+
+// Globally mock ink-spinner to prevent non-deterministic snapshot/act flakes.
+mockInkSpinner();
 
 // Unset CI environment variable so that ink renders dynamically as it does in a real terminal
 if (process.env.CI !== undefined) {


### PR DESCRIPTION
## Summary

Tests were flaking because the animated spinner was animating during tests.

Fixes #24048