### PR TITLE
fix(core): prevent infinite retry loop and UI hang on 429 errors

### DIFF
--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -6,7 +6,6 @@
 
 import { ThinkingLevel } from '@google/genai';
 import type { ModelConfigServiceConfig } from '../services/modelConfigService.js';
-import { DEFAULT_THINKING_MODE } from './models.js';
 
 // The default model configs. We use `base` as the parent for all of our model
 // configs, while `chat-base`, a child of `base`, is the parent of the models

--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -36,7 +36,9 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
     'chat-base-2.5': {
       extends: 'chat-base',
       modelConfig: {
-        generateContentConfig: {},
+        generateContentConfig: {
+          thinkingConfig: undefined,
+        },
       },
     },
     'chat-base-3': {

--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -37,11 +37,7 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
     'chat-base-2.5': {
       extends: 'chat-base',
       modelConfig: {
-        generateContentConfig: {
-          thinkingConfig: {
-            thinkingBudget: DEFAULT_THINKING_MODE,
-          },
-        },
+        generateContentConfig: {},
       },
     },
     'chat-base-3': {

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -324,21 +324,6 @@ export async function retryWithBackoff<T>(
           debugLogger.warn(
             `Attempt ${attempt} failed${errorMessage ? `: ${errorMessage}` : ''}. Max attempts reached`,
           );
-          if (onPersistent429) {
-            try {
-              const fallbackModel = await onPersistent429(
-                authType,
-                classifiedError,
-              );
-              if (fallbackModel) {
-                attempt = 0; // Reset attempts and retry with the new model.
-                currentDelay = initialDelayMs;
-                continue;
-              }
-            } catch (fallbackError) {
-              debugLogger.warn('Model fallback failed:', fallbackError);
-            }
-          }
           throw classifiedError instanceof RetryableQuotaError
             ? classifiedError
             : error;


### PR DESCRIPTION
## Summary

This PR fixes a critical regression introduced in v0.35.2 where the Gemini CLI would get stuck in an infinite retry loop or hang indefinitely when encountering 429 (Too Many Requests) errors. 

## Details

The issue was caused by two primary factors:
1. **Infinite Retry Loop**: In `packages/core/src/utils/retry.ts`, the `retryWithBackoff` function was calling the fallback handler (`onPersistent429`) for standard `RetryableQuotaError` (429) events after exhausting the maximum number of attempts. This triggered a UI dialog in the CLI. Selecting "Retry" would reset the attempt counter, leading to an infinite cycle if the quota was genuinely exhausted.
2. **UI Hang**: The CLI's fallback handler returns a promise that only resolves when the user makes a choice. If the UI state became desynchronized (e.g., the dialog failed to render), the promise would remain pending forever, keeping the agent turn stuck.

**Changes:**
- **`packages/core/src/utils/retry.ts`**: Reverted the `onPersistent429` call from the `RetryableQuotaError` block. Persistent 429s after max attempts are now correctly thrown as final errors, matching the stable v0.34.0 behavior.
- **`packages/core/src/config/defaultModelConfigs.ts`**: 
    - Removed unsupported `thinkingBudget` from the `chat-base-2.5` configuration (Gemini 2.5 models do not support "thoughts").
    - Explicitly set `thinkingConfig: undefined` for `chat-base-2.5` to ensure it correctly overrides inherited settings (per code review feedback).
    - Removed an unused import (`DEFAULT_THINKING_MODE`) that was causing TypeScript compilation errors.

## Related Issues

Fixes #23988
Fixes #24084
Fixes #23990

Cf. also
#24006
#23982
#23900
#23939
etc

Fixes the "this is taking a bit longer..." hang reported by users in version 0.35.2.

(Probably there is also a serverside issue though, as in #24077)


## How to Validate

1. **Simulate 429**: Use a model where the quota is exhausted.
2. **Run CLI**: Start the CLI and send a prompt.
3. **Observe**: The CLI should attempt the configured number of retries and then terminate with a final 429 error message, rather than hanging on "this is taking a bit longer..." indefinitely.
4. **Build**: Verify the project builds successfully using `npm run build:all`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
