### PR TITLE
fix(cli): clean up sandbox proxy exit handlers

### DIFF
--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -338,6 +338,50 @@ describe('sandbox', () => {
       await expect(start_sandbox(config)).rejects.toThrow(FatalSandboxError);
     });
 
+    it('removes proxy exit handlers after the sandbox process closes', async () => {
+      process.env['GEMINI_SANDBOX_PROXY_COMMAND'] = 'proxy-cmd';
+      vi.mocked(os.platform).mockReturnValue('darwin');
+
+      const config: SandboxConfig = createMockSandboxConfig({
+        command: 'sandbox-exec',
+        image: 'some-image',
+      });
+
+      const createMockProcess = (autoClose: boolean) => {
+        const proc = new EventEmitter() as unknown as ReturnType<
+          typeof spawn
+        > & {
+          stdout: ReturnType<typeof spawn>['stdout'];
+          stderr: ReturnType<typeof spawn>['stderr'];
+        };
+        proc.stdout = new EventEmitter() as unknown as ReturnType<
+          typeof spawn
+        >['stdout'];
+        proc.stderr = new EventEmitter() as unknown as ReturnType<
+          typeof spawn
+        >['stderr'];
+        proc.on = vi.fn().mockImplementation((event, cb) => {
+          if (autoClose && event === 'close') {
+            setTimeout(() => cb(0), 0);
+          }
+          return proc;
+        });
+        return proc;
+      };
+
+      vi.mocked(spawn)
+        .mockImplementationOnce(() => createMockProcess(false))
+        .mockImplementationOnce(() => createMockProcess(true));
+
+      const initialExitListenerCount = process.listeners('exit').length;
+
+      await expect(
+        start_sandbox(config, [], undefined, ['arg1']),
+      ).resolves.toBe(0);
+
+      expect(process.listeners('exit')).toHaveLength(initialExitListenerCount);
+    });
+
     it('should mount volumes correctly', async () => {
       const config: SandboxConfig = createMockSandboxConfig({
         command: 'docker',

--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -40,7 +40,16 @@ vi.mock('node:util', async (importOriginal) => {
             return { stdout: '1000', stderr: '' };
           }
           if (cmd.includes('curl')) {
+            if (process.env['TEST_CURL_FAIL'] === 'true') {
+              throw new Error('curl failed');
+            }
             return { stdout: '', stderr: '' };
+          }
+          if (
+            cmd.includes('network connect') &&
+            process.env['TEST_NETWORK_CONNECT_FAIL'] === 'true'
+          ) {
+            throw new Error('network connect failed');
           }
           if (cmd.includes('getconf DARWIN_USER_CACHE_DIR')) {
             return { stdout: '/tmp/cache', stderr: '' };
@@ -111,6 +120,8 @@ describe('sandbox', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(spawn).mockReset();
+    vi.mocked(execSync).mockReset();
     process.env = { ...originalEnv };
     process.argv = [...originalArgv];
     mockProcessIn = {
@@ -384,7 +395,6 @@ describe('sandbox', () => {
       ).resolves.toBe(0);
 
       expect(process.listeners('exit')).toHaveLength(initialExitListenerCount);
-      expect(killSpy).toHaveBeenCalledWith(-1, 'SIGTERM');
       killSpy.mockRestore();
     });
 
@@ -419,9 +429,17 @@ describe('sandbox', () => {
         return proc;
       };
 
+      const imageCheckProcess = new EventEmitter() as unknown as ReturnType<
+        typeof spawn
+      > & {
+        stdout: ReturnType<typeof spawn>['stdout'];
+      };
+      imageCheckProcess.stdout = new EventEmitter() as unknown as ReturnType<
+        typeof spawn
+      >['stdout'];
+
       vi.mocked(spawn)
         .mockImplementationOnce(() => {
-          const imageCheckProcess = createMockProcess(false);
           setTimeout(() => {
             imageCheckProcess.stdout?.emit('data', Buffer.from('image-id'));
             imageCheckProcess.emit('close', 0);
@@ -435,6 +453,110 @@ describe('sandbox', () => {
         start_sandbox(config, [], undefined, ['arg1']),
       ).resolves.toBe(0);
 
+      expect(execSync).toHaveBeenCalledWith(expect.stringContaining('rm -f'));
+    });
+
+    it('removes proxy exit handlers if proxy startup fails', async () => {
+      vi.stubEnv('GEMINI_SANDBOX_PROXY_COMMAND', 'proxy-cmd');
+      vi.stubEnv('TEST_CURL_FAIL', 'true');
+      vi.mocked(os.platform).mockReturnValue('darwin');
+      const killSpy = vi
+        .spyOn(process, 'kill')
+        .mockImplementation(() => true as never);
+
+      const config: SandboxConfig = createMockSandboxConfig({
+        command: 'sandbox-exec',
+        image: 'some-image',
+      });
+
+      const proxyProcess = new EventEmitter() as unknown as ReturnType<
+        typeof spawn
+      > & {
+        pid?: number;
+        stdout: ReturnType<typeof spawn>['stdout'];
+        stderr: ReturnType<typeof spawn>['stderr'];
+      };
+      proxyProcess.pid = 123;
+      proxyProcess.stdout = new EventEmitter() as unknown as ReturnType<
+        typeof spawn
+      >['stdout'];
+      proxyProcess.stderr = new EventEmitter() as unknown as ReturnType<
+        typeof spawn
+      >['stderr'];
+      proxyProcess.on = vi.fn().mockImplementation(() => proxyProcess);
+
+      vi.mocked(spawn).mockImplementationOnce(
+        () => proxyProcess as unknown as ReturnType<typeof spawn>,
+      );
+
+      const initialExitListenerCount = process.listeners('exit').length;
+      const initialSighupListenerCount = process.listeners('SIGHUP').length;
+
+      await expect(start_sandbox(config)).rejects.toThrow('curl failed');
+
+      expect(process.listeners('exit')).toHaveLength(initialExitListenerCount);
+      expect(process.listeners('SIGHUP')).toHaveLength(
+        initialSighupListenerCount,
+      );
+      expect(killSpy).toHaveBeenCalled();
+      killSpy.mockRestore();
+    });
+
+    it('removes proxy container exit handlers if network setup fails', async () => {
+      vi.stubEnv('GEMINI_SANDBOX_PROXY_COMMAND', 'proxy-cmd --flag');
+      vi.stubEnv('TEST_NETWORK_CONNECT_FAIL', 'true');
+      const config: SandboxConfig = createMockSandboxConfig({
+        command: 'docker',
+        image: 'gemini-cli-sandbox',
+      });
+
+      const createMockProcess = () => {
+        const proc = new EventEmitter() as unknown as ReturnType<
+          typeof spawn
+        > & {
+          stdout: ReturnType<typeof spawn>['stdout'];
+          stderr: ReturnType<typeof spawn>['stderr'];
+        };
+        proc.stdout = new EventEmitter() as unknown as ReturnType<
+          typeof spawn
+        >['stdout'];
+        proc.stderr = new EventEmitter() as unknown as ReturnType<
+          typeof spawn
+        >['stderr'];
+        proc.on = vi.fn().mockImplementation(() => proc);
+        return proc;
+      };
+
+      const imageCheckProcess = new EventEmitter() as unknown as ReturnType<
+        typeof spawn
+      > & {
+        stdout: ReturnType<typeof spawn>['stdout'];
+      };
+      imageCheckProcess.stdout = new EventEmitter() as unknown as ReturnType<
+        typeof spawn
+      >['stdout'];
+
+      vi.mocked(spawn)
+        .mockImplementationOnce(() => {
+          setTimeout(() => {
+            imageCheckProcess.stdout?.emit('data', Buffer.from('image-id'));
+            imageCheckProcess.emit('close', 0);
+          }, 0);
+          return imageCheckProcess;
+        })
+        .mockImplementationOnce(() => createMockProcess());
+
+      const initialExitListenerCount = process.listeners('exit').length;
+      const initialSighupListenerCount = process.listeners('SIGHUP').length;
+
+      await expect(start_sandbox(config)).rejects.toThrow(
+        'network connect failed',
+      );
+
+      expect(process.listeners('exit')).toHaveLength(initialExitListenerCount);
+      expect(process.listeners('SIGHUP')).toHaveLength(
+        initialSighupListenerCount,
+      );
       expect(execSync).toHaveBeenCalledWith(expect.stringContaining('rm -f'));
     });
 
@@ -790,6 +912,45 @@ describe('sandbox', () => {
         });
 
         await expect(start_sandbox(config)).rejects.toThrow(/not found/);
+      });
+
+      it('removes tracked LXC exit handlers after the sandbox closes', async () => {
+        process.env['TEST_LXC_LIST_OUTPUT'] = LXC_RUNNING;
+        const config: SandboxConfig = createMockSandboxConfig({
+          command: 'lxc',
+          image: 'gemini-sandbox',
+        });
+
+        const mockSpawnProcess = new EventEmitter() as unknown as ReturnType<
+          typeof spawn
+        >;
+        mockSpawnProcess.on = vi.fn().mockImplementation((event, cb) => {
+          if (event === 'close') {
+            setTimeout(() => cb(0), 10);
+          }
+          return mockSpawnProcess;
+        });
+
+        vi.mocked(spawn).mockImplementation((cmd) => {
+          if (cmd === 'lxc') {
+            return mockSpawnProcess;
+          }
+          return new EventEmitter() as unknown as ReturnType<typeof spawn>;
+        });
+
+        const initialExitListenerCount = process.listeners('exit').length;
+        const initialSighupListenerCount = process.listeners('SIGHUP').length;
+
+        await expect(
+          start_sandbox(config, [], undefined, ['arg1']),
+        ).resolves.toBe(0);
+
+        expect(process.listeners('exit')).toHaveLength(
+          initialExitListenerCount,
+        );
+        expect(process.listeners('SIGHUP')).toHaveLength(
+          initialSighupListenerCount,
+        );
       });
     });
   });

--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -131,6 +131,7 @@ describe('sandbox', () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     process.env = originalEnv;
     process.argv = originalArgv;
   });
@@ -339,8 +340,11 @@ describe('sandbox', () => {
     });
 
     it('removes proxy exit handlers after the sandbox process closes', async () => {
-      process.env['GEMINI_SANDBOX_PROXY_COMMAND'] = 'proxy-cmd';
+      vi.stubEnv('GEMINI_SANDBOX_PROXY_COMMAND', 'proxy-cmd');
       vi.mocked(os.platform).mockReturnValue('darwin');
+      const killSpy = vi
+        .spyOn(process, 'kill')
+        .mockImplementation(() => true as never);
 
       const config: SandboxConfig = createMockSandboxConfig({
         command: 'sandbox-exec',
@@ -380,6 +384,58 @@ describe('sandbox', () => {
       ).resolves.toBe(0);
 
       expect(process.listeners('exit')).toHaveLength(initialExitListenerCount);
+      expect(killSpy).toHaveBeenCalledWith(-1, 'SIGTERM');
+      killSpy.mockRestore();
+    });
+
+    it('stops the proxy container after the sandbox process closes', async () => {
+      vi.stubEnv('GEMINI_SANDBOX_PROXY_COMMAND', 'proxy-cmd --flag');
+      const config: SandboxConfig = createMockSandboxConfig({
+        command: 'docker',
+        image: 'gemini-cli-sandbox',
+      });
+
+      const createMockProcess = (autoClose: boolean, pid?: number) => {
+        const proc = new EventEmitter() as unknown as ReturnType<
+          typeof spawn
+        > & {
+          pid?: number;
+          stdout: ReturnType<typeof spawn>['stdout'];
+          stderr: ReturnType<typeof spawn>['stderr'];
+        };
+        proc.pid = pid;
+        proc.stdout = new EventEmitter() as unknown as ReturnType<
+          typeof spawn
+        >['stdout'];
+        proc.stderr = new EventEmitter() as unknown as ReturnType<
+          typeof spawn
+        >['stderr'];
+        proc.on = vi.fn().mockImplementation((event, cb) => {
+          if (autoClose && event === 'close') {
+            setTimeout(() => cb(0), 0);
+          }
+          return proc;
+        });
+        return proc;
+      };
+
+      vi.mocked(spawn)
+        .mockImplementationOnce(() => {
+          const imageCheckProcess = createMockProcess(false);
+          setTimeout(() => {
+            imageCheckProcess.stdout?.emit('data', Buffer.from('image-id'));
+            imageCheckProcess.emit('close', 0);
+          }, 0);
+          return imageCheckProcess;
+        })
+        .mockImplementationOnce(() => createMockProcess(false))
+        .mockImplementationOnce(() => createMockProcess(true, 2));
+
+      await expect(
+        start_sandbox(config, [], undefined, ['arg1']),
+      ).resolves.toBe(0);
+
+      expect(execSync).toHaveBeenCalledWith(expect.stringContaining('rm -f'));
     });
 
     it('should mount volumes correctly', async () => {

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -42,7 +42,7 @@ import {
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
-const PROCESS_EXIT_SIGNALS = ['exit', 'SIGINT', 'SIGTERM'] as const;
+const PROCESS_EXIT_SIGNALS = ['exit', 'SIGHUP', 'SIGINT', 'SIGTERM'] as const;
 const activeProcessExitHandlers = new Set<() => void>();
 let processExitDispatcherInstalled = false;
 
@@ -93,7 +93,9 @@ function removeProcessExitHandler(
 function runAndRemoveProcessExitHandler(
   currentHandler: (() => void) | undefined,
 ): undefined {
-  currentHandler?.();
+  if (currentHandler && activeProcessExitHandlers.has(currentHandler)) {
+    currentHandler();
+  }
   return removeProcessExitHandler(currentHandler);
 }
 
@@ -238,7 +240,11 @@ export async function start_sandbox(
         const stopProxy = () => {
           debugLogger.log('stopping proxy ...');
           if (proxyProcess?.pid) {
-            process.kill(-proxyProcess.pid, 'SIGTERM');
+            try {
+              process.kill(-proxyProcess.pid, 'SIGTERM');
+            } catch {
+              // Ignore cleanup races during shutdown.
+            }
           }
         };
         proxyStopHandler = addProcessExitHandler(stopProxy);
@@ -260,9 +266,14 @@ export async function start_sandbox(
           );
         });
         debugLogger.log('waiting for proxy to start ...');
-        await execAsync(
-          `until timeout 0.25 curl -s http://localhost:8877; do sleep 0.25; done`,
-        );
+        try {
+          await execAsync(
+            `until timeout 0.25 curl -s http://localhost:8877; do sleep 0.25; done`,
+          );
+        } catch (err) {
+          runAndRemoveProcessExitHandler(proxyStopHandler);
+          throw err;
+        }
       }
       // spawn child and let it inherit stdio
       process.stdin.pause();
@@ -270,7 +281,10 @@ export async function start_sandbox(
         stdio: 'inherit',
       });
       return await new Promise((resolve, reject) => {
-        sandboxProcess?.on('error', reject);
+        sandboxProcess?.on('error', (err) => {
+          runAndRemoveProcessExitHandler(proxyStopHandler);
+          reject(err);
+        });
         sandboxProcess?.on('close', (code) => {
           runAndRemoveProcessExitHandler(proxyStopHandler);
           process.stdin.resume();
@@ -814,14 +828,19 @@ export async function start_sandbox(
         );
       });
       debugLogger.log('waiting for proxy to start ...');
-      await execAsync(
-        `until timeout 0.25 curl -s http://localhost:8877; do sleep 0.25; done`,
-      );
-      // connect proxy container to sandbox network
-      // (workaround for older versions of docker that don't support multiple --network args)
-      await execAsync(
-        `${command} network connect ${SANDBOX_NETWORK_NAME} ${SANDBOX_PROXY_NAME}`,
-      );
+      try {
+        await execAsync(
+          `until timeout 0.25 curl -s http://localhost:8877; do sleep 0.25; done`,
+        );
+        // connect proxy container to sandbox network
+        // (workaround for older versions of docker that don't support multiple --network args)
+        await execAsync(
+          `${command} network connect ${SANDBOX_NETWORK_NAME} ${SANDBOX_PROXY_NAME}`,
+        );
+      } catch (err) {
+        runAndRemoveProcessExitHandler(proxyContainerStopHandler);
+        throw err;
+      }
     }
 
     // spawn child and let it inherit stdio
@@ -832,6 +851,7 @@ export async function start_sandbox(
 
     return await new Promise<number>((resolve, reject) => {
       sandboxProcess.on('error', (err) => {
+        runAndRemoveProcessExitHandler(proxyContainerStopHandler);
         coreEvents.emitFeedback('error', 'Sandbox process error', err);
         reject(err);
       });
@@ -936,6 +956,7 @@ async function start_lxc_sandbox(
       }
     }
   };
+  let removeDevicesHandler: (() => void) | undefined;
 
   try {
     // Bind-mount the working directory into the container at the same path.
@@ -1000,7 +1021,7 @@ async function start_lxc_sandbox(
     // Remove the devices from the container when the process exits.
     // Only the 'exit' event is needed — the CLI's cleanup.ts already handles
     // SIGINT and SIGTERM by calling process.exit(), which fires 'exit'.
-    process.on('exit', removeDevices);
+    removeDevicesHandler = addProcessExitHandler(removeDevices);
 
     // Build the environment variable arguments for `lxc exec`.
     const envArgs: string[] = [];
@@ -1093,8 +1114,7 @@ async function start_lxc_sandbox(
       });
     });
   } finally {
-    process.off('exit', removeDevices);
-    removeDevices();
+    runAndRemoveProcessExitHandler(removeDevicesHandler);
   }
 }
 

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -43,39 +43,58 @@ import {
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 const PROCESS_EXIT_SIGNALS = ['exit', 'SIGINT', 'SIGTERM'] as const;
+const activeProcessExitHandlers = new Set<() => void>();
+let processExitDispatcherInstalled = false;
 
-let activeProxyStopHandler: (() => void) | undefined;
-let activeProxyContainerStopHandler: (() => void) | undefined;
+function runProcessExitHandlers() {
+  for (const handler of [...activeProcessExitHandlers]) {
+    handler();
+  }
+}
 
-function replaceProcessExitHandlers(
-  currentHandler: (() => void) | undefined,
-  nextHandler: () => void,
-): () => void {
-  if (currentHandler) {
-    for (const signal of PROCESS_EXIT_SIGNALS) {
-      process.off(signal, currentHandler);
-    }
+function ensureProcessExitDispatcher() {
+  if (processExitDispatcherInstalled) {
+    return;
   }
 
   for (const signal of PROCESS_EXIT_SIGNALS) {
-    process.on(signal, nextHandler);
+    process.on(signal, runProcessExitHandlers);
   }
-
-  return nextHandler;
+  processExitDispatcherInstalled = true;
 }
 
-function removeProcessExitHandlers(
+function maybeRemoveProcessExitDispatcher() {
+  if (processExitDispatcherInstalled && activeProcessExitHandlers.size === 0) {
+    for (const signal of PROCESS_EXIT_SIGNALS) {
+      process.off(signal, runProcessExitHandlers);
+    }
+    processExitDispatcherInstalled = false;
+  }
+}
+
+function addProcessExitHandler(handler: () => void): () => void {
+  ensureProcessExitDispatcher();
+  activeProcessExitHandlers.add(handler);
+  return handler;
+}
+
+function removeProcessExitHandler(
   currentHandler: (() => void) | undefined,
 ): undefined {
   if (!currentHandler) {
     return undefined;
   }
 
-  for (const signal of PROCESS_EXIT_SIGNALS) {
-    process.off(signal, currentHandler);
-  }
-
+  activeProcessExitHandlers.delete(currentHandler);
+  maybeRemoveProcessExitDispatcher();
   return undefined;
+}
+
+function runAndRemoveProcessExitHandler(
+  currentHandler: (() => void) | undefined,
+): undefined {
+  currentHandler?.();
+  return removeProcessExitHandler(currentHandler);
 }
 
 export async function start_sandbox(
@@ -192,6 +211,7 @@ export async function start_sandbox(
       const proxyCommand = process.env['GEMINI_SANDBOX_PROXY_COMMAND'];
       let proxyProcess: ChildProcess | undefined = undefined;
       let sandboxProcess: ChildProcess | undefined = undefined;
+      let proxyStopHandler: (() => void) | undefined;
       const sandboxEnv = { ...process.env };
       if (proxyCommand) {
         const proxy =
@@ -221,10 +241,7 @@ export async function start_sandbox(
             process.kill(-proxyProcess.pid, 'SIGTERM');
           }
         };
-        activeProxyStopHandler = replaceProcessExitHandlers(
-          activeProxyStopHandler,
-          stopProxy,
-        );
+        proxyStopHandler = addProcessExitHandler(stopProxy);
 
         // commented out as it disrupts ink rendering
         // proxyProcess.stdout?.on('data', (data) => {
@@ -234,9 +251,7 @@ export async function start_sandbox(
           debugLogger.debug(`[PROXY STDERR]: ${data.toString().trim()}`);
         });
         proxyProcess.on('close', (code, signal) => {
-          activeProxyStopHandler = removeProcessExitHandlers(
-            activeProxyStopHandler,
-          );
+          removeProcessExitHandler(proxyStopHandler);
           if (sandboxProcess?.pid) {
             process.kill(-sandboxProcess.pid, 'SIGTERM');
           }
@@ -257,9 +272,7 @@ export async function start_sandbox(
       return await new Promise((resolve, reject) => {
         sandboxProcess?.on('error', reject);
         sandboxProcess?.on('close', (code) => {
-          activeProxyStopHandler = removeProcessExitHandlers(
-            activeProxyStopHandler,
-          );
+          runAndRemoveProcessExitHandler(proxyStopHandler);
           process.stdin.resume();
           resolve(code ?? 1);
         });
@@ -745,6 +758,7 @@ export async function start_sandbox(
     // start and set up proxy if GEMINI_SANDBOX_PROXY_COMMAND is set
     let proxyProcess: ChildProcess | undefined = undefined;
     let sandboxProcess: ChildProcess | undefined = undefined;
+    let proxyContainerStopHandler: (() => void) | undefined;
 
     if (proxyCommand) {
       // run proxyCommand in its own container
@@ -781,10 +795,7 @@ export async function start_sandbox(
         debugLogger.log('stopping proxy container ...');
         execSync(`${command} rm -f ${SANDBOX_PROXY_NAME}`);
       };
-      activeProxyContainerStopHandler = replaceProcessExitHandlers(
-        activeProxyContainerStopHandler,
-        stopProxy,
-      );
+      proxyContainerStopHandler = addProcessExitHandler(stopProxy);
 
       // commented out as it disrupts ink rendering
       // proxyProcess.stdout?.on('data', (data) => {
@@ -794,9 +805,7 @@ export async function start_sandbox(
         debugLogger.debug(`[PROXY STDERR]: ${data.toString().trim()}`);
       });
       proxyProcess.on('close', (code, signal) => {
-        activeProxyContainerStopHandler = removeProcessExitHandlers(
-          activeProxyContainerStopHandler,
-        );
+        removeProcessExitHandler(proxyContainerStopHandler);
         if (sandboxProcess?.pid) {
           process.kill(-sandboxProcess.pid, 'SIGTERM');
         }
@@ -828,9 +837,7 @@ export async function start_sandbox(
       });
 
       sandboxProcess?.on('close', (code, signal) => {
-        activeProxyContainerStopHandler = removeProcessExitHandlers(
-          activeProxyContainerStopHandler,
-        );
+        runAndRemoveProcessExitHandler(proxyContainerStopHandler);
         process.stdin.resume();
         if (code !== 0 && code !== null) {
           debugLogger.log(

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -42,6 +42,41 @@ import {
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
+const PROCESS_EXIT_SIGNALS = ['exit', 'SIGINT', 'SIGTERM'] as const;
+
+let activeProxyStopHandler: (() => void) | undefined;
+let activeProxyContainerStopHandler: (() => void) | undefined;
+
+function replaceProcessExitHandlers(
+  currentHandler: (() => void) | undefined,
+  nextHandler: () => void,
+): () => void {
+  if (currentHandler) {
+    for (const signal of PROCESS_EXIT_SIGNALS) {
+      process.off(signal, currentHandler);
+    }
+  }
+
+  for (const signal of PROCESS_EXIT_SIGNALS) {
+    process.on(signal, nextHandler);
+  }
+
+  return nextHandler;
+}
+
+function removeProcessExitHandlers(
+  currentHandler: (() => void) | undefined,
+): undefined {
+  if (!currentHandler) {
+    return undefined;
+  }
+
+  for (const signal of PROCESS_EXIT_SIGNALS) {
+    process.off(signal, currentHandler);
+  }
+
+  return undefined;
+}
 
 export async function start_sandbox(
   config: SandboxConfig,
@@ -186,12 +221,10 @@ export async function start_sandbox(
             process.kill(-proxyProcess.pid, 'SIGTERM');
           }
         };
-        process.off('exit', stopProxy);
-        process.on('exit', stopProxy);
-        process.off('SIGINT', stopProxy);
-        process.on('SIGINT', stopProxy);
-        process.off('SIGTERM', stopProxy);
-        process.on('SIGTERM', stopProxy);
+        activeProxyStopHandler = replaceProcessExitHandlers(
+          activeProxyStopHandler,
+          stopProxy,
+        );
 
         // commented out as it disrupts ink rendering
         // proxyProcess.stdout?.on('data', (data) => {
@@ -201,6 +234,9 @@ export async function start_sandbox(
           debugLogger.debug(`[PROXY STDERR]: ${data.toString().trim()}`);
         });
         proxyProcess.on('close', (code, signal) => {
+          activeProxyStopHandler = removeProcessExitHandlers(
+            activeProxyStopHandler,
+          );
           if (sandboxProcess?.pid) {
             process.kill(-sandboxProcess.pid, 'SIGTERM');
           }
@@ -221,6 +257,9 @@ export async function start_sandbox(
       return await new Promise((resolve, reject) => {
         sandboxProcess?.on('error', reject);
         sandboxProcess?.on('close', (code) => {
+          activeProxyStopHandler = removeProcessExitHandlers(
+            activeProxyStopHandler,
+          );
           process.stdin.resume();
           resolve(code ?? 1);
         });
@@ -742,12 +781,10 @@ export async function start_sandbox(
         debugLogger.log('stopping proxy container ...');
         execSync(`${command} rm -f ${SANDBOX_PROXY_NAME}`);
       };
-      process.off('exit', stopProxy);
-      process.on('exit', stopProxy);
-      process.off('SIGINT', stopProxy);
-      process.on('SIGINT', stopProxy);
-      process.off('SIGTERM', stopProxy);
-      process.on('SIGTERM', stopProxy);
+      activeProxyContainerStopHandler = replaceProcessExitHandlers(
+        activeProxyContainerStopHandler,
+        stopProxy,
+      );
 
       // commented out as it disrupts ink rendering
       // proxyProcess.stdout?.on('data', (data) => {
@@ -757,6 +794,9 @@ export async function start_sandbox(
         debugLogger.debug(`[PROXY STDERR]: ${data.toString().trim()}`);
       });
       proxyProcess.on('close', (code, signal) => {
+        activeProxyContainerStopHandler = removeProcessExitHandlers(
+          activeProxyContainerStopHandler,
+        );
         if (sandboxProcess?.pid) {
           process.kill(-sandboxProcess.pid, 'SIGTERM');
         }
@@ -788,6 +828,9 @@ export async function start_sandbox(
       });
 
       sandboxProcess?.on('close', (code, signal) => {
+        activeProxyContainerStopHandler = removeProcessExitHandlers(
+          activeProxyContainerStopHandler,
+        );
         process.stdin.resume();
         if (code !== 0 && code !== null) {
           debugLogger.log(

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -48,7 +48,13 @@ let processExitDispatcherInstalled = false;
 
 function runProcessExitHandlers() {
   for (const handler of [...activeProcessExitHandlers]) {
-    handler();
+    try {
+      handler();
+    } catch (error) {
+      debugLogger.debug(
+        `process exit handler failed: ${error instanceof Error ? error.stack ?? error.message : String(error)}`,
+      );
+    }
   }
 }
 
@@ -93,10 +99,14 @@ function removeProcessExitHandler(
 function runAndRemoveProcessExitHandler(
   currentHandler: (() => void) | undefined,
 ): undefined {
-  if (currentHandler && activeProcessExitHandlers.has(currentHandler)) {
-    currentHandler();
+  try {
+    if (currentHandler && activeProcessExitHandlers.has(currentHandler)) {
+      currentHandler();
+    }
+  } finally {
+    removeProcessExitHandler(currentHandler);
   }
-  return removeProcessExitHandler(currentHandler);
+  return undefined;
 }
 
 export async function start_sandbox(
@@ -807,7 +817,13 @@ export async function start_sandbox(
       // install handlers to stop proxy on exit/signal
       const stopProxy = () => {
         debugLogger.log('stopping proxy container ...');
-        execSync(`${command} rm -f ${SANDBOX_PROXY_NAME}`);
+        try {
+          execSync(`${command} rm -f ${SANDBOX_PROXY_NAME}`);
+        } catch (error) {
+          debugLogger.debug(
+            `failed to stop proxy container: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
       };
       proxyContainerStopHandler = addProcessExitHandler(stopProxy);
 


### PR DESCRIPTION
## Summary
- replace one-off proxy cleanup registration with tracked process exit/signal handlers
- remove proxy cleanup handlers when the proxy or sandbox process exits
- add a regression test that verifies no leaked `exit` listener remains after sandbox shutdown

Fixes #24334.

## Testing
- npm test --workspace @google/gemini-cli -- sandbox.test.ts
