### PR TITLE
fix(cli): ensure agent stops when all declinable tools are cancelled

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -52,6 +52,7 @@ import {
   MCPDiscoveryState,
   GeminiCliOperation,
   getPlanModeExitMessage,
+  UPDATE_TOPIC_TOOL_NAME,
 } from '@google/gemini-cli-core';
 import type { Part, PartListUnion } from '@google/genai';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
@@ -906,6 +907,30 @@ describe('useGeminiStream', () => {
     const cancelledToolCalls: TrackedToolCall[] = [
       {
         request: {
+          callId: 'topic1',
+          name: UPDATE_TOPIC_TOOL_NAME,
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-id-3',
+        },
+        status: CoreToolCallStatus.Success,
+        response: {
+          callId: 'topic1',
+          responseParts: [
+            {
+              functionResponse: {
+                name: UPDATE_TOPIC_TOOL_NAME,
+                id: 'topic1',
+                response: {},
+              },
+            },
+          ],
+        },
+        tool: { displayName: 'Update Topic Context' },
+        invocation: { getDescription: () => 'Updating topic' },
+      } as any,
+      {
+        request: {
           callId: '1',
           name: 'testTool',
           args: {},
@@ -924,8 +949,8 @@ describe('useGeminiStream', () => {
         },
         invocation: {
           getDescription: () => `Mock description`,
-        } as unknown as AnyToolInvocation,
-      } as TrackedCancelledToolCall,
+        },
+      } as any,
     ];
     const client = new MockedGeminiClientClass(mockConfig);
 
@@ -978,10 +1003,19 @@ describe('useGeminiStream', () => {
     });
 
     await waitFor(() => {
-      expect(mockMarkToolsAsSubmitted).toHaveBeenCalledWith(['1']);
+      expect(mockMarkToolsAsSubmitted).toHaveBeenCalledWith(['topic1', '1']);
       expect(client.addHistory).toHaveBeenCalledWith({
         role: 'user',
-        parts: [{ text: CoreToolCallStatus.Cancelled }],
+        parts: [
+          {
+            functionResponse: {
+              name: UPDATE_TOPIC_TOOL_NAME,
+              id: 'topic1',
+              response: {},
+            },
+          },
+          { text: CoreToolCallStatus.Cancelled },
+        ],
       });
       // Ensure we do NOT call back to the API
       expect(mockSendMessageStream).not.toHaveBeenCalled();

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -1022,6 +1022,90 @@ describe('useGeminiStream', () => {
     });
   });
 
+  it('should NOT stop responding when only update_topic is called', async () => {
+    const topicToolCalls: TrackedToolCall[] = [
+      {
+        request: {
+          callId: 'topic1',
+          name: UPDATE_TOPIC_TOOL_NAME,
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-id-3',
+        },
+        status: CoreToolCallStatus.Success,
+        response: {
+          callId: 'topic1',
+          responseParts: [
+            {
+              functionResponse: {
+                name: UPDATE_TOPIC_TOOL_NAME,
+                id: 'topic1',
+                response: {},
+              },
+            },
+          ],
+        },
+        tool: { displayName: 'Update Topic Context' },
+        invocation: { getDescription: () => 'Updating topic' },
+      } as any,
+    ];
+    const client = new MockedGeminiClientClass(mockConfig);
+
+    // Capture the onComplete callback
+    let capturedOnComplete:
+      | ((completedTools: TrackedToolCall[]) => Promise<void>)
+      | null = null;
+
+    mockUseToolScheduler.mockImplementation((onComplete) => {
+      capturedOnComplete = onComplete;
+      return [
+        topicToolCalls,
+        vi.fn(),
+        mockMarkToolsAsSubmitted,
+        vi.fn(),
+        vi.fn(),
+        0,
+      ];
+    });
+
+    await renderHookWithProviders(() =>
+      useGeminiStream(
+        client,
+        [],
+        mockAddItem,
+        mockConfig,
+        mockLoadedSettings,
+        mockOnDebugMessage,
+        mockHandleSlashCommand,
+        false,
+        () => 'vscode' as EditorType,
+        () => {},
+        () => Promise.resolve(),
+        false,
+        () => {},
+        () => {},
+        () => {},
+        80,
+        24,
+      ),
+    );
+
+    // Trigger the onComplete callback with the topic tool
+    await act(async () => {
+      if (capturedOnComplete) {
+        await capturedOnComplete(topicToolCalls);
+      }
+    });
+
+    await waitFor(() => {
+      // The streaming state should still be Responding because we didn't cancel anything important
+      // and we expect a continuation.
+      expect(mockMarkToolsAsSubmitted).toHaveBeenCalledWith(['topic1']);
+      // Should HAVE called back to the API for continuation
+      expect(mockSendMessageStream).toHaveBeenCalled();
+    });
+  });
+
   it('should stop agent execution immediately when a tool call returns STOP_EXECUTION error', async () => {
     const stopExecutionToolCalls: TrackedCompletedToolCall[] = [
       {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1969,11 +1969,19 @@ export const useGeminiStream = (
 
       // If all the tools were cancelled, don't submit a response to Gemini.
       // Note: we ignore the topic tool because the user doesn't have a chance to decline it.
-      const allDeclinableToolsCancelled = geminiTools
-        .filter((tc) => !isTopicTool(tc.request.name))
-        .every((tc) => tc.status === CoreToolCallStatus.Cancelled);
+      const declinableTools = geminiTools.filter(
+        (tc) => !isTopicTool(tc.request.name),
+      );
+      const allDeclinableToolsCancelled =
+        declinableTools.length > 0 &&
+        declinableTools.every(
+          (tc) => tc.status === CoreToolCallStatus.Cancelled,
+        );
+      const allToolsCancelled =
+        geminiTools.length > 0 &&
+        geminiTools.every((tc) => tc.status === CoreToolCallStatus.Cancelled);
 
-      if (allDeclinableToolsCancelled && geminiTools.length > 0) {
+      if (allDeclinableToolsCancelled || allToolsCancelled) {
         // If the turn was cancelled via the imperative escape key flow,
         // the cancellation message is added there. We check the ref to avoid duplication.
         if (!turnCancelledRef.current) {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1968,11 +1968,12 @@ export const useGeminiStream = (
       }
 
       // If all the tools were cancelled, don't submit a response to Gemini.
-      const allToolsCancelled = geminiTools.every(
-        (tc) => tc.status === CoreToolCallStatus.Cancelled,
-      );
+      // Note: we ignore the topic tool because the user doesn't have a chance to decline it.
+      const allDeclinableToolsCancelled = geminiTools
+        .filter((tc) => !isTopicTool(tc.request.name))
+        .every((tc) => tc.status === CoreToolCallStatus.Cancelled);
 
-      if (allToolsCancelled) {
+      if (allDeclinableToolsCancelled && geminiTools.length > 0) {
         // If the turn was cancelled via the imperative escape key flow,
         // the cancellation message is added there. We check the ref to avoid duplication.
         if (!turnCancelledRef.current) {


### PR DESCRIPTION
## Summary

Fixes a bug where parallel execution of `update_topic` prevented the agent from stopping when other tools were declined.

## Details

- Updated `useGeminiStream.ts` to ignore machine-oriented tools (currently just `update_topic`) when checking if all user-facing tools were cancelled.
- Fixed `useGeminiStream.test.tsx` by adding `UPDATE_TOPIC_TOOL_NAME` and other missing display name constants to the core module mock.
- Updated the existing cancellation test case in `useGeminiStream.test.tsx` to explicitly verify that the agent correctly stops when a declinable tool is cancelled, even if `update_topic` was successful in the same turn.

## Related Issues

N/A (Reported by user in session)

## How to Validate

Run the unit tests:
```bash
npm test -w @google/gemini-cli -- src/ui/hooks/useGeminiStream.test.tsx
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
