### PR TITLE
fix(browser): handle computer-use model detection for analyze_screenshot

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1242,7 +1242,8 @@ their corresponding top-level category object in your `settings.json` file.
   - **Requires restart:** Yes
 
 - **`agents.browser.visualModel`** (string):
-  - **Description:** Model override for the visual agent.
+  - **Description:** Model for the visual agent's analyze_screenshot tool. When
+    set, enables the tool.
   - **Default:** `undefined`
   - **Requires restart:** Yes
 

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1202,7 +1202,8 @@ const SETTINGS_SCHEMA = {
             category: 'Advanced',
             requiresRestart: true,
             default: undefined as string | undefined,
-            description: 'Model override for the visual agent.',
+            description:
+              "Model for the visual agent's analyze_screenshot tool. When set, enables the tool.",
             showInDialog: false,
           },
           allowedDomains: {

--- a/packages/core/src/agents/browser/analyzeScreenshot.test.ts
+++ b/packages/core/src/agents/browser/analyzeScreenshot.test.ts
@@ -9,6 +9,7 @@ import { createAnalyzeScreenshotTool } from './analyzeScreenshot.js';
 import type { BrowserManager, McpToolCallResult } from './browserManager.js';
 import type { Config } from '../../config/config.js';
 import type { MessageBus } from '../../confirmation-bus/message-bus.js';
+import { Environment } from '@google/genai';
 
 const mockMessageBus = {
   waitForConfirmation: vi.fn().mockResolvedValue({ approved: true }),
@@ -36,6 +37,7 @@ function createMockBrowserManager(
 function createMockConfig(
   generateContentResult?: unknown,
   generateContentError?: Error,
+  modelName: string = 'gemini-2.5-computer-use-preview-10-2025',
 ): Config {
   const generateContent = generateContentError
     ? vi.fn().mockRejectedValue(generateContentError)
@@ -57,7 +59,7 @@ function createMockConfig(
 
   return {
     getBrowserAgentConfig: vi.fn().mockReturnValue({
-      customConfig: { visualModel: 'test-visual-model' },
+      customConfig: { visualModel: modelName },
     }),
     getContentGenerator: vi.fn().mockReturnValue({
       generateContent,
@@ -109,7 +111,22 @@ describe('analyzeScreenshot', () => {
       const contentGenerator = config.getContentGenerator();
       expect(contentGenerator.generateContent).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'test-visual-model',
+          model: 'gemini-2.5-computer-use-preview-10-2025',
+          config: expect.objectContaining({
+            tools: [
+              {
+                computerUse: {
+                  environment: Environment.ENVIRONMENT_BROWSER,
+                  excludedPredefinedFunctions: [
+                    'open_web_browser',
+                    'click_at',
+                    'key_combination',
+                    'drag_and_drop',
+                  ],
+                },
+              },
+            ],
+          }),
           contents: expect.arrayContaining([
             expect.objectContaining({
               role: 'user',
@@ -134,6 +151,33 @@ describe('analyzeScreenshot', () => {
         'The blue submit button is at coordinates (250, 400).',
       );
       expect(result.error).toBeUndefined();
+    });
+
+    it('omits computerUse tools for non-computer-use models', async () => {
+      const browserManager = createMockBrowserManager();
+      const config = createMockConfig(undefined, undefined, 'gemini-2.0-flash');
+      const tool = createAnalyzeScreenshotTool(
+        browserManager,
+        config,
+        mockMessageBus,
+      );
+
+      const invocation = tool.build({
+        instruction: 'Find the search bar',
+      });
+      await invocation.execute(new AbortController().signal);
+
+      const contentGenerator = config.getContentGenerator();
+      expect(contentGenerator.generateContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'gemini-2.0-flash',
+          config: expect.not.objectContaining({
+            tools: expect.anything(),
+          }),
+        }),
+        'visual-analysis',
+        'utility_tool',
+      );
     });
 
     it('returns an error when screenshot capture fails (no image)', async () => {

--- a/packages/core/src/agents/browser/analyzeScreenshot.ts
+++ b/packages/core/src/agents/browser/analyzeScreenshot.ts
@@ -24,10 +24,14 @@ import {
   type ToolResult,
   type ToolInvocation,
 } from '../../tools/tools.js';
+import { Environment } from '@google/genai';
 import type { MessageBus } from '../../confirmation-bus/message-bus.js';
 import type { BrowserManager } from './browserManager.js';
 import type { Config } from '../../config/config.js';
-import { getVisualAgentModel } from './modelAvailability.js';
+import {
+  getVisualAgentModel,
+  isComputerUseModel,
+} from './modelAvailability.js';
 import { debugLogger } from '../../utils/debugLogger.js';
 import { LlmRole } from '../../telemetry/llmRole.js';
 
@@ -116,6 +120,27 @@ class AnalyzeScreenshotInvocation extends BaseToolInvocation<
       const visualModel = getVisualAgentModel(this.config);
       const contentGenerator = this.config.getContentGenerator();
 
+      // Computer-use models require the computerUse tool declaration in every
+      // request. We exclude all predefined action functions so the model
+      // provides text analysis rather than issuing actions.
+      // Non-computer-use models (e.g., gemini-2.0-flash) do plain text
+      // analysis natively and don't need this declaration.
+      const tools = isComputerUseModel(visualModel)
+        ? [
+            {
+              computerUse: {
+                environment: Environment.ENVIRONMENT_BROWSER,
+                excludedPredefinedFunctions: [
+                  'open_web_browser',
+                  'click_at',
+                  'key_combination',
+                  'drag_and_drop',
+                ],
+              },
+            },
+          ]
+        : undefined;
+
       const response = await contentGenerator.generateContent(
         {
           model: visualModel,
@@ -124,6 +149,7 @@ class AnalyzeScreenshotInvocation extends BaseToolInvocation<
             topP: 0.95,
             systemInstruction: VISUAL_SYSTEM_PROMPT,
             abortSignal: signal,
+            ...(tools ? { tools } : {}),
           },
           contents: [
             {
@@ -146,12 +172,22 @@ class AnalyzeScreenshotInvocation extends BaseToolInvocation<
         LlmRole.UTILITY_TOOL,
       );
 
-      // Extract text from response
-      const responseText =
-        response.candidates?.[0]?.content?.parts
-          ?.filter((p) => p.text)
-          .map((p) => p.text)
-          .join('\n') ?? '';
+      // Extract response content. Computer-use models may still return
+      // functionCall parts even with exclusions, so we handle both text
+      // and functionCall parts defensively.
+      const parts = response.candidates?.[0]?.content?.parts ?? [];
+
+      const textParts = parts.filter((p) => p.text).map((p) => p.text!);
+
+      const functionCallParts = parts
+        .filter((p) => p.functionCall)
+        .map((p) => {
+          const fc = p.functionCall!;
+          const argsStr = fc.args ? JSON.stringify(fc.args) : '';
+          return `Action: ${fc.name}${argsStr ? ` with args ${argsStr}` : ''}`;
+        });
+
+      const responseText = [...textParts, ...functionCallParts].join('\n');
 
       if (!responseText) {
         return {

--- a/packages/core/src/agents/browser/modelAvailability.ts
+++ b/packages/core/src/agents/browser/modelAvailability.ts
@@ -20,6 +20,20 @@ import { debugLogger } from '../../utils/debugLogger.js';
 export const VISUAL_AGENT_MODEL = 'gemini-2.5-computer-use-preview-10-2025';
 
 /**
+ * Pattern matching the gemini computer-use model family.
+ * These models require a computerUse tool declaration in every request.
+ */
+const COMPUTER_USE_MODEL_PATTERN = /^gemini-.*-computer-use-/;
+
+/**
+ * Returns true if the model name belongs to the computer-use family
+ * (matches gemini-*-computer-use-*).
+ */
+export function isComputerUseModel(model: string): boolean {
+  return COMPUTER_USE_MODEL_PATTERN.test(model);
+}
+
+/**
  * Gets the visual agent model from config, falling back to default.
  *
  * @param config Runtime configuration

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -369,7 +369,7 @@ export interface BrowserAgentCustomConfig {
   headless?: boolean;
   /** Path to Chrome profile directory for session persistence. */
   profilePath?: string;
-  /** Model override for the visual agent. */
+  /** Model for the visual agent's analyze_screenshot tool. When set, enables the tool. */
   visualModel?: string;
   /** List of allowed domains for the browser agent (e.g., ["github.com", "*.google.com"]). */
   allowedDomains?: string[];

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -2205,8 +2205,8 @@
             },
             "visualModel": {
               "title": "Browser Visual Model",
-              "description": "Model override for the visual agent.",
-              "markdownDescription": "Model override for the visual agent.\n\n- Category: `Advanced`\n- Requires restart: `yes`",
+              "description": "Model for the visual agent's analyze_screenshot tool. When set, enables the tool.",
+              "markdownDescription": "Model for the visual agent's analyze_screenshot tool. When set, enables the tool.\n\n- Category: `Advanced`\n- Requires restart: `yes`",
               "type": "string"
             },
             "allowedDomains": {


### PR DESCRIPTION
## Summary

Fix `analyze_screenshot` tool failing with computer-use models due to missing `computerUse` tool declaration and response parsing that only handled text parts.

## Details

The `gemini-2.5-computer-use-preview-10-2025` model is an agentic action model that returns `functionCall` parts instead of text. This caused:

1. **400 INVALID_ARGUMENT** — Missing required `computerUse` tool declaration
2. **Empty visual analysis** — Response parsing only extracted `text` parts, dropping `functionCall` parts
3. **Agent loops** — The browser agent retried 7+ times over 3+ minutes before giving up

### Changes

- **`modelAvailability.ts`**: Added `isComputerUseModel()` helper matching `gemini-*-computer-use-*` pattern
- **`analyzeScreenshot.ts`**: Conditionally include `computerUse` tool declaration with `excludedPredefinedFunctions` for computer-use models only. Extract both `text` and `functionCall` parts from responses defensively.
- **`config.ts` / `settingsSchema.ts`**: Updated `visualModel` setting description
- **`analyzeScreenshot.test.ts`**: Added test for non-computer-use model path (8 tests total)

## Related Issues

Fixes #24501

## How to Validate

1. Build from source: `npm run clean && npm run build && npm run bundle`
2. Configure `visualModel` and `allowedDomains` in `.gemini/settings.json`:
   ```json
   {
     "agents": {
       "browser": {
         "visualModel": "gemini-2.5-computer-use-preview-10-2025",
         "allowedDomains": ["*.google.com", "google.com"]
       }
     }
   }
   ```
3. Run: "Use the browser agent to go to google.com and use analyze_screenshot to find the search bar coordinates"
4. Verify `analyze_screenshot` returns text analysis with coordinates (not empty/error)
5. Run unit tests: `npm test -w @google/gemini-cli-core -- src/agents/browser/analyzeScreenshot.test.ts` (8/8 pass)

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
