### PR TITLE
fix(core): remove unsafe assertions in core utility files

### DIFF
--- a/packages/core/src/utils/safeJsonStringify.ts
+++ b/packages/core/src/utils/safeJsonStringify.ts
@@ -11,7 +11,6 @@
  * @param space - Optional space parameter for formatting (defaults to no formatting)
  * @returns JSON string with circular references replaced by [Circular]
  */
-import type { Config } from '../config/config.js';
 
 export function safeJsonStringify(
   obj: unknown,
@@ -20,14 +19,13 @@ export function safeJsonStringify(
   const seen = new WeakSet();
   return JSON.stringify(
     obj,
-    (key, value) => {
+    (_key: string, value: unknown) => {
       if (typeof value === 'object' && value !== null) {
         if (seen.has(value)) {
           return '[Circular]';
         }
         seen.add(value);
       }
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return value;
     },
     space,
@@ -57,16 +55,17 @@ function removeEmptyObjects(data: any): object {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function safeJsonStringifyBooleanValuesOnly(obj: any): string {
   let configSeen = false;
-  return JSON.stringify(removeEmptyObjects(obj), (key, value) => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    if ((value as Config) !== null && !configSeen) {
-      configSeen = true;
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return value;
-    }
-    if (typeof value === 'boolean') {
-      return value;
-    }
-    return '';
-  });
+  return JSON.stringify(
+    removeEmptyObjects(obj),
+    (_key: string, value: unknown) => {
+      if (value !== null && !configSeen) {
+        configSeen = true;
+        return value;
+      }
+      if (typeof value === 'boolean') {
+        return value;
+      }
+      return '';
+    },
+  );
 }

--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -11,11 +11,69 @@ import Ajv2020Pkg from 'ajv/dist/2020.js';
 import * as addFormats from 'ajv-formats';
 import { debugLogger } from './debugLogger.js';
 
-// Ajv's ESM/CJS interop: use 'any' for compatibility as recommended by Ajv docs
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-assignment
-const AjvClass = (AjvPkg as any).default || AjvPkg;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-assignment
-const Ajv2020Class = (Ajv2020Pkg as any).default || Ajv2020Pkg;
+type AjvConstructor = new (options?: unknown) => Ajv;
+type AddFormatsFunction = (validator: Ajv) => void;
+
+function getOwnPropertyValue(obj: object, key: string): unknown {
+  return Object.getOwnPropertyDescriptor(obj, key)?.value;
+}
+
+function isAjvConstructor(value: unknown): value is AjvConstructor {
+  return typeof value === 'function';
+}
+
+function resolveAjvConstructor(moduleValue: unknown): AjvConstructor {
+  if (isAjvConstructor(moduleValue)) {
+    return moduleValue;
+  }
+
+  if (typeof moduleValue === 'object' && moduleValue !== null) {
+    const defaultExport = getOwnPropertyValue(moduleValue, 'default');
+    if (isAjvConstructor(defaultExport)) {
+      return defaultExport;
+    }
+  }
+
+  throw new Error('Unable to resolve AJV constructor export.');
+}
+
+function isAddFormatsFunction(value: unknown): value is AddFormatsFunction {
+  return typeof value === 'function';
+}
+
+function resolveAddFormatsFunction(moduleValue: unknown): AddFormatsFunction {
+  if (isAddFormatsFunction(moduleValue)) {
+    return moduleValue;
+  }
+
+  if (typeof moduleValue === 'object' && moduleValue !== null) {
+    const defaultExport = getOwnPropertyValue(moduleValue, 'default');
+    if (isAddFormatsFunction(defaultExport)) {
+      return defaultExport;
+    }
+  }
+
+  throw new Error('Unable to resolve ajv-formats export.');
+}
+
+function isCompileableSchema(schema: unknown): schema is AnySchema {
+  return (
+    typeof schema === 'boolean' ||
+    (typeof schema === 'object' && schema !== null)
+  );
+}
+
+function getSchemaUri(schema: unknown): string {
+  if (typeof schema !== 'object' || schema === null) {
+    return '<no $schema>';
+  }
+
+  const schemaValue = getOwnPropertyValue(schema, '$schema');
+  return typeof schemaValue === 'string' ? schemaValue : '<no $schema>';
+}
+
+const AjvClass = resolveAjvConstructor(AjvPkg);
+const Ajv2020Class = resolveAjvConstructor(Ajv2020Pkg);
 
 const ajvOptions = {
   // See: https://ajv.js.org/options.html#strict-mode-options
@@ -28,16 +86,12 @@ const ajvOptions = {
   strictSchema: false,
 };
 
-// Draft-07 validator (default)
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const ajvDefault: Ajv = new AjvClass(ajvOptions);
 
 // Draft-2020-12 validator for MCP servers using rmcp
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const ajv2020: Ajv = new Ajv2020Class(ajvOptions);
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-assignment
-const addFormatsFunc = (addFormats as any).default || addFormats;
+const addFormatsFunc = resolveAddFormatsFunction(addFormats);
 addFormatsFunc(ajvDefault);
 addFormatsFunc(ajv2020);
 
@@ -76,8 +130,11 @@ export class SchemaValidator {
       return 'Value of params must be an object';
     }
 
-    const anySchema = schema as AnySchema;
-    const validator = getValidator(anySchema);
+    if (!isCompileableSchema(schema)) {
+      return null;
+    }
+
+    const validator = getValidator(schema);
 
     // Try to compile and validate; skip validation if schema can't be compiled.
     // This handles schemas using JSON Schema versions AJV doesn't support
@@ -85,17 +142,15 @@ export class SchemaValidator {
     // This matches LenientJsonSchemaValidator behavior in mcp-client.ts.
     let validate;
     try {
-      validate = validator.compile(anySchema);
+      validate = validator.compile(schema);
     } catch (error) {
       // Schema compilation failed (unsupported version, invalid $ref, etc.)
       // Skip validation rather than blocking tool usage.
       // This matches LenientJsonSchemaValidator behavior in mcp-client.ts.
       debugLogger.warn(
-        `Failed to compile schema (${
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          (schema as Record<string, unknown>)?.['$schema'] ?? '<no $schema>'
-        }): ${error instanceof Error ? error.message : String(error)}. ` +
-          'Skipping parameter validation.',
+        `Failed to compile schema (${getSchemaUri(schema)}): ${
+          error instanceof Error ? error.message : String(error)
+        }. ` + 'Skipping parameter validation.',
       );
       return null;
     }
@@ -123,11 +178,9 @@ export class SchemaValidator {
       // Schema validation failed (unsupported version, etc.)
       // Skip validation rather than blocking tool usage.
       debugLogger.warn(
-        `Failed to validate schema (${
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          (schema as Record<string, unknown>)?.['$schema'] ?? '<no $schema>'
-        }): ${error instanceof Error ? error.message : String(error)}. ` +
-          'Skipping schema validation.',
+        `Failed to validate schema (${getSchemaUri(schema)}): ${
+          error instanceof Error ? error.message : String(error)
+        }. ` + 'Skipping schema validation.',
       );
       return null;
     }

--- a/packages/core/src/utils/userAccountManager.ts
+++ b/packages/core/src/utils/userAccountManager.ts
@@ -8,10 +8,17 @@ import path from 'node:path';
 import { promises as fsp, readFileSync } from 'node:fs';
 import { Storage } from '../config/storage.js';
 import { debugLogger } from './debugLogger.js';
+import { z } from 'zod';
 
-interface UserAccounts {
-  active: string | null;
-  old: string[];
+const userAccountsSchema = z.object({
+  active: z.string().nullable().default(null),
+  old: z.array(z.string()).default([]),
+});
+
+type UserAccounts = z.infer<typeof userAccountsSchema>;
+
+function createDefaultAccountsState(): UserAccounts {
+  return { active: null, old: [] };
 }
 
 export class UserAccountManager {
@@ -25,41 +32,22 @@ export class UserAccountManager {
    * @returns A valid UserAccounts object.
    */
   private parseAndValidateAccounts(content: string): UserAccounts {
-    const defaultState = { active: null, old: [] };
     if (!content.trim()) {
-      return defaultState;
+      return createDefaultAccountsState();
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const parsed = JSON.parse(content);
+    const parsed: unknown = JSON.parse(content);
+    const result = userAccountsSchema.safeParse(parsed);
 
-    // Inlined validation logic
-    if (typeof parsed !== 'object' || parsed === null) {
+    if (!result.success) {
       debugLogger.log('Invalid accounts file schema, starting fresh.');
-      return defaultState;
-    }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    const { active, old } = parsed as Partial<UserAccounts>;
-    const isValid =
-      (active === undefined || active === null || typeof active === 'string') &&
-      (old === undefined ||
-        (Array.isArray(old) && old.every((i) => typeof i === 'string')));
-
-    if (!isValid) {
-      debugLogger.log('Invalid accounts file schema, starting fresh.');
-      return defaultState;
+      return createDefaultAccountsState();
     }
 
-    return {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      active: parsed.active ?? null,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      old: parsed.old ?? [],
-    };
+    return result.data;
   }
 
   private readAccountsSync(filePath: string): UserAccounts {
-    const defaultState = { active: null, old: [] };
     try {
       const content = readFileSync(filePath, 'utf-8');
       return this.parseAndValidateAccounts(content);
@@ -69,18 +57,17 @@ export class UserAccountManager {
         'code' in error &&
         error.code === 'ENOENT'
       ) {
-        return defaultState;
+        return createDefaultAccountsState();
       }
       debugLogger.log(
         'Error during sync read of accounts, starting fresh.',
         error,
       );
-      return defaultState;
+      return createDefaultAccountsState();
     }
   }
 
   private async readAccounts(filePath: string): Promise<UserAccounts> {
-    const defaultState = { active: null, old: [] };
     try {
       const content = await fsp.readFile(filePath, 'utf-8');
       return this.parseAndValidateAccounts(content);
@@ -90,10 +77,10 @@ export class UserAccountManager {
         'code' in error &&
         error.code === 'ENOENT'
       ) {
-        return defaultState;
+        return createDefaultAccountsState();
       }
       debugLogger.log('Could not parse accounts file, starting fresh.', error);
-      return defaultState;
+      return createDefaultAccountsState();
     }
   }
 


### PR DESCRIPTION
## Summary
This PR addresses unsafe assertion/suppression cleanup in core utilities and aligns with the requested files in #19710 while also reducing unsafe return/type assertion patterns relevant to #20606.

## What changed
- Refactored safeJsonStringify replacers to avoid unsafe type assertions/returns.
- Replaced ad-hoc schema casting in schemaValidator with typed helpers for export resolution and schema URI extraction.
- Migrated userAccountManager account parsing to a Zod schema via safeParse and centralized fresh default state creation.

## Validation
- npx eslint packages/core/src/utils/safeJsonStringify.ts packages/core/src/utils/schemaValidator.ts packages/core/src/utils/userAccountManager.ts
- npx vitest run packages/core/src/utils/safeJsonStringify.test.ts packages/core/src/utils/schemaValidator.test.ts packages/core/src/utils/userAccountManager.test.ts

Fixes #19710
Refs #20606