### PR TITLE
docs: add large codebase analysis example to quickstart

### DIFF
--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -118,7 +118,7 @@ Result: Gemini performs a sequence of actions to answer your request.
     them.
 3.  Finally, after analyzing the code, it provides a summary.
 
-Gemini CLI returns an explanation based on the actual source code:
+Result: Gemini CLI returns an explanation based on the actual source code:
 
 ```markdown
 The `chalk` library is a popular npm package for styling terminal output with
@@ -138,6 +138,30 @@ colors. After analyzing the source code, here's how it works:
   a reset code at the end. This produces the final, styled string that the
   terminal can render.
 ```
+
+### Map a large codebase across multiple directories
+
+Gemini CLI can analyze complex monorepos or multi-directory projects by
+leveraging the 1M+ token context window of Gemini 1.5 Pro.
+
+Scenario: You are working in a monorepo and need to understand how the `Core`
+logic is shared between the `CLI` and the `A2A-Server` packages.
+
+Give Gemini CLI the following prompt:
+
+```cli
+@packages/core @packages/cli @packages/a2a-server Map the implementation of the PolicyEngine across these packages and explain any architectural differences.
+```
+
+Result: Gemini CLI reads all requested directories and provides a cross-package
+analysis:
+
+- **Core Package:** Defines the base `PolicyEngine` interface and shared logic
+  for decision making.
+- **CLI Package:** Implements a specialized version of the engine that handles
+  user-interactive prompts and terminal-specific security policies.
+- **A2A-Server Package:** Uses the core engine to enforce programmatic security
+  constraints for automated agent-to-agent communication.
 
 ### Combine two spreadsheets into one spreadsheet
 


### PR DESCRIPTION
## Summary

Adds a **large codebase analysis example** to the getting started guide, demonstrating how Gemini CLI can reason across multiple packages using high-token context.

## Details

This change introduces a new section showcasing a realistic **monorepo workflow**, where the user maps the `PolicyEngine` implementation across `core`, `cli`, and `a2a` server packages using `@`-based context inclusion.

The example is designed to highlight:

* Cross-package reasoning across a layered architecture
* Practical usage of directory-level context injection (`@packages/...`)
* Gemini’s long-context capability (1M+ tokens) in a real-world scenario

The goal is to shift the documentation from single-file examples toward **multi-component reasoning**, which better reflects actual usage of the CLI in large codebases.

## Related Issues

Related to #23316

## How to Validate

1. Open `docs/get-started/index.md`
2. Locate the new **"Map a large codebase"** section
3. Verify:

   * The example prompt is clear and reproducible
   * The output accurately reflects cross-package analysis

## Notes

This is a documentation-only change; no functional behavior is modified.

## Pre-Merge Checklist

* [x] Updated relevant documentation and README (if needed)

* [ ] Added/updated tests (not required — documentation-only change)

* [ ] Noted breaking changes (none)

* [ ] Validated on required platforms/methods (not applicable — docs-only change):

  * [ ] MacOS

    * [ ] npm run
    * [ ] npx
    * [ ] Docker
    * [ ] Podman
    * [ ] Seatbelt
  * [ ] Windows

    * [ ] npm run
    * [ ] npx
    * [ ] Docker
  * [ ] Linux

    * [ ] npm run
    * [ ] npx
    * [ ] Docker

