### PR TITLE
Unused error variables in catch block are not allowed

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -13,7 +13,7 @@ import { wasmLoader } from 'esbuild-plugin-wasm';
 let esbuild;
 try {
   esbuild = (await import('esbuild')).default;
-} catch (_error) {
+} catch {
   console.error('esbuild not available - cannot build bundle');
   process.exit(1);
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,6 +41,11 @@ const commonRestrictedSyntaxRules = [
     message:
       'Do not use typeof to check object properties. Define a TypeScript interface and a type guard function instead.',
   },
+  {
+    selector: 'CatchClause > Identifier[name=/^_/]',
+    message:
+      'Do not use underscored identifiers in catch blocks. If the error is unused, use "catch {}". If it is used, remove the underscore.',
+  },
 ];
 
 export default tseslint.config(

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -129,7 +129,7 @@ export default tseslint.config(
         {
           argsIgnorePattern: '^_',
           varsIgnorePattern: '^_',
-          caughtErrorsIgnorePattern: '^_',
+          caughtErrors: 'all',
         },
       ],
       // Prevent async errors from bypassing catch handlers
@@ -336,7 +336,7 @@ export default tseslint.config(
         {
           argsIgnorePattern: '^_',
           varsIgnorePattern: '^_',
-          caughtErrorsIgnorePattern: '^_',
+          caughtErrors: 'all',
         },
       ],
     },
@@ -360,7 +360,7 @@ export default tseslint.config(
         {
           argsIgnorePattern: '^_',
           varsIgnorePattern: '^_',
-          caughtErrorsIgnorePattern: '^_',
+          caughtErrors: 'all',
         },
       ],
     },
@@ -422,7 +422,7 @@ export default tseslint.config(
         {
           argsIgnorePattern: '^_',
           varsIgnorePattern: '^_',
-          caughtErrorsIgnorePattern: '^_',
+          caughtErrors: 'all',
         },
       ],
     },

--- a/packages/a2a-server/src/commands/restore.ts
+++ b/packages/a2a-server/src/commands/restore.ts
@@ -98,7 +98,7 @@ export class RestoreCommand implements Command {
         name: this.name,
         data: restoreResult,
       };
-    } catch (_error) {
+    } catch {
       return {
         name: this.name,
         data: {
@@ -142,7 +142,7 @@ export class ListCheckpointsCommand implements Command {
           content: JSON.stringify(checkpointInfoList),
         },
       };
-    } catch (_error) {
+    } catch {
       return {
         name: this.name,
         data: {

--- a/packages/cli/src/acp/commands/extensions.ts
+++ b/packages/cli/src/acp/commands/extensions.ts
@@ -284,7 +284,7 @@ export class LinkExtensionCommand implements Command {
 
     try {
       await stat(sourceFilepath);
-    } catch (_error) {
+    } catch {
       return { name: this.name, data: `Invalid source: ${sourceFilepath}` };
     }
 

--- a/packages/cli/src/acp/commands/restore.ts
+++ b/packages/cli/src/acp/commands/restore.ts
@@ -130,7 +130,7 @@ export class ListCheckpointsCommand implements Command {
       const checkpointDir = config.storage.getProjectTempCheckpointsDir();
       try {
         await fs.mkdir(checkpointDir, { recursive: true });
-      } catch (_e) {
+      } catch {
         // Ignore
       }
 
@@ -169,7 +169,7 @@ export class ListCheckpointsCommand implements Command {
         name: this.name,
         data: `Available Checkpoints:\n${formatted}`,
       };
-    } catch (_error) {
+    } catch {
       return {
         name: this.name,
         data: 'An unexpected error occurred while listing checkpoints.',

--- a/packages/cli/src/commands/extensions/new.ts
+++ b/packages/cli/src/commands/extensions/new.ts
@@ -25,7 +25,7 @@ async function pathExists(path: string) {
   try {
     await access(path);
     return true;
-  } catch (_e) {
+  } catch {
     return false;
   }
 }

--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -32,7 +32,7 @@ describe('mcp command', () => {
 
     try {
       await parser.parse('mcp');
-    } catch (_error) {
+    } catch {
       // yargs might throw an error when demandCommand is not met
     }
 

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -121,7 +121,7 @@ async function testMCPConnection(
   try {
     // Use the same transport creation logic as core
     transport = await createTransport(serverName, config, false, mcpContext);
-  } catch (_error) {
+  } catch {
     await client.close();
     return MCPServerStatus.DISCONNECTED;
   }
@@ -135,7 +135,7 @@ async function testMCPConnection(
 
     await client.close();
     return MCPServerStatus.CONNECTED;
-  } catch (_error) {
+  } catch {
     await transport.close();
     return MCPServerStatus.DISCONNECTED;
   }

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1064,7 +1064,7 @@ async function resolveWorktreeSettings(
     if (isGeminiWorktree(toplevel, projectRoot)) {
       worktreePath = toplevel;
     }
-  } catch (_e) {
+  } catch {
     return undefined;
   }
 

--- a/packages/cli/src/config/extension-manager-permissions.test.ts
+++ b/packages/cli/src/config/extension-manager-permissions.test.ts
@@ -33,7 +33,7 @@ describe('copyExtension permissions', () => {
             makeWritableSync(path.join(p, child)),
           );
         }
-      } catch (_e) {
+      } catch {
         // Ignore errors during cleanup
       }
     };

--- a/packages/cli/src/config/extension-manager.test.ts
+++ b/packages/cli/src/config/extension-manager.test.ts
@@ -101,7 +101,7 @@ describe('ExtensionManager', () => {
     themeManager.clearExtensionThemes();
     try {
       fs.rmSync(tempHomeDir, { recursive: true, force: true });
-    } catch (_e) {
+    } catch {
       // Ignore
     }
   });

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -63,7 +63,7 @@ export function loadInstallMetadata(
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const metadata = JSON.parse(configContent) as ExtensionInstallMetadata;
     return metadata;
-  } catch (_e) {
+  } catch {
     return undefined;
   }
 }

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -151,7 +151,7 @@ export async function fetchReleaseFromGithub(
       return await fetchJson(
         `https://api.github.com/repos/${owner}/${repo}/releases/latest`,
       );
-    } catch (_) {
+    } catch {
       // This can fail if there is no release marked latest. In that case
       // we want to just try the pre-release logic below.
     }

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -612,7 +612,7 @@ export function loadEnvironment(
           }
         }
       }
-    } catch (_e) {
+    } catch {
       // Errors are ignored to match the behavior of `dotenv.config({ quiet: true })`.
     }
   }

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -1712,7 +1712,7 @@ describe('runNonInteractive', () => {
           input,
           prompt_id: promptId,
         });
-      } catch (_error) {
+      } catch {
         // Expected exit
       }
 

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -65,7 +65,7 @@ const getSavedChatTags = async (
     );
 
     return chatDetails;
-  } catch (_err) {
+  } catch {
     return [];
   }
 };

--- a/packages/cli/src/ui/commands/directoryCommand.tsx
+++ b/packages/cli/src/ui/commands/directoryCommand.tsx
@@ -198,7 +198,7 @@ export const directoryCommand: SlashCommand = {
               alreadyAdded.push(trimmedPath);
               continue;
             }
-          } catch (_e) {
+          } catch {
             // Path might not exist or be inaccessible.
             // We'll let batchAddDirectories handle it later.
           }

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -321,7 +321,7 @@ async function exploreAction(
     });
     try {
       await open(extensionsUrl);
-    } catch (_error) {
+    } catch {
       context.ui.addItem({
         type: MessageType.ERROR,
         text: `Failed to open browser. Check out the extensions gallery at ${extensionsUrl}`,

--- a/packages/cli/src/ui/commands/restoreCommand.ts
+++ b/packages/cli/src/ui/commands/restoreCommand.ts
@@ -151,7 +151,7 @@ async function completion(
     const files = await fs.readdir(checkpointDir);
     const jsonFiles = files.filter((file) => file.endsWith('.json'));
     return getTruncatedCheckpointNames(jsonFiles);
-  } catch (_err) {
+  } catch {
     return [];
   }
 }

--- a/packages/cli/src/ui/commands/setupGithubCommand.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.ts
@@ -168,8 +168,8 @@ async function downloadFiles({
 async function createDirectory(dirPath: string): Promise<void> {
   try {
     await fs.promises.mkdir(dirPath, { recursive: true });
-  } catch {
-    debugLogger.debug(`Failed to create ${dirPath} directory:`, _error);
+  } catch (error) {
+    debugLogger.debug(`Failed to create ${dirPath} directory:`, error);
     throw new Error(
       `Unable to create ${dirPath} directory. Do you have file permissions in the current directory?`,
     );
@@ -222,8 +222,8 @@ export const setupGithubCommand: SlashCommand = {
     let gitRepoRoot: string;
     try {
       gitRepoRoot = getGitRepoRoot();
-    } catch {
-      debugLogger.debug(`Failed to get git repo root:`, _error);
+    } catch (error) {
+      debugLogger.debug(`Failed to get git repo root:`, error);
       throw new Error(
         'Unable to determine the GitHub repository. /setup-github must be run from a git repository.',
       );

--- a/packages/cli/src/ui/commands/setupGithubCommand.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.ts
@@ -76,7 +76,7 @@ export async function updateGitignore(gitRepoRoot: string): Promise<void> {
     let fileExists = true;
     try {
       existingContent = await fs.promises.readFile(gitignorePath, 'utf8');
-    } catch (_error) {
+    } catch {
       // File doesn't exist
       fileExists = false;
     }
@@ -168,7 +168,7 @@ async function downloadFiles({
 async function createDirectory(dirPath: string): Promise<void> {
   try {
     await fs.promises.mkdir(dirPath, { recursive: true });
-  } catch (_error) {
+  } catch {
     debugLogger.debug(`Failed to create ${dirPath} directory:`, _error);
     throw new Error(
       `Unable to create ${dirPath} directory. Do you have file permissions in the current directory?`,
@@ -222,7 +222,7 @@ export const setupGithubCommand: SlashCommand = {
     let gitRepoRoot: string;
     try {
       gitRepoRoot = getGitRepoRoot();
-    } catch (_error) {
+    } catch {
       debugLogger.debug(`Failed to get git repo root:`, _error);
       throw new Error(
         'Unable to determine the GitHub repository. /setup-github must be run from a git repository.',

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -450,7 +450,7 @@ function* emitKeys(
               insertable: true,
               sequence: decoded,
             });
-          } catch (_e) {
+          } catch {
             debugLogger.log('Failed to decode OSC 52 clipboard data');
           }
         }

--- a/packages/cli/src/ui/hooks/useAtCompletion.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.ts
@@ -319,7 +319,7 @@ export function useAtCompletion(props: UseAtCompletionProps): void {
         if (state.pattern !== null) {
           dispatch({ type: 'SEARCH', payload: state.pattern });
         }
-      } catch (_) {
+      } catch {
         if (initEpoch.current === currentEpoch) {
           dispatch({ type: 'ERROR' });
         }

--- a/packages/cli/src/ui/hooks/useConsoleMessages.test.tsx
+++ b/packages/cli/src/ui/hooks/useConsoleMessages.test.tsx
@@ -51,7 +51,7 @@ describe('useConsoleMessages', () => {
     for (const unmount of unmounts) {
       try {
         unmount();
-      } catch (_e) {
+      } catch {
         // Ignore unmount errors
       }
     }
@@ -161,7 +161,7 @@ describe('useErrorCount', () => {
     for (const unmount of unmounts) {
       try {
         unmount();
-      } catch (_e) {
+      } catch {
         // Ignore unmount errors
       }
     }

--- a/packages/cli/src/ui/hooks/useFolderTrust.ts
+++ b/packages/cli/src/ui/hooks/useFolderTrust.ts
@@ -102,7 +102,7 @@ export const useFolderTrust = (
 
       try {
         await trustedFolders.setValue(cwd, trustLevel);
-      } catch (_e) {
+      } catch {
         coreEvents.emitFeedback(
           'error',
           'Failed to save trust settings. Exiting Gemini CLI.',

--- a/packages/cli/src/ui/hooks/useGitBranchName.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.ts
@@ -31,7 +31,7 @@ export function useGitBranchName(cwd: string): string | undefined {
         );
         setBranchName(hashStdout.toString().trim());
       }
-    } catch (_error) {
+    } catch {
       setBranchName(undefined);
     }
   }, [cwd, setBranchName]);
@@ -57,7 +57,7 @@ export function useGitBranchName(cwd: string): string | undefined {
             fetchBranchName();
           }
         });
-      } catch (_watchError) {
+      } catch {
         // Silently ignore watcher errors (e.g. permissions or file not existing),
         // similar to how exec errors are handled.
         // The branch name will simply not update automatically.

--- a/packages/cli/src/ui/hooks/usePermissionsModifyTrust.ts
+++ b/packages/cli/src/ui/hooks/usePermissionsModifyTrust.ts
@@ -141,7 +141,7 @@ export const usePermissionsModifyTrust = (
         const folders = loadTrustedFolders();
         try {
           await folders.setValue(cwd, trustLevel);
-        } catch (_e) {
+        } catch {
           coreEvents.emitFeedback(
             'error',
             'Failed to save trust settings. Your changes may not persist.',
@@ -159,7 +159,7 @@ export const usePermissionsModifyTrust = (
       try {
         await folders.setValue(cwd, pendingTrustLevel);
         return true;
-      } catch (_e) {
+      } catch {
         coreEvents.emitFeedback(
           'error',
           'Failed to save trust settings. Your changes may not persist.',

--- a/packages/cli/src/ui/themes/theme.ts
+++ b/packages/cli/src/ui/themes/theme.ts
@@ -135,7 +135,7 @@ export function interpolateColor(
     const gradient = tinygradient(color1, color2);
     const color = gradient.rgbAt(factor);
     return color.toHexString();
-  } catch (_e) {
+  } catch {
     return color1;
   }
 }

--- a/packages/cli/src/ui/utils/CodeColorizer.tsx
+++ b/packages/cli/src/ui/utils/CodeColorizer.tsx
@@ -108,7 +108,7 @@ function highlightAndRenderLine(
     const renderedNode = renderHastNode(getHighlightedLine(), theme, undefined);
 
     return renderedNode !== null ? renderedNode : strippedLine;
-  } catch (_error) {
+  } catch {
     return stripAnsi(line);
   }
 }

--- a/packages/cli/src/ui/utils/directoryUtils.ts
+++ b/packages/cli/src/ui/utils/directoryUtils.ts
@@ -135,7 +135,7 @@ export async function getDirectorySuggestions(
       .sort()
       .slice(0, MAX_SUGGESTIONS)
       .map((name) => resultPrefix + name + userSep);
-  } catch (_) {
+  } catch {
     return [];
   }
 }

--- a/packages/cli/src/utils/cleanup.ts
+++ b/packages/cli/src/utils/cleanup.ts
@@ -43,7 +43,7 @@ export function runSyncCleanup() {
   for (const fn of syncCleanupFunctions) {
     try {
       fn();
-    } catch (_) {
+    } catch {
       // Ignore errors during cleanup.
     }
   }
@@ -67,7 +67,7 @@ export async function runExitCleanup() {
   for (const fn of cleanupFunctions) {
     try {
       await fn();
-    } catch (_) {
+    } catch {
       // Ignore errors during cleanup.
     }
   }
@@ -76,14 +76,14 @@ export async function runExitCleanup() {
   // Close persistent browser sessions before disposing config
   try {
     await resetBrowserSession();
-  } catch (_) {
+  } catch {
     // Ignore errors during browser cleanup
   }
 
   if (configForTelemetry) {
     try {
       await configForTelemetry.dispose();
-    } catch (_) {
+    } catch {
       // Ignore errors during disposal
     }
   }
@@ -93,7 +93,7 @@ export async function runExitCleanup() {
   if (configForTelemetry && isTelemetrySdkInitialized()) {
     try {
       await shutdownTelemetry(configForTelemetry);
-    } catch (_) {
+    } catch {
       // Ignore errors during telemetry shutdown
     }
   }

--- a/packages/cli/src/utils/gitUtils.ts
+++ b/packages/cli/src/utils/gitUtils.ts
@@ -23,7 +23,7 @@ export const isGitHubRepository = (): boolean => {
     const pattern = /github\.com/;
 
     return pattern.test(remotes);
-  } catch (_error) {
+  } catch {
     // If any filesystem error occurs, assume not a git repo
     debugLogger.debug(`Failed to get git remote:`, _error);
     return false;
@@ -85,7 +85,7 @@ export const getLatestGitHubRelease = async (
     }
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return releaseTag;
-  } catch (_error) {
+  } catch {
     debugLogger.debug(
       `Failed to determine latest run-gemini-cli release:`,
       _error,

--- a/packages/cli/src/utils/gitUtils.ts
+++ b/packages/cli/src/utils/gitUtils.ts
@@ -23,9 +23,9 @@ export const isGitHubRepository = (): boolean => {
     const pattern = /github\.com/;
 
     return pattern.test(remotes);
-  } catch {
+  } catch (error) {
     // If any filesystem error occurs, assume not a git repo
-    debugLogger.debug(`Failed to get git remote:`, _error);
+    debugLogger.debug(`Failed to get git remote:`, error);
     return false;
   }
 };
@@ -85,10 +85,10 @@ export const getLatestGitHubRelease = async (
     }
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return releaseTag;
-  } catch {
+  } catch (error) {
     debugLogger.debug(
       `Failed to determine latest run-gemini-cli release:`,
-      _error,
+      error,
     );
     throw new Error(
       `Unable to determine the latest run-gemini-cli release on GitHub.`,

--- a/packages/cli/src/utils/installationInfo.ts
+++ b/packages/cli/src/utils/installationInfo.ts
@@ -110,7 +110,7 @@ export function getInstallationInfo(
               'Installed via Homebrew. Please update with "brew upgrade gemini-cli".',
           };
         }
-      } catch (_error) {
+      } catch {
         // Brew is not installed or gemini-cli is not installed via brew.
         // Continue to the next check.
       }

--- a/packages/cli/src/utils/jsonoutput.ts
+++ b/packages/cli/src/utils/jsonoutput.ts
@@ -42,7 +42,7 @@ export function tryParseJSON(input: string): object | null {
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return parsed;
-  } catch (_err) {
+  } catch {
     return null;
   }
 }

--- a/packages/cli/src/utils/sandboxUtils.ts
+++ b/packages/cli/src/utils/sandboxUtils.ts
@@ -60,7 +60,7 @@ export async function shouldUseCurrentUserInSandbox(): Promise<boolean> {
         );
         return true;
       }
-    } catch (_err) {
+    } catch {
       // Silently ignore if /etc/os-release is not found or unreadable.
       // The default (false) will be applied in this case.
       debugLogger.warn(

--- a/packages/cli/src/utils/sessionUtils.test.ts
+++ b/packages/cli/src/utils/sessionUtils.test.ts
@@ -43,7 +43,7 @@ describe('SessionSelector', () => {
     // Clean up test files
     try {
       await fs.rm(tmpDir, { recursive: true, force: true });
-    } catch (_error) {
+    } catch {
       // Ignore cleanup errors
     }
   });

--- a/packages/cli/src/utils/userStartupWarnings.ts
+++ b/packages/cli/src/utils/userStartupWarnings.ts
@@ -52,7 +52,7 @@ const homeDirectoryCheck: WarningCheck = {
         return 'Warning you are running Gemini CLI in your home directory.\nThis warning can be disabled in /settings';
       }
       return null;
-    } catch (_err: unknown) {
+    } catch {
       return 'Could not verify the current directory due to a file system error.';
     }
   },
@@ -73,7 +73,7 @@ const rootDirectoryCheck: WarningCheck = {
       }
 
       return null;
-    } catch (_err: unknown) {
+    } catch {
       return 'Could not verify the current directory due to a file system error.';
     }
   },

--- a/packages/core/src/agents/browser/browserAgentInvocation.ts
+++ b/packages/core/src/agents/browser/browserAgentInvocation.ts
@@ -404,12 +404,12 @@ ${output.result}`;
                 );
                 await removeInputBlocker(browserManager, signal);
                 await removeAutomationOverlay(browserManager, signal);
-              } catch (_err) {
+              } catch {
                 // Ignore errors for individual pages
               }
             }
           }
-        } catch (_) {
+        } catch {
           // Ignore errors for removing the overlays.
         }
       }

--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -1408,7 +1408,7 @@ Important Rules:
           Object.assign(args, parsed);
         }
         return { args };
-      } catch (_) {
+      } catch {
         return {
           args: {},
           error: `Failed to parse JSON arguments for tool "${functionCall.name}": ${functionCall.args}. Ensure you provide a valid JSON object.`,

--- a/packages/core/src/code_assist/admin/admin_controls.ts
+++ b/packages/core/src/code_assist/admin/admin_controls.ts
@@ -59,7 +59,7 @@ export function sanitizeAdminSettings(
           }
         }
       }
-    } catch (_e) {
+    } catch {
       // Ignore parsing errors
     }
   }

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -491,7 +491,7 @@ export class CodeAssistServer implements ContentGenerator {
           const chunk = bufferedLines.join('\n');
           try {
             yield JSON.parse(chunk);
-          } catch (_e) {
+          } catch {
             if (server.config) {
               logInvalidChunk(
                 server.config,

--- a/packages/core/src/config/extensions/integrity.ts
+++ b/packages/core/src/config/extensions/integrity.ts
@@ -138,7 +138,7 @@ class ExtensionIntegrityStore {
     let rawStore: IntegrityStore;
     try {
       rawStore = IntegrityStoreSchema.parse(JSON.parse(content));
-    } catch (_) {
+    } catch {
       throw new Error(
         `Failed to parse extension integrity store. ${resetInstruction}}`,
       );

--- a/packages/core/src/config/projectRegistry.ts
+++ b/packages/core/src/config/projectRegistry.ts
@@ -258,7 +258,7 @@ export class ProjectRegistry {
               diskCollision = true;
               break;
             }
-          } catch (_e) {
+          } catch {
             // If we can't read it, assume it's someone else's to be safe
             diskCollision = true;
             break;
@@ -274,7 +274,7 @@ export class ProjectRegistry {
       try {
         await this.ensureOwnershipMarkers(candidate, projectPath);
         return candidate;
-      } catch (_e) {
+      } catch {
         // Someone might have claimed it between our check and our write.
         // Try next candidate.
         continue;

--- a/packages/core/src/core/baseLlmClient.ts
+++ b/packages/core/src/core/baseLlmClient.ts
@@ -147,7 +147,7 @@ export class BaseLlmClient {
         // We don't use the result, just check if it's valid JSON
         JSON.parse(this.cleanJsonResponse(text, model));
         return false; // It's valid, don't retry
-      } catch (_e) {
+      } catch {
         return true; // It's not valid, retry
       }
     };

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1487,7 +1487,7 @@ ${JSON.stringify(
             break;
           }
         }
-      } catch (_) {
+      } catch {
         // If the test framework times out, that also demonstrates the infinite loop
       }
 

--- a/packages/core/src/core/logger.test.ts
+++ b/packages/core/src/core/logger.test.ts
@@ -50,7 +50,7 @@ const TEST_CHECKPOINT_FILE_PATH = path.join(
 async function cleanupLogAndCheckpointFiles() {
   try {
     await fs.rm(TEST_GEMINI_DIR, { recursive: true, force: true });
-  } catch (_error) {
+  } catch {
     // Ignore errors, as the directory may not exist, which is fine.
   }
 }

--- a/packages/core/src/core/logger.ts
+++ b/packages/core/src/core/logger.ts
@@ -59,7 +59,7 @@ export function encodeTagName(str: string): string {
 export function decodeTagName(str: string): string {
   try {
     return decodeURIComponent(str);
-  } catch (_e) {
+  } catch {
     // Fallback for old, potentially malformed encoding
     return str.replace(/%([0-9A-F]{2})/g, (_, hex) =>
       String.fromCharCode(parseInt(hex, 16)),
@@ -134,7 +134,7 @@ export class Logger {
     try {
       await fs.rename(this.logFilePath, backupPath);
       debugLogger.debug(`Backed up corrupted log file to ${backupPath}`);
-    } catch (_backupError) {
+    } catch {
       // If rename fails (e.g. file doesn't exist), no need to log an error here as the primary error (e.g. invalid JSON) is already handled.
     }
   }
@@ -153,7 +153,7 @@ export class Logger {
       let fileExisted = true;
       try {
         await fs.access(this.logFilePath);
-      } catch (_e) {
+      } catch {
         fileExisted = false;
       }
       this.logs = await this._readLogFile();
@@ -277,7 +277,7 @@ export class Logger {
         // then this instance can increment its idea of the next messageId for this session.
         this.messageId = writtenEntry.messageId + 1;
       }
-    } catch (_error) {
+    } catch {
       // Error already logged by _updateLogFile or _readLogFile
     }
   }

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -294,7 +294,7 @@ export class LoggingContentGenerator implements ContentGenerator {
           if (charCodes.every((code) => !isNaN(code))) {
             response.data = String.fromCharCode(...charCodes);
           }
-        } catch (_e) {
+        } catch {
           // If parsing fails, just leave it alone
         }
       }

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -370,7 +370,7 @@ export class HookRunner {
         if (process.platform === 'win32' && child.pid) {
           try {
             execSync(`taskkill /pid ${child.pid} /f /t`, { timeout: 2000 });
-          } catch (_e) {
+          } catch {
             // Ignore errors if process is already dead or access denied
             debugLogger.debug(`Taskkill failed: ${_e}`);
           }
@@ -384,7 +384,7 @@ export class HookRunner {
             if (process.platform === 'win32' && child.pid) {
               try {
                 execSync(`taskkill /pid ${child.pid} /f /t`, { timeout: 2000 });
-              } catch (_e) {
+              } catch {
                 // Ignore
                 debugLogger.debug(`Taskkill failed: ${_e}`);
               }

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -370,9 +370,9 @@ export class HookRunner {
         if (process.platform === 'win32' && child.pid) {
           try {
             execSync(`taskkill /pid ${child.pid} /f /t`, { timeout: 2000 });
-          } catch {
+          } catch (e) {
             // Ignore errors if process is already dead or access denied
-            debugLogger.debug(`Taskkill failed: ${_e}`);
+            debugLogger.debug(`Taskkill failed: ${e}`);
           }
         } else {
           child.kill('SIGTERM');
@@ -384,9 +384,9 @@ export class HookRunner {
             if (process.platform === 'win32' && child.pid) {
               try {
                 execSync(`taskkill /pid ${child.pid} /f /t`, { timeout: 2000 });
-              } catch {
+              } catch (e) {
                 // Ignore
-                debugLogger.debug(`Taskkill failed: ${_e}`);
+                debugLogger.debug(`Taskkill failed: ${e}`);
               }
             } else {
               child.kill('SIGKILL');

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -354,7 +354,7 @@ export class IdeClient {
           if (parsedJson && parsedJson.content === null) {
             return undefined;
           }
-        } catch (_e) {
+        } catch {
           logger.debug(
             `Invalid JSON in closeDiff response for ${filePath}:`,
             textPart.text,
@@ -602,7 +602,7 @@ export class IdeClient {
       await this.discoverTools();
       this.setState(IDEConnectionStatus.Connected);
       return true;
-    } catch (_error) {
+    } catch {
       if (transport) {
         try {
           await transport.close();
@@ -636,7 +636,7 @@ export class IdeClient {
       await this.discoverTools();
       this.setState(IDEConnectionStatus.Connected);
       return true;
-    } catch (_error) {
+    } catch {
       if (transport) {
         try {
           await transport.close();

--- a/packages/core/src/ide/ide-connection-utils.ts
+++ b/packages/core/src/ide/ide-connection-utils.ts
@@ -125,7 +125,7 @@ export async function getConnectionConfigFromFile(
     const portFileContents = await fs.promises.readFile(portFile, 'utf8');
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return JSON.parse(portFileContents);
-  } catch (_) {
+  } catch {
     // For newer extension versions, the file name matches the pattern
     // /^gemini-ide-server-${pid}-\d+\.json$/. If multiple IDE
     // windows are open, multiple files matching the pattern are expected to

--- a/packages/core/src/ide/ide-installer.ts
+++ b/packages/core/src/ide/ide-installer.ts
@@ -186,7 +186,7 @@ class VsCodeInstaller implements IdeInstaller {
         success: true,
         message: `${this.ideInfo.displayName} companion extension was installed successfully.`,
       };
-    } catch (_error) {
+    } catch {
       return {
         success: false,
         message: `Failed to install ${this.ideInfo.displayName} companion extension. Please try installing '${GEMINI_CLI_COMPANION_EXTENSION_NAME}' manually from the ${this.ideInfo.displayName} extension marketplace.`,
@@ -236,7 +236,7 @@ class PositronInstaller implements IdeInstaller {
         success: true,
         message: `${this.ideInfo.displayName} companion extension was installed successfully.`,
       };
-    } catch (_error) {
+    } catch {
       return {
         success: false,
         message: `Failed to install ${this.ideInfo.displayName} companion extension. Please try installing '${GEMINI_CLI_COMPANION_EXTENSION_NAME}' manually from the ${this.ideInfo.displayName} extension marketplace.`,
@@ -306,7 +306,7 @@ class AntigravityInstaller implements IdeInstaller {
         success: true,
         message: `${this.ideInfo.displayName} companion extension was installed successfully.`,
       };
-    } catch (_error) {
+    } catch {
       return {
         success: false,
         message: `Failed to install ${this.ideInfo.displayName} companion extension. Please try installing '${GEMINI_CLI_COMPANION_EXTENSION_NAME}' manually from the ${this.ideInfo.displayName} extension marketplace.`,

--- a/packages/core/src/ide/process-utils.ts
+++ b/packages/core/src/ide/process-utils.ts
@@ -49,7 +49,7 @@ async function getProcessTableWindows(): Promise<Map<number, ProcessInfo>> {
     try {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       processes = JSON.parse(stdout);
-    } catch (_e) {
+    } catch {
       return processMap;
     }
 
@@ -67,7 +67,7 @@ async function getProcessTableWindows(): Promise<Map<number, ProcessInfo>> {
         });
       }
     }
-  } catch (_e) {
+  } catch {
     // Fallback or error handling if PowerShell fails
   }
   return processMap;
@@ -102,7 +102,7 @@ async function getProcessInfo(pid: number): Promise<{
       name: processName,
       command: fullCommand,
     };
-  } catch (_e) {
+  } catch {
     return { parentPid: 0, name: '', command: '' };
   }
 }

--- a/packages/core/src/safety/built-in.ts
+++ b/packages/core/src/safety/built-in.ts
@@ -98,7 +98,7 @@ export class AllowedPathChecker implements InProcessChecker {
 
       // Fallback if nothing exists (unlikely if root exists)
       return resolved;
-    } catch (_error) {
+    } catch {
       return null;
     }
   }

--- a/packages/core/src/sandbox/macos/seatbeltArgsBuilder.ts
+++ b/packages/core/src/sandbox/macos/seatbeltArgsBuilder.ts
@@ -148,7 +148,7 @@ export function buildSeatbeltProfile(options: SeatbeltArgsOptions): string {
           addedPaths.add(resolved);
           profile += `(allow file-read* (subpath "${escapeSchemeString(resolved)}"))\n`;
         }
-      } catch (_e) {
+      } catch {
         // Ignore paths that do not exist or are inaccessible
       }
     }

--- a/packages/core/src/sandbox/utils/fsUtils.ts
+++ b/packages/core/src/sandbox/utils/fsUtils.ts
@@ -14,7 +14,7 @@ export function isErrnoException(e: unknown): e is NodeJS.ErrnoException {
 export function tryRealpath(p: string): string {
   try {
     return fs.realpathSync(p);
-  } catch (_e) {
+  } catch {
     if (isErrnoException(_e) && _e.code === 'ENOENT') {
       const parentDir = path.dirname(p);
       if (parentDir === p) {
@@ -52,7 +52,7 @@ export function resolveGitWorktreePaths(workspacePath: string): {
           if (tryRealpath(backlink) === tryRealpath(gitPath)) {
             isValid = true;
           }
-        } catch (_e) {
+        } catch {
           // Fallback for submodules: check core.worktree in config
           try {
             const configPath = path.join(resolvedWorktreeGitDir, 'config');
@@ -67,7 +67,7 @@ export function resolveGitWorktreePaths(workspacePath: string): {
                 isValid = true;
               }
             }
-          } catch (_e2) {
+          } catch {
             // Ignore
           }
         }
@@ -85,7 +85,7 @@ export function resolveGitWorktreePaths(workspacePath: string): {
         };
       }
     }
-  } catch (_e) {
+  } catch {
     // Ignore if .git doesn't exist, isn't readable, etc.
   }
   return {};

--- a/packages/core/src/sandbox/utils/fsUtils.ts
+++ b/packages/core/src/sandbox/utils/fsUtils.ts
@@ -14,15 +14,15 @@ export function isErrnoException(e: unknown): e is NodeJS.ErrnoException {
 export function tryRealpath(p: string): string {
   try {
     return fs.realpathSync(p);
-  } catch {
-    if (isErrnoException(_e) && _e.code === 'ENOENT') {
+  } catch (e) {
+    if (isErrnoException(e) && e.code === 'ENOENT') {
       const parentDir = path.dirname(p);
       if (parentDir === p) {
         return p;
       }
       return path.join(tryRealpath(parentDir), path.basename(p));
     }
-    throw _e;
+    throw e;
   }
 }
 

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -901,7 +901,7 @@ export class Scheduler {
           } as ScheduledToolCall,
           signal,
         );
-      } catch (_e) {
+      } catch {
         // Fallback to normal error handling if parsing/looping fails
       }
     }

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -46,7 +46,7 @@ export class GitService {
     try {
       await spawnAsync('git', ['--version']);
       return true;
-    } catch (_error) {
+    } catch {
       return false;
     }
   }

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -313,7 +313,7 @@ export class ShellExecutionService {
             shellExecutionConfig,
             ptyInfo,
           );
-        } catch (_e) {
+        } catch {
           // Fallback to child_process
         }
       }

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -1817,7 +1817,7 @@ export async function connectToMcpServer(
         await mcpClient.notification({
           method: 'notifications/roots/list_changed',
         });
-      } catch (_) {
+      } catch {
         // If this fails, its almost certainly because the connection was closed
         // and we should just stop listening for future directory changes.
         unlistenDirectories?.();

--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -830,7 +830,7 @@ describe('DiscoveredMCPTool', () => {
           if (expectError) {
             try {
               await invocation.execute(controller.signal);
-            } catch (_error) {
+            } catch {
               // Expected error
             }
           } else {

--- a/packages/core/src/tools/ripGrep.test.ts
+++ b/packages/core/src/tools/ripGrep.test.ts
@@ -678,7 +678,7 @@ describe('RipGrepTool', () => {
               stdout.write(match + '\n');
               linesPushed++;
             }
-          } catch (_e) {
+          } catch {
             clearInterval(pushInterval);
           }
         }, 1);

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -539,7 +539,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
                   ) {
                     currentPath = path.dirname(currentPath);
                   }
-                } catch (_e) {
+                } catch {
                   /* ignore */
                 }
                 while (currentPath.length > 1) {
@@ -550,7 +550,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
                   }
                   currentPath = path.dirname(currentPath);
                 }
-              } catch (_e) {
+              } catch {
                 // ignore
               }
             }

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -367,7 +367,7 @@ export abstract class BaseToolInvocation<
 
       try {
         void this.messageBus.publish(request);
-      } catch (_error) {
+      } catch {
         cleanup();
         resolve('allow');
       }

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -73,7 +73,7 @@ function checkRateLimit(url: string): {
     history.push(now);
     hostRequestHistory.set(hostname, history);
     return { allowed: true };
-  } catch (_e) {
+  } catch {
     // If URL parsing fails, we fallback to allowed (should be caught by parsePrompt anyway)
     return { allowed: true };
   }
@@ -132,7 +132,7 @@ export function parsePrompt(text: string): {
             `Unsupported protocol in URL: "${token}". Only http and https are supported.`,
           );
         }
-      } catch (_) {
+      } catch {
         // new URL() threw, so it's malformed according to WHATWG standard
         errors.push(`Malformed URL detected: "${token}".`);
       }

--- a/packages/core/src/tools/xcode-mcp-fix-transport.ts
+++ b/packages/core/src/tools/xcode-mcp-fix-transport.ts
@@ -95,7 +95,7 @@ export class XcodeMcpBridgeFixTransport
           // If successful, populate structuredContent
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           result.structuredContent = parsed;
-        } catch (_) {
+        } catch {
           // Ignored: Content is likely plain text, not JSON.
         }
       }

--- a/packages/core/src/utils/checkpointUtils.ts
+++ b/packages/core/src/utils/checkpointUtils.ts
@@ -176,7 +176,7 @@ export function getCheckpointInfoList(
           checkpoint: file.replace('.json', ''),
         });
       }
-    } catch (_e) {
+    } catch {
       // Ignore invalid JSON files
     }
   }

--- a/packages/core/src/utils/errorParsing.ts
+++ b/packages/core/src/utils/errorParsing.ts
@@ -66,7 +66,7 @@ export function parseAndFormatApiError(
           if (isApiError(nestedError)) {
             finalMessage = nestedError.error.message;
           }
-        } catch (_e) {
+        } catch {
           // It's not a nested JSON error, so we just use the message as is.
         }
         let text = `[API Error: ${finalMessage} (Status: ${parsedError.error.status})]`;
@@ -75,7 +75,7 @@ export function parseAndFormatApiError(
         }
         return text;
       }
-    } catch (_e) {
+    } catch {
       // Not a valid JSON, fall through and return the original message.
     }
     return `[API Error: ${error}]`;

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -576,7 +576,7 @@ export async function fileExists(filePath: string): Promise<boolean> {
   try {
     await fsPromises.access(filePath, fs.constants.F_OK);
     return true;
-  } catch (_: unknown) {
+  } catch {
     return false;
   }
 }

--- a/packages/core/src/utils/filesearch/crawler.ts
+++ b/packages/core/src/utils/filesearch/crawler.ts
@@ -80,7 +80,7 @@ export async function crawl(options: CrawlOptions): Promise<string[]> {
     }
 
     results = await api.crawl(options.crawlDirectory).withPromise();
-  } catch (_e) {
+  } catch {
     // The directory probably doesn't exist.
     return [];
   }

--- a/packages/core/src/utils/getPty.ts
+++ b/packages/core/src/utils/getPty.ts
@@ -27,14 +27,14 @@ export const getPty = async (): Promise<PtyImplementation> => {
     const module = await import(lydell);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     return { module, name: 'lydell-node-pty' };
-  } catch (_e) {
+  } catch {
     try {
       const nodePty = 'node-pty';
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const module = await import(nodePty);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       return { module, name: 'node-pty' };
-    } catch (_e2) {
+    } catch {
       return null;
     }
   }

--- a/packages/core/src/utils/gitIgnoreParser.ts
+++ b/packages/core/src/utils/gitIgnoreParser.ts
@@ -37,7 +37,7 @@ export class GitIgnoreParser implements GitIgnoreFilter {
     let content: string;
     try {
       content = fs.readFileSync(patternsFilePath, 'utf-8');
-    } catch (_error) {
+    } catch {
       return ignore();
     }
 
@@ -189,7 +189,7 @@ export class GitIgnoreParser implements GitIgnoreFilter {
 
       // Extra patterns (like .geminiignore) have final precedence
       return ig.add(this.processedExtraPatterns).ignores(normalizedPath);
-    } catch (_error) {
+    } catch {
       return false;
     }
   }

--- a/packages/core/src/utils/gitUtils.ts
+++ b/packages/core/src/utils/gitUtils.ts
@@ -35,7 +35,7 @@ export function isGitRepository(directory: string): boolean {
     }
 
     return false;
-  } catch (_error) {
+  } catch {
     // If any filesystem error occurs, assume not a git repo
     return false;
   }
@@ -67,7 +67,7 @@ export function findGitRoot(directory: string): string | null {
     }
 
     return null;
-  } catch (_error) {
+  } catch {
     return null;
   }
 }

--- a/packages/core/src/utils/googleErrors.ts
+++ b/packages/core/src/utils/googleErrors.ts
@@ -159,7 +159,7 @@ export function parseGoogleApiError(error: unknown): GoogleApiError | null {
   if (typeof errorObj === 'string') {
     try {
       errorObj = JSON.parse(sanitizeJsonString(errorObj));
-    } catch (_) {
+    } catch {
       // Not a JSON string, can't parse.
       return null;
     }
@@ -200,7 +200,7 @@ export function parseGoogleApiError(error: unknown): GoogleApiError | null {
         // The message is a JSON string, but not a nested error object.
         break;
       }
-    } catch (_error) {
+    } catch {
       // It wasn't a JSON string, so we've drilled down as far as we can.
       break;
     }
@@ -284,7 +284,7 @@ function fromGaxiosError(errorObj: object): ErrorShape | undefined {
       try {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         data = JSON.parse(sanitizeJsonString(data));
-      } catch (_) {
+      } catch {
         // Not a JSON string, can't parse.
       }
     }
@@ -334,7 +334,7 @@ function fromApiError(errorObj: object): ErrorShape | undefined {
       try {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         data = JSON.parse(sanitizeJsonString(data));
-      } catch (_) {
+      } catch {
         // Not a JSON string, can't parse.
         // Try one more fallback: look for the first '{' and last '}'
         if (typeof data === 'string') {
@@ -346,7 +346,7 @@ function fromApiError(errorObj: object): ErrorShape | undefined {
               data = JSON.parse(
                 sanitizeJsonString(data.substring(firstBrace, lastBrace + 1)),
               );
-            } catch (__) {
+            } catch {
               // Still failed
             }
           }

--- a/packages/core/src/utils/ignoreFileParser.ts
+++ b/packages/core/src/utils/ignoreFileParser.ts
@@ -60,7 +60,7 @@ export class IgnoreFileParser implements IgnoreFileFilter {
     let content: string;
     try {
       content = fs.readFileSync(patternsFilePath, 'utf-8');
-    } catch (_error) {
+    } catch {
       debugLogger.debug(
         `Ignore file not found: ${patternsFilePath}, continue without it.`,
       );

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -368,7 +368,7 @@ export function resolveToRealPath(pathStr: string): string {
     }
 
     resolvedPath = decodeURIComponent(resolvedPath);
-  } catch (_e) {
+  } catch {
     // Ignore error (e.g. malformed URI), keep path from previous step
   }
 

--- a/packages/core/src/utils/process-utils.ts
+++ b/packages/core/src/utils/process-utils.ts
@@ -49,7 +49,7 @@ export async function killProcessGroup(options: KillOptions): Promise<void> {
     // Invoke taskkill to ensure the entire tree is terminated and any orphaned descendant processes are reaped.
     try {
       await spawnAsync('taskkill', ['/pid', pid.toString(), '/f', '/t']);
-    } catch (_e) {
+    } catch {
       // Ignore errors if the process tree is already dead
     }
     return;
@@ -72,7 +72,7 @@ export async function killProcessGroup(options: KillOptions): Promise<void> {
         }
       }
     }
-  } catch (_e) {
+  } catch {
     // Fallback to specific process kill if group kill fails or on error
     if (!isExited()) {
       if (pty) {

--- a/packages/core/src/utils/secure-browser-launcher.ts
+++ b/packages/core/src/utils/secure-browser-launcher.ts
@@ -23,7 +23,7 @@ function validateUrl(url: string): void {
 
   try {
     parsedUrl = new URL(url);
-  } catch (_error) {
+  } catch {
     throw new Error(`Invalid URL: ${url}`);
   }
 

--- a/packages/core/src/utils/shell-utils.integration.test.ts
+++ b/packages/core/src/utils/shell-utils.integration.test.ts
@@ -51,7 +51,7 @@ describe('execStreaming (Integration)', () => {
         for await (const line of generator) {
           lines.push(line);
         }
-      } catch (_e) {
+      } catch {
         // ignore
       }
       return lines;

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -455,7 +455,7 @@ export function parseBashCommandDetails(
         'Syntax Errors:',
         syntaxErrors,
       );
-    } catch (_e) {
+    } catch {
       // Ignore query errors
     } finally {
       query?.delete();
@@ -914,7 +914,7 @@ export async function* execStreaming(
     if (!finished && child.exitCode === null && !child.killed) {
       try {
         child.kill();
-      } catch (_e) {
+      } catch {
         // ignore error if process is already dead
       }
       killedByGenerator = true;

--- a/packages/core/src/utils/systemEncoding.ts
+++ b/packages/core/src/utils/systemEncoding.ts
@@ -88,7 +88,7 @@ export function getSystemEncoding(): string | null {
       locale = execSync('locale charmap', { encoding: 'utf8' })
         .toString()
         .trim();
-    } catch (_e) {
+    } catch {
       debugLogger.warn('Failed to get locale charmap.');
       return null;
     }

--- a/packages/core/src/utils/workspaceContext.ts
+++ b/packages/core/src/utils/workspaceContext.ts
@@ -188,7 +188,7 @@ export class WorkspaceContext {
         }
       }
       return false;
-    } catch (_error) {
+    } catch {
       return false;
     }
   }
@@ -216,7 +216,7 @@ export class WorkspaceContext {
         }
       }
       return false;
-    } catch (_error) {
+    } catch {
       return false;
     }
   }

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -206,7 +206,7 @@ export class DevTools extends EventEmitter {
                 res.writeHead(404, { 'Content-Type': 'application/json' });
                 res.end(JSON.stringify({ error: 'Session not found' }));
               }
-            } catch (_err) {
+            } catch {
               res.writeHead(400, { 'Content-Type': 'application/json' });
               res.end(JSON.stringify({ error: 'Invalid request' }));
             }

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -424,7 +424,7 @@ export class IDEServer {
     if (this.portFile) {
       try {
         await fs.unlink(this.portFile);
-      } catch (_err) {
+      } catch {
         // Ignore errors if the file doesn't exist.
       }
     }

--- a/scripts/get-release-version.js
+++ b/scripts/get-release-version.js
@@ -195,7 +195,7 @@ function doesVersionExist({ args, version } = {}) {
       console.error(`Version ${version} already exists on NPM.`);
       return true;
     }
-  } catch (_error) {
+  } catch {
     // This is expected if the version doesn't exist.
   }
 

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -177,7 +177,7 @@ function runCommand(command, stdio = 'inherit') {
     ].join(sep);
     execSync(command, { stdio, env, shell: true });
     return true;
-  } catch (_e) {
+  } catch {
     return false;
   }
 }
@@ -267,7 +267,7 @@ export function runSensitiveKeywordLinter() {
         .trim()
         .split('\n')
         .filter(Boolean);
-    } catch (_error) {
+    } catch {
       console.error(`Could not get changed files against origin/${baseRef}.`);
       try {
         console.log('Falling back to diff against HEAD~1');
@@ -276,7 +276,7 @@ export function runSensitiveKeywordLinter() {
           .trim()
           .split('\n')
           .filter(Boolean);
-      } catch (_fallbackError) {
+      } catch {
         console.error('Could not get changed files against HEAD~1 either.');
         process.exit(1);
       }

--- a/scripts/local_telemetry.js
+++ b/scripts/local_telemetry.js
@@ -105,11 +105,11 @@ async function main() {
   try {
     execSync('pkill -f "otelcol-contrib"');
     console.log('✅ Stopped existing otelcol-contrib process.');
-  } catch (_e) {} // eslint-disable-line no-empty
+  } catch {} // eslint-disable-line no-empty
   try {
     execSync('pkill -f "jaeger"');
     console.log('✅ Stopped existing jaeger process.');
-  } catch (_e) {} // eslint-disable-line no-empty
+  } catch {} // eslint-disable-line no-empty
   try {
     if (fileExists(OTEL_LOG_FILE)) fs.unlinkSync(OTEL_LOG_FILE);
     console.log('✅ Deleted old collector log.');
@@ -155,7 +155,7 @@ async function main() {
   try {
     await waitForPort(JAEGER_PORT);
     console.log(`✅ Jaeger started successfully.`);
-  } catch (_) {
+  } catch {
     console.error(`🛑 Error: Jaeger failed to start on port ${JAEGER_PORT}.`);
     if (jaegerProcess && jaegerProcess.pid) {
       process.kill(jaegerProcess.pid, 'SIGKILL');
@@ -180,7 +180,7 @@ async function main() {
   try {
     await waitForPort(4317);
     console.log(`✅ OTEL collector started successfully.`);
-  } catch (_) {
+  } catch {
     console.error(`🛑 Error: OTEL collector failed to start on port 4317.`);
     if (collectorProcess && collectorProcess.pid) {
       process.kill(collectorProcess.pid, 'SIGKILL');

--- a/scripts/releasing/create-patch-pr.js
+++ b/scripts/releasing/create-patch-pr.js
@@ -180,7 +180,7 @@ async function main() {
           // Re-throw if it's not a conflict error
           throw error;
         }
-      } catch (_statusError) {
+      } catch {
         // Re-throw original error if we can't determine the status
         throw error;
       }
@@ -268,7 +268,7 @@ function branchExists(branchName) {
   try {
     execSync(`git ls-remote --exit-code --heads origin ${branchName}`);
     return true;
-  } catch (_e) {
+  } catch {
     return false;
   }
 }

--- a/scripts/releasing/patch-create-comment.js
+++ b/scripts/releasing/patch-create-comment.js
@@ -374,7 +374,7 @@ No output was generated during patch creation.
       // Clean up temp file
       try {
         unlinkSync(tmpFile);
-      } catch (_e) {
+      } catch {
         // Ignore cleanup errors
       }
     }

--- a/scripts/sync_project_dry_run.js
+++ b/scripts/sync_project_dry_run.js
@@ -32,7 +32,7 @@ function runCommand(command) {
       stdio: ['ignore', 'pipe', 'ignore'],
       maxBuffer: 10 * 1024 * 1024,
     });
-  } catch (_e) {
+  } catch {
     return null;
   }
 }

--- a/scripts/telemetry_gcp.js
+++ b/scripts/telemetry_gcp.js
@@ -118,7 +118,7 @@ async function main() {
   try {
     execSync('pkill -f "otelcol-contrib"');
     console.log('✅ Stopped existing otelcol-contrib process.');
-  } catch (_e) {
+  } catch {
     /* no-op */
   }
   try {

--- a/scripts/telemetry_utils.js
+++ b/scripts/telemetry_utils.js
@@ -438,7 +438,7 @@ export function registerCleanup(
       if (fd) {
         try {
           fs.closeSync(fd);
-        } catch (_) {
+        } catch {
           /* no-op */
         }
       }

--- a/sea/sea-launch.cjs
+++ b/sea/sea-launch.cjs
@@ -78,7 +78,7 @@ function verifyIntegrity(dir, manifest, fsMod = fs, cryptoMod = crypto) {
       }
     }
     return true;
-  } catch (_e) {
+  } catch {
     return false;
   }
 }
@@ -115,7 +115,7 @@ function prepareRuntime(manifest, getAssetFn, deps = {}) {
         fsMod.mkdirSync(appDir, { recursive: true, mode: 0o700 });
       }
       tempBase = appDir;
-    } catch (_) {
+    } catch {
       // Fallback to tmpdir
     }
   }
@@ -137,7 +137,7 @@ function prepareRuntime(manifest, getAssetFn, deps = {}) {
       if (process.platform !== 'win32' && (stat.mode & 0o777) !== 0o700)
         return false;
       return true;
-    } catch (_) {
+    } catch {
       return false;
     }
   };
@@ -151,12 +151,12 @@ function prepareRuntime(manifest, getAssetFn, deps = {}) {
       } else {
         try {
           fsMod.rmSync(finalRuntimeDir, { recursive: true, force: true });
-        } catch (_) {}
+        } catch {}
       }
     } else {
       try {
         fsMod.rmSync(finalRuntimeDir, { recursive: true, force: true });
-      } catch (_) {}
+      } catch {}
     }
   }
 
@@ -202,7 +202,7 @@ function prepareRuntime(manifest, getAssetFn, deps = {}) {
           runtimeDir = finalRuntimeDir;
           try {
             fsMod.rmSync(setupDir, { recursive: true, force: true });
-          } catch (_) {}
+          } catch {}
         } else {
           throw renameErr;
         }
@@ -214,7 +214,7 @@ function prepareRuntime(manifest, getAssetFn, deps = {}) {
       );
       try {
         fsMod.rmSync(setupDir, { recursive: true, force: true });
-      } catch (_) {}
+      } catch {}
       process.exit(1);
     }
   }


### PR DESCRIPTION
# Fix linter issues and format codebase

## Description

This PR addresses several linter errors related to the `no-restricted-syntax` rule for catch block identifiers. The rule enforces a specific pattern for error handling in catch blocks:
- If the error variable is **used**, it must not have a leading underscore.
- If the error variable is **unused**, the catch block should be empty (e.g., `catch {}`).

### Changes

- **Linter Fixes (Catch Block Identifiers):**
  - Removed leading underscores from catch block identifiers that were being used for logging or further processing. This aligns with the project's requirement to use clean identifiers for used variables.
  - Affected files:
    - `packages/cli/src/ui/commands/setupGithubCommand.ts`
    - `packages/cli/src/utils/gitUtils.ts`
    - `packages/core/src/hooks/hookRunner.ts`
    - `packages/core/src/sandbox/utils/fsUtils.ts`
- **Formatting:**
  - Ran `npm run format` to ensure consistent code styling across the repository.

## Verification Results

### Automated Tests
- Ran `npm run lint` - Passed (All 7 identified `no-restricted-syntax` errors resolved).
- Ran `npm run typecheck` - Passed.
