### PR TITLE
test(sdk): add source-aware test output control

### DIFF
--- a/packages/core/src/utils/debugLogger.ts
+++ b/packages/core/src/utils/debugLogger.ts
@@ -8,6 +8,39 @@
 import * as fs from 'node:fs';
 import * as util from 'node:util';
 
+export type DebugLoggerLevel = 'log' | 'warn' | 'error' | 'debug';
+export type DebugLoggerCaptureHook = (
+  level: DebugLoggerLevel,
+  args: unknown[],
+) => void;
+
+const DEBUG_LOGGER_CAPTURE_HOOK = Symbol.for('gemini.debugLogger.captureHook');
+
+function getCaptureHook(): DebugLoggerCaptureHook | undefined {
+  return (
+    globalThis as typeof globalThis & {
+      [DEBUG_LOGGER_CAPTURE_HOOK]?: DebugLoggerCaptureHook;
+    }
+  )[DEBUG_LOGGER_CAPTURE_HOOK];
+}
+
+export function setDebugLoggerCaptureHook(hook?: DebugLoggerCaptureHook): void {
+  const scopedGlobal = globalThis as typeof globalThis & {
+    [DEBUG_LOGGER_CAPTURE_HOOK]?: DebugLoggerCaptureHook;
+  };
+
+  if (hook) {
+    scopedGlobal[DEBUG_LOGGER_CAPTURE_HOOK] = hook;
+    return;
+  }
+
+  delete scopedGlobal[DEBUG_LOGGER_CAPTURE_HOOK];
+}
+
+function shouldSuppressConsoleOutput(): boolean {
+  return process.env['GEMINI_SUPPRESS_DEBUG_LOGGER_CONSOLE'] === 'true';
+}
+
 /**
  * A simple, centralized logger for developer-facing debug messages.
  *
@@ -47,21 +80,41 @@ class DebugLogger {
 
   log(...args: unknown[]): void {
     this.writeToFile('LOG', args);
+    const captureHook = getCaptureHook();
+    captureHook?.('log', args);
+    if (captureHook || shouldSuppressConsoleOutput()) {
+      return;
+    }
     console.log(...args);
   }
 
   warn(...args: unknown[]): void {
     this.writeToFile('WARN', args);
+    const captureHook = getCaptureHook();
+    captureHook?.('warn', args);
+    if (captureHook || shouldSuppressConsoleOutput()) {
+      return;
+    }
     console.warn(...args);
   }
 
   error(...args: unknown[]): void {
     this.writeToFile('ERROR', args);
+    const captureHook = getCaptureHook();
+    captureHook?.('error', args);
+    if (captureHook || shouldSuppressConsoleOutput()) {
+      return;
+    }
     console.error(...args);
   }
 
   debug(...args: unknown[]): void {
     this.writeToFile('DEBUG', args);
+    const captureHook = getCaptureHook();
+    captureHook?.('debug', args);
+    if (captureHook || shouldSuppressConsoleOutput()) {
+      return;
+    }
     console.debug(...args);
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -14,8 +14,8 @@
     "build": "node ../../scripts/build_package.js",
     "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier --write .",
-    "test": "vitest run",
-    "test:ci": "vitest run",
+    "test": "node ../../scripts/run-vitest.js run --config ./vitest.config.ts",
+    "test:ci": "node ../../scripts/run-vitest.js run --config ./vitest.config.ts",
     "typecheck": "tsc --noEmit"
   },
   "files": [

--- a/packages/sdk/src/agent.integration.test.ts
+++ b/packages/sdk/src/agent.integration.test.ts
@@ -4,10 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { GeminiCliAgent } from './agent.js';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  collectResponseText,
+  collectSessionEvents,
+  createManagedSession,
+  trackSession,
+} from '../test-utils/sessionHarness.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -19,13 +25,6 @@ const getGoldenPath = (name: string) =>
   path.resolve(__dirname, '../test-data', `${name}.json`);
 
 describe('GeminiCliAgent Integration', () => {
-  beforeEach(() => {
-    vi.stubEnv('GEMINI_API_KEY', 'test-api-key');
-  });
-
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
   it('handles static instructions', async () => {
     const goldenFile = getGoldenPath('agent-static-instructions');
 
@@ -36,21 +35,12 @@ describe('GeminiCliAgent Integration', () => {
       fakeResponses: RECORD_MODE ? undefined : goldenFile,
     });
 
-    const session = agent.session();
+    const session = createManagedSession(agent);
     expect(session.id).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
     );
-    const events = [];
-    const stream = session.sendStream('Say hello.');
-
-    for await (const event of stream) {
-      events.push(event);
-    }
-
-    const textEvents = events.filter((e) => e.type === 'content');
-    const responseText = textEvents
-      .map((e) => (typeof e.value === 'string' ? e.value : ''))
-      .join('');
+    const events = await collectSessionEvents(session, 'Say hello.');
+    const responseText = collectResponseText(events);
 
     // Expect pirate speak
     expect(responseText.toLowerCase()).toMatch(/ahoy|matey|arrr/);
@@ -70,31 +60,23 @@ describe('GeminiCliAgent Integration', () => {
       fakeResponses: RECORD_MODE ? undefined : goldenFile,
     });
 
-    const session = agent.session();
+    const session = createManagedSession(agent);
 
     // First turn
-    const events1 = [];
-    const stream1 = session.sendStream('What is the secret number?');
-    for await (const event of stream1) {
-      events1.push(event);
-    }
-    const responseText1 = events1
-      .filter((e) => e.type === 'content')
-      .map((e) => (typeof e.value === 'string' ? e.value : ''))
-      .join('');
+    const events1 = await collectSessionEvents(
+      session,
+      'What is the secret number?',
+    );
+    const responseText1 = collectResponseText(events1);
 
     expect(responseText1).toContain('1');
 
     // Second turn
-    const events2 = [];
-    const stream2 = session.sendStream('What is the secret number now?');
-    for await (const event of stream2) {
-      events2.push(event);
-    }
-    const responseText2 = events2
-      .filter((e) => e.type === 'content')
-      .map((e) => (typeof e.value === 'string' ? e.value : ''))
-      .join('');
+    const events2 = await collectSessionEvents(
+      session,
+      'What is the secret number now?',
+    );
+    const responseText2 = collectResponseText(events2);
 
     expect(responseText2).toContain('2');
   }, 30000);
@@ -110,30 +92,24 @@ describe('GeminiCliAgent Integration', () => {
       fakeResponses: RECORD_MODE ? undefined : goldenFile,
     });
 
-    const session1 = agent.session({ sessionId: 'resume-test-fixed-id' });
+    const session1 = createManagedSession(agent, {
+      sessionId: 'resume-test-fixed-id',
+    });
     const sessionId = session1.id;
-    const stream1 = session1.sendStream('What is the word?');
-    for await (const _ of stream1) {
-      // consume stream
-    }
+    await collectSessionEvents(session1, 'What is the word?');
 
     // Resume session
     // Allow some time for async writes if any
     await new Promise((resolve) => setTimeout(resolve, 500));
 
-    const session2 = await agent.resumeSession(sessionId);
+    const session2 = trackSession(await agent.resumeSession(sessionId));
     expect(session2.id).toBe(sessionId);
 
-    const events2 = [];
-    const stream2 = session2.sendStream('What is the word again?');
-    for await (const event of stream2) {
-      events2.push(event);
-    }
-
-    const responseText = events2
-      .filter((e) => e.type === 'content')
-      .map((e) => (typeof e.value === 'string' ? e.value : ''))
-      .join('');
+    const events2 = await collectSessionEvents(
+      session2,
+      'What is the word again?',
+    );
+    const responseText = collectResponseText(events2);
 
     expect(responseText).toContain('BANANA');
   }, 30000);
@@ -160,7 +136,7 @@ describe('GeminiCliAgent Integration', () => {
       fakeResponses: RECORD_MODE ? undefined : goldenFile,
     });
 
-    const session = agent.session();
+    const session = createManagedSession(agent);
     const stream = session.sendStream('Say hello.');
 
     await expect(async () => {

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -22,6 +22,7 @@ import {
   ActivateSkillTool,
   type ResumedSessionData,
   PolicyDecision,
+  debugLogger,
 } from '@google/gemini-cli-core';
 
 import { type Tool, SdkTool } from './tool.js';
@@ -43,6 +44,7 @@ export class GeminiCliSession {
   private readonly instructions: SystemInstructions | undefined;
   private client: GeminiClient | undefined;
   private initialized = false;
+  private disposed = false;
 
   constructor(
     options: GeminiCliAgentOptions,
@@ -90,6 +92,14 @@ export class GeminiCliSession {
     return this.sessionId;
   }
 
+  async dispose(): Promise<void> {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    await this.config.dispose();
+  }
+
   async initialize(): Promise<void> {
     if (this.initialized) return;
 
@@ -108,9 +118,7 @@ export class GeminiCliSession {
             return await loadSkillsFromDir(ref.path);
           }
         } catch (e) {
-          // TODO: refactor this to use a proper logger interface
-          // eslint-disable-next-line no-console
-          console.error(`Failed to load skills from ${ref.path}:`, e);
+          debugLogger.error(`Failed to load skills from ${ref.path}:`, e);
         }
         return [];
       });

--- a/packages/sdk/src/skills.integration.test.ts
+++ b/packages/sdk/src/skills.integration.test.ts
@@ -8,7 +8,15 @@ import { describe, it, expect } from 'vitest';
 import { GeminiCliAgent } from './agent.js';
 import { skillDir } from './skills.js';
 import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
 import { fileURLToPath } from 'node:url';
+import {
+  collectResponseText,
+  collectSessionEvents,
+  createManagedSession,
+} from '../test-utils/sessionHarness.js';
+import { expectTestOutput } from '../test-utils/outputControl.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -37,21 +45,13 @@ describe('GeminiCliAgent Skills Integration', () => {
     });
 
     // 1. Ask to activate the skill
-    const events = [];
-    const session = agent.session();
+    const session = createManagedSession(agent);
     // The prompt explicitly asks to activate the skill by name
-    const stream = session.sendStream(
+    const events = await collectSessionEvents(
+      session,
       'Activate the pirate-skill and then tell me a joke.',
     );
-
-    for await (const event of stream) {
-      events.push(event);
-    }
-
-    const textEvents = events.filter((e) => e.type === 'content');
-    const responseText = textEvents
-      .map((e) => (typeof e.value === 'string' ? e.value : ''))
-      .join('');
+    const responseText = collectResponseText(events);
 
     // Expect pirate speak
     expect(responseText.toLowerCase()).toContain('arrr');
@@ -71,22 +71,46 @@ describe('GeminiCliAgent Skills Integration', () => {
     });
 
     // 1. Ask to activate the skill
-    const events = [];
-    const session = agent.session();
-    const stream = session.sendStream(
+    const session = createManagedSession(agent);
+    const events = await collectSessionEvents(
+      session,
       'Activate the pirate-skill and confirm it is active.',
     );
-
-    for await (const event of stream) {
-      events.push(event);
-    }
-
-    const textEvents = events.filter((e) => e.type === 'content');
-    const responseText = textEvents
-      .map((e) => (typeof e.value === 'string' ? e.value : ''))
-      .join('');
+    const responseText = collectResponseText(events);
 
     // Expect confirmation or pirate speak
     expect(responseText.toLowerCase()).toContain('arrr');
   }, 60000);
+
+  it('logs a controlled debug message for a non-skill directory', async () => {
+    const goldenFile = getGoldenPath('agent-static-instructions');
+    const invalidSkillDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'gemini-sdk-invalid-skill-'),
+    );
+    await fs.writeFile(path.join(invalidSkillDir, 'README.md'), 'not a skill');
+
+    expectTestOutput({
+      source: 'debugLogger',
+      level: 'debug',
+      pattern:
+        /Failed to load skills from .*The directory is not empty but no valid skills were discovered\./,
+    });
+
+    try {
+      const agent = new GeminiCliAgent({
+        instructions: 'You are a pirate. Respond in pirate speak.',
+        skills: [skillDir(invalidSkillDir)],
+        model: RECORD_MODE ? 'gemini-2.0-flash' : undefined,
+        recordResponses: RECORD_MODE ? goldenFile : undefined,
+        fakeResponses: RECORD_MODE ? undefined : goldenFile,
+      });
+
+      const session = createManagedSession(agent);
+      const events = await collectSessionEvents(session, 'Say hello.');
+
+      expect(collectResponseText(events)).toContain('Ahoy');
+    } finally {
+      await fs.rm(invalidSkillDir, { recursive: true, force: true });
+    }
+  }, 30000);
 });

--- a/packages/sdk/test-setup.ts
+++ b/packages/sdk/test-setup.ts
@@ -1,0 +1,164 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  FORCE_FILE_STORAGE_ENV_VAR,
+  coreEvents,
+  setDebugLoggerCaptureHook,
+} from '@google/gemini-cli-core';
+import { afterAll, afterEach, beforeEach, expect, vi } from 'vitest';
+import {
+  captureConsoleOutput,
+  captureDebugLoggerOutput,
+  captureProcessWarning,
+  finishQuietTest,
+  getQuietTestAuditSummary,
+  setQuietTestTrackingEnabled,
+  type TestStatus,
+  startQuietTest,
+} from './test-utils/outputControl.js';
+import { cleanupTrackedSessions } from './test-utils/sessionHarness.js';
+
+type ConsoleMethod = 'log' | 'warn' | 'error' | 'debug';
+type RestorableSpy = { mockRestore(): void };
+
+const verboseTestOutput = process.env['GEMINI_TEST_VERBOSE'] === 'true';
+const auditTestOutput = process.env['GEMINI_TEST_OUTPUT_AUDIT'] === 'true';
+const originalSdkEnv = {
+  apiKey: process.env['GEMINI_API_KEY'],
+  forceFileStorage: process.env[FORCE_FILE_STORAGE_ENV_VAR],
+  suppressDebugLogger: process.env['GEMINI_SUPPRESS_DEBUG_LOGGER_CONSOLE'],
+};
+
+const consoleSpies = new Map<ConsoleMethod, RestorableSpy>();
+let emitWarningSpy: RestorableSpy | undefined;
+const originalMaxListeners = coreEvents.getMaxListeners();
+
+setQuietTestTrackingEnabled(!verboseTestOutput);
+
+if (!verboseTestOutput) {
+  coreEvents.setMaxListeners(Math.max(originalMaxListeners, 100));
+  process.env['GEMINI_API_KEY'] = 'test-api-key';
+  process.env[FORCE_FILE_STORAGE_ENV_VAR] = 'true';
+  process.env['GEMINI_SUPPRESS_DEBUG_LOGGER_CONSOLE'] = 'true';
+  setDebugLoggerCaptureHook((level, args) => {
+    captureDebugLoggerOutput(level, args);
+  });
+}
+
+beforeEach((context) => {
+  if (verboseTestOutput) {
+    return;
+  }
+
+  const currentTestName =
+    expect.getState().currentTestName ?? context.task.name;
+  const currentTestPath =
+    expect.getState().testPath ??
+    context.task.file?.filepath ??
+    'unknown-test-file';
+
+  startQuietTest(currentTestPath, currentTestName);
+
+  for (const level of ['log', 'warn', 'error', 'debug'] as const) {
+    consoleSpies.set(
+      level,
+      vi.spyOn(console, level).mockImplementation((...args) => {
+        captureConsoleOutput(level, args);
+      }),
+    );
+  }
+  emitWarningSpy = vi
+    .spyOn(process, 'emitWarning')
+    .mockImplementation((warning: string | Error, ...args: unknown[]) => {
+      const warningType = typeof args[0] === 'string' ? args[0] : undefined;
+      captureProcessWarning(warning, warningType);
+    });
+});
+
+afterEach(async (context) => {
+  try {
+    await cleanupTrackedSessions();
+
+    if (!verboseTestOutput) {
+      const result = finishQuietTest(getTestStatus(context.task.result?.state));
+      restoreOutputSpies();
+
+      if (getTestStatus(context.task.result?.state) === 'fail') {
+        replayCapturedOutput(result.replayEntries);
+      }
+
+      if (result.error) {
+        throw result.error;
+      }
+    }
+  } finally {
+    restoreOutputSpies();
+    vi.unstubAllEnvs();
+  }
+});
+
+afterAll(() => {
+  if (!verboseTestOutput) {
+    setDebugLoggerCaptureHook(undefined);
+    coreEvents.setMaxListeners(originalMaxListeners);
+    restoreSdkEnv();
+    if (auditTestOutput) {
+      process.stderr.write(getQuietTestAuditSummary());
+    }
+  }
+});
+
+function replayCapturedOutput(
+  entries: ReadonlyArray<{
+    source: 'console' | 'debugLogger' | 'warning';
+    level: ConsoleMethod;
+    message: string;
+  }>,
+): void {
+  for (const entry of entries) {
+    if (entry.source === 'warning') {
+      process.stderr.write(`${entry.message}\n`);
+      continue;
+    }
+    console[entry.level](entry.message);
+  }
+}
+
+function restoreOutputSpies(): void {
+  for (const spy of consoleSpies.values()) {
+    spy.mockRestore();
+  }
+  consoleSpies.clear();
+
+  emitWarningSpy?.mockRestore();
+  emitWarningSpy = undefined;
+}
+
+function restoreSdkEnv(): void {
+  if (originalSdkEnv.apiKey === undefined) {
+    delete process.env['GEMINI_API_KEY'];
+  } else {
+    process.env['GEMINI_API_KEY'] = originalSdkEnv.apiKey;
+  }
+
+  if (originalSdkEnv.forceFileStorage === undefined) {
+    delete process.env[FORCE_FILE_STORAGE_ENV_VAR];
+  } else {
+    process.env[FORCE_FILE_STORAGE_ENV_VAR] = originalSdkEnv.forceFileStorage;
+  }
+
+  if (originalSdkEnv.suppressDebugLogger === undefined) {
+    delete process.env['GEMINI_SUPPRESS_DEBUG_LOGGER_CONSOLE'];
+  } else {
+    process.env['GEMINI_SUPPRESS_DEBUG_LOGGER_CONSOLE'] =
+      originalSdkEnv.suppressDebugLogger;
+  }
+}
+
+function getTestStatus(state: string | undefined): TestStatus {
+  return state === 'fail' ? 'fail' : 'pass';
+}

--- a/packages/sdk/test-utils/outputControl.test.ts
+++ b/packages/sdk/test-utils/outputControl.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { TestOutputController } from './outputControl.js';
+
+describe('TestOutputController', () => {
+  it('fails passing tests that emit unexpected console output', () => {
+    const controller = new TestOutputController();
+    controller.startTest('src/noisy.test.ts', 'noisy test');
+    controller.captureOutput('console', 'error', ['unexpected failure path']);
+
+    const result = controller.finishTest('pass');
+
+    expect(result.error?.message).toContain(
+      'Passing test emitted unexpected output',
+    );
+    expect(result.error?.message).toContain('unexpected failure path');
+  });
+
+  it('allows explicitly expected console output', () => {
+    const controller = new TestOutputController();
+    controller.startTest('src/expected.test.ts', 'expected test');
+    controller.expectOutput({
+      source: 'console',
+      level: 'error',
+      pattern: /expected error/,
+    });
+    controller.captureOutput('console', 'error', ['expected error']);
+
+    const result = controller.finishTest('pass');
+
+    expect(result.error).toBeUndefined();
+  });
+
+  it('audits debugLogger noise without failing the test', () => {
+    const controller = new TestOutputController();
+    controller.startTest('src/audited.test.ts', 'audited test');
+    controller.captureOutput('debugLogger', 'debug', ['Experiments loaded']);
+
+    const result = controller.finishTest('pass');
+
+    expect(result.error).toBeUndefined();
+    expect(controller.formatAuditSummary()).toContain('src/audited.test.ts');
+    expect(controller.formatAuditSummary()).toContain('Experiments loaded');
+  });
+
+  it('no-ops expectations when tracking is disabled', () => {
+    const controller = new TestOutputController();
+    controller.setTrackingEnabled(false);
+
+    expect(() =>
+      controller.expectOutput({
+        source: 'debugLogger',
+        level: 'debug',
+        pattern: /ignored in verbose mode/,
+      }),
+    ).not.toThrow();
+    expect(controller.finishTest('pass')).toEqual({ replayEntries: [] });
+  });
+
+  it('replays captured output for failing tests', () => {
+    const controller = new TestOutputController();
+    controller.startTest('src/failing.test.ts', 'failing test');
+    controller.captureOutput('console', 'warn', ['visible on failure']);
+
+    const result = controller.finishTest('fail');
+
+    expect(result.replayEntries).toEqual([
+      {
+        source: 'console',
+        level: 'warn',
+        message: 'visible on failure',
+      },
+    ]);
+  });
+});

--- a/packages/sdk/test-utils/outputControl.ts
+++ b/packages/sdk/test-utils/outputControl.ts
@@ -1,0 +1,318 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { format } from 'node:util';
+
+export type OutputSource = 'console' | 'debugLogger' | 'warning';
+export type OutputLevel = 'log' | 'warn' | 'error' | 'debug';
+export type TestStatus = 'pass' | 'fail';
+
+export interface CapturedOutput {
+  source: OutputSource;
+  level: OutputLevel;
+  message: string;
+}
+
+export interface OutputMatcher {
+  pattern: RegExp | string;
+  source?: OutputSource;
+  level?: OutputLevel;
+}
+
+interface RegisteredMatcher {
+  matcher: OutputMatcher;
+  required: boolean;
+}
+
+interface ActiveTest {
+  filePath: string;
+  testName: string;
+  entries: CapturedOutput[];
+  matchers: RegisteredMatcher[];
+}
+
+interface AuditEntry {
+  count: number;
+  sampleMessages: string[];
+}
+
+export interface TestCompletionResult {
+  replayEntries: CapturedOutput[];
+  error?: Error;
+}
+
+const AUDITED_SOURCE = 'debugLogger';
+
+export class TestOutputController {
+  private activeTest: ActiveTest | undefined;
+  private readonly auditEntries = new Map<string, AuditEntry>();
+  private trackingEnabled = true;
+
+  setTrackingEnabled(enabled: boolean): void {
+    this.trackingEnabled = enabled;
+    if (!enabled) {
+      this.activeTest = undefined;
+    }
+  }
+
+  startTest(filePath: string, testName: string): void {
+    if (!this.trackingEnabled) {
+      return;
+    }
+
+    if (this.activeTest) {
+      throw new Error(
+        `Output controller already tracking "${this.activeTest.testName}".`,
+      );
+    }
+
+    this.activeTest = {
+      filePath,
+      testName,
+      entries: [],
+      matchers: [],
+    };
+  }
+
+  captureOutput(
+    source: OutputSource,
+    level: OutputLevel,
+    args: unknown[],
+  ): void {
+    if (!this.trackingEnabled || !this.activeTest) {
+      return;
+    }
+
+    this.activeTest.entries.push({
+      source,
+      level,
+      message: format(...args),
+    });
+  }
+
+  captureWarning(warning: string | Error, type?: string): void {
+    const pieces =
+      warning instanceof Error
+        ? [warning.name, warning.message].filter(Boolean)
+        : [warning, type].filter(Boolean);
+    this.captureOutput('warning', 'warn', [pieces.join(': ')]);
+  }
+
+  allowOutput(...matchers: OutputMatcher[]): void {
+    this.registerMatchers(false, matchers);
+  }
+
+  expectOutput(...matchers: OutputMatcher[]): void {
+    this.registerMatchers(true, matchers);
+  }
+
+  finishTest(status: TestStatus): TestCompletionResult {
+    if (!this.trackingEnabled) {
+      return { replayEntries: [] };
+    }
+
+    if (!this.activeTest) {
+      throw new Error('Output controller is not tracking a test.');
+    }
+
+    const completedTest = this.activeTest;
+    this.activeTest = undefined;
+
+    const matchedEntries = new Set<number>();
+    const missingRequiredMatchers: OutputMatcher[] = [];
+
+    for (const registeredMatcher of completedTest.matchers) {
+      const matchedIndex = completedTest.entries.findIndex((entry, index) => {
+        if (matchedEntries.has(index)) {
+          return false;
+        }
+        return this.matches(entry, registeredMatcher.matcher);
+      });
+
+      if (matchedIndex === -1) {
+        if (registeredMatcher.required) {
+          missingRequiredMatchers.push(registeredMatcher.matcher);
+        }
+        continue;
+      }
+
+      matchedEntries.add(matchedIndex);
+    }
+
+    const unexpectedEntries = completedTest.entries.filter(
+      (_entry, index) => !matchedEntries.has(index),
+    );
+    const strictUnexpectedEntries = unexpectedEntries.filter(
+      (entry) => entry.source !== AUDITED_SOURCE,
+    );
+    const auditedEntries = unexpectedEntries.filter(
+      (entry) => entry.source === AUDITED_SOURCE,
+    );
+
+    if (auditedEntries.length > 0) {
+      this.recordAudit(completedTest.filePath, auditedEntries);
+    }
+
+    if (status === 'fail') {
+      return { replayEntries: completedTest.entries };
+    }
+
+    if (
+      strictUnexpectedEntries.length === 0 &&
+      missingRequiredMatchers.length === 0
+    ) {
+      return { replayEntries: [] };
+    }
+
+    const details: string[] = [];
+    if (strictUnexpectedEntries.length > 0) {
+      details.push('Unexpected test output:');
+      details.push(
+        ...strictUnexpectedEntries.map((entry) => this.formatEntry(entry)),
+      );
+    }
+    if (missingRequiredMatchers.length > 0) {
+      details.push('Missing expected output assertions:');
+      details.push(
+        ...missingRequiredMatchers.map((matcher) =>
+          this.formatMatcher(matcher),
+        ),
+      );
+    }
+
+    return {
+      replayEntries: [],
+      error: new Error(
+        [
+          `Passing test emitted unexpected output: ${completedTest.testName}`,
+          ...details,
+          'Use expectTestOutput(...) for intentional logs or remove the source of noise.',
+        ].join('\n'),
+      ),
+    };
+  }
+
+  formatAuditSummary(): string {
+    if (this.auditEntries.size === 0) {
+      return '[quiet-test-audit] No audited debugLogger output recorded.\n';
+    }
+
+    const lines = [
+      '[quiet-test-audit] Files still emitting debugLogger output:',
+    ];
+    for (const [filePath, entry] of [...this.auditEntries.entries()].sort()) {
+      lines.push(`- ${filePath}: ${entry.count} entries`);
+      for (const sample of entry.sampleMessages) {
+        lines.push(`  sample: ${sample}`);
+      }
+    }
+    return lines.join('\n') + '\n';
+  }
+
+  private registerMatchers(required: boolean, matchers: OutputMatcher[]): void {
+    if (!this.trackingEnabled) {
+      return;
+    }
+
+    if (!this.activeTest) {
+      throw new Error('Output controller is not tracking a test.');
+    }
+
+    for (const matcher of matchers) {
+      this.activeTest.matchers.push({ matcher, required });
+    }
+  }
+
+  private matches(entry: CapturedOutput, matcher: OutputMatcher): boolean {
+    if (matcher.source && matcher.source !== entry.source) {
+      return false;
+    }
+    if (matcher.level && matcher.level !== entry.level) {
+      return false;
+    }
+    if (typeof matcher.pattern === 'string') {
+      return entry.message.includes(matcher.pattern);
+    }
+    return matcher.pattern.test(entry.message);
+  }
+
+  private recordAudit(filePath: string, entries: CapturedOutput[]): void {
+    const existing = this.auditEntries.get(filePath) ?? {
+      count: 0,
+      sampleMessages: [],
+    };
+    existing.count += entries.length;
+    for (const entry of entries) {
+      if (existing.sampleMessages.length >= 2) {
+        break;
+      }
+      if (!existing.sampleMessages.includes(entry.message)) {
+        existing.sampleMessages.push(entry.message);
+      }
+    }
+    this.auditEntries.set(filePath, existing);
+  }
+
+  private formatEntry(entry: CapturedOutput): string {
+    return `- [${entry.source}.${entry.level}] ${entry.message}`;
+  }
+
+  private formatMatcher(matcher: OutputMatcher): string {
+    const prefix = [matcher.source, matcher.level].filter(Boolean).join('.');
+    const pattern =
+      typeof matcher.pattern === 'string'
+        ? matcher.pattern
+        : matcher.pattern.toString();
+    return `- [${prefix || 'any'}] ${pattern}`;
+  }
+}
+
+const controller = new TestOutputController();
+
+export function captureConsoleOutput(
+  level: OutputLevel,
+  args: unknown[],
+): void {
+  controller.captureOutput('console', level, args);
+}
+
+export function captureDebugLoggerOutput(
+  level: OutputLevel,
+  args: unknown[],
+): void {
+  controller.captureOutput('debugLogger', level, args);
+}
+
+export function captureProcessWarning(
+  warning: string | Error,
+  type?: string,
+): void {
+  controller.captureWarning(warning, type);
+}
+
+export function startQuietTest(filePath: string, testName: string): void {
+  controller.startTest(filePath, testName);
+}
+
+export function finishQuietTest(status: TestStatus): TestCompletionResult {
+  return controller.finishTest(status);
+}
+
+export function allowTestOutput(...matchers: OutputMatcher[]): void {
+  controller.allowOutput(...matchers);
+}
+
+export function expectTestOutput(...matchers: OutputMatcher[]): void {
+  controller.expectOutput(...matchers);
+}
+
+export function getQuietTestAuditSummary(): string {
+  return controller.formatAuditSummary();
+}
+
+export function setQuietTestTrackingEnabled(enabled: boolean): void {
+  controller.setTrackingEnabled(enabled);
+}

--- a/packages/sdk/test-utils/sessionHarness.ts
+++ b/packages/sdk/test-utils/sessionHarness.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ServerGeminiStreamEvent } from '@google/gemini-cli-core';
+import type { GeminiCliAgent } from '../src/agent.js';
+import type { GeminiCliSession } from '../src/session.js';
+
+const trackedSessions = new Set<GeminiCliSession>();
+
+export function trackSession<T extends GeminiCliSession>(session: T): T {
+  trackedSessions.add(session);
+  return session;
+}
+
+export function createManagedSession(
+  agent: GeminiCliAgent,
+  options?: { sessionId?: string },
+): GeminiCliSession {
+  return trackSession(agent.session(options));
+}
+
+export async function collectSessionEvents(
+  session: GeminiCliSession,
+  prompt: string,
+  signal?: AbortSignal,
+): Promise<ServerGeminiStreamEvent[]> {
+  const events: ServerGeminiStreamEvent[] = [];
+  for await (const event of session.sendStream(prompt, signal)) {
+    events.push(event);
+  }
+  return events;
+}
+
+export function collectResponseText(
+  events: readonly ServerGeminiStreamEvent[],
+): string {
+  return events
+    .filter((event) => event.type === 'content')
+    .map((event) => (typeof event.value === 'string' ? event.value : ''))
+    .join('');
+}
+
+export async function cleanupTrackedSessions(): Promise<void> {
+  const sessions = [...trackedSessions];
+  trackedSessions.clear();
+  await Promise.allSettled(sessions.map((session) => session.dispose()));
+}

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -6,7 +6,13 @@
     "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "types": ["node", "vitest/globals"]
   },
-  "include": ["index.ts", "src/**/*.ts", "package.json"],
+  "include": [
+    "index.ts",
+    "src/**/*.ts",
+    "test-utils/**/*.ts",
+    "test-setup.ts",
+    "package.json"
+  ],
   "exclude": ["node_modules", "dist"],
   "references": [{ "path": "../core" }]
 }

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -4,11 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@google/gemini-cli-core': path.resolve(
+        __dirname,
+        '../core/src/index.ts',
+      ),
+    },
+  },
   test: {
     globals: true,
     environment: 'node',
+    setupFiles: ['./test-setup.ts'],
   },
 });

--- a/scripts/run-vitest.js
+++ b/scripts/run-vitest.js
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { resolveVitestModes } from './vitest/modes.js';
+
+const args = process.argv.slice(2);
+const { verboseMode, auditMode, forwardedArgs } = resolveVitestModes(args);
+
+const requireFromWorkspace = createRequire(
+  path.join(process.cwd(), 'package.json'),
+);
+const vitestCliPath = requireFromWorkspace.resolve('vitest/vitest.mjs');
+
+const env = { ...process.env };
+if (verboseMode) {
+  env['GEMINI_TEST_VERBOSE'] = 'true';
+}
+if (auditMode) {
+  env['GEMINI_TEST_OUTPUT_AUDIT'] = 'true';
+}
+
+const result = spawnSync(process.execPath, [vitestCliPath, ...forwardedArgs], {
+  stdio: 'inherit',
+  env,
+});
+
+if (result.error) {
+  throw result.error;
+}
+
+process.exit(result.status ?? 1);

--- a/scripts/tests/vitest-modes.test.ts
+++ b/scripts/tests/vitest-modes.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { resolveVitestModes } from '../vitest/modes.js';
+
+describe('resolveVitestModes', () => {
+  it('enables verbose mode for an explicit forwarded flag', () => {
+    const result = resolveVitestModes([
+      'run',
+      '--verbose',
+      '--config',
+      'vitest.config.ts',
+    ]);
+
+    expect(result.verboseMode).toBe(true);
+    expect(result.forwardedArgs).toEqual([
+      'run',
+      '--config',
+      'vitest.config.ts',
+    ]);
+  });
+
+  it('enables verbose mode when npm consumes --verbose as loglevel', () => {
+    const result = resolveVitestModes(['run', '--config', 'vitest.config.ts'], {
+      npm_config_loglevel: 'verbose',
+    });
+
+    expect(result.verboseMode).toBe(true);
+  });
+
+  it('does not enable verbose mode for normal npm loglevels', () => {
+    const result = resolveVitestModes(['run'], {
+      npm_config_loglevel: 'notice',
+    });
+
+    expect(result.verboseMode).toBe(false);
+  });
+});

--- a/scripts/vitest/modes.js
+++ b/scripts/vitest/modes.js
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+function isVerboseLogLevel(value) {
+  return value === 'verbose' || value === 'silly';
+}
+
+export function resolveVitestModes(args, env = process.env) {
+  const verboseMode =
+    args.includes('--verbose') || isVerboseLogLevel(env['npm_config_loglevel']);
+  const auditMode = args.includes('--audit-output');
+  const forwardedArgs = args.filter(
+    (arg) => arg !== '--verbose' && arg !== '--audit-output',
+  );
+
+  return {
+    verboseMode,
+    auditMode,
+    forwardedArgs,
+  };
+}


### PR DESCRIPTION

## Summary

Quiet passing test output in the SDK slice by introducing source-aware output control.

This reduces noisy stdout/stderr from passing tests while preserving failure visibility and restoring full logging via `--verbose`.

---

## Details

This PR introduces a layered test-output control system in `packages/sdk`:

- routes test execution through a shared Vitest wrapper
- adds package-level test setup to capture console output and warnings
- introduces an output controller to classify and enforce log behavior
- adds a capture hook to `debugLogger` for source-level interception
- enforces deterministic cleanup via session tracking (`dispose()`)

Key behavior:
- passing tests emit no arbitrary console/debug output
- failing tests replay captured logs
- `--verbose` disables the control layer and restores original logging
- `--audit-output` reports remaining debug logger noise

Measured impact (SDK slice):
- before: ~492 lines
- after: ~20 lines (~96% reduction)
- verbose: ~556 lines (full logging preserved)

This keeps the default Vitest UI unchanged and avoids reporter replacement.

---

## Related Issues

Related to #23328

---

## How to Validate

Run SDK tests in different modes:

```bash
npm run test --workspace @google/gemini-cli-sdk
````

Expected:

* minimal output for passing tests
* standard Vitest summary only

```bash
npm run test --workspace @google/gemini-cli-sdk -- --verbose
```

Expected:

* full logging restored (similar to baseline)

```bash
npm run test --workspace @google/gemini-cli-sdk -- --audit-output
```

Expected:

* quiet run + summary of debug logger noise

---

## Pre-Merge Checklist

* [x] Updated relevant documentation and README (if needed)
* [x] Added/updated tests (if needed)
* [ ] Noted breaking changes (if any)
* [x] Validated on required platforms/methods:

  * [x] MacOS

    * [x] npm run
    * [ ] npx
    * [ ] Docker
    * [ ] Podman
    * [ ] Seatbelt
  * [ ] Windows

    * [ ] npm run
    * [ ] npx
    * [ ] Docker
  * [ ] Linux

    * [ ] npm run
    * [ ] npx
    * [ ] Docker

```


