### PR TITLE
fix(evals): add missing waitForTelemetryReady() before readToolLogs()

### DIFF
--- a/evals/automated-tool-use.eval.ts
+++ b/evals/automated-tool-use.eval.ts
@@ -67,7 +67,7 @@ describe('Automated tool use', () => {
     prompt:
       'Fix the linter errors in this project. Make sure to avoid interactive commands.',
     assert: async (rig) => {
-      // Check if run_shell_command was used with --fix
+      await rig.waitForTelemetryReady();
       const toolCalls = rig.readToolLogs();
       const shellCommands = toolCalls.filter(
         (call) => call.toolRequest.name === 'run_shell_command',
@@ -138,7 +138,7 @@ console.log(data)
     prompt:
       'Fix the formatting errors in this project. Make sure to avoid interactive commands.',
     assert: async (rig) => {
-      // Check if run_shell_command was used with --write
+      await rig.waitForTelemetryReady();
       const toolCalls = rig.readToolLogs();
       const shellCommands = toolCalls.filter(
         (call) => call.toolRequest.name === 'run_shell_command',

--- a/evals/cli_help_delegation.eval.ts
+++ b/evals/cli_help_delegation.eval.ts
@@ -14,6 +14,7 @@ describe('CliHelpAgent Delegation', () => {
     prompt: 'Help me create a subagent in this project',
     timeout: 60000,
     assert: async (rig, _result) => {
+      await rig.waitForTelemetryReady();
       const toolLogs = rig.readToolLogs();
       const toolCallIndex = toolLogs.findIndex(
         (log) => log.toolRequest.name === 'cli_help',

--- a/evals/concurrency-safety.eval.ts
+++ b/evals/concurrency-safety.eval.ts
@@ -34,6 +34,7 @@ describe('concurrency safety eval test cases', () => {
       '.gemini/agents/mutation-agent.md': MUTATION_AGENT_DEFINITION,
     },
     assert: async (rig) => {
+      await rig.waitForTelemetryReady();
       const logs = rig.readToolLogs();
       const mutationCalls = logs.filter(
         (log) => log.toolRequest?.name === 'mutation-agent',

--- a/evals/frugalReads.eval.ts
+++ b/evals/frugalReads.eval.ts
@@ -45,9 +45,9 @@ describe('Frugal reads eval', () => {
     prompt:
       'Fix all linter errors in linter_mess.ts manually by editing the file. Run eslint directly (using "npx --yes eslint") to find them. Do not run the file.',
     assert: async (rig) => {
+      await rig.waitForTelemetryReady();
       const logs = rig.readToolLogs();
 
-      // Check if the agent read the whole file
       const readCalls = logs.filter(
         (log) => log.toolRequest?.name === READ_FILE_TOOL_NAME,
       );
@@ -165,6 +165,7 @@ describe('Frugal reads eval', () => {
     prompt:
       'Fix all linter errors in far_mess.ts manually by editing the file. Run eslint directly (using "npx --yes eslint") to find them. Do not run the file.',
     assert: async (rig) => {
+      await rig.waitForTelemetryReady();
       const logs = rig.readToolLogs();
 
       const readCalls = logs.filter(
@@ -234,6 +235,7 @@ describe('Frugal reads eval', () => {
     prompt:
       'Fix all linter errors in many_mess.ts manually by editing the file. Run eslint directly (using "npx --yes eslint") to find them. Do not run the file.',
     assert: async (rig) => {
+      await rig.waitForTelemetryReady();
       const logs = rig.readToolLogs();
 
       const readCalls = logs.filter(

--- a/evals/frugalSearch.eval.ts
+++ b/evals/frugalSearch.eval.ts
@@ -49,6 +49,7 @@ describe('Frugal Search', () => {
       'README.md': '# Project documentation',
     },
     assert: async (rig) => {
+      await rig.waitForTelemetryReady();
       const toolCalls = rig.readToolLogs();
       const getParams = (call: any) => {
         let args = call.toolRequest.args;

--- a/evals/gitRepo.eval.ts
+++ b/evals/gitRepo.eval.ts
@@ -31,6 +31,7 @@ describe('git repo eval', () => {
       'Finish this up for me by just making a targeted fix for the bug in index.ts. Do not build, install anything, or add tests',
     files: FILES,
     assert: async (rig, _result) => {
+      await rig.waitForTelemetryReady();
       const toolLogs = rig.readToolLogs();
       const commitCalls = toolLogs.filter((log) => {
         if (log.toolRequest.name !== 'run_shell_command') return false;
@@ -60,6 +61,7 @@ describe('git repo eval', () => {
       'Make a targeted fix for the bug in index.ts without building, installing anything, or adding tests. Then, commit your changes.',
     files: FILES,
     assert: async (rig, _result) => {
+      await rig.waitForTelemetryReady();
       const toolLogs = rig.readToolLogs();
       const commitCalls = toolLogs.filter((log) => {
         if (log.toolRequest.name !== 'run_shell_command') return false;

--- a/evals/shell-efficiency.eval.ts
+++ b/evals/shell-efficiency.eval.ts
@@ -24,6 +24,7 @@ describe('Shell Efficiency', () => {
     name: 'should use --silent/--quiet flags when installing packages',
     prompt: 'Install the "lodash" package using npm.',
     assert: async (rig) => {
+      await rig.waitForTelemetryReady();
       const toolCalls = rig.readToolLogs();
       const shellCalls = toolCalls.filter(
         (call) => call.toolRequest.name === 'run_shell_command',
@@ -53,6 +54,7 @@ describe('Shell Efficiency', () => {
     name: 'should use --no-pager with git commands',
     prompt: 'Show the git log.',
     assert: async (rig) => {
+      await rig.waitForTelemetryReady();
       const toolCalls = rig.readToolLogs();
       const shellCalls = toolCalls.filter(
         (call) => call.toolRequest.name === 'run_shell_command',
@@ -85,6 +87,7 @@ describe('Shell Efficiency', () => {
     },
     prompt: 'Install the "lodash" package using npm.',
     assert: async (rig) => {
+      await rig.waitForTelemetryReady();
       const toolCalls = rig.readToolLogs();
       const shellCalls = toolCalls.filter(
         (call) => call.toolRequest.name === 'run_shell_command',

--- a/evals/subagents.eval.ts
+++ b/evals/subagents.eval.ts
@@ -76,6 +76,7 @@ describe('subagent eval test cases', () => {
       'index.ts': INDEX_TS,
     },
     assert: async (rig, _result) => {
+      await rig.waitForTelemetryReady();
       const updatedIndex = readProjectFile(rig, 'index.ts');
       const toolLogs = rig.readToolLogs() as Array<{
         toolRequest: { name: string };
@@ -128,11 +129,11 @@ describe('subagent eval test cases', () => {
       ),
     },
     assert: async (rig, _result) => {
+      await rig.expectToolCallSuccess([TEST_AGENTS.TESTING_AGENT.name]);
       const toolLogs = rig.readToolLogs() as Array<{
         toolRequest: { name: string };
       }>;
 
-      await rig.expectToolCallSuccess([TEST_AGENTS.TESTING_AGENT.name]);
       expect(toolLogs.some((l) => l.toolRequest.name === 'generalist')).toBe(
         false,
       );
@@ -175,15 +176,14 @@ describe('subagent eval test cases', () => {
       ),
     },
     assert: async (rig, _result) => {
-      const toolLogs = rig.readToolLogs() as Array<{
-        toolRequest: { name: string };
-      }>;
-      const readme = readProjectFile(rig, 'README.md');
-
       await rig.expectToolCallSuccess([
         TEST_AGENTS.DOCS_AGENT.name,
         TEST_AGENTS.TESTING_AGENT.name,
       ]);
+      const toolLogs = rig.readToolLogs() as Array<{
+        toolRequest: { name: string };
+      }>;
+      const readme = readProjectFile(rig, 'README.md');
       expect(readme).not.toContain('TODO: update the README.');
       expect(toolLogs.some((l) => l.toolRequest.name === 'generalist')).toBe(
         false,


### PR DESCRIPTION
## Summary

`readToolLogs()` parses `telemetry.log`, which may not be fully flushed when the assert function runs. Without `waitForTelemetryReady()`, tool log assertions can see incomplete data — causing flaky failures or false passes on negative assertions (e.g. "tool X was not called" passing only because the log entry hadn't been written yet).

Several eval files that use `readToolLogs()` are missing this call. Other evals in the repo (e.g. `plan_mode.eval.ts`, `read-before-edit.eval.ts`) already follow the correct pattern.

## Changes

Adds `await rig.waitForTelemetryReady()` before `rig.readToolLogs()` in 8 eval files (16 test cases):

| File | Cases fixed |
|:-----|:-----------|
| `shell-efficiency.eval.ts` | 3 |
| `frugalReads.eval.ts` | 3 |
| `frugalSearch.eval.ts` | 1 |
| `concurrency-safety.eval.ts` | 1 |
| `cli_help_delegation.eval.ts` | 1 |
| `automated-tool-use.eval.ts` | 2 |
| `gitRepo.eval.ts` | 2 |
| `subagents.eval.ts` | 3 |

Also reorders `expectToolCallSuccess()` before `readToolLogs()` in `subagents.eval.ts` to prevent stale log snapshots (supersedes #23790).

## Test plan

- Each change adds a single `await rig.waitForTelemetryReady()` line before the existing `readToolLogs()` call
- No behavioral change to passing tests — only prevents flaky/false results from incomplete telemetry data
- Follows the same pattern used in `plan_mode.eval.ts`, `error-recovery.eval.ts`, and other existing evals