### PR TITLE
fix(core): scope subagent workspace directories without mutating shared state

### DIFF
--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -537,266 +537,282 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
       new AgentStartEvent(this.agentId, this.definition.name),
     );
 
-    let chat: GeminiChat | undefined;
-    let tools: FunctionDeclaration[] | undefined;
-    try {
-      // Inject standard runtime context into inputs
-      const augmentedInputs = {
-        ...inputs,
-        cliVersion: await getVersion(),
-        activeModel: this.context.config.getActiveModel(),
-        today: new Date().toLocaleDateString(),
-      };
+    // Run the agent loop inside a scoped workspace context so that any
+    // additional directories declared by this agent (e.g., ~/.gemini for the
+    // memory manager) are visible only within this async execution tree.
+    return this.context.config.runWithWorkspaceScope(
+      this.definition.workspaceDirs ?? [],
+      async () => {
+        let chat: GeminiChat | undefined;
+        let tools: FunctionDeclaration[] | undefined;
+        try {
+          // Inject standard runtime context into inputs
+          const augmentedInputs = {
+            ...inputs,
+            cliVersion: await getVersion(),
+            activeModel: this.context.config.getActiveModel(),
+            today: new Date().toLocaleDateString(),
+          };
 
-      tools = this.prepareToolsList();
-      chat = await this.createChatObject(augmentedInputs, tools);
-      const query = this.definition.promptConfig.query
-        ? templateString(this.definition.promptConfig.query, augmentedInputs)
-        : DEFAULT_QUERY_STRING;
+          tools = this.prepareToolsList();
+          chat = await this.createChatObject(augmentedInputs, tools);
+          const query = this.definition.promptConfig.query
+            ? templateString(
+                this.definition.promptConfig.query,
+                augmentedInputs,
+              )
+            : DEFAULT_QUERY_STRING;
 
-      const pendingHintsQueue: string[] = [];
-      const pendingBgCompletionsQueue: string[] = [];
-      const injectionListener = (text: string, source: InjectionSource) => {
-        if (source === 'user_steering') {
-          pendingHintsQueue.push(text);
-        } else if (source === 'background_completion') {
-          pendingBgCompletionsQueue.push(text);
-        }
-      };
-      // Capture the index of the last hint before starting to avoid re-injecting old hints.
-      // NOTE: Hints added AFTER this point will be broadcast to all currently running
-      // local agents via the listener below.
-      const startIndex =
-        this.context.config.injectionService.getLatestInjectionIndex();
-      this.context.config.injectionService.onInjection(injectionListener);
-
-      try {
-        const initialHints =
-          this.context.config.injectionService.getInjectionsAfter(
-            startIndex,
-            'user_steering',
-          );
-        const formattedInitialHints = formatUserHintsForModel(initialHints);
-
-        // Inject loaded memory files (JIT + extension/project memory)
-        const environmentMemory = this.context.config.isJitContextEnabled?.()
-          ? this.context.config.getSessionMemory()
-          : this.context.config.getEnvironmentMemory();
-
-        const initialParts: Part[] = [];
-        if (environmentMemory) {
-          initialParts.push({ text: environmentMemory });
-        }
-        if (formattedInitialHints) {
-          initialParts.push({ text: formattedInitialHints });
-        }
-        initialParts.push({ text: query });
-
-        let currentMessage: Content = {
-          role: 'user',
-          parts: initialParts,
-        };
-
-        while (true) {
-          // Check for termination conditions like max turns.
-          const reason = this.checkTermination(turnCounter, maxTurns);
-          if (reason) {
-            terminateReason = reason;
-            break;
-          }
-
-          // Check for timeout or external abort.
-          if (combinedSignal.aborted) {
-            // Determine which signal caused the abort.
-            terminateReason = deadlineTimer.signal.aborted
-              ? AgentTerminateMode.TIMEOUT
-              : AgentTerminateMode.ABORTED;
-            break;
-          }
-
-          const turnResult = await this.executeTurn(
-            chat,
-            currentMessage,
-            turnCounter++,
-            combinedSignal,
-            deadlineTimer.signal,
-            onWaitingForConfirmation,
-          );
-
-          if (turnResult.status === 'stop') {
-            terminateReason = turnResult.terminateReason;
-            // Only set finalResult if the turn provided one (e.g., error or goal).
-            if (turnResult.finalResult) {
-              finalResult = turnResult.finalResult;
+          const pendingHintsQueue: string[] = [];
+          const pendingBgCompletionsQueue: string[] = [];
+          const injectionListener = (text: string, source: InjectionSource) => {
+            if (source === 'user_steering') {
+              pendingHintsQueue.push(text);
+            } else if (source === 'background_completion') {
+              pendingBgCompletionsQueue.push(text);
             }
-            break; // Exit the loop for *any* stop reason.
-          }
+          };
+          // Capture the index of the last hint before starting to avoid re-injecting old hints.
+          // NOTE: Hints added AFTER this point will be broadcast to all currently running
+          // local agents via the listener below.
+          const startIndex =
+            this.context.config.injectionService.getLatestInjectionIndex();
+          this.context.config.injectionService.onInjection(injectionListener);
 
-          // If status is 'continue', update message for the next loop
-          currentMessage = turnResult.nextMessage;
+          try {
+            const initialHints =
+              this.context.config.injectionService.getInjectionsAfter(
+                startIndex,
+                'user_steering',
+              );
+            const formattedInitialHints = formatUserHintsForModel(initialHints);
 
-          // Prepend inter-turn injections. User hints are unshifted first so
-          // that bg completions (unshifted second) appear before them in the
-          // final message — the model sees context before the user's reaction.
-          if (pendingHintsQueue.length > 0) {
-            const hintsToProcess = [...pendingHintsQueue];
-            pendingHintsQueue.length = 0;
-            const formattedHints = formatUserHintsForModel(hintsToProcess);
-            if (formattedHints) {
-              currentMessage.parts ??= [];
-              currentMessage.parts.unshift({ text: formattedHints });
+            // Inject loaded memory files (JIT + extension/project memory)
+            const environmentMemory =
+              this.context.config.isJitContextEnabled?.()
+                ? this.context.config.getSessionMemory()
+                : this.context.config.getEnvironmentMemory();
+
+            const initialParts: Part[] = [];
+            if (environmentMemory) {
+              initialParts.push({ text: environmentMemory });
+            }
+            if (formattedInitialHints) {
+              initialParts.push({ text: formattedInitialHints });
+            }
+            initialParts.push({ text: query });
+
+            let currentMessage: Content = {
+              role: 'user',
+              parts: initialParts,
+            };
+
+            while (true) {
+              // Check for termination conditions like max turns.
+              const reason = this.checkTermination(turnCounter, maxTurns);
+              if (reason) {
+                terminateReason = reason;
+                break;
+              }
+
+              // Check for timeout or external abort.
+              if (combinedSignal.aborted) {
+                // Determine which signal caused the abort.
+                terminateReason = deadlineTimer.signal.aborted
+                  ? AgentTerminateMode.TIMEOUT
+                  : AgentTerminateMode.ABORTED;
+                break;
+              }
+
+              const turnResult = await this.executeTurn(
+                chat,
+                currentMessage,
+                turnCounter++,
+                combinedSignal,
+                deadlineTimer.signal,
+                onWaitingForConfirmation,
+              );
+
+              if (turnResult.status === 'stop') {
+                terminateReason = turnResult.terminateReason;
+                // Only set finalResult if the turn provided one (e.g., error or goal).
+                if (turnResult.finalResult) {
+                  finalResult = turnResult.finalResult;
+                }
+                break; // Exit the loop for *any* stop reason.
+              }
+
+              // If status is 'continue', update message for the next loop
+              currentMessage = turnResult.nextMessage;
+
+              // Prepend inter-turn injections. User hints are unshifted first so
+              // that bg completions (unshifted second) appear before them in the
+              // final message — the model sees context before the user's reaction.
+              if (pendingHintsQueue.length > 0) {
+                const hintsToProcess = [...pendingHintsQueue];
+                pendingHintsQueue.length = 0;
+                const formattedHints = formatUserHintsForModel(hintsToProcess);
+                if (formattedHints) {
+                  currentMessage.parts ??= [];
+                  currentMessage.parts.unshift({ text: formattedHints });
+                }
+              }
+
+              if (pendingBgCompletionsQueue.length > 0) {
+                const bgText = pendingBgCompletionsQueue.join('\n');
+                pendingBgCompletionsQueue.length = 0;
+                currentMessage.parts ??= [];
+                currentMessage.parts.unshift({
+                  text: formatBackgroundCompletionForModel(bgText),
+                });
+              }
+            }
+          } finally {
+            this.context.config.injectionService.offInjection(
+              injectionListener,
+            );
+
+            const globalMcpManager = this.context.config.getMcpClientManager();
+            if (globalMcpManager) {
+              globalMcpManager.removeRegistries({
+                toolRegistry: this.toolRegistry,
+                promptRegistry: this.promptRegistry,
+                resourceRegistry: this.resourceRegistry,
+              });
             }
           }
 
-          if (pendingBgCompletionsQueue.length > 0) {
-            const bgText = pendingBgCompletionsQueue.join('\n');
-            pendingBgCompletionsQueue.length = 0;
-            currentMessage.parts ??= [];
-            currentMessage.parts.unshift({
-              text: formatBackgroundCompletionForModel(bgText),
-            });
+          // === UNIFIED RECOVERY BLOCK ===
+          // Only attempt recovery if it's a known recoverable reason.
+          // We don't recover from GOAL (already done) or ABORTED (user cancelled).
+          if (
+            terminateReason !== AgentTerminateMode.ERROR &&
+            terminateReason !== AgentTerminateMode.ABORTED &&
+            terminateReason !== AgentTerminateMode.GOAL
+          ) {
+            const recoveryResult = await this.executeFinalWarningTurn(
+              chat,
+              turnCounter, // Use current turnCounter for the recovery attempt
+              terminateReason,
+              signal, // Pass the external signal
+              onWaitingForConfirmation,
+            );
+
+            if (recoveryResult !== null) {
+              // Recovery Succeeded
+              terminateReason = AgentTerminateMode.GOAL;
+              finalResult = recoveryResult;
+            } else {
+              // Recovery Failed. Set the final error message based on the *original* reason.
+              if (terminateReason === AgentTerminateMode.TIMEOUT) {
+                finalResult = `Agent timed out after ${maxTimeMinutes} minutes.`;
+                this.emitActivity('ERROR', {
+                  error: finalResult,
+                  context: 'timeout',
+                  errorType: SubagentActivityErrorType.GENERIC,
+                });
+              } else if (terminateReason === AgentTerminateMode.MAX_TURNS) {
+                finalResult = `Agent reached max turns limit (${maxTurns}).`;
+                this.emitActivity('ERROR', {
+                  error: finalResult,
+                  context: 'max_turns',
+                  errorType: SubagentActivityErrorType.GENERIC,
+                });
+              } else if (
+                terminateReason ===
+                AgentTerminateMode.ERROR_NO_COMPLETE_TASK_CALL
+              ) {
+                // The finalResult was already set by executeTurn, but we re-emit just in case.
+                finalResult =
+                  finalResult ||
+                  `Agent stopped calling tools but did not call '${TASK_COMPLETE_TOOL_NAME}'.`;
+                this.emitActivity('ERROR', {
+                  error: finalResult,
+                  context: 'protocol_violation',
+                  errorType: SubagentActivityErrorType.GENERIC,
+                });
+              }
+            }
           }
-        }
-      } finally {
-        this.context.config.injectionService.offInjection(injectionListener);
 
-        const globalMcpManager = this.context.config.getMcpClientManager();
-        if (globalMcpManager) {
-          globalMcpManager.removeRegistries({
-            toolRegistry: this.toolRegistry,
-            promptRegistry: this.promptRegistry,
-            resourceRegistry: this.resourceRegistry,
-          });
-        }
-      }
+          // === FINAL RETURN LOGIC ===
+          if (terminateReason === AgentTerminateMode.GOAL) {
+            return {
+              result: finalResult || 'Task completed.',
+              terminate_reason: terminateReason,
+            };
+          }
 
-      // === UNIFIED RECOVERY BLOCK ===
-      // Only attempt recovery if it's a known recoverable reason.
-      // We don't recover from GOAL (already done) or ABORTED (user cancelled).
-      if (
-        terminateReason !== AgentTerminateMode.ERROR &&
-        terminateReason !== AgentTerminateMode.ABORTED &&
-        terminateReason !== AgentTerminateMode.GOAL
-      ) {
-        const recoveryResult = await this.executeFinalWarningTurn(
-          chat,
-          turnCounter, // Use current turnCounter for the recovery attempt
-          terminateReason,
-          signal, // Pass the external signal
-          onWaitingForConfirmation,
-        );
+          return {
+            result:
+              finalResult ||
+              'Agent execution was terminated before completion.',
+            terminate_reason: terminateReason,
+          };
+        } catch (error) {
+          // Check if the error is an AbortError caused by our internal timeout.
+          if (
+            error instanceof Error &&
+            error.name === 'AbortError' &&
+            deadlineTimer.signal.aborted &&
+            !signal.aborted // Ensure the external signal was not the cause
+          ) {
+            terminateReason = AgentTerminateMode.TIMEOUT;
 
-        if (recoveryResult !== null) {
-          // Recovery Succeeded
-          terminateReason = AgentTerminateMode.GOAL;
-          finalResult = recoveryResult;
-        } else {
-          // Recovery Failed. Set the final error message based on the *original* reason.
-          if (terminateReason === AgentTerminateMode.TIMEOUT) {
+            // Also use the unified recovery logic here
+            if (chat && tools) {
+              const recoveryResult = await this.executeFinalWarningTurn(
+                chat,
+                turnCounter, // Use current turnCounter
+                AgentTerminateMode.TIMEOUT,
+                signal,
+                onWaitingForConfirmation,
+              );
+
+              if (recoveryResult !== null) {
+                // Recovery Succeeded
+                terminateReason = AgentTerminateMode.GOAL;
+                finalResult = recoveryResult;
+                return {
+                  result: finalResult,
+                  terminate_reason: terminateReason,
+                };
+              }
+            }
+
+            // Recovery failed or wasn't possible
             finalResult = `Agent timed out after ${maxTimeMinutes} minutes.`;
             this.emitActivity('ERROR', {
               error: finalResult,
               context: 'timeout',
               errorType: SubagentActivityErrorType.GENERIC,
             });
-          } else if (terminateReason === AgentTerminateMode.MAX_TURNS) {
-            finalResult = `Agent reached max turns limit (${maxTurns}).`;
-            this.emitActivity('ERROR', {
-              error: finalResult,
-              context: 'max_turns',
-              errorType: SubagentActivityErrorType.GENERIC,
-            });
-          } else if (
-            terminateReason === AgentTerminateMode.ERROR_NO_COMPLETE_TASK_CALL
-          ) {
-            // The finalResult was already set by executeTurn, but we re-emit just in case.
-            finalResult =
-              finalResult ||
-              `Agent stopped calling tools but did not call '${TASK_COMPLETE_TOOL_NAME}'.`;
-            this.emitActivity('ERROR', {
-              error: finalResult,
-              context: 'protocol_violation',
-              errorType: SubagentActivityErrorType.GENERIC,
-            });
-          }
-        }
-      }
-
-      // === FINAL RETURN LOGIC ===
-      if (terminateReason === AgentTerminateMode.GOAL) {
-        return {
-          result: finalResult || 'Task completed.',
-          terminate_reason: terminateReason,
-        };
-      }
-
-      return {
-        result:
-          finalResult || 'Agent execution was terminated before completion.',
-        terminate_reason: terminateReason,
-      };
-    } catch (error) {
-      // Check if the error is an AbortError caused by our internal timeout.
-      if (
-        error instanceof Error &&
-        error.name === 'AbortError' &&
-        deadlineTimer.signal.aborted &&
-        !signal.aborted // Ensure the external signal was not the cause
-      ) {
-        terminateReason = AgentTerminateMode.TIMEOUT;
-
-        // Also use the unified recovery logic here
-        if (chat && tools) {
-          const recoveryResult = await this.executeFinalWarningTurn(
-            chat,
-            turnCounter, // Use current turnCounter
-            AgentTerminateMode.TIMEOUT,
-            signal,
-            onWaitingForConfirmation,
-          );
-
-          if (recoveryResult !== null) {
-            // Recovery Succeeded
-            terminateReason = AgentTerminateMode.GOAL;
-            finalResult = recoveryResult;
             return {
               result: finalResult,
               terminate_reason: terminateReason,
             };
           }
+
+          this.emitActivity('ERROR', {
+            error: String(error),
+            errorType: SubagentActivityErrorType.GENERIC,
+          });
+          throw error; // Re-throw other errors or external aborts.
+        } finally {
+          deadlineTimer.abort();
+          logAgentFinish(
+            this.context.config,
+            new AgentFinishEvent(
+              this.agentId,
+              this.definition.name,
+              Date.now() - startTime,
+              turnCounter,
+              terminateReason,
+            ),
+          );
         }
-
-        // Recovery failed or wasn't possible
-        finalResult = `Agent timed out after ${maxTimeMinutes} minutes.`;
-        this.emitActivity('ERROR', {
-          error: finalResult,
-          context: 'timeout',
-          errorType: SubagentActivityErrorType.GENERIC,
-        });
-        return {
-          result: finalResult,
-          terminate_reason: terminateReason,
-        };
-      }
-
-      this.emitActivity('ERROR', {
-        error: String(error),
-        errorType: SubagentActivityErrorType.GENERIC,
-      });
-      throw error; // Re-throw other errors or external aborts.
-    } finally {
-      deadlineTimer.abort();
-      logAgentFinish(
-        this.context.config,
-        new AgentFinishEvent(
-          this.agentId,
-          this.definition.name,
-          Date.now() - startTime,
-          turnCounter,
-          terminateReason,
-        ),
-      );
-    }
+      }, // end of runWithWorkspaceScope callback
+    );
   }
 
   private async tryCompressChat(

--- a/packages/core/src/agents/memory-manager-agent.test.ts
+++ b/packages/core/src/agents/memory-manager-agent.test.ts
@@ -150,4 +150,10 @@ describe('MemoryManagerAgent', () => {
     const agent = MemoryManagerAgent(createMockConfig());
     expect(agent.modelConfig.model).toBe('flash');
   });
+
+  it('should declare workspaceDirs with the global gemini directory', () => {
+    const agent = MemoryManagerAgent(createMockConfig());
+    const globalGeminiDir = Storage.getGlobalGeminiDir();
+    expect(agent.workspaceDirs).toEqual([globalGeminiDir]);
+  });
 });

--- a/packages/core/src/agents/memory-manager-agent.ts
+++ b/packages/core/src/agents/memory-manager-agent.ts
@@ -131,6 +131,7 @@ reply with what you need, and exit. Do not search the codebase for the missing c
     modelConfig: {
       model: GEMINI_MODEL_ALIAS_FLASH,
     },
+    workspaceDirs: [globalGeminiDir],
     toolConfig: {
       tools: [
         READ_FILE_TOOL_NAME,

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -261,21 +261,10 @@ export class AgentRegistry {
     }
 
     // Register the memory manager agent as a replacement for the save_memory tool.
+    // The agent declares its own workspaceDirs (e.g., ~/.gemini) in its definition,
+    // and LocalAgentExecutor creates a scoped child WorkspaceContext for it.
     if (this.config.isMemoryManagerEnabled()) {
       this.registerLocalAgent(MemoryManagerAgent(this.config));
-
-      // Ensure the global .gemini directory is accessible to tools.
-      // This allows the save_memory agent to read and write to it.
-      // Access control is enforced by the Policy Engine (memory-manager.toml).
-      try {
-        const globalDir = Storage.getGlobalGeminiDir();
-        this.config.getWorkspaceContext().addDirectory(globalDir);
-      } catch (e) {
-        debugLogger.warn(
-          `[AgentRegistry] Could not add global .gemini directory to workspace:`,
-          e,
-        );
-      }
     }
   }
 

--- a/packages/core/src/agents/types.ts
+++ b/packages/core/src/agents/types.ts
@@ -215,6 +215,16 @@ export interface LocalAgentDefinition<
   toolConfig?: ToolConfig;
 
   /**
+   * Optional additional workspace directories scoped to this agent.
+   * These directories are added to a child WorkspaceContext for this agent only,
+   * without affecting the parent or other agents' workspace visibility.
+   *
+   * Example: The memory manager agent uses this to access ~/.gemini
+   * without leaking that directory to the main agent.
+   */
+  workspaceDirs?: string[];
+
+  /**
    * Optional inline MCP servers for this agent.
    */
   mcpServers?: Record<string, MCPServerConfig>;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -6,6 +6,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { SandboxPolicyManager } from '../policy/sandboxPolicyManager.js';
 import { inspect } from 'node:util';
 import process from 'node:process';
@@ -734,6 +735,14 @@ export interface ConfigParameters {
 }
 
 export class Config implements McpContext, AgentLoopContext {
+  /**
+   * Async-context-scoped workspace override. Each async execution tree (e.g., a
+   * subagent) gets its own store value, so concurrent subagents never trample
+   * each other's workspace views.
+   */
+  private static readonly workspaceScopeStorage =
+    new AsyncLocalStorage<WorkspaceContext>();
+
   private _toolRegistry!: ToolRegistry;
   private mcpClientManager?: McpClientManager;
   private readonly a2aClientManager?: A2AClientManager;
@@ -1989,7 +1998,28 @@ export class Config implements McpContext, AgentLoopContext {
   }
 
   getWorkspaceContext(): WorkspaceContext {
-    return this.workspaceContext;
+    return Config.workspaceScopeStorage.getStore() ?? this.workspaceContext;
+  }
+
+  /**
+   * Runs `fn` with an expanded workspace context that includes `additionalDirs`.
+   * The expanded scope is visible only within the async execution tree of `fn`,
+   * so concurrent subagents each get their own isolated workspace view.
+   *
+   * @param additionalDirs Directories to add to the scoped workspace.
+   * @param fn The async function to run within the scoped workspace.
+   * @returns The return value of `fn`.
+   */
+  runWithWorkspaceScope<T>(
+    additionalDirs: string[],
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    if (additionalDirs.length === 0) {
+      return fn();
+    }
+    const base = this.getWorkspaceContext();
+    const scoped = base.createChildScope(additionalDirs);
+    return Config.workspaceScopeStorage.run(scoped, fn);
   }
 
   getAgentRegistry(): AgentRegistry {

--- a/packages/core/src/config/path-validation.test.ts
+++ b/packages/core/src/config/path-validation.test.ts
@@ -65,4 +65,130 @@ describe('Config Path Validation', () => {
     expect(config.isPathAllowed(workspacePath)).toBe(true);
     expect(config.validatePathAccess(workspacePath, 'read')).toBeNull();
   });
+
+  describe('runWithWorkspaceScope', () => {
+    it('should temporarily extend workspace with additional directories', async () => {
+      const geminiMdPath = path.join(globalGeminiDir, 'GEMINI.md');
+
+      // Before scope, should be denied
+      expect(
+        config.getWorkspaceContext().isPathWithinWorkspace(geminiMdPath),
+      ).toBe(false);
+
+      await config.runWithWorkspaceScope([globalGeminiDir], async () => {
+        // During scope, should be allowed
+        expect(
+          config.getWorkspaceContext().isPathWithinWorkspace(geminiMdPath),
+        ).toBe(true);
+        expect(config.getWorkspaceContext().getDirectories()).toContain(
+          globalGeminiDir,
+        );
+      });
+
+      // After scope, should be denied again
+      expect(
+        config.getWorkspaceContext().isPathWithinWorkspace(geminiMdPath),
+      ).toBe(false);
+      expect(config.getWorkspaceContext().getDirectories()).not.toContain(
+        globalGeminiDir,
+      );
+    });
+
+    it('should run fn directly when given empty array', async () => {
+      const dirsBefore = config.getWorkspaceContext().getDirectories();
+      await config.runWithWorkspaceScope([], async () => {
+        const dirsInside = config.getWorkspaceContext().getDirectories();
+        expect(dirsInside).toEqual(dirsBefore);
+      });
+    });
+
+    it('should support nested scopes', async () => {
+      const extraDir = '/mock/extra';
+      const geminiMdPath = path.join(globalGeminiDir, 'GEMINI.md');
+      const extraPath = path.join(extraDir, 'file.txt');
+
+      await config.runWithWorkspaceScope([globalGeminiDir], async () => {
+        expect(
+          config.getWorkspaceContext().isPathWithinWorkspace(geminiMdPath),
+        ).toBe(true);
+        expect(
+          config.getWorkspaceContext().isPathWithinWorkspace(extraPath),
+        ).toBe(false);
+
+        await config.runWithWorkspaceScope([extraDir], async () => {
+          expect(
+            config.getWorkspaceContext().isPathWithinWorkspace(geminiMdPath),
+          ).toBe(true);
+          expect(
+            config.getWorkspaceContext().isPathWithinWorkspace(extraPath),
+          ).toBe(true);
+        });
+
+        // After inner scope pops, extraPath should be denied
+        expect(
+          config.getWorkspaceContext().isPathWithinWorkspace(geminiMdPath),
+        ).toBe(true);
+        expect(
+          config.getWorkspaceContext().isPathWithinWorkspace(extraPath),
+        ).toBe(false);
+      });
+
+      // After all scopes pop
+      expect(
+        config.getWorkspaceContext().isPathWithinWorkspace(geminiMdPath),
+      ).toBe(false);
+    });
+
+    it('should isolate concurrent scopes from each other', async () => {
+      const dirA = '/mock/dir-a';
+      const dirB = '/mock/dir-b';
+      const pathA = path.join(dirA, 'a.txt');
+      const pathB = path.join(dirB, 'b.txt');
+
+      await Promise.all([
+        config.runWithWorkspaceScope([dirA], async () => {
+          // Agent A should see dirA but not dirB
+          expect(
+            config.getWorkspaceContext().isPathWithinWorkspace(pathA),
+          ).toBe(true);
+          expect(
+            config.getWorkspaceContext().isPathWithinWorkspace(pathB),
+          ).toBe(false);
+          // Simulate async work to ensure interleaving
+          await new Promise((r) => setTimeout(r, 10));
+          // Still isolated after yielding
+          expect(
+            config.getWorkspaceContext().isPathWithinWorkspace(pathA),
+          ).toBe(true);
+          expect(
+            config.getWorkspaceContext().isPathWithinWorkspace(pathB),
+          ).toBe(false);
+        }),
+        config.runWithWorkspaceScope([dirB], async () => {
+          // Agent B should see dirB but not dirA
+          expect(
+            config.getWorkspaceContext().isPathWithinWorkspace(pathB),
+          ).toBe(true);
+          expect(
+            config.getWorkspaceContext().isPathWithinWorkspace(pathA),
+          ).toBe(false);
+          await new Promise((r) => setTimeout(r, 10));
+          expect(
+            config.getWorkspaceContext().isPathWithinWorkspace(pathB),
+          ).toBe(true);
+          expect(
+            config.getWorkspaceContext().isPathWithinWorkspace(pathA),
+          ).toBe(false);
+        }),
+      ]);
+
+      // After both complete, neither should be visible
+      expect(config.getWorkspaceContext().isPathWithinWorkspace(pathA)).toBe(
+        false,
+      );
+      expect(config.getWorkspaceContext().isPathWithinWorkspace(pathB)).toBe(
+        false,
+      );
+    });
+  });
 });

--- a/packages/core/src/utils/workspaceContext.test.ts
+++ b/packages/core/src/utils/workspaceContext.test.ts
@@ -493,3 +493,83 @@ describe('WorkspaceContext with optional directories', () => {
     expect(debugLogger.warn).not.toHaveBeenCalled();
   });
 });
+
+describe('WorkspaceContext.createChildScope', () => {
+  let tempDir: string;
+  let cwd: string;
+  let extraDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'workspace-context-child-')),
+    );
+    cwd = path.join(tempDir, 'project');
+    extraDir = path.join(tempDir, 'extra');
+    fs.mkdirSync(cwd, { recursive: true });
+    fs.mkdirSync(extraDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should create a child with parent directories plus additional ones', () => {
+    const parent = new WorkspaceContext(cwd);
+    const child = parent.createChildScope([extraDir]);
+
+    expect(child.getDirectories()).toEqual([cwd, extraDir]);
+  });
+
+  it('should not modify the parent workspace', () => {
+    const parent = new WorkspaceContext(cwd);
+    parent.createChildScope([extraDir]);
+
+    expect(parent.getDirectories()).toEqual([cwd]);
+  });
+
+  it('should create an independent child that does not affect the parent', () => {
+    const parent = new WorkspaceContext(cwd);
+    const child = parent.createChildScope([]);
+
+    const anotherDir = path.join(tempDir, 'another');
+    fs.mkdirSync(anotherDir, { recursive: true });
+    child.addDirectory(anotherDir);
+
+    expect(child.getDirectories()).toContain(anotherDir);
+    expect(parent.getDirectories()).not.toContain(anotherDir);
+  });
+
+  it('child should allow paths within extra directories', () => {
+    const parent = new WorkspaceContext(cwd);
+    const child = parent.createChildScope([extraDir]);
+
+    const fileInExtra = path.join(extraDir, 'GEMINI.md');
+    expect(child.isPathWithinWorkspace(fileInExtra)).toBe(true);
+    expect(parent.isPathWithinWorkspace(fileInExtra)).toBe(false);
+  });
+
+  it('should return same directories when called with empty array', () => {
+    const parent = new WorkspaceContext(cwd);
+    const child = parent.createChildScope([]);
+
+    expect(child.getDirectories()).toEqual(parent.getDirectories());
+  });
+
+  it('should inherit readOnlyPaths from the parent', () => {
+    const readOnlyDir = path.join(tempDir, 'readonly');
+    fs.mkdirSync(readOnlyDir, { recursive: true });
+    const readOnlyFile = path.join(readOnlyDir, 'data.txt');
+    fs.writeFileSync(readOnlyFile, 'test');
+
+    const parent = new WorkspaceContext(cwd);
+    parent.addReadOnlyPath(readOnlyDir);
+
+    // Parent allows reading
+    expect(parent.isPathReadable(readOnlyFile)).toBe(true);
+
+    const child = parent.createChildScope([extraDir]);
+
+    // Child should also allow reading the parent's read-only path
+    expect(child.isPathReadable(readOnlyFile)).toBe(true);
+  });
+});

--- a/packages/core/src/utils/workspaceContext.ts
+++ b/packages/core/src/utils/workspaceContext.ts
@@ -174,6 +174,29 @@ export class WorkspaceContext {
   }
 
   /**
+   * Creates a child WorkspaceContext that inherits all directories from this context
+   * plus any additional directories. The child is an independent instance — mutations
+   * to it do not affect the parent, and vice-versa.
+   *
+   * This is used to give subagents a scoped view of the workspace that may include
+   * extra directories (e.g., ~/.gemini for the memory manager) without leaking those
+   * directories to the parent or other agents.
+   *
+   * @param additionalDirectories Extra directories to include in the child scope.
+   * @returns A new WorkspaceContext with the combined set of directories.
+   */
+  createChildScope(additionalDirectories: string[] = []): WorkspaceContext {
+    const childDirs = [...this.getDirectories(), ...additionalDirectories];
+    // Use the same targetDir so relative path resolution is consistent.
+    const child = new WorkspaceContext(this.targetDir, childDirs.slice(1));
+    // Carry over read-only paths so the child inherits the parent's read allowances.
+    for (const roPath of this.readOnlyPaths) {
+      child.readOnlyPaths.add(roPath);
+    }
+    return child;
+  }
+
+  /**
    * Checks if a given path is within any of the workspace directories.
    * @param pathToCheck The path to validate
    * @returns True if the path is within the workspace, false otherwise


### PR DESCRIPTION
## Summary

Scope subagent workspace directories using `AsyncLocalStorage` instead of mutating shared state. Previously, registering the memory manager permanently added `~/.gemini` to the global `WorkspaceContext`, leaking it to the main agent and all other subagents. This PR introduces per-agent workspace scoping that is concurrency-safe.

## Details

**Problem:** The old approach in `AgentRegistry` called `addDirectory(globalGeminiDir)` on the shared `WorkspaceContext`, permanently exposing `~/.gemini` to every agent.

**Solution — three layers:**

1. **`workspaceDirs` on `LocalAgentDefinition`** — agents can now declaratively specify extra directories they need (e.g., the memory manager declares `[~/.gemini]`).
2. **`runWithWorkspaceScope()` on `Config`** — uses `AsyncLocalStorage` (matching the existing `toolCallContext`/`promptIdContext` pattern) so each subagent's async execution tree gets its own isolated workspace view. Concurrent subagents never trample each other.
3. **`createChildScope()` on `WorkspaceContext`** — creates an independent child context inheriting the parent's directories and `readOnlyPaths`.

## Related Issues

Fixes #18007

## How to Validate

```bash
npm test -w @google/gemini-cli-core -- src/config/path-validation.test.ts src/utils/workspaceContext.test.ts src/agents/memory-manager-agent.test.ts
```

Key test cases:
- `should isolate concurrent scopes from each other` — runs two scopes via `Promise.all` and verifies no leaking
- `should support nested scopes` — verifies correct nesting behavior
- `should inherit readOnlyPaths from the parent` — verifies Bug 1 fix

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
