### PR TITLE
refactor(devtools): lazy F12-triggered connection, remove all buffers and auto-promotion

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -464,13 +464,6 @@ export async function main() {
 
     adminControlsListner.setConfig(config);
 
-    if (config.isInteractive() && settings.merged.general.devtools) {
-      const { setupInitialActivityLogger } = await import(
-        './utils/devtoolsService.js'
-      );
-      await setupInitialActivityLogger(config);
-    }
-
     // Register config for telemetry shutdown
     // This ensures telemetry (including SessionEnd hooks) is properly flushed on exit
     registerTelemetryConfig(config);

--- a/packages/cli/src/utils/activityLogger.test.ts
+++ b/packages/cli/src/utils/activityLogger.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ActivityLogger, type NetworkLog } from './activityLogger.js';
 import type { ConsoleLogPayload } from '@google/gemini-cli-core';
 
@@ -13,44 +13,81 @@ describe('ActivityLogger', () => {
 
   beforeEach(() => {
     logger = ActivityLogger.getInstance();
-    logger.clearBufferedLogs();
+    logger.removeAllListeners();
   });
 
-  it('buffers the last 10 requests with all their events grouped', () => {
-    // Emit 15 requests, each with an initial + response event
-    for (let i = 0; i < 15; i++) {
-      const initial: NetworkLog = {
-        id: `req-${i}`,
-        timestamp: i * 2,
-        method: 'GET',
-        url: 'http://example.com',
-        headers: {},
-        pending: true,
-      };
-      logger.emitNetworkEvent(initial);
-      logger.emitNetworkEvent({
-        id: `req-${i}`,
-        pending: false,
-        response: {
-          status: 200,
-          headers: {},
-          body: 'ok',
-          durationMs: 10,
+  it('emits network events with sanitized headers', () => {
+    const events: unknown[] = [];
+    logger.on('network', (payload) => events.push(payload));
+
+    const log: NetworkLog = {
+      id: 'req-1',
+      timestamp: 1,
+      method: 'GET',
+      url: 'http://example.com',
+      headers: {
+        'content-type': 'application/json',
+        authorization: 'Bearer secret',
+        'x-goog-api-key': 'my-api-key',
+      },
+      pending: true,
+    };
+    logger.emitNetworkEvent(log);
+
+    expect(events.length).toBe(1);
+    const emitted = events[0] as NetworkLog;
+    expect(emitted.headers['content-type']).toBe('application/json');
+    expect(emitted.headers['authorization']).toBe('[REDACTED]');
+    expect(emitted.headers['x-goog-api-key']).toBe('[REDACTED]');
+  });
+
+  it('emits network events with sanitized response headers', () => {
+    const events: unknown[] = [];
+    logger.on('network', (payload) => events.push(payload));
+
+    logger.emitNetworkEvent({
+      id: 'req-2',
+      pending: false,
+      response: {
+        status: 200,
+        headers: {
+          'content-type': 'text/html',
+          'set-cookie': 'session=abc123',
         },
-      });
-    }
+        body: 'ok',
+        durationMs: 10,
+      },
+    });
 
-    const logs = logger.getBufferedLogs();
-    // 10 requests * 2 events each = 20 events
-    expect(logs.network.length).toBe(20);
-    // Oldest kept should be req-5 (first 5 evicted)
-    expect(logs.network[0].id).toBe('req-5');
-    // Last should be req-14
-    expect(logs.network[19].id).toBe('req-14');
+    expect(events.length).toBe(1);
+    const emitted = events[0] as NetworkLog;
+    expect(emitted.response?.headers['content-type']).toBe('text/html');
+    expect(emitted.response?.headers['set-cookie']).toBe('[REDACTED]');
   });
 
-  it('keeps all chunk events for a buffered request', () => {
-    // One request with many chunks
+  it('emits console events with timestamp', () => {
+    const events: unknown[] = [];
+    logger.on('console', (payload) => events.push(payload));
+
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    const log: ConsoleLogPayload = { content: 'hello', type: 'log' };
+    logger.logConsole(log);
+
+    expect(events.length).toBe(1);
+    const emitted = events[0] as ConsoleLogPayload & { timestamp: number };
+    expect(emitted.content).toBe('hello');
+    expect(emitted.type).toBe('log');
+    expect(emitted.timestamp).toBe(now);
+
+    vi.useRealTimers();
+  });
+
+  it('emits multiple network events for the same request id', () => {
+    const events: unknown[] = [];
+    logger.on('network', (payload) => events.push(payload));
+
     logger.emitNetworkEvent({
       id: 'chunked',
       timestamp: 1,
@@ -59,7 +96,7 @@ describe('ActivityLogger', () => {
       headers: {},
       pending: true,
     });
-    for (let i = 0; i < 5; i++) {
+    for (let i = 0; i < 3; i++) {
       logger.emitNetworkEvent({
         id: 'chunked',
         pending: true,
@@ -72,64 +109,20 @@ describe('ActivityLogger', () => {
       response: { status: 200, headers: {}, body: 'done', durationMs: 50 },
     });
 
-    const logs = logger.getBufferedLogs();
-    // 1 initial + 5 chunks + 1 response = 7 events, all for 'chunked'
-    expect(logs.network.length).toBe(7);
-    expect(logs.network.every((l) => l.id === 'chunked')).toBe(true);
+    // 1 initial + 3 chunks + 1 response = 5 events
+    expect(events.length).toBe(5);
+    expect(events.every((e) => (e as NetworkLog).id === 'chunked')).toBe(true);
   });
 
-  it('buffers only the last 10 console logs', () => {
+  it('emits console events without buffering', () => {
+    const events: unknown[] = [];
+    logger.on('console', (payload) => events.push(payload));
+
     for (let i = 0; i < 15; i++) {
-      const log: ConsoleLogPayload = { content: `log-${i}`, type: 'log' };
-      logger.logConsole(log);
+      logger.logConsole({ content: `log-${i}`, type: 'log' });
     }
 
-    const logs = logger.getBufferedLogs();
-    expect(logs.console.length).toBe(10);
-    expect(logs.console[0].content).toBe('log-5');
-    expect(logs.console[9].content).toBe('log-14');
-  });
-
-  it('getBufferedLogs is non-destructive', () => {
-    logger.logConsole({ content: 'test', type: 'log' });
-    const first = logger.getBufferedLogs();
-    const second = logger.getBufferedLogs();
-    expect(first.console.length).toBe(1);
-    expect(second.console.length).toBe(1);
-  });
-
-  it('clearBufferedLogs empties both buffers', () => {
-    logger.logConsole({ content: 'test', type: 'log' });
-    logger.emitNetworkEvent({
-      id: 'r1',
-      timestamp: 1,
-      method: 'GET',
-      url: 'http://example.com',
-      headers: {},
-    });
-    logger.clearBufferedLogs();
-    const logs = logger.getBufferedLogs();
-    expect(logs.console.length).toBe(0);
-    expect(logs.network.length).toBe(0);
-  });
-
-  it('drainBufferedLogs returns and clears atomically', () => {
-    logger.logConsole({ content: 'drain-test', type: 'log' });
-    logger.emitNetworkEvent({
-      id: 'r1',
-      timestamp: 1,
-      method: 'GET',
-      url: 'http://example.com',
-      headers: {},
-    });
-
-    const drained = logger.drainBufferedLogs();
-    expect(drained.console.length).toBe(1);
-    expect(drained.network.length).toBe(1);
-
-    // Buffer should now be empty
-    const after = logger.getBufferedLogs();
-    expect(after.console.length).toBe(0);
-    expect(after.network.length).toBe(0);
+    // All 15 events should be emitted (no buffer eviction)
+    expect(events.length).toBe(15);
   });
 });

--- a/packages/cli/src/utils/activityLogger.ts
+++ b/packages/cli/src/utils/activityLogger.ts
@@ -20,7 +20,6 @@ import {
 import WebSocket from 'ws';
 
 const ACTIVITY_ID_HEADER = 'x-activity-request-id';
-const MAX_BUFFER_SIZE = 100;
 
 function isHeaderRecord(
   h: http.OutgoingHttpHeaders | readonly string[],
@@ -131,75 +130,12 @@ export class ActivityLogger extends EventEmitter {
   private static instance: ActivityLogger;
   private isInterceptionEnabled = false;
   private requestStartTimes = new Map<string, number>();
-  private networkLoggingEnabled = false;
-
-  private networkBufferMap = new Map<
-    string,
-    Array<NetworkLog | PartialNetworkLog>
-  >();
-  private networkBufferIds: string[] = [];
-  private consoleBuffer: Array<ConsoleLogPayload & { timestamp: number }> = [];
-  private readonly bufferLimit = 10;
 
   static getInstance(): ActivityLogger {
     if (!ActivityLogger.instance) {
       ActivityLogger.instance = new ActivityLogger();
     }
     return ActivityLogger.instance;
-  }
-
-  enableNetworkLogging() {
-    this.networkLoggingEnabled = true;
-    this.emit('network-logging-enabled');
-  }
-
-  disableNetworkLogging() {
-    this.networkLoggingEnabled = false;
-  }
-
-  isNetworkLoggingEnabled(): boolean {
-    return this.networkLoggingEnabled;
-  }
-
-  /**
-   * Atomically returns and clears all buffered logs.
-   * Prevents data loss from events emitted between get and clear.
-   */
-  drainBufferedLogs(): {
-    network: Array<NetworkLog | PartialNetworkLog>;
-    console: Array<ConsoleLogPayload & { timestamp: number }>;
-  } {
-    const network: Array<NetworkLog | PartialNetworkLog> = [];
-    for (const id of this.networkBufferIds) {
-      const events = this.networkBufferMap.get(id);
-      if (events) network.push(...events);
-    }
-    const console = [...this.consoleBuffer];
-    this.networkBufferMap.clear();
-    this.networkBufferIds = [];
-    this.consoleBuffer = [];
-    return { network, console };
-  }
-
-  getBufferedLogs(): {
-    network: Array<NetworkLog | PartialNetworkLog>;
-    console: Array<ConsoleLogPayload & { timestamp: number }>;
-  } {
-    const network: Array<NetworkLog | PartialNetworkLog> = [];
-    for (const id of this.networkBufferIds) {
-      const events = this.networkBufferMap.get(id);
-      if (events) network.push(...events);
-    }
-    return {
-      network,
-      console: [...this.consoleBuffer],
-    };
-  }
-
-  clearBufferedLogs(): void {
-    this.networkBufferMap.clear();
-    this.networkBufferIds = [];
-    this.consoleBuffer = [];
   }
 
   private stringifyHeaders(headers: unknown): Record<string, string> {
@@ -263,19 +199,6 @@ export class ActivityLogger extends EventEmitter {
 
   private safeEmitNetwork(payload: NetworkLog | PartialNetworkLog) {
     const sanitized = this.sanitizeNetworkLog(payload);
-    const id = sanitized.id;
-
-    if (!this.networkBufferMap.has(id)) {
-      this.networkBufferIds.push(id);
-      this.networkBufferMap.set(id, []);
-      // Evict oldest request group if over limit
-      if (this.networkBufferIds.length > this.bufferLimit) {
-        const evictId = this.networkBufferIds.shift()!;
-        this.networkBufferMap.delete(evictId);
-      }
-    }
-    this.networkBufferMap.get(id)!.push(sanitized);
-
     this.emit('network', sanitized);
   }
 
@@ -661,10 +584,6 @@ export class ActivityLogger extends EventEmitter {
 
   logConsole(payload: ConsoleLogPayload) {
     const enriched = { ...payload, timestamp: Date.now() };
-    this.consoleBuffer.push(enriched);
-    if (this.consoleBuffer.length > this.bufferLimit) {
-      this.consoleBuffer.shift();
-    }
     this.emit('console', enriched);
   }
 }
@@ -716,22 +635,20 @@ function setupFileLogging(
 }
 
 /**
- * Setup network-based logging via WebSocket
+ * Setup network-based logging via WebSocket.
+ * Sends events directly when connected; drops them when disconnected.
+ * Emits 'transport-connected' and 'transport-disconnected' on the capture
+ * instance so upstream services can track connection state.
  */
 function setupNetworkLogging(
   capture: ActivityLogger,
   host: string,
   port: number,
   config: Config,
-  onReconnectFailed?: () => void,
 ) {
-  const transportBuffer: object[] = [];
   let ws: WebSocket | null = null;
-  let reconnectTimer: NodeJS.Timeout | null = null;
   let sessionId: string | null = null;
   let pingInterval: NodeJS.Timeout | null = null;
-  let reconnectAttempts = 0;
-  const MAX_RECONNECT_ATTEMPTS = 2;
 
   const connect = () => {
     try {
@@ -739,7 +656,6 @@ function setupNetworkLogging(
 
       ws.on('open', () => {
         debugLogger.debug(`WebSocket connected to ${host}:${port}`);
-        reconnectAttempts = 0;
         // Register with CLI's session ID
         sendMessage({
           type: 'register',
@@ -773,7 +689,7 @@ function setupNetworkLogging(
       ws.on('close', () => {
         debugLogger.debug(`WebSocket disconnected from ${host}:${port}`);
         cleanup();
-        scheduleReconnect();
+        capture.emit('transport-disconnected');
       });
 
       ws.on('error', (err) => {
@@ -781,7 +697,6 @@ function setupNetworkLogging(
       });
     } catch (err) {
       debugLogger.debug(`Failed to connect WebSocket:`, err);
-      scheduleReconnect();
     }
   };
 
@@ -800,8 +715,7 @@ function setupNetworkLogging(
           sendMessage({ type: 'pong', timestamp: Date.now() });
         }, 15000);
 
-        // Flush buffered logs
-        flushBuffer();
+        capture.emit('transport-connected');
         break;
       case 'trigger-debugger': {
         import('node:inspector')
@@ -847,62 +761,8 @@ function setupNetworkLogging(
       timestamp: Date.now(),
     };
 
-    // If not connected or network logging not enabled, buffer
-    if (
-      !ws ||
-      ws.readyState !== WebSocket.OPEN ||
-      !capture.isNetworkLoggingEnabled()
-    ) {
-      transportBuffer.push(message);
-      if (transportBuffer.length > MAX_BUFFER_SIZE) transportBuffer.shift();
-      return;
-    }
-
-    sendMessage(message);
-  };
-
-  const flushBuffer = () => {
-    if (
-      !ws ||
-      ws.readyState !== WebSocket.OPEN ||
-      !capture.isNetworkLoggingEnabled()
-    ) {
-      return;
-    }
-
-    const { network, console: consoleLogs } = capture.drainBufferedLogs();
-    const allInitialLogs: Array<{
-      type: 'network' | 'console';
-      payload: object;
-      timestamp: number;
-    }> = [
-      ...network.map((l) => ({
-        type: 'network' as const,
-        payload: l,
-        timestamp: 'timestamp' in l && l.timestamp ? l.timestamp : Date.now(),
-      })),
-      ...consoleLogs.map((l) => ({
-        type: 'console' as const,
-        payload: l,
-        timestamp: l.timestamp,
-      })),
-    ].sort((a, b) => a.timestamp - b.timestamp);
-
-    debugLogger.debug(
-      `Flushing ${allInitialLogs.length} initial buffered logs and ${transportBuffer.length} transport buffered logs...`,
-    );
-
-    for (const log of allInitialLogs) {
-      sendMessage({
-        type: log.type,
-        payload: log.payload,
-        sessionId: sessionId || config.getSessionId(),
-        timestamp: Date.now(),
-      });
-    }
-
-    while (transportBuffer.length > 0) {
-      const message = transportBuffer.shift()!;
+    // Send directly if connected, otherwise drop
+    if (ws && ws.readyState === WebSocket.OPEN) {
       sendMessage(message);
     }
   };
@@ -915,39 +775,14 @@ function setupNetworkLogging(
     ws = null;
   };
 
-  const scheduleReconnect = () => {
-    if (reconnectTimer) return;
-
-    reconnectAttempts++;
-    if (reconnectAttempts > MAX_RECONNECT_ATTEMPTS && onReconnectFailed) {
-      debugLogger.debug(
-        `WebSocket reconnect failed after ${MAX_RECONNECT_ATTEMPTS} attempts, promoting to server...`,
-      );
-      onReconnectFailed();
-      return;
-    }
-
-    reconnectTimer = setTimeout(() => {
-      reconnectTimer = null;
-      debugLogger.debug('Reconnecting WebSocket...');
-      connect();
-    }, 1000);
-  };
-
   // Initial connection
   connect();
 
   capture.on('console', (payload) => sendToNetwork('console', payload));
   capture.on('network', (payload) => sendToNetwork('network', payload));
 
-  capture.on('network-logging-enabled', () => {
-    debugLogger.debug('Network logging enabled, flushing buffer...');
-    flushBuffer();
-  });
-
   // Cleanup on process exit
   process.on('exit', () => {
-    if (reconnectTimer) clearTimeout(reconnectTimer);
     if (ws) ws.close();
     cleanup();
   });
@@ -967,53 +802,33 @@ function bridgeCoreEvents(capture: ActivityLogger) {
 }
 
 /**
- * Initialize the activity logger with a specific transport mode.
+ * Initialize the activity logger: enable interception and bridge core events.
  *
  * @param config  CLI configuration
- * @param options Transport configuration: network (WebSocket) or file (JSONL)
+ * @param options Optional file transport configuration
  */
 export function initActivityLogger(
   config: Config,
-  options:
-    | {
-        mode: 'network';
-        host: string;
-        port: number;
-        onReconnectFailed?: () => void;
-      }
-    | { mode: 'file'; filePath?: string }
-    | { mode: 'buffer' },
+  options?: { mode: 'file'; filePath?: string },
 ): void {
   const capture = ActivityLogger.getInstance();
   capture.enable();
 
-  if (options.mode === 'network') {
-    setupNetworkLogging(
-      capture,
-      options.host,
-      options.port,
-      config,
-      options.onReconnectFailed,
-    );
-    capture.enableNetworkLogging();
-  } else if (options.mode === 'file') {
+  if (options?.mode === 'file') {
     setupFileLogging(capture, config, options.filePath);
   }
-  // buffer mode: no transport, just intercept + bridge
 
   bridgeCoreEvents(capture);
 }
 
 /**
  * Add a network (WebSocket) transport to the existing ActivityLogger singleton.
- * Used for promotion re-entry without re-bridging coreEvents.
  */
 export function addNetworkTransport(
   config: Config,
   host: string,
   port: number,
-  onReconnectFailed?: () => void,
 ): void {
   const capture = ActivityLogger.getInstance();
-  setupNetworkLogging(capture, host, port, config, onReconnectFailed);
+  setupNetworkLogging(capture, host, port, config);
 }

--- a/packages/cli/src/utils/devtoolsService.test.ts
+++ b/packages/cli/src/utils/devtoolsService.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import type { Config } from '@google/gemini-cli-core';
 
 // --- Mocks (hoisted) ---
@@ -56,11 +56,22 @@ const mockDevToolsInstance = vi.hoisted(() => ({
   getPort: vi.fn(),
 }));
 
-const mockActivityLoggerInstance = vi.hoisted(() => ({
-  disableNetworkLogging: vi.fn(),
-  enableNetworkLogging: vi.fn(),
-  drainBufferedLogs: vi.fn().mockReturnValue({ network: [], console: [] }),
-}));
+const mockActivityLoggerInstance = vi.hoisted(() => {
+  const listeners = new Map<string, Listener[]>();
+  return {
+    on: vi.fn((event: string, fn: Listener) => {
+      const fns = listeners.get(event) || [];
+      fns.push(fn);
+      listeners.set(event, fns);
+    }),
+    emit: vi.fn((event: string, ...args: unknown[]) => {
+      for (const fn of listeners.get(event) || []) {
+        fn(...args);
+      }
+    }),
+    _clearListeners: () => listeners.clear(),
+  };
+});
 
 vi.mock('./activityLogger.js', () => ({
   initActivityLogger: mockInitActivityLogger,
@@ -119,71 +130,16 @@ describe('devtoolsService', () => {
     vi.clearAllMocks();
     MockWebSocket.instances = [];
     resetForTesting();
-    delete process.env['GEMINI_CLI_ACTIVITY_LOG_TARGET'];
+    mockActivityLoggerInstance._clearListeners();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   describe('setupInitialActivityLogger', () => {
-    it('stays in buffer mode when no existing server found', async () => {
-      const config = createMockConfig();
-      const promise = setupInitialActivityLogger(config);
-
-      // Probe fires immediately — no server running
-      await vi.waitFor(() => expect(MockWebSocket.instances.length).toBe(1));
-      MockWebSocket.instances[0].simulateError();
-
-      await promise;
-
-      expect(mockInitActivityLogger).toHaveBeenCalledWith(config, {
-        mode: 'buffer',
-      });
-      expect(mockAddNetworkTransport).not.toHaveBeenCalled();
-    });
-
-    it('attaches transport when existing server found at startup', async () => {
-      const config = createMockConfig();
-      const promise = setupInitialActivityLogger(config);
-
-      await vi.waitFor(() => expect(MockWebSocket.instances.length).toBe(1));
-      MockWebSocket.instances[0].simulateOpen();
-
-      await promise;
-
-      expect(mockInitActivityLogger).toHaveBeenCalledWith(config, {
-        mode: 'buffer',
-      });
-      expect(mockAddNetworkTransport).toHaveBeenCalledWith(
-        config,
-        '127.0.0.1',
-        25417,
-        expect.any(Function),
-      );
-      expect(
-        mockActivityLoggerInstance.enableNetworkLogging,
-      ).toHaveBeenCalled();
-    });
-
-    it('F12 short-circuits when startup already connected', async () => {
-      const config = createMockConfig();
-
-      // Startup: probe succeeds
-      const setupPromise = setupInitialActivityLogger(config);
-      await vi.waitFor(() => expect(MockWebSocket.instances.length).toBe(1));
-      MockWebSocket.instances[0].simulateOpen();
-      await setupPromise;
-
-      mockAddNetworkTransport.mockClear();
-      mockActivityLoggerInstance.enableNetworkLogging.mockClear();
-
-      // F12: should return URL immediately
-      const url = await startDevToolsServer(config);
-
-      expect(url).toBe('http://localhost:25417');
-      expect(mockAddNetworkTransport).not.toHaveBeenCalled();
-      expect(mockDevToolsInstance.start).not.toHaveBeenCalled();
-    });
-
     it('initializes in file mode when target env var is set', async () => {
-      process.env['GEMINI_CLI_ACTIVITY_LOG_TARGET'] = '/tmp/test.jsonl';
+      vi.stubEnv('GEMINI_CLI_ACTIVITY_LOG_TARGET', '/tmp/test.jsonl');
       const config = createMockConfig();
       await setupInitialActivityLogger(config);
 
@@ -196,8 +152,17 @@ describe('devtoolsService', () => {
     });
 
     it('does nothing in file mode when config.storage is missing', async () => {
-      process.env['GEMINI_CLI_ACTIVITY_LOG_TARGET'] = '/tmp/test.jsonl';
+      vi.stubEnv('GEMINI_CLI_ACTIVITY_LOG_TARGET', '/tmp/test.jsonl');
       const config = createMockConfig({ storage: undefined });
+      await setupInitialActivityLogger(config);
+
+      expect(mockInitActivityLogger).not.toHaveBeenCalled();
+      expect(MockWebSocket.instances.length).toBe(0);
+    });
+
+    it('does nothing in interactive mode (no eager probe)', async () => {
+      vi.stubEnv('GEMINI_CLI_ACTIVITY_LOG_TARGET', '');
+      const config = createMockConfig();
       await setupInitialActivityLogger(config);
 
       expect(mockInitActivityLogger).not.toHaveBeenCalled();
@@ -206,7 +171,7 @@ describe('devtoolsService', () => {
   });
 
   describe('startDevToolsServer', () => {
-    it('starts new server when none exists and enables logging', async () => {
+    it('starts new server when none exists', async () => {
       const config = createMockConfig();
       mockDevToolsInstance.start.mockResolvedValue('http://127.0.0.1:25417');
       mockDevToolsInstance.getPort.mockReturnValue(25417);
@@ -219,15 +184,12 @@ describe('devtoolsService', () => {
       const url = await promise;
 
       expect(url).toBe('http://localhost:25417');
+      expect(mockInitActivityLogger).toHaveBeenCalledWith(config);
       expect(mockAddNetworkTransport).toHaveBeenCalledWith(
         config,
         '127.0.0.1',
         25417,
-        expect.any(Function),
       );
-      expect(
-        mockActivityLoggerInstance.enableNetworkLogging,
-      ).toHaveBeenCalled();
     });
 
     it('connects to existing server if one is found', async () => {
@@ -241,10 +203,8 @@ describe('devtoolsService', () => {
       const url = await promise;
 
       expect(url).toBe('http://localhost:25417');
+      expect(mockInitActivityLogger).toHaveBeenCalledWith(config);
       expect(mockAddNetworkTransport).toHaveBeenCalled();
-      expect(
-        mockActivityLoggerInstance.enableNetworkLogging,
-      ).toHaveBeenCalled();
     });
 
     it('deduplicates concurrent calls (returns same promise)', async () => {
@@ -326,12 +286,14 @@ describe('devtoolsService', () => {
 
       mockAddNetworkTransport.mockClear();
       mockDevToolsInstance.start.mockClear();
+      mockInitActivityLogger.mockClear();
 
       // Second call should short-circuit via connectedUrl
       const url2 = await startDevToolsServer(config);
       expect(url2).toBe('http://localhost:25417');
       expect(mockAddNetworkTransport).not.toHaveBeenCalled();
       expect(mockDevToolsInstance.start).not.toHaveBeenCalled();
+      expect(mockInitActivityLogger).not.toHaveBeenCalled();
     });
 
     it('stops own server and connects to existing when losing port race', async () => {
@@ -364,7 +326,6 @@ describe('devtoolsService', () => {
         config,
         '127.0.0.1',
         25417,
-        expect.any(Function),
       );
     });
 
@@ -396,43 +357,7 @@ describe('devtoolsService', () => {
         config,
         '127.0.0.1',
         25418,
-        expect.any(Function),
       );
-    });
-  });
-
-  describe('handlePromotion (via startDevToolsServer)', () => {
-    it('caps promotion attempts at MAX_PROMOTION_ATTEMPTS', async () => {
-      const config = createMockConfig();
-      mockDevToolsInstance.start.mockResolvedValue('http://127.0.0.1:25417');
-      mockDevToolsInstance.getPort.mockReturnValue(25417);
-
-      // First: set up the logger so we can grab onReconnectFailed
-      const promise = startDevToolsServer(config);
-
-      await vi.waitFor(() => {
-        expect(MockWebSocket.instances.length).toBe(1);
-      });
-      MockWebSocket.instances[0].simulateError();
-
-      await promise;
-
-      // Extract onReconnectFailed callback
-      const initCall = mockAddNetworkTransport.mock.calls[0];
-      const onReconnectFailed = initCall[3];
-      expect(onReconnectFailed).toBeDefined();
-
-      // Trigger promotion MAX_PROMOTION_ATTEMPTS + 1 times
-      // Each call should succeed (addNetworkTransport called) until cap is hit
-      mockAddNetworkTransport.mockClear();
-
-      await onReconnectFailed(); // attempt 1
-      await onReconnectFailed(); // attempt 2
-      await onReconnectFailed(); // attempt 3
-      await onReconnectFailed(); // attempt 4 — should be capped
-
-      // Only 3 calls to addNetworkTransport (capped at MAX_PROMOTION_ATTEMPTS)
-      expect(mockAddNetworkTransport).toHaveBeenCalledTimes(3);
     });
   });
 
@@ -527,6 +452,46 @@ describe('devtoolsService', () => {
 
       expect(toggle).not.toHaveBeenCalled();
       expect(setOpen).toHaveBeenCalledTimes(1);
+    });
+
+    it('resets and re-probes when connectedUrl is set but wsAlive is false', async () => {
+      const config = createMockConfig();
+      const toggle = vi.fn();
+      const setOpen = vi.fn();
+
+      // First F12: establish a connection
+      mockDevToolsInstance.start.mockResolvedValue('http://127.0.0.1:25417');
+      mockDevToolsInstance.getPort.mockReturnValue(25417);
+
+      const promise1 = toggleDevToolsPanel(config, false, toggle, setOpen);
+      await vi.waitFor(() => expect(MockWebSocket.instances.length).toBe(1));
+      MockWebSocket.instances[0].simulateError();
+      await promise1;
+
+      // Simulate transport-disconnected: wsAlive becomes false
+      mockActivityLoggerInstance.emit('transport-disconnected');
+
+      // Reset mocks for second F12
+      mockAddNetworkTransport.mockClear();
+      mockInitActivityLogger.mockClear();
+      MockWebSocket.instances = [];
+      setOpen.mockClear();
+
+      mockShouldLaunchBrowser.mockReturnValue(true);
+      mockOpenBrowserSecurely.mockResolvedValue(undefined);
+
+      // Second F12: should reset connectedUrl and re-probe
+      const promise2 = toggleDevToolsPanel(config, false, toggle, setOpen);
+
+      // Should start a fresh probe (new WebSocket instance)
+      await vi.waitFor(() => expect(MockWebSocket.instances.length).toBe(1));
+      MockWebSocket.instances[0].simulateError();
+
+      await promise2;
+
+      // Should have re-initialized
+      expect(mockInitActivityLogger).toHaveBeenCalledWith(config);
+      expect(mockAddNetworkTransport).toHaveBeenCalled();
     });
   });
 });

--- a/packages/cli/src/utils/devtoolsService.ts
+++ b/packages/cli/src/utils/devtoolsService.ts
@@ -20,10 +20,9 @@ interface IDevTools {
 
 const DEFAULT_DEVTOOLS_PORT = 25417;
 const DEFAULT_DEVTOOLS_HOST = '127.0.0.1';
-const MAX_PROMOTION_ATTEMPTS = 3;
-let promotionAttempts = 0;
 let serverStartPromise: Promise<string> | null = null;
 let connectedUrl: string | null = null;
+let wsAlive = false;
 
 /**
  * Probe whether a DevTools server is already listening on the given host:port.
@@ -88,35 +87,8 @@ async function startOrJoinDevTools(
 }
 
 /**
- * Handle promotion: when reconnect fails, start or join a DevTools server
- * and add a new network transport for the logger.
- */
-async function handlePromotion(config: Config) {
-  promotionAttempts++;
-  if (promotionAttempts > MAX_PROMOTION_ATTEMPTS) {
-    debugLogger.debug(
-      `Giving up on DevTools promotion after ${MAX_PROMOTION_ATTEMPTS} attempts`,
-    );
-    return;
-  }
-
-  try {
-    const result = await startOrJoinDevTools(
-      DEFAULT_DEVTOOLS_HOST,
-      DEFAULT_DEVTOOLS_PORT,
-    );
-    addNetworkTransport(config, result.host, result.port, () =>
-      handlePromotion(config),
-    );
-  } catch (err) {
-    debugLogger.debug('Failed to promote to DevTools server:', err);
-  }
-}
-
-/**
- * Initializes the activity logger.
- * Interception starts immediately in buffering mode.
- * If an existing DevTools server is found, attaches transport eagerly.
+ * Initializes the activity logger for file logging only.
+ * Interactive mode does nothing at startup — F12 triggers connection lazily.
  */
 export async function setupInitialActivityLogger(config: Config) {
   const target = process.env['GEMINI_CLI_ACTIVITY_LOG_TARGET'];
@@ -124,32 +96,8 @@ export async function setupInitialActivityLogger(config: Config) {
   if (target) {
     if (!config.storage) return;
     initActivityLogger(config, { mode: 'file', filePath: target });
-  } else {
-    // Start in buffering mode (no transport attached yet)
-    initActivityLogger(config, { mode: 'buffer' });
-
-    // Eagerly probe for an existing DevTools server
-    try {
-      const existing = await probeDevTools(
-        DEFAULT_DEVTOOLS_HOST,
-        DEFAULT_DEVTOOLS_PORT,
-      );
-      if (existing) {
-        const onReconnectFailed = () => handlePromotion(config);
-        addNetworkTransport(
-          config,
-          DEFAULT_DEVTOOLS_HOST,
-          DEFAULT_DEVTOOLS_PORT,
-          onReconnectFailed,
-        );
-        ActivityLogger.getInstance().enableNetworkLogging();
-        connectedUrl = `http://localhost:${DEFAULT_DEVTOOLS_PORT}`;
-        debugLogger.log(`DevTools (existing) at startup: ${connectedUrl}`);
-      }
-    } catch {
-      // Probe failed silently — stay in buffer mode
-    }
   }
+  // Interactive mode: do nothing at startup. F12 will trigger connection.
 }
 
 /**
@@ -168,8 +116,6 @@ export function startDevToolsServer(config: Config): Promise<string> {
 }
 
 async function startDevToolsServerImpl(config: Config): Promise<string> {
-  const onReconnectFailed = () => handlePromotion(config);
-
   // Probe for an existing DevTools server
   const existing = await probeDevTools(
     DEFAULT_DEVTOOLS_HOST,
@@ -198,10 +144,18 @@ async function startDevToolsServerImpl(config: Config): Promise<string> {
     }
   }
 
-  // Promote the activity logger to use the network transport
-  addNetworkTransport(config, host, port, onReconnectFailed);
+  // Enable interception if not already active, then attach network transport
+  initActivityLogger(config);
+  addNetworkTransport(config, host, port);
+
+  // Track transport connection state
   const capture = ActivityLogger.getInstance();
-  capture.enableNetworkLogging();
+  capture.on('transport-connected', () => {
+    wsAlive = true;
+  });
+  capture.on('transport-disconnected', () => {
+    wsAlive = false;
+  });
 
   const url = `http://localhost:${port}`;
   connectedUrl = url;
@@ -213,6 +167,7 @@ async function startDevToolsServerImpl(config: Config): Promise<string> {
  * Starts the DevTools server, attempts to open the browser.
  * If the panel is already open, it closes it.
  * If the panel is closed:
+ * - Checks if a previous connection died and resets state so we re-probe.
  * - Attempts to open the browser.
  * - If browser opening is successful, the panel remains closed.
  * - If browser opening fails or is not possible, the panel is opened.
@@ -226,6 +181,12 @@ export async function toggleDevToolsPanel(
   if (isOpen) {
     toggle();
     return;
+  }
+
+  // If we had a connection but the WS died, reset so we re-probe
+  if (connectedUrl && !wsAlive) {
+    connectedUrl = null;
+    serverStartPromise = null;
   }
 
   try {
@@ -252,7 +213,7 @@ export async function toggleDevToolsPanel(
 
 /** Reset module-level state — test only. */
 export function resetForTesting() {
-  promotionAttempts = 0;
   serverStartPromise = null;
   connectedUrl = null;
+  wsAlive = false;
 }


### PR DESCRIPTION
## Summary

Simplify devtools initialization by replacing the eager startup buffering and auto-promotion model with a lazy F12-triggered connection. This removes three layers of buffering/caching and the promotion chain, resulting in a net reduction of ~273 lines.

## Details

**Before:** On startup (when `devtools` setting is enabled), the CLI immediately began intercepting network requests in "buffer mode", eagerly probed for an existing DevTools server, and stored logs in multiple buffer layers (ActivityLogger buffer of 10, transportBuffer of 100, DevTools server arrays of 2000/5000). If the connected server died, auto-promotion would attempt to start a new server automatically.

**After:** Startup does nothing for interactive devtools mode. When the user presses F12:
1. Probe for an existing DevTools server
2. Connect to it, or start a new one
3. Enable HTTP/fetch interception and begin sending logs directly

If the server dies (e.g., the CLI instance hosting it exits), the WebSocket disconnect is tracked via `wsAlive`. The next F12 press detects the dead connection, resets state, and re-probes — effectively a manual promotion.

**Trade-off:** Network requests made before pressing F12 are not captured in DevTools. This is acceptable since devtools is a debugging tool activated on demand.

**Removed:**
- `ActivityLogger` buffer fields (`networkBufferMap`, `consoleBuffer`, `bufferLimit`) and methods (`drainBufferedLogs`, `getBufferedLogs`, `clearBufferedLogs`)
- `networkLoggingEnabled` flag and related methods
- `transportBuffer` (100-item WebSocket send queue)
- Reconnect logic in `setupNetworkLogging`
- `handlePromotion`, `promotionAttempts`, `MAX_PROMOTION_ATTEMPTS`
- Eager probe on startup in `setupInitialActivityLogger`
- Startup `setupInitialActivityLogger` call in `gemini.tsx`

**Added:**
- `transport-connected` / `transport-disconnected` events on `ActivityLogger`
- `wsAlive` tracking in `devtoolsService` for dead-connection detection on F12

## Related Issues

Related to #18007

## How to Validate

1. Start the CLI without pressing F12 — no DevTools server should be started, no network interception active
2. Press F12 — DevTools server starts, browser opens, subsequent API calls appear in the inspector
3. Open a second CLI instance, press F12 — it should connect to the existing server
4. Kill the first CLI instance (which hosts the server)
5. In the second CLI, press F12 again — it should detect the dead connection, start a new server, and resume logging

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
