### PR TITLE
fix(devtools): reduce memory usage and defer connection

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -468,7 +468,7 @@ export async function main() {
       const { setupInitialActivityLogger } = await import(
         './utils/devtoolsService.js'
       );
-      await setupInitialActivityLogger(config);
+      setupInitialActivityLogger(config);
     }
 
     // Register config for telemetry shutdown

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -76,7 +76,7 @@ export async function runNonInteractive({
       const { setupInitialActivityLogger } = await import(
         './utils/devtoolsService.js'
       );
-      await setupInitialActivityLogger(config);
+      setupInitialActivityLogger(config);
     }
 
     const { stdout: workingStdout } = createWorkingStdio();

--- a/packages/cli/src/utils/devtoolsService.test.ts
+++ b/packages/cli/src/utils/devtoolsService.test.ts
@@ -123,69 +123,22 @@ describe('devtoolsService', () => {
   });
 
   describe('setupInitialActivityLogger', () => {
-    it('stays in buffer mode when no existing server found', async () => {
+    it('stays in buffer mode (no probe attempted)', () => {
       const config = createMockConfig();
-      const promise = setupInitialActivityLogger(config);
-
-      // Probe fires immediately — no server running
-      await vi.waitFor(() => expect(MockWebSocket.instances.length).toBe(1));
-      MockWebSocket.instances[0].simulateError();
-
-      await promise;
+      setupInitialActivityLogger(config);
 
       expect(mockInitActivityLogger).toHaveBeenCalledWith(config, {
         mode: 'buffer',
       });
       expect(mockAddNetworkTransport).not.toHaveBeenCalled();
+      // No WebSocket probe on startup
+      expect(MockWebSocket.instances.length).toBe(0);
     });
 
-    it('attaches transport when existing server found at startup', async () => {
-      const config = createMockConfig();
-      const promise = setupInitialActivityLogger(config);
-
-      await vi.waitFor(() => expect(MockWebSocket.instances.length).toBe(1));
-      MockWebSocket.instances[0].simulateOpen();
-
-      await promise;
-
-      expect(mockInitActivityLogger).toHaveBeenCalledWith(config, {
-        mode: 'buffer',
-      });
-      expect(mockAddNetworkTransport).toHaveBeenCalledWith(
-        config,
-        '127.0.0.1',
-        25417,
-        expect.any(Function),
-      );
-      expect(
-        mockActivityLoggerInstance.enableNetworkLogging,
-      ).toHaveBeenCalled();
-    });
-
-    it('F12 short-circuits when startup already connected', async () => {
-      const config = createMockConfig();
-
-      // Startup: probe succeeds
-      const setupPromise = setupInitialActivityLogger(config);
-      await vi.waitFor(() => expect(MockWebSocket.instances.length).toBe(1));
-      MockWebSocket.instances[0].simulateOpen();
-      await setupPromise;
-
-      mockAddNetworkTransport.mockClear();
-      mockActivityLoggerInstance.enableNetworkLogging.mockClear();
-
-      // F12: should return URL immediately
-      const url = await startDevToolsServer(config);
-
-      expect(url).toBe('http://localhost:25417');
-      expect(mockAddNetworkTransport).not.toHaveBeenCalled();
-      expect(mockDevToolsInstance.start).not.toHaveBeenCalled();
-    });
-
-    it('initializes in file mode when target env var is set', async () => {
+    it('initializes in file mode when target env var is set', () => {
       process.env['GEMINI_CLI_ACTIVITY_LOG_TARGET'] = '/tmp/test.jsonl';
       const config = createMockConfig();
-      await setupInitialActivityLogger(config);
+      setupInitialActivityLogger(config);
 
       expect(mockInitActivityLogger).toHaveBeenCalledWith(config, {
         mode: 'file',
@@ -195,10 +148,10 @@ describe('devtoolsService', () => {
       expect(MockWebSocket.instances.length).toBe(0);
     });
 
-    it('does nothing in file mode when config.storage is missing', async () => {
+    it('does nothing in file mode when config.storage is missing', () => {
       process.env['GEMINI_CLI_ACTIVITY_LOG_TARGET'] = '/tmp/test.jsonl';
       const config = createMockConfig({ storage: undefined });
-      await setupInitialActivityLogger(config);
+      setupInitialActivityLogger(config);
 
       expect(mockInitActivityLogger).not.toHaveBeenCalled();
       expect(MockWebSocket.instances.length).toBe(0);

--- a/packages/cli/src/utils/devtoolsService.ts
+++ b/packages/cli/src/utils/devtoolsService.ts
@@ -116,39 +116,17 @@ async function handlePromotion(config: Config) {
 /**
  * Initializes the activity logger.
  * Interception starts immediately in buffering mode.
- * If an existing DevTools server is found, attaches transport eagerly.
+ * Transport is only attached when the user presses F12.
  */
-export async function setupInitialActivityLogger(config: Config) {
+export function setupInitialActivityLogger(config: Config) {
   const target = process.env['GEMINI_CLI_ACTIVITY_LOG_TARGET'];
 
   if (target) {
     if (!config.storage) return;
     initActivityLogger(config, { mode: 'file', filePath: target });
   } else {
-    // Start in buffering mode (no transport attached yet)
+    // Start in buffering mode — transport attached later on F12
     initActivityLogger(config, { mode: 'buffer' });
-
-    // Eagerly probe for an existing DevTools server
-    try {
-      const existing = await probeDevTools(
-        DEFAULT_DEVTOOLS_HOST,
-        DEFAULT_DEVTOOLS_PORT,
-      );
-      if (existing) {
-        const onReconnectFailed = () => handlePromotion(config);
-        addNetworkTransport(
-          config,
-          DEFAULT_DEVTOOLS_HOST,
-          DEFAULT_DEVTOOLS_PORT,
-          onReconnectFailed,
-        );
-        ActivityLogger.getInstance().enableNetworkLogging();
-        connectedUrl = `http://localhost:${DEFAULT_DEVTOOLS_PORT}`;
-        debugLogger.log(`DevTools (existing) at startup: ${connectedUrl}`);
-      }
-    } catch {
-      // Probe failed silently — stay in buffer mode
-    }
   }
 }
 

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -124,7 +124,7 @@ export class DevTools extends EventEmitter {
         chunks: payload.chunk ? [payload.chunk] : undefined,
       } as NetworkLog;
       this.logs.push(entry);
-      if (this.logs.length > 2000) this.logs.shift();
+      if (this.logs.length > 10) this.logs.shift();
       this.emit('update', entry);
     }
   }


### PR DESCRIPTION
## Summary

Reduce DevTools memory footprint by lowering the network log buffer from 2000 to 10 entries, and stop eagerly connecting to existing DevTools servers on startup — transport is now only attached when the user presses F12.

## Details

Two changes:

1. **`packages/devtools/src/index.ts`**: Network log cap reduced from 2000 → 10. Each log can hold a full LLM response body (tens to hundreds of KB), so 2000 entries was a significant memory sink. Console logs (5000 cap) are kept as-is since they are small.

2. **`packages/cli/src/utils/devtoolsService.ts`**: Removed the eager `probeDevTools` + `addNetworkTransport` call from `setupInitialActivityLogger`. Previously, every new CLI session would auto-detect and connect to an existing DevTools server at startup, sending data even if the user never opened DevTools. Now the logger starts in pure buffer mode (10 request groups), and only connects when F12 is explicitly pressed. The promotion/reconnect logic after F12 is unchanged.

## Related Issues

Related to #18494

## How to Validate

1. Start a CLI session without pressing F12 — verify no WebSocket connection to `:25417`
2. Press F12 — DevTools should start/connect normally, buffered logs flush to the UI
3. With DevTools open, make >10 API requests — older entries should be evicted from the network panel
4. Monitor memory usage over a long session — should be significantly lower than before

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker