### PR TITLE
docs(evals): add quality PR evidence template

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -164,6 +164,29 @@ npm run test:all_evals
 This command sets the `RUN_EVALS` environment variable to `1`, which enables the
 `USUALLY_PASSES` tests.
 
+## Quality PR Evidence Template
+
+When opening a quality-focused PR related to behavioral evals, include a concise
+evidence section in your PR description so reviewers can validate quickly and
+consistently.
+
+```md
+## Eval Evidence
+
+- Related issue: #<issue-number>
+- Target behavior gap: <one sentence>
+- Commands run:
+  - <command 1>
+  - <command 2>
+- Local rerun results: <for example, 3/3 passes>
+- Nightly evidence (if available): <workflow/run link>
+- Policy impact: <USUALLY_PASSES or ALWAYS_PASSES, and why>
+- Residual risk: <one sentence>
+```
+
+Keep this section factual and brief. Link to logs/runs instead of pasting long
+output blocks.
+
 ## Ensuring Eval is Stable Prior to Check-in
 
 The


### PR DESCRIPTION
## Summary
- add a compact "Quality PR Evidence Template" section to `evals/README.md`
- provide a copy-paste evidence block for eval-related PR descriptions
- standardize what reviewers need (commands, reruns, policy impact, residual risk)

## Why
This reduces review friction for quality/evals contributions and keeps PR evidence consistent and concise.

## Validation
- `npx prettier --check evals/README.md`

## Related Issues
Related to #23331