### PR TITLE
Terminal Serializer Optimization

### DIFF
--- a/packages/core/src/utils/terminalSerializer.ts
+++ b/packages/core/src/utils/terminalSerializer.ts
@@ -162,6 +162,8 @@ export function serializeTerminalToObject(
   const effectiveStart = startLine ?? buffer.viewportY;
   const effectiveEnd = endLine ?? buffer.viewportY + terminal.rows;
 
+  const cellBuffer = terminal.buffer.active.getNullCell();
+
   for (let y = effectiveStart; y < effectiveEnd; y++) {
     const line = buffer.getLine(y);
     const currentLine: AnsiLine = [];
@@ -175,7 +177,7 @@ export function serializeTerminalToObject(
     let currentText = '';
 
     for (let x = 0; x < terminal.cols; x++) {
-      const cellData = line.getCell(x);
+      const cellData = line.getCell(x, cellBuffer);
       currentCell.update(cellData || null, x, y, cursorX, cursorY);
 
       if (x > 0 && !currentCell.equals(lastCell)) {


### PR DESCRIPTION
## Summary

The terminal serializer is called when streaming shell output.
It previously allocated a an object for every character which was inefficient and contributed to V8 memory pressure.

To mitigate, refactored the code to avoid any O(rows x cols) allocs every frame.
