### PR TITLE
chore(core): remove outdated getCustomExcludes TODO

### DIFF
--- a/packages/core/src/utils/ignorePatterns.ts
+++ b/packages/core/src/utils/ignorePatterns.ts
@@ -164,7 +164,6 @@ export class FileExclusions {
     }
 
     // Add custom patterns from configuration
-    // TODO: getCustomExcludes method needs to be implemented in Config interface
     if (this.config) {
       const configCustomExcludes = this.config.getCustomExcludes?.() ?? [];
       patterns.push(...configCustomExcludes);
@@ -199,7 +198,6 @@ export class FileExclusions {
     const corePatterns = this.getCoreIgnorePatterns();
 
     // Add any custom patterns from config if available
-    // TODO: getCustomExcludes method needs to be implemented in Config interface
     const configPatterns = this.config?.getCustomExcludes?.() ?? [];
 
     return [...corePatterns, ...configPatterns, ...additionalExcludes];


### PR DESCRIPTION
Closes #24417

## Summary
- remove stale TODO comments in `packages/core/src/utils/ignorePatterns.ts` referencing `getCustomExcludes` interface work
- no runtime logic changes; this is targeted cleanup requested in the issue

## Verification
- manual code inspection: only comment deletion (2 lines)
- behavior unchanged
