### PR TITLE
improve error message clarity for privileged approval mode restriction

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2514,7 +2514,7 @@ export class Config implements McpContext, AgentLoopContext {
       mode !== ApprovalMode.PLAN
     ) {
       throw new Error(
-        'Cannot enable privileged approval modes in an untrusted folder.',
+        'Cannot enable privileged approval modes in an untrusted folder. Please mark the folder as trusted or disable privileged approval modes in your configuration.',
       );
     }
 


### PR DESCRIPTION
Improves the error message when privileged approval modes are enabled in an untrusted folder.

## Summary

The previous message did not clearly explain how to resolve the issue. This update adds actionable guidance so users understand how to proceed.

## How to Validate

Trigger the error by enabling privileged approval modes in an untrusted folder and confirm the updated message provides clearer guidance.
