### PR TITLE
feat(core): enable topic update narration for legacy models

### DIFF
--- a/packages/core/src/prompts/promptProvider.test.ts
+++ b/packages/core/src/prompts/promptProvider.test.ts
@@ -11,7 +11,10 @@ import {
   getAllGeminiMdFilenames,
   DEFAULT_CONTEXT_FILENAME,
 } from '../tools/memoryTool.js';
-import { PREVIEW_GEMINI_MODEL } from '../config/models.js';
+import {
+  PREVIEW_GEMINI_MODEL,
+  DEFAULT_GEMINI_MODEL,
+} from '../config/models.js';
 import { ApprovalMode } from '../policy/types.js';
 import { DiscoveredMCPTool } from '../tools/mcp-tool.js';
 import { MockTool } from '../test-utils/mock-tool.js';
@@ -300,6 +303,21 @@ describe('PromptProvider', () => {
       const prompt = provider.getCoreSystemPrompt(mockConfig);
 
       expect(prompt).toContain(`<tool>\`${UPDATE_TOPIC_TOOL_NAME}\`</tool>`);
+    });
+
+    it('should include topic update instructions in legacy model prompt when enabled', () => {
+      vi.mocked(mockConfig.getActiveModel).mockReturnValue(
+        DEFAULT_GEMINI_MODEL,
+      );
+      vi.mocked(mockConfig.isTopicUpdateNarrationEnabled).mockReturnValue(true);
+
+      const provider = new PromptProvider();
+      const prompt = provider.getCoreSystemPrompt(mockConfig);
+
+      expect(prompt).toContain('## Topic Updates');
+      expect(prompt).toContain(UPDATE_TOPIC_TOOL_NAME);
+      expect(prompt).toContain('No Chitchat');
+      expect(prompt).toContain('Topic Model');
     });
   });
 });

--- a/packages/core/src/prompts/snippets.legacy.ts
+++ b/packages/core/src/prompts/snippets.legacy.ts
@@ -20,6 +20,9 @@ import {
   TRACKER_CREATE_TASK_TOOL_NAME,
   TRACKER_LIST_TASKS_TOOL_NAME,
   TRACKER_UPDATE_TASK_TOOL_NAME,
+  UPDATE_TOPIC_TOOL_NAME,
+  TOPIC_PARAM_TITLE,
+  TOPIC_PARAM_SUMMARY,
   WRITE_FILE_TOOL_NAME,
   WRITE_TODOS_TOOL_NAME,
 } from '../tools/tool-names.js';
@@ -51,6 +54,8 @@ export interface CoreMandatesOptions {
   isGemini3: boolean;
   hasSkills: boolean;
   hasHierarchicalMemory: boolean;
+  contextFilenames?: string[];
+  topicUpdateNarration?: boolean;
 }
 
 export interface PrimaryWorkflowsOptions {
@@ -60,6 +65,7 @@ export interface PrimaryWorkflowsOptions {
   enableEnterPlanModeTool: boolean;
   approvedPlan?: { path: string };
   taskTracker?: boolean;
+  topicUpdateNarration?: boolean;
 }
 
 export interface OperationalGuidelinesOptions {
@@ -67,6 +73,7 @@ export interface OperationalGuidelinesOptions {
   isGemini3: boolean;
   enableShellEfficiency: boolean;
   interactiveShellEnabled: boolean;
+  topicUpdateNarration?: boolean;
   memoryManagerEnabled: boolean;
 }
 
@@ -146,11 +153,12 @@ ${renderFinalReminder(options.finalReminder)}
 export function renderFinalShell(
   basePrompt: string,
   userMemory?: string | HierarchicalMemory,
+  contextFilenames?: string[],
 ): string {
   return `
 ${basePrompt.trim()}
 
-${renderUserMemory(userMemory)}
+${renderUserMemory(userMemory, contextFilenames)}
 `.trim();
 }
 
@@ -177,7 +185,11 @@ export function renderCoreMandates(options?: CoreMandatesOptions): string {
 - **User Hints:** During execution, the user may provide real-time hints (marked as "User hint:" or "User hints:"). Treat these as high-priority but scope-preserving course corrections: apply the minimal plan change needed, keep unaffected user tasks active, and never cancel/skip tasks unless cancellation is explicit for those tasks. Hints may add new tasks, modify one or more tasks, cancel specific tasks, or provide extra context only. If scope is ambiguous, ask for clarification before dropping work.
 - ${mandateConfirm(options.interactive)}
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
-- **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.${mandateSkillGuidance(options.hasSkills)}${mandateExplainBeforeActing(options.isGemini3)}${mandateContinueWork(options.interactive)}
+- **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.${mandateSkillGuidance(options.hasSkills)}${
+    options.topicUpdateNarration
+      ? mandateTopicUpdateModel()
+      : mandateExplainBeforeActing(options.isGemini3)
+  }${mandateContinueWork(options.interactive)}
 `.trim();
 }
 
@@ -272,7 +284,12 @@ ${shellEfficiencyGuidelines(options.enableShellEfficiency)}
 ## Tone and Style (CLI Interaction)
 - **Concise & Direct:** Adopt a professional, direct, and concise tone suitable for a CLI environment.
 - **Minimal Output:** Aim for fewer than 3 lines of text output (excluding tool use/code generation) per response whenever practical. Focus strictly on the user's query.
-- **Clarity over Brevity (When Needed):** While conciseness is key, prioritize clarity for essential explanations or when seeking necessary clarification if a request is ambiguous.${toneAndStyleNoChitchat(options.isGemini3)}
+- **Clarity over Brevity (When Needed):** While conciseness is key, prioritize clarity for essential explanations or when seeking necessary clarification if a request is ambiguous.${
+    options.topicUpdateNarration
+      ? `
+- **No Chitchat:** Avoid conversational filler, preambles ("Okay, I will now..."), or postambles ("I have finished the changes...") unless they are part of the **Topic Model**.`
+      : toneAndStyleNoChitchat(options.isGemini3)
+  }
 - **Formatting:** Use GitHub-flavored Markdown. Responses will be rendered in monospace.
 - **Tools vs. Text:** Use tools for actions, text output *only* for communication. Do not add explanatory comments within tool calls or code blocks unless specifically part of the required code/command itself.
 - **Handling Inability:** If unable/unwilling to fulfill a request, state so briefly (1-2 sentences) without excessive justification. Offer alternatives if appropriate.
@@ -361,13 +378,18 @@ export function renderFinalReminder(options?: FinalReminderOptions): string {
 Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use '${options.readFileToolName}' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved.`.trim();
 }
 
-export function renderUserMemory(memory?: string | HierarchicalMemory): string {
+export function renderUserMemory(
+  memory?: string | HierarchicalMemory,
+  contextFilenames?: string[],
+): string {
   if (!memory) return '';
   if (typeof memory === 'string') {
     const trimmed = memory.trim();
     if (trimmed.length === 0) return '';
+    const filenames = contextFilenames ?? ['GEMINI.md'];
+    const formattedHeader = filenames.join(', ');
     return `
-# Contextual Instructions (GEMINI.md)
+# Contextual Instructions (${formattedHeader})
 The following content is loaded from local and global configuration files.
 **Context Precedence:**
 - **Global (~/.gemini/):** foundational user preferences. Apply these broadly.
@@ -491,6 +513,23 @@ function mandateConfirm(interactive: boolean): string {
   return interactive
     ? "**Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If the user implies a change (e.g., reports a bug) without explicitly asking for a fix, **ask for confirmation first**. If asked *how* to do something, explain first, don't just do it."
     : '**Handle Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request. If the user implies a change (e.g., reports a bug) without explicitly asking for a fix, do not perform it automatically.';
+}
+
+function mandateTopicUpdateModel(): string {
+  return `
+## Topic Updates
+As you work, the user follows along by reading topic updates that you publish with ${UPDATE_TOPIC_TOOL_NAME}. Keep them informed by doing the following:
+
+- Always call ${UPDATE_TOPIC_TOOL_NAME} in your first and last turn. The final turn should always recap what was done.
+- Each topic update should give a concise description of what you are doing for the next few turns in the \`${TOPIC_PARAM_SUMMARY}\` parameter.
+- Provide topic updates whenever you change "topics". A topic is typically a discrete subgoal and will be every 3 to 10 turns. Do not use ${UPDATE_TOPIC_TOOL_NAME} on every turn.
+- The typical user message should call ${UPDATE_TOPIC_TOOL_NAME} 3 or more times. Each corresponds to a distinct phase of the task, such as "Researching X", "Researching Y", "Implementing Z with X", and "Testing Z".
+- Remember to call ${UPDATE_TOPIC_TOOL_NAME} when you experience an unexpected event (e.g., a test failure, compilation error, environment issue, or unexpected learning) that requires a strategic detour.
+- **Examples:**
+  - \`update_topic(${TOPIC_PARAM_TITLE}="Researching Parser", ${TOPIC_PARAM_SUMMARY}="I am starting an investigation into the parser timeout bug. My goal is to first understand the current test coverage and then attempt to reproduce the failure. This phase will focus on identifying the bottleneck in the main loop before we move to implementation.")\`
+  - \`update_topic(${TOPIC_PARAM_TITLE}="Implementing Buffer Fix", ${TOPIC_PARAM_SUMMARY}="I have completed the research phase and identified a race condition in the tokenizer's buffer management. I am now transitioning to implementation. This new chapter will focus on refactoring the buffer logic to handle async chunks safely, followed by unit testing the fix.")\`
+
+`;
 }
 
 function mandateSkillGuidance(hasSkills: boolean): string {
@@ -677,7 +716,17 @@ function gitRepoKeepUserInformed(interactive: boolean): string {
 /**
  * Provides the system prompt for history compression.
  */
-export function getCompressionPrompt(): string {
+export function getCompressionPrompt(approvedPlanPath?: string): string {
+  const planPreservation = approvedPlanPath
+    ? `
+
+### APPROVED PLAN PRESERVATION
+An approved implementation plan exists at ${approvedPlanPath}. You MUST preserve the following in your snapshot:
+- The plan's file path in <key_knowledge>
+- Completion status of each plan step in <task_state> (mark as [DONE], [IN PROGRESS], or [TODO])
+- Any user feedback or modifications to the plan in <active_constraints>`
+    : '';
+
   return `
 You are a specialized system component responsible for distilling chat history into a structured XML <state_snapshot>.
 
@@ -693,7 +742,7 @@ When the conversation history grows too large, you will be invoked to distill th
 
 First, you will think through the entire history in a private <scratchpad>. Review the user's overall goal, the agent's actions, tool outputs, file modifications, and any unresolved questions. Identify every piece of information for future actions.
 
-After your reasoning is complete, generate the final <state_snapshot> XML object. Be incredibly dense with information. Omit any irrelevant conversational filler.
+After your reasoning is complete, generate the final <state_snapshot> XML object. Be incredibly dense with information. Omit any irrelevant conversational filler.${planPreservation}
 
 The structure MUST be as follows:
 

--- a/packages/core/src/prompts/snippets.legacy.ts
+++ b/packages/core/src/prompts/snippets.legacy.ts
@@ -386,7 +386,7 @@ export function renderUserMemory(
   if (typeof memory === 'string') {
     const trimmed = memory.trim();
     if (trimmed.length === 0) return '';
-    const filenames = contextFilenames ?? ['GEMINI.md'];
+    const filenames = (contextFilenames && contextFilenames.length > 0) ? contextFilenames : ['GEMINI.md'];
     const formattedHeader = filenames.join(', ');
     return `
 # Contextual Instructions (${formattedHeader})

--- a/packages/core/src/prompts/snippets.legacy.ts
+++ b/packages/core/src/prompts/snippets.legacy.ts
@@ -526,8 +526,8 @@ As you work, the user follows along by reading topic updates that you publish wi
 - The typical user message should call ${UPDATE_TOPIC_TOOL_NAME} 3 or more times. Each corresponds to a distinct phase of the task, such as "Researching X", "Researching Y", "Implementing Z with X", and "Testing Z".
 - Remember to call ${UPDATE_TOPIC_TOOL_NAME} when you experience an unexpected event (e.g., a test failure, compilation error, environment issue, or unexpected learning) that requires a strategic detour.
 - **Examples:**
-  - \`update_topic(${TOPIC_PARAM_TITLE}="Researching Parser", ${TOPIC_PARAM_SUMMARY}="I am starting an investigation into the parser timeout bug. My goal is to first understand the current test coverage and then attempt to reproduce the failure. This phase will focus on identifying the bottleneck in the main loop before we move to implementation.")\`
-  - \`update_topic(${TOPIC_PARAM_TITLE}="Implementing Buffer Fix", ${TOPIC_PARAM_SUMMARY}="I have completed the research phase and identified a race condition in the tokenizer's buffer management. I am now transitioning to implementation. This new chapter will focus on refactoring the buffer logic to handle async chunks safely, followed by unit testing the fix.")\`
+  - ' + UPDATE_TOPIC_TOOL_NAME + '(' + TOPIC_PARAM_TITLE + '="Researching Parser", ' + TOPIC_PARAM_SUMMARY + '="I am starting an investigation into the parser timeout bug. My goal is to first understand the current test coverage and then attempt to reproduce the failure. This phase will focus on identifying the bottleneck in the main loop before we move to implementation.")
+  - ' + UPDATE_TOPIC_TOOL_NAME + '(' + TOPIC_PARAM_TITLE + '="Implementing Buffer Fix", ' + TOPIC_PARAM_SUMMARY + '="I have completed the research phase and identified a race condition in the tokenizer\'s buffer management. I am now transitioning to implementation. This new chapter will focus on refactoring the buffer logic to handle async chunks safely, followed by unit testing the fix.")',
 
 `;
 }

--- a/packages/core/src/prompts/snippets.legacy.ts
+++ b/packages/core/src/prompts/snippets.legacy.ts
@@ -54,7 +54,6 @@ export interface CoreMandatesOptions {
   isGemini3: boolean;
   hasSkills: boolean;
   hasHierarchicalMemory: boolean;
-  contextFilenames?: string[];
   topicUpdateNarration?: boolean;
 }
 
@@ -153,12 +152,11 @@ ${renderFinalReminder(options.finalReminder)}
 export function renderFinalShell(
   basePrompt: string,
   userMemory?: string | HierarchicalMemory,
-  _contextFilenames?: string[],
 ): string {
   return `
 ${basePrompt.trim()}
 
-${renderUserMemory(userMemory, _contextFilenames)}
+${renderUserMemory(userMemory)}
 `.trim();
 }
 
@@ -378,10 +376,7 @@ export function renderFinalReminder(options?: FinalReminderOptions): string {
 Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use '${options.readFileToolName}' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved.`.trim();
 }
 
-export function renderUserMemory(
-  memory?: string | HierarchicalMemory,
-  _contextFilenames?: string[],
-): string {
+export function renderUserMemory(memory?: string | HierarchicalMemory): string {
   if (!memory) return '';
   if (typeof memory === 'string') {
     const trimmed = memory.trim();
@@ -714,7 +709,7 @@ function gitRepoKeepUserInformed(interactive: boolean): string {
 /**
  * Provides the system prompt for history compression.
  */
-export function getCompressionPrompt(_approvedPlanPath?: string): string {
+export function getCompressionPrompt(): string {
   return `
 You are a specialized system component responsible for distilling chat history into a structured XML <state_snapshot>.
 

--- a/packages/core/src/prompts/snippets.legacy.ts
+++ b/packages/core/src/prompts/snippets.legacy.ts
@@ -153,12 +153,12 @@ ${renderFinalReminder(options.finalReminder)}
 export function renderFinalShell(
   basePrompt: string,
   userMemory?: string | HierarchicalMemory,
-  contextFilenames?: string[],
+  _contextFilenames?: string[],
 ): string {
   return `
 ${basePrompt.trim()}
 
-${renderUserMemory(userMemory, contextFilenames)}
+${renderUserMemory(userMemory, _contextFilenames)}
 `.trim();
 }
 
@@ -380,16 +380,14 @@ Your core function is efficient and safe assistance. Balance extreme conciseness
 
 export function renderUserMemory(
   memory?: string | HierarchicalMemory,
-  contextFilenames?: string[],
+  _contextFilenames?: string[],
 ): string {
   if (!memory) return '';
   if (typeof memory === 'string') {
     const trimmed = memory.trim();
     if (trimmed.length === 0) return '';
-    const filenames = (contextFilenames && contextFilenames.length > 0) ? contextFilenames : ['GEMINI.md'];
-    const formattedHeader = filenames.join(', ');
     return `
-# Contextual Instructions (${formattedHeader})
+# Contextual Instructions (GEMINI.md)
 The following content is loaded from local and global configuration files.
 **Context Precedence:**
 - **Global (~/.gemini/):** foundational user preferences. Apply these broadly.
@@ -526,8 +524,8 @@ As you work, the user follows along by reading topic updates that you publish wi
 - The typical user message should call ${UPDATE_TOPIC_TOOL_NAME} 3 or more times. Each corresponds to a distinct phase of the task, such as "Researching X", "Researching Y", "Implementing Z with X", and "Testing Z".
 - Remember to call ${UPDATE_TOPIC_TOOL_NAME} when you experience an unexpected event (e.g., a test failure, compilation error, environment issue, or unexpected learning) that requires a strategic detour.
 - **Examples:**
-  - ' + UPDATE_TOPIC_TOOL_NAME + '(' + TOPIC_PARAM_TITLE + '="Researching Parser", ' + TOPIC_PARAM_SUMMARY + '="I am starting an investigation into the parser timeout bug. My goal is to first understand the current test coverage and then attempt to reproduce the failure. This phase will focus on identifying the bottleneck in the main loop before we move to implementation.")
-  - ' + UPDATE_TOPIC_TOOL_NAME + '(' + TOPIC_PARAM_TITLE + '="Implementing Buffer Fix", ' + TOPIC_PARAM_SUMMARY + '="I have completed the research phase and identified a race condition in the tokenizer\'s buffer management. I am now transitioning to implementation. This new chapter will focus on refactoring the buffer logic to handle async chunks safely, followed by unit testing the fix.")',
+  - ${UPDATE_TOPIC_TOOL_NAME}(${TOPIC_PARAM_TITLE}="Researching Parser", ${TOPIC_PARAM_SUMMARY}="I am starting an investigation into the parser timeout bug. My goal is to first understand the current test coverage and then attempt to reproduce the failure. This phase will focus on identifying the bottleneck in the main loop before we move to implementation.")
+  - ${UPDATE_TOPIC_TOOL_NAME}(${TOPIC_PARAM_TITLE}="Implementing Buffer Fix", ${TOPIC_PARAM_SUMMARY}="I have completed the research phase and identified a race condition in the tokenizer's buffer management. I am now transitioning to implementation. This new chapter will focus on refactoring the buffer logic to handle async chunks safely, followed by unit testing the fix.")
 
 `;
 }
@@ -716,17 +714,7 @@ function gitRepoKeepUserInformed(interactive: boolean): string {
 /**
  * Provides the system prompt for history compression.
  */
-export function getCompressionPrompt(approvedPlanPath?: string): string {
-  const planPreservation = approvedPlanPath
-    ? `
-
-### APPROVED PLAN PRESERVATION
-An approved implementation plan exists at ${approvedPlanPath}. You MUST preserve the following in your snapshot:
-- The plan's file path in <key_knowledge>
-- Completion status of each plan step in <task_state> (mark as [DONE], [IN PROGRESS], or [TODO])
-- Any user feedback or modifications to the plan in <active_constraints>`
-    : '';
-
+export function getCompressionPrompt(_approvedPlanPath?: string): string {
   return `
 You are a specialized system component responsible for distilling chat history into a structured XML <state_snapshot>.
 
@@ -742,7 +730,7 @@ When the conversation history grows too large, you will be invoked to distill th
 
 First, you will think through the entire history in a private <scratchpad>. Review the user's overall goal, the agent's actions, tool outputs, file modifications, and any unresolved questions. Identify every piece of information for future actions.
 
-After your reasoning is complete, generate the final <state_snapshot> XML object. Be incredibly dense with information. Omit any irrelevant conversational filler.${planPreservation}
+After your reasoning is complete, generate the final <state_snapshot> XML object. Be incredibly dense with information. Omit any irrelevant conversational filler.
 
 The structure MUST be as follows:
 


### PR DESCRIPTION
## Summary

Enables the `update_topic` tool and prompt logic for legacy models (e.g., Gemini 2.5) by porting the necessary snippets and structural updates to `snippets.legacy.ts`.

## Details

Ported `mandateTopicUpdateModel` and updated `renderCoreMandates`, `renderOperationalGuidelines`, and `renderFinalShell` in `snippets.legacy.ts` to support the experimental `topicUpdateNarration` setting. Added a test case in `promptProvider.test.ts` to verify legacy model support.

## Related Issues

Fixes #24240

## How to Validate

Run `npm test -w @google/gemini-cli-core -- src/prompts/promptProvider.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
