### PR TITLE
fix(config): disable JIT context loading by default

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1647,7 +1647,7 @@ their corresponding top-level category object in your `settings.json` file.
 
 - **`experimental.jitContext`** (boolean):
   - **Description:** Enable Just-In-Time (JIT) context loading.
-  - **Default:** `true`
+  - **Default:** `false`
   - **Requires restart:** Yes
 
 - **`experimental.useOSC52Paste`** (boolean):

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -2056,7 +2056,7 @@ const SETTINGS_SCHEMA = {
         label: 'JIT Context Loading',
         category: 'Experimental',
         requiresRestart: true,
-        default: true,
+        default: false,
         description: 'Enable Just-In-Time (JIT) context loading.',
         showInDialog: false,
       },

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -441,6 +441,7 @@ describe('<Footer />', () => {
 
     it('renders footer with all optional sections hidden (minimal footer)', async () => {
       const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
         width: 120,
         uiState: { sessionStats: mockSessionStats },
         settings: createMockSettings({
@@ -558,6 +559,7 @@ describe('<Footer />', () => {
   describe('Footer Token Formatting', () => {
     const renderWithTokens = async (tokens: number) => {
       const result = await renderWithProviders(<Footer />, {
+        config: mockConfig,
         width: 120,
         uiState: {
           sessionStats: {
@@ -810,6 +812,7 @@ describe('<Footer />', () => {
 
     it('handles empty items array', async () => {
       const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
         width: 120,
         uiState: { sessionStats: mockSessionStats },
         settings: createMockSettings({

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1151,7 +1151,7 @@ export class Config implements McpContext, AgentLoopContext {
       modelConfigServiceConfig ?? DEFAULT_MODEL_CONFIGS,
     );
 
-    this.experimentalJitContext = params.experimentalJitContext ?? true;
+    this.experimentalJitContext = params.experimentalJitContext ?? false;
     this.experimentalMemoryManager = params.experimentalMemoryManager ?? false;
     this.memoryBoundaryMarkers = params.memoryBoundaryMarkers ?? ['.git'];
     this.contextManagement = {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -2838,8 +2838,8 @@
         "jitContext": {
           "title": "JIT Context Loading",
           "description": "Enable Just-In-Time (JIT) context loading.",
-          "markdownDescription": "Enable Just-In-Time (JIT) context loading.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `true`",
-          "default": true,
+          "markdownDescription": "Enable Just-In-Time (JIT) context loading.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
+          "default": false,
           "type": "boolean"
         },
         "useOSC52Paste": {


### PR DESCRIPTION
## Summary

Disables JIT (Just-In-Time) context loading by default. The feature is not yet stable enough to be enabled by default.

## Details

- Changed the default value of `experimentalJitContext` from `true` to `false` in both the settings schema (`settingsSchema.ts`) and the config fallback (`config.ts`).

## Related Issues

Fixes #18007

## How to Validate

1. Run `npm run start` and verify JIT context loading is disabled by default (check settings dialog or config output).

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker