### PR TITLE
fix(core): treat parsedDelay === 0 as valid in classifyGoogleError

### DIFF
--- a/packages/core/src/utils/googleQuotaErrors.ts
+++ b/packages/core/src/utils/googleQuotaErrors.ts
@@ -312,7 +312,7 @@ export function classifyGoogleError(error: unknown): unknown {
 
   if (retryInfo?.retryDelay) {
     const parsedDelay = parseDurationInSeconds(retryInfo.retryDelay);
-    if (parsedDelay) {
+    if (parsedDelay !== null) {
       delaySeconds = parsedDelay;
     }
   }


### PR DESCRIPTION
## Problem

In `googleQuotaErrors.ts`, the `classifyGoogleError` function parses
the `retryDelay` from the API response using `parseDurationInSeconds`,
which correctly returns `0` for a zero-second delay.

However, the result is checked with a truthy check:
```ts
if (parsedDelay) {
  delaySeconds = parsedDelay;
}
```

Since `0` is falsy in JavaScript, a valid `retryDelay` of `"0s"` is
silently ignored and `delaySeconds` remains `undefined`. This causes
the retry logic to fall through incorrectly.

## Fix

Changed the check to an explicit null check:
```ts
if (parsedDelay !== null) {
  delaySeconds = parsedDelay;
}
```

This correctly handles `0` as a valid delay value, consistent with
how `parseDurationInSeconds` signals failure (returns `null`).

## Testing

- Existing tests pass: `npm run test`
- Existing lint passes: `npm run lint`