### PR TITLE
feat(core): update browser agent prompt to check open pages first when bringing up

### DIFF
--- a/packages/core/src/agents/browser/browserAgentDefinition.ts
+++ b/packages/core/src/agents/browser/browserAgentDefinition.ts
@@ -190,7 +190,7 @@ export const BrowserAgentDefinition = (
 \${task}
 </task>
 
-First, use list_pages to check if there are any existing pages that can fulfill the user's request. If not, use new_page to open the relevant URL. Then, call take_snapshot to see the page and proceed with your task.`,
+First, use list_pages to check if there are any existing pages that can fulfill the user's request. If not, you MUST use new_page to open the relevant URL unless the user explicitly provides a different instructions.`,
       systemPrompt: buildBrowserSystemPrompt(
         visionEnabled,
         config.getBrowserAgentConfig().customConfig.allowedDomains,

--- a/packages/core/src/agents/browser/browserAgentDefinition.ts
+++ b/packages/core/src/agents/browser/browserAgentDefinition.ts
@@ -190,7 +190,7 @@ export const BrowserAgentDefinition = (
 \${task}
 </task>
 
-First, use new_page to open the relevant URL. Then call take_snapshot to see the page and proceed with your task.`,
+First, check if there are any existing pages. If so, check if any existing page can fullfill the user's request.`,
       systemPrompt: buildBrowserSystemPrompt(
         visionEnabled,
         config.getBrowserAgentConfig().customConfig.allowedDomains,

--- a/packages/core/src/agents/browser/browserAgentDefinition.ts
+++ b/packages/core/src/agents/browser/browserAgentDefinition.ts
@@ -190,7 +190,7 @@ export const BrowserAgentDefinition = (
 \${task}
 </task>
 
-First, use list_pages to check if there are any existing pages that can fulfill the user's request. If not, you MUST use new_page to open the relevant URL unless the user explicitly provides different instructions.`,
+First, use list_page to check if there are any existing pages that can fulfill the user's request. If not, you MUST use new_page to open the relevant URL unless the user explicitly provides different instructions.`,
       systemPrompt: buildBrowserSystemPrompt(
         visionEnabled,
         config.getBrowserAgentConfig().customConfig.allowedDomains,

--- a/packages/core/src/agents/browser/browserAgentDefinition.ts
+++ b/packages/core/src/agents/browser/browserAgentDefinition.ts
@@ -190,7 +190,7 @@ export const BrowserAgentDefinition = (
 \${task}
 </task>
 
-First, use list_page to check if there are any existing pages that can fulfill the user's request. If not, you MUST use new_page to open the relevant URL unless the user explicitly provides different instructions.`,
+First, use <list_pages/> to check if there are any existing pages that can fulfill the user's request. If not, you MUST use <new_page/> to open the relevant URL unless the user explicitly provides different instructions.`,
       systemPrompt: buildBrowserSystemPrompt(
         visionEnabled,
         config.getBrowserAgentConfig().customConfig.allowedDomains,

--- a/packages/core/src/agents/browser/browserAgentDefinition.ts
+++ b/packages/core/src/agents/browser/browserAgentDefinition.ts
@@ -190,7 +190,7 @@ export const BrowserAgentDefinition = (
 \${task}
 </task>
 
-First, check if there are any existing pages. If so, check if any existing page can fullfill the user's request.`,
+First, use list_pages to check if there are any existing pages that can fulfill the user's request. If not, use new_page to open the relevant URL. Then, call take_snapshot to see the page and proceed with your task.`,
       systemPrompt: buildBrowserSystemPrompt(
         visionEnabled,
         config.getBrowserAgentConfig().customConfig.allowedDomains,

--- a/packages/core/src/agents/browser/browserAgentDefinition.ts
+++ b/packages/core/src/agents/browser/browserAgentDefinition.ts
@@ -190,7 +190,7 @@ export const BrowserAgentDefinition = (
 \${task}
 </task>
 
-First, use list_pages to check if there are any existing pages that can fulfill the user's request. If not, you MUST use new_page to open the relevant URL unless the user explicitly provides a different instructions.`,
+First, use list_pages to check if there are any existing pages that can fulfill the user's request. If not, you MUST use new_page to open the relevant URL unless the user explicitly provides different instructions.`,
       systemPrompt: buildBrowserSystemPrompt(
         visionEnabled,
         config.getBrowserAgentConfig().customConfig.allowedDomains,


### PR DESCRIPTION
## Summary

Update the browser agent's initial instructions to prioritize checking for and reusing existing pages before opening new ones.

related #21247 

## Details

- Update instruction to use `list_page` first to check if existing pages can fulfill user request
- Remove instruction for `take_snapshot` since the agent already know to do so

## How to Validate

1. Start the browser agent with a specific task (e.g., "Search for X").
2. Ensure there is already a page open that might be relevant.
3. Observe the agent's thought process; it should now reflect a check for existing pages before immediately attempting to open a new one.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
  - [ ] Windows
  - [x] Linux
    - [x] npm run
