### PR TITLE
fix(evals): remove debug log and improve assertion robustness in edit…

### DIFF
--- a/evals/edit-locations-eval.eval.ts
+++ b/evals/edit-locations-eval.eval.ts
@@ -95,10 +95,10 @@ test('capitalize capitalizes the first letter', () => {
         }
       });
 
-      // Ignore unparsable tool args so the assertion only measures valid edit targets.
-      const editedPaths = targetFiles.filter(
-        (f): f is string => typeof f === 'string',
-      );
+      // Ignore unparsable tool args and empty strings so assertions only measure valid edit targets.
+      const editedPaths = targetFiles
+        .filter((f): f is string => typeof f === 'string' && f.trim() !== '')
+        .map((f) => f.trim());
 
       expect(
         new Set(editedPaths).size,

--- a/evals/edit-locations-eval.eval.ts
+++ b/evals/edit-locations-eval.eval.ts
@@ -95,14 +95,17 @@ test('capitalize capitalizes the first letter', () => {
         }
       });
 
-      console.log('DEBUG: targetFiles', targetFiles);
+      // Ignore unparsable tool args so the assertion only measures valid edit targets.
+      const editedPaths = targetFiles.filter(
+        (f): f is string => typeof f === 'string',
+      );
 
       expect(
-        new Set(targetFiles).size,
-        'Expected only two files changed',
+        new Set(editedPaths).size,
+        'Expected at least two distinct files to be changed',
       ).greaterThanOrEqual(2);
-      expect(targetFiles.some((f) => f?.endsWith('src/math.ts'))).toBe(true);
-      expect(targetFiles.some((f) => f?.endsWith('src/math.test.ts'))).toBe(
+      expect(editedPaths.some((f) => f.endsWith('src/math.ts'))).toBe(true);
+      expect(editedPaths.some((f) => f.endsWith('src/math.test.ts'))).toBe(
         true,
       );
     },


### PR DESCRIPTION
Summary
This PR improves eval signal quality in the edit-locations eval by removing debug noise and making assertion logic more robust when tool args cannot be parsed.

Details
Removed a leftover debug console.log from the assertion path.
Added filtering so only valid parsed string file paths are used for assertions.
Updated assertions to rely on filtered paths for:
distinct edited-file counting
target-file checks (src/math.ts and src/math.test.ts)
Improved assertion wording to make failures easier to understand.
Impact:

Cleaner eval output
Less brittle assertion behavior in edge cases
Better maintainability for contributors reading eval failures
Related Issues
Related to evaluation reliability/maintainability improvements in evals.

How to Validate
Open the changed eval file and confirm the debug log line is removed.
Confirm assertions now using filtered parsed paths before checks.
Run the eval/test suite locally if the environment is set up:
npm run test:all_evals
or run the specific eval test command used by maintainers
Expected result:
No debug noise from this eval assertion
Assertions still enforce edits on src/math.ts and src/math.test.ts
Pre-Merge Checklist
 Updated relevant documentation and README (if needed)
 Added/updated tests (if needed)
 Noted breaking changes (if any)
Validated on required platforms/methods:
macOS
 npm run
 npx
 Docker
 Podman
 Seatbelt
 Windows
 npm run
 npx
 Docker
 Linux
 npm run
 npx
 Docker