### PR TITLE
chore(test-utils): switch integration tests to use gemini-3.1 model

### DIFF
--- a/packages/test-utils/src/test-rig.ts
+++ b/packages/test-utils/src/test-rig.ts
@@ -11,7 +11,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { env } from 'node:process';
 import { setTimeout as sleep } from 'node:timers/promises';
-import { DEFAULT_GEMINI_MODEL, GEMINI_DIR } from '@google/gemini-cli-core';
+import { PREVIEW_GEMINI_3_1_MODEL, GEMINI_DIR } from '@google/gemini-cli-core';
 export { GEMINI_DIR };
 import * as pty from '@lydell/node-pty';
 import stripAnsi from 'strip-ansi';
@@ -457,7 +457,7 @@ export class TestRig {
         ...(env['GEMINI_TEST_TYPE'] === 'integration'
           ? {
               model: {
-                name: DEFAULT_GEMINI_MODEL,
+                name: PREVIEW_GEMINI_3_1_MODEL,
               },
             }
           : {}),


### PR DESCRIPTION
## Summary

Switches the integration test suite to use `PREVIEW_GEMINI_3_1_MODEL` instead of the default model.

## Details

As requested, this modifies `@packages/test-utils/src/test-rig.ts` to use `PREVIEW_GEMINI_3_1_MODEL` and changes nothing else to see if the GitHub Actions CI passes.

## Related Issues

Related to investigations around model selection for integration tests.

## How to Validate

Watch the CI pipeline on this PR to confirm if integration tests pass cleanly.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
