### PR TITLE
fix(cli): generate and attach standalone bundle to GitHub releases

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -292,7 +292,7 @@ runs:
       shell: 'bash'
       run: |
         gh release create "${INPUTS_RELEASE_TAG}" \
-          bundle/gemini.js \
+          dist/gemini.js \
           --target "${STEPS_RELEASE_BRANCH_OUTPUTS_BRANCH_NAME}" \
           --title "Release ${INPUTS_RELEASE_TAG}" \
           --notes-start-tag "${INPUTS_PREVIOUS_TAG}" \

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -103,6 +103,30 @@ const cliConfig = {
   metafile: true,
 };
 
+const cliStandaloneConfig = {
+  ...baseConfig,
+  banner: {
+    js: `import { createRequire as __createRequire } from 'node:module';\nimport { fileURLToPath as __fileURLToPath } from 'node:url';\nimport { dirname as __dirname } from 'node:path';\nconst require = __createRequire(import.meta.url);\nconst __chunk_filename = __fileURLToPath(import.meta.url);\nconst __chunk_dirname = __dirname(__chunk_filename);`,
+  },
+  entryPoints: { gemini: 'packages/cli/index.ts' },
+  outfile: 'dist/gemini.js',
+  splitting: false,
+  define: {
+    __filename: '__chunk_filename',
+    __dirname: '__chunk_dirname',
+    'process.env.CLI_VERSION': JSON.stringify(pkg.version),
+    'process.env.GEMINI_SANDBOX_IMAGE_DEFAULT': JSON.stringify(
+      pkg.config?.sandboxImageUri,
+    ),
+  },
+  plugins: createWasmPlugins(),
+  alias: {
+    'is-in-ci': path.resolve(__dirname, 'packages/cli/src/patches/is-in-ci.ts'),
+    ...commonAliases,
+  },
+  metafile: false,
+};
+
 const a2aServerConfig = {
   ...baseConfig,
   banner: {
@@ -125,11 +149,19 @@ Promise.allSettled([
       writeFileSync('./bundle/esbuild.json', JSON.stringify(metafile, null, 2));
     }
   }),
+  esbuild.build(cliStandaloneConfig),
   esbuild.build(a2aServerConfig),
 ]).then((results) => {
-  const [cliResult, a2aResult] = results;
+  const [cliResult, cliStandaloneResult, a2aResult] = results;
   if (cliResult.status === 'rejected') {
     console.error('gemini.js build failed:', cliResult.reason);
+    process.exit(1);
+  }
+  if (cliStandaloneResult.status === 'rejected') {
+    console.error(
+      'standalone gemini.js build failed:',
+      cliStandaloneResult.reason,
+    );
     process.exit(1);
   }
   // error in a2a-server bundling will not stop gemini.js bundling process

--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -25,23 +25,48 @@ import { glob } from 'glob';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
 const bundleDir = join(root, 'bundle');
+const distDir = join(root, 'dist');
 
-// Create the bundle directory if it doesn't exist
+// Create the bundle and dist directories if they don't exist
 if (!existsSync(bundleDir)) {
   mkdirSync(bundleDir);
+}
+if (!existsSync(distDir)) {
+  mkdirSync(distDir);
+}
+
+function copyToDirs(src, destSubPath) {
+  const isDir =
+    existsSync(src) &&
+    !src.endsWith('.sb') &&
+    !src.endsWith('.toml') &&
+    !src.endsWith('.json');
+  if (isDir) {
+    cpSync(src, join(bundleDir, destSubPath), {
+      recursive: true,
+      dereference: true,
+    });
+    cpSync(src, join(distDir, destSubPath), {
+      recursive: true,
+      dereference: true,
+    });
+  } else {
+    copyFileSync(src, join(bundleDir, destSubPath));
+    copyFileSync(src, join(distDir, destSubPath));
+  }
 }
 
 // 1. Copy Sandbox definitions (.sb)
 const sbFiles = glob.sync('packages/**/*.sb', { cwd: root });
 for (const file of sbFiles) {
-  copyFileSync(join(root, file), join(bundleDir, basename(file)));
+  copyToDirs(join(root, file), basename(file));
 }
 
 // 2. Copy Policy definitions (.toml)
-const policyDir = join(bundleDir, 'policies');
-if (!existsSync(policyDir)) {
-  mkdirSync(policyDir);
-}
+const policyDirBundle = join(bundleDir, 'policies');
+const policyDirDist = join(distDir, 'policies');
+if (!existsSync(policyDirBundle)) mkdirSync(policyDirBundle);
+if (!existsSync(policyDirDist)) mkdirSync(policyDirDist);
 
 // Locate policy files specifically in the core package
 const policyFiles = glob.sync('packages/core/src/policy/policies/*.toml', {
@@ -49,58 +74,77 @@ const policyFiles = glob.sync('packages/core/src/policy/policies/*.toml', {
 });
 
 for (const file of policyFiles) {
-  copyFileSync(join(root, file), join(policyDir, basename(file)));
+  copyFileSync(join(root, file), join(policyDirBundle, basename(file)));
+  copyFileSync(join(root, file), join(policyDirDist, basename(file)));
 }
 
-console.log(`Copied ${policyFiles.length} policy files to bundle/policies/`);
+console.log(
+  `Copied ${policyFiles.length} policy files to bundle/policies/ and dist/policies/`,
+);
 
 // 3. Copy Documentation (docs/)
 const docsSrc = join(root, 'docs');
-const docsDest = join(bundleDir, 'docs');
 if (existsSync(docsSrc)) {
-  cpSync(docsSrc, docsDest, { recursive: true, dereference: true });
-  console.log('Copied docs to bundle/docs/');
+  copyToDirs(docsSrc, 'docs');
+  console.log('Copied docs to bundle/docs/ and dist/docs/');
 }
 
 // 4. Copy Built-in Skills (packages/core/src/skills/builtin)
 const builtinSkillsSrc = join(root, 'packages/core/src/skills/builtin');
-const builtinSkillsDest = join(bundleDir, 'builtin');
 if (existsSync(builtinSkillsSrc)) {
-  cpSync(builtinSkillsSrc, builtinSkillsDest, {
-    recursive: true,
-    dereference: true,
-  });
-  console.log('Copied built-in skills to bundle/builtin/');
+  copyToDirs(builtinSkillsSrc, 'builtin');
+  console.log('Copied built-in skills to bundle/builtin/ and dist/builtin/');
 }
 
 // 5. Copy DevTools package so the external dynamic import resolves at runtime
 const devtoolsSrc = join(root, 'packages/devtools');
-const devtoolsDest = join(
+const devtoolsDestBundle = join(
   bundleDir,
   'node_modules',
   '@google',
   'gemini-cli-devtools',
 );
+const devtoolsDestDist = join(
+  distDir,
+  'node_modules',
+  '@google',
+  'gemini-cli-devtools',
+);
 const devtoolsDistSrc = join(devtoolsSrc, 'dist');
+
 if (existsSync(devtoolsDistSrc)) {
-  mkdirSync(devtoolsDest, { recursive: true });
-  cpSync(devtoolsDistSrc, join(devtoolsDest, 'dist'), {
+  mkdirSync(devtoolsDestBundle, { recursive: true });
+  mkdirSync(devtoolsDestDist, { recursive: true });
+
+  cpSync(devtoolsDistSrc, join(devtoolsDestBundle, 'dist'), {
     recursive: true,
     dereference: true,
   });
+  cpSync(devtoolsDistSrc, join(devtoolsDestDist, 'dist'), {
+    recursive: true,
+    dereference: true,
+  });
+
   copyFileSync(
     join(devtoolsSrc, 'package.json'),
-    join(devtoolsDest, 'package.json'),
+    join(devtoolsDestBundle, 'package.json'),
   );
-  console.log('Copied devtools package to bundle/node_modules/');
+  copyFileSync(
+    join(devtoolsSrc, 'package.json'),
+    join(devtoolsDestDist, 'package.json'),
+  );
+  console.log(
+    'Copied devtools package to bundle/node_modules/ and dist/node_modules/',
+  );
 }
 
 // 6. Copy bundled chrome-devtools-mcp
 const bundleMcpSrc = join(root, 'packages/core/dist/bundled');
-const bundleMcpDest = join(bundleDir, 'bundled');
 if (existsSync(bundleMcpSrc)) {
-  cpSync(bundleMcpSrc, bundleMcpDest, { recursive: true, dereference: true });
-  console.log('Copied bundled chrome-devtools-mcp to bundle/bundled/');
+  copyToDirs(bundleMcpSrc, 'bundled');
+  console.log(
+    'Copied bundled chrome-devtools-mcp to bundle/bundled/ and dist/bundled/',
+  );
 }
 
-console.log('Assets copied to bundle/');
+console.log('Assets copied to bundle/ and dist/');


### PR DESCRIPTION
Fixes #23770. Restores `splitting: true` to the main CLI bundle to preserve boot-up time improvements, and adds a separate `cliStandaloneConfig` target in `esbuild.config.js` to generate a fully self-contained standalone executable at `dist/gemini.js`. The `publish-release` GitHub Action has been updated to attach this standalone bundle to GitHub releases instead of the split version.