### PR TITLE
feat(config): add experimental.adk.agentSessionNoninteractiveEnabled setting

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1587,6 +1587,11 @@ their corresponding top-level category object in your `settings.json` file.
 
 #### `experimental`
 
+- **`experimental.adk.agentSessionNoninteractiveEnabled`** (boolean):
+  - **Description:** Enable non-interactive agent sessions.
+  - **Default:** `false`
+  - **Requires restart:** Yes
+
 - **`experimental.enableAgents`** (boolean):
   - **Description:** Enable local and remote subagents.
   - **Default:** `true`

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1009,6 +1009,7 @@ export async function loadCliConfig(
       format: (argv.outputFormat ?? settings.output?.format) as OutputFormat,
     },
     gemmaModelRouter: settings.experimental?.gemmaModelRouter,
+    adk: settings.experimental?.adk,
     fakeResponses: argv.fakeResponses,
     recordResponses: argv.recordResponses,
     retryFetchErrors: settings.general?.retryFetchErrors,

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -505,6 +505,31 @@ describe('SettingsSchema', () => {
         'The model to use for the classifier. Only tested on `gemma3-1b-gpu-custom`.',
       );
     });
+
+    it('should have adk setting in schema', () => {
+      const adk = getSettingsSchema().experimental.properties.adk;
+      expect(adk).toBeDefined();
+      expect(adk.type).toBe('object');
+      expect(adk.category).toBe('Experimental');
+      expect(adk.default).toEqual({});
+      expect(adk.requiresRestart).toBe(true);
+      expect(adk.showInDialog).toBe(false);
+      expect(adk.description).toBe(
+        'Settings for the Agent Development Kit (ADK).',
+      );
+
+      const agentSessionNoninteractiveEnabled =
+        adk.properties.agentSessionNoninteractiveEnabled;
+      expect(agentSessionNoninteractiveEnabled).toBeDefined();
+      expect(agentSessionNoninteractiveEnabled.type).toBe('boolean');
+      expect(agentSessionNoninteractiveEnabled.category).toBe('Experimental');
+      expect(agentSessionNoninteractiveEnabled.default).toBe(false);
+      expect(agentSessionNoninteractiveEnabled.requiresRestart).toBe(true);
+      expect(agentSessionNoninteractiveEnabled.showInDialog).toBe(false);
+      expect(agentSessionNoninteractiveEnabled.description).toBe(
+        'Enable non-interactive agent sessions.',
+      );
+    });
   });
 
   it('has JSON schema definitions for every referenced ref', () => {

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1933,6 +1933,26 @@ const SETTINGS_SCHEMA = {
     description: 'Setting to enable experimental features',
     showInDialog: false,
     properties: {
+      adk: {
+        type: 'object',
+        label: 'ADK',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: {},
+        description: 'Settings for the Agent Development Kit (ADK).',
+        showInDialog: false,
+        properties: {
+          agentSessionNoninteractiveEnabled: {
+            type: 'boolean',
+            label: 'Agent Session Non-interactive Enabled',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: false,
+            description: 'Enable non-interactive agent sessions.',
+            showInDialog: false,
+          },
+        },
+      },
       enableAgents: {
         type: 'boolean',
         label: 'Enable Agents',

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -3445,3 +3445,29 @@ describe('ConfigSchema validation', () => {
     }
   });
 });
+
+describe('ADKSettings', () => {
+  const baseParams: ConfigParameters = {
+    sessionId: 'test',
+    targetDir: '.',
+    debugMode: false,
+    model: 'test-model',
+    cwd: '.',
+  };
+
+  it('should default agentSessionNoninteractiveEnabled to false', () => {
+    const config = new Config(baseParams);
+    expect(config.getAgentSessionNoninteractiveEnabled()).toBe(false);
+  });
+
+  it('should return provided agentSessionNoninteractiveEnabled', () => {
+    const params: ConfigParameters = {
+      ...baseParams,
+      adk: {
+        agentSessionNoninteractiveEnabled: true,
+      },
+    };
+    const config = new Config(params);
+    expect(config.getAgentSessionNoninteractiveEnabled()).toBe(true);
+  });
+});

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -240,6 +240,10 @@ export interface GemmaModelRouterSettings {
   };
 }
 
+export interface ADKSettings {
+  agentSessionNoninteractiveEnabled?: boolean;
+}
+
 export interface ExtensionSetting {
   name: string;
   description: string;
@@ -677,6 +681,7 @@ export interface ConfigParameters {
   policyUpdateConfirmationRequest?: PolicyUpdateConfirmationRequest;
   output?: OutputSettings;
   gemmaModelRouter?: GemmaModelRouterSettings;
+  adk?: ADKSettings;
   disableModelRouterForAuth?: AuthType[];
   continueOnFailedApiCall?: boolean;
   retryFetchErrors?: boolean;
@@ -899,6 +904,7 @@ export class Config implements McpContext, AgentLoopContext {
   private readonly outputSettings: OutputSettings;
 
   private readonly gemmaModelRouter: GemmaModelRouterSettings;
+  private readonly agentSessionNoninteractiveEnabled: boolean;
 
   private readonly continueOnFailedApiCall: boolean;
   private readonly retryFetchErrors: boolean;
@@ -1316,6 +1322,9 @@ export class Config implements McpContext, AgentLoopContext {
           params.gemmaModelRouter?.classifier?.model ?? 'gemma3-1b-gpu-custom',
       },
     };
+
+    this.agentSessionNoninteractiveEnabled =
+      params.adk?.agentSessionNoninteractiveEnabled ?? false;
     this.retryFetchErrors = params.retryFetchErrors ?? true;
     this.maxAttempts = Math.min(
       params.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
@@ -3365,6 +3374,10 @@ export class Config implements McpContext, AgentLoopContext {
 
   getGemmaModelRouterSettings(): GemmaModelRouterSettings {
     return this.gemmaModelRouter;
+  }
+
+  getAgentSessionNoninteractiveEnabled(): boolean {
+    return this.agentSessionNoninteractiveEnabled;
   }
 
   /**

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -2748,6 +2748,23 @@
       "default": {},
       "type": "object",
       "properties": {
+        "adk": {
+          "title": "ADK",
+          "description": "Settings for the Agent Development Kit (ADK).",
+          "markdownDescription": "Settings for the Agent Development Kit (ADK).\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `{}`",
+          "default": {},
+          "type": "object",
+          "properties": {
+            "agentSessionNoninteractiveEnabled": {
+              "title": "Agent Session Non-interactive Enabled",
+              "description": "Enable non-interactive agent sessions.",
+              "markdownDescription": "Enable non-interactive agent sessions.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
         "enableAgents": {
           "title": "Enable Agents",
           "description": "Enable local and remote subagents.",


### PR DESCRIPTION
## Summary

This PR adds a new experimental setting, `experimental.adk.agentSessionNoninteractiveEnabled`, to the Gemini CLI configuration.

## Details

The setting is defined as a boolean flag that is disabled by default. It's properly exposed via the `Config` getter method and schema definitions, enabling support for non-interactive agent sessions in the ADK context.

## Related Issues

<!-- None -->

## How to Validate

1. Run the test suite: `npm test -w @google/gemini-cli-core -w @google/gemini-cli`
2. Verify that the tests under `src/config/` pass, indicating the setting is properly handled.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
