### PR TITLE
fix(test): move flaky MainContent tests to non-blocking suite

### DIFF
--- a/packages/cli/src/test-utils/async.ts
+++ b/packages/cli/src/test-utils/async.ts
@@ -12,6 +12,8 @@ import { vi } from 'vitest';
 // or @testing-library/react-native
 // The version of waitFor from vitest is still fine to use if you aren't waiting
 // for React state updates.
+export const skipFlaky = !process.env['RUN_FLAKY_INTEGRATION'];
+
 export async function waitFor(
   assertion: () => void | Promise<void>,
   { timeout = 2000, interval = 50 } = {},

--- a/packages/cli/src/ui/components/MainContent.test.tsx
+++ b/packages/cli/src/ui/components/MainContent.test.tsx
@@ -7,7 +7,7 @@
 import { renderWithProviders } from '../../test-utils/render.js';
 import { createMockSettings } from '../../test-utils/settings.js';
 import { makeFakeConfig, CoreToolCallStatus } from '@google/gemini-cli-core';
-import { waitFor } from '../../test-utils/async.js';
+import { waitFor, skipFlaky } from '../../test-utils/async.js';
 import { MainContent } from './MainContent.js';
 import { getToolGroupBorderAppearance } from '../utils/borderStyles.js';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -318,7 +318,7 @@ describe('getToolGroupBorderAppearance', () => {
   });
 });
 
-describe('MainContent', () => {
+describe.skipIf(skipFlaky)('MainContent', () => {
   const defaultMockUiState = {
     history: [
       { id: 1, type: 'user', text: 'Hello' },


### PR DESCRIPTION
## Summary

This PR moves the flaky `MainContent.test.tsx` unit tests to the non-blocking suite using the standard `skipFlaky` pattern. This prevents CI failures from blocking PRs while the root cause is investigated.

## Details

- Added `skipFlaky` export to `packages/cli/src/test-utils/async.ts`.
- Wrapped the `MainContent` describe block in `packages/cli/src/ui/components/MainContent.test.tsx` with `describe.skipIf(skipFlaky)`.
- The tests continue to run in the flaky/non-blocking CI suite (when `RUN_FLAKY_INTEGRATION=1` is set).

## Related Issues

Related to #24073 (Bug created for original author to address).

## How to Validate

1. Run the test locally without the environment variable:
   ```bash
   npm test -w @google/gemini-cli -- src/ui/components/MainContent.test.tsx
   ```
   **Expected:** 17 tests should be skipped (the `MainContent` suite).

2. Run the test with the environment variable:
   ```bash
   cross-env RUN_FLAKY_INTEGRATION=1 npm test -w @google/gemini-cli -- src/ui/components/MainContent.test.tsx
   ```
   **Expected:** All tests should run (and potentially fail if flaky, confirming the skip logic works).

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
