### PR TITLE
docs(policy): remove unsupported mcpName wildcard edge case

### DIFF
--- a/docs/reference/policy-engine.md
+++ b/docs/reference/policy-engine.md
@@ -419,20 +419,6 @@ decision = "ask_user"
 priority = 10
 ```
 
-**4. Targeting a tool name across all servers**
-
-Use `mcpName = "*"` with a specific `toolName` to target that operation
-regardless of which server provides it.
-
-```toml
-# Allow the `search` tool across all connected MCP servers
-[[rule]]
-mcpName = "*"
-toolName = "search"
-decision = "allow"
-priority = 50
-```
-
 ## Default policies
 
 The Gemini CLI ships with a set of default policies to provide a safe


### PR DESCRIPTION
## Summary

Removes misleading documentation suggesting that targeting a specific tool across all MCP servers using `mcpName = "*"` and a specific `toolName` is supported. 

## Details

The policy engine does not currently support `mcp_*_toolName` wildcard matching. The only wildcards supported are `*` (all tools) or `mcp_serverName_*` (all tools for a given server).

Furthermore, because MCP tool names are not standardized across different servers, auto-allowing a generic tool name across *all* connected servers poses a potential security risk if a malicious or poorly-written server exposes a destructive tool with a generic name (e.g., `read_file`). This pattern is not recommended and is not supported by similar tools. 

We are treating this as a documentation bug rather than a feature gap to align with secure defaults.

## Related Issues

N/A

## How to Validate

Review the updated `docs/reference/policy-engine.md` to ensure the confusing section is removed.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker