### PR TITLE
fix(cli): handle clipboardy loading failure when sysctl is unavailable

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -6,7 +6,7 @@
 
 import type React from 'react';
 import { useCallback, useEffect, useState, useRef, useMemo } from 'react';
-import clipboardy from 'clipboardy';
+import { readClipboard } from '../../utils/clipboardWrapper.js';
 import { Box, Text, useStdout, type DOMElement } from 'ink';
 import { SuggestionsDisplay, MAX_WIDTH } from './SuggestionsDisplay.js';
 import { theme } from '../semantic-colors.js';
@@ -520,7 +520,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       if (settings.experimental?.useOSC52Paste) {
         stdout.write('\x1b]52;c;?\x07');
       } else {
-        const textToInsert = await clipboardy.read();
+        const textToInsert = await readClipboard();
         const escapedText = settings.ui?.escapePastedAtSymbols
           ? escapeAtSymbols(textToInsert)
           : textToInsert;

--- a/packages/cli/src/ui/utils/commandUtils.ts
+++ b/packages/cli/src/ui/utils/commandUtils.ts
@@ -5,7 +5,7 @@
  */
 
 import { debugLogger } from '@google/gemini-cli-core';
-import clipboardy from 'clipboardy';
+import { writeClipboard } from '../../utils/clipboardWrapper.js';
 import type { SlashCommand } from '../commands/types.js';
 import fs from 'node:fs';
 import type { Writable } from 'node:stream';
@@ -280,7 +280,7 @@ export const copyToClipboard = async (
   }
 
   // Local / non-TTY fallback
-  await clipboardy.write(text);
+  await writeClipboard(text);
 };
 
 export const getUrlOpenCommand = (): string => {

--- a/packages/cli/src/utils/clipboardWrapper.ts
+++ b/packages/cli/src/utils/clipboardWrapper.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { debugLogger } from '@google/gemini-cli-core';
+
+// Clipboardy uses system-architecture which calls sysctl on macOS.
+// This can fail with ENOENT if sysctl is not in PATH (e.g., on some macOS Intel setups).
+// We dynamically import clipboardy to handle this gracefully.
+
+let clipboardyModule: typeof import('clipboardy').default | undefined;
+let clipboardyError: Error | undefined;
+
+try {
+  // Dynamic import to catch errors at runtime rather than module load time
+  const module = await import('clipboardy');
+  clipboardyModule = module.default;
+} catch (error) {
+  clipboardyError = error as Error;
+  debugLogger.warn('Failed to load clipboardy module:', error);
+}
+
+function getClipboardy(): typeof import('clipboardy').default {
+  if (!clipboardyModule) {
+    throw new Error(
+      `Clipboard functionality is unavailable: ${clipboardyError?.message ?? 'Unknown error'}. ` +
+        'This may happen if sysctl is not in PATH on macOS.'
+    );
+  }
+  return clipboardyModule;
+}
+
+/**
+ * Read text from the clipboard.
+ * @returns The clipboard text content
+ * @throws If clipboardy module failed to load
+ */
+export async function readClipboard(): Promise<string> {
+  return getClipboardy().read();
+}
+
+/**
+ * Write text to the clipboard.
+ * @param text The text to write to the clipboard
+ * @throws If clipboardy module failed to load
+ */
+export async function writeClipboard(text: string): Promise<void> {
+  return getClipboardy().write(text);
+}
+
+/**
+ * Check if clipboard functionality is available.
+ * @returns True if clipboard operations are available
+ */
+export function isClipboardAvailable(): boolean {
+  return clipboardyModule !== undefined;
+}


### PR DESCRIPTION
## Description

Clipboardy uses system-architecture which calls sysctl on macOS. This can fail with ENOENT if sysctl is not in PATH (e.g., on some macOS Intel setups with Node.js v25), causing the CLI to crash at startup.

## Changes

- Created a new wrapper module `clipboardWrapper.ts` that dynamically imports clipboardy with error handling
- Updated `commandUtils.ts` to use the wrapper instead of direct clipboardy import
- Updated `InputPrompt.tsx` to use the wrapper instead of direct clipboardy import
- Clipboard functionality gracefully degrades when the module fails to load

## Fixes

Fixes #24142

## Testing

The fix prevents the spawnSync sysctl ENOENT crash by:
1. Using dynamic import to catch errors at runtime rather than module load time
2. Providing clear error messages when clipboard functionality is unavailable
3. Allowing the CLI to start even when clipboardy fails to load

## Checklist

- [x] Code follows the project style guidelines
- [x] Changes are focused on a single issue
- [x] Commit message follows conventional commit format