### PR TITLE
fix(core): ensure default agents provide tools and use model-specific schemas

### DIFF
--- a/packages/core/src/agents/local-executor.test.ts
+++ b/packages/core/src/agents/local-executor.test.ts
@@ -348,10 +348,9 @@ describe('LocalAgentExecutor', () => {
       get: () => 'test-prompt-id',
       configurable: true,
     });
-    parentToolRegistry = new ToolRegistry(mockConfig, mockConfig.messageBus);
-    parentToolRegistry.registerTool(
-      new LSTool(mockConfig, mockConfig.messageBus),
-    );
+    const { messageBus } = mockConfig as unknown as { messageBus: MessageBus };
+    parentToolRegistry = new ToolRegistry(mockConfig, messageBus);
+    parentToolRegistry.registerTool(new LSTool(mockConfig, messageBus));
     parentToolRegistry.registerTool(
       new MockTool({ name: READ_FILE_TOOL_NAME }),
     );
@@ -778,6 +777,25 @@ describe('LocalAgentExecutor', () => {
 
       // Assert that there is exactly ONE schema for this tool
       expect(foundSchemas).toHaveLength(1);
+    });
+
+    it('should provide tools to the model when toolConfig is OMITTED (default to all tools)', async () => {
+      const fullDefinition = createTestDefinition();
+      const { toolConfig: _, ...definition } = fullDefinition;
+
+      const executor = await LocalAgentExecutor.create(
+        definition as LocalAgentDefinition,
+        mockConfig,
+        onActivity,
+      );
+
+      const toolsList = (
+        executor as unknown as { prepareToolsList: () => FunctionDeclaration[] }
+      ).prepareToolsList();
+
+      // Verify that LS_TOOL_NAME is in the list (since LS was registered in beforeEach)
+      const toolNames = toolsList.map((t) => t.name);
+      expect(toolNames).toContain(LS_TOOL_NAME);
     });
   });
 

--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -1329,9 +1329,13 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
           toolsList.push(toolRef);
         }
       }
-      // Add schemas from tools that were explicitly registered by name, wildcard, or instance.
-      toolsList.push(...this.toolRegistry.getFunctionDeclarations());
     }
+    // Add schemas from tools that were explicitly registered by name, wildcard, or instance.
+    toolsList.push(
+      ...this.toolRegistry.getFunctionDeclarations(
+        this.definition.modelConfig.model,
+      ),
+    );
 
     // Always inject complete_task.
     // Configure its schema based on whether output is expected.


### PR DESCRIPTION
## Summary

Fixes a bug where agents using the default tool configuration (omitting `toolConfig`) were sent to the model with an empty toolset. Also enables model-specific tool schema optimizations by passing the `modelId` to the tool registry.

## Details

- **Fixed Missing Tools**: Moved the call to `this.toolRegistry.getFunctionDeclarations()` outside of the `if (toolConfig)` block in `LocalAgentExecutor`. This ensures that even agents without an explicit `toolConfig` provide their registered tools to the Gemini model.
- **Model-Specific Schemas**: Updated `getFunctionDeclarations()` to include the agent's `modelId`. This allows the registry to provide optimized schemas (e.g., Gemini 3 surgical reads) instead of legacy defaults.
- **Improved Test Safety**: Modernized the `beforeEach` in `local-executor.test.ts` to avoid deprecated `Config` properties and ensured regression tests are type-safe.
- **Security Alignment**: This PR does NOT implement the `mcpName = "*"` wildcard policy as it was determined to be a security risk and unsupported (ref PR #24133).

## Related Issues

Fixes subagent issues noticed by internal googlers.

## How to Validate

1. Run the targeted tests for local executor:
   `npm test -w @google/gemini-cli-core -- src/agents/local-executor.test.ts`
2. Verify the new regression test case `should provide tools to the model when toolConfig is OMITTED (default to all tools)` passes.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
