### PR TITLE
Add the support of multi-level folders for skills

### DIFF
--- a/packages/core/src/services/FolderTrustDiscoveryService.ts
+++ b/packages/core/src/services/FolderTrustDiscoveryService.ts
@@ -89,6 +89,7 @@ export class FolderTrustDiscoveryService {
         const skillFiles = await glob('**/SKILL.md', {
           cwd: skillsDir,
           nodir: true,
+          dot: true,
           ignore: ['**/node_modules/**', '**/.git/**'],
         });
         for (const skillFile of skillFiles) {

--- a/packages/core/src/services/FolderTrustDiscoveryService.ts
+++ b/packages/core/src/services/FolderTrustDiscoveryService.ts
@@ -6,6 +6,7 @@
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import { glob } from 'glob';
 import stripJsonComments from 'strip-json-comments';
 import { GEMINI_DIR } from '../utils/paths.js';
 import { debugLogger } from '../utils/debugLogger.js';
@@ -85,14 +86,13 @@ export class FolderTrustDiscoveryService {
     const skillsDir = path.join(geminiDir, 'skills');
     if (await this.exists(skillsDir)) {
       try {
-        const entries = await fs.readdir(skillsDir, { withFileTypes: true });
-        for (const entry of entries) {
-          if (entry.isDirectory()) {
-            const skillMdPath = path.join(skillsDir, entry.name, 'SKILL.md');
-            if (await this.exists(skillMdPath)) {
-              results.skills.push(entry.name);
-            }
-          }
+        const skillFiles = await glob('**/SKILL.md', {
+          cwd: skillsDir,
+          nodir: true,
+          ignore: ['**/node_modules/**', '**/.git/**'],
+        });
+        for (const skillFile of skillFiles) {
+          results.skills.push(path.dirname(skillFile));
         }
       } catch (e) {
         results.discoveryErrors.push(

--- a/packages/core/src/skills/skillLoader.test.ts
+++ b/packages/core/src/skills/skillLoader.test.ts
@@ -255,6 +255,44 @@ description:no-space-desc
     expect(skills[0].description).toBe('no-space-desc');
   });
 
+  it('should load skills from nested subdirectories (two-level folders)', async () => {
+    const skillDir = path.join(testRootDir, 'category', 'my-skill');
+    await fs.mkdir(skillDir, { recursive: true });
+    const skillFile = path.join(skillDir, 'SKILL.md');
+    await fs.writeFile(
+      skillFile,
+      `---\nname: nested-skill\ndescription: A nested skill\n---\n# Instructions\nDo something nested.\n`,
+    );
+
+    const skills = await loadSkillsFromDir(testRootDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('nested-skill');
+    expect(skills[0].location).toBe(skillFile);
+  });
+
+  it('should load skills from both flat and nested directories', async () => {
+    const flatSkillDir = path.join(testRootDir, 'flat-skill');
+    await fs.mkdir(flatSkillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(flatSkillDir, 'SKILL.md'),
+      `---\nname: flat-skill\ndescription: A flat skill\n---\nFlat body.\n`,
+    );
+
+    const nestedSkillDir = path.join(testRootDir, 'category', 'nested-skill');
+    await fs.mkdir(nestedSkillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(nestedSkillDir, 'SKILL.md'),
+      `---\nname: nested-skill\ndescription: A nested skill\n---\nNested body.\n`,
+    );
+
+    const skills = await loadSkillsFromDir(testRootDir);
+
+    expect(skills).toHaveLength(2);
+    const names = skills.map((s) => s.name).sort();
+    expect(names).toEqual(['flat-skill', 'nested-skill']);
+  });
+
   it('should sanitize skill names containing invalid filename characters', async () => {
     const skillFile = path.join(testRootDir, 'SKILL.md');
     await fs.writeFile(

--- a/packages/core/src/skills/skillLoader.ts
+++ b/packages/core/src/skills/skillLoader.ts
@@ -124,7 +124,7 @@ export async function loadSkillsFromDir(
       return [];
     }
 
-    const pattern = ['SKILL.md', '*/SKILL.md'];
+    const pattern = '**/SKILL.md';
     const skillFiles = await glob(pattern, {
       cwd: absoluteSearchPath,
       absolute: true,


### PR DESCRIPTION
## Summary

This PR adds support for multi-level folder discoverability for skills.

## Details

Currently, skill discoverability is limited to a single folder level.

## Related Issues

This PR fixes https://github.com/google-gemini/gemini-cli/issues/21653

## How to Validate

 I provided tests for this feature in skillLoader.test.ts, lines [258](https://github.com/ezimuel/gemini-cli/blob/feature/skills-dir/packages/core/src/skills/skillLoader.test.ts#L258) and [274](https://github.com/ezimuel/gemini-cli/blob/feature/skills-dir/packages/core/src/skills/skillLoader.test.ts#L274).

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
