### PR TITLE
feat(policy): explicitly allow web_fetch in plan mode with ask_user

### DIFF
--- a/docs/cli/plan-mode.md
+++ b/docs/cli/plan-mode.md
@@ -123,6 +123,7 @@ These are the only allowed tools:
   [`glob`](../tools/file-system.md#4-glob-findfiles)
 - **Search:** [`grep_search`](../tools/file-system.md#5-grep_search-searchtext),
   [`google_web_search`](../tools/web-search.md),
+  [`web_fetch`](../tools/web-fetch.md) (requires explicit confirmation),
   [`get_internal_docs`](../tools/internal-docs.md)
 - **Research Subagents:**
   [`codebase_investigator`](../core/subagents.md#codebase-investigator),

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -115,10 +115,10 @@ each tool.
 
 ### Web
 
-| Tool                                          | Kind     | Description                                                                                                                                                                                                 |
-| :-------------------------------------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`google_web_search`](../tools/web-search.md) | `Search` | Performs a Google Search to find up-to-date information.                                                                                                                                                    |
-| [`web_fetch`](../tools/web-fetch.md)          | `Fetch`  | Retrieves and processes content from specific URLs. **Warning:** This tool can access local and private network addresses (e.g., localhost), which may pose a security risk if used with untrusted prompts. |
+| Tool                                          | Kind     | Description                                                                                                                                                                                                                                                              |
+| :-------------------------------------------- | :------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`google_web_search`](../tools/web-search.md) | `Search` | Performs a Google Search to find up-to-date information.                                                                                                                                                                                                                 |
+| [`web_fetch`](../tools/web-fetch.md)          | `Fetch`  | Retrieves and processes content from specific URLs. **Warning:** This tool can access local and private network addresses (e.g., localhost), which may pose a security risk if used with untrusted prompts. In Plan Mode, this tool requires explicit user confirmation. |
 
 ## Under the hood
 

--- a/docs/tools/web-fetch.md
+++ b/docs/tools/web-fetch.md
@@ -17,6 +17,9 @@ specific operations like summarization or extraction.
 ## Technical behavior
 
 - **Confirmation:** Triggers a confirmation dialog showing the converted URLs.
+- **Plan Mode:** In [Plan Mode](../cli/plan-mode.md), `web_fetch` is available
+  but always requires explicit user confirmation (`ask_user`) due to security
+  implications of accessing external or private network addresses.
 - **Processing:** Uses the Gemini API's `urlContext` for retrieval.
 - **Fallback:** If API access fails, the tool attempts to fetch raw content
   directly from your local machine.

--- a/packages/core/src/policy/policies/plan.toml
+++ b/packages/core/src/policy/policies/plan.toml
@@ -121,29 +121,14 @@ priority = 70
 modes = ["plan"]
 
 [[rule]]
-toolName = "web_fetch"
+toolName = ["ask_user", "save_memory", "web_fetch"]
 decision = "ask_user"
 priority = 70
 modes = ["plan"]
 interactive = true
 
 [[rule]]
-toolName = "web_fetch"
-decision = "deny"
-denyMessage = "The 'web_fetch' tool requires user confirmation and is not available in non-interactive environments while in Plan Mode."
-priority = 70
-modes = ["plan"]
-interactive = false
-
-[[rule]]
-toolName = ["ask_user", "save_memory"]
-decision = "ask_user"
-priority = 70
-modes = ["plan"]
-interactive = true
-
-[[rule]]
-toolName = ["ask_user", "save_memory"]
+toolName = ["ask_user", "save_memory", "web_fetch"]
 decision = "deny"
 priority = 70
 modes = ["plan"]

--- a/packages/core/src/policy/policies/plan.toml
+++ b/packages/core/src/policy/policies/plan.toml
@@ -130,6 +130,7 @@ interactive = true
 [[rule]]
 toolName = "web_fetch"
 decision = "deny"
+denyMessage = "The 'web_fetch' tool requires user confirmation and is not available in non-interactive environments while in Plan Mode."
 priority = 70
 modes = ["plan"]
 interactive = false

--- a/packages/core/src/policy/policies/plan.toml
+++ b/packages/core/src/policy/policies/plan.toml
@@ -121,6 +121,20 @@ priority = 70
 modes = ["plan"]
 
 [[rule]]
+toolName = "web_fetch"
+decision = "ask_user"
+priority = 70
+modes = ["plan"]
+interactive = true
+
+[[rule]]
+toolName = "web_fetch"
+decision = "deny"
+priority = 70
+modes = ["plan"]
+interactive = false
+
+[[rule]]
 toolName = ["ask_user", "save_memory"]
 decision = "ask_user"
 priority = 70

--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -2930,6 +2930,12 @@ describe('PolicyEngine', () => {
             modes: [ApprovalMode.PLAN],
           },
           {
+            toolName: 'web_fetch',
+            decision: PolicyDecision.ASK_USER,
+            priority: 70,
+            modes: [ApprovalMode.PLAN],
+          },
+          {
             toolName: '*',
             decision: PolicyDecision.DENY,
             priority: 60,
@@ -2972,7 +2978,6 @@ describe('PolicyEngine', () => {
       const excluded = engine.getExcludedTools(toolMetadata, allToolNames);
       // These should be excluded (caught by catch-all DENY)
       expect(excluded.has('shell')).toBe(true);
-      expect(excluded.has('web_fetch')).toBe(true);
       expect(excluded.has('write_todos')).toBe(true);
       expect(excluded.has('memory')).toBe(true);
       // write_file and replace are excluded unless they have argsPattern rules
@@ -2988,6 +2993,7 @@ describe('PolicyEngine', () => {
       expect(excluded.has('list_directory')).toBe(false);
       expect(excluded.has('google_web_search')).toBe(false);
       expect(excluded.has('activate_skill')).toBe(false);
+      expect(excluded.has('web_fetch')).toBe(false);
       expect(excluded.has('ask_user')).toBe(false);
       expect(excluded.has('exit_plan_mode')).toBe(false);
       expect(excluded.has('save_memory')).toBe(false);


### PR DESCRIPTION
Resolves #24450 by explicitly allowing the
   \`web_fetch\` tool in Plan Mode requiring user confirmation (\`ask_user\`).