### PR TITLE
fix(cli): refine shell focus toast color and text

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1108,6 +1108,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     toggleBackgroundShell,
     backgroundCurrentShell,
     backgroundShells,
+    isCursorHidden,
     dismissBackgroundShell,
     retryStatus,
   } = useGeminiStream(
@@ -1177,6 +1178,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     pendingToolCalls,
     embeddedShellFocused,
     isInteractiveShellEnabled: config.isInteractiveShellEnabled(),
+    isCursorHidden,
   });
 
   const shouldShowActionRequiredTitle = inactivityStatus === 'action_required';
@@ -2326,6 +2328,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       settingsNonce,
       backgroundShells,
       activeBackgroundShellPid,
+      isCursorHidden,
       backgroundShellHeight,
       isBackgroundShellListOpen,
       adminSettingsChanged,
@@ -2454,6 +2457,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       isBackgroundShellListOpen,
       activeBackgroundShellPid,
       backgroundShells,
+      isCursorHidden,
       adminSettingsChanged,
       newAgents,
       showIsExpandableHint,

--- a/packages/cli/src/ui/components/StatusRow.test.tsx
+++ b/packages/cli/src/ui/components/StatusRow.test.tsx
@@ -13,6 +13,7 @@ import { type TextBuffer } from '../components/shared/text-buffer.js';
 import { type SessionStatsState } from '../contexts/SessionContext.js';
 import { type ThoughtSummary } from '../types.js';
 import { ApprovalMode } from '@google/gemini-cli-core';
+import { INTERACTIVE_SHELL_WAITING_PHRASE } from '../hooks/usePhraseCycler.js';
 
 vi.mock('../hooks/useComposerStatus.js', () => ({
   useComposerStatus: vi.fn(),
@@ -106,7 +107,7 @@ describe('<StatusRow />', () => {
     );
 
     await waitUntilReady();
-    expect(lastFrame()).toContain('! Shell awaiting input (Tab to focus)');
+    expect(lastFrame()).toContain(INTERACTIVE_SHELL_WAITING_PHRASE);
   });
 
   it('renders tip with absolute positioning when it fits but might collide (verification of container logic)', async () => {

--- a/packages/cli/src/ui/components/StatusRow.tsx
+++ b/packages/cli/src/ui/components/StatusRow.tsx
@@ -313,8 +313,8 @@ export const StatusRow: React.FC<StatusRowProps> = ({
               </Box>
             ) : isInteractiveShellWaiting ? (
               <Box width="100%" marginLeft={LAYOUT.INDICATOR_LEFT_MARGIN}>
-                <Text color={theme.status.warning}>
-                  ! Shell awaiting input (Tab to focus)
+                <Text color={theme.ui.active}>
+                  Shell awaiting input (Tab to focus)
                 </Text>
               </Box>
             ) : (

--- a/packages/cli/src/ui/components/StatusRow.tsx
+++ b/packages/cli/src/ui/components/StatusRow.tsx
@@ -314,7 +314,7 @@ export const StatusRow: React.FC<StatusRowProps> = ({
             ) : isInteractiveShellWaiting ? (
               <Box width="100%" marginLeft={LAYOUT.INDICATOR_LEFT_MARGIN}>
                 <Text color={theme.ui.active}>
-                  Shell awaiting input (Tab to focus)
+                  {INTERACTIVE_SHELL_WAITING_PHRASE}
                 </Text>
               </Box>
             ) : (

--- a/packages/cli/src/ui/components/__snapshots__/InputPrompt.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/InputPrompt.test.tsx.snap
@@ -78,6 +78,13 @@ exports[`InputPrompt > mouse interaction > should toggle paste expansion on doub
 "
 `;
 
+exports[`InputPrompt > mouse interaction > should toggle paste expansion on double-click 4`] = `
+"▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+ > [Pasted Text: 10 lines]                                                                          
+▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+"
+`;
+
 exports[`InputPrompt > snapshots > should not show inverted cursor when shell is focused 1`] = `
 "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
  >   Type your message or @path/to/file                                                             

--- a/packages/cli/src/ui/components/__snapshots__/InputPrompt.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/InputPrompt.test.tsx.snap
@@ -78,13 +78,6 @@ exports[`InputPrompt > mouse interaction > should toggle paste expansion on doub
 "
 `;
 
-exports[`InputPrompt > mouse interaction > should toggle paste expansion on double-click 4`] = `
-"▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
- > [Pasted Text: 10 lines]                                                                          
-▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-"
-`;
-
 exports[`InputPrompt > snapshots > should not show inverted cursor when shell is focused 1`] = `
 "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
  >   Type your message or @path/to/file                                                             

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -217,6 +217,7 @@ export interface UIState {
   settingsNonce: number;
   backgroundShells: Map<number, BackgroundShell>;
   activeBackgroundShellPid: number | null;
+  isCursorHidden?: boolean;
   backgroundShellHeight: number;
   isBackgroundShellListOpen: boolean;
   adminSettingsChanged: boolean;

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -242,7 +242,12 @@ export const useShellCommandProcessor = (
       // Subscribe to future updates (data only)
       const dataUnsubscribe = ShellExecutionService.subscribe(pid, (event) => {
         if (event.type === 'data') {
-          dispatch({ type: 'APPEND_SHELL_OUTPUT', pid, chunk: event.chunk });
+          dispatch({
+            type: 'APPEND_SHELL_OUTPUT',
+            pid,
+            chunk: event.chunk,
+            isCursorHidden: event.isCursorHidden,
+          });
         } else if (event.type === 'binary_detected') {
           dispatch({ type: 'UPDATE_SHELL', pid, update: { isBinary: true } });
         } else if (event.type === 'binary_progress') {
@@ -381,6 +386,8 @@ export const useShellCommandProcessor = (
                     pid: executionPid,
                     chunk:
                       event.type === 'data' ? event.chunk : cumulativeStdout,
+                    isCursorHidden:
+                      event.type === 'data' ? event.isCursorHidden : undefined,
                   });
                   return;
                 }
@@ -396,7 +403,12 @@ export const useShellCommandProcessor = (
                 }
 
                 if (shouldUpdate) {
-                  dispatch({ type: 'SET_OUTPUT_TIME', time: Date.now() });
+                  dispatch({
+                    type: 'SET_OUTPUT_TIME',
+                    time: Date.now(),
+                    isCursorHidden:
+                      event.type === 'data' ? event.isCursorHidden : undefined,
+                  });
                   setPendingHistoryItem((prevItem) => {
                     if (prevItem?.type === 'tool_group') {
                       return {
@@ -550,5 +562,6 @@ export const useShellCommandProcessor = (
     registerBackgroundShell,
     dismissBackgroundShell,
     backgroundShells: state.backgroundShells,
+    isCursorHidden: state.isCursorHidden,
   };
 };

--- a/packages/cli/src/ui/hooks/shellReducer.ts
+++ b/packages/cli/src/ui/hooks/shellReducer.ts
@@ -14,6 +14,7 @@ export interface BackgroundShell {
   binaryBytesReceived: number;
   status: 'running' | 'exited';
   exitCode?: number;
+  isCursorHidden?: boolean;
 }
 
 export interface ShellState {
@@ -21,11 +22,12 @@ export interface ShellState {
   lastShellOutputTime: number;
   backgroundShells: Map<number, BackgroundShell>;
   isBackgroundShellVisible: boolean;
+  isCursorHidden?: boolean;
 }
 
 export type ShellAction =
   | { type: 'SET_ACTIVE_PTY'; pid: number | null }
-  | { type: 'SET_OUTPUT_TIME'; time: number }
+  | { type: 'SET_OUTPUT_TIME'; time: number; isCursorHidden?: boolean }
   | { type: 'SET_VISIBILITY'; visible: boolean }
   | { type: 'TOGGLE_VISIBILITY' }
   | {
@@ -35,7 +37,12 @@ export type ShellAction =
       initialOutput: string | AnsiOutput;
     }
   | { type: 'UPDATE_SHELL'; pid: number; update: Partial<BackgroundShell> }
-  | { type: 'APPEND_SHELL_OUTPUT'; pid: number; chunk: string | AnsiOutput }
+  | {
+      type: 'APPEND_SHELL_OUTPUT';
+      pid: number;
+      chunk: string | AnsiOutput;
+      isCursorHidden?: boolean;
+    }
   | { type: 'SYNC_BACKGROUND_SHELLS' }
   | { type: 'DISMISS_SHELL'; pid: number };
 
@@ -54,7 +61,11 @@ export function shellReducer(
     case 'SET_ACTIVE_PTY':
       return { ...state, activeShellPtyId: action.pid };
     case 'SET_OUTPUT_TIME':
-      return { ...state, lastShellOutputTime: action.time };
+      return {
+        ...state,
+        lastShellOutputTime: action.time,
+        isCursorHidden: action.isCursorHidden,
+      };
     case 'SET_VISIBILITY':
       return { ...state, isBackgroundShellVisible: action.visible };
     case 'TOGGLE_VISIBILITY':
@@ -103,6 +114,9 @@ export function shellReducer(
         newOutput = action.chunk;
       }
       shell.output = newOutput;
+      if (action.isCursorHidden !== undefined) {
+        shell.isCursorHidden = action.isCursorHidden;
+      }
 
       const nextState = { ...state, lastShellOutputTime: Date.now() };
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -371,6 +371,7 @@ export const useGeminiStream = (
     registerBackgroundShell,
     dismissBackgroundShell,
     backgroundShells,
+    isCursorHidden,
   } = useShellCommandProcessor(
     addItem,
     setPendingHistoryItem,
@@ -2028,6 +2029,7 @@ export const useGeminiStream = (
     toggleBackgroundShell,
     backgroundCurrentShell,
     backgroundShells,
+    isCursorHidden,
     dismissBackgroundShell,
     retryStatus,
   };

--- a/packages/cli/src/ui/hooks/usePhraseCycler.ts
+++ b/packages/cli/src/ui/hooks/usePhraseCycler.ts
@@ -11,7 +11,7 @@ import { WITTY_LOADING_PHRASES } from '../constants/wittyPhrases.js';
 export const PHRASE_CHANGE_INTERVAL_MS = 10000;
 export const WITTY_PHRASE_CHANGE_INTERVAL_MS = 5000;
 export const INTERACTIVE_SHELL_WAITING_PHRASE =
-  '! Shell awaiting input (Tab to focus)';
+  'Shell awaiting input (Tab to focus)';
 
 /**
  * Custom hook to manage cycling through loading phrases.

--- a/packages/cli/src/ui/hooks/useShellInactivityStatus.test.ts
+++ b/packages/cli/src/ui/hooks/useShellInactivityStatus.test.ts
@@ -106,4 +106,17 @@ describe('useShellInactivityStatus', () => {
     });
     expect(result.current.shouldShowFocusHint).toBe(false);
   });
+
+  it('should suppress all inactivity indicators when cursor is hidden', async () => {
+    const { result } = await renderHook(() =>
+      useShellInactivityStatus({ ...defaultProps, isCursorHidden: true }),
+    );
+
+    // After 30s, status should still be 'none' and focus hint false
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30000);
+    });
+    expect(result.current.inactivityStatus).toBe('none');
+    expect(result.current.shouldShowFocusHint).toBe(false);
+  });
 });

--- a/packages/cli/src/ui/hooks/useShellInactivityStatus.ts
+++ b/packages/cli/src/ui/hooks/useShellInactivityStatus.ts
@@ -21,6 +21,7 @@ interface ShellInactivityStatusProps {
   pendingToolCalls: TrackedToolCall[];
   embeddedShellFocused: boolean;
   isInteractiveShellEnabled: boolean;
+  isCursorHidden?: boolean;
 }
 
 export type InactivityStatus = 'none' | 'action_required' | 'silent_working';
@@ -41,6 +42,7 @@ export const useShellInactivityStatus = ({
   pendingToolCalls,
   embeddedShellFocused,
   isInteractiveShellEnabled,
+  isCursorHidden,
 }: ShellInactivityStatusProps): ShellInactivityStatus => {
   const { operationStartTime, isRedirectionActive } = useTurnActivityMonitor(
     streamingState,
@@ -49,7 +51,10 @@ export const useShellInactivityStatus = ({
   );
 
   const isAwaitingFocus =
-    !!activePtyId && !embeddedShellFocused && isInteractiveShellEnabled;
+    !!activePtyId &&
+    !embeddedShellFocused &&
+    isInteractiveShellEnabled &&
+    !isCursorHidden;
 
   // Derive whether output was produced by comparing the last output time to when the operation started.
   const hasProducedOutput = lastOutputTime > operationStartTime;

--- a/packages/core/src/services/executionLifecycleService.ts
+++ b/packages/core/src/services/executionLifecycleService.ts
@@ -36,6 +36,7 @@ export type ExecutionOutputEvent =
   | {
       type: 'data';
       chunk: string | AnsiOutput;
+      isCursorHidden?: boolean;
     }
   | {
       type: 'binary_detected';

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -299,10 +299,12 @@ describe('ShellExecutionService', () => {
       expect(result.output.trim()).toBe('file1.txt');
       expect(handle.pid).toBe(12345);
 
-      expect(onOutputEventMock).toHaveBeenCalledWith({
-        type: 'data',
-        chunk: createExpectedAnsiOutput('file1.txt'),
-      });
+      expect(onOutputEventMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'data',
+          chunk: createExpectedAnsiOutput('file1.txt'),
+        }),
+      );
     });
 
     it('should strip ANSI color codes from output', async () => {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -46,6 +46,19 @@ import {
 } from './executionLifecycleService.js';
 const { Terminal } = pkg;
 
+/**
+ * Internal interfaces to access non-public xterm properties.
+ */
+interface XTermCore {
+  coreService: {
+    isCursorHidden: boolean;
+  };
+}
+
+interface XTermInternal {
+  _core?: XTermCore;
+}
+
 const MAX_CHILD_PROCESS_BUFFER_SIZE = 16 * 1024 * 1024; // 16MB
 
 /**
@@ -952,9 +965,10 @@ export class ShellExecutionService {
 
         if (output !== finalOutput) {
           output = finalOutput;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion
-          const isCursorHidden = (headlessTerminal as any)._core?.coreService
-            ?.isCursorHidden as boolean | undefined;
+          const isCursorHidden =
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+            (headlessTerminal as unknown as XTermInternal)._core?.coreService
+              ?.isCursorHidden;
           const event: ShellOutputEvent = {
             type: 'data',
             chunk: finalOutput,
@@ -1307,9 +1321,10 @@ export class ShellExecutionService {
         startLine,
         endLine,
       );
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion
-      const isCursorHidden = (activePty.headlessTerminal as any)._core
-        ?.coreService?.isCursorHidden as boolean | undefined;
+      const isCursorHidden =
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        (activePty.headlessTerminal as unknown as XTermInternal)._core
+          ?.coreService?.isCursorHidden;
       const event: ShellOutputEvent = {
         type: 'data',
         chunk: bufferData,

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -952,9 +952,13 @@ export class ShellExecutionService {
 
         if (output !== finalOutput) {
           output = finalOutput;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion
+          const isCursorHidden = (headlessTerminal as any)._core?.coreService
+            ?.isCursorHidden as boolean | undefined;
           const event: ShellOutputEvent = {
             type: 'data',
             chunk: finalOutput,
+            isCursorHidden,
           };
           onOutputEvent(event);
           ExecutionLifecycleService.emitEvent(ptyPid, event);
@@ -1303,7 +1307,14 @@ export class ShellExecutionService {
         startLine,
         endLine,
       );
-      const event: ShellOutputEvent = { type: 'data', chunk: bufferData };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion
+      const isCursorHidden = (activePty.headlessTerminal as any)._core
+        ?.coreService?.isCursorHidden as boolean | undefined;
+      const event: ShellOutputEvent = {
+        type: 'data',
+        chunk: bufferData,
+        isCursorHidden,
+      };
       ExecutionLifecycleService.emitEvent(pid, event);
     }
   }


### PR DESCRIPTION
## Summary

Refine the "Shell awaiting input" toast UX by changing its color to \`theme.ui.active\` (Accent Blue), removing the \`! \` prefix, and significantly reducing false positives by respecting the shell's cursor visibility state.

<img width="1770" height="558" alt="image" src="https://github.com/user-attachments/assets/87e68d45-0316-4a57-bb6e-7ef49d812f55" />


## Details

- **Color Update**: Changed the "Shell awaiting input" toast color from \`theme.status.warning\` to \`theme.ui.active\` in \`StatusRow.tsx\`.
- **Text Update**: Removed the \`! \` prefix from the \`INTERACTIVE_SHELL_WAITING_PHRASE\` constant in \`usePhraseCycler.ts\`.
- **False Positive Reduction**:
    - **Core**: Added tracking for \`isCursorHidden\` state from \`xterm-headless\` in \`ShellExecutionService\`.
    - **Events**: Included \`isCursorHidden\` in \`ShellOutputEvent\` and \`ExecutionOutputEvent\`.
    - **CLI**: Propagated cursor visibility through \`shellReducer\`, \`useShellCommandProcessor\`, and \`useGeminiStream\` to \`AppContainer\`.
    - **Logic**: Updated \`useShellInactivityStatus\` to suppress focus hints and inactivity statuses when the shell cursor is hidden (indicating the shell is not awaiting input).
- **Refactor**: Updated \`StatusRow.tsx\` to use the \`INTERACTIVE_SHELL_WAITING_PHRASE\` constant instead of a hardcoded string.
- **Snapshots**: Updated an obsolete snapshot in \`InputPrompt.test.tsx.snap\` to reflect the changes.
- **Verification**: 
    - Added unit tests in \`useShellInactivityStatus.test.ts\` to verify suppression logic.
    - Updated core tests in \`shellExecutionService.test.ts\` to match new event structure.
    - All CLI and core tests passed, and the \`preflight\` suite was successful on MacOS.

## Related Issues

Partially fixes #24041 (UX: Refine layout to unify session modes and reorganize composer).
Addresses feedback regarding the jarring nature of the yellow warning color and the prevalence of false positives during standard interactive operations.

## How to Validate

1. Run the CLI in interactive mode with a shell tool.
2. Trigger the "Shell awaiting input" toast (e.g., by running a command that waits for input).
3. Verify that the toast is blue and does not have a leading \`! \`.
4. Run a long-running command that hides the cursor (like \`top\` or some long builds). Verify that the "Shell awaiting input" toast does NOT appear after 5s.
5. Run \`npm test -w @google/gemini-cli -- src/ui/hooks/useShellInactivityStatus.test.ts\` to verify tests pass.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
