### PR TITLE
feat(core): add target parameter to save_memory for project-specific GEMINI.md routing

### DIFF
--- a/packages/core/src/prompts/snippets-memory-manager.test.ts
+++ b/packages/core/src/prompts/snippets-memory-manager.test.ts
@@ -18,7 +18,8 @@ describe('renderOperationalGuidelines - memoryManagerEnabled', () => {
   it('should include standard memory tool guidance when memoryManagerEnabled is false', () => {
     const result = renderOperationalGuidelines(baseOptions);
     expect(result).toContain('save_memory');
-    expect(result).toContain('persistent user-related information');
+    expect(result).toContain('persistent information only');
+    expect(result).toContain('NEVER use `write_file` or `replace`');
     expect(result).not.toContain('subagent');
   });
 
@@ -29,6 +30,7 @@ describe('renderOperationalGuidelines - memoryManagerEnabled', () => {
     });
     expect(result).toContain('save_memory');
     expect(result).toContain('subagent');
+    expect(result).not.toContain('NEVER use `write_file` or `replace`');
     expect(result).not.toContain('persistent user-related information');
   });
 });

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -820,9 +820,9 @@ function toolUsageRememberingFacts(
 - **Memory Tool:** You MUST use ${formatToolName(MEMORY_TOOL_NAME)} to proactively record facts, preferences, and workflows that apply across all sessions. Whenever the user explicitly tells you to "remember" something, or when they state a preference or workflow (like "always lint after editing"), you MUST immediately call the save_memory subagent. Never save transient session state. Do not use memory to store summaries of code changes, bug fixes, or findings discovered during a task; this tool is strictly for persistent general knowledge.`;
   }
   const base = `
-- **Memory Tool:** Use ${formatToolName(MEMORY_TOOL_NAME)} only for global user preferences, personal facts, or high-level information that applies across all sessions. Never save workspace-specific context, local file paths, or transient session state. Do not use memory to store summaries of code changes, bug fixes, or findings discovered during a task; this tool is for persistent user-related information only.`;
+- **Memory Tool:** Use ${formatToolName(MEMORY_TOOL_NAME)} to persist facts, preferences, and context across sessions. By default it appends to the global ~/.gemini/GEMINI.md. For project-specific or directory-specific context, pass the absolute path to an existing GEMINI.md file via the \`target\` parameter. Never save transient session state. Do not use memory to store summaries of code changes, bug fixes, or findings discovered during a task; this tool is for persistent information only. NEVER use \`write_file\` or \`replace\` to add memories to GEMINI.md files — always use ${formatToolName(MEMORY_TOOL_NAME)}.`;
   const suffix = options.interactive
-    ? ' If unsure whether a fact is worth remembering globally, ask the user.'
+    ? ' If unsure whether a fact should be global or project-specific, ask the user.'
     : '';
   return base + suffix;
 }

--- a/packages/core/src/tools/definitions/__snapshots__/coreToolsModelSnapshots.test.ts.snap
+++ b/packages/core/src/tools/definitions/__snapshots__/coreToolsModelSnapshots.test.ts.snap
@@ -640,19 +640,23 @@ exports[`coreTools snapshots for specific models > Model: gemini-2.5-pro > snaps
 exports[`coreTools snapshots for specific models > Model: gemini-2.5-pro > snapshot for tool: save_memory 1`] = `
 {
   "description": "
-Saves concise global user context (preferences, facts) for use across ALL workspaces.
+Saves concise user context (preferences, facts) by appending to a GEMINI.md file.
 
-### CRITICAL: GLOBAL CONTEXT ONLY
-NEVER save workspace-specific context, local paths, or commands (e.g. "The entry point is src/index.js", "The test command is npm test"). These are local to the current workspace and must NOT be saved globally. EXCLUSIVELY for context relevant across ALL workspaces.
+By default, appends to the global ~/.gemini/GEMINI.md (loaded in every workspace). Use the optional 'target' parameter to write to a project or subdirectory GEMINI.md instead (the file must already exist).
 
 - Use for "Remember X" or clear personal facts.
-- Do NOT use for session context.",
+- Do NOT use for session context.
+- For project-specific context, pass the absolute path to the project's GEMINI.md via 'target'.",
   "name": "save_memory",
   "parametersJsonSchema": {
     "additionalProperties": false,
     "properties": {
       "fact": {
         "description": "The specific fact or piece of information to remember. Should be a clear, self-contained statement.",
+        "type": "string",
+      },
+      "target": {
+        "description": "Optional: Absolute path to an existing GEMINI.md file to append to. When omitted, appends to the global ~/.gemini/GEMINI.md. Use this to save project-specific or directory-specific context to an existing GEMINI.md in the workspace.",
         "type": "string",
       },
     },
@@ -1433,13 +1437,17 @@ exports[`coreTools snapshots for specific models > Model: gemini-3-pro-preview >
 
 exports[`coreTools snapshots for specific models > Model: gemini-3-pro-preview > snapshot for tool: save_memory 1`] = `
 {
-  "description": "Persists global preferences or facts across ALL future sessions. Use this for recurring instructions like coding styles or tool aliases. Unlike 'write_file', which is for project-specific files, this appends to a global memory file loaded in every workspace. If you are unsure whether a fact should be remembered globally, ask the user first. CRITICAL: Do not use for session-specific context or temporary data.",
+  "description": "Persists preferences or facts across future sessions by appending to a GEMINI.md file. By default appends to the global ~/.gemini/GEMINI.md (loaded in every workspace). Use the optional 'target' parameter to write to a project or subdirectory GEMINI.md instead (the file must already exist). CRITICAL: Do not use for session-specific context or temporary data.",
   "name": "save_memory",
   "parametersJsonSchema": {
     "additionalProperties": false,
     "properties": {
       "fact": {
-        "description": "A concise, global fact or preference (e.g., 'I prefer using tabs'). Do not include local paths or project-specific names.",
+        "description": "A concise fact or preference to remember. Should be a clear, self-contained statement.",
+        "type": "string",
+      },
+      "target": {
+        "description": "Optional: Absolute path to an existing GEMINI.md file to append to. When omitted, appends to the global ~/.gemini/GEMINI.md. Use this to save project-specific or directory-specific context to an existing GEMINI.md in the workspace.",
         "type": "string",
       },
     },

--- a/packages/core/src/tools/definitions/base-declarations.ts
+++ b/packages/core/src/tools/definitions/base-declarations.ts
@@ -92,6 +92,7 @@ export const READ_MANY_PARAM_USE_DEFAULT_EXCLUDES = 'useDefaultExcludes';
 // -- save_memory --
 export const MEMORY_TOOL_NAME = 'save_memory';
 export const MEMORY_PARAM_FACT = 'fact';
+export const MEMORY_PARAM_TARGET = 'target';
 
 // -- get_internal_docs --
 export const GET_INTERNAL_DOCS_TOOL_NAME = 'get_internal_docs';

--- a/packages/core/src/tools/definitions/model-family-sets/default-legacy.ts
+++ b/packages/core/src/tools/definitions/model-family-sets/default-legacy.ts
@@ -59,6 +59,7 @@ import {
   READ_MANY_PARAM_RECURSIVE,
   READ_MANY_PARAM_USE_DEFAULT_EXCLUDES,
   MEMORY_PARAM_FACT,
+  MEMORY_PARAM_TARGET,
   TODOS_PARAM_TODOS,
   TODOS_ITEM_PARAM_DESCRIPTION,
   TODOS_ITEM_PARAM_STATUS,
@@ -513,13 +514,13 @@ Use this tool when the user's query implies needing the content of several files
   save_memory: {
     name: MEMORY_TOOL_NAME,
     description: `
-Saves concise global user context (preferences, facts) for use across ALL workspaces.
+Saves concise user context (preferences, facts) by appending to a GEMINI.md file.
 
-### CRITICAL: GLOBAL CONTEXT ONLY
-NEVER save workspace-specific context, local paths, or commands (e.g. "The entry point is src/index.js", "The test command is npm test"). These are local to the current workspace and must NOT be saved globally. EXCLUSIVELY for context relevant across ALL workspaces.
+By default, appends to the global ~/.gemini/GEMINI.md (loaded in every workspace). Use the optional 'target' parameter to write to a project or subdirectory GEMINI.md instead (the file must already exist).
 
 - Use for "Remember X" or clear personal facts.
-- Do NOT use for session context.`,
+- Do NOT use for session context.
+- For project-specific context, pass the absolute path to the project's GEMINI.md via 'target'.`,
     parametersJsonSchema: {
       type: 'object',
       properties: {
@@ -527,6 +528,11 @@ NEVER save workspace-specific context, local paths, or commands (e.g. "The entry
           type: 'string',
           description:
             'The specific fact or piece of information to remember. Should be a clear, self-contained statement.',
+        },
+        [MEMORY_PARAM_TARGET]: {
+          type: 'string',
+          description:
+            'Optional: Absolute path to an existing GEMINI.md file to append to. When omitted, appends to the global ~/.gemini/GEMINI.md. Use this to save project-specific or directory-specific context to an existing GEMINI.md in the workspace.',
         },
       },
       required: [MEMORY_PARAM_FACT],

--- a/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts
+++ b/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts
@@ -59,6 +59,7 @@ import {
   READ_MANY_PARAM_RECURSIVE,
   READ_MANY_PARAM_USE_DEFAULT_EXCLUDES,
   MEMORY_PARAM_FACT,
+  MEMORY_PARAM_TARGET,
   TODOS_PARAM_TODOS,
   TODOS_ITEM_PARAM_DESCRIPTION,
   TODOS_ITEM_PARAM_STATUS,
@@ -494,14 +495,19 @@ Use this tool when the user's query implies needing the content of several files
 
   save_memory: {
     name: MEMORY_TOOL_NAME,
-    description: `Persists global preferences or facts across ALL future sessions. Use this for recurring instructions like coding styles or tool aliases. Unlike '${WRITE_FILE_TOOL_NAME}', which is for project-specific files, this appends to a global memory file loaded in every workspace. If you are unsure whether a fact should be remembered globally, ask the user first. CRITICAL: Do not use for session-specific context or temporary data.`,
+    description: `Persists preferences or facts across future sessions by appending to a GEMINI.md file. By default appends to the global ~/.gemini/GEMINI.md (loaded in every workspace). Use the optional 'target' parameter to write to a project or subdirectory GEMINI.md instead (the file must already exist). CRITICAL: Do not use for session-specific context or temporary data.`,
     parametersJsonSchema: {
       type: 'object',
       properties: {
         [MEMORY_PARAM_FACT]: {
           type: 'string',
           description:
-            "A concise, global fact or preference (e.g., 'I prefer using tabs'). Do not include local paths or project-specific names.",
+            'A concise fact or preference to remember. Should be a clear, self-contained statement.',
+        },
+        [MEMORY_PARAM_TARGET]: {
+          type: 'string',
+          description:
+            'Optional: Absolute path to an existing GEMINI.md file to append to. When omitted, appends to the global ~/.gemini/GEMINI.md. Use this to save project-specific or directory-specific context to an existing GEMINI.md in the workspace.',
         },
       },
       required: [MEMORY_PARAM_FACT],

--- a/packages/core/src/tools/memoryTool.test.ts
+++ b/packages/core/src/tools/memoryTool.test.ts
@@ -19,6 +19,9 @@ import {
   getCurrentGeminiMdFilename,
   getAllGeminiMdFilenames,
   DEFAULT_CONTEXT_FILENAME,
+  validateTargetPath,
+  resolveMemoryFilePath,
+  getGlobalMemoryFilePath,
 } from './memoryTool.js';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
@@ -36,6 +39,7 @@ vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...(actual as object),
+    access: vi.fn(),
     mkdir: vi.fn(),
     readFile: vi.fn(),
     writeFile: vi.fn(),
@@ -60,6 +64,7 @@ describe('MemoryTool', () => {
 
   beforeEach(() => {
     vi.mocked(os.homedir).mockReturnValue(path.join('/mock', 'home'));
+    vi.mocked(fs.access).mockReset().mockResolvedValue(undefined);
     vi.mocked(fs.mkdir).mockReset().mockResolvedValue(undefined);
     vi.mocked(fs.readFile).mockReset().mockResolvedValue('');
     vi.mocked(fs.writeFile).mockReset().mockResolvedValue(undefined);
@@ -113,9 +118,7 @@ describe('MemoryTool', () => {
     it('should have correct name, displayName, description, and schema', () => {
       expect(memoryTool.name).toBe('save_memory');
       expect(memoryTool.displayName).toBe('SaveMemory');
-      expect(memoryTool.description).toContain(
-        'Saves concise global user context',
-      );
+      expect(memoryTool.description).toContain('Saves concise user context');
       expect(memoryTool.schema).toBeDefined();
       expect(memoryTool.schema.name).toBe('save_memory');
       expect(memoryTool.schema.parametersJsonSchema).toStrictEqual({
@@ -126,6 +129,11 @@ describe('MemoryTool', () => {
             type: 'string',
             description:
               'The specific fact or piece of information to remember. Should be a clear, self-contained statement.',
+          },
+          target: {
+            type: 'string',
+            description:
+              'Optional: Absolute path to an existing GEMINI.md file to append to. When omitted, appends to the global ~/.gemini/GEMINI.md. Use this to save project-specific or directory-specific context to an existing GEMINI.md in the workspace.',
           },
         },
         required: ['fact'],
@@ -376,6 +384,118 @@ describe('MemoryTool', () => {
       };
 
       expect(() => memoryTool.build(attackParams)).toThrow();
+    });
+  });
+
+  describe('target parameter', () => {
+    describe('validateTargetPath', () => {
+      it('should return null for a valid absolute path ending in GEMINI.md', () => {
+        expect(validateTargetPath('/path/to/project/GEMINI.md')).toBeNull();
+      });
+
+      it('should return error for relative paths', () => {
+        const result = validateTargetPath('./GEMINI.md');
+        expect(result).toContain('must be an absolute path');
+      });
+
+      it('should return error for paths not ending in GEMINI.md', () => {
+        const result = validateTargetPath('/path/to/project/other.md');
+        expect(result).toContain('must point to a GEMINI.md file');
+      });
+
+      it('should return null for paths with ".." that normalize cleanly', () => {
+        // path.normalize resolves '/path/to/../GEMINI.md' to '/path/GEMINI.md'
+        // which no longer contains '..', so validation passes.
+        const result = validateTargetPath('/path/to/../GEMINI.md');
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('resolveMemoryFilePath', () => {
+      it('should return getGlobalMemoryFilePath() when target is undefined', () => {
+        expect(resolveMemoryFilePath(undefined)).toBe(
+          getGlobalMemoryFilePath(),
+        );
+      });
+
+      it('should return the normalized target path when target is provided', () => {
+        const target = '/some/project/GEMINI.md';
+        expect(resolveMemoryFilePath(target)).toBe(path.normalize(target));
+      });
+    });
+
+    describe('writing to a target file', () => {
+      let memoryTool: MemoryTool;
+
+      beforeEach(() => {
+        const bus = createMockMessageBus();
+        getMockMessageBusInstance(bus).defaultToolDecision = 'ask_user';
+        memoryTool = new MemoryTool(bus);
+      });
+
+      it('should write to the target file when it exists', async () => {
+        const targetPath = '/some/project/GEMINI.md';
+        const existingContent = '# Project Context\n';
+
+        vi.mocked(fs.access).mockResolvedValue(undefined);
+        vi.mocked(fs.readFile).mockResolvedValue(existingContent);
+
+        const invocation = memoryTool.build({
+          fact: 'project uses vitest',
+          target: targetPath,
+        });
+        const result = await invocation.execute(mockAbortSignal);
+
+        expect(fs.writeFile).toHaveBeenCalledWith(
+          path.normalize(targetPath),
+          expect.stringContaining('- project uses vitest'),
+          'utf-8',
+        );
+        expect(result.llmContent).toContain('"success":true');
+      });
+
+      it('should return an error when target file does not exist', async () => {
+        const targetPath = '/nonexistent/project/GEMINI.md';
+
+        vi.mocked(fs.access).mockRejectedValue(
+          new Error('ENOENT: no such file or directory'),
+        );
+
+        const invocation = memoryTool.build({
+          fact: 'this should fail',
+          target: targetPath,
+        });
+        const result = await invocation.execute(mockAbortSignal);
+
+        expect(result.llmContent).toContain('"success":false');
+        expect(result.llmContent).toContain('Target file does not exist');
+        expect(result.error?.type).toBe(
+          ToolErrorType.MEMORY_TOOL_EXECUTION_ERROR,
+        );
+      });
+    });
+
+    describe('validation integration', () => {
+      let memoryTool: MemoryTool;
+
+      beforeEach(() => {
+        memoryTool = new MemoryTool(createMockMessageBus());
+      });
+
+      it('should throw when target is a relative path', () => {
+        expect(() =>
+          memoryTool.build({ fact: 'test', target: 'relative/GEMINI.md' }),
+        ).toThrow('must be an absolute path');
+      });
+
+      it('should not throw when target is a valid absolute path', () => {
+        expect(() =>
+          memoryTool.build({
+            fact: 'test',
+            target: '/valid/path/GEMINI.md',
+          }),
+        ).not.toThrow();
+      });
     });
   });
 });

--- a/packages/core/src/tools/memoryTool.ts
+++ b/packages/core/src/tools/memoryTool.ts
@@ -61,6 +61,7 @@ export function getAllGeminiMdFilenames(): string[] {
 
 interface SaveMemoryParams {
   fact: string;
+  target?: string;
   modified_by_user?: boolean;
   modified_content?: string;
 }
@@ -82,17 +83,52 @@ function ensureNewlineSeparation(currentContent: string): string {
 }
 
 /**
- * Reads the current content of the memory file
+ * Reads the current content of a memory file.
  */
-async function readMemoryFileContent(): Promise<string> {
+async function readMemoryFileContent(filePath: string): Promise<string> {
   try {
-    return await fs.readFile(getGlobalMemoryFilePath(), 'utf-8');
+    return await fs.readFile(filePath, 'utf-8');
   } catch (err) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const error = err as Error & { code?: string };
     if (!(error instanceof Error) || error.code !== 'ENOENT') throw err;
     return '';
   }
+}
+
+/**
+ * Validates the target path for a non-global memory save.
+ * Returns an error message string if invalid, or null if valid.
+ */
+export function validateTargetPath(target: string): string | null {
+  if (!path.isAbsolute(target)) {
+    return `Parameter "target" must be an absolute path. Got: "${target}"`;
+  }
+
+  const basename = path.basename(target);
+  const validFilenames = getAllGeminiMdFilenames();
+  if (!validFilenames.includes(basename)) {
+    return `Parameter "target" must point to a ${getCurrentGeminiMdFilename()} file. Got basename: "${basename}"`;
+  }
+
+  // Normalize and reject path traversal
+  const normalized = path.normalize(target);
+  if (normalized.includes('..')) {
+    return `Parameter "target" must not contain path traversal segments (".."). Got: "${target}"`;
+  }
+
+  return null;
+}
+
+/**
+ * Resolves the memory file path from the optional target parameter.
+ * Returns the global memory file path when target is undefined.
+ */
+export function resolveMemoryFilePath(target: string | undefined): string {
+  if (!target) {
+    return getGlobalMemoryFilePath();
+  }
+  return path.normalize(target);
 }
 
 /**
@@ -146,6 +182,7 @@ class MemoryToolInvocation extends BaseToolInvocation<
 > {
   private static readonly allowlist: Set<string> = new Set();
   private proposedNewContent: string | undefined;
+  private readonly resolvedFilePath: string;
 
   constructor(
     params: SaveMemoryParams,
@@ -154,24 +191,24 @@ class MemoryToolInvocation extends BaseToolInvocation<
     displayName?: string,
   ) {
     super(params, messageBus, toolName, displayName);
+    this.resolvedFilePath = resolveMemoryFilePath(params.target);
   }
 
   getDescription(): string {
-    const memoryFilePath = getGlobalMemoryFilePath();
-    return `in ${tildeifyPath(memoryFilePath)}`;
+    return `in ${tildeifyPath(this.resolvedFilePath)}`;
   }
 
   protected override async getConfirmationDetails(
     _abortSignal: AbortSignal,
   ): Promise<ToolEditConfirmationDetails | false> {
-    const memoryFilePath = getGlobalMemoryFilePath();
+    const memoryFilePath = this.resolvedFilePath;
     const allowlistKey = memoryFilePath;
 
     if (MemoryToolInvocation.allowlist.has(allowlistKey)) {
       return false;
     }
 
-    const currentContent = await readMemoryFileContent();
+    const currentContent = await readMemoryFileContent(memoryFilePath);
     const { fact, modified_by_user, modified_content } = this.params;
 
     // If an attacker injects modified_content, use it for the diff
@@ -212,7 +249,28 @@ class MemoryToolInvocation extends BaseToolInvocation<
   }
 
   async execute(_signal: AbortSignal): Promise<ToolResult> {
-    const { fact, modified_by_user, modified_content } = this.params;
+    const { fact, target, modified_by_user, modified_content } = this.params;
+    const memoryFilePath = this.resolvedFilePath;
+
+    // For non-global targets, verify the file already exists.
+    if (target) {
+      try {
+        await fs.access(memoryFilePath);
+      } catch {
+        const errorMsg = `Target file does not exist: "${tildeifyPath(memoryFilePath)}". Omit the "target" parameter to save to the global memory, or create the file first using write_file.`;
+        return {
+          llmContent: JSON.stringify({
+            success: false,
+            error: errorMsg,
+          }),
+          returnDisplay: `Error saving memory: ${errorMsg}`,
+          error: {
+            message: errorMsg,
+            type: ToolErrorType.MEMORY_TOOL_EXECUTION_ERROR,
+          },
+        };
+      }
+    }
 
     try {
       let contentToWrite: string;
@@ -233,17 +291,17 @@ class MemoryToolInvocation extends BaseToolInvocation<
           // This case can be hit in flows without a confirmation step (e.g., --auto-confirm).
           // As a fallback, we recompute the content now. This is safe because
           // computeNewContent sanitizes the input.
-          const currentContent = await readMemoryFileContent();
+          const currentContent = await readMemoryFileContent(memoryFilePath);
           this.proposedNewContent = computeNewContent(currentContent, fact);
         }
         contentToWrite = this.proposedNewContent;
         successMessage = `Okay, I've remembered that: "${sanitizedFact}"`;
       }
 
-      await fs.mkdir(path.dirname(getGlobalMemoryFilePath()), {
+      await fs.mkdir(path.dirname(memoryFilePath), {
         recursive: true,
       });
-      await fs.writeFile(getGlobalMemoryFilePath(), contentToWrite, 'utf-8');
+      await fs.writeFile(memoryFilePath, contentToWrite, 'utf-8');
 
       return {
         llmContent: JSON.stringify({
@@ -296,6 +354,13 @@ export class MemoryTool
       return 'Parameter "fact" must be a non-empty string.';
     }
 
+    if (params.target !== undefined) {
+      const targetError = validateTargetPath(params.target);
+      if (targetError) {
+        return targetError;
+      }
+    }
+
     return null;
   }
 
@@ -319,11 +384,13 @@ export class MemoryTool
 
   getModifyContext(_abortSignal: AbortSignal): ModifyContext<SaveMemoryParams> {
     return {
-      getFilePath: (_params: SaveMemoryParams) => getGlobalMemoryFilePath(),
-      getCurrentContent: async (_params: SaveMemoryParams): Promise<string> =>
-        readMemoryFileContent(),
+      getFilePath: (params: SaveMemoryParams) =>
+        resolveMemoryFilePath(params.target),
+      getCurrentContent: async (params: SaveMemoryParams): Promise<string> =>
+        readMemoryFileContent(resolveMemoryFilePath(params.target)),
       getProposedContent: async (params: SaveMemoryParams): Promise<string> => {
-        const currentContent = await readMemoryFileContent();
+        const filePath = resolveMemoryFilePath(params.target);
+        const currentContent = await readMemoryFileContent(filePath);
         const { fact, modified_by_user, modified_content } = params;
         // Ensure the editor is populated with the same content
         // that the confirmation diff would show.


### PR DESCRIPTION
## Summary

Adds an optional `target` parameter to the `save_memory` tool (non-memory-manager mode) so it can append memories to project-specific or subdirectory-specific GEMINI.md files, not just the global `~/.gemini/GEMINI.md`.

## Details

Previously, with `memoryManager` disabled, `save_memory` was strictly append-only to the global GEMINI.md. If a project or subdirectory already had its own GEMINI.md, there was no way to route memories there — the model would sometimes fall back to `write_file` or `replace` instead.

**Changes:**
- **Tool schema** (`gemini-3.ts`, `default-legacy.ts`): Added optional `target` string parameter accepting an absolute path to an existing GEMINI.md file.
- **Implementation** (`memoryTool.ts`):
  - `validateTargetPath()` — rejects relative paths, non-GEMINI.md filenames, and `..` traversal.
  - `resolveMemoryFilePath()` — returns global path when target is omitted, otherwise the normalized target.
  - File-existence check via `fs.access()` for non-global targets before writing.
  - Threaded resolved path through confirmation, execution, and modify flows.
- **Prompt steering** (`snippets.ts`): Updated non-memory-manager guidance to explain `target` usage and added `NEVER use write_file or replace to add memories to GEMINI.md` steering (non-memory-manager branch only; memory manager agent is unchanged).
- **Tests**: 8 new test cases covering validation, resolution, target file writing, and error handling.

**Behavior:**
| `target` value | Writes to |
|---|---|
| omitted | `~/.gemini/GEMINI.md` (unchanged) |
| `/abs/path/to/GEMINI.md` | That file (must exist) |
| relative path / `..` / wrong filename | Validation error |

## Related Issues

Related to #18007

## How to Validate

1. Run unit tests:
   ```bash
   npm test -w @google/gemini-cli-core -- src/tools/memoryTool.test.ts
   npm test -w @google/gemini-cli-core -- src/prompts/snippets-memory-manager.test.ts
   npm test -w @google/gemini-cli-core -- src/tools/definitions/coreToolsModelSnapshots.test.ts
   ```

2. Manual smoke test with `npm run start`:
   - Ask the CLI to "remember" a project-specific fact — it should use `save_memory` with `target` pointing to the project's existing GEMINI.md.
   - Ask it to remember a global preference — should omit `target` and write to `~/.gemini/GEMINI.md`.
   - If the target file doesn't exist, the tool should return an error message.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
