### PR TITLE
fix(acp): handle all InvalidStreamError types gracefully in prompt

### DIFF
--- a/packages/cli/src/acp/acpClient.test.ts
+++ b/packages/cli/src/acp/acpClient.test.ts
@@ -875,6 +875,32 @@ describe('Session', () => {
     expect(result).toMatchObject({ stopReason: 'end_turn' });
   });
 
+  it('should handle prompt with no finish reason (InvalidStreamError)', async () => {
+    mockChat.sendMessageStream.mockRejectedValue(
+      new InvalidStreamError('No finish reason', 'NO_FINISH_REASON'),
+    );
+
+    const result = await session.prompt({
+      sessionId: 'session-1',
+      prompt: [{ type: 'text', text: 'Hi' }],
+    });
+
+    expect(mockChat.sendMessageStream).toHaveBeenCalled();
+    expect(result).toMatchObject({ stopReason: 'end_turn' });
+  });
+
+  it('should handle prompt with no finish reason (NO_FINISH_REASON anomaly)', async () => {
+    mockChat.sendMessageStream.mockRejectedValue({ type: 'NO_FINISH_REASON' });
+
+    const result = await session.prompt({
+      sessionId: 'session-1',
+      prompt: [{ type: 'text', text: 'Hi' }],
+    });
+
+    expect(mockChat.sendMessageStream).toHaveBeenCalled();
+    expect(result).toMatchObject({ stopReason: 'end_turn' });
+  });
+
   it('should handle /memory command', async () => {
     const handleCommandSpy = vi
       .spyOn(

--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -863,7 +863,10 @@ export class Session {
           (error &&
             typeof error === 'object' &&
             'type' in error &&
-            error.type === 'NO_RESPONSE_TEXT')
+            (error.type === 'NO_RESPONSE_TEXT' ||
+              error.type === 'NO_FINISH_REASON' ||
+              error.type === 'MALFORMED_FUNCTION_CALL' ||
+              error.type === 'UNEXPECTED_TOOL_CALL'))
         ) {
           // The stream ended with an empty response or malformed tool call.
           // Treat this as a graceful end to the model's turn rather than a crash.


### PR DESCRIPTION
## Summary
Address issue where invalid stream events (e.g. no finish reason) would cause sidecar crashes instead of ending the turn gracefully. The prototype check `instanceof InvalidStreamError` can fail across package boundaries in monorepos, necessitating robust fallback type checks.

## Details
- Add explicit fallback checks for 'NO_FINISH_REASON', 'MALFORMED_FUNCTION_CALL', and 'UNEXPECTED_TOOL_CALL' types.
- Treat these anomalies as graceful turn termination events (returning `end_turn`).
- Add tests in `acpClient.test.ts` to verify recovery for `NO_FINISH_REASON` scenarios.


## Related Issues

Fixes [maintainers-gemini-cli#1615](https://github.com/google-gemini/maintainers-gemini-cli/issues/1615)

## How to Validate

Unit tests are done. It's not straightforward to repro when a model responds this way - but the main issue is fixed.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [√] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [√] Validated on required platforms/methods:
  - [√ ] MacOS
    - [√] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
