### PR TITLE
revert(cli): bring back input box and footer visibility in copy mode

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1430,8 +1430,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     (streamingState === StreamingState.Idle ||
       streamingState === StreamingState.Responding ||
       streamingState === StreamingState.WaitingForConfirmation) &&
-    !proQuotaRequest &&
-    !copyModeEnabled;
+    !proQuotaRequest;
 
   const observerRef = useRef<ResizeObserver | null>(null);
   const [controlsHeight, setControlsHeight] = useState(0);

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -172,9 +172,7 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
 
       {showUiDetails &&
         !settings.merged.ui.hideFooter &&
-        !isScreenReaderEnabled && (
-          <Footer copyModeEnabled={uiState.copyModeEnabled} />
-        )}
+        !isScreenReaderEnabled && <Footer />}
     </Box>
   );
 };

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -178,9 +178,7 @@ interface FooterColumn {
   isHighPriority: boolean;
 }
 
-export const Footer: React.FC<{ copyModeEnabled?: boolean }> = ({
-  copyModeEnabled = false,
-}) => {
+export const Footer: React.FC = () => {
   const uiState = useUIState();
   const config = useConfig();
   const settings = useSettings();
@@ -197,10 +195,6 @@ export const Footer: React.FC<{ copyModeEnabled?: boolean }> = ({
       setEmail(undefined);
     }
   }, [authType]);
-
-  if (copyModeEnabled) {
-    return <Box height={1} />;
-  }
 
   const {
     model,

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -1342,7 +1342,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   );
 
   useKeypress(handleInput, {
-    isActive: !isEmbeddedShellFocused,
+    isActive: !isEmbeddedShellFocused && !copyModeEnabled,
     priority: true,
   });
 


### PR DESCRIPTION
## Summary

Reverts the behavior introduced in PR #22584 that hid the Input Prompt and Footer when Copy Mode is enabled.

## Details

This restores the UI elements to remain visible when entering Copy Mode:
- **AppContainer:** Removed the `copyModeEnabled` check that disabled the `isInputActive` state. The Input Prompt will now render in copy mode.
- **InputPrompt:** Updated `useKeypress` and `showCursor` conditions. To prevent breaking terminal scroll resets (one of the original motivations for hiding the UI), `useKeypress` ignores input and the cursor is explicitly hidden when `copyModeEnabled` is active.
- **Footer:** Removed the `if (copyModeEnabled) return <Box height={1} />` early return so the Footer remains visible. Memory update intervals are already paused successfully during copy mode via existing props.

## Related Issues

Reverts the UI-hiding portion of #18701 / PR #22584

## How to Validate

1. Run the CLI.
2. Enter Alternate Buffer Mode (or fullscreen).
3. Type `Ctrl+S` to enter Copy Mode.
4. Verify the Input Prompt remains visible (but cursor is hidden).
5. Verify the Footer remains visible.
6. Scroll using Page Up / Page Down.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run