### PR TITLE
feat(UI): queue messages while compression is running

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -16,7 +16,7 @@ import {
 } from 'vitest';
 import { render, cleanup, persistentStateMock } from '../test-utils/render.js';
 import { waitFor } from '../test-utils/async.js';
-import { act, useContext } from 'react';
+import { act, useContext, useEffect } from 'react';
 import { AppContainer } from './AppContainer.js';
 import { SettingsContext } from './contexts/SettingsContext.js';
 import { type TrackedToolCall } from './hooks/useToolScheduler.js';
@@ -418,6 +418,7 @@ describe('AppContainer State Management', () => {
       addMessage: vi.fn(),
       clearQueue: vi.fn(),
       getQueuedMessagesText: vi.fn().mockReturnValue(''),
+      popAllMessages: vi.fn(),
     });
     mockedUseApprovalModeIndicator.mockReturnValue(false);
     mockedUseGitBranchName.mockReturnValue('main');
@@ -3180,6 +3181,123 @@ describe('AppContainer State Management', () => {
       expect(mocks.mockStdout.write).not.toHaveBeenCalledWith(
         ansiEscapes.clearTerminal,
       );
+      unmount();
+    });
+  });
+
+  describe('Compression Queueing', () => {
+    const pendingCompressionItem = {
+      type: 'compression' as const,
+      compression: {
+        isPending: true,
+        originalTokenCount: null,
+        newTokenCount: null,
+        compressionStatus: null,
+      },
+    };
+
+    it('keeps input active while compression is pending', async () => {
+      mockedUseSlashCommandProcessor.mockImplementation((...args) => {
+        const setIsProcessing = args[7] as (isProcessing: boolean) => void;
+
+        useEffect(() => {
+          setIsProcessing(true);
+        }, [setIsProcessing]);
+
+        return {
+          handleSlashCommand: vi.fn(),
+          slashCommands: [],
+          pendingHistoryItems: [pendingCompressionItem],
+          commandContext: {},
+          confirmationRequest: null,
+        };
+      });
+
+      const { unmount } = await act(async () => renderAppContainer());
+
+      await waitFor(() => {
+        expect(capturedUIState.isInputActive).toBe(true);
+      });
+      expect(mockedUseMessageQueue.mock.lastCall?.[0]).toMatchObject({
+        canSubmitMessages: false,
+      });
+
+      unmount();
+    });
+
+    it('queues plain messages while compression is pending', async () => {
+      const addMessage = vi.fn();
+      const addInput = vi.fn();
+      const submitQuery = vi.fn();
+
+      mockedUseSlashCommandProcessor.mockReturnValue({
+        handleSlashCommand: vi.fn(),
+        slashCommands: [],
+        pendingHistoryItems: [pendingCompressionItem],
+        commandContext: {},
+        confirmationRequest: null,
+      });
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: [],
+        addMessage,
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(''),
+        popAllMessages: vi.fn(),
+      });
+      mockedUseInputHistoryStore.mockReturnValue({
+        inputHistory: [],
+        addInput,
+        initializeFromLogger: vi.fn(),
+      });
+      mockedUseGeminiStream.mockReturnValue({
+        ...DEFAULT_GEMINI_STREAM_MOCK,
+        submitQuery,
+      });
+
+      const { unmount } = await act(async () => renderAppContainer());
+
+      await act(async () => {
+        await capturedUIActions.handleFinalSubmit('queued prompt');
+      });
+
+      expect(addMessage).toHaveBeenCalledWith('queued prompt');
+      expect(addInput).toHaveBeenCalledWith('queued prompt');
+      expect(submitQuery).not.toHaveBeenCalled();
+
+      unmount();
+    });
+
+    it('blocks slash commands while compression is pending', async () => {
+      const addMessage = vi.fn();
+      const handleSlashCommand = vi.fn();
+
+      mockedUseSlashCommandProcessor.mockReturnValue({
+        handleSlashCommand,
+        slashCommands: [],
+        pendingHistoryItems: [pendingCompressionItem],
+        commandContext: {},
+        confirmationRequest: null,
+      });
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: [],
+        addMessage,
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(''),
+        popAllMessages: vi.fn(),
+      });
+
+      const { unmount } = await act(async () => renderAppContainer());
+
+      await act(async () => {
+        await capturedUIActions.handleFinalSubmit('/help');
+      });
+
+      expect(addMessage).not.toHaveBeenCalled();
+      expect(handleSlashCommand).not.toHaveBeenCalled();
+      expect(capturedUIState.queueErrorMessage).toBe(
+        'Slash commands cannot be queued',
+      );
+
       unmount();
     });
   });

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1136,6 +1136,13 @@ Logging in with Google... Restarting Gemini CLI to continue.
     () => [...pendingSlashCommandHistoryItems, ...pendingGeminiHistoryItems],
     [pendingSlashCommandHistoryItems, pendingGeminiHistoryItems],
   );
+  const isCompressionPending = useMemo(
+    () =>
+      pendingHistoryItems.some(
+        (item) => item.type === 'compression' && item.compression.isPending,
+      ),
+    [pendingHistoryItems],
+  );
 
   const hasPendingToolConfirmation = useMemo(
     () => isToolAwaitingConfirmation(pendingHistoryItems),
@@ -1209,6 +1216,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     streamingState,
     submitQuery,
     isMcpReady,
+    canSubmitMessages: !isCompressionPending,
   });
 
   cancelHandlerRef.current = useCallback(
@@ -1279,10 +1287,24 @@ Logging in with Google... Restarting Gemini CLI to continue.
       }
 
       const isSlash = isSlashCommand(submittedValue.trim());
+      const isShell = shellModeActive;
       const isIdle = streamingState === StreamingState.Idle;
       const isAgentRunning =
         streamingState === StreamingState.Responding ||
         isToolExecuting(pendingHistoryItems);
+
+      if (isCompressionPending) {
+        if (isSlash || isShell) {
+          setQueueErrorMessage(
+            `${isShell ? 'Shell' : 'Slash'} commands cannot be queued`,
+          );
+          return;
+        }
+
+        addMessage(submittedValue);
+        addInput(submittedValue);
+        return;
+      }
 
       if (isSlash && isAgentRunning) {
         const { commandToExecute } = parseSlashCommand(
@@ -1344,10 +1366,12 @@ Logging in with Google... Restarting Gemini CLI to continue.
       submitQuery,
       handleSlashCommand,
       slashCommands,
+      shellModeActive,
       isMcpReady,
       streamingState,
       messageQueue.length,
       pendingHistoryItems,
+      isCompressionPending,
       config,
       constrainHeight,
       setConstrainHeight,
@@ -1356,6 +1380,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       reset,
       handleHintSubmit,
       isConfigInitialized,
+      setQueueErrorMessage,
       triggerExpandHint,
     ],
   );
@@ -1387,7 +1412,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
    */
   const isInputActive =
     !initError &&
-    !isProcessing &&
+    (!isProcessing || isCompressionPending) &&
     !isResuming &&
     (streamingState === StreamingState.Idle ||
       streamingState === StreamingState.Responding ||

--- a/packages/cli/src/ui/hooks/useMessageQueue.test.tsx
+++ b/packages/cli/src/ui/hooks/useMessageQueue.test.tsx
@@ -29,6 +29,7 @@ describe('useMessageQueue', () => {
     streamingState: StreamingState;
     submitQuery: (query: string) => void;
     isMcpReady: boolean;
+    canSubmitMessages?: boolean;
   }) => {
     let hookResult: ReturnType<typeof useMessageQueue>;
     function TestComponent(props: typeof initialProps) {
@@ -185,6 +186,30 @@ describe('useMessageQueue', () => {
 
     await waitFor(() => {
       expect(mockSubmitQuery).toHaveBeenCalledWith('Delayed message');
+      expect(result.current.messageQueue).toEqual([]);
+    });
+  });
+
+  it('should hold queued messages until submission is re-enabled', async () => {
+    const { result, rerender } = await renderMessageQueueHook({
+      isConfigInitialized: true,
+      streamingState: StreamingState.Idle,
+      submitQuery: mockSubmitQuery,
+      isMcpReady: true,
+      canSubmitMessages: false,
+    });
+
+    act(() => {
+      result.current.addMessage('Queued during compression');
+    });
+
+    expect(mockSubmitQuery).not.toHaveBeenCalled();
+    expect(result.current.messageQueue).toEqual(['Queued during compression']);
+
+    rerender({ canSubmitMessages: true });
+
+    await waitFor(() => {
+      expect(mockSubmitQuery).toHaveBeenCalledWith('Queued during compression');
       expect(result.current.messageQueue).toEqual([]);
     });
   });

--- a/packages/cli/src/ui/hooks/useMessageQueue.ts
+++ b/packages/cli/src/ui/hooks/useMessageQueue.ts
@@ -12,6 +12,7 @@ export interface UseMessageQueueOptions {
   streamingState: StreamingState;
   submitQuery: (query: string) => void;
   isMcpReady: boolean;
+  canSubmitMessages?: boolean;
 }
 
 export interface UseMessageQueueReturn {
@@ -32,6 +33,7 @@ export function useMessageQueue({
   streamingState,
   submitQuery,
   isMcpReady,
+  canSubmitMessages = true,
 }: UseMessageQueueOptions): UseMessageQueueReturn {
   const [messageQueue, setMessageQueue] = useState<string[]>([]);
 
@@ -70,6 +72,7 @@ export function useMessageQueue({
       isConfigInitialized &&
       streamingState === StreamingState.Idle &&
       isMcpReady &&
+      canSubmitMessages &&
       messageQueue.length > 0
     ) {
       // Combine all messages with double newlines for clarity
@@ -82,6 +85,7 @@ export function useMessageQueue({
     isConfigInitialized,
     streamingState,
     isMcpReady,
+    canSubmitMessages,
     messageQueue,
     submitQuery,
   ]);


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Allows users to type and queue a normal prompt while compression is still pending, so they do not need to wait at the terminal for compression to finish before entering the next message.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
This change keeps the composer active specifically during pending compression and reuses the existing queued-message flow for plain text prompts.

 Changes made:
  - kept the input active while a compression history item is pending
  - queued plain-text submissions during pending compression instead of sending them immediately
  - blocked slash commands and shell commands from being queued during compression
  - delayed automatic queued-message submission until compression has completed
  - added UI and hook test coverage for the new behavior

  Files changed:
  - `packages/cli/src/ui/AppContainer.tsx`
  - `packages/cli/src/ui/AppContainer.test.tsx`
  - `packages/cli/src/ui/hooks/useMessageQueue.ts`
  - `packages/cli/src/ui/hooks/useMessageQueue.test.tsx`

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Closes #24071

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
  1. Start Gemini CLI.
  2. Trigger `/compress`.
  3. While compression is still pending, type a normal prompt and submit it.
  4. Confirm:
     - the prompt is queued instead of being sent immediately
     - the input remains usable during compression
     - the queued prompt is submitted after compression finishes
  5. Try a slash command during compression and confirm it is not queued.

  Validation commands run locally:
  - `npm run test --workspace @google/gemini-cli -- src/ui/hooks/useMessageQueue.test.tsx src/ui/AppContainer.test.tsx`
  - `npx eslint packages/cli/src/ui/AppContainer.tsx packages/cli/src/ui/AppContainer.test.tsx packages/cli/src/ui/hooks/
  useMessageQueue.ts packages/cli/src/ui/hooks/useMessageQueue.test.tsx`
  - `npm run typecheck --workspace @google/gemini-cli`

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
