### PR TITLE
perf(core): lazy stat, parallel I/O, and platform-aware nocase in tools

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1057,7 +1057,6 @@ Logging in with Google... Restarting Gemini CLI to continue.
 
       if (config.isJitContextEnabled()) {
         await config.getMemoryContextManager()?.refresh();
-        config.updateSystemInstructionIfInitialized();
         flattenedMemory = flattenMemory(config.getUserMemory());
         fileCount = config.getGeminiMdFileCount();
       } else {

--- a/packages/core/src/commands/memory.test.ts
+++ b/packages/core/src/commands/memory.test.ts
@@ -129,9 +129,6 @@ describe('memory commands', () => {
       const result = await refreshMemory(mockConfig);
 
       expect(mockRefresh).toHaveBeenCalledWith(mockConfig);
-      expect(
-        mockConfig.updateSystemInstructionIfInitialized,
-      ).toHaveBeenCalled();
       expect(result.type).toBe('message');
       if (result.type === 'message') {
         expect(result.messageType).toBe('info');

--- a/packages/core/src/commands/memory.ts
+++ b/packages/core/src/commands/memory.ts
@@ -60,7 +60,6 @@ export async function refreshMemory(
     fileCount = result.fileCount;
   }
 
-  config.updateSystemInstructionIfInitialized();
   let content: string;
 
   if (memoryContent.length > 0) {

--- a/packages/core/src/tools/definitions/__snapshots__/coreToolsModelSnapshots.test.ts.snap
+++ b/packages/core/src/tools/definitions/__snapshots__/coreToolsModelSnapshots.test.ts.snap
@@ -205,7 +205,7 @@ exports[`coreTools snapshots for specific models > Model: gemini-2.5-pro > snaps
   "parametersJsonSchema": {
     "properties": {
       "case_sensitive": {
-        "description": "Optional: Whether the search should be case-sensitive. Defaults to false.",
+        "description": "Optional: Whether the search should be case-sensitive. Defaults to false on macOS/Windows, true on Linux.",
         "type": "boolean",
       },
       "dir_path": {
@@ -450,6 +450,10 @@ Use this tool when the user's query implies needing the content of several files
   "name": "read_many_files",
   "parametersJsonSchema": {
     "properties": {
+      "case_sensitive": {
+        "description": "Optional: Whether the search should be case-sensitive. Defaults to false on macOS/Windows, true on Linux.",
+        "type": "boolean",
+      },
       "exclude": {
         "default": [],
         "description": "Optional. Glob patterns for files/directories to exclude. Added to default excludes if useDefaultExcludes is true. Example: "**/*.log", "temp/"",
@@ -1035,7 +1039,7 @@ exports[`coreTools snapshots for specific models > Model: gemini-3-pro-preview >
   "parametersJsonSchema": {
     "properties": {
       "case_sensitive": {
-        "description": "Optional: Whether the search should be case-sensitive. Defaults to false.",
+        "description": "Optional: Whether the search should be case-sensitive. Defaults to false on macOS/Windows, true on Linux.",
         "type": "boolean",
       },
       "dir_path": {
@@ -1280,6 +1284,10 @@ Use this tool when the user's query implies needing the content of several files
   "name": "read_many_files",
   "parametersJsonSchema": {
     "properties": {
+      "case_sensitive": {
+        "description": "Optional: Whether the search should be case-sensitive. Defaults to false on macOS/Windows, true on Linux.",
+        "type": "boolean",
+      },
       "exclude": {
         "default": [],
         "description": "Optional. Glob patterns for files/directories to exclude. Added to default excludes if useDefaultExcludes is true. Example: "**/*.log", "temp/"",

--- a/packages/core/src/tools/definitions/model-family-sets/default-legacy.ts
+++ b/packages/core/src/tools/definitions/model-family-sets/default-legacy.ts
@@ -275,7 +275,7 @@ export const DEFAULT_LEGACY_SET: CoreToolSet = {
         },
         [PARAM_CASE_SENSITIVE]: {
           description:
-            'Optional: Whether the search should be case-sensitive. Defaults to false.',
+            'Optional: Whether the search should be case-sensitive. Defaults to false on macOS/Windows, true on Linux.',
           type: 'boolean',
         },
         [PARAM_RESPECT_GIT_IGNORE]: {
@@ -488,6 +488,11 @@ Use this tool when the user's query implies needing the content of several files
           description:
             'Optional. Whether to apply a list of default exclusion patterns (e.g., node_modules, .git, binary files). Defaults to true.',
           default: true,
+        },
+        [PARAM_CASE_SENSITIVE]: {
+          description:
+            'Optional: Whether the search should be case-sensitive. Defaults to false on macOS/Windows, true on Linux.',
+          type: 'boolean',
         },
         [PARAM_FILE_FILTERING_OPTIONS]: {
           description:

--- a/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts
+++ b/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts
@@ -282,7 +282,7 @@ export const GEMINI_3_SET: CoreToolSet = {
         },
         [PARAM_CASE_SENSITIVE]: {
           description:
-            'Optional: Whether the search should be case-sensitive. Defaults to false.',
+            'Optional: Whether the search should be case-sensitive. Defaults to false on macOS/Windows, true on Linux.',
           type: 'boolean',
         },
         [PARAM_RESPECT_GIT_IGNORE]: {
@@ -471,6 +471,11 @@ Use this tool when the user's query implies needing the content of several files
           description:
             'Optional. Whether to apply a list of default exclusion patterns (e.g., node_modules, .git, binary files). Defaults to true.',
           default: true,
+        },
+        [PARAM_CASE_SENSITIVE]: {
+          description:
+            'Optional: Whether the search should be case-sensitive. Defaults to false on macOS/Windows, true on Linux.',
+          type: 'boolean',
         },
         [PARAM_FILE_FILTERING_OPTIONS]: {
           description:

--- a/packages/core/src/tools/glob.test.ts
+++ b/packages/core/src/tools/glob.test.ts
@@ -112,10 +112,21 @@ describe('GlobTool', () => {
       const params: GlobToolParams = { pattern: '*.txt' };
       const invocation = globTool.build(params);
       const result = await invocation.execute(abortSignal);
-      expect(result.llmContent).toContain('Found 2 file(s)');
       expect(result.llmContent).toContain(path.join(tempRootDir, 'fileA.txt'));
-      expect(result.llmContent).toContain(path.join(tempRootDir, 'FileB.TXT'));
-      expect(result.returnDisplay).toBe('Found 2 matching file(s)');
+      if (process.platform === 'linux') {
+        // On Linux, nocase is disabled for performance so *.txt won't match FileB.TXT
+        expect(result.llmContent).toContain('Found 1 file(s)');
+        expect(result.llmContent).not.toContain(
+          path.join(tempRootDir, 'FileB.TXT'),
+        );
+        expect(result.returnDisplay).toBe('Found 1 matching file(s)');
+      } else {
+        expect(result.llmContent).toContain('Found 2 file(s)');
+        expect(result.llmContent).toContain(
+          path.join(tempRootDir, 'FileB.TXT'),
+        );
+        expect(result.returnDisplay).toBe('Found 2 matching file(s)');
+      }
     }, 30000);
 
     it('should find files case-sensitively when case_sensitive is true', async () => {
@@ -135,8 +146,13 @@ describe('GlobTool', () => {
 
       const result = await invocation.execute(abortSignal);
 
-      expect(result.llmContent).toContain('fileA.txt');
       expect(result.llmContent).toContain('FileB.TXT');
+      if (process.platform === 'linux') {
+        // On Linux, nocase is disabled so *.TXT won't match fileA.txt
+        expect(result.llmContent).not.toContain('fileA.txt');
+      } else {
+        expect(result.llmContent).toContain('fileA.txt');
+      }
     }, 30000);
 
     it('should find files case-insensitively when case_sensitive is false (pattern: *.TXT)', async () => {
@@ -146,35 +162,52 @@ describe('GlobTool', () => {
       };
       const invocation = globTool.build(params);
       const result = await invocation.execute(abortSignal);
+      // Explicit case_sensitive: false should enable nocase on all platforms
       expect(result.llmContent).toContain('Found 2 file(s)');
-      expect(result.llmContent).toContain(path.join(tempRootDir, 'fileA.txt'));
       expect(result.llmContent).toContain(path.join(tempRootDir, 'FileB.TXT'));
+      expect(result.llmContent).toContain(path.join(tempRootDir, 'fileA.txt'));
     }, 30000);
 
     it('should find files using a pattern that includes a subdirectory', async () => {
       const params: GlobToolParams = { pattern: 'sub/*.md' };
       const invocation = globTool.build(params);
       const result = await invocation.execute(abortSignal);
-      expect(result.llmContent).toContain('Found 2 file(s)');
       expect(result.llmContent).toContain(
         path.join(tempRootDir, 'sub', 'fileC.md'),
       );
-      expect(result.llmContent).toContain(
-        path.join(tempRootDir, 'sub', 'FileD.MD'),
-      );
+      if (process.platform === 'linux') {
+        // On Linux, nocase is disabled so sub/*.md won't match FileD.MD
+        expect(result.llmContent).toContain('Found 1 file(s)');
+        expect(result.llmContent).not.toContain(
+          path.join(tempRootDir, 'sub', 'FileD.MD'),
+        );
+      } else {
+        expect(result.llmContent).toContain('Found 2 file(s)');
+        expect(result.llmContent).toContain(
+          path.join(tempRootDir, 'sub', 'FileD.MD'),
+        );
+      }
     }, 30000);
 
     it('should find files in a specified relative path (relative to rootDir)', async () => {
       const params: GlobToolParams = { pattern: '*.md', dir_path: 'sub' };
       const invocation = globTool.build(params);
       const result = await invocation.execute(abortSignal);
-      expect(result.llmContent).toContain('Found 2 file(s)');
       expect(result.llmContent).toContain(
         path.join(tempRootDir, 'sub', 'fileC.md'),
       );
-      expect(result.llmContent).toContain(
-        path.join(tempRootDir, 'sub', 'FileD.MD'),
-      );
+      if (process.platform === 'linux') {
+        // On Linux, nocase is disabled so *.md won't match FileD.MD
+        expect(result.llmContent).toContain('Found 1 file(s)');
+        expect(result.llmContent).not.toContain(
+          path.join(tempRootDir, 'sub', 'FileD.MD'),
+        );
+      } else {
+        expect(result.llmContent).toContain('Found 2 file(s)');
+        expect(result.llmContent).toContain(
+          path.join(tempRootDir, 'sub', 'FileD.MD'),
+        );
+      }
     }, 30000);
 
     it('should find files using a deep globstar pattern (e.g., **/*.log)', async () => {
@@ -246,6 +279,35 @@ describe('GlobTool', () => {
       const invocation = globTool.build(params);
       const result = await invocation.execute(abortSignal);
       expect(result.error?.type).toBe(ToolErrorType.GLOB_EXECUTION_ERROR);
+    }, 30000);
+
+    it('should gracefully handle files deleted between glob and stat', async () => {
+      // Create files that glob will find
+      await fs.writeFile(path.join(tempRootDir, 'keep.dat'), 'keep');
+      await fs.writeFile(path.join(tempRootDir, 'vanish.dat'), 'vanish');
+
+      const params: GlobToolParams = { pattern: '*.dat' };
+      const invocation = globTool.build(params);
+
+      // Spy on fsPromises.stat to simulate a file disappearing after glob
+      const fsPromisesMod = await import('node:fs/promises');
+      const originalStat = fsPromisesMod.default.stat;
+      const statSpy = vi
+        .spyOn(fsPromisesMod.default, 'stat')
+        .mockImplementation(async (filePath, ...args) => {
+          if (String(filePath).includes('vanish.dat')) {
+            throw new Error('ENOENT: no such file or directory');
+          }
+          return originalStat(filePath, ...args);
+        });
+
+      const result = await invocation.execute(abortSignal);
+
+      expect(result.llmContent).toContain('keep.dat');
+      expect(result.llmContent).not.toContain('vanish.dat');
+      expect(result.llmContent).toContain('Found 1 file(s)');
+
+      statSpy.mockRestore();
     }, 30000);
   });
 

--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -6,6 +6,7 @@
 
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import { glob, escape } from 'glob';
 import {
@@ -79,7 +80,8 @@ export interface GlobToolParams {
   dir_path?: string;
 
   /**
-   * Whether the search should be case-sensitive (optional, defaults to false)
+   * Whether the search should be case-sensitive (optional, defaults to false
+   * on macOS/Windows, true on Linux for performance)
    */
   case_sensitive?: boolean;
 
@@ -164,8 +166,17 @@ class GlobToolInvocation extends BaseToolInvocation<
       // Get centralized file discovery service
       const fileDiscovery = this.config.getFileService();
 
-      // Collect entries from all search directories
-      const allEntries: GlobPath[] = [];
+      // On Linux, nocase forces readdir at every directory level to simulate
+      // case-insensitive matching on a case-sensitive FS. Default to false
+      // there to avoid expensive readdir storms.
+      const nocase =
+        this.params.case_sensitive === undefined
+          ? process.platform !== 'linux'
+          : !this.params.case_sensitive;
+
+      // Phase 1: Fast discovery without stat (avoids thousands of stat calls
+      // on broad patterns). We stat only after filtering.
+      const allPaths: string[] = [];
       for (const searchDir of searchDirectories) {
         let pattern = this.params.pattern;
         const fullPath = path.join(searchDir, pattern);
@@ -173,25 +184,25 @@ class GlobToolInvocation extends BaseToolInvocation<
           pattern = escape(pattern);
         }
 
-        const entries = (await glob(pattern, {
+        const entries = await glob(pattern, {
           cwd: searchDir,
-          withFileTypes: true,
           nodir: true,
-          stat: true,
-          nocase: !this.params.case_sensitive,
+          nocase,
           dot: true,
           ignore: this.config.getFileExclusions().getGlobExcludes(),
           follow: false,
           signal,
-        })) as GlobPath[];
+          absolute: true,
+        });
 
-        allEntries.push(...entries);
+        allPaths.push(...entries);
       }
 
-      const relativePaths = allEntries.map((p) =>
-        path.relative(this.config.getTargetDir(), p.fullpath()),
+      const relativePaths = allPaths.map((p) =>
+        path.relative(this.config.getTargetDir(), p),
       );
 
+      // Phase 2: Apply gitignore / geminiignore filtering
       const { filteredPaths, ignoredCount } =
         fileDiscovery.filterFilesWithReport(relativePaths, {
           respectGitIgnore:
@@ -204,15 +215,39 @@ class GlobToolInvocation extends BaseToolInvocation<
             DEFAULT_FILE_FILTERING_OPTIONS.respectGeminiIgnore,
         });
 
-      const filteredAbsolutePaths = new Set(
-        filteredPaths.map((p) => path.resolve(this.config.getTargetDir(), p)),
-      );
+      // Phase 3: Stat only the filtered survivors in batches for recency sorting.
+      // Cap concurrency to avoid opening too many file descriptors at once.
+      const CONCURRENT_LIMIT = 20;
+      const statResults: GlobPath[] = [];
+      for (let i = 0; i < filteredPaths.length; i += CONCURRENT_LIMIT) {
+        if (signal.aborted) throw signal.reason;
+        const batch = filteredPaths.slice(i, i + CONCURRENT_LIMIT);
+        const batchResults = await Promise.allSettled(
+          batch.map(async (relativePath) => {
+            const absPath = path.resolve(
+              this.config.getTargetDir(),
+              relativePath,
+            );
+            const stats = await fsPromises.stat(absPath);
+            return {
+              fullpath: () => absPath,
+              mtimeMs: stats.mtimeMs,
+            };
+          }),
+        );
+        for (const result of batchResults) {
+          if (result.status === 'fulfilled') {
+            statResults.push(result.value);
+          }
+          if (result.status === 'rejected') {
+            debugLogger.debug(
+              `Stat failed (file may have been deleted): ${result.reason}`,
+            );
+          }
+        }
+      }
 
-      const filteredEntries = allEntries.filter((entry) =>
-        filteredAbsolutePaths.has(entry.fullpath()),
-      );
-
-      if (!filteredEntries || filteredEntries.length === 0) {
+      if (!statResults || statResults.length === 0) {
         let message = `No files found matching pattern "${this.params.pattern}"`;
         if (searchDirectories.length === 1) {
           message += ` within ${searchDirectories[0]}`;
@@ -234,7 +269,7 @@ class GlobToolInvocation extends BaseToolInvocation<
 
       // Sort the filtered entries using the new helper function
       const sortedEntries = sortFileEntries(
-        filteredEntries,
+        statResults,
         nowTimestamp,
         oneDayInMs,
       );

--- a/packages/core/src/tools/ls.ts
+++ b/packages/core/src/tools/ls.ts
@@ -155,7 +155,7 @@ class LSToolInvocation extends BaseToolInvocation<LSToolParams, ToolResult> {
    * Executes the LS operation with the given parameters
    * @returns Result of the LS operation
    */
-  async execute(_signal: AbortSignal): Promise<ToolResult> {
+  async execute(signal: AbortSignal): Promise<ToolResult> {
     const resolvedDirPath = path.resolve(
       this.config.getTargetDir(),
       this.params.dir_path,
@@ -224,27 +224,50 @@ class LSToolInvocation extends BaseToolInvocation<LSToolParams, ToolResult> {
             DEFAULT_FILE_FILTERING_OPTIONS.respectGeminiIgnore,
         });
 
-      const entries = [];
-      for (const relativePath of filteredPaths) {
-        const fullPath = path.resolve(this.config.getTargetDir(), relativePath);
+      const pathsToStat = filteredPaths.filter(
+        (relativePath) =>
+          !this.shouldIgnore(path.basename(relativePath), this.params.ignore),
+      );
 
-        if (this.shouldIgnore(path.basename(fullPath), this.params.ignore)) {
-          continue;
-        }
-
-        try {
-          const stats = await fs.stat(fullPath);
-          const isDir = stats.isDirectory();
-          entries.push({
-            name: path.basename(fullPath),
-            path: fullPath,
-            isDirectory: isDir,
-            size: isDir ? 0 : stats.size,
-            modifiedTime: stats.mtime,
-          });
-        } catch (error) {
-          // Log error internally but don't fail the whole listing
-          debugLogger.debug(`Error accessing ${fullPath}: ${error}`);
+      // Batch stat calls to avoid opening too many file descriptors at once
+      const CONCURRENT_LIMIT = 20;
+      type LSEntry = {
+        name: string;
+        path: string;
+        isDirectory: boolean;
+        size: number;
+        modifiedTime: Date;
+      };
+      const entries: LSEntry[] = [];
+      for (let i = 0; i < pathsToStat.length; i += CONCURRENT_LIMIT) {
+        if (signal.aborted) throw signal.reason;
+        const batch = pathsToStat.slice(i, i + CONCURRENT_LIMIT);
+        const batchResults = await Promise.allSettled(
+          batch.map(async (relativePath) => {
+            const fullPath = path.resolve(
+              this.config.getTargetDir(),
+              relativePath,
+            );
+            const stats = await fs.stat(fullPath);
+            const isDir = stats.isDirectory();
+            return {
+              name: path.basename(fullPath),
+              path: fullPath,
+              isDirectory: isDir,
+              size: isDir ? 0 : stats.size,
+              modifiedTime: stats.mtime,
+            };
+          }),
+        );
+        for (const result of batchResults) {
+          if (result.status === 'fulfilled') {
+            entries.push(result.value);
+          }
+          if (result.status === 'rejected') {
+            debugLogger.debug(
+              `Stat failed (file may have been deleted): ${result.reason}`,
+            );
+          }
         }
       }
 

--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -82,6 +82,12 @@ export interface ReadManyFilesParams {
   useDefaultExcludes?: boolean;
 
   /**
+   * Whether the search should be case-sensitive (optional, defaults to false
+   * on macOS/Windows, true on Linux for performance)
+   */
+  case_sensitive?: boolean;
+
+  /**
    * Whether to respect .gitignore and .geminiignore patterns (optional, defaults to true)
    */
   file_filtering_options?: {
@@ -218,7 +224,13 @@ ${finalExclusionPatternsForDescription
           nodir: true,
           dot: true,
           absolute: true,
-          nocase: true,
+          // On Linux, nocase forces readdir at every directory level to
+          // simulate case-insensitive matching on a case-sensitive FS.
+          // Default to false there to avoid expensive readdir storms.
+          nocase:
+            this.params.case_sensitive === undefined
+              ? process.platform !== 'linux'
+              : !this.params.case_sensitive,
           signal,
         });
         for (const entry of entriesInDir) {

--- a/packages/core/src/utils/pathReader.test.ts
+++ b/packages/core/src/utils/pathReader.test.ts
@@ -36,6 +36,7 @@ const createMockConfig = (
     getFileService: () => mockFileService,
     getFileFilteringRespectGitIgnore: () => respectGitIgnore,
     getFileFilteringRespectGeminiIgnore: () => respectGeminiIgnore,
+    getFileExclusions: () => ({ getGlobExcludes: () => [] }),
   } as unknown as Config;
 };
 
@@ -270,6 +271,48 @@ describe('readPathFromWorkspace', () => {
           data: imageData.toString('base64'),
         },
       });
+    });
+
+    it('should exclude files matching getGlobExcludes patterns during directory expansion', async () => {
+      mock({
+        [CWD]: {
+          'my-dir': {
+            'file.txt': 'visible',
+            node_modules: {
+              'dep.js': 'should be excluded',
+            },
+          },
+        },
+      });
+      const mockFileService = {
+        filterFiles: vi.fn((files) => files),
+      } as unknown as FileDiscoveryService;
+      // Build a config whose getGlobExcludes returns a real pattern
+      const workspace = new WorkspaceContext(CWD, []);
+      const fileSystemService = new StandardFileSystemService();
+      const config = {
+        getWorkspaceContext: () => workspace,
+        getTargetDir: () => CWD,
+        getFileSystemService: () => fileSystemService,
+        getFileService: () => mockFileService,
+        getFileFilteringRespectGitIgnore: () => true,
+        getFileFilteringRespectGeminiIgnore: () => true,
+        getFileExclusions: () => ({
+          getGlobExcludes: () => ['**/node_modules/**'],
+        }),
+      } as unknown as Config;
+
+      const result = await readPathFromWorkspace('my-dir', config);
+      const resultText = result
+        .map((p) => {
+          if (typeof p === 'string') return p;
+          if (typeof p === 'object' && p && 'text' in p) return p.text;
+          return '';
+        })
+        .join('');
+
+      expect(resultText).toContain('visible');
+      expect(resultText).not.toContain('should be excluded');
     });
 
     it('should handle an empty directory', async () => {

--- a/packages/core/src/utils/pathReader.ts
+++ b/packages/core/src/utils/pathReader.ts
@@ -64,9 +64,15 @@ export async function readPathFromWorkspace(
     // Use glob to recursively find all files within the directory.
     const files = await glob('**/*', {
       cwd: absolutePath,
-      nodir: true, // We only want files
-      dot: true, // Include dotfiles
+      nodir: true,
+      dot: true,
       absolute: true,
+      ignore: config.getFileExclusions().getGlobExcludes(),
+      follow: false,
+      // On Linux, nocase forces readdir at every directory level to simulate
+      // case-insensitive matching on a case-sensitive FS. Default to false
+      // there to avoid expensive readdir storms.
+      nocase: process.platform !== 'linux',
     });
 
     const relativeFiles = files.map((p) =>


### PR DESCRIPTION
## Summary

Fixes several verified I/O performance bottlenecks in GlobTool, LSTool, ReadManyFiles, and PathReader that cause high latency on broad search patterns and on Linux filesystems, especially when jitContext is enabled.

## Details

**GlobTool — Lazy stat (high impact):**
Previously `stat: true` was passed to the glob library, forcing an `fs.stat()` on *every* matched file before gitignore filtering. On broad patterns (`**/*.ts`) in large repos, this meant thousands of wasted stat calls. Now glob runs without stat, filtering is applied first, and only the surviving files are stat'd in parallel via `Promise.all` for recency sorting.

**GlobTool + ReadManyFiles — Platform-aware `nocase` (high impact on Linux):**
`nocase: true` was always enabled, which on Linux forces the glob library to `readdir` at every directory level to simulate case-insensitive matching on a case-sensitive filesystem. This causes "readdir storms" and multi-second hangs. Now defaults to `false` on Linux (where the FS is already case-sensitive) and `true` elsewhere (macOS/Windows where it's a no-op).

**LSTool — Parallel stat (medium impact):**
`fs.stat()` was called sequentially in a `for...of` loop. Directories with hundreds of entries suffered linear I/O latency. Now parallelized with `Promise.all`.

**PathReader — Ignore passthrough (medium impact):**
The `@{dir}` directory expansion glob (`**/*`) was called with no ignore patterns, walking into `node_modules` and other excluded directories, only to filter them post-hoc. Now pushes `getGlobExcludes()` directly into the glob call.

**Remove redundant system instruction updates (low impact):**
`/memory refresh` with jitContext called `updateSystemInstructionIfInitialized()` explicitly after `contextManager.refresh()`, but the refresh already emits `MemoryChanged` which triggers the same update via the event handler. Removed the redundant call in both `AppContainer.tsx` and `memory.ts`.

## Related Issues

Fixes #18007

## How to Validate

1. Run the affected test suites:
   ```bash
   npm test -w @google/gemini-cli-core -- src/tools/glob.test.ts src/tools/ls.test.ts src/tools/read-many-files.test.ts src/utils/pathReader.test.ts src/commands/memory.test.ts
   ```
   All 124 tests pass. Full core suite (6595 tests) also passes with 0 regressions.

2. For the GlobTool lazy stat: use `glob` tool with a broad pattern like `**/*.ts` in a large repo. Observe that the tool returns faster since stat calls are deferred and parallelized.

3. For platform-aware nocase: on a Linux machine, run `glob` or `read_many_files` with a broad pattern. Latency should be significantly reduced since readdir storms are avoided.

4. For LSTool: list a directory with many entries (100+). The response should be noticeably faster.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
