### PR TITLE
fix(core): authentication flow cancellation and Enter key bug

### DIFF
--- a/packages/cli/src/ui/auth/AuthInProgress.tsx
+++ b/packages/cli/src/ui/auth/AuthInProgress.tsx
@@ -10,6 +10,7 @@ import { Box, Text } from 'ink';
 import { CliSpinner } from '../components/CliSpinner.js';
 import { theme } from '../semantic-colors.js';
 import { useKeypress } from '../hooks/useKeypress.js';
+import { KeypressPriority } from '../contexts/KeypressContext.js';
 
 interface AuthInProgressProps {
   onTimeout: () => void;
@@ -24,9 +25,11 @@ export function AuthInProgress({
     (key) => {
       if (key.name === 'escape' || (key.ctrl && key.name === 'c')) {
         onTimeout();
+        return true;
       }
+      return false;
     },
-    { isActive: true },
+    { isActive: true, priority: KeypressPriority.Critical },
   );
 
   useEffect(() => {

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -26,6 +26,7 @@ import { SessionBrowser } from './SessionBrowser.js';
 import { PermissionsModifyTrustDialog } from './PermissionsModifyTrustDialog.js';
 import { ModelDialog } from './ModelDialog.js';
 import { theme } from '../semantic-colors.js';
+import { coreEvents } from '@google/gemini-cli-core';
 import { useUIState } from '../contexts/UIStateContext.js';
 import { useUIActions } from '../contexts/UIActionsContext.js';
 import { useConfig } from '../contexts/ConfigContext.js';
@@ -286,6 +287,7 @@ export const DialogManager = ({
       <AuthInProgress
         onTimeout={() => {
           uiActions.onAuthError('Authentication cancelled.');
+          coreEvents.emitOauthCancelRequest();
         }}
       />
     );

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -348,19 +348,24 @@ async function initOauthClient(
     // Listen for SIGINT to stop waiting for auth so the terminal doesn't hang
     // if the user chooses not to auth.
     let sigIntHandler: (() => void) | undefined;
-    let stdinHandler: ((data: Buffer) => void) | undefined;
+    let stdinHandler: ((data: Buffer | string) => void) | undefined;
+    let cancelEventHandler: (() => void) | undefined;
     const cancellationPromise = new Promise<never>((_, reject) => {
-      sigIntHandler = () =>
+      const onCancel = () =>
         reject(new FatalCancellationError('Authentication cancelled by user.'));
+
+      sigIntHandler = onCancel;
       process.on('SIGINT', sigIntHandler);
+
+      cancelEventHandler = onCancel;
+      coreEvents.on(CoreEvent.OauthCancelRequest, cancelEventHandler);
 
       // Note that SIGINT might not get raised on Ctrl+C in raw mode
       // so we also need to look for Ctrl+C directly in stdin.
-      stdinHandler = (data: Buffer) => {
-        if (data.includes(0x03)) {
-          reject(
-            new FatalCancellationError('Authentication cancelled by user.'),
-          );
+      stdinHandler = (data: Buffer | string) => {
+        const buf = typeof data === 'string' ? Buffer.from(data) : data;
+        if (buf.includes(0x03)) {
+          onCancel();
         }
       };
       process.stdin.on('data', stdinHandler);
@@ -381,6 +386,9 @@ async function initOauthClient(
       }
       if (stdinHandler) {
         process.stdin.removeListener('data', stdinHandler);
+      }
+      if (cancelEventHandler) {
+        coreEvents.off(CoreEvent.OauthCancelRequest, cancelEventHandler);
       }
     }
 

--- a/packages/core/src/utils/events.ts
+++ b/packages/core/src/utils/events.ts
@@ -193,6 +193,7 @@ export enum CoreEvent {
   EditorSelected = 'editor-selected',
   SlashCommandConflicts = 'slash-command-conflicts',
   QuotaChanged = 'quota-changed',
+  OauthCancelRequest = 'oauth-cancel-request',
   TelemetryKeychainAvailability = 'telemetry-keychain-availability',
   TelemetryTokenStorageType = 'telemetry-token-storage-type',
 }
@@ -226,6 +227,7 @@ export interface CoreEvents extends ExtensionEvents {
   [CoreEvent.RequestEditorSelection]: never[];
   [CoreEvent.EditorSelected]: [EditorSelectedPayload];
   [CoreEvent.SlashCommandConflicts]: [SlashCommandConflictsPayload];
+  [CoreEvent.OauthCancelRequest]: never[];
   [CoreEvent.TelemetryKeychainAvailability]: [KeychainAvailabilityEvent];
   [CoreEvent.TelemetryTokenStorageType]: [TokenStorageInitializationEvent];
 }
@@ -389,6 +391,13 @@ export class CoreEventEmitter extends EventEmitter<CoreEvents> {
   emitSlashCommandConflicts(conflicts: SlashCommandConflict[]): void {
     const payload: SlashCommandConflictsPayload = { conflicts };
     this._emitOrQueue(CoreEvent.SlashCommandConflicts, payload);
+  }
+
+  /**
+   * Notifies subscribers that an OAuth authentication flow was cancelled by the user.
+   */
+  emitOauthCancelRequest(): void {
+    this.emit(CoreEvent.OauthCancelRequest);
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR fixes two major bugs in the Google authentication (OAuth2) flow:
1.  **Enter key bug:** Pressing 'Enter' in terminals using modern protocols (like Kitty Keyboard Protocol) erroneously canceled the authentication flow.
2.  **Cancellation regression:** `Ctrl+C` was being intercepted by the global CLI handler instead of canceling the authentication flow, and `Esc` in the UI did not correctly abort the underlying backend authentication promise.

## Details

- **Fix 1 (Enter Key):** Resolved a string coercion bug in `oauth2.ts` where the stdin handler checked for `data.includes(0x03)`. When the input was a UTF-8 string, it matched the character "3" in the Enter key's escape sequence (`\x1b[13u`). Updated to robustly handle both `Buffer` and `string` inputs.
- **Fix 2 (Cancellation Logic):**
    - Introduced `CoreEvent.OauthCancelRequest` to provide an explicit signal for the UI to notify the backend of a user-initiated cancellation.
    - Updated `oauth2.ts` to listen for this event and reject the authentication promise immediately.
    - Elevated the keypress priority of the `AuthInProgress` component to `Critical` to ensure it takes precedence over the global CLI handlers.
    - Updated `DialogManager.tsx` and `AuthInProgress.tsx` to emit the cancellation event and correctly stop event propagation by returning `true`.

## Related Issues

Fixes #24525

## How to Validate

1. Switch to Google Account authentication.
2. Trigger the authentication flow (e.g., by running a command that requires auth).
3. Press 'Enter' when prompted for auth—it should **not** cancel the flow.
4. Press `Ctrl+C` once—it should instantly cancel the flow without showing the "press again to exit" warning.
5. Press `Esc`—it should also instantly cancel the flow and correctly abort the backend process.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Linux
    - [x] npm run
