### PR TITLE
fix(cli): refresh slash command list after /skills reload

### DIFF
--- a/packages/cli/src/test-utils/mockCommandContext.ts
+++ b/packages/cli/src/test-utils/mockCommandContext.ts
@@ -61,6 +61,7 @@ export const createMockCommandContext = (
       toggleCorgiMode: vi.fn(),
       toggleShortcutsHelp: vi.fn(),
       toggleVimEnabled: vi.fn(),
+      reloadCommands: vi.fn(),
       openAgentConfigDialog: vi.fn(),
       closeAgentConfigDialog: vi.fn(),
       extensionsUpdateState: new Map(),

--- a/packages/cli/src/ui/commands/skillsCommand.test.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.test.ts
@@ -528,6 +528,7 @@ describe('skillsCommand', () => {
       await actionPromise;
 
       expect(reloadSkillsMock).toHaveBeenCalled();
+      expect(context.ui.reloadCommands).toHaveBeenCalled();
       expect(context.ui.setPendingItem).toHaveBeenCalledWith(null);
       expect(context.ui.addItem).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/packages/cli/src/ui/commands/skillsCommand.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.ts
@@ -285,6 +285,8 @@ async function reloadAction(
       context.ui.setPendingItem(null);
     }
 
+    context.ui.reloadCommands();
+
     const afterSkills = skillManager.getSkills();
     const afterNames = new Set(afterSkills.map((s) => s.name));
 


### PR DESCRIPTION
## Summary

Refresh the slash command completion list after running `/skills reload`.

## Details

The `/skills reload` command reloaded the skills in the underlying configuration but failed to notify the UI to refresh its list of available slash commands. This resulted in the completion list being stale until some other event triggered a reload. This PR adds a call to `context.ui.reloadCommands()` in the `reloadAction` of `skillsCommand.ts` and updates the necessary mocks and tests.

## Related Issues

N/A (Reported by user in session)

## How to Validate

1. Run the unit tests for `skillsCommand`:
   ```bash
   npm test -w @google/gemini-cli -- src/ui/commands/skillsCommand.test.ts
   ```
2. Verify that `context.ui.reloadCommands` is called when `/skills reload` is executed.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
