### PR TITLE
fix(ui): wrap topic and intent fields in TopicMessage

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -279,8 +279,8 @@ describe('<ToolGroupMessage />', () => {
       );
 
       const output = lastFrame();
-      expect(output).toContain('Testing Topic');
-      expect(output).toContain('— This is the description');
+      expect(output).toContain('Testing Topic: ');
+      expect(output).toContain('This is the description');
       expect(output).toMatchSnapshot('update_topic_tool');
       unmount();
     });
@@ -307,8 +307,8 @@ describe('<ToolGroupMessage />', () => {
       );
 
       const output = lastFrame();
-      expect(output).toContain('Testing Topic');
-      expect(output).toContain('— This is the summary');
+      expect(output).toContain('Testing Topic: ');
+      expect(output).toContain('This is the summary');
       unmount();
     });
 

--- a/packages/cli/src/ui/components/messages/TopicMessage.tsx
+++ b/packages/cli/src/ui/components/messages/TopicMessage.tsx
@@ -31,11 +31,16 @@ export const TopicMessage: React.FC<TopicMessageProps> = ({ args }) => {
   const intent = typeof rawIntent === 'string' ? rawIntent : undefined;
 
   return (
-    <Box flexDirection="row" marginLeft={2}>
-      <Text color={theme.text.primary} bold>
+    <Box flexDirection="row" marginLeft={2} flexWrap="wrap">
+      <Text color={theme.text.primary} bold wrap="truncate-end">
         {title || 'Topic'}
+        {intent && <Text>: </Text>}
       </Text>
-      {intent && <Text color={theme.text.secondary}> — {intent}</Text>}
+      {intent && (
+        <Text color={theme.text.secondary} wrap="wrap">
+          {intent}
+        </Text>
+      )}
     </Box>
   );
 };

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`<ToolGroupMessage /> > Golden Snapshots > renders header when scrolled 
 `;
 
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders mixed tool calls including update_topic 1`] = `
-"  Testing Topic — This is the description
+"  Testing Topic: This is the description
 ╭──────────────────────────────────────────────────────────────────────────╮
 │ ✓  read_file Read a file                                                 │
 │                                                                          │
@@ -141,7 +141,7 @@ exports[`<ToolGroupMessage /> > Golden Snapshots > renders two tool groups where
 `;
 
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders update_topic tool call using TopicMessage > update_topic_tool 1`] = `
-"  Testing Topic — This is the description
+"  Testing Topic: This is the description
 "
 `;
 


### PR DESCRIPTION
## Summary

Allows the Topic tool output (`TopicMessage`) to break the topic and intent fields onto separate lines when needed, and wrap the intent field. This ensures the user stays informed of the agent's intentions even with long outputs.

## Details

- Modified `TopicMessage.tsx` to use `flexWrap="wrap"` on the container and `wrap="wrap"` on the intent text.
- Changed the separator from ` — ` to `: ` to better separate the topic and intent when wrapped.
- Updated relevant test snapshots in `ToolGroupMessage.test.tsx`.

## Related Issues

Fixes #24383

## How to Validate

- Trigger a long topic update during an agent interaction and observe that the topic and intent text wraps correctly instead of overflowing or being truncated.
- Run `npm test -w @google/gemini-cli -- src/ui/components/messages/ToolGroupMessage.test.tsx` to verify the snapshot updates.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker