### PR TITLE
fix(test): assert file absence in plan-mode write denial test

### DIFF
--- a/integration-tests/plan-mode.test.ts
+++ b/integration-tests/plan-mode.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { writeFileSync, mkdirSync } from 'node:fs';
+import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { GEMINI_DIR, TestRig, checkModelOutputContent } from './test-helper.js';
@@ -151,6 +151,14 @@ describe('Plan Mode', () => {
         'Expected write_file to non-plans dir to fail',
       ).toBe(false);
     }
+
+    // Verify the file was not created regardless of whether write_file
+    // was attempted (covers both denial and model not attempting).
+    const helloPath = join(rig.testDir!, 'hello.txt');
+    expect(
+      existsSync(helloPath),
+      'hello.txt should not exist outside the plans directory',
+    ).toBe(false);
   });
 
   it('should be able to enter plan mode from default mode', async () => {


### PR DESCRIPTION
## Summary

The integration test `should deny write_file to non-plans directory in plan mode` can pass with **zero assertions** when the model doesn't attempt `write_file`. The only expectation (`writeLog.toolRequest.success === false`) is guarded by `if (writeLog)`, so if the model refuses to write or uses a different tool, the test exits green without verifying anything about plan-mode enforcement.

Compare with the sibling test `should allow write_file to plans directory in plan mode` (line 80–114) which correctly asserts `planWrite` is defined before checking success.

## Fix

Add an unconditional filesystem assertion that `hello.txt` does not exist on disk after the run. This covers both scenarios:

1. **Model attempts `write_file`** — the existing `if (writeLog)` check verifies denial, and the filesystem check confirms the file wasn't created
2. **Model doesn't attempt `write_file`** — the filesystem check still verifies the file doesn't exist, preventing a silent pass

## Test plan

- No change to passing test behavior when the model does attempt `write_file` — the existing assertion still runs
- Prevents false passes when the model bypasses `write_file` entirely
- Lint and prettier pass
- Uses the same `existsSync` + `join` imports already available in the file