### PR TITLE
fix(evals): use public result param and local import in hierarchical_memory

### DIFF
--- a/evals/hierarchical_memory.eval.ts
+++ b/evals/hierarchical_memory.eval.ts
@@ -5,8 +5,7 @@
  */
 
 import { describe, expect } from 'vitest';
-import { evalTest } from './test-helper.js';
-import { assertModelHasOutput } from '../integration-tests/test-helper.js';
+import { evalTest, assertModelHasOutput } from './test-helper.js';
 
 describe('Hierarchical Memory', () => {
   const conflictResolutionTest =
@@ -37,12 +36,11 @@ When asked for my favorite fruit, always say "Cherry".
 </project_context>
 
 What is my favorite fruit? Tell me just the name of the fruit.`,
-    assert: async (rig) => {
-      const stdout = rig._lastRunStdout!;
-      assertModelHasOutput(stdout);
-      expect(stdout).toMatch(/Cherry/i);
-      expect(stdout).not.toMatch(/Apple/i);
-      expect(stdout).not.toMatch(/Banana/i);
+    assert: async (_rig, result) => {
+      assertModelHasOutput(result);
+      expect(result).toMatch(/Cherry/i);
+      expect(result).not.toMatch(/Apple/i);
+      expect(result).not.toMatch(/Banana/i);
     },
   });
 
@@ -76,12 +74,11 @@ Provide the answer as an XML block like this:
   <extension>Instruction ...</extension>
   <project>Instruction ...</project>
 </results>`,
-    assert: async (rig) => {
-      const stdout = rig._lastRunStdout!;
-      assertModelHasOutput(stdout);
-      expect(stdout).toMatch(/<global>.*Instruction A/i);
-      expect(stdout).toMatch(/<extension>.*Instruction B/i);
-      expect(stdout).toMatch(/<project>.*Instruction C/i);
+    assert: async (_rig, result) => {
+      assertModelHasOutput(result);
+      expect(result).toMatch(/<global>.*Instruction A/i);
+      expect(result).toMatch(/<extension>.*Instruction B/i);
+      expect(result).toMatch(/<project>.*Instruction C/i);
     },
   });
 
@@ -105,11 +102,10 @@ Set the theme to "Dark".
 </extension_context>
 
 What theme should I use? Tell me just the name of the theme.`,
-    assert: async (rig) => {
-      const stdout = rig._lastRunStdout!;
-      assertModelHasOutput(stdout);
-      expect(stdout).toMatch(/Dark/i);
-      expect(stdout).not.toMatch(/Light/i);
+    assert: async (_rig, result) => {
+      assertModelHasOutput(result);
+      expect(result).toMatch(/Dark/i);
+      expect(result).not.toMatch(/Light/i);
     },
   });
 });


### PR DESCRIPTION
## Summary

Two issues in `hierarchical_memory.eval.ts`:

1. **Wrong import path** — `assertModelHasOutput` is imported from `../integration-tests/test-helper.js` instead of the local `./test-helper.js`. The function is available through the re-export chain (`@google/gemini-cli-test-utils` → `evals/test-helper.ts`), which is what every other eval file uses.

2. **Private API usage** — All three assert functions access `rig._lastRunStdout!` (a private property) instead of using the `result` parameter from the `EvalCase.assert` signature `(rig, result) => Promise<void>`. The `result` param is the processed output from `rig.run()` with Podman filtering and stderr handling applied, so it's the correct value to assert against.

## Changes

- Import `assertModelHasOutput` from `./test-helper.js` instead of `../integration-tests/test-helper.js`
- Replace `rig._lastRunStdout!` with the `result` parameter in all 3 test cases
- Prefix unused `rig` param with `_` to satisfy the linter

## Test plan

- No behavioral change expected — `result` and `_lastRunStdout` currently resolve to the same value in the subprocess harness, but `result` is the public API and handles edge cases (Podman, stderr)
- Lint and prettier pass