### PR TITLE
fix(cli): keep input prompt and footer visible in copy mode

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -2648,6 +2648,20 @@ describe('AppContainer State Management', () => {
           unmount();
         });
 
+        it('should keep isInputActive true when copy mode is enabled', async () => {
+          await setupCopyModeTest(true);
+
+          // Enter copy mode
+          act(() => {
+            stdin.write('\x13'); // Ctrl+S
+          });
+          rerender();
+
+          expect(capturedUIState.copyModeEnabled).toBe(true);
+          expect(capturedUIState.isInputActive).toBe(true);
+          unmount();
+        });
+
         it('should have higher priority than other priority listeners when enabled', async () => {
           // 1. Initial state with a child component's priority listener (already subscribed)
           // It should NOT handle Ctrl+S so we can enter copy mode.

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1430,8 +1430,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     (streamingState === StreamingState.Idle ||
       streamingState === StreamingState.Responding ||
       streamingState === StreamingState.WaitingForConfirmation) &&
-    !proQuotaRequest &&
-    !copyModeEnabled;
+    !proQuotaRequest;
 
   const observerRef = useRef<ResizeObserver | null>(null);
   const [controlsHeight, setControlsHeight] = useState(0);

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -170,7 +170,7 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
         />
       )}
 
-      {showUiDetails &&
+      {(showUiDetails || uiState.copyModeEnabled) &&
         !settings.merged.ui.hideFooter &&
         !isScreenReaderEnabled && (
           <Footer copyModeEnabled={uiState.copyModeEnabled} />

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -1342,7 +1342,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   );
 
   useKeypress(handleInput, {
-    isActive: !isEmbeddedShellFocused,
+    isActive: !isEmbeddedShellFocused && !copyModeEnabled,
     priority: true,
   });
 


### PR DESCRIPTION
## Summary

Fixes UI bugs where the input prompt and footer disappear when copy mode is enabled (`Ctrl+S`).

## Details

- Modified `isInputActive` logic in `AppContainer.tsx` to remain true during copy mode.
- Adjusted `useKeypress` in `InputPrompt.tsx` to be inactive when copy mode is enabled, preventing it from capturing keystrokes that should be handled by copy mode for scrolling.
- Ensured the `Footer` component in `Composer.tsx` remains visible by conditionally displaying it even if UI details are hidden while in copy mode.
- Added Vitest tests to cover the new behaviors.

## Related Issues



## How to Validate

1. Run the CLI in development.
2. Enter an alternate buffer if necessary, then toggle copy mode using `Ctrl+S`.
3. Verify that the input prompt does not disappear.
4. Verify that the footer remains visible.
5. Ensure scroll keys still work properly in copy mode and regular typing works when exiting copy mode.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run