### PR TITLE
fix(cli): prevent crash in AnsiOutputText when handling non-array data

### DIFF
--- a/packages/cli/src/ui/components/AnsiOutput.test.tsx
+++ b/packages/cli/src/ui/components/AnsiOutput.test.tsx
@@ -156,4 +156,30 @@ describe('<AnsiOutputText />', () => {
     expect(lastFrame()).toBeDefined();
     unmount();
   });
+
+  describe('robustness', () => {
+    it('does NOT crash when data is undefined', async () => {
+      const { lastFrame, unmount } = await render(
+        <AnsiOutputText
+          data={undefined as unknown as AnsiOutput}
+          width={80}
+          disableTruncation={true}
+        />,
+      );
+      expect(lastFrame({ allowEmpty: true }).trim()).toBe('');
+      unmount();
+    });
+
+    it('does NOT crash when data is an object but not an array', async () => {
+      const { lastFrame, unmount } = await render(
+        <AnsiOutputText
+          data={{ summary: 'test' } as unknown as AnsiOutput}
+          width={80}
+          disableTruncation={true}
+        />,
+      );
+      expect(lastFrame({ allowEmpty: true }).trim()).toBe('');
+      unmount();
+    });
+  });
 });

--- a/packages/cli/src/ui/components/AnsiOutput.tsx
+++ b/packages/cli/src/ui/components/AnsiOutput.tsx
@@ -35,14 +35,16 @@ export const AnsiOutputText: React.FC<AnsiOutputProps> = ({
       ? Math.min(availableHeightLimit, maxLines)
       : (availableHeightLimit ?? maxLines ?? DEFAULT_HEIGHT);
 
-  const lastLines = disableTruncation
-    ? data
-    : numLinesRetained === 0
-      ? []
-      : data.slice(-numLinesRetained);
+  const lastLines = Array.isArray(data)
+    ? disableTruncation
+      ? data
+      : numLinesRetained === 0
+        ? []
+        : data.slice(-numLinesRetained)
+    : [];
   return (
     <Box flexDirection="column" width={width} flexShrink={0} overflow="hidden">
-      {lastLines.map((line: AnsiLine, lineIndex: number) => (
+      {(lastLines as AnsiLine[]).map((line: AnsiLine, lineIndex: number) => (
         <Box key={lineIndex} height={1} overflow="hidden">
           <AnsiLineText line={line} />
         </Box>

--- a/packages/cli/src/ui/components/messages/ToolResultDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/ToolResultDisplay.tsx
@@ -158,7 +158,7 @@ export const ToolResultDisplay: React.FC<ToolResultDisplayProps> = ({
           terminalWidth={childWidth}
         />
       );
-    } else {
+    } else if (Array.isArray(contentData)) {
       const shouldDisableTruncation =
         isAlternateBuffer ||
         (availableTerminalHeight === undefined && maxLines === undefined);
@@ -175,6 +175,15 @@ export const ToolResultDisplay: React.FC<ToolResultDisplayProps> = ({
           disableTruncation={shouldDisableTruncation}
         />
       );
+    } else if (typeof contentData === 'object' && contentData !== null) {
+      // Render as JSON for other non-null objects
+      content = (
+        <Text wrap="wrap" color={theme.text.primary}>
+          {JSON.stringify(contentData, null, 2)}
+        </Text>
+      );
+    } else {
+      content = null;
     }
 
     // Final render based on session mode


### PR DESCRIPTION
## Summary

Fixes a crash in `AnsiOutputText` ("lastLines.map is not a function") caused by handling non-array output types in the interactive CLI message display. Crashed while scrolling

## Details

- Added a check in `ToolResultDisplay` to ensure `contentData` is explicitly an array before routing it to the ANSI output renderer. 
- General objects are now cleanly fallback-rendered as pretty-printed JSON.
- `AnsiOutputText` is made resilient against missing or non-array inputs, defaulting to an empty array instead of triggering a map error.
- Added corresponding unit tests to `AnsiOutput.test.tsx` to verify robustness.

## Related Issues
Fixes https://github.com/google-gemini/gemini-cli/issues/24500
<!-- None -->

## How to Validate

1. Trigger a tool or command in Gemini CLI that generates a non-string and non-ANSI-array object output (e.g., standard generic objects) inside the `ToolResultDisplay`.
2. Confirm that the UI no longer crashes with a "lastLines.map is not a function" error and instead displays the formatted JSON output.
3. Validate tests passing by running `npm test -w @google/gemini-cli -- src/ui/components/AnsiOutput.test.tsx`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
