### PR TITLE
Revert "Add security settings for tool sandboxing"

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -7,8 +7,5 @@
   },
   "general": {
     "devtools": true
-  },
-  "security": {
-    "toolSandboxing": true
   }
 }


### PR DESCRIPTION
Reverts google-gemini/gemini-cli#23923 until https://github.com/google-gemini/gemini-cli/issues/23958 is fixed then we can add it back 