### PR TITLE
feat(core): support plan versioning and diffing

### DIFF
--- a/docs/tools/planning.md
+++ b/docs/tools/planning.md
@@ -51,7 +51,10 @@ finalized plan to the user and requests approval to start the implementation.
     - Marks the plan as approved for implementation.
   - If the user rejects the plan:
     - Stays in Plan Mode.
+    - Saves a versioned backup of the rejected plan.
     - Returns user feedback to the model to refine the plan.
+    - The next time `exit_plan_mode` is called, a diff against the previous
+      version is shown in the approval step.
 - **Output (`llmContent`):**
   - On approval: A message indicating the plan was approved and the new approval
     mode.

--- a/package-lock.json
+++ b/package-lock.json
@@ -486,7 +486,8 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@bundled-es-modules/cookie": {
       "version": "2.0.1",
@@ -1489,6 +1490,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
       "integrity": "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -2195,6 +2197,7 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -2375,6 +2378,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2424,6 +2428,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
       "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2798,6 +2803,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.0.tgz",
       "integrity": "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2831,6 +2837,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.0.tgz",
       "integrity": "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/resources": "2.5.0"
@@ -2885,6 +2892,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.0.tgz",
       "integrity": "sha512-VzRf8LzotASEyNDUxTdaJ9IRJ1/h692WyArDBInf5puLCjxbICD6XkHgpuudis56EndyS7LYFmtTMny6UABNdQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/resources": "2.5.0",
@@ -4121,6 +4129,7 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4395,6 +4404,7 @@
       "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.0",
         "@typescript-eslint/types": "8.35.0",
@@ -5268,6 +5278,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7402,7 +7413,8 @@
       "version": "0.0.1581282",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -7986,6 +7998,7 @@
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8503,6 +8516,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9815,6 +9829,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
       "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10093,6 +10108,7 @@
       "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.5.0.tgz",
       "integrity": "sha512-S4g/ng7fPZmFwclO82iWkOce8vDLy/FIDgHIfkCWGOehqHe6dexHsmq3kNQD21okh198pA5SAQTCqNQJb/svRQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.1",
         "ansi-escapes": "^7.0.0",
@@ -13851,6 +13867,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13861,6 +13878,7 @@
       "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -16010,6 +16028,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16232,7 +16251,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.20.3",
@@ -16240,6 +16260,7 @@
       "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -16405,6 +16426,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16627,6 +16649,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -16740,6 +16763,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16752,6 +16776,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -17399,6 +17424,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -17842,6 +17868,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -17945,6 +17972,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -486,8 +486,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@bundled-es-modules/cookie": {
       "version": "2.0.1",
@@ -1490,7 +1489,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
       "integrity": "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -2197,7 +2195,6 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -2378,7 +2375,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2428,7 +2424,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
       "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2803,7 +2798,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.0.tgz",
       "integrity": "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2837,7 +2831,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.0.tgz",
       "integrity": "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/resources": "2.5.0"
@@ -2892,7 +2885,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.0.tgz",
       "integrity": "sha512-VzRf8LzotASEyNDUxTdaJ9IRJ1/h692WyArDBInf5puLCjxbICD6XkHgpuudis56EndyS7LYFmtTMny6UABNdQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/resources": "2.5.0",
@@ -4129,7 +4121,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4404,7 +4395,6 @@
       "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.0",
         "@typescript-eslint/types": "8.35.0",
@@ -5278,7 +5268,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7413,8 +7402,7 @@
       "version": "0.0.1581282",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -7998,7 +7986,6 @@
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8516,7 +8503,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9829,7 +9815,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
       "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10108,7 +10093,6 @@
       "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.5.0.tgz",
       "integrity": "sha512-S4g/ng7fPZmFwclO82iWkOce8vDLy/FIDgHIfkCWGOehqHe6dexHsmq3kNQD21okh198pA5SAQTCqNQJb/svRQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.1",
         "ansi-escapes": "^7.0.0",
@@ -13867,7 +13851,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13878,7 +13861,6 @@
       "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -16028,7 +16010,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16251,8 +16232,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.20.3",
@@ -16260,7 +16240,6 @@
       "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -16426,7 +16405,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16649,7 +16627,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -16763,7 +16740,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16776,7 +16752,6 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -17424,7 +17399,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -17868,7 +17842,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -17972,7 +17945,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/packages/cli/src/ui/components/AskUserDialog.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.tsx
@@ -191,6 +191,10 @@ interface AskUserDialogProps {
    * Custom keyboard shortcut hints (e.g., ["Ctrl+P to edit"])
    */
   extraParts?: React.ReactNode[];
+  /**
+   * Content to render before the options/input field.
+   */
+  preOptionsContent?: React.ReactNode;
 }
 
 interface ReviewViewProps {
@@ -199,6 +203,7 @@ interface ReviewViewProps {
   onSubmit: () => void;
   progressHeader?: React.ReactNode;
   extraParts?: React.ReactNode[];
+  preOptionsContent?: React.ReactNode;
 }
 
 const ReviewView: React.FC<ReviewViewProps> = ({
@@ -207,6 +212,7 @@ const ReviewView: React.FC<ReviewViewProps> = ({
   onSubmit,
   progressHeader,
   extraParts,
+  preOptionsContent,
 }) => {
   const keyMatchers = useKeyMatchers();
   const unansweredCount = questions.length - Object.keys(answers).length;
@@ -232,6 +238,7 @@ const ReviewView: React.FC<ReviewViewProps> = ({
           Review your answers:
         </Text>
       </Box>
+      {preOptionsContent}
 
       {hasUnanswered && (
         <Box marginBottom={1}>
@@ -276,6 +283,7 @@ interface TextQuestionViewProps {
   initialAnswer?: string;
   progressHeader?: React.ReactNode;
   keyboardHints?: React.ReactNode;
+  preOptionsContent?: React.ReactNode;
 }
 
 const TextQuestionView: React.FC<TextQuestionViewProps> = ({
@@ -288,6 +296,7 @@ const TextQuestionView: React.FC<TextQuestionViewProps> = ({
   initialAnswer,
   progressHeader,
   keyboardHints,
+  preOptionsContent,
 }) => {
   const keyMatchers = useKeyMatchers();
   const isAlternateBuffer = useAlternateBuffer();
@@ -367,11 +376,14 @@ const TextQuestionView: React.FC<TextQuestionViewProps> = ({
           maxWidth={availableWidth}
           overflowDirection="bottom"
         >
-          <MarkdownDisplay
-            text={autoBoldIfPlain(question.question)}
-            terminalWidth={availableWidth - DIALOG_PADDING}
-            isPending={false}
-          />
+          <Box flexDirection="column">
+            <MarkdownDisplay
+              text={autoBoldIfPlain(question.question)}
+              terminalWidth={availableWidth - DIALOG_PADDING}
+              isPending={false}
+            />
+            {preOptionsContent}
+          </Box>
         </MaxSizedBox>
       </Box>
 
@@ -496,6 +508,7 @@ interface ChoiceQuestionViewProps {
   initialAnswer?: string;
   progressHeader?: React.ReactNode;
   keyboardHints?: React.ReactNode;
+  preOptionsContent?: React.ReactNode;
 }
 
 const ChoiceQuestionView: React.FC<ChoiceQuestionViewProps> = ({
@@ -508,6 +521,7 @@ const ChoiceQuestionView: React.FC<ChoiceQuestionViewProps> = ({
   initialAnswer,
   progressHeader,
   keyboardHints,
+  preOptionsContent,
 }) => {
   const keyMatchers = useKeyMatchers();
   const isAlternateBuffer = useAlternateBuffer();
@@ -889,6 +903,7 @@ const ChoiceQuestionView: React.FC<ChoiceQuestionViewProps> = ({
                 (Select all that apply)
               </Text>
             )}
+            {preOptionsContent}
           </Box>
         </MaxSizedBox>
       </Box>
@@ -1009,6 +1024,7 @@ export const AskUserDialog: React.FC<AskUserDialogProps> = ({
   width,
   availableHeight: availableHeightProp,
   extraParts,
+  preOptionsContent,
 }) => {
   const keyMatchers = useKeyMatchers();
   const uiState = useContext(UIStateContext);
@@ -1206,6 +1222,7 @@ export const AskUserDialog: React.FC<AskUserDialogProps> = ({
           onSubmit={handleReviewSubmit}
           progressHeader={progressHeader}
           extraParts={extraParts}
+          preOptionsContent={preOptionsContent}
         />
       </Box>
     );
@@ -1246,6 +1263,7 @@ export const AskUserDialog: React.FC<AskUserDialogProps> = ({
         initialAnswer={answers[currentQuestionIndex]}
         progressHeader={progressHeader}
         keyboardHints={keyboardHints}
+        preOptionsContent={preOptionsContent}
       />
     ) : (
       <ChoiceQuestionView
@@ -1259,6 +1277,7 @@ export const AskUserDialog: React.FC<AskUserDialogProps> = ({
         initialAnswer={answers[currentQuestionIndex]}
         progressHeader={progressHeader}
         keyboardHints={keyboardHints}
+        preOptionsContent={preOptionsContent}
       />
     );
 

--- a/packages/cli/src/ui/components/AskUserDialog.tsx
+++ b/packages/cli/src/ui/components/AskUserDialog.tsx
@@ -190,7 +190,7 @@ interface AskUserDialogProps {
   /**
    * Custom keyboard shortcut hints (e.g., ["Ctrl+P to edit"])
    */
-  extraParts?: string[];
+  extraParts?: React.ReactNode[];
 }
 
 interface ReviewViewProps {
@@ -198,7 +198,7 @@ interface ReviewViewProps {
   answers: { [key: string]: string };
   onSubmit: () => void;
   progressHeader?: React.ReactNode;
-  extraParts?: string[];
+  extraParts?: React.ReactNode[];
 }
 
 const ReviewView: React.FC<ReviewViewProps> = ({

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
@@ -139,17 +139,22 @@ Implement a comprehensive authentication system with multiple providers.
     vi.restoreAllMocks();
   });
 
-  const renderDialog = async (options?: { useAlternateBuffer?: boolean }) => {
+  const renderDialog = async (options?: {
+    useAlternateBuffer?: boolean;
+    diffContent?: string;
+    availableHeight?: number;
+  }) => {
     const useAlternateBuffer = options?.useAlternateBuffer ?? true;
     return renderWithProviders(
       <ExitPlanModeDialog
         planPath={mockPlanFullPath}
+        diffContent={options?.diffContent}
         onApprove={onApprove}
         onFeedback={onFeedback}
         onCancel={onCancel}
         getPreferredEditor={vi.fn()}
         width={80}
-        availableHeight={24}
+        availableHeight={options?.availableHeight ?? 24}
       />,
       {
         ...options,
@@ -198,6 +203,28 @@ Implement a comprehensive authentication system with multiple providers.
         });
 
         expect(lastFrame()).toMatchSnapshot();
+      });
+
+      it('renders diffContent if provided', async () => {
+        const diffContent =
+          '--- test-plan.md\n+++ test-plan.md\n@@ -1,1 +1,1 @@\n- old\n+ new';
+        const { lastFrame } = await act(async () =>
+          renderDialog({
+            useAlternateBuffer,
+            diffContent,
+            availableHeight: 100,
+          }),
+        );
+
+        await act(async () => {
+          vi.runAllTimers();
+        });
+
+        await waitFor(() => {
+          expect(lastFrame()).toContain('Changes since previous version');
+          expect(lastFrame()).toContain('old');
+          expect(lastFrame()).toContain('new');
+        });
       });
 
       it('calls onApprove with AUTO_EDIT when first option is selected', async () => {

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
@@ -225,6 +225,8 @@ Implement a comprehensive authentication system with multiple providers.
           expect(lastFrame()).toContain('old');
           expect(lastFrame()).toContain('new');
         });
+
+        expect(lastFrame()).toMatchSnapshot();
       });
 
       it('calls onApprove with AUTO_EDIT when first option is selected', async () => {

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
@@ -25,9 +25,11 @@ import { useKeypress } from '../hooks/useKeypress.js';
 import { Command } from '../key/keyMatchers.js';
 import { formatCommand } from '../key/keybindingUtils.js';
 import { useKeyMatchers } from '../hooks/useKeyMatchers.js';
+import { DiffRenderer } from './messages/DiffRenderer.js';
 
 export interface ExitPlanModeDialogProps {
   planPath: string;
+  diffContent?: string;
   onApprove: (approvalMode: ApprovalMode) => void;
   onFeedback: (feedback: string) => void;
   onCancel: () => void;
@@ -140,6 +142,7 @@ function usePlanContent(planPath: string, config: Config): PlanContentState {
 
 export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
   planPath,
+  diffContent,
   onApprove,
   onFeedback,
   onCancel,
@@ -226,6 +229,17 @@ export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
 
   const editHint = formatCommand(Command.OPEN_EXTERNAL_EDITOR);
 
+  const extraParts: React.ReactNode[] = [];
+  if (diffContent) {
+    extraParts.push(
+      <Box key="diff" flexDirection="column" marginTop={1}>
+        <Text bold>Changes since previous version:</Text>
+        <DiffRenderer diffContent={diffContent} terminalWidth={width} />
+      </Box>
+    );
+  }
+  extraParts.push(`${editHint} to edit plan`);
+
   return (
     <Box flexDirection="column" width={width}>
       <AskUserDialog
@@ -264,7 +278,7 @@ export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
         onCancel={onCancel}
         width={width}
         availableHeight={availableHeight}
-        extraParts={[`${editHint} to edit plan`]}
+        extraParts={extraParts}
       />
     </Box>
   );

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
@@ -235,7 +235,7 @@ export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
       <Box key="diff" flexDirection="column" marginTop={1}>
         <Text bold>Changes since previous version:</Text>
         <DiffRenderer diffContent={diffContent} terminalWidth={width} />
-      </Box>
+      </Box>,
     );
   }
   extraParts.push(`${editHint} to edit plan`);

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.tsx
@@ -230,15 +230,14 @@ export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
   const editHint = formatCommand(Command.OPEN_EXTERNAL_EDITOR);
 
   const extraParts: React.ReactNode[] = [];
-  if (diffContent) {
-    extraParts.push(
-      <Box key="diff" flexDirection="column" marginTop={1}>
-        <Text bold>Changes since previous version:</Text>
-        <DiffRenderer diffContent={diffContent} terminalWidth={width} />
-      </Box>,
-    );
-  }
   extraParts.push(`${editHint} to edit plan`);
+
+  const preOptionsContent = diffContent ? (
+    <Box key="diff" flexDirection="column" marginTop={1} marginBottom={1}>
+      <Text bold>Changes since previous version:</Text>
+      <DiffRenderer diffContent={diffContent} terminalWidth={width} />
+    </Box>
+  ) : undefined;
 
   return (
     <Box flexDirection="column" width={width}>
@@ -279,6 +278,7 @@ export const ExitPlanModeDialog: React.FC<ExitPlanModeDialogProps> = ({
         width={width}
         availableHeight={availableHeight}
         extraParts={extraParts}
+        preOptionsContent={preOptionsContent}
       />
     </Box>
   );

--- a/packages/cli/src/ui/components/__snapshots__/ExitPlanModeDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ExitPlanModeDialog.test.tsx.snap
@@ -113,6 +113,38 @@ Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
 "
 `;
 
+exports[`ExitPlanModeDialog > useAlternateBuffer: false > renders diffContent if provided 1`] = `
+"Overview
+
+Add user authentication to the CLI application.
+
+Implementation Steps
+
+ 1. Create src/auth/AuthService.ts with login/logout methods
+ 2. Add session storage in src/storage/SessionStore.ts
+ 3. Update src/commands/index.ts to check auth status
+ 4. Add tests in src/auth/__tests__/
+
+Files to Modify
+
+ - src/index.ts - Add auth middleware
+ - src/config.ts - Add auth configuration options
+
+Changes since previous version:
+1 - old
+1 + new
+
+
+● 1.  Yes, automatically accept edits                                           
+      Approves plan and allows tools to run automatically                       
+  2.  Yes, manually accept edits
+      Approves plan but requires confirmation for each tool
+  3.  Type your feedback...
+
+Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
+"
+`;
+
 exports[`ExitPlanModeDialog > useAlternateBuffer: true > bubbles up Ctrl+C when feedback is empty while editing 1`] = `
 "Overview
 
@@ -236,6 +268,38 @@ Files to Modify
 
  - src/index.ts - Add auth middleware
  - src/config.ts - Add auth configuration options
+
+● 1.  Yes, automatically accept edits                                           
+      Approves plan and allows tools to run automatically                       
+  2.  Yes, manually accept edits
+      Approves plan but requires confirmation for each tool
+  3.  Type your feedback...
+
+Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
+"
+`;
+
+exports[`ExitPlanModeDialog > useAlternateBuffer: true > renders diffContent if provided 1`] = `
+"Overview
+
+Add user authentication to the CLI application.
+
+Implementation Steps
+
+ 1. Create src/auth/AuthService.ts with login/logout methods
+ 2. Add session storage in src/storage/SessionStore.ts
+ 3. Update src/commands/index.ts to check auth status
+ 4. Add tests in src/auth/__tests__/
+
+Files to Modify
+
+ - src/index.ts - Add auth middleware
+ - src/config.ts - Add auth configuration options
+
+Changes since previous version:
+1 - old
+1 + new
+
 
 ● 1.  Yes, automatically accept edits                                           
       Approves plan and allows tools to run automatically                       

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -539,6 +539,7 @@ export const ToolConfirmationMessage: React.FC<
         bodyContent = (
           <ExitPlanModeDialog
             planPath={confirmationDetails.planPath}
+            diffContent={confirmationDetails.diffContent}
             getPreferredEditor={getPreferredEditor}
             onApprove={(approvalMode) => {
               handleConfirm(ToolConfirmationOutcome.ProceedOnce, {

--- a/packages/cli/src/ui/components/shared/DialogFooter.tsx
+++ b/packages/cli/src/ui/components/shared/DialogFooter.tsx
@@ -35,7 +35,9 @@ export const DialogFooter: React.FC<DialogFooterProps> = ({
   }
 
   // We split string parts and node parts to properly render nodes without forcing them into a single string join
-  const stringExtras = extraParts.filter((p): p is string => typeof p === 'string');
+  const stringExtras = extraParts.filter(
+    (p): p is string => typeof p === 'string',
+  );
   const nodeExtras = extraParts.filter((p) => typeof p !== 'string');
 
   textParts.push(...stringExtras);

--- a/packages/cli/src/ui/components/shared/DialogFooter.tsx
+++ b/packages/cli/src/ui/components/shared/DialogFooter.tsx
@@ -16,7 +16,7 @@ export interface DialogFooterProps {
   /** Exit shortcut (defaults to "Esc to cancel") */
   cancelAction?: string;
   /** Custom keyboard shortcut hints (e.g., ["Ctrl+P to edit"]) */
-  extraParts?: string[];
+  extraParts?: React.ReactNode[];
 }
 
 /**
@@ -29,16 +29,26 @@ export const DialogFooter: React.FC<DialogFooterProps> = ({
   cancelAction = 'Esc to cancel',
   extraParts = [],
 }) => {
-  const parts = [primaryAction];
+  const textParts: string[] = [primaryAction];
   if (navigationActions) {
-    parts.push(navigationActions);
+    textParts.push(navigationActions);
   }
-  parts.push(...extraParts);
-  parts.push(cancelAction);
+
+  // We split string parts and node parts to properly render nodes without forcing them into a single string join
+  const stringExtras = extraParts.filter((p): p is string => typeof p === 'string');
+  const nodeExtras = extraParts.filter((p) => typeof p !== 'string');
+
+  textParts.push(...stringExtras);
+  textParts.push(cancelAction);
 
   return (
-    <Box marginTop={1}>
-      <Text color={theme.text.secondary}>{parts.join(' · ')}</Text>
+    <Box marginTop={1} flexDirection="column">
+      {nodeExtras.map((part, i) => (
+        <Box key={i}>{part}</Box>
+      ))}
+      <Box>
+        <Text color={theme.text.secondary}>{textParts.join(' · ')}</Text>
+      </Box>
     </Box>
   );
 };

--- a/packages/core/src/confirmation-bus/types.ts
+++ b/packages/core/src/confirmation-bus/types.ts
@@ -137,6 +137,7 @@ export type SerializableConfirmationDetails =
       title: string;
       systemMessage?: string;
       planPath: string;
+      diffContent?: string;
     };
 
 export interface UpdatePolicy {

--- a/packages/core/src/tools/exit-plan-mode.test.ts
+++ b/packages/core/src/tools/exit-plan-mode.test.ts
@@ -141,6 +141,25 @@ describe('ExitPlanModeTool', () => {
       expect(executeResult.llmContent).toContain('Plan approved');
     });
 
+    it('should calculate and return diffContent when a backup exists', async () => {
+      const planRelativePath = createPlanFile('test-md', '# Current Plan');
+      createPlanFile('test-md.v1', '# Old Plan');
+
+      const invocation = tool.build({ plan_filename: planRelativePath });
+      const result = await invocation.shouldConfirmExecute(
+        new AbortController().signal,
+      );
+
+      expect(result).not.toBe(false);
+      if (result === false) return;
+
+      expect(result.type).toBe('exit_plan_mode');
+      if (result.type === 'exit_plan_mode') {
+        expect(result.diffContent).toContain('Current Plan');
+        expect(result.diffContent).toContain('Old Plan');
+      }
+    });
+
     it('should throw error when policy decision is DENY', async () => {
       const planRelativePath = createPlanFile('test.md', '# Content');
       const invocation = tool.build({ plan_filename: planRelativePath });
@@ -266,6 +285,28 @@ The plan is stored at: ${expectedPath}
 Revise the plan based on the feedback.`,
         returnDisplay: 'Feedback: Please add more details.',
       });
+    });
+
+    it('should create a backup file when plan is rejected', async () => {
+      const planRelativePath = createPlanFile('test-backup.md', '# Content');
+      const invocation = tool.build({ plan_filename: planRelativePath });
+
+      const confirmDetails = await invocation.shouldConfirmExecute(
+        new AbortController().signal,
+      );
+      expect(confirmDetails).not.toBe(false);
+      if (confirmDetails === false) return;
+
+      await confirmDetails.onConfirm(ToolConfirmationOutcome.ProceedOnce, {
+        approved: false,
+        feedback: 'Please change.',
+      });
+
+      await invocation.execute(new AbortController().signal);
+
+      const expectedBackupPath = path.join(mockPlansDir, 'test-backup.md.v1');
+      expect(fs.existsSync(expectedBackupPath)).toBe(true);
+      expect(fs.readFileSync(expectedBackupPath, 'utf8')).toBe('# Content');
     });
 
     it('should handle rejection without feedback gracefully', async () => {

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -26,6 +26,11 @@ import { PlanExecutionEvent } from '../telemetry/types.js';
 import { getExitPlanModeDefinition } from './definitions/coreTools.js';
 import { resolveToolDeclaration } from './definitions/resolver.js';
 import { getPlanModeExitMessage } from '../utils/approvalModeUtils.js';
+import * as Diff from 'diff';
+import { DEFAULT_DIFF_OPTIONS } from './diffOptions.js';
+import { debugLogger } from '../utils/debugLogger.js';
+import * as fs from 'node:fs';
+import * as fsPromises from 'node:fs/promises';
 
 export interface ExitPlanModeParams {
   plan_filename: string;
@@ -153,10 +158,44 @@ export class ExitPlanModeInvocation extends BaseToolInvocation<
     }
 
     // decision is 'ask_user'
+    let diffContent: string | undefined;
+    try {
+      let latestVersion = 0;
+      let version = 1;
+      while (fs.existsSync(`${resolvedPlanPath}.v${version}`)) {
+        latestVersion = version;
+        version++;
+      }
+
+      if (latestVersion > 0) {
+        const previousPlanPath = `${resolvedPlanPath}.v${latestVersion}`;
+        const previousPlanContent = await fsPromises.readFile(
+          previousPlanPath,
+          'utf8',
+        );
+        const currentPlanContent = await fsPromises.readFile(
+          resolvedPlanPath,
+          'utf8',
+        );
+
+        diffContent = Diff.createPatch(
+          path.basename(resolvedPlanPath),
+          previousPlanContent,
+          currentPlanContent,
+          `Previous version (v${latestVersion})`,
+          'Current version',
+          DEFAULT_DIFF_OPTIONS,
+        );
+      }
+    } catch (err) {
+      debugLogger.error('Failed to create diff for plan:', err);
+    }
+
     return {
       type: 'exit_plan_mode',
       title: 'Plan Approval',
       planPath: resolvedPlanPath,
+      diffContent,
       onConfirm: async (
         outcome: ToolConfirmationOutcome,
         payload?: ToolConfirmationPayload,
@@ -229,6 +268,19 @@ Read and follow the plan strictly during implementation.`,
         returnDisplay: `Plan approved: ${resolvedPlanPath}`,
       };
     } else {
+      try {
+        let version = 1;
+        let backupPath = `${resolvedPlanPath}.v${version}`;
+        while (fs.existsSync(backupPath)) {
+          version++;
+          backupPath = `${resolvedPlanPath}.v${version}`;
+        }
+        const content = await fsPromises.readFile(resolvedPlanPath, 'utf8');
+        await fsPromises.writeFile(backupPath, content, 'utf8');
+      } catch (err) {
+        debugLogger.error('Failed to create plan backup:', err);
+      }
+
       const feedback = payload?.feedback?.trim();
       if (feedback) {
         return {

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -18,7 +18,11 @@ import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import path from 'node:path';
 import type { Config } from '../config/config.js';
 import { EXIT_PLAN_MODE_TOOL_NAME } from './tool-names.js';
-import { validatePlanPath, validatePlanContent } from '../utils/planUtils.js';
+import {
+  validatePlanPath,
+  validatePlanContent,
+  getPlanVersions,
+} from '../utils/planUtils.js';
 import { ApprovalMode } from '../policy/types.js';
 import { resolveToRealPath, isSubpath } from '../utils/paths.js';
 import { logPlanExecution } from '../telemetry/loggers.js';
@@ -29,7 +33,6 @@ import { getPlanModeExitMessage } from '../utils/approvalModeUtils.js';
 import * as Diff from 'diff';
 import { DEFAULT_DIFF_OPTIONS } from './diffOptions.js';
 import { debugLogger } from '../utils/debugLogger.js';
-import * as fs from 'node:fs';
 import * as fsPromises from 'node:fs/promises';
 
 export interface ExitPlanModeParams {
@@ -160,12 +163,7 @@ export class ExitPlanModeInvocation extends BaseToolInvocation<
     // decision is 'ask_user'
     let diffContent: string | undefined;
     try {
-      const files = await fsPromises.readdir(path.dirname(resolvedPlanPath));
-      const base = path.basename(resolvedPlanPath);
-      const versions = files
-        .filter((f) => f.startsWith(`${base}.v`))
-        .map((f) => parseInt(f.slice(base.length + 2), 10))
-        .filter((v) => !isNaN(v));
+      const versions = await getPlanVersions(resolvedPlanPath);
       const latestVersion = versions.length > 0 ? Math.max(...versions) : 0;
 
       if (latestVersion > 0) {
@@ -270,14 +268,10 @@ Read and follow the plan strictly during implementation.`,
       };
     } else {
       try {
-        const files = await fsPromises.readdir(path.dirname(resolvedPlanPath));
-        const base = path.basename(resolvedPlanPath);
-        const versions = files
-          .filter((f) => f.startsWith(`${base}.v`))
-          .map((f) => parseInt(f.slice(base.length + 2), 10))
-          .filter((v) => !isNaN(v));
-        const nextVersion = (versions.length > 0 ? Math.max(...versions) : 0) + 1;
-        const backupPath = `${resolvedPlanPath}.v${nextVersion}`; 
+        const versions = await getPlanVersions(resolvedPlanPath);
+        const nextVersion =
+          (versions.length > 0 ? Math.max(...versions) : 0) + 1;
+        const backupPath = `${resolvedPlanPath}.v${nextVersion}`;
         const content = await fsPromises.readFile(resolvedPlanPath, 'utf8');
         await fsPromises.writeFile(backupPath, content, 'utf8');
       } catch (err) {

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -270,12 +270,14 @@ Read and follow the plan strictly during implementation.`,
       };
     } else {
       try {
-        let version = 1;
-        let backupPath = `${resolvedPlanPath}.v${version}`;
-        while (fs.existsSync(backupPath)) {
-          version++;
-          backupPath = `${resolvedPlanPath}.v${version}`;
-        }
+        const files = await fsPromises.readdir(path.dirname(resolvedPlanPath));
+        const base = path.basename(resolvedPlanPath);
+        const versions = files
+          .filter((f) => f.startsWith(`${base}.v`))
+          .map((f) => parseInt(f.slice(base.length + 2), 10))
+          .filter((v) => !isNaN(v));
+        const nextVersion = (versions.length > 0 ? Math.max(...versions) : 0) + 1;
+        const backupPath = `${resolvedPlanPath}.v${nextVersion}`; 
         const content = await fsPromises.readFile(resolvedPlanPath, 'utf8');
         await fsPromises.writeFile(backupPath, content, 'utf8');
       } catch (err) {

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -160,12 +160,13 @@ export class ExitPlanModeInvocation extends BaseToolInvocation<
     // decision is 'ask_user'
     let diffContent: string | undefined;
     try {
-      let latestVersion = 0;
-      let version = 1;
-      while (fs.existsSync(`${resolvedPlanPath}.v${version}`)) {
-        latestVersion = version;
-        version++;
-      }
+      const files = await fsPromises.readdir(path.dirname(resolvedPlanPath));
+      const base = path.basename(resolvedPlanPath);
+      const versions = files
+        .filter((f) => f.startsWith(`${base}.v`))
+        .map((f) => parseInt(f.slice(base.length + 2), 10))
+        .filter((v) => !isNaN(v));
+      const latestVersion = versions.length > 0 ? Math.max(...versions) : 0;
 
       if (latestVersion > 0) {
         const previousPlanPath = `${resolvedPlanPath}.v${latestVersion}`;

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -1067,6 +1067,7 @@ export interface ToolExitPlanModeConfirmationDetails {
   title: string;
   systemMessage?: string;
   planPath: string;
+  diffContent?: string;
   onConfirm: (
     outcome: ToolConfirmationOutcome,
     payload?: ToolConfirmationPayload,

--- a/packages/core/src/utils/planUtils.ts
+++ b/packages/core/src/utils/planUtils.ts
@@ -5,8 +5,10 @@
  */
 
 import path from 'node:path';
+import fsPromises from 'node:fs/promises';
 import { isEmpty, fileExists } from './fileUtils.js';
 import { isSubpath, resolveToRealPath } from './paths.js';
+import { debugLogger } from './debugLogger.js';
 
 /**
  * Standard error messages for the plan approval workflow.
@@ -41,12 +43,31 @@ export async function validatePlanPath(
   if (!isSubpath(realPlansDir, realPath)) {
     return PlanErrorMessages.PATH_ACCESS_DENIED(planPath, realPlansDir);
   }
-
   if (!(await fileExists(resolvedPath))) {
     return PlanErrorMessages.FILE_NOT_FOUND(planPath);
   }
 
   return null;
+}
+
+/**
+ * Returns a list of version numbers for a plan file by scanning the directory.
+ * @param planPath The path to the plan file.
+ * @returns A promise that resolves to an array of version numbers.
+ */
+export async function getPlanVersions(planPath: string): Promise<number[]> {
+  const dir = path.dirname(planPath);
+  const base = path.basename(planPath);
+  try {
+    const files = await fsPromises.readdir(dir);
+    return files
+      .filter((f) => f.startsWith(`${base}.v`))
+      .map((f) => parseInt(f.slice(base.length + 2), 10))
+      .filter((v) => !isNaN(v));
+  } catch (err) {
+    debugLogger.error(`Failed to read plan versions in ${dir}:`, err);
+    return [];
+  }
 }
 
 /**


### PR DESCRIPTION
## Objective
   Track plan revisions when users provide feedback instead of just overwriting. This PR introduces versioned backup files (e.g., `plan.v1.md`)
   when a plan is rejected, and displays a color-coded diff between the previous plan and the new one in the approval step.

   ## Changes
   - **Core**: Modified `ExitPlanModeTool` to save rejected plans as versioned backups and compute diffs in `shouldConfirmExecute`.
   - **UI**: Updated `ExitPlanModeDialog` to use the existing `DiffRenderer` component for color-coded highlights (green for additions, red
   for deletions).
   - **UI Framework**: Enhanced `AskUserDialog` and `DialogFooter` to support `ReactNode` in `extraParts`, allowing for rich components
   like diffs to be displayed in the footer area.
   - **Documentation**: Updated `docs/tools/planning.md` to explain the new versioning behavior.

   ## Verification
   - Unit tests added to `exit-plan-mode.test.ts` for versioning and diff logic.
   - Unit tests added to `ExitPlanModeDialog.test.tsx` for UI rendering.
   - All tests passing (`npm test`).

Here's how it looks like 

Uploading Screen Recording 2026-04-01 at 5.04.03 PM.mov…




Fixes #17794 
