### PR TITLE
Docs:Format installation methods as code blocks

### DIFF
--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -81,7 +81,7 @@ You can also run Gemini CLI using one of the following advanced methods:
 ### Run instantly with npx
 
 ```bash
-# Using npx (no installation required)
+# Using  npx (no installation required)
 npx @google/gemini-cli
 ```
 

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -23,10 +23,10 @@ installation methods, and release types.
 We recommend most users install Gemini CLI using one of the following
 installation methods:
 
-- npm
-- Homebrew
-- MacPorts
-- Anaconda
+- `npm`
+- `Homebrew`
+- `MacPorts`
+- `Anaconda`
 
 Note that Gemini CLI comes pre-installed on
 [**Cloud Shell**](https://docs.cloud.google.com/shell/docs) and


### PR DESCRIPTION
Wrap installation method names in backticks for consistent code-like formatting.
Related to #22833
## Summary
