### PR TITLE
feat: add warning when tools.core disables built-in tools

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -3349,6 +3349,8 @@ export class Config implements McpContext, AgentLoopContext {
     );
 
     // helper to create & register core tools that are enabled
+    let hasWarnedAboutCoreToolsAllowlist = false;
+
     const maybeRegister = (
       toolClass: { name: string; Name?: string },
       registerFn: () => void,
@@ -3356,6 +3358,18 @@ export class Config implements McpContext, AgentLoopContext {
       const className = toolClass.name;
       const toolName = toolClass.Name || className;
       const coreTools = this.getCoreTools();
+
+      if (
+        coreTools &&
+        coreTools.length > 0 &&
+        !hasWarnedAboutCoreToolsAllowlist
+      ) {
+        hasWarnedAboutCoreToolsAllowlist = true;
+        console.warn(
+          `[Gemini CLI] tools.core is configured as an allowlist. Only the specified tools will be enabled: ${coreTools.join(', ')}. Other built-in tools are disabled.`,
+        );
+      }
+
       // On some platforms, the className can be minified to _ClassName.
       const normalizedClassName = className.replace(/^_+/, '');
 


### PR DESCRIPTION
Adds a one-time warning when `tools.core` is configured, since it acts as an allowlist and disables other built-in tools.

Related to #18807

## Summary

This PR adds a one-time runtime warning when `tools.core` is set. The warning explains that `tools.core` behaves as an allowlist and that unspecified built-in tools are disabled.

## Details

Users may not realize that configuring `tools.core` with a subset of tools disables the rest of the built-in toolset. This can make the CLI behavior feel surprising or inconsistent.

This change emits a warning once during tool registration and includes the configured tool list to make the behavior more obvious.

## Related Issues

Related to #18807

## How to Validate

1. Configure `tools.core` with a subset such as:

   ```json
   {
     "tools": {
       "core": ["run_shell_command"]
     }
   }
   ```
2. Start Gemini CLI.
3. Confirm a warning is shown explaining that `tools.core` is an allowlist and that other built-in tools are disabled.

## Pre-Merge Checklist

* [ ] Updated relevant documentation and README (if needed)
* [ ] Added/updated tests (if needed)
* [ ] Noted breaking changes (if any)
* [ ] Validated on required platforms/methods:

  * [ ] MacOS

    * [ ] npm run
    * [ ] npx
    * [ ] Docker
    * [ ] Podman
    * [ ] Seatbelt
  * [ ] Windows

    * [ ] npm run
    * [ ] npx
    * [ ] Docker
  * [ ] Linux

    * [ ] npm run
    * [ ] npx
    * [ ] Docker
