### PR TITLE
Silence debugLogger globally in cli test setup

### DIFF
--- a/packages/cli/test-setup.ts
+++ b/packages/cli/test-setup.ts
@@ -38,6 +38,20 @@ process.env.FORCE_GENERIC_KEYBINDING_HINTS = 'true';
 process.env.TERM_PROGRAM = 'generic';
 
 import './src/test-utils/customMatchers.js';
+// Silence debugLogger globally — prevents test noise from custom logger
+// that bypasses Vitest's silent:true config
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    debugLogger: {
+      log: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+});
 
 let consoleErrorSpy: vi.SpyInstance;
 let actWarnings: Array<{ message: string; stack: string }> = [];

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
     testTimeout: 60000,
     hookTimeout: 60000,
     pool: 'forks',
+    silent: true,
     coverage: {
       enabled: true,
       provider: 'v8',


### PR DESCRIPTION
Fixes #23328

silent: true in vitest.config.ts suppresses console.* but not 
the custom debugLogger, which writes directly to stdout. Tests 
that mock it are clean — the ones that don't are the noise source.

This centralizes the debugLogger mock in test-setup.ts so every 
test in the cli package gets it automatically. The existing 
act() warning handler is fully preserved.