### PR TITLE
chore(release): allow bundling for all builds, including stable

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -193,7 +193,7 @@ runs:
         INPUTS_A2A_PACKAGE_NAME: '${{ inputs.a2a-package-name }}'
 
     - name: '📦 Prepare bundled CLI for npm release'
-      if: "inputs.npm-registry-url != 'https://npm.pkg.github.com/' && inputs.npm-tag != 'latest'"
+      if: "inputs.npm-registry-url != 'https://npm.pkg.github.com/'"
       working-directory: '${{ inputs.working-directory }}'
       shell: 'bash'
       run: |


### PR DESCRIPTION
## Summary

Revert #21821 to allow bundling for all builds, including stable builds.

## Details

This PR removes the condition that restricted npm bundling to non-stable tags. Bundling will now occur for all builds, including those with the `latest` npm tag.

## Related Issues

Reverts https://github.com/google-gemini/gemini-cli/pull/21821

## How to Validate

Verify the change in `.github/actions/publish-release/action.yml`:
- Locate the step "Prepare bundled CLI for npm release".
- Ensure the `if` condition is `inputs.npm-registry-url != 'https://npm.pkg.github.com/'`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
