### PR TITLE
feat(cli): add /trace command for execution summary

### DIFF
--- a/packages/cli/src/interactiveCli.tsx
+++ b/packages/cli/src/interactiveCli.tsx
@@ -36,6 +36,7 @@ import { StreamingState } from './ui/types.js';
 import { computeTerminalTitle } from './utils/windowTitle.js';
 
 import { SessionStatsProvider } from './ui/contexts/SessionContext.js';
+import { SessionTraceProvider } from './ui/contexts/SessionTraceContext.js';
 import { VimModeProvider } from './ui/contexts/VimModeContext.js';
 import { KeyMatchersProvider } from './ui/hooks/useKeyMatchers.js';
 import { loadKeyMatchers } from './ui/key/keyMatchers.js';
@@ -106,17 +107,19 @@ export async function startInteractiveUI(
               <TerminalProvider>
                 <ScrollProvider>
                   <OverflowProvider>
-                    <SessionStatsProvider>
-                      <VimModeProvider>
-                        <AppContainer
-                          config={config}
-                          startupWarnings={startupWarnings}
-                          version={version}
-                          resumedSessionData={resumedSessionData}
-                          initializationResult={initializationResult}
-                        />
-                      </VimModeProvider>
-                    </SessionStatsProvider>
+                    <SessionTraceProvider>
+                      <SessionStatsProvider>
+                        <VimModeProvider>
+                          <AppContainer
+                            config={config}
+                            startupWarnings={startupWarnings}
+                            version={version}
+                            resumedSessionData={resumedSessionData}
+                            initializationResult={initializationResult}
+                          />
+                        </VimModeProvider>
+                      </SessionStatsProvider>
+                    </SessionTraceProvider>
                   </OverflowProvider>
                 </ScrollProvider>
               </TerminalProvider>

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -53,6 +53,7 @@ import { restoreCommand } from '../ui/commands/restoreCommand.js';
 import { resumeCommand } from '../ui/commands/resumeCommand.js';
 import { statsCommand } from '../ui/commands/statsCommand.js';
 import { themeCommand } from '../ui/commands/themeCommand.js';
+import { traceCommand } from '../ui/commands/traceCommand.js';
 import { toolsCommand } from '../ui/commands/toolsCommand.js';
 import { skillsCommand } from '../ui/commands/skillsCommand.js';
 import { settingsCommand } from '../ui/commands/settingsCommand.js';
@@ -195,6 +196,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
         subCommands: addDebugToChatResumeSubCommands(resumeCommand.subCommands),
       },
       statsCommand,
+      traceCommand,
       themeCommand,
       toolsCommand,
       ...(this.config?.isSkillsSupportEnabled()

--- a/packages/cli/src/test-utils/render.tsx
+++ b/packages/cli/src/test-utils/render.tsx
@@ -47,6 +47,7 @@ import { FakePersistentState } from './persistentStateFake.js';
 import { AppContext, type AppState } from '../ui/contexts/AppContext.js';
 import { createMockSettings } from './settings.js';
 import { SessionStatsProvider } from '../ui/contexts/SessionContext.js';
+import { SessionTraceProvider } from '../ui/contexts/SessionTraceContext.js';
 import { themeManager, DEFAULT_THEME } from '../ui/themes/theme-manager.js';
 import { DefaultLight } from '../ui/themes/builtin/light/default-light.js';
 import { pickDefaultThemeName } from '../ui/themes/theme.js';
@@ -701,47 +702,49 @@ export const renderWithProviders = async (
           <UIStateContext.Provider value={finalUiState}>
             <VimModeProvider>
               <ShellFocusContext.Provider value={shellFocus}>
-                <SessionStatsProvider>
-                  <StreamingContext.Provider
-                    value={finalUiState.streamingState}
-                  >
-                    <UIActionsContext.Provider value={finalUIActions}>
-                      <OverflowProvider>
-                        <ToolActionsProvider
-                          config={config}
-                          toolCalls={allToolCalls}
-                        >
-                          <AskUserActionsProvider
-                            request={null}
-                            onSubmit={vi.fn()}
-                            onCancel={vi.fn()}
+                <SessionTraceProvider>
+                  <SessionStatsProvider>
+                    <StreamingContext.Provider
+                      value={finalUiState.streamingState}
+                    >
+                      <UIActionsContext.Provider value={finalUIActions}>
+                        <OverflowProvider>
+                          <ToolActionsProvider
+                            config={config}
+                            toolCalls={allToolCalls}
                           >
-                            <KeypressProvider>
-                              <MouseProvider
-                                mouseEventsEnabled={mouseEventsEnabled}
-                              >
-                                <TerminalProvider>
-                                  <ScrollProvider>
-                                    <ContextCapture>
-                                      <Box
-                                        width={terminalWidth}
-                                        flexShrink={0}
-                                        flexGrow={0}
-                                        flexDirection="column"
-                                      >
-                                        {comp}
-                                      </Box>
-                                    </ContextCapture>
-                                  </ScrollProvider>
-                                </TerminalProvider>
-                              </MouseProvider>
-                            </KeypressProvider>
-                          </AskUserActionsProvider>
-                        </ToolActionsProvider>
-                      </OverflowProvider>
-                    </UIActionsContext.Provider>
-                  </StreamingContext.Provider>
-                </SessionStatsProvider>
+                            <AskUserActionsProvider
+                              request={null}
+                              onSubmit={vi.fn()}
+                              onCancel={vi.fn()}
+                            >
+                              <KeypressProvider>
+                                <MouseProvider
+                                  mouseEventsEnabled={mouseEventsEnabled}
+                                >
+                                  <TerminalProvider>
+                                    <ScrollProvider>
+                                      <ContextCapture>
+                                        <Box
+                                          width={terminalWidth}
+                                          flexShrink={0}
+                                          flexGrow={0}
+                                          flexDirection="column"
+                                        >
+                                          {comp}
+                                        </Box>
+                                      </ContextCapture>
+                                    </ScrollProvider>
+                                  </TerminalProvider>
+                                </MouseProvider>
+                              </KeypressProvider>
+                            </AskUserActionsProvider>
+                          </ToolActionsProvider>
+                        </OverflowProvider>
+                      </UIActionsContext.Provider>
+                    </StreamingContext.Provider>
+                  </SessionStatsProvider>
+                </SessionTraceProvider>
               </ShellFocusContext.Provider>
             </VimModeProvider>
           </UIStateContext.Provider>

--- a/packages/cli/src/ui/commands/traceCommand.test.ts
+++ b/packages/cli/src/ui/commands/traceCommand.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { traceCommand } from './traceCommand.js';
+
+describe('traceCommand', () => {
+  it('adds the trace inspector view to history', async () => {
+    const context = createMockCommandContext();
+
+    if (!traceCommand.action) {
+      throw new Error('traceCommand.action is required for this test');
+    }
+
+    await traceCommand.action(context, '');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith({
+      type: 'trace',
+    });
+  });
+
+  it('exposes /perf as an alias for discoverability', () => {
+    expect(traceCommand.altNames).toContain('perf');
+  });
+});

--- a/packages/cli/src/ui/commands/traceCommand.ts
+++ b/packages/cli/src/ui/commands/traceCommand.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  CommandKind,
+  type CommandContext,
+  type SlashCommand,
+} from './types.js';
+
+export const traceCommand: SlashCommand = {
+  name: 'trace',
+  altNames: ['perf'],
+  description: 'Inspect the current session execution summary',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  isSafeConcurrent: true,
+  action: (context: CommandContext) => {
+    context.ui.addItem({
+      type: 'trace',
+    });
+  },
+};

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -22,6 +22,7 @@ import { AboutBox } from './AboutBox.js';
 import { StatsDisplay } from './StatsDisplay.js';
 import { ModelStatsDisplay } from './ModelStatsDisplay.js';
 import { ToolStatsDisplay } from './ToolStatsDisplay.js';
+import { TraceDisplay } from './TraceDisplay.js';
 import { SessionSummaryDisplay } from './SessionSummaryDisplay.js';
 import { Help } from './Help.js';
 import type { SlashCommand } from '../commands/types.js';
@@ -198,6 +199,7 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
         />
       )}
       {itemForDisplay.type === 'tool_stats' && <ToolStatsDisplay />}
+      {itemForDisplay.type === 'trace' && <TraceDisplay />}
       {itemForDisplay.type === 'model' && (
         <ModelMessage model={itemForDisplay.model} />
       )}

--- a/packages/cli/src/ui/components/TraceDisplay.test.tsx
+++ b/packages/cli/src/ui/components/TraceDisplay.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '../../test-utils/render.js';
+import { ToolCallDecision } from '@google/gemini-cli-core';
+import { TraceDisplay } from './TraceDisplay.js';
+import * as SessionContext from '../contexts/SessionContext.js';
+import * as SessionTraceContext from '../contexts/SessionTraceContext.js';
+
+vi.mock('../contexts/SessionContext.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof SessionContext>();
+  return {
+    ...actual,
+    useSessionStats: vi.fn(),
+  };
+});
+
+vi.mock('../contexts/SessionTraceContext.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof SessionTraceContext>();
+  return {
+    ...actual,
+    useSessionTrace: vi.fn(),
+  };
+});
+
+const useSessionStatsMock = vi.mocked(SessionContext.useSessionStats);
+const useSessionTraceMock = vi.mocked(SessionTraceContext.useSessionTrace);
+
+describe('<TraceDisplay />', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-30T12:00:05.000Z'));
+    vi.spyOn(process, 'memoryUsage').mockReturnValue({
+      rss: 180 * 1024 * 1024,
+      heapTotal: 0,
+      heapUsed: 0,
+      external: 0,
+      arrayBuffers: 0,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('renders a graceful empty state when no trace data exists', async () => {
+    useSessionStatsMock.mockReturnValue({
+      stats: {
+        sessionId: 'session-1',
+        sessionStartTime: new Date('2026-03-30T12:00:00.000Z'),
+        metrics: {
+          models: {},
+          tools: {
+            totalCalls: 0,
+            totalSuccess: 0,
+            totalFail: 0,
+            totalDurationMs: 0,
+            totalDecisions: {
+              accept: 0,
+              reject: 0,
+              modify: 0,
+              [ToolCallDecision.AUTO_ACCEPT]: 0,
+            },
+            byName: {},
+          },
+          files: {
+            totalLinesAdded: 0,
+            totalLinesRemoved: 0,
+          },
+        },
+        lastPromptTokenCount: 0,
+        promptCount: 0,
+      },
+      startNewPrompt: vi.fn(),
+      getPromptCount: vi.fn().mockReturnValue(0),
+    });
+    useSessionTraceMock.mockReturnValue({
+      trace: { steps: {} },
+      recordStep: vi.fn(),
+    });
+
+    const { lastFrame, unmount } = await render(<TraceDisplay />);
+
+    expect(lastFrame()).toContain('Agent Execution Inspector');
+    expect(lastFrame()).toContain('No traced execution yet');
+    expect(lastFrame()).toContain('/trace');
+    unmount();
+  });
+
+  it('renders a concise execution summary from session metrics and trace steps', async () => {
+    useSessionStatsMock.mockReturnValue({
+      stats: {
+        sessionId: 'session-2',
+        sessionStartTime: new Date('2026-03-30T12:00:00.000Z'),
+        metrics: {
+          models: {
+            'gemini-2.5-pro': {
+              api: {
+                totalRequests: 2,
+                totalErrors: 0,
+                totalLatencyMs: 2400,
+              },
+              tokens: {
+                input: 1200,
+                prompt: 1400,
+                candidates: 600,
+                total: 2000,
+                cached: 200,
+                thoughts: 0,
+                tool: 0,
+              },
+              roles: {},
+            },
+          },
+          tools: {
+            totalCalls: 3,
+            totalSuccess: 3,
+            totalFail: 0,
+            totalDurationMs: 3200,
+            totalDecisions: {
+              accept: 1,
+              reject: 0,
+              modify: 0,
+              [ToolCallDecision.AUTO_ACCEPT]: 0,
+            },
+            byName: {
+              read_file: {
+                count: 2,
+                success: 2,
+                fail: 0,
+                durationMs: 2200,
+                decisions: {
+                  accept: 1,
+                  reject: 0,
+                  modify: 0,
+                  [ToolCallDecision.AUTO_ACCEPT]: 0,
+                },
+              },
+              grep: {
+                count: 1,
+                success: 1,
+                fail: 0,
+                durationMs: 1000,
+                decisions: {
+                  accept: 0,
+                  reject: 0,
+                  modify: 0,
+                  [ToolCallDecision.AUTO_ACCEPT]: 0,
+                },
+              },
+            },
+          },
+          files: {
+            totalLinesAdded: 10,
+            totalLinesRemoved: 2,
+          },
+        },
+        lastPromptTokenCount: 0,
+        promptCount: 2,
+      },
+      startNewPrompt: vi.fn(),
+      getPromptCount: vi.fn().mockReturnValue(2),
+    });
+    useSessionTraceMock.mockReturnValue({
+      trace: {
+        steps: {
+          [SessionTraceContext.SessionTraceStepKey.AgentTurn]: {
+            key: SessionTraceContext.SessionTraceStepKey.AgentTurn,
+            label: 'Agent turn',
+            count: 2,
+            totalDurationMs: 4300,
+            maxDurationMs: 2600,
+            lastDurationMs: 1700,
+          },
+          [SessionTraceContext.SessionTraceStepKey.SlashCommand]: {
+            key: SessionTraceContext.SessionTraceStepKey.SlashCommand,
+            label: 'Slash command',
+            count: 1,
+            totalDurationMs: 300,
+            maxDurationMs: 300,
+            lastDurationMs: 300,
+          },
+        },
+      },
+      recordStep: vi.fn(),
+    });
+
+    const { lastFrame, unmount } = await render(<TraceDisplay />);
+
+    const output = lastFrame();
+    expect(output).toContain('Prompts Sent');
+    expect(output).toContain('Memory RSS');
+    expect(output).toContain('Bottleneck');
+    expect(output).toContain('Tool execution');
+    expect(output).toContain('read_file');
+    expect(output).toContain('gemini-2.5-pro');
+    unmount();
+  });
+});

--- a/packages/cli/src/ui/components/TraceDisplay.tsx
+++ b/packages/cli/src/ui/components/TraceDisplay.tsx
@@ -1,0 +1,286 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import process from 'node:process';
+import { Box, Text } from 'ink';
+import { theme } from '../semantic-colors.js';
+import { ThemedGradient } from './ThemedGradient.js';
+import { formatBytes, formatDuration } from '../utils/formatters.js';
+import { computeSessionStats } from '../utils/computeStats.js';
+import { useSessionStats } from '../contexts/SessionContext.js';
+import {
+  SessionTraceStepKey,
+  useSessionTrace,
+} from '../contexts/SessionTraceContext.js';
+
+const LABEL_WIDTH = 20;
+
+const Section: React.FC<{ title: string; children: React.ReactNode }> = ({
+  title,
+  children,
+}) => (
+  <Box flexDirection="column" marginBottom={1}>
+    <Text bold color={theme.text.primary}>
+      {title}
+    </Text>
+    {children}
+  </Box>
+);
+
+const StatRow: React.FC<{ label: string; children: React.ReactNode }> = ({
+  label,
+  children,
+}) => (
+  <Box>
+    <Box width={LABEL_WIDTH}>
+      <Text color={theme.text.link}>{label}</Text>
+    </Box>
+    {children}
+  </Box>
+);
+
+const formatPercent = (value: number) => `${value.toFixed(1)}%`;
+
+export const TraceDisplay: React.FC = () => {
+  const { stats } = useSessionStats();
+  const { trace } = useSessionTrace();
+  const computed = computeSessionStats(stats.metrics);
+  const wallDurationMs = Math.max(
+    0,
+    Date.now() - stats.sessionStartTime.getTime(),
+  );
+  const rssBytes = process.memoryUsage().rss;
+  const agentTurnStep = trace.steps[SessionTraceStepKey.AgentTurn];
+  const slashCommandStep = trace.steps[SessionTraceStepKey.SlashCommand];
+  const slashCommandTime = slashCommandStep?.totalDurationMs ?? 0;
+  const apiRequests = Object.values(stats.metrics.models).reduce(
+    (sum, model) => sum + model.api.totalRequests,
+    0,
+  );
+  const trackedTime =
+    computed.totalApiTime + computed.totalToolTime + slashCommandTime;
+  const idleTime = Math.max(0, wallDurationMs - trackedTime);
+  const hasTraceData =
+    apiRequests > 0 ||
+    stats.metrics.tools.totalCalls > 0 ||
+    (agentTurnStep?.count ?? 0) > 0 ||
+    (slashCommandStep?.count ?? 0) > 0;
+
+  const measuredBreakdown = [
+    {
+      label: 'Model API',
+      durationMs: computed.totalApiTime,
+      detail:
+        apiRequests > 0
+          ? `${apiRequests} request${apiRequests === 1 ? '' : 's'}`
+          : undefined,
+    },
+    {
+      label: 'Tool execution',
+      durationMs: computed.totalToolTime,
+      detail:
+        stats.metrics.tools.totalCalls > 0
+          ? `${stats.metrics.tools.totalCalls} call${
+              stats.metrics.tools.totalCalls === 1 ? '' : 's'
+            }`
+          : undefined,
+    },
+    {
+      label: 'Slash commands',
+      durationMs: slashCommandTime,
+      detail:
+        slashCommandStep && slashCommandStep.count > 0
+          ? `${slashCommandStep.count} command${
+              slashCommandStep.count === 1 ? '' : 's'
+            }`
+          : undefined,
+    },
+  ];
+
+  const bottleneck = measuredBreakdown.reduce<
+    (typeof measuredBreakdown)[number] | null
+  >((slowest, current) => {
+    if (current.durationMs <= 0) {
+      return slowest;
+    }
+    if (!slowest || current.durationMs > slowest.durationMs) {
+      return current;
+    }
+    return slowest;
+  }, null);
+
+  const slowestTool = Object.entries(stats.metrics.tools.byName).reduce<{
+    name: string;
+    durationMs: number;
+    count: number;
+  } | null>((slowest, [name, toolStats]) => {
+    if (!slowest || toolStats.durationMs > slowest.durationMs) {
+      return {
+        name,
+        durationMs: toolStats.durationMs,
+        count: toolStats.count,
+      };
+    }
+    return slowest;
+  }, null);
+
+  const slowestModel = Object.entries(stats.metrics.models).reduce<{
+    name: string;
+    durationMs: number;
+    requests: number;
+  } | null>((slowest, [name, modelStats]) => {
+    if (!slowest || modelStats.api.totalLatencyMs > slowest.durationMs) {
+      return {
+        name,
+        durationMs: modelStats.api.totalLatencyMs,
+        requests: modelStats.api.totalRequests,
+      };
+    }
+    return slowest;
+  }, null);
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={theme.border.default}
+      flexDirection="column"
+      paddingTop={1}
+      paddingX={2}
+      overflow="hidden"
+      width={78}
+    >
+      <ThemedGradient bold>Execution Summary</ThemedGradient>
+      <Box height={1} />
+
+      <Section title="Overview">
+        <StatRow label="Session Duration:">
+          <Text color={theme.text.primary}>
+            {formatDuration(wallDurationMs)}
+          </Text>
+        </StatRow>
+        <StatRow label="Prompts Sent:">
+          <Text color={theme.text.primary}>{stats.promptCount}</Text>
+        </StatRow>
+        <StatRow label="Agent Turns:">
+          <Text color={theme.text.primary}>{agentTurnStep?.count ?? 0}</Text>
+        </StatRow>
+        <StatRow label="Tool Calls:">
+          <Text color={theme.text.primary}>
+            {stats.metrics.tools.totalCalls} ({' '}
+            <Text color={theme.status.success}>
+              {stats.metrics.tools.totalSuccess} ok
+            </Text>{' '}
+            <Text color={theme.status.error}>
+              {stats.metrics.tools.totalFail} fail
+            </Text>{' '}
+            )
+          </Text>
+        </StatRow>
+        <StatRow label="API Requests:">
+          <Text color={theme.text.primary}>{apiRequests}</Text>
+        </StatRow>
+        <StatRow label="Memory RSS:">
+          <Text color={theme.text.primary}>{formatBytes(rssBytes)}</Text>
+        </StatRow>
+      </Section>
+
+      {hasTraceData ? (
+        <>
+          <Section title="Time Breakdown">
+            {measuredBreakdown.map((entry) => (
+              <StatRow key={entry.label} label={`${entry.label}:`}>
+                <Text color={theme.text.primary}>
+                  {formatDuration(entry.durationMs)}{' '}
+                  <Text color={theme.text.secondary}>
+                    (
+                    {formatPercent(
+                      wallDurationMs > 0
+                        ? (entry.durationMs / wallDurationMs) * 100
+                        : 0,
+                    )}
+                    {entry.detail ? ` • ${entry.detail}` : ''})
+                  </Text>
+                </Text>
+              </StatRow>
+            ))}
+            <StatRow label="Other / Idle:">
+              <Text color={theme.text.primary}>
+                {formatDuration(idleTime)}{' '}
+                <Text color={theme.text.secondary}>
+                  (
+                  {formatPercent(
+                    wallDurationMs > 0 ? (idleTime / wallDurationMs) * 100 : 0,
+                  )}
+                  )
+                </Text>
+              </Text>
+            </StatRow>
+          </Section>
+
+          <Section title="Highlights">
+            <StatRow label="Bottleneck:">
+              <Text color={theme.text.primary}>
+                {bottleneck
+                  ? `${bottleneck.label} (${formatDuration(
+                      bottleneck.durationMs,
+                    )}, ${formatPercent(
+                      trackedTime > 0
+                        ? (bottleneck.durationMs / trackedTime) * 100
+                        : 0,
+                    )} of measured time)`
+                  : 'No measured bottleneck yet'}
+              </Text>
+            </StatRow>
+            <StatRow label="Avg Turn:">
+              <Text color={theme.text.primary}>
+                {agentTurnStep && agentTurnStep.count > 0
+                  ? formatDuration(
+                      agentTurnStep.totalDurationMs / agentTurnStep.count,
+                    )
+                  : '--'}
+              </Text>
+            </StatRow>
+            <StatRow label="Slowest Turn:">
+              <Text color={theme.text.primary}>
+                {agentTurnStep
+                  ? formatDuration(agentTurnStep.maxDurationMs)
+                  : '--'}
+              </Text>
+            </StatRow>
+            <StatRow label="Slowest Tool:">
+              <Text color={theme.text.primary} wrap="truncate-end">
+                {slowestTool
+                  ? `${slowestTool.name} (${formatDuration(
+                      slowestTool.durationMs,
+                    )} across ${slowestTool.count} call${
+                      slowestTool.count === 1 ? '' : 's'
+                    })`
+                  : 'No tool execution recorded'}
+              </Text>
+            </StatRow>
+            <StatRow label="Slowest Model:">
+              <Text color={theme.text.primary} wrap="truncate-end">
+                {slowestModel
+                  ? `${slowestModel.name} (${formatDuration(
+                      slowestModel.durationMs,
+                    )} across ${slowestModel.requests} request${
+                      slowestModel.requests === 1 ? '' : 's'
+                    })`
+                  : 'No model activity recorded'}
+              </Text>
+            </StatRow>
+          </Section>
+        </>
+      ) : (
+        <Text color={theme.text.secondary}>
+          No traced execution yet. Run a prompt, use a slash command, or invoke
+          a tool and then try `/trace` again.
+        </Text>
+      )}
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/contexts/SessionTraceContext.tsx
+++ b/packages/cli/src/ui/contexts/SessionTraceContext.tsx
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { uiTelemetryService } from '@google/gemini-cli-core';
+
+export const SessionTraceStepKey = {
+  AgentTurn: 'agent_turn',
+  SlashCommand: 'slash_command',
+} as const;
+
+export type SessionTraceStepKey =
+  (typeof SessionTraceStepKey)[keyof typeof SessionTraceStepKey];
+
+export interface SessionTraceStep {
+  key: string;
+  label: string;
+  count: number;
+  totalDurationMs: number;
+  maxDurationMs: number;
+  lastDurationMs: number;
+}
+
+export interface SessionTraceState {
+  steps: Record<string, SessionTraceStep>;
+}
+
+interface SessionTraceContextValue {
+  trace: SessionTraceState;
+  recordStep: (key: string, label: string, durationMs: number) => void;
+}
+
+const INITIAL_TRACE_STATE: SessionTraceState = {
+  steps: {},
+};
+
+const SessionTraceContext = createContext<SessionTraceContextValue | undefined>(
+  undefined,
+);
+
+export const SessionTraceProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [trace, setTrace] = useState<SessionTraceState>(INITIAL_TRACE_STATE);
+
+  useEffect(() => {
+    const handleClear = () => {
+      setTrace(INITIAL_TRACE_STATE);
+    };
+
+    uiTelemetryService.on('clear', handleClear);
+    return () => {
+      uiTelemetryService.off('clear', handleClear);
+    };
+  }, []);
+
+  const recordStep = useCallback(
+    (key: string, label: string, durationMs: number) => {
+      const safeDuration =
+        Number.isFinite(durationMs) && durationMs > 0 ? durationMs : 0;
+
+      setTrace((previous) => {
+        const existing = previous.steps[key];
+
+        return {
+          steps: {
+            ...previous.steps,
+            [key]: {
+              key,
+              label,
+              count: (existing?.count ?? 0) + 1,
+              totalDurationMs: (existing?.totalDurationMs ?? 0) + safeDuration,
+              maxDurationMs: Math.max(
+                existing?.maxDurationMs ?? 0,
+                safeDuration,
+              ),
+              lastDurationMs: safeDuration,
+            },
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const value = useMemo(
+    () => ({
+      trace,
+      recordStep,
+    }),
+    [trace, recordStep],
+  );
+
+  return (
+    <SessionTraceContext.Provider value={value}>
+      {children}
+    </SessionTraceContext.Provider>
+  );
+};
+
+export const useSessionTrace = () => {
+  const context = useContext(SessionTraceContext);
+  if (context === undefined) {
+    throw new Error(
+      'useSessionTrace must be used within a SessionTraceProvider',
+    );
+  }
+  return context;
+};

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -37,6 +37,10 @@ import {
   CoreToolCallStatus,
 } from '@google/gemini-cli-core';
 import { useSessionStats } from '../contexts/SessionContext.js';
+import {
+  SessionTraceStepKey,
+  useSessionTrace,
+} from '../contexts/SessionTraceContext.js';
 import type {
   Message,
   HistoryItemWithoutId,
@@ -108,6 +112,7 @@ export const useSlashCommandProcessor = (
   setCustomDialog: (dialog: React.ReactNode | null) => void,
 ) => {
   const session = useSessionStats();
+  const { recordStep } = useSessionTrace();
   const [commands, setCommands] = useState<readonly SlashCommand[] | undefined>(
     undefined,
   );
@@ -435,10 +440,19 @@ export const useSlashCommandProcessor = (
                 ]),
               };
             }
-            const result = await commandToExecute.action(
-              fullCommandContext,
-              args,
-            );
+            const action = commandToExecute.action;
+            const actionStartTime = Date.now();
+            const result = await (async () => {
+              try {
+                return await action(fullCommandContext, args);
+              } finally {
+                recordStep(
+                  SessionTraceStepKey.SlashCommand,
+                  'Slash command',
+                  Date.now() - actionStartTime,
+                );
+              }
+            })();
 
             if (result) {
               switch (result.type) {
@@ -729,6 +743,7 @@ export const useSlashCommandProcessor = (
       setIsProcessing,
       setConfirmationRequest,
       setCustomDialog,
+      recordStep,
     ],
   );
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -97,6 +97,10 @@ import { getToolGroupBorderAppearance } from '../utils/borderStyles.js';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { useSessionStats } from '../contexts/SessionContext.js';
+import {
+  SessionTraceStepKey,
+  useSessionTrace,
+} from '../contexts/SessionTraceContext.js';
 import { useKeypress } from './useKeypress.js';
 import type { LoadedSettings } from '../../config/settings.js';
 
@@ -268,6 +272,7 @@ export const useGeminiStream = (
     useStateAndRef<boolean>(true);
   const processedMemoryToolsRef = useRef<Set<string>>(new Set());
   const { startNewPrompt, getPromptCount } = useSessionStats();
+  const { recordStep } = useSessionTrace();
   const storage = config.storage;
   const logger = useLogger(storage);
   const gitService = useMemo(() => {
@@ -1523,134 +1528,144 @@ export const useGeminiStream = (
           if (!prompt_id) {
             prompt_id = config.getSessionId() + '########' + getPromptCount();
           }
-          return promptIdContext.run(prompt_id, async () => {
-            const { queryToSend, shouldProceed } = await prepareQueryForGemini(
-              query,
-              userMessageTimestamp,
-              abortSignal,
-              prompt_id!,
-            );
-
-            if (!shouldProceed || queryToSend === null) {
-              return;
-            }
-
-            if (!options?.isContinuation) {
-              if (typeof queryToSend === 'string') {
-                // logging the text prompts only for now
-                const promptText = queryToSend;
-                logUserPrompt(
-                  config,
-                  new UserPromptEvent(
-                    promptText.length,
-                    prompt_id!,
-                    config.getContentGeneratorConfig()?.authType,
-                    promptText,
-                  ),
+          const turnStartTime = Date.now();
+          try {
+            return await promptIdContext.run(prompt_id, async () => {
+              const { queryToSend, shouldProceed } =
+                await prepareQueryForGemini(
+                  query,
+                  userMessageTimestamp,
+                  abortSignal,
+                  prompt_id!,
                 );
-              }
-              startNewPrompt();
-              setThought(null); // Reset thought when starting a new prompt
-            }
 
-            setIsResponding(true);
-            setInitError(null);
-
-            // Store query and prompt_id for potential retry on loop detection
-            lastQueryRef.current = queryToSend;
-            lastPromptIdRef.current = prompt_id!;
-
-            try {
-              const stream = geminiClient.sendMessageStream(
-                queryToSend,
-                abortSignal,
-                prompt_id!,
-                undefined,
-                false,
-                query,
-              );
-              const processingStatus = await processGeminiStreamEvents(
-                stream,
-                userMessageTimestamp,
-                abortSignal,
-              );
-
-              if (processingStatus === StreamProcessingStatus.UserCancelled) {
+              if (!shouldProceed || queryToSend === null) {
                 return;
               }
 
-              if (pendingHistoryItemRef.current) {
-                addItem(pendingHistoryItemRef.current, userMessageTimestamp);
-                setPendingHistoryItem(null);
-              }
-              if (loopDetectedRef.current) {
-                loopDetectedRef.current = false;
-                // Show the confirmation dialog to choose whether to disable loop detection
-                setLoopDetectionConfirmationRequest({
-                  onComplete: async (result: {
-                    userSelection: 'disable' | 'keep';
-                  }) => {
-                    setLoopDetectionConfirmationRequest(null);
-
-                    if (result.userSelection === 'disable') {
-                      config
-                        .getGeminiClient()
-                        .getLoopDetectionService()
-                        .disableForSession();
-                      addItem({
-                        type: 'info',
-                        text: `Loop detection has been disabled for this session. Retrying request...`,
-                      });
-
-                      if (lastQueryRef.current && lastPromptIdRef.current) {
-                        await submitQuery(
-                          lastQueryRef.current,
-                          { isContinuation: true },
-                          lastPromptIdRef.current,
-                        );
-                      }
-                    } else {
-                      addItem({
-                        type: 'info',
-                        text: `A potential loop was detected. This can happen due to repetitive tool calls or other model behavior. The request has been halted.`,
-                      });
-                    }
-                  },
-                });
-              }
-            } catch (error: unknown) {
-              spanMetadata.error = error;
-              if (error instanceof UnauthorizedError) {
-                onAuthError('Session expired or is unauthorized.');
-              } else if (
-                // Suppress ValidationRequiredError if it was marked as handled (e.g. user clicked change_auth or cancelled)
-                error instanceof ValidationRequiredError &&
-                error.userHandled
-              ) {
-                // Error was handled by validation dialog, don't display again
-              } else if (!isNodeError(error) || error.name !== 'AbortError') {
-                maybeAddSuppressedToolErrorNote(userMessageTimestamp);
-                addItem(
-                  {
-                    type: MessageType.ERROR,
-                    text: parseAndFormatApiError(
-                      getErrorMessage(error) || 'Unknown error',
+              if (!options?.isContinuation) {
+                if (typeof queryToSend === 'string') {
+                  // logging the text prompts only for now
+                  const promptText = queryToSend;
+                  logUserPrompt(
+                    config,
+                    new UserPromptEvent(
+                      promptText.length,
+                      prompt_id!,
                       config.getContentGeneratorConfig()?.authType,
-                      undefined,
-                      config.getModel(),
-                      DEFAULT_GEMINI_FLASH_MODEL,
+                      promptText,
                     ),
-                  },
-                  userMessageTimestamp,
+                  );
+                }
+                startNewPrompt();
+                setThought(null); // Reset thought when starting a new prompt
+              }
+
+              setIsResponding(true);
+              setInitError(null);
+
+              // Store query and prompt_id for potential retry on loop detection
+              lastQueryRef.current = queryToSend;
+              lastPromptIdRef.current = prompt_id!;
+
+              try {
+                const stream = geminiClient.sendMessageStream(
+                  queryToSend,
+                  abortSignal,
+                  prompt_id!,
+                  undefined,
+                  false,
+                  query,
                 );
-                maybeAddLowVerbosityFailureNote(userMessageTimestamp);
+                const processingStatus = await processGeminiStreamEvents(
+                  stream,
+                  userMessageTimestamp,
+                  abortSignal,
+                );
+
+                if (processingStatus === StreamProcessingStatus.UserCancelled) {
+                  return;
+                }
+
+                if (pendingHistoryItemRef.current) {
+                  addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+                  setPendingHistoryItem(null);
+                }
+                if (loopDetectedRef.current) {
+                  loopDetectedRef.current = false;
+                  // Show the confirmation dialog to choose whether to disable loop detection
+                  setLoopDetectionConfirmationRequest({
+                    onComplete: async (result: {
+                      userSelection: 'disable' | 'keep';
+                    }) => {
+                      setLoopDetectionConfirmationRequest(null);
+
+                      if (result.userSelection === 'disable') {
+                        config
+                          .getGeminiClient()
+                          .getLoopDetectionService()
+                          .disableForSession();
+                        addItem({
+                          type: 'info',
+                          text: `Loop detection has been disabled for this session. Retrying request...`,
+                        });
+
+                        if (lastQueryRef.current && lastPromptIdRef.current) {
+                          await submitQuery(
+                            lastQueryRef.current,
+                            { isContinuation: true },
+                            lastPromptIdRef.current,
+                          );
+                        }
+                      } else {
+                        addItem({
+                          type: 'info',
+                          text: `A potential loop was detected. This can happen due to repetitive tool calls or other model behavior. The request has been halted.`,
+                        });
+                      }
+                    },
+                  });
+                }
+              } catch (error: unknown) {
+                spanMetadata.error = error;
+                if (error instanceof UnauthorizedError) {
+                  onAuthError('Session expired or is unauthorized.');
+                } else if (
+                  // Suppress ValidationRequiredError if it was marked as handled (e.g. user clicked change_auth or cancelled)
+                  error instanceof ValidationRequiredError &&
+                  error.userHandled
+                ) {
+                  // Error was handled by validation dialog, don't display again
+                } else if (!isNodeError(error) || error.name !== 'AbortError') {
+                  maybeAddSuppressedToolErrorNote(userMessageTimestamp);
+                  addItem(
+                    {
+                      type: MessageType.ERROR,
+                      text: parseAndFormatApiError(
+                        getErrorMessage(error) || 'Unknown error',
+                        config.getContentGeneratorConfig()?.authType,
+                        undefined,
+                        config.getModel(),
+                        DEFAULT_GEMINI_FLASH_MODEL,
+                      ),
+                    },
+                    userMessageTimestamp,
+                  );
+                  maybeAddLowVerbosityFailureNote(userMessageTimestamp);
+                }
+              } finally {
+                if (activeQueryIdRef.current === queryId) {
+                  setIsResponding(false);
+                }
               }
-            } finally {
-              if (activeQueryIdRef.current === queryId) {
-                setIsResponding(false);
-              }
-            }
-          });
+            });
+          } finally {
+            recordStep(
+              SessionTraceStepKey.AgentTurn,
+              'Agent turn',
+              Date.now() - turnStartTime,
+            );
+          }
         },
       ),
     [
@@ -1672,6 +1687,7 @@ export const useGeminiStream = (
       maybeAddLowVerbosityFailureNote,
       settings.merged.billing?.overageStrategy,
       setIsResponding,
+      recordStep,
     ],
   );
 

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -236,6 +236,10 @@ export type HistoryItemToolStats = HistoryItemBase & {
   type: 'tool_stats';
 };
 
+export type HistoryItemTrace = HistoryItemBase & {
+  type: 'trace';
+};
+
 export type HistoryItemModel = HistoryItemBase & {
   type: 'model';
   model: string;
@@ -384,6 +388,7 @@ export type HistoryItemWithoutId =
   | HistoryItemStats
   | HistoryItemModelStats
   | HistoryItemToolStats
+  | HistoryItemTrace
   | HistoryItemModel
   | HistoryItemQuit
   | HistoryItemCompression


### PR DESCRIPTION
## Summary

Adds a lightweight prototype for improving observability of Gemini CLI agent execution via a new `/trace` (alias `/perf`) command.

The command surfaces session-level metrics such as latency, tool usage, API activity, and timing breakdowns, along with simple bottleneck insights. This helps make agent behavior more transparent and easier to debug.

---

## Details

* Introduced a new slash command `/trace` with `/perf` alias
* Reused existing session metrics (API time, tool time, counts)
* Added minimal instrumentation for:

  * agent turn timing
  * slash command execution timing
* Implemented a new `TraceDisplay` component integrated into the existing history rendering flow
* Added a lightweight `SessionTraceContext` for aggregating high-level timing data
* Provided summary insights including:

  * session duration, prompts, API requests
  * tool call success/failure counts
  * memory usage snapshot
  * time breakdown (model, tools, commands, idle)
  * highlights (bottleneck, slowest turn/tool/model)

Design choices:

* Avoided introducing new telemetry systems
* Kept implementation minimal and localized
* Focused on a prototype-level feature for exploration and feedback

---

## Related Issues

Related to Gemini CLI observability and debugging improvements discussed in GSoC ideas and community discussions.

---

## How to Validate

```bash
npm install
npm run build
npm start
```

Steps:

1. Run a few prompts (preferably involving tool usage)
2. Execute:

   ```
   /trace
   ```

   or

   ```
   /perf
   ```

Expected:

* Displays an execution summary with session metrics and timing breakdown
* Highlights bottlenecks and slowest components

Edge cases:

* Running `/trace` before any prompt should show a clean empty state message
* Command should not crash in absence of session data

---

## Pre-Merge Checklist

* [ ] Updated relevant documentation and README (if needed)
* [x] Added/updated tests (if needed)
* [ ] Noted breaking changes (if any)
* [x] Validated on required platforms/methods:

  * [x] MacOS

    * [x] npm run
    * [ ] npx
    * [ ] Docker
    * [ ] Podman
    * [ ] Seatbelt
  * [ ] Windows

    * [ ] npm run
    * [ ] npx
    * [ ] Docker
  * [ ] Linux

    * [ ] npm run
    * [ ] npx
    * [ ] Docker
