### PR TITLE
fix(cli): replace removed StyledLine with StyledChar[] after ink 6.6.3 upgrade

### DIFF
--- a/packages/cli/src/ui/utils/TableRenderer.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.tsx
@@ -8,13 +8,13 @@ import React, { useMemo } from 'react';
 import {
   Text,
   Box,
-  StyledLine,
   toStyledCharacters,
   wordBreakStyledChars,
   wrapStyledChars,
   widestLineFromStyledChars,
   styledCharsWidth,
   styledCharsToString,
+  type StyledChar,
 } from 'ink';
 import { theme } from '../semantic-colors.js';
 import { parseMarkdownToANSI } from './markdownParsingUtils.js';
@@ -38,15 +38,15 @@ const TABLE_MARGIN = 2;
 const parseMarkdownToStyledLine = (
   text: string,
   defaultColor?: string,
-): StyledLine => {
+): StyledChar[] => {
   const ansi = parseMarkdownToANSI(text, defaultColor);
   return toStyledCharacters(ansi);
 };
 
-const calculateWidths = (styledLine: StyledLine) => {
+const calculateWidths = (styledLine: StyledChar[]) => {
   const contentWidth = styledCharsWidth(styledLine);
 
-  const words: StyledLine[] = wordBreakStyledChars(styledLine);
+  const words: StyledChar[][] = wordBreakStyledChars(styledLine);
   const maxWordWidth = widestLineFromStyledChars(words);
 
   return { contentWidth, maxWordWidth };
@@ -67,7 +67,7 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
   rows,
   terminalWidth,
 }) => {
-  const styledHeaders = useMemo<StyledLine[]>(
+  const styledHeaders = useMemo<StyledChar[][]>(
     () =>
       headers.map((header) =>
         parseMarkdownToStyledLine(
@@ -78,7 +78,7 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
     [headers],
   );
 
-  const styledRows = useMemo<StyledLine[][]>(
+  const styledRows = useMemo<StyledChar[][][]>(
     () =>
       rows.map((row) =>
         row.map((cell) =>
@@ -100,12 +100,12 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
     // --- Define Constraints per Column ---
     const constraints = Array.from({ length: numColumns }).map(
       (_, colIndex) => {
-        const headerStyledLine = styledHeaders[colIndex] || StyledLine.empty(0);
+        const headerStyledLine = styledHeaders[colIndex] ?? [];
         let { contentWidth: maxContentWidth, maxWordWidth } =
           calculateWidths(headerStyledLine);
 
         styledRows.forEach((row) => {
-          const cellStyledLine = row[colIndex] || StyledLine.empty(0);
+          const cellStyledLine = row[colIndex] ?? [];
           const { contentWidth: cellWidth, maxWordWidth: cellWordWidth } =
             calculateWidths(cellStyledLine);
 
@@ -176,11 +176,11 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
     // --- Pre-wrap and Optimize Widths ---
     const actualColumnWidths = new Array(numColumns).fill(0);
 
-    const wrapAndProcessRow = (row: StyledLine[]) => {
+    const wrapAndProcessRow = (row: StyledChar[][]) => {
       const rowResult: ProcessedLine[][] = [];
       // Ensure we iterate up to numColumns, filling with empty cells if needed
       for (let colIndex = 0; colIndex < numColumns; colIndex++) {
-        const cellStyledLine = row[colIndex] || StyledLine.empty(0);
+        const cellStyledLine = row[colIndex] ?? [];
         const allocatedWidth = finalContentWidths[colIndex];
         const contentWidth = Math.max(1, allocatedWidth);
 


### PR DESCRIPTION
## Summary

Fixes a build-breaking regression introduced by the `ink 6.6.3` upgrade (#24372).
`ink 6.6.3` silently removed the `StyledLine` named export, causing `TableRenderer.tsx` to fail
TypeScript compilation with `error TS2305: Module '"ink"' has no exported member 'StyledLine'`.

This PR migrates all usages of the removed API to the equivalent `StyledChar[]` type, which is
what `StyledLine` was aliasing internally.

## Details

`StyledLine` in older `ink` versions was:
- A **type alias** for `StyledChar[]`
- Exposed a **static factory** `StyledLine.empty(0)` that returned `[]`

Both were dropped in `ink 6.6.3` without a deprecation notice.

### Changes in `packages/cli/src/ui/utils/TableRenderer.tsx`

| Before | After |
|---|---|
| `import { StyledLine, ... } from 'ink'` | `import { type StyledChar, ... } from 'ink'` |
| `: StyledLine` | `: StyledChar[]` |
| `: StyledLine[]` | `: StyledChar[][]` |
| `: StyledLine[][]` | `: StyledChar[][][]` |
| `StyledLine.empty(0)` | `[]` |

No logic or behaviour is changed — this is a pure type-layer and static-method migration.

## Related Issues

Closes #24441

## How to Validate

```bash
# 1. Build the affected package — must succeed with no TS errors
npm run build -w @google/gemini-cli

# 2. Full type check
npm run typecheck

# 3. Run CLI package tests
npm test -w @google/gemini-cli

# 4. Full build sanity check
npm run build
```

All of the above should complete without errors.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker