### PR TITLE
chore: silence test console output in cli, sdk, and scripts packages

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,4 +1,4 @@
-/**
+it /**
  * @license
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
@@ -20,6 +20,7 @@ export default defineConfig({
     exclude: ['**/node_modules/**', '**/dist/**', '**/cypress/**'],
     environment: 'node',
     globals: true,
+    silent: true,
     reporters: ['default', 'junit'],
 
     outputFile: {

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,4 +1,4 @@
-it /**
+/**
  * @license
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -10,5 +10,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    silent: true,
   },
 });

--- a/scripts/tests/vitest.config.ts
+++ b/scripts/tests/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    silent: true,
     include: ['scripts/tests/**/*.test.{js,ts}'],
     setupFiles: ['scripts/tests/test-setup.ts'],
     coverage: {


### PR DESCRIPTION
## Summary

Adds `silent: true` to vitest configs in `packages/cli`, `packages/sdk`, 
and `scripts/tests` — the three packages missing it. Reduces CLI test 
output from ~16,500 lines to ~850 lines, making actual failures 
significantly easier to spot in CI and local runs.

## Details

`packages/core`, `packages/a2a-server`, and `packages/test-utils` already 
had `silent: true` set. This change brings the remaining packages in line.

The existing `console.error` spy in `packages/cli/test-setup.ts` captures 
`act()` warnings and re-throws them as test failures before vitest's 
suppression applies, so those warnings still surface correctly.

This is a config-only change and does not alter production runtime behavior.
Pre-existing snapshot failures (64 tests across 15 files) were confirmed 
against baseline — unrelated to this change.

## Related Issues

Closes #23328

## How to Validate

1. Run:
   - `npm run test -w @google/gemini-cli`
   - `npm run test -w @google/gemini-cli-core`
2. Confirm passing tests no longer emit excessive console noise.
3. Confirm failures (if any) still show normal Vitest error output and stack traces.
4. Confirm `act()` warnings still cause test failures (not silently swallowed).

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed) — config-only change, no new tests required
- [ ] Noted breaking changes (if any) — none
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker