### PR TITLE
fix(cli): start memory monitoring in interactive sessions

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -31,6 +31,8 @@ import {
   AuthType,
   type AgentDefinition,
   CoreToolCallStatus,
+  startGlobalMemoryMonitoring,
+  stopGlobalMemoryMonitoring,
 } from '@google/gemini-cli-core';
 
 // Mock coreEvents
@@ -92,6 +94,8 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
       start: vi.fn(),
       end: vi.fn(),
     },
+    startGlobalMemoryMonitoring: vi.fn(),
+    stopGlobalMemoryMonitoring: vi.fn(),
   };
 });
 import ansiEscapes from 'ansi-escapes';
@@ -198,6 +202,7 @@ import { useHookDisplayState } from './hooks/useHookDisplayState.js';
 import { useTerminalTheme } from './hooks/useTerminalTheme.js';
 import { useShellInactivityStatus } from './hooks/useShellInactivityStatus.js';
 import { useFocus } from './hooks/useFocus.js';
+import { registerCleanup } from '../utils/cleanup.js';
 
 // Mock external utilities
 vi.mock('../utils/events.js');
@@ -606,6 +611,26 @@ describe('AppContainer State Management', () => {
         }),
       );
 
+      unmount();
+    });
+
+    it('starts and stops the global memory monitor with the interactive app lifecycle', async () => {
+      mockIdeClient.getInstance.mockResolvedValue({
+        disconnect: vi.fn().mockResolvedValue(undefined),
+        getCurrentIde: vi.fn().mockReturnValue(null),
+      });
+
+      const { unmount } = await act(async () => renderAppContainer());
+
+      await waitFor(() => {
+        expect(startGlobalMemoryMonitoring).toHaveBeenCalledWith(mockConfig);
+      });
+
+      const cleanupHandler = vi.mocked(registerCleanup).mock.calls.at(-1)?.[0];
+      expect(cleanupHandler).toBeDefined();
+      await cleanupHandler?.();
+
+      expect(stopGlobalMemoryMonitoring).toHaveBeenCalledWith(mockConfig);
       unmount();
     });
 

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -83,6 +83,8 @@ import {
   logBillingEvent,
   ApiKeyUpdatedEvent,
   type InjectionSource,
+  startGlobalMemoryMonitoring,
+  stopGlobalMemoryMonitoring,
 } from '@google/gemini-cli-core';
 import { validateAuthMethod } from '../config/auth.js';
 import process from 'node:process';
@@ -446,6 +448,9 @@ export const AppContainer = (props: AppContainerProps) => {
       }
       setConfigInitialized(true);
       startupProfiler.flush(config);
+      // The core monitor already implements sampling/rate-limiting; start it
+      // in interactive sessions so telemetry captures real session memory data.
+      startGlobalMemoryMonitoring(config);
 
       const sessionStartSource = resumedSessionData
         ? SessionStartSource.Resume
@@ -495,6 +500,8 @@ export const AppContainer = (props: AppContainerProps) => {
 
       const ideClient = await IdeClient.getInstance();
       await ideClient.disconnect();
+
+      stopGlobalMemoryMonitoring(config);
 
       // Fire SessionEnd hook on cleanup (only if hooks are enabled)
       await config?.getHookSystem()?.fireSessionEndEvent(SessionEndReason.Exit);


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Start the existing global memory monitor in normal interactive CLI sessions so memory telemetry is actually collected during the main app lifecycle.

This PR wires the core MemoryMonitor into AppContainer: monitoring now starts after config initialization and stops during registered app cleanup. It also adds lifecycle test coverage for the new start/stop behavior.


## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
The repo already had a full telemetry-side memory monitoring implementation, including sampling, rate limiting, and cleanup helpers, but the interactive UI path was not starting it. As a result, the functionality existed in core code without being active in standard interactive sessions.

Changes in this PR:

- start global memory monitoring after interactive config initialization
- stop global memory monitoring during app cleanup
- add a focused AppContainer test covering the interactive lifecycle
 
This is a small additive integration with no behavior changes outside telemetry activation for sessions where telemetry/performance monitoring is enabled.
## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
```bash
cd packages/cli
npx vitest run src/ui/AppContainer.test.tsx --coverage.enabled=false

```
Expected result: all tests pass, including the new lifecycle test for starting and stopping global memory monitoring.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [ ] Docker
