### PR TITLE
docs(evals): clarify app-level eval flow for contributors

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -136,6 +136,20 @@ describe('my_feature', () => {
 });
 ```
 
+### Understanding app-level evals at a high level
+
+Some behavioral evals use app-level helpers such as `appEvalTest`, where the
+execution flow is not always obvious from the eval case fields alone.
+
+In general, app-level evals prepare the test workspace first, run any optional
+setup logic, render the app/session environment, wait for the initial ready
+state, inject the prompt, and then validate behavior through assertions.
+
+For contributors who want to understand this flow in more detail, it may be
+helpful to start with a concrete eval such as `model_steering.eval.ts`, then
+follow the helper implementation path in `app-test-helper.ts` and
+`test-helper.ts`.
+
 ## Running Evaluations
 
 First, build the bundled Gemini CLI. You must do this after every code change.


### PR DESCRIPTION
## Summary

Adds a short contributor-facing clarification for the high-level flow of app-level evals in `evals/README.md`.

## Details

While onboarding as a new contributor, I found that the README did not make the app-level eval flow immediately obvious. This PR adds a short high-level note explaining how workspace setup, optional setup logic, rendering, prompt injection, and assertions relate, and points readers to the relevant example/helper files for deeper tracing.

## Related Issues

Related to #23331
Fixes #24201

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

1. Open `evals/README.md`.
2. Go to `Creating an Evaluation`.
3. Confirm there is a new subsection titled `Understanding app-level evals at a high level`.
4. Verify that it explains the flow at a high level and points to relevant files for deeper tracing.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
