### PR TITLE
fix(build): upload full bundle directory archive to GitHub releases

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -291,14 +291,16 @@ runs:
         INPUTS_PREVIOUS_TAG: '${{ inputs.previous-tag }}'
       shell: 'bash'
       run: |
-        (cd bundle && zip -r ../gemini-cli-bundle.zip .)
+        rm -f gemini-cli-bundle.zip
+        (cd bundle && chmod +x gemini.js && zip -r ../gemini-cli-bundle.zip .)
 
         echo "Testing the generated bundle archive..."
+        rm -rf test-bundle
         mkdir -p test-bundle
         unzip -q gemini-cli-bundle.zip -d test-bundle
-        chmod +x test-bundle/gemini.js
+
         # Verify it runs and outputs a version
-        BUNDLE_VERSION=$(node test-bundle/gemini.js --version)
+        BUNDLE_VERSION=$(node test-bundle/gemini.js --version | xargs)
         echo "Bundle version output: ${BUNDLE_VERSION}"
         if [[ -z "${BUNDLE_VERSION}" ]]; then
           echo "Error: Bundle failed to execute or return version."

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -291,7 +291,7 @@ runs:
         INPUTS_PREVIOUS_TAG: '${{ inputs.previous-tag }}'
       shell: 'bash'
       run: |
-        zip -r gemini-cli-bundle.zip bundle/
+        (cd bundle && zip -r ../gemini-cli-bundle.zip .)
         gh release create "${INPUTS_RELEASE_TAG}" \
           gemini-cli-bundle.zip \
           --target "${STEPS_RELEASE_BRANCH_OUTPUTS_BRANCH_NAME}" \

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -291,8 +291,9 @@ runs:
         INPUTS_PREVIOUS_TAG: '${{ inputs.previous-tag }}'
       shell: 'bash'
       run: |
+        zip -r gemini-cli-bundle.zip bundle/
         gh release create "${INPUTS_RELEASE_TAG}" \
-          bundle/gemini.js \
+          gemini-cli-bundle.zip \
           --target "${STEPS_RELEASE_BRANCH_OUTPUTS_BRANCH_NAME}" \
           --title "Release ${INPUTS_RELEASE_TAG}" \
           --notes-start-tag "${INPUTS_PREVIOUS_TAG}" \

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -292,7 +292,7 @@ runs:
       shell: 'bash'
       run: |
         (cd bundle && zip -r ../gemini-cli-bundle.zip .)
-        
+
         echo "Testing the generated bundle archive..."
         mkdir -p test-bundle
         unzip -q gemini-cli-bundle.zip -d test-bundle

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -292,6 +292,20 @@ runs:
       shell: 'bash'
       run: |
         (cd bundle && zip -r ../gemini-cli-bundle.zip .)
+        
+        echo "Testing the generated bundle archive..."
+        mkdir -p test-bundle
+        unzip -q gemini-cli-bundle.zip -d test-bundle
+        chmod +x test-bundle/gemini.js
+        # Verify it runs and outputs a version
+        BUNDLE_VERSION=$(node test-bundle/gemini.js --version)
+        echo "Bundle version output: ${BUNDLE_VERSION}"
+        if [[ -z "${BUNDLE_VERSION}" ]]; then
+          echo "Error: Bundle failed to execute or return version."
+          exit 1
+        fi
+        rm -rf test-bundle
+
         gh release create "${INPUTS_RELEASE_TAG}" \
           gemini-cli-bundle.zip \
           --target "${STEPS_RELEASE_BRANCH_OUTPUTS_BRANCH_NAME}" \


### PR DESCRIPTION
## Summary

This PR fixes issue #23770 where the standalone `gemini.js` artifact uploaded to GitHub releases was failing to run due to missing external chunk files.

Instead of disabling code splitting (which would break the startup performance improvements introduced in #22117 and cause an ESM loader deadlock during single-file bundling), this PR updates the release workflow to compress the entire `bundle/` directory into `gemini-cli-bundle.zip` and attach that archive to the release.

## Details

When `splitting: true` is enabled in esbuild, the bundle relies on dynamically imported chunks (e.g., `chunk-XXXX.js`). The previous GitHub Action only uploaded the entry point (`bundle/gemini.js`), which resulted in
`ERR_MODULE_NOT_FOUND` errors when users tried to run it standalone. Uploading the full directory archive ensures all chunks are available.

## Related Issues

Fixes #23770

## How to Validate

1. Trigger a release build or run the GitHub Action manually (or mock it locally
   by running `zip -r gemini-cli-bundle.zip bundle/` after `npm run bundle`).
2. Verify that `gemini-cli-bundle.zip` contains both `gemini.js` and all
   associated `chunk-*.js` files.
3. Unzip the archive and run `node gemini.js --version`. It should execute
   successfully.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
