### PR TITLE
feat(plan): conditionally add enter/exit plan mode tools based on current mode

### DIFF
--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -26,6 +26,7 @@ import {
   ToolRegistry,
   COMMON_IGNORE_PATTERNS,
   GEMINI_IGNORE_FILE_NAME,
+  ApprovalMode,
   // DEFAULT_FILE_EXCLUDES,
   CoreToolCallStatus,
   type Config,
@@ -146,6 +147,7 @@ describe('handleAtCommand', () => {
         getClient: () => undefined,
       }),
       getMessageBus: () => mockMessageBus,
+      getApprovalMode: () => ApprovalMode.DEFAULT,
     } as unknown as Config;
 
     const registry = new ToolRegistry(mockConfig, mockMessageBus);

--- a/packages/cli/src/ui/hooks/atCommandProcessor_agents.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor_agents.test.ts
@@ -18,6 +18,7 @@ import {
   StandardFileSystemService,
   ToolRegistry,
   COMMON_IGNORE_PATTERNS,
+  ApprovalMode,
 } from '@google/gemini-cli-core';
 import * as os from 'node:os';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
@@ -136,6 +137,7 @@ describe('handleAtCommand with Agents', () => {
       getMessageBus: () => mockMessageBus,
       interactive: true,
       getAgentRegistry: () => mockAgentRegistry,
+      getApprovalMode: () => ApprovalMode.DEFAULT,
     } as unknown as Config;
 
     const registry = new ToolRegistry(mockConfig, mockMessageBus);

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -22,6 +22,8 @@ import { ToolRegistry, DiscoveredTool } from './tool-registry.js';
 import {
   DISCOVERED_TOOL_PREFIX,
   UPDATE_TOPIC_TOOL_NAME,
+  ENTER_PLAN_MODE_TOOL_NAME,
+  EXIT_PLAN_MODE_TOOL_NAME,
 } from './tool-names.js';
 import { DiscoveredMCPTool } from './mcp-tool.js';
 import {
@@ -832,6 +834,40 @@ describe('ToolRegistry', () => {
 
       expect(toolRegistry.getAllToolNames()).toContain(UPDATE_TOPIC_TOOL_NAME);
       expect(toolRegistry.getTool(UPDATE_TOPIC_TOOL_NAME)).toBe(topicTool);
+    });
+
+    it('should show enter_plan_mode only when NOT in plan mode', () => {
+      const enterTool = new MockTool({ name: ENTER_PLAN_MODE_TOOL_NAME });
+      toolRegistry.registerTool(enterTool);
+
+      // Not in plan mode
+      vi.spyOn(config, 'getApprovalMode').mockReturnValue(ApprovalMode.DEFAULT);
+      expect(toolRegistry.getAllToolNames()).toContain(
+        ENTER_PLAN_MODE_TOOL_NAME,
+      );
+
+      // In plan mode
+      vi.spyOn(config, 'getApprovalMode').mockReturnValue(ApprovalMode.PLAN);
+      expect(toolRegistry.getAllToolNames()).not.toContain(
+        ENTER_PLAN_MODE_TOOL_NAME,
+      );
+    });
+
+    it('should show exit_plan_mode only when in plan mode', () => {
+      const exitTool = new MockTool({ name: EXIT_PLAN_MODE_TOOL_NAME });
+      toolRegistry.registerTool(exitTool);
+
+      // Not in plan mode
+      vi.spyOn(config, 'getApprovalMode').mockReturnValue(ApprovalMode.DEFAULT);
+      expect(toolRegistry.getAllToolNames()).not.toContain(
+        EXIT_PLAN_MODE_TOOL_NAME,
+      );
+
+      // In plan mode
+      vi.spyOn(config, 'getApprovalMode').mockReturnValue(ApprovalMode.PLAN);
+      expect(toolRegistry.getAllToolNames()).toContain(
+        EXIT_PLAN_MODE_TOOL_NAME,
+      );
     });
   });
 

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -31,6 +31,8 @@ import {
   WRITE_FILE_TOOL_NAME,
   EDIT_TOOL_NAME,
   UPDATE_TOPIC_TOOL_NAME,
+  ENTER_PLAN_MODE_TOOL_NAME,
+  EXIT_PLAN_MODE_TOOL_NAME,
 } from './tool-names.js';
 
 type ToolParams = Record<string, unknown>;
@@ -581,6 +583,14 @@ export class ToolRegistry {
       if (!this.config.isTopicUpdateNarrationEnabled()) {
         return false;
       }
+    }
+
+    const isPlanMode = this.config.getApprovalMode() === ApprovalMode.PLAN;
+    if (
+      (tool.name === ENTER_PLAN_MODE_TOOL_NAME && isPlanMode) ||
+      (tool.name === EXIT_PLAN_MODE_TOOL_NAME && !isPlanMode)
+    ) {
+      return false;
     }
 
     const normalizedClassName = tool.constructor.name.replace(/^_+/, '');


### PR DESCRIPTION
## Summary

This PR implements dynamic visibility for the `enter_plan_mode` and `exit_plan_mode` tools in the `ToolRegistry`. These tools are now conditionally presented to the model based on the current session's `ApprovalMode`:
- `enter_plan_mode` is hidden when the session is already in `PLAN` mode.
- `exit_plan_mode` is only visible when the session is in `PLAN` mode.

## Details

Previously, both tools were always visible to the model, leading to unnecessary noise and potential misuse (e.g., trying to enter plan mode when already in it). By centralizing this visibility logic in `ToolRegistry.isActiveTool`, we ensure that the model only sees tools that are logically actionable in the current context.

This implementation follows the existing pattern used for the topic narration tool (`UPDATE_TOPIC_TOOL_NAME`).

## Related Issues

Fixes #24370

## How to Validate

1. **Unit Tests**: Run the updated `ToolRegistry` tests:
   ```bash
   npm test -w @google/gemini-cli-core -- src/tools/tool-registry.test.ts
   ```
   Verified that new tests for plan mode tool visibility pass.

2. **Manual Verification**:
   - Start a session and check available tools (e.g., via `--debug`). `enter_plan_mode` should be visible, `exit_plan_mode` should not.
   - Enter plan mode. Check available tools again. `enter_plan_mode` should be hidden, and `exit_plan_mode` should now be visible.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
