### PR TITLE
Fix shell output display

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolResultDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolResultDisplay.test.tsx
@@ -344,9 +344,10 @@ describe('ToolResultDisplay', () => {
 
     expect(output).not.toContain('Line 1');
     expect(output).not.toContain('Line 2');
-    expect(output).not.toContain('Line 3');
+    expect(output).toContain('Line 3');
     expect(output).toContain('Line 4');
     expect(output).toContain('Line 5');
+    expect(output).toMatchSnapshot();
     unmount();
   });
 
@@ -363,7 +364,7 @@ describe('ToolResultDisplay', () => {
         inverse: false,
       },
     ]);
-    const { lastFrame, waitUntilReady, unmount } = await renderWithProviders(
+    const renderResult = await renderWithProviders(
       <ToolResultDisplay
         resultDisplay={ansiResult}
         terminalWidth={80}
@@ -376,12 +377,10 @@ describe('ToolResultDisplay', () => {
         uiState: { constrainHeight: true },
       },
     );
+    const { waitUntilReady, unmount } = renderResult;
     await waitUntilReady();
-    const output = lastFrame();
 
-    // It SHOULD truncate to 25 lines because maxLines is provided
-    expect(output).not.toContain('Line 1');
-    expect(output).toContain('Line 50');
+    await expect(renderResult).toMatchSvgSnapshot();
     unmount();
   });
 });

--- a/packages/cli/src/ui/components/messages/ToolResultDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/ToolResultDisplay.tsx
@@ -198,33 +198,35 @@ export const ToolResultDisplay: React.FC<ToolResultDisplayProps> = ({
     return content;
   };
 
+  if (Array.isArray(resultDisplay)) {
+    const limit = maxLines ?? availableHeight ?? ACTIVE_SHELL_MAX_LINES;
+    const listHeight = Math.min(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      (resultDisplay as AnsiOutput).length,
+      limit,
+    );
+
+    const initialScrollIndex =
+      overflowDirection === 'bottom' ? 0 : SCROLL_TO_ITEM_END;
+
+    return (
+      <Box width={childWidth} flexDirection="column" maxHeight={listHeight}>
+        <ScrollableList
+          width={childWidth}
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          data={resultDisplay as AnsiOutput}
+          renderItem={renderVirtualizedAnsiLine}
+          estimatedItemHeight={() => 1}
+          keyExtractor={keyExtractor}
+          initialScrollIndex={initialScrollIndex}
+          hasFocus={hasFocus}
+        />
+      </Box>
+    );
+  }
+
   // ASB Mode Handling (Interactive/Fullscreen)
   if (isAlternateBuffer) {
-    // Virtualized path for large ANSI arrays
-    if (Array.isArray(resultDisplay)) {
-      const limit = maxLines ?? availableHeight ?? ACTIVE_SHELL_MAX_LINES;
-      const listHeight = Math.min(
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        (resultDisplay as AnsiOutput).length,
-        limit,
-      );
-
-      return (
-        <Box width={childWidth} flexDirection="column" maxHeight={listHeight}>
-          <ScrollableList
-            width={childWidth}
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-            data={resultDisplay as AnsiOutput}
-            renderItem={renderVirtualizedAnsiLine}
-            estimatedItemHeight={() => 1}
-            keyExtractor={keyExtractor}
-            initialScrollIndex={SCROLL_TO_ITEM_END}
-            hasFocus={hasFocus}
-          />
-        </Box>
-      );
-    }
-
     // Standard path for strings/diffs in ASB
     return (
       <Box width={childWidth} flexDirection="column">

--- a/packages/cli/src/ui/components/messages/ToolResultDisplayOverflow.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolResultDisplayOverflow.test.tsx
@@ -96,10 +96,11 @@ describe('ToolResultDisplay Overflow', () => {
 
     expect(output).toContain('Line 1');
     expect(output).toContain('Line 2');
-    expect(output).not.toContain('Line 3');
+    expect(output).toContain('Line 3');
     expect(output).not.toContain('Line 4');
     expect(output).not.toContain('Line 5');
-    expect(output).toContain('hidden');
+    // ScrollableList uses a scroll thumb rather than writing "hidden"
+    expect(output).toContain('█');
     unmount();
   });
 });

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolResultDisplay-ToolResultDisplay-truncates-ANSI-output-when-maxLines-is-provided-even-if-availableTerminalHeight-is-undefined.snap.svg
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolResultDisplay-ToolResultDisplay-truncates-ANSI-output-when-maxLines-is-provided-even-if-availableTerminalHeight-is-undefined.snap.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="445" viewBox="0 0 920 445">
+  <style>
+    text { font-family: Consolas, "Courier New", monospace; font-size: 14px; dominant-baseline: text-before-edge; white-space: pre; }
+  </style>
+  <rect width="920" height="445" fill="#000000" />
+  <g transform="translate(10, 10)">
+    <text x="0" y="2" fill="#ffffff" textLength="900" lengthAdjust="spacingAndGlyphs">Line 26                                                                                             </text>
+    <text x="0" y="19" fill="#ffffff" textLength="900" lengthAdjust="spacingAndGlyphs">Line 27                                                                                             </text>
+    <text x="0" y="36" fill="#ffffff" textLength="900" lengthAdjust="spacingAndGlyphs">Line 28                                                                                             </text>
+    <text x="0" y="53" fill="#ffffff" textLength="900" lengthAdjust="spacingAndGlyphs">Line 29                                                                                             </text>
+    <text x="0" y="70" fill="#ffffff" textLength="900" lengthAdjust="spacingAndGlyphs">Line 30                                                                                             </text>
+    <text x="0" y="87" fill="#ffffff" textLength="900" lengthAdjust="spacingAndGlyphs">Line 31                                                                                             </text>
+    <text x="0" y="104" fill="#ffffff" textLength="900" lengthAdjust="spacingAndGlyphs">Line 32                                                                                             </text>
+    <text x="0" y="121" fill="#ffffff" textLength="900" lengthAdjust="spacingAndGlyphs">Line 33                                                                                             </text>
+    <text x="0" y="138" fill="#ffffff" textLength="900" lengthAdjust="spacingAndGlyphs">Line 34                                                                                             </text>
+    <text x="0" y="155" fill="#ffffff" textLength="900" lengthAdjust="spacingAndGlyphs">Line 35                                                                                             </text>
+    <text x="0" y="172" fill="#ffffff" textLength="900" lengthAdjust="spacingAndGlyphs">Line 36                                                                                             </text>
+    <text x="0" y="189" fill="#ffffff" textLength="900" lengthAdjust="spacingAndGlyphs">Line 37                                                                                             </text>
+    <text x="0" y="206" fill="#ffffff" textLength="675" lengthAdjust="spacingAndGlyphs">Line 38                                                                    </text>
+    <text x="675" y="206" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">▄</text>
+    <text x="0" y="223" fill="#ffffff" textLength="675" lengthAdjust="spacingAndGlyphs">Line 39                                                                    </text>
+    <text x="675" y="223" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
+    <text x="0" y="240" fill="#ffffff" textLength="675" lengthAdjust="spacingAndGlyphs">Line 40                                                                    </text>
+    <text x="675" y="240" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
+    <text x="0" y="257" fill="#ffffff" textLength="675" lengthAdjust="spacingAndGlyphs">Line 41                                                                    </text>
+    <text x="675" y="257" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
+    <text x="0" y="274" fill="#ffffff" textLength="675" lengthAdjust="spacingAndGlyphs">Line 42                                                                    </text>
+    <text x="675" y="274" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
+    <text x="0" y="291" fill="#ffffff" textLength="675" lengthAdjust="spacingAndGlyphs">Line 43                                                                    </text>
+    <text x="675" y="291" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
+    <text x="0" y="308" fill="#ffffff" textLength="675" lengthAdjust="spacingAndGlyphs">Line 44                                                                    </text>
+    <text x="675" y="308" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
+    <text x="0" y="325" fill="#ffffff" textLength="675" lengthAdjust="spacingAndGlyphs">Line 45                                                                    </text>
+    <text x="675" y="325" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
+    <text x="0" y="342" fill="#ffffff" textLength="675" lengthAdjust="spacingAndGlyphs">Line 46                                                                    </text>
+    <text x="675" y="342" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
+    <text x="0" y="359" fill="#ffffff" textLength="675" lengthAdjust="spacingAndGlyphs">Line 47                                                                    </text>
+    <text x="675" y="359" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
+    <text x="0" y="376" fill="#ffffff" textLength="675" lengthAdjust="spacingAndGlyphs">Line 48                                                                    </text>
+    <text x="675" y="376" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
+    <text x="0" y="393" fill="#ffffff" textLength="675" lengthAdjust="spacingAndGlyphs">Line 49                                                                    </text>
+    <text x="675" y="393" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
+    <text x="0" y="410" fill="#ffffff" textLength="675" lengthAdjust="spacingAndGlyphs">Line 50                                                                    </text>
+    <text x="675" y="410" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
+  </g>
+</svg>

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolResultDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolResultDisplay.test.tsx.snap
@@ -36,6 +36,41 @@ exports[`ToolResultDisplay > renders string result as plain text when renderOutp
 "
 `;
 
+exports[`ToolResultDisplay > truncates ANSI output when maxLines is provided 1`] = `
+"Line 3
+Line 4                                                                     █
+Line 5                                                                     █
+"
+`;
+
+exports[`ToolResultDisplay > truncates ANSI output when maxLines is provided, even if availableTerminalHeight is undefined 1`] = `
+"Line 26
+Line 27
+Line 28
+Line 29
+Line 30
+Line 31
+Line 32
+Line 33
+Line 34
+Line 35
+Line 36
+Line 37
+Line 38                                                                    ▄
+Line 39                                                                    █
+Line 40                                                                    █
+Line 41                                                                    █
+Line 42                                                                    █
+Line 43                                                                    █
+Line 44                                                                    █
+Line 45                                                                    █
+Line 46                                                                    █
+Line 47                                                                    █
+Line 48                                                                    █
+Line 49                                                                    █
+Line 50                                                                    █"
+`;
+
 exports[`ToolResultDisplay > truncates very long string results 1`] = `
 "... 250 hidden (Ctrl+O) ...
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/packages/cli/src/ui/hooks/useExecutionLifecycle.test.tsx
+++ b/packages/cli/src/ui/hooks/useExecutionLifecycle.test.tsx
@@ -101,6 +101,7 @@ import {
   type GeminiClient,
   type ShellExecutionResult,
   type ShellOutputEvent,
+  type AnsiOutput,
   CoreToolCallStatus,
 } from '@google/gemini-cli-core';
 import * as fs from 'node:fs';
@@ -519,6 +520,52 @@ describe('useExecutionLifecycle', () => {
     expect(finalHistoryItem.tools[0].resultDisplay).toBe(
       '[Command produced binary output, which is not shown.]',
     );
+  });
+
+  it('should prepend warnings to AnsiOutput array', async () => {
+    const { result } = await renderProcessorHook();
+
+    act(() => {
+      result.current.handleShellCommand('ls', new AbortController().signal);
+    });
+    const execPromise = onExecMock.mock.calls[0][0];
+
+    const ansiOutput: AnsiOutput = [
+      [
+        {
+          text: 'ansi line 1',
+          fg: '',
+          bg: '',
+          bold: false,
+          dim: false,
+          italic: false,
+          underline: false,
+          inverse: false,
+        },
+      ],
+    ];
+
+    act(() => {
+      resolveExecutionPromise(
+        createMockServiceResult({
+          exitCode: 1,
+          output: 'ansi line 1',
+          ansiOutput,
+        }),
+      );
+    });
+    await act(async () => await execPromise);
+
+    expect(setPendingHistoryItemMock).toHaveBeenCalledWith(null);
+    expect(addItemToHistoryMock).toHaveBeenCalledTimes(2);
+
+    const historyCall = addItemToHistoryMock.mock.calls[1][0];
+    const display = historyCall.tools[0].resultDisplay;
+
+    expect(Array.isArray(display)).toBe(true);
+    expect(display.length).toBe(3); // Error line, empty line, original output
+    expect(display[0][0].text).toBe('Command exited with code 1.');
+    expect(display[2][0].text).toBe('ansi line 1');
   });
 
   it('should handle promise rejection and show an error', async () => {

--- a/packages/cli/src/ui/hooks/useExecutionLifecycle.ts
+++ b/packages/cli/src/ui/hooks/useExecutionLifecycle.ts
@@ -534,31 +534,68 @@ export const useExecutionLifecycle = (
               result.output.trim() || '(Command produced no output)';
           }
 
-          let finalOutput = mainContent;
+          let finalOutput: string | AnsiOutput =
+            result.ansiOutput && result.ansiOutput.length > 0
+              ? result.ansiOutput
+              : mainContent;
           let finalStatus = CoreToolCallStatus.Success;
+
+          const prependToAnsiOutput = (
+            output: AnsiOutput,
+            text: string,
+          ): AnsiOutput => {
+            const newLines: AnsiOutput = text.split('\n').map((line) => [
+              {
+                text: line,
+                fg: '',
+                bg: '',
+                dim: false,
+                bold: false,
+                italic: false,
+                underline: false,
+                inverse: false,
+              },
+            ]);
+            return [...newLines, [], ...output];
+          };
+
+          let prefix = '';
 
           if (result.error) {
             finalStatus = CoreToolCallStatus.Error;
-            finalOutput = `${result.error.message}\n${finalOutput}`;
+            prefix = result.error.message;
           } else if (result.aborted) {
             finalStatus = CoreToolCallStatus.Cancelled;
-            finalOutput = `Command was cancelled.\n${finalOutput}`;
+            prefix = 'Command was cancelled.';
           } else if (result.backgrounded) {
             finalStatus = CoreToolCallStatus.Success;
             finalOutput = `Command moved to background (PID: ${result.pid}). Output hidden. Press Ctrl+B to view.`;
+            mainContent = finalOutput;
           } else if (result.signal) {
             finalStatus = CoreToolCallStatus.Error;
-            finalOutput = `Command terminated by signal: ${result.signal}.\n${finalOutput}`;
+            prefix = `Command terminated by signal: ${result.signal}.`;
           } else if (result.exitCode !== 0) {
             finalStatus = CoreToolCallStatus.Error;
-            finalOutput = `Command exited with code ${result.exitCode}.\n${finalOutput}`;
+            prefix = `Command exited with code ${result.exitCode}.`;
+          }
+
+          if (prefix) {
+            finalOutput =
+              typeof finalOutput === 'string'
+                ? `${prefix}\n${finalOutput}`
+                : prependToAnsiOutput(finalOutput, prefix);
+            mainContent = `${prefix}\n${mainContent}`;
           }
 
           if (pwdFilePath && fs.existsSync(pwdFilePath)) {
             const finalPwd = fs.readFileSync(pwdFilePath, 'utf8').trim();
             if (finalPwd && finalPwd !== targetDir) {
               const warning = `WARNING: shell mode is stateless; the directory change to '${finalPwd}' will not persist.`;
-              finalOutput = `${warning}\n\n${finalOutput}`;
+              finalOutput =
+                typeof finalOutput === 'string'
+                  ? `${warning}\n\n${finalOutput}`
+                  : prependToAnsiOutput(finalOutput, warning);
+              mainContent = `${warning}\n\n${mainContent}`;
             }
           }
 
@@ -578,7 +615,7 @@ export const useExecutionLifecycle = (
             );
           }
 
-          addShellCommandToGeminiHistory(geminiClient, rawQuery, finalOutput);
+          addShellCommandToGeminiHistory(geminiClient, rawQuery, mainContent);
         } catch (err) {
           setPendingHistoryItem(null);
           const errorMessage = err instanceof Error ? err.message : String(err);

--- a/packages/core/src/services/executionLifecycleService.ts
+++ b/packages/core/src/services/executionLifecycleService.ts
@@ -19,6 +19,7 @@ export type ExecutionMethod =
 export interface ExecutionResult {
   rawOutput?: Buffer;
   output: string;
+  ansiOutput?: AnsiOutput;
   exitCode: number | null;
   signal: number | null;
   error: Error | null;
@@ -452,10 +453,13 @@ export class ExecutionLifecycleService {
     } = options ?? {};
 
     const output = execution.getBackgroundOutput?.() ?? execution.output;
+    const snapshot = execution.getSubscriptionSnapshot?.();
+    const ansiOutput = Array.isArray(snapshot) ? snapshot : undefined;
 
     this.settleExecution(executionId, {
       rawOutput: Buffer.from(output, 'utf8'),
       output,
+      ansiOutput,
       exitCode,
       signal,
       error,

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -1123,9 +1123,21 @@ export class ShellExecutionService {
               ShellExecutionService.activePtys.delete(ptyPid);
             });
 
+            const endLine = headlessTerminal.buffer.active.length;
+            const startLine = Math.max(
+              0,
+              endLine - (shellExecutionConfig.maxSerializedLines ?? 2000),
+            );
+            const ansiOutputSnapshot = serializeTerminalToObject(
+              headlessTerminal,
+              startLine,
+              endLine,
+            );
+
             ExecutionLifecycleService.completeWithResult(ptyPid, {
               rawOutput: Buffer.from(''),
               output: getFullBufferText(headlessTerminal),
+              ansiOutput: ansiOutputSnapshot,
               exitCode,
               signal: signal ?? null,
               error,

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -661,33 +661,34 @@ export class ShellToolInvocation extends BaseToolInvocation<
         llmContent = llmContentParts.join('\n');
       }
 
-      let returnDisplayMessage = '';
+      let returnDisplay: string | AnsiOutput = '';
       if (this.context.config.getDebugMode()) {
-        returnDisplayMessage = llmContent;
+        returnDisplay = llmContent;
       } else {
         if (this.params.is_background || result.backgrounded) {
-          returnDisplayMessage = `Command moved to background (PID: ${result.pid}). Output hidden. Press Ctrl+B to view.`;
+          returnDisplay = `Command moved to background (PID: ${result.pid}). Output hidden. Press Ctrl+B to view.`;
         } else if (result.aborted) {
           const cancelMsg = timeoutMessage || 'Command cancelled by user.';
           if (result.output.trim()) {
-            returnDisplayMessage = `${cancelMsg}\n\nOutput before cancellation:\n${result.output}`;
+            returnDisplay = `${cancelMsg}\n\nOutput before cancellation:\n${result.output}`;
           } else {
-            returnDisplayMessage = cancelMsg;
+            returnDisplay = cancelMsg;
           }
-        } else if (result.output.trim()) {
-          returnDisplayMessage = result.output;
+        } else if (result.output.trim() || result.ansiOutput) {
+          returnDisplay =
+            result.ansiOutput && result.ansiOutput.length > 0
+              ? result.ansiOutput
+              : result.output;
         } else {
           if (result.signal) {
-            returnDisplayMessage = `Command terminated by signal: ${result.signal}`;
+            returnDisplay = `Command terminated by signal: ${result.signal}`;
           } else if (result.error) {
-            returnDisplayMessage = `Command failed: ${getErrorMessage(
-              result.error,
-            )}`;
+            returnDisplay = `Command failed: ${getErrorMessage(result.error)}`;
           } else if (result.exitCode !== null && result.exitCode !== 0) {
-            returnDisplayMessage = `Command exited with code: ${result.exitCode}`;
+            returnDisplay = `Command exited with code: ${result.exitCode}`;
           }
           // If output is empty and command succeeded (code 0, no error/signal/abort),
-          // returnDisplayMessage will remain empty, which is fine.
+          // returnDisplay will remain empty, which is fine.
         }
       }
 
@@ -824,7 +825,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
 
             return {
               llmContent: 'Sandbox expansion required',
-              returnDisplay: returnDisplayMessage,
+              returnDisplay,
               error: {
                 type: ToolErrorType.SANDBOX_EXPANSION_REQUIRED,
                 message: JSON.stringify(confirmationDetails),
@@ -856,14 +857,14 @@ export class ShellToolInvocation extends BaseToolInvocation<
         );
         return {
           llmContent: summary,
-          returnDisplay: returnDisplayMessage,
+          returnDisplay,
           ...executionError,
         };
       }
 
       return {
         llmContent,
-        returnDisplay: returnDisplayMessage,
+        returnDisplay,
         data,
         ...executionError,
       };


### PR DESCRIPTION
## Summary

We were rendering shell output as markdown resulting is bad performance, memory usage, and missing colors.

Before:

<img width="1019" height="575" alt="image" src="https://github.com/user-attachments/assets/be5f77d4-0047-4863-bd26-d4753afccfd1" />

After:
memory usage 150mb as this is now a ScrollableList supporting lazy rendering instead of rendering all the content as markdown.
<img width="848" height="547" alt="image" src="https://github.com/user-attachments/assets/1b1ee248-f756-4516-b585-8446f8e8a754" />

