### PR TITLE
Auto configure memory.

### DIFF
--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -153,7 +153,7 @@ they appear in the UI.
 
 | UI Label                          | Setting                        | Description                                   | Default |
 | --------------------------------- | ------------------------------ | --------------------------------------------- | ------- |
-| Auto Configure Max Old Space Size | `advanced.autoConfigureMemory` | Automatically configure Node.js memory limits | `false` |
+| Auto Configure Max Old Space Size | `advanced.autoConfigureMemory` | Automatically configure Node.js memory limits | `true`  |
 
 ### Experimental
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1565,7 +1565,7 @@ their corresponding top-level category object in your `settings.json` file.
 
 - **`advanced.autoConfigureMemory`** (boolean):
   - **Description:** Automatically configure Node.js memory limits
-  - **Default:** `false`
+  - **Default:** `true`
   - **Requires restart:** Yes
 
 - **`advanced.dnsResolutionOrder`** (string):

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1887,7 +1887,7 @@ const SETTINGS_SCHEMA = {
         label: 'Auto Configure Max Old Space Size',
         category: 'Advanced',
         requiresRestart: true,
-        default: false,
+        default: true,
         description: 'Automatically configure Node.js memory limits',
         showInDialog: true,
       },

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -2712,8 +2712,8 @@
         "autoConfigureMemory": {
           "title": "Auto Configure Max Old Space Size",
           "description": "Automatically configure Node.js memory limits",
-          "markdownDescription": "Automatically configure Node.js memory limits\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `false`",
-          "default": false,
+          "markdownDescription": "Automatically configure Node.js memory limits\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `true`",
+          "default": true,
           "type": "boolean"
         },
         "dnsResolutionOrder": {


### PR DESCRIPTION
## Summary

We've been afraid to turn on this setting but I think it is time to bite the bullet and just auto configure the maximum heap size. 

This will eliminate almost all Gemini CLI out of memory issues at the cost of allowing Gemini CLI to use more memory.