### PR TITLE
feat(cli): natively emit Thoughts in stream-json mode for API consumers

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -345,6 +345,15 @@ export async function runNonInteractive({
               });
             }
             toolCallRequests.push(event.value);
+          } else if (event.type === GeminiEventType.Thought) {
+            if (streamFormatter) {
+              streamFormatter.emitEvent({
+                type: JsonStreamEventType.THOUGHT,
+                timestamp: new Date().toISOString(),
+                subject: event.value.subject,
+                content: event.value.description,
+              });
+            }
           } else if (event.type === GeminiEventType.LoopDetected) {
             if (streamFormatter) {
               streamFormatter.emitEvent({

--- a/packages/core/src/output/types.ts
+++ b/packages/core/src/output/types.ts
@@ -33,6 +33,7 @@ export enum JsonStreamEventType {
   TOOL_RESULT = 'tool_result',
   ERROR = 'error',
   RESULT = 'result',
+  THOUGHT = 'thought',
 }
 
 export interface BaseJsonStreamEvent {
@@ -107,10 +108,16 @@ export interface ResultEvent extends BaseJsonStreamEvent {
   stats?: StreamStats;
 }
 
+export interface ThoughtEvent extends BaseJsonStreamEvent {
+  type: JsonStreamEventType.THOUGHT;
+  content: string;
+}
+
 export type JsonStreamEvent =
   | InitEvent
   | MessageEvent
   | ToolUseEvent
   | ToolResultEvent
   | ErrorEvent
-  | ResultEvent;
+  | ResultEvent
+  | ThoughtEvent;


### PR DESCRIPTION
## Summary

Exposes native `GeminiEventType.Thought` reasoning traces via the `--output-format stream-json` pipeline. This provides headless orchestrators and API consumers literal access to the AI's internal reasoning streams as parsable NDJSON packets natively, enabling live-rendering of thought accordions without throwing away the structured data.

## Details

Previously, when the configuration was placed into `stream-json` machine-readable output formats, internal `ThoughtSummary` events were bypassed, meaning headless orchestration tools couldn't present live AI thinking phases to their end-users. 

This PR dynamically integrates the gap by mapping the existing `GeminiEventType.Thought` events out of the `core` stream loop straight into a new `JsonStreamEventType.THOUGHT` (`{"type": "thought"}`) emit on the `streamFormatter` when evaluating in non-interactive mode. No existing tools, object payloads, or configurations break, and no command-line arguments are altered.


## Related Issues

Fixes #24058


## How to Validate

1. Start Gemini using `--output-format stream-json` and force a complex logic query to evaluate reasoning:
`gemini -m gemini-3.1-pro-preview -p "Explain quantum superposition in 200 words" --output-format stream-json`
2. Parse the `stdout` NDJSON stream and note the native sequence of packets mapping:
`{"type":"thought", "timestamp":"...", "content":"[subject] description..."}`

## Pre-Merge Checklist
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
