### PR TITLE
fix(browser): reset action counter for each agent session and let it ignore internal actions

### DIFF
--- a/packages/core/src/agents/browser/automationOverlay.ts
+++ b/packages/core/src/agents/browser/automationOverlay.ts
@@ -94,7 +94,7 @@ export async function injectAutomationOverlay(
       'evaluate_script',
       { function: buildInjectionScript() },
       signal,
-      false,
+      true,
     );
 
     if (result.isError) {
@@ -121,7 +121,7 @@ export async function removeAutomationOverlay(
       'evaluate_script',
       { function: buildRemovalScript() },
       signal,
-      false,
+      true,
     );
 
     if (result.isError) {

--- a/packages/core/src/agents/browser/automationOverlay.ts
+++ b/packages/core/src/agents/browser/automationOverlay.ts
@@ -94,6 +94,7 @@ export async function injectAutomationOverlay(
       'evaluate_script',
       { function: buildInjectionScript() },
       signal,
+      false,
     );
 
     if (result.isError) {
@@ -120,6 +121,7 @@ export async function removeAutomationOverlay(
       'evaluate_script',
       { function: buildRemovalScript() },
       signal,
+      false,
     );
 
     if (result.isError) {

--- a/packages/core/src/agents/browser/browserAgentDefinition.ts
+++ b/packages/core/src/agents/browser/browserAgentDefinition.ts
@@ -109,7 +109,7 @@ Many web apps (Google Sheets/Docs, Notion, Figma, etc.) use custom rendering rat
 
 TERMINAL FAILURES — STOP IMMEDIATELY:
 Some errors are unrecoverable and retrying will never help. When you see ANY of these, call complete_task immediately with success=false and include the EXACT error message (including any remediation steps it contains) in your summary:
-- "Could not connect to Chrome" or "Failed to connect to Chrome" or "Timed out connecting to Chrome" — Include the full error message with its remediation steps in your summary verbatim. Do NOT paraphrase or omit instructions.
+- "Could not connect to Chrome" or "Failed to connect to Chrome" or "Timed out connecting to Chrome" or "The browser is already running" — Include the full error message with its remediation steps in your summary verbatim. Do NOT paraphrase or omit instructions.
 - "Browser closed" or "Target closed" or "Session closed" — The browser process has terminated. Include the error and tell the user to try again.
 - "net::ERR_" network errors on the SAME URL after 2 retries — the site is unreachable. Report the URL and error.
 - "reached maximum action limit" — You have performed too many actions in this task. Stop immediately and report this limit to the user.

--- a/packages/core/src/agents/browser/browserAgentDefinition.ts
+++ b/packages/core/src/agents/browser/browserAgentDefinition.ts
@@ -109,7 +109,7 @@ Many web apps (Google Sheets/Docs, Notion, Figma, etc.) use custom rendering rat
 
 TERMINAL FAILURES — STOP IMMEDIATELY:
 Some errors are unrecoverable and retrying will never help. When you see ANY of these, call complete_task immediately with success=false and include the EXACT error message (including any remediation steps it contains) in your summary:
-- "Could not connect to Chrome" or "Failed to connect to Chrome" or "Timed out connecting to Chrome" or "The browser is already running" — Include the full error message with its remediation steps in your summary verbatim. Do NOT paraphrase or omit instructions.
+- "Could not connect to Chrome" or "Failed to connect to Chrome" or "Timed out connecting to Chrome" — Include the full error message with its remediation steps in your summary verbatim. Do NOT paraphrase or omit instructions.
 - "Browser closed" or "Target closed" or "Session closed" — The browser process has terminated. Include the error and tell the user to try again.
 - "net::ERR_" network errors on the SAME URL after 2 retries — the site is unreachable. Report the URL and error.
 - "reached maximum action limit" — You have performed too many actions in this task. Stop immediately and report this limit to the user.

--- a/packages/core/src/agents/browser/browserManager.test.ts
+++ b/packages/core/src/agents/browser/browserManager.test.ts
@@ -980,5 +980,29 @@ describe('BrowserManager', () => {
         /maximum action limit \(3\)/,
       );
     });
+
+    it('should NOT increment action counter when shouldCount is false', async () => {
+      const limitedConfig = makeFakeConfig({
+        agents: {
+          browser: {
+            maxActionsPerTask: 1,
+          },
+        },
+      });
+      const manager = new BrowserManager(limitedConfig);
+
+      // Multiple calls with shouldCount: false should NOT exhaust the limit
+      await manager.callTool('evaluate_script', {}, undefined, false);
+      await manager.callTool('evaluate_script', {}, undefined, false);
+      await manager.callTool('evaluate_script', {}, undefined, false);
+
+      // This should still work
+      await manager.callTool('take_snapshot', {});
+
+      // Next one should throw (limit 1 allows exactly 1 call with >= check)
+      await expect(manager.callTool('take_snapshot', {})).rejects.toThrow(
+        /maximum action limit \(1\)/,
+      );
+    });
   });
 });

--- a/packages/core/src/agents/browser/browserManager.test.ts
+++ b/packages/core/src/agents/browser/browserManager.test.ts
@@ -991,10 +991,10 @@ describe('BrowserManager', () => {
       });
       const manager = new BrowserManager(limitedConfig);
 
-      // Multiple calls with shouldCount: false should NOT exhaust the limit
-      await manager.callTool('evaluate_script', {}, undefined, false);
-      await manager.callTool('evaluate_script', {}, undefined, false);
-      await manager.callTool('evaluate_script', {}, undefined, false);
+      // Multiple calls with isInternal: true should NOT exhaust the limit
+      await manager.callTool('evaluate_script', {}, undefined, true);
+      await manager.callTool('evaluate_script', {}, undefined, true);
+      await manager.callTool('evaluate_script', {}, undefined, true);
 
       // This should still work
       await manager.callTool('take_snapshot', {});

--- a/packages/core/src/agents/browser/browserManager.ts
+++ b/packages/core/src/agents/browser/browserManager.ts
@@ -221,20 +221,23 @@ export class BrowserManager {
     toolName: string,
     args: Record<string, unknown>,
     signal?: AbortSignal,
+    shouldCount: boolean = true,
   ): Promise<McpToolCallResult> {
     if (signal?.aborted) {
       throw signal.reason ?? new Error('Operation cancelled');
     }
 
     // Hard enforcement of per-action rate limit
-    if (this.actionCounter > this.maxActionsPerTask) {
-      const error = new Error(
-        `Browser agent reached maximum action limit (${this.maxActionsPerTask}). ` +
-          `Task terminated to prevent runaway execution. To config the limit, use maxActionsPerTask in the settings.`,
-      );
-      throw error;
+    if (shouldCount) {
+      if (this.actionCounter > this.maxActionsPerTask) {
+        const error = new Error(
+          `Browser agent reached maximum action limit (${this.maxActionsPerTask}). ` +
+            `Task terminated to prevent runaway execution. To config the limit, use maxActionsPerTask in the settings.`,
+        );
+        throw error;
+      }
+      this.actionCounter++;
     }
-    this.actionCounter++;
 
     const errorMessage = this.checkNavigationRestrictions(toolName, args);
     if (errorMessage) {
@@ -588,6 +591,8 @@ export class BrowserManager {
           debugLogger.log('MCP client connected to chrome-devtools-mcp');
           await this.discoverTools();
           this.registerInputBlockerHandler();
+          // clear the action counter for each connection
+          this.actionCounter = 0;
         })(),
         new Promise<never>((_, reject) => {
           timeoutId = setTimeout(

--- a/packages/core/src/agents/browser/browserManager.ts
+++ b/packages/core/src/agents/browser/browserManager.ts
@@ -222,14 +222,14 @@ export class BrowserManager {
     toolName: string,
     args: Record<string, unknown>,
     signal?: AbortSignal,
-    isInternal: boolean = true,
+    isInternal: boolean = false,
   ): Promise<McpToolCallResult> {
     if (signal?.aborted) {
       throw signal.reason ?? new Error('Operation cancelled');
     }
 
     // Hard enforcement of per-action rate limit
-    if (isInternal) {
+    if (!isInternal) {
       if (this.actionCounter >= this.maxActionsPerTask) {
         const error = new Error(
           `Browser agent reached maximum action limit (${this.maxActionsPerTask}). ` +

--- a/packages/core/src/agents/browser/browserManager.ts
+++ b/packages/core/src/agents/browser/browserManager.ts
@@ -229,7 +229,7 @@ export class BrowserManager {
 
     // Hard enforcement of per-action rate limit
     if (shouldCount) {
-      if (this.actionCounter > this.maxActionsPerTask) {
+      if (this.actionCounter >= this.maxActionsPerTask) {
         const error = new Error(
           `Browser agent reached maximum action limit (${this.maxActionsPerTask}). ` +
             `Task terminated to prevent runaway execution. To config the limit, use maxActionsPerTask in the settings.`,

--- a/packages/core/src/agents/browser/browserManager.ts
+++ b/packages/core/src/agents/browser/browserManager.ts
@@ -215,20 +215,21 @@ export class BrowserManager {
    * @param toolName The name of the tool to call
    * @param args Arguments to pass to the tool
    * @param signal Optional AbortSignal to cancel the call
+   * @param isInternal Determine if the tool is for internal execution
    * @returns The result from the MCP server
    */
   async callTool(
     toolName: string,
     args: Record<string, unknown>,
     signal?: AbortSignal,
-    shouldCount: boolean = true,
+    isInternal: boolean = true,
   ): Promise<McpToolCallResult> {
     if (signal?.aborted) {
       throw signal.reason ?? new Error('Operation cancelled');
     }
 
     // Hard enforcement of per-action rate limit
-    if (shouldCount) {
+    if (isInternal) {
       if (this.actionCounter >= this.maxActionsPerTask) {
         const error = new Error(
           `Browser agent reached maximum action limit (${this.maxActionsPerTask}). ` +

--- a/packages/core/src/agents/browser/inputBlocker.test.ts
+++ b/packages/core/src/agents/browser/inputBlocker.test.ts
@@ -106,6 +106,7 @@ describe('inputBlocker', () => {
           function: expect.stringContaining('__gemini_input_blocker'),
         }),
         undefined,
+        true,
       );
     });
   });
@@ -120,6 +121,7 @@ describe('inputBlocker', () => {
           function: expect.stringContaining('__gemini_input_blocker'),
         },
         undefined,
+        true,
       );
     });
 
@@ -165,6 +167,7 @@ describe('inputBlocker', () => {
           function: expect.stringContaining('__gemini_input_blocker'),
         }),
         undefined,
+        true,
       );
       expect(mockBrowserManager.callTool).toHaveBeenNthCalledWith(
         2,
@@ -173,6 +176,7 @@ describe('inputBlocker', () => {
           function: expect.stringContaining('__gemini_input_blocker'),
         }),
         undefined,
+        true,
       );
     });
   });

--- a/packages/core/src/agents/browser/inputBlocker.test.ts
+++ b/packages/core/src/agents/browser/inputBlocker.test.ts
@@ -34,6 +34,7 @@ describe('inputBlocker', () => {
           function: expect.stringContaining('__gemini_input_blocker'),
         },
         undefined,
+        true,
       );
     });
 
@@ -96,6 +97,7 @@ describe('inputBlocker', () => {
           function: expect.stringContaining('__gemini_input_blocker'),
         }),
         undefined,
+        true,
       );
       expect(mockBrowserManager.callTool).toHaveBeenNthCalledWith(
         2,

--- a/packages/core/src/agents/browser/inputBlocker.ts
+++ b/packages/core/src/agents/browser/inputBlocker.ts
@@ -205,7 +205,7 @@ export async function injectInputBlocker(
       'evaluate_script',
       { function: INPUT_BLOCKER_FUNCTION },
       signal,
-      false,
+      true,
     );
     debugLogger.log('Input blocker injected successfully');
   } catch (error) {
@@ -233,7 +233,7 @@ export async function removeInputBlocker(
       'evaluate_script',
       { function: REMOVE_BLOCKER_FUNCTION },
       signal,
-      false,
+      true,
     );
     debugLogger.log('Input blocker removed successfully');
   } catch (error) {
@@ -259,7 +259,7 @@ export async function suspendInputBlocker(
       'evaluate_script',
       { function: SUSPEND_BLOCKER_FUNCTION },
       signal,
-      false,
+      true,
     );
   } catch {
     // Non-critical — tool call will still attempt to proceed
@@ -279,7 +279,7 @@ export async function resumeInputBlocker(
       'evaluate_script',
       { function: RESUME_BLOCKER_FUNCTION },
       signal,
-      false,
+      true,
     );
   } catch {
     // Non-critical

--- a/packages/core/src/agents/browser/inputBlocker.ts
+++ b/packages/core/src/agents/browser/inputBlocker.ts
@@ -205,6 +205,7 @@ export async function injectInputBlocker(
       'evaluate_script',
       { function: INPUT_BLOCKER_FUNCTION },
       signal,
+      false,
     );
     debugLogger.log('Input blocker injected successfully');
   } catch (error) {
@@ -232,6 +233,7 @@ export async function removeInputBlocker(
       'evaluate_script',
       { function: REMOVE_BLOCKER_FUNCTION },
       signal,
+      false,
     );
     debugLogger.log('Input blocker removed successfully');
   } catch (error) {
@@ -257,6 +259,7 @@ export async function suspendInputBlocker(
       'evaluate_script',
       { function: SUSPEND_BLOCKER_FUNCTION },
       signal,
+      false,
     );
   } catch {
     // Non-critical — tool call will still attempt to proceed
@@ -276,6 +279,7 @@ export async function resumeInputBlocker(
       'evaluate_script',
       { function: RESUME_BLOCKER_FUNCTION },
       signal,
+      false,
     );
   } catch {
     // Non-critical

--- a/packages/core/src/agents/browser/mcpToolWrapper.test.ts
+++ b/packages/core/src/agents/browser/mcpToolWrapper.test.ts
@@ -225,6 +225,7 @@ describe('mcpToolWrapper', () => {
           function: expect.stringContaining('__gemini_input_blocker'),
         }),
         expect.any(AbortSignal),
+        true,
       );
 
       // Second call: click
@@ -243,6 +244,7 @@ describe('mcpToolWrapper', () => {
           function: expect.stringContaining('__gemini_input_blocker'),
         }),
         expect.any(AbortSignal),
+        true,
       );
     });
 


### PR DESCRIPTION
## Summary

The goal is to prevent internal, non-mutating browser agent operations (like injecting the input blocker or automation overlay) from consuming the user's `maxActionsPerTask` quota, and reset the action counter for each new browser agent session since the browserManager is a singleton.

## Details

- Added a `shouldCount` parameter to `BrowserManager.callTool` to conditionally increment the `actionCounter`.
- Updated internal utilities in `automationOverlay.ts` and `inputBlocker.ts` to pass `false` for `shouldCount`.
- Resets the `actionCounter` when a new MCP client connects.

## Related Issues

related #15963 #21247 

## How to Validate

1. Configure a low `maxActionsPerTask` setting for the browser agent (e.g., `3`).
2. Run a prompt that utilizes the browser agent to navigate and perform actions.
3. Observe that internal operations like the "pulsating blue border" (automation overlay) and input blocker injections do not trigger the `Browser agent reached maximum action limit` error prematurely.
4. Verify that user-directed actions still correctly increment the counter and terminate the task when the limit is reached.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
