### PR TITLE
feat(sdd): implement spec-to-tracker bridge and root tracker id generation

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -3688,6 +3688,46 @@ describe('loadCliConfig mcpEnabled', () => {
       expect(config.storage.getPlansDir()).not.toContain('ext-plans-dir');
     });
 
+    it('should use tracker directory from active extension when user has not specified one', async () => {
+      process.argv = ['node', 'script.js'];
+      const settings = createTestMergedSettings({
+        experimental: { plan: true },
+      });
+      const argv = await parseArguments(settings);
+
+      vi.spyOn(ExtensionManager.prototype, 'getExtensions').mockReturnValue([
+        {
+          name: 'ext-tracker',
+          isActive: true,
+          tracker: { directory: 'ext-tracker-dir' },
+        } as unknown as GeminiCLIExtension,
+      ]);
+
+      const config = await loadCliConfig(settings, 'test-session', argv);
+      expect(config.storage.getTrackerDir()).toContain('ext-tracker-dir');
+    });
+
+    it('should NOT use tracker directory from active extension when user has specified one', async () => {
+      process.argv = ['node', 'script.js'];
+      const settings = createTestMergedSettings({
+        general: { tracker: { directory: 'user-tracker-dir' } },
+        experimental: { plan: true },
+      });
+      const argv = await parseArguments(settings);
+
+      vi.spyOn(ExtensionManager.prototype, 'getExtensions').mockReturnValue([
+        {
+          name: 'ext-tracker',
+          isActive: true,
+          tracker: { directory: 'ext-tracker-dir' },
+        } as unknown as GeminiCLIExtension,
+      ]);
+
+      const config = await loadCliConfig(settings, 'test-session', argv);
+      expect(config.storage.getTrackerDir()).toContain('user-tracker-dir');
+      expect(config.storage.getTrackerDir()).not.toContain('ext-tracker-dir');
+    });
+
     it('should NOT use plan directory from inactive extension', async () => {
       process.argv = ['node', 'script.js'];
       const settings = createTestMergedSettings({
@@ -3706,6 +3746,27 @@ describe('loadCliConfig mcpEnabled', () => {
       const config = await loadCliConfig(settings, 'test-session', argv);
       expect(config.storage.getPlansDir()).not.toContain(
         'ext-plans-dir-inactive',
+      );
+    });
+
+    it('should NOT use tracker directory from inactive extension', async () => {
+      process.argv = ['node', 'script.js'];
+      const settings = createTestMergedSettings({
+        experimental: { plan: true },
+      });
+      const argv = await parseArguments(settings);
+
+      vi.spyOn(ExtensionManager.prototype, 'getExtensions').mockReturnValue([
+        {
+          name: 'ext-tracker',
+          isActive: false,
+          tracker: { directory: 'ext-tracker-dir-inactive' },
+        } as unknown as GeminiCLIExtension,
+      ]);
+
+      const config = await loadCliConfig(settings, 'test-session', argv);
+      expect(config.storage.getTrackerDir()).not.toContain(
+        'ext-tracker-dir-inactive',
       );
     });
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -570,9 +570,17 @@ export async function loadCliConfig(
   });
   await extensionManager.loadExtensions();
 
-  const extensionPlanSettings = extensionManager
+  const activeExtensions = extensionManager
     .getExtensions()
-    .find((ext) => ext.isActive && ext.plan?.directory)?.plan;
+    .filter((ext) => ext.isActive);
+
+  const extensionPlanSettings = activeExtensions.find(
+    (ext) => !!ext.plan?.directory,
+  )?.plan;
+
+  const extensionTrackerSettings = activeExtensions.find(
+    (ext) => !!ext.tracker?.directory,
+  )?.tracker;
 
   const experimentalJitContext = settings.experimental.jitContext;
 
@@ -931,6 +939,9 @@ export async function loadCliConfig(
     planSettings: settings.general?.plan?.directory
       ? settings.general.plan
       : (extensionPlanSettings ?? settings.general?.plan),
+    trackerSettings: settings.general?.tracker?.directory
+      ? settings.general.tracker
+      : (extensionTrackerSettings ?? settings.general?.tracker),
     enableEventDrivenScheduler: true,
     skillsSupport: settings.skills?.enabled ?? true,
     disabledSkills: settings.skills?.disabled,

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -1050,6 +1050,7 @@ Would you like to attempt to install via "git clone" instead?`,
         rules,
         checkers,
         plan: config.plan,
+        tracker: config.tracker,
       };
     } catch (e) {
       const extName = path.basename(extensionDir);

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -43,6 +43,15 @@ export interface ExtensionConfig {
     directory?: string;
   };
   /**
+   * Task tracking configuration contributed by this extension.
+   */
+  tracker?: {
+    /**
+     * The directory where task tracking data is stored.
+     */
+    directory?: string;
+  };
+  /**
    * Used to migrate an extension to a new repository source.
    */
   migratedTo?: string;

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -125,6 +125,16 @@ describe('SettingsSchema', () => {
       ).toBe('string');
     });
 
+    it('should have tracker nested properties', () => {
+      expect(
+        getSettingsSchema().general?.properties?.tracker?.properties?.directory,
+      ).toBeDefined();
+      expect(
+        getSettingsSchema().general?.properties?.tracker?.properties?.directory
+          .type,
+      ).toBe('string');
+    });
+
     it('should have fileFiltering nested properties', () => {
       expect(
         getSettingsSchema().context.properties.fileFiltering.properties

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -315,6 +315,27 @@ const SETTINGS_SCHEMA = {
           },
         },
       },
+      tracker: {
+        type: 'object',
+        label: 'Task Tracker',
+        category: 'General',
+        requiresRestart: true,
+        default: {},
+        description: 'Task tracking features configuration.',
+        showInDialog: false,
+        properties: {
+          directory: {
+            type: 'string',
+            label: 'Tracker Directory',
+            category: 'General',
+            requiresRestart: true,
+            default: undefined as string | undefined,
+            description:
+              'The directory where task tracking data is stored. If not specified, defaults to the system temporary directory.',
+            showInDialog: true,
+          },
+        },
+      },
       retryFetchErrors: {
         type: 'boolean',
         label: 'Retry Fetch Errors',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -184,6 +184,10 @@ export interface PlanSettings {
   modelRouting?: boolean;
 }
 
+export interface TrackerSettings {
+  directory?: string;
+}
+
 export interface TelemetrySettings {
   enabled?: boolean;
   target?: TelemetryTarget;
@@ -375,6 +379,10 @@ export interface GeminiCLIExtension {
      */
     directory?: string;
   };
+  /**
+   * Task tracking configuration contributed by this extension.
+   */
+  tracker?: TrackerSettings;
   /**
    * Used to migrate an extension to a new repository source.
    */
@@ -657,6 +665,7 @@ export interface ConfigParameters {
   plan?: boolean;
   tracker?: boolean;
   planSettings?: PlanSettings;
+  trackerSettings?: TrackerSettings;
   worktreeSettings?: WorktreeSettings;
   modelSteering?: boolean;
   onModelChange?: (model: string) => void;
@@ -1136,6 +1145,7 @@ export class Config implements McpContext, AgentLoopContext {
     this.enableExtensionReloading = params.enableExtensionReloading ?? false;
     this.storage = new Storage(this.targetDir, this._sessionId);
     this.storage.setCustomPlansDir(params.planSettings?.directory);
+    this.storage.setCustomTrackerDir(params.trackerSettings?.directory);
 
     this.fakeResponses = params.fakeResponses;
     this.recordResponses = params.recordResponses;
@@ -2541,9 +2551,7 @@ export class Config implements McpContext, AgentLoopContext {
 
   getTrackerService(): TrackerService {
     if (!this.trackerService) {
-      this.trackerService = new TrackerService(
-        this.storage.getProjectTempTrackerDir(),
-      );
+      this.trackerService = new TrackerService(this.storage.getTrackerDir());
     }
     return this.trackerService;
   }

--- a/packages/core/src/config/storage.test.ts
+++ b/packages/core/src/config/storage.test.ts
@@ -371,6 +371,78 @@ describe('Storage – additional helpers', () => {
       });
     });
   });
+
+  describe('getTrackerDir', () => {
+    interface TestCase {
+      name: string;
+      customDir: string | undefined;
+      expected: string | (() => string);
+      expectedError?: string;
+      setup?: () => () => void;
+    }
+
+    const testCases: TestCase[] = [
+      {
+        name: 'custom relative path',
+        customDir: '.gemini/tracker',
+        expected: path.resolve(projectRoot, '.gemini/tracker'),
+      },
+      {
+        name: 'custom absolute path outside throws',
+        customDir: '/absolute/path/to/tracker',
+        expected: '',
+        expectedError: `Custom tracker directory '/absolute/path/to/tracker' resolves to '/absolute/path/to/tracker', which is outside the project root '${resolveToRealPath(projectRoot)}'.`,
+      },
+      {
+        name: 'absolute path that happens to be inside project root',
+        customDir: path.join(projectRoot, '.gemini/tracker'),
+        expected: path.join(projectRoot, '.gemini/tracker'),
+      },
+      {
+        name: 'relative path that stays within project root',
+        customDir: 'subdir/../tracker',
+        expected: path.resolve(projectRoot, 'tracker'),
+      },
+      {
+        name: 'dot path',
+        customDir: '.',
+        expected: projectRoot,
+      },
+      {
+        name: 'default behavior when customDir is undefined',
+        customDir: undefined,
+        expected: () => storage.getProjectTempTrackerDir(),
+      },
+      {
+        name: 'escaping relative path throws',
+        customDir: '../escaped-tracker',
+        expected: '',
+        expectedError: `Custom tracker directory '../escaped-tracker' resolves to '${resolveToRealPath(path.resolve(projectRoot, '../escaped-tracker'))}', which is outside the project root '${resolveToRealPath(projectRoot)}'.`,
+      },
+    ];
+
+    testCases.forEach(({ name, customDir, expected, expectedError, setup }) => {
+      it(`should handle ${name}`, async () => {
+        const cleanup = setup?.();
+        try {
+          if (name.includes('default behavior')) {
+            await storage.initialize();
+          }
+
+          storage.setCustomTrackerDir(customDir);
+          if (expectedError) {
+            expect(() => storage.getTrackerDir()).toThrow(expectedError);
+          } else {
+            const expectedValue =
+              typeof expected === 'function' ? expected() : expected;
+            expect(storage.getTrackerDir()).toBe(expectedValue);
+          }
+        } finally {
+          cleanup?.();
+        }
+      });
+    });
+  });
 });
 
 describe('Storage - System Paths', () => {

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -32,6 +32,7 @@ export class Storage {
   private projectIdentifier: string | undefined;
   private initPromise: Promise<void> | undefined;
   private customPlansDir: string | undefined;
+  private customTrackerDir: string | undefined;
 
   constructor(targetDir: string, sessionId?: string) {
     this.targetDir = targetDir;
@@ -40,6 +41,10 @@ export class Storage {
 
   setCustomPlansDir(dir: string | undefined): void {
     this.customPlansDir = dir;
+  }
+
+  setCustomTrackerDir(dir: string | undefined): void {
+    this.customTrackerDir = dir;
   }
 
   static getGlobalGeminiDir(): string {
@@ -326,6 +331,26 @@ export class Storage {
       return resolvedPath;
     }
     return this.getProjectTempPlansDir();
+  }
+
+  getTrackerDir(): string {
+    if (this.customTrackerDir) {
+      const resolvedPath = path.resolve(
+        this.getProjectRoot(),
+        this.customTrackerDir,
+      );
+      const realProjectRoot = resolveToRealPath(this.getProjectRoot());
+      const realResolvedPath = resolveToRealPath(resolvedPath);
+
+      if (!isSubpath(realProjectRoot, realResolvedPath)) {
+        throw new Error(
+          `Custom tracker directory '${this.customTrackerDir}' resolves to '${realResolvedPath}', which is outside the project root '${realProjectRoot}'.`,
+        );
+      }
+
+      return resolvedPath;
+    }
+    return this.getProjectTempTrackerDir();
   }
 
   getProjectTempTasksDir(): string {

--- a/packages/core/src/extensions/builtin/sdd/commands/spec/create.toml
+++ b/packages/core/src/extensions/builtin/sdd/commands/spec/create.toml
@@ -137,12 +137,18 @@ PLAN MODE PROTOCOL: Parts of this process run within Plan Mode. While in Plan Mo
 ### 2.4 Create Spec Artifacts and Update Main Plan
 
 1.  **Check for existing spec name:** Before generating a new Spec ID, resolve the **Spec Directory** by reading `.gemini/specs/index.md`. List all existing spec directories in that resolved path. Extract the short names from these spec IDs (e.g., ``shortname_YYYYMMDD`` -> `shortname`). If the proposed short name for the new spec (derived from the initial description) matches an existing short name, halt the `newSpec` creation. Explain that a spec with that name already exists and suggest choosing a different name or resuming the existing spec.
-2.  **Generate Spec ID:** Create a unique Spec ID (e.g., ``shortname_YYYYMMDD``).
-3.  **Create Directory:** Create a new directory for the specs: `<Spec Directory>/<spec_id>/`.
-4.  **Create `metadata.json`:** Create a metadata file at `<Spec Directory>/<spec_id>/metadata.json` with content like:
+2.  **Generate Spec ID:** Create a unique Spec ID (e.g., `shortname_YYYYMMDD`).
+3.  **Generate Root Tracker ID:** Use the `tracker_create_task` tool to create a root task for this spec.
+    -   **type:** `epic`
+    -   **title:** A concise but highly descriptive title summarizing the spec (e.g., "Feature: Implement User Authentication Flow").
+    -   **description:** A detailed explanation of the spec's purpose and scope, providing context beyond the title.
+    -   **Record the returned Task ID** (this is the `root_tracker_id`).
+4.  **Create Directory:** Create a new directory for the specs: `<Spec Directory>/<spec_id>/`.
+5.  **Create `metadata.json`:** Create a metadata file at `<Spec Directory>/<spec_id>/metadata.json` with content like:
     ```json
     {
       "spec_id": "<spec_id>",
+      "root_tracker_id": "<root_tracker_id>",
       "type": "feature", // or "bug", "chore", etc.
       "status": "new", // or in_progress, completed, cancelled
       "created_at": "YYYY-MM-DDTHH:MM:SSZ",

--- a/packages/core/src/extensions/builtin/sdd/commands/spec/setup.toml
+++ b/packages/core/src/extensions/builtin/sdd/commands/spec/setup.toml
@@ -517,11 +517,17 @@ PLAN MODE PROTOCOL: This setup process runs entirely within Plan Mode. While in 
             - **CRITICAL: Inject Phase Completion Tasks.** You MUST read the `.gemini/specs/workflow.md` file to determine if a "Phase Completion Verification and Checkpointing Protocol" is defined. If this protocol exists, then for each **Phase** that you generate in `plan.md`, you MUST append a final meta-task to that phase. The format for this meta-task is: `- [ ] Task: SDD - User Manual Verification '<Phase Name>' (Protocol in workflow.md)`. You MUST replace `<Phase Name>` with the actual name of the phase.
     c. **Create Spec Artifacts:**
         i. **Generate and Store Spec ID:** Create a unique Spec ID from the spec description using format `shortname_YYYYMMDD` and store it. You MUST use this exact same ID for all subsequent steps for this spec.
-        ii. **Create Single Directory:** Resolve the **Spec Directory** by reading `.gemini/specs/index.md` and create a single new directory: `<Spec Directory>/<spec_id>/`.
-        iii. **Create `metadata.json`:** In the new directory, create a `metadata.json` file with the correct structure and content, using the stored Spec ID. An example is:
+        ii. **Generate Root Tracker ID:** Use the `tracker_create_task` tool to create a root task for this spec.
+            -   **type:** `epic`
+            -   **title:** A concise but highly descriptive title summarizing the spec (e.g., "Feature: Implement User Authentication Flow").
+            -   **description:** A detailed explanation of the spec's purpose and scope, providing context beyond the title.
+            -   **Record the returned Task ID** (this is the `root_tracker_id`).
+        iii. **Create Single Directory:** Resolve the **Spec Directory** by reading `.gemini/specs/index.md` and create a single new directory: `<Spec Directory>/<spec_id>/`.
+        iv. **Create `metadata.json`:** In the new directory, create a `metadata.json` file with the correct structure and content, using the stored Spec ID. An example is:
             - ```json
             {
             "spec_id": "<spec_id>",
+            "root_tracker_id": "<root_tracker_id>",
             "type": "feature", // or "bug"
             "status": "new", // or in_progress, completed, cancelled
             "created_at": "YYYY-MM-DDTHH:MM:SSZ",
@@ -530,8 +536,8 @@ PLAN MODE PROTOCOL: This setup process runs entirely within Plan Mode. While in 
             }
             ```
         Populate fields with actual values. Use the current timestamp.
-        iv. **Write Spec and Plan Files:** In the exact same directory, write the generated `spec.md` and `plan.md` files.
-        v.  **Write Index File:** In the exact same directory, write `index.md` with content:
+        v. **Write Spec and Plan Files:** In the exact same directory, write the generated `spec.md` and `plan.md` files.
+        vi.  **Write Index File:** In the exact same directory, write `index.md` with content:
             ```markdown
             # Spec <spec_id> Context
 

--- a/packages/core/src/extensions/builtin/sdd/gemini-extension.json
+++ b/packages/core/src/extensions/builtin/sdd/gemini-extension.json
@@ -3,5 +3,8 @@
   "contextFileName": "GEMINI.md",
   "plan": {
     "directory": ".gemini/specs"
+  },
+  "tracker": {
+    "directory": ".gemini/tracker"
   }
 }

--- a/packages/core/src/extensions/builtin/sdd/policies/sdd.toml
+++ b/packages/core/src/extensions/builtin/sdd/policies/sdd.toml
@@ -13,3 +13,11 @@ commandPrefix = ["git status", "git diff", "ls", "mkdir", "cp", "mv", "git init"
 decision = "ask_user"
 priority = 100 # prioritize over other extension policies
 modes = ["plan"]
+
+# Allow tracker tools in plan mode
+[[rule]]
+toolName = ["tracker_create_task", "tracker_update_task", "tracker_list_tasks", "tracker_get_task", "tracker_add_dependency", "tracker_visualize"]
+decision = "ask_user"
+priority = 100
+modes = ["plan"]
+


### PR DESCRIPTION
## Summary

This PR implements the foundational Spec-to-Tracker bridge for the SDD extension. It configures a dedicated tracker directory for the extension and updates the `create` and `setup` commands to automatically generate a Root Tracker Epic for each new spec, establishing the 1:1 relationship between intent (spec) and execution state (tracker).

## Details

- **Configuration:** Updated `gemini-extension.json` to configure `.gemini/tracker` as the specific tracker directory for the SDD extension.
- **Policy Updates:** Allowed tracker tools (e.g., `tracker_create_task`, `tracker_update_task`) to be called in Plan Mode via `sdd.toml` with an `ask_user` policy to ensure safety.
- **Workflow Integration:** Modified the interactive `/spec:setup` and `/spec:create` workflows in their respective TOML definitions to:
  - Call `tracker_create_task` (with type `epic`) upon spec approval.
  - Require the model to use detailed titles and descriptions.
  - Store the returned Task ID as `root_tracker_id` inside the spec's `metadata.json`.

## Related Issues

Resolves #23802

## How to Validate

1. Check out this branch and build the core package: `npm run build -w @google/gemini-cli-core`.
2. Start the CLI (`npm start`).
3. Run the command: `/spec:create "Test the tracker integration"`.
4. Follow the interactive prompts and approve the drafted spec.
5. Verify the agent prompts for permission to execute `tracker_create_task`.
6. Inspect the generated `metadata.json` in `.gemini/specs/specs/<spec_id>/` and ensure the `root_tracker_id` is present.
7. Verify the newly created epic task file exists in `.gemini/tracker/`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker