### PR TITLE
docs: add missing .md extensions to internal doc links

### DIFF
--- a/docs/get-started/authentication.md
+++ b/docs/get-started/authentication.md
@@ -398,8 +398,8 @@ on this page.
 
 ## Running in headless mode <a id="headless"></a>
 
-[Headless mode](../cli/headless) will use your existing authentication method,
-if an existing authentication credential is cached.
+[Headless mode](../cli/headless.md) will use your existing authentication
+method, if an existing authentication credential is cached.
 
 If you have not already signed in with an authentication credential, you must
 configure authentication using environment variables:

--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -22,11 +22,11 @@ With hooks, you can:
 
 ### Getting started
 
-- **[Writing hooks guide](../hooks/writing-hooks)**: A tutorial on creating your
-  first hook with comprehensive examples.
-- **[Best practices](../hooks/best-practices)**: Guidelines on security,
+- **[Writing hooks guide](../hooks/writing-hooks.md)**: A tutorial on creating
+  your first hook with comprehensive examples.
+- **[Best practices](../hooks/best-practices.md)**: Guidelines on security,
   performance, and debugging.
-- **[Hooks reference](../hooks/reference)**: The definitive technical
+- **[Hooks reference](../hooks/reference.md)**: The definitive technical
   specification of I/O schemas and exit codes.
 
 ## Core concepts
@@ -154,8 +154,8 @@ Gemini CLI **fingerprints** project hooks. If a hook's name or command changes
 (e.g., via `git pull`), it is treated as a **new, untrusted hook** and you will
 be warned before it executes.
 
-See [Security Considerations](../hooks/best-practices#using-hooks-securely) for
-a detailed threat model.
+See [Security Considerations](../hooks/best-practices.md#using-hooks-securely)
+for a detailed threat model.
 
 ## Managing hooks
 


### PR DESCRIPTION
Fixes #23378

## Summary

Internal documentation links in `authentication.md` and `hooks/index.md` are missing the `.md` extension, causing 404s when browsing the repository on GitHub.

**Affected links:**
- `docs/get-started/authentication.md`: `../cli/headless` → `../cli/headless.md`
- `docs/hooks/index.md`: `../hooks/writing-hooks` → `../hooks/writing-hooks.md`
- `docs/hooks/index.md`: `../hooks/best-practices` → `../hooks/best-practices.md` (2 occurrences)
- `docs/hooks/index.md`: `../hooks/reference` → `../hooks/reference.md`

## Test plan

- Verified all target files exist in the repo
- Links resolve correctly on GitHub after adding `.md` extension