### PR TITLE
fix(cli): keep resumed session ids in quit summaries

### DIFF
--- a/packages/cli/src/ui/hooks/useSessionBrowser.test.ts
+++ b/packages/cli/src/ui/hooks/useSessionBrowser.test.ts
@@ -23,7 +23,6 @@ import {
 import {
   coreEvents,
   convertSessionToClientHistory,
-  uiTelemetryService,
 } from '@google/gemini-cli-core';
 
 // Mock modules
@@ -42,10 +41,6 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     await importOriginal<typeof import('@google/gemini-cli-core')>();
   return {
     ...actual,
-    uiTelemetryService: {
-      clear: vi.fn(),
-      hydrate: vi.fn(),
-    },
   };
 });
 
@@ -114,7 +109,6 @@ describe('useSessionBrowser', () => {
     expect(mockConfig.setSessionId).toHaveBeenCalledWith(
       'existing-session-456',
     );
-    expect(uiTelemetryService.hydrate).toHaveBeenCalledWith(mockConversation);
     expect(result.current.isSessionBrowserOpen).toBe(false);
     expect(mockOnLoadHistory).toHaveBeenCalled();
   });

--- a/packages/cli/src/ui/hooks/useSessionBrowser.ts
+++ b/packages/cli/src/ui/hooks/useSessionBrowser.ts
@@ -11,7 +11,6 @@ import path from 'node:path';
 import {
   coreEvents,
   convertSessionToClientHistory,
-  uiTelemetryService,
   type Config,
   type ConversationRecord,
   type ResumedSessionData,
@@ -69,7 +68,6 @@ export const useSessionBrowser = (
           // Use the old session's ID to continue it.
           const existingSessionId = conversation.sessionId;
           config.setSessionId(existingSessionId);
-          uiTelemetryService.hydrate(conversation);
 
           const resumedSessionData = {
             conversation,

--- a/packages/cli/src/ui/hooks/useSessionResume.test.ts
+++ b/packages/cli/src/ui/hooks/useSessionResume.test.ts
@@ -14,8 +14,21 @@ import type {
   ConversationRecord,
   MessageRecord,
 } from '@google/gemini-cli-core';
+import { uiTelemetryService } from '@google/gemini-cli-core';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
 import type { HistoryItemWithoutId } from '../types.js';
+
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    uiTelemetryService: {
+      clear: vi.fn(),
+      hydrate: vi.fn(),
+    },
+  };
+});
 
 describe('useSessionResume', () => {
   // Mock dependencies
@@ -99,6 +112,9 @@ describe('useSessionResume', () => {
       });
 
       expect(mockSetQuittingMessages).toHaveBeenCalledWith(null);
+      expect(uiTelemetryService.hydrate).toHaveBeenCalledWith(
+        resumedData.conversation,
+      );
       expect(mockHistoryManager.clearItems).toHaveBeenCalled();
       expect(mockHistoryManager.addItem).toHaveBeenCalledTimes(2);
       expect(mockHistoryManager.addItem).toHaveBeenNthCalledWith(
@@ -156,6 +172,7 @@ describe('useSessionResume', () => {
       expect(mockHistoryManager.clearItems).not.toHaveBeenCalled();
       expect(mockHistoryManager.addItem).not.toHaveBeenCalled();
       expect(mockGeminiClient.resumeChat).not.toHaveBeenCalled();
+      expect(uiTelemetryService.hydrate).not.toHaveBeenCalled();
     });
 
     it('should handle empty history arrays', async () => {
@@ -182,6 +199,9 @@ describe('useSessionResume', () => {
       expect(mockHistoryManager.addItem).not.toHaveBeenCalled();
       expect(mockRefreshStatic).toHaveBeenCalledTimes(1);
       expect(mockGeminiClient.resumeChat).toHaveBeenCalledWith([], resumedData);
+      expect(uiTelemetryService.hydrate).toHaveBeenCalledWith(
+        resumedData.conversation,
+      );
     });
 
     it('should restore directories from resumed session data', async () => {
@@ -426,6 +446,7 @@ describe('useSessionResume', () => {
       );
       expect(mockRefreshStatic).toHaveBeenCalledTimes(1);
       expect(mockGeminiClient.resumeChat).toHaveBeenCalled();
+      expect(uiTelemetryService.hydrate).toHaveBeenCalledWith(conversation);
     });
 
     it('should only resume once even if props change', async () => {

--- a/packages/cli/src/ui/hooks/useSessionResume.ts
+++ b/packages/cli/src/ui/hooks/useSessionResume.ts
@@ -10,6 +10,7 @@ import {
   type Config,
   type ResumedSessionData,
   convertSessionToClientHistory,
+  uiTelemetryService,
 } from '@google/gemini-cli-core';
 import type { Part } from '@google/genai';
 import type { HistoryItemWithoutId } from '../types.js';
@@ -64,6 +65,9 @@ export function useSessionResume({
 
       setIsResuming(true);
       try {
+        // Keep the session summary and stats aligned with the resumed conversation.
+        uiTelemetryService.hydrate(resumedData.conversation);
+
         // Now that we have the client, load the history into the UI and the client.
         setQuittingMessages(null);
         historyManagerRef.current.clearItems();


### PR DESCRIPTION
## Summary
- hydrate UI telemetry during command-line resume so the session summary keeps the persisted conversation ID
- centralize resume hydration in the shared resume path so browser and CLI resume flows stay consistent
- update resume hook tests to cover the regression

## Test plan
- [x] `npm run test --workspace @google/gemini-cli -- src/ui/hooks/useSessionResume.test.ts src/ui/hooks/useSessionBrowser.test.ts`

Fixes #24360