### PR TITLE
don't try to remove tags in dry run

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -175,7 +175,9 @@ runs:
           --dry-run="${INPUTS_DRY_RUN}" \
           --workspace="${INPUTS_CORE_PACKAGE_NAME}" \
           --no-tag
-        npm dist-tag rm ${INPUTS_CORE_PACKAGE_NAME} false
+        if [[ "${INPUTS_DRY_RUN}" == "false" ]]; then
+          npm dist-tag rm ${INPUTS_CORE_PACKAGE_NAME} false
+        fi
 
     - name: '🔗 Install latest core package'
       working-directory: '${{ inputs.working-directory }}'
@@ -248,7 +250,9 @@ runs:
           --dry-run="${INPUTS_DRY_RUN}" \
           --workspace="${INPUTS_A2A_PACKAGE_NAME}" \
           --no-tag
-        npm dist-tag rm ${INPUTS_A2A_PACKAGE_NAME} false
+          if [[ "${INPUTS_DRY_RUN}" == "false" ]]; then
+            npm dist-tag rm ${INPUTS_A2A_PACKAGE_NAME} false
+          fi
 
     - name: '🔬 Verify NPM release by version'
       uses: './.github/actions/verify-release'


### PR DESCRIPTION
## Summary

In dry run we don't publish the branch so there's no need to remove the tag from it.

## Details

This was partially fixed in https://github.com/google-gemini/gemini-cli/pull/23830 but there are two other spots we do this that I didn't notice before.