### PR TITLE
test(evals): add cross-module dependency chain reasoning eval

### DIFF
--- a/evals/cross-module-reasoning.eval.ts
+++ b/evals/cross-module-reasoning.eval.ts
@@ -8,9 +8,6 @@ import { describe, expect } from 'vitest';
 import { evalTest } from './test-helper.js';
 import { READ_FILE_TOOL_NAME, EDIT_TOOL_NAME } from '@google/gemini-cli-core';
 
-// READ_FILE_TOOL_NAME = 'read_file'
-// EDIT_TOOL_NAME      = 'replace'
-
 const FILES = {
   'package.json': JSON.stringify({
     name: 'score-api',
@@ -161,6 +158,7 @@ describe('cross_module_reasoning', () => {
         }
       });
 
+      // If repository.ts was never edited, scan all logs — assertion 1 will catch the missing edit
       const logsBeforeEdit =
         firstRepoEditIndex >= 0
           ? toolLogs.slice(0, firstRepoEditIndex)
@@ -188,6 +186,9 @@ describe('cross_module_reasoning', () => {
       ).toBeGreaterThanOrEqual(2);
 
       // --- Assertion 4: fix is correct — broken pattern removed ---
+      // repository.ts always exists on disk (written from FILES before the agent runs),
+      // so readFile will not throw. If the agent never edited it, the original content
+      // still contains r.id.length and this assertion will fail correctly.
       const repoContent = rig.readFile('repository.ts');
       expect(
         repoContent,

--- a/evals/cross-module-reasoning.eval.ts
+++ b/evals/cross-module-reasoning.eval.ts
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { evalTest } from './test-helper.js';
+import { READ_FILE_TOOL_NAME, EDIT_TOOL_NAME } from '@google/gemini-cli-core';
+
+// READ_FILE_TOOL_NAME = 'read_file'
+// EDIT_TOOL_NAME      = 'replace'
+
+const FILES = {
+  'package.json': JSON.stringify({
+    name: 'score-api',
+    version: '1.0.0',
+    type: 'module',
+  }),
+  'config.ts': [
+    "export const SCORE_TABLE = 'user_scores';",
+    'export const MAX_RECORDS_PER_USER = 100;',
+  ].join('\n'),
+  'repository.ts': [
+    "import { SCORE_TABLE } from './config.js';",
+    '',
+    'export interface ScoreRecord {',
+    '  id: string;',
+    '  value: number;',
+    '}',
+    '',
+    'export function getScoreRecords(userId: string): ScoreRecord[] {',
+    '  const table = SCORE_TABLE;',
+    '  console.debug(`Querying ${table}`);',
+    '  return [',
+    "    { id: 'score-abc', value: 42 },",
+    "    { id: 'score-def', value: 18 },",
+    "    { id: 'score-ghi', value: 7 },",
+    '  ];',
+    '}',
+    '',
+    'export function calculateTotal(records: ScoreRecord[]): number {',
+    '  return records.reduce((sum, r) => sum + r.id.length, 0);',
+    '}',
+  ].join('\n'),
+  'services.ts': [
+    "import { getScoreRecords, calculateTotal } from './repository.js';",
+    '',
+    'export function getUserScore(userId: string): number {',
+    '  const records = getScoreRecords(userId);',
+    '  return calculateTotal(records);',
+    '}',
+  ].join('\n'),
+  'handlers.ts': [
+    "import { getUserScore } from './services.js';",
+    '',
+    'export function handleGetUserScore(',
+    '  userId: string,',
+    '): { userId: string; totalScore: number } {',
+    '  const totalScore = getUserScore(userId);',
+    '  return { userId, totalScore };',
+    '}',
+  ].join('\n'),
+  'routes.ts': [
+    "import { handleGetUserScore } from './handlers.js';",
+    '',
+    'type Request = { params: { id: string } };',
+    'type Response = { json: (data: unknown) => void };',
+    'type App = {',
+    '  get: (path: string, fn: (req: Request, res: Response) => void) => void;',
+    '};',
+    '',
+    'export function registerRoutes(app: App): void {',
+    "  app.get('/users/:id/total-score', (req, res) => {",
+    '    const result = handleGetUserScore(req.params.id);',
+    '    res.json(result);',
+    '  });',
+    '}',
+  ].join('\n'),
+} as const;
+
+function getFilePath(args: unknown): string | undefined {
+  if (typeof args === 'object' && args !== null && 'file_path' in args) {
+    return (args as { file_path?: string }).file_path;
+  }
+  return undefined;
+}
+
+describe('cross_module_reasoning', () => {
+  /**
+   * Ensures the agent traces import dependencies to identify root cause
+   * rather than patching the layer where the symptom appears.
+   *
+   * A 4-level chain (routes → handlers → services → repository) is used
+   * where the bug originates in repository.ts but manifests at the HTTP
+   * response layer. The bug (summing r.id.length instead of r.value) is
+   * intentionally not grep-discoverable — the agent must understand the
+   * function's intent by reading the surrounding context.
+   *
+   * Directly relevant to issue #23316 (Long-Context & Complex Reasoning
+   * Evaluation Dataset): correctly attributing bugs in deep dependency
+   * chains is the core capability the benchmark dataset is designed to
+   * measure.
+   */
+  evalTest('USUALLY_PASSES', {
+    name: 'should trace import chain to fix root cause, not symptom layer',
+    prompt:
+      'Users are reporting that the /users/:id/total-score endpoint returns wrong values. Investigate and fix the bug. Do not run the server.',
+    files: FILES,
+    assert: async (rig, _result) => {
+      const toolLogs = rig.readToolLogs();
+
+      // --- Assertion 1: repository.ts was edited ---
+      const editCalls = toolLogs.filter(
+        (log) =>
+          log.toolRequest.name === EDIT_TOOL_NAME ||
+          log.toolRequest.name === 'write_file',
+      );
+      const repoEdits = editCalls.filter((call) => {
+        try {
+          const filePath = getFilePath(JSON.parse(call.toolRequest.args));
+          return filePath?.includes('repository.ts') ?? false;
+        } catch {
+          return false;
+        }
+      });
+      expect(
+        repoEdits.length,
+        'Agent should have edited repository.ts (root cause layer)',
+      ).toBeGreaterThanOrEqual(1);
+
+      // --- Assertion 2: symptom layers were not edited ---
+      const symptomEdits = editCalls.filter((call) => {
+        try {
+          const filePath = getFilePath(JSON.parse(call.toolRequest.args));
+          return (
+            (filePath?.includes('routes.ts') ?? false) ||
+            (filePath?.includes('handlers.ts') ?? false)
+          );
+        } catch {
+          return false;
+        }
+      });
+      expect(
+        symptomEdits.length,
+        'Agent should not have edited routes.ts or handlers.ts (symptom layers)',
+      ).toBe(0);
+
+      // --- Assertion 3: chain traversal happened before the first edit ---
+      const firstRepoEditIndex = toolLogs.findIndex((log) => {
+        if (
+          log.toolRequest.name !== EDIT_TOOL_NAME &&
+          log.toolRequest.name !== 'write_file'
+        )
+          return false;
+        try {
+          const filePath = getFilePath(JSON.parse(log.toolRequest.args));
+          return filePath?.includes('repository.ts') ?? false;
+        } catch {
+          return false;
+        }
+      });
+
+      const logsBeforeEdit =
+        firstRepoEditIndex >= 0
+          ? toolLogs.slice(0, firstRepoEditIndex)
+          : toolLogs;
+
+      const chainFilesRead = new Set<string>();
+      for (const log of logsBeforeEdit) {
+        if (log.toolRequest.name !== READ_FILE_TOOL_NAME) continue;
+        try {
+          const filePath = getFilePath(JSON.parse(log.toolRequest.args));
+          if (filePath?.includes('routes.ts')) chainFilesRead.add('routes.ts');
+          if (filePath?.includes('handlers.ts'))
+            chainFilesRead.add('handlers.ts');
+          if (filePath?.includes('services.ts'))
+            chainFilesRead.add('services.ts');
+        } catch {
+          // ignore malformed log entries
+        }
+      }
+
+      expect(
+        chainFilesRead.size,
+        `Agent should have read at least 2 chain files before editing repository.ts. ` +
+          `Files read: ${[...chainFilesRead].join(', ') || 'none'}`,
+      ).toBeGreaterThanOrEqual(2);
+
+      // --- Assertion 4: fix is correct — broken pattern removed ---
+      const repoContent = rig.readFile('repository.ts');
+      expect(
+        repoContent,
+        'repository.ts should no longer contain r.id.length after the fix',
+      ).not.toContain('r.id.length');
+    },
+  });
+});

--- a/evals/test-helper.ts
+++ b/evals/test-helper.ts
@@ -349,7 +349,7 @@ export function symlinkNodeModules(testDir: string) {
     fs.existsSync(rootNodeModules) &&
     !fs.existsSync(testNodeModules)
   ) {
-    fs.symlinkSync(rootNodeModules, testNodeModules, 'dir');
+    fs.symlinkSync(rootNodeModules, testNodeModules, 'junction');
   }
 }
 


### PR DESCRIPTION
## Summary

Adds a behavioral eval that verifies the agent traces a 4-level import chain to identify the root cause of a bug, rather than patching the symptom layer.

**The scenario:** A minimal TypeScript HTTP server with the chain `routes → handlers → services → repository`. The bug is in `calculateTotal()` in `repository.ts`, which sums `r.id.length` (ID string character count) instead of `r.value`. The bug manifests at the HTTP response layer but originates two layers deeper. It is intentionally not grep-discoverable — the agent must read the call chain to understand the function's intent.

**Four assertions:**
1. `repository.ts` was edited (root cause layer)
2. `routes.ts` and `handlers.ts` were **not** edited (symptom layers)
3. At least 2 chain files were read **before** the first edit to `repository.ts` (traversal verified, not just lucky grep)
4. `r.id.length` no longer appears in `repository.ts` after the fix (correctness check)

**Observed agent behavior on a passing run:**
`grep_search` → `read_file: handlers.ts` → `read_file: services.ts` → `read_file: repository.ts` → identified bug → `replace: repository.ts`. The agent created a reproduction script to verify before and after — without touching `routes.ts` or `handlers.ts`.

Also includes a one-line fix in `evals/test-helper.ts`: uses `'junction'` instead of `'dir'` for the node_modules symlink. Directory symlinks (`'dir'`) require admin privileges or Developer Mode on Windows; junctions do not. This makes evals runnable on Windows without elevated permissions.

## Test plan

- [x] `npm run preflight` passes
- [x] `npm run build && npm run bundle` passes
- [x] `RUN_EVALS=1 npx vitest run --config evals/vitest.config.ts evals/cross-module-reasoning.eval.ts` — PASS

Related: #23316